### PR TITLE
chore(mobile): drop dead deps react-native-pager-view + expo-auth-session

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -241,7 +241,6 @@
         "expo-apple-authentication": "57.0.0",
         "expo-application": "57.0.0",
         "expo-asset": "57.0.3",
-        "expo-auth-session": "57.0.1",
         "expo-clipboard": "57.0.0",
         "expo-constants": "57.0.3",
         "expo-crypto": "57.0.0",
@@ -284,7 +283,6 @@
         "react-native-edge-to-edge": "1.8.1",
         "react-native-gesture-handler": "~2.32.0",
         "react-native-gifted-charts": "^1.4.77",
-        "react-native-pager-view": "8.0.2",
         "react-native-paper": "^5.15.3",
         "react-native-qrcode-svg": "^6.3.15",
         "react-native-reanimated": "4.5.0",
@@ -2830,8 +2828,6 @@
 
     "expo-asset": ["expo-asset@57.0.3", "", { "dependencies": { "@expo/image-utils": "^0.11.1", "expo-constants": "~57.0.3" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-6E08JDuYrktY5pKNn2WiFBPBfj6bvFb++ccuBTijK8BUk/afSoy6n35h583LmC2YHgHTepWHHWNfr61nYcMd8Q=="],
 
-    "expo-auth-session": ["expo-auth-session@57.0.1", "", { "dependencies": { "expo-application": "~57.0.0", "expo-constants": "~57.0.2", "expo-crypto": "~57.0.0", "expo-linking": "~57.0.1", "expo-web-browser": "~57.0.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-B4FnqPPBaAVc46/W8V2Ygs9UDauePDW1GXaA7fkVps4dQx63Q7qw01f/0BretiR7Fyli7GpVZB5L2a+7tyhdtQ=="],
-
     "expo-clipboard": ["expo-clipboard@57.0.0", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-eIt47f6kvR33HOnIEWvs9l1AUAY4GeLY27szwamSuwRl7nntNythSFFbmnrEtiSUaz//y8XVqCG9WLpdMkOpjA=="],
 
     "expo-constants": ["expo-constants@57.0.3", "", { "dependencies": { "@expo/env": "~2.4.1" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-BghbZlzwFnA22BG0CWv6W29zx8w19FozYPfSeZ3HjMitoy4aAmF1FnFbbjYSmZz6HHXXTWOfqwobOEIaglfzxg=="],
@@ -3785,8 +3781,6 @@
     "react-native-gifted-charts": ["react-native-gifted-charts@1.4.77", "", { "dependencies": { "gifted-charts-core": "0.1.81" }, "peerDependencies": { "expo-linear-gradient": "*", "react": "*", "react-native": "*", "react-native-linear-gradient": "*", "react-native-svg": "*" }, "optionalPeers": ["expo-linear-gradient", "react-native-linear-gradient"] }, "sha512-Ul4juHO0Gicng139i61AzQ3h4kLM25dzid1rU+d3d7PuHsI4UypgeChz/luaHMZaWgXkALjq6DLqaM2Y2AEhrA=="],
 
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA=="],
-
-    "react-native-pager-view": ["react-native-pager-view@8.0.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Y8All2BbjidI4ZIF9kBOIIoldkqrY/2FXapHZMdjwD+ByXhiOWTFenPs5rq9KRN5uAH/gOXtQCqHLxQDNBQRiQ=="],
 
     "react-native-paper": ["react-native-paper@5.15.3", "", { "dependencies": { "@callstack/react-theme-provider": "^3.0.9", "color": "^3.1.2", "use-latest-callback": "^0.2.3" }, "peerDependencies": { "react": "*", "react-native": "*", "react-native-safe-area-context": "*" } }, "sha512-GEyNTmWElIZgnYw09AjjCNupRYzCmP79uAAyGSyCEUZz7KBz1wtJcC0wVUkozR1Rn3PK/td/9LlR6+F1hzmYvA=="],
 
@@ -4807,8 +4801,6 @@
     "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "estree-walker/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
-
-    "expo-auth-session/expo-constants": ["expo-constants@57.0.2", "", { "dependencies": { "@expo/env": "~2.4.0" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-Bq0lIOB+olAQrYCS/fZi0cu1i8V0lo/YNr9fqMELerOfYYFkg8zTVrVaRjdFdMYBmz3dtym26UEBxV5dyUYZOg=="],
 
     "expo-linking/expo-constants": ["expo-constants@57.0.2", "", { "dependencies": { "@expo/env": "~2.4.0" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-Bq0lIOB+olAQrYCS/fZi0cu1i8V0lo/YNr9fqMELerOfYYFkg8zTVrVaRjdFdMYBmz3dtym26UEBxV5dyUYZOg=="],
 

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -49,7 +49,6 @@
     "expo-apple-authentication": "57.0.0",
     "expo-application": "57.0.0",
     "expo-asset": "57.0.3",
-    "expo-auth-session": "57.0.1",
     "expo-clipboard": "57.0.0",
     "expo-constants": "57.0.3",
     "expo-crypto": "57.0.0",
@@ -92,7 +91,6 @@
     "react-native-edge-to-edge": "1.8.1",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-gifted-charts": "^1.4.77",
-    "react-native-pager-view": "8.0.2",
     "react-native-paper": "^5.15.3",
     "react-native-qrcode-svg": "^6.3.15",
     "react-native-reanimated": "4.5.0",
@@ -117,7 +115,6 @@
         "@react-native-async-storage/async-storage",
         "@sentry/react-native",
         "@shopify/flash-list",
-        "react-native-pager-view",
         "typescript"
       ]
     }

--- a/packages/mobile/src/data/oss-licenses.generated.json
+++ b/packages/mobile/src/data/oss-licenses.generated.json
@@ -609,7 +609,7 @@
   },
   {
     "name": "@expo/cli",
-    "version": "57.0.3",
+    "version": "57.0.4",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "Expo",
@@ -625,7 +625,7 @@
   },
   {
     "name": "@expo/config",
-    "version": "57.0.1",
+    "version": "57.0.2",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": null,
@@ -641,7 +641,7 @@
   },
   {
     "name": "@expo/config-plugins",
-    "version": "57.0.1",
+    "version": "57.0.2",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": null,
@@ -697,7 +697,7 @@
   },
   {
     "name": "@expo/env",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": null,
@@ -713,7 +713,7 @@
   },
   {
     "name": "@expo/fingerprint",
-    "version": "0.20.1",
+    "version": "0.20.2",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -721,7 +721,7 @@
   },
   {
     "name": "@expo/image-utils",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": null,
@@ -753,7 +753,7 @@
   },
   {
     "name": "@expo/local-build-cache-provider",
-    "version": "57.0.1",
+    "version": "57.0.2",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": null,
@@ -777,7 +777,7 @@
   },
   {
     "name": "@expo/metro-config",
-    "version": "57.0.2",
+    "version": "57.0.3",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": null,
@@ -793,7 +793,7 @@
   },
   {
     "name": "@expo/metro-runtime",
-    "version": "57.0.2",
+    "version": "57.0.3",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -833,7 +833,7 @@
   },
   {
     "name": "@expo/prebuild-config",
-    "version": "57.0.3",
+    "version": "57.0.4",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": null,
@@ -849,7 +849,7 @@
   },
   {
     "name": "@expo/require-utils",
-    "version": "57.0.0",
+    "version": "57.0.1",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": null,
@@ -865,7 +865,7 @@
   },
   {
     "name": "@expo/schema-utils",
-    "version": "57.0.0",
+    "version": "57.0.1",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": null,
@@ -897,7 +897,7 @@
   },
   {
     "name": "@expo/ui",
-    "version": "57.0.2",
+    "version": "57.0.3",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -1686,6 +1686,14 @@
     "repository": "https://github.com/TooTallNate/proxy-agents",
     "publisher": "Nathan Rajlich",
     "licenseText": "(The MIT License)\n\nCopyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>\n\nPermission is hereby granted, free of charge, to any person obtaining\na copy of this software and associated documentation files (the\n'Software'), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to\npermit persons to whom the Software is furnished to do so, subject to\nthe following conditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\nIN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,\nTORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\nSOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+  },
+  {
+    "name": "agent-cli-detector",
+    "version": "0.1.2",
+    "license": "MIT",
+    "repository": null,
+    "publisher": null,
+    "licenseText": "MIT License\n\nCopyright (c) 2026 David Mokos\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
   },
   {
     "name": "anser",
@@ -2569,7 +2577,7 @@
   },
   {
     "name": "expo",
-    "version": "57.0.1",
+    "version": "57.0.2",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "Expo",
@@ -2593,15 +2601,7 @@
   },
   {
     "name": "expo-asset",
-    "version": "57.0.2",
-    "license": "MIT",
-    "repository": "https://github.com/expo/expo",
-    "publisher": "650 Industries, Inc.",
-    "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2015-present 650 Industries, Inc. (aka Expo)\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
-  },
-  {
-    "name": "expo-auth-session",
-    "version": "57.0.1",
+    "version": "57.0.3",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -2632,6 +2632,14 @@
     "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2015-present 650 Industries, Inc. (aka Expo)\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
   },
   {
+    "name": "expo-constants",
+    "version": "57.0.3",
+    "license": "MIT",
+    "repository": "https://github.com/expo/expo",
+    "publisher": "650 Industries, Inc.",
+    "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2015-present 650 Industries, Inc. (aka Expo)\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+  },
+  {
     "name": "expo-crypto",
     "version": "57.0.0",
     "license": "MIT",
@@ -2641,7 +2649,7 @@
   },
   {
     "name": "expo-dev-client",
-    "version": "57.0.4",
+    "version": "57.0.5",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -2649,7 +2657,7 @@
   },
   {
     "name": "expo-dev-launcher",
-    "version": "57.0.4",
+    "version": "57.0.5",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -2657,7 +2665,7 @@
   },
   {
     "name": "expo-dev-menu",
-    "version": "57.0.4",
+    "version": "57.0.5",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -2745,7 +2753,7 @@
   },
   {
     "name": "expo-image-manipulator",
-    "version": "57.0.1",
+    "version": "57.0.2",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -2753,7 +2761,7 @@
   },
   {
     "name": "expo-image-picker",
-    "version": "57.0.1",
+    "version": "57.0.2",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -2809,7 +2817,7 @@
   },
   {
     "name": "expo-location",
-    "version": "57.0.1",
+    "version": "57.0.2",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -2833,7 +2841,7 @@
   },
   {
     "name": "expo-modules-autolinking",
-    "version": "57.0.3",
+    "version": "57.0.4",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -2841,7 +2849,7 @@
   },
   {
     "name": "expo-modules-core",
-    "version": "57.0.1",
+    "version": "57.0.2",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -2857,7 +2865,7 @@
   },
   {
     "name": "expo-router",
-    "version": "57.0.2",
+    "version": "57.0.3",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -2889,7 +2897,7 @@
   },
   {
     "name": "expo-splash-screen",
-    "version": "57.0.1",
+    "version": "57.0.2",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -2921,7 +2929,7 @@
   },
   {
     "name": "expo-updates",
-    "version": "57.0.5",
+    "version": "57.0.6",
     "license": "MIT",
     "repository": "https://github.com/expo/expo",
     "publisher": "650 Industries, Inc.",
@@ -4382,14 +4390,6 @@
     "repository": "https://github.com/zoontek/react-native-edge-to-edge",
     "publisher": "Mathieu Acthernoene",
     "licenseText": "MIT License\n\nCopyright (c) 2024 Mathieu Acthernoene\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
-  },
-  {
-    "name": "react-native-pager-view",
-    "version": "8.0.2",
-    "license": "MIT",
-    "repository": "https://github.com/callstack/react-native-pager-view",
-    "publisher": "troZee",
-    "licenseText": "MIT License\n\nCopyright (c) 2021 Callstack\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
   },
   {
     "name": "react-native-paper",


### PR DESCRIPTION
## Summary

Removes two dependencies from `packages/mobile` that are no longer imported anywhere in source. Part of closing out the @expo/ui native-UI migration epic (#3275) — cleanup, not a control migration.

- **`react-native-pager-view` (8.0.2)** — zero source imports. The only thing that would use it is `@expo/ui`'s *optional* `community/pager-view` wrapper, which we never import (and `@expo/ui` doesn't declare it as a dep or non-optional peer). Also dropped from `expo.install.exclude`.
- **`expo-auth-session` (57.0.1)** — zero source imports. Our OAuth runs through `expo-web-browser`'s `openAuthSessionAsync` (the `AuthSession`-looking grep hits are that API), not this package.

Regenerated `oss-licenses.generated.json`. Note: that regen also **catches up pre-existing drift** — a few `@expo/*` patch bumps (and a transitive `agent-cli-detector`) that were already in the committed `bun.lock` but hadn't been reflected in the generated license file. The `bun.lock` diff here only removes the two packages; no versions were bumped by this PR.

### Fingerprint / release timing ⚠️

`react-native-pager-view` is an **autolinked native module → removing it changes the Expo fingerprint.** This is **not** OTA-deliverable and needs to ride the next native build. If it should be in Monday's App Store cut, **merge to `main` before the native build is cut** (both `ios-testflight-rn.yml` and `android-apk-rn.yml` fire on push to `main` under the `packages/mobile/**` path filter, and the changed fingerprint triggers a fresh build + tag).

`expo-auth-session` is **pure JS → fingerprint-neutral / OTA-safe**; it rides along here but carries no deadline of its own.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` ✅ (418 files, 3283 tests)
- `vp run check:mobile-bundle` ✅ (Metro bundle builds cleanly, 13.2 MB — proves nothing imports the removed JS)
- `vp run check:mobile-platform-imports` ✅
- `vp check` — no **new** errors introduced (the 3 pre-existing `scripts/__tests__/with-screenshot-dev-menu.test.ts` `NODE_ENV`/`ProcessEnv` errors are present on `main` too, unrelated to this change)
- `bun why react-native-pager-view` / `bun why expo-auth-session` → not found in lockfile
- Independent adversarial QA agent verified: zero live imports, no transitive requirement, the `@expo/ui` community pager wrapper is unused, and the native-vs-JS fingerprint split is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
