### PR TITLE
fix(mobile): stop reporting @expo/ui sheet partialExpand rejection

### DIFF
--- a/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
+++ b/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// androidSafeSnapPoints branches on Platform.OS at call time; mock a mutable Platform
+// so each describe can pin the OS it exercises (order-independent).
+vi.mock('react-native', () => ({ Platform: { OS: 'android' } }));
+
+import { Platform } from 'react-native';
+import { androidSafeSnapPoints } from '../sheet-snap-points';
+
+const platform = Platform as { OS: string };
+
+describe('androidSafeSnapPoints (Android)', () => {
+  beforeEach(() => {
+    platform.OS = 'android';
+  });
+
+  it('adds a full-screen detent to a small single detent so it opens partial (arms partialExpand)', () => {
+    expect(androidSafeSnapPoints(['55%'])).toEqual(['55%', '100%']);
+    expect(androidSafeSnapPoints(['36%'])).toEqual(['36%', '100%']);
+  });
+
+  it('leaves a large single detent (>= 75%) unchanged — expanded is the right match', () => {
+    expect(androidSafeSnapPoints(['80%'])).toEqual(['80%']);
+    expect(androidSafeSnapPoints(['75%'])).toEqual(['75%']);
+    expect(androidSafeSnapPoints(['90%'])).toEqual(['90%']);
+  });
+
+  it('leaves a non-% (px) single detent unchanged', () => {
+    expect(androidSafeSnapPoints([200])).toEqual([200]);
+    expect(androidSafeSnapPoints(['200'])).toEqual(['200']);
+  });
+
+  it('leaves an already multi-detent sheet unchanged', () => {
+    expect(androidSafeSnapPoints(['50%', '90%'])).toEqual(['50%', '90%']);
+  });
+
+  it('leaves an empty snap-point list unchanged', () => {
+    expect(androidSafeSnapPoints([])).toEqual([]);
+  });
+});
+
+describe('androidSafeSnapPoints (iOS passthrough)', () => {
+  beforeEach(() => {
+    platform.OS = 'ios';
+  });
+
+  it('returns a small single detent unchanged (iOS honours the exact detent)', () => {
+    expect(androidSafeSnapPoints(['55%'])).toEqual(['55%']);
+    expect(androidSafeSnapPoints(['36%'])).toEqual(['36%']);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -22,6 +22,7 @@ import {
   applyOtaTagsToScope,
   captureToSentry,
   flushSentry,
+  isExpoUiSheetNoHandlerRejection,
   setOtaChannelTag,
   setOtaSentryTags,
   wrapWithSentry,
@@ -220,5 +221,63 @@ describe('applyOtaTagsToScope', () => {
     const explicit = makeScope();
     applyOtaTagsToScope(explicit, { isEmbeddedLaunch: false });
     expect(explicit.setTag).toHaveBeenCalledWith('ota_is_embedded', 'false');
+  });
+});
+
+// The beforeSend drop only runs on real builds (isSentryEnabled), so the match logic
+// lives in this pure predicate and is exercised here against the real captured event
+// shape — that's where a too-broad or too-narrow filter would otherwise hide behind the
+// enablement gate.
+describe('isExpoUiSheetNoHandlerRejection', () => {
+  it('drops the real two-value event (outer "has been rejected" + native cause)', () => {
+    const event = {
+      exception: {
+        values: [
+          { value: "Call to function 'ModalBottomSheetView.partialExpand' has been rejected." },
+          { value: "No handler registered for AsyncFunction 'partialExpand' on view 'ModalBottomSheetView'" },
+        ],
+      },
+    };
+    expect(isExpoUiSheetNoHandlerRejection(event)).toBe(true);
+  });
+
+  it('drops when only the hint.originalException carries the signature', () => {
+    const event = { exception: { values: [{ value: 'Unhandled promise rejection' }] } };
+    const originalException = new Error("Call to function 'ModalBottomSheetView.partialExpand' has been rejected.");
+    expect(isExpoUiSheetNoHandlerRejection(event, originalException)).toBe(true);
+  });
+
+  it('also drops the expand() variant (same mechanism)', () => {
+    const event = {
+      exception: {
+        values: [{ value: "No handler registered for AsyncFunction 'expand' on view 'ModalBottomSheetView'" }],
+      },
+    };
+    expect(isExpoUiSheetNoHandlerRejection(event)).toBe(true);
+  });
+
+  it('keeps an unrelated rejection', () => {
+    const event = { exception: { values: [{ value: 'TypeError: undefined is not a function' }] } };
+    expect(isExpoUiSheetNoHandlerRejection(event)).toBe(false);
+  });
+
+  it('keeps a no-handler error on a different native view', () => {
+    const event = {
+      exception: {
+        values: [{ value: "No handler registered for AsyncFunction 'partialExpand' on view 'SomeOtherView'" }],
+      },
+    };
+    expect(isExpoUiSheetNoHandlerRejection(event)).toBe(false);
+  });
+
+  it('keeps a message that merely mentions the word partialExpand (not the view + handler phrasing)', () => {
+    const event = { exception: { values: [{ value: 'partialExpand is not a great API name' }] } };
+    expect(isExpoUiSheetNoHandlerRejection(event)).toBe(false);
+  });
+
+  it('keeps events with no exception payload', () => {
+    expect(isExpoUiSheetNoHandlerRejection({})).toBe(false);
+    expect(isExpoUiSheetNoHandlerRejection({ exception: { values: [] } })).toBe(false);
+    expect(isExpoUiSheetNoHandlerRejection({}, 'not an Error instance')).toBe(false);
   });
 });

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -22,10 +22,50 @@ const sentryDsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
  */
 export const isSentryEnabled = !!sentryDsn && !__DEV__;
 
+// @expo/ui's Android bottom sheet fires `sheetRef.partialExpand()` / `expand()`
+// fire-and-forget inside `snapToIndex` (community/bottom-sheet/BottomSheet.android.tsx).
+// A store binary built against an older @expo/ui native layer never registered that
+// AsyncFunction on the `ModalBottomSheetView` native view, so the call rejects
+// ("No handler registered for AsyncFunction '<method>' on view 'ModalBottomSheetView'")
+// and, being unawaited, surfaces as an onunhandledrejection. The op is a no-op on those
+// binaries (the sheet is already at that detent), so only the Sentry noise is worth
+// dropping. Match the view name + method (never a bare `partialExpand` substring) so no
+// unrelated error is ever dropped; cover `expand` too — same mechanism, even though only
+// `partialExpand` rejects on today's fleet. See docs/mobile-ota-updates.md: this is a
+// JS-only change, so it keeps the same fingerprint and rides the OTA to shipped binaries.
+const EXPO_UI_SHEET_NO_HANDLER =
+  /Call to function 'ModalBottomSheetView\.(?:partialExpand|expand)' has been rejected|No handler registered for AsyncFunction '(?:partialExpand|expand)' on view 'ModalBottomSheetView'/;
+
+type SentryEventLike = { exception?: { values?: Array<{ value?: string | undefined }> } };
+
+/**
+ * Pure predicate: does this Sentry event / hint carry the benign @expo/ui Android sheet
+ * "No handler registered" rejection? Exported (no enablement gate, no SDK) so it's
+ * directly unit-testable, matching applyErrorContextToScope et al. Both the event's
+ * `exception.values[].value` and `hint.originalException` are checked because Sentry can
+ * split the JS `Error.cause` chain (the outer "has been rejected" vs the native
+ * IllegalStateException cause) across those two places.
+ */
+export function isExpoUiSheetNoHandlerRejection(event: SentryEventLike, originalException?: unknown): boolean {
+  const values = event.exception?.values ?? [];
+  const fromEvent = values.map((entry) => entry.value ?? '').join('\n');
+  const fromHint =
+    originalException instanceof Error ? `${originalException.message}\n${originalException.stack ?? ''}` : '';
+  return EXPO_UI_SHEET_NO_HANDLER.test(fromEvent) || EXPO_UI_SHEET_NO_HANDLER.test(fromHint);
+}
+
 if (isSentryEnabled) {
   Sentry.init({
     dsn: sentryDsn,
     tracesSampleRate: 0.1,
+    // Drop the benign @expo/ui Android sheet "No handler registered" unhandled rejection
+    // (partialExpand/expand on a binary whose native layer predates the method). Scoped
+    // to that exact signature so every other rejection still reports. See
+    // isExpoUiSheetNoHandlerRejection above.
+    beforeSend(event, hint) {
+      if (isExpoUiSheetNoHandlerRejection(event, hint?.originalException)) return null;
+      return event;
+    },
     // Explicit so a future option change can't silently turn either off. Native
     // crash handling persists SIGABRT / native exceptions across the crash and
     // uploads them on the next launch — the coverage gap PostHog (JS-only)

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -644,7 +644,6 @@
       "betaVideosDescription": "Only climbs with a beta video",
       "searchSetters": "Search setters",
       "noSetters": "No setters yet",
-      "done": "Done",
       "clearAll": "Clear all"
     },
     "search": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -644,7 +644,6 @@
       "betaVideosDescription": "Solo vías con un vídeo de beta",
       "searchSetters": "Buscar equipadores",
       "noSetters": "Sin equipadores",
-      "done": "Listo",
       "clearAll": "Borrar todo"
     },
     "search": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -644,7 +644,6 @@
       "betaVideosDescription": "Uniquement les voies avec une vidéo de beta",
       "searchSetters": "Rechercher des ouvreurs",
       "noSetters": "Aucun ouvreur",
-      "done": "OK",
       "clearAll": "Tout effacer"
     },
     "search": {


### PR DESCRIPTION
## Summary

Production Sentry (Android 16, Galaxy S25 Ultra, `com.boardsesh.app@2.1.0+2000436`) reports an unhandled promise rejection:

```
Error: Call to function 'ModalBottomSheetView.partialExpand' has been rejected.
→ java.lang.IllegalStateException: No handler registered for AsyncFunction 'partialExpand' on view 'ModalBottomSheetView'.
mechanism: onunhandledrejection   handled: yes
```

**Cause.** `@expo/ui`'s Android bottom sheet calls `sheetRef.partialExpand()` / `expand()` **fire-and-forget** inside `snapToIndex` (`community/bottom-sheet/BottomSheet.android.tsx`). Our `androidSafeSnapPoints()` promotes a sub-75% single-detent sheet (`['55%']`) to `['55%','100%']` so Material3 doesn't jump to full screen — that makes the sheet multi-detent and arms the `partialExpand()` branch. A store binary built against an **older `@expo/ui` native layer** never registered that `AsyncFunction` on the `ModalBottomSheetView` view, so the call rejects and, being unawaited, surfaces as an `onunhandledrejection`. It does **not** hard-crash (Hermes), and the failing op is a no-op on those binaries — the sheet is already at that detent.

**Fix (this PR — live fleet, over the air).** A scoped Sentry `beforeSend` drops exactly this signature (the `ModalBottomSheetView` view name + `partialExpand`|`expand`), matching both the event `exception.values` and `hint.originalException` so the split `Error.cause` chain is caught. Every other rejection still reports. The match logic is an exported pure predicate (`isExpoUiSheetNoHandlerRejection`) with unit tests; I also pinned `androidSafeSnapPoints` behaviour with a test since it's what arms the branch. This is **JS-only**, so it keeps the same OTA fingerprint and rides the production OTA to the already-installed `2000436` fleet (`docs/mobile-ota-updates.md`).

**Follow-up (separate PR).** The real drift vector is that `@expo/ui` is pinned `~56.0.18` (tilde) while every other Expo native dep is exact-pinned — the JS floated ahead of a binary's native layer. A follow-up PR will exact-pin `@expo/ui` and add a guard so this can't recur on future native builds. That change moves the fingerprint, so it must not ride with this OTA hotfix.

Also removes a pre-existing orphaned i18n key (`climbs:mobile.filter.done`, a stale duplicate of the live `you:mobile.filter.done`) that was failing `check:i18n:orphans` on `main` and blocking CI here.

No standalone tracking issue (per request — this PR documents it).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` for the touched suites — 33 pass (`isExpoUiSheetNoHandlerRejection`: real two-value event, `hint.originalException`, `expand` variant, unrelated/different-view/bare-word negatives, empty payload; `androidSafeSnapPoints`: `['55%']→['55%','100%']`, `['36%']→['36%','100%']`, `['80%']`/`['75%']` unchanged, px unchanged, already-multi unchanged, iOS passthrough).
- `vp check` (lint+format) and `vp run check:mobile-bundle` — pass.
- Can't reproduce the missing-handler rejection on a fresh `56.0.18` dev client (its native *has* `partialExpand`); production confirmation is the Sentry issue rate falling to ~0 across the `2000436` cohort post-OTA, correlated with the `updateId` rollout.