### PR TITLE
fix(mobile): bootstrap PostHog anonymous id from party-profile UUID

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -3,6 +3,12 @@
 // worklet-serialization global-error-capture install, which must wrap Sentry's
 // handler, not the other way round.
 import { wrapWithSentry } from '../src/lib/sentry';
+// Import second, still ahead of anything that reaches posthog-client.ts (e.g.
+// AnalyticsProvider below): resolves the party-profile UUID synchronously and
+// stores it for posthog-client.ts to bootstrap the PostHog SDK's anonymous
+// distinct_id with, before the SDK's own module-eval side effect constructs
+// the client and fires its app-lifecycle autocapture. See analytics-bootstrap.ts.
+import '../src/lib/analytics-bootstrap';
 import { useCallback, useEffect, useRef, useMemo, useState, type ReactNode } from 'react';
 import { LogBox, Pressable, StyleSheet, View } from 'react-native';
 // Navigation theme comes from expo-router's vendored React Navigation. Expo

--- a/packages/mobile/src/lib/__tests__/analytics-bootstrap-id.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-bootstrap-id.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getAnalyticsBootstrapId, setAnalyticsBootstrapId } from '../analytics-bootstrap-id';
+
+describe('analytics-bootstrap-id', () => {
+  beforeEach(() => {
+    setAnalyticsBootstrapId(null);
+  });
+
+  it('defaults to null before anything sets it', () => {
+    expect(getAnalyticsBootstrapId()).toBeNull();
+  });
+
+  it('round-trips whatever id was set', () => {
+    setAnalyticsBootstrapId('party-profile-uuid');
+    expect(getAnalyticsBootstrapId()).toBe('party-profile-uuid');
+  });
+
+  it('can be reset back to null', () => {
+    setAnalyticsBootstrapId('party-profile-uuid');
+    setAnalyticsBootstrapId(null);
+    expect(getAnalyticsBootstrapId()).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/analytics-bootstrap.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-bootstrap.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// analytics-bootstrap.ts is the one module allowed to import party-profile-store.ts
+// (and, transitively, the real expo-secure-store) from the analytics call graph.
+// Mock party-profile-store.ts directly rather than expo-secure-store, so this
+// test never touches the real (RN-Flow-syntax) native module.
+const getOrCreatePartyProfileIdSyncMock = vi.fn();
+vi.mock('../party-profile-store', () => ({
+  getOrCreatePartyProfileIdSync: getOrCreatePartyProfileIdSyncMock,
+}));
+
+describe('analytics-bootstrap', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getOrCreatePartyProfileIdSyncMock.mockReset();
+  });
+
+  it('resolves the party-profile UUID synchronously on import and stores it in the shared slot', async () => {
+    getOrCreatePartyProfileIdSyncMock.mockReturnValue('party-profile-uuid');
+
+    await import('../analytics-bootstrap');
+    const { getAnalyticsBootstrapId } = await import('../analytics-bootstrap-id');
+
+    expect(getOrCreatePartyProfileIdSyncMock).toHaveBeenCalledTimes(1);
+    expect(getAnalyticsBootstrapId()).toBe('party-profile-uuid');
+  });
+
+  it('stores null when the sync party-profile read/create fails', async () => {
+    getOrCreatePartyProfileIdSyncMock.mockReturnValue(null);
+
+    await import('../analytics-bootstrap');
+    const { getAnalyticsBootstrapId } = await import('../analytics-bootstrap-id');
+
+    expect(getAnalyticsBootstrapId()).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/party-profile-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/party-profile-store.test.ts
@@ -10,6 +10,10 @@ vi.mock('expo-secure-store', () => {
     deleteItemAsync: vi.fn(async (key: string) => {
       delete storage[key];
     }),
+    getItem: vi.fn((key: string) => storage[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      storage[key] = value;
+    }),
     __reset: () => {
       storage = {};
     },
@@ -19,6 +23,10 @@ vi.mock('expo-secure-store', () => {
     __throwNext: () => {},
   };
 });
+
+vi.mock('expo-crypto', () => ({
+  randomUUID: () => 'test-uuid',
+}));
 
 describe('partyProfileStorage', () => {
   beforeEach(async () => {
@@ -69,5 +77,73 @@ describe('partyProfileStorage', () => {
 
     const { partyProfileStorage } = await import('../party-profile-store');
     await expect(partyProfileStorage.get()).resolves.toBeNull();
+  });
+});
+
+describe('getOrCreatePartyProfileIdSync', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const secureStore = (await import('expo-secure-store')) as unknown as { __reset: () => void };
+    secureStore.__reset();
+  });
+
+  it('returns the existing stored id without creating a new one', async () => {
+    const secureStore = (await import('expo-secure-store')) as unknown as {
+      __setRaw: (key: string, value: string) => void;
+      setItem: ReturnType<typeof vi.fn>;
+    };
+    secureStore.__setRaw('boardsesh_party_profile', JSON.stringify({ id: 'stored-uuid' }));
+    const { getOrCreatePartyProfileIdSync } = await import('../party-profile-store');
+
+    expect(getOrCreatePartyProfileIdSync()).toBe('stored-uuid');
+    expect(secureStore.setItem).not.toHaveBeenCalled();
+  });
+
+  it('creates and persists a new id via the injected generator when nothing is stored', async () => {
+    const secureStore = (await import('expo-secure-store')) as unknown as { setItem: ReturnType<typeof vi.fn> };
+    const { getOrCreatePartyProfileIdSync } = await import('../party-profile-store');
+
+    const id = getOrCreatePartyProfileIdSync(() => 'generated-uuid');
+
+    expect(id).toBe('generated-uuid');
+    expect(secureStore.setItem).toHaveBeenCalledWith(
+      'boardsesh_party_profile',
+      JSON.stringify({ id: 'generated-uuid' }),
+    );
+  });
+
+  it('uses expo-crypto randomUUID by default', async () => {
+    const { getOrCreatePartyProfileIdSync } = await import('../party-profile-store');
+    expect(getOrCreatePartyProfileIdSync()).toBe('test-uuid');
+  });
+
+  it('returns null on a parse error rather than throwing', async () => {
+    const secureStore = (await import('expo-secure-store')) as unknown as {
+      __setRaw: (key: string, value: string) => void;
+    };
+    secureStore.__setRaw('boardsesh_party_profile', '{not json');
+
+    const { getOrCreatePartyProfileIdSync } = await import('../party-profile-store');
+    expect(getOrCreatePartyProfileIdSync()).toBeNull();
+  });
+
+  it('returns null when SecureStore.getItem throws', async () => {
+    const secureStore = (await import('expo-secure-store')) as unknown as { getItem: ReturnType<typeof vi.fn> };
+    secureStore.getItem.mockImplementationOnce(() => {
+      throw new Error('keychain locked');
+    });
+
+    const { getOrCreatePartyProfileIdSync } = await import('../party-profile-store');
+    expect(getOrCreatePartyProfileIdSync()).toBeNull();
+  });
+
+  it('returns null when SecureStore.setItem throws', async () => {
+    const secureStore = (await import('expo-secure-store')) as unknown as { setItem: ReturnType<typeof vi.fn> };
+    secureStore.setItem.mockImplementationOnce(() => {
+      throw new Error('keychain locked');
+    });
+
+    const { getOrCreatePartyProfileIdSync } = await import('../party-profile-store');
+    expect(getOrCreatePartyProfileIdSync()).toBeNull();
   });
 });

--- a/packages/mobile/src/lib/__tests__/posthog-client.test.ts
+++ b/packages/mobile/src/lib/__tests__/posthog-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { MOBILE_USER_AGENT, registerMobileUserAgent } from '../posthog-client';
+import { MOBILE_USER_AGENT, registerMobileUserAgent, buildPostHogOptions } from '../posthog-client';
 
 // The whole point of MOBILE_USER_AGENT is to give mobile events a User-Agent that
 // PostHog's classifier reads as "Regular" rather than the bot it assigns to an
@@ -33,5 +33,32 @@ describe('registerMobileUserAgent', () => {
     expect(() => registerMobileUserAgent({ register })).not.toThrow();
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+// Guards the fix for the install/open identity race: the party-profile UUID
+// must reach the PostHog constructor as `bootstrap.distinctId` so
+// captureAppLifecycleEvents (which fires during construction) lands on the
+// same id PartyProfileProvider later identifies/aliases, instead of a
+// transient SDK-generated anonymous id that never reliably reconnects.
+describe('buildPostHogOptions', () => {
+  it('bootstraps the anonymous distinct_id from a resolved party-profile UUID', () => {
+    const options = buildPostHogOptions('https://us.i.posthog.com', 'party-profile-uuid');
+    expect(options.bootstrap).toEqual({ distinctId: 'party-profile-uuid', isIdentifiedId: false });
+    expect(options.host).toBe('https://us.i.posthog.com');
+  });
+
+  it('omits bootstrap when the party-profile UUID could not be resolved', () => {
+    const options = buildPostHogOptions('https://us.i.posthog.com', null);
+    expect(options.bootstrap).toBeUndefined();
+  });
+
+  it('always configures session replay masking regardless of bootstrap', () => {
+    const options = buildPostHogOptions('https://us.i.posthog.com', null);
+    expect(options.sessionReplayConfig).toEqual({
+      maskAllTextInputs: true,
+      maskAllImages: true,
+      captureLog: true,
+    });
   });
 });

--- a/packages/mobile/src/lib/analytics-bootstrap-id.ts
+++ b/packages/mobile/src/lib/analytics-bootstrap-id.ts
@@ -1,0 +1,22 @@
+// Pure in-memory slot for the party-profile UUID, resolved synchronously and
+// early by analytics-bootstrap.ts (imported once, from app/_layout.tsx, before
+// anything that triggers posthog-client.ts's own module-eval side effect).
+// posthog-client.ts reads this slot when constructing the PostHog client, so
+// the SDK's app-lifecycle autocapture (Application Installed/Opened) can
+// bootstrap its anonymous distinct_id to the same stable id
+// PartyProfileProvider later identifies/aliases the authenticated user onto.
+//
+// Deliberately dependency-free (no expo-secure-store, no react-native) so
+// importing it from posthog-client.ts/analytics.ts doesn't pull the RN
+// Flow-syntax barrel into their module graph — those two stay importable from
+// the node-env test runner, which analytics-bootstrap.ts (and the
+// expo-secure-store read it performs) is not.
+let bootstrapDistinctId: string | null = null;
+
+export function setAnalyticsBootstrapId(id: string | null): void {
+  bootstrapDistinctId = id;
+}
+
+export function getAnalyticsBootstrapId(): string | null {
+  return bootstrapDistinctId;
+}

--- a/packages/mobile/src/lib/analytics-bootstrap.ts
+++ b/packages/mobile/src/lib/analytics-bootstrap.ts
@@ -1,0 +1,16 @@
+// Side-effect-only module: resolves the party-profile UUID synchronously and
+// stores it in the analytics-bootstrap-id slot. Import this exactly once, from
+// app/_layout.tsx, BEFORE anything that imports posthog-client.ts (directly or
+// via AnalyticsProvider/analytics.ts) — ES module evaluation runs each import
+// in file order, so as long as this import line comes first, the slot is
+// populated before posthog-client.ts's own module-eval side effect reads it to
+// construct the PostHog client.
+//
+// This is the one module allowed to pull in expo-secure-store (via
+// party-profile-store.ts) from the analytics call graph; keep that import out
+// of posthog-client.ts/analytics.ts directly, or their existing RN-free module
+// graph — and the node-env tests that depend on it — breaks.
+import { getOrCreatePartyProfileIdSync } from './party-profile-store';
+import { setAnalyticsBootstrapId } from './analytics-bootstrap-id';
+
+setAnalyticsBootstrapId(getOrCreatePartyProfileIdSync());

--- a/packages/mobile/src/lib/party-profile-store.ts
+++ b/packages/mobile/src/lib/party-profile-store.ts
@@ -1,4 +1,5 @@
 import * as SecureStore from 'expo-secure-store';
+import { randomUUID } from 'expo-crypto';
 import type { PartyProfile, PartyProfileStorage } from '@boardsesh/party-profile';
 
 const PARTY_PROFILE_KEY = 'boardsesh_party_profile';
@@ -19,3 +20,29 @@ export const partyProfileStorage: PartyProfileStorage = {
     await SecureStore.setItemAsync(PARTY_PROFILE_KEY, JSON.stringify(profile));
   },
 };
+
+// Synchronous get-or-create, backed by expo-secure-store's JSI sync API rather
+// than the async one above. Exists solely for analytics-bootstrap.ts, which
+// resolves the party-profile UUID at module-eval time so posthog-client.ts can
+// bootstrap the PostHog SDK's anonymous id with it before the SDK's
+// app-lifecycle autocapture fires — see analytics-bootstrap.ts for why that
+// ordering matters. Reads and writes the same key as partyProfileStorage, so
+// the two never disagree: this runs once at bundle-eval time, strictly before
+// PartyProfileProvider's async effect can fire, so there's no write race
+// between them. Never throws — a locked keychain or unavailable JSI just
+// yields `null`, and the caller falls back to today's behavior (PostHog's own
+// anonymous id).
+export function getOrCreatePartyProfileIdSync(generateId: () => string = randomUUID): string | null {
+  try {
+    const raw = SecureStore.getItem(PARTY_PROFILE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as { id?: unknown };
+      if (typeof parsed.id === 'string' && parsed.id.length > 0) return parsed.id;
+    }
+    const created: PartyProfile = { id: generateId() };
+    SecureStore.setItem(PARTY_PROFILE_KEY, JSON.stringify(created));
+    return created.id;
+  } catch {
+    return null;
+  }
+}

--- a/packages/mobile/src/lib/party-profile-store.ts
+++ b/packages/mobile/src/lib/party-profile-store.ts
@@ -42,7 +42,11 @@ export function getOrCreatePartyProfileIdSync(generateId: () => string = randomU
     const created: PartyProfile = { id: generateId() };
     SecureStore.setItem(PARTY_PROFILE_KEY, JSON.stringify(created));
     return created.id;
-  } catch {
+  } catch (error) {
+    // Dev-only: this failing means the PostHog bootstrap silently falls back to
+    // an unlinked anonymous id (see analytics-bootstrap.ts) with no other
+    // symptom — worth a breadcrumb if the install-funnel fix looks ineffective.
+    if (__DEV__) console.warn('[analytics] failed to resolve party-profile id synchronously', error);
     return null;
   }
 }

--- a/packages/mobile/src/lib/posthog-client.ts
+++ b/packages/mobile/src/lib/posthog-client.ts
@@ -1,4 +1,5 @@
-import { PostHog } from 'posthog-react-native';
+import { PostHog, type PostHogOptions } from 'posthog-react-native';
+import { getAnalyticsBootstrapId } from './analytics-bootstrap-id';
 
 // PostHog flags events with an empty User-Agent as bots, and the RN SDK sends no
 // UA it stores — so without this, real mobile traffic hides behind the bot filter.
@@ -36,6 +37,27 @@ export const isAnalyticsEnabled = !!apiKey && !__DEV__;
 let client: PostHog | null = null;
 let initAttempted = false;
 
+// Pure so the bootstrap wiring is unit-testable without constructing a real
+// PostHog client (isAnalyticsEnabled is always false in the test env).
+// `bootstrapDistinctId` is the party-profile UUID resolved synchronously by the
+// caller, or null if that read/create failed — in which case bootstrap is
+// omitted entirely and the SDK falls back to its own anonymous id, exactly as
+// before this option existed.
+export function buildPostHogOptions(postHogHost: string, bootstrapDistinctId: string | null): PostHogOptions {
+  return {
+    host: postHogHost,
+    bootstrap: bootstrapDistinctId ? { distinctId: bootstrapDistinctId, isIdentifiedId: false } : undefined,
+    // `enableSessionReplay` defaults false, so the SDK never auto-records.
+    // Capture only begins when setSessionRecordingEnabled() calls
+    // startSessionRecording(), which lazily initialises the native replay SDK.
+    sessionReplayConfig: {
+      maskAllTextInputs: true,
+      maskAllImages: true,
+      captureLog: true,
+    },
+  };
+}
+
 // Construct or return the single PostHog client. Returns null in dev / when
 // unkeyed, which makes every wrapper method a no-op. PostHog is product
 // analytics only — error/crash reporting goes to Sentry (src/lib/sentry.ts).
@@ -48,24 +70,19 @@ export function getPostHogClient(): PostHog | null {
   // expo-device + expo-application (installed) enrich events with $device_model,
   // $os_version, $app_version. Screen autocapture is handled in AnalyticsProvider.
   //
-  // Known gap: this client is constructed at AnalyticsProvider mount (top of the
-  // tree), so the first Application Opened fires under PostHog's auto-generated
-  // anonymous distinct_id before PartyProfileProvider has run identify() with
-  // the party-profile UUID (and, for signed-in users, the alias to the user).
-  // PostHog merges those early events into the person record once the alias is
-  // processed, so this is acceptable (web has the same cold-start window), but
-  // don't be surprised to see a few lifecycle events on a transient anon id.
-  client = new PostHog(apiKey, {
-    host,
-    // `enableSessionReplay` defaults false, so the SDK never auto-records.
-    // Capture only begins when setSessionRecordingEnabled() calls
-    // startSessionRecording(), which lazily initialises the native replay SDK.
-    sessionReplayConfig: {
-      maskAllTextInputs: true,
-      maskAllImages: true,
-      captureLog: true,
-    },
-  });
+  // This client is constructed at AnalyticsProvider mount (top of the tree),
+  // before PartyProfileProvider has loaded the party-profile UUID and run
+  // identify()/alias() with it — so captureAppLifecycleEvents would otherwise
+  // fire Application Installed/Opened under PostHog's own transient anonymous
+  // id, an id the later alias-to-user step never reliably reconnects.
+  // getAnalyticsBootstrapId() reads a slot that analytics-bootstrap.ts (wired
+  // up in app/_layout.tsx, ahead of anything that imports this module)
+  // resolves synchronously via expo-secure-store's JSI sync API — passing it
+  // as `bootstrap` seeds the SDK's anonymous id with it before
+  // captureAppLifecycleEvents runs, so those events land on the same id
+  // PartyProfileProvider later identifies/aliases.
+  const bootstrapDistinctId = getAnalyticsBootstrapId();
+  client = new PostHog(apiKey, buildPostHogOptions(host, bootstrapDistinctId));
   registerMobileUserAgent(client);
   return client;
 }


### PR DESCRIPTION
## Summary

Closes #3398.

The mobile install→first-board-send funnel converted at ~1% (iOS) / ~0.2% (Android) against an expected "tens of percent" — a data-quality bug, not a real drop-off. `Application Installed` and the first `Application Opened` were firing under PostHog's own transient anonymous `distinct_id`, before `PartyProfileProvider`'s async `identify()`/`alias()` calls ran with the stable party-profile UUID. PostHog's alias-based person-stitching doesn't reliably reconnect those early events afterward, so any funnel anchored on install/open massively undercounted.

Fix: resolve the party-profile UUID synchronously (via `expo-secure-store`'s JSI sync API) as early as possible — before `posthog-client.ts`'s own module-eval side effect constructs the PostHog client — and pass it as the client's `bootstrap.distinctId`. `posthog-react-native` seeds the anonymous distinct_id from `bootstrap` before its `captureAppLifecycleEvents` autocapture fires, so `Application Installed`/`Application Opened` now land on the same id `PartyProfileProvider` later `identify()`s/`alias()`es — no PostHog dashboard changes needed.

To keep `posthog-client.ts`/`analytics.ts` free of the `expo-secure-store` → React Native (Flow-syntax) import chain they're deliberately built without (so the node-env test runner can still import them), the resolution is split:
- `analytics-bootstrap-id.ts` — a pure, dependency-free in-memory slot that `posthog-client.ts` reads.
- `analytics-bootstrap.ts` — a side-effect-only module, imported once from `app/_layout.tsx` ahead of anything that reaches `posthog-client.ts`, that does the actual `expo-secure-store` read/create and populates the slot.

Web is unaffected — `posthog-js-lite` has no app-lifecycle autocapture and the web client is lazily constructed on first real event, not eagerly.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — passes.
- `vp test run --project mobile` — 400/400 test files, 3109/3109 tests pass (14 new tests covering the sync party-profile accessor, the bootstrap-id slot, the bootstrap wiring, and `buildPostHogOptions`).
- `vp check packages/mobile` — 0 errors (pre-existing warnings unrelated to this change).
- `vp run check:mobile-bundle` — Metro bundle export succeeds with the new `app/_layout.tsx` import wired in.
- Not independently verifiable in this session: real-world confirmation that `Application Installed`/`Application Opened` now land on the party-profile UUID and that the install→activation funnel conversion rate rises, since that requires observing live PostHog data after release.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VA6MxwRK83aBNttFpZ9Jin)_