### PR TITLE
fix(mobile): guard edit routes on canEdit + fix stale config-lock hint

### DIFF
--- a/packages/mobile/app/boards/edit.tsx
+++ b/packages/mobile/app/boards/edit.tsx
@@ -56,6 +56,26 @@ export default function EditBoard() {
     );
   }
 
+  // The edit affordance is only shown when the viewer can edit, but a direct
+  // deep-link can still land here. The server rejects the save regardless, so
+  // show a clear "no access" state instead of a form that can only fail.
+  if (!board.canEdit) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        <Icon name="lock" size={40} color={iosSystemColors.systemGray} />
+        <Text variant="headline" style={styles.stateTitle}>
+          {t('mobile.edit.noAccess')}
+        </Text>
+        <Button
+          title={t('mobile.edit.back')}
+          variant="outlined"
+          onPress={() => router.back()}
+          style={styles.stateButton}
+        />
+      </View>
+    );
+  }
+
   // Remount the form per board so the builder seeds (incl. the More-options meta,
   // which only applies via the state initialisers) from a fully-loaded board.
   return <EditBoardForm key={board.uuid} board={board} />;

--- a/packages/mobile/app/gyms/edit.tsx
+++ b/packages/mobile/app/gyms/edit.tsx
@@ -64,6 +64,27 @@ export default function EditGym() {
     );
   }
 
+  // The edit affordance is only shown when the viewer can edit, but a direct
+  // deep-link can still land here. The server rejects the save regardless, so
+  // show a clear "no access" state instead of a form that can only fail.
+  if (!gym.canEdit) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        {header}
+        <Icon name="lock" size={40} color={iosSystemColors.systemGray} />
+        <Text variant="headline" style={styles.stateTitle}>
+          {t('mobile.gymEdit.noAccess')}
+        </Text>
+        <Button
+          title={t('mobile.gymEdit.back')}
+          variant="outlined"
+          onPress={() => router.back()}
+          style={styles.stateButton}
+        />
+      </View>
+    );
+  }
+
   // Remount the form per gym so its once-only field seeds come from a fully-loaded
   // gym (mirrors the board-edit screen).
   return (

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -35,8 +35,9 @@
       "save": "Save changes",
       "updateError": "Couldn't save your changes. Try again.",
       "notFound": "We couldn't find that board",
+      "noAccess": "You don't have permission to edit this board",
       "back": "Go back",
-      "configLockedHint": "This board has logged climbs, so its layout, size, and sets are locked."
+      "configLockedHint": "You don't have permission to change this board's layout, size, or hold sets."
     },
     "gymEdit": {
       "screenTitle": "Edit gym",
@@ -44,6 +45,7 @@
       "updateError": "Couldn't save your changes. Try again.",
       "updateSuccess": "Gym updated",
       "notFound": "We couldn't find that gym",
+      "noAccess": "You don't have permission to edit this gym",
       "back": "Go back",
       "name": "Name",
       "namePlaceholder": "Gym name",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -35,8 +35,9 @@
       "save": "Guardar cambios",
       "updateError": "No se pudieron guardar los cambios. Inténtalo de nuevo.",
       "notFound": "No encontramos ese plafón",
+      "noAccess": "No tienes permiso para editar este plafón",
       "back": "Volver",
-      "configLockedHint": "Este plafón tiene ascensos registrados, así que su layout, tamaño y sets están bloqueados."
+      "configLockedHint": "No tienes permiso para cambiar el layout, el tamaño ni los sets de este plafón."
     },
     "gymEdit": {
       "screenTitle": "Editar gimnasio",
@@ -44,6 +45,7 @@
       "updateError": "No se pudieron guardar los cambios. Inténtalo de nuevo.",
       "updateSuccess": "Gimnasio actualizado",
       "notFound": "No encontramos ese gimnasio",
+      "noAccess": "No tienes permiso para editar este gimnasio",
       "back": "Volver",
       "name": "Nombre",
       "namePlaceholder": "Nombre del gimnasio",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -35,8 +35,9 @@
       "save": "Enregistrer",
       "updateError": "Impossible d'enregistrer les modifications. Réessaie.",
       "notFound": "Board introuvable",
+      "noAccess": "Vous n'avez pas la permission de modifier ce board",
       "back": "Retour",
-      "configLockedHint": "Ce board a des voies enregistrées : son layout, sa taille et ses sets sont verrouillés."
+      "configLockedHint": "Vous n'avez pas la permission de modifier le layout, la taille ou les sets de ce board."
     },
     "gymEdit": {
       "screenTitle": "Modifier la salle",
@@ -44,6 +45,7 @@
       "updateError": "Impossible d'enregistrer les modifications. Réessaie.",
       "updateSuccess": "Salle mise à jour",
       "notFound": "Salle introuvable",
+      "noAccess": "Vous n'avez pas la permission de modifier cette salle",
       "back": "Retour",
       "name": "Nom",
       "namePlaceholder": "Nom de la salle",


### PR DESCRIPTION
## Summary

Follow-up to the community board/gym editing feature (#3313), clearing the remaining **mobile** review notes from the pre-merge `claude[bot]` pass.

- **Route guards.** `boards/edit` and `gyms/edit` now render a "you don't have permission to edit this" state when `canEdit` is false, instead of a form that can only fail on save. The edit affordance already hides for non-editors, but a direct deep-link could still land on the form and submit into a generic error toast.
- **Config-lock hint copy.** `configLockedHint` no longer blames "logged climbs" — after #3313 the config lock is driven by edit access (`!board.canEdit`), not ticks, so the copy now reflects that. (The new guard also makes the hint unreachable for non-editors, so no owner or moderator sees it.)

The backend notes from the same review — the soft-deleted-gym admin-membership filter (`viewerCanAdminGym`/`adminGymRows`) and a gym-admin-edits-private-linked-board test — already landed in `main` via `6fcb09d7a`, so they're not repeated here.

New i18n keys (`mobile.edit.noAccess`, `mobile.gymEdit.noAccess`) added to en-US/es/fr with the Spanish glossary respected (plafón / gimnasio).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck` (full) — green.
- `vp test run catalog-completeness` + `vp run check:i18n:orphans` — en/es/fr parity holds; the new `noAccess` keys are referenced.
- `vp check` on the changed files — clean.
- Manual: deep-link to `/boards/edit` and `/gyms/edit` for a board/gym you can't edit → "no permission" state with a back button, no form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqifitS6fqvEGHJSSwyatT