### PR TITLE
chore(mobile): set durable analytics person properties for cohorting

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -66,6 +66,7 @@ import { reportError } from '../src/lib/error-reporting';
 import { loadRequiredFonts } from '../src/lib/required-fonts';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
+import { AnalyticsPersonProperties } from '../src/components/analytics/AnalyticsPersonProperties';
 import { OtaUpdateTracker } from '../src/components/analytics/OtaUpdateTracker';
 import { InstallReferrerTracker } from '../src/components/analytics/InstallReferrerTracker';
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
@@ -323,6 +324,10 @@ function RootLayout() {
                   <FeatureFlagsProvider flags={STATIC_FEATURE_FLAGS}>
                     <AuthProvider onReady={onAuthReady}>
                       <PartyProfileProvider>
+                        {/* Durable PostHog person properties (account age, home
+                            board, role, favourite depth) for dashboard cohorting.
+                            Null render; needs auth + query, both in scope here. */}
+                        <AnalyticsPersonProperties />
                         <ConnectionSettingsProvider>
                           <ToastProvider>
                             <ClimbActionsDataWrapper>

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -324,9 +324,7 @@ function RootLayout() {
                   <FeatureFlagsProvider flags={STATIC_FEATURE_FLAGS}>
                     <AuthProvider onReady={onAuthReady}>
                       <PartyProfileProvider>
-                        {/* Durable PostHog person properties (account age, home
-                            board, role, favourite depth) for dashboard cohorting.
-                            Null render; needs auth + query, both in scope here. */}
+                        {/* Needs auth + query, both in scope here. Null render. */}
                         <AnalyticsPersonProperties />
                         <ConnectionSettingsProvider>
                           <ToastProvider>

--- a/packages/mobile/src/components/analytics/AnalyticsPersonProperties.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsPersonProperties.tsx
@@ -1,12 +1,6 @@
-// Writes durable PostHog person properties for the signed-in user (issue #3399):
-// account age, home board, tester role, and favourite depth. These are user
-// *traits*, set once the authenticated profile resolves, so every App Success
-// dashboard tile can segment by who the user is — not only what they did.
-//
-// Mounted once at the app root inside PartyProfileProvider (below AuthProvider +
-// QueryProvider, where both data hooks are valid). Renders null. No-op while
-// signed out, and while analytics is disabled (dev / no key) — the
-// setPersonProperties wrapper drops the write when getClient() returns null.
+// Writes durable PostHog person properties for the signed-in user (issue #3399)
+// so App Success dashboard tiles can segment by who the user is, not just what
+// they did. Mounted once at the app root; renders null.
 
 import { useEffect } from 'react';
 import { setPersonProperties } from '../../lib/analytics';
@@ -17,12 +11,9 @@ import { useAuth } from '../../providers/auth-provider';
 
 export function AnalyticsPersonProperties(): null {
   const { isAuthenticated } = useAuth();
-  // Shared ['profile'] query key — dedupes with PartyProfileProvider and the
-  // profile screens that also read it, so this adds no extra fetch.
   const { data: profile } = useProfile({ enabled: isAuthenticated });
-  // Cheap AsyncStorage-backed read (no network). Deliberately the active board
-  // rather than useHomeBoard(), which would fan out a logbook-ticks query at app
-  // root just for analytics.
+  // The active board (a cheap AsyncStorage read), not useHomeBoard() — the latter
+  // fans out a logbook-ticks query we don't want to run at app root for analytics.
   const { data: activeBoard } = useActiveBoard();
 
   const profileId = profile?.id ?? null;

--- a/packages/mobile/src/components/analytics/AnalyticsPersonProperties.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsPersonProperties.tsx
@@ -1,0 +1,48 @@
+// Writes durable PostHog person properties for the signed-in user (issue #3399):
+// account age, home board, tester role, and favourite depth. These are user
+// *traits*, set once the authenticated profile resolves, so every App Success
+// dashboard tile can segment by who the user is — not only what they did.
+//
+// Mounted once at the app root inside PartyProfileProvider (below AuthProvider +
+// QueryProvider, where both data hooks are valid). Renders null. No-op while
+// signed out, and while analytics is disabled (dev / no key) — the
+// setPersonProperties wrapper drops the write when getClient() returns null.
+
+import { useEffect } from 'react';
+import { setPersonProperties } from '../../lib/analytics';
+import { buildCohortPersonProperties } from '../../lib/analytics-person-properties';
+import { useProfile } from '../../lib/graphql/hooks';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
+import { useAuth } from '../../providers/auth-provider';
+
+export function AnalyticsPersonProperties(): null {
+  const { isAuthenticated } = useAuth();
+  // Shared ['profile'] query key — dedupes with PartyProfileProvider and the
+  // profile screens that also read it, so this adds no extra fetch.
+  const { data: profile } = useProfile({ enabled: isAuthenticated });
+  // Cheap AsyncStorage-backed read (no network). Deliberately the active board
+  // rather than useHomeBoard(), which would fan out a logbook-ticks query at app
+  // root just for analytics.
+  const { data: activeBoard } = useActiveBoard();
+
+  const profileId = profile?.id ?? null;
+  const accountCreatedAt = profile?.createdAt ?? null;
+  const isTester = profile?.isTester ?? false;
+  const favoriteCount = profile?.favoriteCount ?? 0;
+  const homeBoard = activeBoard?.boardType ?? null;
+
+  useEffect(() => {
+    // Need an identified user with a created-at before writing traits; skip while
+    // signed out or before the profile resolves.
+    if (!isAuthenticated || !profileId || !accountCreatedAt) return;
+    const { set, setOnce } = buildCohortPersonProperties({
+      accountCreatedAt,
+      homeBoard,
+      isTester,
+      favoriteCount,
+    });
+    setPersonProperties(set, setOnce);
+  }, [isAuthenticated, profileId, accountCreatedAt, homeBoard, isTester, favoriteCount]);
+
+  return null;
+}

--- a/packages/mobile/src/components/analytics/__tests__/AnalyticsPersonProperties.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/AnalyticsPersonProperties.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const analytics = vi.hoisted(() => ({ setPersonProperties: vi.fn() }));
+const state = vi.hoisted(() => ({
+  isAuthenticated: true,
+  profile: null as Record<string, unknown> | null,
+  activeBoard: null as Record<string, unknown> | null,
+}));
+
+vi.mock('../../../lib/analytics', () => ({ setPersonProperties: analytics.setPersonProperties }));
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: state.isAuthenticated }),
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({ useProfile: () => ({ data: state.profile }) }));
+vi.mock('../../../lib/graphql/use-active-board', () => ({ useActiveBoard: () => ({ data: state.activeBoard }) }));
+
+import { AnalyticsPersonProperties } from '../AnalyticsPersonProperties';
+
+beforeEach(() => {
+  analytics.setPersonProperties.mockClear();
+  state.isAuthenticated = true;
+  state.profile = null;
+  state.activeBoard = null;
+});
+
+describe('AnalyticsPersonProperties', () => {
+  it('writes cohort person properties once the profile resolves', () => {
+    state.profile = {
+      id: 'user-1',
+      createdAt: '2024-01-02T03:04:05.000Z',
+      isTester: false,
+      favoriteCount: 7,
+    };
+    state.activeBoard = { boardType: 'kilter' };
+
+    render(createElement(AnalyticsPersonProperties));
+
+    expect(analytics.setPersonProperties).toHaveBeenCalledWith(
+      { role: 'user', favorite_count: 7, home_board: 'kilter' },
+      { account_created_at: '2024-01-02T03:04:05.000Z' },
+    );
+  });
+
+  it('does not write while signed out', () => {
+    state.isAuthenticated = false;
+    state.profile = null;
+
+    render(createElement(AnalyticsPersonProperties));
+
+    expect(analytics.setPersonProperties).not.toHaveBeenCalled();
+  });
+
+  it('waits for the account-created date before writing', () => {
+    // Authenticated but the profile query hasn't resolved yet.
+    state.profile = null;
+    state.activeBoard = { boardType: 'tension' };
+
+    render(createElement(AnalyticsPersonProperties));
+
+    expect(analytics.setPersonProperties).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/analytics/__tests__/AnalyticsPersonProperties.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/AnalyticsPersonProperties.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+// jsdom is required: @testing-library/react's render() mounts into document.body,
+// even though this component renders null.
 import { render } from '@testing-library/react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -61,5 +63,25 @@ describe('AnalyticsPersonProperties', () => {
     render(createElement(AnalyticsPersonProperties));
 
     expect(analytics.setPersonProperties).not.toHaveBeenCalled();
+  });
+
+  it('re-writes when a live trait changes after the first resolve', () => {
+    state.profile = { id: 'user-1', createdAt: '2024-01-02T03:04:05.000Z', isTester: false, favoriteCount: 1 };
+    state.activeBoard = { boardType: 'kilter' };
+
+    const { rerender } = render(createElement(AnalyticsPersonProperties));
+    expect(analytics.setPersonProperties).toHaveBeenCalledTimes(1);
+
+    // User earns the tester role and switches board — the effect must re-fire with
+    // the new values (React only re-runs it because the deps actually changed).
+    state.profile = { id: 'user-1', createdAt: '2024-01-02T03:04:05.000Z', isTester: true, favoriteCount: 4 };
+    state.activeBoard = { boardType: 'tension' };
+    rerender(createElement(AnalyticsPersonProperties));
+
+    expect(analytics.setPersonProperties).toHaveBeenCalledTimes(2);
+    expect(analytics.setPersonProperties).toHaveBeenLastCalledWith(
+      { role: 'tester', favorite_count: 4, home_board: 'tension' },
+      { account_created_at: '2024-01-02T03:04:05.000Z' },
+    );
   });
 });

--- a/packages/mobile/src/components/analytics/__tests__/AnalyticsPersonProperties.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/AnalyticsPersonProperties.test.tsx
@@ -55,10 +55,22 @@ describe('AnalyticsPersonProperties', () => {
     expect(analytics.setPersonProperties).not.toHaveBeenCalled();
   });
 
-  it('waits for the account-created date before writing', () => {
+  it('does not write until the profile query resolves', () => {
     // Authenticated but the profile query hasn't resolved yet.
     state.profile = null;
     state.activeBoard = { boardType: 'tension' };
+
+    render(createElement(AnalyticsPersonProperties));
+
+    expect(analytics.setPersonProperties).not.toHaveBeenCalled();
+  });
+
+  it('does not write when the profile resolved without a created-at date', () => {
+    // Guards the createdAt branch specifically: an identified user (id present)
+    // whose account age hasn't come back yet must not write a setOnce with
+    // undefined account_created_at.
+    state.profile = { id: 'user-1', createdAt: null, isTester: false, favoriteCount: 2 };
+    state.activeBoard = { boardType: 'kilter' };
 
     render(createElement(AnalyticsPersonProperties));
 

--- a/packages/mobile/src/components/analytics/__tests__/AnalyticsPersonProperties.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/AnalyticsPersonProperties.test.tsx
@@ -77,6 +77,21 @@ describe('AnalyticsPersonProperties', () => {
     expect(analytics.setPersonProperties).not.toHaveBeenCalled();
   });
 
+  it('stops writing after the user signs out', () => {
+    state.profile = { id: 'user-1', createdAt: '2024-01-02T03:04:05.000Z', isTester: false, favoriteCount: 1 };
+    state.activeBoard = { boardType: 'kilter' };
+
+    const { rerender } = render(createElement(AnalyticsPersonProperties));
+    expect(analytics.setPersonProperties).toHaveBeenCalledTimes(1);
+
+    // Sign-out clears auth + the gated profile query — the guard must hold.
+    state.isAuthenticated = false;
+    state.profile = null;
+    rerender(createElement(AnalyticsPersonProperties));
+
+    expect(analytics.setPersonProperties).toHaveBeenCalledTimes(1);
+  });
+
   it('re-writes when a live trait changes after the first resolve', () => {
     state.profile = { id: 'user-1', createdAt: '2024-01-02T03:04:05.000Z', isTester: false, favoriteCount: 1 };
     state.activeBoard = { boardType: 'kilter' };

--- a/packages/mobile/src/lib/__tests__/analytics-person-properties.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-person-properties.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { buildCohortPersonProperties } from '../analytics-person-properties';
+
+describe('buildCohortPersonProperties', () => {
+  it('maps a regular user with an active board', () => {
+    const { set, setOnce } = buildCohortPersonProperties({
+      accountCreatedAt: '2024-01-02T03:04:05.000Z',
+      homeBoard: 'kilter',
+      isTester: false,
+      favoriteCount: 12,
+    });
+
+    expect(set).toEqual({ role: 'user', favorite_count: 12, home_board: 'kilter' });
+    expect(setOnce).toEqual({ account_created_at: '2024-01-02T03:04:05.000Z' });
+  });
+
+  it('marks tester accounts with the tester role', () => {
+    const { set } = buildCohortPersonProperties({
+      accountCreatedAt: '2024-01-02T03:04:05.000Z',
+      homeBoard: 'tension',
+      isTester: true,
+      favoriteCount: 0,
+    });
+
+    expect(set.role).toBe('tester');
+    expect(set.home_board).toBe('tension');
+  });
+
+  it('omits home_board when no board is picked yet', () => {
+    const { set } = buildCohortPersonProperties({
+      accountCreatedAt: '2024-01-02T03:04:05.000Z',
+      homeBoard: null,
+      isTester: false,
+      favoriteCount: 3,
+    });
+
+    expect(set).toEqual({ role: 'user', favorite_count: 3 });
+    expect('home_board' in set).toBe(false);
+  });
+
+  it('keeps account_created_at only in setOnce (immutable trait)', () => {
+    const { set, setOnce } = buildCohortPersonProperties({
+      accountCreatedAt: '2020-06-01T00:00:00.000Z',
+      homeBoard: 'kilter',
+      isTester: false,
+      favoriteCount: 5,
+    });
+
+    expect('account_created_at' in set).toBe(false);
+    expect(setOnce).toEqual({ account_created_at: '2020-06-01T00:00:00.000Z' });
+  });
+});

--- a/packages/mobile/src/lib/analytics-person-properties.ts
+++ b/packages/mobile/src/lib/analytics-person-properties.ts
@@ -1,25 +1,13 @@
-// Durable PostHog person properties for cohorting (issue #3399). These are user
-// *traits* — not behaviour — so the App Success dashboard can split retention and
-// lifecycle tiles by account maturity, home board, tester status, and favourite
-// depth. That segmentation is impossible with behaviour-only cohorts, where the
-// only person property mobile writes today is `email`.
-//
-// Pure and platform-free so it's unit-testable without React Native. The caller
-// (AnalyticsPersonProperties) sources the inputs from the authenticated profile
-// and the active board, then forwards the result to setPersonProperties(set,
-// setOnce): `set` overwrites on every call (mutable traits), `setOnce` writes only
-// once (immutable account age — guards the value web and mobile share on one
-// PostHog person).
+// Durable PostHog person properties for cohorting (issue #3399), split so the
+// caller can forward them to setPersonProperties(set, setOnce): `set` overwrites
+// on every call (mutable traits); `setOnce` writes only once, guarding the
+// immutable account-created date that web and mobile share on one PostHog person.
 
 export type CohortPersonPropertyInputs = {
-  // Account creation timestamp (ISO 8601) from the backend profile. Immutable.
   accountCreatedAt: string;
-  // The board type the user actively climbs on ('kilter' / 'tension' / …), or null
-  // when they haven't picked one yet — omitted rather than written as null.
+  // null when the user hasn't picked a board yet — omitted rather than a null cohort.
   homeBoard: string | null;
-  // Whether the account has the tester/admin role (beta channel).
   isTester: boolean;
-  // Total climbs the user has favourited, across all boards.
   favoriteCount: number;
 };
 
@@ -35,13 +23,11 @@ export function buildCohortPersonProperties({
   favoriteCount,
 }: CohortPersonPropertyInputs): CohortPersonProperties {
   const set: Record<string, string | number | boolean> = {
-    // String enum over a bare boolean, mirroring web's `signup_auth_method` — reads
-    // cleanly in PostHog breakdowns and leaves room for more roles than tester/user.
+    // String enum, not a bare boolean: reads cleanly in PostHog breakdowns and
+    // leaves room for more roles than tester/user.
     role: isTester ? 'tester' : 'user',
     favorite_count: favoriteCount,
   };
-  // Omit home_board entirely until the user picks a board — a null would just be a
-  // meaningless cohort bucket.
   if (homeBoard) {
     set.home_board = homeBoard;
   }

--- a/packages/mobile/src/lib/analytics-person-properties.ts
+++ b/packages/mobile/src/lib/analytics-person-properties.ts
@@ -1,0 +1,52 @@
+// Durable PostHog person properties for cohorting (issue #3399). These are user
+// *traits* — not behaviour — so the App Success dashboard can split retention and
+// lifecycle tiles by account maturity, home board, tester status, and favourite
+// depth. That segmentation is impossible with behaviour-only cohorts, where the
+// only person property mobile writes today is `email`.
+//
+// Pure and platform-free so it's unit-testable without React Native. The caller
+// (AnalyticsPersonProperties) sources the inputs from the authenticated profile
+// and the active board, then forwards the result to setPersonProperties(set,
+// setOnce): `set` overwrites on every call (mutable traits), `setOnce` writes only
+// once (immutable account age — guards the value web and mobile share on one
+// PostHog person).
+
+export type CohortPersonPropertyInputs = {
+  // Account creation timestamp (ISO 8601) from the backend profile. Immutable.
+  accountCreatedAt: string;
+  // The board type the user actively climbs on ('kilter' / 'tension' / …), or null
+  // when they haven't picked one yet — omitted rather than written as null.
+  homeBoard: string | null;
+  // Whether the account has the tester/admin role (beta channel).
+  isTester: boolean;
+  // Total climbs the user has favourited, across all boards.
+  favoriteCount: number;
+};
+
+export type CohortPersonProperties = {
+  set: Record<string, string | number | boolean>;
+  setOnce: Record<string, string>;
+};
+
+export function buildCohortPersonProperties({
+  accountCreatedAt,
+  homeBoard,
+  isTester,
+  favoriteCount,
+}: CohortPersonPropertyInputs): CohortPersonProperties {
+  const set: Record<string, string | number | boolean> = {
+    // String enum over a bare boolean, mirroring web's `signup_auth_method` — reads
+    // cleanly in PostHog breakdowns and leaves room for more roles than tester/user.
+    role: isTester ? 'tester' : 'user',
+    favorite_count: favoriteCount,
+  };
+  // Omit home_board entirely until the user picks a board — a null would just be a
+  // meaningless cohort bucket.
+  if (homeBoard) {
+    set.home_board = homeBoard;
+  }
+  return {
+    set,
+    setOnce: { account_created_at: accountCreatedAt },
+  };
+}


### PR DESCRIPTION
## Summary

Mobile only ever set `email` as a PostHog person property, so every tile on the App Success dashboard could be segmented by **behaviour**, never by durable **user traits**. This adds a small null-render component that writes cohort person properties once the authenticated profile resolves:

- `account_created_at` (`$set_once`) — new-vs-veteran retention cohorts
- `home_board` (`$set`) — the active board type (kilter / tension / …), for board-level PMF splits
- `role` (`$set`) — `tester` vs `user`, to separate the beta channel cleanly (today we lean on `filterTestAccounts`)
- `favorite_count` (`$set`) — favourite depth

Notes:
- The property object is built by a pure, unit-tested helper (`analytics-person-properties.ts`), then forwarded to the existing `setPersonProperties(set, setOnce)` wrapper.
- No new fetch: the backend `profile` query already exposes `createdAt` + `favoriteCount`, and `role`/`isTester` is already in `GET_PROFILE`.
- `home_board` reads the cheap active-board store (AsyncStorage) rather than `useHomeBoard()`, which would fan out a logbook-ticks query at app root purely for analytics.
- The optional extras from the issue (has-connected-board, integrations-connected) are deferred — each needs an extra startup query not justified for analytics alone.

Closes #3399

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — clean (also ran codegen; no drift)
- `vp run test:mobile` — 3280 tests pass, including the new helper + component tests (`analytics-person-properties.test.ts`, `AnalyticsPersonProperties.test.tsx`)
- `vp lint` on the changed files — 0 warnings, 0 errors
- `vp run check:mobile-bundle` — Android bundle OK (the component mounts at app root)

Analytics is disabled in dev (`isAnalyticsEnabled = !!apiKey && !__DEV__`), so there's no live PostHog write to observe locally; correctness is proven by the unit tests asserting the exact `setPersonProperties` arguments (set/setOnce, role mapping, home_board omitted until a board is picked).

---
_Generated by [Claude Code](https://claude.ai/code/session_0161P3evWdF4fxfKvdVMirtV)_