### PR TITLE
fix(mobile): native Button review nits (flex:0, dead tint, spinner, stub)

### DIFF
--- a/packages/mobile/src/components/Button.android.tsx
+++ b/packages/mobile/src/components/Button.android.tsx
@@ -27,7 +27,7 @@ import { fillMaxWidth, padding, size } from '@expo/ui/jetpack-compose/modifiers'
 import type { ImageSourcePropType } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
-import { makeButtonPressHandler } from './Button.logic';
+import { isFullWidthStyle, makeButtonPressHandler } from './Button.logic';
 import { sizeConfig, type ButtonProps } from './Button.types';
 import type { IconName } from './icon-map';
 
@@ -111,10 +111,11 @@ export function Button({
   // button's LocalContentColor for free.
   let spinnerColor: string;
   if (variant === 'filled') {
-    // On-fill white (destructive fills with error + white content too).
+    // White on the brand fill (destructive fills with the error container, still white content).
     spinnerColor = brandColors.onPrimary;
   } else if (variant === 'tonal') {
-    // MD3 tonal content ≈ brand primary; destructive fills with error + white.
+    // Non-destructive tonal content ≈ brand primary; destructive fills the error
+    // container, so its content (and the spinner) is white (onPrimary), not error.
     spinnerColor = isDestructive ? brandColors.onPrimary : brandColors.primary;
   } else {
     spinnerColor = isDestructive ? brandColors.error : accentColor;
@@ -129,10 +130,7 @@ export function Button({
           ? TextButton
           : ComposeButton;
 
-  // Only a positive `flex` grows — `flex: 0` means "don't grow", so it must not
-  // count as full-width (`flex != null` would wrongly catch 0).
-  const isFullWidth =
-    style?.width === '100%' || (typeof style?.flex === 'number' && style.flex > 0) || style?.alignSelf === 'stretch';
+  const isFullWidth = isFullWidthStyle(style);
   const iconSource = icon ? BUTTON_ICON_SOURCE[icon] : undefined;
 
   return (

--- a/packages/mobile/src/components/Button.android.tsx
+++ b/packages/mobile/src/components/Button.android.tsx
@@ -110,12 +110,12 @@ export function Button({
   // button's content colour). The leading Icon omits `color` so it inherits the
   // button's LocalContentColor for free.
   let spinnerColor: string;
-  if (variant === 'filled' || variant === 'tonal') {
-    spinnerColor = isDestructive
-      ? brandColors.onPrimary
-      : variant === 'filled'
-        ? brandColors.onPrimary
-        : brandColors.primary;
+  if (variant === 'filled') {
+    // On-fill white (destructive fills with error + white content too).
+    spinnerColor = brandColors.onPrimary;
+  } else if (variant === 'tonal') {
+    // MD3 tonal content ≈ brand primary; destructive fills with error + white.
+    spinnerColor = isDestructive ? brandColors.onPrimary : brandColors.primary;
   } else {
     spinnerColor = isDestructive ? brandColors.error : accentColor;
   }
@@ -129,7 +129,10 @@ export function Button({
           ? TextButton
           : ComposeButton;
 
-  const isFullWidth = style?.width === '100%' || style?.flex != null || style?.alignSelf === 'stretch';
+  // Only a positive `flex` grows — `flex: 0` means "don't grow", so it must not
+  // count as full-width (`flex != null` would wrongly catch 0).
+  const isFullWidth =
+    style?.width === '100%' || (typeof style?.flex === 'number' && style.flex > 0) || style?.alignSelf === 'stretch';
   const iconSource = icon ? BUTTON_ICON_SOURCE[icon] : undefined;
 
   return (

--- a/packages/mobile/src/components/Button.ios.tsx
+++ b/packages/mobile/src/components/Button.ios.tsx
@@ -40,7 +40,7 @@ import { useGlassCapability } from '../hooks/use-glass-capability';
 import { useTheme } from '../providers/theme-provider';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { overlays } from '../theme/tokens';
-import { makeButtonPressHandler } from './Button.logic';
+import { isFullWidthStyle, makeButtonPressHandler } from './Button.logic';
 import { useButtonSurface } from './Button.surface';
 import { iconMap } from './icon-map';
 import type { ButtonProps, ButtonSize } from './Button.types';
@@ -116,12 +116,9 @@ export function Button({
     }
   }
 
-  // A footer button styled to fill its row needs the native Button to stretch
-  // (it content-hugs otherwise); an inline button hugs its content in BOTH axes.
-  // Only a positive `flex` grows — `flex: 0` means "don't grow", so it must not
-  // count as full-width (`flex != null` would wrongly catch 0).
-  const isFullWidth =
-    style?.width === '100%' || (typeof style?.flex === 'number' && style.flex > 0) || style?.alignSelf === 'stretch';
+  // A footer button styled to fill its row needs the native Button to stretch (it
+  // content-hugs otherwise); an inline button hugs its content in BOTH axes.
+  const isFullWidth = isFullWidthStyle(style);
 
   const modifiers: ModifierConfig[] = [
     styleModifier,

--- a/packages/mobile/src/components/Button.ios.tsx
+++ b/packages/mobile/src/components/Button.ios.tsx
@@ -118,7 +118,10 @@ export function Button({
 
   // A footer button styled to fill its row needs the native Button to stretch
   // (it content-hugs otherwise); an inline button hugs its content in BOTH axes.
-  const isFullWidth = style?.width === '100%' || style?.flex != null || style?.alignSelf === 'stretch';
+  // Only a positive `flex` grows — `flex: 0` means "don't grow", so it must not
+  // count as full-width (`flex != null` would wrongly catch 0).
+  const isFullWidth =
+    style?.width === '100%' || (typeof style?.flex === 'number' && style.flex > 0) || style?.alignSelf === 'stretch';
 
   const modifiers: ModifierConfig[] = [
     styleModifier,

--- a/packages/mobile/src/components/Button.logic.ts
+++ b/packages/mobile/src/components/Button.logic.ts
@@ -3,7 +3,21 @@
 // "what happens on tap", and it can be unit-tested without mounting a native
 // @expo/ui tree. Mirrors SwitchRow.logic.ts.
 
+import type { ViewStyle } from 'react-native';
 import { hapticLight } from '../lib/haptics';
+
+/**
+ * Whether a Button's `style` asks it to fill its row's width. Only a POSITIVE
+ * numeric `flex` grows — `flex: 0` means "don't grow", so it must not count
+ * (`style.flex != null` would wrongly catch 0 and stretch the button). Shared by
+ * both platform files so the iOS `frame({ maxWidth: Infinity })` and the Android
+ * `fillMaxWidth()` stay in lockstep, and node-testable without a native tree.
+ */
+export function isFullWidthStyle(style: ViewStyle | undefined): boolean {
+  return (
+    style?.width === '100%' || (typeof style?.flex === 'number' && style.flex > 0) || style?.alignSelf === 'stretch'
+  );
+}
 
 /**
  * Build the press handler used by both platform Button implementations: fires a

--- a/packages/mobile/src/components/DeleteAccountScreen.tsx
+++ b/packages/mobile/src/components/DeleteAccountScreen.tsx
@@ -49,7 +49,7 @@ function EmphasizedText({
 
 export function DeleteAccountScreen() {
   const { t } = useTranslation('settings');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors } = useTheme();
   const { showToast } = useToast();
   const { signOut } = useAuth();
   const router = useRouter();
@@ -167,7 +167,6 @@ export function DeleteAccountScreen() {
         <Button
           title={t('deleteAccount.dialog.confirm')}
           variant="filled"
-          tintColor={brandColors.error}
           role="destructive"
           onPress={() => {
             void handleDelete();

--- a/packages/mobile/src/components/__tests__/Button.logic.test.ts
+++ b/packages/mobile/src/components/__tests__/Button.logic.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi } from 'vitest';
 // tests inject their own haptic fn, so this just keeps the default import safe.
 vi.mock('../../lib/haptics', () => ({ hapticLight: vi.fn() }));
 
-import { makeButtonPressHandler } from '../Button.logic';
+import { isFullWidthStyle, makeButtonPressHandler } from '../Button.logic';
 
 // The Button is a native @expo/ui control split across Button.ios.tsx /
 // Button.android.tsx, which can't mount under vitest. The press/haptic guard that
@@ -43,5 +43,34 @@ describe('makeButtonPressHandler', () => {
     makeButtonPressHandler({ onPress, haptic: false }, haptic)();
     expect(haptic).not.toHaveBeenCalled();
     expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isFullWidthStyle', () => {
+  it('is false for no style (inline, content-hugging)', () => {
+    expect(isFullWidthStyle(undefined)).toBe(false);
+  });
+
+  // The regression this guards: `flex: 0` means "don't grow", so it must NOT
+  // stretch the button — the old `style.flex != null` check wrongly caught 0.
+  it('is false for flex: 0', () => {
+    expect(isFullWidthStyle({ flex: 0 })).toBe(false);
+  });
+
+  it('is true for a positive flex (fills the flex row)', () => {
+    expect(isFullWidthStyle({ flex: 1 })).toBe(true);
+  });
+
+  it("is true for width: '100%'", () => {
+    expect(isFullWidthStyle({ width: '100%' })).toBe(true);
+  });
+
+  it("is true for alignSelf: 'stretch'", () => {
+    expect(isFullWidthStyle({ alignSelf: 'stretch' })).toBe(true);
+  });
+
+  it('is false for a fixed pixel width or a non-stretch alignSelf', () => {
+    expect(isFullWidthStyle({ width: 120 })).toBe(false);
+    expect(isFullWidthStyle({ alignSelf: 'flex-start' })).toBe(false);
   });
 });

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -757,7 +757,6 @@ function BoardAccountCard({
               icon="delete"
               variant="text"
               size="small"
-              tintColor={brandColors.error}
               role="destructive"
               loading={isRemoving}
               disabled={isRemoving}

--- a/packages/mobile/src/components/integrations/StravaCard.tsx
+++ b/packages/mobile/src/components/integrations/StravaCard.tsx
@@ -148,7 +148,6 @@ export function StravaCard() {
         <Button
           title={t('integrations.strava.disconnect')}
           variant="text"
-          tintColor={brandColors.error}
           role="destructive"
           icon="delete"
           onPress={handleDisconnect}

--- a/packages/mobile/test/button-stub.tsx
+++ b/packages/mobile/test/button-stub.tsx
@@ -17,7 +17,15 @@ import { Pressable, Text } from 'react-native';
 // drifting from the real component.
 import type { ButtonProps } from '../src/components/Button.types';
 
-export function Button({ title, onPress, accessibilityLabel, disabled = false, loading = false, testID }: ButtonProps) {
+export function Button({
+  title,
+  onPress,
+  accessibilityLabel,
+  disabled = false,
+  loading = false,
+  role = 'default',
+  testID,
+}: ButtonProps) {
   const handlePress = () => {
     if (disabled || loading) return;
     onPress();
@@ -30,6 +38,11 @@ export function Button({ title, onPress, accessibilityLabel, disabled = false, l
       accessibilityRole="button"
       accessibilityState={{ disabled: disabled || loading }}
       accessibilityLabel={accessibilityLabel ?? title}
+      // Forward the native `role` so indirect screen tests can assert it was
+      // threaded (the destructive/cancel semantics live in the native tree, which
+      // can't mount under vitest). Only when non-default, to leave ordinary
+      // buttons' accessibility tree untouched.
+      accessibilityValue={role !== 'default' ? { text: role } : undefined}
       testID={testID}
     >
       <Text>{title}</Text>


### PR DESCRIPTION
Follow-up to **#3309** (native @expo/ui `Button`), which merged before the automated review posted. Addresses each claude-review comment; no behaviour change beyond the `flex: 0` bug fix.

## Changes

- **`isFullWidth` false-positive on `flex: 0`** (`Button.ios.tsx` + `Button.android.tsx`) — a button styled `flex: 0` ("don't grow") was wrongly treated as full-width, because `style?.flex != null` is true for `0`, so it stretched (`frame({maxWidth: Infinity})` / `fillMaxWidth()`). Now requires a *positive* numeric flex. **The only real bug.**
- **Dead `tintColor` on destructive buttons** — `DeleteAccountScreen`, `StravaCard`, and `BoardAccountsSection` (unlink) passed both `tintColor={brandColors.error}` and `role="destructive"`. The native role drives the red, so the tint was silently ignored. Removed it (and the now-orphaned `brandColors` destructure in `DeleteAccountScreen`).
- **Flattened `spinnerColor`** in `Button.android.tsx` — dropped the nested filled/tonal ternary; behaviour-identical, clearer.
- **Stub forwards `role`** (`test/button-stub.tsx`) as `accessibilityValue.text` so indirect screen tests can assert the destructive/cancel role was threaded through (the native semantics can't mount under vitest).

## Validation

- `vp run typecheck:mobile` ✓
- `vp run test:mobile` ✓ (3005 tests)
- `vp run check:mobile-platform-imports` ✓
- `vp run check:mobile-bundle` ✓ (iOS + Android)
- `vp check` ✓

JS-only / OTA-deliverable.

## Release Notes

- [x] No release note needed (internal / technical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
