### PR TITLE
fix(mobile): make native session sync survive reconnects and queue edits

### DIFF
--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -232,6 +232,42 @@ final class LiveActivityWidgetTests: XCTestCase {
         // Removing the last item while it is current clamps to the new tail.
         state = QueueStateReducer.apply(.itemRemoved(uuid: "C", sequence: 2), to: state)
         XCTAssertEqual(state.currentIndex, 0)
+
+        // Emptying the queue leaves index 0 into an empty array — every
+        // consumer bounds-checks (SharedQueueState.currentItem returns nil,
+        // displayCurrentItemOnBleQueue clears the board), so this must stay a
+        // representable, non-crashing state.
+        state = QueueStateReducer.apply(.itemRemoved(uuid: "A", sequence: 3), to: state)
+        XCTAssertTrue(state.items.isEmpty)
+        XCTAssertEqual(state.currentIndex, 0)
+        SharedQueueState.save(items: state.items, currentIndex: state.currentIndex, to: defaults)
+        XCTAssertNil(SharedQueueState.currentItem(from: defaults))
+    }
+
+    func testGraphQLErrorRoutingCoversSubscriptionAndMutationIds() {
+        // A subscription-level error must reconnect — it used to fall through
+        // the mutation-only handling and was silently dropped while server
+        // pings kept the connection looking healthy.
+        XCTAssertEqual(
+            QueueGraphQLErrorRouting.action(forOperationId: "1", subscriptionId: "1"),
+            .reconnect
+        )
+        XCTAssertEqual(
+            QueueGraphQLErrorRouting.action(forOperationId: "join-session", subscriptionId: "1"),
+            .reconnect
+        )
+        XCTAssertEqual(
+            QueueGraphQLErrorRouting.action(forOperationId: "mutation-abc123", subscriptionId: "1"),
+            .revertOptimisticNavigation(correlationId: "abc123")
+        )
+        XCTAssertEqual(
+            QueueGraphQLErrorRouting.action(forOperationId: "something-else", subscriptionId: "1"),
+            .ignore
+        )
+        XCTAssertEqual(
+            QueueGraphQLErrorRouting.action(forOperationId: nil, subscriptionId: "1"),
+            .ignore
+        )
     }
 
     func testOffQueueCurrentClimbIsAppendedNotIgnored() {

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -170,6 +170,98 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertNil(BoardBleEncoding.moonboardSerialPosition(holdId: 199))
     }
 
+    // MARK: - Session queue sync (SessionQueueState.swift)
+
+    private func makeQueueState(uuids: [String], currentIndex: Int) -> QueueStateReducer.QueueState {
+        let items = uuids.map { makeQueueItem(uuid: $0, climbUuid: "climb-\($0)", climbName: "Climb \($0)") }
+        return QueueStateReducer.QueueState(items: items, currentIndex: currentIndex)
+    }
+
+    func testFullSyncIsAcceptedRegardlessOfSequenceGap() {
+        // A FullSync is an authoritative snapshot sent on every (re)subscribe.
+        // Gap-checking it against the previous connection's sequence caused an
+        // infinite reconnect loop after ≥2 events were missed while offline.
+        let fullSync = QueueUpdateEvent.fullSync(items: [], currentItem: nil, sequence: 12)
+        XCTAssertEqual(
+            QueueSequencePolicy.decision(for: fullSync, receivedSequence: 12, lastKnown: 3),
+            .apply(newLastSequence: 12)
+        )
+
+        // Deltas still gap-check: one step ahead applies, a jump resyncs.
+        let delta = QueueUpdateEvent.itemRemoved(uuid: "q1", sequence: 5)
+        XCTAssertEqual(
+            QueueSequencePolicy.decision(for: delta, receivedSequence: 5, lastKnown: 4),
+            .apply(newLastSequence: 5)
+        )
+        XCTAssertEqual(
+            QueueSequencePolicy.decision(for: delta, receivedSequence: 5, lastKnown: 3),
+            .resync
+        )
+        // First event after a (re)connect (lastKnown reset to -1) always applies.
+        XCTAssertEqual(
+            QueueSequencePolicy.decision(for: delta, receivedSequence: 5, lastKnown: -1),
+            .apply(newLastSequence: 5)
+        )
+    }
+
+    func testQueueMutationsAheadOfCurrentKeepTheCurrentItem() {
+        // Remove ahead of current: [A, B, C, D] current C → [B, C, D] current C.
+        var state = makeQueueState(uuids: ["A", "B", "C", "D"], currentIndex: 2)
+        state = QueueStateReducer.apply(.itemRemoved(uuid: "A", sequence: 1), to: state)
+        XCTAssertEqual(state.items.map(\.uuid), ["B", "C", "D"])
+        XCTAssertEqual(state.currentIndex, 1)
+
+        // Insert ahead of current keeps following the item.
+        let inserted = makeQueueItem(uuid: "X", climbUuid: "climb-X", climbName: "Climb X")
+        state = QueueStateReducer.apply(.itemAdded(item: inserted, position: 0, sequence: 2), to: state)
+        XCTAssertEqual(state.items.map(\.uuid), ["X", "B", "C", "D"])
+        XCTAssertEqual(state.currentIndex, 2)
+
+        // Reorder across the current item keeps following it too.
+        state = QueueStateReducer.apply(.reordered(uuid: "D", oldIndex: 3, newIndex: 0, sequence: 3), to: state)
+        XCTAssertEqual(state.items.map(\.uuid), ["D", "X", "B", "C"])
+        XCTAssertEqual(state.currentIndex, 3)
+    }
+
+    func testRemovingTheCurrentItemFallsToItsSuccessor() {
+        var state = makeQueueState(uuids: ["A", "B", "C"], currentIndex: 1)
+        state = QueueStateReducer.apply(.itemRemoved(uuid: "B", sequence: 1), to: state)
+        XCTAssertEqual(state.items.map(\.uuid), ["A", "C"])
+        XCTAssertEqual(state.currentIndex, 1) // now C
+
+        // Removing the last item while it is current clamps to the new tail.
+        state = QueueStateReducer.apply(.itemRemoved(uuid: "C", sequence: 2), to: state)
+        XCTAssertEqual(state.currentIndex, 0)
+    }
+
+    func testOffQueueCurrentClimbIsAppendedNotIgnored() {
+        // Mirrors the JS reducer's shouldAddToQueue: a peer navigating to a
+        // search result (not a queue member) must not leave the stale index
+        // repainting the previous climb over theirs.
+        let offQueue = makeQueueItem(uuid: "S", climbUuid: "climb-S", climbName: "Search Pick")
+        var state = makeQueueState(uuids: ["A", "B"], currentIndex: 0)
+        state = QueueStateReducer.apply(.currentClimbChanged(item: offQueue, sequence: 1), to: state)
+        XCTAssertEqual(state.items.map(\.uuid), ["A", "B", "S"])
+        XCTAssertEqual(state.currentIndex, 2)
+
+        // An in-queue current climb just moves the index — no duplicate append.
+        state = QueueStateReducer.apply(
+            .currentClimbChanged(item: state.items[1], sequence: 2), to: state)
+        XCTAssertEqual(state.items.map(\.uuid), ["A", "B", "S"])
+        XCTAssertEqual(state.currentIndex, 1)
+    }
+
+    func testFullSyncWithOffQueueCurrentItemAppendsIt() {
+        let items = ["A", "B"].map { makeQueueItem(uuid: $0, climbUuid: "climb-\($0)", climbName: "Climb \($0)") }
+        let offQueue = makeQueueItem(uuid: "S", climbUuid: "climb-S", climbName: "Search Pick")
+        let state = QueueStateReducer.apply(
+            .fullSync(items: items, currentItem: offQueue, sequence: 7),
+            to: makeQueueState(uuids: [], currentIndex: 0)
+        )
+        XCTAssertEqual(state.items.map(\.uuid), ["A", "B", "S"])
+        XCTAssertEqual(state.currentIndex, 2)
+    }
+
     func testBoardRenderUrlUsesSharedBoardContext() {
         defaults.set("https://www.boardsesh.com", forKey: SharedConstants.serverUrlKey)
         defaults.set("kilter", forKey: SharedConstants.boardNameKey)

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -238,6 +238,11 @@ final class LiveActivityWidgetTests: XCTestCase {
         state = QueueStateReducer.apply(.reordered(uuid: "D", oldIndex: 3, newIndex: 0, sequence: 3), to: state)
         XCTAssertEqual(state.items.map(\.uuid), ["D", "X", "B", "C"])
         XCTAssertEqual(state.currentIndex, 3)
+
+        // Reordering the CURRENT item itself follows it to its new position.
+        state = QueueStateReducer.apply(.reordered(uuid: "C", oldIndex: 3, newIndex: 0, sequence: 4), to: state)
+        XCTAssertEqual(state.items.map(\.uuid), ["C", "D", "X", "B"])
+        XCTAssertEqual(state.currentIndex, 0)
     }
 
     func testRemovingTheCurrentItemFallsToItsSuccessor() {

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -183,25 +183,42 @@ final class LiveActivityWidgetTests: XCTestCase {
         // infinite reconnect loop after ≥2 events were missed while offline.
         let fullSync = QueueUpdateEvent.fullSync(items: [], currentItem: nil, sequence: 12)
         XCTAssertEqual(
-            QueueSequencePolicy.decision(for: fullSync, receivedSequence: 12, lastKnown: 3),
+            QueueSequencePolicy.decision(for: fullSync, lastKnown: 3),
             .apply(newLastSequence: 12)
         )
 
         // Deltas still gap-check: one step ahead applies, a jump resyncs.
         let delta = QueueUpdateEvent.itemRemoved(uuid: "q1", sequence: 5)
         XCTAssertEqual(
-            QueueSequencePolicy.decision(for: delta, receivedSequence: 5, lastKnown: 4),
+            QueueSequencePolicy.decision(for: delta, lastKnown: 4),
             .apply(newLastSequence: 5)
         )
         XCTAssertEqual(
-            QueueSequencePolicy.decision(for: delta, receivedSequence: 5, lastKnown: 3),
+            QueueSequencePolicy.decision(for: delta, lastKnown: 3),
             .resync
         )
         // First event after a (re)connect (lastKnown reset to -1) always applies.
         XCTAssertEqual(
-            QueueSequencePolicy.decision(for: delta, receivedSequence: 5, lastKnown: -1),
+            QueueSequencePolicy.decision(for: delta, lastKnown: -1),
             .apply(newLastSequence: 5)
         )
+    }
+
+    func testClimbMirroredUpdatesOnlyTheMatchingItem() {
+        var state = makeQueueState(uuids: ["A", "B"], currentIndex: 0)
+        state = QueueStateReducer.apply(.climbMirrored(uuid: "B", mirrored: true, sequence: 1), to: state)
+        XCTAssertFalse(state.items[0].mirrored)
+        XCTAssertTrue(state.items[1].mirrored)
+        XCTAssertEqual(state.currentIndex, 0)
+
+        // A nil or unknown uuid is a no-op on the state (the manager still
+        // persists + repaints unconditionally after every event, so downstream
+        // behaviour matches the pre-refactor code).
+        let unchanged = state
+        state = QueueStateReducer.apply(.climbMirrored(uuid: nil, mirrored: true, sequence: 2), to: state)
+        XCTAssertEqual(state, unchanged)
+        state = QueueStateReducer.apply(.climbMirrored(uuid: "missing", mirrored: true, sequence: 3), to: state)
+        XCTAssertEqual(state, unchanged)
     }
 
     func testQueueMutationsAheadOfCurrentKeepTheCurrentItem() {

--- a/packages/mobile/modules/live-activity/ios/SessionQueueState.swift
+++ b/packages/mobile/modules/live-activity/ios/SessionQueueState.swift
@@ -320,14 +320,14 @@ enum QueueMessageParser {
 
     // MARK: - Private Helpers
 
-    static func parseDifficulty(_ value: Any?) -> String {
+    private static func parseDifficulty(_ value: Any?) -> String {
         if let str = value as? String { return str }
         if let num = value as? Double { return String(format: "%.1f", num) }
         if let num = value as? Int { return String(num) }
         return ""
     }
 
-    static func parseIntValue(_ value: Any?) -> Int? {
+    private static func parseIntValue(_ value: Any?) -> Int? {
         if let i = value as? Int { return i }
         if let d = value as? Double { return Int(d) }
         if let s = value as? String { return Int(s) }

--- a/packages/mobile/modules/live-activity/ios/SessionQueueState.swift
+++ b/packages/mobile/modules/live-activity/ios/SessionQueueState.swift
@@ -1,0 +1,295 @@
+import Foundation
+
+// Pure queue-update logic for the native session WebSocket: event types,
+// payload parsing, sequence acceptance, and the state reducer. Split out of
+// SessionWebSocketManager so the state transitions compile into the
+// BoardseshTests target (the manager itself drags in URLSession/BLE and
+// can't) — keep everything here side-effect free.
+
+// MARK: - Queue Update Events
+
+enum QueueUpdateEvent {
+    case fullSync(items: [SharedQueueItem], currentItem: SharedQueueItem?, sequence: Int)
+    case currentClimbChanged(item: SharedQueueItem?, sequence: Int)
+    case itemAdded(item: SharedQueueItem, position: Int, sequence: Int)
+    case itemRemoved(uuid: String, sequence: Int)
+    case reordered(uuid: String, oldIndex: Int, newIndex: Int, sequence: Int)
+    case climbMirrored(uuid: String?, mirrored: Bool, sequence: Int)
+}
+
+enum QueueEventRepaintPolicy {
+    static func shouldRepaintBoard(for event: QueueUpdateEvent) -> Bool {
+        switch event {
+        case .currentClimbChanged(_, _), .climbMirrored(_, _, _):
+            return true
+        case .fullSync(_, _, _), .itemAdded(_, _, _), .itemRemoved(_, _), .reordered(_, _, _, _):
+            return false
+        }
+    }
+}
+
+// MARK: - Sequence Acceptance
+
+/// Decides what to do with an incoming event's sequence number. FullSync is an
+/// authoritative snapshot the server sends on every (re)subscribe, so it is
+/// accepted unconditionally — gap-checking it against a sequence recorded on a
+/// previous connection made every reconnect after ≥2 missed events cancel the
+/// socket, refetch the same FullSync, and cancel again, forever.
+enum QueueSequencePolicy {
+    enum Decision: Equatable {
+        /// Apply the event and advance lastSequence to the given value.
+        case apply(newLastSequence: Int)
+        /// A mid-stream gap — drop the event and resync (reconnect fetches a
+        /// fresh FullSync).
+        case resync
+    }
+
+    static func decision(for event: QueueUpdateEvent, receivedSequence: Int, lastKnown: Int) -> Decision {
+        if case .fullSync = event {
+            return .apply(newLastSequence: receivedSequence)
+        }
+        if QueueMessageParser.hasSequenceGap(lastKnown: lastKnown, received: receivedSequence) {
+            return .resync
+        }
+        return .apply(newLastSequence: receivedSequence)
+    }
+}
+
+// MARK: - State Reducer
+
+/// Applies queue events to (items, currentIndex), keeping the *current item*
+/// stable by uuid the way the JS reducer does — a raw index survives inserts,
+/// removals, and reorders ahead of it only if it moves with the item.
+enum QueueStateReducer {
+    struct QueueState: Equatable {
+        var items: [SharedQueueItem]
+        var currentIndex: Int
+    }
+
+    static func apply(_ event: QueueUpdateEvent, to state: QueueState) -> QueueState {
+        var items = state.items
+        let currentUuid = currentItemUuid(in: state)
+
+        switch event {
+        case .fullSync(let syncedItems, let currentItem, _):
+            return stateSettingCurrent(item: currentItem, items: syncedItems, fallbackIndex: 0)
+
+        case .currentClimbChanged(let item, _):
+            guard let item else { return state }
+            // Mirrors the JS reducer's shouldAddToQueue: a current climb that
+            // isn't a queue member (picked from search) is appended so the
+            // wall, Live Activity, and widget nav all see it — instead of the
+            // stale index repainting the previous climb over the peer's choice.
+            return stateSettingCurrent(item: item, items: items, fallbackIndex: state.currentIndex)
+
+        case .itemAdded(let item, let position, _):
+            let insertIndex = min(max(position, 0), items.count)
+            items.insert(item, at: insertIndex)
+            return QueueState(items: items, currentIndex: resolveCurrentIndex(previousUuid: currentUuid, previousIndex: state.currentIndex, items: items))
+
+        case .itemRemoved(let uuid, _):
+            guard let removeIndex = items.firstIndex(where: { $0.uuid == uuid }) else { return state }
+            items.remove(at: removeIndex)
+            // When the current item itself was removed the uuid lookup misses
+            // and the clamped old index lands on its successor.
+            return QueueState(items: items, currentIndex: resolveCurrentIndex(previousUuid: currentUuid, previousIndex: state.currentIndex, items: items))
+
+        case .reordered(let uuid, let oldIndex, let newIndex, _):
+            let sourceIndex: Int
+            if oldIndex >= 0, oldIndex < items.count, items[oldIndex].uuid == uuid {
+                sourceIndex = oldIndex
+            } else if let found = items.firstIndex(where: { $0.uuid == uuid }) {
+                sourceIndex = found
+            } else {
+                return state
+            }
+            let item = items.remove(at: sourceIndex)
+            let dest = min(max(newIndex, 0), items.count)
+            items.insert(item, at: dest)
+            return QueueState(items: items, currentIndex: resolveCurrentIndex(previousUuid: currentUuid, previousIndex: state.currentIndex, items: items))
+
+        case .climbMirrored(let uuid, let mirrored, _):
+            guard let uuid, let itemIndex = items.firstIndex(where: { $0.uuid == uuid }) else { return state }
+            let item = items[itemIndex]
+            items[itemIndex] = SharedQueueItem(
+                uuid: item.uuid,
+                climbUuid: item.climbUuid,
+                climbName: item.climbName,
+                difficulty: item.difficulty,
+                angle: item.angle,
+                frames: item.frames,
+                setterUsername: item.setterUsername,
+                mirrored: mirrored
+            )
+            return QueueState(items: items, currentIndex: state.currentIndex)
+        }
+    }
+
+    private static func currentItemUuid(in state: QueueState) -> String? {
+        guard state.currentIndex >= 0, state.currentIndex < state.items.count else { return nil }
+        return state.items[state.currentIndex].uuid
+    }
+
+    /// The current item follows its uuid; if it vanished, clamp the old index
+    /// into bounds.
+    private static func resolveCurrentIndex(previousUuid: String?, previousIndex: Int, items: [SharedQueueItem]) -> Int {
+        if let previousUuid, let index = items.firstIndex(where: { $0.uuid == previousUuid }) {
+            return index
+        }
+        return min(max(previousIndex, 0), max(items.count - 1, 0))
+    }
+
+    private static func stateSettingCurrent(item: SharedQueueItem?, items: [SharedQueueItem], fallbackIndex: Int) -> QueueState {
+        guard let item else {
+            return QueueState(items: items, currentIndex: fallbackIndex)
+        }
+        if let index = items.firstIndex(where: { $0.uuid == item.uuid }) {
+            return QueueState(items: items, currentIndex: index)
+        }
+        var appended = items
+        appended.append(item)
+        return QueueState(items: appended, currentIndex: appended.count - 1)
+    }
+}
+
+// MARK: - Message Parsing Helpers
+
+enum QueueMessageParser {
+
+    /// Extract the `queueUpdates` dictionary from a graphql-ws `next` payload.
+    static func extractQueueUpdates(from payload: [String: Any]?) -> [String: Any]? {
+        guard let data = payload?["data"] as? [String: Any],
+              let updates = data["queueUpdates"] as? [String: Any]
+        else {
+            return nil
+        }
+        return updates
+    }
+
+    /// Convert a raw climb+queue-item dictionary into a `SharedQueueItem`.
+    static func parseQueueItem(_ dict: [String: Any]?) -> SharedQueueItem? {
+        guard let dict = dict,
+              let uuid = dict["uuid"] as? String,
+              let climb = dict["climb"] as? [String: Any],
+              let climbUuid = climb["uuid"] as? String
+        else {
+            return nil
+        }
+
+        let name = climb["name"] as? String ?? ""
+        let difficulty = Self.parseDifficulty(climb["difficulty"])
+        let angle = Self.parseIntValue(climb["angle"]) ?? 0
+        let frames = climb["frames"] as? String ?? ""
+        let setter = climb["setter_username"] as? String ?? ""
+        let mirrored = climb["mirrored"] as? Bool ?? false
+
+        return SharedQueueItem(
+            uuid: uuid,
+            climbUuid: climbUuid,
+            climbName: name,
+            difficulty: difficulty,
+            angle: angle,
+            frames: frames,
+            setterUsername: setter,
+            mirrored: mirrored
+        )
+    }
+
+    /// Parse a FullSync event from the queueUpdates dictionary.
+    static func parseFullSync(_ updates: [String: Any]) -> QueueUpdateEvent? {
+        guard let state = updates["state"] as? [String: Any] else { return nil }
+        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
+
+        let queueArray = state["queue"] as? [[String: Any]] ?? []
+        let items = queueArray.compactMap { parseQueueItem($0) }
+
+        let currentItem = parseQueueItem(state["currentClimbQueueItem"] as? [String: Any])
+
+        return .fullSync(items: items, currentItem: currentItem, sequence: sequence)
+    }
+
+    /// Parse a CurrentClimbChanged event.
+    static func parseCurrentClimbChanged(_ updates: [String: Any]) -> QueueUpdateEvent? {
+        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
+        let item = parseQueueItem(updates["currentItem"] as? [String: Any])
+        return .currentClimbChanged(item: item, sequence: sequence)
+    }
+
+    /// Parse a QueueItemAdded event.
+    static func parseQueueItemAdded(_ updates: [String: Any]) -> QueueUpdateEvent? {
+        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
+        let position = Self.parseIntValue(updates["position"]) ?? 0
+        let item = parseQueueItem(updates["addedItem"] as? [String: Any])
+        guard let item = item else { return nil }
+        return .itemAdded(item: item, position: position, sequence: sequence)
+    }
+
+    /// Parse a QueueItemRemoved event.
+    static func parseQueueItemRemoved(_ updates: [String: Any]) -> QueueUpdateEvent? {
+        guard let uuid = updates["uuid"] as? String else { return nil }
+        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
+        return .itemRemoved(uuid: uuid, sequence: sequence)
+    }
+
+    /// Parse a QueueReordered event.
+    static func parseQueueReordered(_ updates: [String: Any]) -> QueueUpdateEvent? {
+        guard let uuid = updates["uuid"] as? String else { return nil }
+        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
+        let oldIndex = Self.parseIntValue(updates["oldIndex"]) ?? 0
+        let newIndex = Self.parseIntValue(updates["newIndex"]) ?? 0
+        return .reordered(uuid: uuid, oldIndex: oldIndex, newIndex: newIndex, sequence: sequence)
+    }
+
+    /// Parse a ClimbMirrored event.
+    static func parseClimbMirrored(_ updates: [String: Any]) -> QueueUpdateEvent? {
+        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
+        let uuid = updates["mirroredUuid"] as? String ?? updates["uuid"] as? String
+        let mirrored = updates["mirrored"] as? Bool ?? false
+        return .climbMirrored(uuid: uuid, mirrored: mirrored, sequence: sequence)
+    }
+
+    /// Route the queueUpdates dictionary to the correct parser based on __typename.
+    static func parseQueueUpdate(_ updates: [String: Any]) -> QueueUpdateEvent? {
+        guard let typename = updates["__typename"] as? String else { return nil }
+        switch typename {
+        case "FullSync":
+            return parseFullSync(updates)
+        case "CurrentClimbChanged":
+            return parseCurrentClimbChanged(updates)
+        case "QueueItemAdded":
+            return parseQueueItemAdded(updates)
+        case "QueueItemRemoved":
+            return parseQueueItemRemoved(updates)
+        case "QueueReordered":
+            return parseQueueReordered(updates)
+        case "ClimbMirrored":
+            return parseClimbMirrored(updates)
+        default:
+            return nil
+        }
+    }
+
+    /// Detect a sequence gap: returns true when `received` is more than one
+    /// step ahead of `lastKnown`. A value of -1 for `lastKnown` means no
+    /// previous sequence has been recorded (first message).
+    static func hasSequenceGap(lastKnown: Int, received: Int) -> Bool {
+        guard lastKnown >= 0 else { return false }
+        return received > lastKnown + 1
+    }
+
+    // MARK: - Private Helpers
+
+    static func parseDifficulty(_ value: Any?) -> String {
+        if let str = value as? String { return str }
+        if let num = value as? Double { return String(format: "%.1f", num) }
+        if let num = value as? Int { return String(num) }
+        return ""
+    }
+
+    static func parseIntValue(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let d = value as? Double { return Int(d) }
+        if let s = value as? String { return Int(s) }
+        return nil
+    }
+}

--- a/packages/mobile/modules/live-activity/ios/SessionQueueState.swift
+++ b/packages/mobile/modules/live-activity/ios/SessionQueueState.swift
@@ -15,6 +15,18 @@ enum QueueUpdateEvent {
     case itemRemoved(uuid: String, sequence: Int)
     case reordered(uuid: String, oldIndex: Int, newIndex: Int, sequence: Int)
     case climbMirrored(uuid: String?, mirrored: Bool, sequence: Int)
+
+    var sequence: Int {
+        switch self {
+        case .fullSync(_, _, let sequence),
+             .currentClimbChanged(_, let sequence),
+             .itemAdded(_, _, let sequence),
+             .itemRemoved(_, let sequence),
+             .reordered(_, _, _, let sequence),
+             .climbMirrored(_, _, let sequence):
+            return sequence
+        }
+    }
 }
 
 enum QueueEventRepaintPolicy {
@@ -44,14 +56,14 @@ enum QueueSequencePolicy {
         case resync
     }
 
-    static func decision(for event: QueueUpdateEvent, receivedSequence: Int, lastKnown: Int) -> Decision {
+    static func decision(for event: QueueUpdateEvent, lastKnown: Int) -> Decision {
         if case .fullSync = event {
-            return .apply(newLastSequence: receivedSequence)
+            return .apply(newLastSequence: event.sequence)
         }
-        if QueueMessageParser.hasSequenceGap(lastKnown: lastKnown, received: receivedSequence) {
+        if QueueMessageParser.hasSequenceGap(lastKnown: lastKnown, received: event.sequence) {
             return .resync
         }
-        return .apply(newLastSequence: receivedSequence)
+        return .apply(newLastSequence: event.sequence)
     }
 }
 

--- a/packages/mobile/modules/live-activity/ios/SessionQueueState.swift
+++ b/packages/mobile/modules/live-activity/ios/SessionQueueState.swift
@@ -55,6 +55,35 @@ enum QueueSequencePolicy {
     }
 }
 
+// MARK: - graphql-ws Error Routing
+
+/// Routes a graphql-ws `error` message by its operation id. Pure so the
+/// routing is testable: a subscription-level error used to fall through the
+/// mutation-only handling and was silently dropped — server pings kept the
+/// connection looking healthy while it delivered zero queue updates.
+enum QueueGraphQLErrorRouting {
+    enum Action: Equatable {
+        /// join-session or the queueUpdates subscription failed — reconnect so
+        /// the session/subscription is re-established.
+        case reconnect
+        /// An optimistic widget navigation was rejected — revert to the index
+        /// recorded before it.
+        case revertOptimisticNavigation(correlationId: String)
+        case ignore
+    }
+
+    static func action(forOperationId id: String?, subscriptionId: String) -> Action {
+        guard let id else { return .ignore }
+        if id == "join-session" || id == subscriptionId {
+            return .reconnect
+        }
+        if id.hasPrefix("mutation-") {
+            return .revertOptimisticNavigation(correlationId: String(id.dropFirst("mutation-".count)))
+        }
+        return .ignore
+    }
+}
+
 // MARK: - State Reducer
 
 /// Applies queue events to (items, currentIndex), keeping the *current item*

--- a/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
+++ b/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
@@ -34,169 +34,9 @@ struct GQLMessage {
     }
 }
 
-// MARK: - Queue Update Events
-
-enum QueueUpdateEvent {
-    case fullSync(items: [SharedQueueItem], currentItem: SharedQueueItem?, sequence: Int)
-    case currentClimbChanged(item: SharedQueueItem?, sequence: Int)
-    case itemAdded(item: SharedQueueItem, position: Int, sequence: Int)
-    case itemRemoved(uuid: String, sequence: Int)
-    case reordered(uuid: String, oldIndex: Int, newIndex: Int, sequence: Int)
-    case climbMirrored(uuid: String?, mirrored: Bool, sequence: Int)
-}
-
-enum QueueEventRepaintPolicy {
-    static func shouldRepaintBoard(for event: QueueUpdateEvent) -> Bool {
-        switch event {
-        case .currentClimbChanged(_, _), .climbMirrored(_, _, _):
-            return true
-        case .fullSync(_, _, _), .itemAdded(_, _, _), .itemRemoved(_, _), .reordered(_, _, _, _):
-            return false
-        }
-    }
-}
-
-// MARK: - Message Parsing Helpers
-
-enum QueueMessageParser {
-
-    /// Extract the `queueUpdates` dictionary from a graphql-ws `next` payload.
-    static func extractQueueUpdates(from payload: [String: Any]?) -> [String: Any]? {
-        guard let data = payload?["data"] as? [String: Any],
-              let updates = data["queueUpdates"] as? [String: Any]
-        else {
-            return nil
-        }
-        return updates
-    }
-
-    /// Convert a raw climb+queue-item dictionary into a `SharedQueueItem`.
-    static func parseQueueItem(_ dict: [String: Any]?) -> SharedQueueItem? {
-        guard let dict = dict,
-              let uuid = dict["uuid"] as? String,
-              let climb = dict["climb"] as? [String: Any],
-              let climbUuid = climb["uuid"] as? String
-        else {
-            return nil
-        }
-
-        let name = climb["name"] as? String ?? ""
-        let difficulty = Self.parseDifficulty(climb["difficulty"])
-        let angle = Self.parseIntValue(climb["angle"]) ?? 0
-        let frames = climb["frames"] as? String ?? ""
-        let setter = climb["setter_username"] as? String ?? ""
-        let mirrored = climb["mirrored"] as? Bool ?? false
-
-        return SharedQueueItem(
-            uuid: uuid,
-            climbUuid: climbUuid,
-            climbName: name,
-            difficulty: difficulty,
-            angle: angle,
-            frames: frames,
-            setterUsername: setter,
-            mirrored: mirrored
-        )
-    }
-
-    /// Parse a FullSync event from the queueUpdates dictionary.
-    static func parseFullSync(_ updates: [String: Any]) -> QueueUpdateEvent? {
-        guard let state = updates["state"] as? [String: Any] else { return nil }
-        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
-
-        let queueArray = state["queue"] as? [[String: Any]] ?? []
-        let items = queueArray.compactMap { parseQueueItem($0) }
-
-        let currentItem = parseQueueItem(state["currentClimbQueueItem"] as? [String: Any])
-
-        return .fullSync(items: items, currentItem: currentItem, sequence: sequence)
-    }
-
-    /// Parse a CurrentClimbChanged event.
-    static func parseCurrentClimbChanged(_ updates: [String: Any]) -> QueueUpdateEvent? {
-        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
-        let item = parseQueueItem(updates["currentItem"] as? [String: Any])
-        return .currentClimbChanged(item: item, sequence: sequence)
-    }
-
-    /// Parse a QueueItemAdded event.
-    static func parseQueueItemAdded(_ updates: [String: Any]) -> QueueUpdateEvent? {
-        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
-        let position = Self.parseIntValue(updates["position"]) ?? 0
-        let item = parseQueueItem(updates["addedItem"] as? [String: Any])
-        guard let item = item else { return nil }
-        return .itemAdded(item: item, position: position, sequence: sequence)
-    }
-
-    /// Parse a QueueItemRemoved event.
-    static func parseQueueItemRemoved(_ updates: [String: Any]) -> QueueUpdateEvent? {
-        guard let uuid = updates["uuid"] as? String else { return nil }
-        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
-        return .itemRemoved(uuid: uuid, sequence: sequence)
-    }
-
-    /// Parse a QueueReordered event.
-    static func parseQueueReordered(_ updates: [String: Any]) -> QueueUpdateEvent? {
-        guard let uuid = updates["uuid"] as? String else { return nil }
-        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
-        let oldIndex = Self.parseIntValue(updates["oldIndex"]) ?? 0
-        let newIndex = Self.parseIntValue(updates["newIndex"]) ?? 0
-        return .reordered(uuid: uuid, oldIndex: oldIndex, newIndex: newIndex, sequence: sequence)
-    }
-
-    /// Parse a ClimbMirrored event.
-    static func parseClimbMirrored(_ updates: [String: Any]) -> QueueUpdateEvent? {
-        let sequence = Self.parseIntValue(updates["sequence"]) ?? 0
-        let uuid = updates["mirroredUuid"] as? String ?? updates["uuid"] as? String
-        let mirrored = updates["mirrored"] as? Bool ?? false
-        return .climbMirrored(uuid: uuid, mirrored: mirrored, sequence: sequence)
-    }
-
-    /// Route the queueUpdates dictionary to the correct parser based on __typename.
-    static func parseQueueUpdate(_ updates: [String: Any]) -> QueueUpdateEvent? {
-        guard let typename = updates["__typename"] as? String else { return nil }
-        switch typename {
-        case "FullSync":
-            return parseFullSync(updates)
-        case "CurrentClimbChanged":
-            return parseCurrentClimbChanged(updates)
-        case "QueueItemAdded":
-            return parseQueueItemAdded(updates)
-        case "QueueItemRemoved":
-            return parseQueueItemRemoved(updates)
-        case "QueueReordered":
-            return parseQueueReordered(updates)
-        case "ClimbMirrored":
-            return parseClimbMirrored(updates)
-        default:
-            return nil
-        }
-    }
-
-    /// Detect a sequence gap: returns true when `received` is more than one
-    /// step ahead of `lastKnown`. A value of -1 for `lastKnown` means no
-    /// previous sequence has been recorded (first message).
-    static func hasSequenceGap(lastKnown: Int, received: Int) -> Bool {
-        guard lastKnown >= 0 else { return false }
-        return received > lastKnown + 1
-    }
-
-    // MARK: - Private Helpers
-
-    static func parseDifficulty(_ value: Any?) -> String {
-        if let str = value as? String { return str }
-        if let num = value as? Double { return String(format: "%.1f", num) }
-        if let num = value as? Int { return String(num) }
-        return ""
-    }
-
-    static func parseIntValue(_ value: Any?) -> Int? {
-        if let i = value as? Int { return i }
-        if let d = value as? Double { return Int(d) }
-        if let s = value as? String { return Int(s) }
-        return nil
-    }
-}
+// Queue event types, payload parsing, sequence acceptance, and the state
+// reducer live in SessionQueueState.swift so they compile into the test
+// target; this file owns the socket, timers, and side effects.
 
 // MARK: - Session WebSocket Manager
 
@@ -322,6 +162,12 @@ final class SessionWebSocketManager {
         // Cancel any existing connection before opening a new one to prevent
         // leaked tasks (e.g. multiple reconnects firing after backgrounding).
         self.webSocketTask?.cancel(with: .goingAway, reason: nil)
+
+        // A fresh subscription starts a fresh sequence stream (the server's
+        // FullSync carries the room's *current* sequence, not a continuation
+        // of the old one), so a sequence carried over from the previous
+        // connection must not gap-check the new stream.
+        self.lastSequence = -1
 
         let urlString: String
         if let wsUrl = self.wsUrl, !wsUrl.isEmpty {
@@ -574,7 +420,12 @@ final class SessionWebSocketManager {
             stateQueue.async { [weak self] in
                 guard let self = self else { return }
                 self.isConnected = true
-                self.reconnectAttempt = 0
+                // reconnectAttempt is deliberately NOT reset here. An ack only
+                // proves the transport; resetting on it let deterministic
+                // post-ack failures (subscription error, joinSession error)
+                // reconnect forever because the max-attempts guard never
+                // tripped. It resets in handleNextMessage once queue data
+                // actually flows.
                 self.sendJoinSession()
                 self.sendSubscription()
                 // Fire after join/subscribe so observers can rely on the
@@ -610,19 +461,25 @@ final class SessionWebSocketManager {
 
         let receivedSeq = sequenceFromEvent(event)
 
-        // Sequence gap check and lastSequence update must be atomic
+        // Sequence acceptance and lastSequence update must be atomic
         stateQueue.async { [weak self] in
             guard let self = self else { return }
 
-            if QueueMessageParser.hasSequenceGap(lastKnown: self.lastSequence, received: receivedSeq) {
-                // Gap detected — cancel the current task so listenForMessages' failure
-                // path calls handleDisconnect(), which schedules a reconnect and will
-                // receive a FullSync restoring consistent state.
+            switch QueueSequencePolicy.decision(for: event, receivedSequence: receivedSeq, lastKnown: self.lastSequence) {
+            case .resync:
+                // Mid-stream gap — cancel the current task so listenForMessages'
+                // failure path calls handleDisconnect(), which schedules a
+                // reconnect whose FullSync restores consistent state.
                 print("[SessionWS] Sequence gap: expected \(self.lastSequence + 1), got \(receivedSeq) — reconnecting")
                 self.webSocketTask?.cancel(with: .goingAway, reason: nil)
                 return
+            case .apply(let newLastSequence):
+                self.lastSequence = newLastSequence
             }
-            self.lastSequence = receivedSeq
+
+            // Queue data is flowing — the connection is genuinely healthy, so
+            // the backoff ladder restarts from the bottom on the next drop.
+            self.reconnectAttempt = 0
 
             // Apply event inline (already on stateQueue) rather than calling
             // applyEvent which would double-dispatch
@@ -641,86 +498,15 @@ final class SessionWebSocketManager {
         }
     }
 
-    private func applyEvent(_ event: QueueUpdateEvent) {
-        stateQueue.async { [weak self] in
-            guard let self = self else { return }
-            self.applyEventOnQueue(event)
-        }
-    }
-
     /// Applies a queue update event. MUST be called on `stateQueue`.
     private func applyEventOnQueue(_ event: QueueUpdateEvent) {
-        let shouldRepaintBoard = QueueEventRepaintPolicy.shouldRepaintBoard(for: event)
-
-        switch event {
-        case .fullSync(let items, let currentItem, _):
-            queueItems = items
-            if let currentItem = currentItem {
-                currentIndex = items.firstIndex(where: { $0.uuid == currentItem.uuid }) ?? 0
-            } else {
-                currentIndex = 0
-            }
-
-        case .currentClimbChanged(let item, _):
-            if let item = item {
-                currentIndex = queueItems.firstIndex(where: { $0.uuid == item.uuid }) ?? currentIndex
-            }
-
-        case .itemAdded(let item, let position, _):
-            let insertIndex = min(max(position, 0), queueItems.count)
-            queueItems.insert(item, at: insertIndex)
-
-        case .itemRemoved(let uuid, _):
-            if let removeIndex = queueItems.firstIndex(where: { $0.uuid == uuid }) {
-                queueItems.remove(at: removeIndex)
-                if currentIndex >= queueItems.count {
-                    currentIndex = max(0, queueItems.count - 1)
-                }
-            }
-
-        case .reordered(let uuid, let oldIndex, let newIndex, _):
-            guard oldIndex >= 0, oldIndex < queueItems.count else { return }
-            let validOldItem = queueItems[oldIndex]
-            // Prefer using the oldIndex if the uuid matches, otherwise search
-            let item: SharedQueueItem
-            if validOldItem.uuid == uuid {
-                item = validOldItem
-            } else if let found = queueItems.firstIndex(where: { $0.uuid == uuid }) {
-                item = queueItems[found]
-                queueItems.remove(at: found)
-                let dest = min(max(newIndex, 0), queueItems.count)
-                queueItems.insert(item, at: dest)
-                persistAndNotify(repaintBoard: shouldRepaintBoard)
-                return
-            } else {
-                return
-            }
-            queueItems.remove(at: oldIndex)
-            let dest = min(max(newIndex, 0), queueItems.count)
-            queueItems.insert(item, at: dest)
-
-        case .climbMirrored(let uuid, let mirrored, _):
-            guard let uuid,
-                  let itemIndex = queueItems.firstIndex(where: { $0.uuid == uuid })
-            else {
-                persistAndNotify(repaintBoard: shouldRepaintBoard)
-                return
-            }
-            let item = queueItems[itemIndex]
-            let updatedItem = SharedQueueItem(
-                uuid: item.uuid,
-                climbUuid: item.climbUuid,
-                climbName: item.climbName,
-                difficulty: item.difficulty,
-                angle: item.angle,
-                frames: item.frames,
-                setterUsername: item.setterUsername,
-                mirrored: mirrored
-            )
-            queueItems[itemIndex] = updatedItem
-        }
-
-        persistAndNotify(repaintBoard: shouldRepaintBoard)
+        let newState = QueueStateReducer.apply(
+            event,
+            to: QueueStateReducer.QueueState(items: queueItems, currentIndex: currentIndex)
+        )
+        queueItems = newState.items
+        currentIndex = newState.currentIndex
+        persistAndNotify(repaintBoard: QueueEventRepaintPolicy.shouldRepaintBoard(for: event))
     }
 
     private func persistAndNotify(repaintBoard: Bool = false) {
@@ -826,6 +612,19 @@ final class SessionWebSocketManager {
             // joinSession failed — the connection can't send mutations without a session.
             // Reconnect to retry.
             print("[SessionWS] joinSession failed — reconnecting")
+            stateQueue.async { [weak self] in
+                self?.webSocketTask?.cancel(with: .goingAway, reason: nil)
+            }
+            return
+        }
+
+        if id == subscriptionId {
+            // The queueUpdates subscription itself errored. Server pings keep
+            // the ping-timeout watchdog quiet, so without this the connection
+            // would look healthy while delivering zero queue updates for the
+            // rest of the session. Reconnect to resubscribe — bounded, because
+            // reconnectAttempt only resets once queue data actually flows.
+            print("[SessionWS] queueUpdates subscription errored: \(msg.payload ?? [:]) — reconnecting")
             stateQueue.async { [weak self] in
                 self?.webSocketTask?.cancel(with: .goingAway, reason: nil)
             }

--- a/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
+++ b/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
@@ -459,18 +459,16 @@ final class SessionWebSocketManager {
         guard let updates = QueueMessageParser.extractQueueUpdates(from: msg.payload) else { return }
         guard let event = QueueMessageParser.parseQueueUpdate(updates) else { return }
 
-        let receivedSeq = sequenceFromEvent(event)
-
         // Sequence acceptance and lastSequence update must be atomic
         stateQueue.async { [weak self] in
             guard let self = self else { return }
 
-            switch QueueSequencePolicy.decision(for: event, receivedSequence: receivedSeq, lastKnown: self.lastSequence) {
+            switch QueueSequencePolicy.decision(for: event, lastKnown: self.lastSequence) {
             case .resync:
                 // Mid-stream gap — cancel the current task so listenForMessages'
                 // failure path calls handleDisconnect(), which schedules a
                 // reconnect whose FullSync restores consistent state.
-                print("[SessionWS] Sequence gap: expected \(self.lastSequence + 1), got \(receivedSeq) — reconnecting")
+                print("[SessionWS] Sequence gap: expected \(self.lastSequence + 1), got \(event.sequence) — reconnecting")
                 self.webSocketTask?.cancel(with: .goingAway, reason: nil)
                 return
             case .apply(let newLastSequence):
@@ -484,17 +482,6 @@ final class SessionWebSocketManager {
             // Apply event inline (already on stateQueue) rather than calling
             // applyEvent which would double-dispatch
             self.applyEventOnQueue(event)
-        }
-    }
-
-    private func sequenceFromEvent(_ event: QueueUpdateEvent) -> Int {
-        switch event {
-        case .fullSync(_, _, let seq): return seq
-        case .currentClimbChanged(_, let seq): return seq
-        case .itemAdded(_, _, let seq): return seq
-        case .itemRemoved(_, let seq): return seq
-        case .reordered(_, _, _, let seq): return seq
-        case .climbMirrored(_, _, let seq): return seq
         }
     }
 

--- a/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
+++ b/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
@@ -606,40 +606,32 @@ final class SessionWebSocketManager {
     // MARK: - Mutation Response Handling
 
     private func handleMutationError(_ msg: GQLMessage) {
-        guard let id = msg.id else { return }
-
-        if id == "join-session" {
-            // joinSession failed — the connection can't send mutations without a session.
-            // Reconnect to retry.
-            print("[SessionWS] joinSession failed — reconnecting")
+        switch QueueGraphQLErrorRouting.action(forOperationId: msg.id, subscriptionId: subscriptionId) {
+        case .reconnect:
+            // joinSession failed (no session → mutations rejected) or the
+            // queueUpdates subscription itself errored. For the latter, server
+            // pings keep the ping-timeout watchdog quiet, so without this the
+            // connection would look healthy while delivering zero queue
+            // updates for the rest of the session. Reconnect to re-establish —
+            // bounded, because reconnectAttempt only resets once queue data
+            // actually flows.
+            print("[SessionWS] operation \(msg.id ?? "?") errored: \(msg.payload ?? [:]) — reconnecting")
             stateQueue.async { [weak self] in
                 self?.webSocketTask?.cancel(with: .goingAway, reason: nil)
             }
-            return
-        }
 
-        if id == subscriptionId {
-            // The queueUpdates subscription itself errored. Server pings keep
-            // the ping-timeout watchdog quiet, so without this the connection
-            // would look healthy while delivering zero queue updates for the
-            // rest of the session. Reconnect to resubscribe — bounded, because
-            // reconnectAttempt only resets once queue data actually flows.
-            print("[SessionWS] queueUpdates subscription errored: \(msg.payload ?? [:]) — reconnecting")
+        case .revertOptimisticNavigation(let correlationId):
+            // Server rejected the navigation — revert to the index before the optimistic update
             stateQueue.async { [weak self] in
-                self?.webSocketTask?.cancel(with: .goingAway, reason: nil)
+                guard let self = self else { return }
+                if let previousIndex = self.pendingMutations.removeValue(forKey: correlationId) {
+                    self.currentIndex = previousIndex
+                    self.persistAndNotify(repaintBoard: true)
+                }
             }
-            return
-        }
 
-        guard id.hasPrefix("mutation-") else { return }
-        let correlationId = String(id.dropFirst("mutation-".count))
-        // Server rejected the navigation — revert to the index before the optimistic update
-        stateQueue.async { [weak self] in
-            guard let self = self else { return }
-            if let previousIndex = self.pendingMutations.removeValue(forKey: correlationId) {
-                self.currentIndex = previousIndex
-                self.persistAndNotify(repaintBoard: true)
-            }
+        case .ignore:
+            break
         }
     }
 

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -33,6 +33,10 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/LiveActivitySources/SharedConstants.swift',
   },
   {
+    sourcePath: '../modules/live-activity/ios/SessionQueueState.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/SessionQueueState.swift',
+  },
+  {
     sourcePath: '../modules/live-activity/ios/SharedKeychain.swift',
     projectPath: 'BoardseshTests/LiveActivitySources/SharedKeychain.swift',
   },


### PR DESCRIPTION
## Summary

Four bugs in the native (backgrounded) session WebSocket manager, found in an adversarial review of the Live Activity stack. All native Swift — ships with the next binary, not OTA.

1. **Reconnect loop killed background updates.** `lastSequence` was never reset on reconnect and FullSync was gap-checked, so after a background WS drop plus ≥2 peer navigations, every reconnect's FullSync tripped `hasSequenceGap` → cancel → reconnect → same FullSync, forever (`reconnectAttempt` reset on every ack, so the max-attempts guard never fired). Background Live Activity updates were dead for the rest of the session, with constant connect/join/subscribe churn. FullSync is now accepted unconditionally as the authoritative snapshot (`QueueSequencePolicy`), and `lastSequence` resets when a connection opens.
2. **Queue edits above the current climb shifted it.** `currentIndex` was a raw index, so a peer removing/inserting/reordering an item ahead of the current climb pointed the Live Activity — and widget next/prev + the BLE re-light — at the wrong climb until the next FullSync. The current item is now tracked by uuid across mutations (pure `QueueStateReducer`, mirroring the JS reducer).
3. **A peer navigating to a search result repainted the OLD climb.** A `CurrentClimbChanged` for a climb not in the queue kept the stale index and, because that event repaints, re-wrote the previous climb's holds to the wall — actively fighting the peer. It now appends the climb and points at it, mirroring the JS reducer's `shouldAddToQueue`.
4. **Subscription errors were silently swallowed.** A graphql-ws `error` for the queueUpdates subscription fell through the mutation-error guard; server pings kept the ping-timeout watchdog quiet, so the connection looked healthy while delivering nothing. It now reconnects to resubscribe — bounded, because `reconnectAttempt` now resets when queue data actually flows rather than on `connection_ack` (which also bounds the pre-existing joinSession retry loop).

Queue event parsing and state transitions moved verbatim-plus-fixes from `SessionWebSocketManager.swift` into `SessionQueueState.swift` so they compile into the `BoardseshTests` target.

## Release Notes

- Party sessions stay in sync on the lock screen: reconnecting after a dead spot no longer freezes the Live Activity, and a crew mate shuffling the queue no longer flips it to the wrong climb

## Test plan

- New XCTests (`ios-rn-ci`): FullSync accepted across a sequence jump while deltas still resync; current climb followed by uuid across remove/insert/reorder; removing the current climb falls to its successor; off-queue current climb appended (event + FullSync variants).
- `swiftc -typecheck` clean on the extracted `SessionQueueState.swift`; full-app compile covered by CI.
- `vp check` clean on the touched script (`prepare-rn-ios-tests.mjs` gains the new source file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G77gsNZteEQB7ehifY4iRN