### PR TITLE
feat(mobile): anchor approved store releases for JS-only OTA backports

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -559,6 +559,31 @@ jobs:
             exit 1
           fi
 
+      # Map the STORE BUILD NUMBER (Android versionCode) back to this commit +
+      # fingerprint, so the approval workflow can cut the
+      # release/android-v<version>-<shortfp> anchor at the exact commit the
+      # approved binary was built from. Google Play later tells the approval step
+      # only the approved versionCode; this tag is the lookup. <shortfp> is the
+      # first 12 chars of the canonical gate fingerprint the binary embeds. Gated
+      # like the fingerprint tag (github_release + build_aab succeeded), NOT on the
+      # best-effort Play upload. Same idempotent push. See docs/mobile-ota-updates.md.
+      - name: Tag the uploaded Android build number
+        if: github.ref == 'refs/heads/main' && steps.github_release.outcome == 'success' && steps.build_aab.outcome == 'success' && env.FINGERPRINT_ANDROID != '' && steps.version_code.outputs.value != '' && env.BOARDSESH_MOBILE_VERSION != ''
+        env:
+          VERSION_CODE: ${{ steps.version_code.outputs.value }}
+        run: |
+          set -uo pipefail
+          tag="build-android-v${BOARDSESH_MOBILE_VERSION}-${VERSION_CODE}-${FINGERPRINT_ANDROID:0:12}"
+          git tag "$tag" "$GITHUB_SHA" 2>/dev/null || true
+          if git push origin "refs/tags/$tag"; then
+            echo "::notice::Tagged $tag — maps Play versionCode $VERSION_CODE to this commit + fingerprint for the approval anchor."
+          elif git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "::notice::$tag already exists (concurrent run) — nothing to do."
+          else
+            echo "::error::Failed to push $tag."
+            exit 1
+          fi
+
       - name: Clean up keystore
         if: always()
         run: rm -f packages/mobile/android/app/release.keystore

--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -573,7 +573,10 @@ jobs:
           VERSION_CODE: ${{ steps.version_code.outputs.value }}
         run: |
           set -uo pipefail
-          tag="build-android-v${BOARDSESH_MOBILE_VERSION}-${VERSION_CODE}-${FINGERPRINT_ANDROID:0:12}"
+          # Lowercase the short fingerprint so the tag matches the lowercase hex the
+          # tag parsers expect.
+          shortfp="$(printf '%s' "${FINGERPRINT_ANDROID:0:12}" | tr '[:upper:]' '[:lower:]')"
+          tag="build-android-v${BOARDSESH_MOBILE_VERSION}-${VERSION_CODE}-${shortfp}"
           git tag "$tag" "$GITHUB_SHA" 2>/dev/null || true
           if git push origin "refs/tags/$tag"; then
             echo "::notice::Tagged $tag — maps Play versionCode $VERSION_CODE to this commit + fingerprint for the approval anchor."

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -600,7 +600,10 @@ jobs:
           BUILD_NUMBER: ${{ steps.build_number.outputs.value }}
         run: |
           set -uo pipefail
-          tag="build-ios-v${BOARDSESH_MOBILE_VERSION}-${BUILD_NUMBER}-${FINGERPRINT_IOS:0:12}"
+          # Lowercase the short fingerprint so the tag always matches the lowercase
+          # hex the tag parsers expect (macOS bash lacks ${var,,}, so use tr).
+          shortfp="$(printf '%s' "${FINGERPRINT_IOS:0:12}" | tr '[:upper:]' '[:lower:]')"
+          tag="build-ios-v${BOARDSESH_MOBILE_VERSION}-${BUILD_NUMBER}-${shortfp}"
           git tag "$tag" "$GITHUB_SHA" 2>/dev/null || true
           if git push origin "refs/tags/$tag"; then
             echo "::notice::Tagged $tag — maps App Store build $BUILD_NUMBER to this commit + fingerprint for the approval anchor."

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -586,6 +586,31 @@ jobs:
             exit 1
           fi
 
+      # Map the STORE BUILD NUMBER back to this commit + fingerprint. App Store
+      # Connect later tells the approval workflow only the APPROVED build number
+      # (not its commit or runtimeVersion), so this tag is the lookup that lets
+      # mobile-auto-version-bump cut the release/ios-v<version>-<shortfp> anchor at
+      # exactly the commit the approved binary was built from. <shortfp> is the
+      # first 12 chars of the canonical gate fingerprint (same value the binary
+      # embeds), so the anchor records the fingerprint OTAs must match. Same
+      # idempotent push as the fingerprint tag above. See docs/mobile-ota-updates.md.
+      - name: Tag the uploaded iOS build number
+        if: github.ref == 'refs/heads/main' && steps.testflight_upload.outcome == 'success' && env.FINGERPRINT_IOS != '' && steps.build_number.outputs.value != '' && env.BOARDSESH_MOBILE_VERSION != ''
+        env:
+          BUILD_NUMBER: ${{ steps.build_number.outputs.value }}
+        run: |
+          set -uo pipefail
+          tag="build-ios-v${BOARDSESH_MOBILE_VERSION}-${BUILD_NUMBER}-${FINGERPRINT_IOS:0:12}"
+          git tag "$tag" "$GITHUB_SHA" 2>/dev/null || true
+          if git push origin "refs/tags/$tag"; then
+            echo "::notice::Tagged $tag — maps App Store build $BUILD_NUMBER to this commit + fingerprint for the approval anchor."
+          elif git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "::notice::$tag already exists (concurrent run) — nothing to do."
+          else
+            echo "::error::Failed to push $tag."
+            exit 1
+          fi
+
       - name: Clean up keychain and credentials
         if: always()
         run: |

--- a/.github/workflows/mobile-auto-version-bump.yml
+++ b/.github/workflows/mobile-auto-version-bump.yml
@@ -83,8 +83,14 @@ jobs:
       # accepted version may still be unanchored). Idempotent, so the sibling
       # platform's approval and any re-run are safe. Uses the checkout's persisted
       # token to push the tags. dry_run mirrors the bump step.
+      #
+      # continue-on-error: a transient tag-push failure for an old release must not
+      # block the (independent) version bump below — accepted versions are re-anchored
+      # on the next scheduled run. Skipped when there are no accepted versions
+      # (accepted_builds is '[]' or unset), so it doesn't run for nothing.
       - name: Cut release anchor tags for accepted versions
-        if: steps.bump.outputs.accepted_builds != ''
+        if: steps.bump.outputs.accepted_builds != '' && steps.bump.outputs.accepted_builds != '[]'
+        continue-on-error: true
         env:
           ACCEPTED_BUILDS: ${{ steps.bump.outputs.accepted_builds }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}

--- a/.github/workflows/mobile-auto-version-bump.yml
+++ b/.github/workflows/mobile-auto-version-bump.yml
@@ -1,24 +1,34 @@
-name: Mobile Auto Version Bump
+name: Mobile Release Anchor & Version Bump
 
-# Manual-only (workflow_dispatch). The hourly schedule is intentionally disabled:
-# an automatic bump on main rewrites the native version, which busts the fingerprint
-# and breaks parity between the native build and the OTA publish. Run this only when a
-# version bump is actually needed.
+# Runs on a schedule (and on demand) to react to App Store approvals. Two jobs of
+# work, both keyed on "which versions has Apple accepted?" (PENDING_DEVELOPER_RELEASE,
+# PENDING_APPLE_RELEASE, PROCESSING_FOR_APP_STORE, READY_FOR_SALE):
 #
-# What it does when run: checks App Store Connect for the current marketing version in
-# packages/mobile/app.config.ts. When it has been accepted by Apple (PENDING_DEVELOPER_RELEASE,
-# PENDING_APPLE_RELEASE, PROCESSING_FOR_APP_STORE, or READY_FOR_SALE), it bumps the patch
-# version and pushes directly to main via the OTA push-back app token, bypassing the PR
-# requirement. The commit carries [skip ci] to prevent a spurious OTA publish (the version
-# change busts the fingerprint; no binary can pull such an OTA).
+#   1. Anchor the approved release. For each accepted version it cuts a
+#      release/<platform>-v<version>-<shortfp> tag at the commit the approved binary
+#      was built from (located via the build-<platform>-v<version>-<buildNumber>-<shortfp>
+#      tags the native builds push). Because an approved store binary is frozen
+#      forever, this tag permanently records the fingerprint an OTA must resolve to
+#      reach that release — the backport anchor. See docs/mobile-ota-updates.md and
+#      scripts/mobile-cut-release-tags.ts.
+#   2. Bump the marketing version. When the CURRENT app.config version is accepted,
+#      bump the patch and push to main via the OTA push-back app token (bypassing the
+#      PR rule). The commit carries [skip ci].
 #
-# Minor version bumps are intentionally excluded — those are a manual decision.
+# The version bump DOES change the fingerprint, and that's fine by design: we anchor
+# only APPROVED (immutable) fingerprints, so intermediate fingerprint churn between
+# approvals never needs to stay OTA-compatible. This is why the schedule — disabled
+# under the old model precisely because a bump busts the fingerprint — is safe to run
+# now. Minor version bumps stay a manual decision.
 
 on:
+  schedule:
+    # Every 6h so an approval is anchored + bumped without waiting for a manual run.
+    - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Log what would change without writing or pushing'
+        description: 'Log what would change without writing, tagging, or pushing'
         type: boolean
         default: true
 
@@ -50,13 +60,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          # Full history + tags: the anchor step reads the build-<platform>-* tags
+          # and resolves the commits they point at.
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ steps.push_token.outputs.token || github.token }}
 
       - uses: oven-sh/setup-bun@v2
 
-      # No bun install needed — the script only uses built-in node:crypto / node:fs.
-      - name: Check ASC and bump version if accepted
+      # No bun install needed — both scripts use only built-in node modules + git.
+      - name: Check ASC for accepted versions and bump if current is accepted
         id: bump
         env:
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
@@ -64,6 +77,21 @@ jobs:
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bun scripts/mobile-auto-version-bump.ts
+
+      # Cut release/<platform>-v<version>-<shortfp> anchors for every accepted
+      # version (independent of whether the CURRENT version is accepted — an older
+      # accepted version may still be unanchored). Idempotent, so the sibling
+      # platform's approval and any re-run are safe. Uses the checkout's persisted
+      # token to push the tags. dry_run mirrors the bump step.
+      - name: Cut release anchor tags for accepted versions
+        if: steps.bump.outputs.accepted_builds != ''
+        env:
+          ACCEPTED_BUILDS: ${{ steps.bump.outputs.accepted_builds }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          git config user.name "boardsesh-repo-bot[bot]"
+          git config user.email "boardsesh-repo-bot[bot]@users.noreply.github.com"
+          bun scripts/mobile-cut-release-tags.ts
 
       - name: Commit and push version bump to main
         if: steps.bump.outputs.bumped == 'true' && vars.OTA_PUSH_APP_ID != ''

--- a/.github/workflows/mobile-auto-version-bump.yml
+++ b/.github/workflows/mobile-auto-version-bump.yml
@@ -89,6 +89,7 @@ jobs:
       # on the next scheduled run. Skipped when there are no accepted versions
       # (accepted_builds is '[]' or unset), so it doesn't run for nothing.
       - name: Cut release anchor tags for accepted versions
+        id: anchor
         if: steps.bump.outputs.accepted_builds != '' && steps.bump.outputs.accepted_builds != '[]'
         continue-on-error: true
         env:
@@ -98,6 +99,14 @@ jobs:
           git config user.name "boardsesh-repo-bot[bot]"
           git config user.email "boardsesh-repo-bot[bot]@users.noreply.github.com"
           bun scripts/mobile-cut-release-tags.ts
+
+      # Surface an anchor-cut failure loudly. continue-on-error keeps it from
+      # blocking the bump, but a persistent failure (e.g. a tag-push permission
+      # error) would otherwise be easy to miss — accepted versions are re-anchored
+      # next run, so this is a signal to investigate, not a hard failure.
+      - name: Warn if anchoring failed
+        if: steps.anchor.outcome == 'failure'
+        run: echo "::warning::Cutting release anchor tags failed (see the step above). The version bump still proceeds and accepted versions are re-anchored on the next scheduled run; investigate if this persists."
 
       - name: Commit and push version bump to main
         if: steps.bump.outputs.bumped == 'true' && vars.OTA_PUSH_APP_ID != ''

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -114,6 +114,13 @@ jobs:
           FIX_COMMITS: ${{ inputs.fix_commits }}
         run: |
           set -euo pipefail
+          # Validate the version is x.y.z before using it in a tag glob, so a
+          # glob-like input (e.g. '*') can't match unrelated anchors and surface a
+          # confusing "Multiple anchors" error instead of a clear bad-input one.
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::version must be x.y.z (got '$VERSION')."
+            exit 1
+          fi
           mapfile -t tags < <(git tag -l "release/${PLATFORM}-v${VERSION}-*")
           if [ "${#tags[@]}" -eq 0 ]; then
             echo "::error::No release/${PLATFORM}-v${VERSION}-* anchor tag. Has ${VERSION} been approved and anchored on ${PLATFORM}?"

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -29,6 +29,10 @@ on:
       fix_commits:
         description: 'JS-only commit SHA(s) to cherry-pick onto the anchor (space/comma separated)'
         required: true
+      confirm_android_shipped:
+        description: 'Required for an Android backport: the Android anchor is cut on iOS approval, so confirm this version actually shipped on Google Play first.'
+        type: boolean
+        default: false
       dry_run:
         description: 'Resolve + verify the fingerprint but skip the actual OTA publish'
         type: boolean
@@ -112,6 +116,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           PLATFORM: ${{ matrix.platform }}
           FIX_COMMITS: ${{ inputs.fix_commits }}
+          CONFIRM_ANDROID_SHIPPED: ${{ inputs.confirm_android_shipped }}
         run: |
           set -euo pipefail
           # Validate the version is x.y.z before using it in a tag glob, so a
@@ -119,6 +124,13 @@ jobs:
           # confusing "Multiple anchors" error instead of a clear bad-input one.
           if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::version must be x.y.z (got '$VERSION')."
+            exit 1
+          fi
+          # The Android anchor is cut on iOS approval (no Google Play query), so it
+          # can be premature. Require an explicit confirmation that the version
+          # actually shipped on Play before an Android backport can publish.
+          if [ "$PLATFORM" = "android" ] && [ "$CONFIRM_ANDROID_SHIPPED" != "true" ]; then
+            echo "::error::Android backport requires confirm_android_shipped=true — verify v${VERSION} actually shipped on Google Play first (its anchor is cut on iOS approval)."
             exit 1
           fi
           mapfile -t tags < <(git tag -l "release/${PLATFORM}-v${VERSION}-*")
@@ -146,6 +158,12 @@ jobs:
             case "$commit" in
               -*) echo "::error::Refusing commit-ish '$commit' that looks like a flag."; exit 1 ;;
             esac
+            # Require explicit SHAs (7-40 hex): reject moving refs like main/HEAD or
+            # branch names so a backport always cherry-picks a fixed, auditable commit.
+            if ! printf '%s' "$commit" | grep -qE '^[0-9a-f]{7,40}$'; then
+              echo "::error::'$commit' is not a commit SHA (7-40 hex). Pass explicit SHAs, not refs like main/HEAD."
+              exit 1
+            fi
           done
           echo "Cherry-picking onto $tag: ${commits[*]}"
           git cherry-pick "${commits[@]}"

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -134,10 +134,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "hotfix/${PLATFORM}-v${VERSION}-${GITHUB_RUN_ID}" "$tag"
 
-          commits="$(printf '%s' "$FIX_COMMITS" | tr ',' ' ')"
-          echo "Cherry-picking onto $tag: $commits"
-          # shellcheck disable=SC2086
-          git cherry-pick $commits
+          # Split into an array and reject any token that looks like a git flag, so
+          # a malformed "commit" like -n / --abort can't be smuggled in as an option.
+          read -r -a commits <<< "$(printf '%s' "$FIX_COMMITS" | tr ',' ' ')"
+          if [ "${#commits[@]}" -eq 0 ]; then echo "::error::No fix commits provided."; exit 1; fi
+          for commit in "${commits[@]}"; do
+            case "$commit" in
+              -*) echo "::error::Refusing commit-ish '$commit' that looks like a flag."; exit 1 ;;
+            esac
+          done
+          echo "Cherry-picking onto $tag: ${commits[*]}"
+          git cherry-pick "${commits[@]}"
 
       - name: Write .env for Expo build-time inlining
         working-directory: packages/mobile
@@ -167,7 +174,9 @@ jobs:
             echo "::error::Could not resolve the $PLATFORM fingerprint for the hotfix tree."
             exit 1
           fi
-          short="${fp:0:12}"
+          # Lowercase before comparing: the anchor's shortfp is always lowercase hex,
+          # so a stray uppercase resolve would false-mismatch and wrongly abort.
+          short="$(printf '%s' "${fp:0:12}" | tr '[:upper:]' '[:lower:]')"
           if [ "$short" != "$EXPECTED_SHORTFP" ]; then
             echo "::error::Resolved fingerprint $short != approved anchor $EXPECTED_SHORTFP. The cherry-pick changed native inputs, so an OTA published now would resolve a fingerprint no shipped ${{ inputs.version }} binary has and never land. Aborting — ship this fix as a new native build instead."
             exit 1

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -174,7 +174,9 @@ jobs:
           set -uo pipefail
           raw="$(cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform "$PLATFORM" 2>/dev/null || true)"
           fp="$(printf '%s' "$raw" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)"
-          if ! printf '%s' "$fp" | grep -qiE '^[0-9a-f]{8,}$'; then
+          # Require >= 12 hex chars: we compare the first 12 against the anchor's
+          # shortfp, so anything shorter couldn't form a valid comparison anyway.
+          if ! printf '%s' "$fp" | grep -qiE '^[0-9a-f]{12,}$'; then
             echo "::error::Could not resolve the $PLATFORM fingerprint for the hotfix tree."
             exit 1
           fi

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -106,9 +106,6 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
-      - name: Install Node.js dependencies (workspace root)
-        run: bun install --frozen-lockfile
-
       - name: Locate the release anchor and prepare the hotfix tree
         id: anchor
         env:
@@ -145,6 +142,13 @@ jobs:
           done
           echo "Cherry-picking onto $tag: ${commits[*]}"
           git cherry-pick "${commits[@]}"
+
+      # Install AFTER the anchor checkout + cherry-pick so node_modules matches the
+      # OLD release's lockfile, not main's. Resolving the fingerprint against
+      # main's deps would diverge from what the shipped binary embedded and cause
+      # a spurious mismatch (or, worse, a false match).
+      - name: Install Node.js dependencies (workspace root)
+        run: bun install --frozen-lockfile
 
       - name: Write .env for Expo build-time inlining
         working-directory: packages/mobile

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -197,7 +197,10 @@ jobs:
           GOOGLE_MAPS_API_KEY: ${{ matrix.platform == 'android' && secrets.GOOGLE_MAPS_API_KEY || '' }}
         run: |
           set -uo pipefail
-          raw="$(cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform "$PLATFORM" 2>/dev/null || true)"
+          # Keep stderr visible: if the resolve fails for a reason other than a
+          # fingerprint mismatch (missing dep, config/network error), surfacing it
+          # beats the bare "Could not resolve" message below with no root cause.
+          raw="$(cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform "$PLATFORM" || true)"
           fp="$(printf '%s' "$raw" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)"
           # Require >= 12 hex chars: we compare the first 12 against the anchor's
           # shortfp, so anything shorter couldn't form a valid comparison anyway.

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -1,0 +1,189 @@
+name: Mobile OTA Backport (Approved Release)
+
+# Ships a JS-only fix to an already-APPROVED store release over-the-air, without a
+# new store build. It checks out that release's frozen anchor
+# (release/<platform>-v<version>-<shortfp>, cut by mobile-auto-version-bump.yml on
+# approval), cherry-picks the fix onto it, and publishes an OTA under the anchor's
+# fingerprint — which is exactly the fingerprint that release's installs request.
+#
+# The safety rail is the fingerprint check: after the cherry-pick it resolves the
+# runtimeVersion and aborts unless its 12-char prefix equals the <shortfp> baked
+# into the anchor tag. A drift means the cherry-pick touched native inputs, so the
+# OTA would resolve a fingerprint no shipped binary has and silently never land —
+# better to fail loudly. See docs/mobile-ota-updates.md.
+#
+# Manual only. Prepare the fix as normal commits on main (or anywhere fetchable)
+# first, then dispatch this with those commit SHAs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Approved marketing version to patch, e.g. 2.1.0'
+        required: true
+      platform:
+        description: 'Which approved store binary to reach'
+        type: choice
+        options: [all, ios, android]
+        default: all
+      fix_commits:
+        description: 'JS-only commit SHA(s) to cherry-pick onto the anchor (space/comma separated)'
+        required: true
+      dry_run:
+        description: 'Resolve + verify the fingerprint but skip the actual OTA publish'
+        type: boolean
+        default: true
+
+# Share the production OTA lane so a backport can never publish concurrently with a
+# main production OTA (repo-wide group, across workflows). Queued, never cancelled.
+concurrency:
+  group: mobile-ota-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+# ─── SHARED BUILD ENV (workflow-level) ───────────────────────────────────────
+# Byte-identical to ios-testflight-rn.yml / android-apk-rn.yml / mobile-ota-production.yml
+# — scripts/mobile-ci-env-parity.test.ts fails the build if these drift. The
+# fingerprint check below only means anything if this resolves under the same env
+# the shipped binary did. GOOGLE_MAPS_API_KEY is Android-only and set per-step.
+env:
+  EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
+  EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
+  EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+  EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
+  EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
+  EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  EXPO_UPDATES_CHANNEL: production
+  EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
+
+jobs:
+  # Turn the platform choice into a matrix so iOS and Android publish independently
+  # (each under its own release anchor / fingerprint).
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.platforms.outputs.platforms }}
+    steps:
+      - id: platforms
+        env:
+          PLATFORM: ${{ inputs.platform }}
+        run: |
+          set -euo pipefail
+          case "$PLATFORM" in
+            all) echo 'platforms=["ios","android"]' >> "$GITHUB_OUTPUT" ;;
+            ios) echo 'platforms=["ios"]' >> "$GITHUB_OUTPUT" ;;
+            android) echo 'platforms=["android"]' >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::Unknown platform '$PLATFORM'"; exit 1 ;;
+          esac
+
+  backport:
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Gates EXPO_TOKEN + GOOGLE_MAPS_API_KEY + the EXPO_UPDATES_URL variable.
+    environment: Production
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJSON(needs.setup.outputs.platforms) }}
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Full history + tags: need the release anchor tag and the fix commits
+          # (on main) reachable for the cherry-pick.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: voidzero-dev/setup-vp@v1
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install Node.js dependencies (workspace root)
+        run: bun install --frozen-lockfile
+
+      - name: Locate the release anchor and prepare the hotfix tree
+        id: anchor
+        env:
+          VERSION: ${{ inputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+          FIX_COMMITS: ${{ inputs.fix_commits }}
+        run: |
+          set -euo pipefail
+          mapfile -t tags < <(git tag -l "release/${PLATFORM}-v${VERSION}-*")
+          if [ "${#tags[@]}" -eq 0 ]; then
+            echo "::error::No release/${PLATFORM}-v${VERSION}-* anchor tag. Has ${VERSION} been approved and anchored on ${PLATFORM}?"
+            exit 1
+          fi
+          if [ "${#tags[@]}" -gt 1 ]; then
+            echo "::error::Multiple ${PLATFORM} anchors for ${VERSION}: ${tags[*]}. Expected exactly one."
+            exit 1
+          fi
+          tag="${tags[0]}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "shortfp=${tag##*-}" >> "$GITHUB_OUTPUT"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "hotfix/${PLATFORM}-v${VERSION}-${GITHUB_RUN_ID}" "$tag"
+
+          commits="$(printf '%s' "$FIX_COMMITS" | tr ',' ' ')"
+          echo "Cherry-picking onto $tag: $commits"
+          # shellcheck disable=SC2086
+          git cherry-pick $commits
+
+      - name: Write .env for Expo build-time inlining
+        working-directory: packages/mobile
+        run: |
+          cat > .env <<EOF
+          EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
+          EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
+          EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
+          EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID
+          EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID
+          EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
+          EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
+          EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
+          EOF
+
+      - name: Resolve fingerprint and verify it matches the approved anchor
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          EXPECTED_SHORTFP: ${{ steps.anchor.outputs.shortfp }}
+          # Android's approved fingerprint was resolved WITH the maps key; iOS without.
+          GOOGLE_MAPS_API_KEY: ${{ matrix.platform == 'android' && secrets.GOOGLE_MAPS_API_KEY || '' }}
+        run: |
+          set -uo pipefail
+          raw="$(cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform "$PLATFORM" 2>/dev/null || true)"
+          fp="$(printf '%s' "$raw" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)"
+          if ! printf '%s' "$fp" | grep -qiE '^[0-9a-f]{8,}$'; then
+            echo "::error::Could not resolve the $PLATFORM fingerprint for the hotfix tree."
+            exit 1
+          fi
+          short="${fp:0:12}"
+          if [ "$short" != "$EXPECTED_SHORTFP" ]; then
+            echo "::error::Resolved fingerprint $short != approved anchor $EXPECTED_SHORTFP. The cherry-pick changed native inputs, so an OTA published now would resolve a fingerprint no shipped ${{ inputs.version }} binary has and never land. Aborting — ship this fix as a new native build instead."
+            exit 1
+          fi
+          echo "::notice::$PLATFORM fingerprint $short matches the approved anchor — safe to publish."
+
+      - name: Publish OTA to the approved release
+        if: ${{ !inputs.dry_run }}
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          GOOGLE_MAPS_API_KEY: ${{ matrix.platform == 'android' && secrets.GOOGLE_MAPS_API_KEY || '' }}
+          VERSION: ${{ inputs.version }}
+          FIX_COMMITS: ${{ inputs.fix_commits }}
+        run: |
+          vp run mobile:publish -- --channel production --platform "$PLATFORM" --message "Backport to v$VERSION ($FIX_COMMITS)"
+
+      - name: Dry-run note
+        if: ${{ inputs.dry_run }}
+        run: echo "::notice::dry_run — verified the fingerprint match for ${{ matrix.platform }} but skipped the publish. Re-run with dry_run unchecked to ship."

--- a/.github/workflows/mobile-store-draft.yml
+++ b/.github/workflows/mobile-store-draft.yml
@@ -36,6 +36,11 @@ concurrency:
   group: mobile-store-draft
   cancel-in-progress: false
 
+# Only checkout is needed; store uploads authenticate via secrets, not the
+# GitHub token. Explicit read-only, consistent with the other new workflows.
+permissions:
+  contents: read
+
 jobs:
   ios:
     if: >-

--- a/.github/workflows/mobile-store-draft.yml
+++ b/.github/workflows/mobile-store-draft.yml
@@ -77,6 +77,7 @@ jobs:
           echo "ASC_KEY_PATH=$key_path" >> "$GITHUB_ENV"
 
       - name: Prepare App Store draft submission
+        id: draft
         continue-on-error: true
         working-directory: fastlane
         env:
@@ -88,6 +89,12 @@ jobs:
           set -euo pipefail
           [ -n "$APP_STORE_CONNECT_ISSUER_ID" ] || { echo "::error::Missing APP_STORE_CONNECT_ISSUER_ID."; exit 1; }
           bundle exec fastlane ios draft_submission
+
+      # Surface a best-effort failure loudly (continue-on-error keeps the job
+      # green otherwise, which would hide a broken draft submission).
+      - name: Warn if the App Store draft step failed
+        if: steps.draft.outcome == 'failure'
+        run: echo "::warning::App Store draft submission failed (see the step above). Best-effort — re-run after resolving, or prepare the draft manually in App Store Connect."
 
       - name: Clean up App Store Connect key
         if: always()
@@ -113,6 +120,7 @@ jobs:
           working-directory: fastlane
 
       - name: Prepare Play Store draft release
+        id: draft
         continue-on-error: true
         working-directory: fastlane
         env:
@@ -123,3 +131,7 @@ jobs:
           set -euo pipefail
           [ -n "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" ] || { echo "::error::Missing GOOGLE_PLAY_SERVICE_ACCOUNT_JSON."; exit 1; }
           bundle exec fastlane android draft_submission
+
+      - name: Warn if the Play draft step failed
+        if: steps.draft.outcome == 'failure'
+        run: echo "::warning::Play draft release failed (see the step above). Best-effort — re-run after resolving, or prepare the draft manually in the Play Console."

--- a/.github/workflows/mobile-store-draft.yml
+++ b/.github/workflows/mobile-store-draft.yml
@@ -1,0 +1,120 @@
+name: Mobile Store Draft Submission
+
+# Best-effort preparation of a DRAFT store submission for the current marketing
+# version, so a human only has to review and hit Submit — we never auto-submit for
+# review. iOS: create/prepare the 'Prepare for Submission' App Store version and
+# attach the latest processed TestFlight build. Android: create a DRAFT production
+# release referencing the latest uploaded build. No binary upload, no screenshots,
+# no metadata (those are owned by mobile-store-metadata.yml / the screenshot
+# workflows), no review submission, no rollout.
+#
+# OFF BY DEFAULT: both jobs are gated on the repo variable
+# ENABLE_STORE_DRAFT_SUBMISSION == 'true' because they mutate live store state.
+# Flip the variable on once you've validated the lanes. Runs on a schedule (so a
+# draft is prepared shortly after a build finishes processing) and on demand.
+# Lives on cheap ubuntu (not the 60-min macOS build) and separate from the native
+# builds so build-processing latency never blocks a release. Idempotent — deliver
+# / supply update the existing draft rather than duplicating it.
+
+on:
+  schedule:
+    # Offset from mobile-auto-version-bump.yml (0 */6) so they don't collide.
+    - cron: '30 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Which store(s) to prepare a draft for'
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - ios
+          - android
+
+concurrency:
+  group: mobile-store-draft
+  cancel-in-progress: false
+
+jobs:
+  ios:
+    if: >-
+      vars.ENABLE_STORE_DRAFT_SUBMISSION == 'true' &&
+      (github.event_name != 'workflow_dispatch' || github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'all')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Production environment for the App Store Connect credentials.
+    environment: Production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby and fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+          working-directory: fastlane
+
+      - name: Decode App Store Connect API key
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          [ -n "$APP_STORE_CONNECT_API_KEY_ID" ] || { echo "::error::Missing APP_STORE_CONNECT_API_KEY_ID."; exit 1; }
+          [ -n "$APP_STORE_CONNECT_API_KEY_BASE64" ] || { echo "::error::Missing APP_STORE_CONNECT_API_KEY_BASE64."; exit 1; }
+          mkdir -p "$HOME/.private_keys"
+          key_path="$HOME/.private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          printf '%s' "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > "$key_path"
+          grep -q 'BEGIN PRIVATE KEY' "$key_path" || { echo "::error::APP_STORE_CONNECT_API_KEY_BASE64 did not decode to an App Store Connect private key."; exit 1; }
+          echo "ASC_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+
+      - name: Prepare App Store draft submission
+        continue-on-error: true
+        working-directory: fastlane
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          FASTLANE_SKIP_UPDATE_CHECK: '1'
+          FASTLANE_DISABLE_ANIMATION: '1'
+        run: |
+          set -euo pipefail
+          [ -n "$APP_STORE_CONNECT_ISSUER_ID" ] || { echo "::error::Missing APP_STORE_CONNECT_ISSUER_ID."; exit 1; }
+          bundle exec fastlane ios draft_submission
+
+      - name: Clean up App Store Connect key
+        if: always()
+        run: rm -f "$HOME/.private_keys/AuthKey_"*.p8 2>/dev/null || true
+
+  android:
+    if: >-
+      vars.ENABLE_STORE_DRAFT_SUBMISSION == 'true' &&
+      (github.event_name != 'workflow_dispatch' || github.event.inputs.platform == 'android' || github.event.inputs.platform == 'all')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: Production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby and fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+          working-directory: fastlane
+
+      - name: Prepare Play Store draft release
+        continue-on-error: true
+        working-directory: fastlane
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          FASTLANE_SKIP_UPDATE_CHECK: '1'
+          FASTLANE_DISABLE_ANIMATION: '1'
+        run: |
+          set -euo pipefail
+          [ -n "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" ] || { echo "::error::Missing GOOGLE_PLAY_SERVICE_ACCOUNT_JSON."; exit 1; }
+          bundle exec fastlane android draft_submission

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -186,6 +186,54 @@ Resolve the current fingerprint locally to predict what the gate will see: `cd p
 bunx expo-updates runtimeversion:resolve --platform ios` (add the production env to match CI
 exactly — see the parity check above).
 
+## Backporting a JS fix to an approved release (release anchors)
+
+The gating above delivers a JS fix to binaries whose fingerprint still matches `main`. Once native
+churn has moved `main`'s fingerprint, an **already-released** (approved) store binary is
+OTA-orphaned: a fix published from `main` goes out under the new fingerprint that old install never
+requests (issue #3098). The remedy is to publish an OTA under the *old* release's fingerprint. We
+make that reproducible by anchoring each approved release with a tag.
+
+**Anchoring is tied to App Store approval, not to merge.** `main` iterates through many fingerprints
+between releases; we only care about the ones that actually shipped and were approved (an approved
+binary is frozen forever). The marketing `version` *is* part of the fingerprint, so bumping it moves
+the fingerprint — which is fine, because we never rely on an intermediate fingerprint staying
+OTA-compatible; we only anchor approved ones.
+
+Two tag families do this:
+
+- `build-<platform>-v<version>-<buildNumber>-<shortfp>` — pushed by the native build workflows
+  (`ios-testflight-rn.yml` / `android-apk-rn.yml`) on a successful store upload. Maps a store build
+  number (iOS `CFBundleVersion` / Android `versionCode`) to the commit and the canonical gate
+  fingerprint the binary embeds. `<shortfp>` is the first 12 hex chars of the fingerprint.
+- `release/<platform>-v<version>-<shortfp>` — cut by `mobile-auto-version-bump.yml` when App Store
+  Connect reports a version accepted (`scripts/mobile-cut-release-tags.ts`). It points at the commit
+  the approved binary was built from; its `<shortfp>` records the fingerprint an OTA must resolve to
+  reach that release. This is the frozen **backport anchor**.
+
+`mobile-auto-version-bump.yml` runs on a schedule (every 6h) and, per accepted version: looks up the
+approved build's `build-*` tag (iOS by the approved build number, Android by the latest build of the
+same marketing version — the app ships both platforms at one version), cuts the `release/*` anchor at
+that commit, and — once per version — bumps the patch on `main` (`[skip ci]`). All idempotent, so the
+second platform's approval and any re-run are safe.
+
+### Backport runbook
+
+1. Land the JS-only fix on `main` as normal (get its commit SHA). It also ships to current-`main`
+   installs via the usual production OTA.
+2. Run the **Mobile OTA Backport** workflow (`mobile-ota-backport.yml`, `workflow_dispatch`) with the
+   approved `version` (e.g. `2.1.0`), the `platform` (`all`/`ios`/`android`), and the fix commit
+   SHA(s). Leave `dry_run` on for the first pass.
+3. It checks out `release/<platform>-v<version>-<shortfp>`, cherry-picks the fix, and **verifies the
+   resolved fingerprint's 12-char prefix equals the anchor's `<shortfp>`**. A mismatch means the
+   cherry-pick touched native inputs — it aborts, because an OTA would resolve a fingerprint no
+   shipped binary has and silently never land. Ship such a fix as a new native build instead.
+4. Re-run with `dry_run` off to `eoas publish --channel production` under the approved fingerprint,
+   reaching that release's installs. It shares the `mobile-ota-production` concurrency lane, so it
+   never races a `main` OTA.
+
+To find the anchor for a release: `git tag -l 'release/ios-v2.1.0-*'`.
+
 ## OTA observability (adoption + funnel)
 
 A JS-only fix lands OTA-only, so "did it actually reach users?" needs telemetry — without it an

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -213,9 +213,20 @@ Two tag families do this:
 
 `mobile-auto-version-bump.yml` runs on a schedule (every 6h) and, per accepted version: looks up the
 approved build's `build-*` tag (iOS by the approved build number, Android by the latest build of the
-same marketing version — the app ships both platforms at one version), cuts the `release/*` anchor at
-that commit, and — once per version — bumps the patch on `main` (`[skip ci]`). All idempotent, so the
-second platform's approval and any re-run are safe.
+same marketing version), cuts the `release/*` anchor at that commit, and — once per version — bumps
+the patch on `main` (`[skip ci]`). All idempotent, so the second platform's approval and any re-run
+are safe.
+
+**iOS anchoring is strict:** it uses App Store Connect's exact approved build number, and if no
+`build-ios-v<version>-<buildNumber>-*` tag matches it, it skips (rather than anchoring a different
+build's commit + fingerprint) and retries on the next run once the tag exists.
+
+**Android caveat:** approval is detected from App Store Connect only — there is no Google Play query.
+The Android anchor is cut alongside the iOS approval, pointing at the *latest* Android build of the
+same marketing version. If Android hasn't actually shipped that version to the store, the anchor is
+premature; a backport under it would just reach whatever installs hold that fingerprint (and the
+backport re-verifies the fingerprint before publishing), so it is ineffective rather than incorrect.
+Confirm the Android release actually shipped before relying on an Android backport.
 
 ### Backport runbook
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -208,6 +208,30 @@ rescue => error
   nil
 end
 
+# Highest versionCode uploaded to any Play track (internal/alpha/beta/production),
+# used by the Android draft-submission lane to know which build to draft to
+# production. Returns nil when nothing has been uploaded (or the tracks can't be
+# read), so the lane skips instead of erroring.
+def latest_uploaded_version_code(json_key_data)
+  codes = []
+  %w[internal alpha beta production].each do |track|
+    begin
+      codes.concat(
+        Array(
+          google_play_track_version_codes(
+            package_name: APP_IDENTIFIER,
+            json_key_data: json_key_data,
+            track: track
+          )
+        ).map(&:to_i)
+      )
+    rescue => error
+      UI.important("Could not read '#{track}' track: #{error.message}")
+    end
+  end
+  codes.empty? ? nil : codes.max
+end
+
 platform :ios do
   desc "Upload App Store screenshots to App Store Connect (no binary, no metadata, no review)"
   lane :screenshots do
@@ -319,6 +343,47 @@ platform :ios do
     UI.success("iOS build number: #{number}")
     emit_ci_output(number)
     number
+  end
+
+  desc "Prepare a DRAFT App Store version for the current marketing version with its latest build attached (no review submission)"
+  lane :draft_submission do
+    api_key = asc_api_key
+    version = mobile_app_version
+
+    # Attach the highest TestFlight build for this marketing version. 0 means no
+    # build has finished processing yet — nothing to draft, so skip cleanly (this
+    # lane is best-effort and re-runs on a schedule once a build is available).
+    build_number = latest_testflight_build_number(
+      api_key: api_key,
+      app_identifier: APP_IDENTIFIER,
+      version: version,
+      initial_build_number: 0
+    )
+    if build_number.to_i <= 0
+      UI.important("No processed TestFlight build for #{version} yet — nothing to attach. Skipping the draft submission.")
+      next
+    end
+
+    # Create the App Store version if it doesn't exist and attach the build,
+    # leaving it in 'Prepare for Submission' (a DRAFT). No screenshots/metadata
+    # here (owned by the screenshots/metadata lanes); crucially submit_for_review:
+    # false, so a human reviews and hits Submit — we never auto-submit.
+    upload_to_app_store(
+      api_key: api_key,
+      app_identifier: APP_IDENTIFIER,
+      app_version: version,
+      build_number: build_number.to_s,
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      skip_metadata: true,
+      submit_for_review: false,
+      automatic_release: false,
+      run_precheck_before_submit: false,
+      precheck_include_in_app_purchases: false,
+      # force: true — no interactive HTML preview in CI (same as the other lanes).
+      force: true
+    )
+    UI.success("Prepared a draft App Store version #{version} with build #{build_number}.")
   end
 end
 
@@ -498,5 +563,36 @@ platform :android do
     UI.success("Android versionCode: #{code}")
     emit_ci_output(code)
     code
+  end
+
+  desc "Prepare a DRAFT production release for the latest uploaded build (no review submission, no rollout)"
+  lane :draft_submission do
+    json_key_data = ENV.fetch("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")
+    version_code = latest_uploaded_version_code(json_key_data)
+    if version_code.nil?
+      UI.important("No uploaded Android build found on any track — nothing to draft. Skipping.")
+      next
+    end
+
+    # Create a production release in DRAFT status referencing the build already
+    # uploaded (to the internal track by android-apk-rn.yml). release_status:
+    # 'draft' means it is never sent for review — a human promotes/rolls it out.
+    # No text/images/screenshots here (owned by the metadata/images/screenshots
+    # lanes); no AAB upload (the binary already exists).
+    upload_to_play_store(
+      package_name: APP_IDENTIFIER,
+      json_key_data: json_key_data,
+      track: "production",
+      version_code: version_code,
+      release_status: "draft",
+      skip_upload_apk: true,
+      skip_upload_aab: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      timeout: 300
+    )
+    UI.success("Prepared a draft production release for versionCode #{version_code}.")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -210,8 +210,11 @@ end
 
 # Highest versionCode uploaded to any Play track (internal/alpha/beta/production),
 # used by the Android draft-submission lane to know which build to draft to
-# production. Returns nil when nothing has been uploaded (or the tracks can't be
-# read), so the lane skips instead of erroring.
+# production. versionCode is monotonic (android-apk-rn.yml only ever raises it —
+# max(sideload floor, Play ceiling + 1)), so the global max IS the most recently
+# built binary, i.e. the latest marketing version's build — never an older release
+# sitting on a track. Returns nil when nothing has been uploaded (or the tracks
+# can't be read), so the lane skips instead of erroring.
 def latest_uploaded_version_code(json_key_data)
   codes = []
   %w[internal alpha beta production].each do |track|

--- a/scripts/__tests__/mobile-auto-version-bump.test.ts
+++ b/scripts/__tests__/mobile-auto-version-bump.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { mapAcceptedVersions } from '../mobile-auto-version-bump';
+
+describe('mapAcceptedVersions', () => {
+  it('maps an attached build to its build number', () => {
+    const out = mapAcceptedVersions({
+      data: [
+        {
+          type: 'appStoreVersions',
+          id: 'v1',
+          attributes: { versionString: '2.1.0', appStoreState: 'READY_FOR_SALE' },
+          relationships: { build: { data: { type: 'builds', id: 'b1' } } },
+        },
+      ],
+      included: [{ type: 'builds', id: 'b1', attributes: { version: '42' } }],
+    });
+    expect(out).toEqual([{ versionString: '2.1.0', buildNumber: 42 }]);
+  });
+
+  it('yields buildNumber null when the relationship is explicitly null or absent', () => {
+    const out = mapAcceptedVersions({
+      data: [
+        {
+          type: 'appStoreVersions',
+          id: 'v2',
+          attributes: { versionString: '2.0.9', appStoreState: 'PROCESSING_FOR_APP_STORE' },
+          relationships: { build: { data: null } },
+        },
+        {
+          type: 'appStoreVersions',
+          id: 'v3',
+          attributes: { versionString: '2.2.0', appStoreState: 'PENDING_APPLE_RELEASE' },
+        },
+      ],
+      included: [],
+    });
+    expect(out).toEqual([
+      { versionString: '2.0.9', buildNumber: null },
+      { versionString: '2.2.0', buildNumber: null },
+    ]);
+  });
+
+  it('yields buildNumber null when the referenced build is missing from included', () => {
+    const out = mapAcceptedVersions({
+      data: [
+        {
+          type: 'appStoreVersions',
+          id: 'v1',
+          attributes: { versionString: '2.1.0', appStoreState: 'READY_FOR_SALE' },
+          relationships: { build: { data: { type: 'builds', id: 'ghost' } } },
+        },
+      ],
+      included: [],
+    });
+    expect(out).toEqual([{ versionString: '2.1.0', buildNumber: null }]);
+  });
+
+  it('drops versions without a usable versionString', () => {
+    const out = mapAcceptedVersions({
+      data: [
+        { type: 'appStoreVersions', id: 'v0', attributes: { versionString: '', appStoreState: 'READY_FOR_SALE' } },
+        { type: 'appStoreVersions', id: 'v1', attributes: { appStoreState: 'READY_FOR_SALE' } },
+        {
+          type: 'appStoreVersions',
+          id: 'v2',
+          attributes: { versionString: '3.0.0', appStoreState: 'READY_FOR_SALE' },
+          relationships: { build: { data: { type: 'builds', id: 'b9' } } },
+        },
+      ],
+      included: [{ type: 'builds', id: 'b9', attributes: { version: '7' } }],
+    });
+    expect(out).toEqual([{ versionString: '3.0.0', buildNumber: 7 }]);
+  });
+});

--- a/scripts/__tests__/mobile-auto-version-bump.test.ts
+++ b/scripts/__tests__/mobile-auto-version-bump.test.ts
@@ -56,6 +56,40 @@ describe('mapAcceptedVersions', () => {
     expect(out).toEqual([{ versionString: '2.1.0', buildNumber: null }]);
   });
 
+  it('ignores non-build included resources (their ids must not shadow build ids)', () => {
+    const out = mapAcceptedVersions({
+      data: [
+        {
+          type: 'appStoreVersions',
+          id: 'v1',
+          attributes: { versionString: '2.1.0', appStoreState: 'READY_FOR_SALE' },
+          relationships: { build: { data: { type: 'builds', id: 'shared-id' } } },
+        },
+      ],
+      // A non-build resource sharing the build's id must not be mapped as a build.
+      included: [
+        { type: 'appStoreVersionSubmissions', id: 'shared-id', attributes: { version: '999' } },
+        { type: 'builds', id: 'shared-id', attributes: { version: '42' } },
+      ],
+    });
+    expect(out).toEqual([{ versionString: '2.1.0', buildNumber: 42 }]);
+  });
+
+  it('treats a non-numeric build version as null', () => {
+    const out = mapAcceptedVersions({
+      data: [
+        {
+          type: 'appStoreVersions',
+          id: 'v1',
+          attributes: { versionString: '2.1.0', appStoreState: 'READY_FOR_SALE' },
+          relationships: { build: { data: { type: 'builds', id: 'b1' } } },
+        },
+      ],
+      included: [{ type: 'builds', id: 'b1', attributes: { version: 'abc' } }],
+    });
+    expect(out).toEqual([{ versionString: '2.1.0', buildNumber: null }]);
+  });
+
   it('drops versions without a usable versionString', () => {
     const out = mapAcceptedVersions({
       data: [

--- a/scripts/__tests__/mobile-cut-release-tags.test.ts
+++ b/scripts/__tests__/mobile-cut-release-tags.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseAcceptedBuilds } from '../mobile-cut-release-tags';
+
+describe('parseAcceptedBuilds', () => {
+  it('parses a JSON array of version/build pairs', () => {
+    expect(
+      parseAcceptedBuilds('[{"versionString":"2.1.0","buildNumber":42},{"versionString":"2.0.9","buildNumber":null}]'),
+    ).toEqual([
+      { versionString: '2.1.0', buildNumber: 42 },
+      { versionString: '2.0.9', buildNumber: null },
+    ]);
+  });
+
+  it('coerces a missing or non-number buildNumber to null', () => {
+    expect(parseAcceptedBuilds('[{"versionString":"3.0.0"},{"versionString":"3.0.1","buildNumber":"7"}]')).toEqual([
+      { versionString: '3.0.0', buildNumber: null },
+      { versionString: '3.0.1', buildNumber: null },
+    ]);
+  });
+
+  it('returns [] for empty, whitespace, or undefined input', () => {
+    expect(parseAcceptedBuilds(undefined)).toEqual([]);
+    expect(parseAcceptedBuilds('')).toEqual([]);
+    expect(parseAcceptedBuilds('   ')).toEqual([]);
+  });
+
+  it('handles the empty-array sentinel', () => {
+    expect(parseAcceptedBuilds('[]')).toEqual([]);
+  });
+
+  it('throws on non-array JSON', () => {
+    expect(() => parseAcceptedBuilds('{"versionString":"2.1.0"}')).toThrow(/must be a JSON array/);
+  });
+
+  it('throws when an entry lacks a versionString', () => {
+    expect(() => parseAcceptedBuilds('[{"buildNumber":42}]')).toThrow(/Bad accepted-build entry/);
+  });
+});

--- a/scripts/__tests__/release-tags.test.ts
+++ b/scripts/__tests__/release-tags.test.ts
@@ -37,7 +37,12 @@ describe('formatBuildTag / parseBuildTag round-trip', () => {
 
   it('handles a large Android versionCode', () => {
     const tag = formatBuildTag('android', '2.1.0', 2_000_042, SHORT);
-    expect(parseBuildTag(tag)).toEqual({ platform: 'android', version: '2.1.0', buildNumber: 2_000_042, shortFp: SHORT });
+    expect(parseBuildTag(tag)).toEqual({
+      platform: 'android',
+      version: '2.1.0',
+      buildNumber: 2_000_042,
+      shortFp: SHORT,
+    });
   });
 
   it('rejects unrelated or malformed tags', () => {
@@ -72,14 +77,20 @@ describe('pickBuildTagForVersion', () => {
     'fingerprint-ios-a1b2c3d4e5f6', // noise
   ];
 
-  it('prefers the exact approved build number when present', () => {
-    expect(pickBuildTagForVersion(tags, 'ios', '2.1.0', 41)).toMatchObject({ buildNumber: 41, shortFp: 'cccccccccccc' });
+  it('returns the exact approved build number when present', () => {
+    expect(pickBuildTagForVersion(tags, 'ios', '2.1.0', 41)).toMatchObject({
+      buildNumber: 41,
+      shortFp: 'cccccccccccc',
+    });
   });
 
-  it('falls back to the highest build number when no preferred / no exact match', () => {
+  it('returns null (never the highest) when a preferred build number has no exact match', () => {
+    // Strict: a wrong-commit anchor is worse than none. The caller warns + skips.
+    expect(pickBuildTagForVersion(tags, 'ios', '2.1.0', 999)).toBeNull();
+  });
+
+  it('falls back to the highest build number only when no preferred is given', () => {
     expect(pickBuildTagForVersion(tags, 'ios', '2.1.0')).toMatchObject({ buildNumber: 42, shortFp: 'bbbbbbbbbbbb' });
-    // preferred build number not present -> highest wins
-    expect(pickBuildTagForVersion(tags, 'ios', '2.1.0', 999)).toMatchObject({ buildNumber: 42 });
   });
 
   it('picks the sibling platform by highest build number', () => {

--- a/scripts/__tests__/release-tags.test.ts
+++ b/scripts/__tests__/release-tags.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  bumpPatch,
+  formatBuildTag,
+  formatReleaseTag,
+  parseBuildTag,
+  parseReleaseTag,
+  pickBuildTagForVersion,
+  shortFingerprint,
+} from '../lib/release-tags';
+
+const FP = 'a1b2c3d4e5f6a7b8'; // 16 hex chars
+const SHORT = 'a1b2c3d4e5f6'; // first 12
+
+describe('shortFingerprint', () => {
+  it('takes the first 12 hex chars', () => {
+    expect(shortFingerprint(FP)).toBe(SHORT);
+  });
+
+  it('lowercases and trims', () => {
+    expect(shortFingerprint(`  ${FP.toUpperCase()}\n`)).toBe(SHORT);
+  });
+
+  it('rejects a too-short or non-hex value', () => {
+    expect(() => shortFingerprint('a1b2c3')).toThrow();
+    expect(() => shortFingerprint('nothexnothex')).toThrow();
+  });
+});
+
+describe('formatBuildTag / parseBuildTag round-trip', () => {
+  it('formats then parses back', () => {
+    const tag = formatBuildTag('ios', '2.1.0', 42, SHORT);
+    expect(tag).toBe('build-ios-v2.1.0-42-a1b2c3d4e5f6');
+    expect(parseBuildTag(tag)).toEqual({ platform: 'ios', version: '2.1.0', buildNumber: 42, shortFp: SHORT });
+  });
+
+  it('handles a large Android versionCode', () => {
+    const tag = formatBuildTag('android', '2.1.0', 2_000_042, SHORT);
+    expect(parseBuildTag(tag)).toEqual({ platform: 'android', version: '2.1.0', buildNumber: 2_000_042, shortFp: SHORT });
+  });
+
+  it('rejects unrelated or malformed tags', () => {
+    expect(parseBuildTag('fingerprint-ios-a1b2c3d4e5f6')).toBeNull();
+    expect(parseBuildTag('build-web-v2.1.0-42-a1b2c3d4e5f6')).toBeNull();
+    expect(parseBuildTag('build-ios-v2.1-42-a1b2c3d4e5f6')).toBeNull(); // not x.y.z
+    expect(parseBuildTag('build-ios-v2.1.0-42-tooshort')).toBeNull();
+  });
+});
+
+describe('formatReleaseTag / parseReleaseTag round-trip', () => {
+  it('formats then parses back', () => {
+    const tag = formatReleaseTag('android', '2.1.0', SHORT);
+    expect(tag).toBe('release/android-v2.1.0-a1b2c3d4e5f6');
+    expect(parseReleaseTag(tag)).toEqual({ platform: 'android', version: '2.1.0', shortFp: SHORT });
+  });
+
+  it('rejects a build tag or arbitrary release branch', () => {
+    expect(parseReleaseTag('build-ios-v2.1.0-42-a1b2c3d4e5f6')).toBeNull();
+    expect(parseReleaseTag('release/some-feature')).toBeNull();
+  });
+});
+
+describe('pickBuildTagForVersion', () => {
+  const tags = [
+    'build-ios-v2.1.0-40-aaaaaaaaaaaa',
+    'build-ios-v2.1.0-42-bbbbbbbbbbbb',
+    'build-ios-v2.1.0-41-cccccccccccc',
+    'build-ios-v2.0.9-99-dddddddddddd',
+    'build-android-v2.1.0-2000041-eeeeeeeeeeee',
+    'build-android-v2.1.0-2000042-ffffffffffff',
+    'fingerprint-ios-a1b2c3d4e5f6', // noise
+  ];
+
+  it('prefers the exact approved build number when present', () => {
+    expect(pickBuildTagForVersion(tags, 'ios', '2.1.0', 41)).toMatchObject({ buildNumber: 41, shortFp: 'cccccccccccc' });
+  });
+
+  it('falls back to the highest build number when no preferred / no exact match', () => {
+    expect(pickBuildTagForVersion(tags, 'ios', '2.1.0')).toMatchObject({ buildNumber: 42, shortFp: 'bbbbbbbbbbbb' });
+    // preferred build number not present -> highest wins
+    expect(pickBuildTagForVersion(tags, 'ios', '2.1.0', 999)).toMatchObject({ buildNumber: 42 });
+  });
+
+  it('picks the sibling platform by highest build number', () => {
+    expect(pickBuildTagForVersion(tags, 'android', '2.1.0')).toMatchObject({
+      buildNumber: 2_000_042,
+      shortFp: 'ffffffffffff',
+    });
+  });
+
+  it('returns null when nothing matches the version', () => {
+    expect(pickBuildTagForVersion(tags, 'ios', '9.9.9')).toBeNull();
+    expect(pickBuildTagForVersion([], 'ios', '2.1.0')).toBeNull();
+  });
+});
+
+describe('bumpPatch', () => {
+  it('increments the patch component', () => {
+    expect(bumpPatch('2.1.0')).toBe('2.1.1');
+    expect(bumpPatch('2.1.9')).toBe('2.1.10');
+    expect(bumpPatch('10.20.30')).toBe('10.20.31');
+  });
+
+  it('rejects non x.y.z', () => {
+    expect(() => bumpPatch('2.1')).toThrow();
+    expect(() => bumpPatch('v2.1.0')).toThrow();
+  });
+});

--- a/scripts/lib/release-tags.ts
+++ b/scripts/lib/release-tags.ts
@@ -30,9 +30,7 @@ export const SHORT_FP_LENGTH = 12;
 
 const VERSION_PATTERN = String.raw`\d+\.\d+\.\d+`;
 const SHORT_FP_PATTERN = `[0-9a-f]{${SHORT_FP_LENGTH}}`;
-const BUILD_TAG_RE = new RegExp(
-  String.raw`^build-(ios|android)-v(${VERSION_PATTERN})-(\d+)-(${SHORT_FP_PATTERN})$`,
-);
+const BUILD_TAG_RE = new RegExp(String.raw`^build-(ios|android)-v(${VERSION_PATTERN})-(\d+)-(${SHORT_FP_PATTERN})$`);
 const RELEASE_TAG_RE = new RegExp(String.raw`^release/(ios|android)-v(${VERSION_PATTERN})-(${SHORT_FP_PATTERN})$`);
 
 export type BuildTag = {
@@ -85,12 +83,21 @@ export function parseReleaseTag(tag: string): ReleaseTag | null {
 
 /**
  * From a list of tag names, pick the build tag that identifies the store binary
- * for (platform, version). When `preferredBuildNumber` is given (the store's
- * approved build number) and an exact match exists, that wins — it's the precise
- * binary the store approved. Otherwise fall back to the highest build number for
- * that version, i.e. the most recent build of it (used for the sibling platform,
- * which the store doesn't report an approved number for). Returns null when no
- * build tag matches — the caller warns and skips that platform's anchor.
+ * for (platform, version).
+ *
+ * When `preferredBuildNumber` is given, the store told us the EXACT approved build
+ * number, so only that build's tag is a correct anchor — this returns the exact
+ * match or `null` (it does NOT fall back to the highest build). Falling back would
+ * anchor a different commit + fingerprint than the approved binary, silently
+ * publishing backports that never reach it; returning null lets the caller warn
+ * and skip, and a later run retries once the exact build tag exists.
+ *
+ * When `preferredBuildNumber` is omitted — the sibling platform, for which the
+ * store reports no approved number (see the Android caveat in
+ * mobile-cut-release-tags.ts) — it best-effort returns the highest build number
+ * for that version, i.e. the most recent build of it.
+ *
+ * Returns `null` when no build tag matches the (platform, version) at all.
  */
 export function pickBuildTagForVersion(
   tags: readonly string[],
@@ -100,13 +107,14 @@ export function pickBuildTagForVersion(
 ): BuildTag | null {
   const candidates = tags
     .map(parseBuildTag)
-    .filter((parsed): parsed is BuildTag => parsed !== null && parsed.platform === platform && parsed.version === version);
+    .filter(
+      (parsed): parsed is BuildTag => parsed !== null && parsed.platform === platform && parsed.version === version,
+    );
 
   if (candidates.length === 0) return null;
 
   if (preferredBuildNumber !== undefined) {
-    const exact = candidates.find((candidate) => candidate.buildNumber === preferredBuildNumber);
-    if (exact) return exact;
+    return candidates.find((candidate) => candidate.buildNumber === preferredBuildNumber) ?? null;
   }
 
   return candidates.reduce((best, candidate) => (candidate.buildNumber > best.buildNumber ? candidate : best));

--- a/scripts/lib/release-tags.ts
+++ b/scripts/lib/release-tags.ts
@@ -1,0 +1,120 @@
+/// <reference types="node" />
+
+/**
+ * Pure helpers for the mobile release-anchoring tag scheme. Two tag families:
+ *
+ *   build-<platform>-v<version>-<buildNumber>-<shortfp>
+ *     Pushed by the native build workflows (ios-testflight-rn.yml /
+ *     android-apk-rn.yml) on a successful store upload. Maps a STORE BUILD NUMBER
+ *     (iOS CFBundleVersion / Android versionCode) back to the exact commit and
+ *     the canonical gate fingerprint the binary embeds. The store only ever tells
+ *     us the *approved build number*, so this tag is the lookup that turns that
+ *     number into a commit + fingerprint.
+ *
+ *   release/<platform>-v<version>-<shortfp>
+ *     Cut by the approval workflow (mobile-auto-version-bump) when App Store
+ *     Connect reports a version accepted. Points at the commit the approved binary
+ *     was built from; the <shortfp> in the name is the fingerprint an OTA must
+ *     resolve to reach that release's installs. This frozen tag is the backport
+ *     anchor: check it out, cherry-pick a JS fix, and publish an OTA under its
+ *     fingerprint. See docs/mobile-ota-updates.md.
+ *
+ * These are string-only, so they unit-test without git or the network.
+ */
+
+export type Platform = 'ios' | 'android';
+
+/** First 12 hex chars of a fingerprint. Long enough to be collision-free across
+ * the handful of releases a repo ever ships, short enough to keep tag names sane. */
+export const SHORT_FP_LENGTH = 12;
+
+const VERSION_PATTERN = String.raw`\d+\.\d+\.\d+`;
+const SHORT_FP_PATTERN = `[0-9a-f]{${SHORT_FP_LENGTH}}`;
+const BUILD_TAG_RE = new RegExp(
+  String.raw`^build-(ios|android)-v(${VERSION_PATTERN})-(\d+)-(${SHORT_FP_PATTERN})$`,
+);
+const RELEASE_TAG_RE = new RegExp(String.raw`^release/(ios|android)-v(${VERSION_PATTERN})-(${SHORT_FP_PATTERN})$`);
+
+export type BuildTag = {
+  platform: Platform;
+  version: string;
+  buildNumber: number;
+  shortFp: string;
+};
+
+export type ReleaseTag = {
+  platform: Platform;
+  version: string;
+  shortFp: string;
+};
+
+/** Truncate a full fingerprint to the tag-name form. Throws on a non-hex or
+ * too-short input so a malformed gate value can't silently produce a bad tag. */
+export function shortFingerprint(fingerprint: string): string {
+  const trimmed = fingerprint.trim().toLowerCase();
+  if (!/^[0-9a-f]+$/.test(trimmed) || trimmed.length < SHORT_FP_LENGTH) {
+    throw new Error(`Not a resolvable fingerprint (need >= ${SHORT_FP_LENGTH} hex chars): ${fingerprint}`);
+  }
+  return trimmed.slice(0, SHORT_FP_LENGTH);
+}
+
+export function formatBuildTag(platform: Platform, version: string, buildNumber: number, shortFp: string): string {
+  return `build-${platform}-v${version}-${buildNumber}-${shortFp}`;
+}
+
+export function formatReleaseTag(platform: Platform, version: string, shortFp: string): string {
+  return `release/${platform}-v${version}-${shortFp}`;
+}
+
+export function parseBuildTag(tag: string): BuildTag | null {
+  const match = BUILD_TAG_RE.exec(tag);
+  if (!match) return null;
+  return {
+    platform: match[1] as Platform,
+    version: match[2],
+    buildNumber: Number.parseInt(match[3], 10),
+    shortFp: match[4],
+  };
+}
+
+export function parseReleaseTag(tag: string): ReleaseTag | null {
+  const match = RELEASE_TAG_RE.exec(tag);
+  if (!match) return null;
+  return { platform: match[1] as Platform, version: match[2], shortFp: match[3] };
+}
+
+/**
+ * From a list of tag names, pick the build tag that identifies the store binary
+ * for (platform, version). When `preferredBuildNumber` is given (the store's
+ * approved build number) and an exact match exists, that wins — it's the precise
+ * binary the store approved. Otherwise fall back to the highest build number for
+ * that version, i.e. the most recent build of it (used for the sibling platform,
+ * which the store doesn't report an approved number for). Returns null when no
+ * build tag matches — the caller warns and skips that platform's anchor.
+ */
+export function pickBuildTagForVersion(
+  tags: readonly string[],
+  platform: Platform,
+  version: string,
+  preferredBuildNumber?: number,
+): BuildTag | null {
+  const candidates = tags
+    .map(parseBuildTag)
+    .filter((parsed): parsed is BuildTag => parsed !== null && parsed.platform === platform && parsed.version === version);
+
+  if (candidates.length === 0) return null;
+
+  if (preferredBuildNumber !== undefined) {
+    const exact = candidates.find((candidate) => candidate.buildNumber === preferredBuildNumber);
+    if (exact) return exact;
+  }
+
+  return candidates.reduce((best, candidate) => (candidate.buildNumber > best.buildNumber ? candidate : best));
+}
+
+/** Bump the patch component of an x.y.z version string. */
+export function bumpPatch(version: string): string {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version.trim());
+  if (!match) throw new Error(`Not an x.y.z version: ${version}`);
+  return `${match[1]}.${match[2]}.${Number.parseInt(match[3], 10) + 1}`;
+}

--- a/scripts/mobile-auto-version-bump.ts
+++ b/scripts/mobile-auto-version-bump.ts
@@ -39,11 +39,29 @@ type AppStoreVersionResource = {
     versionString?: string;
     appStoreState?: string;
   };
+  relationships?: {
+    build?: { data?: { type: 'builds'; id: string } | null };
+  };
+};
+
+type BuildResource = {
+  type: 'builds';
+  id: string;
+  attributes?: { version?: string };
 };
 
 type JsonApiCollectionResponse<T> = {
   data: T[];
+  included?: BuildResource[];
 };
+
+// A version App Store Connect has accepted, plus the build number of the build
+// attached to it (CFBundleVersion). The build number is what the approval
+// workflow matches against the build-ios-v<version>-<buildNumber>-<shortfp> tag
+// to find the exact commit + fingerprint to anchor. null when ASC returned no
+// attached build (the approval step then falls back to the latest build tag for
+// the version).
+type AcceptedVersion = { versionString: string; buildNumber: number | null };
 
 function base64UrlEncode(input: Buffer | string): string {
   return Buffer.from(input).toString('base64url');
@@ -104,19 +122,37 @@ async function resolveAppId(token: string): Promise<string> {
   return app.id;
 }
 
-async function getAcceptedVersionStrings(token: string, appId: string): Promise<string[]> {
+async function getAcceptedVersions(token: string, appId: string): Promise<AcceptedVersion[]> {
   const data = await ascFetch<JsonApiCollectionResponse<AppStoreVersionResource>>(
     `/v1/apps/${appId}/appStoreVersions`,
     token,
     {
       'filter[appStoreState]': ACCEPTED_APP_STORE_STATES,
-      'fields[appStoreVersions]': 'versionString,appStoreState',
+      'fields[appStoreVersions]': 'versionString,appStoreState,build',
+      // Pull the attached build inline so we learn its build number without a
+      // second round-trip per version.
+      include: 'build',
+      'fields[builds]': 'version',
       limit: '10',
     },
   );
+
+  const buildNumberById = new Map<string, number>();
+  for (const included of data.included ?? []) {
+    const rawVersion = included.attributes?.version;
+    const parsed = typeof rawVersion === 'string' ? Number.parseInt(rawVersion, 10) : Number.NaN;
+    if (Number.isFinite(parsed)) buildNumberById.set(included.id, parsed);
+  }
+
   return data.data
-    .map((v) => v.attributes?.versionString)
-    .filter((v): v is string => typeof v === 'string' && v.length > 0);
+    .map((version): AcceptedVersion | null => {
+      const versionString = version.attributes?.versionString;
+      if (typeof versionString !== 'string' || versionString.length === 0) return null;
+      const buildId = version.relationships?.build?.data?.id;
+      const buildNumber = buildId ? (buildNumberById.get(buildId) ?? null) : null;
+      return { versionString, buildNumber };
+    })
+    .filter((version): version is AcceptedVersion => version !== null);
 }
 
 function emitOutput(name: string, value: string): void {
@@ -150,10 +186,23 @@ async function main(): Promise<number> {
     console.log(`Current marketing version: ${currentVersion}`);
 
     const appId = await resolveAppId(token);
-    const accepted = await getAcceptedVersionStrings(token, appId);
-    console.log(`Accepted App Store versions: ${accepted.length > 0 ? accepted.join(', ') : 'none'}`);
+    const accepted = await getAcceptedVersions(token, appId);
+    console.log(
+      `Accepted App Store versions: ${
+        accepted.length > 0
+          ? accepted.map((version) => `${version.versionString} (build ${version.buildNumber ?? '?'})`).join(', ')
+          : 'none'
+      }`,
+    );
 
-    if (!accepted.includes(currentVersion)) {
+    // Emit the accepted (version, build number) pairs so the workflow can cut the
+    // release/<platform>-v<version>-<shortfp> anchor tags — independent of whether
+    // the CURRENT app.config version is among them (an older accepted version may
+    // still need anchoring). One-line JSON so it fits a single GITHUB_OUTPUT value.
+    emitOutput('accepted_builds', JSON.stringify(accepted));
+
+    const acceptedStrings = accepted.map((version) => version.versionString);
+    if (!acceptedStrings.includes(currentVersion)) {
       console.log(`${currentVersion} is not yet in an accepted state — nothing to bump.`);
       emitOutput('bumped', 'false');
       return 0;

--- a/scripts/mobile-auto-version-bump.ts
+++ b/scripts/mobile-auto-version-bump.ts
@@ -44,15 +44,18 @@ type AppStoreVersionResource = {
   };
 };
 
-type BuildResource = {
-  type: 'builds';
+// A side-loaded resource in the JSON:API `included` array. Typed loosely on
+// `type` so the runtime `type === 'builds'` filter below is meaningful — ASC could
+// include other resource types, whose ids must not shadow build ids.
+type IncludedResource = {
+  type: string;
   id: string;
   attributes?: { version?: string };
 };
 
 type JsonApiCollectionResponse<T> = {
   data: T[];
-  included?: BuildResource[];
+  included?: IncludedResource[];
 };
 
 // A version App Store Connect has accepted, plus the build number of the build
@@ -128,6 +131,7 @@ async function resolveAppId(token: string): Promise<string> {
 export function mapAcceptedVersions(data: JsonApiCollectionResponse<AppStoreVersionResource>): AcceptedVersion[] {
   const buildNumberById = new Map<string, number>();
   for (const included of data.included ?? []) {
+    if (included.type !== 'builds') continue;
     const rawVersion = included.attributes?.version;
     const parsed = typeof rawVersion === 'string' ? Number.parseInt(rawVersion, 10) : Number.NaN;
     if (Number.isFinite(parsed)) buildNumberById.set(included.id, parsed);

--- a/scripts/mobile-auto-version-bump.ts
+++ b/scripts/mobile-auto-version-bump.ts
@@ -122,21 +122,10 @@ async function resolveAppId(token: string): Promise<string> {
   return app.id;
 }
 
-async function getAcceptedVersions(token: string, appId: string): Promise<AcceptedVersion[]> {
-  const data = await ascFetch<JsonApiCollectionResponse<AppStoreVersionResource>>(
-    `/v1/apps/${appId}/appStoreVersions`,
-    token,
-    {
-      'filter[appStoreState]': ACCEPTED_APP_STORE_STATES,
-      'fields[appStoreVersions]': 'versionString,appStoreState,build',
-      // Pull the attached build inline so we learn its build number without a
-      // second round-trip per version.
-      include: 'build',
-      'fields[builds]': 'version',
-      limit: '10',
-    },
-  );
-
+// Pure mapping from the ASC appStoreVersions response (with `include=build`) to
+// the accepted (version, build number) pairs. Exported so it can be unit-tested
+// without the network; getAcceptedVersions is the thin fetch wrapper.
+export function mapAcceptedVersions(data: JsonApiCollectionResponse<AppStoreVersionResource>): AcceptedVersion[] {
   const buildNumberById = new Map<string, number>();
   for (const included of data.included ?? []) {
     const rawVersion = included.attributes?.version;
@@ -153,6 +142,24 @@ async function getAcceptedVersions(token: string, appId: string): Promise<Accept
       return { versionString, buildNumber };
     })
     .filter((version): version is AcceptedVersion => version !== null);
+}
+
+async function getAcceptedVersions(token: string, appId: string): Promise<AcceptedVersion[]> {
+  const data = await ascFetch<JsonApiCollectionResponse<AppStoreVersionResource>>(
+    `/v1/apps/${appId}/appStoreVersions`,
+    token,
+    {
+      'filter[appStoreState]': ACCEPTED_APP_STORE_STATES,
+      'fields[appStoreVersions]': 'versionString,appStoreState,build',
+      // Pull the attached build inline so we learn its build number without a
+      // second round-trip per version.
+      include: 'build',
+      'fields[builds]': 'version',
+      limit: '10',
+    },
+  );
+
+  return mapAcceptedVersions(data);
 }
 
 function emitOutput(name: string, value: string): void {

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -40,6 +40,12 @@ const OTA_CHECK = 'mobile-ota-check.yml';
 // fingerprint — including EXPO_UPDATES_CHANNEL=production (the baked header), NOT
 // pr-N (which is only the eoas upload target). Same parity rule as the rest.
 const OTA_PREVIEW = 'mobile-ota-preview.yml';
+// The approved-release backport publish (mobile-ota-backport.yml) resolves the
+// fingerprint of an OLD release and asserts it against the anchor tag before
+// publishing an OTA under it — so its fingerprint-affecting env must match the
+// native builds too, or the assertion diverges from the value the shipped binary
+// actually embeds.
+const OTA_BACKPORT = 'mobile-ota-backport.yml';
 
 // Workflow-level env keys that feed the resolved config (fingerprint) and/or the
 // inlined JS bundle (runtime correctness). Every one must be declared identically
@@ -73,7 +79,7 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
   // The PR-time OTA-compat check + the per-PR preview publish resolve the same
   // fingerprint as the native builds + OTA publish, so they must share the same
   // fingerprint-affecting env.
-  const workflows = [NATIVE_IOS, NATIVE_ANDROID, OTA, OTA_CHECK, OTA_PREVIEW];
+  const workflows = [NATIVE_IOS, NATIVE_ANDROID, OTA, OTA_CHECK, OTA_PREVIEW, OTA_BACKPORT];
 
   it.each(SHARED_ENV_KEYS)('declares %s identically across all mobile fingerprint workflows', (key) => {
     const values = workflows.map((name) => ({ name, value: workflowEnvValue(readWorkflow(name), key) }));

--- a/scripts/mobile-cut-release-tags.ts
+++ b/scripts/mobile-cut-release-tags.ts
@@ -1,0 +1,142 @@
+/// <reference types="node" />
+
+/**
+ * Cuts the release/<platform>-v<version>-<shortfp> anchor tags for App Store
+ * versions that have been accepted by Apple. Driven by mobile-auto-version-bump.yml
+ * after scripts/mobile-auto-version-bump.ts reports the accepted (version, build
+ * number) pairs.
+ *
+ * For each accepted version it locates the build-<platform>-v<version>-<buildNumber>-<shortfp>
+ * tag the native build workflow pushed (iOS by the store's approved build number,
+ * Android by the latest build of the same marketing version — the app ships both
+ * platforms at one version, and Google Play doesn't report an approved build
+ * number here), then creates release/<platform>-v<version>-<shortfp> at that
+ * commit. The tag is the frozen backport anchor: its <shortfp> records the
+ * fingerprint an OTA must resolve to reach that release's installs. Idempotent —
+ * an anchor that already exists on the remote is left untouched, so re-runs and
+ * the second platform's approval are safe.
+ *
+ * Input: ACCEPTED_BUILDS env = JSON array of { versionString, buildNumber }.
+ * DRY_RUN=true logs what it would cut without creating or pushing tags.
+ *
+ * Usage: bun scripts/mobile-cut-release-tags.ts
+ */
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { formatBuildTag, formatReleaseTag, pickBuildTagForVersion, type Platform } from './lib/release-tags';
+
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PLATFORMS: readonly Platform[] = ['ios', 'android'];
+
+type AcceptedVersion = { versionString: string; buildNumber: number | null };
+
+function git(args: string[], options: { allowFail?: boolean } = {}): string {
+  try {
+    return execFileSync('git', args, {
+      cwd: ROOT_DIR,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', options.allowFail ? 'ignore' : 'inherit'],
+    }).trim();
+  } catch (error) {
+    if (options.allowFail) return '';
+    throw error;
+  }
+}
+
+function remoteTagExists(tag: string): boolean {
+  // Non-zero exit (no such tag) is expected, so swallow stderr and treat empty as absent.
+  return git(['ls-remote', '--tags', 'origin', `refs/tags/${tag}`], { allowFail: true }).length > 0;
+}
+
+function emitOutput(name: string, value: string): void {
+  const githubOutput = process.env['GITHUB_OUTPUT'];
+  if (githubOutput) appendFileSync(githubOutput, `${name}=${value}\n`);
+  console.log(`output: ${name}=${value}`);
+}
+
+function parseAcceptedBuilds(raw: string | undefined): AcceptedVersion[] {
+  if (!raw || raw.trim().length === 0) return [];
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error('ACCEPTED_BUILDS must be a JSON array');
+  return parsed.map((entry) => {
+    const record = entry as Record<string, unknown>;
+    const versionString = record.versionString;
+    if (typeof versionString !== 'string') throw new Error(`Bad accepted-build entry: ${JSON.stringify(entry)}`);
+    const buildNumber = typeof record.buildNumber === 'number' ? record.buildNumber : null;
+    return { versionString, buildNumber };
+  });
+}
+
+function main(): number {
+  const dryRun = process.env['DRY_RUN'] === 'true';
+  const accepted = parseAcceptedBuilds(process.env['ACCEPTED_BUILDS']);
+
+  if (accepted.length === 0) {
+    console.log('No accepted versions reported — nothing to anchor.');
+    emitOutput('cut_count', '0');
+    return 0;
+  }
+
+  // Refresh tags so the build-* lookups and existence checks see the latest state.
+  git(['fetch', 'origin', '--tags', '--force'], { allowFail: true });
+  const allTags = git(['tag', '--list']).split('\n').filter(Boolean);
+
+  const cut: string[] = [];
+
+  for (const { versionString, buildNumber } of accepted) {
+    for (const platform of PLATFORMS) {
+      // iOS: prefer the store's approved build number. Android: no approved number
+      // is available here, so take the latest build of this marketing version.
+      const preferredBuildNumber = platform === 'ios' ? (buildNumber ?? undefined) : undefined;
+      const buildTag = pickBuildTagForVersion(allTags, platform, versionString, preferredBuildNumber);
+      if (!buildTag) {
+        console.log(`No build-${platform}-v${versionString}-* tag found — skipping ${platform} anchor for ${versionString}.`);
+        continue;
+      }
+
+      const releaseTag = formatReleaseTag(platform, versionString, buildTag.shortFp);
+      if (remoteTagExists(releaseTag)) {
+        console.log(`${releaseTag} already exists — nothing to anchor.`);
+        continue;
+      }
+
+      const buildTagName = formatBuildTag(platform, versionString, buildTag.buildNumber, buildTag.shortFp);
+      const commit = git(['rev-list', '-n', '1', buildTagName]);
+      if (!commit) {
+        console.log(`::warning::Could not resolve a commit for ${buildTagName} — skipping ${releaseTag}.`);
+        continue;
+      }
+
+      if (dryRun) {
+        console.log(`[dry-run] would cut ${releaseTag} at ${commit.slice(0, 12)} (from ${buildTagName}).`);
+        cut.push(releaseTag);
+        continue;
+      }
+
+      git(['tag', releaseTag, commit], { allowFail: true }); // no-op if it already exists locally
+      try {
+        git(['push', 'origin', `refs/tags/${releaseTag}`]);
+      } catch (error) {
+        // A concurrent run may have pushed it between the check and here.
+        if (!remoteTagExists(releaseTag)) throw error;
+      }
+      console.log(`::notice::Cut ${releaseTag} at ${commit.slice(0, 12)} — backport anchor for ${platform} ${versionString}.`);
+      cut.push(releaseTag);
+    }
+  }
+
+  emitOutput('cut_count', String(cut.length));
+  emitOutput('cut_tags', cut.join(','));
+  return 0;
+}
+
+try {
+  process.exit(main());
+} catch (error) {
+  console.error(`[mobile-cut-release-tags] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/scripts/mobile-cut-release-tags.ts
+++ b/scripts/mobile-cut-release-tags.ts
@@ -25,7 +25,7 @@
 import { execFileSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { formatBuildTag, formatReleaseTag, pickBuildTagForVersion, type Platform } from './lib/release-tags';
 
@@ -58,7 +58,7 @@ function emitOutput(name: string, value: string): void {
   console.log(`output: ${name}=${value}`);
 }
 
-function parseAcceptedBuilds(raw: string | undefined): AcceptedVersion[] {
+export function parseAcceptedBuilds(raw: string | undefined): AcceptedVersion[] {
   if (!raw || raw.trim().length === 0) return [];
   const parsed: unknown = JSON.parse(raw);
   if (!Array.isArray(parsed)) throw new Error('ACCEPTED_BUILDS must be a JSON array');
@@ -146,9 +146,12 @@ function main(): number {
   return 0;
 }
 
-try {
-  process.exit(main());
-} catch (error) {
-  console.error(`[mobile-cut-release-tags] ${error instanceof Error ? error.message : String(error)}`);
-  process.exit(1);
+// Only run when invoked directly (not when imported by a test).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.exit(main());
+  } catch (error) {
+    console.error(`[mobile-cut-release-tags] ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
 }

--- a/scripts/mobile-cut-release-tags.ts
+++ b/scripts/mobile-cut-release-tags.ts
@@ -89,12 +89,22 @@ function main(): number {
 
   for (const { versionString, buildNumber } of accepted) {
     for (const platform of PLATFORMS) {
-      // iOS: prefer the store's approved build number. Android: no approved number
-      // is available here, so take the latest build of this marketing version.
+      // iOS: the store reports the EXACT approved build number, so anchor that build
+      // (pickBuildTagForVersion is strict — it won't fall back to another build).
+      // Android CAVEAT: approval is detected from App Store Connect only; there is no
+      // Google Play query here. We assume the app ships both platforms at one
+      // marketing version and take the latest Android build of that version. If
+      // Android hasn't actually shipped that version to the store, its anchor is
+      // premature — but a backport under it just reaches whatever installs hold that
+      // fingerprint (and the backport re-verifies the fingerprint before publishing),
+      // so it's ineffective rather than wrong. Verify the Android release actually
+      // shipped before relying on an Android backport. See docs/mobile-ota-updates.md.
       const preferredBuildNumber = platform === 'ios' ? (buildNumber ?? undefined) : undefined;
       const buildTag = pickBuildTagForVersion(allTags, platform, versionString, preferredBuildNumber);
       if (!buildTag) {
-        console.log(`No build-${platform}-v${versionString}-* tag found — skipping ${platform} anchor for ${versionString}.`);
+        console.log(
+          `No build-${platform}-v${versionString}-* tag found — skipping ${platform} anchor for ${versionString}.`,
+        );
         continue;
       }
 
@@ -124,7 +134,9 @@ function main(): number {
         // A concurrent run may have pushed it between the check and here.
         if (!remoteTagExists(releaseTag)) throw error;
       }
-      console.log(`::notice::Cut ${releaseTag} at ${commit.slice(0, 12)} — backport anchor for ${platform} ${versionString}.`);
+      console.log(
+        `::notice::Cut ${releaseTag} at ${commit.slice(0, 12)} — backport anchor for ${platform} ${versionString}.`,
+      );
       cut.push(releaseTag);
     }
   }


### PR DESCRIPTION
## Summary

Lets a JS-only fix reach an **already-approved** store binary over the air. Because `runtimeVersion` uses the `fingerprint` policy, an OTA published from `main` only reaches installs whose fingerprint still matches; once native churn moves it, older releases are OTA-orphaned (issue #3098). This records each approved release's fingerprint in a git tag and adds a workflow to publish backport OTAs under it.

**Model — anchored on App Store approval, not on merge.** `main` iterates through many fingerprints between releases; we only anchor the ones that actually shipped and were approved (an approved binary is frozen forever). The marketing `version` *is* part of the fingerprint, so bumping it moves the fingerprint — which is fine, because we never rely on an intermediate fingerprint staying OTA-compatible.

What's in the change:

- **Build-time tags** — `ios-testflight-rn.yml` / `android-apk-rn.yml` push `build-<platform>-v<version>-<buildNumber>-<shortfp>` on a successful store upload, mapping a store build number → commit + canonical gate fingerprint (`<shortfp>` = first 12 hex chars).
- **Approval anchoring** — `mobile-auto-version-bump.yml` (now scheduled every 6h, renamed "Mobile Release Anchor & Version Bump"): `scripts/mobile-auto-version-bump.ts` reports each accepted version + its attached build number; `scripts/mobile-cut-release-tags.ts` (+ `scripts/lib/release-tags.ts`) cuts `release/<platform>-v<version>-<shortfp>` at the approved commit (idempotent), then it bumps the marketing patch version. The old "schedule disabled because a bump busts the fingerprint" rationale no longer applies under this model.
- **Backport OTA** — `mobile-ota-backport.yml` (`workflow_dispatch`): checks out the anchor, cherry-picks the fix commit(s), **asserts the resolved fingerprint's 12-char prefix equals the anchor's `<shortfp>`** (aborts on drift — the cherry-pick touched native, so an OTA would never land), then `eoas publish --channel production` under that fingerprint. Shares the `mobile-ota-production` concurrency lane.
- **Draft store submissions** — Fastlane `ios`/`android draft_submission` lanes + `mobile-store-draft.yml`, best-effort and **off by default** behind the `ENABLE_STORE_DRAFT_SUBMISSION` repo variable (they mutate live store state). Never auto-submit for review.
- Adds `release-tags` unit tests and locks the backport workflow into the mobile CI env-parity check. Runbook in `docs/mobile-ota-updates.md`.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

`bun install` is proxy-throttled in the dev sandbox, so the full `vp` suite runs in CI. Validated offline:

- Pure tag logic (`scripts/lib/release-tags.ts`) — 21 assertions pass (format/parse round-trips, `pickBuildTagForVersion` exact-vs-highest, `shortFingerprint` guards).
- ASC `include=build` → build-number mapping logic against a mock payload (attached / null / missing-relationship cases).
- All new/changed TS transpiles; `fastlane/Fastfile` `ruby -c` OK; all workflow YAML parses.
- Backport workflow's shared fingerprint env byte-matches `mobile-ota-production.yml` (added to `mobile-ci-env-parity.test.ts`).
- Every referenced step id (`build_number`, `version_code`, `build_aab`, `github_release`, `testflight_upload`) exists in the build workflows.

CI runs `vp check` / `vp run typecheck` / `vp test` (incl. the new `release-tags` test + the env-parity test). End-to-end store paths (ASC approval detection, anchor cut, backport publish, draft lanes) exercise on real credentials/schedule after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8RE71Mvc4jLmcPT9bg5sr

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8RE71Mvc4jLmcPT9bg5sr)_