### PR TITLE
fix(backend): benchmark badge on grouped ascents group header (#3393)

### DIFF
--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -38,6 +38,7 @@ type GroupedItem = {
   uuid: string;
   status: string;
   climbedAt: string;
+  isBenchmark: boolean;
 };
 
 type Group = {
@@ -48,6 +49,7 @@ type Group = {
   flashCount: number;
   sendCount: number;
   attemptCount: number;
+  isBenchmark: boolean;
 };
 
 type GroupedResult = {
@@ -161,13 +163,14 @@ const insertBoardClimbStats = async (params: {
   boardType?: string;
   angle?: number;
   displayDifficulty: number;
+  benchmarkDifficulty?: number;
 }) => {
   const boardType = params.boardType ?? 'kilter';
   const angle = params.angle ?? 40;
   await db.execute(sql`
-    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, ascensionist_count, difficulty_average, quality_average)
-    VALUES (${boardType}, ${params.climbUuid}, ${angle}, ${params.displayDifficulty}, 10, ${params.displayDifficulty}, 4)
-    ON CONFLICT (board_type, climb_uuid, angle) DO UPDATE SET display_difficulty = excluded.display_difficulty
+    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, benchmark_difficulty, ascensionist_count, difficulty_average, quality_average)
+    VALUES (${boardType}, ${params.climbUuid}, ${angle}, ${params.displayDifficulty}, ${params.benchmarkDifficulty ?? null}, 10, ${params.displayDifficulty}, 4)
+    ON CONFLICT (board_type, climb_uuid, angle) DO UPDATE SET display_difficulty = excluded.display_difficulty, benchmark_difficulty = excluded.benchmark_difficulty
   `);
 };
 
@@ -1191,6 +1194,27 @@ describe('tickQueries — behavior fixes', () => {
       const projectGroup = both.groups.find((group) => group.climbUuid === projectUuid);
       expect(sentGroup?.items.every((item) => item.hasBetaVideo)).toBe(true);
       expect(projectGroup?.items.every((item) => !item.hasBetaVideo)).toBe(true);
+    });
+
+    it('flags the group header as benchmark when the consensus stats say so, matching its rows', async () => {
+      // Consensus-benchmark climb (benchmark_difficulty > 0) ticked without the
+      // tick's own is_benchmark flag. Both the header and the rows must resolve
+      // to benchmark — regression guard for #3393 (header was on the raw flag).
+      const climbUuid = `${CLIMB_PREFIX}grouped-benchmark`;
+      await insertClimb(climbUuid, 'Consensus Benchmark');
+      await insertBoardClimbStats({ climbUuid, displayDifficulty: 15, benchmarkDifficulty: 15 });
+      await insertTick({
+        uuid: 'grp-bench-1',
+        climbUuid,
+        climbedAt: '2026-06-25T10:00:00',
+        status: 'send',
+      });
+
+      const result = await callUserGroupedAscentsFeed(TEST_USER_ID, { limit: 20, offset: 0 });
+      const group = result.groups.find((candidate) => candidate.climbUuid === climbUuid);
+
+      expect(group?.isBenchmark).toBe(true);
+      expect(group?.items.every((item) => item.isBenchmark)).toBe(true);
     });
   });
 

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -993,7 +993,7 @@ export const tickQueries = {
           isMirror: tick.isMirror ?? false,
           frames,
           difficultyName,
-          isBenchmark: tick.isBenchmark ?? false,
+          isBenchmark: Boolean(resolvedIsBenchmark),
           isNoMatch,
           date: day,
           items: [],


### PR DESCRIPTION
## Summary

In the grouped ascents feed, the benchmark badge on a **group header** disagreed with the badge on its own **rows**. A consensus-benchmark climb (`benchmarkDifficulty > 0`) ticked without the tick's own benchmark flag set showed the badge on every row but not on the group header.

The per-row path resolved benchmark as stats-OR-tick (`resolvedIsBenchmark`), while the header still read the raw `tick.isBenchmark` flag. This PR points the header at the same resolved expression so header and rows always agree.

Regression from #3377, which upgraded the per-row path but left the header on the raw flag.

Closes #3393.

## Release Notes

- The benchmark badge on a grouped ascents header now matches its climbs — a consensus benchmark no longer shows up on the rows but goes missing on the header.

## Test plan

- Added a backend test asserting header `isBenchmark` equals the rows for a consensus-benchmark tick (`benchmark_difficulty > 0`, `tick.isBenchmark = false`). Confirmed it fails on the old code and passes with the fix.
- `vp test run --project backend tick-queries.test` — 44 passed.
- `vp run typecheck:backend` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TPC7uHCbnxXkEUXkaDxNm

---
_Generated by [Claude Code](https://claude.ai/code/session_017TPC7uHCbnxXkEUXkaDxNm)_