### PR TITLE
fix(backend): revoke gym-admin board edit rights for soft-deleted gyms

### DIFF
--- a/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
+++ b/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
@@ -67,12 +67,23 @@ const insertBoard = async (opts: {
   gymId?: number | null;
   boardType?: string;
   name?: string;
+  isPublic?: boolean;
 }): Promise<number> => {
-  const { uuid, ownerId, layoutId, sizeId, setIds, gymId = null, boardType = 'kilter', name = 'Board' } = opts;
+  const {
+    uuid,
+    ownerId,
+    layoutId,
+    sizeId,
+    setIds,
+    gymId = null,
+    boardType = 'kilter',
+    name = 'Board',
+    isPublic = true,
+  } = opts;
   const result = await db.execute(sql`
     INSERT INTO user_boards
       (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, gym_id, is_public, created_at, updated_at)
-    VALUES (${uuid}, ${uuid}, ${ownerId}, ${boardType}, ${layoutId}, ${sizeId}, ${setIds}, ${name}, ${gymId}, true, now(), now())
+    VALUES (${uuid}, ${uuid}, ${ownerId}, ${boardType}, ${layoutId}, ${sizeId}, ${setIds}, ${name}, ${gymId}, ${isPublic}, now(), now())
     RETURNING id
   `);
   return Number(Array.from(result as Iterable<{ id: number }>)[0].id);
@@ -541,11 +552,16 @@ describe('gym admin member can edit a PRIVATE board linked to their gym', () => 
 
   beforeEach(async () => {
     privateGymBoardUuid = uuidv4();
-    await db.execute(sql`
-      INSERT INTO user_boards
-        (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, gym_id, is_public, created_at, updated_at)
-      VALUES (${privateGymBoardUuid}, ${privateGymBoardUuid}, ${SYS_OWNER}, 'kilter', 7, 7, '7,8', 'Private gym wall', ${kilterGymId}, false, now(), now())
-    `);
+    await insertBoard({
+      uuid: privateGymBoardUuid,
+      ownerId: SYS_OWNER,
+      layoutId: 7,
+      sizeId: 7,
+      setIds: '7,8',
+      gymId: kilterGymId,
+      name: 'Private gym wall',
+      isPublic: false,
+    });
   });
 
   it('lets the gym admin member update the private linked board', async () => {

--- a/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
+++ b/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
@@ -506,6 +506,65 @@ describe('gym membership management excludes community moderators (escalation gu
   });
 });
 
+describe('gym admin edit access is revoked when the linked gym is soft-deleted', () => {
+  // The board keeps its gym_id, but the gym is soft-deleted. A gym admin member
+  // should lose the linked-gym edit path — a removed gym must not keep granting
+  // edit rights on the boards that still point at it.
+  beforeEach(async () => {
+    await db.execute(sql`UPDATE gyms SET deleted_at = now() WHERE id = ${kilterGymId}`);
+  });
+
+  it('rejects a gym admin member updating a board linked to the deleted gym', async () => {
+    await expect(
+      socialBoardMutations.updateBoard(
+        null,
+        { input: { boardUuid: kilterBoardUuid, name: 'deleted-gym edit' } },
+        authCtx(GYM_ADMIN_MEMBER),
+      ),
+    ).rejects.toThrow(/Not authorized to update this board/);
+
+    expect((await boardConfig(kilterBoardUuid)).name).toBe('Bonsist Wall');
+  });
+
+  it('reports canEdit=false for a gym admin member of the deleted gym', async () => {
+    const board = await socialBoardQueries.board(null, { boardUuid: kilterBoardUuid }, authCtx(GYM_ADMIN_MEMBER));
+    expect(board?.canEdit).toBe(false);
+  });
+});
+
+describe('gym admin member can edit a PRIVATE board linked to their gym', () => {
+  // Linking a board to a gym requires the board's own owner (linkBoardToGym),
+  // so this is opt-in: the owner deliberately connected their private board to
+  // the gym, and gym admins manage the gym's physical boards. Unlike a community
+  // role, the linked-gym path intentionally reaches private boards.
+  let privateGymBoardUuid: string;
+
+  beforeEach(async () => {
+    privateGymBoardUuid = uuidv4();
+    await db.execute(sql`
+      INSERT INTO user_boards
+        (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, gym_id, is_public, created_at, updated_at)
+      VALUES (${privateGymBoardUuid}, ${privateGymBoardUuid}, ${SYS_OWNER}, 'kilter', 7, 7, '7,8', 'Private gym wall', ${kilterGymId}, false, now(), now())
+    `);
+  });
+
+  it('lets the gym admin member update the private linked board', async () => {
+    const result = await socialBoardMutations.updateBoard(
+      null,
+      { input: { boardUuid: privateGymBoardUuid, name: 'Gym-admin private edit' } },
+      authCtx(GYM_ADMIN_MEMBER),
+    );
+
+    expect(result.name).toBe('Gym-admin private edit');
+    expect((await boardConfig(privateGymBoardUuid)).name).toBe('Gym-admin private edit');
+  });
+
+  it('reports canEdit=true for the gym admin member on the private linked board', async () => {
+    const board = await socialBoardQueries.board(null, { boardUuid: privateGymBoardUuid }, authCtx(GYM_ADMIN_MEMBER));
+    expect(board?.canEdit).toBe(true);
+  });
+});
+
 describe('community roles reach public/catalog boards only, not private ones', () => {
   let privateBoardUuid: string;
 

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -130,11 +130,13 @@ async function viewerCanAdminGym(gymId: number, userId: string): Promise<boolean
   const [adminMembership] = await db
     .select({ role: dbSchema.gymMembers.role })
     .from(dbSchema.gymMembers)
+    .innerJoin(dbSchema.gyms, eq(dbSchema.gyms.id, dbSchema.gymMembers.gymId))
     .where(
       and(
         eq(dbSchema.gymMembers.gymId, gymId),
         eq(dbSchema.gymMembers.userId, userId),
         eq(dbSchema.gymMembers.role, 'admin'),
+        isNull(dbSchema.gyms.deletedAt),
       ),
     )
     .limit(1);
@@ -425,11 +427,13 @@ async function enrichBoards(
         ? db
             .select({ gymId: dbSchema.gymMembers.gymId })
             .from(dbSchema.gymMembers)
+            .innerJoin(dbSchema.gyms, eq(dbSchema.gyms.id, dbSchema.gymMembers.gymId))
             .where(
               and(
                 inArray(dbSchema.gymMembers.gymId, gymIds),
                 eq(dbSchema.gymMembers.userId, authenticatedUserId),
                 eq(dbSchema.gymMembers.role, 'admin'),
+                isNull(dbSchema.gyms.deletedAt),
               ),
             )
         : Promise.resolve([]),


### PR DESCRIPTION
## Summary

`viewerCanAdminGym` (`packages/backend/src/graphql/resolvers/social/boards.ts`) gates its **owner** branch on `isNull(gyms.deletedAt)`, but the **admin-member** branch queried `gym_members` with no join to `gyms` — so an admin member of a *soft-deleted* gym kept edit rights on any board that still carries that gym's `gym_id`. The batch `adminGymRows` query inside `enrichBoards` had the same gap, which fed the `canEdit` flag returned to clients.

This joins `gyms` and adds `isNull(gyms.deletedAt)` to both the single-board and batch admin-membership queries, bringing them into parity with the owner branch (and with `ownedGymRows`, which already filtered deleted gyms).

A second review item flagged a missing test rather than a bug: a gym admin editing a *private* board linked to their gym is intended behaviour (linking requires the board's own owner via `linkBoardToGym`, so it's opt-in — distinct from the public/catalog-only community-role path). This adds a test locking that in.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:backend` — passes.
- `vp test run --project backend board-gym-edit-authorization --reporter=agent` — 43 passed, including 4 new cases:
  - gym admin member of a soft-deleted gym is rejected by `updateBoard`
  - `board(...).canEdit` is `false` for that member (exercises the batch `adminGymRows` path)
  - gym admin member can still `updateBoard` a private board linked to their gym
  - `board(...).canEdit` is `true` for that member on the private linked board
- `vp check` on the two changed files — clean (lint + format).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PhdFsJ1haEprNDKJwBhJYa)_