### PR TITLE
fix(mobile): wire the accurate native sheet-dismiss signal on iOS (#3394)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -791,6 +791,7 @@
     },
   },
   "patchedDependencies": {
+    "@expo/ui@56.0.18": "patches/@expo%2Fui@56.0.18.patch",
     "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch",
     "expo-dev-launcher@56.0.20": "patches/expo-dev-launcher@56.0.20.patch",
   },

--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -61,6 +61,19 @@ coordinator — it opens once as the create-climb route's primary sheet, and its
 presenter) and the `FullWindowOverlay` menus (e.g. `ClimbReactionMenu`), which are custom overlays
 in a higher window, not native sheets.
 
+**How a dismiss "settles."** The coordinator needs to know when a dismiss animation has
+really finished before it starts the next transition. On **iOS** that's the accurate native
+signal: our `@expo/ui` patch (`patches/@expo%2Fui@56.0.18.patch`) forwards SwiftUI's
+post-animation `.sheet(onDismiss:)` out of the community wrapper as `onFullyDismissed`, which
+`useManagedSheet` routes into `coordinator.notifyFullyDismissed`. So a surface that renders the
+raw `BottomSheetModal`/`BottomSheet` must pass `onFullyDismissed={managed.onFullyDismissed}` (the
+`Sheet`/`ModalSheet` wrappers already do) — otherwise its handoffs fall back to the ceiling timer
+and wait the full delay. A fixed per-platform timer (`IOS_SHEET_SETTLE_MS` / `ANDROID_SHEET_SETTLE_MS`)
+is the fallback: it's the only settle signal on **Android** (Compose has no post-animation event),
+and on iOS it's the ceiling for the rare case the native event never arrives (a Host torn down
+mid-animation). A `__DEV__` warning fires only when the ceiling beats a native signal that was
+expected (an iOS dismiss of a still-registered sheet).
+
 **iOS sizing — the single-flex-child contract.** Hand the native `@expo/ui` sheet exactly ONE
 flex child; multiple direct children make it size to content and collapse a `flex: 1` scroll body.
 And on iOS the SwiftUI host can propose an **unbounded** height to that child, so a `flex: 1`

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "packageManager": "bun@1.3.14",
   "patchedDependencies": {
     "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch",
-    "expo-dev-launcher@56.0.20": "patches/expo-dev-launcher@56.0.20.patch"
+    "expo-dev-launcher@56.0.20": "patches/expo-dev-launcher@56.0.20.patch",
+    "@expo/ui@56.0.18": "patches/@expo%2Fui@56.0.18.patch"
   }
 }

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -678,6 +678,7 @@ export function ClimbFilterSheet({
       enableDynamicSizing={false}
       enablePanDownToClose
       onChange={managed.onChange}
+      onFullyDismissed={managed.onFullyDismissed}
       handleIndicatorStyle={[styles.indicator, { backgroundColor: systemColors.separator }]}
     >
       {/* One column child bounded to the detent height (JS-computed on iOS, see

--- a/packages/mobile/src/components/EndSessionSheet.tsx
+++ b/packages/mobile/src/components/EndSessionSheet.tsx
@@ -40,6 +40,7 @@ export function EndSessionSheet({ visible, onDismiss, onConfirm, isEnding, climb
       enableDynamicSizing
       enablePanDownToClose
       onChange={managed.onChange}
+      onFullyDismissed={managed.onFullyDismissed}
       backgroundStyle={{ backgroundColor: systemColors.secondaryBackground }}
       handleIndicatorStyle={sheetStyles.indicator}
     >

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -75,6 +75,7 @@ export function LogAscentSheet({
       snapPoints={snapPoints}
       enablePanDownToClose
       onChange={managed.onChange}
+      onFullyDismissed={managed.onFullyDismissed}
       handleIndicatorStyle={styles.indicator}
       keyboardBehavior="extend"
       keyboardBlurBehavior="restore"

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -32,7 +32,9 @@ type ModalSheetProps = {
   /** Fired when the user closes the sheet themselves (pan-down / backdrop), so a
    * controlled parent can clear the state driving `visible`. */
   onClose?: () => void;
-  /** Fired AFTER the dismiss animation has really settled (the accurate hook). */
+  /** Fired AFTER the dismiss animation has really settled. On iOS this rides the
+   * native post-animation `onDismiss` (accurate); on Android it settles off the
+   * coordinator's ceiling timer (no native signal there). */
   onFullyDismissed?: () => void;
   /** Serialization domain. Sheets presented off the same view controller share a
    * group; defaults to the root window VC. */
@@ -148,6 +150,7 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
       enablePanDownToClose={enablePanDownToClose}
       handleIndicatorStyle={sheet.handleStyle}
       onChange={handleChange}
+      onFullyDismissed={managed.onFullyDismissed}
       style={styles.sheet}
     >
       {footer ? (

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -29,7 +29,9 @@ type SheetProps = {
   /** Fired when the user closes the sheet themselves (pan-down / backdrop), so a
    * controlled parent can clear the state driving `visible`. */
   onClose?: () => void;
-  /** Fired AFTER the dismiss animation has really settled (the accurate hook). */
+  /** Fired AFTER the dismiss animation has really settled. On iOS this rides the
+   * native post-animation `onDismiss` (accurate); on Android it settles off the
+   * coordinator's ceiling timer (no native signal there). */
   onFullyDismissed?: () => void;
   /** Serialization domain. Sheets presented off the same view controller share a
    * group; defaults to the root window VC. */
@@ -148,6 +150,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
       enableDynamicSizing={enableDynamicSizing}
       enablePanDownToClose={enablePanDownToClose}
       onChange={handleChange}
+      onFullyDismissed={managed.onFullyDismissed}
       handleIndicatorStyle={sheetChrome.handleStyle}
       style={styles.sheet}
     >

--- a/packages/mobile/src/components/ble/DevicePickerSheet.tsx
+++ b/packages/mobile/src/components/ble/DevicePickerSheet.tsx
@@ -90,6 +90,7 @@ export function DevicePickerSheet({
       snapPoints={snapPoints}
       enablePanDownToClose
       onChange={managed.onChange}
+      onFullyDismissed={managed.onFullyDismissed}
       handleIndicatorStyle={styles.indicator}
     >
       <BottomSheetView style={styles.header}>

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -457,6 +457,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       enableDynamicSizing={false}
       enablePanDownToClose
       onChange={handleSheetChange}
+      onFullyDismissed={managed.onFullyDismissed}
       handleIndicatorStyle={sheet.handleStyle}
       style={styles.sheet}
     >

--- a/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
@@ -94,6 +94,7 @@ export const AngleSelectorSheet = memo(function AngleSelectorSheet({
       snapPoints={snapPoints}
       enablePanDownToClose
       onChange={managed.onChange}
+      onFullyDismissed={managed.onFullyDismissed}
       handleIndicatorStyle={sheetStyles.indicator}
     >
       <BottomSheetView style={[styles.container, { paddingBottom: insets.bottom + spacing[4] }]}>

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -176,6 +176,7 @@ export const QueueSheet = forwardRef<QueueSheetHandle, QueueSheetProps>(function
       enableContentPanningGesture={!isDragging}
       enableHandlePanningGesture={!isDragging}
       onChange={handleSheetChange}
+      onFullyDismissed={managed.onFullyDismissed}
       handleIndicatorStyle={sheet.handleStyle}
       style={styles.sheet}
     >

--- a/packages/mobile/src/components/session-screen/InviteSheet.tsx
+++ b/packages/mobile/src/components/session-screen/InviteSheet.tsx
@@ -68,6 +68,7 @@ export function InviteSheet({ visible, onDismiss, sessionId }: InviteSheetProps)
       snapPoints={snapPoints}
       enablePanDownToClose
       onChange={managed.onChange}
+      onFullyDismissed={managed.onFullyDismissed}
       backgroundStyle={{ backgroundColor: systemColors.secondaryBackground }}
       handleIndicatorStyle={sheetStyles.indicator}
     >

--- a/packages/mobile/src/components/you/LogbookFilterSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookFilterSheet.tsx
@@ -231,6 +231,7 @@ export function LogbookFilterSheet({
       enableDynamicSizing={false}
       enablePanDownToClose
       onChange={managed.onChange}
+      onFullyDismissed={managed.onFullyDismissed}
       handleIndicatorStyle={styles.indicator}
     >
       <View style={styles.header}>

--- a/packages/mobile/src/providers/__tests__/sheet-presentation-provider-android.test.tsx
+++ b/packages/mobile/src/providers/__tests__/sheet-presentation-provider-android.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+// Android counterpart to sheet-presentation-provider.test.tsx: the ceiling __DEV__
+// warning must NOT fire on Android, where there is no native onDismiss to beat the
+// timer (Compose has no post-animation event, so the ceiling is the intended path).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createElement } from 'react';
+import { render } from '@testing-library/react';
+
+// Pin Platform.OS to Android so SETTLE_MS = 350 and dismiss inFlight expectNative=false.
+vi.mock('react-native', () => ({ Platform: { OS: 'android' } }));
+
+import { SheetPresentationProvider, useSheetPresentation, type SheetCoordinator } from '../sheet-presentation-provider';
+
+const SETTLE_MS = 350;
+
+let coordinator: SheetCoordinator;
+function Capture() {
+  coordinator = useSheetPresentation();
+  return null;
+}
+
+function makeSheet() {
+  return { present: vi.fn(), dismiss: vi.fn(), onFullyDismissed: vi.fn() };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  render(createElement(SheetPresentationProvider, null, createElement(Capture)));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('SheetPresentationProvider coordinator (Android)', () => {
+  it('does not warn (dev) when a coordinator-driven dismiss settles via the ceiling timer', () => {
+    vi.stubGlobal('__DEV__', true);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    coordinator.setDesiredOpen('a', false);
+    vi.advanceTimersByTime(SETTLE_MS); // ceiling settles — the only settle path on Android
+    expect(a.onFullyDismissed).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
@@ -154,6 +154,21 @@ describe('SheetPresentationProvider coordinator', () => {
     expect(coordinator.isPresented('a')).toBe(false);
   });
 
+  it('warns (dev) when an iOS user-initiated close (notifyClosed) settles via the ceiling timer', () => {
+    vi.stubGlobal('__DEV__', true);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    coordinator.notifyClosed('a'); // pan-down opens a settle window (expectNative on iOS)
+    vi.advanceTimersByTime(SETTLE_MS); // native onDismiss never arrived → ceiling wins
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('outran the ceiling');
+    warn.mockRestore();
+  });
+
   it('is a no-op to close a sheet that is not presented', () => {
     const a = makeSheet();
     coordinator.register({ id: 'a', group: 'root', ...a });

--- a/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
@@ -108,6 +108,35 @@ describe('SheetPresentationProvider coordinator', () => {
     expect(a.onFullyDismissed).toHaveBeenCalledTimes(1);
   });
 
+  it('warns (dev) when an iOS coordinator-driven dismiss settles via the ceiling timer', () => {
+    vi.stubGlobal('__DEV__', true);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    coordinator.setDesiredOpen('a', false); // coordinator drives the dismiss (expectNative on iOS)
+    vi.advanceTimersByTime(SETTLE_MS); // no native onDismiss arrived → ceiling wins
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('outran the ceiling');
+    warn.mockRestore();
+  });
+
+  it('does not warn when an unmounted-while-presented sheet settles via the ceiling (no native signal expected)', () => {
+    vi.stubGlobal('__DEV__', true);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const a = makeSheet();
+    const unregister = coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    unregister(); // registration gone → notifyFullyDismissed can never match; ceiling is the only settle
+    vi.advanceTimersByTime(SETTLE_MS);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it('opens a settle window on a user-initiated close (notifyClosed) and fires onFullyDismissed at settle', () => {
     const a = makeSheet();
     coordinator.register({ id: 'a', group: 'root', ...a });

--- a/packages/mobile/src/providers/sheet-presentation-provider.tsx
+++ b/packages/mobile/src/providers/sheet-presentation-provider.tsx
@@ -20,10 +20,14 @@
  *      auto-sequences dismiss(A) → settle → present(B). This makes sheet-over-
  *      sheet handoffs safe and enforces docs hard-rule 1 at runtime.
  *
- * "Settled" is detected two ways: a fixed per-platform timer (the baseline, works
- * with no native support), upgraded to the real post-animation signal when the
- * `@expo/ui` patch forwards SwiftUI's `onDismiss` (see notifyFullyDismissed). The
- * timer then degrades to a ceiling/fallback.
+ * "Settled" is detected two ways. On iOS the real post-animation signal arrives
+ * via `notifyFullyDismissed`: our `@expo/ui` patch forwards SwiftUI's
+ * `.sheet(onDismiss:)` closure out of the community bottom-sheet wrapper (see
+ * patches/@expo%2Fui@…patch and useManagedSheet's onFullyDismissed handler). A
+ * fixed per-platform timer is the fallback: it's the only settle signal on
+ * Android (Compose has no post-animation event), and on iOS it's the ceiling for
+ * the rare case the native event is late or never arrives (e.g. a Host torn down
+ * mid-animation).
  */
 
 import {
@@ -44,9 +48,10 @@ export type PresenterGroup = 'root' | (string & {});
 
 /** How long after JS asks a native sheet to dismiss we treat it as still
  * animating (the ceiling before we let the next transition run). iOS modal sheet
- * present/dismiss is ~0.4-0.5s; Android material is quicker. Used as a fallback
- * when the accurate native `onDismiss` signal isn't available (pre-patch, or when
- * a Host was torn down mid-animation and the event never arrives). */
+ * present/dismiss is ~0.4-0.5s; Android material is quicker. This is the primary
+ * settle signal on Android and the fallback ceiling on iOS (where the accurate
+ * native `onDismiss` normally resolves the settle first, unless a Host was torn
+ * down mid-animation and the event never arrives). */
 const IOS_SHEET_SETTLE_MS = 550;
 const ANDROID_SHEET_SETTLE_MS = 350;
 const SETTLE_MS = Platform.OS === 'ios' ? IOS_SHEET_SETTLE_MS : ANDROID_SHEET_SETTLE_MS;
@@ -62,6 +67,13 @@ type InFlight = {
   op: 'present' | 'dismiss';
   id: string;
   timer: ReturnType<typeof setTimeout>;
+  /** True when an accurate native `onDismiss` is expected to resolve this settle
+   * (an iOS coordinator- or user-driven dismiss of a still-registered sheet). If
+   * the ceiling timer fires first for one of these, the animation genuinely
+   * outran the ceiling — the one case the __DEV__ warning is meant to catch.
+   * False on Android (no native signal) and for unmount teardowns (the
+   * registration is gone, so notifyFullyDismissed can never match). */
+  expectNative: boolean;
 };
 
 type GroupState = {
@@ -146,10 +158,11 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
       } else {
         state.presentedId = null;
         registrations.current.get(inFlight.id)?.onFullyDismissed?.();
-        if (__DEV__ && viaCeiling) {
+        if (__DEV__ && viaCeiling && inFlight.expectNative) {
           console.warn(
             `[sheet-presentation] dismiss of "${inFlight.id}" settled via the ${SETTLE_MS}ms ceiling timer ` +
-              `(no native onDismiss). If this is frequent on a device, the dismiss animation outran the ceiling.`,
+              `before the native onDismiss arrived — the dismiss animation outran the ceiling. ` +
+              `If this is frequent on a device, raise SETTLE_MS.`,
           );
         }
       }
@@ -159,7 +172,7 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
     function startTransition(group: PresenterGroup, op: 'present' | 'dismiss', id: string): void {
       const state = groupState(group);
       const timer = setTimeout(() => onSettle(group, true), SETTLE_MS);
-      state.inFlight = { op, id, timer };
+      state.inFlight = { op, id, timer, expectNative: op === 'dismiss' && Platform.OS === 'ios' };
       const registration = registrations.current.get(id);
       if (op === 'present') registration?.present();
       else registration?.dismiss();
@@ -210,7 +223,9 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
             // onFullyDismissed is a no-op (the component unmounted).
             state.presentedId = null;
             const timer = setTimeout(() => onSettle(reg.group, true), SETTLE_MS);
-            state.inFlight = { op: 'dismiss', id: reg.id, timer };
+            // The registration is already gone, so no native onDismiss can match
+            // here — the ceiling is the only possible settle; don't warn on it.
+            state.inFlight = { op: 'dismiss', id: reg.id, timer, expectNative: false };
           } else {
             pump(reg.group);
           }
@@ -245,7 +260,9 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
         // present waits for the animation, then reconcile.
         if (state.presentedId === id && !state.inFlight) {
           const timer = setTimeout(() => onSettle(group, true), SETTLE_MS);
-          state.inFlight = { op: 'dismiss', id, timer };
+          // A user pan-down / backdrop tap still fires SwiftUI's onDismiss on iOS,
+          // so the native settle is expected to early-resolve this window there.
+          state.inFlight = { op: 'dismiss', id, timer, expectNative: Platform.OS === 'ios' };
         } else {
           pump(group);
         }

--- a/patches/@expo%2Fui@56.0.18.patch
+++ b/patches/@expo%2Fui@56.0.18.patch
@@ -1,0 +1,75 @@
+diff --git a/build/community/bottom-sheet/types.d.ts b/build/community/bottom-sheet/types.d.ts
+index 72fc6be..d1cf11e 100644
+--- a/build/community/bottom-sheet/types.d.ts
++++ b/build/community/bottom-sheet/types.d.ts
+@@ -159,6 +159,14 @@ export interface BottomSheetProps {
+      * Alias for `onClose`.
+      */
+     onDismiss?: () => void;
++    /**
++     * Callback fired AFTER the dismiss animation has fully settled, driven by the
++     * native post-animation signal (iOS SwiftUI `.sheet(onDismiss:)`). Unlike
++     * `onClose`/`onDismiss` — which fire synchronously when the close is requested
++     * — this reflects the real end of the animation. iOS only: Android's Compose
++     * sheet has no equivalent post-animation event.
++     */
++    onFullyDismissed?: () => void;
+     /**
+      * Whether the sheet can be dismissed by panning down.
+      * @default false
+diff --git a/src/community/bottom-sheet/BottomSheet.ios.tsx b/src/community/bottom-sheet/BottomSheet.ios.tsx
+index 0dd7d25..5bef3f2 100644
+--- a/src/community/bottom-sheet/BottomSheet.ios.tsx
++++ b/src/community/bottom-sheet/BottomSheet.ios.tsx
+@@ -86,6 +86,7 @@ export function BottomSheet(props: BottomSheetProps) {
+     onChange,
+     onClose,
+     onDismiss,
++    onFullyDismissed,
+     enablePanDownToClose = false,
+     enableDynamicSizing = true,
+     handleComponent,
+@@ -108,6 +109,15 @@ export function BottomSheet(props: BottomSheetProps) {
+   onCloseRef.current = onClose;
+   const onDismissRef = useRef(onDismiss);
+   onDismissRef.current = onDismiss;
++  const onFullyDismissedRef = useRef(onFullyDismissed);
++  onFullyDismissedRef.current = onFullyDismissed;
++
++  // The native post-animation dismiss signal (SwiftUI `.sheet(onDismiss:)`),
++  // forwarded from the swift-ui layer. Distinct from `fireCloseCallbacks` (the
++  // synchronous close path) — this fires once the animation has really settled.
++  const handleNativeDismiss = useCallback(() => {
++    onFullyDismissedRef.current?.();
++  }, []);
+ 
+   const detents = useMemo<PresentationDetent[]>(() => {
+     if (!snapPointsProp || snapPointsProp.length === 0) return ['medium', 'large'];
+@@ -234,6 +244,7 @@ export function BottomSheet(props: BottomSheetProps) {
+           <NativeBottomSheet
+             isPresented={isPresented}
+             onIsPresentedChange={handlePresentedChange}
++            onDismiss={handleNativeDismiss}
+             fitToContents={fitToContents}>
+             <Group modifiers={modifiers}>
+               <RNHostView matchContents={fitToContents}>
+diff --git a/src/community/bottom-sheet/types.ts b/src/community/bottom-sheet/types.ts
+index d7372fc..efcf425 100644
+--- a/src/community/bottom-sheet/types.ts
++++ b/src/community/bottom-sheet/types.ts
+@@ -178,6 +178,15 @@ export interface BottomSheetProps {
+    */
+   onDismiss?: () => void;
+ 
++  /**
++   * Callback fired AFTER the dismiss animation has fully settled, driven by the
++   * native post-animation signal (iOS SwiftUI `.sheet(onDismiss:)`). Unlike
++   * `onClose`/`onDismiss` — which fire synchronously when the close is requested
++   * — this reflects the real end of the animation. iOS only: Android's Compose
++   * sheet has no equivalent post-animation event.
++   */
++  onFullyDismissed?: () => void;
++
+   // --- Behavior ---
+ 
+   /**


### PR DESCRIPTION
## Summary

Closes #3394.

The mobile sheet-transition coordinator (`sheet-presentation-provider.tsx`) was built to early-resolve a dismiss the instant the native sheet's animation *actually* settles, via `notifyFullyDismissed`. That accurate path was never fed a real event: both sheet wrappers rendered the native `<BottomSheet>` with only `onChange`, and the `handleNativeFullyDismissed` handler `useManagedSheet` returns was never attached to anything. So **every** close fell back to the fixed ceiling timer (550 ms iOS / 350 ms Android) — sheet-over-sheet handoffs ate the full delay, and a `__DEV__` warning fired on **every** close (drowning the "animation outran the ceiling" case it was meant to catch).

The accurate iOS signal already exists natively: `@expo/ui@56.0.18`'s `BottomSheetView.swift` fires a post-animation `onDismiss` from SwiftUI's `.sheet(isPresented:onDismiss:)`, and the low-level `swift-ui/BottomSheet` layer already forwards it. The only gap was the higher-level `community/bottom-sheet` wrapper not passing it through. Because `@expo/ui`'s `exports` map resolves to TSX source, closing that gap is a small **pure-TypeScript** patch — no Swift/Kotlin change.

Android's Compose sheet has no equivalent post-animation event, so Android intentionally keeps the ceiling timer.

### Changes

- **`patches/@expo%2Fui@56.0.18.patch`** (bun `patchedDependencies`, iOS-only, pure TSX): the community `BottomSheet.ios.tsx` now accepts `onFullyDismissed` and forwards it to the native view's `onDismiss` event (separate from the synchronous `fireCloseCallbacks` path). `BottomSheetModal` spreads props through, so both `<Sheet>` and `<ModalSheet>` are covered.
- **`Sheet.tsx` / `ModalSheet.tsx` / `LogAscentSheet.tsx`**: pass `onFullyDismissed={managed.onFullyDismissed}` to the native sheet, feeding the existing `notifyFullyDismissed` path (native `onDismiss` → `handleNativeFullyDismissed` → `coordinator.notifyFullyDismissed`).
- **`sheet-presentation-provider.tsx`**: add `InFlight.expectNative` and gate the ceiling `__DEV__` warning so it only fires when a native signal was expected but the timer beat it (iOS coordinator- or user-driven dismiss of a still-registered sheet) — never on Android or on unmount teardowns. Comments updated to describe the native path as live on iOS and the timer as the fallback/Android path.
- **Tests**: the warning fires on an iOS ceiling-beats-native dismiss, and does **not** fire on an unmount-teardown ceiling (iOS) or on Android (`sheet-presentation-provider-android.test.tsx`).

## Release Notes

- On iPhone, opening one sheet right after another no longer stalls — the second one comes up as soon as the first finishes sliding away, instead of waiting out a fixed half-second.

## Test plan

- `vp run typecheck:mobile` — green; the patched `@expo/ui` `onFullyDismissed` prop flows into `Sheet`/`ModalSheet`/`LogAscentSheet`.
- `vp run test:mobile` — 3098 tests pass, including the new warning-gating cases (iOS warns; Android + unmount don't).
- `vp run check:mobile-bundle` — Metro bundles the patched community wrapper on both platforms.
- `vp check` — clean for all changed files.
- `bun install` — records the patch in `bun.lock` and re-applies it to the store.
- **On-device (needs reviewer QA — not runnable in the headless CI/dev env):** iOS simulator/device — confirm a sheet-over-sheet handoff no longer waits the full 550 ms (the second sheet presents right after the first's animation ends), and the per-close `__DEV__` warning no longer fires on normal closes. This is the only step that exercises the real native `onDismiss`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V7YJwspgyjWnAk8Y4uVvxh)_