### PR TITLE
fix(mobile): iPad rail hover/focus flicker + screenshot orientation, test polish

### DIFF
--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -326,8 +326,8 @@ split, falls through to the phone UI **verbatim**. The size class is pure and un
 `PlayDrawer presentation="pane"`) follows the user's **selection** — tapping a list row updates it —
 mirroring Mail/Notes/Files. It is the SELECTION surface; do not repoint it at shared/live status (that
 was the original bug). A `setAsCurrent:false` open (feed / beta / climb view) previews in the pane
-without committing to the queue (`drawer-host-provider`'s `panePreviewItem`), so every climb-open entry
-point populates the pane.
+without committing to the queue (`openPlayDrawer(..., { previewQueueItem })`, carried on
+`playDrawerPaneProps.openTarget.options`), so every climb-open entry point populates the pane.
 
 **The live wall is STATUS, with its own width-adaptive home** (`resolveWallSurface({ width, widthClass,
 sidebarWidth })` → `'none' | 'strip' | 'column'`):

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -207,12 +207,6 @@ vi.mock('expo-router/unstable-native-tabs', () => {
 
 import TabLayout, { unstable_settings } from '../_layout';
 
-function renderedViewStyles(container: HTMLElement): string[] {
-  return Array.from(container.querySelectorAll('[data-style]')).map(
-    (element) => element.getAttribute('data-style') ?? '',
-  );
-}
-
 describe('TabLayout', () => {
   beforeEach(() => {
     cfg.bluetoothConnected = false;
@@ -356,8 +350,10 @@ describe('TabLayout', () => {
 
     expect(container.querySelector('[data-ipad-wall-column="true"]')).not.toBeNull();
     expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('false');
-    expect(renderedViewStyles(container).some((style) => style.includes('"width":485'))).toBe(true);
-    expect(renderedViewStyles(container).some((style) => style.includes('"width":300'))).toBe(true);
+    // The detail pane mounts alongside the list and the dedicated wall column — the
+    // pixel widths of each are covered by size-class.test.ts (resolveDetailPaneWidth,
+    // WALL_COLUMN_WIDTH), so assert the surfaces are present, not their arithmetic.
+    expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();
   });
 
   it('hides the sidebar wall cell when the portrait play-pane strip owns the wall surface', () => {

--- a/packages/mobile/src/components/PressableSurface.tsx
+++ b/packages/mobile/src/components/PressableSurface.tsx
@@ -11,12 +11,12 @@ import {
   type StyleProp,
   type ViewStyle,
 } from 'react-native';
-
-type RNPressableProps = ComponentProps<typeof Pressable>;
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { springs } from '../theme/animations';
 import { androidRipple } from '../theme/tokens';
 import { brandColors } from '../theme/colors';
+
+type RNPressableProps = ComponentProps<typeof Pressable>;
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 

--- a/packages/mobile/src/components/navigation/IpadSidebar.tsx
+++ b/packages/mobile/src/components/navigation/IpadSidebar.tsx
@@ -52,26 +52,30 @@ function SidebarItem({
   onPress: (destination: SidebarDestination) => void;
 }) {
   const { systemColors } = useTheme();
-  // Pointer-hover / keyboard-focus on the iPad rail (no-op on touch). Treated as
-  // a single "active-ish" cue: it brightens the glyph and fills the pill, the
-  // same affordance selection uses, so hovering/focusing previews selection.
-  const [interactive, setInteractive] = useState(false);
-  const active = focused || interactive;
+  // Pointer-hover and keyboard-focus are tracked separately (both no-op on touch):
+  // hovering and focusing each light the same "active-ish" cue — brighter glyph,
+  // filled pill — but a hover-out must not drop the highlight while the item still
+  // holds keyboard focus, so we OR two independent flags instead of sharing one.
+  const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const active = focused || isHovered || isFocused;
   // Neutral chrome glyphs, matching NativeTabs / MaterialTabBar (the systemFill
   // pill is the sole active affordance, not a brand tint). See
   // docs/ai-design-guidelines.md — chrome carries state with fills, not colour.
   const tint = active ? systemColors.label : systemColors.secondaryLabel;
   const handlePress = useCallback(() => onPress(destination), [onPress, destination]);
-  const handleInteractiveOn = useCallback(() => setInteractive(true), []);
-  const handleInteractiveOff = useCallback(() => setInteractive(false), []);
+  const handleHoverIn = useCallback(() => setIsHovered(true), []);
+  const handleHoverOut = useCallback(() => setIsHovered(false), []);
+  const handleFocus = useCallback(() => setIsFocused(true), []);
+  const handleBlur = useCallback(() => setIsFocused(false), []);
 
   return (
     <PressableSurface
       onPress={handlePress}
-      onHoverIn={handleInteractiveOn}
-      onHoverOut={handleInteractiveOff}
-      onFocus={handleInteractiveOn}
-      onBlur={handleInteractiveOff}
+      onHoverIn={handleHoverIn}
+      onHoverOut={handleHoverOut}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
       feedback="scale"
       accessibilityRole="tab"
       accessibilityState={{ selected: focused }}

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -1203,4 +1203,31 @@ describe('DrawerHostProvider iPad pane open (regular width)', () => {
     // an open target on compact — that path drives the route's playTarget instead.
     expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget).toBeNull();
   });
+
+  it('clears the pane open target when a resize drops out of pane width', async () => {
+    // Open a climb in the pane at regular width, then resize to compact (Stage
+    // Manager / Split View shrink). The pane goes away, so its stale selection must
+    // be dropped — otherwise returning to pane width would flash the old climb.
+    const hosts: Array<HostValue> = [];
+    const onHost = (host: HostValue) => hosts.push(host);
+    const { rerender } = renderHost(onHost);
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const climb = makeQueueItem('queue-x', 'pane-resize-1').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(climb);
+    });
+    await waitFor(() => {
+      expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget?.climb.uuid).toBe('pane-resize-1');
+    });
+
+    // Resize below the pane budget: usesDetailPane flips false and the reset effect
+    // fires, clearing the target (not merely that compact starts null — it was set).
+    layoutCfg.widthClass = 'compact';
+    rerender(createElement(DrawerHostProvider, null, createElement(Probe, { onHost, onRoute: () => {} })));
+
+    await waitFor(() => {
+      expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget).toBeNull();
+    });
+  });
 });

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -11,6 +11,7 @@ import {
   parseArgs,
   renderMaestroFlowForIosDevice,
   resolveAppStoreLocaleTargets,
+  resolveIosScreenshotDevices,
   rotationDegreesForIosOrientation,
   validateIosAppLauncherUrl,
   type IosScreenshotDevice,
@@ -34,6 +35,7 @@ function makeOptions(overrides: Partial<ScreenshotOptions> = {}): ScreenshotOpti
     theme: 'dark',
     workout: 'volume',
     appPath: null,
+    orientation: null,
     shutdown: false,
     ...overrides,
   };
@@ -102,8 +104,16 @@ describe('parseArgs', () => {
       theme: 'light',
       workout: 'ladder',
       appPath: '/tmp/Boardsesh.app',
+      orientation: null,
       shutdown: true,
     });
+  });
+
+  it('maps --orientation landscape/portrait to the iOS orientation override', () => {
+    expect(parseArgs(['--orientation', 'landscape']).orientation).toBe('LANDSCAPE_LEFT');
+    expect(parseArgs(['--orientation', 'portrait']).orientation).toBe('PORTRAIT');
+    expect(parseArgs([]).orientation).toBeNull();
+    expect(() => parseArgs(['--orientation', 'sideways'])).toThrow(/--orientation must be one of/);
   });
 
   it('defaults Android captures to the Play phone emulator device', () => {
@@ -297,6 +307,30 @@ describe('rotationDegreesForIosOrientation', () => {
   it('normalizes raw iPad landscape-left captures into upright landscape PNGs', () => {
     expect(rotationDegreesForIosOrientation('LANDSCAPE_LEFT')).toBe(-90);
     expect(rotationDegreesForIosOrientation('PORTRAIT')).toBeNull();
+  });
+});
+
+describe('resolveIosScreenshotDevices', () => {
+  it('keeps a known device record and its orientation', () => {
+    const [ipad] = resolveIosScreenshotDevices(['iPad Pro 13-inch (M5)']);
+    expect(ipad.typeId).toBe('com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M5-12GB');
+    expect(ipad.orientation).toBe('LANDSCAPE_LEFT');
+  });
+
+  it('falls back to portrait for an unlisted device name with no override', () => {
+    const [device] = resolveIosScreenshotDevices(['iPad Air 13-inch (M3)']);
+    expect(device).toEqual({ name: 'iPad Air 13-inch (M3)', typeId: '', orientation: 'PORTRAIT' });
+  });
+
+  it('applies an orientation override to unlisted devices only, never to known ones', () => {
+    const [unlisted, known] = resolveIosScreenshotDevices(
+      ['iPad Air 13-inch (M3)', 'iPhone 16 Pro Max'],
+      'LANDSCAPE_LEFT',
+    );
+    // The ad-hoc iPad captures landscape instead of the portrait default…
+    expect(unlisted.orientation).toBe('LANDSCAPE_LEFT');
+    // …but the known iPhone keeps its own portrait orientation.
+    expect(known.orientation).toBe('PORTRAIT');
   });
 });
 

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -25,6 +25,7 @@
  *                                 [--locales all|<comma-list>] [--device "iPhone 16 Pro Max"]
  *                                 [--variant material|liquidGlass] [--shutdown]
  *                                 [--app-path <path/to/Boardsesh.app|app.apk>]
+ *                                 [--orientation portrait|landscape]
  *
  * Requires: Maestro (https://maestro.mobile.dev) plus platform tooling (xcrun for
  * iOS, adb for Android). For --backend local, bring up the seeded dev DB +
@@ -160,6 +161,12 @@ export interface ScreenshotOptions {
   workout: string | null;
   /** Prebuilt/cached app artifact to install; iOS can build one when null. */
   appPath: string | null;
+  /**
+   * Capture orientation override for iOS device names not in IOS_SCREENSHOT_DEVICES
+   * (e.g. an ad-hoc iPad passed via --device). Known devices keep their own
+   * orientation; null falls back to portrait for unlisted names.
+   */
+  orientation: IosDeviceOrientation | null;
   shutdown: boolean;
 }
 
@@ -180,6 +187,7 @@ export function parseArgs(argv: readonly string[]): ScreenshotOptions {
     // can't tap/scroll). `--workout off` leaves the generator Off ("Start a session").
     workout: 'volume',
     appPath: null,
+    orientation: null,
     shutdown: false,
   };
 
@@ -232,6 +240,12 @@ export function parseArgs(argv: readonly string[]): ScreenshotOptions {
         options.appPath = resolve(expectValue(flag, value));
         index++;
         break;
+      case '--orientation': {
+        const orientation = expectEnum(flag, value, ['portrait', 'landscape']);
+        options.orientation = orientation === 'landscape' ? 'LANDSCAPE_LEFT' : 'PORTRAIT';
+        index++;
+        break;
+      }
       case '--shutdown':
         options.shutdown = true;
         break;
@@ -432,17 +446,23 @@ function newestIosRuntime(): string | null {
   return ios.length > 0 ? ios[ios.length - 1].identifier : null;
 }
 
-export function resolveIosScreenshotDevices(deviceNames: readonly string[]): IosScreenshotDevice[] {
+export function resolveIosScreenshotDevices(
+  deviceNames: readonly string[],
+  orientationOverride: IosDeviceOrientation | null = null,
+): IosScreenshotDevice[] {
   return deviceNames.map((deviceName) => {
     const knownDevice = IOS_SCREENSHOT_DEVICES.find((device) => device.name === deviceName);
+    // A known device keeps its own orientation — an override never clobbers a
+    // record whose orientation we already know is correct.
     if (knownDevice) return knownDevice;
     // An unlisted device name: usable only if a simulator by that name already
     // exists (typeId: '' tells findOrCreateIosDevice it can't auto-create one, so
-    // it errors with a clear message instead).
+    // it errors with a clear message instead). Portrait is the fallback, but an
+    // explicit --orientation lets an ad-hoc iPad capture in landscape.
     return {
       name: deviceName,
       typeId: '',
-      orientation: 'PORTRAIT',
+      orientation: orientationOverride ?? 'PORTRAIT',
     };
   });
 }
@@ -1003,7 +1023,7 @@ function runIos(options: ScreenshotOptions): number {
   }
 
   const appPath = resolveAppPath(options);
-  const screenshotDevices = resolveIosScreenshotDevices(options.devices);
+  const screenshotDevices = resolveIosScreenshotDevices(options.devices, options.orientation);
   const localeTargets = resolveAppStoreLocaleTargets(options.appLocales);
 
   for (let localeIndex = 0; localeIndex < localeTargets.length; localeIndex++) {


### PR DESCRIPTION
## Summary

Follow-up polish on the merged iPad adaptive-shell work (#2904), addressing review findings:

- **iPad rail hover/focus flicker (bug).** `SidebarItem` shared one `interactive` boolean for both pointer-hover and keyboard-focus, so a hover-out cleared the rail highlight even while the item still held keyboard focus. Split into independent `isHovered` / `isFocused` flags and OR them.
- **Screenshot orientation fallback (bug).** `resolveIosScreenshotDevices` fell back to portrait for any device name not in the known set, so an ad-hoc iPad passed via `--device` would capture portrait (skipping the landscape rotation). Added an explicit `--orientation portrait|landscape` override to `mobile:screenshots`; known devices keep their own orientation, unlisted names still default to portrait.
- **Missing test: pane-target reset on resize.** Added coverage in `drawer-host-provider.test.tsx` for the effect that clears the detail-pane selection when a resize drops out of pane width (regular → compact) — guarding against a stale climb re-appearing after a Stage Manager resize. Previously only the "compact from the start" case was tested.
- **Brittle pixel assertions.** `tab-layout.test.tsx` asserted computed pixel widths (`"width":485` / `300`); replaced with structural assertions (wall column + detail pane present). The width arithmetic stays covered by `size-class.test.ts`.
- **Import ordering.** Moved the `RNPressableProps` type alias below the imports in `PressableSurface.tsx`.
- **Stale doc.** `ai-design-guidelines.md` referenced a `panePreviewItem` field that doesn't exist; pointed it at the real `openPlayDrawer` `previewQueueItem` option (carried on `openTarget.options`).

Added unit tests for the new `--orientation` flag and the `resolveIosScreenshotDevices` override behavior.

## Release Notes

- On iPad, the sidebar highlight no longer flickers off when you move the pointer away from a tab you're navigating with the keyboard.

## Test plan

- `vp run typecheck:mobile` — passes.
- `vp test run --project mobile` (drawer-host-provider, tab-layout, component suites) — passes; new resize-reset test green.
- `vp test run scripts/__tests__/mobile-screenshots.test.ts` — passes; new `--orientation` / resolver tests green.
- `vp check` / `vp lint` on the changed files — 0 warnings, 0 errors.
- `vp run check:mobile-bundle` — Android Metro bundle OK.
- macOS-only simulator capture not runnable here; the `--orientation` behavior is covered by the resolver unit tests (matched device keeps orientation; unmatched + `--orientation landscape` → `LANDSCAPE_LEFT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7pX5iLrUx45AVkPeEQpH

---
_Generated by [Claude Code](https://claude.ai/code/session_018E7pX5iLrUx45AVkPeEQpH)_