### PR TITLE
fix(backend): hasBetaVideo matches user's beta by ownership, per climb

### DIFF
--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -21,6 +21,15 @@ export const schemaSQL = `
     "updated_at" timestamp DEFAULT now() NOT NULL
   );
 
+  CREATE TABLE IF NOT EXISTS "user_profiles" (
+    "user_id" text PRIMARY KEY,
+    "display_name" text,
+    "avatar_url" text,
+    "instagram_url" text,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+  );
+
   CREATE TABLE IF NOT EXISTS "user_climb_percentiles" (
     "user_id" text PRIMARY KEY NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
     "total_distinct_climbs" integer DEFAULT 0 NOT NULL,

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -21,15 +21,6 @@ export const schemaSQL = `
     "updated_at" timestamp DEFAULT now() NOT NULL
   );
 
-  CREATE TABLE IF NOT EXISTS "user_profiles" (
-    "user_id" text PRIMARY KEY,
-    "display_name" text,
-    "avatar_url" text,
-    "instagram_url" text,
-    "created_at" timestamp DEFAULT now() NOT NULL,
-    "updated_at" timestamp DEFAULT now() NOT NULL
-  );
-
   CREATE TABLE IF NOT EXISTS "user_climb_percentiles" (
     "user_id" text PRIMARY KEY NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
     "total_distinct_climbs" integer DEFAULT 0 NOT NULL,
@@ -347,6 +338,7 @@ export const schemaSQL = `
     "user_id" text PRIMARY KEY NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
     "display_name" text,
     "avatar_url" text,
+    "instagram_url" text,
     "created_at" timestamp DEFAULT now() NOT NULL,
     "updated_at" timestamp DEFAULT now() NOT NULL
   );

--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -520,14 +520,19 @@ describe('tickQueries — behavior fixes', () => {
   });
 
   describe('userAscentsFeed — hasBetaVideo', () => {
-    it('marks only the ascents with a directly-attached beta link', async () => {
-      const climbUuid = `${CLIMB_PREFIX}beta`;
-      await insertClimb(climbUuid, 'Beta Test Climb');
-      await insertTick({ uuid: 'tick-beta-1', climbUuid, climbedAt: '2026-06-01T10:00:00', status: 'send' });
-      await insertTick({ uuid: 'tick-beta-2', climbUuid, climbedAt: '2026-06-02T10:00:00', status: 'send' });
+    it('marks every ascent of a climb with an attached beta link, and no others', async () => {
+      // Climb-level semantics: "do I have beta for this climb" — a tick-attached
+      // link lights up ALL of the user's ascents of that climb.
+      const withBetaUuid = `${CLIMB_PREFIX}beta`;
+      const withoutBetaUuid = `${CLIMB_PREFIX}no-beta`;
+      await insertClimb(withBetaUuid, 'Beta Test Climb');
+      await insertClimb(withoutBetaUuid, 'No Beta Climb');
+      await insertTick({ uuid: 'tick-beta-1', climbUuid: withBetaUuid, climbedAt: '2026-06-01T10:00:00', status: 'send' });
+      await insertTick({ uuid: 'tick-beta-2', climbUuid: withBetaUuid, climbedAt: '2026-06-02T10:00:00', status: 'send' });
+      await insertTick({ uuid: 'tick-beta-3', climbUuid: withoutBetaUuid, climbedAt: '2026-06-03T10:00:00', status: 'send' });
       await db.execute(sql`
         INSERT INTO board_beta_links (board_type, climb_uuid, link, tick_uuid)
-        VALUES ('kilter', ${climbUuid}, 'https://instagram.com/p/test-beta', 'tick-beta-1')
+        VALUES ('kilter', ${withBetaUuid}, 'https://instagram.com/p/test-beta', 'tick-beta-1')
       `);
 
       const result = await callUserAscentsFeed(TEST_USER_ID, { sortBy: 'recent' });
@@ -535,7 +540,26 @@ describe('tickQueries — behavior fixes', () => {
         (result.items as Array<FeedItem & { hasBetaVideo: boolean }>).map((item) => [item.uuid, item.hasBetaVideo]),
       );
       expect(byUuid.get('tick-beta-1')).toBe(true);
-      expect(byUuid.get('tick-beta-2')).toBe(false);
+      expect(byUuid.get('tick-beta-2')).toBe(true);
+      expect(byUuid.get('tick-beta-3')).toBe(false);
+    });
+
+    it('matches legacy links by createdByUserId when tick_uuid is null', async () => {
+      // Aurora-synced/backfilled rows carry no tick_uuid — ownership matches
+      // the shelf's userBetaLinks semantics instead.
+      const legacyUuid = `${CLIMB_PREFIX}beta-legacy`;
+      await insertClimb(legacyUuid, 'Legacy Beta Climb');
+      await insertTick({ uuid: 'tick-beta-legacy', climbUuid: legacyUuid, climbedAt: '2026-06-04T10:00:00', status: 'send' });
+      await db.execute(sql`
+        INSERT INTO board_beta_links (board_type, climb_uuid, link, created_by_user_id)
+        VALUES ('kilter', ${legacyUuid}, 'https://instagram.com/p/test-beta-legacy', ${TEST_USER_ID})
+      `);
+
+      const result = await callUserAscentsFeed(TEST_USER_ID, { sortBy: 'recent' });
+      const byUuid = new Map(
+        (result.items as Array<FeedItem & { hasBetaVideo: boolean }>).map((item) => [item.uuid, item.hasBetaVideo]),
+      );
+      expect(byUuid.get('tick-beta-legacy')).toBe(true);
     });
 
     it('flows hasBetaVideo through the caption-matches shared builder', async () => {

--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -527,9 +527,24 @@ describe('tickQueries — behavior fixes', () => {
       const withoutBetaUuid = `${CLIMB_PREFIX}no-beta`;
       await insertClimb(withBetaUuid, 'Beta Test Climb');
       await insertClimb(withoutBetaUuid, 'No Beta Climb');
-      await insertTick({ uuid: 'tick-beta-1', climbUuid: withBetaUuid, climbedAt: '2026-06-01T10:00:00', status: 'send' });
-      await insertTick({ uuid: 'tick-beta-2', climbUuid: withBetaUuid, climbedAt: '2026-06-02T10:00:00', status: 'send' });
-      await insertTick({ uuid: 'tick-beta-3', climbUuid: withoutBetaUuid, climbedAt: '2026-06-03T10:00:00', status: 'send' });
+      await insertTick({
+        uuid: 'tick-beta-1',
+        climbUuid: withBetaUuid,
+        climbedAt: '2026-06-01T10:00:00',
+        status: 'send',
+      });
+      await insertTick({
+        uuid: 'tick-beta-2',
+        climbUuid: withBetaUuid,
+        climbedAt: '2026-06-02T10:00:00',
+        status: 'send',
+      });
+      await insertTick({
+        uuid: 'tick-beta-3',
+        climbUuid: withoutBetaUuid,
+        climbedAt: '2026-06-03T10:00:00',
+        status: 'send',
+      });
       await db.execute(sql`
         INSERT INTO board_beta_links (board_type, climb_uuid, link, tick_uuid)
         VALUES ('kilter', ${withBetaUuid}, 'https://instagram.com/p/test-beta', 'tick-beta-1')
@@ -549,7 +564,12 @@ describe('tickQueries — behavior fixes', () => {
       // the shelf's userBetaLinks semantics instead.
       const legacyUuid = `${CLIMB_PREFIX}beta-legacy`;
       await insertClimb(legacyUuid, 'Legacy Beta Climb');
-      await insertTick({ uuid: 'tick-beta-legacy', climbUuid: legacyUuid, climbedAt: '2026-06-04T10:00:00', status: 'send' });
+      await insertTick({
+        uuid: 'tick-beta-legacy',
+        climbUuid: legacyUuid,
+        climbedAt: '2026-06-04T10:00:00',
+        status: 'send',
+      });
       await db.execute(sql`
         INSERT INTO board_beta_links (board_type, climb_uuid, link, created_by_user_id)
         VALUES ('kilter', ${legacyUuid}, 'https://instagram.com/p/test-beta-legacy', ${TEST_USER_ID})

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -84,8 +84,9 @@ const RECENT_BETA_LINKS_CACHE_SIZE = RECENT_BETA_LINKS_MAX_LIMIT * 2;
 // Extract an Instagram handle from `userProfiles.instagramUrl`. The field
 // holds a profile URL — we only want the handle so we can match against
 // `board_beta_links.foreign_username`. Returns null for anything that
-// doesn't look like a recognisable instagram.com profile URL.
-function extractInstagramHandle(profileUrl: string | null): string | null {
+// doesn't look like a recognisable instagram.com profile URL. Exported for
+// the ascents feed's hasBetaVideo, which shares these ownership semantics.
+export function extractInstagramHandle(profileUrl: string | null): string | null {
   if (!profileUrl) return null;
   const trimmed = profileUrl.trim();
   if (!trimmed) return null;

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -18,6 +18,7 @@ import {
 } from '../shared/sql-expressions';
 import { GetTicksInputSchema, BoardNameSchema, AscentFeedInputSchema } from '../../../validation/schemas';
 import { escapeLikePattern } from '../../../utils/like-pattern';
+import { extractInstagramHandle } from '../beta-videos/queries';
 
 // Shape of a row produced by the userAscentsFeed item mapper. Declared so
 // userAscentCaptionMatches (which reuses that builder) returns a typed ascent
@@ -522,20 +523,33 @@ export const tickQueries = {
       .limit(limit)
       .offset(offset);
 
-    // One query for the whole page: which of these ascents have a beta video
-    // directly attached (board_beta_links.tick_uuid, unique per tick). Drives
-    // the logbook row's video marker without an N+1.
+    // Which of this page's CLIMBS carry a beta video of this user's. Ownership
+    // mirrors userBetaLinks (the profile beta shelf): a link the user created,
+    // one matching their Instagram handle (Aurora-synced/backfilled legacy rows
+    // have tick_uuid NULL), or one directly attached to a tick on this page.
+    // Climb-level on purpose — "do I have beta for this climb" — and batched:
+    // two queries per page (profile handle + links), no N+1.
     const pageTickUuids = results.map(({ tick }) => tick.uuid);
-    const betaLinkRows =
-      pageTickUuids.length > 0
-        ? await db
-            .select({ tickUuid: dbSchema.boardBetaLinks.tickUuid })
-            .from(dbSchema.boardBetaLinks)
-            .where(inArray(dbSchema.boardBetaLinks.tickUuid, pageTickUuids))
-        : [];
-    const ticksWithBeta = new Set(
-      betaLinkRows.map((row) => row.tickUuid).filter((tickUuid): tickUuid is string => tickUuid !== null),
-    );
+    const pageClimbUuids = Array.from(new Set(results.map(({ tick }) => tick.climbUuid)));
+    let climbsWithBeta = new Set<string>();
+    if (pageClimbUuids.length > 0) {
+      const profileRows = await db
+        .select({ instagramUrl: dbSchema.userProfiles.instagramUrl })
+        .from(dbSchema.userProfiles)
+        .where(eq(dbSchema.userProfiles.userId, userId))
+        .limit(1);
+      const igHandle = extractInstagramHandle(profileRows[0]?.instagramUrl ?? null);
+      const ownershipConditions = [
+        eq(dbSchema.boardBetaLinks.createdByUserId, userId),
+        inArray(dbSchema.boardBetaLinks.tickUuid, pageTickUuids),
+        ...(igHandle ? [eq(dbSchema.boardBetaLinks.foreignUsername, igHandle)] : []),
+      ];
+      const betaLinkRows = await db
+        .select({ boardType: dbSchema.boardBetaLinks.boardType, climbUuid: dbSchema.boardBetaLinks.climbUuid })
+        .from(dbSchema.boardBetaLinks)
+        .where(and(inArray(dbSchema.boardBetaLinks.climbUuid, pageClimbUuids), or(...ownershipConditions)));
+      climbsWithBeta = new Set(betaLinkRows.map((row) => `${row.boardType}:${row.climbUuid}`));
+    }
 
     // Map results to response format
     const items = results.map(
@@ -584,7 +598,7 @@ export const tickQueries = {
           comment: tick.comment || '',
           climbedAt: tick.climbedAt,
           frames,
-          hasBetaVideo: ticksWithBeta.has(tick.uuid),
+          hasBetaVideo: climbsWithBeta.has(`${tick.boardType}:${tick.climbUuid}`),
         };
       },
     );

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -984,9 +984,11 @@ type AscentFeedItem {
   "Average quality rating from all users"
   qualityAverage: Float
   """
-  Whether a beta video is attached to this ascent (board_beta_links.tick_uuid).
-  Populated by userAscentsFeed/userAscentCaptionMatches; null on feeds that
-  don't resolve it (following/global activity).
+  Whether the user has a beta video for this CLIMB — a board_beta_links row
+  they created, one matching their Instagram handle (legacy synced rows), or
+  one attached to the tick. Populated by userAscentsFeed and
+  userAscentCaptionMatches; null on feeds that don't resolve it
+  (following/global activity).
   """
   hasBetaVideo: Boolean
   "Whether this is a benchmark climb"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -239,9 +239,11 @@ export type AscentFeedItem = {
   /** Encoded hold frames for thumbnail display */
   frames?: Maybe<Scalars['String']['output']>;
   /**
-   * Whether a beta video is attached to this ascent (board_beta_links.tick_uuid).
-   * Populated by userAscentsFeed/userAscentCaptionMatches; null on feeds that
-   * don't resolve it (following/global activity).
+   * Whether the user has a beta video for this CLIMB — a board_beta_links row
+   * they created, one matching their Instagram handle (legacy synced rows), or
+   * one attached to the tick. Populated by userAscentsFeed and
+   * userAscentCaptionMatches; null on feeds that don't resolve it
+   * (following/global activity).
    */
   hasBetaVideo?: Maybe<Scalars['Boolean']['output']>;
   /** Whether this is a benchmark climb */

--- a/packages/shared-schema/src/schema/activity-feed.ts
+++ b/packages/shared-schema/src/schema/activity-feed.ts
@@ -44,9 +44,11 @@ export const activityFeedTypeDefs = /* GraphQL */ `
     "Average quality rating from all users"
     qualityAverage: Float
     """
-    Whether a beta video is attached to this ascent (board_beta_links.tick_uuid).
-    Populated by userAscentsFeed/userAscentCaptionMatches; null on feeds that
-    don't resolve it (following/global activity).
+    Whether the user has a beta video for this CLIMB — a board_beta_links row
+    they created, one matching their Instagram handle (legacy synced rows), or
+    one attached to the tick. Populated by userAscentsFeed and
+    userAscentCaptionMatches; null on feeds that don't resolve it
+    (following/global activity).
     """
     hasBetaVideo: Boolean
     "Whether this is a benchmark climb"

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -236,9 +236,11 @@ export type AscentFeedItem = {
   /** Encoded hold frames for thumbnail display */
   frames?: Maybe<Scalars['String']['output']>;
   /**
-   * Whether a beta video is attached to this ascent (board_beta_links.tick_uuid).
-   * Populated by userAscentsFeed/userAscentCaptionMatches; null on feeds that
-   * don't resolve it (following/global activity).
+   * Whether the user has a beta video for this CLIMB — a board_beta_links row
+   * they created, one matching their Instagram handle (legacy synced rows), or
+   * one attached to the tick. Populated by userAscentsFeed and
+   * userAscentCaptionMatches; null on feeds that don't resolve it
+   * (following/global activity).
    */
   hasBetaVideo?: Maybe<Scalars['Boolean']['output']>;
   /** Whether this is a benchmark climb */


### PR DESCRIPTION
## Summary

Follow-up to #3355, found during on-device review of #3350: the `tick_uuid`-only join missed every legacy beta link (Aurora-synced and IG-backfilled rows have `tick_uuid = NULL`), so the logbook's video marker never lit on real data.

`hasBetaVideo` now uses the same ownership semantics as `userBetaLinks` (the profile beta shelf): `createdByUserId = user` OR `foreignUsername = user's IG handle` OR a directly attached tick — keyed per **climb**, which matches the product ask ("do I have a video for this climb"). Batched as before: two queries per feed page (profile-handle lookup + links), no N+1.

No mobile change needed — the deployed bundle already selects the field; icons appear as soon as this deploys.

Integration tests updated for climb-level semantics + a new legacy `created_by_user_id` case.

## Release Notes

- [x] No release note needed (internal / technical change — user-facing part ships with #3350)

## Test plan

- `vp run typecheck:backend` / `typecheck:shared` — green.
- `tick-queries.test.ts`: same-climb ascents all marked, different climb unmarked, legacy createdByUserId row marked (CI runs the DB suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
