### PR TITLE
fix(web): address session end/leave review findings

### DIFF
--- a/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
@@ -171,6 +171,9 @@ export function useSessionIdManagement({
     // cookie again — a harmless, idempotent double-clear.
     clearClimbSessionCookie();
     setCookieSessionId(null);
+    // Nothing to end — cookie already cleared above. Skip so we don't deactivate
+    // a persistent session that isn't active.
+    if (!endingSessionId) return;
     const boardType =
       persistentSession.activeSession?.parsedParams?.board_name ?? baseBoardPath.split('/').filter(Boolean)[0] ?? null;
     persistentSession.endSessionWithSummary({ sessionId: endingSessionId, boardType });

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
@@ -551,8 +551,11 @@ describe('QueueControlBar leave session branch', () => {
   });
 
   it('ends the session for an authenticated user on two tabs (same participant id)', () => {
-    // Two connections of one authed user share the same participant id, so the
-    // roster dedupes to a single "me" — still the last participant → end.
+    // Two connections of one authed user share the same participant id. Every
+    // roster row carries the caller's own userId, so the "any other participant?"
+    // check finds none → caller is the last participant → end. (This asserts the
+    // last-participant decision, not roster dedup: the check would still find no
+    // "other" even without dedup, since both rows equal `myUserId`.)
     const { endSession, disconnect } = leaveFromBar({
       users: [
         makeRosterUser('user-uuid', { userId: 'user-uuid' }),

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -540,7 +540,7 @@ function usePersistentSessionQueueAdapter(): {
     clearClimbSessionCookie();
     ps.endSessionWithSummary({
       sessionId: endingSessionId,
-      boardType: ps.activeSession?.parsedParams.board_name ?? null,
+      boardType: ps.activeSession?.parsedParams?.board_name ?? null,
     });
   }, []);
 


### PR DESCRIPTION
## Summary

Three small correctness/clarity cleanups in the session end/leave flow, from code review. No user-visible behavior change.

- **Optional-chaining guard** in `queue-bridge-context.tsx` `stableEndSession`: `ps.activeSession?.parsedParams.board_name` → `ps.activeSession?.parsedParams?.board_name`, matching the defensive access already used in `use-session-id-management.ts`.
- **Null-session guard** in `use-session-id-management.ts` `endSession`: after the (intentionally unconditional) eager cookie clear, early-return when there is no session id so `endSessionWithSummary` doesn't run `deactivateSession` against a session that was never active. The documented cookie-clear asymmetry is preserved.
- **Corrected test comment** in `queue-control-bar-pivot.test.tsx` two-tabs test: it asserts the last-participant decision (every roster row equals the caller's `userId`, so no "other" is found → end), not roster dedup. The old comment overstated what the test verifies.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:web` — clean
- `vp test run --project web queue-control-bar-pivot` — 10/10 pass
- `vp test run --project web use-session-id-management` — 10/10 pass
- `vp check` — no new lint/format issues on the changed files (pre-existing repo warnings unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015bFBYaP7VTeFf2BnxFVZ3h)_