### PR TITLE
feat(mobile): classify BLE disconnects and tag them with the board id

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/disconnect-category.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/disconnect-category.test.ts
@@ -45,6 +45,9 @@ describe('classifyBleDisconnect', () => {
     expect(classifyBleDisconnect({ source: 'native-ios', iosErrorCode: 7, errorDomain: 'CBATTErrorDomain' })).toBe(
       'unknown',
     );
+    // The native adapter always carries a domain; a domain-less native-ios code
+    // is off-contract and must not be trusted.
+    expect(classifyBleDisconnect({ source: 'native-ios', iosErrorCode: 7 })).toBe('unknown');
   });
 
   it('classifies ble-plx iOS codes without a domain', () => {

--- a/packages/mobile/src/lib/ble/__tests__/disconnect-category.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/disconnect-category.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { classifyBleDisconnect } from '../disconnect-category';
+
+describe('classifyBleDisconnect', () => {
+  it('returns unknown when no info was captured', () => {
+    expect(classifyBleDisconnect(undefined)).toBe('unknown');
+    expect(classifyBleDisconnect(null)).toBe('unknown');
+    expect(classifyBleDisconnect({ source: 'native-ios' })).toBe('unknown');
+  });
+
+  it('gives the write-failure drop path its own bucket', () => {
+    expect(classifyBleDisconnect({ source: 'write-failure' })).toBe('write_failure');
+  });
+
+  it('maps the write-stall recovery contexts to app_recovery', () => {
+    expect(classifyBleDisconnect({ source: 'native-ios', context: 'write_stall_recovery_failed' })).toBe(
+      'app_recovery',
+    );
+    expect(classifyBleDisconnect({ source: 'native-ios', context: 'write_stall_budget_exhausted' })).toBe(
+      'app_recovery',
+    );
+    expect(classifyBleDisconnect({ source: 'native-ios', context: 'write_stall_recovery_timeout' })).toBe(
+      'app_recovery',
+    );
+  });
+
+  it('maps the central-state marker to bluetooth_off', () => {
+    expect(classifyBleDisconnect({ source: 'native-ios', context: 'bluetooth_unavailable' })).toBe('bluetooth_off');
+  });
+
+  it('leaves an unrecognised context unknown rather than guessing', () => {
+    expect(classifyBleDisconnect({ source: 'native-ios', context: 'some_future_marker' })).toBe('unknown');
+  });
+
+  it('classifies CoreBluetooth codes from the native adapter (domain-gated)', () => {
+    // CBError 7 peripheralDisconnected — the takeover signature.
+    expect(classifyBleDisconnect({ source: 'native-ios', iosErrorCode: 7, errorDomain: 'CBErrorDomain' })).toBe(
+      'peer_terminated',
+    );
+    // CBError 6 connectionTimeout — range/idle drop.
+    expect(classifyBleDisconnect({ source: 'native-ios', iosErrorCode: 6, errorDomain: 'CBErrorDomain' })).toBe(
+      'link_timeout',
+    );
+    // Same numeric code in CBATTErrorDomain means something else entirely.
+    expect(classifyBleDisconnect({ source: 'native-ios', iosErrorCode: 7, errorDomain: 'CBATTErrorDomain' })).toBe(
+      'unknown',
+    );
+  });
+
+  it('classifies ble-plx iOS codes without a domain', () => {
+    expect(classifyBleDisconnect({ source: 'ble-plx', iosErrorCode: 7, bleErrorCode: 205 })).toBe('peer_terminated');
+    expect(classifyBleDisconnect({ source: 'ble-plx', iosErrorCode: 6 })).toBe('link_timeout');
+  });
+
+  it('classifies Android GATT status codes', () => {
+    // 19 = 0x13 remote user terminated — the takeover signature on Android.
+    expect(classifyBleDisconnect({ source: 'ble-plx', androidErrorCode: 19 })).toBe('peer_terminated');
+    // 8 = 0x08 connection (supervision) timeout.
+    expect(classifyBleDisconnect({ source: 'ble-plx', androidErrorCode: 8 })).toBe('link_timeout');
+    // Unmapped status stays unknown.
+    expect(classifyBleDisconnect({ source: 'ble-plx', androidErrorCode: 22 })).toBe('unknown');
+  });
+});

--- a/packages/mobile/src/lib/ble/disconnect-category.ts
+++ b/packages/mobile/src/lib/ble/disconnect-category.ts
@@ -51,10 +51,12 @@ export function classifyBleDisconnect(info: BleDisconnectInfo | null | undefined
     return 'unknown';
   }
 
-  // iOS: only trust the code when it's a CBError. The native adapter reports
-  // the NSError domain (CBATTErrorDomain codes overlap numerically and mean
-  // different things); ble-plx pre-splits into iosErrorCode without a domain.
-  const iosCodeIsCbError = info.errorDomain === undefined || info.errorDomain === 'CBErrorDomain';
+  // iOS: only trust the code when it's a CBError. The native adapter always
+  // reports the NSError domain (CBATTErrorDomain codes overlap numerically and
+  // mean different things), so a domain-less code is trusted only from ble-plx,
+  // which pre-splits into iosErrorCode and never carries a domain.
+  const iosCodeIsCbError =
+    info.errorDomain === 'CBErrorDomain' || (info.errorDomain === undefined && info.source === 'ble-plx');
   if (info.iosErrorCode !== undefined && iosCodeIsCbError) {
     if (info.iosErrorCode === CB_ERROR_PERIPHERAL_DISCONNECTED) return 'peer_terminated';
     if (info.iosErrorCode === CB_ERROR_CONNECTION_TIMEOUT) return 'link_timeout';

--- a/packages/mobile/src/lib/ble/disconnect-category.ts
+++ b/packages/mobile/src/lib/ble/disconnect-category.ts
@@ -1,0 +1,69 @@
+import type { BleDisconnectInfo } from './types';
+
+// Human-meaningful bucket for an unsolicited BLE drop, derived from the raw
+// platform codes in BleDisconnectInfo so PostHog queries don't need per-OS
+// lookup tables. Buckets describe what the radio observed, not intent:
+// - peer_terminated: the board closed the link. On last-connection-wins boards
+//   this is the takeover signature (another phone grabbed the wall), but it's
+//   also what a board power-off looks like — pair with a same-board connect
+//   from another user to confirm a takeover.
+// - link_timeout: supervision timeout — out of range, RF loss, or the board
+//   lost power mid-link without a clean teardown.
+// - app_recovery: we dropped the link ourselves (write-stall recovery, #3181).
+// - bluetooth_off: the phone's Bluetooth radio left poweredOn.
+// - write_failure: a write flushed out an already-dead link the adapter never
+//   reported (frequently a takeover on shared boards, but unproven).
+// - unknown: platform reported nothing, or a code we don't map.
+export type BleDisconnectCategory =
+  | 'peer_terminated'
+  | 'link_timeout'
+  | 'app_recovery'
+  | 'bluetooth_off'
+  | 'write_failure'
+  | 'unknown';
+
+// CoreBluetooth CBError.Code values (CBErrorDomain). Only the two codes whose
+// meaning is unambiguous for a mid-session drop are mapped; everything else
+// stays 'unknown' rather than guessing.
+const CB_ERROR_CONNECTION_TIMEOUT = 6;
+const CB_ERROR_PERIPHERAL_DISCONNECTED = 7;
+
+// Android GATT status codes (BLE spec HCI error codes, ble-plx androidErrorCode).
+const GATT_CONN_TIMEOUT = 8; // 0x08 connection timeout
+const GATT_REMOTE_USER_TERMINATED = 19; // 0x13 remote device terminated the connection
+
+// The Swift write-stall recovery paths tag app-driven drops with these markers
+// (BoardBleManager.swift); bluetooth_unavailable is the central-state marker.
+const APP_RECOVERY_CONTEXTS = new Set([
+  'write_stall_recovery_failed',
+  'write_stall_budget_exhausted',
+  'write_stall_recovery_timeout',
+]);
+
+export function classifyBleDisconnect(info: BleDisconnectInfo | null | undefined): BleDisconnectCategory {
+  if (!info) return 'unknown';
+
+  if (info.source === 'write-failure') return 'write_failure';
+
+  if (info.context) {
+    if (APP_RECOVERY_CONTEXTS.has(info.context)) return 'app_recovery';
+    if (info.context === 'bluetooth_unavailable') return 'bluetooth_off';
+    return 'unknown';
+  }
+
+  // iOS: only trust the code when it's a CBError. The native adapter reports
+  // the NSError domain (CBATTErrorDomain codes overlap numerically and mean
+  // different things); ble-plx pre-splits into iosErrorCode without a domain.
+  const iosCodeIsCbError = info.errorDomain === undefined || info.errorDomain === 'CBErrorDomain';
+  if (info.iosErrorCode !== undefined && iosCodeIsCbError) {
+    if (info.iosErrorCode === CB_ERROR_PERIPHERAL_DISCONNECTED) return 'peer_terminated';
+    if (info.iosErrorCode === CB_ERROR_CONNECTION_TIMEOUT) return 'link_timeout';
+  }
+
+  if (info.androidErrorCode !== undefined) {
+    if (info.androidErrorCode === GATT_REMOTE_USER_TERMINATED) return 'peer_terminated';
+    if (info.androidErrorCode === GATT_CONN_TIMEOUT) return 'link_timeout';
+  }
+
+  return 'unknown';
+}

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -816,6 +816,10 @@ describe('BluetoothProvider wall-confirm integration', () => {
         'Bluetooth Disconnected',
         expect.objectContaining({ reason: 'user', boardId: 99 }),
       );
+      // Deliberate disconnects have nothing to classify — the category is an
+      // unexpected-drop-only field, so queries read its absence as "user chose".
+      const userDisconnectCall = analytics.track.mock.calls.find(([event]) => event === 'Bluetooth Disconnected');
+      expect(userDisconnectCall?.[1].disconnectCategory).toBeUndefined();
     });
 
     it('shows the Undo snackbar once after an armed control gain reports a wall change', async () => {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -692,6 +692,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
     it('attaches the captured disconnect reason to the unexpected-drop analytics event', async () => {
       // Start connected so the next transition reads as a real drop, not the
       // initial mount.
+      presence.boardId = 99;
       bluetooth.state.isConnected = true;
       bluetooth.state.lastDisconnectInfoRef.current = null;
 
@@ -722,10 +723,12 @@ describe('BluetoothProvider wall-confirm integration', () => {
           'Bluetooth Disconnected',
           expect.objectContaining({
             reason: 'unexpected',
+            boardId: 99,
             disconnectSource: 'native-ios',
             disconnectIosCode: 7,
             disconnectErrorDomain: 'CBErrorDomain',
             disconnectReason: 'The specified device has disconnected from us.',
+            disconnectCategory: 'peer_terminated',
           }),
         );
       });
@@ -755,7 +758,11 @@ describe('BluetoothProvider wall-confirm integration', () => {
       await waitFor(() => {
         expect(analytics.track).toHaveBeenCalledWith(
           'Bluetooth Disconnected',
-          expect.objectContaining({ reason: 'unexpected', disconnectSource: 'write-failure' }),
+          expect.objectContaining({
+            reason: 'unexpected',
+            disconnectSource: 'write-failure',
+            disconnectCategory: 'write_failure',
+          }),
         );
       });
     });
@@ -789,6 +796,9 @@ describe('BluetoothProvider wall-confirm integration', () => {
       const disconnectCall = analytics.track.mock.calls.find(([event]) => event === 'Bluetooth Disconnected');
       expect(disconnectCall?.[1].disconnectSource).toBeUndefined();
       expect(disconnectCall?.[1].disconnectIosCode).toBeUndefined();
+      // The category is always present on unexpected drops — an unclassifiable
+      // one reads 'unknown' so its share stays measurable in PostHog.
+      expect(disconnectCall?.[1].disconnectCategory).toBe('unknown');
     });
 
     it('shows the Undo snackbar once after an armed control gain reports a wall change', async () => {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -801,6 +801,23 @@ describe('BluetoothProvider wall-confirm integration', () => {
       expect(disconnectCall?.[1].disconnectCategory).toBe('unknown');
     });
 
+    it('tags a user-initiated disconnect with the resolved board id', async () => {
+      presence.boardId = 99;
+      bluetooth.state.isConnected = true;
+
+      renderProvider(createElement(BluetoothProbe));
+      analytics.track.mockClear();
+
+      await act(async () => {
+        await capturedBluetooth?.disconnect();
+      });
+
+      expect(analytics.track).toHaveBeenCalledWith(
+        'Bluetooth Disconnected',
+        expect.objectContaining({ reason: 'user', boardId: 99 }),
+      );
+    });
+
     it('shows the Undo snackbar once after an armed control gain reports a wall change', async () => {
       presence.enabled = true;
       presence.boardId = 99;

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -11,6 +11,7 @@ import type { BoardPresenceClimb, ClimbQueueItemInput } from '@boardsesh/shared-
 import { emitWallConfirm } from '@boardsesh/play-view';
 import { useBoardBluetooth, boardConfigKey, type SendFramesToBoard } from '../lib/ble/use-board-bluetooth';
 import { useResolvedBleDeviceBoards } from '../lib/ble/resolve-serials';
+import { classifyBleDisconnect } from '../lib/ble/disconnect-category';
 import {
   decideBlePickerSelection,
   classifyClimbBoardCompatibility,
@@ -1108,7 +1109,12 @@ export function BluetoothProvider({
     releaseBoardHolder();
     connectedViaMismatchOverrideRef.current = false;
     isUserDisconnectRef.current = true;
-    track(SHARED_EVENTS.BluetoothDisconnected, { boardName, reason: 'user', inSession: sessionIdRef.current != null });
+    track(SHARED_EVENTS.BluetoothDisconnected, {
+      boardName,
+      boardId: resolvedPresenceBoardIdRef.current ?? presenceBoardIdRef.current ?? undefined,
+      reason: 'user',
+      inSession: sessionIdRef.current != null,
+    });
     try {
       await disconnect();
     } catch {
@@ -1155,6 +1161,10 @@ export function BluetoothProvider({
       const disconnectInfo = lastDisconnectInfoRef.current;
       track(SHARED_EVENTS.BluetoothDisconnected, {
         boardName,
+        // The resolved DB board id (same value the send events carry), so
+        // takeover analysis can join disconnects to another user's connect on
+        // the SAME board instead of a fragile last-connect join per user.
+        boardId: resolvedPresenceBoardIdRef.current ?? presenceBoardIdRef.current ?? undefined,
         reason: 'unexpected',
         inSession: sessionIdRef.current != null,
         disconnectSource: disconnectInfo?.source,
@@ -1164,6 +1174,7 @@ export function BluetoothProvider({
         disconnectAndroidCode: disconnectInfo?.androidErrorCode,
         disconnectBleCode: disconnectInfo?.bleErrorCode,
         disconnectErrorDomain: disconnectInfo?.errorDomain,
+        disconnectCategory: classifyBleDisconnect(disconnectInfo),
       });
     }
     wasConnectedRef.current = isConnected;


### PR DESCRIPTION
## Summary

Analytics follow-up to #3288/#3289, motivated by the adversarial telemetry re-run on #3235 (2026-07-03 comment): 52% of `Bluetooth Disconnected` events are unexpected, and only ~14% could be attributed to takeover — via a fragile per-user last-connect join, because the event carried no board id and only raw per-OS codes.

- **`disconnectCategory`** — new `classifyBleDisconnect` (`src/lib/ble/disconnect-category.ts`) buckets the sparse `BleDisconnectInfo` into `peer_terminated` (CBError 7 / GATT 19 — the takeover signature on last-connection-wins boards), `link_timeout` (CBError 6 / GATT 8 — range/idle), `app_recovery` (the #3181 write-stall context markers), `bluetooth_off` (the #3289 central-state marker), `write_failure` (a write flushing out a dead link), or `unknown`. iOS codes are domain-gated so a numerically-overlapping `CBATTErrorDomain` code is never misread. Unmapped codes stay `unknown` rather than guessing.
- **`boardId`** — both `Bluetooth Disconnected` emissions (user + unexpected) now carry the resolved presence board id, the same value the send events use, so disconnects join directly to another user's connect on the same board.

JS-only → ships via OTA; no fingerprint change. The iOS CBError codes themselves only start flowing once #3289 ships in a native build — until then the classifier covers Android (ble-plx codes), the write-failure path, and `unknown`.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 3,094 pass (8 new: classifier matrix incl. domain-gating and per-platform codes; provider events assert `boardId` + `disconnectCategory` on the peer-terminated, write-failure, and no-info paths)
- `vp run check:mobile-bundle` — pass
- Field verification: after OTA, `disconnectCategory` distribution in PostHog should split the current 86%-unexplained unexpected disconnects; once #3289 ships in a build, `peer_terminated` vs `link_timeout` becomes the takeover-vs-range readout.

Refs #3235, #3288, #3289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JamZgH5gcHSFUSjNJvJAn