### PR TITLE
feat: send actual difficulty value on tick-save analytics events

### DIFF
--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -182,6 +182,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
               attemptCount: finalAttempts,
               hasQuality: tickState.quality != null && tickState.quality > 0,
               hasDifficulty: tickState.difficulty != null,
+              difficulty: tickState.difficulty ?? null,
               hasComment: comment.length > 0,
             });
             hapticSuccess();

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -211,6 +211,8 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
       track('Tick Logged', {
         boardLayout: boardDetails.layout_name || '',
         status,
+        hasDifficulty: logType === 'ascent' && values.difficulty !== undefined,
+        difficulty: logType === 'ascent' ? (values.difficulty ?? null) : null,
       });
 
       setFormValues(getInitialValues());

--- a/packages/web/app/hooks/use-tick-save.ts
+++ b/packages/web/app/hooks/use-tick-save.ts
@@ -164,6 +164,7 @@ export function useTickSave(options: UseTickSaveOptions): {
             attemptCount,
             hasQuality: quality !== null,
             hasDifficulty: difficulty !== undefined,
+            difficulty: difficulty ?? null,
             hasComment: comment.length > 0,
           });
           void clearTickDraft(climb.uuid, Number(targetAngle));


### PR DESCRIPTION
## Summary
- `Quick Tick Saved` (web + mobile) and `Tick Logged` (web) analytics events previously sent only a `hasDifficulty` boolean, never the grade itself
- Adds the numeric `difficulty` id (Aurora's internal difficulty scale, e.g. 27 = V10/7c+) alongside the existing boolean, so grade-based analysis (e.g. identifying strong climbers, send distribution by grade) is possible in PostHog going forward
- Existing `hasDifficulty` property is kept unchanged for backward compatibility with any saved insights

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan
- [x] `vp run typecheck:web` passes
- [x] `vp run typecheck:mobile` passes
- [x] `vp check` on changed files passes
- [x] `vp test run --project web` passes (4807 tests)
- [x] `vp test run --project mobile` passes (2627 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cf6cV5eqeCWatsA6w2Buv7