### PR TITLE
feat: enrich session and tick analytics events (duration, grade value, tick-form dismiss)

### DIFF
--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -5,16 +5,18 @@
 //
 // Uses `BottomSheetModal` (not the regular `BottomSheet`) so it presents as
 // a native modal above the play drawer's own modal.
-import { useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { useManagedSheet } from '../providers/sheet-presentation-provider';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
+import { track } from '../lib/analytics';
 import { Icon } from './Icon';
-import { QuickTickBar } from './play-drawer/QuickTickBar';
+import { QuickTickBar, type QuickTickDismissSnapshot } from './play-drawer/QuickTickBar';
 
 type LogAscentSheetProps = {
   visible: boolean;
@@ -57,10 +59,39 @@ export function LogAscentSheet({
   const { systemColors } = useTheme();
   const { t } = useTranslation('session');
 
+  // Tracks whether the open tick got saved, so handleClose below can tell a
+  // completed save (QuickTickSaved already covers it) apart from a genuine
+  // abandon via the X-button / pan-down / backdrop tap (none of which call
+  // back into QuickTickBar, so it can't distinguish these itself).
+  const savedRef = useRef(false);
+  const fieldSnapshotRef = useRef<QuickTickDismissSnapshot>({
+    hasQuality: false,
+    hasDifficulty: false,
+    hasComment: false,
+    attemptCountChanged: false,
+  });
+
+  // A fresh present (new climb, or reopening on the same one) must not
+  // inherit a stale `true` left over from a previous save-then-dismiss cycle.
+  useEffect(() => {
+    if (visible) savedRef.current = false;
+  }, [visible]);
+
+  const handleClose = useCallback(() => {
+    if (!savedRef.current) {
+      track(SHARED_EVENTS.QuickTickDismissed, {
+        climbUuid,
+        layoutId: layoutId ?? null,
+        ...fieldSnapshotRef.current,
+      });
+    }
+    onClose();
+  }, [climbUuid, layoutId, onClose]);
+
   // Present/dismiss go through the coordinator (serialized, no overlapping
   // transitions); `onClose` fires on a user pan-down, `onFullyDismissed` after
   // the animation settles.
-  const managed = useManagedSheet({ open: visible, sheetRef, onClose, onFullyDismissed });
+  const managed = useManagedSheet({ open: visible, sheetRef, onClose: handleClose, onFullyDismissed });
 
   // Default to 60% so the climb image stays visible above the sheet (the
   // UX review flagged full-cover + carousel-disabled as the wrong
@@ -82,7 +113,7 @@ export function LogAscentSheet({
       <View style={styles.content}>
         <View style={styles.closeButtonRow}>
           <Pressable
-            onPress={onClose}
+            onPress={handleClose}
             accessibilityRole="button"
             accessibilityLabel={t('playView.tickBar.closeAria')}
             hitSlop={8}
@@ -106,7 +137,9 @@ export function LogAscentSheet({
           setIds={setIds}
           sessionId={sessionId}
           consensusGradeName={consensusGradeName}
-          onDismiss={onClose}
+          onDismiss={handleClose}
+          savedRef={savedRef}
+          fieldSnapshotRef={fieldSnapshotRef}
         />
       </View>
     </BottomSheetModal>

--- a/packages/mobile/src/components/__tests__/log-ascent-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/log-ascent-sheet.test.tsx
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, forwardRef, type ReactNode, type Ref } from 'react';
+
+// LogAscentSheet wraps `onClose` in a `handleClose` that fires
+// `Quick Tick Dismissed` unless the just-closed tick was actually saved
+// (tracked via a `savedRef` it hands down to QuickTickBar). Three paths all
+// end up calling `handleClose` today: the X-button, native pan-down/backdrop
+// (simulated here through the mocked `BottomSheetModal`'s `onChange`), and a
+// successful save (simulated through the stubbed QuickTickBar).
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({
+    children,
+    accessibilityLabel,
+    onPress,
+  }: {
+    children?: ReactNode;
+    accessibilityLabel?: string;
+    onPress?: () => void;
+  }) => createElement('button', { 'data-label': accessibilityLabel, onClick: onPress }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+// Stub BottomSheetModal: renders an extra button that invokes the `onChange`
+// prop with index -1, standing in for a native pan-down/backdrop dismiss.
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  BottomSheetModal: forwardRef(
+    ({ children, onChange }: { children?: ReactNode; onChange?: (index: number) => void }, _ref: Ref<unknown>) =>
+      createElement('div', null, [
+        createElement('button', {
+          key: 'pandown',
+          'data-testid': 'simulate-pandown',
+          onClick: () => onChange?.(-1),
+        }),
+        children,
+      ]),
+  ),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+// Isolate from the real presentation coordinator (covered by its own test);
+// forward straight to the `onClose` LogAscentSheet passes in — a -1 onChange
+// stands in for the native pan-down/backdrop-tap dismiss.
+vi.mock('../../providers/sheet-presentation-provider', () => ({
+  useManagedSheet: ({ onClose }: { onClose?: () => void }) => ({
+    onChange: (index: number) => {
+      if (index === -1) onClose?.();
+    },
+  }),
+}));
+
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { fill: '#eee', secondaryLabel: '#888' } }),
+}));
+
+vi.mock('../Icon', () => ({ Icon: () => createElement('span') }));
+vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: {} }));
+vi.mock('../../theme/tokens', () => ({ spacing: new Proxy({}, { get: () => 0 }) }));
+
+vi.mock('@boardsesh/analytics', () => ({
+  SHARED_EVENTS: { QuickTickDismissed: 'Quick Tick Dismissed' },
+}));
+vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
+
+// Stub QuickTickBar: exposes one button that simulates a completed save (sets
+// savedRef then calls onDismiss, mirroring the real onSuccess handler) so the
+// "save, don't double-count as a dismiss" path can be driven without the real
+// form.
+vi.mock('../play-drawer/QuickTickBar', () => ({
+  QuickTickBar: ({ onDismiss, savedRef }: { onDismiss: () => void; savedRef?: { current: boolean } }) =>
+    createElement('button', {
+      'data-testid': 'simulate-save-success',
+      onClick: () => {
+        if (savedRef) savedRef.current = true;
+        onDismiss();
+      },
+    }),
+}));
+
+import { LogAscentSheet } from '../LogAscentSheet';
+import { track } from '../../lib/analytics';
+
+function renderSheet(overrides: Partial<Parameters<typeof LogAscentSheet>[0]> = {}) {
+  const onClose = vi.fn();
+  const utils = render(
+    createElement(LogAscentSheet, {
+      visible: true,
+      onClose,
+      climbUuid: 'climb-1',
+      boardName: 'kilter',
+      angle: 40,
+      isMirror: false,
+      isBenchmark: false,
+      layoutId: 7,
+      ...overrides,
+    }),
+  );
+  return { ...utils, onClose };
+}
+
+beforeEach(() => {
+  vi.mocked(track).mockClear();
+});
+
+describe('LogAscentSheet dismiss tracking', () => {
+  it('fires Quick Tick Dismissed when the X-button closes an unsaved form', () => {
+    const { container, onClose } = renderSheet();
+
+    fireEvent.click(container.querySelector('[data-label="playView.tickBar.closeAria"]') as Element);
+
+    expect(track).toHaveBeenCalledWith(
+      'Quick Tick Dismissed',
+      expect.objectContaining({ climbUuid: 'climb-1', layoutId: 7 }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires Quick Tick Dismissed on a simulated pan-down/backdrop dismiss', () => {
+    const { getByTestId, onClose } = renderSheet();
+
+    fireEvent.click(getByTestId('simulate-pandown'));
+
+    expect(track).toHaveBeenCalledWith('Quick Tick Dismissed', expect.objectContaining({ climbUuid: 'climb-1' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire Quick Tick Dismissed when the tick was just saved', () => {
+    const { getByTestId, onClose } = renderSheet();
+
+    fireEvent.click(getByTestId('simulate-save-success'));
+
+    expect(track).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the saved flag on reopen, so a later abandon after a save still fires the event', () => {
+    const onClose = vi.fn();
+    const { getByTestId, rerender } = render(
+      createElement(LogAscentSheet, {
+        visible: true,
+        onClose,
+        climbUuid: 'climb-1',
+        boardName: 'kilter',
+        angle: 40,
+        isMirror: false,
+        isBenchmark: false,
+      }),
+    );
+
+    // Save once — no dismiss event, matches the "just saved" case above.
+    fireEvent.click(getByTestId('simulate-save-success'));
+    expect(track).not.toHaveBeenCalled();
+
+    // Close, then reopen for a new tick on the same climb.
+    rerender(
+      createElement(LogAscentSheet, {
+        visible: false,
+        onClose,
+        climbUuid: 'climb-1',
+        boardName: 'kilter',
+        angle: 40,
+        isMirror: false,
+        isBenchmark: false,
+      }),
+    );
+    rerender(
+      createElement(LogAscentSheet, {
+        visible: true,
+        onClose,
+        climbUuid: 'climb-1',
+        boardName: 'kilter',
+        angle: 40,
+        isMirror: false,
+        isBenchmark: false,
+      }),
+    );
+
+    // Abandon this second tick — without the reset-on-reopen effect this would
+    // stay silently swallowed by the stale `savedRef.current === true` from
+    // the first save.
+    fireEvent.click(getByTestId('simulate-pandown'));
+    expect(track).toHaveBeenCalledWith('Quick Tick Dismissed', expect.objectContaining({ climbUuid: 'climb-1' }));
+  });
+});

--- a/packages/mobile/src/components/__tests__/log-ascent-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/log-ascent-sheet.test.tsx
@@ -128,6 +128,14 @@ describe('LogAscentSheet dismiss tracking', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('sends layoutId: null (not undefined) when the sheet has no layoutId', () => {
+    const { container } = renderSheet({ layoutId: undefined });
+
+    fireEvent.click(container.querySelector('[data-label="playView.tickBar.closeAria"]') as Element);
+
+    expect(track).toHaveBeenCalledWith('Quick Tick Dismissed', expect.objectContaining({ layoutId: null }));
+  });
+
   it('does not fire Quick Tick Dismissed when the tick was just saved', () => {
     const { getByTestId, onClose } = renderSheet();
 

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -39,6 +39,10 @@ import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 
+// Read once at module load rather than allocating a fresh createInitialTickState()
+// on every field-snapshot sync (see below) just to read this one default.
+const DEFAULT_ATTEMPT_COUNT = createInitialTickState().attemptCount;
+
 // Field-completeness snapshot for the "abandoned the form" analytics event.
 // Owned by QuickTickBar (only place with the tick-state fields) but read by
 // LogAscentSheet, which is the only place able to see the X-button and
@@ -171,7 +175,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
       hasQuality: tickState.quality != null && tickState.quality > 0,
       hasDifficulty: tickState.difficulty != null,
       hasComment: comment.length > 0,
-      attemptCountChanged: tickState.attemptCount !== createInitialTickState().attemptCount,
+      attemptCountChanged: tickState.attemptCount !== DEFAULT_ATTEMPT_COUNT,
     };
   }, [fieldSnapshotRef, tickState.quality, tickState.difficulty, tickState.attemptCount, comment]);
 

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -39,7 +39,18 @@ import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 
-type QuickTickBarProps = {
+// Field-completeness snapshot for the "abandoned the form" analytics event.
+// Owned by QuickTickBar (only place with the tick-state fields) but read by
+// LogAscentSheet, which is the only place able to see the X-button and
+// pan-down dismiss paths that never call onDismiss themselves.
+export type QuickTickDismissSnapshot = {
+  hasQuality: boolean;
+  hasDifficulty: boolean;
+  hasComment: boolean;
+  attemptCountChanged: boolean;
+};
+
+export type QuickTickBarProps = {
   climbUuid: string;
   boardName: string;
   angle: number;
@@ -55,6 +66,10 @@ type QuickTickBarProps = {
   // visually outlined) without being preselected.
   consensusGradeName?: string;
   onDismiss: () => void;
+  // Optional analytics plumbing for LogAscentSheet's dismiss tracking. Both
+  // are refs (not state) so updating them never triggers a re-render.
+  savedRef?: React.RefObject<boolean>;
+  fieldSnapshotRef?: React.RefObject<QuickTickDismissSnapshot>;
 };
 
 export const QuickTickBar = React.memo(function QuickTickBar({
@@ -69,6 +84,8 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   sessionId,
   consensusGradeName,
   onDismiss,
+  savedRef,
+  fieldSnapshotRef,
 }: QuickTickBarProps) {
   const { t } = useTranslation('session');
   const { t: tClimbs } = useTranslation('climbs');
@@ -135,8 +152,28 @@ export const QuickTickBar = React.memo(function QuickTickBar({
     return grades.find((grade) => grade.name === consensusGradeName)?.difficultyId;
   }, [consensusGradeName, grades]);
 
+  // Inverse of consensusDifficultyId: resolve the picked numeric difficulty
+  // id back to its human-readable grade name (e.g. "V5") for analytics.
+  const resolvedGradeName = useMemo(() => {
+    if (tickState.difficulty == null || !grades) return undefined;
+    return grades.find((grade) => grade.difficultyId === tickState.difficulty)?.name;
+  }, [tickState.difficulty, grades]);
+
   const ascentType = deriveAscentType(hasPriorHistory, tickState.attemptCount);
   const minAttempts = useMemo(() => getMinAttempts(ascentType), [ascentType]);
+
+  // Keep the dismiss-analytics snapshot current so LogAscentSheet can read
+  // field-completeness at close time — its X-button/pan-down paths never
+  // call back into this component, so they can't read tickState directly.
+  useEffect(() => {
+    if (!fieldSnapshotRef) return;
+    fieldSnapshotRef.current = {
+      hasQuality: tickState.quality != null && tickState.quality > 0,
+      hasDifficulty: tickState.difficulty != null,
+      hasComment: comment.length > 0,
+      attemptCountChanged: tickState.attemptCount !== createInitialTickState().attemptCount,
+    };
+  }, [fieldSnapshotRef, tickState.quality, tickState.difficulty, tickState.attemptCount, comment]);
 
   // Reset form state when the climb context changes underneath an open
   // sheet (e.g. user swiped to next while the sheet was already open).
@@ -220,6 +257,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
               hasQuality: tickState.quality != null && tickState.quality > 0,
               hasDifficulty: tickState.difficulty != null,
               difficulty: tickState.difficulty ?? null,
+              grade: resolvedGradeName ?? null,
               hasComment: comment.length > 0,
             });
             hapticSuccess();
@@ -232,6 +270,9 @@ export const QuickTickBar = React.memo(function QuickTickBar({
             setMaximumClimbedAtDate(new Date());
             hasEditedClimbedAtRef.current = false;
             showToast(tClimbs('mobile.logAscent.savedToast'), 'success');
+            // Tell LogAscentSheet this close is a completed save, not an
+            // abandon, so its wrapped onClose doesn't fire QuickTickDismissed.
+            if (savedRef) savedRef.current = true;
             onDismiss();
           },
           onError: (error: unknown) => {
@@ -262,6 +303,8 @@ export const QuickTickBar = React.memo(function QuickTickBar({
       onDismiss,
       showToast,
       tClimbs,
+      resolvedGradeName,
+      savedRef,
     ],
   );
 

--- a/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
@@ -17,8 +17,20 @@ const boardState = vi.hoisted(() => ({
   current: null as unknown,
 }));
 
+// Grades list returned by useGrades — empty by default (matches most tests,
+// which don't exercise grade selection), overridable per-test.
+const gradesState = vi.hoisted(() => ({
+  current: [] as Array<{ difficultyId: number; name: string }>,
+}));
+
 // Stable save mock so a test can assert on the input passed to saveTick.mutate.
-const saveMock = vi.hoisted(() => ({ mutate: vi.fn() }));
+// Auto-invokes onSuccess so the QuickTickSaved track call (and the
+// savedRef/onDismiss wiring) fires the same way the real mutation would.
+const saveMock = vi.hoisted(() => ({
+  mutate: vi.fn((_input: unknown, callbacks?: { onSuccess?: () => void; onError?: (error: unknown) => void }) =>
+    callbacks?.onSuccess?.(),
+  ),
+}));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -45,7 +57,15 @@ vi.mock('../../Text', () => ({
 vi.mock('../../Icon', () => ({ Icon: () => createElement('span') }));
 vi.mock('../InlineStarPicker', () => ({ InlineStarPicker: () => null }));
 vi.mock('../InlineTriesPicker', () => ({ InlineTriesPicker: () => null }));
-vi.mock('../../grade', () => ({ GradeSingleSelectRail: () => null }));
+// Stub GradeSingleSelectRail: clicking the rail always selects the first
+// loaded grade, so a test can drive grade selection without the real chip UI.
+vi.mock('../../grade', () => ({
+  GradeSingleSelectRail: ({ onSelect }: { onSelect: (difficultyId: number | undefined) => void }) =>
+    createElement('button', {
+      'data-testid': 'grade-rail-select',
+      onClick: () => onSelect(gradesState.current[0]?.difficultyId),
+    }),
+}));
 // Stub ClimbedAtField: clicking the date button drives a fixed past date, so a
 // test can prove the picked value threads into saveTick without the native
 // datetimepicker (which doesn't load under jsdom).
@@ -59,7 +79,7 @@ vi.mock('../../logbook/ClimbedAtField', () => ({
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({ systemColors: {}, brandColors: { primary: '#6D28D9' } }),
 }));
-vi.mock('../../../lib/graphql/hooks', () => ({ useGrades: () => ({ data: [] }) }));
+vi.mock('../../../lib/graphql/hooks', () => ({ useGrades: () => ({ data: gradesState.current }) }));
 // Partial mock: keep the real exports (BOULDER_GRADES et al., pulled in
 // transitively via climbed-at.ts → @boardsesh/profile-stats) and override only
 // the board-name normaliser.
@@ -67,7 +87,13 @@ vi.mock('@boardsesh/board-config', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@boardsesh/board-config')>();
   return { ...actual, toBoardName: (name: string) => name };
 });
-vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: {} }));
+vi.mock('@boardsesh/analytics', () => ({
+  SHARED_EVENTS: {
+    TickButtonClicked: 'Tick Button Clicked',
+    QuickTickSaved: 'Quick Tick Saved',
+    QuickTickFailed: 'Quick Tick Failed',
+  },
+}));
 vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 // QuickTickBar reads board-presence flags; mock the provider so the test doesn't
 // pull in its ws-client → expo-secure-store chain (un-mockable native module).
@@ -95,9 +121,10 @@ vi.mock('@boardsesh/board-react', async (importOriginal) => {
   };
 });
 
-import { QuickTickBar } from '../QuickTickBar';
+import { QuickTickBar, type QuickTickBarProps, type QuickTickDismissSnapshot } from '../QuickTickBar';
+import { track } from '../../../lib/analytics';
 
-function renderBar() {
+function renderBar(overrides: Partial<QuickTickBarProps> = {}) {
   return render(
     createElement(QuickTickBar, {
       climbUuid: CLIMB_UUID,
@@ -106,12 +133,15 @@ function renderBar() {
       isMirror: false,
       isBenchmark: false,
       onDismiss: vi.fn(),
+      ...overrides,
     }),
   );
 }
 
 beforeEach(() => {
   saveMock.mutate.mockClear();
+  gradesState.current = [];
+  vi.mocked(track).mockClear();
 });
 
 afterEach(() => {
@@ -195,5 +225,70 @@ describe('QuickTickBar climbedAt', () => {
     expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({
       climbedAt: '2025-03-15T12:10:00.000Z',
     });
+  });
+});
+
+describe('QuickTickBar grade value on Quick Tick Saved', () => {
+  it('resolves the picked numeric difficulty id to a human grade label', () => {
+    boardState.current = null;
+    gradesState.current = [{ difficultyId: 5, name: 'V5' }];
+    const { container, getByTestId } = renderBar();
+
+    fireEvent.click(getByTestId('grade-rail-select'));
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.sendSaveLabel',
+    );
+    fireEvent.click(sendButton as Element);
+
+    expect(track).toHaveBeenCalledWith(
+      'Quick Tick Saved',
+      expect.objectContaining({ difficulty: 5, grade: 'V5', hasDifficulty: true }),
+    );
+  });
+
+  it('sends grade: null when no grade was picked', () => {
+    boardState.current = null;
+    const { container } = renderBar();
+
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.sendSaveLabel',
+    );
+    fireEvent.click(sendButton as Element);
+
+    expect(track).toHaveBeenCalledWith('Quick Tick Saved', expect.objectContaining({ grade: null, difficulty: null }));
+  });
+});
+
+describe('QuickTickBar dismiss-analytics plumbing (savedRef / fieldSnapshotRef)', () => {
+  it('keeps fieldSnapshotRef in sync with the field-completeness state', () => {
+    boardState.current = null;
+    gradesState.current = [{ difficultyId: 5, name: 'V5' }];
+    const fieldSnapshotRef: { current: QuickTickDismissSnapshot } = {
+      current: { hasQuality: false, hasDifficulty: false, hasComment: false, attemptCountChanged: false },
+    };
+    const { getByTestId } = renderBar({ fieldSnapshotRef });
+
+    fireEvent.click(getByTestId('grade-rail-select'));
+
+    expect(fieldSnapshotRef.current).toMatchObject({ hasDifficulty: true });
+  });
+
+  it('sets savedRef to true right before calling onDismiss on a successful save', () => {
+    boardState.current = null;
+    const savedRef: { current: boolean } = { current: false };
+    const onDismiss = vi.fn(() => {
+      // Assert inside the callback so we prove the flag was already flipped
+      // by the time the sheet is told to close (ordering matters — the
+      // wrapping close handler in LogAscentSheet reads this synchronously).
+      expect(savedRef.current).toBe(true);
+    });
+    const { container } = renderBar({ savedRef, onDismiss });
+
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.sendSaveLabel',
+    );
+    fireEvent.click(sendButton as Element);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/providers/queue/use-session-commands.ts
+++ b/packages/mobile/src/providers/queue/use-session-commands.ts
@@ -230,7 +230,14 @@ export function useSessionCommands({
       await clearSession();
       locallyEndingSessionIdRef.current = null;
       suppressedRemoteEndSessionIdRef.current = null;
-      track(SHARED_EVENTS.SessionEnded, { sessionId: currentSessionId });
+      track(SHARED_EVENTS.SessionEnded, {
+        sessionId: currentSessionId,
+        // Seconds (not minutes) to match web's Session Ended property/unit
+        // (session-lifecycle-tracking.ts) so both platforms land on one
+        // PostHog dimension.
+        durationSec:
+          response.endSession?.durationMinutes != null ? Math.round(response.endSession.durationMinutes * 60) : null,
+      });
       showToast(t('mobile.toast.sessionEnded'), 'success');
       return response.endSession;
     } catch {

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -75,6 +75,11 @@ export const SHARED_EVENTS = {
   TickButtonClicked: 'Tick Button Clicked',
   QuickTickSaved: 'Quick Tick Saved',
   QuickTickFailed: 'Quick Tick Failed',
+  // Mobile-only for now: fired when the tick sheet is closed (X button,
+  // pan-down, backdrop tap) without a save completing. Props include a
+  // field-completeness snapshot so abandonment can be measured directly
+  // instead of inferred from TickButtonClicked - QuickTickSaved - QuickTickFailed.
+  QuickTickDismissed: 'Quick Tick Dismissed',
   TickLogged: 'Tick Logged',
   // Bluetooth / hardware
   BluetoothConnectionSuccess: 'Bluetooth Connection Success',

--- a/packages/web/app/components/logbook/inline-list-tick-bar.tsx
+++ b/packages/web/app/components/logbook/inline-list-tick-bar.tsx
@@ -101,6 +101,13 @@ export const InlineListTickBar: React.FC<InlineListTickBarProps> = ({
     return grades.find((g) => g.difficulty_name === source)?.difficulty_id;
   }, [tickTarget, grades]);
 
+  // Inverse of consensusGradeId: resolve the picked numeric difficulty id
+  // back to its human-readable grade name (e.g. "V5") for analytics.
+  const resolvedGradeName = useMemo(
+    () => grades.find((g) => g.difficulty_id === difficulty)?.difficulty_name,
+    [grades, difficulty],
+  );
+
   const handleStarSelect = useCallback((value: number | null) => {
     setQuality(value);
     setExpandedControl(null);
@@ -122,6 +129,7 @@ export const InlineListTickBar: React.FC<InlineListTickBarProps> = ({
     difficulty,
     attemptCount,
     comment: '',
+    gradeName: resolvedGradeName,
     onSave: onClose,
     onError,
   });

--- a/packages/web/app/components/logbook/quick-tick-bar.tsx
+++ b/packages/web/app/components/logbook/quick-tick-bar.tsx
@@ -173,6 +173,13 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(
       return grades.find((g) => g.difficulty_name === source)?.difficulty_id;
     }, [tickTarget, grades]);
 
+    // Inverse of consensusGradeId: resolve the picked numeric difficulty id
+    // back to its human-readable grade name (e.g. "V5") for analytics.
+    const resolvedGradeName = useMemo(
+      () => grades.find((g) => g.difficulty_id === difficulty)?.difficulty_name,
+      [grades, difficulty],
+    );
+
     // Picker selection handlers.
     const handleStarSelect = useCallback(
       (value: number | null) => {
@@ -205,6 +212,7 @@ export const QuickTickBar = forwardRef<QuickTickBarHandle, QuickTickBarProps>(
       attemptCount,
       comment,
       ascentType,
+      gradeName: resolvedGradeName,
       onSave,
       onError,
     });

--- a/packages/web/app/hooks/__tests__/use-tick-save.test.ts
+++ b/packages/web/app/hooks/__tests__/use-tick-save.test.ts
@@ -6,6 +6,7 @@ import type { Climb, Angle, BoardDetails, BoardName } from '@/app/lib/types';
 import type { LogbookEntry } from '@boardsesh/board-react';
 import { hasPriorHistoryForClimb, buildTickTarget, useTickSave, type UseTickSaveOptions } from '../use-tick-save';
 import { saveTickDraft } from '@/app/lib/tick-draft-db';
+import { track } from '@/app/lib/analytics';
 
 // --- Mocks (must be hoisted before imports of the module under test) ---
 
@@ -394,6 +395,51 @@ describe('useTickSave', () => {
 
     const call = mockSaveTick.mock.calls[0][0];
     expect(call.status).toBe('attempt');
+  });
+
+  it('save() sends the resolved grade label alongside the numeric difficulty on Quick Tick Saved', async () => {
+    const opts = makeOptions({
+      difficulty: 5,
+      gradeName: 'V5',
+      tickTarget: {
+        climb: makeClimb(),
+        angle: 40 as Angle,
+        boardDetails: makeBoardDetails(),
+        hasPriorHistory: true,
+      },
+    });
+
+    const { result } = renderHook(() => useTickSave(opts));
+
+    await act(async () => {
+      result.current.save();
+      await vi.waitFor(() => expect(track).toHaveBeenCalledWith('Quick Tick Saved', expect.anything()));
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      'Quick Tick Saved',
+      expect.objectContaining({ difficulty: 5, grade: 'V5', hasDifficulty: true }),
+    );
+  });
+
+  it('save() sends grade: null when no gradeName was resolved', async () => {
+    const opts = makeOptions({
+      tickTarget: {
+        climb: makeClimb(),
+        angle: 40 as Angle,
+        boardDetails: makeBoardDetails(),
+        hasPriorHistory: true,
+      },
+    });
+
+    const { result } = renderHook(() => useTickSave(opts));
+
+    await act(async () => {
+      result.current.save();
+      await vi.waitFor(() => expect(track).toHaveBeenCalledWith('Quick Tick Saved', expect.anything()));
+    });
+
+    expect(track).toHaveBeenCalledWith('Quick Tick Saved', expect.objectContaining({ grade: null }));
   });
 
   describe('confetti variant selection', () => {

--- a/packages/web/app/hooks/use-tick-save.ts
+++ b/packages/web/app/hooks/use-tick-save.ts
@@ -27,6 +27,9 @@ export type UseTickSaveOptions = {
   comment: string;
   /** Explicit ascent type. When provided, overrides the inferred status logic. */
   ascentType?: TickStatus;
+  /** Human-readable grade label (e.g. "V5") resolved by the caller from its own
+   * loaded grades list, for the Quick Tick Saved analytics event. */
+  gradeName?: string;
   onSave: () => void;
   onError?: () => void;
 };
@@ -70,6 +73,7 @@ export function useTickSave(options: UseTickSaveOptions): {
     attemptCount,
     comment,
     ascentType: explicitAscentType,
+    gradeName,
     onSave,
     onError,
   } = options;
@@ -165,6 +169,7 @@ export function useTickSave(options: UseTickSaveOptions): {
             hasQuality: quality !== null,
             hasDifficulty: difficulty !== undefined,
             difficulty: difficulty ?? null,
+            grade: gradeName ?? null,
             hasComment: comment.length > 0,
           });
           void clearTickDraft(climb.uuid, Number(targetAngle));
@@ -185,6 +190,7 @@ export function useTickSave(options: UseTickSaveOptions): {
       difficulty,
       comment,
       explicitAscentType,
+      gradeName,
       saveTick,
       onSave,
       attemptCount,


### PR DESCRIPTION
## Summary

Closes #3403 (partially — see note on goal outcome below).

The App Success PostHog dashboard has session-quality and progression tiles that were starved of data because a few events were missing properties. This PR closes the gaps that are pure enrichment of data already available in scope — no new fetches needed:

- **Session duration** — mobile's `Session Ended` now sends `durationSec`, read from the `SessionSummary` the `EndSession` mutation already returns (`durationMinutes * 60`, matching web's existing property name/unit in `session-lifecycle-tracking.ts`).
- **Grade value on ticks** — `Quick Tick Saved` (mobile **and** web) now sends a resolved grade label (e.g. `"V5"`) alongside the existing numeric `difficulty` id, using each platform's already-loaded grades list (the same inverse lookup pattern the consensus-grade highlighting already does).
- **Explicit tick-form dismiss** — added a mobile-only `Quick Tick Dismissed` event, fired when the tick sheet closes (X button, pan-down, backdrop tap) without a save completing, carrying a field-completeness snapshot (grade/stars/comment/attempt-count picked or not). Previously abandonment could only be inferred by subtracting `Quick Tick Saved` + `Quick Tick Failed` from `Tick Button Clicked`.
  - This required a small plumbing change: all three dismiss paths in `LogAscentSheet` used to call the exact same `onClose` reference, so there was no way to tell a genuine abandon apart from the sheet closing because a save just succeeded. `LogAscentSheet` now wraps `onClose` in a `handleClose` that checks a `savedRef` (set by `QuickTickBar` right before its own save-success `onDismiss()` call) before deciding whether to fire the new event.

**Session goal outcome is deferred**, not implemented here. Investigation found `goal` is unstructured free text with no target/completion concept to key an "achieved" event off, and no mobile UI path currently even sets a goal at session start. A comment explaining this will be left on #3403 so a follow-up can pick it up once goal-setting gets a structured UX.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` and `vp run typecheck:web` — pass.
- `vp test run --project mobile` — 399 files / 3103 tests pass, including new coverage for grade-label resolution, the `savedRef`/`fieldSnapshotRef` plumbing, and a new `log-ascent-sheet.test.tsx` covering all three dismiss paths (X button, simulated pan-down, and the no-op-on-save-success case, plus a regression test for the reset-on-reopen behavior).
- `vp test run --project web` — 377 files / 4984 tests pass, including new `use-tick-save` coverage asserting the resolved `grade` field on `Quick Tick Saved`.
- `vp check` — clean on all touched files (pre-existing formatting issues in two unrelated docs files, untouched by this PR).
- Manual verification not performed in this session (telemetry-only change, no UI surface to visually check) — the added/updated unit tests exercise the actual `track()` call payloads end-to-end through the component/hook logic.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NkTQov5CoaUo2KkFYgbzaN)_