### PR TITLE
chore(mobile): exact-pin @expo/ui and guard Expo dep pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -535,6 +535,13 @@ jobs:
       # push-to-main. Runs before the heavier Metro bundle so it fails fast.
       - name: Check native build-phase deps resolve
         run: vp run check:mobile-native-deps
+      # Every @expo/* and expo-* dep must be exact-pinned: they ship a JS+native
+      # pair, and a `~`/`^` range lets the JS float ahead of a shipped binary's
+      # native layer. With the OTA fingerprint pinned via an override, that
+      # drifted JS still lands on the old binary — the ModalBottomSheetView
+      # .partialExpand "No handler registered" crash from a `~56.0.18` @expo/ui.
+      - name: Check Expo deps are exact-pinned
+        run: vp run check:mobile-expo-deps-pinned
       # Deterministic, read-only dep-health check: compares our declared pins
       # against packages/mobile/node_modules/expo/bundledNativeModules.json for
       # the SDK release we actually have installed, and flags installed-version

--- a/bun.lock
+++ b/bun.lock
@@ -225,7 +225,7 @@
         "@boardsesh/queue-react": "*",
         "@boardsesh/queue-runtime": "*",
         "@boardsesh/shared-schema": "*",
-        "@expo/ui": "~56.0.18",
+        "@expo/ui": "56.0.18",
         "@expo/vector-icons": "15.1.1",
         "@react-native-async-storage/async-storage": "3.1.1",
         "@react-native-community/blur": "4.4.1",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -33,7 +33,7 @@
     "@boardsesh/queue-react": "*",
     "@boardsesh/queue-runtime": "*",
     "@boardsesh/shared-schema": "*",
-    "@expo/ui": "~56.0.18",
+    "@expo/ui": "56.0.18",
     "@expo/vector-icons": "15.1.1",
     "@react-native-async-storage/async-storage": "3.1.1",
     "@react-native-community/blur": "4.4.1",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -644,7 +644,6 @@
       "betaVideosDescription": "Only climbs with a beta video",
       "searchSetters": "Search setters",
       "noSetters": "No setters yet",
-      "done": "Done",
       "clearAll": "Clear all"
     },
     "search": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -644,7 +644,6 @@
       "betaVideosDescription": "Solo vías con un vídeo de beta",
       "searchSetters": "Buscar equipadores",
       "noSetters": "Sin equipadores",
-      "done": "Listo",
       "clearAll": "Borrar todo"
     },
     "search": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -644,7 +644,6 @@
       "betaVideosDescription": "Uniquement les voies avec une vidéo de beta",
       "searchSetters": "Rechercher des ouvreurs",
       "noSetters": "Aucun ouvreur",
-      "done": "OK",
       "clearAll": "Tout effacer"
     },
     "search": {

--- a/scripts/__tests__/mobile-expo-deps-pinned-check.test.ts
+++ b/scripts/__tests__/mobile-expo-deps-pinned-check.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { findUnpinnedExpoDeps, isExpoPackage } from '../mobile-expo-deps-pinned-check';
+
+describe('isExpoPackage', () => {
+  it('matches the whole @expo/ scope (native and pure-JS), bare expo, and expo-* names', () => {
+    expect(isExpoPackage('@expo/ui')).toBe(true);
+    expect(isExpoPackage('@expo/vector-icons')).toBe(true);
+    expect(isExpoPackage('@expo/config-plugins')).toBe(true); // pure-JS tooling still in scope
+    expect(isExpoPackage('expo')).toBe(true);
+    expect(isExpoPackage('expo-image')).toBe(true);
+  });
+
+  it('does not match non-Expo packages (including expo-lookalikes)', () => {
+    expect(isExpoPackage('react-native-gesture-handler')).toBe(false);
+    expect(isExpoPackage('react')).toBe(false);
+    expect(isExpoPackage('exposition')).toBe(false); // not `expo` and not `expo-`
+    expect(isExpoPackage('@expora/thing')).toBe(false);
+  });
+});
+
+describe('findUnpinnedExpoDeps', () => {
+  it('flags a tilde-ranged Expo dep (the @expo/ui drift that caused the crash)', () => {
+    expect(findUnpinnedExpoDeps({ '@expo/ui': '~56.0.18' })).toEqual(['@expo/ui@~56.0.18']);
+  });
+
+  it('passes an all-exact Expo set', () => {
+    expect(
+      findUnpinnedExpoDeps({
+        '@expo/ui': '56.0.18',
+        '@expo/vector-icons': '15.1.1',
+        expo: '56.0.12',
+        'expo-image': '56.0.11',
+        'expo-router': '56.2.11',
+        'expo-share-intent': '7.0.0',
+      }),
+    ).toEqual([]);
+  });
+
+  it('accepts an exact prerelease version', () => {
+    expect(findUnpinnedExpoDeps({ 'expo-modules-core': '56.0.17-rc.1' })).toEqual([]);
+  });
+
+  it('flags every range operator form', () => {
+    expect(
+      findUnpinnedExpoDeps({
+        'expo-a': '^56.0.0',
+        'expo-b': '~56.0.0',
+        'expo-c': '*',
+        'expo-d': '56.x',
+        'expo-e': '>=56.0.0 <57.0.0',
+        'expo-f': '56 || 57',
+      }),
+    ).toEqual([
+      'expo-a@^56.0.0',
+      'expo-b@~56.0.0',
+      'expo-c@*',
+      'expo-d@56.x',
+      'expo-e@>=56.0.0 <57.0.0',
+      'expo-f@56 || 57',
+    ]);
+  });
+
+  it('ignores unpinned NON-Expo deps (some RN deps use ~ on purpose)', () => {
+    expect(
+      findUnpinnedExpoDeps({
+        'react-native-gesture-handler': '~2.31.1',
+        'react-native-safe-area-context': '~5.7.0',
+        'react-native-paper': '^5.15.3',
+      }),
+    ).toEqual([]);
+  });
+});

--- a/scripts/mobile-expo-deps-pinned-check.ts
+++ b/scripts/mobile-expo-deps-pinned-check.ts
@@ -1,0 +1,86 @@
+/// <reference types="node" />
+
+/**
+ * Guards that every Expo-published dependency in packages/mobile is EXACT-pinned
+ * (no ^ ~ * x / range). This intentionally covers the whole `@expo/*` scope plus
+ * `expo` / `expo-*` — not just the native modules — because the repo already
+ * exact-pins all of them and stricter is safer here: a ranged Expo package (even
+ * pure-JS tooling that affects prebuild) is a reproducibility hazard, and a
+ * ranged native module is a JS/native drift hazard.
+ *
+ * The drift case is what motivated this check: a `~`/`^` range lets a later
+ * (non-frozen) `bun install` float the JS ahead of the version a shipped binary's
+ * native layer was built against. Normally the OTA runtimeVersion fingerprint
+ * would refuse the mismatched bundle — but this app pins the fingerprint via
+ * EXPO_UPDATES_FINGERPRINT_OVERRIDE (app.config.ts), so the drifted JS still lands
+ * on the old binary. That is exactly what produced the
+ * `ModalBottomSheetView.partialExpand` "No handler registered" crash: a
+ * `~56.0.18`-pinned @expo/ui floated the JS `partialExpand()` call ahead of a
+ * binary whose native layer never registered that AsyncFunction.
+ *
+ * Non-Expo React Native deps are intentionally NOT covered — some pin with `~`
+ * on purpose (e.g. react-native-gesture-handler, react-native-safe-area-context).
+ * If a genuinely range-safe pure-JS `@expo/*` dev tool ever needs a range, add an
+ * explicit allowlist here rather than loosening the whole rule.
+ *
+ * Usage: vp run check:mobile-expo-deps-pinned
+ */
+
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { readMobileDeps } from './mobile-native-deps-check';
+
+// A version with no range operator: X.Y.Z plus an optional -prerelease. Anything
+// carrying ^ ~ * x, a hyphen range, or a `||` union is treated as unpinned.
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+/** An Expo-published package: the `@expo/*` scope or an `expo` / `expo-*` name. */
+export function isExpoPackage(name: string): boolean {
+  return name.startsWith('@expo/') || name === 'expo' || name.startsWith('expo-');
+}
+
+/**
+ * Pure: the `name@spec` of every Expo package whose spec is not exact-pinned.
+ * Empty means all Expo packages are pinned. No filesystem access — the caller
+ * passes the merged dependency map, so this is directly unit-testable.
+ */
+export function findUnpinnedExpoDeps(deps: Record<string, string>): string[] {
+  return Object.entries(deps)
+    .filter(([name, spec]) => isExpoPackage(name) && !EXACT_VERSION.test(spec.trim()))
+    .map(([name, spec]) => `${name}@${spec}`);
+}
+
+/** Wire the real filesystem and run the check. Returns the process exit code. */
+export function main(): number {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const mobilePackageJson = resolve(repoRoot, 'packages', 'mobile', 'package.json');
+
+  let mobileDeps: Record<string, string>;
+  try {
+    mobileDeps = readMobileDeps(mobilePackageJson);
+  } catch (error) {
+    console.error(`[mobile-expo-deps-pinned] FAILED — ${(error as Error).message}`);
+    return 1;
+  }
+
+  const unpinned = findUnpinnedExpoDeps(mobileDeps);
+  if (unpinned.length > 0) {
+    console.error('[mobile-expo-deps-pinned] FAILED — these Expo packages must be exact-pinned (no ^ ~ * / range):');
+    for (const dep of unpinned) console.error(`  ✗ ${dep}`);
+    console.error(
+      '  An Expo native module ships a JS + native pair; a range lets the JS drift ahead of a shipped\n' +
+        "  binary's native layer (the ModalBottomSheetView.partialExpand crash). Pin to the exact version.",
+    );
+    return 1;
+  }
+
+  const count = Object.keys(mobileDeps).filter(isExpoPackage).length;
+  console.log(`[mobile-expo-deps-pinned] OK — all ${count} Expo package(s) exact-pinned.`);
+  return 0;
+}
+
+// Run only when executed directly (tsx scripts/mobile-expo-deps-pinned-check.ts),
+// not when imported by tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -531,6 +531,10 @@ export default defineConfig({
         command: 'tsx scripts/mobile-native-deps-check.ts',
         cache: false,
       },
+      'check:mobile-expo-deps-pinned': {
+        command: 'tsx scripts/mobile-expo-deps-pinned-check.ts',
+        cache: false,
+      },
       'check:mobile-deps': {
         command: 'tsx scripts/mobile-deps-check.ts',
         cache: false,


### PR DESCRIPTION
## Summary

Forward-looking follow-up to #3387 (the JS-only OTA hotfix for the `ModalBottomSheetView.partialExpand` "No handler registered" crash). This removes the drift vector that caused it.

`@expo/ui` was the **only** Expo native dep left on a tilde range (`~56.0.18`) — every other `expo` / `@expo/*` dep is exact-pinned. An Expo native module ships a JS + native pair; a `~`/`^` range lets a later non-frozen install float the **JS** ahead of the version a shipped binary's **native** layer was built against. Normally the OTA runtimeVersion fingerprint would refuse the mismatched bundle, but this app pins the fingerprint via `EXPO_UPDATES_FINGERPRINT_OVERRIDE` (`app.config.ts`), so the drifted JS still lands on the old binary — exactly the `partialExpand()` call reaching a native view that never registered that `AsyncFunction`.

Changes:
- **Pin `@expo/ui` → `56.0.18`.** The resolved version is unchanged (`bun.lock` already resolved to `56.0.18`, same integrity hash), so this does **not** move the OTA fingerprint — verified equal iOS/Android fingerprints with and without the pin locally. `56.0.18` native registers `partialExpand` (`ExpoUIModule.kt` / `ModalBottomSheetView.kt`), so JS and native agree on the next build.
- **Add `scripts/mobile-expo-deps-pinned-check.ts` + test:** every `@expo/*` and `expo-*` dep must be exact-pinned (non-Expo RN deps that intentionally use `~`, e.g. `react-native-gesture-handler`, are exempt). Wired into `vite` (`check:mobile-expo-deps-pinned`) and CI so this class can't recur.

Also carries the same orphaned-i18n-key removal as #3387 (`climbs:mobile.filter.done`) so this branch's CI is green independently; whichever PR merges first, the other's rebase drops the duplicate.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run check:mobile-expo-deps-pinned` — OK (all 35 Expo native deps exact-pinned); goes red on `~56.0.18`, green after the pin.
- `vp test run scripts/__tests__/mobile-expo-deps-pinned-check.test.ts` — 7 pass (tilde flagged, exact set passes, exact prerelease, every range form flagged, non-Expo `~` ignored).
- `vp run check:mobile-ota-compat` — iOS/Android fingerprints identical with and without the pin (resolved version unchanged), confirming this doesn't strand installed binaries.
- `bun install` leaves the resolved tree unchanged (only the recorded spec string).