### PR TITLE
fix(mobile): playlist empty-state Create button + verify edit-confirm reachability (#3296)

### DIFF
--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -17,6 +17,7 @@ import type { DiscoverablePlaylist, Playlist, SmartPlaylistType } from '@boardse
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
+import { Button } from '../../../src/components/Button';
 import { SectionHeader } from '../../../src/components/SectionHeader';
 import { HorizontalScrollSection } from '../../../src/components/HorizontalScrollSection';
 import { PlaylistCard, PlaylistFormSheet, type PlaylistFormValues } from '../../../src/components/playlist';
@@ -616,6 +617,9 @@ export default function DiscoverLibrary() {
             <Text variant="subheadline" style={styles.emptySubtitle}>
               {t('library.empty.description')}
             </Text>
+            <View style={styles.emptyCta}>
+              <Button title={t('library.empty.createCta')} icon="plus" size="large" onPress={handleCreatePress} />
+            </View>
           </View>
         ) : null}
 
@@ -740,6 +744,9 @@ const styles = StyleSheet.create({
   emptySubtitle: {
     opacity: 0.4,
     textAlign: 'center',
+  },
+  emptyCta: {
+    marginTop: spacing[4],
   },
   retryCta: {
     marginTop: spacing[3],

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -88,7 +88,8 @@
     },
     "empty": {
       "title": "No playlists yet",
-      "description": "Tap the + button to create your first playlist."
+      "description": "Save your projects and go-to sends into a playlist so they're easy to find.",
+      "createCta": "Create playlist"
     },
     "createFab": {
       "ariaLabel": "Create playlist"

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -88,7 +88,8 @@
     },
     "empty": {
       "title": "Aún no tienes playlists",
-      "description": "Toca el botón + para crear tu primera playlist."
+      "description": "Guarda tus proyectos y tus bloques favoritos en una playlist para tenerlos a mano.",
+      "createCta": "Crear playlist"
     },
     "createFab": {
       "ariaLabel": "Crear playlist"

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -88,7 +88,8 @@
     },
     "empty": {
       "title": "Aucune playlist pour l'instant",
-      "description": "Appuyez sur le bouton + pour créer votre première playlist."
+      "description": "Enregistre tes projets et tes voies préférées dans une playlist pour les retrouver vite.",
+      "createCta": "Créer une playlist"
     },
     "createFab": {
       "ariaLabel": "Créer une playlist"


### PR DESCRIPTION
## Summary

Fixes the two iOS playlist issues from #3296 (from PostHog in-app bug triage).

**Empty-playlist state — misleading "+" (fixed here).** The empty state said "Tap the + button to create your first playlist," but that + is a Material FAB or a Liquid-Glass floating-chrome island that's easy to miss, and it doesn't exist at all on the "My Playlists" list. The Discover empty state now shows an explicit **Create playlist** button wired to the existing create sheet (`handleCreatePress` → shared `PlaylistFormSheet`), and the shared `library.empty.description` copy is reworded across en/es/fr to drop the "+" reference and describe what a playlist gives you. The "My Playlists" list inherits the corrected copy; its empty branch is unreachable through the UI (the "See all" link only renders once you already have playlists), so no button is duplicated there.

**Edit-confirm button unreachable — already fixed-forward.** The other half of #3296 (edit-playlist Save button below the fold, can't scroll to it) was reported on **2.1.0 build 3 (2026-06-29)**. The iOS sheet overhaul that resolves this class of bug landed **after** that build:

- `ebde81fdb` (2026-07-03) — bounds the native sheet's column to the detent height on iOS so a pinned footer can't fall off-screen (#3330).
- `06eceaea9` (2026-07-03) — pads the footer over the keyboard.

On current `main` (2.2.0) the confirm button is a pinned sibling below the scroll body, and the detent-bound column deliberately errs short, so Save sits just above the bottom edge and stays reachable. No code change is needed for that half. (A live-simulator screenshot to double-confirm was blocked in this environment: port 8081 was held by another worktree's dev server and the create sheet has no deep-link entry point to drive without tap automation. The Debug sim `.app` is now built and cached at `packages/mobile/.app-cache/Boardsesh.app` for a future live check.)

Addresses #3296 (does not auto-close — see follow-up).

## Follow-up

Confirm the edit-playlist **Save** button is reachable (keyboard open + closed, on a short device) on a real **2.2.0+** build before closing #3296. This PR fixes the empty-state half outright; the edit-confirm half is believed fixed-forward by the #3330 sheet work but hasn't been live-verified.

## Release Notes

- Empty playlists screen now has a clear "Create playlist" button instead of pointing at a hard-to-spot +

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 3283 passed (incl. i18n `catalog-completeness` parity for the new `library.empty.createCta` key)
- `vp run check:mobile-bundle` — OK
- Debug simulator `.app` built successfully (`** BUILD SUCCEEDED **`) and installed on iPhone 16 Pro Max; interactive edit/create-sheet capture blocked by an in-use Metro port + no create-sheet deep link (see summary)
