### PR TITLE
fix(mobile): harden the Live Activity lifecycle (token race, ordering, dedup, retry, stale window)

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -372,7 +372,7 @@ This is the key test — verifying that APNs keeps the Live Activity alive when 
 3. Wait 30+ seconds for iOS to fully suspend the app
 4. From a **second device or browser**, change the current climb
 5. Check your iPhone's lock screen — the Live Activity should update within a few seconds via APNs push
-6. The stale date (3 minutes) should NOT trigger because APNs pushes refresh it
+6. The stale date (10 minutes, `SharedConstants.liveActivityStaleInterval`) should NOT trigger because APNs pushes refresh it
 
 ### Verify the Update Source
 
@@ -510,7 +510,7 @@ The .p8 key JWT has expired (tokens are valid for 1 hour). The `@parse/node-apn`
 - The widget extension must have the App Group entitlement to read SharedDefaults.
 - Check backend logs for incoming requests to `/api/widget/navigate` or `/api/widget/take-control`.
 
-### Live Activity goes stale after 3 minutes
+### Live Activity goes stale after 10 minutes
 
 - APNs pushes are not reaching the device. Check backend logs for send failures.
 - The APNs rate limit may be exceeded (~4/hr for non-prominent activities). When the activity is on the lock screen, the limit is much higher.

--- a/packages/mobile/modules/live-activity/ios/ClimbNavigationIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/ClimbNavigationIntent.swift
@@ -88,7 +88,7 @@ enum ClimbNavigationIntent {
 
         for activity in Activity<ClimbSessionAttributes>.activities {
             guard activity.activityState == .active else { continue }
-            let content = ActivityContent(state: newState, staleDate: Date().addingTimeInterval(180))
+            let content = ActivityContent(state: newState, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval))
             await activity.update(content)
         }
 

--- a/packages/mobile/modules/live-activity/ios/LiveActivityManager.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityManager.swift
@@ -31,14 +31,18 @@ actor LiveActivityManager {
     /// Timestamp of the last ActivityKit update, used for deduplication.
     private var lastUpdateTime: Date?
 
-    /// How far in the future the stale date is set. The server-side APNs
-    /// heartbeat (`packages/backend/src/services/apns/heartbeat.ts`) re-sends
-    /// the latest content state every 90 s while at least one push token is
-    /// registered for the session, so a 10-minute stale interval gives ~6×
-    /// headroom against missed pushes (network blip, APNs latency, server
-    /// restart). After a force-quit with no server keepalive the activity
-    /// goes stale in 10 minutes instead of lingering indefinitely.
-    private let staleInterval: TimeInterval = 10 * 60
+    /// How far in the future the stale date is set — see the rationale on
+    /// `SharedConstants.liveActivityStaleInterval` (shared with the
+    /// widget-extension intents so a lock-screen tap can't shorten the
+    /// deadline the app maintains).
+    private let staleInterval = SharedConstants.liveActivityStaleInterval
+
+    /// Bumped by every startActivity/endAllActivities entry. Ended-then-
+    /// restarted flows interleave on this reentrant actor (both hop through
+    /// `await activity.end` / `Activity.request`), and an end that resumes
+    /// after a newer start must not sweep the activity that start just
+    /// created.
+    private var lifecycleGeneration = 0
 
     // MARK: - Init
 
@@ -74,11 +78,25 @@ actor LiveActivityManager {
         // Clean up any existing activities first.
         await endAllActivities()
 
+        // Claim the lifecycle AFTER the cleanup sweep (which takes its own
+        // generation) so a later end can supersede this start across the
+        // suspension below.
+        lifecycleGeneration += 1
+        let generation = lifecycleGeneration
+
         // A new session/board is starting — drop the previous board's decoded
         // background layers now instead of waiting for the next composite to
         // prune them (which never runs if no thumbnail is requested before the
         // app backgrounds).
         await thumbnailFetcher.clearBackgroundLayerCache()
+
+        // A newer start/end entered the actor while we were suspended — it
+        // owns the lifecycle now; requesting an activity here would leak one
+        // nobody tracks.
+        guard generation == lifecycleGeneration else {
+            logger.info("startActivity superseded during setup; skipping Activity.request")
+            return
+        }
 
         // Install the push-token callback before requesting the activity.
         // ActivityKit can emit the first token between Activity.request returning
@@ -162,6 +180,14 @@ actor LiveActivityManager {
         return Date().timeIntervalSince(lastUpdateTime)
     }
 
+    /// The content state currently shown by the tracked activity, or nil when
+    /// none is active. Lets the dedup gate skip only pushes whose content is
+    /// actually identical — a time-only window dropped the second of two
+    /// quick navigations and left the widget on the wrong climb.
+    func lastPushedState() -> ClimbSessionAttributes.ContentState? {
+        currentActivity?.content.state
+    }
+
     // MARK: - Refresh Stale Date
 
     /// Pushes the stale deadline forward without changing the displayed content.
@@ -177,20 +203,31 @@ actor LiveActivityManager {
     /// Ends all Live Activities, including the tracked one and any stale
     /// activities from previous sessions that may still be visible.
     func endAllActivities() async {
+        lifecycleGeneration += 1
+        let generation = lifecycleGeneration
+
         pushTokenTask?.cancel()
         pushTokenTask = nil
 
-        // End the currently tracked activity.
+        // End the currently tracked activity. Clear the reference BEFORE the
+        // await: a start that interleaves during the suspension assigns a new
+        // activity, and resuming here must not nil that out.
         if let activity = currentActivity {
+            currentActivity = nil
             let activityId = activity.id
             await activity.end(nil, dismissalPolicy: .immediate)
             logger.info("Ended tracked Live Activity \(activityId, privacy: .public)")
-            currentActivity = nil
         }
 
         // Also clean up any stale activities that might linger from crashes
-        // or previous sessions.
+        // or previous sessions — unless a newer start claimed the lifecycle
+        // while we were suspended, in which case sweeping would kill the
+        // activity it just created.
         for activity in Activity<ClimbSessionAttributes>.activities {
+            guard generation == lifecycleGeneration else {
+                logger.info("endAllActivities superseded by a newer start; leaving remaining activities")
+                return
+            }
             await activity.end(nil, dismissalPolicy: .immediate)
         }
     }

--- a/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -54,6 +54,26 @@ public class LiveActivityModule: Module {
     private var hasListener = false
     private var isDraining = false
 
+    /// FIFO chain for ActivityKit lifecycle work (start/end/update). The
+    /// naked `Task {}`s these used to spawn are unordered, so a fast
+    /// end-then-start (board switch) could run endAllActivities AFTER the new
+    /// start (killing the fresh activity), a start-then-end (quick unmount)
+    /// could start AFTER the end (orphaning a "Loading..." activity), and an
+    /// older update could land after a newer one. Chaining preserves the JS
+    /// call order end-to-end.
+    private let lifecycleQueue = DispatchQueue(label: "com.boardsesh.LiveActivityModule.lifecycle")
+    private var _lifecycleTask: Task<Void, Never>?
+
+    private func enqueueLifecycleWork(_ operation: @escaping () async -> Void) {
+        lifecycleQueue.sync {
+            let previous = _lifecycleTask
+            _lifecycleTask = Task {
+                await previous?.value
+                await operation()
+            }
+        }
+    }
+
     public func definition() -> ModuleDefinition {
         Name("LiveActivity")
 
@@ -736,7 +756,7 @@ public class LiveActivityModule: Module {
             }
         }
 
-        Task {
+        enqueueLifecycleWork {
             do {
                 try await activityManager.startActivity(
                     boardName: boardName,
@@ -796,7 +816,7 @@ public class LiveActivityModule: Module {
         SharedKeychain.remove(SharedKeychain.livePushTokenKey)
 
         if #available(iOS 17.0, *) {
-            Task {
+            enqueueLifecycleWork {
                 await LiveActivityManager.shared.endAllActivities()
                 self.logger.info("Ended session and cleaned up Live Activity")
                 promise.resolve(nil)
@@ -861,9 +881,10 @@ public class LiveActivityModule: Module {
         )
 
         let activityManager = LiveActivityManager.shared
-        Task {
+        enqueueLifecycleWork {
             let elapsed = await activityManager.timeSinceLastUpdate()
-            if !wallControlChanged, let elapsed, elapsed < SharedConstants.liveActivityDedupWindow {
+            let unchanged = await activityManager.lastPushedState() == state
+            if !wallControlChanged, unchanged, let elapsed, elapsed < SharedConstants.liveActivityDedupWindow {
                 self.logger.debug("Skipping redundant ActivityKit push (\(Int(elapsed * 1000))ms since last native update)")
             } else {
                 await activityManager.updateActivity(state: state)
@@ -912,9 +933,10 @@ public class LiveActivityModule: Module {
         )
 
         let activityManager = LiveActivityManager.shared
-        Task {
+        enqueueLifecycleWork {
             let elapsed = await activityManager.timeSinceLastUpdate()
-            if !wallControlChanged, let elapsed, elapsed < SharedConstants.liveActivityDedupWindow {
+            let unchanged = await activityManager.lastPushedState() == state
+            if !wallControlChanged, unchanged, let elapsed, elapsed < SharedConstants.liveActivityDedupWindow {
                 self.logger.debug("Skipping redundant climb ActivityKit push (\(Int(elapsed * 1000))ms since last native update)")
             } else {
                 await activityManager.updateActivity(state: state)

--- a/packages/mobile/modules/live-activity/ios/ReconnectBoardIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/ReconnectBoardIntent.swift
@@ -51,7 +51,7 @@ struct ReconnectBoardIntent: LiveActivityIntent {
     private func refreshActivities() async {
         for activity in Activity<ClimbSessionAttributes>.activities {
             guard activity.activityState == .active else { continue }
-            let content = ActivityContent(state: activity.content.state, staleDate: Date().addingTimeInterval(180))
+            let content = ActivityContent(state: activity.content.state, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval))
             await activity.update(content)
         }
     }

--- a/packages/mobile/modules/live-activity/ios/SharedConstants.swift
+++ b/packages/mobile/modules/live-activity/ios/SharedConstants.swift
@@ -105,7 +105,21 @@ enum SharedConstants {
     /// Minimum seconds between consecutive ActivityKit pushes.
     /// Redundant JS-side updates that arrive within this window are skipped
     /// because the native WebSocket callback already applied the state.
+    /// Only truly redundant pushes are skipped: a push whose content differs
+    /// from the last pushed state always goes through (a dropped
+    /// content-changing update would leave the widget on the wrong climb
+    /// until some later update).
     static let liveActivityDedupWindow: TimeInterval = 0.5
+
+    /// How far in the future every ActivityKit update pushes the stale date.
+    /// The server-side APNs heartbeat (`packages/backend/src/services/apns/
+    /// heartbeat.ts`) re-sends the latest content state every 90 s while a
+    /// push token is registered, so 10 minutes gives ~6× headroom against
+    /// missed pushes. Shared with the widget-extension intents — they used a
+    /// 180 s stale date, which flipped the activity to "Session ended" three
+    /// minutes after a lock-screen tap whenever no heartbeat covered the
+    /// session (push registration pending, local session).
+    static let liveActivityStaleInterval: TimeInterval = 10 * 60
 
     // MARK: Helpers
 

--- a/packages/mobile/modules/live-activity/ios/TakeControlIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/TakeControlIntent.swift
@@ -39,7 +39,7 @@ struct TakeControlIntent: LiveActivityIntent {
     private func refreshActivities() async {
         for activity in Activity<ClimbSessionAttributes>.activities {
             guard activity.activityState == .active else { continue }
-            let content = ActivityContent(state: activity.content.state, staleDate: Date().addingTimeInterval(180))
+            let content = ActivityContent(state: activity.content.state, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval))
             await activity.update(content)
         }
     }

--- a/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -213,7 +213,11 @@ describe('LiveActivityBridge widget navigation (always-live)', () => {
     expect(queue.dispatchWidgetNavigation).not.toHaveBeenCalled();
   });
 
-  it('always allows widget navigation in a party session (no driver gate)', () => {
+  it('keeps widget navigation enabled in a party session while this device holds the board', () => {
+    // Navigation IS gated on holding the board (boardConnection ===
+    // 'connectedByMe', set in beforeEach) — being in a party session doesn't
+    // disable it. The heldByPeer/disconnected cases above cover the gate.
+    boardState.boardConnection = 'connectedByMe';
     renderBridge();
 
     expect(widget.useLiveActivity).toHaveBeenCalledWith(

--- a/packages/mobile/src/lib/live-activity/__tests__/use-live-activity.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/use-live-activity.test.tsx
@@ -27,6 +27,7 @@ const plugin = vi.hoisted(() => ({
 vi.mock('../live-activity-plugin', () => plugin);
 
 import { useLiveActivity } from '../use-live-activity';
+import { getAuthToken } from '../../auth-store';
 
 const queueItem = {
   uuid: 'queue-item-1',
@@ -165,6 +166,72 @@ describe('useLiveActivity start-failure contract', () => {
     );
   });
 
+  it('retries the start automatically after a transient failure, within budget', async () => {
+    vi.useFakeTimers();
+    try {
+      // Two transient rejections (e.g. a stale activity still counting against
+      // the ActivityKit limit), then success — all within one activation.
+      plugin.startLiveActivitySession
+        .mockRejectedValueOnce(new Error('transient'))
+        .mockRejectedValueOnce(new Error('transient'))
+        .mockResolvedValue(undefined);
+
+      render(<Harness {...activeProps()} />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(1);
+
+      // Attempt 2 fires after one backoff step…
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+      expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(2);
+
+      // …attempt 3 after two steps, and it succeeds: initial state pushed.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(8000);
+      });
+      expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(3);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(plugin.updateLiveActivity).toHaveBeenCalledWith(
+        expect.objectContaining({ climbName: 'Test Climb', currentIndex: 0, totalClimbs: 1 }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops retrying once the budget is exhausted', async () => {
+    vi.useFakeTimers();
+    try {
+      plugin.startLiveActivitySession.mockRejectedValue(new Error('persistent'));
+
+      render(<Harness {...activeProps()} />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+      expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(2);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(8000);
+      });
+      expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(3);
+      // Budget exhausted (initial attempt + 2 retries) — silence from here.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps a newer session active when an older start rejects late', async () => {
     const firstStart = createDeferredStartPromise();
     plugin.startLiveActivitySession.mockReturnValueOnce(firstStart.promise).mockResolvedValueOnce(undefined);
@@ -197,6 +264,59 @@ describe('useLiveActivity start-failure contract', () => {
       expect(plugin.updateLiveActivityClimb).toHaveBeenCalledWith(
         expect.objectContaining({ climbName: 'Next Climb', currentIndex: 1, totalClimbs: 2 }),
       ),
+    );
+  });
+});
+
+describe('useLiveActivity auth-token gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin.isLiveActivityAvailable.mockResolvedValue(true);
+    plugin.updateLiveActivity.mockResolvedValue(undefined);
+    plugin.updateLiveActivityClimb.mockResolvedValue(undefined);
+    plugin.endLiveActivitySession.mockResolvedValue(undefined);
+    plugin.startLiveActivitySession.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("waits for the new session's token load instead of starting with the previous one", async () => {
+    // Guest phase: SecureStore answers null while no session is active.
+    vi.mocked(getAuthToken).mockResolvedValueOnce(null);
+
+    const { rerender } = render(<Harness {...activeProps({ sessionId: null, isSessionActive: false })} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(plugin.startLiveActivitySession).not.toHaveBeenCalled();
+
+    // The user signed in; the next SecureStore read returns the fresh token,
+    // but slowly — the start must wait for it rather than racing ahead with
+    // the guest-phase null (which silently killed push registration for the
+    // whole session).
+    let resolveToken!: (token: string | null) => void;
+    vi.mocked(getAuthToken).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveToken = resolve;
+        }),
+    );
+
+    rerender(<Harness {...activeProps({ sessionId: 'session-2' })} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(plugin.startLiveActivitySession).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveToken('fresh-token');
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(1));
+    expect(plugin.startLiveActivitySession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'session-2', authToken: 'fresh-token' }),
     );
   });
 });

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -54,6 +54,12 @@ type UseLiveActivityOptions = {
 // presence surface; everything else short-circuits at the plugin layer.
 const supportsSessionPresence = Platform.OS === 'ios' || Platform.OS === 'android';
 
+// Retry budget for a failed native start (transient ActivityKit rejections).
+// Attempt n waits n × START_RETRY_DELAY_MS; the budget resets on a successful
+// start or a deactivation.
+const MAX_START_RETRIES = 2;
+const START_RETRY_DELAY_MS = 4000;
+
 function getGraphqlHttpUrl(): string {
   return `${BACKEND_URL.replace(/\/+$/, '')}/graphql`;
 }
@@ -142,14 +148,25 @@ export function useLiveActivity({
   const isActiveRef = useRef(false);
   const generationRef = useRef(0);
   const [available, setAvailable] = useState<boolean | null>(null);
-  const [authToken, setAuthToken] = useState<string | null>(null);
-  const [authTokenLoaded, setAuthTokenLoaded] = useState(false);
+  // The token is stored WITH the sessionId it was loaded for. Deriving
+  // authTokenLoaded from that pairing (instead of a boolean that latched true
+  // on the first load and never reset) closes a race: when sessionId changes,
+  // shouldBeActive stays false until SecureStore answers for the NEW session,
+  // so startSession can no longer ship the previous session's token — which
+  // silently killed push-token registration for the whole session (native
+  // retries all bail on "no auth token in keychain", and no later update
+  // carries the token). It also forces an end/restart when sessionId swaps
+  // directly A→B, rebinding the native WebSocket and push registration.
+  const [loadedAuthToken, setLoadedAuthToken] = useState<{ forSessionId: string | null; token: string | null } | null>(
+    null,
+  );
+  const authTokenLoaded = loadedAuthToken !== null && loadedAuthToken.forSessionId === sessionId;
 
   // Keep refs for values the start callback needs without triggering restarts
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
-  const authTokenRef = useRef(authToken);
-  authTokenRef.current = authToken;
+  const authTokenRef = useRef<string | null>(null);
+  authTokenRef.current = authTokenLoaded ? loadedAuthToken.token : null;
   const androidNotificationRef = useRef(androidNotification);
   androidNotificationRef.current = androidNotification;
   const widgetNavigationAllowedRef = useRef(widgetNavigationAllowed);
@@ -205,15 +222,15 @@ export function useLiveActivity({
     };
   }, []);
 
-  // Load auth token once. Re-load if the start effect's deps change (cheap
-  // enough — SecureStore read).
+  // (Re)load the auth token for the current sessionId (cheap — SecureStore
+  // read). The result is paired with the sessionId it answers for; see
+  // loadedAuthToken above.
   useEffect(() => {
     if (!supportsSessionPresence) return;
     let cancelled = false;
     void getAuthToken().then((token) => {
       if (cancelled) return;
-      setAuthToken(token);
-      setAuthTokenLoaded(true);
+      setLoadedAuthToken({ forSessionId: sessionId, token });
     });
     return () => {
       cancelled = true;
@@ -224,6 +241,22 @@ export function useLiveActivity({
   // board config. Does NOT restart when the current climb changes.
   const hasContent = queue.length > 0 || currentClimbQueueItem !== null;
   const shouldBeActive = isSessionActive && hasContent && stableBoard !== null && available === true && authTokenLoaded;
+
+  // ActivityKit start failures include transient ones (a stale activity still
+  // counting against the per-app limit, momentary throttling). Without a
+  // retry, one failure killed the widget for the whole session — the effect's
+  // deps never change again, so it only recovered on a full deactivate/
+  // reactivate. Bounded: the nonce re-fires the start effect, the counter
+  // stops after MAX_START_RETRIES, and both reset on success or deactivation.
+  const [startRetryNonce, setStartRetryNonce] = useState(0);
+  const startFailureCountRef = useRef(0);
+  const startRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearStartRetry = () => {
+    if (startRetryTimerRef.current !== null) {
+      clearTimeout(startRetryTimerRef.current);
+      startRetryTimerRef.current = null;
+    }
+  };
 
   useEffect(() => {
     if (!supportsSessionPresence || available !== true) return;
@@ -258,6 +291,7 @@ export function useLiveActivity({
         })
         .then(() => {
           if (!isActiveRef.current || generationRef.current !== startGeneration) return;
+          startFailureCountRef.current = 0;
           // Send an initial update so the widget doesn't stay on "Loading...".
           const q = queueRef.current;
           const displayItem = currentClimbRef.current ?? (q.length > 0 ? q[0] : null);
@@ -297,19 +331,36 @@ export function useLiveActivity({
           // tear those down here — JS otherwise believes nothing is active and
           // never reaches the teardown paths. endSession is idempotent.
           void endLiveActivitySession();
+          startFailureCountRef.current += 1;
+          if (startFailureCountRef.current <= MAX_START_RETRIES) {
+            const attempt = startFailureCountRef.current;
+            startRetryTimerRef.current = setTimeout(() => {
+              startRetryTimerRef.current = null;
+              setStartRetryNonce((nonce) => nonce + 1);
+            }, START_RETRY_DELAY_MS * attempt);
+          }
         });
     } else if (!shouldBeActive && isActiveRef.current) {
       void endLiveActivitySession();
       isActiveRef.current = false;
     }
 
+    if (!shouldBeActive) {
+      // Deactivation abandons any scheduled retry and resets the budget for
+      // the next activation.
+      clearStartRetry();
+      startFailureCountRef.current = 0;
+    }
+
     return () => {
+      clearStartRetry();
       if (isActiveRef.current) {
         void endLiveActivitySession();
         isActiveRef.current = false;
       }
     };
-  }, [shouldBeActive, stableBoard, available]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- startRetryNonce re-fires the start after a failed attempt
+  }, [shouldBeActive, stableBoard, available, startRetryNonce]);
 
   // Stable scalar trigger for the on-device thumbnail backgrounds: the paths array
   // has a fresh identity each render, so depending on it directly would churn the

--- a/packages/mobile/targets/BoardseshWidgets/ClimbNavigationIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/ClimbNavigationIntent.swift
@@ -88,7 +88,7 @@ enum ClimbNavigationIntent {
 
         for activity in Activity<ClimbSessionAttributes>.activities {
             guard activity.activityState == .active else { continue }
-            let content = ActivityContent(state: newState, staleDate: Date().addingTimeInterval(180))
+            let content = ActivityContent(state: newState, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval))
             await activity.update(content)
         }
 

--- a/packages/mobile/targets/BoardseshWidgets/ReconnectBoardIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/ReconnectBoardIntent.swift
@@ -51,7 +51,7 @@ struct ReconnectBoardIntent: LiveActivityIntent {
     private func refreshActivities() async {
         for activity in Activity<ClimbSessionAttributes>.activities {
             guard activity.activityState == .active else { continue }
-            let content = ActivityContent(state: activity.content.state, staleDate: Date().addingTimeInterval(180))
+            let content = ActivityContent(state: activity.content.state, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval))
             await activity.update(content)
         }
     }

--- a/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
+++ b/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
@@ -105,7 +105,21 @@ enum SharedConstants {
     /// Minimum seconds between consecutive ActivityKit pushes.
     /// Redundant JS-side updates that arrive within this window are skipped
     /// because the native WebSocket callback already applied the state.
+    /// Only truly redundant pushes are skipped: a push whose content differs
+    /// from the last pushed state always goes through (a dropped
+    /// content-changing update would leave the widget on the wrong climb
+    /// until some later update).
     static let liveActivityDedupWindow: TimeInterval = 0.5
+
+    /// How far in the future every ActivityKit update pushes the stale date.
+    /// The server-side APNs heartbeat (`packages/backend/src/services/apns/
+    /// heartbeat.ts`) re-sends the latest content state every 90 s while a
+    /// push token is registered, so 10 minutes gives ~6× headroom against
+    /// missed pushes. Shared with the widget-extension intents — they used a
+    /// 180 s stale date, which flipped the activity to "Session ended" three
+    /// minutes after a lock-screen tap whenever no heartbeat covered the
+    /// session (push registration pending, local session).
+    static let liveActivityStaleInterval: TimeInterval = 10 * 60
 
     // MARK: Helpers
 

--- a/packages/mobile/targets/BoardseshWidgets/TakeControlIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/TakeControlIntent.swift
@@ -39,7 +39,7 @@ struct TakeControlIntent: LiveActivityIntent {
     private func refreshActivities() async {
         for activity in Activity<ClimbSessionAttributes>.activities {
             guard activity.activityState == .active else { continue }
-            let content = ActivityContent(state: activity.content.state, staleDate: Date().addingTimeInterval(180))
+            let content = ActivityContent(state: activity.content.state, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval))
             await activity.update(content)
         }
     }


### PR DESCRIPTION
## Summary

Five bugs in the Live Activity lifecycle (JS hook + native module), found in an adversarial review of the stack. Contains native Swift changes — ships with the next binary, not OTA.

1. **Auth-token race silently killed push updates.** `authTokenLoaded` latched `true` on the first SecureStore read and never reset, so joining a session right after signing in raced the fresh token read and could ship the guest-phase `null` token to `startSession`. Native push-token registration then bailed on every retry ("no auth token in keychain") for the entire session, and no later call re-sends the token. The token is now stored with the sessionId it was loaded for, and the start gates on that pairing at render time. Bonus: a direct A→B sessionId swap now ends and restarts the activity instead of leaving the native WebSocket, App Group state, and push registration bound to the old session (widget taps were mutating the wrong session).
2. **start/end/update ran in unordered `Task {}`s.** A fast end-then-start (board switch) could run `endAllActivities` after the new start and kill the fresh activity (JS still believes it's active — dead widget for the session); a start-then-end (quick unmount) could orphan a "Loading…" activity on the lock screen; an older update could land after a newer one. Lifecycle work is now a FIFO chain (`enqueueLifecycleWork`), with a lifecycle-generation guard inside the `LiveActivityManager` actor as a backstop against actor-reentrancy interleavings.
3. **Time-only dedup dropped content changes.** The 500 ms dedup window compared wall-control flags and elapsed time only — a quick double-Next dropped the second push and left the Dynamic Island on the wrong climb indefinitely whenever the native WS echo wasn't around to repair it (`refreshStaleDate` even re-pushed the stale state every 60 s). The gate now also requires the content state to equal the last pushed state.
4. **One failed start = dead widget for the session.** ActivityKit start failures include transient ones; the effect deps never changed after a failure, so recovery required leaving and rejoining. Failed starts retry twice with linear backoff (4 s, 8 s); the budget resets on success or deactivation. The old no-self-retry contract test is superseded by explicit retry-budget tests.
5. **Widget intents shrank the stale window from 600 s to 180 s.** A lock-screen Prev/Next/reconnect tap could flip the activity to "Session ended" three minutes later when no APNs heartbeat covered the session (push registration pending, local session). All paths now share `SharedConstants.liveActivityStaleInterval` (10 min, ~6× heartbeat headroom).

Also retitles a bridge test whose name claimed party sessions have "no driver gate" — they do (`boardConnection === 'connectedByMe'`); the test only passed because `beforeEach` set that state.

Widget-target duplicate files (`SharedConstants`, three intents) re-synced byte-identically (drift test green).

## Release Notes

- Lock-screen and Dynamic Island controls are more reliable: the session card no longer freezes on the wrong climb after quick navigation, dies after a hiccup starting up, or flips to "Session ended" minutes after you use it

## Test plan

- New Vitest coverage: auto-retry within budget + stop-after-budget (fake timers), auth-token gating (start waits for the new session's token and passes it through), retitled driver-gate test.
- Existing suites green: `vp run test:mobile` (3098 passed), `vp run typecheck:mobile`, `vp run check:mobile-bundle`, widget-target drift test.
- `swiftc -typecheck` clean on the widget-extension file set (`-D WIDGET_EXTENSION`); full-app compile covered by `ios-rn-ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G77gsNZteEQB7ehifY4iRN