### PR TITLE
fix(web): drop W1-removed QueueState fields from queue-bridge pseudo state

### DIFF
--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -289,10 +289,7 @@ function usePersistentSessionQueueAdapter(): {
       playlistSuggestionSource,
       climbSearchParams: DEFAULT_SEARCH_PARAMS,
       hasDoneFirstFetch: false,
-      initialQueueDataReceivedFromPeers: false,
       pendingCurrentClimbUpdates: [],
-      lastReceivedSequence: null,
-      lastReceivedStateHash: null,
       needsResync: false,
     };
     let nextState = queueReducer(pseudoState, action);


### PR DESCRIPTION
Main's typecheck is red since #3359 merged after #3342: W5's bridge pseudo-`QueueState` still initialises the three fields W1 deleted from the shared type (`initialQueueDataReceivedFromPeers`, `lastReceivedSequence`, `lastReceivedStateHash`). Three-line deletion, no behavior change — the reducer never read them.

Validated on this branch: `vp run typecheck` exit 0 (was failing on clean main), web suite 4926/4926.

Note: #3367 (W4) temporarily carries this same fix as its last commit; it rebases away once this merges.

## Release Notes

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9eAY2yZDGSqossL5UtUQo