### PR TITLE
fix(mobile): surface RedBearLab MoonBoard boxes in the device picker filter

### DIFF
--- a/docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md
+++ b/docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md
@@ -116,7 +116,7 @@ Neither matches the RedBearLab or Nordic UART families, and neither is part of t
 
 ✅ The app scans with `flutter_reactive_ble` (symbols `ScanForDevicesRequest`, `scanMode`, `requireLocationServicesEnabled`). Discovered devices arrive as `DiscoveredDevice(id: …)`; services and characteristics are resolved per `DiscoveredService(serviceId: …)` after connect.
 
-MoonBoard controllers advertise a BLE name beginning with **`MoonBoard`** (the app's user-facing copy and Boardsesh's existing `MOONBOARD_DEVICE_NAME_PREFIXES = ['MoonBoard', 'Moonboard']` both key on this prefix). The exact membership of the scan's service-UUID filter is not provable from static strings; what is certain is that the app carries **both** service UUIDs from §2 and resolves the right write characteristic after connecting.
+MoonBoard controllers advertise a BLE name beginning with **`MoonBoard`** (the app's user-facing copy and Boardsesh's existing `MOONBOARD_DEVICE_NAME_PREFIXES = ['MoonBoard', 'Moonboard']` both key on this prefix). The exact membership of the **official app's** scan service-UUID filter is not provable from static strings; what is certain is that the app carries **both** service UUIDs from §2 and resolves the right write characteristic after connecting. (Boardsesh scans unfiltered for the MoonBoard family and accepts a result on either generation's service UUID or the name prefix.)
 
 ---
 

--- a/packages/mobile/src/lib/ble/__tests__/board-device-filter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/board-device-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID } from '@boardsesh/ble-protocol';
+import { AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID, REDBEARLAB_SERVICE_UUID } from '@boardsesh/ble-protocol';
 import { isLikelyBoardDevice } from '../board-device-filter';
 
 describe('isLikelyBoardDevice', () => {
@@ -31,6 +31,28 @@ describe('isLikelyBoardDevice', () => {
         scanFamily: 'moonboard',
       }),
     ).toBe(true);
+  });
+
+  it('accepts an original RedBearLab box on MoonBoard scans regardless of name', () => {
+    // First-generation MoonBoard LED boxes (RedBearLab controller, #3299): if
+    // the box advertises its service UUID, don't depend on the name prefix.
+    expect(
+      isLikelyBoardDevice({
+        name: undefined,
+        serviceUuids: [REDBEARLAB_SERVICE_UUID.toUpperCase()],
+        scanFamily: 'moonboard',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not accept RedBearLab devices on Aurora scans', () => {
+    expect(
+      isLikelyBoardDevice({
+        name: 'whatever',
+        serviceUuids: [REDBEARLAB_SERVICE_UUID],
+        scanFamily: 'aurora',
+      }),
+    ).toBe(false);
   });
 
   it('accepts a MoonBoard by name even when no service UUIDs are advertised', () => {

--- a/packages/mobile/src/lib/ble/__tests__/board-device-filter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/board-device-filter.test.ts
@@ -81,6 +81,17 @@ describe('isLikelyBoardDevice', () => {
     expect(isLikelyBoardDevice({ name: 'Garage Wall', serviceUuids: null, scanFamily: 'aurora' })).toBe(false);
   });
 
+  it('falls back to name matching when a moonboard scan omits serviceUuids entirely', () => {
+    // Unlike the Aurora branch, `undefined` is not vouched for on moonboard
+    // scans (old iOS binaries filtered those natively on [UART, RedBearLab],
+    // but the name check still applies).
+    expect(isLikelyBoardDevice({ name: 'MoonBoard A1B2', serviceUuids: undefined, scanFamily: 'moonboard' })).toBe(
+      true,
+    );
+    expect(isLikelyBoardDevice({ name: 'Garage Wall', serviceUuids: undefined, scanFamily: 'moonboard' })).toBe(false);
+    expect(isLikelyBoardDevice({ name: undefined, serviceUuids: undefined, scanFamily: 'moonboard' })).toBe(false);
+  });
+
   it('rejects unrelated devices', () => {
     expect(isLikelyBoardDevice({ name: 'JBL Flip 6', serviceUuids: [], scanFamily: 'moonboard' })).toBe(false);
     expect(isLikelyBoardDevice({ name: undefined, serviceUuids: [], scanFamily: 'aurora' })).toBe(false);

--- a/packages/mobile/src/lib/ble/board-device-filter.ts
+++ b/packages/mobile/src/lib/ble/board-device-filter.ts
@@ -1,10 +1,20 @@
-import { AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID, parseSerialNumber } from '@boardsesh/ble-protocol';
+import {
+  AURORA_ADVERTISED_SERVICE_UUID,
+  UART_SERVICE_UUID,
+  REDBEARLAB_SERVICE_UUID,
+  parseSerialNumber,
+} from '@boardsesh/ble-protocol';
 import { parseBoardTypeFromDeviceName } from '@boardsesh/ble-protocol/aurora';
 import { isMoonboardDeviceName } from '@boardsesh/ble-protocol/moonboard';
 import type { BoardScanFamily } from './types';
 
 const AURORA_SERVICE_UUID = AURORA_ADVERTISED_SERVICE_UUID.toLowerCase();
 const UART_SERVICE_UUID_LOWER = UART_SERVICE_UUID.toLowerCase();
+const REDBEARLAB_SERVICE_UUID_LOWER = REDBEARLAB_SERVICE_UUID.toLowerCase();
+// Both MoonBoard controller generations: newer boards advertise Nordic UART,
+// the original RedBearLab LED box its own service. Matches the service-UUID
+// scan filters in native-ios-adapter.ts and BoardBleManager.swift.
+const MOONBOARD_SERVICE_UUIDS = [UART_SERVICE_UUID_LOWER, REDBEARLAB_SERVICE_UUID_LOWER];
 const STRICT_AURORA_SERIAL_SUFFIX = /#[A-Za-z0-9-]+@\d+$/;
 
 /**
@@ -45,7 +55,7 @@ export function isLikelyBoardDevice({
     return STRICT_AURORA_SERIAL_SUFFIX.test(name.trim()) && parseSerialNumber(name) !== undefined;
   }
 
-  if (serviceUuids?.some((serviceUuid) => serviceUuid.toLowerCase() === UART_SERVICE_UUID_LOWER)) {
+  if (serviceUuids?.some((serviceUuid) => MOONBOARD_SERVICE_UUIDS.includes(serviceUuid.toLowerCase()))) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

Hardens the mobile BLE scan-result filter for issue #3299 (original MoonBoard LED boxes). `isLikelyBoardDevice`'s moonboard branch accepted a device only when it advertised the Nordic UART service UUID or carried a `MoonBoard`/`Moonboard` name prefix — the original RedBearLab box's own service UUID (`713d0000-…`) wasn't matched, so a first-gen box advertising its service UUID under a nonstandard name would never surface in the picker. Every service-UUID scan filter already includes RedBearLab (`native-ios-adapter.ts` on old binaries, the Swift reconnect-by-last-known scan); this makes the JS result filter consistent with them.

Found during a code review of the RedBearLab path against `docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md` — the rest of the path (UART→RedBearLab discovery fallback, write-with-response gating, 20-byte chunks, MTU skip) checked out on both platforms. Part of #3299; hardware verification on an original box is still the outstanding step there.

## Release Notes

- Original (first-generation) MoonBoard LED boxes are easier to find in the board picker

## Test plan

- New unit tests: RedBearLab service UUID accepted on moonboard scans (case-insensitive, no name required), still rejected on Aurora scans.
- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 418 files / 3285 tests passed.
- `vp run check:mobile-bundle` — Android bundle OK.
- Not verified on real first-gen hardware (none available); the name-prefix path that real boxes use is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PqxKRPAQSJyQ7Eecb5wZh