### PR TITLE
refactor(mobile): simplify advanced-expand handler, cover disabled filter rows

### DIFF
--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -493,10 +493,6 @@ export function ClimbFilterSheet({
     [scheduleBoardHoldsPrewarm],
   );
 
-  const handleAdvancedExpandedChange = useCallback((expanded: boolean) => {
-    setAdvancedExpanded(expanded);
-  }, []);
-
   const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
     scrollOffsetRef.current = event.nativeEvent.contentOffset.y;
   }, []);
@@ -898,7 +894,7 @@ export function ClimbFilterSheet({
               defaultExpanded={advancedExpanded}
               summary={advancedSummary ?? t('mobile.filter.advancedHint')}
               resetKey={sectionResetKey}
-              onExpandedChange={handleAdvancedExpandedChange}
+              onExpandedChange={setAdvancedExpanded}
             >
               <Text variant="footnote" style={styles.subsectionLabel}>
                 {t('mobile.filter.section.status')}

--- a/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
@@ -10,13 +10,23 @@ import { hapticSelection } from '../../lib/haptics';
 import { emitHoldsFilterSelection } from '../../lib/hold-filter-handoff';
 import { emitZoneFilterSelection } from '../../lib/zone-filter-handoff';
 
+type StyleProp = Record<string, unknown> | unknown[] | ((state: { pressed: boolean }) => unknown) | undefined;
+
 type PressableProps = {
   children?: ReactNode | ((state: { pressed: boolean }) => ReactNode);
   onPress?: () => void;
   accessibilityLabel?: string;
   accessibilityRole?: string;
   disabled?: boolean;
+  style?: StyleProp;
 };
+
+// Serialize a style prop (array | object | style-returning fn) so a test can
+// assert the resting (unpressed) style applied to a row.
+function resolveStyle(style: StyleProp): string {
+  const resolved = typeof style === 'function' ? style({ pressed: false }) : style;
+  return JSON.stringify(resolved);
+}
 
 type BottomSheetModalHandle = {
   present: () => void;
@@ -94,7 +104,7 @@ vi.mock('react-native', () => ({
   Platform: { OS: 'android' },
   useWindowDimensions: () => ({ width: 390, height: 844 }),
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  Pressable: ({ children, onPress, accessibilityLabel, accessibilityRole, disabled }: PressableProps) => {
+  Pressable: ({ children, onPress, accessibilityLabel, accessibilityRole, disabled, style }: PressableProps) => {
     const renderedChildren = typeof children === 'function' ? children({ pressed: false }) : children;
     return createElement(
       'button',
@@ -102,6 +112,7 @@ vi.mock('react-native', () => ({
         onClick: disabled ? undefined : onPress,
         'aria-label': accessibilityLabel,
         'data-role': accessibilityRole,
+        'data-style': resolveStyle(style),
         disabled,
       },
       renderedChildren,
@@ -631,5 +642,30 @@ describe('ClimbFilterSheet sub-pickers', () => {
 
     expect(bottomSheetScrollViewProps.scrollTo).toHaveBeenCalledTimes(1);
     expect(bottomSheetScrollViewProps.scrollTo).toHaveBeenCalledWith({ y: 240, animated: false });
+  });
+});
+
+describe('ClimbFilterSheet rows without a board config', () => {
+  it('disables the Setters row and applies the disabled style when boardConfig is null', () => {
+    const { getByLabelText } = renderFilterSheet({ boardConfig: null });
+
+    const setters = getByLabelText('mobile.filter.setters') as HTMLButtonElement;
+    expect(setters.disabled).toBe(true);
+
+    fireEvent.click(setters);
+    expect(routerPush).not.toHaveBeenCalled();
+
+    const rowStyle = JSON.parse(setters.getAttribute('data-style') ?? 'null');
+    expect(rowStyle ?? []).toContainEqual({ opacity: 0.4 });
+  });
+
+  it('keeps the Setters row enabled and unstyled when a board config is present', () => {
+    const { getByLabelText } = renderFilterSheet();
+
+    const setters = getByLabelText('mobile.filter.setters') as HTMLButtonElement;
+    expect(setters.disabled).toBe(false);
+
+    const rowStyle = JSON.parse(setters.getAttribute('data-style') ?? 'null');
+    expect(rowStyle ?? []).not.toContainEqual({ opacity: 0.4 });
   });
 });


### PR DESCRIPTION
## Summary

Follows up a review of `ClimbFilterSheet.tsx` that flagged four points around the iOS #3330 sheet-height fix. While this was in flight, `main` landed the `useSheetColumnStyle` hook, which extracts the iOS detent-height math into a shared, well-tested place — so two of the four points are already resolved there:

- **`SHEET_TOP_CHROME_PT` magic number** → now the single source of truth in `use-sheet-column-style.ts`, documented, with `use-sheet-column-style.test.tsx` asserting exact heights across `%`/px/multi-detent cases. ✅ on main
- **iOS `sheetColumnStyle` untested** → the hook's test flips `Platform` to iOS and covers the height-bounded path directly. ✅ on main

This PR keeps only what that refactor didn't touch:

- **`handleAdvancedExpandedChange` indirection** — dropped the redundant closure; the Advanced section's `onExpandedChange` gets `setAdvancedExpanded` directly.
- **Disabled Setters row had no coverage** — added a `boardConfig: null` test: the row is disabled, doesn't navigate, and carries the `tappableRowDisabled` style; plus the enabled counter-case. The test's `Pressable` mock now forwards its resolved style so the disabled branch is assertable.

Rebased on latest `main`; no on-device behaviour change.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — clean for the changed files (one pre-existing `@expo/ui` type-resolution error on `main` unrelated to this diff).
- `vp test run --project mobile climb-filter-sheet` — 16 passed (existing suite + the two new disabled-row tests).
- `vp lint` + `vp fmt --check` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAvAb1dHV8LszD4u9XC66N