### PR TITLE
fix(mobile): stop reporting GraphQL RATE_LIMITED rejections as exceptions

### DIFF
--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -84,6 +84,38 @@ describe('reportHandledError', () => {
     });
   });
 
+  it('downgrades a RATE_LIMITED GraphQL rejection to a warning and tags it (expected backpressure — #3285)', () => {
+    const rateLimited = Object.assign(new Error('Rate limit exceeded. Try again in 7 seconds.'), {
+      response: {
+        status: 200,
+        errors: [
+          {
+            message: 'Rate limit exceeded. Try again in 7 seconds.',
+            extensions: { code: 'RATE_LIMITED', operation: 'searchBoards', retryAfterSeconds: 7 },
+          },
+        ],
+      },
+    });
+    reportHandledError(rateLimited, { tags: { source: 'react-query', kind: 'query' } });
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(rateLimited, {
+      level: 'warning',
+      tags: { source: 'react-query', kind: 'query', rate_limited: true },
+    });
+  });
+
+  it('catches a RATE_LIMITED error via direct extensions before the network check', () => {
+    // No `response` at all here, so if the rate-limit guard didn't run first this
+    // would otherwise fall into isNetworkError's "no numeric status" branch.
+    const rateLimited = Object.assign(new Error('Rate limit exceeded. Try again in 3 seconds.'), {
+      extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 3 },
+    });
+    reportHandledError(rateLimited, { tags: { source: 'react-query' } });
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(rateLimited, {
+      level: 'warning',
+      tags: { source: 'react-query', rate_limited: true },
+    });
+  });
+
   it('downgrades offline fetch failures to a warning and tags them network', () => {
     const offline = new TypeError('Network request failed');
     reportHandledError(offline, { tags: { source: 'react-query' } });

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -1,6 +1,10 @@
 import { isBleWriteTimeoutError } from '@boardsesh/ble-protocol/connection-error';
 import { captureToSentry, type ErrorReportContext } from './sentry';
-import { isExpectedAuthError, isExpectedBetaValidationError } from './graphql/extract-error-message';
+import {
+  isExpectedAuthError,
+  isExpectedBetaValidationError,
+  isGraphqlRateLimitedError,
+} from './graphql/extract-error-message';
 
 // Re-exported so the public reporting surface (`{ ErrorReportContext }` from
 // './error-reporting') is unchanged; the type itself lives in './sentry' to keep
@@ -54,6 +58,9 @@ function isNetworkError(error: unknown): boolean {
  *   - cancellations are dropped entirely,
  *   - expected auth-required GraphQL failures are dropped entirely,
  *   - expected beta-attach validation rejections are dropped entirely,
+ *   - GraphQL rate-limit rejections (RATE_LIMITED) are downgraded to `warning`
+ *     and tagged `rate_limited` — expected backpressure from typing/panning
+ *     discovery searches too fast, not a bug (#3285),
  *   - offline/network failures are downgraded to `warning` and tagged `network`,
  *   - BLE write-resume timeouts are downgraded to `warning` and tagged
  *     `ble_write_timeout` (the native layer auto-recovers them by cycling the
@@ -66,6 +73,14 @@ export function reportHandledError(error: unknown, context?: ErrorReportContext)
   if (isCancellation(error)) return;
   if (isExpectedAuthError(error)) return;
   if (isExpectedBetaValidationError(error)) return;
+  if (isGraphqlRateLimitedError(error)) {
+    reportError(error, {
+      ...context,
+      level: 'warning',
+      tags: { ...context?.tags, rate_limited: true },
+    });
+    return;
+  }
   if (isNetworkError(error)) {
     reportError(error, {
       ...context,

--- a/packages/mobile/src/providers/__tests__/query-provider.test.ts
+++ b/packages/mobile/src/providers/__tests__/query-provider.test.ts
@@ -63,21 +63,22 @@ describe('createQueryClient default retry', () => {
   // everything else keeps the previous retry-up-to-2-times behavior.
   it('never retries a RATE_LIMITED GraphQL rejection', () => {
     const retry = createQueryClient().getDefaultOptions().queries?.retry;
-    expect(typeof retry).toBe('function');
+    if (typeof retry !== 'function') throw new Error('expected retry to be a function');
     const rateLimited = Object.assign(new Error('Rate limit exceeded. Try again in 7 seconds.'), {
       response: {
         status: 200,
         errors: [{ message: 'Rate limit exceeded.', extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 7 } }],
       },
     });
-    expect(typeof retry === 'function' && retry(0, rateLimited)).toBe(false);
+    expect(retry(0, rateLimited)).toBe(false);
   });
 
   it('retries an ordinary error up to 2 times, matching the previous retry: 2 behavior', () => {
     const retry = createQueryClient().getDefaultOptions().queries?.retry;
+    if (typeof retry !== 'function') throw new Error('expected retry to be a function');
     const plainError = new Error('boom');
-    expect(typeof retry === 'function' && retry(0, plainError)).toBe(true);
-    expect(typeof retry === 'function' && retry(1, plainError)).toBe(true);
-    expect(typeof retry === 'function' && retry(2, plainError)).toBe(false);
+    expect(retry(0, plainError)).toBe(true);
+    expect(retry(1, plainError)).toBe(true);
+    expect(retry(2, plainError)).toBe(false);
   });
 });

--- a/packages/mobile/src/providers/__tests__/query-provider.test.ts
+++ b/packages/mobile/src/providers/__tests__/query-provider.test.ts
@@ -9,7 +9,7 @@ vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
 }));
 
-import { reportMutationFailure, reportQueryFailure } from '../query-provider';
+import { createQueryClient, reportMutationFailure, reportQueryFailure } from '../query-provider';
 import { reportHandledError } from '../../lib/error-reporting';
 
 // The global caches are the whole point — a query/mutation failure anywhere in
@@ -54,5 +54,30 @@ describe('reportMutationFailure', () => {
       tags: { source: 'react-query', kind: 'mutation' },
       extra: { mutationKey: null },
     });
+  });
+});
+
+describe('createQueryClient default retry', () => {
+  // Retrying a RATE_LIMITED response only hammers the already-throttled
+  // endpoint harder (#3285), so it must never retry regardless of failureCount;
+  // everything else keeps the previous retry-up-to-2-times behavior.
+  it('never retries a RATE_LIMITED GraphQL rejection', () => {
+    const retry = createQueryClient().getDefaultOptions().queries?.retry;
+    expect(typeof retry).toBe('function');
+    const rateLimited = Object.assign(new Error('Rate limit exceeded. Try again in 7 seconds.'), {
+      response: {
+        status: 200,
+        errors: [{ message: 'Rate limit exceeded.', extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 7 } }],
+      },
+    });
+    expect(typeof retry === 'function' && retry(0, rateLimited)).toBe(false);
+  });
+
+  it('retries an ordinary error up to 2 times, matching the previous retry: 2 behavior', () => {
+    const retry = createQueryClient().getDefaultOptions().queries?.retry;
+    const plainError = new Error('boom');
+    expect(typeof retry === 'function' && retry(0, plainError)).toBe(true);
+    expect(typeof retry === 'function' && retry(1, plainError)).toBe(true);
+    expect(typeof retry === 'function' && retry(2, plainError)).toBe(false);
   });
 });

--- a/packages/mobile/src/providers/query-provider.tsx
+++ b/packages/mobile/src/providers/query-provider.tsx
@@ -10,6 +10,7 @@ import {
   onlineManager,
 } from '@tanstack/react-query';
 import { reportHandledError } from '../lib/error-reporting';
+import { isGraphqlRateLimitedError } from '../lib/graphql/extract-error-message';
 
 // React Query keys `refetchOnReconnect` / `refetchOnWindowFocus` off a browser's
 // `navigator.onLine` and window-focus events, neither of which exists on React
@@ -98,7 +99,13 @@ export function createQueryClient(): QueryClient {
         networkMode: 'offlineFirst',
         staleTime: 5 * 60 * 1000,
         gcTime: 30 * 60 * 1000,
-        retry: 2,
+        // Never retry a RATE_LIMITED rejection — retrying only hammers the
+        // already-throttled endpoint harder (#3285). Everything else keeps
+        // the previous retry-up-to-2-times behavior.
+        retry: (failureCount, error) => {
+          if (isGraphqlRateLimitedError(error)) return false;
+          return failureCount < 2;
+        },
       },
       mutations: {
         networkMode: 'offlineFirst',


### PR DESCRIPTION
## Summary

Board/gym discovery on mobile fires `searchBoards` fast enough (typing into the gym filter, panning the map) to occasionally hit the backend's rate limiter, which throws a `RATE_LIMITED` GraphQL error. That's expected backpressure, not a bug — the user doesn't notice since `placeholderData: keepPreviousData` keeps prior results on screen — but two things made it noisy/harmful:

1. `reportHandledError` (`packages/mobile/src/lib/error-reporting.ts`) had no `RATE_LIMITED` guard, so every throttled search fell through to `level: 'error'` and shipped to Sentry/PostHog as a real exception.
2. `packages/mobile/src/providers/query-provider.tsx` set a blanket `retry: 2`, so TanStack Query retried each rejected request twice, ignoring `retryAfterSeconds` and hammering the already-throttled endpoint.

The detector for this (`isGraphqlRateLimitedError`) already existed and was already unit-tested — it just wasn't wired into either chokepoint. This PR wires it into both:

- `reportHandledError` now downgrades `RATE_LIMITED` GraphQL errors to `level: 'warning'` tagged `rate_limited: true`, mirroring the existing network/BLE downgrade pattern. This keeps a low-severity breadcrumb for monitoring rate-limit frequency without polluting the error-level stream.
- The default React Query `retry` option is now a callback that returns `false` for `RATE_LIMITED` errors and otherwise preserves the previous retry-up-to-2-times behavior.

I checked the issue's optional third item (debounce `gyms/index.tsx` and `boards/index.tsx`): `gyms/index.tsx` already debounces map-region changes at 500ms and the gym-name filter is submit-driven (not on-change); `boards/index.tsx` doesn't call `searchBoards` at all. No changes needed there.

Closes #3285.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Added test cases to `packages/mobile/src/lib/__tests__/error-reporting.test.ts` covering both the `response.errors[]` and direct-`extensions` RATE_LIMITED shapes, asserting the warning-level downgrade with the `rate_limited` tag.
- Added test cases to `packages/mobile/src/providers/__tests__/query-provider.test.ts` asserting the default `retry` callback returns `false` immediately for a RATE_LIMITED error, and preserves the previous retry-up-to-2-times behavior for ordinary errors.
- `vp run typecheck:mobile` — passes.
- `vp test run --project mobile --reporter=agent` — 416 files / 3277 tests pass.
- `vp check` scoped to the four changed files — pass (format + lint clean).


---
_Generated by [Claude Code](https://claude.ai/code/session_018Fm8gdN19Dhg2nRznH2u3J)_