### PR TITLE
fix(shared): drop orphaned climbs.mobile.filter.done i18n key

### DIFF
--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -644,7 +644,6 @@
       "betaVideosDescription": "Only climbs with a beta video",
       "searchSetters": "Search setters",
       "noSetters": "No setters yet",
-      "done": "Done",
       "clearAll": "Clear all"
     },
     "search": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -644,7 +644,6 @@
       "betaVideosDescription": "Solo vías con un vídeo de beta",
       "searchSetters": "Buscar equipadores",
       "noSetters": "Sin equipadores",
-      "done": "Listo",
       "clearAll": "Borrar todo"
     },
     "search": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -644,7 +644,6 @@
       "betaVideosDescription": "Uniquement les voies avec une vidéo de beta",
       "searchSetters": "Rechercher des ouvreurs",
       "noSetters": "Aucun ouvreur",
-      "done": "OK",
       "clearAll": "Tout effacer"
     },
     "search": {


### PR DESCRIPTION
## What

`check:i18n:orphans` is failing on **main** (and therefore on every open PR via the merge ref): `climbs.mobile.filter.done` is orphaned.

## Why

A mobile climbs-filter refactor removed the `climbs`-namespace callers of `mobile.filter.done`. The only remaining caller, `YouFilterSheet.tsx`, binds `t` to the `you` namespace (`useTranslation('you')`) and uses `you.mobile.filter.done`, which exists in all three locales. So the `climbs.json` copy is a dead duplicate (its `fr` value 'OK' was already stale vs the live 'Terminé').

## Change

Deleted `mobile.filter.done` from `climbs.json` in en-US, es, fr (3 lines). `mobile.filter` retains all its other keys; the live `you.mobile.filter.done` is untouched.

Validated: `check:i18n:orphans` OK (3467 keys all referenced), `check:i18n` OK.

## Release Notes

- [x] No release note needed (internal / technical change)
