### PR TITLE
fix(mobile): copy-mutate BLE write telemetry to satisfy Swift exclusivity

### DIFF
--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -1134,10 +1134,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         writeResumePoller = nil
         guard let resume = pendingWriteResume else { return }
         pendingWriteResume = nil
-        if let parkStartedAt {
+        if let parkStartedAt, var telemetry = currentWriteTelemetry {
+            // Copy-mutate-writeback: reading `currentWriteTelemetry?.maxParkMs`
+            // inside `max(...)` while assigning back through the same optional
+            // chain is an overlapping access the Swift 6 / SDK 57 toolchain
+            // rejects (exclusivity error). Mutate a local struct copy instead —
+            // same idiom used by `finishWriteTelemetry` below.
             let parkMs = Int((DispatchTime.now().uptimeNanoseconds - parkStartedAt.uptimeNanoseconds) / 1_000_000)
-            currentWriteTelemetry?.maxParkMs = max(currentWriteTelemetry?.maxParkMs ?? 0, parkMs)
-            currentWriteTelemetry?.totalParkMs += parkMs
+            telemetry.maxParkMs = max(telemetry.maxParkMs, parkMs)
+            telemetry.totalParkMs += parkMs
+            currentWriteTelemetry = telemetry
         }
         parkStartedAt = nil
         currentWriteTelemetry?.lastResumeSource = source


### PR DESCRIPTION
## Summary

The iOS TestFlight build (`ios-testflight-rn.yml`) has failed at the **Archive** step since the SDK 57 / RN 0.86 merge (#3396). The SDK-57 toolchain (Swift 6) enforces exclusive-access rules that the previous toolchain didn't:

```
BoardBleManager.swift:1139:34: error: overlapping accesses to 'currentWriteTelemetry',
but modification requires exclusive access
```

`resumeParkedWrite` read `currentWriteTelemetry?.maxParkMs` inside `max(...)` while assigning back through the same optional chain in a single statement — a read and a write to the same storage overlap, which Swift 6 rejects.

This is the last thing blocking a native iOS build from reaching TestFlight. Because a marketing-version bump alone doesn't change the Expo fingerprint, TestFlight builds only happen when a *native* change lands — and the SDK-57 native change has been unable to Archive, so nothing has uploaded since.

## Fix

Copy `currentWriteTelemetry` into a mutable local struct, mutate the local, and write it back — the same copy-mutate-writeback idiom already used by `finishWriteTelemetry` a few lines down. No behaviour change: the update still no-ops when no write telemetry is in flight, and `parkStartedAt`/`lastResumeSource` handling is unchanged.

This was the only overlapping read+write site on `currentWriteTelemetry` (verified by grep); the other `?.prop += x` mutations are single combined accesses and compile fine.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Swift-only change; no `vp` target covers `.swift` files. Verification is the `ios-testflight-rn.yml` Archive step going green on this branch — the same step that fails on `main` today.
- Confirmed no other `currentWriteTelemetry?.X = (...currentWriteTelemetry...)` overlapping-access patterns remain in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7tnpNAQWiEuD6sqRVtR78