### PR TITLE
feat(sync): order-sensitive state hash via additive dual-hash rollout

### DIFF
--- a/packages/backend/src/__tests__/build-session-payload.test.ts
+++ b/packages/backend/src/__tests__/build-session-payload.test.ts
@@ -77,6 +77,7 @@ const sampleSessionData = {
 const sampleQueueState = {
   sequence: 5,
   stateHash: 'hash-5',
+  stateHashOrdered: 'hash-5-ordered',
   queue: [],
   currentClimbQueueItem: null,
   version: 3,
@@ -106,6 +107,7 @@ describe('buildSessionPayload — defaults (no overrides)', () => {
       queueState: {
         sequence: 5,
         stateHash: 'hash-5',
+        stateHashOrdered: 'hash-5-ordered',
         queue: [],
         currentClimbQueueItem: null,
       },
@@ -146,6 +148,7 @@ describe('buildSessionPayload — override short-circuits', () => {
     const prefetched = {
       sequence: 99,
       stateHash: 'fresh',
+      stateHashOrdered: 'fresh-ordered',
       queue: [],
       currentClimbQueueItem: null,
     };

--- a/packages/backend/src/__tests__/queue-sync-fixes.test.ts
+++ b/packages/backend/src/__tests__/queue-sync-fixes.test.ts
@@ -521,7 +521,7 @@ describe('reorderQueueItem - Return type handling', () => {
   });
 });
 
-describe('X1: order-sensitive dual-hash (stateHashOrdered)', () => {
+describe('order-sensitive dual-hash (stateHashOrdered)', () => {
   let mockRedis: MockRedis;
   let publishSpy: ReturnType<typeof vi.spyOn>;
 

--- a/packages/backend/src/__tests__/queue-sync-fixes.test.ts
+++ b/packages/backend/src/__tests__/queue-sync-fixes.test.ts
@@ -521,6 +521,129 @@ describe('reorderQueueItem - Return type handling', () => {
   });
 });
 
+describe('X1: order-sensitive dual-hash (stateHashOrdered)', () => {
+  let mockRedis: MockRedis;
+  let publishSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    mockRedis = createMockRedis();
+    roomManager.reset();
+    await roomManager.initialize(mockRedis);
+    publishSpy = vi.spyOn(pubsub, 'publishQueueEvent').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const ctxFor = (sessionId: string) => ({
+    connectionId: 'client-1',
+    sessionId,
+    rateLimitTokens: 60,
+    rateLimitLastReset: Date.now(),
+  });
+
+  it('updateQueueState / updateQueueOnly / getQueueState all return both hashes', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+
+    const climbs = [createTestClimb(), createTestClimb()];
+    const updateResult = await roomManager.updateQueueState(sessionId, climbs, null);
+    expect(typeof updateResult.stateHash).toBe('string');
+    expect(updateResult.stateHash.length).toBeGreaterThan(0);
+    expect(typeof updateResult.stateHashOrdered).toBe('string');
+    expect(updateResult.stateHashOrdered.length).toBeGreaterThan(0);
+
+    const onlyResult = await roomManager.updateQueueOnly(sessionId, climbs);
+    expect(typeof onlyResult.stateHashOrdered).toBe('string');
+    expect(onlyResult.stateHashOrdered.length).toBeGreaterThan(0);
+
+    const state = await roomManager.getQueueState(sessionId);
+    expect(typeof state.stateHash).toBe('string');
+    expect(typeof state.stateHashOrdered).toBe('string');
+    expect(state.stateHashOrdered.length).toBeGreaterThan(0);
+  });
+
+  it('a reorder changes stateHashOrdered but NOT stateHash (the whole point of v2)', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+
+    const climb1 = createTestClimb();
+    const climb2 = createTestClimb();
+    const initial = await roomManager.getQueueState(sessionId);
+    await roomManager.updateQueueState(sessionId, [climb1, climb2], null, initial.version);
+    const before = await roomManager.getQueueState(sessionId);
+    publishSpy.mockClear();
+
+    // Move climb1 from index 0 to index 1 — same members, different order.
+    await queueMutations.reorderQueueItem({}, { uuid: climb1.uuid, oldIndex: 0, newIndex: 1 }, ctxFor(sessionId));
+
+    const reorderedCall = publishSpy.mock.calls.find(
+      (call: unknown[]) => (call[1] as { __typename: string }).__typename === 'QueueReordered',
+    );
+    expect(reorderedCall).toBeDefined();
+    const event = reorderedCall![1] as { stateHash: string; stateHashOrdered: string };
+
+    // v1 is order-insensitive → unchanged by the reorder.
+    expect(event.stateHash).toBe(before.stateHash);
+    // v2 is order-sensitive → it moves. This is the drift the watchdog now sees.
+    expect(typeof event.stateHashOrdered).toBe('string');
+    expect(event.stateHashOrdered.length).toBeGreaterThan(0);
+    expect(event.stateHashOrdered).not.toBe(before.stateHashOrdered);
+  });
+
+  it('QueueItemAdded and QueueItemRemoved deltas carry both hashes (and both change)', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+
+    const climb1 = createTestClimb();
+    const before = await roomManager.getQueueState(sessionId);
+    publishSpy.mockClear();
+
+    await queueMutations.addQueueItem({}, { item: climb1 }, ctxFor(sessionId));
+    const addedCall = publishSpy.mock.calls.find(
+      (call: unknown[]) => (call[1] as { __typename: string }).__typename === 'QueueItemAdded',
+    );
+    expect(addedCall).toBeDefined();
+    const added = addedCall![1] as { stateHash: string; stateHashOrdered: string };
+    expect(added.stateHashOrdered.length).toBeGreaterThan(0);
+    // An add changes BOTH hashes.
+    expect(added.stateHash).not.toBe(before.stateHash);
+    expect(added.stateHashOrdered).not.toBe(before.stateHashOrdered);
+
+    publishSpy.mockClear();
+    await queueMutations.removeQueueItem({}, { uuid: climb1.uuid }, ctxFor(sessionId));
+    const removedCall = publishSpy.mock.calls.find(
+      (call: unknown[]) => (call[1] as { __typename: string }).__typename === 'QueueItemRemoved',
+    );
+    expect(removedCall).toBeDefined();
+    const removed = removedCall![1] as { stateHash: string; stateHashOrdered: string };
+    expect(removed.stateHashOrdered.length).toBeGreaterThan(0);
+    // Removing the just-added climb returns to the empty-queue hashes.
+    expect(removed.stateHash).toBe(before.stateHash);
+    expect(removed.stateHashOrdered).toBe(before.stateHashOrdered);
+  });
+
+  it('setQueue publishes a FullSync whose state carries both hashes', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+    publishSpy.mockClear();
+
+    await queueMutations.setQueue({}, { queue: [createTestClimb(), createTestClimb()] }, ctxFor(sessionId));
+
+    expect(publishSpy).toHaveBeenCalledWith(
+      sessionId,
+      expect.objectContaining({
+        __typename: 'FullSync',
+        state: expect.objectContaining({
+          stateHash: expect.any(String),
+          stateHashOrdered: expect.any(String),
+        }),
+      }),
+    );
+  });
+});
+
 describe('setCurrentClimb - combined queue/current state publishing', () => {
   let mockRedis: MockRedis;
   let publishSpy: ReturnType<typeof vi.spyOn>;

--- a/packages/backend/src/__tests__/session-query-gate.test.ts
+++ b/packages/backend/src/__tests__/session-query-gate.test.ts
@@ -113,6 +113,7 @@ const sampleUsers = [
 const sampleQueueState = {
   sequence: 5,
   stateHash: 'hash-5',
+  stateHashOrdered: 'hash-5-ordered',
   queue: [],
   currentClimbQueueItem: null,
   version: 1,
@@ -141,6 +142,7 @@ describe('session query — membership gate compat matrix', () => {
     expect(result!.queueState).toEqual({
       sequence: 5,
       stateHash: 'hash-5',
+      stateHashOrdered: 'hash-5-ordered',
       queue: [],
       currentClimbQueueItem: null,
     });

--- a/packages/backend/src/graphql/resolvers/controller/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/controller/mutations.ts
@@ -192,6 +192,7 @@ export const controllerMutations = {
         __typename: 'CurrentClimbChanged',
         sequence: currentState.sequence,
         stateHash: currentState.stateHash,
+        stateHashOrdered: currentState.stateHashOrdered,
         item: null, // No queue item for unknown climb
         frames: framesString,
         clientId: clientIdForEvent, // ESP32 compares this with its MAC
@@ -241,7 +242,11 @@ export const controllerMutations = {
         ? [...currentState.queue, queueItem]
         : [...currentState.queue.slice(0, currentIndex + 1), queueItem, ...currentState.queue.slice(currentIndex + 1)];
 
-    const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, updatedQueue, queueItem);
+    const { sequence, stateHash, stateHashOrdered } = await roomManager.updateQueueState(
+      sessionId,
+      updatedQueue,
+      queueItem,
+    );
 
     // Publish a FullSync for clients because one mutation changed both queue
     // membership and current climb. The controller-specific CurrentClimbChanged
@@ -252,6 +257,7 @@ export const controllerMutations = {
       state: {
         sequence,
         stateHash,
+        stateHashOrdered,
         queue: updatedQueue,
         currentClimbQueueItem: queueItem,
       },
@@ -265,6 +271,7 @@ export const controllerMutations = {
       __typename: 'CurrentClimbChanged',
       sequence,
       stateHash,
+      stateHashOrdered,
       item: queueItem,
       clientId: matchClientId,
       correlationId: null,
@@ -389,13 +396,18 @@ export const controllerMutations = {
         );
 
         // Update queue state
-        const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, queue, newCurrentClimb);
+        const { sequence, stateHash, stateHashOrdered } = await roomManager.updateQueueState(
+          sessionId,
+          queue,
+          newCurrentClimb,
+        );
 
         // Publish CurrentClimbChanged event
         pubsub.publishQueueEvent(sessionId, {
           __typename: 'CurrentClimbChanged',
           sequence,
           stateHash,
+          stateHashOrdered,
           item: newCurrentClimb,
           clientId: null,
           correlationId: null,
@@ -454,7 +466,11 @@ export const controllerMutations = {
     logger.info(`[Controller] Queue has ${queue.length} items, updating current to index ${targetIndex}`);
 
     // Update queue state (keep the same queue, just change current climb)
-    const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, queue, newCurrentClimb);
+    const { sequence, stateHash, stateHashOrdered } = await roomManager.updateQueueState(
+      sessionId,
+      queue,
+      newCurrentClimb,
+    );
 
     // Publish CurrentClimbChanged event WITHOUT clientId
     // Unlike setClimbFromLedPositions (where we skip because ESP32 already has LEDs from BLE),
@@ -463,6 +479,7 @@ export const controllerMutations = {
       __typename: 'CurrentClimbChanged',
       sequence,
       stateHash,
+      stateHashOrdered,
       item: newCurrentClimb,
       clientId: null, // Don't skip - ESP32 needs the new climb data
       correlationId: null,

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -61,6 +61,7 @@ export const queueMutations = {
     let itemWasAdded = false;
     let resultSequence = 0;
     let resultStateHash = '';
+    let resultStateHashOrdered = '';
 
     // Retry loop for optimistic locking
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
@@ -95,6 +96,7 @@ export const queueMutations = {
         itemWasAdded = true;
         resultSequence = result.sequence;
         resultStateHash = result.stateHash;
+        resultStateHashOrdered = result.stateHashOrdered;
         break; // Success, exit retry loop
       } catch (error) {
         if (error instanceof VersionConflictError && attempt < MAX_RETRIES - 1) {
@@ -117,6 +119,7 @@ export const queueMutations = {
         __typename: 'QueueItemAdded',
         sequence: resultSequence,
         stateHash: resultStateHash,
+        stateHashOrdered: resultStateHashOrdered,
         item: item,
         position: actualPosition,
       });
@@ -149,12 +152,17 @@ export const queueMutations = {
       currentClimb = null;
     }
 
-    const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, queue, currentClimb);
+    const { sequence, stateHash, stateHashOrdered } = await roomManager.updateQueueState(
+      sessionId,
+      queue,
+      currentClimb,
+    );
 
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'QueueItemRemoved',
       sequence,
       stateHash,
+      stateHashOrdered,
       uuid,
     });
 
@@ -189,6 +197,7 @@ export const queueMutations = {
 
     let resultSequence = currentState.sequence;
     let resultStateHash = currentState.stateHash;
+    let resultStateHashOrdered = currentState.stateHashOrdered;
 
     if (oldIndex >= 0 && oldIndex < queue.length && newIndex >= 0 && newIndex < queue.length) {
       const [movedItem] = queue.splice(oldIndex, 1);
@@ -197,12 +206,16 @@ export const queueMutations = {
       const result = await roomManager.updateQueueOnly(sessionId, queue);
       resultSequence = result.sequence;
       resultStateHash = result.stateHash;
+      resultStateHashOrdered = result.stateHashOrdered;
     }
 
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'QueueReordered',
       sequence: resultSequence,
       stateHash: resultStateHash,
+      // The v1 stateHash is unchanged by a reorder (sorted UUIDs); the ordered
+      // v2 hash is what actually moves — this is the drift the watchdog now sees.
+      stateHashOrdered: resultStateHashOrdered,
       uuid,
       oldIndex,
       newIndex,
@@ -304,12 +317,17 @@ export const queueMutations = {
       i.uuid === currentClimb!.uuid ? { ...i, climb: { ...i.climb, mirrored } } : i,
     );
 
-    const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, queue, currentClimb);
+    const { sequence, stateHash, stateHashOrdered } = await roomManager.updateQueueState(
+      sessionId,
+      queue,
+      currentClimb,
+    );
 
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'ClimbMirrored',
       sequence,
       stateHash,
+      stateHashOrdered,
       uuid: currentClimb.uuid,
       mirrored,
     });
@@ -344,13 +362,17 @@ export const queueMutations = {
       currentClimb = item;
     }
 
-    const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, queue, currentClimb);
+    const { sequence, stateHash, stateHashOrdered } = await roomManager.updateQueueState(
+      sessionId,
+      queue,
+      currentClimb,
+    );
 
     // Publish as FullSync since replace is less common
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'FullSync',
       sequence,
-      state: { sequence, stateHash, queue, currentClimbQueueItem: currentClimb },
+      state: { sequence, stateHash, stateHashOrdered, queue, currentClimbQueueItem: currentClimb },
     });
 
     logMutationMetrics('replaceQueueItem', performance.now() - startTime, sessionId);
@@ -385,7 +407,7 @@ export const queueMutations = {
     // had, the client was wrong about the drift — usually a bug in the
     // local hash computation or event processor — and the loop will fire
     // again next minute. The warn surfaces those loops.
-    const { sequence, stateHash, previousStateHash } = await roomManager.updateQueueState(
+    const { sequence, stateHash, stateHashOrdered, previousStateHash } = await roomManager.updateQueueState(
       sessionId,
       queue,
       currentClimbQueueItem || null,
@@ -400,6 +422,7 @@ export const queueMutations = {
     const state: QueueState = {
       sequence,
       stateHash,
+      stateHashOrdered,
       queue,
       currentClimbQueueItem: currentClimbQueueItem || null,
     };

--- a/packages/backend/src/graphql/resolvers/sessions/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/helpers.ts
@@ -10,6 +10,7 @@ import type { Session as SessionDbRow } from '../../../db/schema';
 type SessionQueueState = {
   sequence: number;
   stateHash: string;
+  stateHashOrdered?: string | null;
   queue: ClimbQueueItem[];
   currentClimbQueueItem: ClimbQueueItem | null;
 };
@@ -94,6 +95,7 @@ export async function buildSessionPayload(
       ? {
           sequence: queueState.sequence,
           stateHash: queueState.stateHash,
+          stateHashOrdered: queueState.stateHashOrdered ?? null,
           queue: queueState.queue,
           currentClimbQueueItem: queueState.currentClimbQueueItem,
         }

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -181,6 +181,7 @@ export const sessionMutations = {
       queueState: {
         sequence: result.sequence,
         stateHash: result.stateHash,
+        stateHashOrdered: result.stateHashOrdered,
         queue: result.queue,
         currentClimbQueueItem: result.currentClimbQueueItem,
       },
@@ -287,6 +288,7 @@ export const sessionMutations = {
           queueState: {
             sequence: result.sequence,
             stateHash: result.stateHash,
+            stateHashOrdered: result.stateHashOrdered,
             queue: result.queue,
             currentClimbQueueItem: result.currentClimbQueueItem,
           },
@@ -614,6 +616,7 @@ export const sessionMutations = {
       queueState: {
         sequence: queueState.sequence,
         stateHash: queueState.stateHash,
+        stateHashOrdered: queueState.stateHashOrdered,
         queue: queueState.queue,
         currentClimbQueueItem: queueState.currentClimbQueueItem,
       },

--- a/packages/backend/src/services/queue-navigation.ts
+++ b/packages/backend/src/services/queue-navigation.ts
@@ -28,6 +28,7 @@ export async function setCurrentClimbAndPublish(
 ): Promise<{ sequence: number; stateHash: string; queue: ClimbQueueItem[]; addedToQueue: boolean }> {
   let sequence = 0;
   let stateHash = '';
+  let stateHashOrdered = '';
   let addedToQueue = false;
   let updatedQueue: ClimbQueueItem[] = [];
 
@@ -45,6 +46,7 @@ export async function setCurrentClimbAndPublish(
       const result = await roomManager.updateQueueState(sessionId, queue, item, currentState.version);
       sequence = result.sequence;
       stateHash = result.stateHash;
+      stateHashOrdered = result.stateHashOrdered;
       updatedQueue = queue;
       addedToQueue = addedInThisAttempt;
       break;
@@ -64,6 +66,7 @@ export async function setCurrentClimbAndPublish(
       __typename: 'CurrentClimbChanged',
       sequence,
       stateHash,
+      stateHashOrdered,
       item: null,
       clientId: clientId ?? null,
       correlationId: correlationId ?? null,
@@ -81,13 +84,14 @@ export async function setCurrentClimbAndPublish(
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'FullSync',
       sequence,
-      state: { sequence, stateHash, queue: updatedQueue, currentClimbQueueItem: item },
+      state: { sequence, stateHash, stateHashOrdered, queue: updatedQueue, currentClimbQueueItem: item },
     });
   } else {
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'CurrentClimbChanged',
       sequence,
       stateHash,
+      stateHashOrdered,
       item,
       clientId: clientId ?? null,
       correlationId: correlationId ?? null,
@@ -118,6 +122,7 @@ export async function navigateToQueueItem(
   let resultItem: ClimbQueueItem | null = null;
   let resultSequence = 0;
   let resultStateHash = '';
+  let resultStateHashOrdered = '';
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     const currentState = await roomManager.getQueueState(sessionId);
@@ -135,6 +140,7 @@ export async function navigateToQueueItem(
       resultItem = item;
       resultSequence = result.sequence;
       resultStateHash = result.stateHash;
+      resultStateHashOrdered = result.stateHashOrdered;
       break; // success
     } catch (error) {
       if (error instanceof VersionConflictError && attempt < MAX_RETRIES - 1) {
@@ -153,6 +159,7 @@ export async function navigateToQueueItem(
       __typename: 'CurrentClimbChanged',
       sequence: resultSequence,
       stateHash: resultStateHash,
+      stateHashOrdered: resultStateHashOrdered,
       item: resultItem,
       clientId: clientId ?? null,
       correlationId: correlationId ?? null,

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -70,6 +70,7 @@ export async function joinSession(
   currentClimbQueueItem: ClimbQueueItem | null;
   sequence: number;
   stateHash: string;
+  stateHashOrdered: string;
   isLeader: boolean;
   sessionName: string | null;
   participantId: string;
@@ -264,6 +265,7 @@ export async function joinSession(
     currentClimbQueueItem: queueState.currentClimbQueueItem,
     sequence: queueState.sequence,
     stateHash: queueState.stateHash,
+    stateHashOrdered: queueState.stateHashOrdered,
     isLeader,
     sessionName: resolvedSessionName,
     participantId: resolvedParticipantId,

--- a/packages/backend/src/services/room-manager/queue-state.ts
+++ b/packages/backend/src/services/room-manager/queue-state.ts
@@ -3,7 +3,7 @@ import { db } from '../../db/client';
 import { sessionQueues } from '../../db/schema';
 import { eq, and, sql } from 'drizzle-orm';
 import type { RedisSessionStore } from '../redis-session-store';
-import { computeQueueStateHash } from '@boardsesh/queue';
+import { computeQueueStateHash, computeQueueStateHashOrdered } from '@boardsesh/queue';
 import { VersionConflictError, type QueueState, type RoomManagerDeps } from './types';
 import { writeQueueStateToPostgres } from './write-scheduler';
 
@@ -16,7 +16,13 @@ export async function updateQueueState(
   queue: ClimbQueueItem[],
   currentClimbQueueItem: ClimbQueueItem | null,
   expectedVersion: number | undefined,
-): Promise<{ version: number; sequence: number; stateHash: string; previousStateHash: string | null }> {
+): Promise<{
+  version: number;
+  sequence: number;
+  stateHash: string;
+  stateHashOrdered: string;
+  previousStateHash: string | null;
+}> {
   const { redisStore, writeScheduler, distributedState } = deps;
 
   // Get current version, sequence, and prior state hash from Redis if
@@ -69,6 +75,10 @@ export async function updateQueueState(
   const newVersion = currentVersion + 1;
   const newSequence = currentSequence + 1;
   const stateHash = computeQueueStateHash(queue, currentClimbQueueItem?.uuid || null);
+  // Order-sensitive companion (v2), computed from the exact same inputs so the
+  // pair stays consistent. Additive: only Redis's v1 hash is persisted; the
+  // ordered one is recomputed on read (see getQueueState) and sent on the wire.
+  const stateHashOrdered = computeQueueStateHashOrdered(queue, currentClimbQueueItem?.uuid || null);
 
   // Write to Redis immediately (source of truth for active sessions)
   if (redisStore) {
@@ -91,7 +101,7 @@ export async function updateQueueState(
     );
   }
 
-  return { version: newVersion, sequence: newSequence, stateHash, previousStateHash };
+  return { version: newVersion, sequence: newSequence, stateHash, stateHashOrdered, previousStateHash };
 }
 
 /**
@@ -220,7 +230,7 @@ export async function updateQueueOnly(
   sessionId: string,
   queue: ClimbQueueItem[],
   expectedVersion: number | undefined,
-): Promise<{ version: number; sequence: number; stateHash: string }> {
+): Promise<{ version: number; sequence: number; stateHash: string; stateHashOrdered: string }> {
   const { redisStore, writeScheduler, distributedState } = deps;
 
   // Get current state from Redis (source of truth for real-time sync)
@@ -253,6 +263,7 @@ export async function updateQueueOnly(
   const newVersion = currentVersion + 1;
   const newSequence = currentSequence + 1;
   const stateHash = computeQueueStateHash(queue, currentClimbQueueItem?.uuid || null);
+  const stateHashOrdered = computeQueueStateHashOrdered(queue, currentClimbQueueItem?.uuid || null);
 
   // Write to Redis immediately (source of truth for real-time state)
   if (redisStore) {
@@ -275,7 +286,7 @@ export async function updateQueueOnly(
     );
   }
 
-  return { version: newVersion, sequence: newSequence, stateHash };
+  return { version: newVersion, sequence: newSequence, stateHash, stateHashOrdered };
 }
 
 /**
@@ -292,6 +303,13 @@ export async function getQueueState(sessionId: string, redisStore: RedisSessionS
         version: redisSession.version,
         sequence: redisSession.sequence,
         stateHash: redisSession.stateHash,
+        // Only the v1 hash is persisted in Redis; recompute the order-sensitive
+        // v2 hash from the same stored queue so the pair stays consistent
+        // without a Redis schema change (additive dual-hash rollout).
+        stateHashOrdered: computeQueueStateHashOrdered(
+          redisSession.queue,
+          redisSession.currentClimbQueueItem?.uuid || null,
+        ),
       };
     }
   }
@@ -306,10 +324,12 @@ export async function getQueueState(sessionId: string, redisStore: RedisSessionS
       version: 0,
       sequence: 0,
       stateHash: computeQueueStateHash([], null),
+      stateHashOrdered: computeQueueStateHashOrdered([], null),
     };
   }
 
   const stateHash = computeQueueStateHash(result[0].queue, result[0].currentClimbQueueItem?.uuid || null);
+  const stateHashOrdered = computeQueueStateHashOrdered(result[0].queue, result[0].currentClimbQueueItem?.uuid || null);
 
   return {
     queue: result[0].queue,
@@ -317,5 +337,6 @@ export async function getQueueState(sessionId: string, redisStore: RedisSessionS
     version: result[0].version,
     sequence: result[0].sequence,
     stateHash,
+    stateHashOrdered,
   };
 }

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -310,6 +310,7 @@ class RoomManager {
     currentClimbQueueItem: ClimbQueueItem | null;
     sequence: number;
     stateHash: string;
+    stateHashOrdered: string;
     isLeader: boolean;
     sessionName: string | null;
     participantId: string;
@@ -535,7 +536,13 @@ class RoomManager {
     queue: ClimbQueueItem[],
     currentClimbQueueItem: ClimbQueueItem | null,
     expectedVersion?: number,
-  ): Promise<{ version: number; sequence: number; stateHash: string; previousStateHash: string | null }> {
+  ): Promise<{
+    version: number;
+    sequence: number;
+    stateHash: string;
+    stateHashOrdered: string;
+    previousStateHash: string | null;
+  }> {
     return updateQueueStateFn(this.deps(), sessionId, queue, currentClimbQueueItem, expectedVersion);
   }
 
@@ -552,7 +559,7 @@ class RoomManager {
     sessionId: string,
     queue: ClimbQueueItem[],
     expectedVersion?: number,
-  ): Promise<{ version: number; sequence: number; stateHash: string }> {
+  ): Promise<{ version: number; sequence: number; stateHash: string; stateHashOrdered: string }> {
     return updateQueueOnlyFn(this.deps(), sessionId, queue, expectedVersion);
   }
 

--- a/packages/backend/src/services/room-manager/types.ts
+++ b/packages/backend/src/services/room-manager/types.ts
@@ -111,6 +111,7 @@ export type JoinSessionCallbacks = {
     version: number;
     sequence: number;
     stateHash: string;
+    stateHashOrdered: string;
   }>;
   getSessionUsers: (sessionId: string) => Promise<SessionUser[]>;
   getSessionUsersLocal: (sessionId: string) => SessionUser[];
@@ -156,6 +157,7 @@ export type QueueState = {
   version: number;
   sequence: number;
   stateHash: string;
+  stateHashOrdered: string;
 };
 
 export type PendingWrite = {

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -729,6 +729,8 @@ export type GetSessionQueueStateQueryResponse = {
       // after applying it — see resyncQueueFromServer in queue-provider.tsx.
       sequence: number;
       stateHash: string;
+      // Order-sensitive (v2) hash — optional during the dual-hash rollout.
+      stateHashOrdered?: string | null;
       queue: SubscriptionQueueItem[];
       currentClimbQueueItem: SubscriptionQueueItem | null;
     } | null;
@@ -1190,6 +1192,7 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
         state {
           sequence
           stateHash
+          stateHashOrdered
           queue { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
           currentClimbQueueItem { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
         }
@@ -1197,17 +1200,20 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
       ... on QueueItemAdded {
         sequence
         stateHash
+        stateHashOrdered
         addedItem: item { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
         position
       }
       ... on QueueItemRemoved {
         sequence
         stateHash
+        stateHashOrdered
         uuid
       }
       ... on QueueReordered {
         sequence
         stateHash
+        stateHashOrdered
         uuid
         oldIndex
         newIndex
@@ -1215,6 +1221,7 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
       ... on CurrentClimbChanged {
         sequence
         stateHash
+        stateHashOrdered
         currentItem: item { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
         clientId
         correlationId
@@ -1222,6 +1229,7 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
       ... on ClimbMirrored {
         sequence
         stateHash
+        stateHashOrdered
         mirroredUuid: uuid
         mirrored
       }
@@ -1240,6 +1248,7 @@ export const GET_SESSION_QUEUE_STATE = gql`
       queueState {
         sequence
         stateHash
+        stateHashOrdered
         queue { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
         currentClimbQueueItem { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
       }

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -455,6 +455,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         __typename: 'FullSync',
         sequence: queueState.sequence,
         stateHash: queueState.stateHash,
+        stateHashOrdered: queueState.stateHashOrdered ?? null,
       });
       return true;
     } catch (error) {

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { computeQueueStateHash } from '@boardsesh/queue';
+import { computeQueueStateHash, computeQueueStateHashOrdered } from '@boardsesh/queue';
 import type { QueueAction, QueueState } from '@boardsesh/queue';
 import {
   applySessionRuntimeEvent,
@@ -57,9 +57,15 @@ function toSyncQueueEvent(event: QueueUpdateEvent): QueueSyncGateEvent {
     return {
       __typename: 'FullSync',
       sequence: event.sequence,
-      stateHash: (event.state as { stateHash?: string | null }).stateHash ?? null,
+      stateHash: event.state.stateHash ?? null,
+      // Order-sensitive (v2) hash — nested under `state` like stateHash. Rides
+      // through to the gate so it can prefer ordered-vs-ordered on reorder drift.
+      stateHashOrdered: event.state.stateHashOrdered ?? null,
     };
   }
+  // Non-FullSync variants carry `stateHash`/`stateHashOrdered` at the top level
+  // (matching the subscription selection), so the raw envelope is already a
+  // valid QueueSyncGateEvent — the ordered hash flows through untouched.
   return event;
 }
 
@@ -521,15 +527,19 @@ export function useSessionRealtime({
       const gate = queueSyncGateRef.current;
       if (!gate) return;
       const { queue, currentClimbQueueItem } = stateRef.current;
+      // Compute both hashes; the gate prefers the ordered (v2) comparison when
+      // the server sent an ordered hash, else falls back to v1. `localHash` (v1)
+      // is retained for the drift log/analytics below.
       const localHash = computeQueueStateHash(queue, currentClimbQueueItem?.uuid ?? null);
-      const result = gate.verifyLocalHash(localHash);
+      const localHashOrdered = computeQueueStateHashOrdered(queue, currentClimbQueueItem?.uuid ?? null);
+      const result = gate.verifyLocalHash({ stateHash: localHash, stateHashOrdered: localHashOrdered });
       if (result.verdict === 'ok') return;
 
       if (result.verdict === 'resync-drift') {
         if (__DEV__) {
           console.warn(
             '[queue] hash drift detected; resyncing',
-            `local=${localHash} server=${result.serverHash} strikes=${result.consecutiveResyncs}`,
+            `localV1=${localHash} localV2=${localHashOrdered} server(compared)=${result.serverHash} strikes=${result.consecutiveResyncs}`,
           );
         }
         track(SHARED_EVENTS.QueueSyncHashDrift, {
@@ -551,7 +561,7 @@ export function useSessionRealtime({
       if (__DEV__) {
         console.warn(
           '[queue] hash drift backoff — resync loop threshold hit',
-          `local=${localHash} server=${result.serverHash} strikes=${result.consecutiveResyncs}`,
+          `localV1=${localHash} localV2=${localHashOrdered} server(compared)=${result.serverHash} strikes=${result.consecutiveResyncs}`,
         );
       }
       // Report to analytics ONCE per drift streak — the first backoff tick

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -299,8 +299,10 @@ Used for synchronization between clients.
 type QueueState {
   "Monotonically increasing sequence number for ordering events"
   sequence: Int!
-  "Hash of the current state for consistency checking"
+  "Order-insensitive hash (v1) of the current state for consistency checking (sorted UUIDs)"
   stateHash: String!
+  "Order-SENSITIVE hash (v2) of the current state (UUIDs in queue order). Optional during the dual-hash rollout: old clients ignore it; new clients prefer it when present so a reorder that diverges is detectable."
+  stateHashOrdered: String
   "List of climbs in the queue"
   queue: [ClimbQueueItem!]!
   "The climb currently being attempted"
@@ -5476,8 +5478,10 @@ Event when an item is added to the queue.
 type QueueItemAdded {
   "Sequence number of this event"
   sequence: Int!
-  "Queue state hash after this event is applied"
+  "Order-insensitive queue state hash (v1) after this event is applied"
   stateHash: String!
+  "Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered."
+  stateHashOrdered: String
   "The added item"
   item: ClimbQueueItem!
   "Position where item was inserted (null = end)"
@@ -5490,8 +5494,10 @@ Event when an item is removed from the queue.
 type QueueItemRemoved {
   "Sequence number of this event"
   sequence: Int!
-  "Queue state hash after this event is applied"
+  "Order-insensitive queue state hash (v1) after this event is applied"
   stateHash: String!
+  "Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered."
+  stateHashOrdered: String
   "UUID of the removed item"
   uuid: ID!
 }
@@ -5502,8 +5508,10 @@ Event when queue order changes.
 type QueueReordered {
   "Sequence number of this event"
   sequence: Int!
-  "Queue state hash after this event is applied"
+  "Order-insensitive queue state hash (v1) after this event is applied. Reorders leave this UNCHANGED — that blind spot is why stateHashOrdered exists."
   stateHash: String!
+  "Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered."
+  stateHashOrdered: String
   "UUID of the moved item"
   uuid: ID!
   "Previous position"
@@ -5518,8 +5526,10 @@ Event when the current climb changes.
 type CurrentClimbChanged {
   "Sequence number of this event"
   sequence: Int!
-  "Queue state hash after this event is applied"
+  "Order-insensitive queue state hash (v1) after this event is applied"
   stateHash: String!
+  "Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered."
+  stateHashOrdered: String
   "New current climb (null to clear)"
   item: ClimbQueueItem
   "Raw Aurora frames for an unknown BLE climb when no database match exists"
@@ -5536,8 +5546,10 @@ Event when the current climb's mirror state changes.
 type ClimbMirrored {
   "Sequence number of this event"
   sequence: Int!
-  "Queue state hash after this event is applied"
+  "Order-insensitive queue state hash (v1) after this event is applied"
   stateHash: String!
+  "Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered."
+  stateHashOrdered: String
   "UUID of the mirrored queue item, when a current climb exists"
   uuid: ID
   "New mirror state"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -760,8 +760,10 @@ export type ClimbMirrored = {
   mirrored: Scalars['Boolean']['output'];
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
-  /** Queue state hash after this event is applied */
+  /** Order-insensitive queue state hash (v1) after this event is applied */
   stateHash: Scalars['String']['output'];
+  /** Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
   /** UUID of the mirrored queue item, when a current climb exists */
   uuid?: Maybe<Scalars['ID']['output']>;
 };
@@ -1223,8 +1225,10 @@ export type CurrentClimbChanged = {
   item?: Maybe<ClimbQueueItem>;
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
-  /** Queue state hash after this event is applied */
+  /** Order-insensitive queue state hash (v1) after this event is applied */
   stateHash: Scalars['String']['output'];
+  /** Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
 };
 
 /** Information needed before account deletion. */
@@ -4402,8 +4406,10 @@ export type QueueItemAdded = {
   position?: Maybe<Scalars['Int']['output']>;
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
-  /** Queue state hash after this event is applied */
+  /** Order-insensitive queue state hash (v1) after this event is applied */
   stateHash: Scalars['String']['output'];
+  /** Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
 };
 
 /** Event when an item is removed from the queue. */
@@ -4411,8 +4417,10 @@ export type QueueItemRemoved = {
   __typename?: 'QueueItemRemoved';
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
-  /** Queue state hash after this event is applied */
+  /** Order-insensitive queue state hash (v1) after this event is applied */
   stateHash: Scalars['String']['output'];
+  /** Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
   /** UUID of the removed item */
   uuid: Scalars['ID']['output'];
 };
@@ -4463,8 +4471,10 @@ export type QueueReordered = {
   oldIndex: Scalars['Int']['output'];
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
-  /** Queue state hash after this event is applied */
+  /** Order-insensitive queue state hash (v1) after this event is applied. Reorders leave this UNCHANGED — that blind spot is why stateHashOrdered exists. */
   stateHash: Scalars['String']['output'];
+  /** Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
   /** UUID of the moved item */
   uuid: Scalars['ID']['output'];
 };
@@ -4481,8 +4491,10 @@ export type QueueState = {
   queue: Array<ClimbQueueItem>;
   /** Monotonically increasing sequence number for ordering events */
   sequence: Scalars['Int']['output'];
-  /** Hash of the current state for consistency checking */
+  /** Order-insensitive hash (v1) of the current state for consistency checking (sorted UUIDs) */
   stateHash: Scalars['String']['output'];
+  /** Order-SENSITIVE hash (v2) of the current state (UUIDs in queue order). Optional during the dual-hash rollout: old clients ignore it; new clients prefer it when present so a reorder that diverges is detectable. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
 };
 
 /**
@@ -7173,6 +7185,7 @@ export type ClimbMirroredResolvers<
   mirrored?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  stateHashOrdered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   uuid?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -7406,6 +7419,7 @@ export type CurrentClimbChangedResolvers<
   item?: Resolver<Maybe<ResolversTypes['ClimbQueueItem']>, ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  stateHashOrdered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -9299,6 +9313,7 @@ export type QueueItemAddedResolvers<
   position?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  stateHashOrdered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -9308,6 +9323,7 @@ export type QueueItemRemovedResolvers<
 > = ResolversObject<{
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  stateHashOrdered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -9351,6 +9367,7 @@ export type QueueReorderedResolvers<
   oldIndex?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  stateHashOrdered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -9363,6 +9380,7 @@ export type QueueStateResolvers<
   queue?: Resolver<Array<ResolversTypes['ClimbQueueItem']>, ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  stateHashOrdered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/packages/shared-schema/src/schema/events.ts
+++ b/packages/shared-schema/src/schema/events.ts
@@ -196,8 +196,10 @@ export const eventsTypeDefs = /* GraphQL */ `
   type QueueItemAdded {
     "Sequence number of this event"
     sequence: Int!
-    "Queue state hash after this event is applied"
+    "Order-insensitive queue state hash (v1) after this event is applied"
     stateHash: String!
+    "Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered."
+    stateHashOrdered: String
     "The added item"
     item: ClimbQueueItem!
     "Position where item was inserted (null = end)"
@@ -210,8 +212,10 @@ export const eventsTypeDefs = /* GraphQL */ `
   type QueueItemRemoved {
     "Sequence number of this event"
     sequence: Int!
-    "Queue state hash after this event is applied"
+    "Order-insensitive queue state hash (v1) after this event is applied"
     stateHash: String!
+    "Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered."
+    stateHashOrdered: String
     "UUID of the removed item"
     uuid: ID!
   }
@@ -222,8 +226,10 @@ export const eventsTypeDefs = /* GraphQL */ `
   type QueueReordered {
     "Sequence number of this event"
     sequence: Int!
-    "Queue state hash after this event is applied"
+    "Order-insensitive queue state hash (v1) after this event is applied. Reorders leave this UNCHANGED — that blind spot is why stateHashOrdered exists."
     stateHash: String!
+    "Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered."
+    stateHashOrdered: String
     "UUID of the moved item"
     uuid: ID!
     "Previous position"
@@ -238,8 +244,10 @@ export const eventsTypeDefs = /* GraphQL */ `
   type CurrentClimbChanged {
     "Sequence number of this event"
     sequence: Int!
-    "Queue state hash after this event is applied"
+    "Order-insensitive queue state hash (v1) after this event is applied"
     stateHash: String!
+    "Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered."
+    stateHashOrdered: String
     "New current climb (null to clear)"
     item: ClimbQueueItem
     "Raw Aurora frames for an unknown BLE climb when no database match exists"
@@ -256,8 +264,10 @@ export const eventsTypeDefs = /* GraphQL */ `
   type ClimbMirrored {
     "Sequence number of this event"
     sequence: Int!
-    "Queue state hash after this event is applied"
+    "Order-insensitive queue state hash (v1) after this event is applied"
     stateHash: String!
+    "Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered."
+    stateHashOrdered: String
     "UUID of the mirrored queue item, when a current climb exists"
     uuid: ID
     "New mirror state"

--- a/packages/shared-schema/src/schema/queue.ts
+++ b/packages/shared-schema/src/schema/queue.ts
@@ -57,8 +57,10 @@ export const queueTypeDefs = /* GraphQL */ `
   type QueueState {
     "Monotonically increasing sequence number for ordering events"
     sequence: Int!
-    "Hash of the current state for consistency checking"
+    "Order-insensitive hash (v1) of the current state for consistency checking (sorted UUIDs)"
     stateHash: String!
+    "Order-SENSITIVE hash (v2) of the current state (UUIDs in queue order). Optional during the dual-hash rollout: old clients ignore it; new clients prefer it when present so a reorder that diverges is detectable."
+    stateHashOrdered: String
     "List of climbs in the queue"
     queue: [ClimbQueueItem!]!
     "The climb currently being attempted"

--- a/packages/shared-schema/src/types/events.ts
+++ b/packages/shared-schema/src/types/events.ts
@@ -32,21 +32,31 @@ export type EventsReplayResponse = {
 
 export type ReplayQueueEvent = QueueEvent | SubscriptionQueueEvent;
 
-// Server-side event type - uses actual GraphQL field names
+// Server-side event type - uses actual GraphQL field names.
+// `stateHashOrdered` is the optional order-sensitive (v2) hash, additive during
+// the dual-hash rollout — the backend always sends it now; old clients ignore it.
 export type QueueEvent =
   | { __typename: 'FullSync'; sequence: number; state: QueueState }
   | {
       __typename: 'QueueItemAdded';
       sequence: number;
       stateHash: string;
+      stateHashOrdered?: string | null;
       item: ClimbQueueItem;
       position?: number | null;
     }
-  | { __typename: 'QueueItemRemoved'; sequence: number; stateHash: string; uuid: string }
+  | {
+      __typename: 'QueueItemRemoved';
+      sequence: number;
+      stateHash: string;
+      stateHashOrdered?: string | null;
+      uuid: string;
+    }
   | {
       __typename: 'QueueReordered';
       sequence: number;
       stateHash: string;
+      stateHashOrdered?: string | null;
       uuid: string;
       oldIndex: number;
       newIndex: number;
@@ -55,12 +65,20 @@ export type QueueEvent =
       __typename: 'CurrentClimbChanged';
       sequence: number;
       stateHash: string;
+      stateHashOrdered?: string | null;
       item: ClimbQueueItem | null;
       frames?: string | null;
       clientId: string | null;
       correlationId: string | null;
     }
-  | { __typename: 'ClimbMirrored'; sequence: number; stateHash: string; uuid?: string | null; mirrored: boolean }
+  | {
+      __typename: 'ClimbMirrored';
+      sequence: number;
+      stateHash: string;
+      stateHashOrdered?: string | null;
+      uuid?: string | null;
+      mirrored: boolean;
+    }
   | {
       __typename: 'PlaybackStateChanged';
       sequence: number;
@@ -73,21 +91,30 @@ export type QueueEvent =
       clientId: string | null;
     };
 
-// Client-side subscription event type - uses aliased field names to avoid GraphQL union conflicts
+// Client-side subscription event type - uses aliased field names to avoid GraphQL union conflicts.
+// `stateHashOrdered` mirrors the server type's optional order-sensitive (v2) hash.
 export type SubscriptionQueueEvent =
   | { __typename: 'FullSync'; sequence: number; state: QueueState }
   | {
       __typename: 'QueueItemAdded';
       sequence: number;
       stateHash: string;
+      stateHashOrdered?: string | null;
       addedItem: ClimbQueueItem;
       position?: number | null;
     }
-  | { __typename: 'QueueItemRemoved'; sequence: number; stateHash: string; uuid: string }
+  | {
+      __typename: 'QueueItemRemoved';
+      sequence: number;
+      stateHash: string;
+      stateHashOrdered?: string | null;
+      uuid: string;
+    }
   | {
       __typename: 'QueueReordered';
       sequence: number;
       stateHash: string;
+      stateHashOrdered?: string | null;
       uuid: string;
       oldIndex: number;
       newIndex: number;
@@ -96,6 +123,7 @@ export type SubscriptionQueueEvent =
       __typename: 'CurrentClimbChanged';
       sequence: number;
       stateHash: string;
+      stateHashOrdered?: string | null;
       currentItem: ClimbQueueItem | null;
       frames?: string | null;
       clientId: string | null;
@@ -105,6 +133,7 @@ export type SubscriptionQueueEvent =
       __typename: 'ClimbMirrored';
       sequence: number;
       stateHash: string;
+      stateHashOrdered?: string | null;
       mirroredUuid?: string | null;
       mirrored: boolean;
     }

--- a/packages/shared-schema/src/types/queue.ts
+++ b/packages/shared-schema/src/types/queue.ts
@@ -38,6 +38,10 @@ export type ClimbQueueItemInput = {
 export type QueueState = {
   sequence: number;
   stateHash: string;
+  /** Order-sensitive hash (v2). Optional during the dual-hash rollout: old
+   *  backends omit it, new backends always send it. See
+   *  `computeQueueStateHashOrdered` in `@boardsesh/queue`. */
+  stateHashOrdered?: string | null;
   queue: ClimbQueueItem[];
   currentClimbQueueItem: ClimbQueueItem | null;
 };

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -757,8 +757,10 @@ export type ClimbMirrored = {
   mirrored: Scalars['Boolean']['output'];
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
-  /** Queue state hash after this event is applied */
+  /** Order-insensitive queue state hash (v1) after this event is applied */
   stateHash: Scalars['String']['output'];
+  /** Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
   /** UUID of the mirrored queue item, when a current climb exists */
   uuid?: Maybe<Scalars['ID']['output']>;
 };
@@ -1220,8 +1222,10 @@ export type CurrentClimbChanged = {
   item?: Maybe<ClimbQueueItem>;
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
-  /** Queue state hash after this event is applied */
+  /** Order-insensitive queue state hash (v1) after this event is applied */
   stateHash: Scalars['String']['output'];
+  /** Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
 };
 
 /** Information needed before account deletion. */
@@ -4399,8 +4403,10 @@ export type QueueItemAdded = {
   position?: Maybe<Scalars['Int']['output']>;
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
-  /** Queue state hash after this event is applied */
+  /** Order-insensitive queue state hash (v1) after this event is applied */
   stateHash: Scalars['String']['output'];
+  /** Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
 };
 
 /** Event when an item is removed from the queue. */
@@ -4408,8 +4414,10 @@ export type QueueItemRemoved = {
   __typename?: 'QueueItemRemoved';
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
-  /** Queue state hash after this event is applied */
+  /** Order-insensitive queue state hash (v1) after this event is applied */
   stateHash: Scalars['String']['output'];
+  /** Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
   /** UUID of the removed item */
   uuid: Scalars['ID']['output'];
 };
@@ -4460,8 +4468,10 @@ export type QueueReordered = {
   oldIndex: Scalars['Int']['output'];
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
-  /** Queue state hash after this event is applied */
+  /** Order-insensitive queue state hash (v1) after this event is applied. Reorders leave this UNCHANGED — that blind spot is why stateHashOrdered exists. */
   stateHash: Scalars['String']['output'];
+  /** Order-sensitive queue state hash (v2) after this event is applied. Optional during the dual-hash rollout; see QueueState.stateHashOrdered. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
   /** UUID of the moved item */
   uuid: Scalars['ID']['output'];
 };
@@ -4478,8 +4488,10 @@ export type QueueState = {
   queue: Array<ClimbQueueItem>;
   /** Monotonically increasing sequence number for ordering events */
   sequence: Scalars['Int']['output'];
-  /** Hash of the current state for consistency checking */
+  /** Order-insensitive hash (v1) of the current state for consistency checking (sorted UUIDs) */
   stateHash: Scalars['String']['output'];
+  /** Order-SENSITIVE hash (v2) of the current state (UUIDs in queue order). Optional during the dual-hash rollout: old clients ignore it; new clients prefer it when present so a reorder that diverges is detectable. */
+  stateHashOrdered?: Maybe<Scalars['String']['output']>;
 };
 
 /**

--- a/packages/shared/graphql/src/operations/queue-session.ts
+++ b/packages/shared/graphql/src/operations/queue-session.ts
@@ -70,6 +70,7 @@ export const JOIN_SESSION = `
       queueState {
         sequence
         stateHash
+        stateHashOrdered
         queue {
           ${QUEUE_ITEM_FIELDS}
         }
@@ -229,6 +230,7 @@ export const SET_QUEUE = `
     setQueue(queue: $queue, currentClimbQueueItem: $currentClimbQueueItem) {
       sequence
       stateHash
+      stateHashOrdered
       queue {
         ${QUEUE_ITEM_FIELDS}
       }
@@ -266,6 +268,7 @@ export const CREATE_SESSION = `
       queueState {
         sequence
         stateHash
+        stateHashOrdered
         queue {
           ${QUEUE_ITEM_FIELDS}
         }
@@ -392,6 +395,7 @@ export const EVENTS_REPLAY = `
           state {
             sequence
             stateHash
+            stateHashOrdered
             queue {
               ${QUEUE_ITEM_FIELDS}
             }
@@ -403,6 +407,7 @@ export const EVENTS_REPLAY = `
         ... on QueueItemAdded {
           sequence
           stateHash
+          stateHashOrdered
           addedItem: item {
             ${QUEUE_ITEM_FIELDS}
           }
@@ -411,11 +416,13 @@ export const EVENTS_REPLAY = `
         ... on QueueItemRemoved {
           sequence
           stateHash
+          stateHashOrdered
           uuid
         }
         ... on QueueReordered {
           sequence
           stateHash
+          stateHashOrdered
           uuid
           oldIndex
           newIndex
@@ -423,6 +430,7 @@ export const EVENTS_REPLAY = `
         ... on CurrentClimbChanged {
           sequence
           stateHash
+          stateHashOrdered
           currentItem: item {
             ${QUEUE_ITEM_FIELDS}
           }
@@ -432,6 +440,7 @@ export const EVENTS_REPLAY = `
         ... on ClimbMirrored {
           sequence
           stateHash
+          stateHashOrdered
           mirroredUuid: uuid
           mirrored
         }
@@ -459,6 +468,7 @@ export const QUEUE_UPDATES = `
         state {
           sequence
           stateHash
+          stateHashOrdered
           queue {
             ${QUEUE_ITEM_FIELDS}
           }
@@ -470,6 +480,7 @@ export const QUEUE_UPDATES = `
       ... on QueueItemAdded {
         sequence
         stateHash
+        stateHashOrdered
         addedItem: item {
           ${QUEUE_ITEM_FIELDS}
         }
@@ -478,11 +489,13 @@ export const QUEUE_UPDATES = `
       ... on QueueItemRemoved {
         sequence
         stateHash
+        stateHashOrdered
         uuid
       }
       ... on QueueReordered {
         sequence
         stateHash
+        stateHashOrdered
         uuid
         oldIndex
         newIndex
@@ -490,6 +503,7 @@ export const QUEUE_UPDATES = `
       ... on CurrentClimbChanged {
         sequence
         stateHash
+        stateHashOrdered
         currentItem: item {
           ${QUEUE_ITEM_FIELDS}
         }
@@ -499,6 +513,7 @@ export const QUEUE_UPDATES = `
       ... on ClimbMirrored {
         sequence
         stateHash
+        stateHashOrdered
         mirroredUuid: uuid
         mirrored
       }

--- a/packages/shared/queue-runtime/src/__tests__/sync-gate.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/sync-gate.test.ts
@@ -445,7 +445,12 @@ describe('createQueueSyncGate', () => {
     // DIVERGE but the ordered (v2) hashes AGREE. If the gate OR-ed the two
     // comparisons (v1-mismatch → full-sync) this would wrongly resync. Because the
     // ordered pair is preferred outright, the v1 divergence is ignored → 'none'.
-    it('does nothing at gap 0 when the ordered (v2) hashes match even though v1 diverges', () => {
+    // Synthetic adversarial case: with a real queue, equal ordered (v2) hashes
+    // imply equal sorted (v1) hashes, so "v2 agree + v1 diverge" cannot occur.
+    // The hardcoded hash values force that impossible pairing to prove the code
+    // path — that when preferOrdered is true, the v1 comparison is discarded
+    // entirely (an OR of the two would wrongly full-sync on the v1 divergence).
+    it('discards the v1 comparison at gap 0 when preferOrdered (ordered agree, v1 forced to diverge)', () => {
       const gate = createQueueSyncGate();
       expect(
         gate.decideReconnectStrategy({

--- a/packages/shared/queue-runtime/src/__tests__/sync-gate.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/sync-gate.test.ts
@@ -139,7 +139,11 @@ describe('createQueueSyncGate', () => {
   describe('verifyLocalHash', () => {
     it('returns ok with no server hash tracked yet', () => {
       const gate = createQueueSyncGate();
-      expect(gate.verifyLocalHash('anything')).toEqual({ verdict: 'ok', consecutiveResyncs: 0, serverHash: null });
+      expect(gate.verifyLocalHash({ stateHash: 'anything' })).toEqual({
+        verdict: 'ok',
+        consecutiveResyncs: 0,
+        serverHash: null,
+      });
     });
 
     it('returns ok when the local hash matches the tracked server hash', () => {
@@ -147,14 +151,20 @@ describe('createQueueSyncGate', () => {
       const event = fullSync(1, 'hash-a');
       gate.evaluateIncoming(event);
 
-      expect(gate.verifyLocalHash('hash-a')).toEqual({ verdict: 'ok', consecutiveResyncs: 0, serverHash: 'hash-a' });
+      expect(gate.verifyLocalHash({ stateHash: 'hash-a' })).toEqual({
+        verdict: 'ok',
+        consecutiveResyncs: 0,
+        serverHash: 'hash-a',
+      });
     });
 
     it('escalates through resync-drift for the first RESYNC_LOOP_THRESHOLD mismatches, then backs off', () => {
       const gate = createQueueSyncGate();
       gate.evaluateIncoming(fullSync(1, 'server-hash'));
 
-      const results = Array.from({ length: RESYNC_LOOP_THRESHOLD + 2 }, () => gate.verifyLocalHash('local-hash'));
+      const results = Array.from({ length: RESYNC_LOOP_THRESHOLD + 2 }, () =>
+        gate.verifyLocalHash({ stateHash: 'local-hash' }),
+      );
 
       for (let strike = 0; strike < RESYNC_LOOP_THRESHOLD; strike++) {
         expect(results[strike]).toEqual({
@@ -181,9 +191,9 @@ describe('createQueueSyncGate', () => {
       const gate = createQueueSyncGate();
       gate.evaluateIncoming(fullSync(1, 'server-hash'));
 
-      gate.verifyLocalHash('local-hash');
-      gate.verifyLocalHash('local-hash');
-      expect(gate.verifyLocalHash('server-hash')).toEqual({
+      gate.verifyLocalHash({ stateHash: 'local-hash' });
+      gate.verifyLocalHash({ stateHash: 'local-hash' });
+      expect(gate.verifyLocalHash({ stateHash: 'server-hash' })).toEqual({
         verdict: 'ok',
         consecutiveResyncs: 0,
         serverHash: 'server-hash',
@@ -191,7 +201,7 @@ describe('createQueueSyncGate', () => {
 
       // A subsequent mismatch against the *same* server hash starts a fresh
       // streak at strike 1, not 3.
-      expect(gate.verifyLocalHash('local-hash')).toEqual({
+      expect(gate.verifyLocalHash({ stateHash: 'local-hash' })).toEqual({
         verdict: 'resync-drift',
         consecutiveResyncs: 1,
         serverHash: 'server-hash',
@@ -202,9 +212,9 @@ describe('createQueueSyncGate', () => {
       const gate = createQueueSyncGate();
       gate.evaluateIncoming(fullSync(1, 'server-hash-a'));
 
-      gate.verifyLocalHash('local-hash');
-      gate.verifyLocalHash('local-hash');
-      expect(gate.verifyLocalHash('local-hash')).toEqual({
+      gate.verifyLocalHash({ stateHash: 'local-hash' });
+      gate.verifyLocalHash({ stateHash: 'local-hash' });
+      expect(gate.verifyLocalHash({ stateHash: 'local-hash' })).toEqual({
         verdict: 'resync-drift',
         consecutiveResyncs: 3,
         serverHash: 'server-hash-a',
@@ -218,10 +228,100 @@ describe('createQueueSyncGate', () => {
       gate.evaluateIncoming(next);
       gate.noteApplied(next);
 
-      expect(gate.verifyLocalHash('local-hash')).toEqual({
+      expect(gate.verifyLocalHash({ stateHash: 'local-hash' })).toEqual({
         verdict: 'resync-drift',
         consecutiveResyncs: 1,
         serverHash: 'server-hash-b',
+      });
+    });
+  });
+
+  // X1: the whole point of the order-sensitive (v2) hash — a reorder that keeps
+  // the same members produces the SAME v1 hash but a DIFFERENT ordered hash.
+  // These tests prove v1's blind spot and v2's fix, and that the dual-hash
+  // preference degrades cleanly to v1 when either side lacks an ordered hash.
+  describe('verifyLocalHash — dual-hash (v2 ordered) preference', () => {
+    // A reorder drift: identical v1 (members unchanged), diverging ordered.
+    const V1_SAME = 'v1-shared';
+    const ORDERED_SERVER = 'ordered-server';
+    const ORDERED_LOCAL = 'ordered-local-diverged';
+
+    function fullSyncDual(sequence: number, stateHash: string, stateHashOrdered: string): QueueSyncGateEvent {
+      return { __typename: 'FullSync', sequence, stateHash, stateHashOrdered };
+    }
+
+    it('CATCHES reorder drift (same v1, different ordered) as resync-drift when ordered hashes are present', () => {
+      const gate = createQueueSyncGate();
+      gate.evaluateIncoming(fullSyncDual(1, V1_SAME, ORDERED_SERVER));
+
+      // v1 matches — the v1-only watchdog would have called this 'ok' (its blind
+      // spot). With ordered hashes on both sides the gate compares them and sees
+      // the divergence.
+      expect(gate.verifyLocalHash({ stateHash: V1_SAME, stateHashOrdered: ORDERED_LOCAL })).toEqual({
+        verdict: 'resync-drift',
+        consecutiveResyncs: 1,
+        // The reported serverHash is the ACTIVE (ordered) comparison hash.
+        serverHash: ORDERED_SERVER,
+      });
+    });
+
+    it("does NOT catch the same reorder drift when only v1 hashes are present (proves v1's blind spot)", () => {
+      const gate = createQueueSyncGate();
+      // Old backend: FullSync carries only v1, no ordered hash.
+      gate.evaluateIncoming(fullSync(1, V1_SAME));
+
+      // Even though the caller has a diverged ordered hash, the server never sent
+      // one, so the gate falls back to v1 — which matches → 'ok'. This is exactly
+      // the reorder-drift the 60s watchdog used to miss entirely.
+      expect(gate.verifyLocalHash({ stateHash: V1_SAME, stateHashOrdered: ORDERED_LOCAL })).toEqual({
+        verdict: 'ok',
+        consecutiveResyncs: 0,
+        serverHash: V1_SAME,
+      });
+    });
+
+    it('falls back to v1 when the caller omits the local ordered hash (old client, new backend)', () => {
+      const gate = createQueueSyncGate();
+      gate.evaluateIncoming(fullSyncDual(1, V1_SAME, ORDERED_SERVER));
+
+      // Caller passes only v1 → cannot compare ordered → v1 comparison, matches.
+      expect(gate.verifyLocalHash({ stateHash: V1_SAME })).toEqual({
+        verdict: 'ok',
+        consecutiveResyncs: 0,
+        serverHash: V1_SAME,
+      });
+    });
+
+    it('reports ok via the ordered path when both ordered hashes agree', () => {
+      const gate = createQueueSyncGate();
+      gate.evaluateIncoming(fullSyncDual(1, V1_SAME, ORDERED_SERVER));
+
+      expect(gate.verifyLocalHash({ stateHash: V1_SAME, stateHashOrdered: ORDERED_SERVER })).toEqual({
+        verdict: 'ok',
+        consecutiveResyncs: 0,
+        serverHash: ORDERED_SERVER,
+      });
+    });
+
+    it('tracks the ordered hash through a delta via noteApplied, then catches ordered drift', () => {
+      const gate = createQueueSyncGate();
+      gate.evaluateIncoming(fullSyncDual(1, 'v1-a', 'ordered-a'));
+
+      const reorder: QueueSyncGateEvent = {
+        __typename: 'QueueReordered',
+        sequence: 2,
+        // A pure reorder: v1 unchanged, ordered advanced.
+        stateHash: 'v1-a',
+        stateHashOrdered: 'ordered-b',
+      };
+      expect(gate.evaluateIncoming(reorder)).toBe('apply');
+      gate.noteApplied(reorder);
+
+      // Local still has the pre-reorder ordering → ordered mismatch caught.
+      expect(gate.verifyLocalHash({ stateHash: 'v1-a', stateHashOrdered: 'ordered-a' })).toEqual({
+        verdict: 'resync-drift',
+        consecutiveResyncs: 1,
+        serverHash: 'ordered-b',
       });
     });
   });
@@ -296,6 +396,52 @@ describe('createQueueSyncGate', () => {
       ).toBe('full-sync');
     });
 
+    // The recovery half of the reorder-drift fix: at the same sequence with an
+    // equal v1 hash but a diverged ordered hash, the reconnect must full-sync so
+    // the client's queue is actually re-ordered — not just detected as drifted.
+    it('full-syncs at gap 0 when v1 hashes match but the ordered (v2) hashes diverge', () => {
+      const gate = createQueueSyncGate();
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: 10,
+          serverSequence: 10,
+          serverStateHash: 'same-v1',
+          localStateHash: 'same-v1',
+          serverStateHashOrdered: 'ordered-server',
+          localStateHashOrdered: 'ordered-local-diverged',
+        }),
+      ).toBe('full-sync');
+    });
+
+    it('does nothing at gap 0 when both v1 and ordered hashes match', () => {
+      const gate = createQueueSyncGate();
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: 10,
+          serverSequence: 10,
+          serverStateHash: 'same-v1',
+          localStateHash: 'same-v1',
+          serverStateHashOrdered: 'same-ordered',
+          localStateHashOrdered: 'same-ordered',
+        }),
+      ).toBe('none');
+    });
+
+    it('falls back to v1 at gap 0 when ordered hashes are not both present (old backend)', () => {
+      const gate = createQueueSyncGate();
+      // Server sent no ordered hash: a diverged local ordered hash is ignored,
+      // v1 matches → 'none' (exactly the pre-dual-hash behaviour).
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: 10,
+          serverSequence: 10,
+          serverStateHash: 'same-v1',
+          localStateHash: 'same-v1',
+          localStateHashOrdered: 'ordered-local-diverged',
+        }),
+      ).toBe('none');
+    });
+
     it('delta-replays for a small gap (1..100)', () => {
       const gate = createQueueSyncGate();
       expect(
@@ -329,10 +475,14 @@ describe('createQueueSyncGate', () => {
       ).toBe('full-sync');
     });
 
-    it('does nothing when the server-reported sequence is behind the last one applied (negative gap)', () => {
-      // Matches web's current use-session-lifecycle.ts behaviour: none of
-      // the gap>0/gap>100/lastSeq===null/gap===0 branches fire for a
-      // negative gap, so the reconnect flow falls through with no resync.
+    it('full-syncs when the server-reported sequence is behind the last one applied (negative gap)', () => {
+      // MIGRATED from the old 'none' assertion (carried in from the W3 review):
+      // a negative gap means the backend re-seeded its sequence counter LOW
+      // (restart with Redis lost / a dormant Postgres row), leaving this client
+      // permanently ahead. Under the old 'none' verdict every later delta looked
+      // stale against the client's higher tracked sequence and was dropped
+      // forever ('ignore-stale' loop). A full-sync re-baselines the client to
+      // the server's authoritative state and recovers it.
       const gate = createQueueSyncGate();
       expect(
         gate.decideReconnectStrategy({
@@ -341,7 +491,7 @@ describe('createQueueSyncGate', () => {
           serverStateHash: 'server-hash',
           localStateHash: 'local-hash',
         }),
-      ).toBe('none');
+      ).toBe('full-sync');
     });
 
     it('is pure with respect to gate-tracked state — ignores getLastSequence() and only reads its input', () => {
@@ -371,8 +521,8 @@ describe('createQueueSyncGate', () => {
 
       const event = fullSync(10, 'server-hash');
       gate.evaluateIncoming(event);
-      gate.verifyLocalHash('local-hash');
-      gate.verifyLocalHash('local-hash');
+      gate.verifyLocalHash({ stateHash: 'local-hash' });
+      gate.verifyLocalHash({ stateHash: 'local-hash' });
       gate.evaluateCorruption();
 
       gate.reset();
@@ -382,7 +532,7 @@ describe('createQueueSyncGate', () => {
       // from 2.
       const event2 = fullSync(1, 'server-hash-2');
       gate.evaluateIncoming(event2);
-      expect(gate.verifyLocalHash('local-hash')).toEqual({
+      expect(gate.verifyLocalHash({ stateHash: 'local-hash' })).toEqual({
         verdict: 'resync-drift',
         consecutiveResyncs: 1,
         serverHash: 'server-hash-2',

--- a/packages/shared/queue-runtime/src/__tests__/sync-gate.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/sync-gate.test.ts
@@ -324,6 +324,33 @@ describe('createQueueSyncGate', () => {
         serverHash: 'ordered-b',
       });
     });
+
+    // Rolling-deploy hardening: a new-backend FullSync seeds an ordered hash, then
+    // a delta from an OLD backend instance still draining carries only v1 (no
+    // ordered). advanceTracking must CLEAR the seeded ordered hash so the gate
+    // never compares local-ordered against the now-stale FullSync ordered value —
+    // it falls back to the v1 comparison the same delta just refreshed.
+    it('clears a stale seeded ordered hash when a v1-only delta arrives (rolling-deploy mixed signal)', () => {
+      const gate = createQueueSyncGate();
+      // New backend: FullSync seeds BOTH hashes.
+      gate.evaluateIncoming(fullSyncDual(1, 'v1-a', 'ordered-a'));
+
+      // Old backend instance mid-rollout: a real queue-mutating delta with a v1
+      // hash but NO ordered hash (the plain `delta()` helper omits it).
+      const v1OnlyDelta = delta('QueueItemAdded', 2, 'v1-b');
+      expect(gate.evaluateIncoming(v1OnlyDelta)).toBe('apply');
+      gate.noteApplied(v1OnlyDelta);
+
+      // The caller still computes a local ordered hash that DIVERGES from the
+      // stale 'ordered-a'. Had the seed survived, the gate would prefer the
+      // ordered comparison and (wrongly) flag drift. Because the v1-only delta
+      // cleared it, the gate compares v1 ('v1-b' vs 'v1-b') → 'ok'.
+      expect(gate.verifyLocalHash({ stateHash: 'v1-b', stateHashOrdered: 'ordered-local-diverged' })).toEqual({
+        verdict: 'ok',
+        consecutiveResyncs: 0,
+        serverHash: 'v1-b',
+      });
+    });
   });
 
   describe('evaluateCorruption', () => {
@@ -411,6 +438,25 @@ describe('createQueueSyncGate', () => {
           localStateHashOrdered: 'ordered-local-diverged',
         }),
       ).toBe('full-sync');
+    });
+
+    // The inverse of the test above, and the load-bearing proof that at gap 0 the
+    // ordered comparison REPLACES v1 rather than supplementing it: v1 hashes
+    // DIVERGE but the ordered (v2) hashes AGREE. If the gate OR-ed the two
+    // comparisons (v1-mismatch → full-sync) this would wrongly resync. Because the
+    // ordered pair is preferred outright, the v1 divergence is ignored → 'none'.
+    it('does nothing at gap 0 when the ordered (v2) hashes match even though v1 diverges', () => {
+      const gate = createQueueSyncGate();
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: 10,
+          serverSequence: 10,
+          serverStateHash: 'v1-server',
+          localStateHash: 'v1-local-diverged',
+          serverStateHashOrdered: 'ordered-same',
+          localStateHashOrdered: 'ordered-same',
+        }),
+      ).toBe('none');
     });
 
     it('does nothing at gap 0 when both v1 and ordered hashes match', () => {

--- a/packages/shared/queue-runtime/src/session-connection.ts
+++ b/packages/shared/queue-runtime/src/session-connection.ts
@@ -91,6 +91,11 @@ export type SessionConnectionSessionData = {
   queueState: {
     sequence: number;
     stateHash: string;
+    /** Order-sensitive (v2) hash — optional during the dual-hash rollout. Fed
+     *  into `gate.decideReconnectStrategy` so a pure reorder drift (same
+     *  members/sequence, equal v1 hash) full-syncs and recovers. Null when the
+     *  server predates the rollout. */
+    stateHashOrdered?: string | null;
   } | null;
 };
 
@@ -194,6 +199,12 @@ export type SessionConnectionDeps<
    *  `computeQueueStateHash(queueRef.current, currentClimbQueueItemRef.current?.uuid || null)`
    *  in `use-session-lifecycle.ts:530`. */
   getLocalStateHash: () => string;
+  /** Synchronous local order-sensitive (v2) queue-state hash, fed into
+   *  `gate.decideReconnectStrategy` alongside `getLocalStateHash`. Optional
+   *  during the dual-hash rollout — when omitted (or it returns null) the gate
+   *  falls back to the v1 comparison. Web supplies
+   *  `computeQueueStateHashOrdered(queueRef.current, currentClimbQueueItemRef.current?.uuid || null)`. */
+  getLocalStateHashOrdered?: () => string | null;
   /** Apply a full-sync snapshot from freshly (re)joined session data.
    *  Mirrors the `applyFullSync` local helper in
    *  `use-session-lifecycle.ts:603-611` — the controller can't construct a
@@ -588,6 +599,11 @@ export function createSessionConnectionController<
         serverSequence,
         serverStateHash: rejoinedQueueState.stateHash,
         localStateHash: deps.getLocalStateHash(),
+        // Order-sensitive hashes so a pure reorder drift (same members/sequence,
+        // equal v1 hash) full-syncs and recovers instead of returning 'none'.
+        // Both null when either side predates the rollout → gate falls back to v1.
+        serverStateHashOrdered: rejoinedQueueState.stateHashOrdered ?? null,
+        localStateHashOrdered: deps.getLocalStateHashOrdered?.() ?? null,
       });
 
       // The original's delta-replay branch also required a truthy

--- a/packages/shared/queue-runtime/src/subscription-adapter.ts
+++ b/packages/shared/queue-runtime/src/subscription-adapter.ts
@@ -24,10 +24,12 @@ import {
  * `currentItem`/`item` on CurrentClimbChanged, `mirroredUuid`/`uuid` on
  * ClimbMirrored.
  *
- * `sequence`/`stateHash` are optional on every variant so callers can pass
- * the same envelope through `@boardsesh/queue-runtime`'s `createQueueSyncGate`
- * (see `sync-gate.ts`) for resync decisions before lifting it to a reducer
- * action here. Additive — existing callers that omit them are unaffected.
+ * `sequence`/`stateHash`/`stateHashOrdered` are optional on every variant so
+ * callers can pass the same envelope through `@boardsesh/queue-runtime`'s
+ * `createQueueSyncGate` (see `sync-gate.ts`) for resync decisions before lifting
+ * it to a reducer action here. `stateHashOrdered` is the order-sensitive (v2)
+ * hash — additive during the dual-hash rollout; existing callers that omit any
+ * of these are unaffected.
  */
 export type SubscriptionWireEnvelope<TWireItem> =
   | {
@@ -35,9 +37,12 @@ export type SubscriptionWireEnvelope<TWireItem> =
       state: {
         queue: TWireItem[];
         currentClimbQueueItem: TWireItem | null;
+        stateHash?: string | null;
+        stateHashOrdered?: string | null;
       };
       sequence?: number | null;
       stateHash?: string | null;
+      stateHashOrdered?: string | null;
     }
   | {
       __typename: 'QueueItemAdded';
@@ -46,12 +51,14 @@ export type SubscriptionWireEnvelope<TWireItem> =
       position?: number | null;
       sequence?: number | null;
       stateHash?: string | null;
+      stateHashOrdered?: string | null;
     }
   | {
       __typename: 'QueueItemRemoved';
       uuid: string;
       sequence?: number | null;
       stateHash?: string | null;
+      stateHashOrdered?: string | null;
     }
   | {
       __typename: 'QueueReordered';
@@ -60,6 +67,7 @@ export type SubscriptionWireEnvelope<TWireItem> =
       newIndex: number;
       sequence?: number | null;
       stateHash?: string | null;
+      stateHashOrdered?: string | null;
     }
   | {
       __typename: 'CurrentClimbChanged';
@@ -69,6 +77,7 @@ export type SubscriptionWireEnvelope<TWireItem> =
       correlationId?: string | null;
       sequence?: number | null;
       stateHash?: string | null;
+      stateHashOrdered?: string | null;
     }
   | {
       __typename: 'ClimbMirrored';
@@ -77,6 +86,7 @@ export type SubscriptionWireEnvelope<TWireItem> =
       uuid?: string | null;
       sequence?: number | null;
       stateHash?: string | null;
+      stateHashOrdered?: string | null;
     };
 
 export type MapEnvelopeOptions<TWireItem> = {

--- a/packages/shared/queue-runtime/src/sync-gate.ts
+++ b/packages/shared/queue-runtime/src/sync-gate.ts
@@ -203,10 +203,22 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
     // unconditional `setLastReceivedStateHash(event.stateHash)` assignment.
     if (event.stateHash != null) {
       lastServerStateHash = event.stateHash;
-    }
-    // Track the ordered hash the same way. A null (old backend) doesn't clobber
-    // a previously-tracked ordered hash — matching the v1 conditional above.
-    if (event.stateHashOrdered != null) {
+      // Mixed-signal hardening for a rolling deploy. The backend sends BOTH
+      // hashes on every queue-mutating event, so a delta that carries a v1
+      // stateHash but NO ordered hash came from an OLD backend instance still
+      // draining mid-rollout. Sync the ordered tracking to exactly what THIS
+      // delta carried: track it when present, and CLEAR any ordered hash a
+      // prior (new-backend) FullSync seeded when absent. Without the clear,
+      // `verifyLocalHash`/`decideReconnectStrategy` would keep preferring the
+      // ordered comparison and match local-ordered against a now-stale FullSync
+      // ordered value; clearing makes both fall back to the v1 comparison, which
+      // the same delta just refreshed. (The invariant makes the clear a no-op in
+      // practice — it only fires against a genuinely old, ordered-less backend.)
+      lastServerStateHashOrdered = event.stateHashOrdered ?? null;
+    } else if (event.stateHashOrdered != null) {
+      // A v1-less event that still carries an ordered hash isn't produced by the
+      // real backend (both or neither), but keep tracking it rather than dropping
+      // the signal — mirrors the pre-hardening tolerance for a lone hash.
       lastServerStateHashOrdered = event.stateHashOrdered;
     }
   }

--- a/packages/shared/queue-runtime/src/sync-gate.ts
+++ b/packages/shared/queue-runtime/src/sync-gate.ts
@@ -51,7 +51,26 @@ export const CORRUPTION_RESYNC_COOLDOWN_MS = 30_000;
 export type QueueSyncGateEvent = {
   __typename: string;
   sequence?: number | null;
+  /** Order-insensitive hash (v1). */
   stateHash?: string | null;
+  /** Order-SENSITIVE hash (v2). Optional during the dual-hash rollout: an old
+   *  backend omits it and the gate falls back to comparing v1; a new backend
+   *  always sends it and the gate prefers ordered-vs-ordered so a reorder that
+   *  diverges is finally caught (v1 is blind to reorders). */
+  stateHashOrdered?: string | null;
+};
+
+/**
+ * The pair of locally-computed hashes the watchdog passes to `verifyLocalHash`.
+ * `stateHash` (v1) is always present; `stateHashOrdered` (v2) is present once
+ * the platform computes it. The gate compares ordered-vs-ordered only when BOTH
+ * the server sent an ordered hash and this local ordered hash is present —
+ * otherwise it falls back to the v1 comparison, so behaviour is identical to
+ * today's against an old backend.
+ */
+export type LocalStateHashes = {
+  stateHash: string;
+  stateHashOrdered?: string | null;
 };
 
 export type IncomingEventDecision = 'apply' | 'ignore-stale' | 'resync-gap';
@@ -65,11 +84,12 @@ export type HashVerifyResult = {
    *  streak by checking `consecutiveResyncs === RESYNC_LOOP_THRESHOLD`
    *  (the same one-shot point `use-session-subscriptions.ts` reports at). */
   consecutiveResyncs: number;
-  /** The server hash the local hash was compared against (the gate's tracked
-   *  `lastServerStateHash`), or `null` when nothing was tracked yet. Web's
-   *  Sentry drift report includes it (`use-session-subscriptions.ts:150-160`)
-   *  — returning it here keeps callers from mirroring the exact value the
-   *  gate exists to own. */
+  /** The server hash the local hash was compared against, or `null` when
+   *  nothing was tracked yet. This is the *active* comparison hash: the
+   *  tracked ordered (v2) server hash when the gate compared ordered-vs-ordered,
+   *  otherwise the tracked v1 server hash. Web's Sentry drift report includes
+   *  it (`use-session-subscriptions.ts:150-160`) — returning it here keeps
+   *  callers from mirroring the exact value the gate exists to own. */
   serverHash: string | null;
 };
 
@@ -82,6 +102,14 @@ export type ReconnectStrategyInput = {
   serverSequence: number;
   serverStateHash: string;
   localStateHash: string;
+  /** Order-sensitive (v2) hashes. Optional during the dual-hash rollout: when
+   *  BOTH are present the `gap === 0` branch compares them instead of v1, so a
+   *  pure reorder drift (identical members, same sequence, equal v1 hash but
+   *  diverged order) triggers a recovering `'full-sync'` — v1 alone returns
+   *  `'none'` and would leave the client detecting the drift forever without
+   *  fixing it. Omitting either falls back to the exact v1 comparison. */
+  serverStateHashOrdered?: string | null;
+  localStateHashOrdered?: string | null;
 };
 
 export type QueueSyncGateOptions = {
@@ -116,11 +144,15 @@ export type QueueSyncGate = {
    */
   noteApplied(event: QueueSyncGateEvent): void;
   /**
-   * Periodic watchdog: compare a freshly computed local hash against the
-   * last known server hash. Tracks consecutive resyncs against the same
-   * server hash and backs off after `RESYNC_LOOP_THRESHOLD` strikes.
+   * Periodic watchdog: compare freshly computed local hashes against the last
+   * known server hashes. Prefers the order-sensitive (v2) comparison when the
+   * server sent an ordered hash AND the caller provides a local ordered hash;
+   * otherwise falls back to the v1 comparison (identical to pre-dual-hash
+   * behaviour against an old backend). Tracks consecutive resyncs against the
+   * *active* comparison server hash and backs off after `RESYNC_LOOP_THRESHOLD`
+   * strikes.
    */
-  verifyLocalHash(localHash: string): HashVerifyResult;
+  verifyLocalHash(local: LocalStateHashes): HashVerifyResult;
   /**
    * Corrupted (null/undefined) queue item detected locally. Returns
    * `'cooldown'` when a corruption-triggered resync already happened within
@@ -147,6 +179,10 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
 
   let lastSequence: number | null = null;
   let lastServerStateHash: string | null = null;
+  // Order-sensitive (v2) server hash, tracked alongside v1. Stays null against
+  // an old backend that never sends one, which is exactly what makes
+  // `verifyLocalHash` fall back to the v1 comparison there.
+  let lastServerStateHashOrdered: string | null = null;
 
   let resyncLoopHash: string | null = null;
   let consecutiveResyncCount = 0;
@@ -168,6 +204,11 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
     if (event.stateHash != null) {
       lastServerStateHash = event.stateHash;
     }
+    // Track the ordered hash the same way. A null (old backend) doesn't clobber
+    // a previously-tracked ordered hash — matching the v1 conditional above.
+    if (event.stateHashOrdered != null) {
+      lastServerStateHashOrdered = event.stateHashOrdered;
+    }
   }
 
   return {
@@ -175,6 +216,9 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
       if (event.__typename === 'FullSync') {
         lastSequence = event.sequence ?? null;
         lastServerStateHash = event.stateHash ?? null;
+        // Re-baseline the ordered hash too. A FullSync from an old backend
+        // carries no ordered hash → null → verifyLocalHash compares v1.
+        lastServerStateHashOrdered = event.stateHashOrdered ?? null;
         return 'apply';
       }
 
@@ -208,24 +252,35 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
       advanceTracking(event);
     },
 
-    verifyLocalHash(localHash) {
-      if (lastServerStateHash === null || localHash === lastServerStateHash) {
+    verifyLocalHash(local) {
+      // Prefer the order-sensitive comparison only when BOTH sides have an
+      // ordered hash: the server sent one (new backend) and the caller computed
+      // one. Otherwise fall back to v1 — identical to the pre-dual-hash
+      // behaviour, so an old backend (no server ordered hash) keeps working and
+      // a caller that only passes v1 keeps working. The chosen pair is compared
+      // and the *active* server hash keys the resync-loop counter, so a reorder
+      // that changes only the ordered hash resets/advances the streak correctly.
+      const preferOrdered = lastServerStateHashOrdered != null && local.stateHashOrdered != null;
+      const serverHash = preferOrdered ? lastServerStateHashOrdered : lastServerStateHash;
+      const localHash = preferOrdered ? (local.stateHashOrdered as string) : local.stateHash;
+
+      if (serverHash === null || localHash === serverHash) {
         // Hashes agree (or nothing to compare against yet) — reset the loop
         // counter so future drift starts fresh.
         resyncLoopHash = null;
         consecutiveResyncCount = 0;
-        return { verdict: 'ok', consecutiveResyncs: 0, serverHash: lastServerStateHash };
+        return { verdict: 'ok', consecutiveResyncs: 0, serverHash };
       }
 
-      if (resyncLoopHash === lastServerStateHash) {
+      if (resyncLoopHash === serverHash) {
         consecutiveResyncCount += 1;
       } else {
-        resyncLoopHash = lastServerStateHash;
+        resyncLoopHash = serverHash;
         consecutiveResyncCount = 1;
       }
 
       const verdict: HashVerifyVerdict = consecutiveResyncCount <= RESYNC_LOOP_THRESHOLD ? 'resync-drift' : 'backoff';
-      return { verdict, consecutiveResyncs: consecutiveResyncCount, serverHash: lastServerStateHash };
+      return { verdict, consecutiveResyncs: consecutiveResyncCount, serverHash };
     },
 
     evaluateCorruption() {
@@ -238,7 +293,14 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
       return 'resync';
     },
 
-    decideReconnectStrategy({ lastSequence: lastSeq, serverSequence, serverStateHash, localStateHash }) {
+    decideReconnectStrategy({
+      lastSequence: lastSeq,
+      serverSequence,
+      serverStateHash,
+      localStateHash,
+      serverStateHashOrdered,
+      localStateHashOrdered,
+    }) {
       if (lastSeq === null) {
         return 'full-sync';
       }
@@ -255,23 +317,33 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
         return 'full-sync';
       }
       if (gap === 0) {
-        return localStateHash !== serverStateHash ? 'full-sync' : 'none';
+        // Same sequence: only a hash mismatch means state diverged. Prefer the
+        // order-sensitive comparison when both ordered hashes are present so a
+        // pure reorder (equal v1 hash, diverged order) still full-syncs and
+        // RECOVERS — not just gets detected by the watchdog. Falls back to v1
+        // against an old backend / a caller that didn't pass ordered hashes.
+        const preferOrdered = serverStateHashOrdered != null && localStateHashOrdered != null;
+        const serverHash = preferOrdered ? (serverStateHashOrdered as string) : serverStateHash;
+        const localHash = preferOrdered ? (localStateHashOrdered as string) : localStateHash;
+        return localHash !== serverHash ? 'full-sync' : 'none';
       }
 
-      // gap < 0: the freshly rejoined session reports a sequence *behind*
-      // what this client already applied. Web's
-      // `use-session-lifecycle.ts:555-609` if/else-if chain has no branch
-      // for this case — `gap > 0 && gap <= 100` and `gap > 100` both fail
-      // (gap is negative), `lastSeq === null` fails (we're in the `else`
-      // already), and `gap === 0` fails too, so the chain falls straight
-      // through with no resync at all before `setSession`/resubscribe.
-      // Match that behaviour exactly instead of assuming a full-sync.
-      return 'none';
+      // gap < 0: the freshly rejoined session reports a sequence *behind* what
+      // this client already applied. This happens when the backend restarts and
+      // re-seeds sequence counters low (e.g. Redis lost, Postgres row dormant) —
+      // the client is then permanently ahead and, under the old 'none' verdict,
+      // would sit in 'ignore-stale' forever, dropping every subsequent delta
+      // because they all look stale against its higher tracked sequence. A
+      // full-sync re-baselines the client to the server's authoritative state
+      // and recovers it. (Carried in from the W3 review — the ported web chain
+      // fell through to no resync here, which is the bug this fixes.)
+      return 'full-sync';
     },
 
     reset() {
       lastSequence = null;
       lastServerStateHash = null;
+      lastServerStateHashOrdered = null;
       resyncLoopHash = null;
       consecutiveResyncCount = 0;
       // Deliberate per-session scoping: web's `lastCorruptionResyncRef`

--- a/packages/shared/queue/src/__tests__/state-hash.test.ts
+++ b/packages/shared/queue/src/__tests__/state-hash.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fnv1aHash, computeQueueStateHash } from '../state-hash';
+import { fnv1aHash, computeQueueStateHash, computeQueueStateHashOrdered } from '../state-hash';
 
 describe('state-hash', () => {
   describe('fnv1aHash', () => {
@@ -125,6 +125,69 @@ describe('state-hash', () => {
       it('does not throw on a literal null entry (the pre-fix backend crash)', () => {
         expect(() => computeQueueStateHash([null, { uuid: 'climb-a' }], 'climb-a')).not.toThrow();
       });
+    });
+  });
+
+  describe('computeQueueStateHashOrdered (v2, order-sensitive)', () => {
+    it('returns a consistent hash for the same queue state', () => {
+      const queue = [{ uuid: 'item-1' }, { uuid: 'item-2' }];
+      expect(computeQueueStateHashOrdered(queue, 'item-1')).toBe(computeQueueStateHashOrdered(queue, 'item-1'));
+    });
+
+    it('returns an 8-character hex string', () => {
+      expect(computeQueueStateHashOrdered([{ uuid: 'item-1' }], 'item-1')).toMatch(/^[0-9a-f]{8}$/);
+    });
+
+    it('changes when currentItemUuid changes', () => {
+      const queue = [{ uuid: 'item-1' }, { uuid: 'item-2' }];
+      expect(computeQueueStateHashOrdered(queue, 'item-1')).not.toBe(computeQueueStateHashOrdered(queue, 'item-2'));
+    });
+
+    it('handles the empty queue and the single-item queue', () => {
+      expect(computeQueueStateHashOrdered([], null)).toMatch(/^[0-9a-f]{8}$/);
+      expect(computeQueueStateHashOrdered([], 'item-1')).toMatch(/^[0-9a-f]{8}$/);
+      expect(computeQueueStateHashOrdered([{ uuid: 'only' }], 'only')).toMatch(/^[0-9a-f]{8}$/);
+    });
+
+    it('filters malformed entries identically to v1 (same lock-step corruption handling)', () => {
+      const withNulls = computeQueueStateHashOrdered(
+        [{ uuid: 'item-1' }, null, { uuid: null as unknown as string }, undefined, { uuid: 'item-2' }],
+        'item-1',
+      );
+      const clean = computeQueueStateHashOrdered([{ uuid: 'item-1' }, { uuid: 'item-2' }], 'item-1');
+      expect(withNulls).toBe(clean);
+    });
+
+    // The core reason v2 exists: a reorder that keeps membership is invisible
+    // to v1 (sorted uuids) but MUST change v2 (uuids in order).
+    it('CHANGES on a reorder that keeps the same members (v1 does NOT)', () => {
+      const original = [{ uuid: 'item-1' }, { uuid: 'item-2' }, { uuid: 'item-3' }];
+      const reordered = [{ uuid: 'item-2' }, { uuid: 'item-1' }, { uuid: 'item-3' }];
+
+      // v1 is blind to the reorder (sorted internally)...
+      expect(computeQueueStateHash(original, 'item-1')).toBe(computeQueueStateHash(reordered, 'item-1'));
+      // ...v2 catches it.
+      expect(computeQueueStateHashOrdered(original, 'item-1')).not.toBe(
+        computeQueueStateHashOrdered(reordered, 'item-1'),
+      );
+    });
+
+    it('changes for BOTH v1 and v2 on an add', () => {
+      const before = [{ uuid: 'item-1' }, { uuid: 'item-2' }];
+      const afterAdd = [{ uuid: 'item-1' }, { uuid: 'item-2' }, { uuid: 'item-3' }];
+
+      expect(computeQueueStateHash(before, 'item-1')).not.toBe(computeQueueStateHash(afterAdd, 'item-1'));
+      expect(computeQueueStateHashOrdered(before, 'item-1')).not.toBe(computeQueueStateHashOrdered(afterAdd, 'item-1'));
+    });
+
+    it('changes for BOTH v1 and v2 on a remove', () => {
+      const before = [{ uuid: 'item-1' }, { uuid: 'item-2' }, { uuid: 'item-3' }];
+      const afterRemove = [{ uuid: 'item-1' }, { uuid: 'item-3' }];
+
+      expect(computeQueueStateHash(before, 'item-1')).not.toBe(computeQueueStateHash(afterRemove, 'item-1'));
+      expect(computeQueueStateHashOrdered(before, 'item-1')).not.toBe(
+        computeQueueStateHashOrdered(afterRemove, 'item-1'),
+      );
     });
   });
 });

--- a/packages/shared/queue/src/index.ts
+++ b/packages/shared/queue/src/index.ts
@@ -4,7 +4,7 @@
 
 export { queueReducer, initialState } from './reducer';
 
-export { fnv1aHash, computeQueueStateHash } from './state-hash';
+export { fnv1aHash, computeQueueStateHash, computeQueueStateHashOrdered } from './state-hash';
 
 export type {
   QueueState,

--- a/packages/shared/queue/src/state-hash.ts
+++ b/packages/shared/queue/src/state-hash.ts
@@ -32,24 +32,68 @@ export function fnv1aHash(str: string): string {
 }
 
 /**
- * Compute a deterministic hash of queue state: sorted queue UUIDs + current
- * item UUID. Only UUIDs contribute — climb metadata is intentionally ignored.
+ * Sanitize a queue into the list of UUIDs that contribute to a hash.
  *
  * Malformed entries (null/undefined items, or items without a string `uuid`)
- * are filtered out before hashing. This keeps the hash crash-safe and, more
- * importantly, invariant to the shape corruption that the reducer's
- * `climb != null` filter lets through — so client and server agree even when a
- * queue item is missing its uuid.
+ * are filtered out. This keeps hashing crash-safe and, more importantly,
+ * invariant to the shape corruption that the reducer's `climb != null` filter
+ * lets through — so client and server agree even when a queue item is missing
+ * its uuid. Shared by the order-insensitive (v1) and order-sensitive (v2)
+ * hashes so both filter identically.
+ */
+function sanitizeQueueUuids(queue: Array<{ uuid: string } | null | undefined>): string[] {
+  return queue
+    .filter((item): item is { uuid: string } => item != null && typeof item === 'object' && item.uuid != null)
+    .map((item) => item.uuid);
+}
+
+/**
+ * Compute a deterministic hash of queue state: SORTED queue UUIDs + current
+ * item UUID. Only UUIDs contribute — climb metadata is intentionally ignored.
+ *
+ * Because the UUIDs are sorted before hashing, this hash is ORDER-INSENSITIVE:
+ * a reorder that keeps the same membership produces the same hash. That blind
+ * spot is exactly why the order-sensitive `computeQueueStateHashOrdered` (v2)
+ * exists — see its doc.
+ *
+ * TODO(x1-cleanup): once telemetry confirms every live client is v2-aware
+ * (computes/compares `computeQueueStateHashOrdered`), this v1 hash can be
+ * retired in favour of the ordered one. Kept until then so the dual-hash
+ * transition stays non-breaking for clients that only understand v1 — same
+ * client-adoption-gated deferral pattern as B7.
  */
 export function computeQueueStateHash(
   queue: Array<{ uuid: string } | null | undefined>,
   currentItemUuid: string | null,
 ): string {
-  const queueUuids = queue
-    .filter((item): item is { uuid: string } => item != null && typeof item === 'object' && item.uuid != null)
-    .map((item) => item.uuid)
-    .sort()
-    .join(',');
+  const queueUuids = sanitizeQueueUuids(queue).sort().join(',');
+  const currentUuid = currentItemUuid || 'null';
+
+  const canonical = `${queueUuids}|${currentUuid}`;
+
+  return fnv1aHash(canonical);
+}
+
+/**
+ * Compute a deterministic hash of queue state: queue UUIDs IN ORDER (not
+ * sorted) + current item UUID. Only UUIDs contribute — climb metadata is
+ * intentionally ignored. The order-sensitive (v2) companion to
+ * `computeQueueStateHash`.
+ *
+ * Unlike v1, this hash CHANGES when the queue is reordered even though the
+ * membership is unchanged — so a reorder that diverges between client and
+ * server is finally visible to the hash watchdog. Add/remove changes both v1
+ * and v2; a pure reorder changes only v2.
+ *
+ * Malformed-entry filtering is identical to v1 (via `sanitizeQueueUuids`), so
+ * the two hashes stay in lock-step on corruption handling and both sides agree
+ * for identical queues.
+ */
+export function computeQueueStateHashOrdered(
+  queue: Array<{ uuid: string } | null | undefined>,
+  currentItemUuid: string | null,
+): string {
+  const queueUuids = sanitizeQueueUuids(queue).join(',');
   const currentUuid = currentItemUuid || 'null';
 
   const canonical = `${queueUuids}|${currentUuid}`;

--- a/packages/web/app/components/persistent-session/__tests__/use-session-subscriptions.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/use-session-subscriptions.test.tsx
@@ -4,8 +4,14 @@ import { createQueueSyncGate, CORRUPTION_RESYNC_COOLDOWN_MS } from '@boardsesh/q
 
 // Force the watchdog into a permanent mismatch: the local hash never equals the
 // server hash below, so every 60s tick sees drift and would resync forever
-// without the convergence guard (issue #2359).
-vi.mock('@/app/utils/hash', () => ({ computeQueueStateHash: () => 'local-hash' }));
+// without the convergence guard (issue #2359). The gate here is only seeded
+// with a v1 server hash (via noteApplied), so it compares v1 — the ordered mock
+// value is present only so the watchdog's dual-hash computation has something to
+// pass; it never wins the comparison here.
+vi.mock('@/app/utils/hash', () => ({
+  computeQueueStateHash: () => 'local-hash',
+  computeQueueStateHashOrdered: () => 'local-hash-ordered',
+}));
 vi.mock('@sentry/nextjs', () => ({ captureMessage: vi.fn() }));
 
 import { useSessionSubscriptions } from '../hooks/use-session-subscriptions';

--- a/packages/web/app/components/persistent-session/hooks/session-connection-ports.ts
+++ b/packages/web/app/components/persistent-session/hooks/session-connection-ports.ts
@@ -29,7 +29,7 @@ import {
 } from '@boardsesh/queue-runtime';
 import type { SubscriptionQueueEvent, SessionEvent, QueueEvent, EventsReplayResponse } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
-import { computeQueueStateHash } from '@/app/utils/hash';
+import { computeQueueStateHash, computeQueueStateHashOrdered } from '@/app/utils/hash';
 import { removePreference } from '@/app/lib/user-preferences-db';
 import { coerceSessionUser } from '../event-utils';
 import {
@@ -324,6 +324,12 @@ export function createWebSessionConnectionDeps({
     gate: syncGate,
 
     getLocalStateHash: () => computeQueueStateHash(queueRef.current, currentClimbQueueItemRef.current?.uuid || null),
+
+    // Order-sensitive (v2) local hash — paired with the server's
+    // `queueState.stateHashOrdered` so `decideReconnectStrategy` can full-sync
+    // and re-order on a pure reorder drift the v1 comparison can't see.
+    getLocalStateHashOrdered: () =>
+      computeQueueStateHashOrdered(queueRef.current, currentClimbQueueItemRef.current?.uuid || null),
 
     applyFullSync: (sessionData) => {
       if (sessionData.queueState) {

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -56,16 +56,29 @@ export type EventProcessorActions = {
 /**
  * Flatten a wire event into the shape the sync gate reasons about. FullSync
  * nests its stateHash under `state`; PlaybackStateChanged carries no hash
- * (it doesn't mutate the queue).
+ * (it doesn't mutate the queue). The order-sensitive `stateHashOrdered` (v2)
+ * rides alongside `stateHash` when the backend sends it — the gate prefers it
+ * so reorder drift is detectable; an old backend omits it and the gate falls
+ * back to v1.
  */
 function toGateEvent(event: SubscriptionQueueEvent): QueueSyncGateEvent {
   if (event.__typename === 'FullSync') {
-    return { __typename: event.__typename, sequence: event.sequence, stateHash: event.state.stateHash };
+    return {
+      __typename: event.__typename,
+      sequence: event.sequence,
+      stateHash: event.state.stateHash,
+      stateHashOrdered: event.state.stateHashOrdered ?? null,
+    };
   }
   if (event.__typename === 'PlaybackStateChanged') {
     return { __typename: event.__typename, sequence: event.sequence };
   }
-  return { __typename: event.__typename, sequence: event.sequence, stateHash: event.stateHash };
+  return {
+    __typename: event.__typename,
+    sequence: event.sequence,
+    stateHash: event.stateHash,
+    stateHashOrdered: event.stateHashOrdered ?? null,
+  };
 }
 
 /**

--- a/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect } from 'react';
 import * as Sentry from '@sentry/nextjs';
 import type { SubscriptionQueueEvent, SessionEvent } from '@boardsesh/shared-schema';
 import { RESYNC_LOOP_THRESHOLD, type QueueSyncGate } from '@boardsesh/queue-runtime';
-import { computeQueueStateHash } from '@/app/utils/hash';
+import { computeQueueStateHash, computeQueueStateHashOrdered } from '@/app/utils/hash';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
 import { type Session, type SharedRefs, DEBUG } from '../types';
 
@@ -80,8 +80,18 @@ export function useSessionSubscriptions({
     }
 
     const verifyInterval = setInterval(() => {
+      // Compute both hashes; the gate prefers the ordered (v2) comparison when
+      // the server sent an ordered hash, else falls back to v1. The returned
+      // `serverHash` is whichever version the gate actually compared, so the
+      // drift report below carries BOTH local hashes — otherwise a v2 serverHash
+      // would be logged next to a v1 localHash and look mismatched by version,
+      // not by drift.
       const localHash = computeQueueStateHash(queue, currentClimbQueueItem?.uuid || null);
-      const { verdict, consecutiveResyncs, serverHash } = syncGate.verifyLocalHash(localHash);
+      const localHashOrdered = computeQueueStateHashOrdered(queue, currentClimbQueueItem?.uuid || null);
+      const { verdict, consecutiveResyncs, serverHash } = syncGate.verifyLocalHash({
+        stateHash: localHash,
+        stateHashOrdered: localHashOrdered,
+      });
 
       if (verdict === 'ok') {
         if (DEBUG) console.info('[PersistentSession] State hash verification passed');
@@ -90,7 +100,7 @@ export function useSessionSubscriptions({
 
       console.warn(
         '[PersistentSession] State hash mismatch detected!',
-        `Local: ${localHash}, Server: ${serverHash}`,
+        `Local v1: ${localHash}, Local v2: ${localHashOrdered}, Server (compared): ${serverHash}`,
         'Triggering automatic resync...',
       );
 
@@ -99,7 +109,7 @@ export function useSessionSubscriptions({
       // ref-based implementation reported at).
       if (consecutiveResyncs === RESYNC_LOOP_THRESHOLD) {
         console.error(
-          `[PersistentSession] Resync loop detected: ${consecutiveResyncs} consecutive resyncs for server hash ${serverHash} (local hash ${localHash}). Capturing Sentry message.`,
+          `[PersistentSession] Resync loop detected: ${consecutiveResyncs} consecutive resyncs for server hash ${serverHash} (local v1 ${localHash}, local v2 ${localHashOrdered}). Capturing Sentry message.`,
         );
         Sentry.captureMessage('Resync loop: client keeps disagreeing with server hash', {
           level: 'warning',
@@ -107,8 +117,12 @@ export function useSessionSubscriptions({
           fingerprint: ['party-session', 'hash-resync-loop'],
           extra: {
             sessionId: session.id,
+            // `serverHash` is the active comparison hash (v2 when the gate
+            // preferred ordered). Include both local hashes so triage can line
+            // the right pair up regardless of which version was compared.
             serverHash,
             localHash,
+            localHashOrdered,
             consecutiveResyncs,
             queueLength: queue.length,
             currentClimbUuid: currentClimbQueueItem?.uuid ?? null,

--- a/packages/web/app/utils/hash.ts
+++ b/packages/web/app/utils/hash.ts
@@ -4,4 +4,4 @@
  * existing `@/app/utils/hash` import path — and the test mocks pinned to it —
  * working without duplicating the logic.
  */
-export { fnv1aHash, computeQueueStateHash } from '@boardsesh/queue';
+export { fnv1aHash, computeQueueStateHash, computeQueueStateHashOrdered } from '@boardsesh/queue';


### PR DESCRIPTION
## What & why

The shared `computeQueueStateHash` (v1) is FNV-1a over **sorted** queue UUIDs + current UUID, so it is **order-insensitive**. A reorder that diverges between client and server keeps the same v1 hash and is invisible to the 60s hash watchdog — only add/remove drift is caught. This adds an **order-sensitive** hash (v2, `computeQueueStateHashOrdered`: UUIDs **in order**) via a coordinated, additive dual-hash rollout so reorder drift is finally detectable.

## Rollout (additive, backend-first, no flag-day)

- **Schema is additive.** Every wire type that carries `stateHash` gains an **optional** `stateHashOrdered: String` (`QueueState` + `QueueItemAdded/Removed/Reordered/CurrentClimbChanged/ClimbMirrored` + FullSync state). Old clients ignore the new field.
- **Backend sends both hashes** everywhere it computed v1 (queue-state write paths, all queue-event publishes in the queue/controller resolvers and `queue-navigation`, and every wire `QueueState`/`FullSync` payload). Redis still persists only v1; the ordered hash is recomputed from the stored queue on read, so no Redis/Postgres schema change.
- **Clients prefer ordered when present.** The shared sync gate tracks both server hashes; `verifyLocalHash` compares ordered-vs-ordered only when the server sent an ordered hash **and** the client computed one, else it falls back to the exact v1 comparison. Against an old backend, behaviour is byte-for-byte today's. Web and mobile watchdogs now compute both local hashes and pass them to the gate.
- **Detection *and* recovery.** `decideReconnectStrategy`'s `gap === 0` branch also prefers the ordered comparison, so web's resync path (`handleReconnect`) actually full-syncs and re-orders the queue on a pure reorder drift — not just detects it and backs off. The drift log/Sentry report carries both local hashes so the compared pair lines up regardless of which version the gate used.
- **v1 removal is deferred** (telemetry-gated on client v2 adoption, `// TODO(x1-cleanup)` at the v1 site) — the transition needs v1 until all clients are v2-aware. Same client-adoption-gated deferral pattern as B7.

## Also: reconnect gap<0 → full-sync (carry-in from the W3 review)

`decideReconnectStrategy` now returns `'full-sync'` (was `'none'`) when the rejoined server sequence is **behind** the client's last-applied sequence. A negative gap means the backend re-seeded its sequence counter low (restart with Redis lost / dormant Postgres row); under the old `'none'` verdict the client stayed permanently ahead and dropped every later delta as stale forever. A full-sync re-baselines and recovers it. Test migrated deliberately (with a comment) from the old `'none'` assertion.

## Tests

- **state-hash**: a reorder changes v2 but NOT v1; add/remove changes both; empty/single/malformed cases.
- **sync gate**: a manufactured reorder-drift (same members, different order) is caught as `'resync-drift'` when ordered hashes are present, and returns `'ok'` when only v1 is present — proving v1's blind spot and v2's fix; plus the fallback paths and the gap<0 migration.
- **backend**: delta events and `QueueState` carry both hashes; a reorder moves v2 but not v1.
- **web/mobile watchdog**: pass both hashes; existing suites updated for the additive field.

## Release Notes

- [x] No release note needed (internal / technical change)
