### PR TITLE
refactor(web): derive session id and unify end/leave with a single summary dialog

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -25,7 +25,6 @@ import { PlaylistsProvider } from '../climb-actions/playlists-batch-context';
 import { useClimbActionsData } from '@/app/hooks/use-climb-actions-data';
 import { SUGGESTIONS_THRESHOLD } from '../board-page/constants';
 import { useSnackbar } from '../providers/snackbar-provider';
-import SessionSummaryDialog from '../session-summary/session-summary-dialog';
 import { trackQueueOperation, trackQueueOperationError } from '@/app/lib/queue-metrics';
 
 import { useSessionIdManagement } from './hooks/use-session-id-management';
@@ -178,8 +177,6 @@ export const GraphQLQueueProvider = ({
     startSession,
     joinSession,
     endSession,
-    sessionSummary,
-    dismissSessionSummary,
   } = useSessionIdManagement({
     isOffBoardMode,
     propsBaseBoardPath,
@@ -469,7 +466,6 @@ export const GraphQLQueueProvider = ({
     startSession,
     joinSession,
     endSession,
-    dismissSessionSummary,
     fetchMoreClimbs,
     validateQueueAdd,
     boardDetails,
@@ -495,7 +491,6 @@ export const GraphQLQueueProvider = ({
     startSession,
     joinSession,
     endSession,
-    dismissSessionSummary,
     fetchMoreClimbs,
     validateQueueAdd,
     boardDetails,
@@ -773,10 +768,6 @@ export const GraphQLQueueProvider = ({
     latestRef.current.endSession();
   }, []);
 
-  const stableDismissSessionSummary = useCallback(() => {
-    latestRef.current.dismissSessionSummary();
-  }, []);
-
   const stableDisconnect = useCallback(() => {
     latestRef.current.persistentSession.deactivateSession();
   }, []);
@@ -810,7 +801,6 @@ export const GraphQLQueueProvider = ({
       startSession: stableStartSession,
       joinSession: stableJoinSession,
       endSession: stableEndSession,
-      dismissSessionSummary: stableDismissSessionSummary,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
@@ -841,7 +831,6 @@ export const GraphQLQueueProvider = ({
       isSessionActive,
       isPersistentSessionActive,
       sessionId,
-      sessionSummary,
       sessionGoal: isPersistentSessionActive ? (persistentSession.session?.goal ?? null) : null,
       connectionState,
       canMutate,
@@ -873,7 +862,6 @@ export const GraphQLQueueProvider = ({
       parsedParams,
       isSessionActive,
       sessionId,
-      sessionSummary,
       isPersistentSessionActive,
       persistentSession.session?.goal,
       connectionState,
@@ -939,7 +927,6 @@ export const GraphQLQueueProvider = ({
       isSessionActive,
       isPersistentSessionActive,
       sessionId,
-      sessionSummary,
       sessionGoal: isPersistentSessionActive ? (persistentSession.session?.goal ?? null) : null,
       connectionState,
       canMutate,
@@ -958,7 +945,6 @@ export const GraphQLQueueProvider = ({
       viewOnlyMode,
       isSessionActive,
       sessionId,
-      sessionSummary,
       isPersistentSessionActive,
       persistentSession.session?.goal,
       connectionState,
@@ -987,7 +973,9 @@ export const GraphQLQueueProvider = ({
                   <FavoritesProvider {...favoritesProviderProps}>
                     <PlaylistsProvider {...playlistsProviderProps}>{children}</PlaylistsProvider>
                   </FavoritesProvider>
-                  <SessionSummaryDialog summary={sessionSummary} onDismiss={stableDismissSessionSummary} />
+                  {/* Session summary dialog is rendered once at the root
+                      (persistent-session-wrapper.tsx), reading the single
+                      root-owned summary state — no board-route-local copy. */}
                 </SessionContext.Provider>
               </SearchContext.Provider>
             </QueueListContext.Provider>

--- a/packages/web/app/components/graphql-queue/hooks/__tests__/use-session-id-management.test.tsx
+++ b/packages/web/app/components/graphql-queue/hooks/__tests__/use-session-id-management.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { renderHook, act } from '@testing-library/react';
+import { useSessionIdManagement } from '../use-session-id-management';
+
+// --- Cookie (non-reactive document.cookie) — mocked with a module-level mirror ---
+let mockCookie: string | null = null;
+const mockSetCookie = vi.fn((value: string) => {
+  mockCookie = value;
+});
+const mockClearCookie = vi.fn(() => {
+  mockCookie = null;
+});
+vi.mock('@/app/lib/climb-session-cookie', () => ({
+  getClimbSessionCookie: () => mockCookie,
+  setClimbSessionCookie: (value: string) => mockSetCookie(value),
+  clearClimbSessionCookie: () => mockClearCookie(),
+}));
+
+// --- Routing ---
+let mockSearchParams = new URLSearchParams();
+let mockPathname = '/kilter/8/5/12/40';
+const mockRouterReplace = vi.fn();
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  usePathname: () => mockPathname,
+}));
+vi.mock('@/app/lib/i18n/use-locale-router', () => ({
+  useLocaleRouter: () => ({ replace: mockRouterReplace, push: vi.fn() }),
+}));
+
+// --- Persistent session (root) ---
+type MockActiveSession = {
+  sessionId: string;
+  boardPath: string;
+  parsedParams?: { board_name?: string };
+} | null;
+let mockActiveSession: MockActiveSession = null;
+const mockEndSessionWithSummary = vi.fn();
+const mockDeactivateSession = vi.fn();
+const mockSetInitialQueueForSession = vi.fn();
+vi.mock('@/app/components/persistent-session', () => ({
+  usePersistentSession: () => ({
+    activeSession: mockActiveSession,
+    endSessionWithSummary: mockEndSessionWithSummary,
+    deactivateSession: mockDeactivateSession,
+    setInitialQueueForSession: mockSetInitialQueueForSession,
+  }),
+}));
+
+vi.mock('@/app/components/connection-manager/connection-settings-context', () => ({
+  useConnectionSettings: () => ({ backendUrl: 'wss://backend.test' }),
+}));
+
+const mockEmitSessionEnded = vi.fn();
+vi.mock('@/app/lib/session-lifecycle-tracking', () => ({
+  emitSessionEnded: (...args: unknown[]) => mockEmitSessionEnded(...args),
+}));
+
+vi.mock('@/app/lib/session-history-db', () => ({
+  saveSessionToHistory: vi.fn(async () => {}),
+}));
+
+function renderSessionId(params?: { isOffBoardMode?: boolean; propsBaseBoardPath?: string }) {
+  return renderHook(() =>
+    useSessionIdManagement({
+      isOffBoardMode: params?.isOffBoardMode ?? false,
+      propsBaseBoardPath: params?.propsBaseBoardPath,
+      currentQueue: [],
+      currentClimbQueueItem: null,
+    }),
+  );
+}
+
+describe('useSessionIdManagement — session id derivation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCookie = null;
+    mockSearchParams = new URLSearchParams();
+    mockPathname = '/kilter/8/5/12/40';
+    mockActiveSession = null;
+  });
+
+  it('board route: derives the id from the cookie when no persistent session exists', () => {
+    mockCookie = 'cookie-sess';
+    const { result } = renderSessionId();
+    expect(result.current.sessionId).toBe('cookie-sess');
+    expect(result.current.isPersistentSessionActive).toBe(false);
+  });
+
+  it('off-board: derives the id from the persistent session and ignores the cookie', () => {
+    mockCookie = 'stale-cookie';
+    mockActiveSession = { sessionId: 'persist-sess', boardPath: '/kilter/8/5/12/40' };
+    const { result } = renderSessionId({ isOffBoardMode: true, propsBaseBoardPath: '/kilter/8/5/12' });
+    expect(result.current.sessionId).toBe('persist-sess');
+  });
+
+  it('board route: adopts the persistent session id when its board matches the route', () => {
+    mockCookie = 'persist-sess';
+    mockActiveSession = { sessionId: 'persist-sess', boardPath: '/kilter/8/5/12/40' };
+    const { result } = renderSessionId();
+    expect(result.current.sessionId).toBe('persist-sess');
+    expect(result.current.isPersistentSessionActive).toBe(true);
+  });
+
+  it('board route: does NOT leak a different board’s persistent session id (multi-session restore race)', () => {
+    // Session for a kilter board is held in IndexedDB while the user browses a
+    // tension board that has its own cookie. The derivation must read the
+    // tension cookie, not the foreign kilter session id.
+    mockPathname = '/tension/1/2/3/40';
+    mockCookie = 'tension-cookie-sess';
+    mockActiveSession = { sessionId: 'kilter-board-sess', boardPath: '/kilter/8/5/12/40' };
+    const { result } = renderSessionId();
+    expect(result.current.sessionId).toBe('tension-cookie-sess');
+    expect(result.current.isPersistentSessionActive).toBe(false);
+  });
+
+  it('board route: keeps reading the cookie during the IndexedDB-load window (persistent id briefly null)', () => {
+    mockCookie = 'cookie-sess';
+    mockActiveSession = null; // restore not yet complete
+    const { result } = renderSessionId();
+    expect(result.current.sessionId).toBe('cookie-sess');
+  });
+
+  it('migrates a legacy ?session= param to the cookie and strips it from the URL', () => {
+    mockSearchParams = new URLSearchParams('session=migrated-sess&foo=bar');
+    const { result } = renderSessionId();
+    expect(mockSetCookie).toHaveBeenCalledWith('migrated-sess');
+    expect(result.current.sessionId).toBe('migrated-sess');
+    expect(mockRouterReplace).toHaveBeenCalledWith('/kilter/8/5/12/40?foo=bar', { scroll: false });
+  });
+
+  it('clears the cookie mirror when the persistent session is deactivated externally (active→null)', () => {
+    mockCookie = 'persist-sess';
+    mockActiveSession = { sessionId: 'persist-sess', boardPath: '/kilter/8/5/12/40' };
+    const { result, rerender } = renderSessionId();
+    expect(result.current.sessionId).toBe('persist-sess');
+
+    // External deactivation (e.g. the sesh-settings drawer's stop).
+    mockActiveSession = null;
+    rerender();
+
+    expect(mockClearCookie).toHaveBeenCalled();
+    expect(result.current.sessionId).toBeNull();
+  });
+});
+
+describe('useSessionIdManagement — endSession routes through the root summary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCookie = null;
+    mockSearchParams = new URLSearchParams();
+    mockPathname = '/kilter/8/5/12/40';
+    mockActiveSession = null;
+  });
+
+  it('emits user_left, clears the cookie, and delegates to endSessionWithSummary with board type', () => {
+    mockCookie = 'persist-sess';
+    mockActiveSession = {
+      sessionId: 'persist-sess',
+      boardPath: '/kilter/8/5/12/40',
+      parsedParams: { board_name: 'kilter' },
+    };
+    const { result } = renderSessionId();
+
+    act(() => {
+      result.current.endSession();
+    });
+
+    expect(mockEmitSessionEnded).toHaveBeenCalledWith('persist-sess', 'user_left');
+    expect(mockClearCookie).toHaveBeenCalled();
+    expect(mockEndSessionWithSummary).toHaveBeenCalledWith({ sessionId: 'persist-sess', boardType: 'kilter' });
+    // The root owns deactivation now (endSessionWithSummary calls it) — the hook
+    // no longer deactivates directly.
+    expect(mockDeactivateSession).not.toHaveBeenCalled();
+  });
+
+  it('cookie-only edge case: passes the cookie id and a path-derived board type when no session was activated', () => {
+    // Cookie holds a session BoardSessionBridge never activated, so there is no
+    // active persistent session to read the id/board type from.
+    mockPathname = '/tension/1/2/3/40';
+    mockCookie = 'cookie-only-sess';
+    mockActiveSession = null;
+    const { result } = renderSessionId();
+
+    act(() => {
+      result.current.endSession();
+    });
+
+    expect(mockEndSessionWithSummary).toHaveBeenCalledWith({ sessionId: 'cookie-only-sess', boardType: 'tension' });
+  });
+});

--- a/packages/web/app/components/graphql-queue/hooks/__tests__/use-session-id-management.test.tsx
+++ b/packages/web/app/components/graphql-queue/hooks/__tests__/use-session-id-management.test.tsx
@@ -114,6 +114,17 @@ describe('useSessionIdManagement — session id derivation', () => {
     expect(result.current.isPersistentSessionActive).toBe(false);
   });
 
+  it('board route: does NOT adopt a persistent session that has no boardPath (falls back to the cookie)', () => {
+    // A malformed/boardless active session must match NOTHING — the strict match
+    // (activeSessionBoardPath === baseBoardPath) makes its null board path fail
+    // for every route, so the derivation reads the cookie rather than adopting it.
+    mockCookie = 'cookie-sess';
+    mockActiveSession = { sessionId: 'boardless-sess', boardPath: '' };
+    const { result } = renderSessionId();
+    expect(result.current.sessionId).toBe('cookie-sess');
+    expect(result.current.isPersistentSessionActive).toBe(false);
+  });
+
   it('board route: keeps reading the cookie during the IndexedDB-load window (persistent id briefly null)', () => {
     mockCookie = 'cookie-sess';
     mockActiveSession = null; // restore not yet complete

--- a/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
@@ -61,10 +61,14 @@ export function useSessionIdManagement({
   //     the user browses board Y must not leak X's id into board Y (which would
   //     flicker `isPersistentSessionActive` true on the wrong board); the match
   //     keeps board Y reading its own cookie.
+  //
+  // The match is intentionally strict: an active session with no `boardPath`
+  // matches NOTHING (its `activeSessionBoardPath` is null), so every board route
+  // falls back to its own cookie rather than adopting the boardless session.
+  // A permissive `!activeSessionBoardPath` arm would re-open the multi-session
+  // restore race the deleted sync effects guarded against.
   const boardMatchedPersistentSessionId =
-    persistentSessionId && (!activeSessionBoardPath || activeSessionBoardPath === baseBoardPath)
-      ? persistentSessionId
-      : null;
+    persistentSessionId && activeSessionBoardPath === baseBoardPath ? persistentSessionId : null;
 
   const sessionId = isOffBoardMode ? persistentSessionId : (boardMatchedPersistentSessionId ?? cookieSessionId);
 
@@ -162,10 +166,13 @@ export function useSessionIdManagement({
   const endSession = useCallback(() => {
     const endingSessionId = sessionId;
     if (endingSessionId) emitSessionEnded(endingSessionId, 'user_left');
+    // Eager clear. `endSessionWithSummary` below deactivates the persistent
+    // session, which trips the `prevPersistentSessionIdRef` effect to clear the
+    // cookie again — a harmless, idempotent double-clear.
     clearClimbSessionCookie();
     setCookieSessionId(null);
     const boardType =
-      persistentSession.activeSession?.parsedParams.board_name ?? baseBoardPath.split('/').filter(Boolean)[0] ?? null;
+      persistentSession.activeSession?.parsedParams?.board_name ?? baseBoardPath.split('/').filter(Boolean)[0] ?? null;
     persistentSession.endSessionWithSummary({ sessionId: endingSessionId, boardType });
   }, [persistentSession, sessionId, baseBoardPath]);
 

--- a/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
@@ -7,13 +7,8 @@ import { saveSessionToHistory } from '@/app/lib/session-history-db';
 import { getClimbSessionCookie, setClimbSessionCookie, clearClimbSessionCookie } from '@/app/lib/climb-session-cookie';
 import { usePersistentSession } from '../../persistent-session';
 import { useConnectionSettings } from '../../connection-manager/connection-settings-context';
-import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
-import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
-import { END_SESSION as END_SESSION_GQL, type EndSessionResponse } from '@boardsesh/graphql/operations/sessions';
 import { emitSessionEnded } from '@/app/lib/session-lifecycle-tracking';
-import type { SessionSummary } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem } from '../../queue-control/types';
-import { getBrowserTimezone } from '@/app/lib/browser-timezone';
 
 type UseSessionIdManagementParams = {
   isOffBoardMode: boolean;
@@ -32,23 +27,46 @@ export function useSessionIdManagement({
   const router = useLocaleRouter();
   const pathname = usePathname();
   const { backendUrl } = useConnectionSettings();
-  const { token: wsAuthToken } = useWsAuthToken();
   const persistentSession = usePersistentSession();
 
-  // Session ID source differs by mode:
-  // - Board mode: read from cookie (previously URL ?session= param)
-  // - Off-board mode: read from persistent IndexedDB storage
-  const sessionIdFromCookie = getClimbSessionCookie();
-  const persistentSessionId = persistentSession.activeSession?.sessionId ?? null;
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(
-    isOffBoardMode ? persistentSessionId : sessionIdFromCookie,
+  // Cookie reads (`document.cookie`) are non-reactive, so we mirror the board
+  // route's session cookie in state. The start/join/migration/clear paths keep
+  // it in sync; the derived `sessionId` below reads it. Off-board mode never
+  // touches the cookie (the persistent IndexedDB session is authoritative), so
+  // its mirror starts null.
+  const [cookieSessionId, setCookieSessionId] = useState<string | null>(() =>
+    isOffBoardMode ? null : getClimbSessionCookie(),
   );
+  const persistentSessionId = persistentSession.activeSession?.sessionId ?? null;
 
-  // Compute base board path up front — the board-path gate on the
-  // persistent-session sync effect below reads it. This used to live further
-  // down (after the sync effect), so moving it up keeps the lexical order in
-  // sync with the React hook order it always ran in.
   const baseBoardPath = useMemo(() => propsBaseBoardPath ?? getBaseBoardPath(pathname), [propsBaseBoardPath, pathname]);
+
+  // Board path the persistent session belongs to (null when there's no session).
+  const activeSessionBoardPath = persistentSession.activeSession?.boardPath
+    ? getBaseBoardPath(persistentSession.activeSession.boardPath)
+    : null;
+
+  // The session id is now a pure DERIVATION of its three sources, no longer
+  // reconciled by a local `useState` + two sync effects:
+  //   - Off-board: the persistent (IndexedDB) session is the only authority.
+  //   - Board route: adopt the persistent session's id ONLY when its board
+  //     matches the route we're on, otherwise fall back to the cookie.
+  //
+  // The board-path match folds in both race windows the deleted sync effects
+  // defended:
+  //   * IndexedDB-load window — while `persistentSessionId` is briefly null
+  //     before restore completes, the fallback keeps reading the cookie instead
+  //     of wiping the id.
+  //   * Multi-session restore — a session for board X held in IndexedDB while
+  //     the user browses board Y must not leak X's id into board Y (which would
+  //     flicker `isPersistentSessionActive` true on the wrong board); the match
+  //     keeps board Y reading its own cookie.
+  const boardMatchedPersistentSessionId =
+    persistentSessionId && (!activeSessionBoardPath || activeSessionBoardPath === baseBoardPath)
+      ? persistentSessionId
+      : null;
+
+  const sessionId = isOffBoardMode ? persistentSessionId : (boardMatchedPersistentSessionId ?? cookieSessionId);
 
   // Backward compat: migrate ?session= URL param to cookie and strip from URL
   useEffect(() => {
@@ -56,7 +74,7 @@ export function useSessionIdManagement({
     const sessionFromUrl = searchParams.get('session');
     if (sessionFromUrl) {
       setClimbSessionCookie(sessionFromUrl);
-      setActiveSessionId(sessionFromUrl);
+      setCookieSessionId(sessionFromUrl);
       const params = new URLSearchParams(searchParams.toString());
       params.delete('session');
       const queryString = params.toString();
@@ -64,43 +82,12 @@ export function useSessionIdManagement({
     }
   }, [searchParams, isOffBoardMode, pathname, router]);
 
-  // Sync activeSessionId from persistent session when a new session is
-  // activated. Covers both modes:
-  //   - Off-board: persistentSessionId is the only source of truth.
-  //   - Board: the cookie set by start-sesh-drawer is the initial value, but
-  //     when the user creates a session from THIS provider's route (no
-  //     navigation, same baseBoardPath as the page they're on), nothing
-  //     else picks up the new id. Without this sync, isPersistentSessionActive
-  //     stays false and the drawer lightbulb keeps reading as "lit BLE"
-  //     (solo) instead of the session-scoped wall-confirmed indicator.
-  //
-  // Guarded on persistentSessionId being non-null so the cookie value isn't
-  // wiped during the initial IndexedDB-load window (where activeSession is
-  // briefly null before restoration completes). The active→null deactivation
-  // case is handled by the prevPersistentSessionIdRef effect below.
-  //
-  // In board mode we further gate the sync on the active session's board path
-  // matching the current route. Multi-session restore can leave session C
-  // (board X) in IndexedDB while the user is browsing board Y — without this
-  // gate we'd write C's id into board Y's cookie/state and have isPersistentSessionActive
-  // briefly flicker true on the wrong board until the boardPath check on
-  // L101-L104 settled. Off-board mode skips the gate (there's no route board
-  // to compare against; persistentSessionId is the authority).
-  const activeSessionBoardPath = persistentSession.activeSession?.boardPath
-    ? getBaseBoardPath(persistentSession.activeSession.boardPath)
-    : null;
-  useEffect(() => {
-    if (!persistentSessionId) return;
-    if (!isOffBoardMode && activeSessionBoardPath && activeSessionBoardPath !== baseBoardPath) {
-      return;
-    }
-    setActiveSessionId(persistentSessionId);
-  }, [persistentSessionId, isOffBoardMode, activeSessionBoardPath, baseBoardPath]);
-
-  // Sync when persistent session is deactivated externally (e.g. sesh-settings-drawer
-  // calling deactivateSession() directly). We track the previous persistentSessionId
-  // so we only clear on an active→inactive transition, not on initial mount where
-  // persistentSessionId starts null before IndexedDB loads.
+  // Clear the cookie mirror when the persistent session is deactivated
+  // externally (e.g. the sesh-settings drawer's stop calling deactivateSession()
+  // directly). We track the previous persistentSessionId so we only clear on an
+  // active→inactive transition, not on the initial mount where persistentSessionId
+  // starts null before IndexedDB loads. This is the ONE cookie-clear effect that
+  // survives the derivation refactor.
   const prevPersistentSessionIdRef = useRef(persistentSessionId);
   useEffect(() => {
     const prev = prevPersistentSessionIdRef.current;
@@ -108,21 +95,15 @@ export function useSessionIdManagement({
 
     if (prev && !persistentSessionId) {
       clearClimbSessionCookie();
-      setActiveSessionId(null);
+      setCookieSessionId(null);
     }
   }, [persistentSessionId]);
-
-  const sessionId = activeSessionId;
 
   // Check if persistent session is active for this board
   const isPersistentSessionActive =
     persistentSession.activeSession?.sessionId === sessionId &&
     (persistentSession.activeSession?.boardPath ? getBaseBoardPath(persistentSession.activeSession.boardPath) : '') ===
       baseBoardPath;
-
-  // Session summary state
-  const [sessionSummary, setSessionSummary] = useState<SessionSummary | null>(null);
-  const dismissSessionSummary = useCallback(() => setSessionSummary(null), []);
 
   // Session management functions
   const startSession = useCallback(
@@ -137,7 +118,7 @@ export function useSessionIdManagement({
       }
 
       setClimbSessionCookie(newSessionId);
-      setActiveSessionId(newSessionId);
+      setCookieSessionId(newSessionId);
 
       await saveSessionToHistory({
         id: newSessionId,
@@ -158,7 +139,7 @@ export function useSessionIdManagement({
       if (!backendUrl) throw new Error('Backend URL not configured');
 
       setClimbSessionCookie(sessionIdToJoin);
-      setActiveSessionId(sessionIdToJoin);
+      setCookieSessionId(sessionIdToJoin);
 
       await saveSessionToHistory({
         id: sessionIdToJoin,
@@ -171,27 +152,25 @@ export function useSessionIdManagement({
     [backendUrl, pathname, isOffBoardMode],
   );
 
+  // End the session for everyone (with a summary dialog). Routes through the
+  // root `endSessionWithSummary`, which owns the single session-summary state +
+  // dialog (persistent-session-wrapper.tsx) — no more board-route-local summary.
+  // The `{ sessionId, boardType }` override preserves the board-route edge case:
+  // the cookie can hold a session the persistent provider never activated (before
+  // `BoardSessionBridge` runs), so we pass the cookie-derived id/board type
+  // directly rather than relying on the (possibly still-null) active session.
   const endSession = useCallback(() => {
-    const endingSessionId = activeSessionId;
+    const endingSessionId = sessionId;
     if (endingSessionId) emitSessionEnded(endingSessionId, 'user_left');
-    persistentSession.deactivateSession({ notifyServer: false });
     clearClimbSessionCookie();
-    setActiveSessionId(null);
-
-    if (endingSessionId && wsAuthToken) {
-      const client = createGraphQLHttpClient(wsAuthToken);
-      client
-        .request<EndSessionResponse>(END_SESSION_GQL, { sessionId: endingSessionId, timezone: getBrowserTimezone() })
-        .then((response: EndSessionResponse) => {
-          if (response.endSession) setSessionSummary(response.endSession);
-        })
-        .catch((err: unknown) => console.error('[QueueContext] Failed to get session summary:', err));
-    }
-  }, [persistentSession, activeSessionId, wsAuthToken]);
+    setCookieSessionId(null);
+    const boardType =
+      persistentSession.activeSession?.parsedParams.board_name ?? baseBoardPath.split('/').filter(Boolean)[0] ?? null;
+    persistentSession.endSessionWithSummary({ sessionId: endingSessionId, boardType });
+  }, [persistentSession, sessionId, baseBoardPath]);
 
   return {
     sessionId,
-    activeSessionId,
     baseBoardPath,
     isPersistentSessionActive,
     persistentSession,
@@ -203,7 +182,5 @@ export function useSessionIdManagement({
     startSession,
     joinSession,
     endSession,
-    sessionSummary,
-    dismissSessionSummary,
   };
 }

--- a/packages/web/app/components/graphql-queue/types.ts
+++ b/packages/web/app/components/graphql-queue/types.ts
@@ -1,15 +1,16 @@
 import type { QueueActionsType, QueueDataType, ClimbQueueItem, ClimbQueue } from '../queue-control/types';
 import type { ConnectionState } from '../connection-manager/websocket-connection-manager';
-import type { SessionSummary, SessionUser } from '@boardsesh/shared-schema';
+import type { SessionUser } from '@boardsesh/shared-schema';
 import type { ReactNode } from 'react';
 import type { ParsedBoardRouteParameters, BoardDetails, Climb, SearchRequestPagination } from '@/app/lib/types';
 
-// Stable action functions extended with session management
+// Stable action functions extended with session management. The session-summary
+// dialog + its dismiss are owned by the root persistent session
+// (persistent-session-wrapper.tsx), so they no longer live on the queue actions.
 export type GraphQLQueueActionsType = {
   startSession: (options?: { discoverable?: boolean; name?: string; sessionId?: string }) => Promise<string>;
   joinSession: (sessionId: string) => Promise<void>;
   endSession: () => void;
-  dismissSessionSummary: () => void;
 } & QueueActionsType;
 
 // Combined type for the test-only `useQueueContext` hook + the queue-bridge
@@ -24,7 +25,6 @@ export type GraphQLQueueContextType = GraphQLQueueActionsType &
      *  reading the combined queue context don't need a second hook. */
     isPersistentSessionActive: boolean;
     sessionId: string | null;
-    sessionSummary: SessionSummary | null;
     sessionGoal: string | null;
     connectionState: ConnectionState;
     canMutate: boolean;
@@ -66,7 +66,6 @@ export type SessionDataType = {
    *  still drive the BLE send as today. */
   isPersistentSessionActive: boolean;
   sessionId: string | null;
-  sessionSummary: SessionSummary | null;
   sessionGoal: string | null;
   connectionState: ConnectionState;
   canMutate: boolean;

--- a/packages/web/app/components/persistent-session/__tests__/use-session-lifecycle-end-session.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/use-session-lifecycle-end-session.test.tsx
@@ -1,0 +1,102 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { MutableRefObject } from 'react';
+import type { SessionSummary } from '@boardsesh/shared-schema';
+import { createQueueSyncGate } from '@boardsesh/queue-runtime';
+import { END_SESSION } from '@boardsesh/graphql/operations/sessions';
+import { useSessionLifecycle } from '../hooks/use-session-lifecycle';
+import type { ActiveSessionInfo, Session } from '../types';
+import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
+
+// The END_SESSION mutation goes over the HTTP GraphQL client. Mock the client so
+// `endSessionWithSummary` never hits the network and we can assert what it sent.
+const { requestMock } = vi.hoisted(() => ({ requestMock: vi.fn() }));
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: vi.fn(() => ({ request: requestMock })),
+}));
+
+function activeSession(sessionId: string, boardName: string): ActiveSessionInfo {
+  return {
+    sessionId,
+    boardPath: `/${boardName}/1/10/1,2/40/list`,
+    boardDetails: { board_name: boardName } as unknown as ActiveSessionInfo['boardDetails'],
+    parsedParams: { board_name: boardName } as unknown as ActiveSessionInfo['parsedParams'],
+  };
+}
+
+// Builds the hook args with a set auth token (the override path only fires the
+// mutation when a token is present). Returns the refs so a test can plant a
+// DIFFERENT active session before ending the override one.
+function buildArgs() {
+  const refs = {
+    wsAuthTokenRef: { current: 'test-token' } as MutableRefObject<string | null>,
+    usernameRef: { current: undefined } as MutableRefObject<string | undefined>,
+    avatarUrlRef: { current: undefined } as MutableRefObject<string | undefined>,
+    sessionRef: { current: null } as MutableRefObject<Session | null>,
+    activeSessionRef: { current: null } as MutableRefObject<ActiveSessionInfo | null>,
+    queueRef: { current: [] } as MutableRefObject<LocalClimbQueueItem[]>,
+    currentClimbQueueItemRef: { current: null } as MutableRefObject<LocalClimbQueueItem | null>,
+    triggerResyncRef: { current: null } as MutableRefObject<(() => void) | null>,
+    lastReceivedSequenceRef: { current: null } as MutableRefObject<number | null>,
+  };
+  const args = {
+    isAuthLoading: false,
+    handleQueueEvent: vi.fn(),
+    handleSessionEvent: vi.fn(),
+    syncGate: createQueueSyncGate(),
+    refs,
+  };
+  return { args, refs };
+}
+
+describe('useSessionLifecycle — endSessionWithSummary override path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ends the override session, not the active one, when a different session is active', async () => {
+    const summary = { sessionId: 'override-session' } as unknown as SessionSummary;
+    requestMock.mockResolvedValueOnce({ endSession: summary });
+
+    const { args, refs } = buildArgs();
+    const { result } = renderHook(() => useSessionLifecycle(args));
+
+    // A DIFFERENT session is active (e.g. a tension party the provider connected
+    // to), but the caller ends a kilter session held only in the cookie.
+    refs.activeSessionRef.current = activeSession('active-session', 'tension');
+
+    act(() => {
+      result.current.endSessionWithSummary({ sessionId: 'override-session', boardType: 'kilter' });
+    });
+
+    await waitFor(() => expect(result.current.sessionSummary).toBe(summary));
+
+    // The END_SESSION mutation targeted the OVERRIDE id, not the active one.
+    expect(requestMock).toHaveBeenCalledTimes(1);
+    expect(requestMock).toHaveBeenCalledWith(END_SESSION, expect.objectContaining({ sessionId: 'override-session' }));
+    // The summary surfaces for the override's board type, not the active session's.
+    expect(result.current.sessionSummaryBoardType).toBe('kilter');
+    expect(result.current.sessionSummaryAutoFinished).toBe(false);
+  });
+
+  it('ends the override session when no session was ever activated (board-route cookie case)', async () => {
+    const summary = { sessionId: 'cookie-session' } as unknown as SessionSummary;
+    requestMock.mockResolvedValueOnce({ endSession: summary });
+
+    const { args, refs } = buildArgs();
+    const { result } = renderHook(() => useSessionLifecycle(args));
+
+    // The provider never activated this session, so the active-session ref is null.
+    expect(refs.activeSessionRef.current).toBeNull();
+
+    act(() => {
+      result.current.endSessionWithSummary({ sessionId: 'cookie-session', boardType: 'kilter' });
+    });
+
+    await waitFor(() => expect(result.current.sessionSummary).toBe(summary));
+
+    expect(requestMock).toHaveBeenCalledWith(END_SESSION, expect.objectContaining({ sessionId: 'cookie-session' }));
+    expect(result.current.sessionSummaryBoardType).toBe('kilter');
+  });
+});

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -83,7 +83,7 @@ export type SessionLifecycleActions = {
     currentClimb: LocalClimbQueueItem | null,
     sessionName?: string,
   ) => void;
-  endSessionWithSummary: () => void;
+  endSessionWithSummary: (override?: { sessionId?: string | null; boardType?: string | null }) => void;
   setAutoFinishedSummary: (summary: SessionSummary, boardType: string | null) => void;
   dismissSessionSummary: () => void;
   setSession: Dispatch<SetStateAction<Session | null>>;
@@ -196,31 +196,39 @@ export function useSessionLifecycle({
     setSessionSummaryAutoFinished(true);
   }, []);
 
-  const endSessionWithSummary = useCallback(() => {
-    const endingSessionId = activeSessionRef.current?.sessionId;
-    const boardType = activeSessionRef.current?.parsedParams.board_name ?? null;
-    const token = wsAuthTokenRef.current;
+  // `override` lets a caller end a session the persistent provider never
+  // activated — the board-route path (`use-session-id-management`) can hold a
+  // session id in the cookie before `BoardSessionBridge` activates it, so
+  // `activeSessionRef.current` is null there. The override supplies that id (and
+  // its board type) directly. When omitted, we fall back to the active session.
+  const endSessionWithSummary = useCallback(
+    (override?: { sessionId?: string | null; boardType?: string | null }) => {
+      const endingSessionId = override?.sessionId ?? activeSessionRef.current?.sessionId;
+      const boardType = override?.boardType ?? activeSessionRef.current?.parsedParams.board_name ?? null;
+      const token = wsAuthTokenRef.current;
 
-    deactivateSession({ notifyServer: false });
+      deactivateSession({ notifyServer: false });
 
-    if (endingSessionId && token) {
-      const httpClient = createGraphQLHttpClient(token);
-      httpClient
-        .request<EndSessionResponse>(END_SESSION_GQL, { sessionId: endingSessionId, timezone: getBrowserTimezone() })
-        .then((response) => {
-          if (response.endSession) {
-            setSessionSummary(response.endSession);
-            setSessionSummaryBoardType(boardType);
-            setSessionSummaryHealthKitWorkoutId(null);
-            setSessionSummaryAutoFinished(false);
-          }
-        })
-        .catch((err) => {
-          console.error('[PersistentSession] Failed to get session summary:', err);
-        });
-    }
+      if (endingSessionId && token) {
+        const httpClient = createGraphQLHttpClient(token);
+        httpClient
+          .request<EndSessionResponse>(END_SESSION_GQL, { sessionId: endingSessionId, timezone: getBrowserTimezone() })
+          .then((response) => {
+            if (response.endSession) {
+              setSessionSummary(response.endSession);
+              setSessionSummaryBoardType(boardType);
+              setSessionSummaryHealthKitWorkoutId(null);
+              setSessionSummaryAutoFinished(false);
+            }
+          })
+          .catch((err) => {
+            console.error('[PersistentSession] Failed to get session summary:', err);
+          });
+      }
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- refs are stable, only .current changes
-  }, [deactivateSession]);
+    [deactivateSession],
+  );
 
   // Re-run the auto-finished pre-flight when the tab returns to visible — backend may have swept the session.
   const visibilityCheckInFlightRef = useRef(false);

--- a/packages/web/app/components/persistent-session/types.ts
+++ b/packages/web/app/components/persistent-session/types.ts
@@ -150,8 +150,10 @@ export type PersistentSessionActionsType = {
   // Trigger a resync with the server (useful when corrupted data is detected)
   triggerResync: () => void;
 
-  // Session ending with summary
-  endSessionWithSummary: () => void;
+  // Session ending with summary. The optional override lets a caller end a
+  // session the provider never activated (board-route cookie edge case) by
+  // supplying the id/board type directly instead of reading the active session.
+  endSessionWithSummary: (override?: { sessionId?: string | null; boardType?: string | null }) => void;
   dismissSessionSummary: () => void;
 
   // Surface a session that the backend already auto-ended due to inactivity.

--- a/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
@@ -319,10 +319,6 @@ function createFakeQueueContext(overrides?: Partial<GraphQLQueueContextType>): G
     startSession: vi.fn(async () => ''),
     joinSession: vi.fn(async () => {}),
     endSession: vi.fn(),
-    sessionSummary: null,
-    sessionSummaryBoardType: null,
-    sessionSummaryHealthKitWorkoutId: null,
-    dismissSessionSummary: vi.fn(),
     sessionGoal: null,
     users: [],
     clientId: null,
@@ -400,7 +396,6 @@ function extractActions(ctx: GraphQLQueueContextType): GraphQLQueueActionsType {
     startSession: ctx.startSession,
     joinSession: ctx.joinSession,
     endSession: ctx.endSession,
-    dismissSessionSummary: ctx.dismissSessionSummary,
     disconnect: ctx.disconnect,
     reportWallDisconnect: ctx.reportWallDisconnect,
   };
@@ -1933,7 +1928,6 @@ describe('queue-bridge-context', () => {
         startSession: vi.fn(async () => ''),
         joinSession: vi.fn(async () => {}),
         endSession: vi.fn(),
-        dismissSessionSummary: vi.fn(),
         disconnect: vi.fn(),
         reportWallDisconnect: vi.fn(async () => {}),
       };

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
@@ -461,20 +461,30 @@ describe('QueueControlBar pivot', () => {
 // The bar's "Leave session" button (reached by cancelling a failed reconnect)
 // used to end the session for the whole crew. It now branches on the roster:
 // leave when peers remain, end only when the caller is the last participant.
+//
+// `SessionUser.id` is the PARTICIPANT id — the DB user UUID for an authenticated
+// user, the connection id for an anonymous one (backend room-manager). Self is
+// therefore identified by `participantId` (== the local user's own SessionUser.id),
+// NOT by the connection-only `clientId`. A roster row's stable key is `userId ?? id`.
 describe('QueueControlBar leave session branch', () => {
-  const makeRosterUser = (id: string, connectionState: 'CONNECTED' | 'RECONNECTING' = 'CONNECTED') => ({
+  const makeRosterUser = (
+    id: string,
+    options: { userId?: string | null; connectionState?: 'CONNECTED' | 'RECONNECTING' } = {},
+  ) => ({
     id,
     username: id,
     isLeader: false,
-    userId: `user-${id}`,
-    connectionState,
+    userId: options.userId ?? null,
+    connectionState: options.connectionState ?? 'CONNECTED',
   });
 
   // Drive the bar into the reconnect-cancel confirm row and click "Leave
-  // session". Returns the end/leave spies so each test can assert which fired.
+  // session". `clientId` is a connection id; `participantId` is the local user's
+  // participant id (== their own SessionUser.id). Returns the end/leave spies.
   const leaveFromBar = (options: {
     users: ReturnType<typeof makeRosterUser>[];
     clientId: string | null;
+    participantId?: string | null;
   }): { endSession: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> } => {
     const endSession = vi.fn();
     const disconnect = vi.fn();
@@ -484,6 +494,7 @@ describe('QueueControlBar leave session branch', () => {
       connectionState: 'reconnecting',
       isDisconnected: false,
       clientId: options.clientId,
+      participantId: options.participantId ?? null,
       endSession,
       disconnect,
     };
@@ -506,16 +517,54 @@ describe('QueueControlBar leave session branch', () => {
     mockSetPreference.mockResolvedValue(undefined);
   });
 
-  it('ends the session (summary path) when the caller is the sole participant', () => {
-    const { endSession, disconnect } = leaveFromBar({ users: [makeRosterUser('me')], clientId: 'me' });
+  it('ends the session (summary) when an anonymous user is the sole participant', () => {
+    // Anon: SessionUser.id === connection id === participantId; no userId.
+    const { endSession, disconnect } = leaveFromBar({
+      users: [makeRosterUser('conn-me')],
+      clientId: 'conn-me',
+      participantId: 'conn-me',
+    });
+    expect(endSession).toHaveBeenCalledTimes(1);
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it('ends the session (summary) when an AUTHENTICATED user is the sole participant', () => {
+    // Authed: SessionUser.id === participantId === user UUID, distinct from the
+    // connection id carried in clientId. Self-identification must use
+    // participantId — comparing against clientId would misread the user's own
+    // row as a peer and silently LEAVE with no recap (the HIGH bug).
+    const { endSession, disconnect } = leaveFromBar({
+      users: [makeRosterUser('user-uuid', { userId: 'user-uuid' })],
+      clientId: 'conn-abc',
+      participantId: 'user-uuid',
+    });
+    expect(endSession).toHaveBeenCalledTimes(1);
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it('ends the session for an authenticated user on two tabs (same participant id)', () => {
+    // Two connections of one authed user share the same participant id, so the
+    // roster dedupes to a single "me" — still the last participant → end.
+    const { endSession, disconnect } = leaveFromBar({
+      users: [
+        makeRosterUser('user-uuid', { userId: 'user-uuid' }),
+        makeRosterUser('user-uuid', { userId: 'user-uuid' }),
+      ],
+      clientId: 'conn-tab-2',
+      participantId: 'user-uuid',
+    });
     expect(endSession).toHaveBeenCalledTimes(1);
     expect(disconnect).not.toHaveBeenCalled();
   });
 
   it('leaves (no summary) when other participants remain', () => {
     const { endSession, disconnect } = leaveFromBar({
-      users: [makeRosterUser('me'), makeRosterUser('friend')],
-      clientId: 'me',
+      users: [
+        makeRosterUser('user-uuid', { userId: 'user-uuid' }),
+        makeRosterUser('friend-uuid', { userId: 'friend-uuid' }),
+      ],
+      clientId: 'conn-abc',
+      participantId: 'user-uuid',
     });
     expect(disconnect).toHaveBeenCalledTimes(1);
     expect(endSession).not.toHaveBeenCalled();
@@ -523,17 +572,25 @@ describe('QueueControlBar leave session branch', () => {
 
   it('counts a RECONNECTING peer as present, so it leaves instead of ending', () => {
     const { endSession, disconnect } = leaveFromBar({
-      users: [makeRosterUser('me'), makeRosterUser('friend', 'RECONNECTING')],
-      clientId: 'me',
+      users: [
+        makeRosterUser('user-uuid', { userId: 'user-uuid' }),
+        makeRosterUser('friend-uuid', { userId: 'friend-uuid', connectionState: 'RECONNECTING' }),
+      ],
+      clientId: 'conn-abc',
+      participantId: 'user-uuid',
     });
     expect(disconnect).toHaveBeenCalledTimes(1);
     expect(endSession).not.toHaveBeenCalled();
   });
 
-  it('ends the session when only the caller remains, even if clientId is unknown', () => {
-    // clientId null (e.g. mid-reconnect): fall back to roster size — a single
-    // entry is the caller, so end.
-    const { endSession, disconnect } = leaveFromBar({ users: [makeRosterUser('me')], clientId: null });
+  it('ends the session when only the caller remains, even if the participant id is unknown', () => {
+    // Mid-reconnect: neither participantId nor clientId known → fall back to
+    // roster size — a single entry is the caller, so end.
+    const { endSession, disconnect } = leaveFromBar({
+      users: [makeRosterUser('conn-me')],
+      clientId: null,
+      participantId: null,
+    });
     expect(endSession).toHaveBeenCalledTimes(1);
     expect(disconnect).not.toHaveBeenCalled();
   });

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
@@ -51,7 +51,8 @@ vi.mock('@/app/components/graphql-queue', () => ({
     canMutate: mockQueueContext.canMutate ?? true,
     isDisconnected: mockQueueContext.isDisconnected ?? false,
     users: mockQueueContext.users ?? [],
-    clientId: null,
+    clientId: mockQueueContext.clientId ?? null,
+    participantId: mockQueueContext.participantId ?? null,
     isLeader: true,
     isBackendMode: false,
     hasConnected: true,
@@ -454,5 +455,86 @@ describe('QueueControlBar pivot', () => {
     const orderedUsernames = Array.from(items).map((el) => el.textContent?.trim());
     expect(orderedUsernames).toEqual(['alice', 'bob', 'carol']);
     expect(screen.queryByLabelText(/is driving/)).toBeNull();
+  });
+});
+
+// The bar's "Leave session" button (reached by cancelling a failed reconnect)
+// used to end the session for the whole crew. It now branches on the roster:
+// leave when peers remain, end only when the caller is the last participant.
+describe('QueueControlBar leave session branch', () => {
+  const makeRosterUser = (id: string, connectionState: 'CONNECTED' | 'RECONNECTING' = 'CONNECTED') => ({
+    id,
+    username: id,
+    isLeader: false,
+    userId: `user-${id}`,
+    connectionState,
+  });
+
+  // Drive the bar into the reconnect-cancel confirm row and click "Leave
+  // session". Returns the end/leave spies so each test can assert which fired.
+  const leaveFromBar = (options: {
+    users: ReturnType<typeof makeRosterUser>[];
+    clientId: string | null;
+  }): { endSession: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> } => {
+    const endSession = vi.fn();
+    const disconnect = vi.fn();
+    mockQueueContext = {
+      ...baseQueueContext,
+      sessionId: 'session-1',
+      connectionState: 'reconnecting',
+      isDisconnected: false,
+      clientId: options.clientId,
+      endSession,
+      disconnect,
+    };
+    mockPersistentSessionState = {
+      activeSession: { sessionId: 'session-1', sessionName: 'Test Session' },
+      session: { id: 'session-1', name: 'Test Session' },
+      users: options.users,
+    };
+    render(<QueueControlBar {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    fireEvent.click(screen.getByLabelText('Leave session'));
+    return { endSession, disconnect };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueueContext = { ...baseQueueContext };
+    mockPersistentSessionState = { activeSession: null, session: null, users: [] };
+    mockGetPreference.mockResolvedValue(null);
+    mockSetPreference.mockResolvedValue(undefined);
+  });
+
+  it('ends the session (summary path) when the caller is the sole participant', () => {
+    const { endSession, disconnect } = leaveFromBar({ users: [makeRosterUser('me')], clientId: 'me' });
+    expect(endSession).toHaveBeenCalledTimes(1);
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it('leaves (no summary) when other participants remain', () => {
+    const { endSession, disconnect } = leaveFromBar({
+      users: [makeRosterUser('me'), makeRosterUser('friend')],
+      clientId: 'me',
+    });
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(endSession).not.toHaveBeenCalled();
+  });
+
+  it('counts a RECONNECTING peer as present, so it leaves instead of ending', () => {
+    const { endSession, disconnect } = leaveFromBar({
+      users: [makeRosterUser('me'), makeRosterUser('friend', 'RECONNECTING')],
+      clientId: 'me',
+    });
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(endSession).not.toHaveBeenCalled();
+  });
+
+  it('ends the session when only the caller remains, even if clientId is unknown', () => {
+    // clientId null (e.g. mid-reconnect): fall back to roster size — a single
+    // entry is the caller, so end.
+    const { endSession, disconnect } = leaveFromBar({ users: [makeRosterUser('me')], clientId: null });
+    expect(endSession).toHaveBeenCalledTimes(1);
+    expect(disconnect).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
@@ -217,6 +217,14 @@ vi.mock('@/app/lib/share-utils', () => ({
   shareWithFallback: vi.fn(),
 }));
 
+// Spy on the session cookie clear so the leave-path assertion can check it.
+const mockClearClimbSessionCookie = vi.fn();
+vi.mock('@/app/lib/climb-session-cookie', () => ({
+  clearClimbSessionCookie: () => mockClearClimbSessionCookie(),
+  getClimbSessionCookie: vi.fn(() => null),
+  setClimbSessionCookie: vi.fn(),
+}));
+
 // jsdom doesn't provide window.matchMedia — stub it before the component
 // accesses it (the swipe-hint effect calls matchMedia on mount).
 Object.defineProperty(window, 'matchMedia', {
@@ -557,7 +565,7 @@ describe('QueueControlBar leave session branch', () => {
     expect(disconnect).not.toHaveBeenCalled();
   });
 
-  it('leaves (no summary) when other participants remain', () => {
+  it('leaves (no summary) when other participants remain, and clears the session cookie', () => {
     const { endSession, disconnect } = leaveFromBar({
       users: [
         makeRosterUser('user-uuid', { userId: 'user-uuid' }),
@@ -568,6 +576,9 @@ describe('QueueControlBar leave session branch', () => {
     });
     expect(disconnect).toHaveBeenCalledTimes(1);
     expect(endSession).not.toHaveBeenCalled();
+    // The leave path clears the cookie so a board-route remount doesn't
+    // re-activate the session this participant just left.
+    expect(mockClearClimbSessionCookie).toHaveBeenCalledTimes(1);
   });
 
   it('counts a RECONNECTING peer as present, so it leaves instead of ending', () => {

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -532,6 +532,10 @@ function usePersistentSessionQueueAdapter(): {
   const stableEndSession = useCallback(() => {
     const { ps } = latestRef.current;
     const endingSessionId = ps.activeSession?.sessionId ?? null;
+    // Intentional asymmetry: clearing the cookie is unconditional (ending always
+    // clears the climb-session cookie, which can hold a session id `ps.activeSession`
+    // never reflected — the board-route cookie edge case), while emitSessionEnded is
+    // guarded because its lifecycle event needs a session id to key off.
     if (endingSessionId) emitSessionEnded(endingSessionId, 'user_left');
     clearClimbSessionCookie();
     ps.endSessionWithSummary({

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -34,6 +34,8 @@ import { canAddClimbToBoard } from '@/app/lib/board-compatibility';
 import { getBoardDetailsForPlaylist } from '@/app/lib/board-config-for-playlist';
 import { useSnackbar } from '../providers/snackbar-provider';
 import { queueAddErrorMessage } from '../board-lock/queue-add-error-messages';
+import { emitSessionEnded } from '@/app/lib/session-lifecycle-tracking';
+import { clearClimbSessionCookie } from '@/app/lib/climb-session-cookie';
 import { QueueBridgeBoardInfoContext, type QueueBridgeBoardInfo } from './queue-bridge-board-info-context';
 import { track } from '@/app/lib/analytics';
 import { getPlaylistSuggestedClimbs } from './playlist-suggestions';
@@ -514,9 +516,28 @@ function usePersistentSessionQueueAdapter(): {
   );
   const noopJoinSession = useCallback(async (_sessionId: string) => {}, []);
   const noopSetClimbSearchParams = useCallback((_params: SearchRequestPagination) => {}, []);
-  // Wrap deactivateSession via ref so actionsValue deps are fully stable
+  // Wrap deactivateSession via ref so actionsValue deps are fully stable. This
+  // is the LEAVE path (exposed as `disconnect`): the participant departs and
+  // the session continues for everyone else — `deactivateSession()` sends
+  // LEAVE_SESSION on cleanup (notifyServer defaults true).
   const stableDeactivateSession = useCallback(() => {
     latestRef.current.ps.deactivateSession();
+  }, []);
+
+  // The END path (exposed as `endSession`): ends the session for everyone and
+  // shows the summary dialog. Routes through the root `endSessionWithSummary`
+  // (the single owner of summary state + dialog) so it behaves identically on
+  // and off board routes. Mirrors `use-session-id-management`'s board-route
+  // `endSession`.
+  const stableEndSession = useCallback(() => {
+    const { ps } = latestRef.current;
+    const endingSessionId = ps.activeSession?.sessionId ?? null;
+    if (endingSessionId) emitSessionEnded(endingSessionId, 'user_left');
+    clearClimbSessionCookie();
+    ps.endSessionWithSummary({
+      sessionId: endingSessionId,
+      boardType: ps.activeSession?.parsedParams.board_name ?? null,
+    });
   }, []);
 
   // Actions value is now stable — all callbacks use latestRef with empty deps
@@ -540,8 +561,7 @@ function usePersistentSessionQueueAdapter(): {
       reportWallDisconnect,
       startSession: noopStartSession,
       joinSession: noopJoinSession,
-      endSession: stableDeactivateSession,
-      dismissSessionSummary: noop,
+      endSession: stableEndSession,
       disconnect: stableDeactivateSession,
     }),
     [
@@ -561,6 +581,7 @@ function usePersistentSessionQueueAdapter(): {
       setQueue,
       reportWallDisconnect,
       stableDeactivateSession,
+      stableEndSession,
       noopStartSession,
       noopJoinSession,
     ],
@@ -588,7 +609,6 @@ function usePersistentSessionQueueAdapter(): {
       isSessionActive: isParty && ps.hasConnected,
       isPersistentSessionActive: isParty,
       sessionId: ps.activeSession?.sessionId ?? null,
-      sessionSummary: null,
       sessionGoal: ps.session?.goal ?? null,
       users: isParty ? ps.users : [],
       clientId: ps.clientId,
@@ -857,7 +877,6 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
       isSessionActive: effectiveContext.isSessionActive,
       isPersistentSessionActive: effectiveContext.isPersistentSessionActive,
       sessionId: effectiveContext.sessionId,
-      sessionSummary: effectiveContext.sessionSummary,
       sessionGoal: effectiveContext.sessionGoal,
       connectionState: effectiveContext.connectionState,
       canMutate: effectiveContext.canMutate,
@@ -877,7 +896,6 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
       effectiveContext.isSessionActive,
       effectiveContext.isPersistentSessionActive,
       effectiveContext.sessionId,
-      effectiveContext.sessionSummary,
       effectiveContext.sessionGoal,
       effectiveContext.connectionState,
       effectiveContext.canMutate,

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -112,8 +112,16 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const isViewPage = pathname.includes('/view/');
   const { currentClimb } = useCurrentClimb();
   const { queue } = useQueueList();
-  const { viewOnlyMode, connectionState, sessionId, isDisconnected, users, clientId, isPersistentSessionActive } =
-    useSessionData();
+  const {
+    viewOnlyMode,
+    connectionState,
+    sessionId,
+    isDisconnected,
+    users,
+    clientId,
+    participantId,
+    isPersistentSessionActive,
+  } = useSessionData();
 
   // Drawer-local "displayed climb" — populated when a browse caller (list
   // row, suggestion thumbnail, logbook row) opens the drawer with a climb
@@ -363,12 +371,15 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     });
   }, [sessionUsers]);
 
-  // Resolve the current user's stable userId from the session users list
-  const myUserId = useMemo(() => {
-    if (!clientId) return null;
-    const me = sessionUsers.find((u) => u.id === clientId);
-    return me?.userId ?? clientId;
-  }, [sessionUsers, clientId]);
+  // Resolve the current user's stable session id. `participantId` is the local
+  // user's participant id — it equals `SessionUser.id` (the DB user UUID for an
+  // authenticated user, the connection id for an anonymous one), which is what
+  // the roster is keyed by. `clientId` is only a connection id, so for an
+  // authenticated user it never matches their own roster row; comparing against
+  // it would misread self as "someone else" (e.g. a solo authed user's leave
+  // would silently disconnect instead of ending with a recap). Fall back to
+  // clientId only for the brief pre-join window before participantId is known.
+  const myUserId = participantId ?? clientId;
 
   // Track which participants have ticked the current climb.
   // Merges backend-provided tickedBy with locally tracked ticks.

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -648,6 +648,9 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         disconnect();
         clearClimbSessionCookie();
       } else {
+        // Unreachable while a session is active: both queue providers expose
+        // `disconnect` whenever there's a session to leave, so this only
+        // satisfies the optional type.
         showMessage(t('queueBar.leaveFailed'), 'warning');
       }
       return;
@@ -658,6 +661,10 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     if (endSession) {
       endSession();
     } else if (disconnect) {
+      // Unreachable while a session is active: both queue providers always
+      // expose `endSession` then, so this fallback only satisfies the optional
+      // type. It intentionally leaves WITHOUT a summary — if it ever ran (no
+      // active session) there's no recap to show anyway.
       disconnect();
       clearClimbSessionCookie();
     } else {

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -58,6 +58,7 @@ import IosShare from '@mui/icons-material/IosShare';
 import { QRCodeSVG } from 'qrcode.react';
 import { shareWithFallback } from '@/app/lib/share-utils';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+import { clearClimbSessionCookie } from '@/app/lib/climb-session-cookie';
 import styles from './queue-control-bar.module.css';
 import { PLAY_DRAWER_EVENT, dispatchOpenPlayDrawer } from './play-drawer-event';
 
@@ -614,17 +615,44 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   const reconnectMessage =
     connectionState === 'error' ? t('queueBar.reconnect.connectionError') : t('queueBar.reconnect.reconnecting');
 
+  // Bar "leave session" (user-approved behaviour change). It used to always end
+  // the session for the whole crew. Now it branches on the roster:
+  //   - Peers still present → truly LEAVE. This participant departs, the
+  //     session keeps going for everyone else, and no summary shows.
+  //   - Sole participant → END the session (root summary dialog).
+  //
+  // "Last participant" reads the WHOLE roster (no connectionState filter):
+  // RECONNECTING peers count as present because their socket merely dropped and
+  // they may return — ending the session would pull it out from under them.
   const handleLeaveSession = useCallback(() => {
-    if (endSession) {
-      endSession();
+    const otherParticipantsPresent = myUserId
+      ? uniqueSessionUsers.some((user) => (user.userId ?? user.id) !== myUserId)
+      : uniqueSessionUsers.length > 1;
+
+    if (otherParticipantsPresent) {
+      // Leave path: `disconnect` (deactivateSession) sends LEAVE_SESSION; clear
+      // the cookie so a board-route remount doesn't re-activate the session we
+      // just left (mirrors the sesh-settings drawer's quiet stop).
+      if (disconnect) {
+        disconnect();
+        clearClimbSessionCookie();
+      } else {
+        showMessage(t('queueBar.leaveFailed'), 'warning');
+      }
       return;
     }
-    if (disconnect) {
+
+    // End path: `endSession` emits the lifecycle event, clears the cookie, and
+    // routes through the root `endSessionWithSummary` (the single summary dialog).
+    if (endSession) {
+      endSession();
+    } else if (disconnect) {
       disconnect();
+      clearClimbSessionCookie();
     } else {
       showMessage(t('queueBar.leaveFailed'), 'warning');
     }
-  }, [endSession, disconnect, showMessage, t]);
+  }, [endSession, disconnect, uniqueSessionUsers, myUserId, showMessage, t]);
 
   // Reconnect-only view helpers
   const renderReconnectingRow = () => (

--- a/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
+++ b/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
@@ -26,6 +26,7 @@ let mockSession: Record<string, unknown> | null = {
   startedAt: new Date(Date.now() - 30 * 60000).toISOString(),
 };
 const mockDeactivateSession = vi.fn();
+const mockEndSessionWithSummary = vi.fn();
 let mockAngle: number | undefined = 40;
 let mockBoardDetails: Record<string, unknown> | null = { board_name: 'kilter' };
 let mockSessionDetail: Record<string, unknown> | null = {
@@ -65,6 +66,7 @@ vi.mock('@/app/components/persistent-session/persistent-session-context', () => 
     session: mockSession,
     users: [],
     deactivateSession: mockDeactivateSession,
+    endSessionWithSummary: mockEndSessionWithSummary,
   }),
   usePersistentSessionState: () => ({
     activeSession: mockActiveSession,
@@ -320,6 +322,9 @@ describe('SeshSettingsDrawer', () => {
       expect(mockDeactivateSession).toHaveBeenCalled();
       expect(mockClearClimbSessionCookie).toHaveBeenCalled();
       expect(onClose).not.toHaveBeenCalled();
+      // The drawer's stop keeps quiet-leave semantics — it never ends the
+      // session for the crew, so no summary dialog is triggered.
+      expect(mockEndSessionWithSummary).not.toHaveBeenCalled();
     });
 
     it('shows Dismiss button after stopping session', () => {


### PR DESCRIPTION
## Summary

**Stacked on #3372** (`refactor/sessions-w6-root-queue-state`) — auto-retargets to `main` when W6 merges. Workstream W7 of the multi-user-sessions plan. Three related cleanups plus one user-approved behaviour change.

**(A) Session id is now a derivation, not a reconciled `useState`.** `graphql-queue/hooks/use-session-id-management.ts` used to source the session id three ways (board-route cookie, off-board IndexedDB `activeSession`, legacy `?session=` migration) and reconcile them through a local `activeSessionId` state + two flicker/wipe-race sync effects. That's gone. `sessionId` is now:

```
isOffBoardMode ? persistentSessionId : (boardPath-matched persistentSessionId ?? cookieSessionId)
```

One cookie `useState` mirror remains (cookie reads are non-reactive; the start/join/migration/clear paths keep it in sync), plus the legacy `?session=` migration effect and the single active→null cookie-clear effect. The board-path match folds in both race windows the deleted effects defended — the IndexedDB-load window (persistent id briefly null → keep reading the cookie) and multi-session restore (a session for board X in IndexedDB while browsing board Y must not leak X's id into board Y).

**(B) One end-session path, one summary dialog.** There were two `sessionSummary` states and two `SessionSummaryDialog` renders. All end-session now routes through the root `useSessionLifecycle.endSessionWithSummary` (persistent-session), which gains an optional `{ sessionId, boardType }` override so it can end a session the persistent provider never activated (the board-route cookie edge case). The board-route-local summary state + dialog are deleted from `QueueContext`; the root dialog in `persistent-session-wrapper.tsx` is the only one. `use-session-id-management`'s `endSession` and the bridge's `endSession` both delegate to it.

**(C) Bar "Leave session" now truly leaves when the crew stays (user-approved).** See below.

## Behavior change

The queue-bar "Leave session" button (reached by cancelling a failed reconnect) used to **end the session for the whole group** and pop the summary. Now it branches on the roster:

- **Other participants present → you leave.** Your seat drops (`LEAVE_SESSION` + cookie cleared), no summary shows, and the session keeps running for everyone else.
- **You're the last one → the session ends** through the root `endSessionWithSummary`, with the summary dialog.

"Last participant" reads the whole session roster — **RECONNECTING peers count as present** (their socket merely dropped and they may come back, so we don't end the session out from under them). The sesh-settings drawer's "stop" is unchanged: it stays a quiet leave with no summary.

No new user-facing strings — the action just branches on roster size, so no i18n was added.

## Release Notes

- Leaving a session from the queue bar now just takes you out of the crew's session — it keeps going for everyone else. It only wraps up the whole session (with the recap) when you're the last one on the wall.

## Test plan

- `vp run typecheck` — clean.
- `vp run test:web` (x2) + full `vp test run` — green.
- New tests: session-id derivation across all three sources incl. both race windows and the active→null clear; `endSession` routing to the root summary (with board type, and the path-derived board type for the cookie-only edge case); bar leave-vs-end branch (sole → end, peers present → leave, RECONNECTING peer counts as present, unknown clientId falls back to roster size); drawer "stop" never triggers a summary.
- `vp check --fix` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9eAY2yZDGSqossL5UtUQo
