### PR TITLE
feat(mobile): Signup Completed event + Android install attribution

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -506,6 +506,12 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
       // Play device filtering. Unconditional (EAS-safe) — it's a pure manifest
       // addition with no signing/credential implications.
       './plugins/with-android-bluetooth-feature',
+      // Declares com.android.vending as a visible package under Android 11+
+      // package-visibility filtering, so the Play Install Referrer native module
+      // (packages/mobile/modules/install-referrer) can bind to the Play Store
+      // service instead of always resolving FEATURE_NOT_SUPPORTED. EAS-safe pure
+      // manifest addition.
+      './plugins/with-android-install-referrer-queries',
       // Adds the <service android:foregroundServiceType="connectedDevice"> + the
       // notification-action <receiver> for the background BLE session (the
       // Android counterpart to the iOS Live Activity). EAS-safe manifest-only mod.

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -61,6 +61,7 @@ import { loadRequiredFonts } from '../src/lib/required-fonts';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
 import { OtaUpdateTracker } from '../src/components/analytics/OtaUpdateTracker';
+import { InstallReferrerTracker } from '../src/components/analytics/InstallReferrerTracker';
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 import { AccessoryOnboardingTip } from '../src/components/onboarding/AccessoryOnboardingTip';
 import { FreezeDebugOverlay } from '../src/components/FreezeDebugOverlay';
@@ -502,6 +503,7 @@ function RootLayout() {
                                                         </TabBarHeightProvider>
                                                         <AnalyticsScreenTracker />
                                                         <OtaUpdateTracker />
+                                                        <InstallReferrerTracker />
                                                       </ShareTargetProvider>
                                                     </DeepLinkProvider>
                                                   </DrawerHostProvider>

--- a/packages/mobile/app/auth/__tests__/register-analytics.test.tsx
+++ b/packages/mobile/app/auth/__tests__/register-analytics.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { act, render, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+
+const analytics = vi.hoisted(() => ({ track: vi.fn(), setPersonProperties: vi.fn() }));
+const auth = vi.hoisted(() => ({ register: vi.fn() }));
+const router = vi.hoisted(() => ({ replace: vi.fn() }));
+
+// Captures the fields + submit callback AuthFieldset receives, so the test can
+// drive the form like a real user (fill email/password/confirmPassword, then
+// submit) without mounting the platform-split native field/button trees.
+const form = vi.hoisted(() => ({
+  setters: {} as Record<string, (text: string) => void>,
+  submit: null as (() => void) | null,
+}));
+
+vi.mock('../../../src/lib/analytics', () => ({
+  track: analytics.track,
+  setPersonProperties: analytics.setPersonProperties,
+}));
+vi.mock('../../../src/providers/auth-provider', () => ({ useAuth: () => ({ register: auth.register }) }));
+vi.mock('../../../src/hooks/use-native-oauth-sign-in', () => ({
+  useNativeOAuthSignIn: () => ({ signIn: vi.fn(), inProgress: false }),
+}));
+vi.mock('../../../src/lib/auth', () => ({ isGoogleSignInConfigured: () => false }));
+vi.mock('../../../src/lib/error-reporting', () => ({ reportError: vi.fn() }));
+vi.mock('../../../src/lib/haptics', () => ({ hapticLight: vi.fn() }));
+vi.mock('../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({ colorScheme: 'light', systemColors: {} }),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('expo-router', () => ({
+  Stack: { Screen: () => null },
+  useRouter: () => router,
+}));
+vi.mock('expo-apple-authentication', () => ({
+  AppleAuthenticationButton: () => null,
+  AppleAuthenticationButtonType: { SIGN_UP: 'sign_up' },
+  AppleAuthenticationButtonStyle: { WHITE: 'white', BLACK: 'black' },
+}));
+vi.mock('@react-native-google-signin/google-signin', () => ({
+  GoogleSigninButton: Object.assign(() => null, {
+    Size: { Wide: 'wide' },
+    Color: { Dark: 'dark', Light: 'light' },
+  }),
+}));
+vi.mock('react-native', () => ({
+  KeyboardAvoidingView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Platform: { OS: 'android' },
+  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { onClick: onPress }, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('../../../src/components/AuthFieldset', () => ({
+  AuthFieldset: ({
+    fields,
+    onSubmit,
+  }: {
+    fields: Array<{ key: string; onChangeText: (text: string) => void }>;
+    onSubmit?: () => void;
+  }) => {
+    fields.forEach((field) => {
+      form.setters[field.key] = field.onChangeText;
+    });
+    form.submit = onSubmit ?? null;
+    return createElement('div');
+  },
+}));
+vi.mock('../../../src/components/Button', () => ({
+  Button: ({ onPress }: { onPress?: () => void }) => createElement('button', { onClick: onPress }),
+}));
+vi.mock('../../../src/components/Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+import RegisterScreen from '../register';
+
+beforeEach(() => {
+  analytics.track.mockClear();
+  analytics.setPersonProperties.mockClear();
+  auth.register.mockReset();
+  router.replace.mockClear();
+  form.setters = {};
+  form.submit = null;
+});
+
+async function fillAndSubmit() {
+  render(createElement(RegisterScreen));
+  await act(async () => {
+    form.setters.email?.('new@example.com');
+    form.setters.password?.('supersecure1');
+    form.setters.confirmPassword?.('supersecure1');
+  });
+  await act(async () => {
+    form.submit?.();
+  });
+}
+
+describe('RegisterScreen analytics', () => {
+  it('fires SignupCompleted + first-touch person properties alongside LoginSucceeded on success', async () => {
+    auth.register.mockResolvedValue({ success: true });
+
+    await fillAndSubmit();
+
+    await waitFor(() =>
+      expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.LoginSucceeded, {
+        auth_method: 'credentials',
+        flow: 'native',
+        is_registration: true,
+      }),
+    );
+    expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.SignupCompleted, {
+      auth_method: 'credentials',
+      flow: 'native',
+    });
+    expect(analytics.setPersonProperties).toHaveBeenCalledWith(undefined, {
+      signup_at: expect.any(String),
+      signup_auth_method: 'credentials',
+    });
+  });
+
+  it('does not fire SignupCompleted when registration fails', async () => {
+    auth.register.mockResolvedValue({ success: false, status: 400, error: 'Email already registered' });
+
+    await fillAndSubmit();
+
+    await waitFor(() =>
+      expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.LoginFailed, expect.any(Object)),
+    );
+    expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.SignupCompleted, expect.any(Object));
+    expect(analytics.setPersonProperties).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/app/auth/__tests__/register-analytics.test.tsx
+++ b/packages/mobile/app/auth/__tests__/register-analytics.test.tsx
@@ -129,9 +129,7 @@ describe('RegisterScreen analytics', () => {
 
     await fillAndSubmit();
 
-    await waitFor(() =>
-      expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.LoginFailed, expect.any(Object)),
-    );
+    await waitFor(() => expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.LoginFailed, expect.any(Object)));
     expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.SignupCompleted, expect.any(Object));
     expect(analytics.setPersonProperties).not.toHaveBeenCalled();
   });

--- a/packages/mobile/app/auth/__tests__/register-analytics.test.tsx
+++ b/packages/mobile/app/auth/__tests__/register-analytics.test.tsx
@@ -7,6 +7,8 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 const analytics = vi.hoisted(() => ({ track: vi.fn(), setPersonProperties: vi.fn() }));
 const auth = vi.hoisted(() => ({ register: vi.fn() }));
 const router = vi.hoisted(() => ({ replace: vi.fn() }));
+const oauth = vi.hoisted(() => ({ signIn: vi.fn(async () => ({ success: true }) as unknown) }));
+const googleButton = vi.hoisted(() => ({ press: null as (() => void) | null }));
 
 // Captures the fields + submit callback AuthFieldset receives, so the test can
 // drive the form like a real user (fill email/password/confirmPassword, then
@@ -22,9 +24,11 @@ vi.mock('../../../src/lib/analytics', () => ({
 }));
 vi.mock('../../../src/providers/auth-provider', () => ({ useAuth: () => ({ register: auth.register }) }));
 vi.mock('../../../src/hooks/use-native-oauth-sign-in', () => ({
-  useNativeOAuthSignIn: () => ({ signIn: vi.fn(), inProgress: false }),
+  useNativeOAuthSignIn: () => ({ signIn: oauth.signIn, inProgress: false }),
 }));
-vi.mock('../../../src/lib/auth', () => ({ isGoogleSignInConfigured: () => false }));
+// true (not the earlier false) so the Google button renders — needed to drive
+// the OAuth-path negative test below via a real press, not just a stubbed hook.
+vi.mock('../../../src/lib/auth', () => ({ isGoogleSignInConfigured: () => true }));
 vi.mock('../../../src/lib/error-reporting', () => ({ reportError: vi.fn() }));
 vi.mock('../../../src/lib/haptics', () => ({ hapticLight: vi.fn() }));
 vi.mock('../../../src/providers/theme-provider', () => ({
@@ -41,10 +45,13 @@ vi.mock('expo-apple-authentication', () => ({
   AppleAuthenticationButtonStyle: { WHITE: 'white', BLACK: 'black' },
 }));
 vi.mock('@react-native-google-signin/google-signin', () => ({
-  GoogleSigninButton: Object.assign(() => null, {
-    Size: { Wide: 'wide' },
-    Color: { Dark: 'dark', Light: 'light' },
-  }),
+  GoogleSigninButton: Object.assign(
+    ({ onPress }: { onPress?: () => void }) => {
+      googleButton.press = onPress ?? null;
+      return createElement('button');
+    },
+    { Size: { Wide: 'wide' }, Color: { Dark: 'dark', Light: 'light' } },
+  ),
 }));
 vi.mock('react-native', () => ({
   KeyboardAvoidingView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -85,8 +92,10 @@ beforeEach(() => {
   analytics.setPersonProperties.mockClear();
   auth.register.mockReset();
   router.replace.mockClear();
+  oauth.signIn.mockClear();
   form.setters = {};
   form.submit = null;
+  googleButton.press = null;
 });
 
 async function fillAndSubmit() {
@@ -130,6 +139,25 @@ describe('RegisterScreen analytics', () => {
     await fillAndSubmit();
 
     await waitFor(() => expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.LoginFailed, expect.any(Object)));
+    expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.SignupCompleted, expect.any(Object));
+    expect(analytics.setPersonProperties).not.toHaveBeenCalled();
+  });
+
+  it('does not fire SignupCompleted through the OAuth sign-in path', async () => {
+    // register.tsx has exactly one SignupCompleted call site: the credentials
+    // onSubmit() success branch. OAuth registration goes through
+    // useNativeOAuthSignIn (already tagged is_registration: true on
+    // LoginSucceeded there, tested separately in
+    // use-native-oauth-sign-in.test.tsx) and must not also fire SignupCompleted
+    // — matching web, which has no OAuth-signup-distinct event either.
+    render(createElement(RegisterScreen));
+    expect(googleButton.press).not.toBeNull();
+
+    await act(async () => {
+      googleButton.press?.();
+    });
+
+    expect(oauth.signIn).toHaveBeenCalledWith('google');
     expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.SignupCompleted, expect.any(Object));
     expect(analytics.setPersonProperties).not.toHaveBeenCalled();
   });

--- a/packages/mobile/app/auth/register.tsx
+++ b/packages/mobile/app/auth/register.tsx
@@ -14,7 +14,7 @@ import { useNativeOAuthSignIn } from '../../src/hooks/use-native-oauth-sign-in';
 import { AuthFieldset } from '../../src/components/AuthFieldset';
 import { Button } from '../../src/components/Button';
 import { Text } from '../../src/components/Text';
-import { track } from '../../src/lib/analytics';
+import { track, setPersonProperties } from '../../src/lib/analytics';
 import { reportError } from '../../src/lib/error-reporting';
 import { hapticLight } from '../../src/lib/haptics';
 
@@ -97,6 +97,17 @@ export default function RegisterScreen() {
       const result = await register(trimmedEmail, values.password, values.name.trim() || undefined);
       if (result.success) {
         track(SHARED_EVENTS.LoginSucceeded, { auth_method: 'credentials', flow: 'native', is_registration: true });
+        track(SHARED_EVENTS.SignupCompleted, { auth_method: 'credentials', flow: 'native' });
+        // First-touch attribution — written once and never overwritten. Mirrors
+        // web's handleRegister (auth-page-content.tsx): PostHog merges these onto
+        // the authenticated user once reconcileAnalyticsIdentity's alias() runs.
+        // Native registration always auto-logs-in (registerWithCredentials has no
+        // email-verification branch, unlike web's /api/auth/register), so unlike
+        // web there's no "early return before alias()" caveat here.
+        setPersonProperties(undefined, {
+          signup_at: new Date().toISOString(),
+          signup_auth_method: 'credentials',
+        });
         // AuthProvider flips isAuthenticated and the auth-group Redirect lands the
         // new user in the app — same auto-login path as signInWithCredentials.
         return;

--- a/packages/mobile/modules/install-referrer/android/build.gradle
+++ b/packages/mobile/modules/install-referrer/android/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+  id 'com.android.library'
+  // Canonical Expo local-module plugin: applies Kotlin + provides
+  // expo-modules-core (Module/ModuleDefinition API) on the compile classpath,
+  // version-proof. Groovy (not .kts) so the library defaultConfig
+  // versionCode/versionName the plugin requires can be set.
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'com.boardsesh'
+version = '1.0.0'
+
+android {
+  namespace 'com.boardsesh.installreferrer'
+  compileSdk 36
+
+  defaultConfig {
+    minSdk 24
+    // Required by expo-module-gradle-plugin's publication setup.
+    versionCode 1
+    versionName '1.0.0'
+  }
+}
+
+dependencies {
+  // Google's official Play Install Referrer client — resolves off the
+  // google() Maven repo already on the generated project's classpath.
+  // InstallReferrerClient is a one-shot, callback-based service binding; the
+  // Kotlin module wraps it in a coroutine (kotlinx-coroutines-core comes
+  // transitively via expo-modules-core, which the plugin above provides).
+  implementation 'com.android.installreferrer:installreferrer:2.2'
+}

--- a/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
+++ b/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
@@ -1,0 +1,85 @@
+package com.boardsesh.installreferrer
+
+import com.android.installreferrer.api.InstallReferrerClient
+import com.android.installreferrer.api.InstallReferrerClient.InstallReferrerResponse
+import com.android.installreferrer.api.InstallReferrerStateListener
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+class InstallReferrerModule : Module() {
+    override fun definition() = ModuleDefinition {
+        Name("InstallReferrer")
+
+        // Fetches the Play Install Referrer once (see maybeFetchAndAttachInstallReferrer
+        // in src/lib/install-referrer.ts for the JS-side fetch-once/cache policy).
+        // Resolves null — never throws — on any non-OK response, disconnect, or
+        // exception, so a sideloaded/non-Play install degrades silently.
+        AsyncFunction("getInstallReferrer") {
+            fetchInstallReferrer()
+        }
+    }
+
+    private suspend fun fetchInstallReferrer(): Map<String, Any?>? {
+        val reactContext = appContext.reactContext ?: return null
+        return try {
+            suspendCancellableCoroutine { continuation ->
+                val client = InstallReferrerClient.newBuilder(reactContext).build()
+                var settled = false
+
+                fun finish(result: Map<String, Any?>?) {
+                    // InstallReferrerClient docs: call endConnection() promptly once
+                    // done with the binding. Guarded by `settled` so a listener
+                    // callback firing after cancellation/timeout can't double-resume.
+                    if (settled) return
+                    settled = true
+                    try {
+                        client.endConnection()
+                    } catch (endError: Exception) {
+                        // Best-effort — the binding is being torn down regardless.
+                    }
+                    if (continuation.isActive) continuation.resume(result) { }
+                }
+
+                try {
+                    client.startConnection(object : InstallReferrerStateListener {
+                        override fun onInstallReferrerSetupFinished(responseCode: Int) {
+                            if (responseCode != InstallReferrerResponse.OK) {
+                                finish(null)
+                                return
+                            }
+                            try {
+                                val details = client.installReferrer
+                                finish(
+                                    mapOf(
+                                        "installReferrer" to details.installReferrer,
+                                        "referrerClickTimestampSeconds" to details.referrerClickTimestampSeconds,
+                                        "installBeginTimestampSeconds" to details.installBeginTimestampSeconds,
+                                    ),
+                                )
+                            } catch (readError: Exception) {
+                                finish(null)
+                            }
+                        }
+
+                        override fun onInstallReferrerServiceDisconnected() {
+                            finish(null)
+                        }
+                    })
+                } catch (connectError: Exception) {
+                    finish(null)
+                }
+
+                continuation.invokeOnCancellation {
+                    try {
+                        client.endConnection()
+                    } catch (endError: Exception) {
+                        // Best-effort cleanup on cancellation.
+                    }
+                }
+            }
+        } catch (unexpectedError: Exception) {
+            null
+        }
+    }
+}

--- a/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
+++ b/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
@@ -38,6 +38,9 @@ class InstallReferrerModule : Module() {
                     } catch (endError: Exception) {
                         // Best-effort — the binding is being torn down regardless.
                     }
+                    // Empty onCancellation is deliberate: endConnection() above already
+                    // ran before this resume() call, so there's nothing left to clean up
+                    // if cancellation races the resume itself.
                     if (continuation.isActive) continuation.resume(result) { }
                 }
 

--- a/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
+++ b/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
@@ -6,6 +6,7 @@ import com.android.installreferrer.api.InstallReferrerStateListener
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.concurrent.atomic.AtomicBoolean
 
 class InstallReferrerModule : Module() {
     override fun definition() = ModuleDefinition {
@@ -25,14 +26,19 @@ class InstallReferrerModule : Module() {
         return try {
             suspendCancellableCoroutine { continuation ->
                 val client = InstallReferrerClient.newBuilder(reactContext).build()
-                var settled = false
+                // AtomicBoolean, not a plain var: InstallReferrerStateListener callbacks
+                // and the coroutine's cancellation handler can dispatch on different
+                // threads, and a plain var gives no cross-thread visibility guarantee —
+                // a cancellation racing a listener callback could observe a stale
+                // pre-write value and double-run the settle path. compareAndSet makes
+                // the check-and-set atomic and visible across threads.
+                val settled = AtomicBoolean(false)
 
                 fun finish(result: Map<String, Any?>?) {
                     // InstallReferrerClient docs: call endConnection() promptly once
-                    // done with the binding. Guarded by `settled` so a listener
-                    // callback firing after cancellation/timeout can't double-resume.
-                    if (settled) return
-                    settled = true
+                    // done with the binding. compareAndSet so a listener callback firing
+                    // after cancellation/timeout can't double-resume.
+                    if (!settled.compareAndSet(false, true)) return
                     try {
                         client.endConnection()
                     } catch (endError: Exception) {
@@ -47,7 +53,10 @@ class InstallReferrerModule : Module() {
                 // Registered BEFORE startConnection: a cancellation landing in the
                 // window between the two calls must still close the binding — if this
                 // were registered after, a cancel in that gap would never fire cleanup.
+                // Gated on the same `settled` flag as finish() so a cancellation racing
+                // an already-settled listener callback doesn't call endConnection() twice.
                 continuation.invokeOnCancellation {
+                    if (!settled.compareAndSet(false, true)) return@invokeOnCancellation
                     try {
                         client.endConnection()
                     } catch (endError: Exception) {

--- a/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
+++ b/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
@@ -5,6 +5,8 @@ import com.android.installreferrer.api.InstallReferrerClient.InstallReferrerResp
 import com.android.installreferrer.api.InstallReferrerStateListener
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
 import java.util.concurrent.atomic.AtomicBoolean
@@ -107,10 +109,18 @@ class InstallReferrerModule : Module() {
                     }
                 }
             }
+        } catch (timeoutError: TimeoutCancellationException) {
+            // Our own withTimeout expiring — this is an internal, expected degrade
+            // path (same outcome as FEATURE_NOT_SUPPORTED etc.), not a signal from
+            // an outer scope, so it's fine to swallow and resolve null.
+            null
+        } catch (cancellationError: CancellationException) {
+            // Any OTHER cancellation is the coroutine's own scope being cancelled
+            // from outside (e.g. the caller torn down) — rethrow so structured
+            // concurrency's cancellation propagates instead of this call silently
+            // reporting "no referrer found" for a cancellation that was never ours.
+            throw cancellationError
         } catch (unexpectedError: Exception) {
-            // Also catches TimeoutCancellationException from withTimeout above —
-            // resolving null on a timeout matches every other degrade-gracefully path
-            // in this function.
             null
         }
     }

--- a/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
+++ b/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
@@ -3,6 +3,7 @@ package com.boardsesh.installreferrer
 import com.android.installreferrer.api.InstallReferrerClient
 import com.android.installreferrer.api.InstallReferrerClient.InstallReferrerResponse
 import com.android.installreferrer.api.InstallReferrerStateListener
+import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import kotlinx.coroutines.CancellationException
@@ -19,7 +20,11 @@ class InstallReferrerModule : Module() {
         // in src/lib/install-referrer.ts for the JS-side fetch-once/cache policy).
         // Resolves null — never throws — on any non-OK response, disconnect, or
         // exception, so a sideloaded/non-Play install degrades silently.
-        AsyncFunction("getInstallReferrer") {
+        // The `Coroutine` infix (not a plain trailing lambda) is required for the
+        // body to run as a suspend function — a plain AsyncFunction lambda is not
+        // itself a coroutine, so calling the suspend fetchInstallReferrer() from
+        // inside it doesn't compile.
+        AsyncFunction("getInstallReferrer") Coroutine {
             fetchInstallReferrer()
         }
     }

--- a/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
+++ b/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
@@ -41,6 +41,17 @@ class InstallReferrerModule : Module() {
                     if (continuation.isActive) continuation.resume(result) { }
                 }
 
+                // Registered BEFORE startConnection: a cancellation landing in the
+                // window between the two calls must still close the binding — if this
+                // were registered after, a cancel in that gap would never fire cleanup.
+                continuation.invokeOnCancellation {
+                    try {
+                        client.endConnection()
+                    } catch (endError: Exception) {
+                        // Best-effort cleanup on cancellation.
+                    }
+                }
+
                 try {
                     client.startConnection(object : InstallReferrerStateListener {
                         override fun onInstallReferrerSetupFinished(responseCode: Int) {
@@ -68,14 +79,6 @@ class InstallReferrerModule : Module() {
                     })
                 } catch (connectError: Exception) {
                     finish(null)
-                }
-
-                continuation.invokeOnCancellation {
-                    try {
-                        client.endConnection()
-                    } catch (endError: Exception) {
-                        // Best-effort cleanup on cancellation.
-                    }
                 }
             }
         } catch (unexpectedError: Exception) {

--- a/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
+++ b/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
@@ -6,6 +6,7 @@ import com.android.installreferrer.api.InstallReferrerStateListener
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
 import java.util.concurrent.atomic.AtomicBoolean
 
 class InstallReferrerModule : Module() {
@@ -24,77 +25,97 @@ class InstallReferrerModule : Module() {
     private suspend fun fetchInstallReferrer(): Map<String, Any?>? {
         val reactContext = appContext.reactContext ?: return null
         return try {
-            suspendCancellableCoroutine { continuation ->
-                val client = InstallReferrerClient.newBuilder(reactContext).build()
-                // AtomicBoolean, not a plain var: InstallReferrerStateListener callbacks
-                // and the coroutine's cancellation handler can dispatch on different
-                // threads, and a plain var gives no cross-thread visibility guarantee —
-                // a cancellation racing a listener callback could observe a stale
-                // pre-write value and double-run the settle path. compareAndSet makes
-                // the check-and-set atomic and visible across threads.
-                val settled = AtomicBoolean(false)
+            // Bounds the wait: startConnection relies entirely on Play's service
+            // binding calling back, so a wedged/misbehaving service with neither
+            // onInstallReferrerSetupFinished nor onInstallReferrerServiceDisconnected
+            // firing would otherwise hang this coroutine indefinitely. Timing out
+            // cancels the coroutine, which runs invokeOnCancellation below and closes
+            // the binding — same cleanup path as any other cancellation.
+            withTimeout(TIMEOUT_MS) {
+                suspendCancellableCoroutine { continuation ->
+                    val client = InstallReferrerClient.newBuilder(reactContext).build()
+                    // AtomicBoolean, not a plain var: InstallReferrerStateListener
+                    // callbacks and the coroutine's cancellation handler can dispatch on
+                    // different threads, and a plain var gives no cross-thread visibility
+                    // guarantee — a cancellation racing a listener callback could observe
+                    // a stale pre-write value and double-run the settle path.
+                    // compareAndSet makes the check-and-set atomic and visible across
+                    // threads.
+                    val settled = AtomicBoolean(false)
 
-                fun finish(result: Map<String, Any?>?) {
-                    // InstallReferrerClient docs: call endConnection() promptly once
-                    // done with the binding. compareAndSet so a listener callback firing
-                    // after cancellation/timeout can't double-resume.
-                    if (!settled.compareAndSet(false, true)) return
-                    try {
-                        client.endConnection()
-                    } catch (endError: Exception) {
-                        // Best-effort — the binding is being torn down regardless.
-                    }
-                    // Empty onCancellation is deliberate: endConnection() above already
-                    // ran before this resume() call, so there's nothing left to clean up
-                    // if cancellation races the resume itself.
-                    if (continuation.isActive) continuation.resume(result) { }
-                }
-
-                // Registered BEFORE startConnection: a cancellation landing in the
-                // window between the two calls must still close the binding — if this
-                // were registered after, a cancel in that gap would never fire cleanup.
-                // Gated on the same `settled` flag as finish() so a cancellation racing
-                // an already-settled listener callback doesn't call endConnection() twice.
-                continuation.invokeOnCancellation {
-                    if (!settled.compareAndSet(false, true)) return@invokeOnCancellation
-                    try {
-                        client.endConnection()
-                    } catch (endError: Exception) {
-                        // Best-effort cleanup on cancellation.
-                    }
-                }
-
-                try {
-                    client.startConnection(object : InstallReferrerStateListener {
-                        override fun onInstallReferrerSetupFinished(responseCode: Int) {
-                            if (responseCode != InstallReferrerResponse.OK) {
-                                finish(null)
-                                return
-                            }
-                            try {
-                                val details = client.installReferrer
-                                finish(
-                                    mapOf(
-                                        "installReferrer" to details.installReferrer,
-                                        "referrerClickTimestampSeconds" to details.referrerClickTimestampSeconds,
-                                        "installBeginTimestampSeconds" to details.installBeginTimestampSeconds,
-                                    ),
-                                )
-                            } catch (readError: Exception) {
-                                finish(null)
-                            }
+                    fun finish(result: Map<String, Any?>?) {
+                        // InstallReferrerClient docs: call endConnection() promptly once
+                        // done with the binding. compareAndSet so a listener callback
+                        // firing after cancellation/timeout can't double-resume.
+                        if (!settled.compareAndSet(false, true)) return
+                        try {
+                            client.endConnection()
+                        } catch (endError: Exception) {
+                            // Best-effort — the binding is being torn down regardless.
                         }
+                        // Empty onCancellation is deliberate: endConnection() above
+                        // already ran before this resume() call, so there's nothing left
+                        // to clean up if cancellation races the resume itself.
+                        if (continuation.isActive) continuation.resume(result) { }
+                    }
 
-                        override fun onInstallReferrerServiceDisconnected() {
-                            finish(null)
+                    // Registered BEFORE startConnection: a cancellation landing in the
+                    // window between the two calls must still close the binding — if
+                    // this were registered after, a cancel in that gap would never fire
+                    // cleanup.
+                    // Gated on the same `settled` flag as finish() so a cancellation
+                    // racing an already-settled listener callback doesn't call
+                    // endConnection() twice.
+                    continuation.invokeOnCancellation {
+                        if (!settled.compareAndSet(false, true)) return@invokeOnCancellation
+                        try {
+                            client.endConnection()
+                        } catch (endError: Exception) {
+                            // Best-effort cleanup on cancellation.
                         }
-                    })
-                } catch (connectError: Exception) {
-                    finish(null)
+                    }
+
+                    try {
+                        client.startConnection(object : InstallReferrerStateListener {
+                            override fun onInstallReferrerSetupFinished(responseCode: Int) {
+                                if (responseCode != InstallReferrerResponse.OK) {
+                                    finish(null)
+                                    return
+                                }
+                                try {
+                                    val details = client.installReferrer
+                                    finish(
+                                        mapOf(
+                                            "installReferrer" to details.installReferrer,
+                                            "referrerClickTimestampSeconds" to
+                                                details.referrerClickTimestampSeconds,
+                                            "installBeginTimestampSeconds" to
+                                                details.installBeginTimestampSeconds,
+                                        ),
+                                    )
+                                } catch (readError: Exception) {
+                                    finish(null)
+                                }
+                            }
+
+                            override fun onInstallReferrerServiceDisconnected() {
+                                finish(null)
+                            }
+                        })
+                    } catch (connectError: Exception) {
+                        finish(null)
+                    }
                 }
             }
         } catch (unexpectedError: Exception) {
+            // Also catches TimeoutCancellationException from withTimeout above —
+            // resolving null on a timeout matches every other degrade-gracefully path
+            // in this function.
             null
         }
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 10_000L
     }
 }

--- a/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
+++ b/packages/mobile/modules/install-referrer/android/src/main/java/com/boardsesh/installreferrer/InstallReferrerModule.kt
@@ -23,8 +23,12 @@ class InstallReferrerModule : Module() {
         // The `Coroutine` infix (not a plain trailing lambda) is required for the
         // body to run as a suspend function — a plain AsyncFunction lambda is not
         // itself a coroutine, so calling the suspend fetchInstallReferrer() from
-        // inside it doesn't compile.
-        AsyncFunction("getInstallReferrer") Coroutine {
+        // inside it doesn't compile. `Coroutine` is overloaded for 0-8 params; an
+        // explicit empty parameter list (`->` with nothing before it) is required
+        // too — a lambda with no declared params is otherwise ambiguous between the
+        // 0-arg overload and a 1-arg overload's implicit unused `it`, and the
+        // compiler can't pick one ("Overload resolution ambiguity").
+        AsyncFunction("getInstallReferrer") Coroutine { ->
             fetchInstallReferrer()
         }
     }

--- a/packages/mobile/modules/install-referrer/expo-module.config.json
+++ b/packages/mobile/modules/install-referrer/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["com.boardsesh.installreferrer.InstallReferrerModule"]
+  }
+}

--- a/packages/mobile/modules/install-referrer/package.json
+++ b/packages/mobile/modules/install-referrer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@boardsesh/install-referrer-module",
   "version": "0.1.0",
+  "private": true,
   "description": "Native Play Install Referrer bridge for Android first-install attribution",
   "license": "MIT",
   "main": "src/index.ts"

--- a/packages/mobile/modules/install-referrer/package.json
+++ b/packages/mobile/modules/install-referrer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@boardsesh/install-referrer-module",
+  "version": "0.1.0",
+  "description": "Native Play Install Referrer bridge for Android first-install attribution",
+  "license": "MIT",
+  "main": "src/index.ts"
+}

--- a/packages/mobile/modules/install-referrer/src/index.ts
+++ b/packages/mobile/modules/install-referrer/src/index.ts
@@ -14,5 +14,4 @@ type InstallReferrerNativeModule = {
 // linked into the running binary — iOS (this module is Android-only), Expo
 // Go, or a dev client built before this module existed — so callers never
 // need a platform/linked check before calling.
-export const installReferrerNative =
-  requireOptionalNativeModule<InstallReferrerNativeModule>('InstallReferrer');
+export const installReferrerNative = requireOptionalNativeModule<InstallReferrerNativeModule>('InstallReferrer');

--- a/packages/mobile/modules/install-referrer/src/index.ts
+++ b/packages/mobile/modules/install-referrer/src/index.ts
@@ -1,0 +1,18 @@
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+export type NativeInstallReferrerResult = {
+  installReferrer: string;
+  referrerClickTimestampSeconds: number;
+  installBeginTimestampSeconds: number;
+};
+
+type InstallReferrerNativeModule = {
+  getInstallReferrer(): Promise<NativeInstallReferrerResult | null>;
+};
+
+// requireOptionalNativeModule returns null (silently) when the module isn't
+// linked into the running binary — iOS (this module is Android-only), Expo
+// Go, or a dev client built before this module existed — so callers never
+// need a platform/linked check before calling.
+export const installReferrerNative =
+  requireOptionalNativeModule<InstallReferrerNativeModule>('InstallReferrer');

--- a/packages/mobile/plugins/with-android-install-referrer-queries.js
+++ b/packages/mobile/plugins/with-android-install-referrer-queries.js
@@ -1,0 +1,45 @@
+const { createRunOncePlugin, withAndroidManifest } = require('expo/config-plugins');
+
+// Play Install Referrer needs to bind to the Play Store's service. On
+// Android 11+ (API 30+) package-visibility filtering hides other apps'
+// packages by default, so com.android.vending must be explicitly declared
+// visible via <queries>, or InstallReferrerClient always resolves
+// FEATURE_NOT_SUPPORTED even on a genuine Play Store install.
+const VENDING_PACKAGE = 'com.android.vending';
+
+/**
+ * Adds `<queries><package android:name="com.android.vending"/></queries>` to
+ * the parsed AndroidManifest. Idempotent: a second pass (or a double-registered
+ * plugin) leaves the manifest unchanged. Pure transform over the
+ * @expo/config-plugins manifest object for testability.
+ *
+ * @param {{ manifest: { queries?: Array<{ package?: Array<{ $: Record<string, string> }> }> } }} androidManifest
+ * @returns {typeof androidManifest}
+ */
+function addInstallReferrerQueries(androidManifest) {
+  const manifest = androidManifest.manifest;
+  const queries = manifest.queries ?? [];
+  const container = queries[0] ?? {};
+  const packages = container.package ?? [];
+
+  const alreadyDeclared = packages.some((entry) => entry?.$?.['android:name'] === VENDING_PACKAGE);
+  if (!alreadyDeclared) {
+    packages.push({ $: { 'android:name': VENDING_PACKAGE } });
+  }
+  container.package = packages;
+  queries[0] = container;
+  manifest.queries = queries;
+
+  return androidManifest;
+}
+
+function withAndroidInstallReferrerQueries(config) {
+  return withAndroidManifest(config, (modConfig) => {
+    modConfig.modResults = addInstallReferrerQueries(modConfig.modResults);
+    return modConfig;
+  });
+}
+
+module.exports = createRunOncePlugin(withAndroidInstallReferrerQueries, 'with-android-install-referrer-queries', '1.0.0');
+module.exports.addInstallReferrerQueries = addInstallReferrerQueries;
+module.exports.VENDING_PACKAGE = VENDING_PACKAGE;

--- a/packages/mobile/plugins/with-android-install-referrer-queries.js
+++ b/packages/mobile/plugins/with-android-install-referrer-queries.js
@@ -40,6 +40,10 @@ function withAndroidInstallReferrerQueries(config) {
   });
 }
 
-module.exports = createRunOncePlugin(withAndroidInstallReferrerQueries, 'with-android-install-referrer-queries', '1.0.0');
+module.exports = createRunOncePlugin(
+  withAndroidInstallReferrerQueries,
+  'with-android-install-referrer-queries',
+  '1.0.0',
+);
 module.exports.addInstallReferrerQueries = addInstallReferrerQueries;
 module.exports.VENDING_PACKAGE = VENDING_PACKAGE;

--- a/packages/mobile/src/components/analytics/InstallReferrerTracker.tsx
+++ b/packages/mobile/src/components/analytics/InstallReferrerTracker.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+import { maybeFetchAndAttachInstallReferrer } from '../../lib/install-referrer';
+
+// Android-only: Play Install Referrer is a Play Store mechanism with no iOS
+// equivalent in this PR (see install-referrer.ts). Fire-and-forget after
+// mount so this never blocks the splash/auth gate — matches OtaUpdateTracker's
+// shape. Renders nothing; mounted once near the app root beside it.
+export function InstallReferrerTracker(): null {
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+    void maybeFetchAndAttachInstallReferrer();
+  }, []);
+
+  return null;
+}

--- a/packages/mobile/src/components/analytics/__tests__/install-referrer-tracker.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/install-referrer-tracker.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { render, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const installReferrer = vi.hoisted(() => ({ maybeFetchAndAttachInstallReferrer: vi.fn(async () => {}) }));
+const platform = vi.hoisted(() => ({ OS: 'android' as 'android' | 'ios' }));
+
+vi.mock('../../../lib/install-referrer', () => ({
+  maybeFetchAndAttachInstallReferrer: installReferrer.maybeFetchAndAttachInstallReferrer,
+}));
+vi.mock('react-native', () => ({ Platform: platform }));
+
+import { InstallReferrerTracker } from '../InstallReferrerTracker';
+
+beforeEach(() => {
+  installReferrer.maybeFetchAndAttachInstallReferrer.mockClear();
+  platform.OS = 'android';
+});
+
+describe('InstallReferrerTracker', () => {
+  it('fetches the install referrer on mount when running on Android', async () => {
+    render(createElement(InstallReferrerTracker));
+
+    await waitFor(() => expect(installReferrer.maybeFetchAndAttachInstallReferrer).toHaveBeenCalledTimes(1));
+  });
+
+  it('does nothing on iOS — Play Install Referrer has no iOS equivalent', async () => {
+    platform.OS = 'ios';
+
+    render(createElement(InstallReferrerTracker));
+
+    // No affirmative "never called" signal exists here, so flush a macrotask
+    // boundary (draining the mount effect) before asserting the negative.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(installReferrer.maybeFetchAndAttachInstallReferrer).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/android-install-referrer-queries-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/android-install-referrer-queries-plugin.test.ts
@@ -1,0 +1,65 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+type PackageEntry = {
+  $: Record<string, string>;
+};
+
+type QueriesEntry = {
+  package?: PackageEntry[];
+};
+
+type AndroidManifestShape = {
+  manifest: {
+    queries?: QueriesEntry[];
+  };
+};
+
+type InstallReferrerQueriesPlugin = {
+  addInstallReferrerQueries(androidManifest: AndroidManifestShape): AndroidManifestShape;
+  VENDING_PACKAGE: string;
+};
+
+const plugin = require('../../../plugins/with-android-install-referrer-queries.js') as InstallReferrerQueriesPlugin;
+
+function emptyManifest(): AndroidManifestShape {
+  return { manifest: {} };
+}
+
+describe('with-android-install-referrer-queries', () => {
+  it('adds a <queries><package android:name="com.android.vending"/></queries> entry', () => {
+    const result = plugin.addInstallReferrerQueries(emptyManifest());
+
+    const packages = result.manifest.queries?.[0]?.package ?? [];
+    const vending = packages.find((entry) => entry.$['android:name'] === plugin.VENDING_PACKAGE);
+
+    expect(vending).toBeDefined();
+  });
+
+  it('preserves existing queries/package entries', () => {
+    const manifest: AndroidManifestShape = {
+      manifest: {
+        queries: [{ package: [{ $: { 'android:name': 'com.some.other.app' } }] }],
+      },
+    };
+
+    const result = plugin.addInstallReferrerQueries(manifest);
+    const names = (result.manifest.queries?.[0]?.package ?? []).map((entry) => entry.$['android:name']);
+
+    expect(names).toContain('com.some.other.app');
+    expect(names).toContain(plugin.VENDING_PACKAGE);
+  });
+
+  it('is idempotent — a second pass adds no duplicate', () => {
+    const once = plugin.addInstallReferrerQueries(emptyManifest());
+    const twice = plugin.addInstallReferrerQueries(once);
+
+    const vendingEntries = (twice.manifest.queries?.[0]?.package ?? []).filter(
+      (entry) => entry.$['android:name'] === plugin.VENDING_PACKAGE,
+    );
+    expect(vendingEntries).toHaveLength(1);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/install-referrer.test.ts
+++ b/packages/mobile/src/lib/__tests__/install-referrer.test.ts
@@ -155,4 +155,18 @@ describe('maybeFetchAndAttachInstallReferrer', () => {
     await maybeFetchAndAttachInstallReferrer(fetchNative);
     expect(fetchNative).toHaveBeenCalledTimes(2);
   });
+
+  it('never throws when getPreference itself rejects, reports the error, and never reaches fetchNative', async () => {
+    const rejection = new Error('AsyncStorage unavailable');
+    getPreferenceMock.mockRejectedValueOnce(rejection);
+    const fetchNative = vi.fn(async () => null);
+
+    await expect(maybeFetchAndAttachInstallReferrer(fetchNative)).resolves.toBeUndefined();
+
+    expect(fetchNative).not.toHaveBeenCalled();
+    expect(setPreferenceMock).not.toHaveBeenCalled();
+    expect(analytics.setPersonProperties).not.toHaveBeenCalled();
+    expect(analytics.track).not.toHaveBeenCalled();
+    expect(reportErrorMock).toHaveBeenCalledWith(rejection);
+  });
 });

--- a/packages/mobile/src/lib/__tests__/install-referrer.test.ts
+++ b/packages/mobile/src/lib/__tests__/install-referrer.test.ts
@@ -12,6 +12,7 @@ vi.mock('../preference-store', () => ({
   }),
 }));
 vi.mock('../analytics', () => ({ track: analytics.track, setPersonProperties: analytics.setPersonProperties }));
+vi.mock('../error-reporting', () => ({ reportError: vi.fn() }));
 // Every test drives maybeFetchAndAttachInstallReferrer via its injectable
 // `fetchNative` param, so the native module itself is never exercised — but
 // install-referrer.ts still imports it at module scope (for the default
@@ -25,9 +26,11 @@ import {
   parseInstallReferrer,
 } from '../install-referrer';
 import { getPreference, setPreference } from '../preference-store';
+import { reportError } from '../error-reporting';
 
 const getPreferenceMock = vi.mocked(getPreference);
 const setPreferenceMock = vi.mocked(setPreference);
+const reportErrorMock = vi.mocked(reportError);
 
 beforeEach(() => {
   preferenceStore.values.clear();
@@ -35,6 +38,7 @@ beforeEach(() => {
   analytics.setPersonProperties.mockClear();
   getPreferenceMock.mockClear();
   setPreferenceMock.mockClear();
+  reportErrorMock.mockClear();
 });
 
 describe('parseInstallReferrer', () => {
@@ -132,9 +136,10 @@ describe('maybeFetchAndAttachInstallReferrer', () => {
     expect(analytics.track).not.toHaveBeenCalled();
   });
 
-  it('never throws when the native call rejects, and leaves the flag unset so the next launch retries', async () => {
+  it('never throws when the native call rejects, reports the error, and leaves the flag unset so the next launch retries', async () => {
+    const rejection = new Error('SERVICE_UNAVAILABLE');
     const fetchNative = vi.fn(async () => {
-      throw new Error('SERVICE_UNAVAILABLE');
+      throw rejection;
     });
 
     await expect(maybeFetchAndAttachInstallReferrer(fetchNative)).resolves.toBeUndefined();
@@ -142,5 +147,12 @@ describe('maybeFetchAndAttachInstallReferrer', () => {
     expect(setPreferenceMock).not.toHaveBeenCalled();
     expect(analytics.setPersonProperties).not.toHaveBeenCalled();
     expect(analytics.track).not.toHaveBeenCalled();
+    expect(reportErrorMock).toHaveBeenCalledWith(rejection);
+
+    // The flag was never set, so a second call (the next launch) actually
+    // re-invokes fetchNative instead of short-circuiting like the
+    // already-fetched case above.
+    await maybeFetchAndAttachInstallReferrer(fetchNative);
+    expect(fetchNative).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/mobile/src/lib/__tests__/install-referrer.test.ts
+++ b/packages/mobile/src/lib/__tests__/install-referrer.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const preferenceStore = vi.hoisted(() => ({
+  values: new Map<string, unknown>(),
+}));
+const analytics = vi.hoisted(() => ({ track: vi.fn(), setPersonProperties: vi.fn() }));
+
+vi.mock('../preference-store', () => ({
+  getPreference: vi.fn(async (key: string) => preferenceStore.values.get(key) ?? null),
+  setPreference: vi.fn(async (key: string, value: unknown) => {
+    preferenceStore.values.set(key, value);
+  }),
+}));
+vi.mock('../analytics', () => ({ track: analytics.track, setPersonProperties: analytics.setPersonProperties }));
+// Every test drives maybeFetchAndAttachInstallReferrer via its injectable
+// `fetchNative` param, so the native module itself is never exercised — but
+// install-referrer.ts still imports it at module scope (for the default
+// param), and the real module transitively calls expo-modules-core's
+// requireOptionalNativeModule, which can't resolve under vitest's node env.
+vi.mock('../../../modules/install-referrer/src/index', () => ({ installReferrerNative: null }));
+
+import { maybeFetchAndAttachInstallReferrer, parseInstallReferrer } from '../install-referrer';
+import { getPreference, setPreference } from '../preference-store';
+
+const getPreferenceMock = vi.mocked(getPreference);
+const setPreferenceMock = vi.mocked(setPreference);
+
+beforeEach(() => {
+  preferenceStore.values.clear();
+  analytics.track.mockClear();
+  analytics.setPersonProperties.mockClear();
+  getPreferenceMock.mockClear();
+  setPreferenceMock.mockClear();
+});
+
+describe('parseInstallReferrer', () => {
+  it('extracts utm_source/medium/campaign and preserves the raw string', () => {
+    const parsed = parseInstallReferrer('utm_source=google&utm_medium=cpc&utm_campaign=spring_sale');
+
+    expect(parsed).toEqual({
+      raw: 'utm_source=google&utm_medium=cpc&utm_campaign=spring_sale',
+      source: 'google',
+      medium: 'cpc',
+      campaign: 'spring_sale',
+    });
+  });
+
+  it('resolves missing params to null', () => {
+    const parsed = parseInstallReferrer('');
+
+    expect(parsed).toEqual({ raw: '', source: null, medium: null, campaign: null });
+  });
+
+  it('round-trips an unrecognized param inside `raw` without dropping it', () => {
+    const raw = 'utm_source=google&gclid=abc123';
+    const parsed = parseInstallReferrer(raw);
+
+    expect(parsed.raw).toBe(raw);
+    expect(parsed.source).toBe('google');
+  });
+});
+
+describe('maybeFetchAndAttachInstallReferrer', () => {
+  it('fetches once, marks the flag, and attaches parsed referrer data', async () => {
+    const fetchNative = vi.fn(async () => ({
+      installReferrer: 'utm_source=google&utm_medium=cpc&utm_campaign=spring_sale',
+      referrerClickTimestampSeconds: 100,
+      installBeginTimestampSeconds: 200,
+    }));
+
+    await maybeFetchAndAttachInstallReferrer(fetchNative);
+
+    expect(fetchNative).toHaveBeenCalledTimes(1);
+    expect(setPreferenceMock).toHaveBeenCalledWith('installReferrerFetched', true);
+    expect(analytics.setPersonProperties).toHaveBeenCalledWith(undefined, {
+      install_referrer_raw: 'utm_source=google&utm_medium=cpc&utm_campaign=spring_sale',
+      install_source: 'google',
+      install_medium: 'cpc',
+      install_campaign: 'spring_sale',
+      install_click_timestamp: 100,
+      install_begin_timestamp: 200,
+    });
+    expect(analytics.track).toHaveBeenCalledWith('Install Attributed', {
+      install_source: 'google',
+      install_medium: 'cpc',
+      install_campaign: 'spring_sale',
+    });
+  });
+
+  it('skips the native call entirely once already fetched', async () => {
+    preferenceStore.values.set('installReferrerFetched', true);
+    const fetchNative = vi.fn(async () => null);
+
+    await maybeFetchAndAttachInstallReferrer(fetchNative);
+
+    expect(fetchNative).not.toHaveBeenCalled();
+    expect(analytics.setPersonProperties).not.toHaveBeenCalled();
+    expect(analytics.track).not.toHaveBeenCalled();
+  });
+
+  it('marks the flag fetched but attaches nothing when the native call resolves null', async () => {
+    const fetchNative = vi.fn(async () => null);
+
+    await maybeFetchAndAttachInstallReferrer(fetchNative);
+
+    expect(setPreferenceMock).toHaveBeenCalledWith('installReferrerFetched', true);
+    expect(analytics.setPersonProperties).not.toHaveBeenCalled();
+    expect(analytics.track).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the native call rejects, and leaves the flag unset so the next launch retries', async () => {
+    const fetchNative = vi.fn(async () => {
+      throw new Error('SERVICE_UNAVAILABLE');
+    });
+
+    await expect(maybeFetchAndAttachInstallReferrer(fetchNative)).resolves.toBeUndefined();
+
+    expect(setPreferenceMock).not.toHaveBeenCalled();
+    expect(analytics.setPersonProperties).not.toHaveBeenCalled();
+    expect(analytics.track).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/install-referrer.test.ts
+++ b/packages/mobile/src/lib/__tests__/install-referrer.test.ts
@@ -19,7 +19,11 @@ vi.mock('../analytics', () => ({ track: analytics.track, setPersonProperties: an
 // requireOptionalNativeModule, which can't resolve under vitest's node env.
 vi.mock('../../../modules/install-referrer/src/index', () => ({ installReferrerNative: null }));
 
-import { maybeFetchAndAttachInstallReferrer, parseInstallReferrer } from '../install-referrer';
+import {
+  INSTALL_ATTRIBUTED_EVENT,
+  maybeFetchAndAttachInstallReferrer,
+  parseInstallReferrer,
+} from '../install-referrer';
 import { getPreference, setPreference } from '../preference-store';
 
 const getPreferenceMock = vi.mocked(getPreference);
@@ -80,11 +84,31 @@ describe('maybeFetchAndAttachInstallReferrer', () => {
       install_click_timestamp: 100,
       install_begin_timestamp: 200,
     });
-    expect(analytics.track).toHaveBeenCalledWith('Install Attributed', {
+    expect(analytics.track).toHaveBeenCalledWith(INSTALL_ATTRIBUTED_EVENT, {
       install_source: 'google',
       install_medium: 'cpc',
       install_campaign: 'spring_sale',
     });
+  });
+
+  it('writes person properties but does NOT fire Install Attributed for an organic install (no utm params)', async () => {
+    const fetchNative = vi.fn(async () => ({
+      installReferrer: '',
+      referrerClickTimestampSeconds: 0,
+      installBeginTimestampSeconds: 300,
+    }));
+
+    await maybeFetchAndAttachInstallReferrer(fetchNative);
+
+    expect(analytics.setPersonProperties).toHaveBeenCalledWith(undefined, {
+      install_referrer_raw: '',
+      install_source: null,
+      install_medium: null,
+      install_campaign: null,
+      install_click_timestamp: 0,
+      install_begin_timestamp: 300,
+    });
+    expect(analytics.track).not.toHaveBeenCalled();
   });
 
   it('skips the native call entirely once already fetched', async () => {

--- a/packages/mobile/src/lib/__tests__/install-referrer.test.ts
+++ b/packages/mobile/src/lib/__tests__/install-referrer.test.ts
@@ -68,6 +68,20 @@ describe('parseInstallReferrer', () => {
     expect(parsed.raw).toBe(raw);
     expect(parsed.source).toBe('google');
   });
+
+  it('decodes URL-encoded params for the parsed fields but preserves raw verbatim', () => {
+    // URLSearchParams treats a literal `+` as a space (application/x-www-form-
+    // urlencoded convention) and decodes %XX escapes for the parsed fields —
+    // intentional, since that's the correct decoding of a query string. `raw`
+    // stays untouched either way, so nothing is lost if that divergence ever
+    // matters downstream.
+    const raw = 'utm_campaign=spring+sale&utm_source=go%20ogle';
+    const parsed = parseInstallReferrer(raw);
+
+    expect(parsed.raw).toBe(raw);
+    expect(parsed.campaign).toBe('spring sale');
+    expect(parsed.source).toBe('go ogle');
+  });
 });
 
 describe('maybeFetchAndAttachInstallReferrer', () => {
@@ -178,6 +192,26 @@ describe('maybeFetchAndAttachInstallReferrer', () => {
     // already-fetched case above.
     await maybeFetchAndAttachInstallReferrer(fetchNative);
     expect(fetchNative).toHaveBeenCalledTimes(2);
+  });
+
+  it('never throws when setPreference rejects after a successful fetch, reports the error, and leaves the flag unset so the next launch retries', async () => {
+    const rejection = new Error('AsyncStorage write failed');
+    setPreferenceMock.mockRejectedValueOnce(rejection);
+    const fetchNative = vi.fn(async () => ({
+      installReferrer: 'utm_source=google',
+      referrerClickTimestampSeconds: 100,
+      installBeginTimestampSeconds: 200,
+    }));
+
+    await expect(maybeFetchAndAttachInstallReferrer(fetchNative)).resolves.toBeUndefined();
+
+    expect(fetchNative).toHaveBeenCalledTimes(1);
+    // The flag write itself is what rejected, so the attribution attach steps
+    // after it never run — the failed write is the reported error, not a
+    // downstream side effect.
+    expect(analytics.setPersonProperties).not.toHaveBeenCalled();
+    expect(analytics.track).not.toHaveBeenCalled();
+    expect(reportErrorMock).toHaveBeenCalledWith(rejection);
   });
 
   it('never throws when getPreference itself rejects, reports the error, and never reaches fetchNative', async () => {

--- a/packages/mobile/src/lib/__tests__/install-referrer.test.ts
+++ b/packages/mobile/src/lib/__tests__/install-referrer.test.ts
@@ -24,6 +24,7 @@ import {
   INSTALL_ATTRIBUTED_EVENT,
   maybeFetchAndAttachInstallReferrer,
   parseInstallReferrer,
+  resetInstallReferrerFetchInFlightForTests,
 } from '../install-referrer';
 import { getPreference, setPreference } from '../preference-store';
 import { reportError } from '../error-reporting';
@@ -39,6 +40,7 @@ beforeEach(() => {
   getPreferenceMock.mockClear();
   setPreferenceMock.mockClear();
   reportErrorMock.mockClear();
+  resetInstallReferrerFetchInFlightForTests();
 });
 
 describe('parseInstallReferrer', () => {

--- a/packages/mobile/src/lib/__tests__/install-referrer.test.ts
+++ b/packages/mobile/src/lib/__tests__/install-referrer.test.ts
@@ -115,6 +115,28 @@ describe('maybeFetchAndAttachInstallReferrer', () => {
     expect(analytics.track).not.toHaveBeenCalled();
   });
 
+  it('ignores a concurrent overlapping call — only the first invocation reaches fetchNative', async () => {
+    let resolveFetch: (() => void) | undefined;
+    const fetchNative = vi.fn(
+      () =>
+        new Promise<null>((resolve) => {
+          resolveFetch = () => resolve(null);
+        }),
+    );
+
+    const first = maybeFetchAndAttachInstallReferrer(fetchNative);
+    // Give the first call's getPreference() microtask a chance to resolve and
+    // set fetchInFlight before the second call starts, mirroring a real
+    // remount racing the first mount's in-flight fetch.
+    await Promise.resolve();
+    const second = maybeFetchAndAttachInstallReferrer(fetchNative);
+
+    resolveFetch?.();
+    await Promise.all([first, second]);
+
+    expect(fetchNative).toHaveBeenCalledTimes(1);
+  });
+
   it('skips the native call entirely once already fetched', async () => {
     preferenceStore.values.set('installReferrerFetched', true);
     const fetchNative = vi.fn(async () => null);

--- a/packages/mobile/src/lib/install-referrer.ts
+++ b/packages/mobile/src/lib/install-referrer.ts
@@ -1,0 +1,71 @@
+import { installReferrerNative, type NativeInstallReferrerResult } from '../../modules/install-referrer/src/index';
+import { setPersonProperties, track } from './analytics';
+import { getPreference, setPreference } from './preference-store';
+
+// Android-only: Play Install Referrer is a Play Store mechanism with no iOS
+// equivalent in this PR (an iOS equivalent — SKAdNetwork / Apple Search Ads
+// attribution — is out of scope, see boardsesh#3402). InstallReferrerTracker
+// gates the call site on Platform.OS so this module is never invoked on iOS.
+
+const INSTALL_REFERRER_FETCHED_KEY = 'installReferrerFetched';
+
+export type ParsedInstallReferrer = {
+  raw: string;
+  source: string | null;
+  medium: string | null;
+  campaign: string | null;
+};
+
+// Pure — unit-testable with a plain string, no native module involved. Parses
+// the installReferrer query string for the utm_* params Play forwards
+// verbatim when the install came from a tagged Play Store link. Unknown or
+// absent params resolve to null; `raw` always preserves the untouched string
+// so nothing is lost if a param this parsing doesn't cover shows up later.
+export function parseInstallReferrer(raw: string): ParsedInstallReferrer {
+  const params = new URLSearchParams(raw);
+  return {
+    raw,
+    source: params.get('utm_source'),
+    medium: params.get('utm_medium'),
+    campaign: params.get('utm_campaign'),
+  };
+}
+
+// Fetch-once-ever, cache-the-flag, never-throw. `fetchNative` is injectable so
+// tests can supply a fake result without mocking the native module resolver.
+export async function maybeFetchAndAttachInstallReferrer(
+  fetchNative: () => Promise<NativeInstallReferrerResult | null> = () =>
+    installReferrerNative?.getInstallReferrer() ?? Promise.resolve(null),
+): Promise<void> {
+  try {
+    const alreadyFetched = await getPreference<boolean>(INSTALL_REFERRER_FETCHED_KEY);
+    if (alreadyFetched) return;
+
+    const result = await fetchNative();
+    // Mark fetched regardless of a clean outcome (success or a resolved null,
+    // e.g. FEATURE_NOT_SUPPORTED on a sideloaded install) — Play's referrer is
+    // only reliably available in a short window after install, so retrying on
+    // every future launch has little value. A thrown exception below skips
+    // this write, so a transient failure (e.g. SERVICE_UNAVAILABLE) does retry
+    // on the next launch.
+    await setPreference(INSTALL_REFERRER_FETCHED_KEY, true);
+    if (!result) return;
+
+    const parsed = parseInstallReferrer(result.installReferrer);
+    setPersonProperties(undefined, {
+      install_referrer_raw: parsed.raw,
+      install_source: parsed.source,
+      install_medium: parsed.medium,
+      install_campaign: parsed.campaign,
+      install_click_timestamp: result.referrerClickTimestampSeconds,
+      install_begin_timestamp: result.installBeginTimestampSeconds,
+    });
+    track('Install Attributed', {
+      install_source: parsed.source,
+      install_medium: parsed.medium,
+      install_campaign: parsed.campaign,
+    });
+  } catch {
+    // Must never throw — this runs fire-and-forget at startup.
+  }
+}

--- a/packages/mobile/src/lib/install-referrer.ts
+++ b/packages/mobile/src/lib/install-referrer.ts
@@ -1,5 +1,6 @@
 import { installReferrerNative, type NativeInstallReferrerResult } from '../../modules/install-referrer/src/index';
 import { setPersonProperties, track } from './analytics';
+import { reportError } from './error-reporting';
 import { getPreference, setPreference } from './preference-store';
 
 // Android-only: Play Install Referrer is a Play Store mechanism with no iOS
@@ -79,7 +80,10 @@ export async function maybeFetchAndAttachInstallReferrer(
         install_campaign: parsed.campaign,
       });
     }
-  } catch {
-    // Must never throw — this runs fire-and-forget at startup.
+  } catch (error) {
+    // Must never throw — this runs fire-and-forget at startup. Still reported
+    // so a broken preference store / PostHog init doesn't fail this pipeline
+    // invisibly.
+    reportError(error);
   }
 }

--- a/packages/mobile/src/lib/install-referrer.ts
+++ b/packages/mobile/src/lib/install-referrer.ts
@@ -24,6 +24,13 @@ const INSTALL_REFERRER_FETCHED_KEY = 'installReferrerFetched';
 // launches; this only closes the same-process overlap window.
 let fetchInFlight = false;
 
+// Test-only: resets the in-flight guard so each test starts clean, even if a
+// prior test's async chain didn't run to its `finally` (e.g. an aborted test).
+// Mirrors resetOtaStatusReportedForTests in OtaUpdateTracker.tsx.
+export function resetInstallReferrerFetchInFlightForTests(): void {
+  fetchInFlight = false;
+}
+
 export type ParsedInstallReferrer = {
   raw: string;
   source: string | null;

--- a/packages/mobile/src/lib/install-referrer.ts
+++ b/packages/mobile/src/lib/install-referrer.ts
@@ -6,6 +6,11 @@ import { getPreference, setPreference } from './preference-store';
 // equivalent in this PR (an iOS equivalent — SKAdNetwork / Apple Search Ads
 // attribution — is out of scope, see boardsesh#3402). InstallReferrerTracker
 // gates the call site on Platform.OS so this module is never invoked on iOS.
+// Mobile-only (web has no Play Store install), so the event name stays a
+// free-string constant rather than an entry in @boardsesh/analytics'
+// SHARED_EVENTS (which is for names fired by BOTH platforms) — same
+// convention as OTA_UPDATE_STATUS_EVENT in ota-telemetry.ts.
+export const INSTALL_ATTRIBUTED_EVENT = 'Install Attributed';
 
 const INSTALL_REFERRER_FETCHED_KEY = 'installReferrerFetched';
 
@@ -52,6 +57,12 @@ export async function maybeFetchAndAttachInstallReferrer(
     if (!result) return;
 
     const parsed = parseInstallReferrer(result.installReferrer);
+    // Person properties are written even for an organic/direct install (all
+    // three utm_* fields null) — that's honest, useful data for channel-mix
+    // cohorting. But INSTALL_ATTRIBUTED_EVENT specifically means "we resolved
+    // a campaign for this install", so only fire it when at least one utm_*
+    // field is present — an unconditional fire here would name every organic
+    // install "attributed" and inflate attributed-install counts.
     setPersonProperties(undefined, {
       install_referrer_raw: parsed.raw,
       install_source: parsed.source,
@@ -60,11 +71,14 @@ export async function maybeFetchAndAttachInstallReferrer(
       install_click_timestamp: result.referrerClickTimestampSeconds,
       install_begin_timestamp: result.installBeginTimestampSeconds,
     });
-    track('Install Attributed', {
-      install_source: parsed.source,
-      install_medium: parsed.medium,
-      install_campaign: parsed.campaign,
-    });
+    const hasAttribution = parsed.source !== null || parsed.medium !== null || parsed.campaign !== null;
+    if (hasAttribution) {
+      track(INSTALL_ATTRIBUTED_EVENT, {
+        install_source: parsed.source,
+        install_medium: parsed.medium,
+        install_campaign: parsed.campaign,
+      });
+    }
   } catch {
     // Must never throw — this runs fire-and-forget at startup.
   }

--- a/packages/mobile/src/lib/install-referrer.ts
+++ b/packages/mobile/src/lib/install-referrer.ts
@@ -15,6 +15,15 @@ export const INSTALL_ATTRIBUTED_EVENT = 'Install Attributed';
 
 const INSTALL_REFERRER_FETCHED_KEY = 'installReferrerFetched';
 
+// In-memory guard against a concurrent overlapping call — e.g. if the mount
+// effect that drives this ever re-fires (remount, fast refresh) before the
+// first call's async preference read resolves. Without it, two concurrent
+// callers could both observe the persisted flag as unset and both invoke
+// fetchNative, doubling the native call and sending duplicate PostHog events.
+// The persisted flag alone still does the real "once ever" job across
+// launches; this only closes the same-process overlap window.
+let fetchInFlight = false;
+
 export type ParsedInstallReferrer = {
   raw: string;
   source: string | null;
@@ -43,6 +52,8 @@ export async function maybeFetchAndAttachInstallReferrer(
   fetchNative: () => Promise<NativeInstallReferrerResult | null> = () =>
     installReferrerNative?.getInstallReferrer() ?? Promise.resolve(null),
 ): Promise<void> {
+  if (fetchInFlight) return;
+  fetchInFlight = true;
   try {
     const alreadyFetched = await getPreference<boolean>(INSTALL_REFERRER_FETCHED_KEY);
     if (alreadyFetched) return;
@@ -85,5 +96,7 @@ export async function maybeFetchAndAttachInstallReferrer(
     // so a broken preference store / PostHog init doesn't fail this pipeline
     // invisibly.
     reportError(error);
+  } finally {
+    fetchInFlight = false;
   }
 }

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -16,6 +16,14 @@ export const SHARED_EVENTS = {
   // Kept distinct from LoginFailed so the failure metric isn't inflated by cancels.
   LoginCancelled: 'Login Cancelled',
   Logout: 'Logout',
+  // Fired once, immediately after a NEW account is created via credentials
+  // (both platforms). OAuth registration is indistinguishable from OAuth
+  // sign-in and stays tagged only via LoginSucceeded's `is_registration: true`
+  // — web has no separate OAuth-signup event either. Kept distinct from
+  // LoginSucceeded so "created an account" and "successfully authenticated"
+  // stay separately measurable — web's signup can require email verification
+  // and never reach a LoginSucceeded in that same session.
+  SignupCompleted: 'Signup Completed',
   // Queue / session
   AddToQueue: 'Add to Queue',
   ClimbAddedToQueue: 'Climb Added to Queue',

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -35,6 +35,7 @@ import { TabPanel } from '@/app/components/ui/tab-panel';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
 import { track, setPersonProperties } from '@/app/lib/analytics';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { authMethodFromError, safeAuthError } from './auth-error-classification';
 import LocaleLink from '@/app/components/i18n/locale-link';
 
@@ -158,7 +159,7 @@ export default function AuthPageContent() {
         return;
       }
 
-      track('Signup Completed', {
+      track(SHARED_EVENTS.SignupCompleted, {
         auth_method: 'credentials',
         requires_verification: Boolean(data.requiresVerification),
       });


### PR DESCRIPTION
## Summary

Closes part of #3402 (install attribution + a mobile `Signup Completed` event). Push/notification instrumentation from that issue is **not** included here — there's no push-notification system on mobile at all yet (no `expo-notifications`, no permission flow, no token registration), so building it is a separate, much larger follow-up (tracked in a new issue linked from #3402).

- **`SignupCompleted` shared event** — added to `SHARED_EVENTS` (`packages/shared/analytics/src/events.ts`). Web's existing raw-string `'Signup Completed'` fire is migrated to the shared constant (`auth-page-content.tsx`). Mobile's credentials registration (`app/auth/register.tsx`) now fires it too, alongside the existing `LoginSucceeded(is_registration: true)`, plus first-touch `signup_at`/`signup_auth_method` person properties matching web's pattern. OAuth registration on both platforms is unchanged — it stays tagged only via `LoginSucceeded`'s `is_registration: true`, matching web (which has no separate OAuth-signup event either).
- **Android Play Install Referrer attribution** — a new local Expo native module (`packages/mobile/modules/install-referrer`) wraps Google's `InstallReferrerClient` in a coroutine, resolving `null` (never throwing) on any non-OK response or exception. A new config plugin (`with-android-install-referrer-queries`) declares `com.android.vending` package visibility (required on API 30+). The JS wrapper (`src/lib/install-referrer.ts`) fetches once, caches the flag, and — on a real result — attaches parsed `utm_source`/`utm_medium`/`utm_campaign` (plus the raw referrer string and click/begin timestamps) as PostHog person properties, and fires a distinct `Install Attributed` event. Mounted via a new `InstallReferrerTracker` component (Android-only, fire-and-forget on mount) beside the existing `OtaUpdateTracker`. iOS gets no attribution data in this PR — documented as a known gap (no equivalent without Apple Search Ads/SKAdNetwork).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `packages/mobile/app/auth/__tests__/register-analytics.test.tsx` — new: asserts `SignupCompleted` + person properties fire on a successful credentials registration, and do **not** fire on a failed one.
- `packages/mobile/src/lib/__tests__/install-referrer.test.ts` — new: covers fetch-once/cache-the-flag/never-throw for `maybeFetchAndAttachInstallReferrer`, plus `parseInstallReferrer`'s utm-param parsing.
- `packages/mobile/src/lib/__tests__/android-install-referrer-queries-plugin.test.ts` — new: mirrors the existing bluetooth-feature manifest-plugin test (add/preserve/idempotent).
- Native/Gradle path (the actual `InstallReferrerClient` binding) can't be exercised in CI/sandbox — no Play Store, no tracked install link. Will do a manual Play Console internal-testing-track verification post-merge with a tagged referrer URL, and confirm `expo prebuild --platform android` generates the `<queries>` manifest block + links the new module.
- `vp run typecheck:mobile`, `vp run typecheck:web`, `vp run test:mobile`, `vp test run --project web`, `vp check` — running now, will report results/push fixes if anything fails.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FRiZ9UwHC24FVJunmhnhge)_