### PR TITLE
feat(backend): grouped ascents feed — shared filters + full item enrichment

### DIFF
--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -1046,6 +1046,113 @@ describe('tickQueries — behavior fixes', () => {
     });
   });
 
+  describe('userGroupedAscentsFeed — filters & enrichment', () => {
+    const seedProjectDay = async () => {
+      const sentUuid = `${CLIMB_PREFIX}grouped-sent`;
+      const projectUuid = `${CLIMB_PREFIX}grouped-project`;
+      await insertClimb(sentUuid, 'Grouped Sent Climb');
+      await insertClimb(projectUuid, 'Grouped Project Climb');
+      // Same climb, same day: two burns then the send — one group of three.
+      await insertTick({
+        uuid: 'grp-a1',
+        climbUuid: sentUuid,
+        climbedAt: '2026-06-20T10:00:00',
+        status: 'attempt',
+        attemptCount: 3,
+      });
+      await insertTick({
+        uuid: 'grp-a2',
+        climbUuid: sentUuid,
+        climbedAt: '2026-06-20T11:00:00',
+        status: 'attempt',
+        attemptCount: 2,
+      });
+      await insertTick({
+        uuid: 'grp-s1',
+        climbUuid: sentUuid,
+        climbedAt: '2026-06-20T12:00:00',
+        status: 'send',
+        attemptCount: 1,
+      });
+      // A different climb still projecting that day.
+      await insertTick({
+        uuid: 'grp-p1',
+        climbUuid: projectUuid,
+        climbedAt: '2026-06-20T13:00:00',
+        status: 'attempt',
+        attemptCount: 4,
+      });
+      return { sentUuid, projectUuid };
+    };
+
+    type EnrichedGroup = {
+      key: string;
+      climbUuid: string;
+      items: Array<{ uuid: string; status: string; hasBetaVideo: boolean; consensusDifficulty: number | null }>;
+      flashCount: number;
+      sendCount: number;
+      attemptCount: number;
+    };
+    const callGrouped = (input: Record<string, unknown>) =>
+      tickQueries.userGroupedAscentsFeed(undefined, { userId: TEST_USER_ID, input }) as Promise<{
+        groups: EnrichedGroup[];
+        totalCount: number;
+        hasMore: boolean;
+      }>;
+
+    it('applies statusMode to groups AND their aggregates (sends-only hides project groups)', async () => {
+      const { sentUuid, projectUuid } = await seedProjectDay();
+
+      const sendsOnly = await callGrouped({ statusMode: 'send' });
+      const groupClimbs = sendsOnly.groups.map((group) => group.climbUuid);
+      expect(groupClimbs).toContain(sentUuid);
+      // The still-projecting climb has no sends — its group must not appear,
+      // and totalCount must agree with the filtered group list.
+      expect(groupClimbs).not.toContain(projectUuid);
+      expect(sendsOnly.totalCount).toBe(1);
+
+      // The surviving group's aggregates reflect only the visible entries.
+      const sentGroup = sendsOnly.groups.find((group) => group.climbUuid === sentUuid);
+      expect(sentGroup?.items.map((item) => item.uuid)).toEqual(['grp-s1']);
+      expect(sentGroup?.sendCount).toBe(1);
+      expect(sentGroup?.attemptCount).toBe(0);
+    });
+
+    it('keeps burns and the send in ONE group with both statuses visible', async () => {
+      const { sentUuid } = await seedProjectDay();
+
+      const both = await callGrouped({ statusMode: 'both' });
+      const sentGroup = both.groups.find((group) => group.climbUuid === sentUuid);
+      expect(sentGroup?.items).toHaveLength(3);
+      expect(sentGroup?.sendCount).toBe(1);
+      expect(sentGroup?.attemptCount).toBe(2);
+      expect(both.totalCount).toBe(2);
+    });
+
+    it('filters by climbName without breaking group pagination counts', async () => {
+      await seedProjectDay();
+
+      const named = await callGrouped({ climbName: 'Grouped Project', statusMode: 'both' });
+      expect(named.groups).toHaveLength(1);
+      expect(named.totalCount).toBe(1);
+      expect(named.hasMore).toBe(false);
+    });
+
+    it('enriches group items with hasBetaVideo under ownership semantics', async () => {
+      const { sentUuid, projectUuid } = await seedProjectDay();
+      await db.execute(sql`
+        INSERT INTO board_beta_links (board_type, climb_uuid, link, created_by_user_id)
+        VALUES ('kilter', ${sentUuid}, 'https://instagram.com/p/grouped-beta', ${TEST_USER_ID})
+      `);
+
+      const both = await callGrouped({ statusMode: 'both' });
+      const sentGroup = both.groups.find((group) => group.climbUuid === sentUuid);
+      const projectGroup = both.groups.find((group) => group.climbUuid === projectUuid);
+      expect(sentGroup?.items.every((item) => item.hasBetaVideo)).toBe(true);
+      expect(projectGroup?.items.every((item) => !item.hasBetaVideo)).toBe(true);
+    });
+  });
+
   describe('userAscentCaptionMatches — quoted-name caption suggestions', () => {
     it('matches the quoted climb name anywhere in the logbook and returns board art', async () => {
       const climbUuid = CLIMB_PREFIX + 'caption-purple';

--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -120,15 +120,25 @@ const insertTick = async (params: {
   boardType?: string;
   difficulty?: number;
   angle?: number;
+  boardId?: number;
 }) => {
   const userId = params.userId ?? TEST_USER_ID;
   const attemptCount = params.attemptCount ?? 1;
   const boardType = params.boardType ?? 'kilter';
   const angle = params.angle ?? 40;
   await db.execute(sql`
-    INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status, attempt_count, difficulty, climbed_at)
-    VALUES (${params.uuid}, ${userId}, ${boardType}, ${params.climbUuid}, ${angle}, ${params.status}, ${attemptCount}, ${params.difficulty ?? null}, ${params.climbedAt})
+    INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status, attempt_count, difficulty, climbed_at, board_id)
+    VALUES (${params.uuid}, ${userId}, ${boardType}, ${params.climbUuid}, ${angle}, ${params.status}, ${attemptCount}, ${params.difficulty ?? null}, ${params.climbedAt}, ${params.boardId ?? null})
   `);
+};
+
+const insertPrivateBoard = async (name: string): Promise<number> => {
+  const rows = (await db.execute(sql`
+    INSERT INTO user_boards (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public)
+    VALUES (${`${CLIMB_PREFIX}board-${name}`}, ${`${CLIMB_PREFIX}slug-${name}`}, ${TEST_USER_ID}, 'kilter', 1, 1, '1', ${name}, false)
+    RETURNING id
+  `)) as unknown as Array<{ id: number }>;
+  return Number(rows[0].id);
 };
 
 const insertAlias = async (params: {
@@ -165,6 +175,7 @@ const cleanup = async () => {
   await db.execute(sql`DELETE FROM user_climb_percentiles WHERE user_id IN (${TEST_USER_ID}, ${OTHER_USER_ID})`);
   await db.execute(sql`DELETE FROM board_beta_links WHERE climb_uuid LIKE ${CLIMB_PREFIX + '%'}`);
   await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id IN (${TEST_USER_ID}, ${OTHER_USER_ID})`);
+  await db.execute(sql`DELETE FROM user_boards WHERE owner_id IN (${TEST_USER_ID}, ${OTHER_USER_ID})`);
   await db.execute(sql`DELETE FROM board_climb_stats WHERE climb_uuid LIKE ${CLIMB_PREFIX + '%'}`);
   await db.execute(
     sql`DELETE FROM board_climb_aliases WHERE alias_uuid LIKE ${CLIMB_PREFIX + '%'} OR canonical_uuid LIKE ${CLIMB_PREFIX + '%'}`,
@@ -1136,6 +1147,36 @@ describe('tickQueries — behavior fixes', () => {
       expect(named.groups).toHaveLength(1);
       expect(named.totalCount).toBe(1);
       expect(named.hasMore).toBe(false);
+    });
+
+    it('gates board identity on group items by viewer, like the flat feed', async () => {
+      const climbUuid = `${CLIMB_PREFIX}grouped-board`;
+      await insertClimb(climbUuid, 'Grouped Board Climb');
+      const boardId = await insertPrivateBoard('Secret Garage');
+      await insertTick({ uuid: 'grp-b1', climbUuid, climbedAt: '2026-06-21T10:00:00', status: 'send', boardId });
+
+      type BoardItem = { uuid: string; boardDisplayName: string | null };
+      const asOwner = (await tickQueries.userGroupedAscentsFeed(
+        undefined,
+        { userId: TEST_USER_ID, input: {} },
+        {
+          connectionId: 'grouped-test-conn',
+          isAuthenticated: true,
+          userId: TEST_USER_ID,
+          sessionId: undefined,
+          controllerId: undefined,
+          controllerApiKey: undefined,
+        },
+      )) as { groups: Array<{ climbUuid: string; items: BoardItem[] }> };
+      const ownGroup = asOwner.groups.find((group) => group.climbUuid === climbUuid);
+      expect(ownGroup?.items[0]?.boardDisplayName).toBe('Secret Garage');
+
+      const asPublic = (await tickQueries.userGroupedAscentsFeed(undefined, {
+        userId: TEST_USER_ID,
+        input: {},
+      })) as { groups: Array<{ climbUuid: string; items: BoardItem[] }> };
+      const publicGroup = asPublic.groups.find((group) => group.climbUuid === climbUuid);
+      expect(publicGroup?.items[0]?.boardDisplayName).toBeNull();
     });
 
     it('enriches group items with hasBetaVideo under ownership semantics', async () => {

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -16,6 +16,7 @@ import {
   consensusGradeTable,
   consensusGradeJoinCondition,
 } from '../shared/sql-expressions';
+import type { z } from 'zod';
 import { GetTicksInputSchema, BoardNameSchema, AscentFeedInputSchema } from '../../../validation/schemas';
 import { escapeLikePattern } from '../../../utils/like-pattern';
 import { extractInstagramHandle } from '../beta-videos/queries';
@@ -33,23 +34,9 @@ END`;
 // in range. See docs/ascents-and-attempts.md.
 const effectiveDifficultyExpr = sql<number>`COALESCE(${dbSchema.boardseshTicks.difficulty}, ${consensusDifficultyExpr})`;
 
-// The validated slice of AscentFeedInput both feeds filter on.
-type AscentFeedFilterInput = {
-  boardType?: string;
-  boardTypes?: string[];
-  layoutIds?: number[];
-  climbName?: string;
-  statusMode?: string;
-  status?: string;
-  flashOnly?: boolean;
-  minDifficulty?: number;
-  maxDifficulty?: number;
-  minAngle?: number;
-  maxAngle?: number;
-  benchmarkOnly?: boolean;
-  fromDate?: string;
-  toDate?: string;
-};
+// The validated AscentFeedInput both feeds filter on — inferred from the zod
+// schema so a new filter field can't silently diverge from validation.
+type AscentFeedFilterInput = z.infer<typeof AscentFeedInputSchema>;
 
 /**
  * WHERE conditions over the ticks table (+ stats/consensus joins for grade and
@@ -132,6 +119,9 @@ async function fetchUserBetaClimbKeys(userId: string, climbUuids: string[], tick
     .where(eq(dbSchema.userProfiles.userId, userId))
     .limit(1);
   const igHandle = extractInstagramHandle(profileRows[0]?.instagramUrl ?? null);
+  // createdByUserId is unconditional, so this array is never empty — or()
+  // always gets at least one condition (single-arg or() is valid but don't
+  // let a refactor remove the guaranteed first element).
   const ownershipConditions = [
     eq(dbSchema.boardBetaLinks.createdByUserId, userId),
     ...(tickUuids.length > 0 ? [inArray(dbSchema.boardBetaLinks.tickUuid, tickUuids)] : []),
@@ -739,9 +729,11 @@ export const tickQueries = {
 
     // 1) Page of (climbUuid, day) keys, ordered by latest activity in that group.
     //    Bounds the SQL fetch to exactly the groups we'll return.
-    // The filter joins (canonical climb for layout/name, stats + consensus for
-    // grade/benchmark) are 1:1 per tick, so they never multiply group rows.
-    const pageGroups = await db
+    // One filtered-groups base: joins (canonical climb for layout/name, stats +
+    // consensus for grade/benchmark — 1:1 per tick, never multiplying group
+    // rows) and WHERE applied ONCE, then both the page query and the count read
+    // from it, so a join change can't drift between them.
+    const filteredGroupsBase = db
       .select({
         climbUuid: dbSchema.boardseshTicks.climbUuid,
         day: dayExpr.as('day'),
@@ -773,45 +765,21 @@ export const tickQueries = {
       .leftJoin(consensusGradeTable, consensusGradeJoinCondition)
       .where(and(...groupFilterConditions))
       .groupBy(dbSchema.boardseshTicks.climbUuid, dayExpr)
-      .orderBy(sql`max(${dbSchema.boardseshTicks.climbedAt}) desc`)
+      .as('filtered_groups');
+
+    const pageGroups = await db
+      .select({
+        climbUuid: filteredGroupsBase.climbUuid,
+        day: filteredGroupsBase.day,
+        latestClimbedAt: filteredGroupsBase.latestClimbedAt,
+      })
+      .from(filteredGroupsBase)
+      .orderBy(sql`${filteredGroupsBase.latestClimbedAt} desc`)
       .limit(limit)
       .offset(offset);
 
     // 2) True total group count — runs in parallel with the data fetch below.
-    const totalCountPromise = db.select({ count: count() }).from(
-      db
-        .select({
-          climbUuid: dbSchema.boardseshTicks.climbUuid,
-          day: dayExpr.as('day'),
-        })
-        .from(dbSchema.boardseshTicks)
-        .leftJoin(
-          dbSchema.boardClimbAliases,
-          and(
-            eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbAliases.aliasUuid),
-            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbAliases.boardType),
-          ),
-        )
-        .leftJoin(
-          dbSchema.boardClimbs,
-          and(
-            sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbs.uuid}`,
-            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbs.boardType),
-          ),
-        )
-        .leftJoin(
-          dbSchema.boardClimbStats,
-          and(
-            sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbStats.climbUuid}`,
-            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbStats.boardType),
-            eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
-          ),
-        )
-        .leftJoin(consensusGradeTable, consensusGradeJoinCondition)
-        .where(and(...groupFilterConditions))
-        .groupBy(dbSchema.boardseshTicks.climbUuid, dayExpr)
-        .as('group_keys'),
-    );
+    const totalCountPromise = db.select({ count: count() }).from(filteredGroupsBase);
 
     if (pageGroups.length === 0) {
       const totalCountResult = await totalCountPromise;

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -20,6 +20,130 @@ import { GetTicksInputSchema, BoardNameSchema, AscentFeedInputSchema } from '../
 import { escapeLikePattern } from '../../../utils/like-pattern';
 import { extractInstagramHandle } from '../beta-videos/queries';
 
+// Benchmark resolution shared by the flat and grouped ascent feeds: a climb
+// counts as benchmark when the stats row says so or the tick itself was
+// imported as one.
+const resolvedBenchmarkExpr = sql<boolean>`CASE
+  WHEN COALESCE(${dbSchema.boardClimbStats.benchmarkDifficulty}, 0) > 0 OR ${dbSchema.boardseshTicks.isBenchmark} = true THEN true
+  ELSE false
+END`;
+
+// Filter on the effective difficulty (user override → consensus fallback) so a
+// grade-range filter doesn't silently hide ungraded ascents whose consensus is
+// in range. See docs/ascents-and-attempts.md.
+const effectiveDifficultyExpr = sql<number>`COALESCE(${dbSchema.boardseshTicks.difficulty}, ${consensusDifficultyExpr})`;
+
+// The validated slice of AscentFeedInput both feeds filter on.
+type AscentFeedFilterInput = {
+  boardType?: string;
+  boardTypes?: string[];
+  layoutIds?: number[];
+  climbName?: string;
+  statusMode?: string;
+  status?: string;
+  flashOnly?: boolean;
+  minDifficulty?: number;
+  maxDifficulty?: number;
+  minAngle?: number;
+  maxAngle?: number;
+  benchmarkOnly?: boolean;
+  fromDate?: string;
+  toDate?: string;
+};
+
+/**
+ * WHERE conditions over the ticks table (+ stats/consensus joins for grade and
+ * benchmark filters) shared by userAscentsFeed and userGroupedAscentsFeed so
+ * the two feeds can never disagree about what a filter means.
+ */
+function buildAscentTickConditions(validated: AscentFeedFilterInput, userId: string) {
+  const legacyStatus = validated.status;
+  let inferredStatusMode = 'both';
+  if (legacyStatus === 'attempt') {
+    inferredStatusMode = 'attempt';
+  } else if (legacyStatus) {
+    inferredStatusMode = 'send';
+  }
+  const statusMode = validated.statusMode ?? inferredStatusMode;
+  const flashOnly = validated.flashOnly ?? legacyStatus === 'flash';
+
+  const conditions = [
+    eq(dbSchema.boardseshTicks.userId, userId),
+    ...(validated.boardType ? [eq(dbSchema.boardseshTicks.boardType, validated.boardType)] : []),
+    ...(validated.boardTypes && validated.boardTypes.length > 0 && !validated.boardType
+      ? [inArray(dbSchema.boardseshTicks.boardType, validated.boardTypes)]
+      : []),
+    ...(validated.minDifficulty !== undefined ? [gte(effectiveDifficultyExpr, validated.minDifficulty)] : []),
+    ...(validated.maxDifficulty !== undefined ? [lte(effectiveDifficultyExpr, validated.maxDifficulty)] : []),
+    ...(validated.minAngle !== undefined ? [gte(dbSchema.boardseshTicks.angle, validated.minAngle)] : []),
+    ...(validated.maxAngle !== undefined ? [lte(dbSchema.boardseshTicks.angle, validated.maxAngle)] : []),
+    ...(validated.fromDate ? [gte(dbSchema.boardseshTicks.climbedAt, validated.fromDate)] : []),
+    ...(validated.toDate ? [lte(dbSchema.boardseshTicks.climbedAt, validated.toDate + 'T23:59:59.999Z')] : []),
+  ];
+
+  if (statusMode === 'attempt') {
+    conditions.push(eq(dbSchema.boardseshTicks.status, 'attempt'));
+  } else if (statusMode === 'send') {
+    conditions.push(
+      flashOnly
+        ? eq(dbSchema.boardseshTicks.status, 'flash')
+        : inArray(dbSchema.boardseshTicks.status, ['flash', 'send']),
+    );
+  } else if (flashOnly) {
+    conditions.push(eq(dbSchema.boardseshTicks.status, 'flash'));
+  }
+
+  if (validated.benchmarkOnly) {
+    conditions.push(sql`(${resolvedBenchmarkExpr}) = true`);
+  }
+
+  return conditions;
+}
+
+/** Conditions that need the canonical board_climbs join (layout + name search). */
+function buildAscentClimbConditions(validated: AscentFeedFilterInput) {
+  return [
+    ...(validated.layoutIds && validated.layoutIds.length > 0
+      ? [inArray(dbSchema.boardClimbs.layoutId, validated.layoutIds)]
+      : []),
+    ...(validated.climbName
+      ? [
+          or(
+            ilike(dbSchema.boardClimbs.name, `%${escapeLikePattern(validated.climbName)}%`),
+            ilike(dbSchema.boardseshTicks.comment, `%${escapeLikePattern(validated.climbName)}%`),
+          ),
+        ]
+      : []),
+  ];
+}
+
+/**
+ * Which of these climbs carry a beta video of THIS user's — created by them,
+ * matching their Instagram handle (legacy synced rows have tick_uuid NULL), or
+ * directly attached to one of the given ticks. Ownership mirrors userBetaLinks
+ * (the profile beta shelf). One profile lookup + one links query per call.
+ * Returns `boardType:climbUuid` keys.
+ */
+async function fetchUserBetaClimbKeys(userId: string, climbUuids: string[], tickUuids: string[]): Promise<Set<string>> {
+  if (climbUuids.length === 0) return new Set();
+  const profileRows = await db
+    .select({ instagramUrl: dbSchema.userProfiles.instagramUrl })
+    .from(dbSchema.userProfiles)
+    .where(eq(dbSchema.userProfiles.userId, userId))
+    .limit(1);
+  const igHandle = extractInstagramHandle(profileRows[0]?.instagramUrl ?? null);
+  const ownershipConditions = [
+    eq(dbSchema.boardBetaLinks.createdByUserId, userId),
+    ...(tickUuids.length > 0 ? [inArray(dbSchema.boardBetaLinks.tickUuid, tickUuids)] : []),
+    ...(igHandle ? [eq(dbSchema.boardBetaLinks.foreignUsername, igHandle)] : []),
+  ];
+  const betaLinkRows = await db
+    .select({ boardType: dbSchema.boardBetaLinks.boardType, climbUuid: dbSchema.boardBetaLinks.climbUuid })
+    .from(dbSchema.boardBetaLinks)
+    .where(and(inArray(dbSchema.boardBetaLinks.climbUuid, climbUuids), or(...ownershipConditions)));
+  return new Set(betaLinkRows.map((row) => `${row.boardType}:${row.climbUuid}`));
+}
+
 // Shape of a row produced by the userAscentsFeed item mapper. Declared so
 // userAscentCaptionMatches (which reuses that builder) returns a typed ascent
 // row instead of unknown[]. Mirrors the GraphQL AscentFeedItem fields.
@@ -289,71 +413,14 @@ export const tickQueries = {
     const validatedInput = validateInput(AscentFeedInputSchema, input || {}, 'input');
     const limit = validatedInput.limit ?? 20;
     const offset = validatedInput.offset ?? 0;
-    const boardType = validatedInput.boardType;
-    const boardTypes = validatedInput.boardTypes;
-    const layoutIds = validatedInput.layoutIds;
-    const climbName = validatedInput.climbName;
     const sortBy = validatedInput.sortBy ?? 'recent';
     const sortOrder = validatedInput.sortOrder ?? 'desc';
     const secondarySortBy = validatedInput.secondarySortBy;
     const secondarySortOrder = validatedInput.secondarySortOrder ?? 'desc';
-    const minDifficulty = validatedInput.minDifficulty;
-    const maxDifficulty = validatedInput.maxDifficulty;
-    const minAngle = validatedInput.minAngle;
-    const maxAngle = validatedInput.maxAngle;
-    const benchmarkOnly = validatedInput.benchmarkOnly ?? false;
-    const fromDate = validatedInput.fromDate;
-    const toDate = validatedInput.toDate;
-    const legacyStatus = validatedInput.status;
-    let inferredStatusMode = 'both';
-    if (legacyStatus === 'attempt') {
-      inferredStatusMode = 'attempt';
-    } else if (legacyStatus) {
-      inferredStatusMode = 'send';
-    }
-    const statusMode = validatedInput.statusMode ?? inferredStatusMode;
-    const flashOnly = validatedInput.flashOnly ?? legacyStatus === 'flash';
 
-    const resolvedBenchmarkExpr = sql<boolean>`CASE
-      WHEN COALESCE(${dbSchema.boardClimbStats.benchmarkDifficulty}, 0) > 0 OR ${dbSchema.boardseshTicks.isBenchmark} = true THEN true
-      ELSE false
-    END`;
-
-    // Filter on the effective difficulty (user override → consensus fallback) so
-    // a grade-range filter doesn't silently hide ungraded ascents whose consensus
-    // is in range. See docs/ascents-and-attempts.md.
-    const effectiveDifficultyExpr = sql<number>`COALESCE(${dbSchema.boardseshTicks.difficulty}, ${consensusDifficultyExpr})`;
-
-    // Build shared WHERE conditions
-    const tickConditions = [
-      eq(dbSchema.boardseshTicks.userId, userId),
-      ...(boardType ? [eq(dbSchema.boardseshTicks.boardType, boardType)] : []),
-      ...(boardTypes && boardTypes.length > 0 && !boardType
-        ? [inArray(dbSchema.boardseshTicks.boardType, boardTypes)]
-        : []),
-      ...(minDifficulty !== undefined ? [gte(effectiveDifficultyExpr, minDifficulty)] : []),
-      ...(maxDifficulty !== undefined ? [lte(effectiveDifficultyExpr, maxDifficulty)] : []),
-      ...(minAngle !== undefined ? [gte(dbSchema.boardseshTicks.angle, minAngle)] : []),
-      ...(maxAngle !== undefined ? [lte(dbSchema.boardseshTicks.angle, maxAngle)] : []),
-      ...(fromDate ? [gte(dbSchema.boardseshTicks.climbedAt, fromDate)] : []),
-      ...(toDate ? [lte(dbSchema.boardseshTicks.climbedAt, toDate + 'T23:59:59.999Z')] : []),
-    ];
-
-    if (statusMode === 'attempt') {
-      tickConditions.push(eq(dbSchema.boardseshTicks.status, 'attempt'));
-    } else if (statusMode === 'send') {
-      tickConditions.push(
-        flashOnly
-          ? eq(dbSchema.boardseshTicks.status, 'flash')
-          : inArray(dbSchema.boardseshTicks.status, ['flash', 'send']),
-      );
-    } else if (flashOnly) {
-      tickConditions.push(eq(dbSchema.boardseshTicks.status, 'flash'));
-    }
-
-    if (benchmarkOnly) {
-      tickConditions.push(sql`(${resolvedBenchmarkExpr}) = true`);
-    }
+    // WHERE conditions shared with userGroupedAscentsFeed — one definition of
+    // what every filter means (see buildAscentTickConditions at module scope).
+    const tickConditions = buildAscentTickConditions(validatedInput, userId);
 
     // Base query with JOINs (shared by count and data queries)
     const baseQuery = db
@@ -409,18 +476,7 @@ export const tickQueries = {
       .leftJoin(consensusGradeTable, consensusGradeJoinCondition);
 
     // Full conditions including climb name filter (requires JOIN)
-    const allConditions = [
-      ...tickConditions,
-      ...(layoutIds && layoutIds.length > 0 ? [inArray(dbSchema.boardClimbs.layoutId, layoutIds)] : []),
-      ...(climbName
-        ? [
-            or(
-              ilike(dbSchema.boardClimbs.name, `%${escapeLikePattern(climbName)}%`),
-              ilike(dbSchema.boardseshTicks.comment, `%${escapeLikePattern(climbName)}%`),
-            ),
-          ]
-        : []),
-    ];
+    const allConditions = [...tickConditions, ...buildAscentClimbConditions(validatedInput)];
 
     // Get total count
     const countQuery = db
@@ -523,33 +579,13 @@ export const tickQueries = {
       .limit(limit)
       .offset(offset);
 
-    // Which of this page's CLIMBS carry a beta video of this user's. Ownership
-    // mirrors userBetaLinks (the profile beta shelf): a link the user created,
-    // one matching their Instagram handle (Aurora-synced/backfilled legacy rows
-    // have tick_uuid NULL), or one directly attached to a tick on this page.
-    // Climb-level on purpose — "do I have beta for this climb" — and batched:
-    // two queries per page (profile handle + links), no N+1.
-    const pageTickUuids = results.map(({ tick }) => tick.uuid);
-    const pageClimbUuids = Array.from(new Set(results.map(({ tick }) => tick.climbUuid)));
-    let climbsWithBeta = new Set<string>();
-    if (pageClimbUuids.length > 0) {
-      const profileRows = await db
-        .select({ instagramUrl: dbSchema.userProfiles.instagramUrl })
-        .from(dbSchema.userProfiles)
-        .where(eq(dbSchema.userProfiles.userId, userId))
-        .limit(1);
-      const igHandle = extractInstagramHandle(profileRows[0]?.instagramUrl ?? null);
-      const ownershipConditions = [
-        eq(dbSchema.boardBetaLinks.createdByUserId, userId),
-        inArray(dbSchema.boardBetaLinks.tickUuid, pageTickUuids),
-        ...(igHandle ? [eq(dbSchema.boardBetaLinks.foreignUsername, igHandle)] : []),
-      ];
-      const betaLinkRows = await db
-        .select({ boardType: dbSchema.boardBetaLinks.boardType, climbUuid: dbSchema.boardBetaLinks.climbUuid })
-        .from(dbSchema.boardBetaLinks)
-        .where(and(inArray(dbSchema.boardBetaLinks.climbUuid, pageClimbUuids), or(...ownershipConditions)));
-      climbsWithBeta = new Set(betaLinkRows.map((row) => `${row.boardType}:${row.climbUuid}`));
-    }
+    // Which of this page's CLIMBS carry a beta video of this user's — shared
+    // helper (ownership mirrors the profile beta shelf), batched per page.
+    const climbsWithBeta = await fetchUserBetaClimbKeys(
+      userId,
+      Array.from(new Set(results.map(({ tick }) => tick.climbUuid))),
+      results.map(({ tick }) => tick.uuid),
+    );
 
     // Map results to response format
     const items = results.map(
@@ -675,16 +711,24 @@ export const tickQueries = {
    */
   userGroupedAscentsFeed: async (
     _: unknown,
-    { userId, input }: { userId: string; input?: { limit?: number; offset?: number } },
+    { userId, input }: { userId: string; input?: Record<string, unknown> },
+    ctx?: ConnectionContext,
   ): Promise<{
     groups: unknown[];
     totalCount: number;
     hasMore: boolean;
   }> => {
-    // Validate and set defaults
+    // Validate and set defaults. Accepts the full AscentFeedInput: filters are
+    // shared with userAscentsFeed (one definition per filter), applied to BOTH
+    // the group page and the tick fetch so group aggregates reflect exactly the
+    // visible entries. Sort stays latest-activity — grouping is a date-view
+    // concept; clients use the flat feed for grade-ordered views.
     const validatedInput = validateInput(AscentFeedInputSchema, input || {}, 'input');
     const limit = validatedInput.limit ?? 20;
     const offset = validatedInput.offset ?? 0;
+    const tickConditions = buildAscentTickConditions(validatedInput, userId);
+    const climbConditions = buildAscentClimbConditions(validatedInput);
+    const groupFilterConditions = [...tickConditions, ...climbConditions];
 
     // boardsesh_ticks.climbed_at is `timestamp without time zone` storing the
     // climber's wall-clock time at the moment of the tick (the rest of the
@@ -695,6 +739,8 @@ export const tickQueries = {
 
     // 1) Page of (climbUuid, day) keys, ordered by latest activity in that group.
     //    Bounds the SQL fetch to exactly the groups we'll return.
+    // The filter joins (canonical climb for layout/name, stats + consensus for
+    // grade/benchmark) are 1:1 per tick, so they never multiply group rows.
     const pageGroups = await db
       .select({
         climbUuid: dbSchema.boardseshTicks.climbUuid,
@@ -702,7 +748,30 @@ export const tickQueries = {
         latestClimbedAt: sql<string>`max(${dbSchema.boardseshTicks.climbedAt})`.as('latest_climbed_at'),
       })
       .from(dbSchema.boardseshTicks)
-      .where(eq(dbSchema.boardseshTicks.userId, userId))
+      .leftJoin(
+        dbSchema.boardClimbAliases,
+        and(
+          eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbAliases.aliasUuid),
+          eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbAliases.boardType),
+        ),
+      )
+      .leftJoin(
+        dbSchema.boardClimbs,
+        and(
+          sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbs.uuid}`,
+          eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbs.boardType),
+        ),
+      )
+      .leftJoin(
+        dbSchema.boardClimbStats,
+        and(
+          sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbStats.climbUuid}`,
+          eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbStats.boardType),
+          eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
+        ),
+      )
+      .leftJoin(consensusGradeTable, consensusGradeJoinCondition)
+      .where(and(...groupFilterConditions))
       .groupBy(dbSchema.boardseshTicks.climbUuid, dayExpr)
       .orderBy(sql`max(${dbSchema.boardseshTicks.climbedAt}) desc`)
       .limit(limit)
@@ -716,7 +785,30 @@ export const tickQueries = {
           day: dayExpr.as('day'),
         })
         .from(dbSchema.boardseshTicks)
-        .where(eq(dbSchema.boardseshTicks.userId, userId))
+        .leftJoin(
+          dbSchema.boardClimbAliases,
+          and(
+            eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbAliases.aliasUuid),
+            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbAliases.boardType),
+          ),
+        )
+        .leftJoin(
+          dbSchema.boardClimbs,
+          and(
+            sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbs.uuid}`,
+            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbs.boardType),
+          ),
+        )
+        .leftJoin(
+          dbSchema.boardClimbStats,
+          and(
+            sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbStats.climbUuid}`,
+            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbStats.boardType),
+            eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
+          ),
+        )
+        .leftJoin(consensusGradeTable, consensusGradeJoinCondition)
+        .where(and(...groupFilterConditions))
         .groupBy(dbSchema.boardseshTicks.climbUuid, dayExpr)
         .as('group_keys'),
     );
@@ -752,9 +844,17 @@ export const tickQueries = {
         layoutId: dbSchema.boardClimbs.layoutId,
         frames: dbSchema.boardClimbs.frames,
         difficultyName: difficultyNameWithFallbackExpr,
+        boardName: dbSchema.userBoards.name,
+        boardIsPublic: dbSchema.userBoards.isPublic,
+        boardIsUnlisted: dbSchema.userBoards.isUnlisted,
+        consensusDifficulty: consensusDifficultyExpr,
+        consensusDifficultyName: consensusDifficultyNameExpr,
+        resolvedIsBenchmark: resolvedBenchmarkExpr,
+        qualityAverage: dbSchema.boardClimbStats.qualityAverage,
         day: dayExpr.as('day'),
       })
       .from(dbSchema.boardseshTicks)
+      .leftJoin(dbSchema.userBoards, eq(dbSchema.boardseshTicks.boardId, dbSchema.userBoards.id))
       // Resolve dedup-merged climbs to their canonical UUID before joining
       // board_climbs / board_climb_stats. See the `ticks` resolver for rationale.
       // The (climbUuid, day) grouping itself stays keyed on the tick's own
@@ -792,7 +892,7 @@ export const tickQueries = {
       .leftJoin(consensusGradeTable, consensusGradeJoinCondition)
       .where(
         and(
-          eq(dbSchema.boardseshTicks.userId, userId),
+          ...groupFilterConditions,
           inArray(dbSchema.boardseshTicks.climbUuid, climbUuidsInPage),
           gte(dbSchema.boardseshTicks.climbedAt, minTimestamp),
           lte(dbSchema.boardseshTicks.climbedAt, maxTimestamp),
@@ -806,6 +906,8 @@ export const tickQueries = {
       climbName: string;
       setterUsername: string | null;
       boardType: string;
+      boardId: number | null;
+      boardDisplayName: string | null;
       layoutId: number | null;
       angle: number;
       isMirror: boolean;
@@ -814,11 +916,15 @@ export const tickQueries = {
       quality: number | null;
       difficulty: number | null;
       difficultyName: string | null;
+      consensusDifficulty: number | null;
+      consensusDifficultyName: string | null;
+      qualityAverage: number | null;
       isBenchmark: boolean;
       isNoMatch: boolean;
       comment: string;
       climbedAt: string;
       frames: string | null;
+      hasBetaVideo: boolean;
     };
 
     type GroupedAscent = {
@@ -843,6 +949,14 @@ export const tickQueries = {
       latestComment: string | null;
     };
 
+    // Beta ownership for the page's climbs — same helper + semantics as the
+    // flat feed, so a group item and its flat-feed twin can never disagree.
+    const climbsWithBeta = await fetchUserBetaClimbKeys(
+      userId,
+      climbUuidsInPage,
+      tickRows.map(({ tick }) => tick.uuid),
+    );
+
     const groupMap = new Map<string, GroupedAscent>();
 
     for (const {
@@ -853,6 +967,13 @@ export const tickQueries = {
       layoutId,
       frames,
       difficultyName,
+      boardName,
+      boardIsPublic,
+      boardIsUnlisted,
+      consensusDifficulty,
+      consensusDifficultyName,
+      resolvedIsBenchmark,
+      qualityAverage,
       day,
     } of tickRows) {
       const key = `${tick.climbUuid}-${day}`;
@@ -861,12 +982,16 @@ export const tickQueries = {
 
       const isNoMatch = isNoMatchClimb(climbDescription);
 
+      const canShowBoard =
+        tick.boardId != null && (ctx?.userId === userId || (boardIsPublic === true && boardIsUnlisted !== true));
       const item: AscentItem = {
         uuid: tick.uuid,
         climbUuid: tick.climbUuid,
         climbName: climbName || 'Unknown Climb',
         setterUsername,
         boardType: tick.boardType,
+        boardId: canShowBoard ? tick.boardId : null,
+        boardDisplayName: canShowBoard ? boardName : null,
         layoutId,
         angle: tick.angle,
         isMirror: tick.isMirror ?? false,
@@ -875,11 +1000,16 @@ export const tickQueries = {
         quality: tick.quality,
         difficulty: tick.difficulty,
         difficultyName,
-        isBenchmark: tick.isBenchmark ?? false,
+        consensusDifficulty:
+          consensusDifficulty !== null && consensusDifficulty !== undefined ? Number(consensusDifficulty) : null,
+        consensusDifficultyName,
+        qualityAverage: qualityAverage != null ? Number(qualityAverage) : null,
+        isBenchmark: Boolean(resolvedIsBenchmark),
         isNoMatch,
         comment: tick.comment || '',
         climbedAt: tick.climbedAt,
         frames,
+        hasBetaVideo: climbsWithBeta.has(`${tick.boardType}:${tick.climbUuid}`),
       };
 
       let group = groupMap.get(key);


### PR DESCRIPTION
## Summary

Backend half of the logbook follow-up agreed in #3350 (day-scoped grouping of repeat ascents + attempts-by-default):

- `userGroupedAscentsFeed` accepts the full `AscentFeedInput`. Filter semantics are extracted into shared builders (`buildAscentTickConditions` / `buildAscentClimbConditions`) used by BOTH the flat and grouped feeds, so a filter can never mean two things. Filters apply to the group page, the total count, and the tick fetch — group aggregates (flash/send/attempt counts, bestQuality) reflect exactly the visible entries.
- Group items are enriched to the full `AscentFeedItem` shape: board identity (with the same visibility gating as the flat feed), consensus grade pair, `qualityAverage`, and `hasBetaVideo` via the shared ownership helper extracted from #3373. The SDL already typed items as `AscentFeedItem`, so this is resolver-only.
- Group-level SQL pagination is preserved (the property the resolver was built for).
- Existing consumer (web activity feed, no input) is unaffected: no filters → identical behaviour.

**Ordering:** deploy before the client PR that consumes the new fields/filters (per the backend-first rollout rule — OTA bundles hit prod).

## Release Notes

- [x] No release note needed (internal / technical change — the user-facing grouping ships with the client PR)

## Test plan

- 4 new integration tests: statusMode filters groups AND aggregates; burns+send stay one group under `both`; climbName respects group pagination counts; `hasBetaVideo` ownership on group items.
- Full tick-queries suite green locally against the shared test DB (42 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
