### PR TITLE
fix(sync): make Kilter catalog sync only touch Kilter-synced climbs

### DIFF
--- a/packages/kilter-sync/src/cli/index.ts
+++ b/packages/kilter-sync/src/cli/index.ts
@@ -94,6 +94,7 @@ program
   .option('--user <userId>', 'use this linked user’s stored Kilter credential (refresh grant)')
   .option('--layouts <uuids>', 'comma-separated product_layout_uuids to sync (default: all listed)')
   .option('--apply-deletions', 'apply /delteduuids reconciliation (default: report only)')
+  .option('--delete-batch-limit <n>', 'max deletion changes to apply per run (default: 500)')
   .option('--suppress-notifications', 'skip setter-follow notifications (use for the first bulk ingest)')
   .option('-v, --verbose', 'verbose per-layout logging')
   .action(
@@ -101,6 +102,7 @@ program
       user?: string;
       layouts?: string;
       applyDeletions?: boolean;
+      deleteBatchLimit?: string;
       suppressNotifications?: boolean;
       verbose?: boolean;
     }) => {
@@ -123,8 +125,15 @@ program
           return;
         }
         const layoutUuids = parseLayoutUuids(opts.layouts);
+        const deleteBatchLimit = opts.deleteBatchLimit != null ? Number(opts.deleteBatchLimit) : undefined;
+        if (deleteBatchLimit != null && (!Number.isInteger(deleteBatchLimit) || deleteBatchLimit <= 0)) {
+          console.error('--delete-batch-limit must be a positive integer');
+          process.exitCode = 1;
+          return;
+        }
         const summary = await runner.runCatalogSync(tokenProvider, {
           applyDeletions: opts.applyDeletions,
+          deleteBatchLimit,
           layoutUuids,
           suppressNotifications: opts.suppressNotifications,
         });

--- a/packages/kilter-sync/src/runner/sync-runner.ts
+++ b/packages/kilter-sync/src/runner/sync-runner.ts
@@ -294,7 +294,12 @@ export class SyncRunner {
    */
   async runCatalogSync(
     tokenProvider: KilterTokenProvider,
-    opts: { applyDeletions?: boolean; layoutUuids?: string[]; suppressNotifications?: boolean } = {},
+    opts: {
+      applyDeletions?: boolean;
+      deleteBatchLimit?: number;
+      layoutUuids?: string[];
+      suppressNotifications?: boolean;
+    } = {},
   ): Promise<KilterCatalogSummary> {
     const { db } = this.getClient();
     return syncKilterCatalog({
@@ -302,6 +307,7 @@ export class SyncRunner {
       tokenProvider,
       log: (message) => this.log(message),
       applyDeletions: opts.applyDeletions,
+      deleteBatchLimit: opts.deleteBatchLimit,
       layoutUuids: opts.layoutUuids,
       suppressNotifications: opts.suppressNotifications,
     });

--- a/packages/kilter-sync/src/runner/sync-runner.ts
+++ b/packages/kilter-sync/src/runner/sync-runner.ts
@@ -271,7 +271,15 @@ export class SyncRunner {
     };
 
     try {
-      await syncKilterCatalog({ db, tokenProvider, log: (message) => this.log(message), applyDeletions: false });
+      // Deletions default ON: batched, reversible (soft-delete), and scoped to
+      // Kilter-synced climbs only (never user-authored). See deletions.ts.
+      await syncKilterCatalog({
+        db,
+        tokenProvider,
+        log: (message) => this.log(message),
+        applyDeletions: this.config.applyCatalogDeletions ?? true,
+        deleteBatchLimit: this.config.deleteBatchLimit,
+      });
     } catch (error) {
       this.handleError(error instanceof Error ? error : new Error(String(error)), { board });
     } finally {

--- a/packages/kilter-sync/src/runner/types.ts
+++ b/packages/kilter-sync/src/runner/types.ts
@@ -11,6 +11,15 @@ export type SyncRunnerConfig = {
    * later cycles skip until the cooldown elapses. Default: 1 hour.
    */
   sharedSyncCooldownMs?: number;
+  /**
+   * Apply Kilter's server-side deletions during the daemon's catalog piggyback.
+   * Default true — reconciliation is batched, reversible (soft-delete), and only
+   * ever touches Kilter-synced climbs (never user-authored). Set false to keep
+   * the daemon report-only.
+   */
+  applyCatalogDeletions?: boolean;
+  /** Max deletion changes applied per catalog run; the backlog drains over cycles. */
+  deleteBatchLimit?: number;
   onLog?: (message: string) => void;
   onError?: (error: Error, context: { userId?: string; board?: string }) => void;
 };

--- a/packages/kilter-sync/src/sync/catalog-parse.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-parse.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { gripsClimbConcatToFrames, framesToHolds, fingerprintFrames } from './catalog-parse';
+import { gripsClimbConcatToFrames, framesToHolds, fingerprintFrames, firstUnplaceableHole } from './catalog-parse';
 
 // hole_id → placement_id, the board_placements bridge. Real Kilter values are
 // in the thousands; small numbers here keep the expectations readable.
@@ -27,6 +27,24 @@ void describe('gripsClimbConcatToFrames', () => {
 
   it('preserves comma-separated multi-frame structure', () => {
     expect(gripsClimbConcatToFrames('h10p12,h20p13', REMAP)).toBe('p100r12,p200r13');
+  });
+});
+
+void describe('firstUnplaceableHole', () => {
+  it('returns the first holeId with no placement on the layout', () => {
+    expect(firstUnplaceableHole('h10p12h99p13', REMAP)).toBe(99);
+  });
+
+  it('returns the first unplaceable hole across multiple frames', () => {
+    expect(firstUnplaceableHole('h10p12,h20p13,h77p14', REMAP)).toBe(77);
+  });
+
+  it('returns null when every hole is placeable (malformed-encoding case)', () => {
+    expect(firstUnplaceableHole('h10p12h20p13', REMAP)).toBeNull();
+  });
+
+  it('returns null on a concat with no hold tokens', () => {
+    expect(firstUnplaceableHole('', REMAP)).toBeNull();
   });
 });
 

--- a/packages/kilter-sync/src/sync/catalog-parse.ts
+++ b/packages/kilter-sync/src/sync/catalog-parse.ts
@@ -54,6 +54,22 @@ export function gripsClimbConcatToFrames(climbConcat: string, holeToPlacement: M
 }
 
 /**
+ * Diagnostic-only: the first holeId in `climb_concat` with no placement on this
+ * layout — i.e. why `gripsClimbConcatToFrames` returned null. Called only on the
+ * (rare) unmapped path to make the climbsUnmapped counter diagnosable in logs.
+ * Returns null when the failure wasn't a missing hole (e.g. a malformed frame).
+ */
+export function firstUnplaceableHole(climbConcat: string, holeToPlacement: Map<number, number>): number | null {
+  const holdRe = /h(\d+)p(\d+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = holdRe.exec(climbConcat)) !== null) {
+    const holeId = Number(match[1]);
+    if (!holeToPlacement.has(holeId)) return holeId;
+  }
+  return null;
+}
+
+/**
  * Flatten an Aurora-format frames string into fingerprint tuples — identical
  * to aurora-sync `shared-sync.ts` so board_climb_holds rows match exactly.
  */

--- a/packages/kilter-sync/src/sync/catalog-sync.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import {
   boardClimbs,
@@ -22,7 +22,7 @@ import {
 import { KilterApiError } from '../api/errors';
 import { pullKilterReference, type KilterReferencePull } from './reference-pull';
 import { buildLayoutResolver } from './layout-resolver';
-import { gripsClimbConcatToFrames, framesToHolds } from './catalog-parse';
+import { gripsClimbConcatToFrames, framesToHolds, firstUnplaceableHole } from './catalog-parse';
 import { fingerprintFromHolds } from './fingerprint';
 import { createSetterSyncNotifications, type NewClimbInfo } from './notifications';
 import { reconcileDeletions, type DeletionReport } from './deletions';
@@ -45,8 +45,11 @@ export type SyncKilterCatalogArgs = {
   /**
    * Apply /delteduuids reconciliation. Default false = classify + report only.
    * Deleting catalog rows is data deletion (see CLAUDE.md) — opt in explicitly.
+   * Only ever touches Kilter-synced climbs (never user-authored). See deletions.ts.
    */
   applyDeletions?: boolean;
+  /** Max deletion changes to apply per run; the backlog drains over cycles. */
+  deleteBatchLimit?: number;
   /**
    * Skip setter-follow notifications for newly-inserted canonicals. Use for the
    * first bulk ingest — it backfills tens of thousands of *historical* climbs,
@@ -105,6 +108,8 @@ async function loadHoleToPlacement(db: DrizzleDb, layoutId: number): Promise<Map
   return map;
 }
 
+type UnmappedClimbSample = { climbUuid: string; holeId: number | null };
+
 type GroupResult = {
   climbsSeen: number;
   climbsUnmapped: number;
@@ -112,7 +117,12 @@ type GroupResult = {
   aliasesUpserted: number;
   statsUpserted: number;
   newCanonicals: NewClimbInfo[];
+  /** A few unmapped climbs (uuid + offending holeId) for a diagnostic log line. */
+  unmappedSamples: UnmappedClimbSample[];
 };
+
+// Cap the diagnostic sample so a systemic mapping break can't balloon the log.
+const UNMAPPED_SAMPLE_LIMIT = 10;
 
 // Mutable per-(canonical, angle) stat accumulator. kilterCount is summed across
 // every source UUID that resolves to the canonical; the display fields are
@@ -230,6 +240,7 @@ async function syncBoardLayoutGroup(
     aliasesUpserted: 0,
     statsUpserted: 0,
     newCanonicals: [],
+    unmappedSamples: [],
   };
 
   // Existing catalog for this layout: uuid identity + fingerprint → canonical.
@@ -288,6 +299,12 @@ async function syncBoardLayoutGroup(
       const frames = gripsClimbConcatToFrames(climb.climbConcat, holeToPlacement);
       if (frames === null) {
         result.climbsUnmapped += 1;
+        if (result.unmappedSamples.length < UNMAPPED_SAMPLE_LIMIT) {
+          result.unmappedSamples.push({
+            climbUuid: climb.climbUuid,
+            holeId: firstUnplaceableHole(climb.climbConcat, holeToPlacement),
+          });
+        }
         continue;
       }
       const fingerprint = fingerprintFromHolds(framesToHolds(frames));
@@ -360,6 +377,9 @@ async function syncBoardLayoutGroup(
           .values(chunk)
           .onConflictDoUpdate({
             target: [boardClimbs.uuid],
+            // Never overwrite a user-authored climb on a UUID collision — the
+            // catalog sync only owns Kilter-synced rows (user_id IS NULL).
+            setWhere: isNull(boardClimbs.userId),
             set: {
               holdFingerprint: sql`COALESCE(${boardClimbs.holdFingerprint}, excluded.hold_fingerprint)`,
               frames: sql`COALESCE(${boardClimbs.frames}, excluded.frames)`,
@@ -508,12 +528,19 @@ export async function syncKilterCatalog(args: SyncKilterCatalogArgs): Promise<Ki
       reported: 0,
       aliasDeletes: 0,
       softDeletes: 0,
+      protectedUserAuthored: 0,
+      skippedForeignSource: 0,
       skippedCanonicalWithAliases: 0,
+      alreadyUnlisted: 0,
       unknown: 0,
       applied: false,
+      appliedThisRun: 0,
+      remaining: 0,
+      refused: false,
     },
   };
   const allNewCanonicals: NewClimbInfo[] = [];
+  const unmappedSamples: UnmappedClimbSample[] = [];
 
   for (const [boardLayoutId, gripsLayoutUuids] of byBoardLayout) {
     const groupResult = await syncBoardLayoutGroup(args.db, state, boardLayoutId, gripsLayoutUuids, log);
@@ -524,6 +551,18 @@ export async function syncKilterCatalog(args: SyncKilterCatalogArgs): Promise<Ki
     summary.aliasesUpserted += groupResult.aliasesUpserted;
     summary.statsUpserted += groupResult.statsUpserted;
     allNewCanonicals.push(...groupResult.newCanonicals);
+    for (const sample of groupResult.unmappedSamples) {
+      if (unmappedSamples.length < UNMAPPED_SAMPLE_LIMIT) unmappedSamples.push(sample);
+    }
+  }
+
+  // Surface a sample of unmapped climbs so climbsUnmapped is diagnosable (holds
+  // that have no placement on the resolved layout — usually a fringe variant).
+  if (summary.climbsUnmapped > 0) {
+    const sample = unmappedSamples
+      .map((entry) => (entry.holeId != null ? `${entry.climbUuid}(hole ${entry.holeId})` : entry.climbUuid))
+      .join(', ');
+    log(`[kilter-catalog] ${summary.climbsUnmapped} climb(s) unmapped; sample: ${sample}`);
   }
 
   // Persist the layout uuid → layout_id mappings discovered this run.
@@ -559,7 +598,9 @@ export async function syncKilterCatalog(args: SyncKilterCatalogArgs): Promise<Ki
   // Deletion reconciliation runs last (report-only unless applyDeletions).
   try {
     const deletedUuids = await withToken(state, (token) => fetchDeletedClimbUuids(token));
-    summary.deletions = await reconcileDeletions(args.db, deletedUuids, args.applyDeletions ?? false, log);
+    summary.deletions = await reconcileDeletions(args.db, deletedUuids, args.applyDeletions ?? false, log, {
+      batchLimit: args.deleteBatchLimit,
+    });
   } catch (error) {
     log(`[kilter-catalog] deletion reconciliation failed: ${error instanceof Error ? error.message : String(error)}`);
   }

--- a/packages/kilter-sync/src/sync/deletions.test.ts
+++ b/packages/kilter-sync/src/sync/deletions.test.ts
@@ -1,26 +1,136 @@
 import { describe, expect, it } from 'vitest';
 
-import { reconcileDeletions } from './deletions';
+import {
+  classifyKilterDeletions,
+  isAnomalousDeletionBacklog,
+  planDeletionBatch,
+  reconcileDeletions,
+  type AliasClassificationRow,
+} from './deletions';
 
-type Row = Record<string, unknown>;
+const noop = () => {};
 
-// Drizzle shim. reconcileDeletions issues two reads against board_climb_aliases:
-// the 1st is select().from().where() (alias rows), the 2nd adds .groupBy()
-// (alias counts) and only runs when there are canonicals. A select-call counter
-// returns the right shape for each, and delete/update calls are recorded.
-function mockDb(seed: { aliasRows: Row[]; counts: Row[] }) {
+function aliasRow(
+  overrides: Partial<AliasClassificationRow> & Pick<AliasClassificationRow, 'aliasUuid'>,
+): AliasClassificationRow {
+  return {
+    canonicalUuid: overrides.aliasUuid,
+    source: 'kilter',
+    canonicalUserId: null,
+    canonicalIsListed: true,
+    ...overrides,
+  };
+}
+
+describe('classifyKilterDeletions', () => {
+  const noCounts = new Map<string, number>();
+
+  it('drops a pure kilter alias but never a foreign-source one', () => {
+    const result = classifyKilterDeletions({
+      loweredUuids: ['dup', 'foreign'],
+      aliasRows: [
+        aliasRow({ aliasUuid: 'dup', canonicalUuid: 'canon' }),
+        aliasRow({ aliasUuid: 'foreign', canonicalUuid: 'canon2', source: 'backfill' }),
+      ],
+      aliasCounts: noCounts,
+    });
+    expect(result.aliasUuidsToDelete).toEqual(['dup']);
+    expect(result.skippedForeignSource).toBe(1);
+  });
+
+  it('protects a user-authored self-canonical', () => {
+    const result = classifyKilterDeletions({
+      loweredUuids: ['mine'],
+      aliasRows: [aliasRow({ aliasUuid: 'mine', canonicalUserId: 'user-1' })],
+      aliasCounts: noCounts,
+    });
+    expect(result.canonicalsToSoftDelete).toEqual([]);
+    expect(result.protectedUserAuthored).toBe(1);
+  });
+
+  it('soft-deletes a lone synced self-canonical, skips one already unlisted', () => {
+    const result = classifyKilterDeletions({
+      loweredUuids: ['a', 'b'],
+      aliasRows: [aliasRow({ aliasUuid: 'a' }), aliasRow({ aliasUuid: 'b', canonicalIsListed: false })],
+      aliasCounts: new Map([
+        ['a', 1],
+        ['b', 1],
+      ]),
+    });
+    expect(result.canonicalsToSoftDelete).toEqual(['a']);
+    expect(result.alreadyUnlisted).toBe(1);
+  });
+
+  it('skips a canonical that still backs live aliases (no orphaning)', () => {
+    const result = classifyKilterDeletions({
+      loweredUuids: ['a'],
+      aliasRows: [aliasRow({ aliasUuid: 'a' })],
+      aliasCounts: new Map([['a', 3]]),
+    });
+    expect(result.canonicalsToSoftDelete).toEqual([]);
+    expect(result.skippedCanonicalWithAliases).toBe(1);
+  });
+
+  it('counts uuids not present in board_climb_aliases as unknown', () => {
+    const result = classifyKilterDeletions({ loweredUuids: ['ghost'], aliasRows: [], aliasCounts: noCounts });
+    expect(result.unknown).toBe(1);
+  });
+});
+
+describe('planDeletionBatch', () => {
+  it('caps applied changes at the batch limit, alias drops first', () => {
+    const plan = planDeletionBatch({ aliasUuidsToDelete: ['a1', 'a2', 'a3'], canonicalsToSoftDelete: ['s1', 's2'] }, 3);
+    expect(plan.aliasBatch).toEqual(['a1', 'a2', 'a3']);
+    expect(plan.softBatch).toEqual([]);
+    expect(plan.appliedThisRun).toBe(3);
+    expect(plan.remaining).toBe(2);
+  });
+
+  it('spills the remaining budget into soft-deletes', () => {
+    const plan = planDeletionBatch({ aliasUuidsToDelete: ['a1'], canonicalsToSoftDelete: ['s1', 's2', 's3'] }, 3);
+    expect(plan.aliasBatch).toEqual(['a1']);
+    expect(plan.softBatch).toEqual(['s1', 's2']);
+    expect(plan.appliedThisRun).toBe(3);
+    expect(plan.remaining).toBe(1);
+  });
+});
+
+describe('isAnomalousDeletionBacklog', () => {
+  it('trips when the backlog exceeds the fraction of live climbs', () => {
+    expect(isAnomalousDeletionBacklog(30, 100)).toBe(true);
+    expect(isAnomalousDeletionBacklog(20, 100)).toBe(false);
+  });
+
+  it('never trips on an empty catalog', () => {
+    expect(isAnomalousDeletionBacklog(5, 0)).toBe(false);
+  });
+});
+
+// Drizzle shim. Each select() call consumes the next canned result in order:
+// (1) alias rows (leftJoin), (2) alias counts (groupBy) when canonicals exist,
+// (3) the live-catalog count (only when applying with candidates). Each stub is a
+// real resolved Promise with chain methods attached, so `await db.select()...`
+// resolves to the canned rows regardless of which leftJoin/where/groupBy shape
+// the query uses.
+type Rows = Array<Record<string, unknown>>;
+type QueryStub = Promise<Rows> & {
+  leftJoin: () => QueryStub;
+  where: () => QueryStub;
+  groupBy: () => QueryStub;
+};
+function mockDb(selectResults: Rows[]) {
   const deletes: unknown[] = [];
   const updates: Array<{ set: unknown }> = [];
   let selectCall = 0;
+  const stub = (rows: Rows): QueryStub => {
+    const query = Promise.resolve(rows) as QueryStub;
+    query.leftJoin = () => query;
+    query.where = () => query;
+    query.groupBy = () => query;
+    return query;
+  };
   const db = {
-    select() {
-      const isFirst = selectCall++ === 0;
-      return {
-        from: () => ({
-          where: () => (isFirst ? Promise.resolve(seed.aliasRows) : { groupBy: () => Promise.resolve(seed.counts) }),
-        }),
-      };
-    },
+    select: () => ({ from: () => stub(selectResults[selectCall++] ?? []) }),
     delete: () => ({
       where: (cond: unknown) => {
         deletes.push(cond);
@@ -37,67 +147,100 @@ function mockDb(seed: { aliasRows: Row[]; counts: Row[] }) {
   return { db: db as unknown as Parameters<typeof reconcileDeletions>[0], deletes, updates };
 }
 
-const noop = () => {};
-
-void describe('reconcileDeletions', () => {
-  it('drops a pure alias and leaves the canonical intact', async () => {
-    const { db, deletes, updates } = mockDb({
-      aliasRows: [{ aliasUuid: 'dup', canonicalUuid: 'canon' }],
-      counts: [{ canonicalUuid: 'canon', count: 2 }],
-    });
-    const report = await reconcileDeletions(db, ['dup'], true, noop);
+describe('reconcileDeletions', () => {
+  it('reports only when applyDeletions is false', async () => {
+    const { db, deletes, updates } = mockDb([
+      [{ aliasUuid: 'dup', canonicalUuid: 'canon', source: 'kilter', canonicalUserId: null, canonicalIsListed: true }],
+      [{ canonicalUuid: 'canon', count: 2 }],
+    ]);
+    const report = await reconcileDeletions(db, ['dup'], false, noop);
     expect(report.aliasDeletes).toBe(1);
+    expect(report.applied).toBe(false);
+    expect(report.remaining).toBe(1);
+    expect(deletes).toHaveLength(0);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('applies a pure alias drop and a lone soft-delete', async () => {
+    const { db, deletes, updates } = mockDb([
+      [
+        { aliasUuid: 'dup', canonicalUuid: 'canon', source: 'kilter', canonicalUserId: null, canonicalIsListed: true },
+        { aliasUuid: 'solo', canonicalUuid: 'solo', source: 'kilter', canonicalUserId: null, canonicalIsListed: true },
+      ],
+      [
+        { canonicalUuid: 'canon', count: 2 },
+        { canonicalUuid: 'solo', count: 1 },
+      ],
+      [{ count: 1000 }],
+    ]);
+    const report = await reconcileDeletions(db, ['dup', 'solo'], true, noop);
+    expect(report.aliasDeletes).toBe(1);
+    expect(report.softDeletes).toBe(1);
+    expect(report.applied).toBe(true);
+    expect(report.appliedThisRun).toBe(2);
+    expect(deletes).toHaveLength(1);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].set).toEqual({ isListed: false });
+  });
+
+  it('never soft-deletes a user-authored climb', async () => {
+    const { db, deletes, updates } = mockDb([
+      [
+        {
+          aliasUuid: 'mine',
+          canonicalUuid: 'mine',
+          source: 'kilter',
+          canonicalUserId: 'user-1',
+          canonicalIsListed: true,
+        },
+      ],
+      [{ canonicalUuid: 'mine', count: 1 }],
+    ]);
+    const report = await reconcileDeletions(db, ['mine'], true, noop);
+    expect(report.protectedUserAuthored).toBe(1);
     expect(report.softDeletes).toBe(0);
+    expect(deletes).toHaveLength(0);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('refuses an anomalous backlog and applies nothing', async () => {
+    const { db, deletes, updates } = mockDb([
+      [{ aliasUuid: 'solo', canonicalUuid: 'solo', source: 'kilter', canonicalUserId: null, canonicalIsListed: true }],
+      [{ canonicalUuid: 'solo', count: 1 }],
+      [{ count: 1 }], // 1 candidate vs 1 live climb → over the 25% guard.
+    ]);
+    const report = await reconcileDeletions(db, ['solo'], true, noop);
+    expect(report.refused).toBe(true);
+    expect(report.applied).toBe(false);
+    expect(report.remaining).toBe(1);
+    expect(deletes).toHaveLength(0);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('does not refuse a pure alias-drop backlog (only soft-deletes gate the guard)', async () => {
+    // Two pure kilter aliases → alias drops, zero soft-deletes. No live-count
+    // query is issued (softDeletes === 0 short-circuits the guard).
+    const { db, deletes, updates } = mockDb([
+      [
+        { aliasUuid: 'd1', canonicalUuid: 'c1', source: 'kilter', canonicalUserId: null, canonicalIsListed: true },
+        { aliasUuid: 'd2', canonicalUuid: 'c2', source: 'kilter', canonicalUserId: null, canonicalIsListed: true },
+      ],
+      [
+        { canonicalUuid: 'c1', count: 2 },
+        { canonicalUuid: 'c2', count: 2 },
+      ],
+    ]);
+    const report = await reconcileDeletions(db, ['d1', 'd2'], true, noop);
+    expect(report.softDeletes).toBe(0);
+    expect(report.aliasDeletes).toBe(2);
+    expect(report.refused).toBe(false);
     expect(report.applied).toBe(true);
     expect(deletes).toHaveLength(1);
     expect(updates).toHaveLength(0);
   });
 
-  it('soft-deletes a lone self-canonical (is_listed=false), never hard-deletes', async () => {
-    const { db, deletes, updates } = mockDb({
-      aliasRows: [{ aliasUuid: 'solo', canonicalUuid: 'solo' }],
-      counts: [{ canonicalUuid: 'solo', count: 1 }],
-    });
-    const report = await reconcileDeletions(db, ['solo'], true, noop);
-    expect(report.softDeletes).toBe(1);
-    expect(report.aliasDeletes).toBe(0);
-    expect(updates).toHaveLength(1);
-    expect(updates[0].set).toEqual({ isListed: false });
-    expect(deletes).toHaveLength(0); // canonical climb is never deleted
-  });
-
-  it('skips a canonical that still backs live aliases (no orphaning)', async () => {
-    const { db, deletes, updates } = mockDb({
-      aliasRows: [{ aliasUuid: 'canon', canonicalUuid: 'canon' }],
-      counts: [{ canonicalUuid: 'canon', count: 3 }],
-    });
-    const report = await reconcileDeletions(db, ['canon'], true, noop);
-    expect(report.skippedCanonicalWithAliases).toBe(1);
-    expect(deletes).toHaveLength(0);
-    expect(updates).toHaveLength(0);
-  });
-
-  it('reports only when applyDeletions is false', async () => {
-    const { db, deletes, updates } = mockDb({
-      aliasRows: [{ aliasUuid: 'dup', canonicalUuid: 'canon' }],
-      counts: [{ canonicalUuid: 'canon', count: 2 }],
-    });
-    const report = await reconcileDeletions(db, ['dup'], false, noop);
-    expect(report.aliasDeletes).toBe(1);
-    expect(report.applied).toBe(false);
-    expect(deletes).toHaveLength(0);
-    expect(updates).toHaveLength(0);
-  });
-
-  it('counts unknown uuids not present in board_*', async () => {
-    const { db } = mockDb({ aliasRows: [], counts: [] });
-    const report = await reconcileDeletions(db, ['ghost-1', 'ghost-2'], true, noop);
-    expect(report.unknown).toBe(2);
-    expect(report.aliasDeletes).toBe(0);
-  });
-
   it('is a no-op on an empty delete set', async () => {
-    const { db, deletes } = mockDb({ aliasRows: [], counts: [] });
+    const { db, deletes } = mockDb([]);
     const report = await reconcileDeletions(db, [], true, noop);
     expect(report.reported).toBe(0);
     expect(deletes).toHaveLength(0);

--- a/packages/kilter-sync/src/sync/deletions.test.ts
+++ b/packages/kilter-sync/src/sync/deletions.test.ts
@@ -129,8 +129,7 @@ function mockDb(selectResults: Rows[]) {
     query.groupBy = () => query;
     return query;
   };
-  const db = {
-    select: () => ({ from: () => stub(selectResults[selectCall++] ?? []) }),
+  const writer = {
     delete: () => ({
       where: (cond: unknown) => {
         deletes.push(cond);
@@ -143,6 +142,13 @@ function mockDb(selectResults: Rows[]) {
         return { where: () => Promise.resolve() };
       },
     }),
+  };
+  const db = {
+    select: () => ({ from: () => stub(selectResults[selectCall++] ?? []) }),
+    // The apply path runs inside db.transaction(cb); hand the callback a tx that
+    // records deletes/updates the same way.
+    transaction: (cb: (tx: typeof writer) => Promise<unknown>) => cb(writer),
+    ...writer,
   };
   return { db: db as unknown as Parameters<typeof reconcileDeletions>[0], deletes, updates };
 }

--- a/packages/kilter-sync/src/sync/deletions.ts
+++ b/packages/kilter-sync/src/sync/deletions.ts
@@ -88,7 +88,10 @@ export function classifyKilterDeletions(input: {
 
   for (const row of aliasRows) {
     knownLower.add(row.aliasUuid.toLowerCase());
-    const isSelfCanonical = row.aliasUuid === row.canonicalUuid;
+    // Case-insensitive: the lookup matches on lower(alias_uuid), and a self-alias
+    // is the same climb regardless of casing — comparing raw could misclassify a
+    // case-variant self-canonical as a pure alias.
+    const isSelfCanonical = row.aliasUuid.toLowerCase() === row.canonicalUuid.toLowerCase();
 
     if (!isSelfCanonical) {
       // Pure alias → drop the alias row only if the catalog sync created it.
@@ -267,6 +270,10 @@ export async function reconcileDeletions(
   // Anomaly guard against a malformed /delteduuids or a mass upstream unpublish.
   // Only soft-deletes remove climbs from view, so gate on them — a backlog of pure
   // alias drops is safe duplicate-row cleanup and applies (batch-capped) unguarded.
+  // NB: gate on the TOTAL soft-delete backlog, not the per-run batch — a genuine
+  // mass-delete would otherwise drain a batch at a time and silently unlist a big
+  // slice of the catalog without ever tripping. If a large drop is legitimate, the
+  // operator reviews it and raises ANOMALY_FRACTION for a one-off manual apply.
   if (report.softDeletes > 0) {
     const [liveRow] = await db
       .select({ count: sql<number>`count(*)::int` })
@@ -284,26 +291,31 @@ export async function reconcileDeletions(
   }
 
   const { aliasBatch, softBatch, appliedThisRun, remaining } = planDeletionBatch(classification, batchLimit);
-  if (aliasBatch.length > 0) {
-    // source='kilter' + board_type guards belt-and-suspenders the classifier.
-    await db
-      .delete(boardClimbAliases)
-      .where(
-        and(
-          eq(boardClimbAliases.boardType, KILTER),
-          eq(boardClimbAliases.source, KILTER),
-          inArray(boardClimbAliases.aliasUuid, aliasBatch),
-        ),
-      );
-  }
-  if (softBatch.length > 0) {
-    // isNull(userId) guard ensures we never flip a user-authored climb, even if
-    // classification and apply somehow raced against a concurrent write.
-    await db
-      .update(boardClimbs)
-      .set({ isListed: false })
-      .where(and(eq(boardClimbs.boardType, KILTER), isNull(boardClimbs.userId), inArray(boardClimbs.uuid, softBatch)));
-  }
+  // Apply both writes atomically so a crash can't leave the batch half-applied.
+  await db.transaction(async (tx) => {
+    if (aliasBatch.length > 0) {
+      // source='kilter' + board_type guards belt-and-suspenders the classifier.
+      await tx
+        .delete(boardClimbAliases)
+        .where(
+          and(
+            eq(boardClimbAliases.boardType, KILTER),
+            eq(boardClimbAliases.source, KILTER),
+            inArray(boardClimbAliases.aliasUuid, aliasBatch),
+          ),
+        );
+    }
+    if (softBatch.length > 0) {
+      // isNull(userId) guard ensures we never flip a user-authored climb, even if
+      // classification and apply somehow raced against a concurrent write.
+      await tx
+        .update(boardClimbs)
+        .set({ isListed: false })
+        .where(
+          and(eq(boardClimbs.boardType, KILTER), isNull(boardClimbs.userId), inArray(boardClimbs.uuid, softBatch)),
+        );
+    }
+  });
   report.applied = true;
   report.appliedThisRun = appliedThisRun;
   report.remaining = remaining;

--- a/packages/kilter-sync/src/sync/deletions.ts
+++ b/packages/kilter-sync/src/sync/deletions.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import { boardClimbs, boardClimbAliases } from '@boardsesh/db/schema';
 
@@ -6,45 +6,200 @@ type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
 
 const KILTER = 'kilter';
 
-// Refuse to auto-apply a delete set larger than this — a malformed or
-// empty-token /delteduuids response could otherwise wipe a big slice of the
-// catalog. Above this, classify + report only and require a human.
-const LARGE_DELETE_THRESHOLD = 2000;
+// Apply at most this many changes (alias drops + soft-deletes) per run. Kilter's
+// /delteduuids is a full history of server-side deletions, so the first reconcile
+// has a large backlog; draining it a batch at a time keeps any single cycle's
+// blast radius small and lets the daemon work through it over successive runs.
+export const DEFAULT_DELETE_BATCH_LIMIT = 500;
+
+// Refuse to apply if the candidate backlog exceeds this fraction of the live,
+// synced Kilter catalog. A malformed /delteduuids (empty token, mass upstream
+// unpublish) shows up as a backlog spike; above this we report only and wait for
+// a human rather than unlist a big slice of the catalog in one go.
+export const ANOMALY_FRACTION = 0.25;
 
 export type DeletionReport = {
   reported: number;
-  /** Pure-alias rows (alias_uuid ≠ canonical) safe to drop. */
+  /** Pure-alias rows (alias_uuid ≠ canonical), source='kilter', eligible to drop. */
   aliasDeletes: number;
-  /** Lone self-canonicals (no other live alias) eligible for soft-delete. */
+  /** Lone synced (userId null) self-canonicals still listed — eligible to unlist. */
   softDeletes: number;
-  /** Canonicals that still have live aliases — skipped (would orphan survivors). */
+  /** Canonical is user-authored (userId set) — never touched by the catalog sync. */
+  protectedUserAuthored: number;
+  /** Pure alias whose source ≠ 'kilter' (backfill/aurora) — not ours to drop. */
+  skippedForeignSource: number;
+  /** Canonicals that still back live aliases — skipped (would orphan survivors). */
   skippedCanonicalWithAliases: number;
-  /** UUIDs not found in board_* at all. */
+  /** Self-canonicals already is_listed=false from a prior run (drained). */
+  alreadyUnlisted: number;
+  /** Reported uuids not found in board_climb_aliases at all (never imported). */
   unknown: number;
   applied: boolean;
+  /** Changes actually written this cycle (alias drops + soft-deletes). */
+  appliedThisRun: number;
+  /** Candidates not applied this run — the backlog tail for the next cycle. */
+  remaining: number;
+  /** Anomaly guard tripped — backlog too large, nothing applied. */
+  refused: boolean;
+};
+
+export type AliasClassificationRow = {
+  aliasUuid: string;
+  canonicalUuid: string;
+  source: string;
+  canonicalUserId: string | null;
+  canonicalIsListed: boolean | null;
+};
+
+export type DeletionClassification = {
+  aliasUuidsToDelete: string[];
+  canonicalsToSoftDelete: string[];
+  protectedUserAuthored: number;
+  skippedForeignSource: number;
+  skippedCanonicalWithAliases: number;
+  alreadyUnlisted: number;
+  unknown: number;
 };
 
 /**
+ * Pure classification of Kilter's reported deletions against the alias graph.
+ * The safety rules live here so they're unit-testable without a database:
+ *
+ *  - A pure alias (alias ≠ canonical) is dropped ONLY when its `source` is
+ *    'kilter' — i.e. the catalog sync created it. 'backfill'/'aurora' alias rows
+ *    are never dropped by this pass.
+ *  - A self-canonical is soft-deleted ONLY when the underlying climb is
+ *    Kilter-synced (`userId` is null), still listed, and no other live alias
+ *    backs it. A climb with a `userId` is user-authored and is always protected.
+ */
+export function classifyKilterDeletions(input: {
+  loweredUuids: string[];
+  aliasRows: AliasClassificationRow[];
+  aliasCounts: Map<string, number>;
+}): DeletionClassification {
+  const { loweredUuids, aliasRows, aliasCounts } = input;
+  const aliasUuidsToDelete: string[] = [];
+  const canonicalsToSoftDelete: string[] = [];
+  const knownLower = new Set<string>();
+  let protectedUserAuthored = 0;
+  let skippedForeignSource = 0;
+  let skippedCanonicalWithAliases = 0;
+  let alreadyUnlisted = 0;
+
+  for (const row of aliasRows) {
+    knownLower.add(row.aliasUuid.toLowerCase());
+    const isSelfCanonical = row.aliasUuid === row.canonicalUuid;
+
+    if (!isSelfCanonical) {
+      // Pure alias → drop the alias row only if the catalog sync created it.
+      if (row.source === KILTER) {
+        aliasUuidsToDelete.push(row.aliasUuid);
+      } else {
+        skippedForeignSource += 1;
+      }
+      continue;
+    }
+
+    // Self-canonical → decide whether to unlist the underlying climb.
+    if (row.canonicalUserId != null) {
+      // User-authored climb. Off-limits to the catalog sync, full stop.
+      protectedUserAuthored += 1;
+      continue;
+    }
+    if (row.canonicalIsListed === false) {
+      // Already unlisted on a prior run — drained, nothing to do.
+      alreadyUnlisted += 1;
+      continue;
+    }
+    if ((aliasCounts.get(row.canonicalUuid) ?? 1) <= 1) {
+      canonicalsToSoftDelete.push(row.canonicalUuid);
+    } else {
+      // Still backs live aliases — soft-deleting now would orphan them. Once the
+      // alias rows drain on later runs it becomes lone and is picked up.
+      skippedCanonicalWithAliases += 1;
+    }
+  }
+
+  const unknown = loweredUuids.filter((uuid) => !knownLower.has(uuid)).length;
+  return {
+    aliasUuidsToDelete,
+    canonicalsToSoftDelete,
+    protectedUserAuthored,
+    skippedForeignSource,
+    skippedCanonicalWithAliases,
+    alreadyUnlisted,
+    unknown,
+  };
+}
+
+/**
+ * Slice the classified candidates down to a single run's batch. Deterministic
+ * (sorted) so successive runs cover fresh candidates; alias drops go first
+ * because they permanently shrink the backlog.
+ */
+export function planDeletionBatch(
+  classification: Pick<DeletionClassification, 'aliasUuidsToDelete' | 'canonicalsToSoftDelete'>,
+  batchLimit: number,
+): { aliasBatch: string[]; softBatch: string[]; appliedThisRun: number; remaining: number } {
+  const aliasSorted = [...classification.aliasUuidsToDelete].sort();
+  const softSorted = [...classification.canonicalsToSoftDelete].sort();
+  const backlog = aliasSorted.length + softSorted.length;
+  const limit = Math.max(0, batchLimit);
+  const aliasBatch = aliasSorted.slice(0, limit);
+  const softBatch = softSorted.slice(0, Math.max(0, limit - aliasBatch.length));
+  const appliedThisRun = aliasBatch.length + softBatch.length;
+  return { aliasBatch, softBatch, appliedThisRun, remaining: backlog - appliedThisRun };
+}
+
+/**
+ * Wipe-signal check: would this run unlist an implausibly large slice of the live
+ * catalog? Keyed on the SOFT-DELETE count — the action that actually removes
+ * climbs from view — not alias-drops, which are safe duplicate-row cleanup that
+ * leave every canonical listed. A benign backlog of pure alias drops therefore
+ * can't trip the guard.
+ */
+export function isAnomalousDeletionBacklog(softDeleteCount: number, liveListedCount: number): boolean {
+  if (liveListedCount <= 0) return false;
+  return softDeleteCount > liveListedCount * ANOMALY_FRACTION;
+}
+
+/**
  * Reconcile Kilter's server-side deletions (GET /climbs/delteduuids) against
- * board_*. Data deletion is gated: `applyDeletions` defaults off, in which case
- * we only classify and report what *would* happen. Even when on, we never hard
- * delete a canonical climb — pure aliases are removed, and a lone self-canonical
- * is soft-deleted (`is_listed = false`) so its holds/stats/history survive.
- * Canonicals that still back live aliases are left untouched.
+ * board_*. Only ever touches climbs the Kilter catalog sync itself owns:
+ *
+ *  - user-authored climbs (board_climbs.user_id set) are never modified;
+ *  - only 'kilter'-sourced pure-alias rows are hard-deleted (canonical survives);
+ *  - a lone synced self-canonical is soft-deleted (`is_listed = false`), which is
+ *    reversible and preserves its holds/stats/history.
+ *
+ * `applyDeletions` defaults off (classify + report only). When on, changes are
+ * applied a `batchLimit`-sized batch per run and the backlog drains over
+ * successive cycles; an anomaly guard refuses an implausibly large batch.
  */
 export async function reconcileDeletions(
   db: DrizzleDb,
   deletedUuids: string[],
   applyDeletions: boolean,
   log: (message: string) => void,
+  options?: { batchLimit?: number },
 ): Promise<DeletionReport> {
+  // A non-positive batch limit would silently stall the drain (0 changes/run,
+  // never erroring); fall back to the default instead.
+  const configuredLimit = options?.batchLimit;
+  const batchLimit = configuredLimit != null && configuredLimit > 0 ? configuredLimit : DEFAULT_DELETE_BATCH_LIMIT;
   const report: DeletionReport = {
     reported: deletedUuids.length,
     aliasDeletes: 0,
     softDeletes: 0,
+    protectedUserAuthored: 0,
+    skippedForeignSource: 0,
     skippedCanonicalWithAliases: 0,
+    alreadyUnlisted: 0,
     unknown: 0,
     applied: false,
+    appliedThisRun: 0,
+    remaining: 0,
+    refused: false,
   };
   if (deletedUuids.length === 0) return report;
 
@@ -52,10 +207,22 @@ export async function reconcileDeletions(
   // casing Aurora used. Match case-insensitively.
   const lowered = deletedUuids.map((uuid) => uuid.toLowerCase());
 
-  // Resolve each deleted uuid against the alias graph.
-  const aliasRows = await db
-    .select({ aliasUuid: boardClimbAliases.aliasUuid, canonicalUuid: boardClimbAliases.canonicalUuid })
+  // Resolve each deleted uuid against the alias graph, carrying the canonical
+  // climb's provenance (userId) and listing state so the classifier can protect
+  // user content and skip already-drained rows.
+  const aliasRows: AliasClassificationRow[] = await db
+    .select({
+      aliasUuid: boardClimbAliases.aliasUuid,
+      canonicalUuid: boardClimbAliases.canonicalUuid,
+      source: boardClimbAliases.source,
+      canonicalUserId: boardClimbs.userId,
+      canonicalIsListed: boardClimbs.isListed,
+    })
     .from(boardClimbAliases)
+    .leftJoin(
+      boardClimbs,
+      and(eq(boardClimbs.uuid, boardClimbAliases.canonicalUuid), eq(boardClimbs.boardType, KILTER)),
+    )
     .where(and(eq(boardClimbAliases.boardType, KILTER), inArray(sql`lower(${boardClimbAliases.aliasUuid})`, lowered)));
 
   // How many live aliases does each canonical still have? (to avoid orphaning)
@@ -70,55 +237,78 @@ export async function reconcileDeletions(
     for (const row of counts) aliasCounts.set(row.canonicalUuid, row.count);
   }
 
-  const aliasUuidsToDelete: string[] = [];
-  const canonicalsToSoftDelete: string[] = [];
-  const knownLower = new Set<string>();
+  const classification = classifyKilterDeletions({ loweredUuids: lowered, aliasRows, aliasCounts });
+  report.aliasDeletes = classification.aliasUuidsToDelete.length;
+  report.softDeletes = classification.canonicalsToSoftDelete.length;
+  report.protectedUserAuthored = classification.protectedUserAuthored;
+  report.skippedForeignSource = classification.skippedForeignSource;
+  report.skippedCanonicalWithAliases = classification.skippedCanonicalWithAliases;
+  report.alreadyUnlisted = classification.alreadyUnlisted;
+  report.unknown = classification.unknown;
 
-  for (const alias of aliasRows) {
-    knownLower.add(alias.aliasUuid.toLowerCase());
-    const isSelfCanonical = alias.aliasUuid === alias.canonicalUuid;
-    if (!isSelfCanonical) {
-      // Pure alias → safe to drop the alias row; canonical + survivors stay.
-      aliasUuidsToDelete.push(alias.aliasUuid);
-      report.aliasDeletes += 1;
-    } else if ((aliasCounts.get(alias.canonicalUuid) ?? 1) <= 1) {
-      // Lone self-canonical → soft-delete only.
-      canonicalsToSoftDelete.push(alias.canonicalUuid);
-      report.softDeletes += 1;
-    } else {
-      // Canonical still has live aliases pointing at it — leave it.
-      report.skippedCanonicalWithAliases += 1;
-    }
-  }
-  report.unknown = lowered.filter((uuid) => !knownLower.has(uuid)).length;
+  const backlog = report.aliasDeletes + report.softDeletes;
 
   if (!applyDeletions) {
+    report.remaining = backlog;
     log(
-      `[kilter-catalog] deletions (report only): ${report.reported} reported → ${report.aliasDeletes} alias drops, ${report.softDeletes} soft-deletes, ${report.skippedCanonicalWithAliases} skipped (live aliases), ${report.unknown} unknown`,
+      `[kilter-catalog] deletions (report only): ${report.reported} reported → ${report.aliasDeletes} alias drops, ${report.softDeletes} soft-deletes, ${report.skippedCanonicalWithAliases} skipped (live aliases), ${report.protectedUserAuthored} protected (user-authored), ${report.alreadyUnlisted} already unlisted, ${report.unknown} never-imported (expected)`,
     );
     return report;
   }
 
-  const totalChanges = report.aliasDeletes + report.softDeletes;
-  if (totalChanges > LARGE_DELETE_THRESHOLD) {
+  if (backlog === 0) {
+    report.applied = true;
     log(
-      `[kilter-catalog] REFUSING to apply ${totalChanges} deletions (> ${LARGE_DELETE_THRESHOLD}); rerun with manual review`,
+      `[kilter-catalog] deletions: nothing to apply (${report.reported} reported, ${report.protectedUserAuthored} protected, ${report.unknown} never-imported)`,
     );
     return report;
   }
 
-  if (aliasUuidsToDelete.length > 0) {
+  // Anomaly guard against a malformed /delteduuids or a mass upstream unpublish.
+  // Only soft-deletes remove climbs from view, so gate on them — a backlog of pure
+  // alias drops is safe duplicate-row cleanup and applies (batch-capped) unguarded.
+  if (report.softDeletes > 0) {
+    const [liveRow] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(boardClimbs)
+      .where(and(eq(boardClimbs.boardType, KILTER), eq(boardClimbs.isListed, true), isNull(boardClimbs.userId)));
+    const liveListedCount = liveRow?.count ?? 0;
+    if (isAnomalousDeletionBacklog(report.softDeletes, liveListedCount)) {
+      report.refused = true;
+      report.remaining = backlog;
+      log(
+        `[kilter-catalog] REFUSING deletions: ${report.softDeletes} soft-deletes exceed ${Math.round(ANOMALY_FRACTION * 100)}% of ${liveListedCount} live climbs — manual review required`,
+      );
+      return report;
+    }
+  }
+
+  const { aliasBatch, softBatch, appliedThisRun, remaining } = planDeletionBatch(classification, batchLimit);
+  if (aliasBatch.length > 0) {
+    // source='kilter' + board_type guards belt-and-suspenders the classifier.
     await db
       .delete(boardClimbAliases)
-      .where(and(eq(boardClimbAliases.boardType, KILTER), inArray(boardClimbAliases.aliasUuid, aliasUuidsToDelete)));
+      .where(
+        and(
+          eq(boardClimbAliases.boardType, KILTER),
+          eq(boardClimbAliases.source, KILTER),
+          inArray(boardClimbAliases.aliasUuid, aliasBatch),
+        ),
+      );
   }
-  if (canonicalsToSoftDelete.length > 0) {
+  if (softBatch.length > 0) {
+    // isNull(userId) guard ensures we never flip a user-authored climb, even if
+    // classification and apply somehow raced against a concurrent write.
     await db
       .update(boardClimbs)
       .set({ isListed: false })
-      .where(and(eq(boardClimbs.boardType, KILTER), inArray(boardClimbs.uuid, canonicalsToSoftDelete)));
+      .where(and(eq(boardClimbs.boardType, KILTER), isNull(boardClimbs.userId), inArray(boardClimbs.uuid, softBatch)));
   }
   report.applied = true;
-  log(`[kilter-catalog] deletions applied: ${report.aliasDeletes} alias drops, ${report.softDeletes} soft-deletes`);
+  report.appliedThisRun = appliedThisRun;
+  report.remaining = remaining;
+  log(
+    `[kilter-catalog] deletions applied: ${aliasBatch.length} alias drops, ${softBatch.length} soft-deletes (${remaining} remaining, batch limit ${batchLimit})`,
+  );
   return report;
 }

--- a/packages/kilter-sync/src/sync/locations-sync.test.ts
+++ b/packages/kilter-sync/src/sync/locations-sync.test.ts
@@ -139,4 +139,53 @@ describe('buildKilterLocationRecords', () => {
       skipped: [{ sourceKey: 'kilter:gym-uuid:wall-uuid', reason: 'unlisted gym' }],
     });
   });
+
+  it('dedupes repeated skip entries for the same wall (defense-in-depth)', () => {
+    const gym = {
+      id: 'gym-row',
+      gymUuid: 'gym-uuid',
+      name: 'Board House',
+      address: null,
+      city: null,
+      country: null,
+      countryCode: null,
+      postalCode: null,
+      latitude: 1,
+      longitude: 2,
+      instagramUsername: null,
+      gymLogo: null,
+      bannerLogo: null,
+      isListed: true,
+    };
+    const wall = {
+      id: 'wall-row',
+      wallUuid: 'wall-uuid',
+      gymUuid: 'gym-uuid',
+      name: null,
+      productName: 'Unknown Product',
+      productLayoutUuid: '99',
+      isAdjustable: true,
+      minAngle: null,
+      maxAngle: null,
+      angleIncrements: null,
+      angle: 35,
+      serialNumber: null,
+      accumulatedHoldSetValue: 1,
+      isListed: true,
+      createdAt: null,
+    };
+    // Same wall surfaced twice (a dup that slipped past the reference pull).
+    const reference: KilterReferencePull = {
+      products: [],
+      holds: [],
+      difficultyGrades: [],
+      productLayouts: [],
+      gyms: [gym],
+      walls: [wall, { ...wall }],
+    };
+
+    const { records, skipped } = buildKilterLocationRecords(reference, resolver());
+    expect(records).toEqual([]);
+    expect(skipped).toEqual([{ sourceKey: 'kilter:gym-uuid:wall-uuid', reason: 'unmapped product layout 99' }]);
+  });
 });

--- a/packages/kilter-sync/src/sync/locations-sync.ts
+++ b/packages/kilter-sync/src/sync/locations-sync.ts
@@ -63,6 +63,27 @@ function wallSourceKey(gym: KilterRefGym, wall: KilterRefWall): string {
   return `kilter:${gym.gymUuid}:${wall.wallUuid || wall.id}`;
 }
 
+/**
+ * Collapse identical skip entries. A wall is processed once and skipped for a
+ * single reason, so any repeat of the same (sourceKey, reason) is spurious —
+ * historically from a `wall_uuid` streamed multiple times over PowerSync. The
+ * reference pull now dedups at the source; this is defense-in-depth so the run
+ * summary never reports the same wall twice.
+ */
+export function dedupeSkipped(
+  skipped: Array<{ sourceKey: string; reason: string }>,
+): Array<{ sourceKey: string; reason: string }> {
+  const seen = new Set<string>();
+  const deduped: Array<{ sourceKey: string; reason: string }> = [];
+  for (const entry of skipped) {
+    const key = `${entry.sourceKey} ${entry.reason}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(entry);
+  }
+  return deduped;
+}
+
 export function buildKilterLocationRecords(
   reference: KilterReferencePull,
   resolver: LayoutResolver,
@@ -134,7 +155,7 @@ export function buildKilterLocationRecords(
     }
   }
 
-  return { records, skipped };
+  return { records, skipped: dedupeSkipped(skipped) };
 }
 
 export async function syncKilterLocations(args: {
@@ -145,10 +166,14 @@ export async function syncKilterLocations(args: {
 }): Promise<LocationSyncSummary> {
   const { records, skipped } = buildKilterLocationRecords(args.reference, args.resolver);
   const summary = await upsertPublicBoardLocations(args.db, records);
+  // Merge the upsert-side skips (e.g. invalid coordinates) with the kilter-side
+  // skips (unlisted / unmapped / unsupported) and dedupe — boardsSkipped tracks
+  // the deduped length so the count and the array stay in step.
+  const mergedSkipped = dedupeSkipped([...summary.skipped, ...skipped]);
   const mergedSummary = {
     ...summary,
-    boardsSkipped: summary.boardsSkipped + skipped.length,
-    skipped: [...summary.skipped, ...skipped],
+    boardsSkipped: mergedSkipped.length,
+    skipped: mergedSkipped,
   };
   args.log?.(
     `[kilter-locations] upserted ${mergedSummary.boardsUpserted}/${mergedSummary.boardsSeen} board(s), ${mergedSummary.gymsUpserted} gym(s), skipped ${mergedSummary.boardsSkipped}`,

--- a/packages/kilter-sync/src/sync/locations-sync.ts
+++ b/packages/kilter-sync/src/sync/locations-sync.ts
@@ -76,7 +76,9 @@ export function dedupeSkipped(
   const seen = new Set<string>();
   const deduped: Array<{ sourceKey: string; reason: string }> = [];
   for (const entry of skipped) {
-    const key = `${entry.sourceKey} ${entry.reason}`;
+    // Newline can't appear in a sourceKey (`kilter:gym:wall`) or a reason string,
+    // so it's an unambiguous composite-key separator.
+    const key = `${entry.sourceKey}\n${entry.reason}`;
     if (seen.has(key)) continue;
     seen.add(key);
     deduped.push(entry);

--- a/packages/kilter-sync/src/sync/reference-pull.test.ts
+++ b/packages/kilter-sync/src/sync/reference-pull.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Capture the ops the mocked PowerSync stream should replay. vi.hoisted so the
+// vi.mock factory (hoisted above imports) can close over it safely.
+const hoisted = vi.hoisted(() => ({ ops: [] as Array<Record<string, unknown>> }));
+
+vi.mock('../api/powersync-client', () => ({
+  streamKilterPowerSync: async (args: { onOp: (op: Record<string, unknown>) => void | Promise<void> }) => {
+    for (const op of hoisted.ops) {
+      await args.onOp(op);
+    }
+  },
+}));
+
+import { pullKilterReference } from './reference-pull';
+
+function put(objectType: string, objectId: string, data: Record<string, unknown>): Record<string, unknown> {
+  return { op_id: objectId, op: 'PUT', object_type: objectType, object_id: objectId, data };
+}
+
+const layoutOp = put('product_layouts', '27', {
+  product_layout_uuid: '27',
+  product_name: 'Kilter Board Original',
+  is_listed: 1,
+  edge_left: 0,
+  edge_right: 144,
+  edge_bottom: 12,
+  edge_top: 156,
+});
+
+describe('pullKilterReference', () => {
+  it('dedups repeated PUTs for the same wall/gym, last write wins', async () => {
+    hoisted.ops = [
+      layoutOp,
+      // Same wall_uuid streamed twice (snapshot + update) — later op wins.
+      put('walls', 'row-1', { wall_uuid: 'wall-a', product_name: 'Kilter Board Original', angle: 30, is_listed: 1 }),
+      put('walls', 'row-1', { wall_uuid: 'wall-a', product_name: 'Kilter Board Original', angle: 40, is_listed: 1 }),
+      // A distinct wall stays.
+      put('walls', 'row-2', { wall_uuid: 'wall-b', product_name: 'Kilter Board Original', angle: 25, is_listed: 1 }),
+      // Same gym_uuid twice — later name wins.
+      put('gyms', 'g-1', { gym_uuid: 'gym-a', name: 'First Name' }),
+      put('gyms', 'g-1', { gym_uuid: 'gym-a', name: 'Second Name' }),
+    ];
+
+    const reference = await pullKilterReference({ accessToken: 'token' });
+
+    expect(reference.walls).toHaveLength(2);
+    const wallA = reference.walls.find((wall) => wall.wallUuid === 'wall-a');
+    expect(wallA?.angle).toBe(40);
+
+    expect(reference.gyms).toHaveLength(1);
+    expect(reference.gyms[0].name).toBe('Second Name');
+
+    expect(reference.productLayouts).toHaveLength(1);
+  });
+
+  it('dedups product_layouts / holds / grades by their natural key', async () => {
+    hoisted.ops = [
+      layoutOp,
+      // Duplicate product_layout row — collapses to one.
+      { ...layoutOp, op_id: '27b' },
+      put('holds', 'h-1', { hold_id: 100, hold_set_name: 'A' }),
+      put('holds', 'h-1', { hold_id: 100, hold_set_name: 'A-renamed' }),
+      put('difficulty_grades', 'd-1', { difficulty_grade_id: 10, boulder_difficulty: 'V4', is_listed: 1 }),
+      put('difficulty_grades', 'd-1', { difficulty_grade_id: 10, boulder_difficulty: 'V5', is_listed: 1 }),
+    ];
+
+    const reference = await pullKilterReference({ accessToken: 'token' });
+
+    expect(reference.productLayouts).toHaveLength(1);
+    expect(reference.holds).toHaveLength(1);
+    expect(reference.holds[0].holdSetName).toBe('A-renamed');
+    expect(reference.difficultyGrades).toHaveLength(1);
+    expect(reference.difficultyGrades[0].boulderDifficulty).toBe('V5');
+  });
+
+  it('throws when no product_layouts stream (cannot enumerate the catalog)', async () => {
+    hoisted.ops = [put('walls', 'row-1', { wall_uuid: 'wall-a', is_listed: 1 })];
+    await expect(pullKilterReference({ accessToken: 'token' })).rejects.toThrow(/no product_layouts/);
+  });
+});

--- a/packages/kilter-sync/src/sync/reference-pull.ts
+++ b/packages/kilter-sync/src/sync/reference-pull.ts
@@ -109,12 +109,18 @@ export async function pullKilterReference(args: {
   accessToken: string;
   log?: (message: string) => void;
 }): Promise<KilterReferencePull> {
-  const products: KilterRefProduct[] = [];
-  const productLayouts: KilterRefProductLayout[] = [];
-  const holds: KilterRefHold[] = [];
-  const difficultyGrades: KilterRefDifficultyGrade[] = [];
-  const gyms: KilterRefGym[] = [];
-  const walls: KilterRefWall[] = [];
+  // A PowerSync stream can emit multiple PUT ops for the same row (initial
+  // snapshot then updates, or the same row surfaced by both the `global` and
+  // `global_gyms` buckets). Key each entity by its natural id so the latest op
+  // wins and we never enumerate — or skip-log — the same wall/gym twice. Before
+  // this, flat push() arrays let one duplicated `wall_uuid` inflate boardsSeen
+  // and stack identical entries in the locations skip report.
+  const products = new Map<string, KilterRefProduct>();
+  const productLayouts = new Map<string, KilterRefProductLayout>();
+  const holds = new Map<number, KilterRefHold>();
+  const difficultyGrades = new Map<number, KilterRefDifficultyGrade>();
+  const gyms = new Map<string, KilterRefGym>();
+  const walls = new Map<string, KilterRefWall>();
 
   await streamKilterPowerSync({
     accessToken: args.accessToken,
@@ -124,10 +130,14 @@ export async function pullKilterReference(args: {
       const data = op.data;
       switch (op.object_type) {
         case 'products':
-          products.push({ id: str(data.id), productName: str(data.product_name), isListed: bool(data.is_listed) });
+          products.set(str(data.id), {
+            id: str(data.id),
+            productName: str(data.product_name),
+            isListed: bool(data.is_listed),
+          });
           break;
         case 'product_layouts':
-          productLayouts.push({
+          productLayouts.set(str(data.product_layout_uuid), {
             productLayoutUuid: str(data.product_layout_uuid),
             productName: str(data.product_name),
             isListed: bool(data.is_listed),
@@ -138,20 +148,22 @@ export async function pullKilterReference(args: {
           });
           break;
         case 'holds':
-          holds.push({ holdId: num(data.hold_id), holdSetName: nullableStr(data.hold_set_name) });
+          holds.set(num(data.hold_id), { holdId: num(data.hold_id), holdSetName: nullableStr(data.hold_set_name) });
           break;
         case 'difficulty_grades':
-          difficultyGrades.push({
+          difficultyGrades.set(num(data.difficulty_grade_id), {
             difficultyGradeId: num(data.difficulty_grade_id),
             boulderDifficulty: nullableStr(data.boulder_difficulty),
             routeDifficulty: nullableStr(data.route_difficulty),
             isListed: bool(data.is_listed),
           });
           break;
-        case 'gyms':
-          gyms.push({
-            id: str(data.id ?? op.object_id),
-            gymUuid: str(data.gym_uuid),
+        case 'gyms': {
+          const id = str(data.id ?? op.object_id);
+          const gymUuid = str(data.gym_uuid);
+          gyms.set(gymUuid || id, {
+            id,
+            gymUuid,
             name: nullableStr(data.name),
             address: nullableStr(data.address),
             city: nullableStr(data.city),
@@ -166,10 +178,13 @@ export async function pullKilterReference(args: {
             isListed: nullableBool(data.isListed ?? data.is_listed),
           });
           break;
-        case 'walls':
-          walls.push({
-            id: str(data.id ?? op.object_id),
-            wallUuid: str(data.wall_uuid),
+        }
+        case 'walls': {
+          const id = str(data.id ?? op.object_id);
+          const wallUuid = str(data.wall_uuid);
+          walls.set(wallUuid || id, {
+            id,
+            wallUuid,
             gymUuid: nullableStr(data.gym_uuid),
             name: nullableStr(data.name),
             productName: nullableStr(data.product_name),
@@ -185,6 +200,7 @@ export async function pullKilterReference(args: {
             createdAt: nullableStr(data.created_at),
           });
           break;
+        }
         default:
           // hold_sets / placement_types / videos / grade_systems stream too but
           // aren't needed for catalog ingest — ignore.
@@ -195,15 +211,23 @@ export async function pullKilterReference(args: {
 
   // An empty product_layouts pull means we can't enumerate the catalog at
   // all — fail loud rather than silently sync nothing.
-  if (productLayouts.length === 0) {
+  if (productLayouts.size === 0) {
     throw new KilterApiError(
       'powersync',
       'Kilter reference pull returned no product_layouts — cannot enumerate the catalog',
     );
   }
 
+  const result: KilterReferencePull = {
+    products: [...products.values()],
+    productLayouts: [...productLayouts.values()],
+    holds: [...holds.values()],
+    difficultyGrades: [...difficultyGrades.values()],
+    gyms: [...gyms.values()],
+    walls: [...walls.values()],
+  };
   args.log?.(
-    `[kilter-catalog] reference pulled: ${products.length} products, ${productLayouts.length} layouts, ${holds.length} holds, ${difficultyGrades.length} grades, ${gyms.length} gyms, ${walls.length} walls`,
+    `[kilter-catalog] reference pulled: ${result.products.length} products, ${result.productLayouts.length} layouts, ${result.holds.length} holds, ${result.difficultyGrades.length} grades, ${result.gyms.length} gyms, ${result.walls.length} walls`,
   );
-  return { products, productLayouts, holds, difficultyGrades, gyms, walls };
+  return result;
 }


### PR DESCRIPTION
## Summary

The Kilter catalog sync daemon was logging a mix of one real bug and several benign diagnostics that read as errors (e.g. `deletions: applied:false`, duplicate `skipped[]` entries, an opaque `climbsUnmapped: 24`). This triages each, fixes the real bug, and turns the report-only deletion pass into a safe, batched auto-apply.

**The hard rule:** the Kilter sync may only ever delete or modify climbs that came from Kilter's catalog sync — **never user-authored climbs**. Provenance is enforced with `board_climbs.user_id IS NULL` (synced, not user-created) and `board_climb_aliases.source = 'kilter'`, at both the classification layer and the final SQL `WHERE` clauses.

What changed:

- **Dedup the PowerSync reference pull** (`reference-pull.ts`) — key each entity by its natural id (last-write-wins). A `wall_uuid`/`gym_uuid` streamed more than once no longer inflates `boardsSeen` or stacks duplicate rows in the locations skip report. Also dedupes the merged `skipped[]` array defensively.
- **Provenance-guarded, batched, reversible deletions** (`deletions.ts`):
  - Soft-delete (`is_listed = false`) a canonical only when `user_id IS NULL`, it's still listed, and it's a lone self-canonical. User-authored climbs are counted `protectedUserAuthored` and never touched.
  - Hard-delete only `source = 'kilter'` pure-alias rows (canonical always survives). `backfill`/`aurora` aliases are left alone.
  - Both the `UPDATE` and `DELETE` carry the same guards (belt-and-suspenders vs the classifier).
  - Applies at most `deleteBatchLimit` changes/run (default 500); the backlog drains over cycles via the `is_listed` guard. An anomaly guard refuses an implausibly large soft-delete batch (wipe signal) for manual review.
- **Ingest guard** (`catalog-sync.ts`) — the climb upsert gets `setWhere(user_id IS NULL)` so a re-sync can't overwrite a user-authored row on a UUID collision.
- **Observability** — a sample of unmapped climbs (uuid + offending `holeId`) so `climbsUnmapped` is diagnosable, and the deletions log now labels `unknown` as never-imported (expected).
- **Daemon opts in** by default (`SyncRunnerConfig.applyCatalogDeletions`, reversible + scoped); the CLI stays report-only unless `--apply-deletions`.

Left as expected (deduped, quieter) skips, not fixed here per scope: unmapped product layout 33 / unsupported wall config 30.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project kilter-sync` — 127 tests pass, including new coverage: reference dedup (last-write-wins), skip dedup, deletion classification (user-authored protected, foreign-source alias never dropped, drain convergence), batch cap, and the soft-delete-only anomaly guard.
- `vp check packages/kilter-sync/src` — lint + format + types clean.
- `tsc --noEmit` on the package — clean.
- A dedicated QA/reviewer pass audited every delete/modify path against the "Kilter-synced only" requirement and confirmed it is upheld at both the classification and SQL-WHERE layers.
