### PR TITLE
fix(mobile): light Mini MoonBoard holds on the correct 12-row grid natively

### DIFF
--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -320,6 +320,30 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertEqual(state.currentIndex, 2)
     }
 
+    func testMoonboardSerialPositionMiniGridMath() {
+        // Parity with moonboard.test.ts §Mini (numRows = 12): the Mini LED strip
+        // is 11×12, so the odd-column serpentine reversal folds at row 12 (#3392).
+        XCTAssertEqual(BoardBleEncoding.moonboardSerialPosition(holdId: 1, numRows: 12), 0)
+        XCTAssertEqual(BoardBleEncoding.moonboardSerialPosition(holdId: 2, numRows: 12), 23)
+        XCTAssertEqual(BoardBleEncoding.moonboardSerialPosition(holdId: 11, numRows: 12), 120)
+        XCTAssertEqual(BoardBleEncoding.moonboardSerialPosition(holdId: 12, numRows: 12), 1)
+        XCTAssertEqual(BoardBleEncoding.moonboardSerialPosition(holdId: 123, numRows: 12), 12)
+        XCTAssertEqual(BoardBleEncoding.moonboardSerialPosition(holdId: 132, numRows: 12), 131)
+        // Past the 132-LED Mini strip; valid only on the 18-row wall.
+        XCTAssertNil(BoardBleEncoding.moonboardSerialPosition(holdId: 133, numRows: 12))
+    }
+
+    func testMoonboardPacketEncodesMiniPositions() {
+        // Same holds address different LEDs on the two grids: B1 is serial 35 on
+        // the 18-row wall but 23 on the 12-row Mini.
+        let mini = BoardBleEncoding.makeMoonboardPacket(frames: "p1r42p2r43p132r44", numRows: 12)
+        XCTAssertEqual(String(decoding: mini.packet, as: UTF8.self), "l#S0,P23,E131#")
+        XCTAssertEqual(mini.skippedPositionCount, 0)
+
+        let standard = BoardBleEncoding.makeMoonboardPacket(frames: "p2r43")
+        XCTAssertEqual(String(decoding: standard.packet, as: UTF8.self), "l#P35#")
+    }
+
     func testBoardRenderUrlUsesSharedBoardContext() {
         defaults.set("https://www.boardsesh.com", forKey: SharedConstants.serverUrlKey)
         defaults.set("kilter", forKey: SharedConstants.boardNameKey)

--- a/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
@@ -8,6 +8,9 @@ struct BoardBleConfiguration: Codable, Equatable {
     let apiLevel: Int?
     let deviceName: String?
     let colorOverrides: [String: String]
+    // MoonBoard grid rows (18 standard, 12 Mini). Optional so configs
+    // persisted by builds that predate it still decode (#3392).
+    let numRows: Int?
 }
 
 struct BoardBlePacketResult: Equatable {
@@ -283,14 +286,20 @@ enum BoardBleEncoding {
     // placement map and no binary packet wrapper. Ported from
     // packages/shared/ble-protocol/src/moonboard.ts; keep the two in lockstep
     // (parity asserted in LiveActivityWidgetTests).
+    //
+    // All layouts are 11 columns wide, but the row count varies: the standard
+    // wall is 18 rows while the Mini's LED strip is 12 (#3392). The row count
+    // comes from the JS-side board config (getMoonBoardGeometryByLayoutId) via
+    // configureBoard; 18 is the fallback for configs persisted before numRows
+    // existed.
     private static let moonboardGridColumns = 11
-    private static let moonboardGridRows = 18
+    static let moonboardDefaultGridRows = 18
     private static let moonboardRoleMap: [Int: String] = [42: "S", 43: "P", 44: "E"]
     private static let moonboardFramePrefix = "l#"
     private static let moonboardFrameSuffix = "#"
 
-    static func moonboardSerialPosition(holdId: Int) -> Int? {
-        let maxHoldId = moonboardGridColumns * moonboardGridRows
+    static func moonboardSerialPosition(holdId: Int, numRows: Int = moonboardDefaultGridRows) -> Int? {
+        let maxHoldId = moonboardGridColumns * numRows
         guard holdId >= 1, holdId <= maxHoldId else { return nil }
 
         let zeroBasedHoldId = holdId - 1
@@ -299,12 +308,12 @@ enum BoardBleEncoding {
 
         // Odd columns are wired bottom-to-top, so their row order is reversed.
         if colIndex % 2 == 0 {
-            return colIndex * moonboardGridRows + rowIndex
+            return colIndex * numRows + rowIndex
         }
-        return colIndex * moonboardGridRows + (moonboardGridRows - 1 - rowIndex)
+        return colIndex * numRows + (numRows - 1 - rowIndex)
     }
 
-    static func makeMoonboardPacket(frames: String) -> BoardBlePacketResult {
+    static func makeMoonboardPacket(frames: String, numRows: Int = moonboardDefaultGridRows) -> BoardBlePacketResult {
         var encodedHolds: [String] = []
         var skippedRoleCount = 0
         var skippedPositionCount = 0
@@ -315,7 +324,7 @@ enum BoardBleEncoding {
                 skippedRoleCount += 1
                 continue
             }
-            guard let position = moonboardSerialPosition(holdId: frame.placementId) else {
+            guard let position = moonboardSerialPosition(holdId: frame.placementId, numRows: numRows) else {
                 skippedPositionCount += 1
                 continue
             }

--- a/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
@@ -293,13 +293,14 @@ enum BoardBleEncoding {
     // configureBoard; 18 is the fallback for configs persisted before numRows
     // existed.
     private static let moonboardGridColumns = 11
-    static let moonboardDefaultGridRows = 18
+    private static let moonboardDefaultGridRows = 18
     private static let moonboardRoleMap: [Int: String] = [42: "S", 43: "P", 44: "E"]
     private static let moonboardFramePrefix = "l#"
     private static let moonboardFrameSuffix = "#"
 
-    static func moonboardSerialPosition(holdId: Int, numRows: Int = moonboardDefaultGridRows) -> Int? {
-        let maxHoldId = moonboardGridColumns * numRows
+    static func moonboardSerialPosition(holdId: Int, numRows: Int? = nil) -> Int? {
+        let gridRows = numRows ?? moonboardDefaultGridRows
+        let maxHoldId = moonboardGridColumns * gridRows
         guard holdId >= 1, holdId <= maxHoldId else { return nil }
 
         let zeroBasedHoldId = holdId - 1
@@ -308,12 +309,12 @@ enum BoardBleEncoding {
 
         // Odd columns are wired bottom-to-top, so their row order is reversed.
         if colIndex % 2 == 0 {
-            return colIndex * numRows + rowIndex
+            return colIndex * gridRows + rowIndex
         }
-        return colIndex * numRows + (numRows - 1 - rowIndex)
+        return colIndex * gridRows + (gridRows - 1 - rowIndex)
     }
 
-    static func makeMoonboardPacket(frames: String, numRows: Int = moonboardDefaultGridRows) -> BoardBlePacketResult {
+    static func makeMoonboardPacket(frames: String, numRows: Int? = nil) -> BoardBlePacketResult {
         var encodedHolds: [String] = []
         var skippedRoleCount = 0
         var skippedPositionCount = 0

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -654,10 +654,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // supported on MoonBoard (boardSupportsMirroring is false), so frames go
         // out as-is.
         if configuration.boardName == "moonboard" {
-            let result = BoardBleEncoding.makeMoonboardPacket(
-                frames: item.frames,
-                numRows: configuration.numRows ?? BoardBleEncoding.moonboardDefaultGridRows
-            )
+            // numRows nil (config persisted by an older build) → the encoder's
+            // 18-row standard-wall default.
+            let result = BoardBleEncoding.makeMoonboardPacket(frames: item.frames, numRows: configuration.numRows)
             guard !result.packet.isEmpty else {
                 // Every hold was unrecognised/out-of-range, or the climb has no
                 // holds. Refuse to write rather than dark the wall — there is no

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -654,7 +654,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // supported on MoonBoard (boardSupportsMirroring is false), so frames go
         // out as-is.
         if configuration.boardName == "moonboard" {
-            let result = BoardBleEncoding.makeMoonboardPacket(frames: item.frames)
+            let result = BoardBleEncoding.makeMoonboardPacket(
+                frames: item.frames,
+                numRows: configuration.numRows ?? BoardBleEncoding.moonboardDefaultGridRows
+            )
             guard !result.packet.isEmpty else {
                 // Every hold was unrecognised/out-of-range, or the climb has no
                 // holds. Refuse to write rather than dark the wall — there is no

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -160,7 +160,8 @@ public class BoardBleModule: Module {
                     sizeId: options.sizeId,
                     apiLevel: options.apiLevel,
                     deviceName: options.deviceName,
-                    colorOverrides: options.colorOverrides ?? [:]
+                    colorOverrides: options.colorOverrides ?? [:],
+                    numRows: options.numRows
                 )
             )
         }
@@ -211,4 +212,6 @@ struct ConfigureBoardOptions: Record {
     @Field var apiLevel: Int?
     @Field var deviceName: String?
     @Field var colorOverrides: [String: String]?
+    // MoonBoard grid rows (18 standard, 12 Mini) — see #3392.
+    @Field var numRows: Int?
 }

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -56,6 +56,12 @@ export type NativeBleConfigureBoardOptions = {
   apiLevel?: number;
   deviceName?: string;
   colorOverrides?: Record<string, string>;
+  /**
+   * MoonBoard grid rows (18 standard, 12 Mini) so native re-encodes (widget
+   * intents, reconnect re-light) address the right serpentine grid (#3392).
+   * Older binaries ignore it.
+   */
+  numRows?: number;
 };
 
 type BoardBleNativeModule = {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -116,6 +116,7 @@ import {
   bleConnectReportLevel,
   convertToMirroredFramesString,
   dispatchMoonboardPacket,
+  moonboardNumRowsForNative,
   useBoardBluetooth,
 } from '../use-board-bluetooth';
 
@@ -1175,6 +1176,22 @@ describe('dispatchMoonboardPacket', () => {
 
     expect(result).toBe(true);
     expect(write).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('moonboardNumRowsForNative', () => {
+  // The value native re-encodes address the serpentine grid with (#3392) —
+  // Mini layouts (6 = 2020, 7 = 2025) are 12 rows, everything else 18.
+  it('resolves 12 rows for Mini layouts and 18 for standard walls', () => {
+    expect(moonboardNumRowsForNative('moonboard', 6)).toBe(12);
+    expect(moonboardNumRowsForNative('moonboard', 7)).toBe(12);
+    expect(moonboardNumRowsForNative('moonboard', 1)).toBe(18);
+    expect(moonboardNumRowsForNative('moonboard', 3)).toBe(18);
+  });
+
+  it('is undefined for non-MoonBoard boards (Aurora has no grid maths)', () => {
+    expect(moonboardNumRowsForNative('kilter', 6)).toBeUndefined();
+    expect(moonboardNumRowsForNative(undefined, 6)).toBeUndefined();
   });
 });
 

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1180,13 +1180,19 @@ describe('dispatchMoonboardPacket', () => {
 });
 
 describe('moonboardNumRowsForNative', () => {
-  // The value native re-encodes address the serpentine grid with (#3392) —
+  // The row count native re-encodes use to address the serpentine grid —
   // Mini layouts (6 = 2020, 7 = 2025) are 12 rows, everything else 18.
   it('resolves 12 rows for Mini layouts and 18 for standard walls', () => {
     expect(moonboardNumRowsForNative('moonboard', 6)).toBe(12);
     expect(moonboardNumRowsForNative('moonboard', 7)).toBe(12);
     expect(moonboardNumRowsForNative('moonboard', 1)).toBe(18);
     expect(moonboardNumRowsForNative('moonboard', 3)).toBe(18);
+  });
+
+  it('falls back to the standard 18-row wall for an unknown layout id', () => {
+    // getMoonBoardGeometryByLayoutId returns STANDARD_MOONBOARD_GEOMETRY when
+    // the layout lookup misses, so this never throws.
+    expect(moonboardNumRowsForNative('moonboard', 999)).toBe(18);
   });
 
   it('is undefined for non-MoonBoard boards (Aurora has no grid maths)', () => {

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -79,6 +79,14 @@ export async function dispatchMoonboardPacket(
   return true;
 }
 
+// MoonBoard grid rows for the native configureBoard payload, so native
+// re-encodes (widget intents, reconnect re-light) use the same serpentine grid
+// as the JS send path — Mini strips are 12 rows, standard 18 (#3392). Undefined
+// for Aurora boards, whose encoder has no grid maths.
+export function moonboardNumRowsForNative(boardName: string | undefined, layoutId: number): number | undefined {
+  return boardName === 'moonboard' ? getMoonBoardGeometryByLayoutId(layoutId).numRows : undefined;
+}
+
 export type PickerState = {
   devices: DiscoveredDevice[];
   isScanning: boolean;
@@ -706,6 +714,7 @@ export function useBoardBluetooth({
               apiLevel: apiLevelRef.current,
               deviceName: connection.deviceName,
               colorOverrides: sanitizedColorOverrides,
+              numRows: moonboardNumRowsForNative(boardName, layoutId),
             });
           } catch (error) {
             console.warn('[BLE] Failed to push board configuration to native side:', error);
@@ -983,6 +992,7 @@ export function useBoardBluetooth({
           apiLevel: apiLevelRef.current,
           deviceName,
           colorOverrides: sanitizedColorOverrides,
+          numRows: moonboardNumRowsForNative(boardName, layoutId),
         })
         .catch(() => {});
 
@@ -1056,6 +1066,7 @@ export function useBoardBluetooth({
         apiLevel: apiLevelRef.current,
         deviceName: configuredDeviceNameRef.current,
         colorOverrides: sanitizedColorOverrides,
+        numRows: moonboardNumRowsForNative(boardName, layoutId),
       })
       .catch(() => {});
   }, [boardName, layoutId, sizeId, isConnected, sanitizedColorOverrides]);


### PR DESCRIPTION
## Summary

The native iOS BLE encoder (`BoardBleEncoding.swift`) hardcoded an 18-row MoonBoard grid, so a Mini MoonBoard (11×12 — layouts 6 `mini-moonboard-2020` and 7 `mini-moonboard-2025`) lit the **wrong holds** whenever a send went through the native encode path: Dynamic Island / Live Activity next-prev intents, the lightbulb reconnect re-light, write-stall recovery, and state restoration. The foreground JS path was already row-aware (`getMoonboardBluetoothPacket(frames, numRows)`), which is why the bug never showed in-app and never registered as a send failure.

Fix threads the row count through, keeping TS board config as the single source of truth:

- `configureBoard` (JS → native) now carries `numRows`, resolved via `getMoonBoardGeometryByLayoutId(layoutId).numRows` for MoonBoard, `undefined` for Aurora boards (no grid maths).
- `BoardBleConfiguration` persists it in the App Group (optional field — configs persisted by older builds decode as `nil` and fall back to 18, i.e. today's behaviour, self-healing on the next `configureBoard`).
- `makeMoonboardPacket`/`moonboardSerialPosition` take `numRows` (default 18, mirroring the TS encoder's default) — the serpentine column fold and the max-hold bound now use it.
- Android has no native encoder (BLE is JS-side there) — no change.

**Native change** — ships with the next binary, an OTA can't carry it.

Closes #3392

## Release Notes

- Mini MoonBoard now lights the right holds when you drive the wall from the lock screen or Dynamic Island

## Test plan

- Swift: new `testMoonboardSerialPositionMiniGridMath` + `testMoonboardPacketEncodesMiniPositions` in `LiveActivityWidgetTests` mirror the TS Mini parity vectors (`moonboard.test.ts` §Mini, verified against the reverse-engineered MoonBoard app protocol): B1 = serial 23 on 12 rows vs 35 on 18, K12 = 131, hold 133 rejected; packet `p1r42p2r43p132r44` @12 → `l#S0,P23,E131#`. Existing 18-row tests unchanged (default param).
- TS: `moonboardNumRowsForNative` unit tests (12 for layouts 6/7, 18 for standard, undefined for Aurora).
- `vp run typecheck:mobile`, `vp run test:mobile` (3097 passed), `vp run check:mobile-bundle` all green locally.
- No Mini hardware on hand — correctness anchors to the TS parity vectors the JS path already ships with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G77gsNZteEQB7ehifY4iRN