### PR TITLE
fix(mobile): resume parked BLE writes when iOS 26.5 skips peripheralIsReady

### DIFF
--- a/docs/AURORA_BLUETOOTH_PROTOCOL_SPEC.md
+++ b/docs/AURORA_BLUETOOTH_PROTOCOL_SPEC.md
@@ -457,6 +457,8 @@ bluetoothChunkSize = 20
 
 Each 20-byte chunk is written to the RX characteristic as a separate GATT write operation, sequenced through the command queue (Section 14).
 
+> **Boardsesh implementation note (#3230):** the 20-byte chunk is the Aurora *app's* classic transport size, not a protocol requirement — framing is byte-identical at any chunk size (the Kilter Grips app negotiates a larger MTU; see `LED_BOX_BLE_CONNECTION_PROTOCOL.md` §5). Boardsesh sizes chunks from the connection's negotiated max write length, clamped to **[20, 244]** (ATT 247): iOS-26.5 field telemetry showed write failures clustering at the full ATT 512, so the negotiated maximum is never used unclamped. See `BoardBleEncoding.effectiveChunkSize` (iOS) and `effectiveChunkSizeForMtu` in `packages/shared/ble-protocol/src/transport.ts`. The iOS write loop additionally polls `canSendWriteWithoutResponse` while parked, because iOS 26.5 can update the property without delivering the `peripheralIsReady` delegate.
+
 ### Write Properties
 
 - **Write type**: Write Without Response (implied by Nordic UART RX characteristic)

--- a/docs/LED_BOX_BLE_CONNECTION_PROTOCOL.md
+++ b/docs/LED_BOX_BLE_CONNECTION_PROTOCOL.md
@@ -246,6 +246,8 @@ Colour comes from the placement role's 6-hex LED colour (`_colorFromHex`); unkno
 - LED records are packed into frames; when a frame would exceed 255 payload bytes a new frame is started. One frame → `Single`; many → `First` / `Middle…` / `Last`.
 - All frames are concatenated, then the byte stream is split into BLE writes. The classic transport size is **20 bytes/write**; with this app's negotiated MTU each `writeWithoutResponse` can be larger. ✅ Write type is **Write Without Response** (`, writeWithoutResponse: …`).
 
+> **Boardsesh implementation note (#3230):** Boardsesh follows this app's MTU-negotiated chunking, but clamps the without-response chunk to **[20, 244]** (ATT 247) — iOS-26.5 field telemetry showed write failures clustering at the full ATT 512. Android requests ATT 247 explicitly (`requestMTU(247)`); iOS clamps whatever CoreBluetooth auto-negotiated. See `effectiveChunkSizeForMtu` in `packages/shared/ble-protocol/src/transport.ts` and its Swift twin `BoardBleEncoding.effectiveChunkSize`.
+
 ### 6.6 Power budget (API v2 only)
 
 🔁 v2 caps total board draw at **18 W** by trying brightness scales `[1.0, 0.8, 0.6, 0.4, 0.2, 0.1, 0.05]` until it fits, with Kilter counting **2 LEDs per hold**. v3 omits this (firmware-managed). `_brightnessFor` in this app is the analogue. Full algorithm: `computeV2Scale` in `aurora.ts`.

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -222,20 +222,24 @@ final class LiveActivityWidgetTests: XCTestCase {
     // the negotiated maximumWriteValueLength clamped to [20, 244] — never the
     // ATT-512-derived 509 the failing iOS 26.5 cohort clusters at. MoonBoard
     // (both controller generations) and any with-response path stay at 20.
-    // Mirrors `effectiveChunkSizeForMtu` in
-    // packages/shared/ble-protocol/src/transport.ts — keep the value matrices
-    // in lockstep.
+    // Twin of `effectiveChunkSizeForMtu` in
+    // packages/shared/ble-protocol/src/transport.ts, with one domain
+    // difference: this side takes maximumWriteValueLength, which iOS reports
+    // as a PAYLOAD length (ATT MTU − 3), while the TS side takes the raw MTU —
+    // so the matrices differ by exactly 3 (TS mtu 23 ↔ Swift length 20).
     func testEffectiveChunkSizeClampsAuroraAndPinsMoonboard() {
         // Aurora without-response: clamp to the ATT-247 ceiling (244 payload).
         XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 509, writeType: .withoutResponse, boardName: "kilter"), 244)
         XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 512, writeType: .withoutResponse, boardName: "tension"), 244)
-        // Pass through negotiated values inside the window.
+        // Pass through negotiated payload lengths inside the window.
         XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 244, writeType: .withoutResponse, boardName: "kilter"), 244)
         XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 182, writeType: .withoutResponse, boardName: "kilter"), 182)
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 23, writeType: .withoutResponse, boardName: "kilter"), 23)
         XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 252, writeType: .withoutResponse, boardName: "tension"), 244)
-        // Floor at the classic 20 for degenerate/default negotiations.
-        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 23, writeType: .withoutResponse, boardName: "kilter"), 20)
+        // Floor at the classic 20: the BLE-default link reports payload 20
+        // (ATT 23 − 3); anything below is degenerate and must not shrink chunks.
         XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 20, writeType: .withoutResponse, boardName: "kilter"), 20)
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 19, writeType: .withoutResponse, boardName: "kilter"), 20)
         XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 0, writeType: .withoutResponse, boardName: "kilter"), 20)
         // nil board (a JS write before configureBoard) is Aurora-shaped: clamped MTU sizing.
         XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 509, writeType: .withoutResponse, boardName: nil), 244)

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -218,6 +218,34 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.read], boardName: "moonboard"), .withResponse)
     }
 
+    // Transport chunk sizing (#3230). Aurora without-response chunks come from
+    // the negotiated maximumWriteValueLength clamped to [20, 244] — never the
+    // ATT-512-derived 509 the failing iOS 26.5 cohort clusters at. MoonBoard
+    // (both controller generations) and any with-response path stay at 20.
+    // Mirrors `effectiveChunkSizeForMtu` in
+    // packages/shared/ble-protocol/src/transport.ts — keep the value matrices
+    // in lockstep.
+    func testEffectiveChunkSizeClampsAuroraAndPinsMoonboard() {
+        // Aurora without-response: clamp to the ATT-247 ceiling (244 payload).
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 509, writeType: .withoutResponse, boardName: "kilter"), 244)
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 512, writeType: .withoutResponse, boardName: "tension"), 244)
+        // Pass through negotiated values inside the window.
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 244, writeType: .withoutResponse, boardName: "kilter"), 244)
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 182, writeType: .withoutResponse, boardName: "kilter"), 182)
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 252, writeType: .withoutResponse, boardName: "tension"), 244)
+        // Floor at the classic 20 for degenerate/default negotiations.
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 23, writeType: .withoutResponse, boardName: "kilter"), 20)
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 20, writeType: .withoutResponse, boardName: "kilter"), 20)
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 0, writeType: .withoutResponse, boardName: "kilter"), 20)
+        // nil board (a JS write before configureBoard) is Aurora-shaped: clamped MTU sizing.
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 509, writeType: .withoutResponse, boardName: nil), 244)
+        // MoonBoard stays on the proven 20-byte chunks on BOTH write types.
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 509, writeType: .withoutResponse, boardName: "moonboard"), 20)
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 509, writeType: .withResponse, boardName: "moonboard"), 20)
+        // Any with-response path stays at 20 regardless of board.
+        XCTAssertEqual(BoardBleEncoding.effectiveChunkSize(negotiatedMaxWriteLength: 512, writeType: .withResponse, boardName: "kilter"), 20)
+    }
+
     // MARK: - Aurora packet encoding (parity with @boardsesh/ble-protocol)
 
     private func hex(_ data: Data) -> String {

--- a/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
@@ -44,6 +44,34 @@ enum BoardBleEncoding {
         return properties.contains(.writeWithoutResponse) ? .withoutResponse : .withResponse
     }
 
+    /// The classic 20-byte BLE payload (ATT 23 − 3): the floor every controller
+    /// generation is proven on, and the fixed size for both MoonBoard paths.
+    static let classicChunkSize = 20
+    /// Ceiling for MTU-sized Aurora chunks: ATT 247 − 3 header bytes. iOS-26.5
+    /// telemetry (#3230) shows the failing "oversized" cohort clusters at the
+    /// full ATT 512 (`maximumWriteValueLength` 509), while ATT ≤255 is clean in
+    /// the field — so never pass the negotiated maximum straight through.
+    /// Lockstep with `MAX_ATT_CHUNK_SIZE` in
+    /// packages/shared/ble-protocol/src/transport.ts (Android mirror).
+    static let maxAttChunkSize = 244
+
+    /// Transport chunk size for one GATT write. Chunking is a transport detail —
+    /// framing (SOH·LEN·CHK·STX·payload·ETX) is byte-identical at any size; the
+    /// official Kilter app negotiates MTU the same way (#3230).
+    ///
+    /// Aurora on write-without-response sizes chunks from the connection's
+    /// negotiated `maximumWriteValueLength`, clamped to [20, 244]. MoonBoard —
+    /// both the Nordic-UART and RedBearLab boxes — and any with-response path
+    /// stay at the proven 20 bytes.
+    static func effectiveChunkSize(
+        negotiatedMaxWriteLength: Int,
+        writeType: CBCharacteristicWriteType,
+        boardName: String?
+    ) -> Int {
+        guard writeType == .withoutResponse, boardName != "moonboard" else { return classicChunkSize }
+        return min(max(negotiatedMaxWriteLength, classicChunkSize), maxAttChunkSize)
+    }
+
     private struct HoldRoleInfo {
         let state: String
         let color: String

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -26,6 +26,59 @@ struct BoardBleConnectionDiagnostics {
     let maxWriteWithoutResponse: Int
 }
 
+/// Who enqueued a write: the JS bridge (`BoardBleModule.write`) or native code
+/// (widget intents, stall-recovery re-lights, clear-on-connect). Surfaced in the
+/// per-write telemetry so PostHog can segment the two populations.
+enum BoardBleWriteOrigin: String {
+    case js
+    case native
+}
+
+/// Per-write transport telemetry (#3230): how a single queued write moved
+/// through the without-response flow-control machinery. Attached to the JS
+/// write promise (success) or stashed for `getLastWriteDiagnostics` (failure)
+/// so `Climb Sent to Board` events carry a measurable before/after for the
+/// iOS 26.5 `peripheralIsReady` stall.
+struct BoardBleWriteTelemetry {
+    let origin: String              // BoardBleWriteOrigin.rawValue
+    let writeType: String           // "withoutResponse" | "withResponse"
+    let chunkSize: Int
+    let chunkCount: Int
+    let negotiatedMaxWriteWithoutResponse: Int
+    let startedAt: DispatchTime     // internal timing anchor; not surfaced
+    var parkCount = 0               // times a chunk parked on canSendWriteWithoutResponse
+    var peripheralIsReadyFired = false
+    var lastResumeSource: String?   // "callback" | "poll"
+    var maxParkMs = 0
+    var totalParkMs = 0
+    var watchdogTripped = false
+    var canSendAtTrip: Bool?        // canSendWriteWithoutResponse when the watchdog fired
+    var durationMs = 0
+
+    var analyticsDictionary: [String: Any] {
+        var dictionary: [String: Any] = [
+            "origin": origin,
+            "writeType": writeType,
+            "chunkSize": chunkSize,
+            "chunkCount": chunkCount,
+            "negotiatedMaxWriteWithoutResponse": negotiatedMaxWriteWithoutResponse,
+            "parkCount": parkCount,
+            "peripheralIsReadyFired": peripheralIsReadyFired,
+            "maxParkMs": maxParkMs,
+            "totalParkMs": totalParkMs,
+            "watchdogTripped": watchdogTripped,
+            "durationMs": durationMs,
+        ]
+        if let lastResumeSource {
+            dictionary["lastResumeSource"] = lastResumeSource
+        }
+        if let canSendAtTrip {
+            dictionary["canSendAtTrip"] = canSendAtTrip
+        }
+        return dictionary
+    }
+}
+
 enum BoardBleError: LocalizedError {
     case bluetoothUnavailable
     case deviceNotFound
@@ -82,9 +135,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     private struct WriteRequest {
         let chunks: [Data]
+        // Write type and chunk size are snapshotted at enqueue so one request is
+        // internally consistent: a configureBoard landing mid-request must not
+        // flip the write type (or pacing) between chunks of a single frame.
+        let writeType: CBCharacteristicWriteType
+        let chunkSize: Int
+        let negotiatedMaxWriteWithoutResponse: Int
+        let origin: BoardBleWriteOrigin
         let connectionGeneration: UInt64
         let writeGeneration: UInt64
-        let completion: (Error?) -> Void
+        let completion: (Error?, BoardBleWriteTelemetry?) -> Void
     }
 
     private let logger = Logger(subsystem: "com.boardsesh.app", category: "BoardBleManager")
@@ -99,13 +159,18 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // family. See docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md §2.1.
     private let redBearLabServiceUuid = CBUUID(string: "713D0000-503E-4C75-BA94-3148F18D941E")
     private let redBearLabWriteCharacteristicUuid = CBUUID(string: "713D0003-503E-4C75-BA94-3148F18D941E")
-    private let chunkSize = 20
     private let chunkDelay: TimeInterval = 0.005
     private let connectTimeout: TimeInterval = 8
     // How long a write parked on `canSendWriteWithoutResponse` may wait for
     // peripheralIsReady before the queue is failed. Generous: a healthy link
     // drains its transmit buffer in milliseconds.
     private let writeResumeTimeout: TimeInterval = 5
+    // Second resume path for a parked write (#3230): iOS 26.5 updates
+    // `canSendWriteWithoutResponse` but can skip the `peripheralIsReady`
+    // delegate entirely, so a poller re-checks the property while parked.
+    // 50 ms ≈ 100 chances inside the 5 s watchdog; healthy parks last tens of
+    // milliseconds.
+    private let writeResumePollInterval: TimeInterval = 0.05
     // How many CONSECUTIVE write stalls (with no successful write between them)
     // we recover from by cycling the connection before giving up and surfacing
     // the disconnect to JS. A fresh GATT link clears CoreBluetooth's wedged
@@ -146,6 +211,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var isWriting = false
     private var pendingWriteResume: (() -> Void)?
     private var pendingWriteResumeWatchdog: DispatchWorkItem?
+    // Poller behind the parked write (#3230): re-checks
+    // `canSendWriteWithoutResponse` while `pendingWriteResume` is set, because
+    // iOS 26.5 can flip the property without ever delivering the
+    // `peripheralIsReady` delegate. Cancelled wherever the watchdog is.
+    private var writeResumePoller: DispatchSourceTimer?
+    // Telemetry for the request currently being written (#3230). Requests are
+    // strictly serial (`isWriting`), so one slot suffices: seeded when a request
+    // starts, finalized at whichever settle point delivers its completion.
+    private var currentWriteTelemetry: BoardBleWriteTelemetry?
+    private var parkStartedAt: DispatchTime?
     // Write-WITH-response pacing (the original MoonBoard LED box, whose UART RX
     // characteristic advertises only `.write`). The `didWriteValueFor` ack is
     // the resume signal — the with-response analogue of `pendingWriteResume`.
@@ -277,23 +352,20 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
     }
 
-    func write(hex: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    /// JS-bridge write entry point. The completion carries the per-write
+    /// telemetry (#3230) on BOTH outcomes so the module can resolve it with the
+    /// promise (success) or stash it for `getLastWriteDiagnostics` (failure).
+    func write(hex: String, completion: @escaping (Error?, BoardBleWriteTelemetry?) -> Void) {
         guard let data = Data(hexString: hex) else {
-            completion(.failure(BoardBleError.invalidHex))
+            completion(BoardBleError.invalidHex, nil)
             return
         }
-        write(data: data) { error in
-            if let error {
-                completion(.failure(error))
-            } else {
-                completion(.success(()))
-            }
-        }
+        write(data: data, origin: .js, completion: completion)
     }
 
-    func write(data: Data, completion: ((Error?) -> Void)? = nil) {
+    func write(data: Data, origin: BoardBleWriteOrigin = .native, completion: ((Error?, BoardBleWriteTelemetry?) -> Void)? = nil) {
         runOnBleQueue { [weak self] in
-            self?.writeOnBleQueue(data: data, completion: completion)
+            self?.writeOnBleQueue(data: data, origin: origin, completion: completion)
         }
     }
 
@@ -577,17 +649,26 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         completion?()
     }
 
-    private func writeOnBleQueue(data: Data, completion: ((Error?) -> Void)? = nil) {
-        guard connectedPeripheral != nil, writeCharacteristic != nil else {
+    private func writeOnBleQueue(data: Data, origin: BoardBleWriteOrigin = .native, completion: ((Error?, BoardBleWriteTelemetry?) -> Void)? = nil) {
+        guard let peripheral = connectedPeripheral, let characteristic = writeCharacteristic else {
             // During a write-stall recovery the link is briefly down between the
             // cancel and the reconnect. Surface the self-healing `writeTimedOut`
             // (a warning JS rides out with `isConnected` kept) rather than
             // `notConnected`, which the JS classifier treats as a hard drop and
             // would tear the connection down mid-recovery (#3181).
-            completion?(writeStallRecoveringPeripheralId != nil ? BoardBleError.writeTimedOut : BoardBleError.notConnected)
+            completion?(writeStallRecoveringPeripheralId != nil ? BoardBleError.writeTimedOut : BoardBleError.notConnected, nil)
             return
         }
 
+        let writeType = BoardBleEncoding.preferredWriteType(
+            for: characteristic.properties,
+            boardName: configuration?.boardName
+        )
+        let chunkSize = BoardBleEncoding.effectiveChunkSize(
+            negotiatedMaxWriteLength: peripheral.maximumWriteValueLength(for: writeType),
+            writeType: writeType,
+            boardName: configuration?.boardName
+        )
         let chunks = stride(from: 0, to: data.count, by: chunkSize).map { offset in
             data.subdata(in: offset..<min(offset + chunkSize, data.count))
         }
@@ -595,9 +676,13 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         writeQueue.append(
             WriteRequest(
                 chunks: chunks,
+                writeType: writeType,
+                chunkSize: chunkSize,
+                negotiatedMaxWriteWithoutResponse: peripheral.maximumWriteValueLength(for: .withoutResponse),
+                origin: origin,
                 connectionGeneration: connectionGeneration,
                 writeGeneration: writeGeneration,
-                completion: completion ?? { _ in }
+                completion: completion ?? { _, _ in }
             )
         )
         processWriteQueue()
@@ -635,7 +720,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         )
 
         guard !result.packet.isEmpty else { return }
-        writeOnBleQueue(data: result.packet) { [weak self] error in
+        writeOnBleQueue(data: result.packet) { [weak self] error, _ in
             if let error {
                 self?.logger.error("BLE clear failed: \(error.localizedDescription, privacy: .public)")
             }
@@ -662,7 +747,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 logger.warning("Skipping MoonBoard BLE write: no encodable holds for climb \(item.climbUuid, privacy: .public)")
                 return
             }
-            writeOnBleQueue(data: result.packet) { [weak self] error in
+            writeOnBleQueue(data: result.packet) { [weak self] error, _ in
                 if let error {
                     self?.logger.error("BLE write failed: \(error.localizedDescription, privacy: .public)")
                 }
@@ -708,7 +793,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
-        writeOnBleQueue(data: result.packet) { [weak self] error in
+        writeOnBleQueue(data: result.packet) { [weak self] error, _ in
             if let error {
                 self?.logger.error("BLE write failed: \(error.localizedDescription, privacy: .public)")
             }
@@ -1027,11 +1112,68 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        // Recorded even when nothing is parked: the diagnostic question for
+        // #3230 is whether iOS delivered this delegate at all during a request.
+        currentWriteTelemetry?.peripheralIsReadyFired = true
+        resumeParkedWrite(source: "callback")
+    }
+
+    /// Single resume point for a write parked on `canSendWriteWithoutResponse`,
+    /// shared by the `peripheralIsReady` delegate and the #3230 poller. Strict
+    /// ordering: retire BOTH wake-up sources and capture-and-nil the parked
+    /// continuation BEFORE invoking it — the resume can synchronously re-park
+    /// (the property is CoreBluetooth-internal and can flip back between our
+    /// read and `writeChunk`'s) and install a fresh poller + watchdog, which a
+    /// late cancel here would otherwise kill. Safe to call with nothing parked.
+    private func resumeParkedWrite(source: String) {
         pendingWriteResumeWatchdog?.cancel()
         pendingWriteResumeWatchdog = nil
-        let resume = pendingWriteResume
+        writeResumePoller?.cancel()
+        writeResumePoller = nil
+        guard let resume = pendingWriteResume else { return }
         pendingWriteResume = nil
-        resume?()
+        if let parkStartedAt {
+            let parkMs = Int((DispatchTime.now().uptimeNanoseconds - parkStartedAt.uptimeNanoseconds) / 1_000_000)
+            currentWriteTelemetry?.maxParkMs = max(currentWriteTelemetry?.maxParkMs ?? 0, parkMs)
+            currentWriteTelemetry?.totalParkMs += parkMs
+        }
+        parkStartedAt = nil
+        currentWriteTelemetry?.lastResumeSource = source
+        resume()
+    }
+
+    /// Second resume path for a parked write (#3230): on iOS 26.5 CoreBluetooth
+    /// can update `canSendWriteWithoutResponse` without ever calling
+    /// `peripheralIsReady`, leaving the park to the 5 s watchdog → link cycle →
+    /// `write_timeout`. While parked, re-check the property on a repeating
+    /// timer and resume the instant it flips true. The timer is created,
+    /// scheduled and activated in one place and never suspended; stale ticks
+    /// are provably inert via the identity guard + the `pendingWriteResume`
+    /// guard (and, beyond those, `writeChunk`'s generation guards).
+    private func startWriteResumePollerOnBleQueue() {
+        writeResumePoller?.cancel()
+        let poller = DispatchSource.makeTimerSource(queue: bleQueue)
+        poller.setEventHandler { [weak self, weak poller] in
+            guard let self, let poller, self.writeResumePoller === poller else { return }
+            guard self.pendingWriteResume != nil else {
+                self.writeResumePoller?.cancel()
+                self.writeResumePoller = nil
+                return
+            }
+            // Read the live connection each tick rather than capturing the
+            // parked CBPeripheral: while a park exists the connected peripheral
+            // can't change without failQueuedWrites cancelling this poller
+            // first, and not capturing avoids keeping a dead peripheral alive.
+            guard let peripheral = self.connectedPeripheral, peripheral.canSendWriteWithoutResponse else { return }
+            self.resumeParkedWrite(source: "poll")
+        }
+        poller.schedule(
+            deadline: .now() + writeResumePollInterval,
+            repeating: writeResumePollInterval,
+            leeway: .milliseconds(20)
+        )
+        writeResumePoller = poller
+        poller.activate()
     }
 
     // The ack for the write-WITH-response path. Mirrors `peripheralIsReady`:
@@ -1056,7 +1198,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 return
             }
             let request = writeQueue.removeFirst()
-            request.completion(error)
+            request.completion(error, finalizeCurrentWriteTelemetry())
             isWriting = false
             processWriteQueue()
             return
@@ -1158,12 +1300,41 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
         isWriting = true
         let request = writeQueue[0]
+        // Single seed point for the per-write telemetry: `isWriting` just
+        // flipped false→true, so exactly one request owns the slot until a
+        // settle point finalizes it (#3230).
+        currentWriteTelemetry = BoardBleWriteTelemetry(
+            origin: request.origin.rawValue,
+            writeType: request.writeType == .withoutResponse ? "withoutResponse" : "withResponse",
+            chunkSize: request.chunkSize,
+            chunkCount: request.chunks.count,
+            negotiatedMaxWriteWithoutResponse: request.negotiatedMaxWriteWithoutResponse,
+            startedAt: .now()
+        )
         writeChunk(
             requestIndex: 0,
             chunkIndex: 0,
             connectionGeneration: request.connectionGeneration,
             writeGeneration: request.writeGeneration
         )
+    }
+
+    /// Close out the in-flight request's telemetry (duration stamp, plus any
+    /// still-open park — a watchdog-tripped write settles while parked, and
+    /// that fatal park must count) and clear the slot so a later settle point
+    /// can't re-deliver stale data. Every path that settles the head request
+    /// routes its completion through this.
+    private func finalizeCurrentWriteTelemetry() -> BoardBleWriteTelemetry? {
+        guard var telemetry = currentWriteTelemetry else { return nil }
+        currentWriteTelemetry = nil
+        if let parkStartedAt {
+            let parkMs = Int((DispatchTime.now().uptimeNanoseconds - parkStartedAt.uptimeNanoseconds) / 1_000_000)
+            telemetry.maxParkMs = max(telemetry.maxParkMs, parkMs)
+            telemetry.totalParkMs += parkMs
+        }
+        parkStartedAt = nil
+        telemetry.durationMs = Int((DispatchTime.now().uptimeNanoseconds - telemetry.startedAt.uptimeNanoseconds) / 1_000_000)
+        return telemetry
     }
 
     private func writeChunk(
@@ -1198,7 +1369,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         guard let peripheral = connectedPeripheral, let characteristic = writeCharacteristic else {
             let request = writeQueue.removeFirst()
-            request.completion(BoardBleError.notConnected)
+            request.completion(BoardBleError.notConnected, finalizeCurrentWriteTelemetry())
             isWriting = false
             processWriteQueue()
             return
@@ -1209,19 +1380,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // A write got through end-to-end: the link is healthy, so refresh the
             // write-stall recovery budget (#3181).
             writeStallRecoveries = 0
-            request.completion(nil)
+            request.completion(nil, finalizeCurrentWriteTelemetry())
             isWriting = false
             processWriteQueue()
             return
         }
 
-        let writeType = BoardBleEncoding.preferredWriteType(
-            for: characteristic.properties,
-            boardName: configuration?.boardName
-        )
-
-        if writeType == .withoutResponse {
+        if request.writeType == .withoutResponse {
             guard peripheral.canSendWriteWithoutResponse else {
+                currentWriteTelemetry?.parkCount += 1
+                parkStartedAt = .now()
                 pendingWriteResume = { [weak self] in
                     self?.writeChunk(
                         requestIndex: requestIndex,
@@ -1230,18 +1398,26 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                         writeGeneration: writeGeneration
                     )
                 }
-                // Watchdog: peripheralIsReady is the ONLY resume signal, and a
-                // marginal link can simply never deliver it (without ever
-                // disconnecting either). Unbounded, `isWriting` would stay true
-                // forever and the wall would freeze until a manual disconnect.
+                // Watchdog: last resort when NEITHER resume path fires — the
+                // peripheralIsReady delegate stays silent AND the poller below
+                // never sees `canSendWriteWithoutResponse` flip true (a
+                // genuinely wedged transmit buffer). Unbounded, `isWriting`
+                // would stay true forever and the wall would freeze until a
+                // manual disconnect. `canSendAtTrip` disambiguates in the
+                // field: true would mean the poller missed a flip (logic bug);
+                // false proves the wedge that only a link cycle clears.
                 let watchdog = DispatchWorkItem { [weak self] in
                     guard let self, self.pendingWriteResume != nil else { return }
-                    self.logger.error("BLE write stalled: peripheral never became ready for write-without-response; attempting recovery")
+                    let canSendAtTrip = self.connectedPeripheral?.canSendWriteWithoutResponse ?? false
+                    self.currentWriteTelemetry?.watchdogTripped = true
+                    self.currentWriteTelemetry?.canSendAtTrip = canSendAtTrip
+                    self.logger.error("BLE write stalled: peripheral never became ready for write-without-response (canSendAtTrip=\(canSendAtTrip, privacy: .public)); attempting recovery")
                     self.handleWriteStall()
                 }
                 pendingWriteResumeWatchdog?.cancel()
                 pendingWriteResumeWatchdog = watchdog
                 bleQueue.asyncAfter(deadline: .now() + writeResumeTimeout, execute: watchdog)
+                startWriteResumePollerOnBleQueue()
                 return
             }
 
@@ -1275,6 +1451,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // acks within writeResumeTimeout, recover by cycling the link (#3181).
         let ackWatchdog = DispatchWorkItem { [weak self] in
             guard let self, self.pendingWriteAck != nil else { return }
+            self.currentWriteTelemetry?.watchdogTripped = true
             self.logger.error("BLE write stalled: peripheral never acked write-with-response; attempting recovery")
             self.handleWriteStall()
         }
@@ -1288,15 +1465,25 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         writeGeneration += 1
         let queuedWrites = writeQueue
         writeQueue = []
+        let wasWriting = isWriting
         isWriting = false
         pendingWriteResume = nil
         pendingWriteResumeWatchdog?.cancel()
         pendingWriteResumeWatchdog = nil
+        writeResumePoller?.cancel()
+        writeResumePoller = nil
         pendingWriteAck = nil
         pendingWriteAckWatchdog?.cancel()
         pendingWriteAckWatchdog = nil
-        for request in queuedWrites {
-            request.completion(error)
+        // Only the in-flight head request has meaningful telemetry; requests
+        // that never started get nil. Finalizing folds any still-open park into
+        // the totals and clears the slot (and parkStartedAt), so a later
+        // defensive call on an empty queue can't re-deliver stale data.
+        let headTelemetry = wasWriting ? finalizeCurrentWriteTelemetry() : nil
+        currentWriteTelemetry = nil
+        parkStartedAt = nil
+        for (requestIndex, request) in queuedWrites.enumerated() {
+            request.completion(error, requestIndex == 0 ? headTelemetry : nil)
         }
         notifyDrainWaitersIfDrainedOnBleQueue()
     }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -1478,10 +1478,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // Only the in-flight head request has meaningful telemetry; requests
         // that never started get nil. Finalizing folds any still-open park into
         // the totals and clears the slot (and parkStartedAt), so a later
-        // defensive call on an empty queue can't re-deliver stale data.
-        let headTelemetry = wasWriting ? finalizeCurrentWriteTelemetry() : nil
-        currentWriteTelemetry = nil
-        parkStartedAt = nil
+        // defensive call on an empty queue can't re-deliver stale data. When
+        // nothing was writing, both should already be nil — clear defensively.
+        let headTelemetry: BoardBleWriteTelemetry?
+        if wasWriting {
+            headTelemetry = finalizeCurrentWriteTelemetry()
+        } else {
+            headTelemetry = nil
+            currentWriteTelemetry = nil
+            parkStartedAt = nil
+        }
         for (requestIndex, request) in queuedWrites.enumerated() {
             request.completion(error, requestIndex == 0 ? headTelemetry : nil)
         }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -1405,13 +1405,18 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 // would stay true forever and the wall would freeze until a
                 // manual disconnect. `canSendAtTrip` disambiguates in the
                 // field: true would mean the poller missed a flip (logic bug);
-                // false proves the wedge that only a link cycle clears.
+                // false proves the wedge that only a link cycle clears; absent
+                // means the peripheral was already gone when the watchdog ran.
                 let watchdog = DispatchWorkItem { [weak self] in
                     guard let self, self.pendingWriteResume != nil else { return }
-                    let canSendAtTrip = self.connectedPeripheral?.canSendWriteWithoutResponse ?? false
+                    // Tri-state on purpose: true = the poller missed a flip
+                    // (logic bug), false = wedged buffer on a live link, nil
+                    // (omitted from analytics) = the peripheral was already
+                    // gone at trip time, so neither claim would be honest.
+                    let canSendAtTrip = self.connectedPeripheral?.canSendWriteWithoutResponse
                     self.currentWriteTelemetry?.watchdogTripped = true
                     self.currentWriteTelemetry?.canSendAtTrip = canSendAtTrip
-                    self.logger.error("BLE write stalled: peripheral never became ready for write-without-response (canSendAtTrip=\(canSendAtTrip, privacy: .public)); attempting recovery")
+                    self.logger.error("BLE write stalled: peripheral never became ready for write-without-response (canSendAtTrip=\(String(describing: canSendAtTrip), privacy: .public)); attempting recovery")
                     self.handleWriteStall()
                 }
                 pendingWriteResumeWatchdog?.cancel()

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -24,6 +24,12 @@ public class BoardBleModule: Module {
     private var pendingEvents: [PendingEvent] = []
     private var hasListener = false
     private var isDraining = false
+    /// Telemetry of the most recent FAILED JS-originated write (#3230). Expo's
+    /// `promise.reject` can't carry structured data, so `write` stashes it here
+    /// and JS fetches it via `getLastWriteDiagnostics` right after the reject.
+    /// Native-origin writes (widget intents) never route through this module's
+    /// `write`, so they can't overwrite a failure JS is about to fetch.
+    private var lastFailedWriteDiagnostics: [String: Any]?
 
     public func definition() -> ModuleDefinition {
         Name("BoardBle")
@@ -119,15 +125,26 @@ public class BoardBleModule: Module {
                 promise.reject("BLE_BAD_ARG", "Missing required parameter: value")
                 return
             }
-            BoardBleManager.shared.write(hex: value) { result in
-                switch result {
-                case .success:
-                    promise.resolve(nil)
-                case .failure(let error):
+            BoardBleManager.shared.write(hex: value) { error, telemetry in
+                if let error {
                     self.logger.error("BLE write failed: \(error.localizedDescription, privacy: .public)")
+                    self.bufferQueue.sync {
+                        self.lastFailedWriteDiagnostics = telemetry?.analyticsDictionary
+                    }
                     promise.reject("BLE_WRITE_FAILED", error.localizedDescription)
+                } else {
+                    // Additive: older JS bundles ignore the resolved value; older
+                    // binaries resolve nil and newer JS treats that as "no
+                    // diagnostics" (#3230).
+                    promise.resolve(telemetry?.analyticsDictionary)
                 }
             }
+        }
+
+        // Diagnostics for the most recent failed JS write (#3230). Presence of
+        // this function is the JS feature gate, mirroring getConnectedDevice.
+        AsyncFunction("getLastWriteDiagnostics") { () -> [String: Any]? in
+            self.bufferQueue.sync { self.lastFailedWriteDiagnostics }
         }
 
         AsyncFunction("cancelWrites") { () -> Void in

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -29,6 +29,9 @@ public class BoardBleModule: Module {
     /// and JS fetches it via `getLastWriteDiagnostics` right after the reject.
     /// Native-origin writes (widget intents) never route through this module's
     /// `write`, so they can't overwrite a failure JS is about to fetch.
+    /// Guarded by `bufferQueue`, which is safe to enter synchronously from the
+    /// BLE queue (the write completion's context): `bufferQueue` blocks only
+    /// touch this module's own state and never dispatch onto `bleQueue`.
     private var lastFailedWriteDiagnostics: [String: Any]?
 
     public func definition() -> ModuleDefinition {

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -143,8 +143,13 @@ public class BoardBleModule: Module {
 
         // Diagnostics for the most recent failed JS write (#3230). Presence of
         // this function is the JS feature gate, mirroring getConnectedDevice.
+        // Clear-on-read: the stash describes exactly one failure, and a later
+        // fetch must not re-attribute it to a different analytics event.
         AsyncFunction("getLastWriteDiagnostics") { () -> [String: Any]? in
-            self.bufferQueue.sync { self.lastFailedWriteDiagnostics }
+            self.bufferQueue.sync {
+                defer { self.lastFailedWriteDiagnostics = nil }
+                return self.lastFailedWriteDiagnostics
+            }
         }
 
         AsyncFunction("cancelWrites") { () -> Void in

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -29,9 +29,10 @@ public class BoardBleModule: Module {
     /// and JS fetches it via `getLastWriteDiagnostics` right after the reject.
     /// Native-origin writes (widget intents) never route through this module's
     /// `write`, so they can't overwrite a failure JS is about to fetch.
-    /// Guarded by `bufferQueue`, which is safe to enter synchronously from the
-    /// BLE queue (the write completion's context): `bufferQueue` blocks only
-    /// touch this module's own state and never dispatch onto `bleQueue`.
+    /// Guarded by `bufferQueue`. The write completion (on the BLE queue)
+    /// stashes with `bufferQueue.async` so the BLE queue never blocks on this
+    /// queue; the serial FIFO still orders that stash before any
+    /// `getLastWriteDiagnostics` read that follows the promise rejection.
     private var lastFailedWriteDiagnostics: [String: Any]?
 
     public func definition() -> ModuleDefinition {
@@ -131,7 +132,13 @@ public class BoardBleModule: Module {
             BoardBleManager.shared.write(hex: value) { error, telemetry in
                 if let error {
                     self.logger.error("BLE write failed: \(error.localizedDescription, privacy: .public)")
-                    self.bufferQueue.sync {
+                    // async, not sync: this completion runs on the BLE queue and
+                    // must never block on another queue. Ordering is still
+                    // guaranteed — the stash block is enqueued on the serial
+                    // bufferQueue before the reject reaches JS, so a subsequent
+                    // getLastWriteDiagnostics read (also on bufferQueue) runs
+                    // after it.
+                    self.bufferQueue.async {
                         self.lastFailedWriteDiagnostics = telemetry?.analyticsDictionary
                     }
                     promise.reject("BLE_WRITE_FAILED", error.localizedDescription)

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -49,6 +49,34 @@ export type NativeBleConnectedDevice = {
   maxWriteWithoutResponse?: number;
 };
 
+/**
+ * Per-write BLE transport telemetry (#3230), reported by the native write path
+ * so `Climb Sent to Board` events can carry a measurable before/after for the
+ * iOS 26.5 `peripheralIsReady` write stall. `write()` resolves it on success;
+ * after a rejected write, fetch the failed write's copy via
+ * `getLastWriteDiagnostics`.
+ */
+export type NativeBleWriteDiagnostics = {
+  origin: 'js' | 'native';
+  writeType: 'withoutResponse' | 'withResponse';
+  chunkSize: number;
+  chunkCount: number;
+  negotiatedMaxWriteWithoutResponse: number;
+  /** Times a chunk parked on `canSendWriteWithoutResponse` during this write. */
+  parkCount: number;
+  /** Whether iOS delivered the `peripheralIsReady` delegate during this write. */
+  peripheralIsReadyFired: boolean;
+  /** What woke the last parked chunk: the delegate, or the #3230 poller. */
+  lastResumeSource?: 'callback' | 'poll';
+  maxParkMs: number;
+  totalParkMs: number;
+  /** The 5 s stall watchdog fired (the write then failed as write_timeout). */
+  watchdogTripped: boolean;
+  /** `canSendWriteWithoutResponse` at the moment the watchdog fired. */
+  canSendAtTrip?: boolean;
+  durationMs: number;
+};
+
 export type NativeBleConfigureBoardOptions = {
   boardName: string;
   layoutId: number;
@@ -65,7 +93,12 @@ type BoardBleNativeModule = {
   stopScan(): Promise<void>;
   connect(deviceId: string): Promise<void>;
   disconnect(): Promise<void>;
-  write(value: string): Promise<void>;
+  /**
+   * Resolves the write's transport diagnostics on binaries new enough to
+   * report them; older binaries resolve nothing. Treat a nullish result as
+   * "no diagnostics".
+   */
+  write(value: string): Promise<NativeBleWriteDiagnostics | null | void>;
   cancelWrites(): Promise<void>;
   configureBoard(options: NativeBleConfigureBoardOptions): Promise<void>;
   /**
@@ -76,6 +109,13 @@ type BoardBleNativeModule = {
    * (an OTA JS update can run against an older binary).
    */
   getConnectedDevice?(): Promise<NativeBleConnectedDevice | null>;
+  /**
+   * Diagnostics of the most recent failed JS write, for tagging the failure
+   * analytics event (a rejected promise can't carry them). Only present on
+   * newer binaries — gate on `typeof getLastWriteDiagnostics === 'function'`
+   * (an OTA JS update can run against an older binary).
+   */
+  getLastWriteDiagnostics?(): Promise<NativeBleWriteDiagnostics | null>;
   addListener(event: 'scanResult', listener: (payload: NativeBleScanEvent) => void): EventSubscription;
   addListener(event: 'disconnected', listener: (payload: NativeBleDisconnectEvent) => void): EventSubscription;
   addListener(event: 'connected', listener: (payload: NativeBleConnectedEvent) => void): EventSubscription;

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -60,6 +60,7 @@ export type NativeBleWriteDiagnostics = {
   origin: 'js' | 'native';
   writeType: 'withoutResponse' | 'withResponse';
   chunkSize: number;
+  /** Planned chunks for the write (stamped at enqueue), not progress. */
   chunkCount: number;
   negotiatedMaxWriteWithoutResponse: number;
   /** Times a chunk parked on `canSendWriteWithoutResponse` during this write. */

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -38,6 +38,10 @@ vi.mock('@boardsesh/ble-protocol', () => ({
   REDBEARLAB_SERVICE_UUID: 'redbearlab-uuid',
   REDBEARLAB_WRITE_CHARACTERISTIC_UUID: 'redbearlab-write-uuid',
   splitMessages: vi.fn((passedData: Uint8Array) => [passedData]),
+  // Real chunk-sizing maths so the #3230 assertions (mtu 247 → 244, fallback
+  // 23 → 20) exercise the actual clamp the adapter passes to splitMessages.
+  MAX_BLUETOOTH_MESSAGE_SIZE: 20,
+  effectiveChunkSizeForMtu: (mtu: number) => Math.min(Math.max(mtu - 3, 20), 244),
   INTER_CHUNK_DELAY_MS: 0,
   parseSerialNumber: vi.fn(),
 }));
@@ -80,16 +84,58 @@ function setupConnectableAdapter(
   const mockDeviceWithServices = {
     id: deviceId,
     characteristicsForService,
-    requestMTU: vi.fn().mockResolvedValue(undefined),
+    requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
     discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
   };
   mockBleManager.connectToDevice.mockResolvedValue({
     id: deviceId,
-    requestMTU: vi.fn().mockResolvedValue(undefined),
+    requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
     discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
   });
 
   return new RNBleAdapter(() => Promise.resolve(deviceId), family);
+}
+
+// Connects a single board the way setupConnectableAdapter does, but hands back
+// the requestMTU + write mock fns so the #3230 MTU/chunking tests can control
+// negotiation and assert on the chunk size. `connectedDeviceMtu` is the value
+// read on the requestMTU-rejection fallback (`connected.mtu`).
+function setupWriteDiagnosticsAdapter(
+  family: BoardScanFamily,
+  requestMtuFn: ReturnType<typeof vi.fn>,
+  connectedDeviceMtu?: number,
+): { adapter: RNBleAdapter; requestMtuFn: ReturnType<typeof vi.fn>; writeFn: ReturnType<typeof vi.fn> } {
+  const deviceId = `write-diag-${family}-device`;
+  const writeFn = vi.fn().mockResolvedValue(undefined);
+  const characteristic = {
+    uuid: 'uart-write-uuid',
+    isWritableWithoutResponse: true,
+    writeWithoutResponse: writeFn,
+    writeWithResponse: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockDeviceWithServices = {
+    id: deviceId,
+    characteristicsForService: vi.fn().mockResolvedValue([characteristic]),
+    requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
+    discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
+  };
+  mockBleManager.connectToDevice.mockResolvedValue({
+    id: deviceId,
+    mtu: connectedDeviceMtu,
+    requestMTU: requestMtuFn,
+    discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
+  });
+  mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
+
+  const scanName = family === 'aurora' ? 'Kilter Board#TEST@3' : 'MoonBoard A1';
+  const serviceUUIDs = family === 'aurora' ? ['aurora-uuid'] : undefined;
+  mockBleManager.startDeviceScan.mockImplementation(
+    (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
+      callback(null, { id: deviceId, localName: scanName, name: scanName, rssi: -40, serviceUUIDs });
+    },
+  );
+
+  return { adapter: new RNBleAdapter(() => Promise.resolve(deviceId), family), requestMtuFn, writeFn };
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -189,13 +235,13 @@ describe('RNBleAdapter', () => {
       const mockDeviceWithServices = {
         id: 'test-device-id',
         characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
       };
 
       const mockConnectedDevice = {
         id: 'test-device-id',
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
       };
 
@@ -251,13 +297,13 @@ describe('RNBleAdapter', () => {
       const mockDeviceWithServices = {
         id: 'device-1',
         characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
       };
 
       const mockConnectedDevice = {
         id: 'device-1',
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
       };
 
@@ -298,13 +344,13 @@ describe('RNBleAdapter', () => {
       const mockDeviceWithServices = {
         id: 'write-device',
         characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
       };
 
       const mockConnectedDevice = {
         id: 'write-device',
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
       };
 
@@ -331,7 +377,8 @@ describe('RNBleAdapter', () => {
 
       await adapter.write(testData);
 
-      expect(splitMessages).toHaveBeenCalledWith(testData);
+      // Aurora chunk size comes from the negotiated ATT MTU (247 → 244), #3230.
+      expect(splitMessages).toHaveBeenCalledWith(testData, 244);
       expect(mockWriteFn).toHaveBeenCalledOnce();
       // The written value should be base64-encoded
       expect(mockWriteFn).toHaveBeenCalledWith(expect.stringMatching(/^[A-Za-z0-9+/=]+$/));
@@ -347,13 +394,13 @@ describe('RNBleAdapter', () => {
       const mockDeviceWithServices = {
         id: 'chunk-device',
         characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
       };
 
       const mockConnectedDevice = {
         id: 'chunk-device',
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
       };
 
@@ -401,13 +448,13 @@ describe('RNBleAdapter', () => {
       const mockDeviceWithServices = {
         id: 'abort-device',
         characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
       };
 
       const mockConnectedDevice = {
         id: 'abort-device',
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
       };
 
@@ -457,13 +504,13 @@ describe('RNBleAdapter', () => {
         const mockDeviceWithServices = {
           id: 'abort-delay-device',
           characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-          requestMTU: vi.fn().mockResolvedValue(undefined),
+          requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
           discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
         };
 
         const mockConnectedDevice = {
           id: 'abort-delay-device',
-          requestMTU: vi.fn().mockResolvedValue(undefined),
+          requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
           discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
         };
 
@@ -519,12 +566,12 @@ describe('RNBleAdapter', () => {
         id: 'drop-device',
         isConnected: isConnectedFn,
         characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
       };
       const mockConnectedDevice = {
         id: 'drop-device',
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
       };
 
@@ -564,12 +611,12 @@ describe('RNBleAdapter', () => {
         id: 'live-device',
         isConnected: isConnectedFn,
         characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
       };
       const mockConnectedDevice = {
         id: 'live-device',
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
       };
 
@@ -623,12 +670,12 @@ describe('RNBleAdapter', () => {
       const mockDeviceWithServices = {
         id: 'moon-device',
         characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
       };
       mockBleManager.connectToDevice.mockResolvedValue({
         id: 'moon-device',
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
       });
 
@@ -667,12 +714,12 @@ describe('RNBleAdapter', () => {
       const mockDeviceWithServices = {
         id: 'kilter-device',
         characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
       };
       mockBleManager.connectToDevice.mockResolvedValue({
         id: 'kilter-device',
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
       });
 
@@ -716,12 +763,12 @@ describe('RNBleAdapter', () => {
       const mockDeviceWithServices = {
         id: 'second-native-id',
         characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
       };
       mockBleManager.connectToDevice.mockResolvedValue({
         id: 'second-native-id',
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
       });
 
@@ -765,12 +812,12 @@ describe('RNBleAdapter', () => {
       const mockDeviceWithServices = {
         id: 'late-name-device',
         characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
       };
       mockBleManager.connectToDevice.mockResolvedValue({
         id: 'late-name-device',
-        requestMTU: vi.fn().mockResolvedValue(undefined),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
         discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
       });
 
@@ -1149,6 +1196,70 @@ describe('RNBleAdapter', () => {
       // Family gate wins over the characteristic's reported property.
       expect(characteristic.writeWithoutResponse).toHaveBeenCalledOnce();
       expect(characteristic.writeWithResponse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('write — MTU-sized chunking and diagnostics (#3230)', () => {
+    it('requests ATT MTU 247 on connect (below the iOS-26.5 ATT-512 cliff)', async () => {
+      const requestMtuFn = vi.fn().mockResolvedValue({ mtu: 247 });
+      const { adapter } = setupWriteDiagnosticsAdapter('aurora', requestMtuFn);
+
+      await adapter.requestAndConnect();
+
+      expect(requestMtuFn).toHaveBeenCalledWith(247);
+    });
+
+    it('sizes Aurora write chunks from the negotiated MTU (247 → 244)', async () => {
+      const { adapter } = setupWriteDiagnosticsAdapter('aurora', vi.fn().mockResolvedValue({ mtu: 247 }));
+      await adapter.requestAndConnect();
+
+      const data = new Uint8Array([0x01, 0x02, 0x03]);
+      vi.mocked(splitMessages).mockReturnValue([data]);
+      await adapter.write(data);
+
+      expect(splitMessages).toHaveBeenCalledWith(data, 244);
+    });
+
+    it('keeps MoonBoard writes on the proven 20-byte chunks regardless of MTU', async () => {
+      const { adapter } = setupWriteDiagnosticsAdapter('moonboard', vi.fn().mockResolvedValue({ mtu: 247 }));
+      await adapter.requestAndConnect();
+
+      const data = new Uint8Array([0x01, 0x02, 0x03]);
+      vi.mocked(splitMessages).mockReturnValue([data]);
+      await adapter.write(data);
+
+      expect(splitMessages).toHaveBeenCalledWith(data, 20);
+    });
+
+    it('falls back to the default ATT chunk (20) when MTU negotiation rejects', async () => {
+      // requestMTU rejects → negotiatedMtu = connected.mtu (23) → chunk clamps to 20.
+      const { adapter } = setupWriteDiagnosticsAdapter(
+        'aurora',
+        vi.fn().mockRejectedValue(new Error('MTU negotiation failed')),
+        23,
+      );
+      await adapter.requestAndConnect();
+
+      const data = new Uint8Array([0x01]);
+      vi.mocked(splitMessages).mockReturnValue([data]);
+      await adapter.write(data);
+
+      expect(splitMessages).toHaveBeenCalledWith(data, 20);
+    });
+
+    it('exposes the last write MTU, chunk size and chunk count via getLastWriteDiagnostics', async () => {
+      const { adapter } = setupWriteDiagnosticsAdapter('aurora', vi.fn().mockResolvedValue({ mtu: 247 }));
+      await adapter.requestAndConnect();
+
+      const data = new Uint8Array([0x01, 0x02]);
+      vi.mocked(splitMessages).mockReturnValue([new Uint8Array([0x01]), new Uint8Array([0x02])]);
+      await adapter.write(data);
+
+      await expect(adapter.getLastWriteDiagnostics()).resolves.toEqual({
+        negotiatedMtu: 247,
+        chunkSize: 244,
+        chunkCount: 2,
+      });
     });
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -1220,14 +1220,18 @@ describe('RNBleAdapter', () => {
       expect(splitMessages).toHaveBeenCalledWith(data, 244);
     });
 
-    it('keeps MoonBoard writes on the proven 20-byte chunks regardless of MTU', async () => {
-      const { adapter } = setupWriteDiagnosticsAdapter('moonboard', vi.fn().mockResolvedValue({ mtu: 247 }));
+    it('keeps MoonBoard writes on the proven 20-byte chunks and skips MTU negotiation entirely', async () => {
+      const requestMtuFn = vi.fn().mockResolvedValue({ mtu: 247 });
+      const { adapter } = setupWriteDiagnosticsAdapter('moonboard', requestMtuFn);
       await adapter.requestAndConnect();
 
       const data = new Uint8Array([0x01, 0x02, 0x03]);
       vi.mocked(splitMessages).mockReturnValue([data]);
       await adapter.write(data);
 
+      // No requestMTU for the moonboard family — chunks are pinned at 20 and
+      // the RedBearLab box shouldn't see avoidable GATT ops.
+      expect(requestMtuFn).not.toHaveBeenCalled();
       expect(splitMessages).toHaveBeenCalledWith(data, 20);
     });
 

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -1256,6 +1256,8 @@ describe('RNBleAdapter', () => {
       await adapter.write(data);
 
       await expect(adapter.getLastWriteDiagnostics()).resolves.toEqual({
+        origin: 'js',
+        writeType: 'withoutResponse',
         negotiatedMtu: 247,
         chunkSize: 244,
         chunkCount: 2,

--- a/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
@@ -65,6 +65,7 @@ vi.mock('../../../../modules/live-activity/src/index', () => ({
 
 import { NativeIosBleAdapter } from '../native-ios-adapter';
 import { SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
+import type { BleWriteDiagnostics } from '../types';
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -527,5 +528,76 @@ describe('NativeIosBleAdapter on older binaries (no adoption surface)', () => {
     // Original RedBearLab MoonBoards advertise their own service, newer ones the
     // Nordic UART service — without an unfiltered scan we must list both.
     expect(nativeMock.startScan).toHaveBeenCalledWith(['UART-UUID', 'REDBEARLAB-UUID']);
+  });
+});
+
+// ── Per-write transport diagnostics (#3230) ─────────────────────────────────
+
+describe('NativeIosBleAdapter write diagnostics', () => {
+  // A representative full-fidelity native diagnostics payload (iOS reports the
+  // whole flow-control story). Shape-only — the adapter stores it verbatim.
+  const sampleDiagnostics: BleWriteDiagnostics = {
+    origin: 'native',
+    writeType: 'withoutResponse',
+    chunkSize: 244,
+    chunkCount: 3,
+    negotiatedMaxWriteWithoutResponse: 244,
+    parkCount: 1,
+    peripheralIsReadyFired: true,
+    lastResumeSource: 'callback',
+    maxParkMs: 12,
+    totalParkMs: 12,
+    watchdogTripped: false,
+    durationMs: 40,
+  };
+
+  afterEach(() => {
+    // Some cases attach the newer-binary getLastWriteDiagnostics; keep the
+    // default native mock (old binary) clean for the next test.
+    delete (nativeMock as Record<string, unknown>).getLastWriteDiagnostics;
+  });
+
+  it('stores the diagnostics the native write resolves on success', async () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    adapter.adoptConnection('adopted-dev');
+    nativeMock.write.mockResolvedValueOnce(sampleDiagnostics);
+
+    await adapter.write(new Uint8Array([0x01, 0x02]));
+
+    await expect(adapter.getLastWriteDiagnostics()).resolves.toEqual(sampleDiagnostics);
+  });
+
+  it('records null (not undefined) when an old binary resolves no diagnostics', async () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    adapter.adoptConnection('adopted-dev');
+    nativeMock.write.mockResolvedValueOnce(undefined);
+
+    await expect(adapter.write(new Uint8Array([0x01]))).resolves.toBeUndefined();
+    await expect(adapter.getLastWriteDiagnostics()).resolves.toBeNull();
+  });
+
+  it('fetches the native stash and rethrows when a write rejects on a newer binary', async () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    adapter.adoptConnection('adopted-dev');
+    const writeError = new Error('write_timeout');
+    nativeMock.write.mockRejectedValueOnce(writeError);
+    const getStash = vi.fn().mockResolvedValue(sampleDiagnostics);
+    (nativeMock as Record<string, unknown>).getLastWriteDiagnostics = getStash;
+
+    await expect(adapter.write(new Uint8Array([0x01]))).rejects.toBe(writeError);
+    expect(getStash).toHaveBeenCalledOnce();
+    await expect(adapter.getLastWriteDiagnostics()).resolves.toEqual(sampleDiagnostics);
+  });
+
+  it('rethrows without a stash fetch when a write rejects on an old binary', async () => {
+    // The default native mock has no getLastWriteDiagnostics — the old-binary
+    // case where the reject path must not attempt (and must not throw from) a fetch.
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    adapter.adoptConnection('adopted-dev');
+    const writeError = new Error('write_timeout');
+    nativeMock.write.mockRejectedValueOnce(writeError);
+
+    await expect(adapter.write(new Uint8Array([0x01]))).rejects.toBe(writeError);
+    await expect(adapter.getLastWriteDiagnostics()).resolves.toBeNull();
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -114,10 +114,12 @@ import {
 import { parseBoardTypeFromDeviceName, parseSerialNumber } from '@boardsesh/ble-protocol/aurora';
 import {
   bleConnectReportLevel,
+  bleWriteDiagnosticsProperties,
   convertToMirroredFramesString,
   dispatchMoonboardPacket,
   useBoardBluetooth,
 } from '../use-board-bluetooth';
+import type { BleWriteDiagnostics } from '../types';
 
 // ── Factory helpers ────────────────────────────────────────────────────────
 
@@ -592,6 +594,90 @@ describe('useBoardBluetooth', () => {
     const successCall = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success');
     expect(successCall).toBeDefined();
     expect(successCall?.[1]).toMatchObject({ apiLevel: 2, deviceNamePresent: false });
+  });
+
+  it('attaches per-write transport diagnostics to the send-success event (#3230)', async () => {
+    const writeDiagnostics: BleWriteDiagnostics = {
+      chunkSize: 244,
+      chunkCount: 2,
+      negotiatedMtu: 247,
+      lastResumeSource: 'poll',
+    };
+    // The adapter reports getLastWriteDiagnostics — the iOS-native / ble-plx path.
+    const fakeAdapter = {
+      ...makeFakeAdapter(),
+      getLastWriteDiagnostics: vi.fn().mockResolvedValue(writeDiagnostics),
+    };
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetLedPlacements.mockReturnValue({ 100: 7 });
+    mockGetAuroraBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x01]),
+      skippedPositionCount: 0,
+      skippedRoleCount: 0,
+      totalPlacements: 1,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+    await act(async () => {
+      await result.current.sendFramesToBoard('p100r13');
+    });
+
+    expect(fakeAdapter.getLastWriteDiagnostics).toHaveBeenCalled();
+    const successCall = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Success');
+    expect(successCall?.[1]).toMatchObject({
+      bleChunkSize: 244,
+      bleChunkCount: 2,
+      bleNegotiatedMtu: 247,
+      bleLastResumeSource: 'poll',
+    });
+  });
+
+  it('attaches write diagnostics alongside failureReason on a failed send (#3230)', async () => {
+    const writeDiagnostics: BleWriteDiagnostics = {
+      chunkSize: 244,
+      chunkCount: 2,
+      watchdogTripped: true,
+      parkCount: 5,
+    };
+    const fakeAdapter = {
+      // A write-resume stall on a still-live link (classifies as write_timeout).
+      ...makeFakeAdapter({
+        write: vi.fn().mockRejectedValue(new Error('BLE write timed out waiting for the board to accept data')),
+      }),
+      getLastWriteDiagnostics: vi.fn().mockResolvedValue(writeDiagnostics),
+    };
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetLedPlacements.mockReturnValue({ 100: 7 });
+    mockGetAuroraBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x09]),
+      skippedPositionCount: 0,
+      skippedRoleCount: 0,
+      totalPlacements: 1,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+    await act(async () => {
+      await result.current.sendFramesToBoard('p100r12');
+    });
+
+    const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');
+    expect(failureCall?.[1]).toMatchObject({
+      failureReason: 'write_timeout',
+      bleChunkSize: 244,
+      bleChunkCount: 2,
+      bleWatchdogTripped: true,
+      bleParkCount: 5,
+    });
   });
 });
 
@@ -1192,5 +1278,48 @@ describe('bleConnectReportLevel', () => {
     expect(bleConnectReportLevel('unavailable')).toBe('error');
     expect(bleConnectReportLevel('service_missing')).toBe('error');
     expect(bleConnectReportLevel('unknown')).toBe('error');
+  });
+});
+
+describe('bleWriteDiagnosticsProperties', () => {
+  it('returns an empty object for null or undefined diagnostics', () => {
+    expect(bleWriteDiagnosticsProperties(null)).toEqual({});
+    expect(bleWriteDiagnosticsProperties(undefined)).toEqual({});
+  });
+
+  it('maps every field to its ble*-prefixed analytics prop', () => {
+    const diagnostics: BleWriteDiagnostics = {
+      origin: 'native',
+      writeType: 'withoutResponse',
+      chunkSize: 244,
+      chunkCount: 3,
+      negotiatedMaxWriteWithoutResponse: 244,
+      negotiatedMtu: 247,
+      parkCount: 2,
+      peripheralIsReadyFired: true,
+      lastResumeSource: 'poll',
+      maxParkMs: 30,
+      totalParkMs: 45,
+      watchdogTripped: false,
+      canSendAtTrip: true,
+      durationMs: 88,
+    };
+
+    expect(bleWriteDiagnosticsProperties(diagnostics)).toEqual({
+      bleWriteOrigin: 'native',
+      bleWriteType: 'withoutResponse',
+      bleChunkSize: 244,
+      bleChunkCount: 3,
+      bleMaxWriteWithoutResponse: 244,
+      bleNegotiatedMtu: 247,
+      bleParkCount: 2,
+      blePeripheralIsReadyFired: true,
+      bleLastResumeSource: 'poll',
+      bleMaxParkMs: 30,
+      bleTotalParkMs: 45,
+      bleWatchdogTripped: false,
+      bleCanSendAtTrip: true,
+      bleWriteDurationMs: 88,
+    });
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -637,6 +637,39 @@ describe('useBoardBluetooth', () => {
     });
   });
 
+  it('attaches write diagnostics to the MoonBoard send-success event too (#3230)', async () => {
+    // MoonBoard sends route through dispatchMoonboardPacket rather than the
+    // Aurora branch — the diagnostics wiring must reach this track call too.
+    const fakeAdapter = {
+      ...makeFakeAdapter(),
+      getLastWriteDiagnostics: vi.fn().mockResolvedValue({ negotiatedMtu: 23, chunkSize: 20, chunkCount: 3 }),
+    };
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x01]),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 1,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+    await act(async () => {
+      await result.current.sendFramesToBoard('p100r12');
+    });
+
+    const successCall = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Success');
+    expect(successCall?.[1]).toMatchObject({
+      bleNegotiatedMtu: 23,
+      bleChunkSize: 20,
+      bleChunkCount: 3,
+    });
+  });
+
   it('attaches write diagnostics alongside failureReason on a failed send (#3230)', async () => {
     const writeDiagnostics: BleWriteDiagnostics = {
       chunkSize: 244,

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1287,6 +1287,15 @@ describe('bleWriteDiagnosticsProperties', () => {
     expect(bleWriteDiagnosticsProperties(undefined)).toEqual({});
   });
 
+  it('drops unreported fields instead of spreading undefined keys (Android reports only MTU/chunking)', () => {
+    expect(bleWriteDiagnosticsProperties({ origin: 'js', negotiatedMtu: 247, chunkSize: 244, chunkCount: 2 })).toEqual({
+      bleWriteOrigin: 'js',
+      bleNegotiatedMtu: 247,
+      bleChunkSize: 244,
+      bleChunkCount: 2,
+    });
+  });
+
   it('maps every field to its ble*-prefixed analytics prop', () => {
     const diagnostics: BleWriteDiagnostics = {
       origin: 'native',

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -679,6 +679,52 @@ describe('useBoardBluetooth', () => {
       bleParkCount: 5,
     });
   });
+
+  it('suppresses the failure event when the drop event lands before the write rejection (#3365)', async () => {
+    let hookDisconnectCallback: ((info?: unknown) => void) | null = null;
+    const fakeAdapter = {
+      ...makeFakeAdapter(),
+      onDisconnect: vi.fn((callback: (info?: unknown) => void) => {
+        hookDisconnectCallback = callback;
+        return () => {};
+      }),
+      getLastWriteDiagnostics: vi.fn().mockResolvedValue({ chunkSize: 20 }),
+    };
+    // A mid-write link drop where the adapter delivers the disconnect event
+    // BEFORE the write rejection reaches performSend's catch. The disconnect
+    // handler runs clearConnectionAfterDrop, which aborts the write generation
+    // — so the catch classifies this send as aborted and must NOT emit a
+    // ClimbSentToBoardFailure event: the drop is reported once, via the
+    // Bluetooth Disconnected transition, not double-counted as a send failure.
+    // (This is also why the diagnostics fetch reads the captured send adapter,
+    // not adapterRef — the ref is already null in this ordering.)
+    fakeAdapter.write = vi.fn().mockImplementation(() => {
+      hookDisconnectCallback?.({ source: 'ble-plx' });
+      return Promise.reject(new Error('Device disconnected during write'));
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetLedPlacements.mockReturnValue({ 100: 7 });
+    mockGetAuroraBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x09]),
+      skippedPositionCount: 0,
+      skippedRoleCount: 0,
+      totalPlacements: 1,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+    await act(async () => {
+      await result.current.sendFramesToBoard('p100r12');
+    });
+
+    const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');
+    expect(failureCall).toBeUndefined();
+    expect(result.current.isConnected).toBe(false);
+  });
 });
 
 // ── Native connection adoption (iOS) ───────────────────────────────────────

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -226,6 +226,8 @@ export class RNBleAdapter implements BluetoothAdapter {
     // The negotiated value sizes write chunks below — fewer, larger writes
     // per climb, mirroring the native iOS path and the official Kilter app
     // (#3230).
+    // `||` (not `??`) is deliberate: ble-plx types mtu as number, so the only
+    // bad runtime values are falsy ones (0/NaN), which must also fall back.
     try {
       const negotiated = await connected.requestMTU(REQUESTED_ATT_MTU);
       this.negotiatedMtu = negotiated.mtu || DEFAULT_ATT_MTU;

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -293,7 +293,8 @@ export class RNBleAdapter implements BluetoothAdapter {
   }
 
   async write(data: Uint8Array, signal?: AbortSignal): Promise<void> {
-    if (!this.writeCharacteristic) {
+    const writeCharacteristic = this.writeCharacteristic;
+    if (!writeCharacteristic) {
       throw new Error('Not connected');
     }
 
@@ -303,7 +304,14 @@ export class RNBleAdapter implements BluetoothAdapter {
     const chunkSize =
       this.scanFamily === 'moonboard' ? MAX_BLUETOOTH_MESSAGE_SIZE : effectiveChunkSizeForMtu(this.negotiatedMtu);
     const chunks = splitMessages(data, chunkSize);
+    // Every write through this adapter is JS-driven (Android has no
+    // widget-intent write path), hence the fixed 'js' origin.
     this.lastWriteDiagnostics = {
+      origin: 'js',
+      writeType:
+        this.scanFamily !== 'moonboard' || (writeCharacteristic.isWritableWithoutResponse ?? true)
+          ? 'withoutResponse'
+          : 'withResponse',
       negotiatedMtu: this.negotiatedMtu,
       chunkSize,
       chunkCount: chunks.length,

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -225,15 +225,21 @@ export class RNBleAdapter implements BluetoothAdapter {
     // for best results; iOS handles MTU automatically but the call is safe).
     // The negotiated value sizes write chunks below — fewer, larger writes
     // per climb, mirroring the native iOS path and the official Kilter app
-    // (#3230).
+    // (#3230). Skipped for the moonboard family: chunks stay at 20 there
+    // regardless, and the original RedBearLab box is old enough that the
+    // fewer GATT ops we throw at it, the better.
     // `||` (not `??`) is deliberate: ble-plx types mtu as number, so the only
     // bad runtime values are falsy ones (0/NaN), which must also fall back.
-    try {
-      const negotiated = await connected.requestMTU(REQUESTED_ATT_MTU);
-      this.negotiatedMtu = negotiated.mtu || DEFAULT_ATT_MTU;
-    } catch {
-      // Negotiation failed — fall back to the default ATT 23 (20 usable).
-      this.negotiatedMtu = connected.mtu || DEFAULT_ATT_MTU;
+    if (this.scanFamily === 'moonboard') {
+      this.negotiatedMtu = DEFAULT_ATT_MTU;
+    } else {
+      try {
+        const negotiated = await connected.requestMTU(REQUESTED_ATT_MTU);
+        this.negotiatedMtu = negotiated.mtu || DEFAULT_ATT_MTU;
+      } catch {
+        // Negotiation failed — fall back to the default ATT 23 (20 usable).
+        this.negotiatedMtu = connected.mtu || DEFAULT_ATT_MTU;
+      }
     }
 
     const deviceWithServices = await connected.discoverAllServicesAndCharacteristics();

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -6,7 +6,9 @@ import {
   REDBEARLAB_SERVICE_UUID,
   REDBEARLAB_WRITE_CHARACTERISTIC_UUID,
   splitMessages,
+  effectiveChunkSizeForMtu,
   INTER_CHUNK_DELAY_MS,
+  MAX_BLUETOOTH_MESSAGE_SIZE,
   parseSerialNumber,
 } from '@boardsesh/ble-protocol';
 import { bleManager } from './ble-manager';
@@ -17,6 +19,7 @@ import type {
   BluetoothAdapter,
   BleConnection,
   BleDisconnectInfo,
+  BleWriteDiagnostics,
   BoardScanFamily,
   DevicePickerFn,
   DiscoveredDevice,
@@ -24,6 +27,13 @@ import type {
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
 
 const CONNECTION_TIMEOUT_MS = 12_000;
+
+// The ATT MTU requested after connect. 247 (chunk 244) is the DLE-friendly
+// sweet spot: the iOS-26.5 failure cohort clusters at ATT 512 (#3230), so
+// don't ask for more than we'd ever write. The default ATT 23 (chunk 20) is
+// the fallback when negotiation fails.
+const REQUESTED_ATT_MTU = 247;
+const DEFAULT_ATT_MTU = 23;
 
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
@@ -52,6 +62,10 @@ export class RNBleAdapter implements BluetoothAdapter {
   private writeCharacteristic: Characteristic | null = null;
   private disconnectCallback: ((info?: BleDisconnectInfo) => void) | null = null;
   private disconnectSubscription: { remove: () => void } | null = null;
+  // Negotiated ATT MTU for the current connection; sizes write chunks (#3230).
+  private negotiatedMtu = DEFAULT_ATT_MTU;
+  // Transport diagnostics of the most recently settled write, for analytics.
+  private lastWriteDiagnostics: BleWriteDiagnostics | null = null;
 
   constructor(
     private readonly devicePicker: DevicePickerFn,
@@ -209,10 +223,15 @@ export class RNBleAdapter implements BluetoothAdapter {
 
     // Negotiate MTU before service discovery (Android requires this order
     // for best results; iOS handles MTU automatically but the call is safe).
+    // The negotiated value sizes write chunks below — fewer, larger writes
+    // per climb, mirroring the native iOS path and the official Kilter app
+    // (#3230).
     try {
-      await connected.requestMTU(512);
+      const negotiated = await connected.requestMTU(REQUESTED_ATT_MTU);
+      this.negotiatedMtu = negotiated.mtu || DEFAULT_ATT_MTU;
     } catch {
-      // Fall back to default MTU (23 bytes, 20 usable) — splitMessages handles chunking.
+      // Negotiation failed — fall back to the default ATT 23 (20 usable).
+      this.negotiatedMtu = connected.mtu || DEFAULT_ATT_MTU;
     }
 
     const deviceWithServices = await connected.discoverAllServicesAndCharacteristics();
@@ -278,7 +297,17 @@ export class RNBleAdapter implements BluetoothAdapter {
       throw new Error('Not connected');
     }
 
-    const chunks = splitMessages(data);
+    // Aurora chunks are sized from the negotiated MTU (clamped well below the
+    // ATT-512 cliff, see #3230). Both MoonBoard generations stay on the proven
+    // 20-byte chunks, mirroring the native iOS effectiveChunkSize gating.
+    const chunkSize =
+      this.scanFamily === 'moonboard' ? MAX_BLUETOOTH_MESSAGE_SIZE : effectiveChunkSizeForMtu(this.negotiatedMtu);
+    const chunks = splitMessages(data, chunkSize);
+    this.lastWriteDiagnostics = {
+      negotiatedMtu: this.negotiatedMtu,
+      chunkSize,
+      chunkCount: chunks.length,
+    };
 
     for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
       if (signal?.aborted) {
@@ -340,6 +369,12 @@ export class RNBleAdapter implements BluetoothAdapter {
     return () => {
       this.disconnectCallback = null;
     };
+  }
+
+  // ble-plx can't observe CoreBluetooth-style flow control, so this only
+  // carries the MTU/chunking story; the park/resume fields are iOS-native-only.
+  async getLastWriteDiagnostics(): Promise<BleWriteDiagnostics | null> {
+    return this.lastWriteDiagnostics;
   }
 }
 

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -80,6 +80,9 @@ export class RNBleAdapter implements BluetoothAdapter {
   // fallback → scan timeout) mirrors NativeIosBleAdapter.requestAndConnect and
   // the web adapters. Kept in lockstep by hand; if you change one, change the others.
   async requestAndConnect(targetSerial?: string): Promise<BleConnection> {
+    // Reset up front so a reused adapter whose reconnect fails before MTU
+    // negotiation can't write with the previous connection's stale MTU.
+    this.negotiatedMtu = DEFAULT_ATT_MTU;
     const devices = new Map<string, DiscoveredDevice>();
     let updateListener: ((devices: DiscoveredDevice[]) => void) | null = null;
     let scanStoppedListener: (() => void) | null = null;

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -306,14 +306,22 @@ export class RNBleAdapter implements BluetoothAdapter {
     const chunkSize =
       this.scanFamily === 'moonboard' ? MAX_BLUETOOTH_MESSAGE_SIZE : effectiveChunkSizeForMtu(this.negotiatedMtu);
     const chunks = splitMessages(data, chunkSize);
+    // Aurora boards always use write-without-response (proven path; on some
+    // iOS versions the characteristic under-reports the property but still
+    // needs no-response). Only the original MoonBoard (RedBearLab) write
+    // characteristic — which advertises `.write` only — falls back to
+    // write-with-response, mirroring the native preferredWriteType gating.
+    // Android sends no-response writes regardless, so this only matters on
+    // Expo Go iOS. Decided once per write (the characteristic object never
+    // changes mid-write, only nulls on disconnect) so the dispatch below and
+    // the diagnostics report the same value by construction.
+    const usesWithoutResponse =
+      this.scanFamily !== 'moonboard' || (writeCharacteristic.isWritableWithoutResponse ?? true);
     // Every write through this adapter is JS-driven (Android has no
     // widget-intent write path), hence the fixed 'js' origin.
     this.lastWriteDiagnostics = {
       origin: 'js',
-      writeType:
-        this.scanFamily !== 'moonboard' || (writeCharacteristic.isWritableWithoutResponse ?? true)
-          ? 'withoutResponse'
-          : 'withResponse',
+      writeType: usesWithoutResponse ? 'withoutResponse' : 'withResponse',
       negotiatedMtu: this.negotiatedMtu,
       chunkSize,
       chunkCount: chunks.length,
@@ -341,17 +349,8 @@ export class RNBleAdapter implements BluetoothAdapter {
       const chunk = chunks[chunkIndex];
       const base64Chunk = uint8ArrayToBase64(chunk);
 
-      // Aurora boards always use write-without-response (proven path; on some
-      // iOS versions the characteristic under-reports the property but still
-      // needs no-response). Only the original MoonBoard (RedBearLab) write
-      // characteristic — which advertises `.write` only — falls back to
-      // write-with-response, mirroring the native preferredWriteType gating.
-      // Android sends no-response writes regardless, so this only matters on
-      // Expo Go iOS.
-      const useWithoutResponse = this.scanFamily !== 'moonboard' || (characteristic.isWritableWithoutResponse ?? true);
-
       try {
-        if (useWithoutResponse) {
+        if (usesWithoutResponse) {
           await characteristic.writeWithoutResponse(base64Chunk);
         } else {
           await characteristic.writeWithResponse(base64Chunk);

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -331,6 +331,10 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
     }
   }
 
+  // Unlike the native module's stash (clear-on-read, one failure exactly),
+  // this adapter-level copy deliberately persists until the next write
+  // settles: one settle can feed several consumers (the success/failure
+  // analytics event and the Sentry report), so reads must not consume it.
   async getLastWriteDiagnostics(): Promise<BleWriteDiagnostics | null> {
     return this.lastWriteDiagnostics;
   }

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -14,6 +14,7 @@ import type {
   BluetoothAdapter,
   BleConnection,
   BleDisconnectInfo,
+  BleWriteDiagnostics,
   BoardScanFamily,
   DevicePickerFn,
   DiscoveredDevice,
@@ -67,6 +68,9 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
   private connectedDeviceId: string | null = null;
   private disconnectCallback: ((info?: BleDisconnectInfo) => void) | null = null;
   private disconnectSubscription: { remove: () => void } | null = null;
+  // Transport diagnostics of the most recently settled write (#3230): the
+  // resolved value on success, the native module's stash after a reject.
+  private lastWriteDiagnostics: BleWriteDiagnostics | null = null;
 
   constructor(
     private readonly devicePicker: DevicePickerFn,
@@ -279,13 +283,13 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
     if (signal?.aborted) {
       throw new DOMException('Write aborted', 'AbortError');
     }
-    // Native side handles chunking (20-byte UART chunks with 5ms inter-chunk
+    // Native side handles chunking (MTU-sized UART chunks with 5ms inter-chunk
     // delay) inside BoardBleManager, so we pass the full payload as a single
     // hex string. An abort while the chunks are still draining natively flushes
     // the native queue too — without cancelWrites the stale climb would keep
     // streaming to the wall after the caller gave up on it.
     if (!signal) {
-      await native.write(uint8ArrayToHex(data));
+      await this.writeCapturingDiagnostics(uint8ArrayToHex(data));
       return;
     }
     const onAbort = () => {
@@ -293,7 +297,7 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
     };
     signal.addEventListener('abort', onAbort, { once: true });
     try {
-      await native.write(uint8ArrayToHex(data));
+      await this.writeCapturingDiagnostics(uint8ArrayToHex(data));
     } catch (error) {
       // The native queue rejects cancelled writes with its own error shape;
       // normalise to AbortError so callers classify it as a cancellation.
@@ -304,6 +308,31 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
     } finally {
       signal.removeEventListener('abort', onAbort);
     }
+  }
+
+  // Runs the native write and captures its transport diagnostics (#3230):
+  // resolved with the promise on success; after a reject, fetched from the
+  // module's stash (an Expo reject can't carry structured data). The stash is
+  // written before the reject reaches JS, so the fetch never races it. Both
+  // capabilities are absent on older binaries (OTA JS can outrun the native
+  // build) — then the write resolves nothing and there's no stash to fetch.
+  private async writeCapturingDiagnostics(hex: string): Promise<void> {
+    const native = this.requireNative();
+    try {
+      const diagnostics = await native.write(hex);
+      this.lastWriteDiagnostics = diagnostics ?? null;
+    } catch (error) {
+      if (typeof native.getLastWriteDiagnostics === 'function') {
+        this.lastWriteDiagnostics = await native.getLastWriteDiagnostics().catch(() => null);
+      } else {
+        this.lastWriteDiagnostics = null;
+      }
+      throw error;
+    }
+  }
+
+  async getLastWriteDiagnostics(): Promise<BleWriteDiagnostics | null> {
+    return this.lastWriteDiagnostics;
   }
 
   onDisconnect(callback: (info?: BleDisconnectInfo) => void): () => void {

--- a/packages/mobile/src/lib/ble/types.ts
+++ b/packages/mobile/src/lib/ble/types.ts
@@ -49,6 +49,8 @@ export type BleWriteDiagnostics = {
   origin?: 'js' | 'native';
   writeType?: 'withoutResponse' | 'withResponse';
   chunkSize?: number;
+  // PLANNED chunks for the write on both platforms (stamped at enqueue), not
+  // progress — a write that fails mid-stream still reports the full plan.
   chunkCount?: number;
   negotiatedMaxWriteWithoutResponse?: number;
   negotiatedMtu?: number;

--- a/packages/mobile/src/lib/ble/types.ts
+++ b/packages/mobile/src/lib/ble/types.ts
@@ -40,10 +40,36 @@ export type DevicePickerFn = (
   subscribe: (onUpdate: (devices: DiscoveredDevice[]) => void, onScanStopped?: () => void) => void,
 ) => Promise<string>;
 
+// Per-write transport diagnostics (#3230), attached to the Climb Sent to Board
+// analytics events. Sparse by platform: native iOS reports the full
+// flow-control story (parks, resume source, watchdog); the ble-plx (Android)
+// adapter only knows its negotiated MTU and chunking. Every field optional so
+// adapters/binaries that can't report a value simply omit it.
+export type BleWriteDiagnostics = {
+  origin?: 'js' | 'native';
+  writeType?: 'withoutResponse' | 'withResponse';
+  chunkSize?: number;
+  chunkCount?: number;
+  negotiatedMaxWriteWithoutResponse?: number;
+  negotiatedMtu?: number;
+  parkCount?: number;
+  peripheralIsReadyFired?: boolean;
+  lastResumeSource?: 'callback' | 'poll';
+  maxParkMs?: number;
+  totalParkMs?: number;
+  watchdogTripped?: boolean;
+  canSendAtTrip?: boolean;
+  durationMs?: number;
+};
+
 export type BluetoothAdapter = {
   isAvailable(): Promise<boolean>;
   requestAndConnect(targetSerial?: string): Promise<BleConnection>;
   disconnect(): Promise<void>;
   write(data: Uint8Array, signal?: AbortSignal): Promise<void>;
   onDisconnect(callback: (info?: BleDisconnectInfo) => void): () => void;
+  // Transport diagnostics of the adapter's most recently settled write
+  // (success or failure), for analytics tagging. Optional: web-era adapters
+  // and old binaries don't report any.
+  getLastWriteDiagnostics?(): Promise<BleWriteDiagnostics | null>;
 };

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -30,7 +30,13 @@ import {
   subscribeNativeBleConnected,
 } from './adapter-factory';
 import { requestBleRuntimePermissions } from './use-ble-permissions';
-import type { BleDisconnectInfo, BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from './types';
+import type {
+  BleDisconnectInfo,
+  BleWriteDiagnostics,
+  BluetoothAdapter,
+  DevicePickerFn,
+  DiscoveredDevice,
+} from './types';
 import type { HoldPlacement } from '../../components/board-renderer/types';
 import { track } from '../analytics';
 import { reportHandledError } from '../error-reporting';
@@ -49,6 +55,30 @@ export function bleConnectReportLevel(category: BleFailureCategory): 'warning' |
   if (category === 'user_cancelled') return null;
   if (category === 'board_not_found' || category === 'connect_failed') return 'warning';
   return 'error';
+}
+
+// Per-write transport diagnostics → analytics props (#3230). Prefixed `ble` to
+// sit beside the connect-time `bleChosenWriteType`/`bleMaxWriteWithoutResponse`
+// props; every field optional so Android/web adapters and old binaries simply
+// omit what they can't report. Exported for testing.
+export function bleWriteDiagnosticsProperties(diagnostics: BleWriteDiagnostics | null | undefined) {
+  if (!diagnostics) return {};
+  return {
+    bleWriteOrigin: diagnostics.origin,
+    bleWriteType: diagnostics.writeType,
+    bleChunkSize: diagnostics.chunkSize,
+    bleChunkCount: diagnostics.chunkCount,
+    bleMaxWriteWithoutResponse: diagnostics.negotiatedMaxWriteWithoutResponse,
+    bleNegotiatedMtu: diagnostics.negotiatedMtu,
+    bleParkCount: diagnostics.parkCount,
+    blePeripheralIsReadyFired: diagnostics.peripheralIsReadyFired,
+    bleLastResumeSource: diagnostics.lastResumeSource,
+    bleMaxParkMs: diagnostics.maxParkMs,
+    bleTotalParkMs: diagnostics.totalParkMs,
+    bleWatchdogTripped: diagnostics.watchdogTripped,
+    bleCanSendAtTrip: diagnostics.canSendAtTrip,
+    bleWriteDurationMs: diagnostics.durationMs,
+  };
 }
 
 // Exported for testing — isolates the .packet extraction so regressions are caught.
@@ -444,6 +474,12 @@ export function useBoardBluetooth({
       const combinedSignal = merged ? merged.signal : generationSignal;
 
       const performSend = async (): Promise<boolean | undefined> => {
+        // Transport diagnostics of the write that just settled (#3230) — iOS
+        // native adapter (full flow-control story) or ble-plx (MTU/chunking
+        // only); null on web-era adapters and old binaries. Never let the
+        // fetch itself fail an already-settled send.
+        const fetchWriteDiagnostics = async (): Promise<BleWriteDiagnostics | null> =>
+          (await adapterRef.current?.getLastWriteDiagnostics?.().catch(() => null)) ?? null;
         try {
           // The send may have queued behind another write; by the time it runs
           // the connection generation may be gone (reconnect/disconnect) — bail
@@ -471,7 +507,12 @@ export function useBoardBluetooth({
               });
               return false;
             }
-            if (sent) track(SHARED_EVENTS.ClimbSentToBoardSuccess, boardAnalyticsProperties);
+            if (sent) {
+              track(SHARED_EVENTS.ClimbSentToBoardSuccess, {
+                ...boardAnalyticsProperties,
+                ...bleWriteDiagnosticsProperties(await fetchWriteDiagnostics()),
+              });
+            }
             return sent;
           }
 
@@ -551,7 +592,10 @@ export function useBoardBluetooth({
           }
 
           await adapterRef.current.write(result.packet, combinedSignal);
-          track(SHARED_EVENTS.ClimbSentToBoardSuccess, boardAnalyticsProperties);
+          track(SHARED_EVENTS.ClimbSentToBoardSuccess, {
+            ...boardAnalyticsProperties,
+            ...bleWriteDiagnosticsProperties(await fetchWriteDiagnostics()),
+          });
           return true;
         } catch (error) {
           // An aborted write (unmount, or a reconnect cancelling the old
@@ -563,9 +607,11 @@ export function useBoardBluetooth({
           }
           const bleFailureReason = classifyBleFailureReason(error);
           console.error('Error sending frames to board:', error);
+          const writeDiagnostics = await fetchWriteDiagnostics();
           track(SHARED_EVENTS.ClimbSentToBoardFailure, {
             ...boardAnalyticsProperties,
             failureReason: bleFailureReason,
+            ...bleWriteDiagnosticsProperties(writeDiagnostics),
           });
           // A dropped link is routine on these last-connection-wins boards
           // (another climber grabbed it, or it disconnected mid-session), so keep
@@ -574,6 +620,7 @@ export function useBoardBluetooth({
           reportHandledError(error, {
             level: bleFailureReason === 'disconnected' ? 'warning' : 'error',
             tags: { source: 'ble-send', failure_reason: bleFailureReason },
+            extra: writeDiagnostics ? { bleWriteDiagnostics: writeDiagnostics } : undefined,
           });
           // A write that fails because the link is gone (the board dropped or
           // another device grabbed it — these boards are last-connection-wins) is

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -59,11 +59,14 @@ export function bleConnectReportLevel(category: BleFailureCategory): 'warning' |
 
 // Per-write transport diagnostics → analytics props (#3230). Prefixed `ble` to
 // sit beside the connect-time `bleChosenWriteType`/`bleMaxWriteWithoutResponse`
-// props; every field optional so Android/web adapters and old binaries simply
-// omit what they can't report. Exported for testing.
-export function bleWriteDiagnosticsProperties(diagnostics: BleWriteDiagnostics | null | undefined) {
+// props. Every field is optional (Android reports only its MTU/chunking story;
+// old binaries none), and unreported fields are dropped rather than spread as
+// undefined so the event payload carries only real values. Exported for testing.
+export function bleWriteDiagnosticsProperties(
+  diagnostics: BleWriteDiagnostics | null | undefined,
+): Record<string, string | number | boolean> {
   if (!diagnostics) return {};
-  return {
+  const mappedProperties = {
     bleWriteOrigin: diagnostics.origin,
     bleWriteType: diagnostics.writeType,
     bleChunkSize: diagnostics.chunkSize,
@@ -79,6 +82,10 @@ export function bleWriteDiagnosticsProperties(diagnostics: BleWriteDiagnostics |
     bleCanSendAtTrip: diagnostics.canSendAtTrip,
     bleWriteDurationMs: diagnostics.durationMs,
   };
+  return Object.fromEntries(Object.entries(mappedProperties).filter(([, value]) => value !== undefined)) as Record<
+    string,
+    string | number | boolean
+  >;
 }
 
 // Exported for testing — isolates the .packet extraction so regressions are caught.

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -483,15 +483,21 @@ export function useBoardBluetooth({
       const performSend = async (): Promise<boolean | undefined> => {
         // Transport diagnostics of the write that just settled (#3230) — iOS
         // native adapter (full flow-control story) or ble-plx (MTU/chunking
-        // only); null on web-era adapters and old binaries. Never let the
-        // fetch itself fail an already-settled send.
+        // only); null on web-era adapters and old binaries. Read from the
+        // adapter INSTANCE that performed the send, not the mutable ref: a
+        // mid-write link drop runs clearConnectionAfterDrop (which nulls
+        // adapterRef) before this send's catch fetches, and the failures that
+        // race that way are exactly the ones whose diagnostics matter. Never
+        // let the fetch itself fail an already-settled send.
+        let sendAdapter: BluetoothAdapter | null = null;
         const fetchWriteDiagnostics = async (): Promise<BleWriteDiagnostics | null> =>
-          (await adapterRef.current?.getLastWriteDiagnostics?.().catch(() => null)) ?? null;
+          (await sendAdapter?.getLastWriteDiagnostics?.().catch(() => null)) ?? null;
         try {
           // The send may have queued behind another write; by the time it runs
           // the connection generation may be gone (reconnect/disconnect) — bail
           // before touching the (possibly new) adapter.
           if (combinedSignal.aborted || !adapterRef.current) return;
+          sendAdapter = adapterRef.current;
 
           if (boardName === 'moonboard') {
             const sent = await dispatchMoonboardPacket(

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -81,7 +81,10 @@ export function bleWriteDiagnosticsProperties(
     bleWatchdogTripped: diagnostics.watchdogTripped,
     bleCanSendAtTrip: diagnostics.canSendAtTrip,
     bleWriteDurationMs: diagnostics.durationMs,
-  };
+    // `satisfies` keeps the literal honest if BleWriteDiagnostics grows an
+    // incompatible field; the cast below only asserts what the filter
+    // guarantees at runtime — no undefined values survive.
+  } satisfies Record<string, string | number | boolean | undefined>;
   return Object.fromEntries(Object.entries(mappedProperties).filter(([, value]) => value !== undefined)) as Record<
     string,
     string | number | boolean

--- a/packages/shared/ble-protocol/src/__tests__/transport.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/transport.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   splitMessages,
+  effectiveChunkSizeForMtu,
+  MAX_ATT_CHUNK_SIZE,
   MAX_BLUETOOTH_MESSAGE_SIZE,
   AURORA_ADVERTISED_SERVICE_UUID,
   UART_SERVICE_UUID,
@@ -69,5 +71,48 @@ describe('splitMessages', () => {
       offset += chunk.length;
     }
     expect(reassembled).toEqual(buffer);
+  });
+
+  // MTU-sized chunks (#3230): the chunk size is a transport detail, so an
+  // explicit size must only change segmentation, never the byte stream.
+  it('splits by an explicit chunk size', () => {
+    const buffer = new Uint8Array(500);
+    for (let byteIndex = 0; byteIndex < 500; byteIndex++) buffer[byteIndex] = byteIndex % 251;
+
+    const chunks = splitMessages(buffer, MAX_ATT_CHUNK_SIZE);
+    expect(chunks).toHaveLength(3); // ceil(500/244)
+    expect(chunks[0].length).toBe(244);
+    expect(chunks[1].length).toBe(244);
+    expect(chunks[2].length).toBe(12);
+
+    const reassembled = new Uint8Array(500);
+    let offset = 0;
+    for (const chunk of chunks) {
+      reassembled.set(chunk, offset);
+      offset += chunk.length;
+    }
+    expect(reassembled).toEqual(buffer);
+  });
+});
+
+describe('effectiveChunkSizeForMtu', () => {
+  // Value matrix kept in lockstep with the Swift twin
+  // (BoardBleEncoding.effectiveChunkSize, tested in
+  // packages/mobile/ios-tests/LiveActivityWidgetTests.swift).
+  it('clamps to the ATT-247 ceiling — never the 512 cliff the iOS-26.5 cohort fails on', () => {
+    expect(effectiveChunkSizeForMtu(512)).toBe(244);
+    expect(effectiveChunkSizeForMtu(517)).toBe(244); // Android 14 default request
+    expect(effectiveChunkSizeForMtu(247)).toBe(244);
+  });
+
+  it('passes through negotiated MTUs inside the window', () => {
+    expect(effectiveChunkSizeForMtu(185)).toBe(182);
+    expect(effectiveChunkSizeForMtu(100)).toBe(97);
+  });
+
+  it('floors at the classic 20-byte chunk for default/degenerate MTUs', () => {
+    expect(effectiveChunkSizeForMtu(23)).toBe(20);
+    expect(effectiveChunkSizeForMtu(20)).toBe(MAX_BLUETOOTH_MESSAGE_SIZE);
+    expect(effectiveChunkSizeForMtu(0)).toBe(20);
   });
 });

--- a/packages/shared/ble-protocol/src/transport.ts
+++ b/packages/shared/ble-protocol/src/transport.ts
@@ -19,7 +19,20 @@ export const REDBEARLAB_WRITE_CHARACTERISTIC_UUID = '713d0003-503e-4c75-ba94-314
 
 export const INTER_CHUNK_DELAY_MS = 5;
 
-export const splitMessages = (buffer: Uint8Array) =>
-  Array.from({ length: Math.ceil(buffer.length / MAX_BLUETOOTH_MESSAGE_SIZE) }, (_, i) =>
-    buffer.slice(i * MAX_BLUETOOTH_MESSAGE_SIZE, (i + 1) * MAX_BLUETOOTH_MESSAGE_SIZE),
+// Ceiling for MTU-sized chunks: ATT 247 minus the 3-byte write header. iOS-26.5
+// telemetry (#3230) shows failures clustering at the full ATT 512 while ATT
+// ≤255 is clean in the field, so a negotiated maximum is never passed through
+// unclamped. Lockstep with `BoardBleEncoding.maxAttChunkSize` in
+// packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift.
+export const MAX_ATT_CHUNK_SIZE = 244;
+
+// Chunk size for a negotiated ATT MTU (`mtu - 3` write-header bytes), clamped
+// to [MAX_BLUETOOTH_MESSAGE_SIZE, MAX_ATT_CHUNK_SIZE]. Chunking is a transport
+// detail — framing is byte-identical at any size (#3230).
+export const effectiveChunkSizeForMtu = (mtu: number) =>
+  Math.min(Math.max(mtu - 3, MAX_BLUETOOTH_MESSAGE_SIZE), MAX_ATT_CHUNK_SIZE);
+
+export const splitMessages = (buffer: Uint8Array, chunkSize: number = MAX_BLUETOOTH_MESSAGE_SIZE) =>
+  Array.from({ length: Math.ceil(buffer.length / chunkSize) }, (_, i) =>
+    buffer.slice(i * chunkSize, (i + 1) * chunkSize),
   );


### PR DESCRIPTION
## Summary

Fixes the iOS 26.5.x BLE write stall (`failureReason=write_timeout`, ~15 users, 2.8% of iOS-26.5 sends on 2.1.0, 0% on every other iOS version): the board clears but the new climb never lights, then the app churns through connect→timeout→disconnect→reconnect. Root cause and fix levers are the two-cohort analysis on #3230; telemetry and repro timelines on #3235.

**Root cause.** The without-response write loop parks on `guard peripheral.canSendWriteWithoutResponse` and waits for the `peripheralIsReady(toSendWriteWithoutResponse:)` delegate — previously the ONLY resume path — under a 5 s watchdog. On iOS 26.5 CoreBluetooth updates the property but skips the delegate, so every parked write rode the watchdog into the #3181 link cycle and surfaced as `write_timeout`.

### What changed

1. **Poll resume path (the correctness fix)** — `BoardBleManager.swift`: while a write is parked, a repeating 50 ms `DispatchSourceTimer` on the BLE queue re-checks `canSendWriteWithoutResponse` and resumes the instant it flips true. The delegate callback and the 5 s watchdog stay (callback preferred; watchdog is last resort for a genuinely wedged buffer). A shared `resumeParkedWrite(source:)` enforces capture-and-nil-before-invoke so a synchronous re-park can't have its poller killed.
2. **MTU-sized chunks, clamped** — Aurora writes are chunked at the connection's negotiated `maximumWriteValueLength(for: .withoutResponse)` clamped to **[20, 244]** (ATT 247): the failing iOS-26.5 "oversized" cohort clusters at ATT 512, so the negotiated maximum is never passed through unclamped. Fewer chunks = fewer park points. MoonBoard (both controller generations) stays at the proven 20. Android mirror (separate commit): `requestMTU(247)` (was 512, result previously discarded), chunks at `mtu − 3` with the same clamp via the shared `effectiveChunkSizeForMtu`. Web unchanged (no MTU API).
3. **Watchdog-trip telemetry instead of the analysis's "re-issue writeValue once" lever** — deliberate, user-approved deviation: with the poller in place the watchdog only trips when the property stayed false for 5 full seconds; a blind re-issue in that state either drops (frame hole) or duplicates (corrupt frame), and Aurora framing silently discards either → dark wall with a reported success. The existing link cycle already re-sends the whole frame on reconnect. Instead the trip records `watchdogTripped` + `canSendAtTrip` (true would expose a poller bug; false proves a wedged buffer).
4. **Per-write telemetry, end to end** — every write settles with `{origin, writeType, chunkSize, chunkCount, negotiatedMaxWriteWithoutResponse, parkCount, peripheralIsReadyFired, lastResumeSource (callback|poll), maxParkMs, totalParkMs, watchdogTripped, canSendAtTrip, durationMs}`. Success resolves it with the JS write promise; failure stashes it for a new `getLastWriteDiagnostics()` (Expo rejects can't carry data). `Climb Sent to Board Success/Failure` PostHog events and the Sentry report now carry `ble*` props, so the 26.5 residual is a measurable before/after.

### Invariants kept

- Aurora stays **write-without-response** (#3228 — Aurora boxes don't ack with-response); `preferredWriteType` untouched; MoonBoard with-response path unchanged.
- Framing is byte-for-byte identical — chunking is transport-only. Swift↔TS parity fixtures unchanged and green.
- Swift error strings unchanged (the `connection-error.ts` classifier contract).
- Write type + chunk size are now snapshotted per request, fixing a latent bug where a `configureBoard` landing mid-request could flip the write type between chunks of one frame.
- OTA-skew safe both directions: old JS ignores the newly-resolved value; new JS presence-gates `getLastWriteDiagnostics`.

### How the fix is proven in the field (PostHog)

- iOS-26.5 `write_timeout` rate → ~0; `bleWatchdogTripped` ~0.
- Diagnosis confirmation: 26.5 sends resume with `bleLastResumeSource="poll"` + `blePeripheralIsReadyFired=false`; healthy iOS shows `"callback"`.
- Tripwires: failure rate segmented by `bleChunkSize` (any firmware unhappy with 244 → one-constant revert), any `bleCanSendAtTrip=true` (poller bug), Android failure rate by `bleNegotiatedMtu`.

Closes #3230. Refs #3235, #3228, #3181.

## Release Notes

- Fixed climbs not lighting up on Kilter and Tension boards for iPhones on iOS 26.5 — no more blank board mid-session or connect–disconnect churn while your partner queues the next problem.
- Sending climbs over Bluetooth is faster: LED data now rides bigger Bluetooth packets when your phone and board support them.

## Test plan

- `vp run typecheck` (all packages) — pass
- `vp run test:mobile` — 3000 tests pass (13 new: chunk-size matrix, MTU negotiation/fallback, diagnostics plumbing on success/failure/old-binary paths, `ble*` props on the send events); `ble-protocol` suite 219 pass (new `splitMessages` chunk-size + `effectiveChunkSizeForMtu` cases)
- `vp run check:mobile-bundle` — pass
- Swift: `BoardBleManager`/`BoardBleEncoding` typecheck clean against the iOS simulator SDK locally; new `testEffectiveChunkSizeClampsAuroraAndPinsMoonboard` matrix + existing write-type/parity tests run in `ios-rn-ci.yml`
- **Native change** — reaches users via a new build (TestFlight / `vp run mobile:preview-build`), not OTA. True end-to-end verification needs a physical Kilter/Tension board on an iOS 26.5.x device; the per-write telemetry above is the field verification. QA notes in `.boardsesh/qa-notes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPH7XrZaah9GcqA5zDV5e5
