### PR TITLE
chore(mobile): bump marketing version to 2.2.0

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -197,7 +197,7 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
     name: appName,
     slug: 'boardsesh',
     owner: 'boardsesh',
-    version: '2.1.1',
+    version: '2.2.0',
     scheme: 'com.boardsesh.app',
     orientation: 'portrait',
     icon: iconPath,


### PR DESCRIPTION
## Summary

Bumps the mobile marketing version from `2.1.1` to `2.2.0` in `packages/mobile/app.config.ts`. This single `version` field is shared by both the iOS and Android builds, so this covers both platforms.

Prompted by an investigation into why no `2.1.1` TestFlight build was produced automatically by the main-branch build pipeline (findings to follow separately).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check packages/mobile/app.config.ts` — pass (format + lint + types)
- No other occurrence of the marketing version exists in the codebase (remaining `2.1.1` hits are OSS-license metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7tnpNAQWiEuD6sqRVtR78