### PR TITLE
refactor(mobile): bound sheet columns on iOS, prune legacy sheet props, native sub-picker headers

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -19,19 +19,29 @@ Most things are sheets. Routes are the exception, and each route variant earns i
 Wrapped by two helpers so they don't drift (both supply the scrim, drag handle, iOS 26 glass
 background, and keyboard avoidance natively):
 
-| Wrapper                                            | Backing            | Opened by                                         | Use when                                                                                                                          |
-| -------------------------------------------------- | ------------------ | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| **`ModalSheet`** (`src/components/ModalSheet.tsx`) | `BottomSheetModal` | imperatively via ref — `present()` / `dismiss()`  | A button/handler opens it. Presents **above root chrome** (the queue bar / tab bar) for free. The default for an on-demand sheet. |
-| **`Sheet`** (`src/components/Sheet.tsx`)           | `BottomSheet`      | declaratively — its presence in the tree shows it | Its lifetime is tied to parent state. Has a **`fullWindowOverlay`** prop to float above other sheets.                             |
+| Wrapper                                            | Backing            | Opened by                                                                          | Use when                                                                                                                          |
+| -------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **`ModalSheet`** (`src/components/ModalSheet.tsx`) | `BottomSheetModal` | imperatively via ref — `present()` / `dismiss()`, or the controlled `visible` prop | A button/handler opens it. Presents **above root chrome** (the queue bar / tab bar) for free. The default for an on-demand sheet. |
+| **`Sheet`** (`src/components/Sheet.tsx`)           | `BottomSheet`      | declaratively — its presence in the tree shows it                                  | Its lifetime is tied to parent state.                                                                                             |
 
 Examples: `QueueSheet`, `BoardSheet`, `LogAscentSheet`, `AngleSelectorSheet`,
 `ClimbActionsSheet`, `AddBetaVideoSheet` (sheet surfaces), `CreateDrawer` + `HoldRoleSheet`
 (declarative `Sheet`s).
 
-**Stacking a sheet above another sheet / above everything:** add `fullWindowOverlay` to a
-`Sheet` (renders it in a higher window), or use a `FullWindowOverlay` directly. This is how
-`HoldRoleSheet` floats above the create drawer and how `ClimbReactionMenu` (the long-press
-context menu) floats above whatever's underneath.
+Prefer the controlled `visible` prop over an imperative ref + a local `isPresentedRef`: the
+coordinator reconciles present/dismiss from `visible`, and `onClose` fires only on a genuine user
+pan-down / backdrop (not on coordinator-driven closes), so parent state can't be cleared behind
+your back. `AddToPlaylistSheet` is the reference.
+
+**Stacking above everything:** a **custom, non-sheet** overlay (Reanimated + plain views) can
+render in a higher iOS window via react-native-screens' `FullWindowOverlay` — that's how
+`ClimbReactionMenu` (the long-press context menu) floats above whatever's underneath. This does
+**not** work for a native `@expo/ui` sheet: a SwiftUI `.sheet` presents off the **key window**
+regardless of a `FullWindowOverlay` wrapper (the scar the player learned — see rule 1), so
+wrapping a sheet in one pushes it _under_ the overlay window, not above. Sibling native sheets
+instead stack via their own SwiftUI hosts — that's how `HoldRoleSheet` shows over the create
+drawer (they're siblings in the create-climb route, not one nested in the other). There is **no**
+`fullWindowOverlay` prop on `Sheet`; it was an inert no-op and has been removed.
 
 **Every native sheet must go through the presentation coordinator.** `@expo/ui`
 sheets all present off the **same** root-window view controller, and the library
@@ -44,9 +54,20 @@ drive present/dismiss with `useManagedSheet` (see `QueueSheet`, `BoardSheet`,
 `LogAscentSheet`). The coordinator serializes transitions per **presenter group**
 (default `'root'`) and auto-sequences a sheet-over-sheet open as
 dismiss(A) → settle → present(B). Two exceptions, both documented in-file:
-`CreateDrawer` (a route-primary drawer that opens once and whose only sub-sheet is
-a `fullWindowOverlay`, so it never overlaps a coordinated transition) and the
-`fullWindowOverlay` menus, which live in a higher window.
+`CreateDrawer` (a route-primary drawer that renders the raw `BottomSheet` without the
+coordinator — it opens once as the create-climb route's primary sheet, and its only sub-sheet,
+`HoldRoleSheet`, presents from its own sibling SwiftUI host, so the two never contend for the same
+presenter) and the `FullWindowOverlay` menus (e.g. `ClimbReactionMenu`), which are custom overlays
+in a higher window, not native sheets.
+
+**iOS sizing — the single-flex-child contract.** Hand the native `@expo/ui` sheet exactly ONE
+flex child; multiple direct children make it size to content and collapse a `flex: 1` scroll body.
+And on iOS the SwiftUI host can propose an **unbounded** height to that child, so a `flex: 1`
+column sizes to its content instead of the detent and anything past the detent (a pinned footer)
+lands off-screen (#3330). The `Sheet` / `ModalSheet` wrappers pin that single flex child to the
+active detent's height on iOS via `useSheetColumnStyle` (`src/components/use-sheet-column-style.ts`);
+Android bounds it natively and keeps `flex: 1`. A raw-`BottomSheet` surface with a pinned footer
+(e.g. `ClimbFilterSheet`) must apply the same hook itself.
 
 ### Routes (`expo-router` `Stack.Screen`)
 
@@ -65,8 +86,9 @@ Is it a secondary surface OVER the current screen, or its own full surface?
 ├─ Secondary surface ─────────────────────────► BOTTOM SHEET
 │    ├─ Opened imperatively (button → present)?  → ModalSheet
 │    ├─ Tied to parent state (declarative)?      → Sheet
-│    └─ Must stack above an open sheet?           → Sheet + fullWindowOverlay
-│                                                   (or FullWindowOverlay)
+│    └─ Must float above everything (CUSTOM overlay,   → FullWindowOverlay
+│        not a native sheet)?                            (native sheets present off the key
+│                                                         window — a wrapper can't lift them)
 │
 └─ Its own full surface ──────────────────────► ROUTE
      ├─ Deep destination (back / URL)?            → pushed route
@@ -106,9 +128,9 @@ Is it a secondary surface OVER the current screen, or its own full surface?
    gesture competes with the board's.
 
 4. **`ModalSheet` (imperative) vs `Sheet` (declarative) is about _how it opens_**, not how it
-   looks: a ref you `.present()` vs a component whose presence in the tree shows it. Pick
-   `ModalSheet` for on-demand surfaces (the common case); `Sheet` when the sheet's lifetime is
-   bound to parent state and especially when you need `fullWindowOverlay`.
+   looks: a ref you `.present()` (or its controlled `visible` prop) vs a component whose presence
+   in the tree shows it. Pick `ModalSheet` for on-demand surfaces (the common case); `Sheet` when
+   the sheet's lifetime is bound to parent state.
 
 ## A latency footgun (any route)
 
@@ -123,9 +145,9 @@ waits out the whole transition and is disabled in screenshot mode.
 
 - **Queue / Board / LogAscent / Angle / ClimbActions / AddBetaVideo** — secondary, opened on
   demand → `ModalSheet`. The bread and butter.
-- **Create-climb** — a drawer that shows the dimmed climbs list behind it, with one sub-sheet
-  (`HoldRoleSheet`, via `fullWindowOverlay`) → `transparentModal` route hosting a `Sheet`
-  (`CreateDrawer`). Correctly _not_ a full-screen cover.
+- **Create-climb** — a drawer that shows the dimmed climbs list behind it, with one sibling
+  sub-sheet (`HoldRoleSheet`, which stacks via its own SwiftUI host) → `transparentModal` route
+  hosting a `Sheet` (`CreateDrawer`). Correctly _not_ a full-screen cover.
 - **Player (now-playing)** — immersive full-screen, hosts 5–6 sub-sheets that must stack above
   it → `transparentModal` + opaque backing route. The exception that proves rule 1.
 - **Boards picker / share-beta / join** — self-contained flows from a tab → `modal` card.

--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -16,8 +16,9 @@ Most things are sheets. Routes are the exception, and each route variant earns i
 
 ### Bottom sheets (`@expo/ui/community/bottom-sheet`)
 
-Wrapped by two helpers so they don't drift (both supply the scrim, drag handle, iOS 26 glass
-background, and keyboard avoidance natively):
+Wrapped by two helpers so they don't drift (both supply the scrim, drag handle, and iOS 26 glass
+background natively, plus JS-side keyboard avoidance for the `footer` slot — the Android Compose
+dialog window does **not** resize for the keyboard, so the wrappers pad on both platforms):
 
 | Wrapper                                            | Backing            | Opened by                                                                          | Use when                                                                                                                          |
 | -------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/mobile/app/(tabs)/climbs/__tests__/holds.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/holds.test.tsx
@@ -15,6 +15,9 @@ const TAPPED_HOLD_ID = 42;
 
 const trackMock = vi.hoisted(() => vi.fn());
 const emitMock = vi.hoisted(() => vi.fn());
+// Captures navigation.setOptions calls so tests can assert the headerRight
+// "Clear all" shows only while there's something to clear.
+const navMock = vi.hoisted(() => ({ setOptions: vi.fn() }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
@@ -27,7 +30,7 @@ vi.mock('expo-router', () => ({
     holdsFilter: undefined,
   }),
   // The screen drives the native header (title + headerRight) through setOptions.
-  useNavigation: () => ({ setOptions: vi.fn() }),
+  useNavigation: () => navMock,
   // Run the effect immediately and stash its cleanup so the test can fire it.
   useFocusEffect: (effect: () => void | (() => void)) => {
     const cleanup = effect();
@@ -131,8 +134,15 @@ import HoldFilterScreen from '../holds';
 beforeEach(() => {
   trackMock.mockClear();
   emitMock.mockClear();
+  navMock.setOptions.mockClear();
   focus.cleanup = null;
 });
+
+// The headerRight the screen last handed the native header via setOptions.
+function lastHeaderRight(): unknown {
+  const lastOptions = navMock.setOptions.mock.calls.at(-1)?.[0] as { headerRight?: unknown } | undefined;
+  return lastOptions?.headerRight;
+}
 
 describe('HoldFilterScreen', () => {
   it('emits a hold-filter-changed analytics event with the layout name when a hold is painted', () => {
@@ -148,6 +158,18 @@ describe('HoldFilterScreen', () => {
       mode: 'include',
       boardLayout: 'Kilter Board Original',
     });
+  });
+
+  it('shows the headerRight Clear all only while a hold is filtered', () => {
+    const { getByText } = render(<HoldFilterScreen />);
+
+    // Nothing to clear yet → no headerRight.
+    expect(lastHeaderRight()).toBeUndefined();
+
+    // Paint a hold → the Clear all headerRight appears.
+    fireEvent.click(getByText('select start'));
+    fireEvent.click(getByText('board'));
+    expect(lastHeaderRight()).toBeTypeOf('function');
   });
 
   it('hands the current filter back when the screen loses focus', () => {

--- a/packages/mobile/app/(tabs)/climbs/__tests__/holds.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/holds.test.tsx
@@ -26,7 +26,8 @@ vi.mock('expo-router', () => ({
     setIds: '1,2',
     holdsFilter: undefined,
   }),
-  useRouter: () => ({ back: vi.fn() }),
+  // The screen drives the native header (title + headerRight) through setOptions.
+  useNavigation: () => ({ setOptions: vi.fn() }),
   // Run the effect immediately and stash its cleanup so the test can fire it.
   useFocusEffect: (effect: () => void | (() => void)) => {
     const cleanup = effect();

--- a/packages/mobile/app/(tabs)/climbs/__tests__/setters.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/setters.test.tsx
@@ -31,7 +31,8 @@ vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => k
 
 vi.mock('expo-router', () => ({
   useLocalSearchParams: () => params.value,
-  useRouter: () => ({ back: vi.fn() }),
+  // The screen drives the native header (title + headerRight) through setOptions.
+  useNavigation: () => ({ setOptions: vi.fn() }),
   // Run the effect immediately and stash its cleanup so the test can fire it.
   useFocusEffect: (effect: () => void | (() => void)) => {
     const cleanup = effect();
@@ -74,14 +75,17 @@ vi.mock('../../../../src/lib/haptics', () => ({ hapticSelection: vi.fn() }));
 
 vi.mock('../../../../src/providers/theme-provider', () => ({
   useTheme: () => ({
-    systemColors: { background: '#fff', secondaryBackground: '#eee', label: '#000' },
+    systemColors: {
+      background: '#fff',
+      secondaryBackground: '#eee',
+      label: '#000',
+      secondaryLabel: '#666',
+      separator: '#ccc',
+    },
     brandColors: { primary: '#6D28D9' },
   }),
 }));
 
-vi.mock('../../../../src/theme/ios-colors', () => ({
-  iosSystemColors: { separator: '#ccc', systemGray: '#999' },
-}));
 vi.mock('../../../../src/theme/typography', () => ({ textStyles: { callout: { fontSize: 16 } } }));
 vi.mock('../../../../src/theme/tokens', () => ({
   spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24 },

--- a/packages/mobile/app/(tabs)/climbs/__tests__/setters.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/setters.test.tsx
@@ -20,6 +20,9 @@ const params = vi.hoisted(() => ({
   },
 }));
 const emitMock = vi.hoisted(() => vi.fn());
+// Captures navigation.setOptions calls so tests can assert the headerRight
+// "Clear all" shows only while setters are selected.
+const navMock = vi.hoisted(() => ({ setOptions: vi.fn() }));
 const setterStats = vi.hoisted(() => ({
   data: [
     { setterUsername: 'alice', climbCount: 5 },
@@ -32,7 +35,7 @@ vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => k
 vi.mock('expo-router', () => ({
   useLocalSearchParams: () => params.value,
   // The screen drives the native header (title + headerRight) through setOptions.
-  useNavigation: () => ({ setOptions: vi.fn() }),
+  useNavigation: () => navMock,
   // Run the effect immediately and stash its cleanup so the test can fire it.
   useFocusEffect: (effect: () => void | (() => void)) => {
     const cleanup = effect();
@@ -141,11 +144,29 @@ import SettersFilterScreen from '../setters';
 
 beforeEach(() => {
   emitMock.mockClear();
+  navMock.setOptions.mockClear();
   focus.cleanup = null;
   params.value.setters = undefined;
 });
 
+// The headerRight the screen last handed the native header via setOptions.
+function lastHeaderRight(): unknown {
+  const lastOptions = navMock.setOptions.mock.calls.at(-1)?.[0] as { headerRight?: unknown } | undefined;
+  return lastOptions?.headerRight;
+}
+
 describe('SettersFilterScreen', () => {
+  it('shows the headerRight Clear all only while setters are selected', () => {
+    const { getByLabelText } = render(<SettersFilterScreen />);
+
+    // Nothing selected yet → no headerRight.
+    expect(lastHeaderRight()).toBeUndefined();
+
+    // Select a setter → the Clear all headerRight appears.
+    fireEvent.click(getByLabelText('alice'));
+    expect(lastHeaderRight()).toBeTypeOf('function');
+  });
+
   it('hands the selected setters back when the screen loses focus', () => {
     const { getByLabelText } = render(<SettersFilterScreen />);
 

--- a/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
@@ -7,6 +7,9 @@ import type { HoldsFilter, ZoneBoxInput } from '@boardsesh/shared-schema';
 const track = vi.hoisted(() => vi.fn());
 const haptics = vi.hoisted(() => ({ selection: vi.fn() }));
 const emitZoneFilterSelection = vi.hoisted(() => vi.fn());
+// Captures navigation.setOptions calls so tests can assert the headerRight
+// "Clear all" shows only while a zone exists.
+const navMock = vi.hoisted(() => ({ setOptions: vi.fn() }));
 // Mutable across tests so each can seed its own route params.
 const routeParams = vi.hoisted(() => ({ current: {} as Record<string, string> }));
 
@@ -38,7 +41,7 @@ vi.mock('react-native', () => ({
 vi.mock('expo-router', () => ({
   useLocalSearchParams: () => routeParams.current,
   // The screen drives the native header (title + headerRight) through setOptions.
-  useNavigation: () => ({ setOptions: vi.fn() }),
+  useNavigation: () => navMock,
   // Route the focus effect through a real useEffect so its cleanup (the handoff
   // emit) fires on unmount — matching useFocusEffect's blur/unmount behaviour.
   useFocusEffect: (effect: () => void | (() => void)) => {
@@ -140,7 +143,25 @@ describe('ZoneFilterScreen', () => {
     track.mockClear();
     haptics.selection.mockClear();
     emitZoneFilterSelection.mockClear();
+    navMock.setOptions.mockClear();
     routeParams.current = baseParams();
+  });
+
+  // The headerRight the screen last handed the native header via setOptions.
+  function lastHeaderRight(): unknown {
+    const lastOptions = navMock.setOptions.mock.calls.at(-1)?.[0] as { headerRight?: unknown } | undefined;
+    return lastOptions?.headerRight;
+  }
+
+  it('shows the headerRight Clear all only while a zone exists', () => {
+    const { container } = render(<ZoneFilterScreen />);
+
+    // No zone yet → no headerRight.
+    expect(lastHeaderRight()).toBeUndefined();
+
+    // Enable a zone → the Clear all headerRight appears.
+    fireEvent.click(container.querySelector('[data-button="mobile.zoneFilter.enable"]') as HTMLButtonElement);
+    expect(lastHeaderRight()).toBeTypeOf('function');
   });
 
   it('shows the Add-a-region affordance when no zone is set yet', () => {

--- a/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
@@ -7,7 +7,6 @@ import type { HoldsFilter, ZoneBoxInput } from '@boardsesh/shared-schema';
 const track = vi.hoisted(() => vi.fn());
 const haptics = vi.hoisted(() => ({ selection: vi.fn() }));
 const emitZoneFilterSelection = vi.hoisted(() => vi.fn());
-const routerBack = vi.hoisted(() => vi.fn());
 // Mutable across tests so each can seed its own route params.
 const routeParams = vi.hoisted(() => ({ current: {} as Record<string, string> }));
 
@@ -38,7 +37,8 @@ vi.mock('react-native', () => ({
 
 vi.mock('expo-router', () => ({
   useLocalSearchParams: () => routeParams.current,
-  useRouter: () => ({ back: routerBack }),
+  // The screen drives the native header (title + headerRight) through setOptions.
+  useNavigation: () => ({ setOptions: vi.fn() }),
   // Route the focus effect through a real useEffect so its cleanup (the handoff
   // emit) fires on unmount — matching useFocusEffect's blur/unmount behaviour.
   useFocusEffect: (effect: () => void | (() => void)) => {
@@ -140,7 +140,6 @@ describe('ZoneFilterScreen', () => {
     track.mockClear();
     haptics.selection.mockClear();
     emitZoneFilterSelection.mockClear();
-    routerBack.mockClear();
     routeParams.current = baseParams();
   });
 
@@ -212,15 +211,6 @@ describe('ZoneFilterScreen', () => {
     expect(emitZoneFilterSelection).toHaveBeenCalled();
     const selection = emitZoneFilterSelection.mock.calls.at(-1)?.[0] as { zoneBox: ZoneBoxInput | null };
     expect(selection.zoneBox).toEqual({ edgeLeft: 20, edgeRight: 80, edgeBottom: 20, edgeTop: 80 });
-  });
-
-  it('Done pops the screen', () => {
-    const { container } = render(<ZoneFilterScreen />);
-    const doneButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button.textContent === 'mobile.filter.done',
-    ) as HTMLButtonElement;
-    fireEvent.click(doneButton);
-    expect(routerBack).toHaveBeenCalledTimes(1);
   });
 
   // Route params arrive as strings from the navigator and can be malformed

--- a/packages/mobile/app/(tabs)/climbs/_layout.tsx
+++ b/packages/mobile/app/(tabs)/climbs/_layout.tsx
@@ -39,32 +39,34 @@ export default function ClimbsLayout() {
       <Stack.Screen
         name="holds"
         options={{
-          // Full-screen interactive board for the hold-type filter. Owns its own
-          // header (Done / Clear all), and the board gestures need the full card,
-          // so the native header is hidden and it's a pushed route (not a modal,
-          // which would compete with the board's pan/pinch).
+          // Full-screen interactive board for the hold-type filter (a pushed route,
+          // not a modal, so the board's pan/pinch never competes with a modal's
+          // pan). The native stack header carries the title + back chevron; "Clear
+          // all" is a headerRight (set per-screen). Opaque, not the app's glass push
+          // header, so the board lays out below the bar (mirrors users/[userId]).
           title: t('mobile.nav.holdFilter'),
-          headerShown: false,
+          headerTransparent: false,
         }}
       />
       <Stack.Screen
         name="zone"
         options={{
-          // Full-screen interactive board for the board-region (zone) filter.
-          // Like the hold filter: owns its own header and a pushed route so the
-          // board's drag/pinch never competes with a modal sheet's pan.
+          // Full-screen interactive board for the board-region (zone) filter. Same
+          // as the hold filter: native header (title + back chevron), opaque so the
+          // board sits below the bar, headerRight "Clear all" set per-screen.
           title: t('mobile.nav.zoneFilter'),
-          headerShown: false,
+          headerTransparent: false,
         }}
       />
       <Stack.Screen
         name="setters"
         options={{
           // Setter search/multi-select for the climb filter. A pushed route (not a
-          // stacked sheet) because native sheets can't stack above the filter
-          // sheet; owns its own header (Done / Clear all).
+          // stacked sheet) because native sheets can't stack above the filter sheet.
+          // Native header (title + back chevron), opaque so the search bar sits below
+          // the bar; headerRight "Clear all" set per-screen.
           title: t('mobile.nav.setters'),
-          headerShown: false,
+          headerTransparent: false,
         }}
       />
     </Stack>

--- a/packages/mobile/app/(tabs)/climbs/holds.tsx
+++ b/packages/mobile/app/(tabs)/climbs/holds.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, Pressable, StyleSheet, useWindowDimensions } from 'react-native';
-import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
+import { useLocalSearchParams, useNavigation, useFocusEffect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -26,12 +26,13 @@ type Params = {
 };
 
 // Vertical space (px) reserved for the on-screen chrome around the board so the
-// full board fits without scroll: the header row plus its top padding, and the
-// below-board hold-type controls (include/exclude toggle + chip row +
-// clear/hint) plus the bottom safe area. A rough constant is fine: the board
-// still fits as long as the budget is in the right ballpark, and `availHeight`
-// is clamped below.
-const CHROME_BUDGET = 320;
+// full board fits without scroll: the native header bar (the title + back
+// chevron live there now, not an in-body row), and the below-board hold-type
+// controls (include/exclude toggle + chip row + clear/hint). The status bar and
+// bottom safe area are subtracted separately. A rough constant is fine: the
+// board still fits as long as the budget is in the right ballpark, and
+// `availHeight` is clamped below.
+const CHROME_BUDGET = 300;
 
 /**
  * Full-screen route variant for the hold-type search filter. The climb filter
@@ -44,7 +45,7 @@ const CHROME_BUDGET = 320;
  */
 export default function HoldFilterScreen() {
   const params = useLocalSearchParams<Params>();
-  const router = useRouter();
+  const navigation = useNavigation();
   const { t } = useTranslation('climbs');
   const { systemColors, brandColors } = useTheme();
   const insets = useSafeAreaInsets();
@@ -99,10 +100,6 @@ export default function HoldFilterScreen() {
     }, []),
   );
 
-  const done = useCallback(() => {
-    router.back();
-  }, [router]);
-
   // Paint the selected brush (type + include/exclude) onto the tapped hold:
   // toggle that type at the current mode, dropping the hold if it ends up empty.
   const handleHoldTap = useCallback(
@@ -135,6 +132,24 @@ export default function HoldFilterScreen() {
 
   const filteredCount = countFilteredHolds(holdsFilter);
 
+  // "Clear all" moves to the native header's headerRight, shown only when there's
+  // something to clear. The back chevron / swipe-back replaces the old in-body
+  // "Done" (the selection is handed back on blur via the focus-cleanup above).
+  useEffect(() => {
+    navigation.setOptions({
+      headerRight:
+        filteredCount > 0
+          ? () => (
+              <Pressable onPress={handleClearAll} hitSlop={8} accessibilityRole="button">
+                <Text variant="subheadline" color={brandColors.primary}>
+                  {t('mobile.filter.clearAll')}
+                </Text>
+              </Pressable>
+            )
+          : undefined,
+    });
+  }, [navigation, filteredCount, handleClearAll, brandColors.primary, t]);
+
   if (!boardHolds || !boardName) {
     return (
       <View style={[styles.loading, { backgroundColor: systemColors.background }]}>
@@ -145,24 +160,6 @@ export default function HoldFilterScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: systemColors.background }]}>
-      <View style={[styles.header, { paddingTop: insets.top + spacing[2] }]}>
-        <Text variant="title3">{t('mobile.holdFilter.title')}</Text>
-        <View style={styles.headerActions}>
-          {filteredCount > 0 ? (
-            <Pressable onPress={handleClearAll} hitSlop={8} accessibilityRole="button">
-              <Text variant="subheadline" color={brandColors.primary}>
-                {t('mobile.filter.clearAll')}
-              </Text>
-            </Pressable>
-          ) : null}
-          <Pressable onPress={done} hitSlop={8} accessibilityRole="button">
-            <Text variant="subheadline" color={brandColors.primary} style={styles.doneLabel}>
-              {t('mobile.filter.done')}
-            </Text>
-          </Pressable>
-        </View>
-      </View>
-
       <View style={styles.boardSection}>
         {/* Known follow-up (not in this PR): `BoardSearchConfig` doesn't carry a
             `mirrored` flag today, so the board always renders un-mirrored here
@@ -202,21 +199,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: spacing[4],
-    paddingBottom: spacing[2],
-  },
-  headerActions: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[4],
-  },
-  doneLabel: {
-    fontWeight: '600',
   },
   boardSection: {
     flex: 1,

--- a/packages/mobile/app/(tabs)/climbs/setters.tsx
+++ b/packages/mobile/app/(tabs)/climbs/setters.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, Pressable, StyleSheet, TextInput } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
-import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
+import { useLocalSearchParams, useNavigation, useFocusEffect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { BoardName } from '@boardsesh/shared-schema';
@@ -12,7 +12,6 @@ import { useTheme } from '../../../src/providers/theme-provider';
 import { useSetterStats } from '../../../src/lib/graphql/hooks';
 import { emitSetterFilterSelection } from '../../../src/lib/setter-filter-handoff';
 import { hapticSelection } from '../../../src/lib/haptics';
-import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { textStyles } from '../../../src/theme/typography';
 import { spacing, borderRadius } from '../../../src/theme/tokens';
 
@@ -43,7 +42,8 @@ function parseSelectedSetters(serialized: string | undefined): string[] {
 }
 
 const SetterSeparator = memo(function SetterSeparator() {
-  return <View style={[styles.separator, { backgroundColor: iosSystemColors.separator }]} />;
+  const { systemColors } = useTheme();
+  return <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />;
 });
 
 type SetterRowProps = {
@@ -83,7 +83,7 @@ const SetterRow = memo(function SetterRow({ setter, isSelected, onToggle }: Sett
  */
 export default function SettersFilterScreen() {
   const params = useLocalSearchParams<Params>();
-  const router = useRouter();
+  const navigation = useNavigation();
   const { t } = useTranslation('climbs');
   const { systemColors, brandColors } = useTheme();
   const insets = useSafeAreaInsets();
@@ -162,9 +162,23 @@ export default function SettersFilterScreen() {
     setSelectedSetters([]);
   }, []);
 
-  const done = useCallback(() => {
-    router.back();
-  }, [router]);
+  // "Clear all" moves to the native header's headerRight, shown only when setters
+  // are selected. The back chevron / swipe-back replaces the old in-body "Done"
+  // (the selection is handed back on blur via the focus-cleanup above).
+  useEffect(() => {
+    navigation.setOptions({
+      headerRight:
+        selectedSet.size > 0
+          ? () => (
+              <Pressable onPress={clear} hitSlop={8} accessibilityRole="button">
+                <Text variant="subheadline" color={brandColors.primary}>
+                  {t('mobile.filter.clearAll')}
+                </Text>
+              </Pressable>
+            )
+          : undefined,
+    });
+  }, [navigation, selectedSet.size, clear, brandColors.primary, t]);
 
   const renderRow = useCallback(
     ({ item }: { item: SetterStat }) => (
@@ -175,31 +189,14 @@ export default function SettersFilterScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: systemColors.background }]}>
-      <View style={[styles.header, { paddingTop: insets.top + spacing[2] }]}>
-        <Text variant="title3">{t('mobile.filter.setters')}</Text>
-        <View style={styles.headerActions}>
-          {selectedSet.size > 0 ? (
-            <Pressable onPress={clear} hitSlop={8} accessibilityRole="button">
-              <Text variant="subheadline" color={brandColors.primary}>
-                {t('mobile.filter.clearAll')}
-              </Text>
-            </Pressable>
-          ) : null}
-          <Pressable onPress={done} hitSlop={8} accessibilityRole="button">
-            <Text variant="subheadline" color={brandColors.primary} style={styles.doneLabel}>
-              {t('mobile.filter.done')}
-            </Text>
-          </Pressable>
-        </View>
-      </View>
-
       <View style={[styles.searchBarWrapper, { backgroundColor: systemColors.secondaryBackground }]}>
-        <Icon name="search" size={16} color={iosSystemColors.systemGray} />
+        <Icon name="search" size={16} color={systemColors.secondaryLabel} />
         <TextInput
           value={searchInput}
           onChangeText={handleSearchChange}
           placeholder={t('mobile.filter.searchSetters')}
-          placeholderTextColor={iosSystemColors.systemGray}
+          placeholderTextColor={systemColors.secondaryLabel}
+          accessibilityLabel={t('mobile.filter.searchSetters')}
           autoCorrect={false}
           autoCapitalize="none"
           returnKeyType="search"
@@ -229,7 +226,7 @@ export default function SettersFilterScreen() {
           contentInsetAdjustmentBehavior="automatic"
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag"
-          contentContainerStyle={styles.listContent}
+          contentContainerStyle={{ paddingBottom: insets.bottom + spacing[6] }}
           ListEmptyComponent={
             <View style={styles.empty}>
               <Text variant="subheadline" style={styles.emptyText}>
@@ -246,21 +243,6 @@ export default function SettersFilterScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: spacing[4],
-    paddingBottom: spacing[2],
-  },
-  headerActions: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[4],
-  },
-  doneLabel: {
-    fontWeight: '600',
   },
   searchBarWrapper: {
     flexDirection: 'row',
@@ -314,9 +296,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  listContent: {
-    paddingBottom: spacing[6],
   },
   empty: {
     paddingTop: spacing[6],

--- a/packages/mobile/app/(tabs)/climbs/zone.tsx
+++ b/packages/mobile/app/(tabs)/climbs/zone.tsx
@@ -298,8 +298,6 @@ export default function ZoneFilterScreen() {
     );
   }
 
-  const zoneEnabled = zoneBox != null;
-
   return (
     <View style={[styles.container, { backgroundColor: systemColors.background }]}>
       <View style={styles.boardSection}>
@@ -317,7 +315,7 @@ export default function ZoneFilterScreen() {
         />
       </View>
 
-      {zoneEnabled ? (
+      {zoneActive ? (
         <GlassSurface
           glassEffectStyle="regular"
           fallbackColor={systemColors.elevatedSurface}
@@ -347,7 +345,7 @@ export default function ZoneFilterScreen() {
 
       <View style={[styles.footer, { paddingBottom: insets.bottom + spacing[3] }]}>
         <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.footerText}>
-          {zoneEnabled ? t('mobile.zoneFilter.activeHint') : t('mobile.zoneFilter.hint')}
+          {zoneActive ? t('mobile.zoneFilter.activeHint') : t('mobile.zoneFilter.hint')}
         </Text>
       </View>
     </View>

--- a/packages/mobile/app/(tabs)/climbs/zone.tsx
+++ b/packages/mobile/app/(tabs)/climbs/zone.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, Pressable, StyleSheet, useWindowDimensions } from 'react-native';
-import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
+import { useLocalSearchParams, useNavigation, useFocusEffect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -41,9 +41,11 @@ type Params = {
   holdsFilter?: string;
 };
 
-// Chrome above the board (header + mode island + footer) the board height budget
-// must leave room for, so the full board fits without scroll.
-const CHROME_BUDGET = 220;
+// Chrome the board height budget must leave room for so the full board fits
+// without scroll: the native header bar (title + back chevron), the mode island,
+// and the footer hint. The status bar and bottom safe area are subtracted
+// separately.
+const CHROME_BUDGET = 200;
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
@@ -92,7 +94,7 @@ function parseZoneMode(raw: string | undefined): ZoneMatchMode {
  */
 export default function ZoneFilterScreen() {
   const params = useLocalSearchParams<Params>();
-  const router = useRouter();
+  const navigation = useNavigation();
   const { t } = useTranslation('climbs');
   const { systemColors, brandColors } = useTheme();
   const insets = useSafeAreaInsets();
@@ -171,10 +173,6 @@ export default function ZoneFilterScreen() {
         });
     }, []),
   );
-
-  const done = useCallback(() => {
-    router.back();
-  }, [router]);
 
   const handleEnable = useCallback(() => {
     if (!dims) return;
@@ -275,6 +273,23 @@ export default function ZoneFilterScreen() {
     [zoneActive, dims, handleCommitZone, brandColors.primary, t, cornerLabels],
   );
 
+  // "Clear all" moves to the native header's headerRight, shown only while a zone
+  // exists. The back chevron / swipe-back replaces the old in-body "Done" (the
+  // selection is handed back on blur via the focus-cleanup above).
+  useEffect(() => {
+    navigation.setOptions({
+      headerRight: zoneActive
+        ? () => (
+            <Pressable onPress={handleClear} hitSlop={8} accessibilityRole="button">
+              <Text variant="subheadline" color={brandColors.primary}>
+                {t('mobile.filter.clearAll')}
+              </Text>
+            </Pressable>
+          )
+        : undefined,
+    });
+  }, [navigation, zoneActive, handleClear, brandColors.primary, t]);
+
   if (!boardHolds || !boardName || !dims) {
     return (
       <View style={[styles.loading, { backgroundColor: systemColors.background }]}>
@@ -287,24 +302,6 @@ export default function ZoneFilterScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: systemColors.background }]}>
-      <View style={[styles.header, { paddingTop: insets.top + spacing[2] }]}>
-        <Text variant="title3">{t('mobile.zoneFilter.title')}</Text>
-        <View style={styles.headerActions}>
-          {zoneEnabled ? (
-            <Pressable onPress={handleClear} hitSlop={8} accessibilityRole="button">
-              <Text variant="subheadline" color={brandColors.primary}>
-                {t('mobile.filter.clearAll')}
-              </Text>
-            </Pressable>
-          ) : null}
-          <Pressable onPress={done} hitSlop={8} accessibilityRole="button">
-            <Text variant="subheadline" color={brandColors.primary} style={styles.doneLabel}>
-              {t('mobile.filter.done')}
-            </Text>
-          </Pressable>
-        </View>
-      </View>
-
       <View style={styles.boardSection}>
         <InteractiveFilterBoard
           boardName={boardName}
@@ -365,21 +362,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: spacing[4],
-    paddingBottom: spacing[2],
-  },
-  headerActions: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[4],
-  },
-  doneLabel: {
-    fontWeight: '600',
   },
   boardSection: {
     flex: 1,

--- a/packages/mobile/src/components/AddBetaVideoSheet.tsx
+++ b/packages/mobile/src/components/AddBetaVideoSheet.tsx
@@ -5,8 +5,8 @@
 // brings the link back. A manual "already have a link?" paste field is kept at
 // the bottom as a fallback (reuses the attachBetaLink mutation).
 //
-// Driven by a `visible` prop (mirrors ClimbActionsSheet / LogAscentSheet) so it
-// can present above the play drawer's own modal via stackBehavior="push".
+// Driven by a controlled `visible` prop (mirrors ClimbActionsSheet): the
+// ModalSheet coordinator presents it above the play drawer's own native modal.
 import { useCallback, useMemo, useState, type ReactNode } from 'react';
 import { View, StyleSheet, Pressable } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
@@ -129,6 +129,57 @@ export function AddBetaVideoSheet({
   const snapPoints = useMemo(() => ['85%'], []);
   const submitDisabled = !isValid || attach.isPending;
 
+  // The paste fallback lives in the sheet's `footer` slot: the wrapper wraps the
+  // footer in a KeyboardAvoidingView that lifts the input + submit clear of the
+  // software keyboard (the three share-steps scroll above). It previously sat in
+  // the scroll body with no avoidance, so the keyboard covered this bottom field.
+  const pasteFooter = (
+    <View style={styles.pasteFooter}>
+      <View style={styles.divider}>
+        <View style={[styles.dividerLine, { backgroundColor: systemColors.separator }]} />
+        <Text variant="footnote" color={systemColors.tertiaryLabel}>
+          {t('mobile.betaVideos.pasteSectionLabel')}
+        </Text>
+        <View style={[styles.dividerLine, { backgroundColor: systemColors.separator }]} />
+      </View>
+
+      <BottomSheetTextInput
+        value={url}
+        onChangeText={setUrl}
+        placeholder={t('mobile.betaVideos.urlPlaceholder')}
+        placeholderTextColor={iosSystemColors.systemGray}
+        keyboardType="url"
+        autoCapitalize="none"
+        autoCorrect={false}
+        returnKeyType="send"
+        onSubmitEditing={handleSubmit}
+        style={[styles.input, { color: systemColors.label, borderColor: systemColors.separator }]}
+      />
+      {showError && (
+        <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
+          {t('mobile.betaVideos.urlInvalid')}
+        </Text>
+      )}
+
+      <Pressable
+        onPress={handleSubmit}
+        disabled={submitDisabled}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: submitDisabled }}
+        style={({ pressed }) => [
+          styles.submitButton,
+          { backgroundColor: brandColors.primaryFill },
+          submitDisabled && styles.submitButtonDisabled,
+          pressed && !submitDisabled && styles.submitButtonPressed,
+        ]}
+      >
+        <Text variant="headline" color={brandColors.onPrimary}>
+          {attach.isPending ? t('mobile.betaVideos.submitting') : t('mobile.betaVideos.submitButton')}
+        </Text>
+      </Pressable>
+    </View>
+  );
+
   return (
     <ModalSheet
       visible={visible && !!climb}
@@ -136,6 +187,7 @@ export function AddBetaVideoSheet({
       onClose={onClose}
       onFullyDismissed={handleFullyDismissed}
       scrollable
+      footer={pasteFooter}
     >
       <View style={styles.container}>
         <Text variant="title3" style={styles.title}>
@@ -175,53 +227,6 @@ export function AddBetaVideoSheet({
             {t('mobile.betaVideos.shareBackInstructions')}
           </Text>
         </StepRow>
-
-        <View style={styles.divider}>
-          <View style={[styles.dividerLine, { backgroundColor: systemColors.separator }]} />
-          <Text variant="footnote" color={systemColors.tertiaryLabel}>
-            {t('mobile.betaVideos.pasteSectionLabel')}
-          </Text>
-          <View style={[styles.dividerLine, { backgroundColor: systemColors.separator }]} />
-        </View>
-
-        {/* `BottomSheetTextInput` (vs the bare `TextInput`) is what makes the host
-            sheet stay above the keyboard — paired with ModalSheet's
-            keyboardBehavior="interactive" it lifts the input clear of the
-            software keyboard instead of letting it cover this bottom field. */}
-        <BottomSheetTextInput
-          value={url}
-          onChangeText={setUrl}
-          placeholder={t('mobile.betaVideos.urlPlaceholder')}
-          placeholderTextColor={iosSystemColors.systemGray}
-          keyboardType="url"
-          autoCapitalize="none"
-          autoCorrect={false}
-          returnKeyType="send"
-          onSubmitEditing={handleSubmit}
-          style={[styles.input, { color: systemColors.label, borderColor: systemColors.separator }]}
-        />
-        {showError && (
-          <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
-            {t('mobile.betaVideos.urlInvalid')}
-          </Text>
-        )}
-
-        <Pressable
-          onPress={handleSubmit}
-          disabled={submitDisabled}
-          accessibilityRole="button"
-          accessibilityState={{ disabled: submitDisabled }}
-          style={({ pressed }) => [
-            styles.submitButton,
-            { backgroundColor: brandColors.primaryFill },
-            submitDisabled && styles.submitButtonDisabled,
-            pressed && !submitDisabled && styles.submitButtonPressed,
-          ]}
-        >
-          <Text variant="headline" color={brandColors.onPrimary}>
-            {attach.isPending ? t('mobile.betaVideos.submitting') : t('mobile.betaVideos.submitButton')}
-          </Text>
-        </Pressable>
       </View>
     </ModalSheet>
   );
@@ -290,6 +295,9 @@ const styles = StyleSheet.create({
   },
   actionButton: {
     alignSelf: 'flex-start',
+  },
+  pasteFooter: {
+    gap: spacing[3],
   },
   divider: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/AddBetaVideoSheet.tsx
+++ b/packages/mobile/src/components/AddBetaVideoSheet.tsx
@@ -26,7 +26,6 @@ import { useAttachBetaLink } from '../lib/graphql/hooks';
 import { extractGraphqlMessage } from '../lib/graphql/extract-error-message';
 import { useToast } from '../providers/toast-provider';
 import { useTheme } from '../providers/theme-provider';
-import { iosSystemColors } from '../theme/ios-colors';
 import { spacing, borderRadius } from '../theme/tokens';
 import { textStyles } from '../theme/typography';
 
@@ -147,7 +146,7 @@ export function AddBetaVideoSheet({
         value={url}
         onChangeText={setUrl}
         placeholder={t('mobile.betaVideos.urlPlaceholder')}
-        placeholderTextColor={iosSystemColors.systemGray}
+        placeholderTextColor={systemColors.secondaryLabel}
         keyboardType="url"
         autoCapitalize="none"
         autoCorrect={false}
@@ -156,7 +155,7 @@ export function AddBetaVideoSheet({
         style={[styles.input, { color: systemColors.label, borderColor: systemColors.separator }]}
       />
       {showError && (
-        <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
+        <Text variant="footnote" color={brandColors.error} style={styles.errorText}>
           {t('mobile.betaVideos.urlInvalid')}
         </Text>
       )}

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import { useRouter } from 'expo-router';
 import * as Clipboard from 'expo-clipboard';
@@ -70,22 +69,6 @@ function ClimbActionsSheet({
   const { showToast } = useToast();
   const theme = useTheme();
   const router = useRouter();
-  const sheetRef = useRef<BottomSheetModal>(null);
-  // Track presented state so we never dismiss() a not-presented modal (which
-  // leaves gorhom unable to present() again — the "nothing happens" bug).
-  // Presenting on a real `visible` transition is also what lets this sheet stack
-  // reliably above the Play Drawer's own modal. Mirrors LogAscentSheet.
-  const isPresentedRef = useRef(false);
-
-  useEffect(() => {
-    if (visible && climb && !isPresentedRef.current) {
-      sheetRef.current?.present();
-      isPresentedRef.current = true;
-    } else if ((!visible || !climb) && isPresentedRef.current) {
-      sheetRef.current?.dismiss();
-      isPresentedRef.current = false;
-    }
-  }, [visible, climb]);
 
   const handleAddToQueue = useCallback(() => {
     onAddToQueue?.();
@@ -149,11 +132,6 @@ function ClimbActionsSheet({
     }
   }, [climb, boardName, layoutId, sizeId, setIds, angle, onClose, showToast, t]);
 
-  const handleDismiss = useCallback(() => {
-    isPresentedRef.current = false;
-    onClose();
-  }, [onClose]);
-
   const handleFork = useCallback(() => {
     if (!climb) return;
     onClose();
@@ -216,7 +194,7 @@ function ClimbActionsSheet({
   } = theme.actionColors;
 
   return (
-    <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss} enablePanDownToClose>
+    <ModalSheet visible={visible && !!climb} snapPoints={snapPoints} onClose={onClose} enablePanDownToClose>
       {climb && (
         <ClimbPreviewCard
           climb={climb}

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -816,7 +816,7 @@ export function ClimbFilterSheet({
                       ? formatSetterSelection(localFilters.setter)
                       : t('mobile.filter.none')}
                   </Text>
-                  <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
+                  <Icon name="chevron.right" size={14} color={systemColors.tertiaryLabel} />
                 </View>
               </Pressable>
 
@@ -840,7 +840,7 @@ export function ClimbFilterSheet({
                       ? t('mobile.holdFilter.summaryCount', { count: holdFilterCount })
                       : t('mobile.filter.none')}
                   </Text>
-                  <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
+                  <Icon name="chevron.right" size={14} color={systemColors.tertiaryLabel} />
                 </View>
               </Pressable>
 
@@ -862,7 +862,7 @@ export function ClimbFilterSheet({
                   <Text variant="footnote" style={styles.tappableRowValue}>
                     {zoneActive ? t('mobile.zoneFilter.summaryActive') : t('mobile.filter.none')}
                   </Text>
-                  <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
+                  <Icon name="chevron.right" size={14} color={systemColors.tertiaryLabel} />
                 </View>
               </Pressable>
 

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -678,7 +678,7 @@ export function ClimbFilterSheet({
       enableDynamicSizing={false}
       enablePanDownToClose
       onChange={managed.onChange}
-      handleIndicatorStyle={styles.indicator}
+      handleIndicatorStyle={[styles.indicator, { backgroundColor: systemColors.separator }]}
     >
       {/* One column child bounded to the detent height (JS-computed on iOS, see
           sheetColumnStyle) — the scroll body then actually scrolls and the
@@ -983,7 +983,8 @@ export function ClimbFilterSheet({
 
 const styles = StyleSheet.create({
   indicator: {
-    backgroundColor: iosSystemColors.separator,
+    // Colour is themed at the call site (systemColors.separator adapts light/dark);
+    // only the static dimensions live here.
     width: 36,
     height: 5,
     borderRadius: 3,
@@ -1078,7 +1079,7 @@ const styles = StyleSheet.create({
     paddingTop: spacing[3],
     paddingBottom: spacing[3],
     borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: iosSystemColors.separator,
+    // borderTopColor is themed at the call site (systemColors.separator).
   },
   applyButton: {
     width: '100%',

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -1,10 +1,8 @@
 import { useCallback, useMemo, useRef, useState, useEffect, type ComponentRef, type SetStateAction } from 'react';
 import {
   View,
-  Platform,
   Pressable,
   StyleSheet,
-  useWindowDimensions,
   type ViewStyle,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
@@ -44,6 +42,7 @@ import { Icon } from './Icon';
 import { useTheme } from '../providers/theme-provider';
 import { useManagedSheet } from '../providers/sheet-presentation-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
+import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useGrades, useSearchClimbsCount } from '../lib/graphql/hooks';
 import type { BoardName, HoldsFilter } from '@boardsesh/shared-schema';
 import { buildFilterLabels, formatSettersLabel } from '../lib/filter-labels';
@@ -94,10 +93,9 @@ const STATUS_OPTIONS_UI = ['any', 'drafts', 'projects'] as const;
 const POPULARITY_BUCKETS: ReadonlyArray<number | undefined> = [undefined, 2, 10, 100, 1000];
 const PREWARM_BOARD_HOLDS_AFTER_REFINE_EXPAND_MS = 150;
 
-// One source of truth for the sheet's native detent and the iOS JS-side height
-// bound derived from it (see sheetColumnStyle).
+// The sheet's single native detent. The iOS JS-side height bound derived from it
+// lives in the shared useSheetColumnStyle hook (see the sheetColumnStyle below).
 const SHEET_DETENT_FRACTION = 0.9;
-const SHEET_TOP_CHROME_PT = 20;
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
@@ -230,24 +228,13 @@ export function ClimbFilterSheet({
     };
   }, []);
 
-  const snapPoints = useMemo(() => androidSafeSnapPoints([`${SHEET_DETENT_FRACTION * 100}%`]), []);
-  // iOS cannot be trusted to bound the sheet's flex column: SwiftUI can propose
-  // an unbounded height to the RN host, so a flex:1 column sizes to its CONTENT
-  // and anything past the detent (the pinned Apply footer) lands off-screen
-  // (#3330 — reproduced on-device even on a freshly mounted host). Pin the
-  // column to the detent height computed JS-side instead. `.fraction` detents
-  // resolve against the sheet's maximum height (window minus the top safe
-  // area); the extra SHEET_TOP_CHROME_PT covers the wrapper's drag-indicator
-  // padding, erring short — a few spare points below the footer beat a clipped
-  // footer. Android bounds the column natively, so it keeps flex:1.
-  const { height: windowHeight } = useWindowDimensions();
-  const sheetColumnStyle = useMemo<ViewStyle>(
-    () =>
-      Platform.OS === 'ios'
-        ? { height: Math.round((windowHeight - insets.top) * SHEET_DETENT_FRACTION) - SHEET_TOP_CHROME_PT }
-        : styles.fill,
-    [insets.top, windowHeight],
-  );
+  const detentSnapPoints = useMemo(() => [`${SHEET_DETENT_FRACTION * 100}%`], []);
+  const snapPoints = useMemo(() => androidSafeSnapPoints(detentSnapPoints), [detentSnapPoints]);
+  // On iOS the SwiftUI sheet host can propose an unbounded height, so a flex:1
+  // column sizes to its CONTENT and the pinned Apply footer lands off-screen
+  // (#3330). The shared hook pins the column to this single detent's height;
+  // Android bounds the column natively, so it keeps flex:1.
+  const sheetColumnStyle = useSheetColumnStyle(detentSnapPoints);
   const isKilter = boardName === 'kilter';
 
   // Live "Show N" preview for the in-progress edits (matches what Apply yields).
@@ -995,9 +982,6 @@ export function ClimbFilterSheet({
 }
 
 const styles = StyleSheet.create({
-  fill: {
-    flex: 1,
-  },
   indicator: {
     backgroundColor: iosSystemColors.separator,
     width: 36,

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -34,9 +34,6 @@ type ModalSheetProps = {
   onClose?: () => void;
   /** Fired AFTER the dismiss animation has really settled (the accurate hook). */
   onFullyDismissed?: () => void;
-  /** @deprecated source-compat: fires on every close (user or programmatic),
-   * synchronously, like the old native onDismiss. Prefer onClose/onFullyDismissed. */
-  onDismiss?: () => void;
   /** Serialization domain. Sheets presented off the same view controller share a
    * group; defaults to the root window VC. */
   presenterGroup?: PresenterGroup;
@@ -55,7 +52,6 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
     onChange,
     onClose,
     onFullyDismissed,
-    onDismiss,
     presenterGroup,
     enablePanDownToClose = true,
     scrollable = false,
@@ -84,8 +80,6 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
 
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
-  const onDismissRef = useRef(onDismiss);
-  onDismissRef.current = onDismiss;
 
   // Track the resting detent so the iOS column bound follows drags between detents.
   const [activeIndex, setActiveIndex] = useState(0);
@@ -98,7 +92,6 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
         setActiveIndex(index);
       }
       managed.onChange(index);
-      if (index === -1) onDismissRef.current?.();
       onChangeRef.current?.(index);
     },
     [managed],

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -44,10 +44,6 @@ type ModalSheetProps = {
   scrollable?: boolean;
   contentContainerStyle?: StyleProp<ViewStyle>;
   footer?: ReactNode;
-  // Legacy gorhom knobs kept for source-compatibility; the native sheet handles
-  // stacking, keyboard avoidance and the background itself, so these no-op now.
-  stackBehavior?: 'push' | 'replace' | 'switch';
-  glass?: boolean;
 };
 
 export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(function ModalSheet(

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -10,7 +10,7 @@
 // serializes native sheet transitions so two never overlap on the same presenter
 // (the iOS UIKit deadlock / app freeze — see sheet-presentation-provider.tsx).
 
-import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, type ReactNode } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState, type ReactNode } from 'react';
 import { KeyboardAvoidingView, Platform, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 import { BottomSheetModal, BottomSheetScrollView, type BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -18,6 +18,7 @@ import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
+import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useManagedSheet, type PresenterGroup } from '../providers/sheet-presentation-provider';
 
 type ModalSheetProps = {
@@ -90,9 +91,16 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
   const onDismissRef = useRef(onDismiss);
   onDismissRef.current = onDismiss;
 
+  // Track the resting detent so the iOS column bound follows drags between detents.
+  const [activeIndex, setActiveIndex] = useState(0);
+  const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex });
+
   const handleChange = useCallback(
     (index: number) => {
-      if (index >= 0) hapticMedium();
+      if (index >= 0) {
+        hapticMedium();
+        setActiveIndex(index);
+      }
       managed.onChange(index);
       if (index === -1) onDismissRef.current?.();
       onChangeRef.current?.(index);
@@ -141,7 +149,10 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
       style={styles.sheet}
     >
       {footer ? (
-        <KeyboardAvoidingView style={styles.fill} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        // The single flex child of the native sheet: bound to the detent height on
+        // iOS (see useSheetColumnStyle) so the pinned footer can't fall off-screen
+        // (#3330); flex:1 on Android / fitToContents.
+        <KeyboardAvoidingView style={columnStyle} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
           {body}
           {footerBar}
         </KeyboardAvoidingView>
@@ -165,9 +176,6 @@ const styles = StyleSheet.create({
         elevation: 16,
       },
     }),
-  },
-  fill: {
-    flex: 1,
   },
   content: {
     flex: 1,

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -103,9 +103,16 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
     [managed],
   );
 
+  // The sheet's single child must carry the iOS detent bound (see
+  // useSheetColumnStyle): with a footer the KeyboardAvoidingView below is that
+  // child and the body just fills it (flex:1); without one the body itself is
+  // the child, so it carries the bound directly — otherwise an iOS scrollable
+  // sheet sizes to its content and anything past the detent is clipped and
+  // unreachable instead of scrolling.
+  const bodyStyle = footer ? styles.content : columnStyle;
   const body = scrollable ? (
     <BottomSheetScrollView
-      style={styles.content}
+      style={bodyStyle}
       contentContainerStyle={contentContainerStyle}
       showsVerticalScrollIndicator={false}
       keyboardShouldPersistTaps="handled"
@@ -114,7 +121,7 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
       {children}
     </BottomSheetScrollView>
   ) : (
-    <View style={[styles.content, contentContainerStyle]}>{children}</View>
+    <View style={[bodyStyle, contentContainerStyle]}>{children}</View>
   );
 
   const footerBar = footer ? (
@@ -146,8 +153,10 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
       {footer ? (
         // The single flex child of the native sheet: bound to the detent height on
         // iOS (see useSheetColumnStyle) so the pinned footer can't fall off-screen
-        // (#3330); flex:1 on Android / fitToContents.
-        <KeyboardAvoidingView style={columnStyle} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        // (#3330); flex:1 on Android / fitToContents. `padding` on both platforms:
+        // the Android Compose dialog window does not resize for the keyboard, so
+        // without it the keyboard covers the footer's input (emulator-verified).
+        <KeyboardAvoidingView style={columnStyle} behavior="padding">
           {body}
           {footerBar}
         </KeyboardAvoidingView>

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -90,6 +90,12 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
       if (index >= 0) {
         hapticMedium();
         setActiveIndex(index);
+      } else {
+        // Reset on close so a re-open of an always-mounted sheet starts at the
+        // first detent's (shortest) column height until the native onChange
+        // confirms the detent — erring short beats a stale taller column pushing
+        // the pinned footer off-screen for a frame.
+        setActiveIndex(0);
       }
       managed.onChange(index);
       onChangeRef.current?.(index);

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -43,14 +43,6 @@ type SheetProps = {
   // here (e.g. the comment composer) a KeyboardAvoidingView lifts it above the
   // keyboard on iOS; Android resizes the native sheet.
   footer?: ReactNode;
-  // The native sheet owns keyboard avoidance, lifts above root chrome, and uses
-  // the system (glass on iOS 26) background, so these legacy gorhom knobs are
-  // accepted for source-compatibility but no longer do anything.
-  keyboardBehavior?: 'extend' | 'fillParent' | 'interactive';
-  keyboardBlurBehavior?: 'none' | 'restore';
-  android_keyboardInputMode?: 'adjustPan' | 'adjustResize';
-  fullWindowOverlay?: boolean;
-  glass?: boolean;
 };
 
 export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, type ReactNode } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState, type ReactNode } from 'react';
 import { KeyboardAvoidingView, Platform, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 // Migrated off @gorhom/bottom-sheet to Expo's native bottom sheet (#3167).
 // The native sheet draws its own scrim, drag handle and (on iOS 26) glass
@@ -14,6 +14,7 @@ import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
+import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useManagedSheet, type PresenterGroup } from '../providers/sheet-presentation-provider';
 
 type SheetProps = {
@@ -86,9 +87,16 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
 
+  // Track the resting detent so the iOS column bound follows drags between detents.
+  const [activeIndex, setActiveIndex] = useState(0);
+  const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex });
+
   const handleChange = useCallback(
     (index: number) => {
-      if (index >= 0) hapticMedium();
+      if (index >= 0) {
+        hapticMedium();
+        setActiveIndex(index);
+      }
       managed.onChange(index);
       onChangeRef.current?.(index);
     },
@@ -136,7 +144,10 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
       style={styles.sheet}
     >
       {footer ? (
-        <KeyboardAvoidingView style={styles.fill} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        // The single flex child of the native sheet: bound to the detent height on
+        // iOS (see useSheetColumnStyle) so the pinned footer can't fall off-screen
+        // (#3330); flex:1 on Android / fitToContents.
+        <KeyboardAvoidingView style={columnStyle} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
           {body}
           {footerBar}
         </KeyboardAvoidingView>
@@ -160,9 +171,6 @@ const styles = StyleSheet.create({
         elevation: 16,
       },
     }),
-  },
-  fill: {
-    flex: 1,
   },
   content: {
     flex: 1,

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -3,7 +3,8 @@ import { KeyboardAvoidingView, Platform, StyleSheet, View, type StyleProp, type 
 // Migrated off @gorhom/bottom-sheet to Expo's native bottom sheet (#3167).
 // The native sheet draws its own scrim, drag handle and (on iOS 26) glass
 // background, so the old SheetBackdrop / GlassSheetBackground / FullWindowOverlay
-// wiring is gone. Scroll/keyboard coordination is handled natively.
+// wiring is gone. Scroll coordination is native; keyboard avoidance for a pinned
+// footer is JS-side (the KeyboardAvoidingView below) on BOTH platforms.
 //
 // Present/dismiss route through the SheetPresentationProvider coordinator so two
 // native sheet transitions never overlap (the iOS UIKit deadlock / app freeze —
@@ -41,7 +42,9 @@ type SheetProps = {
   contentContainerStyle?: StyleProp<ViewStyle>;
   // Optional bottom action area, pinned below the content. When an input lives
   // here (e.g. the comment composer) a KeyboardAvoidingView lifts it above the
-  // keyboard on iOS; Android resizes the native sheet.
+  // keyboard on BOTH platforms — the Android Compose dialog window does not
+  // resize itself when the keyboard opens (emulator-verified), so Android needs
+  // the JS-side padding just like iOS.
   footer?: ReactNode;
 };
 
@@ -101,9 +104,16 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
     [managed],
   );
 
+  // The sheet's single child must carry the iOS detent bound (see
+  // useSheetColumnStyle): with a footer the KeyboardAvoidingView below is that
+  // child and the body just fills it (flex:1); without one the body itself is
+  // the child, so it carries the bound directly — otherwise an iOS scrollable
+  // sheet sizes to its content and anything past the detent is clipped and
+  // unreachable instead of scrolling.
+  const bodyStyle = footer ? styles.content : columnStyle;
   const body = scrollable ? (
     <BottomSheetScrollView
-      style={styles.content}
+      style={bodyStyle}
       contentContainerStyle={contentContainerStyle}
       showsVerticalScrollIndicator={false}
       keyboardShouldPersistTaps="handled"
@@ -112,7 +122,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
       {children}
     </BottomSheetScrollView>
   ) : (
-    <View style={[styles.content, contentContainerStyle]}>{children}</View>
+    <View style={[bodyStyle, contentContainerStyle]}>{children}</View>
   );
 
   const footerBar = footer ? (
@@ -144,8 +154,10 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
       {footer ? (
         // The single flex child of the native sheet: bound to the detent height on
         // iOS (see useSheetColumnStyle) so the pinned footer can't fall off-screen
-        // (#3330); flex:1 on Android / fitToContents.
-        <KeyboardAvoidingView style={columnStyle} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        // (#3330); flex:1 on Android / fitToContents. `padding` on both platforms:
+        // the Android Compose dialog window does not resize for the keyboard, so
+        // without it the keyboard covers the footer's input (emulator-verified).
+        <KeyboardAvoidingView style={columnStyle} behavior="padding">
           {body}
           {footerBar}
         </KeyboardAvoidingView>

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -88,6 +88,12 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
       if (index >= 0) {
         hapticMedium();
         setActiveIndex(index);
+      } else {
+        // Reset on close so a re-open of an always-mounted sheet starts at the
+        // first detent's (shortest) column height until the native onChange
+        // confirms the detent — erring short beats a stale taller column pushing
+        // the pinned footer off-screen for a frame.
+        setActiveIndex(0);
       }
       managed.onChange(index);
       onChangeRef.current?.(index);

--- a/packages/mobile/src/components/__tests__/add-beta-video-sheet-analytics.test.tsx
+++ b/packages/mobile/src/components/__tests__/add-beta-video-sheet-analytics.test.tsx
@@ -55,7 +55,9 @@ vi.mock('expo-haptics', () => ({
   NotificationFeedbackType: { Success: 'success', Error: 'error' },
 }));
 vi.mock('../ModalSheet', () => ({
-  ModalSheet: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  // Render both slots: the paste field + submit now live in `footer`.
+  ModalSheet: ({ children, footer }: { children?: ReactNode; footer?: ReactNode }) =>
+    createElement('div', null, children, footer),
 }));
 vi.mock('../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),

--- a/packages/mobile/src/components/__tests__/add-beta-video-sheet-analytics.test.tsx
+++ b/packages/mobile/src/components/__tests__/add-beta-video-sheet-analytics.test.tsx
@@ -75,11 +75,10 @@ vi.mock('../../lib/graphql/extract-error-message', () => ({ extractGraphqlMessag
 vi.mock('../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
-    brandColors: { primary: '#000', primaryFill: '#000', onPrimary: '#fff' },
+    brandColors: { primary: '#000', primaryFill: '#000', onPrimary: '#fff', error: '#C81E1E' },
     systemColors: { separator: '#ccc', secondaryLabel: '#666', tertiaryLabel: '#999', label: '#000' },
   }),
 }));
-vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: {} }));
 vi.mock('../../theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
 
 import { AddBetaVideoSheet } from '../AddBetaVideoSheet';

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -1,14 +1,13 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { createElement, type ReactNode, type Ref } from 'react';
+import { createElement, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
 
-// The sheet is mounted always-on inside the Play Drawer and toggled via
-// `visible`; it must present/dismiss on real visible transitions (the only way a
-// BottomSheetModal stacks above the already-open drawer). The ModalSheet mock
-// exposes the present/dismiss it would call through the forwarded ref.
-const modal = vi.hoisted(() => ({ present: vi.fn(), dismiss: vi.fn() }));
+// The sheet is mounted always-on inside the Play Drawer and toggled via the
+// controlled `visible` prop (the ModalSheet coordinator drives present/dismiss).
+// The mock captures the latest `visible` it was handed.
+const sheet = vi.hoisted(() => ({ visible: undefined as boolean | undefined }));
 const preview = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
 const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material', canUpdate: false }));
 const clipboard = vi.hoisted(() => ({ setStringAsync: vi.fn() }));
@@ -21,15 +20,12 @@ vi.mock('react-native', () => ({
 
 vi.mock('@expo/ui/community/bottom-sheet', () => ({ BottomSheetModal: function BottomSheetModal() {} }));
 
-vi.mock('../ModalSheet', async () => {
-  const React = await vi.importActual<typeof import('react')>('react');
-  return {
-    ModalSheet: React.forwardRef(({ children }: { children?: ReactNode }, ref: Ref<unknown>) => {
-      React.useImperativeHandle(ref, () => ({ present: modal.present, dismiss: modal.dismiss }));
-      return React.createElement('div', { 'data-modal-sheet': 'true' }, children);
-    }),
-  };
-});
+vi.mock('../ModalSheet', () => ({
+  ModalSheet: ({ children, visible }: { children?: ReactNode; visible?: boolean }) => {
+    sheet.visible = visible;
+    return createElement('div', { 'data-modal-sheet': 'true', 'data-visible': String(visible) }, children);
+  },
+}));
 
 vi.mock('../ClimbPreviewCard', () => ({
   ClimbPreviewCard: (props: Record<string, unknown>) => {
@@ -103,8 +99,7 @@ const baseProps = {
 };
 
 beforeEach(() => {
-  modal.present.mockClear();
-  modal.dismiss.mockClear();
+  sheet.visible = undefined;
   clipboard.setStringAsync.mockClear();
   urlBuilder.buildReadableClimbViewPath.mockClear();
   preview.props = null;
@@ -112,36 +107,33 @@ beforeEach(() => {
   ctrl.canUpdate = false;
 });
 
-describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
-  it('stays mounted while closed without presenting or dismissing', () => {
+describe('ClimbActionsSheet controlled visible (always-mounted toggle)', () => {
+  it('hands the sheet visible=false while closed', () => {
     render(<ClimbActionsSheet visible={false} {...baseProps} />);
-    expect(modal.present).not.toHaveBeenCalled();
-    expect(modal.dismiss).not.toHaveBeenCalled();
+    expect(sheet.visible).toBe(false);
   });
 
-  it('presents when visible flips true, dismisses when false, and re-presents on the next open', () => {
+  it('drives the coordinator open on visible+climb and closed otherwise', () => {
     const { rerender } = render(<ClimbActionsSheet visible={false} {...baseProps} />);
-    expect(modal.present).not.toHaveBeenCalled();
+    expect(sheet.visible).toBe(false);
 
     rerender(<ClimbActionsSheet visible={true} {...baseProps} />);
-    expect(modal.present).toHaveBeenCalledTimes(1);
-    expect(modal.dismiss).not.toHaveBeenCalled();
+    expect(sheet.visible).toBe(true);
 
     rerender(<ClimbActionsSheet visible={false} {...baseProps} />);
-    expect(modal.dismiss).toHaveBeenCalledTimes(1);
+    expect(sheet.visible).toBe(false);
 
     rerender(<ClimbActionsSheet visible={true} {...baseProps} />);
-    expect(modal.present).toHaveBeenCalledTimes(2);
+    expect(sheet.visible).toBe(true);
   });
 
-  it('never dismisses an instance that was never presented (no gorhom no-op trap)', () => {
-    // Mounting straight to visible=false (drawer open, actions closed), then
-    // clearing the climb, must not fire dismiss() — calling dismiss on a
-    // not-presented modal leaves gorhom unable to present() it next time.
+  it('stays closed when visible is true but the climb is null', () => {
+    // The coordinator only presents on a real climb; a null climb keeps it closed
+    // (the wrapper reconciles the controlled prop, so there is no gorhom no-op trap).
     const { rerender } = render(<ClimbActionsSheet {...baseProps} visible={false} />);
-    rerender(<ClimbActionsSheet {...baseProps} visible={false} climb={null} />);
-    expect(modal.present).not.toHaveBeenCalled();
-    expect(modal.dismiss).not.toHaveBeenCalled();
+    expect(sheet.visible).toBe(false);
+    rerender(<ClimbActionsSheet {...baseProps} visible={true} climb={null} />);
+    expect(sheet.visible).toBe(false);
   });
 
   it('renders the climb preview with the climb + board config when open', () => {

--- a/packages/mobile/src/components/__tests__/sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet.test.tsx
@@ -4,11 +4,16 @@ import { render } from '@testing-library/react';
 import { createElement, forwardRef, type ReactNode, type Ref } from 'react';
 
 // Captured across renders so tests can assert what Sheet hands the native sheet:
-// the onChange handler, the snap points, and whether a footer subtree rendered.
+// the onChange handler, the snap points, whether a footer subtree rendered, the
+// scroll body's style (the iOS detent bound), and the footer KeyboardAvoidingView's
+// behavior (must be "padding" on BOTH platforms — the Android Compose dialog
+// window does not resize for the keyboard).
 const captures = vi.hoisted(() => ({
   onChange: null as null | ((index: number) => void),
   snapPoints: undefined as unknown,
   scrollUsed: false,
+  scrollStyle: undefined as unknown,
+  kavBehavior: undefined as string | undefined,
 }));
 
 type SheetMockProps = {
@@ -25,8 +30,9 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
     captures.snapPoints = snapPoints;
     return createElement('div', { 'data-sheet': 'true', ref }, children);
   }),
-  BottomSheetScrollView: ({ children }: ViewMockProps) => {
+  BottomSheetScrollView: ({ children, style }: ViewMockProps & { style?: unknown }) => {
     captures.scrollUsed = true;
+    captures.scrollStyle = style;
     return createElement('div', { 'data-scroll': 'true' }, children);
   },
 }));
@@ -34,7 +40,10 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios', select: (options: { ios?: unknown; android?: unknown }) => options.ios },
   View: ({ children }: ViewMockProps) => createElement('div', null, children),
-  KeyboardAvoidingView: ({ children }: ViewMockProps) => createElement('div', { 'data-kav': 'true' }, children),
+  KeyboardAvoidingView: ({ children, behavior }: ViewMockProps & { behavior?: string }) => {
+    captures.kavBehavior = behavior;
+    return createElement('div', { 'data-kav': 'true' }, children);
+  },
   // Consumed by useSheetColumnStyle to bound the sheet column to the detent on iOS.
   useWindowDimensions: () => ({ width: 390, height: 844 }),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
@@ -86,6 +95,8 @@ beforeEach(() => {
   captures.onChange = null;
   captures.snapPoints = undefined;
   captures.scrollUsed = false;
+  captures.scrollStyle = undefined;
+  captures.kavBehavior = undefined;
   hapticMedium.mockClear();
 });
 
@@ -125,6 +136,32 @@ describe('Sheet', () => {
       </Sheet>,
     );
     expect(captures.snapPoints).toEqual(['50%', '90%']);
+  });
+
+  it('lifts the footer above the keyboard with padding on both platforms', () => {
+    // The Android Compose dialog window does NOT resize for the keyboard
+    // (emulator-verified), so the KeyboardAvoidingView must pad unconditionally —
+    // a platform-gated `undefined` leaves the footer's input covered on Android.
+    render(
+      <Sheet footer={<div>save</div>}>
+        <div>body</div>
+      </Sheet>,
+    );
+    expect(captures.kavBehavior).toBe('padding');
+  });
+
+  it('bounds a footerless scrollable body to the detent height on iOS (#3330)', () => {
+    // Without a footer the body itself is the sheet's single child, so it must
+    // carry the iOS detent bound directly — a flex:1 body sizes to content under
+    // SwiftUI's unbounded proposal and clips anything past the detent. Default
+    // snap points ['50%','90%'] at index 0 on an 844pt window with a 0 top inset:
+    // round(844 * 0.5) - 20pt top chrome = 402.
+    render(
+      <Sheet scrollable>
+        <div>body</div>
+      </Sheet>,
+    );
+    expect(captures.scrollStyle).toEqual({ height: 402 });
   });
 
   it('fires a haptic and onChange only when the sheet opens (index >= 0)', () => {

--- a/packages/mobile/src/components/__tests__/sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet.test.tsx
@@ -35,6 +35,8 @@ vi.mock('react-native', () => ({
   Platform: { OS: 'ios', select: (options: { ios?: unknown; android?: unknown }) => options.ios },
   View: ({ children }: ViewMockProps) => createElement('div', null, children),
   KeyboardAvoidingView: ({ children }: ViewMockProps) => createElement('div', { 'data-kav': 'true' }, children),
+  // Consumed by useSheetColumnStyle to bound the sheet column to the detent on iOS.
+  useWindowDimensions: () => ({ width: 390, height: 844 }),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
 

--- a/packages/mobile/src/components/__tests__/use-sheet-column-style.test.tsx
+++ b/packages/mobile/src/components/__tests__/use-sheet-column-style.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// Mutable so a test can flip the platform; reset to ios in beforeEach.
+const platformMock = vi.hoisted(() => ({ OS: 'ios' as 'ios' | 'android' }));
+
+vi.mock('react-native', () => ({
+  Platform: platformMock,
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  useWindowDimensions: () => ({ width: 390, height: 844 }),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 44, bottom: 34, left: 0, right: 0 }),
+}));
+
+import { useSheetColumnStyle } from '../use-sheet-column-style';
+
+// window 844 − top inset 44 = 800 usable; minus the 20pt chrome margin.
+const FILL = { flex: 1 };
+
+beforeEach(() => {
+  platformMock.OS = 'ios';
+});
+
+describe('useSheetColumnStyle', () => {
+  it('bounds an iOS % detent to (window − topInset) × fraction − chrome', () => {
+    const { result } = renderHook(() => useSheetColumnStyle(['90%']));
+    // round(800 × 0.9) − 20 = 700
+    expect(result.current).toEqual({ height: 700 });
+  });
+
+  it('bounds an iOS px detent to the literal height − chrome', () => {
+    const { result } = renderHook(() => useSheetColumnStyle([500]));
+    expect(result.current).toEqual({ height: 480 });
+  });
+
+  it('selects the active detent among multiple % snap points', () => {
+    const { result: shorter } = renderHook(() => useSheetColumnStyle(['50%', '90%'], { activeIndex: 0 }));
+    const { result: taller } = renderHook(() => useSheetColumnStyle(['50%', '90%'], { activeIndex: 1 }));
+    // round(800 × 0.5) − 20 = 380 ; round(800 × 0.9) − 20 = 700
+    expect(shorter.current).toEqual({ height: 380 });
+    expect(taller.current).toEqual({ height: 700 });
+  });
+
+  it('clamps activeIndex into range (over and under)', () => {
+    const { result: over } = renderHook(() => useSheetColumnStyle(['50%', '90%'], { activeIndex: 9 }));
+    const { result: under } = renderHook(() => useSheetColumnStyle(['50%', '90%'], { activeIndex: -3 }));
+    expect(over.current).toEqual({ height: 700 }); // clamped to last (90%)
+    expect(under.current).toEqual({ height: 380 }); // clamped to first (50%)
+  });
+
+  it('falls through to flex for a non-% string detent', () => {
+    const { result } = renderHook(() => useSheetColumnStyle(['auto']));
+    expect(result.current).toEqual(FILL);
+  });
+
+  it('stays flex when dynamic sizing is on', () => {
+    const { result } = renderHook(() => useSheetColumnStyle(['90%'], { enableDynamicSizing: true }));
+    expect(result.current).toEqual(FILL);
+  });
+
+  it('stays flex with no snap points', () => {
+    const undefinedPoints = renderHook(() => useSheetColumnStyle(undefined));
+    const emptyPoints = renderHook(() => useSheetColumnStyle([]));
+    expect(undefinedPoints.result.current).toEqual(FILL);
+    expect(emptyPoints.result.current).toEqual(FILL);
+  });
+
+  it('stays flex on Android (the native Material sheet bounds the column itself)', () => {
+    platformMock.OS = 'android';
+    const { result } = renderHook(() => useSheetColumnStyle(['90%']));
+    expect(result.current).toEqual(FILL);
+  });
+});

--- a/packages/mobile/src/components/ble/BleControlSheet.tsx
+++ b/packages/mobile/src/components/ble/BleControlSheet.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
-import type { BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import { ModalSheet } from '../ModalSheet';
 import { ListRow } from '../ListRow';
@@ -41,27 +40,6 @@ function BleControlSheet({
   const { t: tSettings } = useTranslation('settings');
   const { t: tCommon } = useTranslation('common');
   const { brandColors, systemColors } = useTheme();
-  const sheetRef = useRef<BottomSheetMethods>(null);
-  // Present/dismiss imperatively via ModalSheet (BottomSheetModal): it presents as
-  // its OWN modal view controller so it stacks ABOVE the play route. The old
-  // declarative `Sheet` (regular BottomSheet) presented inline and dismissed the
-  // route instead. The presented-state guard avoids dismiss()-ing a not-presented
-  // modal (which would wedge present() — the "nothing happens" bug).
-  const isPresentedRef = useRef(false);
-  useEffect(() => {
-    if (visible && !isPresentedRef.current) {
-      sheetRef.current?.present();
-      isPresentedRef.current = true;
-    } else if (!visible && isPresentedRef.current) {
-      sheetRef.current?.dismiss();
-      isPresentedRef.current = false;
-    }
-  }, [visible]);
-
-  const handleDismiss = useCallback(() => {
-    isPresentedRef.current = false;
-    onClose();
-  }, [onClose]);
 
   const handleReassert = useCallback(() => {
     onReassert();
@@ -81,7 +59,7 @@ function BleControlSheet({
   const snapPoints = useMemo(() => ['32%'], []);
 
   return (
-    <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss} enablePanDownToClose>
+    <ModalSheet visible={visible} snapPoints={snapPoints} onClose={onClose} enablePanDownToClose>
       <View style={styles.content}>
         <ListRow
           title={tSettings('ble.relightBoard')}

--- a/packages/mobile/src/components/create-climb/HoldRoleSheet.tsx
+++ b/packages/mobile/src/components/create-climb/HoldRoleSheet.tsx
@@ -71,7 +71,7 @@ export function HoldRoleSheet({
   };
 
   return (
-    <Sheet ref={sheetRef} snapPoints={snapPoints} onClose={onClose} enablePanDownToClose fullWindowOverlay scrollable>
+    <Sheet ref={sheetRef} snapPoints={snapPoints} onClose={onClose} enablePanDownToClose scrollable>
       <View style={styles.content}>
         <Text variant="headline" style={styles.title}>
           {t('mobile.create.holdRole.title')}

--- a/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import { ModalSheet } from '../ModalSheet';
 import { ListRow } from '../ListRow';
@@ -35,33 +34,13 @@ export function PlaylistActionsMenu({
 }: PlaylistActionsMenuProps) {
   const { t } = useTranslation('playlists');
   const { actionColors } = useTheme();
-  const sheetRef = useRef<BottomSheetModal>(null);
-  // Track presented state so we never call dismiss() on a not-presented modal
-  // (which can leave the next present() a no-op — the "nothing happens" bug).
-  // Mirrors LogAscentSheet.
-  const isPresentedRef = useRef(false);
   // 36% leaves room for the three rows on short screens (e.g. iPhone SE landscape).
   const snapPoints = useMemo(() => ['36%'], []);
-
-  useEffect(() => {
-    if (visible && !isPresentedRef.current) {
-      sheetRef.current?.present();
-      isPresentedRef.current = true;
-    } else if (!visible && isPresentedRef.current) {
-      sheetRef.current?.dismiss();
-      isPresentedRef.current = false;
-    }
-  }, [visible]);
-
-  const handleDismiss = useCallback(() => {
-    isPresentedRef.current = false;
-    onClose();
-  }, [onClose]);
   // Monochrome on Liquid Glass, semantic on Material — resolved once as a token.
   const { accent: accentActionIconColor, pin: pinActionIconColor } = actionColors;
 
   return (
-    <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss}>
+    <ModalSheet visible={visible} snapPoints={snapPoints} onClose={onClose}>
       <View style={styles.content}>
         <ListRow
           title={isPinned ? t('library.pin.unpin') : t('library.pin.pin')}

--- a/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet, Pressable } from 'react-native';
-import { BottomSheetModal, BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
+import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { Playlist } from '@boardsesh/graphql/operations/playlists';
 import { ModalSheet } from '../ModalSheet';
@@ -63,7 +63,6 @@ export function PlaylistFormSheet({
 }: PlaylistFormSheetProps) {
   const { t } = useTranslation('playlists');
   const { systemColors, brandColors } = useTheme();
-  const sheetRef = useRef<BottomSheetModal>(null);
   const isEdit = mode === 'edit';
 
   const [name, setName] = useState('');
@@ -81,13 +80,12 @@ export function PlaylistFormSheet({
   }, [submitError]);
   const dismissSubmitError = useCallback(() => setSubmitErrorDismissed(true), []);
 
-  // Seed (edit) or clear (create) the fields when the sheet opens, then drive
-  // the modal off the `visible` prop. `isPresentedRef` guards against calling
-  // dismiss() on a not-presented modal (which makes the next present() a no-op)
-  // and is reset in onDismiss so a swipe-dismiss + reopen works.
-  const isPresentedRef = useRef(false);
+  // Seed (edit) or clear (create) the fields each time the sheet opens; the
+  // ModalSheet is driven declaratively off `visible`, so this only tracks the
+  // closed→open transition to re-seed.
+  const wasVisibleRef = useRef(false);
   useEffect(() => {
-    if (visible && !isPresentedRef.current) {
+    if (visible && !wasVisibleRef.current) {
       if (isEdit && playlist) {
         setName(playlist.name);
         setDescription(playlist.description ?? '');
@@ -102,18 +100,9 @@ export function PlaylistFormSheet({
         setIsPublic(false);
       }
       setError(null);
-      sheetRef.current?.present();
-      isPresentedRef.current = true;
-    } else if (!visible && isPresentedRef.current) {
-      sheetRef.current?.dismiss();
-      isPresentedRef.current = false;
     }
+    wasVisibleRef.current = visible;
   }, [visible, isEdit, playlist]);
-
-  const handleDismiss = useCallback(() => {
-    isPresentedRef.current = false;
-    onClose();
-  }, [onClose]);
 
   const handleSubmit = useCallback(() => {
     const result = buildPlaylistFormValues(mode, { name, description, color, icon, isPublic });
@@ -162,7 +151,7 @@ export function PlaylistFormSheet({
   );
 
   return (
-    <ModalSheet ref={sheetRef} snapPoints={['90%']} onDismiss={handleDismiss} scrollable footer={footer}>
+    <ModalSheet visible={visible} snapPoints={['90%']} onClose={onClose} scrollable footer={footer}>
       <View style={styles.body}>
         <View style={styles.header}>
           <PlaylistPreviewSquare color={color} icon={icon} size={56} />

--- a/packages/mobile/src/components/session-screen/InviteSheet.tsx
+++ b/packages/mobile/src/components/session-screen/InviteSheet.tsx
@@ -12,6 +12,7 @@ import { Button } from '../Button';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
 import { useManagedSheet } from '../../providers/sheet-presentation-provider';
+import { androidSafeSnapPoints } from '../sheet-snap-points';
 import { hapticSelection } from '../../lib/haptics';
 import { spacing, borderRadius, sheetStyles } from '../../theme/tokens';
 import { buildSessionShareUrl } from '../../lib/session-share';
@@ -43,7 +44,10 @@ export function InviteSheet({ visible, onDismiss, sessionId }: InviteSheetProps)
   // on a user pan-down / backdrop.
   const managed = useManagedSheet({ open: visible, sheetRef, onClose: onDismiss });
 
-  const snapPoints = useMemo(() => ['60%'], []);
+  // Route the single detent through androidSafeSnapPoints: a lone '60%' would make
+  // @expo/ui's Material sheet skip the partial state and open full-screen; this
+  // adds a full detent so Android opens partial (draggable to full). iOS keeps 60%.
+  const snapPoints = useMemo(() => androidSafeSnapPoints(['60%']), []);
 
   const handleCopyLink = useCallback(() => {
     hapticSelection();

--- a/packages/mobile/src/components/settings/AccessibilitySettingsScreen.tsx
+++ b/packages/mobile/src/components/settings/AccessibilitySettingsScreen.tsx
@@ -464,7 +464,6 @@ function HoldColorPickerSheet({
       snapPoints={['95%']}
       onDismiss={handleDismiss}
       footer={footer}
-      stackBehavior="push"
       scrollable
     >
       <View style={styles.pickerBody}>
@@ -575,7 +574,6 @@ function BrushThicknessSheet({ open, value, shapeSize, onSave, onClose }: BrushT
       snapPoints={['48%', '80%']}
       onDismiss={handleDismiss}
       footer={footer}
-      stackBehavior="push"
       scrollable
     >
       <View style={styles.pickerBody}>
@@ -646,7 +644,6 @@ function ShapeSizeSheet({ open, value, brushThickness, onSave, onClose }: ShapeS
       snapPoints={['48%', '80%']}
       onDismiss={handleDismiss}
       footer={footer}
-      stackBehavior="push"
       scrollable
     >
       <View style={styles.pickerBody}>

--- a/packages/mobile/src/components/settings/AccessibilitySettingsScreen.tsx
+++ b/packages/mobile/src/components/settings/AccessibilitySettingsScreen.tsx
@@ -8,7 +8,6 @@ import {
   type ColorValue,
   type GestureResponderEvent,
 } from 'react-native';
-import { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { toBoardName } from '@boardsesh/board-config';
@@ -403,12 +402,13 @@ function HoldColorPickerSheet({
 }: HoldColorPickerSheetProps) {
   const { t } = useTranslation('common');
   const { systemColors } = useTheme();
-  const sheetRef = useRef<BottomSheetModal>(null);
   const [mode, setMode] = useState<ColorMode>('default');
   const [userColor, setUserColor] = useState<string>('#00ff00');
   const [shape, setShape] = useState<HoldMarkerShape>(DEFAULT_HOLD_MARKER_SHAPE);
   const [seedCounter, setSeedCounter] = useState(0);
-  const isPresentedRef = useRef(false);
+  // Tracks the closed→open transition so the fields re-seed each time the picker
+  // opens; the ModalSheet is driven declaratively off `role != null`.
+  const wasOpenRef = useRef(false);
 
   const modeOptions = useMemo<{ key: ColorMode; label: string }[]>(
     () => [
@@ -419,26 +419,17 @@ function HoldColorPickerSheet({
   );
 
   useEffect(() => {
-    if (role && !isPresentedRef.current) {
+    if (role != null && !wasOpenRef.current) {
       const seedColor = currentColor ?? getDefaultHoldRoleColor(boardName, role, 'led');
       setMode(currentColor ? 'user' : 'default');
       setUserColor(seedColor);
       setShape(currentShape);
       setSeedCounter((value) => value + 1);
-      sheetRef.current?.present();
-      isPresentedRef.current = true;
-    } else if (!role && isPresentedRef.current) {
-      sheetRef.current?.dismiss();
-      isPresentedRef.current = false;
     }
+    wasOpenRef.current = role != null;
   }, [boardName, currentColor, currentShape, role]);
 
   const previewColor = mode === 'user' ? userColor : role ? getDefaultHoldRoleColor(boardName, role) : '#000000';
-
-  const handleDismiss = useCallback(() => {
-    isPresentedRef.current = false;
-    onClose();
-  }, [onClose]);
 
   const handleModeSelect = useCallback(
     (nextMode: ColorMode) => {
@@ -460,9 +451,9 @@ function HoldColorPickerSheet({
 
   return (
     <ModalSheet
-      ref={sheetRef}
+      visible={role != null}
       snapPoints={['95%']}
-      onDismiss={handleDismiss}
+      onClose={onClose}
       footer={footer}
       scrollable
     >
@@ -541,25 +532,17 @@ type BrushThicknessSheetProps = {
 function BrushThicknessSheet({ open, value, shapeSize, onSave, onClose }: BrushThicknessSheetProps) {
   const { t } = useTranslation('common');
   const { systemColors } = useTheme();
-  const sheetRef = useRef<BottomSheetModal>(null);
-  const isPresentedRef = useRef(false);
+  // Tracks the closed→open transition so the draft re-seeds each time the sheet
+  // opens; the ModalSheet is driven declaratively off `open`.
+  const wasOpenRef = useRef(false);
   const [draftValue, setDraftValue] = useState(value);
 
   useEffect(() => {
-    if (open && !isPresentedRef.current) {
+    if (open && !wasOpenRef.current) {
       setDraftValue(value);
-      sheetRef.current?.present();
-      isPresentedRef.current = true;
-    } else if (!open && isPresentedRef.current) {
-      sheetRef.current?.dismiss();
-      isPresentedRef.current = false;
     }
+    wasOpenRef.current = open;
   }, [open, value]);
-
-  const handleDismiss = useCallback(() => {
-    isPresentedRef.current = false;
-    onClose();
-  }, [onClose]);
 
   const handleSave = useCallback(() => {
     onSave(draftValue);
@@ -570,9 +553,9 @@ function BrushThicknessSheet({ open, value, shapeSize, onSave, onClose }: BrushT
 
   return (
     <ModalSheet
-      ref={sheetRef}
+      visible={open}
       snapPoints={['48%', '80%']}
-      onDismiss={handleDismiss}
+      onClose={onClose}
       footer={footer}
       scrollable
     >
@@ -611,25 +594,17 @@ type ShapeSizeSheetProps = {
 function ShapeSizeSheet({ open, value, brushThickness, onSave, onClose }: ShapeSizeSheetProps) {
   const { t } = useTranslation('common');
   const { systemColors } = useTheme();
-  const sheetRef = useRef<BottomSheetModal>(null);
-  const isPresentedRef = useRef(false);
+  // Tracks the closed→open transition so the draft re-seeds each time the sheet
+  // opens; the ModalSheet is driven declaratively off `open`.
+  const wasOpenRef = useRef(false);
   const [draftValue, setDraftValue] = useState(value);
 
   useEffect(() => {
-    if (open && !isPresentedRef.current) {
+    if (open && !wasOpenRef.current) {
       setDraftValue(value);
-      sheetRef.current?.present();
-      isPresentedRef.current = true;
-    } else if (!open && isPresentedRef.current) {
-      sheetRef.current?.dismiss();
-      isPresentedRef.current = false;
     }
+    wasOpenRef.current = open;
   }, [open, value]);
-
-  const handleDismiss = useCallback(() => {
-    isPresentedRef.current = false;
-    onClose();
-  }, [onClose]);
 
   const handleSave = useCallback(() => {
     onSave(draftValue);
@@ -640,9 +615,9 @@ function ShapeSizeSheet({ open, value, brushThickness, onSave, onClose }: ShapeS
 
   return (
     <ModalSheet
-      ref={sheetRef}
+      visible={open}
       snapPoints={['48%', '80%']}
-      onDismiss={handleDismiss}
+      onClose={onClose}
       footer={footer}
       scrollable
     >

--- a/packages/mobile/src/components/settings/AccessibilitySettingsScreen.tsx
+++ b/packages/mobile/src/components/settings/AccessibilitySettingsScreen.tsx
@@ -450,13 +450,7 @@ function HoldColorPickerSheet({
   const footer = <Button title={t('mobile.more.accessibility.save')} onPress={handleSave} size="large" />;
 
   return (
-    <ModalSheet
-      visible={role != null}
-      snapPoints={['95%']}
-      onClose={onClose}
-      footer={footer}
-      scrollable
-    >
+    <ModalSheet visible={role != null} snapPoints={['95%']} onClose={onClose} footer={footer} scrollable>
       <View style={styles.pickerBody}>
         <View style={styles.pickerHeader}>
           <MarkerSwatch color={previewColor} shape={shape} size={shapeSize} />
@@ -552,13 +546,7 @@ function BrushThicknessSheet({ open, value, shapeSize, onSave, onClose }: BrushT
   const footer = <Button title={t('mobile.more.accessibility.brush.save')} onPress={handleSave} size="large" />;
 
   return (
-    <ModalSheet
-      visible={open}
-      snapPoints={['48%', '80%']}
-      onClose={onClose}
-      footer={footer}
-      scrollable
-    >
+    <ModalSheet visible={open} snapPoints={['48%', '80%']} onClose={onClose} footer={footer} scrollable>
       <View style={styles.pickerBody}>
         <View style={styles.pickerHeader}>
           <MarkerSwatch color={systemColors.accent} shape="circle" thickness={draftValue} size={shapeSize} />
@@ -614,13 +602,7 @@ function ShapeSizeSheet({ open, value, brushThickness, onSave, onClose }: ShapeS
   const footer = <Button title={t('mobile.more.accessibility.size.save')} onPress={handleSave} size="large" />;
 
   return (
-    <ModalSheet
-      visible={open}
-      snapPoints={['48%', '80%']}
-      onClose={onClose}
-      footer={footer}
-      scrollable
-    >
+    <ModalSheet visible={open} snapPoints={['48%', '80%']} onClose={onClose} footer={footer} scrollable>
       <View style={styles.pickerBody}>
         <View style={styles.pickerHeader}>
           <MarkerSwatch color={systemColors.accent} shape="diamond" thickness={brushThickness} size={draftValue} />

--- a/packages/mobile/src/components/use-sheet-column-style.ts
+++ b/packages/mobile/src/components/use-sheet-column-style.ts
@@ -1,0 +1,62 @@
+import { useMemo } from 'react';
+import { Platform, StyleSheet, useWindowDimensions, type ViewStyle } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+// The wrapper's drag-indicator padding plus a little slack. The bound errs SHORT
+// on purpose — a few spare points below a pinned footer beat a clipped footer
+// (see #3330). Kept here as the single source of truth for every sheet's iOS
+// column bound.
+export const SHEET_TOP_CHROME_PT = 20;
+
+const fillStyle = StyleSheet.create({ fill: { flex: 1 } }).fill;
+
+type SheetColumnStyleOptions = {
+  /** fitToContents sheets (no snap points) let the native side measure content
+   * height, so the JS column must stay flex — never a fixed height. */
+  enableDynamicSizing?: boolean;
+  /** The detent the sheet is currently resting at (from the native `onChange`
+   * index). Drives the height when a sheet has multiple `%` detents. */
+  activeIndex?: number;
+};
+
+/**
+ * The style for a native bottom sheet's single flex column.
+ *
+ * On iOS the `@expo/ui` SwiftUI sheet host can propose an UNBOUNDED height to the
+ * RN content, so a `flex: 1` column sizes to its CONTENT height instead of the
+ * detent — anything past the detent (a pinned footer) then lands off-screen
+ * (#3330, device-verified). So on iOS we pin the column to the current detent's
+ * height, computed JS-side: a `%`/fraction detent resolves against the sheet's
+ * maximum height (the window minus the top safe area, where SwiftUI's `.fraction`
+ * detents measure from); a px detent is the literal sheet height. The
+ * `SHEET_TOP_CHROME_PT` margin covers the drag-indicator chrome, erring short.
+ *
+ * Android's Material sheet bounds the column natively, and fitToContents sheets
+ * are measured natively too, so both keep `flex: 1`.
+ */
+export function useSheetColumnStyle(
+  snapPoints: (string | number)[] | undefined,
+  { enableDynamicSizing = false, activeIndex = 0 }: SheetColumnStyleOptions = {},
+): ViewStyle {
+  const { height: windowHeight } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  return useMemo<ViewStyle>(() => {
+    if (Platform.OS !== 'ios' || enableDynamicSizing || !snapPoints || snapPoints.length === 0) {
+      return fillStyle;
+    }
+    const index = Math.min(Math.max(activeIndex, 0), snapPoints.length - 1);
+    const height = detentColumnHeight(snapPoints[index], windowHeight, insets.top);
+    return height == null ? fillStyle : { height };
+  }, [snapPoints, enableDynamicSizing, activeIndex, windowHeight, insets.top]);
+}
+
+function detentColumnHeight(snapPoint: string | number, windowHeight: number, topInset: number): number | null {
+  if (typeof snapPoint === 'number') {
+    return Math.round(snapPoint) - SHEET_TOP_CHROME_PT;
+  }
+  const trimmed = snapPoint.trim();
+  if (!trimmed.endsWith('%')) return null;
+  const fraction = parseFloat(trimmed) / 100;
+  if (!Number.isFinite(fraction)) return null;
+  return Math.round((windowHeight - topInset) * fraction) - SHEET_TOP_CHROME_PT;
+}

--- a/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
+++ b/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
@@ -78,7 +78,7 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
   };
 
   return (
-    <ModalSheet ref={sheetRef} snapPoints={snapPoints} scrollable contentContainerStyle={styles.content} glass={false}>
+    <ModalSheet ref={sheetRef} snapPoints={snapPoints} scrollable contentContainerStyle={styles.content}>
       <View style={styles.headerRow}>
         <Text variant="title3" style={styles.title}>
           {title}

--- a/packages/mobile/src/components/you/CommentSheet.tsx
+++ b/packages/mobile/src/components/you/CommentSheet.tsx
@@ -56,11 +56,7 @@ export function CommentSheet({ sheetRef, entityId, entityType = 'session', onClo
       ref={sheetRef}
       snapPoints={['60%', '90%']}
       scrollable
-      fullWindowOverlay
       onClose={onClose}
-      keyboardBehavior="interactive"
-      keyboardBlurBehavior="restore"
-      android_keyboardInputMode="adjustResize"
       footer={
         <View style={styles.composer}>
           <BottomSheetTextInput

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -270,11 +270,7 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
       ref={sheetRef}
       snapPoints={['75%', '92%']}
       scrollable
-      fullWindowOverlay
       onClose={onClose}
-      keyboardBehavior="interactive"
-      keyboardBlurBehavior="restore"
-      android_keyboardInputMode="adjustResize"
       footer={
         <Button title={t('mobile.logbook.save')} onPress={save} loading={updateTick.isPending} disabled={isMutating} />
       }

--- a/packages/mobile/src/components/you/LogbookFilterSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookFilterSheet.tsx
@@ -82,22 +82,41 @@ export function LogbookFilterSheet({
   const [sectionResetKey, setSectionResetKey] = useState(0);
 
   // Commit-on-close: there's no Apply button — the draft applies when the sheet
-  // is dismissed (swipe down / scrim). The ref holds the latest draft so the
-  // stable dismiss handler commits the newest values, never a stale closure.
+  // closes. The ref holds the latest draft so the stable commit reads the newest
+  // values, never a stale closure.
   const draftRef = useRef({ filters: draftFilters, sort: draftSort });
   useEffect(() => {
     draftRef.current = { filters: draftFilters, sort: draftSort };
   }, [draftFilters, draftSort]);
 
-  const handleDismiss = useCallback(() => {
+  // One commit per open. A user pan-down (onClose → handleDismiss) and the
+  // unmount cleanup below both call this, so the guard prevents a double-apply.
+  const committedRef = useRef(false);
+  const commitDraft = useCallback(() => {
+    if (committedRef.current) return;
+    committedRef.current = true;
     onApply(draftRef.current.filters, draftRef.current.sort);
+  }, [onApply]);
+
+  const handleDismiss = useCallback(() => {
+    commitDraft();
     onDismiss();
-  }, [onApply, onDismiss]);
+  }, [commitDraft, onDismiss]);
 
   // The parent only mounts the sheet while it should be open, so present/dismiss
   // route through the coordinator (serialized, no overlapping native transitions).
   // A user pan-down / scrim tap fires onClose → handleDismiss (commit the draft).
   const managed = useManagedSheet({ open: true, sheetRef, onClose: handleDismiss });
+
+  // Commit on unmount too: a programmatic close — the parent unmounting the sheet,
+  // or a coordinator-driven dismiss — never fires onClose, so the draft would
+  // otherwise be discarded silently. Read commitDraft through a ref so the cleanup
+  // runs only on real unmount (empty deps), not on every onApply identity change.
+  const commitDraftRef = useRef(commitDraft);
+  commitDraftRef.current = commitDraft;
+  useEffect(() => {
+    return () => commitDraftRef.current();
+  }, []);
 
   const snapPoints = useMemo(() => androidSafeSnapPoints(['90%']), []);
   // One stable "today" ceiling so the To-date row's maximumDate prop keeps a

--- a/packages/mobile/src/components/you/YouFilterSheet.tsx
+++ b/packages/mobile/src/components/you/YouFilterSheet.tsx
@@ -49,7 +49,6 @@ export function YouFilterSheet({
       ref={sheetRef}
       snapPoints={['55%']}
       scrollable
-      fullWindowOverlay
       footer={<Button title={t('mobile.filter.done')} onPress={() => sheetRef.current?.close()} />}
     >
       <Text variant="title3" style={styles.title}>

--- a/packages/mobile/src/components/you/__tests__/logbook-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-filter-sheet.test.tsx
@@ -288,6 +288,35 @@ describe('LogbookFilterSheet', () => {
     expect(filters.fromDate).toBe('');
   });
 
+  // Behavior 5: a programmatic close (parent unmounts the sheet without a
+  // pan-down / scrim onChange(-1)) still commits the in-progress draft, so an
+  // edit isn't discarded silently.
+  it('commits the draft on unmount when closed programmatically', () => {
+    const onApply = vi.fn();
+    const { getByTestId, unmount } = renderSheet({ onApply });
+
+    fireEvent.click(getByTestId('segment-mobile.logbook.sort-hardest'));
+    // No closeSheet() — the parent just unmounts.
+    unmount();
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    const { sort } = lastApply(onApply);
+    expect(sort.preset).toBe('hardest');
+  });
+
+  // Behavior 5 (continued): a user pan-down that already committed must not
+  // double-apply when the parent then unmounts the sheet.
+  it('does not double-commit when a user close is followed by unmount', () => {
+    const onApply = vi.fn();
+    const { getByTestId, unmount } = renderSheet({ onApply });
+
+    fireEvent.click(getByTestId('segment-mobile.logbook.sort-hardest'));
+    closeSheet();
+    unmount();
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+  });
+
   // Behavior 4 (continued): tapping the From field reveals the picker but still
   // commits nothing until a date is actually picked — Apply leaves fromDate ''.
   it('reveals the From picker without committing a date until one is picked', () => {


### PR DESCRIPTION
## Summary

Follow-up to #3352: a full pass over the post-gorhom sheet wiring, plus the HIG rework of the three climb-filter sub-pickers. JS + docs only — no native, config, or dependency changes, so everything rides OTA.

**Generalizes the #3352 iOS fix to every sheet.** The root cause we confirmed on-device (iOS can hand the RN content an unbounded height, so `flex:1` columns size to content and anything past the detent lands off-screen) applies to every `Sheet`/`ModalSheet`, not just the climb filters. A shared `useSheetColumnStyle` hook now pins each sheet's column to its active detent height on iOS — footer and footerless paths, multi-detent aware, dynamic-sizing sheets untouched — and `ClimbFilterSheet` uses the same hook.

**Sheet wiring fixes:**
- Android keyboard avoidance actually works now: the wrappers assumed the native sheet resizes for the keyboard — the Compose dialog doesn't. Footers with inputs (beta-video link, comment composer) pad above the keyboard on both platforms (was iOS-only).
- The beta-video paste field + Attach moved into a pinned footer that lifts above the keyboard (verified on emulator — previously the keyboard covered the field while typing).
- Invite sheet opens at ~60% on Android instead of full-screen (`androidSafeSnapPoints`).
- 7 sheets migrated off the legacy `isPresentedRef` + deprecated `onDismiss` pattern to the controlled `visible` prop (climb actions, playlist actions/form, BLE control, 3 accessibility pickers). The deprecated `onDismiss` prop is gone — it fired on coordinator-driven closes too, silently clearing parent state.
- Logbook filter edits also commit when the sheet unmounts, not just on pan-down (guarded against double-commit).
- Removed the inert legacy gorhom props (`glass`, `stackBehavior`, `keyboardBehavior`, `keyboardBlurBehavior`, `android_keyboardInputMode`, `fullWindowOverlay`) from the wrappers and every call site. `fullWindowOverlay` deserves a note: it was silently ignored, and restoring it can't work — native sheets present off the key window *beneath* any `FullWindowOverlay` (the PlayDrawer migration comment records this scar). `CreateDrawer`/`HoldRoleSheet` stack as sibling native hosts, which is the actual mechanism; docs updated to match reality.

**HIG rework of the filter sub-pickers** (holds / board region / setters): native stack headers with back chevron + title, "Clear all" as a headerRight (shown only when there's something to clear), hand-rolled in-body headers and "Done" buttons deleted (selection still hands off on blur, so back ≡ done). Setters page now themes through `systemColors` (was static iOS hexes), gets a bottom safe-area inset and a labeled search field.

`docs/mobile-sheets-vs-routes.md` reconciled with all of the above.

## Release Notes

- The hold, area, and setter filter pickers get proper navigation headers with a back button.
- Pasting a beta-video link no longer hides the text field behind the keyboard.
- The invite sheet opens at its intended height on Android.

## Test plan

- `vp run typecheck:mobile`, `vp run test:mobile` (389 files / 3008 tests, +2 wrapper-behavior tests, migrated sheet tests rewritten), `vp run check:mobile-bundle`, `vp check` — all green.
- Android emulator, end-to-end: all three sub-pickers (native header, headerRight Clear-all, selection handoff round trips, Apply pinned & committing), beta-video footer above the keyboard while typing (before/after verified), long-press flows, filter Reset/Apply regression sweep of #3330.
- **iOS OTA QA requested** (`pr-3371` channel) — the iOS-only surfaces: every sheet's detent-height bound (log ascent, device picker, comment composer, you-filters — footers should sit at the sheet bottom, tall footerless sheets should scroll, none clipped), the create-flow long-press hold-role picker presenting over the drawer (pre-existing behavior, unchanged by this PR, but worth confirming), and the sub-pickers' opaque native headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vegna6LURUUfTrynUmLK5N
