### PR TITLE
fix(mobile): paint backgrounds on pushed screens with transparent glass scenes

### DIFF
--- a/packages/mobile/app/about.tsx
+++ b/packages/mobile/app/about.tsx
@@ -69,9 +69,7 @@ export default function AboutScreen() {
       {/* Variant-aware header (transparent blur on Liquid Glass, opaque M3 on
           Material) from the shared hook; this screen just turns it on + titles it. */}
       <Stack.Screen options={{ ...screenOptions, title: t('mobile.about.title'), headerShown: true }} />
-      {/* Paints groupedBackground (mirrors changelog.tsx): the glass contentStyle
-          is transparent and this route is pushed root-level off the user-drawer,
-          so an unpainted scene shows the drawer's near-black scrim. */}
+      {/* Glass contentStyle is transparent: unpainted, this scene shows the user-drawer's scrim (see changelog.tsx). */}
       <ScrollView
         style={{ backgroundColor: systemColors.groupedBackground }}
         contentInsetAdjustmentBehavior="automatic"

--- a/packages/mobile/app/about.tsx
+++ b/packages/mobile/app/about.tsx
@@ -69,7 +69,11 @@ export default function AboutScreen() {
       {/* Variant-aware header (transparent blur on Liquid Glass, opaque M3 on
           Material) from the shared hook; this screen just turns it on + titles it. */}
       <Stack.Screen options={{ ...screenOptions, title: t('mobile.about.title'), headerShown: true }} />
+      {/* Paints groupedBackground (mirrors changelog.tsx): the glass contentStyle
+          is transparent and this route is pushed root-level off the user-drawer,
+          so an unpainted scene shows the drawer's near-black scrim. */}
       <ScrollView
+        style={{ backgroundColor: systemColors.groupedBackground }}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={[styles.container, { paddingBottom: bottomChrome.scrollBottomPadding + spacing[6] }]}
       >

--- a/packages/mobile/app/acknowledgements.tsx
+++ b/packages/mobile/app/acknowledgements.tsx
@@ -119,7 +119,11 @@ export default function AcknowledgementsScreen() {
   return (
     <>
       <Stack.Screen options={{ ...screenOptions, title: t('mobile.acknowledgements.title'), headerShown: true }} />
+      {/* Paints groupedBackground (mirrors changelog.tsx): the glass contentStyle
+          is transparent and this root-level route is reached via the user-drawer →
+          About chain, so an unpainted scene shows the drawer's near-black scrim. */}
       <ScrollView
+        style={{ backgroundColor: systemColors.groupedBackground }}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={[styles.container, { paddingBottom: bottomChrome.scrollBottomPadding + spacing[6] }]}
       >

--- a/packages/mobile/app/acknowledgements.tsx
+++ b/packages/mobile/app/acknowledgements.tsx
@@ -119,9 +119,7 @@ export default function AcknowledgementsScreen() {
   return (
     <>
       <Stack.Screen options={{ ...screenOptions, title: t('mobile.acknowledgements.title'), headerShown: true }} />
-      {/* Paints groupedBackground (mirrors changelog.tsx): the glass contentStyle
-          is transparent and this root-level route is reached via the user-drawer →
-          About chain, so an unpainted scene shows the drawer's near-black scrim. */}
+      {/* Glass contentStyle is transparent: unpainted, this scene shows the user-drawer's scrim (see changelog.tsx). */}
       <ScrollView
         style={{ backgroundColor: systemColors.groupedBackground }}
         contentInsetAdjustmentBehavior="automatic"

--- a/packages/mobile/app/gyms/edit.tsx
+++ b/packages/mobile/app/gyms/edit.tsx
@@ -86,12 +86,16 @@ export default function EditGym() {
   }
 
   // Remount the form per gym so its once-only field seeds come from a fully-loaded
-  // gym (mirrors the board-edit screen).
+  // gym (mirrors the board-edit screen). The wrapper paints `background` like the
+  // loading/not-found states above (the glass contentStyle is transparent, so an
+  // unpainted root-level scene shows whatever sits behind the push — see
+  // changelog.tsx); `background`, not groupedBackground, so the form's
+  // secondaryBackground inputs keep their contrast step.
   return (
-    <>
+    <View style={[styles.flex, { backgroundColor: systemColors.background }]}>
       {header}
       <EditGymForm key={gym.uuid} gym={gym} />
-    </>
+    </View>
   );
 }
 
@@ -163,6 +167,9 @@ function EditGymForm({ gym }: { gym: Gym }) {
 }
 
 const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
   centered: {
     flex: 1,
     alignItems: 'center',

--- a/packages/mobile/app/gyms/edit.tsx
+++ b/packages/mobile/app/gyms/edit.tsx
@@ -87,10 +87,7 @@ export default function EditGym() {
 
   // Remount the form per gym so its once-only field seeds come from a fully-loaded
   // gym (mirrors the board-edit screen). The wrapper paints `background` like the
-  // loading/not-found states above (the glass contentStyle is transparent, so an
-  // unpainted root-level scene shows whatever sits behind the push — see
-  // changelog.tsx); `background`, not groupedBackground, so the form's
-  // secondaryBackground inputs keep their contrast step.
+  // states above — the glass contentStyle is transparent (see changelog.tsx).
   return (
     <View style={[styles.flex, { backgroundColor: systemColors.background }]}>
       {header}

--- a/packages/mobile/app/licenses.tsx
+++ b/packages/mobile/app/licenses.tsx
@@ -89,10 +89,7 @@ export default function LicensesScreen() {
   return (
     <>
       <Stack.Screen options={{ ...screenOptions, title: t('mobile.licenses.title'), headerShown: true }} />
-      {/* flex:1 bounds the FlashList; the groupedBackground paint (mirrors
-          changelog.tsx) covers the transparent glass scene — this root-level
-          route is reached via the user-drawer chain, where an unpainted scene
-          shows the drawer's near-black scrim. */}
+      {/* Glass contentStyle is transparent: unpainted, this scene shows the user-drawer's scrim (see changelog.tsx). */}
       <View style={[styles.flex, { backgroundColor: systemColors.groupedBackground }]}>
         {licenses === null ? (
           <View style={styles.loading}>

--- a/packages/mobile/app/licenses.tsx
+++ b/packages/mobile/app/licenses.tsx
@@ -89,7 +89,11 @@ export default function LicensesScreen() {
   return (
     <>
       <Stack.Screen options={{ ...screenOptions, title: t('mobile.licenses.title'), headerShown: true }} />
-      <View style={styles.flex}>
+      {/* flex:1 bounds the FlashList; the groupedBackground paint (mirrors
+          changelog.tsx) covers the transparent glass scene — this root-level
+          route is reached via the user-drawer chain, where an unpainted scene
+          shows the drawer's near-black scrim. */}
+      <View style={[styles.flex, { backgroundColor: systemColors.groupedBackground }]}>
         {licenses === null ? (
           <View style={styles.loading}>
             <ActivityIndicator size="large" />

--- a/packages/mobile/app/scout.tsx
+++ b/packages/mobile/app/scout.tsx
@@ -22,10 +22,7 @@ export default function ScoutScreen() {
   return (
     <>
       <Stack.Screen options={{ ...screenOptions, title: dogName, headerShown: true }} />
-      {/* Paints groupedBackground (mirrors changelog.tsx): the glass contentStyle
-          is transparent and this root-level route is reached via the user-drawer →
-          About → Acknowledgements chain, so an unpainted scene shows the drawer's
-          near-black scrim. */}
+      {/* Glass contentStyle is transparent: unpainted, this scene shows the user-drawer's scrim (see changelog.tsx). */}
       <ScrollView
         style={{ backgroundColor: systemColors.groupedBackground }}
         contentInsetAdjustmentBehavior="automatic"

--- a/packages/mobile/app/scout.tsx
+++ b/packages/mobile/app/scout.tsx
@@ -22,7 +22,12 @@ export default function ScoutScreen() {
   return (
     <>
       <Stack.Screen options={{ ...screenOptions, title: dogName, headerShown: true }} />
+      {/* Paints groupedBackground (mirrors changelog.tsx): the glass contentStyle
+          is transparent and this root-level route is reached via the user-drawer →
+          About → Acknowledgements chain, so an unpainted scene shows the drawer's
+          near-black scrim. */}
       <ScrollView
+        style={{ backgroundColor: systemColors.groupedBackground }}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={[styles.container, { paddingBottom: bottomChrome.scrollBottomPadding + spacing[6] }]}
       >


### PR DESCRIPTION
## Summary

Follow-up audit to the What's New backdrop fix in #3424. On the Liquid Glass variant, `useStackScreenOptions()` spreads `glassStackScreenOptions` whose `contentStyle` is transparent. The root stack keeps an opaque themed scene as a backstop (`contentStyle: undefined`), but root-level routes that re-spread the hook per-screen via `<Stack.Screen options>` override it — an unpainted screen then shows whatever sits behind the scene. Reached off the user-drawer (a `transparentModal` route with a near-black scrim), light-scheme tokens become unreadable.

Audited every `useStackScreenOptions()` usage:

- **Nested-stack children** (auth, boards, and the five tab stacks, where the hook is spread as layout `screenOptions`): their transparent scenes sit inside an opaque root-level scene — backstopped, no change needed.
- **Root-level per-screen spreads without a painted body** — fixed here, mirroring the `changelog.tsx` / `users/[userId]` pattern:
  - `about` (pushed directly from the user-drawer — the exact #3424 repro)
  - `acknowledgements` (drawer → About), `licenses` and `scout` (→ Acknowledgements) — painted `systemColors.groupedBackground`, matching their grouped-card surfaces. On Material and the Android glass fallback `groupedBackground` equals `background`, so the paint is a no-op there; on iOS glass it matches what the themed nav background already showed on the healthy path (`systemGroupedBackground`).
  - `gyms/edit`: the loaded-form state now paints `systemColors.background`, matching the screen's own loading/not-found states (and keeping the form's `secondaryBackground` inputs on their contrast step).

`changelog.tsx` is left alone — its paint rides #3424. The channel switcher was in the original audit but is covered since `main`'s SwitcherForm rewrite: its body is now a native @expo/ui form that paints its own opaque grouped background, so no RN paint is needed there.

## Release Notes

- The About, Acknowledgements, Licenses, and gym-edit screens no longer flash a black background when opened from the side menu in light mode

## Test plan

- `vp run typecheck:mobile` — clean (re-run post-rebase)
- `vp run test:mobile` — 419 files / 3290 tests passed (post-rebase)
- `vp run check:mobile-bundle` — Metro export OK
- `vp check` — format + lint clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
