### PR TITLE
feat(mobile): log a tick on a date other than today

### DIFF
--- a/packages/mobile/src/components/logbook/ClimbedAtField.tsx
+++ b/packages/mobile/src/components/logbook/ClimbedAtField.tsx
@@ -1,0 +1,101 @@
+// A single date-or-time field for a tick's `climbedAt`, shared by the create
+// flow (QuickTickBar) and the edit flow (LogbookEditSheet). One instance edits
+// one part (`mode="date"` or `mode="time"`); render two side by side for a full
+// timestamp. Controlled + stateless: it merges the picked part onto `value`,
+// clamps to now (a tick can't be in the future), and reports the clamp via
+// `onFutureAdjusted` so the parent can surface a toast in its own namespace —
+// the field itself stays free of provider/i18n coupling.
+import React, { useCallback } from 'react';
+import { Platform, Pressable, StyleSheet } from 'react-native';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { applyDatePart, applyTimePart, clampToNow, formatDateForDisplay, formatTimeForDisplay } from './climbed-at';
+import { openAndroidDatePicker } from './native-date-picker';
+
+type ClimbedAtFieldProps = {
+  value: Date;
+  mode: 'date' | 'time';
+  maximumDate: Date;
+  /** Receives the fully-merged, clamped `Date`. */
+  onChange: (next: Date) => void;
+  /** Fired when the clamp pulled a future selection back to now. */
+  onFutureAdjusted?: () => void;
+  accessibilityLabel: string;
+};
+
+export const ClimbedAtField = React.memo(function ClimbedAtField({
+  value,
+  mode,
+  maximumDate,
+  onChange,
+  onFutureAdjusted,
+  accessibilityLabel,
+}: ClimbedAtFieldProps) {
+  const { systemColors } = useTheme();
+
+  const commitPicked = useCallback(
+    (picked: Date) => {
+      const requested =
+        mode === 'date'
+          ? applyDatePart(value, picked, { clampToPresent: false })
+          : applyTimePart(value, picked, { clampToPresent: false });
+      const clamped = clampToNow(requested);
+      if (clamped.getTime() !== requested.getTime()) onFutureAdjusted?.();
+      onChange(clamped);
+    },
+    [mode, value, onChange, onFutureAdjusted],
+  );
+
+  const handleIosChange = useCallback(
+    (_event: DateTimePickerEvent, picked?: Date) => {
+      if (!picked) return;
+      commitPicked(picked);
+    },
+    [commitPicked],
+  );
+
+  const openAndroid = useCallback(() => {
+    openAndroidDatePicker({ value, mode, maximumDate, onPicked: commitPicked });
+  }, [value, mode, maximumDate, commitPicked]);
+
+  if (Platform.OS === 'ios') {
+    return (
+      <DateTimePicker
+        value={value}
+        mode={mode}
+        display="compact"
+        maximumDate={maximumDate}
+        accessibilityLabel={accessibilityLabel}
+        onChange={handleIosChange}
+      />
+    );
+  }
+
+  return (
+    <Pressable
+      onPress={openAndroid}
+      style={[styles.trigger, { backgroundColor: systemColors.fill }]}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+    >
+      <Text variant="body" color={systemColors.label}>
+        {mode === 'date' ? formatDateForDisplay(value) : formatTimeForDisplay(value)}
+      </Text>
+      <Icon name={mode === 'date' ? 'calendar' : 'clock'} size={18} color={systemColors.secondaryLabel} />
+    </Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  trigger: {
+    minHeight: 44,
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing[3],
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+});

--- a/packages/mobile/src/components/logbook/__tests__/ClimbedAtField.test.tsx
+++ b/packages/mobile/src/components/logbook/__tests__/ClimbedAtField.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The date/time the mocked pickers report on interaction.
+const pickerSelection = vi.hoisted(() => ({ value: new Date(2025, 0, 10, 8, 30, 0, 0) }));
+const nativePlatform = vi.hoisted(() => ({ OS: 'ios' as 'ios' | 'android' }));
+
+vi.mock('react-native', () => ({
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { 'aria-label': accessibilityLabel, onClick: () => onPress?.() }, children),
+  Platform: nativePlatform,
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('@react-native-community/datetimepicker', () => ({
+  default: ({ mode, onChange }: { mode: 'date' | 'time'; onChange: (event: unknown, selected?: Date) => void }) =>
+    createElement(
+      'button',
+      { 'data-testid': `picker-${mode}`, onClick: () => onChange({ type: 'set' }, pickerSelection.value) },
+      mode,
+    ),
+  DateTimePickerAndroid: {
+    open: ({ onChange }: { onChange: (event: { type: 'set' }, selected?: Date) => void }) =>
+      onChange({ type: 'set' }, pickerSelection.value),
+  },
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('span') }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { fill: '#eee', label: '#111', secondaryLabel: '#666' } }),
+}));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: new Proxy({}, { get: () => 0 }),
+  borderRadius: { lg: 12 },
+}));
+
+import { ClimbedAtField } from '../ClimbedAtField';
+
+beforeEach(() => {
+  nativePlatform.OS = 'ios';
+  pickerSelection.value = new Date(2025, 0, 10, 8, 30, 0, 0);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ClimbedAtField', () => {
+  it('iOS: renders the inline picker and merges the picked day onto the existing time', () => {
+    const onChange = vi.fn();
+    const onFutureAdjusted = vi.fn();
+    render(
+      createElement(ClimbedAtField, {
+        value: new Date(2025, 0, 5, 14, 0, 0, 0),
+        mode: 'date',
+        maximumDate: new Date(2030, 0, 1),
+        onChange,
+        onFutureAdjusted,
+        accessibilityLabel: 'Date',
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId('picker-date'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const merged = onChange.mock.calls[0][0] as Date;
+    expect(merged.getFullYear()).toBe(2025);
+    expect(merged.getMonth()).toBe(0);
+    expect(merged.getDate()).toBe(10); // day from the selection
+    expect(merged.getHours()).toBe(14); // time preserved from `value`
+    expect(onFutureAdjusted).not.toHaveBeenCalled();
+  });
+
+  it('Android: renders a tappable trigger showing the formatted value and reports on tap', () => {
+    nativePlatform.OS = 'android';
+    const onChange = vi.fn();
+    render(
+      createElement(ClimbedAtField, {
+        value: new Date(2025, 0, 5, 14, 0, 0, 0),
+        mode: 'date',
+        maximumDate: new Date(2030, 0, 1),
+        onChange,
+        accessibilityLabel: 'Date',
+      }),
+    );
+
+    expect(screen.getByText('2025-01-05')).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText('Date'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect((onChange.mock.calls[0][0] as Date).getDate()).toBe(10);
+  });
+
+  it('clamps a future selection to now and reports the adjustment', () => {
+    vi.useFakeTimers();
+    const now = new Date(2025, 0, 10, 9, 0, 0, 0);
+    vi.setSystemTime(now);
+    pickerSelection.value = new Date(2025, 0, 10, 20, 0, 0, 0); // 20:00 is after "now" (09:00)
+
+    const onChange = vi.fn();
+    const onFutureAdjusted = vi.fn();
+    render(
+      createElement(ClimbedAtField, {
+        value: new Date(2025, 0, 10, 8, 0, 0, 0),
+        mode: 'time',
+        maximumDate: now,
+        onChange,
+        onFutureAdjusted,
+        accessibilityLabel: 'Time',
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId('picker-time'));
+
+    expect(onFutureAdjusted).toHaveBeenCalledTimes(1);
+    expect((onChange.mock.calls[0][0] as Date).getTime()).toBe(now.getTime());
+  });
+});

--- a/packages/mobile/src/components/logbook/__tests__/climbed-at.test.ts
+++ b/packages/mobile/src/components/logbook/__tests__/climbed-at.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyDatePart,
+  applyTimePart,
+  clampToNow,
+  formatDateForDisplay,
+  formatTimeForDisplay,
+  toEditableDate,
+} from '../climbed-at';
+
+describe('clampToNow', () => {
+  it('leaves a past instant untouched', () => {
+    const past = new Date(Date.now() - 60_000);
+    expect(clampToNow(past).getTime()).toBe(past.getTime());
+  });
+
+  it('pulls a future instant back to about now', () => {
+    const future = new Date(Date.now() + 60 * 60_000);
+    const before = Date.now();
+    const clamped = clampToNow(future).getTime();
+    const after = Date.now();
+    expect(clamped).toBeGreaterThanOrEqual(before);
+    expect(clamped).toBeLessThanOrEqual(after);
+  });
+});
+
+describe('applyDatePart', () => {
+  it('takes the calendar day from the selection and keeps the time of day', () => {
+    const current = new Date(2026, 5, 1, 14, 30, 45, 123); // Jun 1 2026 14:30 local
+    const selected = new Date(2025, 0, 20, 9, 0, 0); // Jan 20 2025 09:00 local
+    const result = applyDatePart(current, selected, { clampToPresent: false });
+    expect(result.getFullYear()).toBe(2025);
+    expect(result.getMonth()).toBe(0);
+    expect(result.getDate()).toBe(20);
+    expect(result.getHours()).toBe(14);
+    expect(result.getMinutes()).toBe(30);
+  });
+
+  it('clamps to now when the merged day lands in the future and clampToPresent is set', () => {
+    const current = new Date(Date.now() - 60_000);
+    const futureDay = new Date(Date.now() + 7 * 24 * 60 * 60_000);
+    const result = applyDatePart(current, futureDay, { clampToPresent: true });
+    expect(result.getTime()).toBeLessThanOrEqual(Date.now());
+  });
+});
+
+describe('applyTimePart', () => {
+  it('takes the time of day from the selection and keeps the calendar day', () => {
+    const current = new Date(2026, 5, 1, 14, 30);
+    const selected = new Date(2020, 0, 1, 8, 15, 30);
+    const result = applyTimePart(current, selected, { clampToPresent: false });
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(5);
+    expect(result.getDate()).toBe(1);
+    expect(result.getHours()).toBe(8);
+    expect(result.getMinutes()).toBe(15);
+    // seconds/millis are zeroed so equal saves don't jitter
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+  });
+});
+
+describe('formatDateForDisplay / formatTimeForDisplay', () => {
+  it('zero-pads the date parts', () => {
+    expect(formatDateForDisplay(new Date(2026, 0, 3))).toBe('2026-01-03');
+  });
+
+  it('zero-pads the time parts', () => {
+    expect(formatTimeForDisplay(new Date(2026, 0, 3, 9, 5))).toBe('09:05');
+  });
+});
+
+describe('toEditableDate', () => {
+  it('parses a stored ISO timestamp to the same instant', () => {
+    const iso = '2026-06-01T10:30:00.000Z';
+    expect(toEditableDate(iso).getTime()).toBe(Date.parse(iso));
+  });
+
+  it('falls back to about now for an unparseable value', () => {
+    const before = Date.now();
+    const result = toEditableDate('not a date').getTime();
+    const after = Date.now();
+    expect(result).toBeGreaterThanOrEqual(before);
+    expect(result).toBeLessThanOrEqual(after);
+  });
+});

--- a/packages/mobile/src/components/logbook/climbed-at.ts
+++ b/packages/mobile/src/components/logbook/climbed-at.ts
@@ -3,6 +3,10 @@
 // React Native imports — kept pure so the merge/clamp rules are unit-testable.
 import { parseTickTime } from '@boardsesh/profile-stats';
 
+/** How often the tick sheets re-sample "now" so a long-open sheet's picker
+ *  bound (and the create sheet's unedited default) can't drift into the past. */
+export const MAXIMUM_CLIMBED_AT_REFRESH_MS = 60_000;
+
 /** Parse a stored `climbedAt` ISO string into a local `Date`, falling back to
  *  now when the value is missing or unparseable. */
 export function toEditableDate(climbedAt: string): Date {

--- a/packages/mobile/src/components/logbook/climbed-at.ts
+++ b/packages/mobile/src/components/logbook/climbed-at.ts
@@ -1,0 +1,46 @@
+// Pure date helpers for editing a tick's `climbedAt` timestamp, shared by the
+// create flow (QuickTickBar) and the edit flow (LogbookEditSheet). No React or
+// React Native imports — kept pure so the merge/clamp rules are unit-testable.
+import { parseTickTime } from '@boardsesh/profile-stats';
+
+/** Parse a stored `climbedAt` ISO string into a local `Date`, falling back to
+ *  now when the value is missing or unparseable. */
+export function toEditableDate(climbedAt: string): Date {
+  const parsed = parseTickTime(climbedAt).toDate();
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+/** A tick can't be logged in the future — pull any future instant back to now. */
+export function clampToNow(date: Date): Date {
+  const now = new Date();
+  return date.getTime() > now.getTime() ? now : date;
+}
+
+/** Apply the calendar day (year/month/day) of `selected` onto `current`,
+ *  keeping the time-of-day. */
+export function applyDatePart(current: Date, selectedDate: Date, options: { clampToPresent: boolean }): Date {
+  const next = new Date(current);
+  next.setFullYear(selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate());
+  return options.clampToPresent ? clampToNow(next) : next;
+}
+
+/** Apply the time-of-day (hours/minutes) of `selected` onto `current`, keeping
+ *  the calendar day. */
+export function applyTimePart(current: Date, selectedTime: Date, options: { clampToPresent: boolean }): Date {
+  const next = new Date(current);
+  next.setHours(selectedTime.getHours(), selectedTime.getMinutes(), 0, 0);
+  return options.clampToPresent ? clampToNow(next) : next;
+}
+
+export function formatDateForDisplay(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function formatTimeForDisplay(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${hours}:${minutes}`;
+}

--- a/packages/mobile/src/components/logbook/native-date-picker.ts
+++ b/packages/mobile/src/components/logbook/native-date-picker.ts
@@ -1,0 +1,37 @@
+// Thin wrapper around the Android imperative date/time dialog. On Android the
+// picker is opened programmatically (there's no inline widget like iOS), and
+// every call site has to remember to gate on `event.type === 'set'` so a
+// dismissed dialog doesn't commit a value. Centralising that here keeps the
+// three logbook date consumers — ClimbedAtField (create + edit) and the
+// filter's DateRangeRow — consistent. iOS uses the inline `<DateTimePicker>`
+// component directly and never calls this.
+import { DateTimePickerAndroid } from '@react-native-community/datetimepicker';
+
+type OpenAndroidDatePickerOptions = {
+  value: Date;
+  mode: 'date' | 'time';
+  /** Fired only when the user confirms a value (dismiss is ignored). */
+  onPicked: (picked: Date) => void;
+  maximumDate?: Date;
+  minimumDate?: Date;
+};
+
+export function openAndroidDatePicker({
+  value,
+  mode,
+  onPicked,
+  maximumDate,
+  minimumDate,
+}: OpenAndroidDatePickerOptions) {
+  DateTimePickerAndroid.open({
+    value,
+    mode,
+    display: 'default',
+    maximumDate,
+    minimumDate,
+    onChange: (event, picked) => {
+      if (event.type !== 'set' || !picked) return;
+      onPicked(picked);
+    },
+  });
+}

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -2,7 +2,7 @@
 // BottomSheetModal — the sheet owns positioning, slide-in, backdrop,
 // pan-down-to-close, and the drag handle. This component is just the
 // pickers + save row.
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, Pressable, StyleSheet, type TextStyle } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -120,6 +120,11 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   // user backdate a send they forgot to log (issue #3303).
   const [climbedAt, setClimbedAt] = useState(() => new Date());
   const [maximumClimbedAtDate, setMaximumClimbedAtDate] = useState(() => new Date());
+  // Whether the user explicitly picked a date/time. Until they do, the tick logs
+  // at *save-time* now — this sheet stays mounted (PlayDrawer only toggles
+  // visibility), so a value frozen at mount would otherwise save a stale
+  // timestamp minutes/hours in the past.
+  const hasEditedClimbedAtRef = useRef(false);
   // Renders an inline error row above the save buttons when the last
   // save attempt failed. Cleared on the next attempt or on success.
   const [lastError, setLastError] = useState<string | null>(null);
@@ -143,17 +148,28 @@ export const QuickTickBar = React.memo(function QuickTickBar({
     setLastError(null);
     setClimbedAt(new Date());
     setMaximumClimbedAtDate(new Date());
+    hasEditedClimbedAtRef.current = false;
   }, [climbUuid]);
 
-  // Keep the picker's upper bound close to "now" so a long-open sheet can't let
-  // the user select a future minute. Mirrors LogbookEditSheet.
+  // Keep "now" fresh while the sheet lives on. The picker's upper bound tracks
+  // now so a long-open sheet can't select a future minute; and, until the user
+  // picks a date, the displayed default tracks now too so a reopened sheet
+  // doesn't show a stale day. Mirrors LogbookEditSheet's max-date refresh.
   useEffect(() => {
-    const intervalId = setInterval(() => setMaximumClimbedAtDate(new Date()), MAXIMUM_CLIMBED_AT_REFRESH_MS);
+    const intervalId = setInterval(() => {
+      setMaximumClimbedAtDate(new Date());
+      if (!hasEditedClimbedAtRef.current) setClimbedAt(new Date());
+    }, MAXIMUM_CLIMBED_AT_REFRESH_MS);
     return () => clearInterval(intervalId);
   }, []);
 
   const handleQualitySelect = useCallback((value: number | null) => {
     setTickState((prev) => ({ ...prev, quality: value }));
+  }, []);
+
+  const handleClimbedAtChange = useCallback((next: Date) => {
+    hasEditedClimbedAtRef.current = true;
+    setClimbedAt(next);
   }, []);
 
   const handleFutureAdjusted = useCallback(() => {
@@ -187,7 +203,9 @@ export const QuickTickBar = React.memo(function QuickTickBar({
           difficulty: tickState.difficulty ?? null,
           isBenchmark,
           comment,
-          climbedAt: clampToNow(climbedAt).toISOString(),
+          // Untouched: log a fresh save-time "now". Edited: honour the pick
+          // (clamped, in case the sheet sat open past the chosen minute).
+          climbedAt: (hasEditedClimbedAtRef.current ? clampToNow(climbedAt) : new Date()).toISOString(),
           ...(sessionId ? { sessionId } : {}),
           ...(layoutId != null ? { layoutId } : {}),
           ...(sizeId != null ? { sizeId } : {}),
@@ -213,6 +231,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
             setLastError(null);
             setClimbedAt(new Date());
             setMaximumClimbedAtDate(new Date());
+            hasEditedClimbedAtRef.current = false;
             showToast(tClimbs('mobile.logAscent.savedToast'), 'success');
             onDismiss();
           },
@@ -304,7 +323,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
             value={climbedAt}
             mode="date"
             maximumDate={maximumClimbedAtDate}
-            onChange={setClimbedAt}
+            onChange={handleClimbedAtChange}
             onFutureAdjusted={handleFutureAdjusted}
             accessibilityLabel={t('playView.tickBar.dateLabel')}
           />
@@ -320,7 +339,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
             value={climbedAt}
             mode="time"
             maximumDate={maximumClimbedAtDate}
-            onChange={setClimbedAt}
+            onChange={handleClimbedAtChange}
             onFutureAdjusted={handleFutureAdjusted}
             accessibilityLabel={t('playView.tickBar.timeLabel')}
           />

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -212,6 +212,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
             setComment('');
             setLastError(null);
             setClimbedAt(new Date());
+            setMaximumClimbedAtDate(new Date());
             showToast(tClimbs('mobile.logAscent.savedToast'), 'success');
             onDismiss();
           },

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -19,6 +19,8 @@ import { Icon } from '../Icon';
 import { InlineStarPicker } from './InlineStarPicker';
 import { InlineTriesPicker } from './InlineTriesPicker';
 import { GradeSingleSelectRail } from '../grade';
+import { ClimbedAtField } from '../logbook/ClimbedAtField';
+import { clampToNow } from '../logbook/climbed-at';
 import { useTheme } from '../../providers/theme-provider';
 import { useGrades } from '../../lib/graphql/hooks';
 import {
@@ -36,6 +38,8 @@ import { hapticSuccess, hapticError } from '../../lib/haptics';
 import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
+
+const MAXIMUM_CLIMBED_AT_REFRESH_MS = 60_000;
 
 type QuickTickBarProps = {
   climbUuid: string;
@@ -112,6 +116,10 @@ export const QuickTickBar = React.memo(function QuickTickBar({
 
   const [tickState, setTickState] = useState(createInitialTickState);
   const [comment, setComment] = useState('');
+  // The climb date/time to log. Defaults to now; the Date/Time rows let the
+  // user backdate a send they forgot to log (issue #3303).
+  const [climbedAt, setClimbedAt] = useState(() => new Date());
+  const [maximumClimbedAtDate, setMaximumClimbedAtDate] = useState(() => new Date());
   // Renders an inline error row above the save buttons when the last
   // save attempt failed. Cleared on the next attempt or on success.
   const [lastError, setLastError] = useState<string | null>(null);
@@ -133,11 +141,24 @@ export const QuickTickBar = React.memo(function QuickTickBar({
     setTickState(createInitialTickState());
     setComment('');
     setLastError(null);
+    setClimbedAt(new Date());
+    setMaximumClimbedAtDate(new Date());
   }, [climbUuid]);
+
+  // Keep the picker's upper bound close to "now" so a long-open sheet can't let
+  // the user select a future minute. Mirrors LogbookEditSheet.
+  useEffect(() => {
+    const intervalId = setInterval(() => setMaximumClimbedAtDate(new Date()), MAXIMUM_CLIMBED_AT_REFRESH_MS);
+    return () => clearInterval(intervalId);
+  }, []);
 
   const handleQualitySelect = useCallback((value: number | null) => {
     setTickState((prev) => ({ ...prev, quality: value }));
   }, []);
+
+  const handleFutureAdjusted = useCallback(() => {
+    showToast(t('playView.tickBar.futureTimeAdjusted'), 'warning');
+  }, [showToast, t]);
 
   const handleGradeSelect = useCallback((difficultyId: number | undefined) => {
     setTickState((prev) => ({ ...prev, difficulty: difficultyId }));
@@ -166,7 +187,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
           difficulty: tickState.difficulty ?? null,
           isBenchmark,
           comment,
-          climbedAt: new Date().toISOString(),
+          climbedAt: clampToNow(climbedAt).toISOString(),
           ...(sessionId ? { sessionId } : {}),
           ...(layoutId != null ? { layoutId } : {}),
           ...(sizeId != null ? { sizeId } : {}),
@@ -190,6 +211,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
             setTickState(createInitialTickState());
             setComment('');
             setLastError(null);
+            setClimbedAt(new Date());
             showToast(tClimbs('mobile.logAscent.savedToast'), 'success');
             onDismiss();
           },
@@ -217,6 +239,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
       boardPresenceBoardId,
       tickState,
       comment,
+      climbedAt,
       onDismiss,
       showToast,
       tClimbs,
@@ -268,6 +291,38 @@ export const QuickTickBar = React.memo(function QuickTickBar({
         </Text>
         <View style={styles.rowPicker}>
           <InlineStarPicker quality={tickState.quality} onSelect={handleQualitySelect} />
+        </View>
+      </View>
+
+      <View style={styles.row}>
+        <Text variant="footnote" color={iosSystemColors.systemGray} style={styles.rowLabel}>
+          {t('playView.tickBar.dateLabel')}
+        </Text>
+        <View style={styles.rowPicker}>
+          <ClimbedAtField
+            value={climbedAt}
+            mode="date"
+            maximumDate={maximumClimbedAtDate}
+            onChange={setClimbedAt}
+            onFutureAdjusted={handleFutureAdjusted}
+            accessibilityLabel={t('playView.tickBar.dateLabel')}
+          />
+        </View>
+      </View>
+
+      <View style={styles.row}>
+        <Text variant="footnote" color={iosSystemColors.systemGray} style={styles.rowLabel}>
+          {t('playView.tickBar.timeLabel')}
+        </Text>
+        <View style={styles.rowPicker}>
+          <ClimbedAtField
+            value={climbedAt}
+            mode="time"
+            maximumDate={maximumClimbedAtDate}
+            onChange={setClimbedAt}
+            onFutureAdjusted={handleFutureAdjusted}
+            accessibilityLabel={t('playView.tickBar.timeLabel')}
+          />
         </View>
       </View>
 

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -20,7 +20,7 @@ import { InlineStarPicker } from './InlineStarPicker';
 import { InlineTriesPicker } from './InlineTriesPicker';
 import { GradeSingleSelectRail } from '../grade';
 import { ClimbedAtField } from '../logbook/ClimbedAtField';
-import { clampToNow } from '../logbook/climbed-at';
+import { clampToNow, MAXIMUM_CLIMBED_AT_REFRESH_MS } from '../logbook/climbed-at';
 import { useTheme } from '../../providers/theme-provider';
 import { useGrades } from '../../lib/graphql/hooks';
 import {
@@ -38,8 +38,6 @@ import { hapticSuccess, hapticError } from '../../lib/haptics';
 import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
-
-const MAXIMUM_CLIMBED_AT_REFRESH_MS = 60_000;
 
 type QuickTickBarProps = {
   climbUuid: string;

--- a/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { logbookClimbAngleKey, type LogbookEntry } from '@boardsesh/board-react';
 
@@ -17,10 +17,22 @@ const boardState = vi.hoisted(() => ({
   current: null as unknown,
 }));
 
+// Stable save mock so a test can assert on the input passed to saveTick.mutate.
+const saveMock = vi.hoisted(() => ({ mutate: vi.fn() }));
+
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  Pressable: ({ children, accessibilityLabel }: { children?: ReactNode; accessibilityLabel?: string }) =>
-    createElement('button', { 'data-label': accessibilityLabel }, children),
+  Pressable: ({
+    children,
+    accessibilityLabel,
+    onPress,
+    disabled,
+  }: {
+    children?: ReactNode;
+    accessibilityLabel?: string;
+    onPress?: () => void;
+    disabled?: boolean;
+  }) => createElement('button', { 'data-label': accessibilityLabel, onClick: onPress, disabled }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
 vi.mock('@expo/ui/community/bottom-sheet', () => ({ BottomSheetTextInput: () => null }));
@@ -34,11 +46,27 @@ vi.mock('../../Icon', () => ({ Icon: () => createElement('span') }));
 vi.mock('../InlineStarPicker', () => ({ InlineStarPicker: () => null }));
 vi.mock('../InlineTriesPicker', () => ({ InlineTriesPicker: () => null }));
 vi.mock('../../grade', () => ({ GradeSingleSelectRail: () => null }));
+// Stub ClimbedAtField: clicking the date button drives a fixed past date, so a
+// test can prove the picked value threads into saveTick without the native
+// datetimepicker (which doesn't load under jsdom).
+vi.mock('../../logbook/ClimbedAtField', () => ({
+  ClimbedAtField: ({ mode, onChange }: { mode: 'date' | 'time'; onChange: (next: Date) => void }) =>
+    createElement('button', {
+      'data-testid': `climbedat-${mode}`,
+      onClick: () => onChange(new Date('2025-03-15T12:00:00.000Z')),
+    }),
+}));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({ systemColors: {}, brandColors: { primary: '#6D28D9' } }),
 }));
 vi.mock('../../../lib/graphql/hooks', () => ({ useGrades: () => ({ data: [] }) }));
-vi.mock('@boardsesh/board-config', () => ({ toBoardName: (name: string) => name }));
+// Partial mock: keep the real exports (BOULDER_GRADES et al., pulled in
+// transitively via climbed-at.ts → @boardsesh/profile-stats) and override only
+// the board-name normaliser.
+vi.mock('@boardsesh/board-config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@boardsesh/board-config')>();
+  return { ...actual, toBoardName: (name: string) => name };
+});
 vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: {} }));
 vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 // QuickTickBar reads board-presence flags; mock the provider so the test doesn't
@@ -63,7 +91,7 @@ vi.mock('@boardsesh/board-react', async (importOriginal) => {
     ...actual,
     useOptionalBoardActions: () => boardState.current,
     useOptionalBoardLogbook: () => boardState.current,
-    useSaveTick: () => ({ mutate: vi.fn(), isPending: false }),
+    useSaveTick: () => ({ mutate: saveMock.mutate, isPending: false }),
   };
 });
 
@@ -81,6 +109,10 @@ function renderBar() {
     }),
   );
 }
+
+beforeEach(() => {
+  saveMock.mutate.mockClear();
+});
 
 describe('QuickTickBar hasPriorHistory', () => {
   it('reads the logbookByClimbAngle index, not the raw logbook array', () => {
@@ -117,5 +149,25 @@ describe('QuickTickBar hasPriorHistory', () => {
       (node) => node.textContent === 'playView.tickBar.flashSaveLabel',
     );
     expect(flashButton).toBeUndefined();
+  });
+});
+
+describe('QuickTickBar climbedAt', () => {
+  it('threads the picked climb date into saveTick instead of always sending now', () => {
+    boardState.current = null;
+    const { getByTestId, container } = renderBar();
+
+    // Pick a fixed past date via the stubbed ClimbedAtField.
+    fireEvent.click(getByTestId('climbedat-date'));
+
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.sendSaveLabel',
+    );
+    fireEvent.click(sendButton as Element);
+
+    expect(saveMock.mutate).toHaveBeenCalledTimes(1);
+    expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({
+      climbedAt: '2025-03-15T12:00:00.000Z',
+    });
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { logbookClimbAngleKey, type LogbookEntry } from '@boardsesh/board-react';
@@ -114,6 +114,10 @@ beforeEach(() => {
   saveMock.mutate.mockClear();
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe('QuickTickBar hasPriorHistory', () => {
   it('reads the logbookByClimbAngle index, not the raw logbook array', () => {
     const tick = { climb_uuid: CLIMB_UUID, angle: ANGLE } as unknown as LogbookEntry;
@@ -168,6 +172,28 @@ describe('QuickTickBar climbedAt', () => {
     expect(saveMock.mutate).toHaveBeenCalledTimes(1);
     expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({
       climbedAt: '2025-03-15T12:00:00.000Z',
+    });
+  });
+
+  it('logs a fresh save-time now when the date is left untouched', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-03-15T12:00:00.000Z'));
+    boardState.current = null;
+    const { container } = renderBar();
+
+    // The sheet stays mounted (PlayDrawer) and time passes without the user
+    // touching the date field — the saved timestamp must be save-time now,
+    // not the value captured at mount.
+    vi.setSystemTime(new Date('2025-03-15T12:10:00.000Z'));
+
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.sendSaveLabel',
+    );
+    fireEvent.click(sendButton as Element);
+
+    expect(saveMock.mutate).toHaveBeenCalledTimes(1);
+    expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({
+      climbedAt: '2025-03-15T12:10:00.000Z',
     });
   });
 });

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -1,16 +1,11 @@
 import { type RefObject, useCallback, useEffect, useMemo, useState } from 'react';
-import { View, Pressable, Platform, StyleSheet } from 'react-native';
+import { View, Pressable, StyleSheet } from 'react-native';
 import { BottomSheetTextInput, type BottomSheet } from '@expo/ui/community/bottom-sheet';
-import DateTimePicker, {
-  DateTimePickerAndroid,
-  type DateTimePickerEvent,
-} from '@react-native-community/datetimepicker';
 import { useTranslation } from 'react-i18next';
 import { useUpdateTick, useDeleteTick } from '@boardsesh/board-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../lib/analytics';
 import type { AscentFeedItem, UpdateTickInput } from '@boardsesh/graphql/operations';
-import { parseTickTime } from '@boardsesh/profile-stats';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { Sheet } from '../Sheet';
@@ -19,6 +14,8 @@ import { StarRating } from '../StarRating';
 import { SegmentedControl } from '../SegmentedControl';
 import { SectionHeader } from '../SectionHeader';
 import { GradeSingleSelectRail } from '../grade';
+import { ClimbedAtField } from '../logbook/ClimbedAtField';
+import { clampToNow, toEditableDate } from '../logbook/climbed-at';
 import { useGrades } from '../../lib/graphql/hooks';
 import { hapticSuccess, hapticError } from '../../lib/haptics';
 import { spacing, borderRadius } from '../../theme/tokens';
@@ -35,41 +32,6 @@ type LogbookEditSheetProps = {
   ascent: AscentFeedItem | null;
   onClose: () => void;
 };
-
-function toEditableDate(climbedAt: string): Date {
-  const parsed = parseTickTime(climbedAt).toDate();
-  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
-}
-
-function clampToNow(date: Date): Date {
-  const now = new Date();
-  return date.getTime() > now.getTime() ? now : date;
-}
-
-function applyDatePart(current: Date, selectedDate: Date, options: { clampToPresent: boolean }): Date {
-  const next = new Date(current);
-  next.setFullYear(selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate());
-  return options.clampToPresent ? clampToNow(next) : next;
-}
-
-function applyTimePart(current: Date, selectedTime: Date, options: { clampToPresent: boolean }): Date {
-  const next = new Date(current);
-  next.setHours(selectedTime.getHours(), selectedTime.getMinutes(), 0, 0);
-  return options.clampToPresent ? clampToNow(next) : next;
-}
-
-function formatDateForDisplay(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-function formatTimeForDisplay(date: Date): string {
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  return `${hours}:${minutes}`;
-}
 
 /** Edit (status / grade / stars / tries / comment) or delete a logged ascent. */
 export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheetProps) {
@@ -129,79 +91,14 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
     setStatus(nextStatus);
   }, []);
 
-  const handleDateChange = useCallback(
-    (_event: DateTimePickerEvent, selectedDate?: Date) => {
-      if (!selectedDate) return;
-      setHasClimbedAtChanged(true);
-      setClimbedAt((current) => {
-        const requestedDate = applyDatePart(current, selectedDate, { clampToPresent: false });
-        const clampedDate = clampToNow(requestedDate);
-        if (clampedDate.getTime() !== requestedDate.getTime()) {
-          showToast(t('mobile.logbook.futureTimeAdjusted'), 'warning');
-        }
-        return clampedDate;
-      });
-    },
-    [showToast, t],
-  );
+  const handleClimbedAtChange = useCallback((next: Date) => {
+    setHasClimbedAtChanged(true);
+    setClimbedAt(next);
+  }, []);
 
-  const handleTimeChange = useCallback(
-    (_event: DateTimePickerEvent, selectedTime?: Date) => {
-      if (!selectedTime) return;
-      setHasClimbedAtChanged(true);
-      setClimbedAt((current) => {
-        const requestedTime = applyTimePart(current, selectedTime, { clampToPresent: false });
-        const clampedTime = clampToNow(requestedTime);
-        if (clampedTime.getTime() !== requestedTime.getTime()) {
-          showToast(t('mobile.logbook.futureTimeAdjusted'), 'warning');
-        }
-        return clampedTime;
-      });
-    },
-    [showToast, t],
-  );
-
-  const openAndroidDatePicker = useCallback(() => {
-    DateTimePickerAndroid.open({
-      value: climbedAt,
-      mode: 'date',
-      display: 'default',
-      maximumDate: new Date(),
-      onChange: (event, selectedDate) => {
-        if (event.type !== 'set' || !selectedDate) return;
-        setHasClimbedAtChanged(true);
-        setClimbedAt((current) => {
-          const requestedDate = applyDatePart(current, selectedDate, { clampToPresent: false });
-          const clampedDate = clampToNow(requestedDate);
-          if (clampedDate.getTime() !== requestedDate.getTime()) {
-            showToast(t('mobile.logbook.futureTimeAdjusted'), 'warning');
-          }
-          return clampedDate;
-        });
-      },
-    });
-  }, [climbedAt, showToast, t]);
-
-  const openAndroidTimePicker = useCallback(() => {
-    DateTimePickerAndroid.open({
-      value: climbedAt,
-      mode: 'time',
-      display: 'default',
-      maximumDate: new Date(),
-      onChange: (event, selectedTime) => {
-        if (event.type !== 'set' || !selectedTime) return;
-        setHasClimbedAtChanged(true);
-        setClimbedAt((current) => {
-          const requestedTime = applyTimePart(current, selectedTime, { clampToPresent: false });
-          const clampedTime = clampToNow(requestedTime);
-          if (clampedTime.getTime() !== requestedTime.getTime()) {
-            showToast(t('mobile.logbook.futureTimeAdjusted'), 'warning');
-          }
-          return clampedTime;
-        });
-      },
-    });
-  }, [climbedAt, showToast, t]);
+  const handleFutureAdjusted = useCallback(() => {
+    showToast(t('mobile.logbook.futureTimeAdjusted'), 'warning');
+  }, [showToast, t]);
 
   const save = useCallback(() => {
     if (!ascent || isMutating) return;
@@ -298,54 +195,26 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
 
       <SectionHeader title={t('mobile.logbook.dateLabel')} />
       <View style={styles.field}>
-        {Platform.OS === 'ios' ? (
-          <DateTimePicker
-            value={climbedAt}
-            mode="date"
-            display="compact"
-            maximumDate={maximumClimbedAtDate}
-            accessibilityLabel={t('mobile.logbook.dateLabel')}
-            onChange={handleDateChange}
-          />
-        ) : (
-          <Pressable
-            onPress={openAndroidDatePicker}
-            style={[styles.dateTimeButton, { backgroundColor: systemColors.fill }]}
-            accessibilityRole="button"
-            accessibilityLabel={t('mobile.logbook.dateLabel')}
-          >
-            <Text variant="body" color={systemColors.label}>
-              {formatDateForDisplay(climbedAt)}
-            </Text>
-            <Icon name="calendar" size={18} color={systemColors.secondaryLabel} />
-          </Pressable>
-        )}
+        <ClimbedAtField
+          value={climbedAt}
+          mode="date"
+          maximumDate={maximumClimbedAtDate}
+          onChange={handleClimbedAtChange}
+          onFutureAdjusted={handleFutureAdjusted}
+          accessibilityLabel={t('mobile.logbook.dateLabel')}
+        />
       </View>
 
       <SectionHeader title={t('mobile.logbook.timeLabel')} />
       <View style={styles.field}>
-        {Platform.OS === 'ios' ? (
-          <DateTimePicker
-            value={climbedAt}
-            mode="time"
-            display="compact"
-            maximumDate={maximumClimbedAtDate}
-            accessibilityLabel={t('mobile.logbook.timeLabel')}
-            onChange={handleTimeChange}
-          />
-        ) : (
-          <Pressable
-            onPress={openAndroidTimePicker}
-            style={[styles.dateTimeButton, { backgroundColor: systemColors.fill }]}
-            accessibilityRole="button"
-            accessibilityLabel={t('mobile.logbook.timeLabel')}
-          >
-            <Text variant="body" color={systemColors.label}>
-              {formatTimeForDisplay(climbedAt)}
-            </Text>
-            <Icon name="clock" size={18} color={systemColors.secondaryLabel} />
-          </Pressable>
-        )}
+        <ClimbedAtField
+          value={climbedAt}
+          mode="time"
+          maximumDate={maximumClimbedAtDate}
+          onChange={handleClimbedAtChange}
+          onFutureAdjusted={handleFutureAdjusted}
+          accessibilityLabel={t('mobile.logbook.timeLabel')}
+        />
       </View>
 
       <SectionHeader title={t('mobile.logbook.gradeLabel')} />
@@ -412,14 +281,6 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
 const styles = StyleSheet.create({
   title: { paddingHorizontal: spacing[4], paddingTop: spacing[2] },
   field: { paddingHorizontal: spacing[4] },
-  dateTimeButton: {
-    minHeight: 44,
-    borderRadius: borderRadius.lg,
-    paddingHorizontal: spacing[3],
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
   stepper: { flexDirection: 'row', alignItems: 'center', gap: spacing[5] },
   stepperValue: { minWidth: 40, textAlign: 'center' },
   input: {

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -15,7 +15,7 @@ import { SegmentedControl } from '../SegmentedControl';
 import { SectionHeader } from '../SectionHeader';
 import { GradeSingleSelectRail } from '../grade';
 import { ClimbedAtField } from '../logbook/ClimbedAtField';
-import { clampToNow, toEditableDate } from '../logbook/climbed-at';
+import { clampToNow, toEditableDate, MAXIMUM_CLIMBED_AT_REFRESH_MS } from '../logbook/climbed-at';
 import { useGrades } from '../../lib/graphql/hooks';
 import { hapticSuccess, hapticError } from '../../lib/haptics';
 import { spacing, borderRadius } from '../../theme/tokens';
@@ -24,8 +24,6 @@ import { useToast } from '../../providers/toast-provider';
 import { useConfirm } from '../../providers/dialog-provider';
 
 type TickStatus = 'flash' | 'send' | 'attempt';
-
-const MAXIMUM_CLIMBED_AT_REFRESH_MS = 60_000;
 
 type LogbookEditSheetProps = {
   sheetRef: RefObject<BottomSheet | null>;

--- a/packages/mobile/src/components/you/logbook-facet-controls.tsx
+++ b/packages/mobile/src/components/you/logbook-facet-controls.tsx
@@ -10,10 +10,7 @@
 
 import { memo, useCallback, useState } from 'react';
 import { View, Pressable, StyleSheet, Platform, type ViewStyle } from 'react-native';
-import DateTimePicker, {
-  DateTimePickerAndroid,
-  type DateTimePickerEvent,
-} from '@react-native-community/datetimepicker';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import { DEFAULT_LOGBOOK_ANGLE_RANGE } from '@boardsesh/logbook';
@@ -24,6 +21,7 @@ import { hapticSelection } from '../../lib/haptics';
 import { springs } from '../../theme/animations';
 import { spacing } from '../../theme/tokens';
 import { readableTextColor } from '../grade';
+import { openAndroidDatePicker } from '../logbook/native-date-picker';
 
 // Angle filter granularity — mirrors the web slider (0–70°, step 5).
 const ANGLE_STEP = 5;
@@ -198,15 +196,11 @@ export const DateRangeRow = memo(function DateRangeRow({
   );
 
   const openAndroid = useCallback(() => {
-    DateTimePickerAndroid.open({
+    openAndroidDatePicker({
       value: selectedDate ?? new Date(),
       mode: 'date',
-      display: 'default',
       maximumDate,
-      onChange: (event, picked) => {
-        if (event.type !== 'set' || !picked) return;
-        onChange(formatIsoDate(picked));
-      },
+      onPicked: (picked) => onChange(formatIsoDate(picked)),
     });
   }, [selectedDate, maximumDate, onChange]);
 

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -575,7 +575,10 @@
       "decreaseTriesAria": "Decrease attempts",
       "increaseTriesAria": "Increase attempts",
       "starRating_one": "{{count}} star",
-      "starRating_other": "{{count}} stars"
+      "starRating_other": "{{count}} stars",
+      "dateLabel": "Date",
+      "timeLabel": "Time",
+      "futureTimeAdjusted": "Future time adjusted to now."
     }
   },
   "mobileDetail": {

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -575,7 +575,10 @@
       "decreaseTriesAria": "Disminuir intentos",
       "increaseTriesAria": "Aumentar intentos",
       "starRating_one": "{{count}} estrella",
-      "starRating_other": "{{count}} estrellas"
+      "starRating_other": "{{count}} estrellas",
+      "dateLabel": "Fecha",
+      "timeLabel": "Hora",
+      "futureTimeAdjusted": "Hora futura ajustada a ahora."
     }
   },
   "mobileDetail": {

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -575,7 +575,10 @@
       "decreaseTriesAria": "Diminuer les essais",
       "increaseTriesAria": "Augmenter les essais",
       "starRating_one": "{{count}} etoile",
-      "starRating_other": "{{count}} etoiles"
+      "starRating_other": "{{count}} etoiles",
+      "dateLabel": "Date",
+      "timeLabel": "Heure",
+      "futureTimeAdjusted": "Heure future ajustée à maintenant."
     }
   },
   "mobileDetail": {


### PR DESCRIPTION
## Summary

The mobile Quick Tick (create) sheet always stamped a tick with the current moment, so climbers couldn't backdate a send they forgot to log. Closes #3303.

This adds **Date** and **Time** rows to the create sheet, matching the edit sheet (which already had them). To avoid duplicating that logic, the edit sheet's date/time handling is extracted into shared pieces the two flows now share:

- `packages/mobile/src/components/logbook/climbed-at.ts` — pure, unit-tested date helpers (`clampToNow`, `applyDatePart`/`applyTimePart`, `toEditableDate`, formatters), moved verbatim from `LogbookEditSheet`.
- `packages/mobile/src/components/logbook/ClimbedAtField.tsx` — one date-or-time field (iOS inline `DateTimePicker`, Android tappable → native dialog) with clamp-to-now + an `onFutureAdjusted` callback so each parent owns its own toast.
- `packages/mobile/src/components/logbook/native-date-picker.ts` — `openAndroidDatePicker`, a thin wrapper around the imperative Android dialog (with the `event.type === 'set'` gate). Reused by `ClimbedAtField` **and** the logbook filter's `DateRangeRow`, removing three copies of that boilerplate.

`LogbookEditSheet` is refactored onto these (behaviour unchanged, ~150 fewer lines). `QuickTickBar` gains the picker and now sends `clampToNow(climbedAt).toISOString()` instead of `new Date()`.

**No backend / GraphQL / DB change:** `saveTick`'s `climbedAt` was already a required client-provided field. The mobile picker's `maximumDate` + `clampToNow` keep the sent value at-or-before now, so nothing malformed or future-dated reaches the resolver.

## Release Notes

- Log a climb on a date other than today — backdate a send you forgot to tick, right from the log sheet.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — full suite green (393 files, 3050 tests). New: `climbed-at` helper unit tests + a `QuickTickBar` test proving a picked date threads into `saveTick.mutate`. Existing `logbook-edit-sheet` and `logbook-filter-sheet` tests stay green through the refactor.
- `vp run check:mobile-bundle` — Android bundle OK.
- `vp check` — 0 lint errors, format clean.

**On-device QA:** the Quick Tick create sheet opens from a tick-button tap and isn't one of the preset screenshot deep-links, so an automated emulator capture isn't a clean fit here. Behaviour is covered by tests (the new `QuickTickBar` test asserts a picked date reaches `saveTick.mutate`) and the UI mirrors the already-shipped edit sheet rows. For real-device QA, this PR auto-publishes to the **OTA `pr-3389`** channel — testers can switch to it in-app (More → Development → OTA Channel Switcher) on iOS or Android.
