### PR TITLE
fix(mobile): inline playlist picker in the reaction menu (#3294)

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -44,6 +44,14 @@ instead stack via their own SwiftUI hosts — that's how `HoldRoleSheet` shows o
 drawer (they're siblings in the create-climb route, not one nested in the other). There is **no**
 `fullWindowOverlay` prop on `Sheet`; it was an inert no-op and has been removed.
 
+**Inline body instead of a nested sheet:** when a surface needs a secondary picker/form but a
+second native sheet can't stack (rule 1), extract the body as a **presentation-agnostic component**
+that mounts no sheet/overlay of its own and takes its text input by injection, then render it inline
+in both hosts. `InlinePlaylistPicker` (the "add to playlist" list + create form) is the reference:
+it renders inline in `ClimbReactionMenu`'s `FullWindowOverlay` (plain `TextInput`) and inside
+`AddToPlaylistSheet`'s `ModalSheet` (`BottomSheetTextInput`), so add-to-playlist never stacks a
+second sheet. Feedback is inline, not a toast (a toast renders behind the overlay/sheet).
+
 **Every native sheet must go through the presentation coordinator.** `@expo/ui`
 sheets all present off the **same** root-window view controller, and the library
 does no serialization — overlapping a present with another sheet's dismiss

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -1,10 +1,9 @@
 import { useMemo, type ComponentType } from 'react';
-import { type TextInputProps } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { ModalSheet } from './ModalSheet';
 import { ClimbPreviewCard } from './ClimbPreviewCard';
-import { InlinePlaylistPicker } from './playlist/InlinePlaylistPicker';
+import { InlinePlaylistPicker, type PickerTextInputProps } from './playlist/InlinePlaylistPicker';
 
 type AddToPlaylistSheetProps = {
   visible: boolean;
@@ -23,8 +22,9 @@ type AddToPlaylistSheetProps = {
 
 // The native bottom-sheet text input pushes the sheet up for the keyboard; the
 // reaction overlay injects the plain RN TextInput instead. Both satisfy the
-// picker's TextInputProps contract.
-const SheetTextInput = BottomSheetTextInput as unknown as ComponentType<TextInputProps>;
+// picker's narrowed text-input contract — a single, honest cast (BottomSheetTextInput
+// carries extra bottom-sheet-only props but accepts everything the picker drives).
+const SheetTextInput = BottomSheetTextInput as ComponentType<PickerTextInputProps>;
 
 /**
  * The swipe/ellipsis "Add to playlist" surface. Since #3167 native sheets can't

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -1,19 +1,10 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Pressable, View, StyleSheet } from 'react-native';
-import { useTranslation } from 'react-i18next';
+import { useMemo, type ComponentType } from 'react';
+import { type TextInputProps } from 'react-native';
+import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { ModalSheet } from './ModalSheet';
 import { ClimbPreviewCard } from './ClimbPreviewCard';
-import { ListRow } from './ListRow';
-import { Icon } from './Icon';
-import { Text } from './Text';
-import { PlaylistFormSheet, type PlaylistFormValues } from './playlist';
-import { useToast } from '../providers/toast-provider';
-import { usePlaylistsContext, type Playlist } from '../providers/playlists-provider';
-import { useTheme } from '../providers/theme-provider';
-import { sortPlaylistsByName } from '../lib/sort-filter-playlists';
-import { iosSystemColors } from '../theme/ios-colors';
-import { borderRadius, spacing } from '../theme/tokens';
+import { InlinePlaylistPicker } from './playlist/InlinePlaylistPicker';
 
 type AddToPlaylistSheetProps = {
   visible: boolean;
@@ -23,20 +14,24 @@ type AddToPlaylistSheetProps = {
   sizeId: number;
   setIds: string;
   angle: number;
-  /** Request an animated close (pan-down, after add/create). */
+  /** Request an animated close (pan-down). */
   onClose: () => void;
   /** Fired once the dismiss animation has settled — safe to unmount/clear.
    * Optional: always-mounted hosts don't unmount, so they may omit it. */
   onFullyDismissed?: () => void;
 };
 
-// Mirrors web's isValidHexColor gate before rendering a playlist's accent: a
-// stray value would otherwise paint the leading swatch an undefined colour.
-const HEX_COLOR = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
-function validHexColor(color: string | undefined): string | null {
-  return color && HEX_COLOR.test(color) ? color : null;
-}
+// The native bottom-sheet text input pushes the sheet up for the keyboard; the
+// reaction overlay injects the plain RN TextInput instead. Both satisfy the
+// picker's TextInputProps contract.
+const SheetTextInput = BottomSheetTextInput as unknown as ComponentType<TextInputProps>;
 
+/**
+ * The swipe/ellipsis "Add to playlist" surface. Since #3167 native sheets can't
+ * stack, so both the playlist list AND the create-new form live INLINE in this
+ * one sheet (`InlinePlaylistPicker`) — no nested sheet to be dismissed on
+ * present. The reaction overlay reuses the same picker without a sheet at all.
+ */
 function AddToPlaylistSheet({
   visible,
   climb,
@@ -48,140 +43,19 @@ function AddToPlaylistSheet({
   onClose,
   onFullyDismissed,
 }: AddToPlaylistSheetProps) {
-  const { t } = useTranslation('climbs');
-  const { brandColors, systemColors } = useTheme();
-  const { showToast } = useToast();
-  const { playlists, addToPlaylist, createPlaylist, isLoading, isAuthenticated } = usePlaylistsContext();
-  const [createVisible, setCreateVisible] = useState(false);
-  const [creating, setCreating] = useState(false);
-  // Create failures surface INLINE in the nested create sheet, not via a root
-  // toast — a toast fired while the native sheet is open renders behind it and is
-  // invisible. The sheet stays open on failure so the user can fix and retry.
-  const [createError, setCreateError] = useState<string | null>(null);
-  // Mirror the latest open intent so an in-flight create can tell whether the
-  // sheet is still open (replaces the old isPresentedRef gate).
-  const visibleRef = useRef(visible);
-  visibleRef.current = visible;
-  const createRequestIdRef = useRef(0);
-  const sortedPlaylists = useMemo(() => sortPlaylistsByName(playlists), [playlists]);
-
-  const handleAddToPlaylist = useCallback(
-    async (playlist: Playlist) => {
-      if (!climb) return;
-      try {
-        // The backend addClimbToPlaylist resolver matches playlists.uuid, so
-        // the playlist *uuid* (not the bigserial id) must go on the wire — the
-        // id round-trips a "Playlist not found" error. It also keys the
-        // post-add cache invalidation onto the detail screen's ['playlist', uuid]
-        // / ['playlistClimbs', uuid] entries.
-        await addToPlaylist(playlist.uuid, climb.uuid, angle);
-        showToast(t('actions.playlist.toast.added'), 'success');
-      } catch (error) {
-        // The toast is intentionally generic, but a swallowed error makes
-        // "failed to add" impossible to diagnose. Log the real reason in dev.
-        if (__DEV__) {
-          console.warn('[playlist] add to playlist failed', {
-            playlistUuid: playlist.uuid,
-            climbUuid: climb.uuid,
-            angle,
-            error,
-          });
-        }
-        showToast(t('actions.playlist.toast.addFailed'), 'error');
-      } finally {
-        onClose();
-      }
-    },
-    [climb, angle, addToPlaylist, showToast, t, onClose],
-  );
-
-  const handleCreatePlaylist = useCallback(
-    async (values: PlaylistFormValues) => {
-      if (!climb) return;
-      const createRequestId = createRequestIdRef.current + 1;
-      createRequestIdRef.current = createRequestId;
-      const isCurrentCreateRequest = () => createRequestIdRef.current === createRequestId && visibleRef.current;
-      setCreating(true);
-      setCreateError(null);
-      try {
-        const created = await createPlaylist(values.name, values.description, values.color, values.icon, {
-          boardType: boardName,
-          layoutId,
-        });
-        if (!isCurrentCreateRequest()) return;
-        setCreateVisible(false);
-        try {
-          await addToPlaylist(created.uuid, climb.uuid, angle);
-          if (!isCurrentCreateRequest()) return;
-          showToast(t('actions.playlist.toast.createdNamed', { name: created.name }), 'success');
-          onClose();
-        } catch (error) {
-          if (!isCurrentCreateRequest()) return;
-          if (__DEV__) {
-            console.warn('[playlist] created playlist but failed to add climb', {
-              playlistUuid: created.uuid,
-              climbUuid: climb.uuid,
-              angle,
-              error,
-            });
-          }
-          showToast(t('actions.playlist.toast.addFailed'), 'error');
-        }
-      } catch (error) {
-        if (!isCurrentCreateRequest()) return;
-        if (__DEV__) {
-          console.warn('[playlist] create playlist from add sheet failed', {
-            climbUuid: climb.uuid,
-            boardName,
-            layoutId,
-            error,
-          });
-        }
-        // Inline, not a toast: the create sheet is still open, so a root toast
-        // would be hidden behind it.
-        setCreateError(t('actions.playlist.toast.createFailed'));
-      } finally {
-        if (createRequestIdRef.current === createRequestId) setCreating(false);
-      }
-    },
-    [climb, createPlaylist, boardName, layoutId, addToPlaylist, angle, showToast, t, onClose],
-  );
-
-  // The dismiss animation has settled: cancel any in-flight create, reset the
-  // nested form, then let the parent clear the climb / unmount.
-  const handleFullyDismissed = useCallback(() => {
-    createRequestIdRef.current += 1;
-    setCreateVisible(false);
-    setCreating(false);
-    setCreateError(null);
-    onFullyDismissed?.();
-  }, [onFullyDismissed]);
-
-  const handleShowCreate = useCallback(() => {
-    setCreateError(null);
-    setCreateVisible(true);
-  }, []);
-
-  const handleCloseCreate = useCallback(() => {
-    createRequestIdRef.current += 1;
-    setCreateVisible(false);
-    setCreating(false);
-    setCreateError(null);
-  }, []);
-
   const snapPoints = useMemo(() => ['50%', '90%'], []);
 
   return (
-    <>
-      <ModalSheet
-        visible={visible && !!climb}
-        snapPoints={snapPoints}
-        onClose={onClose}
-        onFullyDismissed={handleFullyDismissed}
-        enablePanDownToClose
-        scrollable
-      >
-        {climb && (
+    <ModalSheet
+      visible={visible && !!climb}
+      snapPoints={snapPoints}
+      onClose={onClose}
+      onFullyDismissed={onFullyDismissed}
+      enablePanDownToClose
+      scrollable
+    >
+      {climb && (
+        <>
           <ClimbPreviewCard
             climb={climb}
             boardName={boardName}
@@ -190,97 +64,17 @@ function AddToPlaylistSheet({
             setIds={setIds}
             angle={angle}
           />
-        )}
-        <View style={styles.header}>
-          <Icon name="playlist" size={20} color={systemColors.accent} />
-          <Text variant="headline" style={styles.headerTitle}>
-            {t('actions.playlist.popover.title')}
-          </Text>
-          {climb && isAuthenticated ? (
-            <Pressable
-              onPress={handleShowCreate}
-              accessibilityRole="button"
-              accessibilityLabel={t('actions.playlist.popover.createNew')}
-              hitSlop={8}
-              style={[styles.createButton, { backgroundColor: systemColors.fill }]}
-            >
-              <Icon name="plus" size={18} color={brandColors.primary} />
-            </Pressable>
-          ) : null}
-        </View>
-
-        {!climb ? null : !isAuthenticated ? (
-          <View style={styles.message}>
-            <Text variant="subheadline" color={iosSystemColors.systemGray}>
-              {t('actions.playlist.popover.signInBlurb')}
-            </Text>
-          </View>
-        ) : isLoading ? (
-          <View style={styles.message}>
-            <ActivityIndicator />
-          </View>
-        ) : sortedPlaylists.length === 0 ? (
-          <View style={styles.message}>
-            <Text variant="subheadline" color={iosSystemColors.systemGray}>
-              {t('actions.playlist.popover.empty')}
-            </Text>
-          </View>
-        ) : (
-          sortedPlaylists.map((playlist, index) => {
-            const accent = validHexColor(playlist.color);
-            return (
-              <ListRow
-                key={playlist.id}
-                title={playlist.name}
-                subtitle={t('multiboardList.count', { count: playlist.climbCount })}
-                leading={<Icon name="playlist" size={22} color={accent ?? brandColors.primary} />}
-                onPress={() => {
-                  void handleAddToPlaylist(playlist);
-                }}
-                showSeparator={index < sortedPlaylists.length - 1}
-              />
-            );
-          })
-        )}
-      </ModalSheet>
-
-      <PlaylistFormSheet
-        mode="create"
-        visible={createVisible}
-        submitting={creating}
-        submitError={createError}
-        onSubmit={handleCreatePlaylist}
-        onClose={handleCloseCreate}
-      />
-    </>
+          <InlinePlaylistPicker
+            climb={climb}
+            angle={angle}
+            boardName={boardName}
+            layoutId={layoutId}
+            TextInputComponent={SheetTextInput}
+          />
+        </>
+      )}
+    </ModalSheet>
   );
 }
 
 export { AddToPlaylistSheet };
-
-const styles = StyleSheet.create({
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[2],
-    paddingHorizontal: spacing[4],
-    paddingTop: spacing[2],
-    paddingBottom: spacing[3],
-  },
-  headerTitle: {
-    flex: 1,
-  },
-  createButton: {
-    width: spacing[8],
-    height: spacing[8],
-    borderRadius: borderRadius.full,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  message: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: spacing[6],
-    paddingHorizontal: spacing[4],
-  },
-});

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -1,6 +1,8 @@
 import { useMemo, type ComponentType } from 'react';
-import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
+import { type FlatListProps } from 'react-native';
+import { BottomSheetTextInput, BottomSheetFlatList } from '@expo/ui/community/bottom-sheet';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
+import type { Playlist } from '@boardsesh/graphql/operations/playlists';
 import { ModalSheet } from './ModalSheet';
 import { ClimbPreviewCard } from './ClimbPreviewCard';
 import { InlinePlaylistPicker, type PickerTextInputProps } from './playlist/InlinePlaylistPicker';
@@ -25,6 +27,10 @@ type AddToPlaylistSheetProps = {
 // picker's narrowed text-input contract — a single, honest cast (BottomSheetTextInput
 // carries extra bottom-sheet-only props but accepts everything the picker drives).
 const SheetTextInput = BottomSheetTextInput as ComponentType<PickerTextInputProps>;
+// The bottom-sheet-aware list scrolls within the native sheet detent (its
+// virtualization plugs into the sheet's gesture handling); the reaction overlay
+// uses the picker's default RN FlatList.
+const SheetFlatList = BottomSheetFlatList as ComponentType<FlatListProps<Playlist>>;
 
 /**
  * The swipe/ellipsis "Add to playlist" surface. Since #3167 native sheets can't
@@ -52,7 +58,6 @@ function AddToPlaylistSheet({
       onClose={onClose}
       onFullyDismissed={onFullyDismissed}
       enablePanDownToClose
-      scrollable
     >
       {climb && (
         <>
@@ -64,12 +69,15 @@ function AddToPlaylistSheet({
             setIds={setIds}
             angle={angle}
           />
+          {/* The picker's own BottomSheetFlatList scrolls with the sheet, so the
+              sheet itself isn't `scrollable` (no nested scroll views). */}
           <InlinePlaylistPicker
             climb={climb}
             angle={angle}
             boardName={boardName}
             layoutId={layoutId}
             TextInputComponent={SheetTextInput}
+            ListComponent={SheetFlatList}
           />
         </>
       )}

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -14,6 +14,9 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
   BottomSheetTextInput: function BottomSheetTextInput() {
     return null;
   },
+  BottomSheetFlatList: function BottomSheetFlatList() {
+    return null;
+  },
 }));
 
 vi.mock('../ModalSheet', () => ({
@@ -79,8 +82,10 @@ describe('AddToPlaylistSheet', () => {
       boardName: 'kilter',
       layoutId: 1,
     });
-    // The sheet injects the native bottom-sheet text input (keyboard pushes the sheet).
+    // The sheet injects the native bottom-sheet text input + list so they scroll
+    // with the sheet.
     expect(typeof captured.pickerProps?.TextInputComponent).toBe('function');
+    expect(typeof captured.pickerProps?.ListComponent).toBe('function');
     // No back affordance in the sheet host.
     expect(captured.pickerProps?.onBack).toBeUndefined();
   });

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -6,6 +6,7 @@ import type { Climb } from '@boardsesh/shared-schema';
 
 const captured = vi.hoisted(() => ({
   sheetVisible: undefined as boolean | undefined,
+  sheetProps: null as Record<string, unknown> | null,
   pickerProps: null as Record<string, unknown> | null,
 }));
 
@@ -16,8 +17,9 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
 }));
 
 vi.mock('../ModalSheet', () => ({
-  ModalSheet: ({ visible, children }: { visible?: boolean; children?: ReactNode }) => {
+  ModalSheet: ({ visible, children, ...rest }: { visible?: boolean; children?: ReactNode }) => {
     captured.sheetVisible = visible;
+    captured.sheetProps = rest;
     return createElement('div', { 'data-modal-sheet': 'true' }, children);
   },
 }));
@@ -38,23 +40,31 @@ import { AddToPlaylistSheet } from '../AddToPlaylistSheet';
 const climb = { uuid: 'climb-1', name: 'Big Move', frames: '' } as Climb;
 
 function renderSheet(climbArg: Climb | null) {
-  return render(
-    <AddToPlaylistSheet
-      visible
-      climb={climbArg}
-      boardName="kilter"
-      layoutId={1}
-      sizeId={10}
-      setIds="1,2"
-      angle={40}
-      onClose={vi.fn()}
-    />,
-  );
+  const onClose = vi.fn();
+  const onFullyDismissed = vi.fn();
+  return {
+    onClose,
+    onFullyDismissed,
+    ...render(
+      <AddToPlaylistSheet
+        visible
+        climb={climbArg}
+        boardName="kilter"
+        layoutId={1}
+        sizeId={10}
+        setIds="1,2"
+        angle={40}
+        onClose={onClose}
+        onFullyDismissed={onFullyDismissed}
+      />,
+    ),
+  };
 }
 
 describe('AddToPlaylistSheet', () => {
   beforeEach(() => {
     captured.sheetVisible = undefined;
+    captured.sheetProps = null;
     captured.pickerProps = null;
   });
 
@@ -79,5 +89,13 @@ describe('AddToPlaylistSheet', () => {
     const { container } = renderSheet(null);
     expect(captured.sheetVisible).toBe(false);
     expect(container.querySelector('[data-inline-picker="true"]')).toBeNull();
+  });
+
+  it('forwards the close + fully-dismissed lifecycle callbacks to ModalSheet', () => {
+    const { onClose, onFullyDismissed } = renderSheet(climb);
+    // The host clears its deferred sheet state on onFullyDismissed, so it must
+    // reach the ModalSheet rather than being swallowed by the wrapper.
+    expect(captured.sheetProps?.onClose).toBe(onClose);
+    expect(captured.sheetProps?.onFullyDismissed).toBe(onFullyDismissed);
   });
 });

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -1,102 +1,24 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
-import type { Playlist } from '@boardsesh/graphql/operations/playlists';
 
-const playlistContext = vi.hoisted(() => ({
-  playlists: [] as Playlist[],
-  addToPlaylist: vi.fn(),
-  createPlaylist: vi.fn(),
-  isLoading: false,
-  isAuthenticated: true,
-}));
-const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
-
-vi.mock('react-native', () => ({
-  ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
-  Pressable: ({
-    children,
-    onPress,
-    accessibilityLabel,
-  }: {
-    children?: ReactNode;
-    onPress?: () => void;
-    accessibilityLabel?: string;
-  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
-  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+const captured = vi.hoisted(() => ({
+  sheetVisible: undefined as boolean | undefined,
+  pickerProps: null as Record<string, unknown> | null,
 }));
 
 vi.mock('@expo/ui/community/bottom-sheet', () => ({
-  BottomSheetModal: function BottomSheetModal() {
+  BottomSheetTextInput: function BottomSheetTextInput() {
     return null;
   },
 }));
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string, options?: Record<string, unknown>) =>
-      key === 'actions.playlist.toast.createdNamed' && typeof options?.name === 'string'
-        ? `${key} ${options.name}`
-        : key,
-  }),
-}));
-
-vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({
-    brandColors: { primary: '#6D28D9' },
-    systemColors: { accent: '#6D28D9', fill: '#eeeeee' },
-  }),
-}));
-
-vi.mock('../../providers/toast-provider', () => ({
-  useToast: () => toast,
-}));
-
-vi.mock('../../providers/playlists-provider', () => ({
-  usePlaylistsContext: () => playlistContext,
-}));
-
-vi.mock('../../theme/ios-colors', () => ({
-  iosSystemColors: { systemGray: '#8E8E93' },
-}));
-
-vi.mock('../../theme/tokens', () => ({
-  borderRadius: { full: 9999 },
-  spacing: { 2: 8, 3: 12, 4: 16, 6: 24, 8: 32 },
-}));
-
 vi.mock('../ModalSheet', () => ({
-  ModalSheet: function ModalSheet({
-    children,
-    onClose,
-    onFullyDismissed,
-  }: {
-    children?: ReactNode;
-    visible?: boolean;
-    onClose?: () => void;
-    onFullyDismissed?: () => void;
-  }) {
-    return createElement(
-      'div',
-      { 'data-modal-sheet': 'true' },
-      children,
-      // The user-initiated close (pan-down/backdrop) → onClose; the parent then
-      // clears state on the settled onFullyDismissed.
-      createElement(
-        'button',
-        {
-          'aria-label': 'dismiss-add-to-playlist-sheet',
-          onClick: () => {
-            onClose?.();
-            onFullyDismissed?.();
-          },
-        },
-        'dismiss',
-      ),
-    );
+  ModalSheet: ({ visible, children }: { visible?: boolean; children?: ReactNode }) => {
+    captured.sheetVisible = visible;
+    return createElement('div', { 'data-modal-sheet': 'true' }, children);
   },
 }));
 
@@ -104,307 +26,58 @@ vi.mock('../ClimbPreviewCard', () => ({
   ClimbPreviewCard: () => createElement('div', { 'data-climb-preview': 'true' }),
 }));
 
-vi.mock('../ListRow', () => ({
-  ListRow: ({ title, subtitle, onPress }: { title: string; subtitle?: string; onPress?: () => void }) =>
-    createElement('button', { onClick: onPress, 'aria-label': title }, `${title}${subtitle ? ` ${subtitle}` : ''}`),
-}));
-
-vi.mock('../Icon', () => ({
-  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
-}));
-
-vi.mock('../Text', () => ({
-  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
-}));
-
-vi.mock('../playlist', () => ({
-  PlaylistFormSheet: ({
-    visible,
-    submitting,
-    submitError,
-    onSubmit,
-    onClose,
-  }: {
-    visible: boolean;
-    submitting?: boolean;
-    submitError?: string | null;
-    onSubmit: (values: { name: string; description?: string; color?: string; icon?: string }) => void;
-    onClose: () => void;
-  }) =>
-    visible
-      ? createElement(
-          'div',
-          null,
-          submitError ? createElement('span', { 'data-create-error': 'true' }, submitError) : null,
-          createElement(
-            'button',
-            {
-              'aria-label': 'submit-created-playlist',
-              'data-submitting': submitting ? 'true' : 'false',
-              onClick: () =>
-                onSubmit({
-                  name: 'Projects',
-                  description: 'Moon projects',
-                  color: '#ff00ff',
-                  icon: 'star',
-                }),
-            },
-            'submit create',
-          ),
-          createElement('button', { 'aria-label': 'close-created-playlist-form', onClick: onClose }, 'close create'),
-        )
-      : null,
+vi.mock('../playlist/InlinePlaylistPicker', () => ({
+  InlinePlaylistPicker: (props: Record<string, unknown>) => {
+    captured.pickerProps = props;
+    return createElement('div', { 'data-inline-picker': 'true' });
+  },
 }));
 
 import { AddToPlaylistSheet } from '../AddToPlaylistSheet';
 
-const climb = {
-  uuid: 'climb-1',
-  name: 'Big Move',
-  frames: '',
-  angle: 40,
-} as Climb;
+const climb = { uuid: 'climb-1', name: 'Big Move', frames: '' } as Climb;
 
-const playlist = {
-  id: 'p-1',
-  uuid: 'p-1',
-  name: 'Hard Crimps',
-  climbCount: 3,
-  isPublic: false,
-  boardType: 'kilter',
-  layoutId: 1,
-  followerCount: 0,
-  isFollowedByMe: false,
-  isPinnedByMe: false,
-  createdAt: '2026-01-01T00:00:00Z',
-  updatedAt: '2026-01-01T00:00:00Z',
-} satisfies Playlist;
-
-function makeSheetPlaylist(uuid: string, name: string): Playlist {
-  return { ...playlist, id: uuid, uuid, name };
-}
-
-function renderedPlaylistRowLabels(container: HTMLElement, playlistNames: string[]): string[] {
-  const expectedNames = new Set(playlistNames);
-  return Array.from(container.querySelectorAll('button[aria-label]'))
-    .map((button) => button.getAttribute('aria-label') ?? '')
-    .filter((label) => expectedNames.has(label));
-}
-
-function deferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve;
-    reject = promiseReject;
-  });
-  return { promise, resolve, reject };
-}
-
-function renderSheet(onClose = vi.fn()) {
-  return {
-    onClose,
-    ...render(
-      <AddToPlaylistSheet
-        visible
-        climb={climb}
-        boardName="kilter"
-        layoutId={1}
-        sizeId={10}
-        setIds="1,2"
-        angle={40}
-        onClose={onClose}
-      />,
-    ),
-  };
+function renderSheet(climbArg: Climb | null) {
+  return render(
+    <AddToPlaylistSheet
+      visible
+      climb={climbArg}
+      boardName="kilter"
+      layoutId={1}
+      sizeId={10}
+      setIds="1,2"
+      angle={40}
+      onClose={vi.fn()}
+    />,
+  );
 }
 
 describe('AddToPlaylistSheet', () => {
   beforeEach(() => {
-    playlistContext.playlists = [];
-    playlistContext.isLoading = false;
-    playlistContext.isAuthenticated = true;
-    playlistContext.addToPlaylist.mockReset();
-    playlistContext.createPlaylist.mockReset();
-    toast.showToast.mockReset();
+    captured.sheetVisible = undefined;
+    captured.pickerProps = null;
   });
 
-  it('renders existing playlist rows alphabetically by name', () => {
-    const unsortedPlaylists = [
-      makeSheetPlaylist('p-banana', 'banana'),
-      makeSheetPlaylist('p-apple', 'Apple'),
-      makeSheetPlaylist('p-eclair', 'Éclair'),
-      makeSheetPlaylist('p-cherry', 'cherry'),
-    ];
-    playlistContext.playlists = unsortedPlaylists;
-    const { container } = renderSheet();
-
-    expect(
-      renderedPlaylistRowLabels(
-        container,
-        unsortedPlaylists.map((entry) => entry.name),
-      ),
-    ).toEqual(['Apple', 'banana', 'cherry', 'Éclair']);
+  it('renders the preview + inline picker with the climb/board props when a climb is present', () => {
+    const { container } = renderSheet(climb);
+    expect(captured.sheetVisible).toBe(true);
+    expect(container.querySelector('[data-climb-preview="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-inline-picker="true"]')).not.toBeNull();
+    expect(captured.pickerProps).toMatchObject({
+      climb,
+      angle: 40,
+      boardName: 'kilter',
+      layoutId: 1,
+    });
+    // The sheet injects the native bottom-sheet text input (keyboard pushes the sheet).
+    expect(typeof captured.pickerProps?.TextInputComponent).toBe('function');
+    // No back affordance in the sheet host.
+    expect(captured.pickerProps?.onBack).toBeUndefined();
   });
 
-  it('creates a playlist from the sheet and adds the current climb to it', async () => {
-    const created = { ...playlist, uuid: 'p-new', id: 'p-new', name: 'Projects', climbCount: 0 };
-    const createDeferred = deferred<typeof created>();
-    playlistContext.createPlaylist.mockReturnValueOnce(createDeferred.promise);
-    playlistContext.addToPlaylist.mockResolvedValueOnce(undefined);
-    const { getByLabelText, onClose } = renderSheet();
-
-    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
-    fireEvent.click(getByLabelText('submit-created-playlist'));
-
-    await waitFor(() => {
-      expect(playlistContext.createPlaylist).toHaveBeenCalledWith('Projects', 'Moon projects', '#ff00ff', 'star', {
-        boardType: 'kilter',
-        layoutId: 1,
-      });
-      expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('true');
-    });
-
-    createDeferred.resolve(created);
-
-    await waitFor(() => {
-      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-new', 'climb-1', 40);
-    });
-    expect(toast.showToast).toHaveBeenCalledWith(expect.stringContaining('Projects'), 'success');
-    expect(onClose).toHaveBeenCalled();
-  });
-
-  it('adds the current climb to an existing playlist row', async () => {
-    playlistContext.playlists = [playlist];
-    playlistContext.addToPlaylist.mockResolvedValueOnce(undefined);
-    const { getByLabelText, onClose } = renderSheet();
-
-    fireEvent.click(getByLabelText('Hard Crimps'));
-
-    await waitFor(() => {
-      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-1', 'climb-1', 40);
-    });
-    expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.added', 'success');
-    expect(onClose).toHaveBeenCalled();
-  });
-
-  it('closes the add sheet and shows an error when adding an existing playlist row fails', async () => {
-    playlistContext.playlists = [playlist];
-    playlistContext.addToPlaylist.mockRejectedValueOnce(new Error('add failed'));
-    const { getByLabelText, onClose } = renderSheet();
-
-    fireEvent.click(getByLabelText('Hard Crimps'));
-
-    await waitFor(() => {
-      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-1', 'climb-1', 40);
-    });
-    expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.addFailed', 'error');
-    expect(onClose).toHaveBeenCalled();
-  });
-
-  it('resets the create sheet when the add sheet is dismissed mid-create', async () => {
-    const created = { ...playlist, uuid: 'p-new', id: 'p-new', name: 'Projects', climbCount: 0 };
-    const createDeferred = deferred<typeof created>();
-    playlistContext.createPlaylist.mockReturnValueOnce(createDeferred.promise);
-    playlistContext.addToPlaylist.mockResolvedValueOnce(undefined);
-    const { getByLabelText, queryByLabelText, onClose } = renderSheet();
-
-    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
-    fireEvent.click(getByLabelText('submit-created-playlist'));
-
-    await waitFor(() => {
-      expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('true');
-    });
-
-    fireEvent.click(getByLabelText('dismiss-add-to-playlist-sheet'));
-
-    expect(queryByLabelText('submit-created-playlist')).toBeNull();
-    expect(onClose).toHaveBeenCalled();
-
-    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
-    expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('false');
-
-    await act(async () => {
-      createDeferred.resolve(created);
-      await createDeferred.promise;
-    });
-    expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
-    expect(onClose).toHaveBeenCalledTimes(1);
-    expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('false');
-  });
-
-  it('resets the create sheet when the create form is closed mid-create', async () => {
-    const created = { ...playlist, uuid: 'p-new', id: 'p-new', name: 'Projects', climbCount: 0 };
-    const createDeferred = deferred<typeof created>();
-    playlistContext.createPlaylist.mockReturnValueOnce(createDeferred.promise);
-    playlistContext.addToPlaylist.mockResolvedValueOnce(undefined);
-    const { getByLabelText, queryByLabelText, onClose } = renderSheet();
-
-    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
-    fireEvent.click(getByLabelText('submit-created-playlist'));
-
-    await waitFor(() => {
-      expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('true');
-    });
-
-    fireEvent.click(getByLabelText('close-created-playlist-form'));
-
-    expect(queryByLabelText('submit-created-playlist')).toBeNull();
-    expect(onClose).not.toHaveBeenCalled();
-
-    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
-    expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('false');
-
-    await act(async () => {
-      createDeferred.resolve(created);
-      await createDeferred.promise;
-    });
-    expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
-    expect(onClose).not.toHaveBeenCalled();
-    expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('false');
-  });
-
-  it('keeps the add sheet open when playlist creation succeeds but adding the climb fails', async () => {
-    const created = { ...playlist, uuid: 'p-new', id: 'p-new', name: 'Projects', climbCount: 0 };
-    playlistContext.createPlaylist.mockResolvedValueOnce(created);
-    playlistContext.addToPlaylist.mockRejectedValueOnce(new Error('add failed'));
-    const { getByLabelText, queryByLabelText, onClose } = renderSheet();
-
-    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
-    fireEvent.click(getByLabelText('submit-created-playlist'));
-
-    await waitFor(() => {
-      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-new', 'climb-1', 40);
-    });
-    expect(queryByLabelText('submit-created-playlist')).toBeNull();
-    expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.addFailed', 'error');
-    expect(onClose).not.toHaveBeenCalled();
-  });
-
-  it('shows the create failure inline (not a toast) and keeps the sheet open', async () => {
-    playlistContext.createPlaylist.mockRejectedValueOnce(new Error('create failed'));
-    const { getByLabelText, container, onClose } = renderSheet();
-
-    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
-    fireEvent.click(getByLabelText('submit-created-playlist'));
-
-    await waitFor(() => {
-      expect(container.querySelector('[data-create-error="true"]')?.textContent).toBe(
-        'actions.playlist.toast.createFailed',
-      );
-    });
-    // No toast at all — a root toast would render behind the native sheet.
-    expect(toast.showToast).not.toHaveBeenCalled();
-    expect(getByLabelText('submit-created-playlist')).not.toBeNull();
-    expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
-    expect(onClose).not.toHaveBeenCalled();
-  });
-
-  it('does not show the create action for signed-out users', () => {
-    playlistContext.isAuthenticated = false;
-    const { queryByLabelText, getByText } = renderSheet();
-
-    expect(queryByLabelText('actions.playlist.popover.createNew')).toBeNull();
-    expect(getByText('actions.playlist.popover.signInBlurb')).not.toBeNull();
+  it('keeps the sheet closed and renders no picker when there is no climb', () => {
+    const { container } = renderSheet(null);
+    expect(captured.sheetVisible).toBe(false);
+    expect(container.querySelector('[data-inline-picker="true"]')).toBeNull();
   });
 });

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -151,10 +151,14 @@ export function ClimbReactionMenu({
   // climb art shrinks so the preview + form still fit above it on shorter phones.
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   useEffect(() => {
-    const onShow = Keyboard.addListener('keyboardWillChangeFrame', (event) =>
+    // iOS `will*` events fire before the animation (and don't exist on Android);
+    // Android only fires the `did*` pair. Pick the right ones per platform.
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillChangeFrame' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+    const onShow = Keyboard.addListener(showEvent, (event) =>
       setKeyboardHeight(Math.max(0, windowHeight - event.endCoordinates.screenY)),
     );
-    const onHide = Keyboard.addListener('keyboardWillHide', () => setKeyboardHeight(0));
+    const onHide = Keyboard.addListener(hideEvent, () => setKeyboardHeight(0));
     return () => {
       onShow.remove();
       onHide.remove();
@@ -245,8 +249,9 @@ export function ClimbReactionMenu({
         </Animated.View>
 
         {/* Floating content: enlarged climb + action menu. box-none so empty space
-            falls through to the backdrop Pressable. */}
-        <Animated.View
+            falls through to the backdrop Pressable. Plain View — the animated nodes
+            are the inner preview and menu wrap. */}
+        <View
           pointerEvents="box-none"
           // Contain VoiceOver focus to the floating content (don't let it wander into
           // the screen behind), and let the VO escape gesture pop the view / dismiss.
@@ -339,7 +344,7 @@ export function ClimbReactionMenu({
               )}
             </GlassSurface>
           </Animated.View>
-        </Animated.View>
+        </View>
       </View>
     </OverlayPortal>
   );

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -152,18 +152,19 @@ export function ClimbReactionMenu({
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   useEffect(() => {
     // iOS `will*` events fire before the animation (and don't exist on Android);
-    // Android only fires the `did*` pair. Pick the right ones per platform.
+    // Android only fires the `did*` pair. Read the keyboard height straight off the
+    // event (absolute — no windowHeight), so empty deps: on Android `adjustResize`
+    // the keyboard shrinks windowHeight, and a windowHeight dep would tear down and
+    // re-register this listener mid-event and miss it.
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillChangeFrame' : 'keyboardDidShow';
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
-    const onShow = Keyboard.addListener(showEvent, (event) =>
-      setKeyboardHeight(Math.max(0, windowHeight - event.endCoordinates.screenY)),
-    );
+    const onShow = Keyboard.addListener(showEvent, (event) => setKeyboardHeight(event.endCoordinates?.height ?? 0));
     const onHide = Keyboard.addListener(hideEvent, () => setKeyboardHeight(0));
     return () => {
       onShow.remove();
       onHide.remove();
     };
-  }, [windowHeight]);
+  }, []);
 
   // Enlarged board art, reusing the list thumbnail's cache (filledStyle + renderWidth
   // 400) so no new render is needed. Sized to the screen so it stays "blown up" but

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -238,46 +238,46 @@ export function ClimbReactionMenu({
             contentKeyboardStyle,
           ]}
         >
-          {view === 'menu' ? (
-            <Animated.View pointerEvents="box-none" style={[styles.preview, previewStyle]}>
-              {boardRenderData && artStyle ? (
-                <BoardImageNative
-                  frames={climb.frames}
-                  boardName={boardConfig.boardName as BoardName}
-                  layoutId={boardConfig.layoutId}
-                  sizeId={boardConfig.sizeId}
-                  setIds={boardConfig.setIds}
-                  boardWidth={boardRenderData.boardWidth}
-                  boardHeight={boardRenderData.boardHeight}
-                  mirrored={climb.mirrored === true}
-                  filledStyle
-                  renderWidth={400}
-                  style={artStyle}
+          {/* The enlarged climb stays visible in both views — the playlist picker
+              replaces the action list below it, not the climb itself. */}
+          <Animated.View pointerEvents="box-none" style={[styles.preview, previewStyle]}>
+            {boardRenderData && artStyle ? (
+              <BoardImageNative
+                frames={climb.frames}
+                boardName={boardConfig.boardName as BoardName}
+                layoutId={boardConfig.layoutId}
+                sizeId={boardConfig.sizeId}
+                setIds={boardConfig.setIds}
+                boardWidth={boardRenderData.boardWidth}
+                boardHeight={boardRenderData.boardHeight}
+                mirrored={climb.mirrored === true}
+                filledStyle
+                renderWidth={400}
+                style={artStyle}
+              />
+            ) : null}
+            <View style={styles.previewText}>
+              <View style={styles.nameRow}>
+                <Text variant="headline" numberOfLines={1} style={styles.name}>
+                  {climb.name}
+                </Text>
+                <ClimbAttributeIcons
+                  benchmarkDifficulty={climb.benchmark_difficulty}
+                  characteristics={climb.characteristics}
                 />
-              ) : null}
-              <View style={styles.previewText}>
-                <View style={styles.nameRow}>
-                  <Text variant="headline" numberOfLines={1} style={styles.name}>
-                    {climb.name}
-                  </Text>
-                  <ClimbAttributeIcons
-                    benchmarkDifficulty={climb.benchmark_difficulty}
-                    characteristics={climb.characteristics}
-                  />
-                  {formattedGrade || climb.difficulty ? (
-                    <Text variant="headline" numberOfLines={1} style={[styles.grade, { color: gradeColor }]}>
-                      {formattedGrade ?? climb.difficulty}
-                    </Text>
-                  ) : null}
-                </View>
-                {byline ? (
-                  <Text variant="footnote" numberOfLines={1} style={styles.byline}>
-                    {byline}
+                {formattedGrade || climb.difficulty ? (
+                  <Text variant="headline" numberOfLines={1} style={[styles.grade, { color: gradeColor }]}>
+                    {formattedGrade ?? climb.difficulty}
                   </Text>
                 ) : null}
               </View>
-            </Animated.View>
-          ) : null}
+              {byline ? (
+                <Text variant="footnote" numberOfLines={1} style={styles.byline}>
+                  {byline}
+                </Text>
+              ) : null}
+            </View>
+          </Animated.View>
 
           <Animated.View style={[styles.menuWrap, menuStyle]}>
             <GlassSurface role="base" level="level2" borderRadius={borderRadius.xl} style={styles.menuCard}>

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -181,11 +181,15 @@ export function ClimbReactionMenu({
   // bottom safe area now that the content is top-aligned rather than centered.
   const contentTopOffset = Math.round(windowHeight * 0.06);
 
-  // Cap the menu so preview + menu always fit; it scrolls internally if the action
-  // list is long on a short screen.
+  // Cap the menu/picker so it fills all the way down to the bottom safe area — no
+  // taller (it would clip past it), no shorter (wasting vertical space). Measure
+  // the preview's real height rather than reserving a fixed guess; fall back to an
+  // estimate until the first layout. The card scrolls internally past this cap.
+  const [previewHeight, setPreviewHeight] = useState(0);
+  const reservedForPreview = previewHeight > 0 ? previewHeight : artMaxSize + spacing[5] * 4;
   const menuMaxHeight = Math.max(
     180,
-    windowHeight - insets.top - insets.bottom - contentTopOffset - artMaxSize - 140 - spacing[5],
+    windowHeight - insets.top - insets.bottom - contentTopOffset - spacing[5] * 2 - reservedForPreview,
   );
 
   const backdropStyle = useAnimatedStyle(() => ({ opacity: progress.value }));
@@ -247,8 +251,13 @@ export function ClimbReactionMenu({
           ]}
         >
           {/* The enlarged climb stays visible in both views — the playlist picker
-              replaces the action list below it, not the climb itself. */}
-          <Animated.View pointerEvents="box-none" style={[styles.preview, previewStyle]}>
+              replaces the action list below it, not the climb itself. onLayout
+              feeds the real preview height into the menu/picker cap. */}
+          <Animated.View
+            pointerEvents="box-none"
+            onLayout={(event) => setPreviewHeight(event.nativeEvent.layout.height)}
+            style={[styles.preview, previewStyle]}
+          >
             {boardRenderData && artStyle ? (
               <BoardImageNative
                 frames={climb.frames}

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -289,24 +289,27 @@ export function ClimbReactionMenu({
 
           <Animated.View style={[styles.menuWrap, menuStyle]}>
             <GlassSurface role="base" level="level2" borderRadius={borderRadius.xl} style={styles.menuCard}>
-              <ScrollView
-                style={{ maxHeight: menuMaxHeight }}
-                bounces={false}
-                showsVerticalScrollIndicator={false}
-                keyboardShouldPersistTaps="handled"
-                contentContainerStyle={styles.menuContent}
-              >
-                {view === 'playlist' ? (
-                  <InlinePlaylistPicker
-                    climb={climb}
-                    angle={boardConfig.angle}
-                    boardName={boardConfig.boardName as BoardName}
-                    layoutId={boardConfig.layoutId}
-                    TextInputComponent={TextInput}
-                    onBack={backToMenu}
-                  />
-                ) : (
-                  actions.map((action, index) => (
+              {view === 'playlist' ? (
+                // The picker pins its own header and scrolls the list within
+                // menuMaxHeight, so "back" stays put however far you scroll.
+                <InlinePlaylistPicker
+                  climb={climb}
+                  angle={boardConfig.angle}
+                  boardName={boardConfig.boardName as BoardName}
+                  layoutId={boardConfig.layoutId}
+                  TextInputComponent={TextInput}
+                  onBack={backToMenu}
+                  maxHeight={menuMaxHeight}
+                />
+              ) : (
+                <ScrollView
+                  style={{ maxHeight: menuMaxHeight }}
+                  bounces={false}
+                  showsVerticalScrollIndicator={false}
+                  keyboardShouldPersistTaps="handled"
+                  contentContainerStyle={styles.menuContent}
+                >
+                  {actions.map((action, index) => (
                     <ListRow
                       key={action.id}
                       title={action.title}
@@ -315,9 +318,9 @@ export function ClimbReactionMenu({
                       showSeparator={index < actions.length - 1}
                       separatorInset={56}
                     />
-                  ))
-                )}
-              </ScrollView>
+                  ))}
+                </ScrollView>
+              )}
             </GlassSurface>
           </Animated.View>
         </Animated.View>

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  Keyboard,
   Modal,
   Platform,
   Pressable,
@@ -10,14 +11,7 @@ import {
   useWindowDimensions,
   type ViewStyle,
 } from 'react-native';
-import Animated, {
-  runOnJS,
-  useAnimatedKeyboard,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-  withTiming,
-} from 'react-native-reanimated';
+import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withSpring, withTiming } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import { BlurView } from '@react-native-community/blur';
 import { FullWindowOverlay } from 'react-native-screens';
@@ -152,10 +146,30 @@ export function ClimbReactionMenu({
     return parts.join(' · ');
   }, [climb.is_draft, climb.ascensionist_count, climb.quality_average, climb.setter_username, t]);
 
+  // Track the keyboard height (the inline create form focuses a TextInput). When it's
+  // up, the card's bottom must sit at the keyboard's top (not the screen's), and the
+  // climb art shrinks so the preview + form still fit above it on shorter phones.
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+  useEffect(() => {
+    const onShow = Keyboard.addListener('keyboardWillChangeFrame', (event) =>
+      setKeyboardHeight(Math.max(0, windowHeight - event.endCoordinates.screenY)),
+    );
+    const onHide = Keyboard.addListener('keyboardWillHide', () => setKeyboardHeight(0));
+    return () => {
+      onShow.remove();
+      onHide.remove();
+    };
+  }, [windowHeight]);
+
   // Enlarged board art, reusing the list thumbnail's cache (filledStyle + renderWidth
   // 400) so no new render is needed. Sized to the screen so it stays "blown up" but
-  // leaves room for the menu (~20% larger than the first pass).
-  const artMaxSize = Math.min(235, Math.round(windowHeight * 0.31), Math.round(windowWidth * 0.66));
+  // leaves room for the menu (~20% larger than the first pass); shrunk while the
+  // keyboard is up so the create form clears it.
+  const artMaxSize = Math.min(
+    keyboardHeight > 0 ? Math.round(windowHeight * 0.18) : 235,
+    Math.round(windowHeight * 0.31),
+    Math.round(windowWidth * 0.66),
+  );
   const boardRenderData = useMemo(() => {
     const setIdValues = boardConfig.setIds
       .split(',')
@@ -181,15 +195,17 @@ export function ClimbReactionMenu({
   // bottom safe area now that the content is top-aligned rather than centered.
   const contentTopOffset = Math.round(windowHeight * 0.06);
 
-  // Cap the menu/picker so it fills all the way down to the bottom safe area — no
-  // taller (it would clip past it), no shorter (wasting vertical space). Measure
-  // the preview's real height rather than reserving a fixed guess; fall back to an
-  // estimate until the first layout. The card scrolls internally past this cap.
+  // Cap the menu/picker so it fills down to the bottom safe area — no taller (it
+  // would clip past it), no shorter (wasting vertical space) — and no lower than
+  // the keyboard when one is up. Measure the preview's real height rather than
+  // reserving a fixed guess; fall back to an estimate until the first layout. The
+  // card scrolls internally past this cap.
   const [previewHeight, setPreviewHeight] = useState(0);
   const reservedForPreview = previewHeight > 0 ? previewHeight : artMaxSize + spacing[5] * 4;
+  const bottomReserve = keyboardHeight > 0 ? keyboardHeight : insets.bottom + spacing[5];
   const menuMaxHeight = Math.max(
     180,
-    windowHeight - insets.top - insets.bottom - contentTopOffset - spacing[5] * 2 - reservedForPreview,
+    windowHeight - insets.top - contentTopOffset - spacing[5] - reservedForPreview - bottomReserve,
   );
 
   const backdropStyle = useAnimatedStyle(() => ({ opacity: progress.value }));
@@ -200,14 +216,6 @@ export function ClimbReactionMenu({
   const menuStyle = useAnimatedStyle(() => ({
     opacity: progress.value,
     transform: [{ translateY: (1 - progress.value) * 18 }, { scale: 0.96 + progress.value * 0.04 }],
-  }));
-
-  // The inline create form's TextInput lives in this FullWindowOverlay. Re-centre
-  // the floating content in the space left above the keyboard (shifting centered
-  // content up by half the keyboard height keeps it centred in the visible band).
-  const keyboard = useAnimatedKeyboard();
-  const contentKeyboardStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: -keyboard.height.value / 2 }],
   }));
 
   const scrimColor = colorScheme === 'dark' ? 'rgba(0,0,0,0.5)' : 'rgba(0,0,0,0.35)';
@@ -247,7 +255,6 @@ export function ClimbReactionMenu({
           style={[
             styles.content,
             { paddingTop: insets.top + contentTopOffset, paddingBottom: insets.bottom + spacing[5] },
-            contentKeyboardStyle,
           ]}
         >
           {/* The enlarged climb stays visible in both views — the playlist picker

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -112,6 +112,8 @@ export function ClimbReactionMenu({
   }, [progress, reduceMotion, finishClose]);
 
   const backToMenu = useCallback(() => setView('menu'), []);
+  // Stable so useClimbActions' memo doesn't rebuild the action list every render.
+  const openPlaylist = useCallback(() => setView('playlist'), []);
 
   // Hardware back (Android) / VoiceOver escape: pop the playlist view first,
   // dismiss the whole overlay only from the top-level menu.
@@ -130,7 +132,7 @@ export function ClimbReactionMenu({
     isAuthenticated,
     onEditEntry,
     onAfterAction: dismiss,
-    onSelectPlaylist: () => setView('playlist'),
+    onSelectPlaylist: openPlaylist,
   });
 
   const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -1,15 +1,23 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Modal,
   Platform,
   Pressable,
   ScrollView,
   StyleSheet,
+  TextInput,
   View,
   useWindowDimensions,
   type ViewStyle,
 } from 'react-native';
-import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withSpring, withTiming } from 'react-native-reanimated';
+import Animated, {
+  runOnJS,
+  useAnimatedKeyboard,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import { BlurView } from '@react-native-community/blur';
 import { FullWindowOverlay } from 'react-native-screens';
@@ -22,6 +30,7 @@ import { ListRow } from '../ListRow';
 import { GlassSurface } from '../GlassSurface';
 import { BoardImageNative } from '../BoardImageNative';
 import { ClimbAttributeIcons } from '../ClimbAttributeIcons';
+import { InlinePlaylistPicker } from '../playlist/InlinePlaylistPicker';
 import { getBoardRenderData } from '../../lib/board-details';
 import { formatSends, formatQuality } from '../../lib/format-climb-stats';
 import { useGradeFormat } from '../../hooks/use-grade-format';
@@ -88,6 +97,9 @@ export function ClimbReactionMenu({
   const { formatGrade } = useGradeFormat();
 
   const progress = useSharedValue(0);
+  // 'menu' shows the action list; 'playlist' swaps the card to the inline
+  // playlist picker (no second sheet — that's the #3294 fix).
+  const [view, setView] = useState<'menu' | 'playlist'>('menu');
 
   const finishClose = useCallback(() => onClose(), [onClose]);
 
@@ -105,6 +117,18 @@ export function ClimbReactionMenu({
     });
   }, [progress, reduceMotion, finishClose]);
 
+  const backToMenu = useCallback(() => setView('menu'), []);
+
+  // Hardware back (Android) / VoiceOver escape: pop the playlist view first,
+  // dismiss the whole overlay only from the top-level menu.
+  const handleRequestClose = useCallback(() => {
+    if (view === 'playlist') {
+      backToMenu();
+      return;
+    }
+    dismiss();
+  }, [view, backToMenu, dismiss]);
+
   const actions = useClimbActions({
     climb,
     boardConfig,
@@ -112,6 +136,7 @@ export function ClimbReactionMenu({
     isAuthenticated,
     onEditEntry,
     onAfterAction: dismiss,
+    onSelectPlaylist: () => setView('playlist'),
   });
 
   const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
@@ -165,12 +190,22 @@ export function ClimbReactionMenu({
     transform: [{ translateY: (1 - progress.value) * 18 }, { scale: 0.96 + progress.value * 0.04 }],
   }));
 
+  // The inline create form's TextInput lives in this FullWindowOverlay. Re-centre
+  // the floating content in the space left above the keyboard (shifting centered
+  // content up by half the keyboard height keeps it centred in the visible band).
+  const keyboard = useAnimatedKeyboard();
+  const contentKeyboardStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: -keyboard.height.value / 2 }],
+  }));
+
   const scrimColor = colorScheme === 'dark' ? 'rgba(0,0,0,0.5)' : 'rgba(0,0,0,0.35)';
 
   return (
-    <OverlayPortal onRequestClose={dismiss}>
+    <OverlayPortal onRequestClose={handleRequestClose}>
       <View style={StyleSheet.absoluteFill}>
-        {/* Blurred / dimmed backdrop, tap to dismiss. */}
+        {/* Blurred / dimmed backdrop. Tapping it pops the playlist view back to
+            the menu first (matching the back button), and dismisses from the menu
+            — so a stray tap can't tear down a half-typed create form. */}
         <Animated.View style={[StyleSheet.absoluteFill, backdropStyle]}>
           {Platform.OS === 'ios' ? (
             <BlurView
@@ -183,7 +218,7 @@ export function ClimbReactionMenu({
           <View style={[StyleSheet.absoluteFill, { backgroundColor: scrimColor }]} />
           <Pressable
             style={StyleSheet.absoluteFill}
-            onPress={dismiss}
+            onPress={handleRequestClose}
             accessibilityRole="button"
             accessibilityLabel={climb.name}
           />
@@ -191,52 +226,58 @@ export function ClimbReactionMenu({
 
         {/* Floating content: enlarged climb + action menu. box-none so empty space
             falls through to the backdrop Pressable. */}
-        <View
+        <Animated.View
           pointerEvents="box-none"
           // Contain VoiceOver focus to the floating content (don't let it wander into
-          // the screen behind), and let the VO escape gesture dismiss the overlay.
+          // the screen behind), and let the VO escape gesture pop the view / dismiss.
           accessibilityViewIsModal={Platform.OS === 'ios'}
-          onAccessibilityEscape={dismiss}
-          style={[styles.content, { paddingTop: insets.top + spacing[5], paddingBottom: insets.bottom + spacing[5] }]}
+          onAccessibilityEscape={handleRequestClose}
+          style={[
+            styles.content,
+            { paddingTop: insets.top + spacing[5], paddingBottom: insets.bottom + spacing[5] },
+            contentKeyboardStyle,
+          ]}
         >
-          <Animated.View pointerEvents="box-none" style={[styles.preview, previewStyle]}>
-            {boardRenderData && artStyle ? (
-              <BoardImageNative
-                frames={climb.frames}
-                boardName={boardConfig.boardName as BoardName}
-                layoutId={boardConfig.layoutId}
-                sizeId={boardConfig.sizeId}
-                setIds={boardConfig.setIds}
-                boardWidth={boardRenderData.boardWidth}
-                boardHeight={boardRenderData.boardHeight}
-                mirrored={climb.mirrored === true}
-                filledStyle
-                renderWidth={400}
-                style={artStyle}
-              />
-            ) : null}
-            <View style={styles.previewText}>
-              <View style={styles.nameRow}>
-                <Text variant="headline" numberOfLines={1} style={styles.name}>
-                  {climb.name}
-                </Text>
-                <ClimbAttributeIcons
-                  benchmarkDifficulty={climb.benchmark_difficulty}
-                  characteristics={climb.characteristics}
+          {view === 'menu' ? (
+            <Animated.View pointerEvents="box-none" style={[styles.preview, previewStyle]}>
+              {boardRenderData && artStyle ? (
+                <BoardImageNative
+                  frames={climb.frames}
+                  boardName={boardConfig.boardName as BoardName}
+                  layoutId={boardConfig.layoutId}
+                  sizeId={boardConfig.sizeId}
+                  setIds={boardConfig.setIds}
+                  boardWidth={boardRenderData.boardWidth}
+                  boardHeight={boardRenderData.boardHeight}
+                  mirrored={climb.mirrored === true}
+                  filledStyle
+                  renderWidth={400}
+                  style={artStyle}
                 />
-                {formattedGrade || climb.difficulty ? (
-                  <Text variant="headline" numberOfLines={1} style={[styles.grade, { color: gradeColor }]}>
-                    {formattedGrade ?? climb.difficulty}
+              ) : null}
+              <View style={styles.previewText}>
+                <View style={styles.nameRow}>
+                  <Text variant="headline" numberOfLines={1} style={styles.name}>
+                    {climb.name}
+                  </Text>
+                  <ClimbAttributeIcons
+                    benchmarkDifficulty={climb.benchmark_difficulty}
+                    characteristics={climb.characteristics}
+                  />
+                  {formattedGrade || climb.difficulty ? (
+                    <Text variant="headline" numberOfLines={1} style={[styles.grade, { color: gradeColor }]}>
+                      {formattedGrade ?? climb.difficulty}
+                    </Text>
+                  ) : null}
+                </View>
+                {byline ? (
+                  <Text variant="footnote" numberOfLines={1} style={styles.byline}>
+                    {byline}
                   </Text>
                 ) : null}
               </View>
-              {byline ? (
-                <Text variant="footnote" numberOfLines={1} style={styles.byline}>
-                  {byline}
-                </Text>
-              ) : null}
-            </View>
-          </Animated.View>
+            </Animated.View>
+          ) : null}
 
           <Animated.View style={[styles.menuWrap, menuStyle]}>
             <GlassSurface role="base" level="level2" borderRadius={borderRadius.xl} style={styles.menuCard}>
@@ -244,22 +285,34 @@ export function ClimbReactionMenu({
                 style={{ maxHeight: menuMaxHeight }}
                 bounces={false}
                 showsVerticalScrollIndicator={false}
+                keyboardShouldPersistTaps="handled"
                 contentContainerStyle={styles.menuContent}
               >
-                {actions.map((action, index) => (
-                  <ListRow
-                    key={action.id}
-                    title={action.title}
-                    leading={<Icon name={action.icon} size={22} color={action.color} />}
-                    onPress={action.run}
-                    showSeparator={index < actions.length - 1}
-                    separatorInset={56}
+                {view === 'playlist' ? (
+                  <InlinePlaylistPicker
+                    climb={climb}
+                    angle={boardConfig.angle}
+                    boardName={boardConfig.boardName as BoardName}
+                    layoutId={boardConfig.layoutId}
+                    TextInputComponent={TextInput}
+                    onBack={backToMenu}
                   />
-                ))}
+                ) : (
+                  actions.map((action, index) => (
+                    <ListRow
+                      key={action.id}
+                      title={action.title}
+                      leading={<Icon name={action.icon} size={22} color={action.color} />}
+                      onPress={action.run}
+                      showSeparator={index < actions.length - 1}
+                      separatorInset={56}
+                    />
+                  ))
+                )}
               </ScrollView>
             </GlassSurface>
           </Animated.View>
-        </View>
+        </Animated.View>
       </View>
     </OverlayPortal>
   );

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -176,9 +176,17 @@ export function ClimbReactionMenu({
     return { width: fitted.width, height: fitted.height, borderRadius: borderRadius.lg, overflow: 'hidden' };
   }, [boardRenderData, artMaxSize]);
 
+  // Top offset for the floating content — anchors the preview at a fixed position
+  // (see styles.content). Shared with the menu cap so the card can't run past the
+  // bottom safe area now that the content is top-aligned rather than centered.
+  const contentTopOffset = Math.round(windowHeight * 0.06);
+
   // Cap the menu so preview + menu always fit; it scrolls internally if the action
   // list is long on a short screen.
-  const menuMaxHeight = Math.max(180, windowHeight - insets.top - insets.bottom - artMaxSize - 140 - spacing[5] * 2);
+  const menuMaxHeight = Math.max(
+    180,
+    windowHeight - insets.top - insets.bottom - contentTopOffset - artMaxSize - 140 - spacing[5],
+  );
 
   const backdropStyle = useAnimatedStyle(() => ({ opacity: progress.value }));
   const previewStyle = useAnimatedStyle(() => ({
@@ -234,7 +242,7 @@ export function ClimbReactionMenu({
           onAccessibilityEscape={handleRequestClose}
           style={[
             styles.content,
-            { paddingTop: insets.top + spacing[5], paddingBottom: insets.bottom + spacing[5] },
+            { paddingTop: insets.top + contentTopOffset, paddingBottom: insets.bottom + spacing[5] },
             contentKeyboardStyle,
           ]}
         >
@@ -326,7 +334,10 @@ const styles = StyleSheet.create({
     right: 0,
     bottom: 0,
     alignItems: 'center',
-    justifyContent: 'center',
+    // Anchor from the top, not centered: the climb preview keeps a fixed position
+    // whether the action list or the (shorter/taller) playlist picker sits below
+    // it, so switching views never shifts the climb up or down.
+    justifyContent: 'flex-start',
     paddingHorizontal: spacing[6],
     gap: spacing[5],
   },

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { Climb } from '@boardsesh/shared-schema';
+
+// Capture what ClimbReactionMenu passes into useClimbActions (so we can assert the
+// playlist action is wired to the inline view switch) and what the picker gets.
+const captured = vi.hoisted(() => ({
+  actionArgs: null as Record<string, unknown> | null,
+  pickerOnBack: undefined as undefined | (() => void),
+  modalOnRequestClose: undefined as undefined | (() => void),
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android', select: (o: Record<string, unknown>) => o.android },
+  Keyboard: { addListener: () => ({ remove: () => {} }) },
+  Modal: ({ children, onRequestClose }: { children?: ReactNode; onRequestClose?: () => void }) => {
+    captured.modalOnRequestClose = onRequestClose;
+    return createElement('div', { 'data-modal': 'true' }, children);
+  },
+  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { onClick: onPress }, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  TextInput: () => null,
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (s: Record<string, unknown>) => s, absoluteFill: {}, hairlineWidth: 1 },
+  useWindowDimensions: () => ({ width: 400, height: 800 }),
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
+  useAnimatedStyle: () => ({}),
+  useSharedValue: (v: number) => ({ value: v }),
+  withSpring: (v: number) => v,
+  withTiming: (v: number) => v,
+  runOnJS: (fn: () => void) => fn,
+}));
+
+vi.mock('@react-native-community/blur', () => ({ BlurView: () => null }));
+vi.mock('react-native-screens', () => ({
+  FullWindowOverlay: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('@boardsesh/board-constants/grade-colors', () => ({
+  getGradeColor: () => '#fff',
+  DEFAULT_GRADE_COLOR: '#fff',
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => null }));
+vi.mock('../../ListRow', () => ({
+  ListRow: ({ title, onPress }: { title: string; onPress?: () => void }) =>
+    createElement('button', { onClick: onPress, 'aria-label': title }, title),
+}));
+vi.mock('../../GlassSurface', () => ({
+  GlassSurface: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../BoardImageNative', () => ({ BoardImageNative: () => null }));
+vi.mock('../../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => null }));
+vi.mock('../../playlist/InlinePlaylistPicker', () => ({
+  InlinePlaylistPicker: ({ onBack }: { onBack?: () => void }) => {
+    captured.pickerOnBack = onBack;
+    return createElement('div', { 'data-picker': 'true' }, 'picker');
+  },
+}));
+vi.mock('../../../lib/board-details', () => ({ getBoardRenderData: () => null }));
+vi.mock('../../../lib/format-climb-stats', () => ({ formatSends: () => '', formatQuality: () => '' }));
+vi.mock('../../../hooks/use-grade-format', () => ({ useGradeFormat: () => ({ formatGrade: () => 'V4' }) }));
+vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ colorScheme: 'dark' }) }));
+vi.mock('../../../theme/animations', () => ({ springs: { gentle: {} }, timing: { fast: 150 } }));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 5: 20, 6: 24 },
+  borderRadius: { lg: 12, xl: 16 },
+}));
+
+// The playlist action's run() calls onSelectPlaylist (mirroring the real hook), so
+// tapping it drives the view switch we want to test.
+vi.mock('../use-climb-actions', () => ({
+  useClimbActions: (args: Record<string, unknown>) => {
+    captured.actionArgs = args;
+    return [
+      { id: 'preview', title: 'Preview', icon: 'visibility', color: '#00f', run: () => {} },
+      {
+        id: 'playlist',
+        title: 'Add to Playlist',
+        icon: 'playlist',
+        color: '#00f',
+        run: () => (args.onSelectPlaylist as (() => void) | undefined)?.(),
+      },
+    ];
+  },
+}));
+
+import { ClimbReactionMenu } from '../ClimbReactionMenu';
+
+const climb = { uuid: 'climb-1', name: 'Big Move', frames: '', difficulty: 'V4', quality_average: '0' } as Climb;
+const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
+
+function renderMenu(onClose = vi.fn()) {
+  return {
+    onClose,
+    ...render(
+      <ClimbReactionMenu
+        climb={climb}
+        boardConfig={boardConfig as never}
+        isAuthenticated
+        reduceMotion
+        onClose={onClose}
+      />,
+    ),
+  };
+}
+
+describe('ClimbReactionMenu view switching', () => {
+  beforeEach(() => {
+    captured.actionArgs = null;
+    captured.pickerOnBack = undefined;
+    captured.modalOnRequestClose = undefined;
+  });
+
+  it('renders the action list first and swaps to the inline picker when the playlist action runs', () => {
+    const { getByLabelText, queryByLabelText, container } = renderMenu();
+    // Menu view: actions present, no picker.
+    expect(getByLabelText('Add to Playlist')).not.toBeNull();
+    expect(container.querySelector('[data-picker="true"]')).toBeNull();
+
+    // Tapping the playlist action → onSelectPlaylist → view 'playlist'.
+    act(() => {
+      fireEvent.click(getByLabelText('Add to Playlist'));
+    });
+    expect(container.querySelector('[data-picker="true"]')).not.toBeNull();
+    expect(queryByLabelText('Add to Playlist')).toBeNull();
+  });
+
+  it('returns to the action list when the picker calls onBack', () => {
+    const { getByLabelText, container } = renderMenu();
+    act(() => fireEvent.click(getByLabelText('Add to Playlist')));
+    expect(container.querySelector('[data-picker="true"]')).not.toBeNull();
+
+    act(() => captured.pickerOnBack?.());
+    expect(container.querySelector('[data-picker="true"]')).toBeNull();
+    expect(getByLabelText('Add to Playlist')).not.toBeNull();
+  });
+
+  it('hardware back dismisses from the menu but only pops the picker from the playlist view', () => {
+    const { getByLabelText, onClose, container } = renderMenu();
+
+    // From the playlist view, back pops to the menu without dismissing.
+    act(() => fireEvent.click(getByLabelText('Add to Playlist')));
+    act(() => captured.modalOnRequestClose?.());
+    expect(onClose).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-picker="true"]')).toBeNull();
+
+    // From the menu, back dismisses the whole overlay (reduceMotion → immediate).
+    act(() => captured.modalOnRequestClose?.());
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
@@ -143,6 +143,19 @@ describe('useClimbActions colours and dispatch', () => {
     expect(openers.openAddToPlaylist).toHaveBeenCalledWith(climb, kilterBoard);
   });
 
+  it('playlist.run calls onSelectPlaylist (inline) instead of opening the sheet when provided', () => {
+    const onSelectPlaylist = vi.fn();
+    const onAfterAction = vi.fn();
+    const { result } = renderHook(() =>
+      useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false, onSelectPlaylist, onAfterAction }),
+    );
+    result.current.find((action) => action.id === 'playlist')?.run();
+    expect(onSelectPlaylist).toHaveBeenCalledTimes(1);
+    // Inline host keeps the overlay up — no sheet, no dismiss.
+    expect(openers.openAddToPlaylist).not.toHaveBeenCalled();
+    expect(onAfterAction).not.toHaveBeenCalled();
+  });
+
   it('share.run opens the native share sheet', () => {
     const { result } = renderHook(() => useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false }));
     result.current.find((action) => action.id === 'share')?.run();

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -65,6 +65,13 @@ type UseClimbActionsArgs = {
   onEditEntry?: () => void;
   /** Run after any action fires. The sheet passes its `onClose`; the native menu omits it. */
   onAfterAction?: () => void;
+  /**
+   * When provided, the "Add to playlist" action runs this INSTEAD of opening the
+   * `AddToPlaylistSheet` (and does NOT dismiss). The reaction overlay passes a
+   * view-switcher so it can host the picker inline — stacking a second native
+   * sheet dismisses the first (#3294). Omit it and playlist opens the sheet.
+   */
+  onSelectPlaylist?: () => void;
 };
 
 // Mirrors web's constructClimbInfoUrl: Kilter no longer has a public app URL.
@@ -81,6 +88,7 @@ export function useClimbActions({
   isAuthenticated,
   onEditEntry,
   onAfterAction,
+  onSelectPlaylist,
 }: UseClimbActionsArgs): ClimbActionItem[] {
   const { t } = useTranslation('climbs');
   const router = useRouter();
@@ -177,6 +185,12 @@ export function useClimbActions({
       icon: 'playlist',
       color: accentColor,
       run: () => {
+        // Inline host (reaction overlay) keeps the overlay up and swaps to its
+        // playlist view; otherwise fall back to the bottom sheet.
+        if (onSelectPlaylist) {
+          onSelectPlaylist();
+          return;
+        }
         openAddToPlaylist(climb, boardConfig);
         after();
       },
@@ -331,6 +345,7 @@ export function useClimbActions({
     currentUserId,
     isAuthenticated,
     onEditEntry,
+    onSelectPlaylist,
     after,
     t,
     actionColors,

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useState, type ComponentType } from 'react';
-import { ActivityIndicator, Pressable, StyleSheet, View, type TextInputProps } from 'react-native';
+import { useCallback, useMemo, useState, type ComponentType, type ReactNode } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, View, type TextInputProps } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
@@ -45,7 +45,28 @@ type InlinePlaylistPickerProps = {
   /** Rendered on the left of the header when the host wants a back affordance
    *  (the reaction overlay returns to its action list; the sheet omits it). */
   onBack?: () => void;
+  /** When set, the header (with the back button) is pinned and the body scrolls
+   *  within this height — so scrolling a long playlist list never hides "back".
+   *  Omit in a sheet host, whose own scroll view already scrolls the whole body. */
+  maxHeight?: number;
 };
+
+// Pins the header: when a maxHeight is given the body scrolls inside it, otherwise
+// the body renders inline (a sheet host provides the scroll). `flexShrink` bounds
+// the ScrollView to the space left under the pinned header within maxHeight.
+function ScrollableBody({ maxHeight, children }: { maxHeight?: number; children: ReactNode }) {
+  if (maxHeight == null) return <>{children}</>;
+  return (
+    <ScrollView
+      style={styles.scrollBody}
+      keyboardShouldPersistTaps="handled"
+      showsVerticalScrollIndicator={false}
+      bounces={false}
+    >
+      {children}
+    </ScrollView>
+  );
+}
 
 /**
  * Membership-aware "add to playlist" body: a toggle list (checkmark = the climb
@@ -65,6 +86,7 @@ export function InlinePlaylistPicker({
   layoutId,
   TextInputComponent,
   onBack,
+  maxHeight,
 }: InlinePlaylistPickerProps) {
   const { t } = useTranslation('climbs');
   const { t: tc } = useTranslation('common');
@@ -264,7 +286,7 @@ export function InlinePlaylistPicker({
   );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, maxHeight != null ? { maxHeight } : null]}>
       <View style={styles.header}>
         {onBack ? (
           <Pressable
@@ -295,154 +317,156 @@ export function InlinePlaylistPicker({
         ) : null}
       </View>
 
-      {createOpen ? (
-        <View style={styles.createForm}>
-          <TextInputComponent
-            value={name}
-            onChangeText={(text) => {
-              setCreateError(null);
-              setName(text);
-            }}
-            placeholder={t('actions.playlist.create.namePlaceholder')}
-            placeholderTextColor={systemColors.tertiaryLabel}
-            maxLength={NAME_MAX}
-            style={inputStyle}
-            returnKeyType="done"
-            autoFocus
-            onSubmitEditing={() => {
-              void handleSubmitCreate();
-            }}
-          />
-          <View style={styles.swatchRow}>
-            {PLAYLIST_COLORS.map((swatch) => {
-              const selected = color === swatch;
-              return (
-                <Pressable
-                  key={swatch}
-                  onPress={() => setColor(selected ? undefined : swatch)}
-                  accessibilityRole="button"
-                  accessibilityState={{ selected }}
-                  style={[
-                    styles.swatch,
-                    { backgroundColor: swatch, borderColor: systemColors.separator },
-                    selected && styles.swatchSelected,
-                  ]}
-                >
-                  {selected ? <Icon name="check.small" size={14} color={iosSystemColors.white} /> : null}
-                </Pressable>
-              );
-            })}
-          </View>
-          <View style={styles.emojiRow}>
-            {QUICK_EMOJI.map((preset) => {
-              const selected = icon === preset;
-              return (
-                <Pressable
-                  key={preset}
-                  onPress={() => setIcon(selected ? undefined : preset)}
-                  accessibilityRole="button"
-                  accessibilityState={{ selected }}
-                  style={[
-                    styles.emojiChip,
-                    { backgroundColor: systemColors.fill },
-                    selected && [styles.emojiChipSelected, { borderColor: brandColors.primary }],
-                  ]}
-                >
-                  <Text style={styles.emoji} allowFontScaling={false}>
-                    {preset}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </View>
-          {createError ? (
-            <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
-              {createError}
-            </Text>
-          ) : null}
-          <View style={styles.createActions}>
-            <Pressable
-              onPress={handleCloseCreate}
-              accessibilityRole="button"
-              accessibilityLabel={tc('actions.cancel')}
-              hitSlop={8}
-              style={styles.cancelButton}
-              disabled={submitting}
-            >
-              <Text variant="body" color={systemColors.secondaryLabel}>
-                {tc('actions.cancel')}
-              </Text>
-            </Pressable>
-            <Pressable
-              onPress={() => {
+      <ScrollableBody maxHeight={maxHeight}>
+        {createOpen ? (
+          <View style={styles.createForm}>
+            <TextInputComponent
+              value={name}
+              onChangeText={(text) => {
+                setCreateError(null);
+                setName(text);
+              }}
+              placeholder={t('actions.playlist.create.namePlaceholder')}
+              placeholderTextColor={systemColors.tertiaryLabel}
+              maxLength={NAME_MAX}
+              style={inputStyle}
+              returnKeyType="done"
+              autoFocus
+              onSubmitEditing={() => {
                 void handleSubmitCreate();
               }}
-              accessibilityRole="button"
-              accessibilityLabel={t('actions.playlist.create.submit')}
-              hitSlop={8}
-              style={[styles.submitButton, { backgroundColor: brandColors.primary }]}
-              disabled={submitting}
-            >
-              {submitting ? (
-                <ActivityIndicator color={iosSystemColors.white} />
-              ) : (
-                <Text variant="body" color={iosSystemColors.white} style={styles.submitLabel}>
-                  {t('actions.playlist.create.submit')}
+            />
+            <View style={styles.swatchRow}>
+              {PLAYLIST_COLORS.map((swatch) => {
+                const selected = color === swatch;
+                return (
+                  <Pressable
+                    key={swatch}
+                    onPress={() => setColor(selected ? undefined : swatch)}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected }}
+                    style={[
+                      styles.swatch,
+                      { backgroundColor: swatch, borderColor: systemColors.separator },
+                      selected && styles.swatchSelected,
+                    ]}
+                  >
+                    {selected ? <Icon name="check.small" size={14} color={iosSystemColors.white} /> : null}
+                  </Pressable>
+                );
+              })}
+            </View>
+            <View style={styles.emojiRow}>
+              {QUICK_EMOJI.map((preset) => {
+                const selected = icon === preset;
+                return (
+                  <Pressable
+                    key={preset}
+                    onPress={() => setIcon(selected ? undefined : preset)}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected }}
+                    style={[
+                      styles.emojiChip,
+                      { backgroundColor: systemColors.fill },
+                      selected && [styles.emojiChipSelected, { borderColor: brandColors.primary }],
+                    ]}
+                  >
+                    <Text style={styles.emoji} allowFontScaling={false}>
+                      {preset}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            {createError ? (
+              <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
+                {createError}
+              </Text>
+            ) : null}
+            <View style={styles.createActions}>
+              <Pressable
+                onPress={handleCloseCreate}
+                accessibilityRole="button"
+                accessibilityLabel={tc('actions.cancel')}
+                hitSlop={8}
+                style={styles.cancelButton}
+                disabled={submitting}
+              >
+                <Text variant="body" color={systemColors.secondaryLabel}>
+                  {tc('actions.cancel')}
                 </Text>
-              )}
-            </Pressable>
-          </View>
-        </View>
-      ) : null}
-
-      {error ? (
-        <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
-          {error}
-        </Text>
-      ) : null}
-
-      {/* Hide the playlist list while the create form is open — the form takes
-          over the body rather than stacking above the existing playlists. */}
-      {!createOpen &&
-        (!isAuthenticated ? (
-          <View style={styles.message}>
-            <Text variant="subheadline" color={iosSystemColors.systemGray}>
-              {t('actions.playlist.popover.signInBlurb')}
-            </Text>
-          </View>
-        ) : isLoading && sortedPlaylists.length === 0 ? (
-          // Spinner only before the user's playlists are cached at all; once
-          // they're available we render immediately and checkmarks fill in.
-          <View style={styles.message}>
-            <ActivityIndicator />
-          </View>
-        ) : sortedPlaylists.length === 0 ? (
-          <View style={styles.message}>
-            <Text variant="subheadline" color={iosSystemColors.systemGray}>
-              {t('actions.playlist.popover.empty')}
-            </Text>
-          </View>
-        ) : (
-          sortedPlaylists.map((playlist, index) => {
-            const accent = playlist.color && isValidHexColor(playlist.color) ? playlist.color : brandColors.primary;
-            const member = members.has(playlist.uuid);
-            return (
-              <ListRow
-                key={playlist.id}
-                title={playlist.name}
-                subtitle={t('multiboardList.count', { count: playlist.climbCount })}
-                leading={<Icon name="playlist" size={22} color={accent} />}
-                trailing={member ? <Icon name="check.small" size={18} color={brandColors.primary} /> : undefined}
+              </Pressable>
+              <Pressable
                 onPress={() => {
-                  void handleToggle(playlist);
+                  void handleSubmitCreate();
                 }}
-                accessibilityLabel={playlist.name}
-                accessibilityHint={member ? t('actions.playlist.toast.removed') : t('actions.playlist.toast.added')}
-                showSeparator={index < sortedPlaylists.length - 1}
-              />
-            );
-          })
-        ))}
+                accessibilityRole="button"
+                accessibilityLabel={t('actions.playlist.create.submit')}
+                hitSlop={8}
+                style={[styles.submitButton, { backgroundColor: brandColors.primary }]}
+                disabled={submitting}
+              >
+                {submitting ? (
+                  <ActivityIndicator color={iosSystemColors.white} />
+                ) : (
+                  <Text variant="body" color={iosSystemColors.white} style={styles.submitLabel}>
+                    {t('actions.playlist.create.submit')}
+                  </Text>
+                )}
+              </Pressable>
+            </View>
+          </View>
+        ) : null}
+
+        {error ? (
+          <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
+            {error}
+          </Text>
+        ) : null}
+
+        {/* Hide the playlist list while the create form is open — the form takes
+          over the body rather than stacking above the existing playlists. */}
+        {!createOpen &&
+          (!isAuthenticated ? (
+            <View style={styles.message}>
+              <Text variant="subheadline" color={iosSystemColors.systemGray}>
+                {t('actions.playlist.popover.signInBlurb')}
+              </Text>
+            </View>
+          ) : isLoading && sortedPlaylists.length === 0 ? (
+            // Spinner only before the user's playlists are cached at all; once
+            // they're available we render immediately and checkmarks fill in.
+            <View style={styles.message}>
+              <ActivityIndicator />
+            </View>
+          ) : sortedPlaylists.length === 0 ? (
+            <View style={styles.message}>
+              <Text variant="subheadline" color={iosSystemColors.systemGray}>
+                {t('actions.playlist.popover.empty')}
+              </Text>
+            </View>
+          ) : (
+            sortedPlaylists.map((playlist, index) => {
+              const accent = playlist.color && isValidHexColor(playlist.color) ? playlist.color : brandColors.primary;
+              const member = members.has(playlist.uuid);
+              return (
+                <ListRow
+                  key={playlist.id}
+                  title={playlist.name}
+                  subtitle={t('multiboardList.count', { count: playlist.climbCount })}
+                  leading={<Icon name="playlist" size={22} color={accent} />}
+                  trailing={member ? <Icon name="check.small" size={18} color={brandColors.primary} /> : undefined}
+                  onPress={() => {
+                    void handleToggle(playlist);
+                  }}
+                  accessibilityLabel={playlist.name}
+                  accessibilityHint={member ? t('actions.playlist.toast.removed') : t('actions.playlist.toast.added')}
+                  showSeparator={index < sortedPlaylists.length - 1}
+                />
+              );
+            })
+          ))}
+      </ScrollableBody>
     </View>
   );
 }
@@ -450,6 +474,11 @@ export function InlinePlaylistPicker({
 const styles = StyleSheet.create({
   container: {
     width: '100%',
+  },
+  // Bounded by the container's maxHeight (minus the pinned header) so the list
+  // scrolls under the header rather than pushing it off-screen.
+  scrollBody: {
+    flexShrink: 1,
   },
   header: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -1,5 +1,16 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType, type ReactNode } from 'react';
-import { ActivityIndicator, Pressable, ScrollView, StyleSheet, View, type TextInputProps } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+  type FlatListProps,
+  type LayoutChangeEvent,
+  type ListRenderItem,
+  type TextInputProps,
+} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
@@ -61,29 +72,17 @@ type InlinePlaylistPickerProps = {
   /** Rendered on the left of the header when the host wants a back affordance
    *  (the reaction overlay returns to its action list; the sheet omits it). */
   onBack?: () => void;
-  /** When set, the header (with the back button) is pinned and the body scrolls
+  /** When set, the header (with the back button) is pinned and the list scrolls
    *  within this height — so scrolling a long playlist list never hides "back".
-   *  Omit in a sheet host, whose own scroll view already scrolls the whole body. */
+   *  Omit in a sheet host, whose own scroll already scrolls the body. */
   maxHeight?: number;
+  /** Virtualized list host for the playlist rows: the RN `FlatList` in the reaction
+   *  overlay (default), `BottomSheetFlatList` inside a `ModalSheet` so it scrolls
+   *  with the sheet. Injected rather than `.map`-ing rows in a ScrollView. */
+  ListComponent?: ComponentType<FlatListProps<Playlist>>;
 };
 
-// Pins the header: when a scroll height is given the body scrolls inside a
-// ScrollView capped at that explicit maxHeight (flexShrink alone doesn't bound a
-// ScrollView under a maxHeight-only parent — it would clip). Otherwise the body
-// renders inline and a sheet host provides the scroll.
-function ScrollableBody({ maxHeight, children }: { maxHeight?: number; children: ReactNode }) {
-  if (maxHeight == null) return <>{children}</>;
-  return (
-    <ScrollView
-      style={{ maxHeight }}
-      keyboardShouldPersistTaps="handled"
-      showsVerticalScrollIndicator={false}
-      bounces={false}
-    >
-      {children}
-    </ScrollView>
-  );
-}
+const playlistKey = (playlist: Playlist) => playlist.id;
 
 /**
  * Membership-aware "add to playlist" body: a toggle list (checkmark = the climb
@@ -104,6 +103,7 @@ export function InlinePlaylistPicker({
   TextInputComponent,
   onBack,
   maxHeight,
+  ListComponent = FlatList,
 }: InlinePlaylistPickerProps) {
   const { t } = useTranslation('climbs');
   const { t: tc } = useTranslation('common');
@@ -338,10 +338,34 @@ export function InlinePlaylistPicker({
   // the list scrolls (not clips) whatever the header's height.
   const [headerHeight, setHeaderHeight] = useState(0);
   const scrollMaxHeight = maxHeight != null ? Math.max(120, maxHeight - headerHeight) : undefined;
+  const onHeaderLayout = useCallback(
+    (event: LayoutChangeEvent) => setHeaderHeight(event.nativeEvent.layout.height),
+    [],
+  );
+
+  const renderPlaylistRow = useCallback<ListRenderItem<Playlist>>(
+    ({ item, index }) => {
+      const accent = item.color && isValidHexColor(item.color) ? item.color : brandColors.primary;
+      const member = members.has(item.uuid);
+      return (
+        <ListRow
+          title={item.name}
+          subtitle={t('multiboardList.count', { count: item.climbCount })}
+          leading={<Icon name="playlist" size={22} color={accent} />}
+          trailing={member ? <Icon name="check.small" size={18} color={brandColors.primary} /> : undefined}
+          onPress={() => void handleToggle(item)}
+          accessibilityLabel={item.name}
+          accessibilityHint={member ? t('actions.playlist.toast.removed') : t('actions.playlist.toast.added')}
+          showSeparator={index < sortedPlaylists.length - 1}
+        />
+      );
+    },
+    [sortedPlaylists, members, handleToggle, brandColors, t],
+  );
 
   return (
     <View style={[styles.container, maxHeight != null ? { maxHeight } : null]}>
-      <View style={styles.header} onLayout={(event) => setHeaderHeight(event.nativeEvent.layout.height)}>
+      <View style={styles.header} onLayout={onHeaderLayout}>
         {onBack ? (
           <Pressable
             onPress={onBack}
@@ -371,8 +395,13 @@ export function InlinePlaylistPicker({
         ) : null}
       </View>
 
-      <ScrollableBody maxHeight={scrollMaxHeight}>
-        {createOpen ? (
+      {createOpen ? (
+        <ScrollView
+          style={scrollMaxHeight != null ? { maxHeight: scrollMaxHeight } : undefined}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+          bounces={false}
+        >
           <View style={styles.createForm}>
             <TextInputComponent
               value={name}
@@ -470,57 +499,46 @@ export function InlinePlaylistPicker({
               </Pressable>
             </View>
           </View>
-        ) : null}
-
-        {error ? (
-          <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
-            {error}
+        </ScrollView>
+      ) : !isAuthenticated ? (
+        <View style={styles.message}>
+          <Text variant="subheadline" color={iosSystemColors.systemGray}>
+            {t('actions.playlist.popover.signInBlurb')}
           </Text>
-        ) : null}
-
-        {/* Hide the playlist list while the create form is open — the form takes
-          over the body rather than stacking above the existing playlists. */}
-        {!createOpen &&
-          (!isAuthenticated ? (
-            <View style={styles.message}>
-              <Text variant="subheadline" color={iosSystemColors.systemGray}>
-                {t('actions.playlist.popover.signInBlurb')}
+        </View>
+      ) : isLoading && sortedPlaylists.length === 0 ? (
+        // Spinner only before the user's playlists are cached at all; once they're
+        // available we render immediately and checkmarks fill in.
+        <View style={styles.message}>
+          <ActivityIndicator />
+        </View>
+      ) : (
+        // Virtualized (FlatList in the overlay, BottomSheetFlatList in a sheet) — a
+        // toggle-failure line rides in the header, the empty state in ListEmpty.
+        <ListComponent
+          data={sortedPlaylists}
+          keyExtractor={playlistKey}
+          renderItem={renderPlaylistRow}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+          bounces={false}
+          style={scrollMaxHeight != null ? { maxHeight: scrollMaxHeight } : undefined}
+          ListHeaderComponent={
+            error ? (
+              <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
+                {error}
               </Text>
-            </View>
-          ) : isLoading && sortedPlaylists.length === 0 ? (
-            // Spinner only before the user's playlists are cached at all; once
-            // they're available we render immediately and checkmarks fill in.
-            <View style={styles.message}>
-              <ActivityIndicator />
-            </View>
-          ) : sortedPlaylists.length === 0 ? (
+            ) : null
+          }
+          ListEmptyComponent={
             <View style={styles.message}>
               <Text variant="subheadline" color={iosSystemColors.systemGray}>
                 {t('actions.playlist.popover.empty')}
               </Text>
             </View>
-          ) : (
-            sortedPlaylists.map((playlist, index) => {
-              const accent = playlist.color && isValidHexColor(playlist.color) ? playlist.color : brandColors.primary;
-              const member = members.has(playlist.uuid);
-              return (
-                <ListRow
-                  key={playlist.id}
-                  title={playlist.name}
-                  subtitle={t('multiboardList.count', { count: playlist.climbCount })}
-                  leading={<Icon name="playlist" size={22} color={accent} />}
-                  trailing={member ? <Icon name="check.small" size={18} color={brandColors.primary} /> : undefined}
-                  onPress={() => {
-                    void handleToggle(playlist);
-                  }}
-                  accessibilityLabel={playlist.name}
-                  accessibilityHint={member ? t('actions.playlist.toast.removed') : t('actions.playlist.toast.added')}
-                  showSeparator={index < sortedPlaylists.length - 1}
-                />
-              );
-            })
-          ))}
-      </ScrollableBody>
+          }
+        />
+      )}
     </View>
   );
 }

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -27,6 +27,22 @@ import { NAME_MAX } from './playlist-form-values';
 // floating card.
 const QUICK_EMOJI = ['🔥', '💪', '🎯', '⭐', '🧗', '🪨', '🏆'] as const;
 
+// The subset of TextInput props the create form actually drives. Typing the
+// injected component against this (not full TextInputProps) lets both the RN
+// `TextInput` and @expo/ui's `BottomSheetTextInput` satisfy it without a cast.
+export type PickerTextInputProps = Pick<
+  TextInputProps,
+  | 'value'
+  | 'onChangeText'
+  | 'placeholder'
+  | 'placeholderTextColor'
+  | 'maxLength'
+  | 'style'
+  | 'returnKeyType'
+  | 'autoFocus'
+  | 'onSubmitEditing'
+>;
+
 type InlinePlaylistPickerProps = {
   climb: Climb;
   /** Angle the membership add targets (the climb's board config angle). */
@@ -41,7 +57,7 @@ type InlinePlaylistPickerProps = {
    * which is the whole point (#3294: stacking a second native sheet dismisses
    * the first).
    */
-  TextInputComponent: ComponentType<TextInputProps>;
+  TextInputComponent: ComponentType<PickerTextInputProps>;
   /** Rendered on the left of the header when the host wants a back affordance
    *  (the reaction overlay returns to its action list; the sheet omits it). */
   onBack?: () => void;
@@ -51,14 +67,15 @@ type InlinePlaylistPickerProps = {
   maxHeight?: number;
 };
 
-// Pins the header: when a maxHeight is given the body scrolls inside it, otherwise
-// the body renders inline (a sheet host provides the scroll). `flexShrink` bounds
-// the ScrollView to the space left under the pinned header within maxHeight.
+// Pins the header: when a scroll height is given the body scrolls inside a
+// ScrollView capped at that explicit maxHeight (flexShrink alone doesn't bound a
+// ScrollView under a maxHeight-only parent — it would clip). Otherwise the body
+// renders inline and a sheet host provides the scroll.
 function ScrollableBody({ maxHeight, children }: { maxHeight?: number; children: ReactNode }) {
   if (maxHeight == null) return <>{children}</>;
   return (
     <ScrollView
-      style={styles.scrollBody}
+      style={{ maxHeight }}
       keyboardShouldPersistTaps="handled"
       showsVerticalScrollIndicator={false}
       bounces={false}
@@ -313,9 +330,14 @@ export function InlinePlaylistPicker({
     [systemColors],
   );
 
+  // Bound the scroll area to the space left under the pinned header, measured so
+  // the list scrolls (not clips) whatever the header's height.
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const scrollMaxHeight = maxHeight != null ? Math.max(120, maxHeight - headerHeight) : undefined;
+
   return (
     <View style={[styles.container, maxHeight != null ? { maxHeight } : null]}>
-      <View style={styles.header}>
+      <View style={styles.header} onLayout={(event) => setHeaderHeight(event.nativeEvent.layout.height)}>
         {onBack ? (
           <Pressable
             onPress={onBack}
@@ -345,7 +367,7 @@ export function InlinePlaylistPicker({
         ) : null}
       </View>
 
-      <ScrollableBody maxHeight={maxHeight}>
+      <ScrollableBody maxHeight={scrollMaxHeight}>
         {createOpen ? (
           <View style={styles.createForm}>
             <TextInputComponent
@@ -502,11 +524,6 @@ export function InlinePlaylistPicker({
 const styles = StyleSheet.create({
   container: {
     width: '100%',
-  },
-  // Bounded by the container's maxHeight (minus the pinned header) so the list
-  // scrolls under the header rather than pushing it off-screen.
-  scrollBody: {
-    flexShrink: 1,
   },
   header: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -132,6 +132,10 @@ export function InlinePlaylistPicker({
     },
     enabled: isAuthenticated,
     staleTime: 30 * 1000,
+    // Optimistic toggle writes are the source of truth while the picker is open;
+    // don't let a focus/reconnect refetch land a stale response over a checkmark.
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 
   // Seed checkmarks from the shared membership store (the climb list populates it

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, type ComponentType, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType, type ReactNode } from 'react';
 import { ActivityIndicator, Pressable, ScrollView, StyleSheet, View, type TextInputProps } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -137,42 +137,53 @@ export function InlinePlaylistPicker({
     [queryClient, membershipKey, climb.uuid],
   );
 
+  // Serialize toggles per playlist: a row stays tappable while its mutation is in
+  // flight, so ignore repeat taps on the same row until it settles — otherwise a
+  // fast add-then-remove could reorder on the backend and leave the cache/UI out
+  // of sync with the row's real membership.
+  const togglingRef = useRef<Set<string>>(new Set());
+
   // Toggle one playlist's membership. Reads and writes are surgical — computed
-  // against the *latest* cache each time — so overlapping toggles (or a failure
-  // while another is in flight) never clobber each other. Rows are tappable before
-  // the membership fetch resolves, so cancel it first: a late response must not
-  // overwrite the optimistic checkmark.
+  // against the *latest* cache each time — so overlapping toggles of DIFFERENT rows
+  // never clobber each other. Rows are tappable before the membership fetch
+  // resolves, so cancel it first: a late response must not overwrite the checkmark.
   const handleToggle = useCallback(
     async (playlist: Playlist) => {
-      await queryClient.cancelQueries({ queryKey: membershipKey });
-      const before = queryClient.getQueryData<string[]>(membershipKey) ?? [...members];
-      const willBeMember = !before.includes(playlist.uuid);
-      setError(null);
-      writeMembership(willBeMember ? [...before, playlist.uuid] : before.filter((uuid) => uuid !== playlist.uuid));
+      if (togglingRef.current.has(playlist.uuid)) return;
+      togglingRef.current.add(playlist.uuid);
       try {
-        if (willBeMember) {
-          // The backend resolvers key on playlists.uuid, so the uuid (not the
-          // bigserial id) goes on the wire.
-          await addToPlaylist(playlist.uuid, climb.uuid, angle);
-        } else {
-          await removeFromPlaylist(playlist.uuid, climb.uuid);
+        await queryClient.cancelQueries({ queryKey: membershipKey });
+        const before = queryClient.getQueryData<string[]>(membershipKey) ?? [...members];
+        const willBeMember = !before.includes(playlist.uuid);
+        setError(null);
+        writeMembership(willBeMember ? [...before, playlist.uuid] : before.filter((uuid) => uuid !== playlist.uuid));
+        try {
+          if (willBeMember) {
+            // The backend resolvers key on playlists.uuid, so the uuid (not the
+            // bigserial id) goes on the wire.
+            await addToPlaylist(playlist.uuid, climb.uuid, angle);
+          } else {
+            await removeFromPlaylist(playlist.uuid, climb.uuid);
+          }
+        } catch (toggleError) {
+          // Undo ONLY this row's change against the current cache — not a stale
+          // snapshot — so a sibling toggle that succeeded meanwhile is preserved.
+          const current = queryClient.getQueryData<string[]>(membershipKey) ?? [];
+          writeMembership(
+            willBeMember ? current.filter((uuid) => uuid !== playlist.uuid) : [...new Set([...current, playlist.uuid])],
+          );
+          setError(t(willBeMember ? 'actions.playlist.toast.addFailed' : 'actions.playlist.toast.removeFailed'));
+          if (__DEV__) {
+            console.warn('[playlist] toggle membership failed', {
+              playlistUuid: playlist.uuid,
+              climbUuid: climb.uuid,
+              add: willBeMember,
+              error: toggleError,
+            });
+          }
         }
-      } catch (toggleError) {
-        // Undo ONLY this row's change against the current cache — not a stale
-        // snapshot — so a sibling toggle that succeeded meanwhile is preserved.
-        const current = queryClient.getQueryData<string[]>(membershipKey) ?? [];
-        writeMembership(
-          willBeMember ? current.filter((uuid) => uuid !== playlist.uuid) : [...new Set([...current, playlist.uuid])],
-        );
-        setError(t(willBeMember ? 'actions.playlist.toast.addFailed' : 'actions.playlist.toast.removeFailed'));
-        if (__DEV__) {
-          console.warn('[playlist] toggle membership failed', {
-            playlistUuid: playlist.uuid,
-            climbUuid: climb.uuid,
-            add: willBeMember,
-            error: toggleError,
-          });
-        }
+      } finally {
+        togglingRef.current.delete(playlist.uuid);
       }
     },
     [queryClient, membershipKey, members, writeMembership, addToPlaylist, removeFromPlaylist, climb.uuid, angle, t],
@@ -186,6 +197,13 @@ export function InlinePlaylistPicker({
   const [submitting, setSubmitting] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
 
+  // Guards the async create flow against cancel/unmount: each submit takes a token;
+  // cancelling the form or unmounting the picker bumps it, so an in-flight create's
+  // continuation (add + UI updates) aborts instead of adding the climb after the
+  // user backed out.
+  const createRequestIdRef = useRef(0);
+  useEffect(() => () => void (createRequestIdRef.current += 1), []);
+
   const resetCreate = useCallback(() => {
     setName('');
     setColor(undefined);
@@ -196,11 +214,15 @@ export function InlinePlaylistPicker({
   const handleOpenCreate = useCallback(() => {
     setError(null);
     resetCreate();
+    setSubmitting(false);
     setCreateOpen(true);
   }, [resetCreate]);
 
   const handleCloseCreate = useCallback(() => {
+    // Bump the token so an in-flight create's continuation aborts, then reset.
+    createRequestIdRef.current += 1;
     resetCreate();
+    setSubmitting(false);
     setCreateOpen(false);
   }, [resetCreate]);
 
@@ -212,6 +234,8 @@ export function InlinePlaylistPicker({
     }
     // No length check needed: the input caps at NAME_MAX (maxLength) and trim only
     // shortens, so the name can't exceed it.
+    const requestId = (createRequestIdRef.current += 1);
+    const isCurrent = () => createRequestIdRef.current === requestId;
     setSubmitting(true);
     setCreateError(null);
     // Create and add are separate operations with separate failure handling: if
@@ -222,8 +246,10 @@ export function InlinePlaylistPicker({
       created = await createPlaylist(trimmed, undefined, color, icon, { boardType: boardName, layoutId });
     } catch (submitError) {
       // Inline, not a toast — the picker (and its host overlay/sheet) stays up.
-      setCreateError(t('actions.playlist.toast.createFailed'));
-      setSubmitting(false);
+      if (isCurrent()) {
+        setCreateError(t('actions.playlist.toast.createFailed'));
+        setSubmitting(false);
+      }
       if (__DEV__) {
         console.warn('[playlist] inline create failed', {
           climbUuid: climb.uuid,
@@ -234,19 +260,23 @@ export function InlinePlaylistPicker({
       }
       return;
     }
+    // If the user cancelled / dismissed while the playlist was being created, stop:
+    // don't add the climb or touch UI they've left (the empty playlist may persist).
+    if (!isCurrent()) return;
     // Playlist exists now; close the form so a retry can't duplicate it. The new
     // (still-unchecked) playlist is already in the list to tap if the add fails.
     setCreateOpen(false);
     resetCreate();
     try {
       await addToPlaylist(created.uuid, climb.uuid, angle);
+      if (!isCurrent()) return;
       // Cancel any in-flight membership fetch (it was sent before this playlist
       // existed) so it can't overwrite the new checkmark, then optimistically add.
       await queryClient.cancelQueries({ queryKey: membershipKey });
       const current = queryClient.getQueryData<string[]>(membershipKey) ?? [...members];
       writeMembership([...new Set([...current, created.uuid])]);
     } catch (addError) {
-      setError(t('actions.playlist.toast.addFailed'));
+      if (isCurrent()) setError(t('actions.playlist.toast.addFailed'));
       if (__DEV__) {
         console.warn('[playlist] created playlist but failed to add climb', {
           playlistUuid: created.uuid,
@@ -255,7 +285,7 @@ export function InlinePlaylistPicker({
         });
       }
     } finally {
-      setSubmitting(false);
+      if (isCurrent()) setSubmitting(false);
     }
   }, [
     name,

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -11,6 +11,7 @@ import { playlistMembershipStore } from '@boardsesh/climb-actions';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { ListRow } from '../ListRow';
+import { useClimbPlaylistMemberships } from '../../hooks/use-climb-playlist-memberships';
 import { getHttpClient } from '../../lib/graphql/client';
 import { usePlaylistsContext, type Playlist } from '../../providers/playlists-provider';
 import { useTheme } from '../../providers/theme-provider';
@@ -82,7 +83,7 @@ export function InlinePlaylistPicker({
     () => ['playlistsForClimb', boardName, layoutId, climb.uuid] as const,
     [boardName, layoutId, climb.uuid],
   );
-  const { data: memberUuids, isLoading: membershipLoading } = useQuery({
+  const { data: memberUuids } = useQuery({
     queryKey: membershipKey,
     queryFn: async (): Promise<string[]> => {
       const response = await getHttpClient().request<GetPlaylistsForClimbQueryResponse>(GET_PLAYLISTS_FOR_CLIMB, {
@@ -94,7 +95,11 @@ export function InlinePlaylistPicker({
     staleTime: 30 * 1000,
   });
 
-  const members = useMemo(() => new Set(memberUuids ?? []), [memberUuids]);
+  // Seed checkmarks from the shared membership store (the climb list populates it
+  // when playlist tags are on) so they show instantly; the per-climb query then
+  // confirms. The list itself never waits on this fetch — no membership spinner.
+  const seededMembers = useClimbPlaylistMemberships(climb.uuid);
+  const members = useMemo(() => new Set(memberUuids ?? seededMembers), [memberUuids, seededMembers]);
 
   const [error, setError] = useState<string | null>(null);
 
@@ -110,12 +115,14 @@ export function InlinePlaylistPicker({
     [queryClient, membershipKey, climb.uuid],
   );
 
-  // Toggle one playlist's membership. Rows are gated behind the membership load
-  // below, so the initial fetch has resolved before any toggle. Reads and writes
-  // are surgical — computed against the *latest* cache each time — so overlapping
-  // toggles (or a failure while another is in flight) never clobber each other.
+  // Toggle one playlist's membership. Reads and writes are surgical — computed
+  // against the *latest* cache each time — so overlapping toggles (or a failure
+  // while another is in flight) never clobber each other. Rows are tappable before
+  // the membership fetch resolves, so cancel it first: a late response must not
+  // overwrite the optimistic checkmark.
   const handleToggle = useCallback(
     async (playlist: Playlist) => {
+      await queryClient.cancelQueries({ queryKey: membershipKey });
       const before = queryClient.getQueryData<string[]>(membershipKey) ?? [...members];
       const willBeMember = !before.includes(playlist.uuid);
       setError(null);
@@ -403,7 +410,9 @@ export function InlinePlaylistPicker({
               {t('actions.playlist.popover.signInBlurb')}
             </Text>
           </View>
-        ) : isLoading || membershipLoading ? (
+        ) : isLoading && sortedPlaylists.length === 0 ? (
+          // Spinner only before the user's playlists are cached at all; once
+          // they're available we render immediately and checkmarks fill in.
           <View style={styles.message}>
             <ActivityIndicator />
           </View>

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -394,45 +394,46 @@ export function InlinePlaylistPicker({
         </Text>
       ) : null}
 
-      {!isAuthenticated ? (
-        <View style={styles.message}>
-          <Text variant="subheadline" color={iosSystemColors.systemGray}>
-            {t('actions.playlist.popover.signInBlurb')}
-          </Text>
-        </View>
-      ) : isLoading || membershipLoading ? (
-        <View style={styles.message}>
-          <ActivityIndicator />
-        </View>
-      ) : sortedPlaylists.length === 0 ? (
-        !createOpen ? (
+      {/* Hide the playlist list while the create form is open — the form takes
+          over the body rather than stacking above the existing playlists. */}
+      {!createOpen &&
+        (!isAuthenticated ? (
+          <View style={styles.message}>
+            <Text variant="subheadline" color={iosSystemColors.systemGray}>
+              {t('actions.playlist.popover.signInBlurb')}
+            </Text>
+          </View>
+        ) : isLoading || membershipLoading ? (
+          <View style={styles.message}>
+            <ActivityIndicator />
+          </View>
+        ) : sortedPlaylists.length === 0 ? (
           <View style={styles.message}>
             <Text variant="subheadline" color={iosSystemColors.systemGray}>
               {t('actions.playlist.popover.empty')}
             </Text>
           </View>
-        ) : null
-      ) : (
-        sortedPlaylists.map((playlist, index) => {
-          const accent = playlist.color && isValidHexColor(playlist.color) ? playlist.color : brandColors.primary;
-          const member = members.has(playlist.uuid);
-          return (
-            <ListRow
-              key={playlist.id}
-              title={playlist.name}
-              subtitle={t('multiboardList.count', { count: playlist.climbCount })}
-              leading={<Icon name="playlist" size={22} color={accent} />}
-              trailing={member ? <Icon name="check.small" size={18} color={brandColors.primary} /> : undefined}
-              onPress={() => {
-                void handleToggle(playlist);
-              }}
-              accessibilityLabel={playlist.name}
-              accessibilityHint={member ? t('actions.playlist.toast.removed') : t('actions.playlist.toast.added')}
-              showSeparator={index < sortedPlaylists.length - 1}
-            />
-          );
-        })
-      )}
+        ) : (
+          sortedPlaylists.map((playlist, index) => {
+            const accent = playlist.color && isValidHexColor(playlist.color) ? playlist.color : brandColors.primary;
+            const member = members.has(playlist.uuid);
+            return (
+              <ListRow
+                key={playlist.id}
+                title={playlist.name}
+                subtitle={t('multiboardList.count', { count: playlist.climbCount })}
+                leading={<Icon name="playlist" size={22} color={accent} />}
+                trailing={member ? <Icon name="check.small" size={18} color={brandColors.primary} /> : undefined}
+                onPress={() => {
+                  void handleToggle(playlist);
+                }}
+                accessibilityLabel={playlist.name}
+                accessibilityHint={member ? t('actions.playlist.toast.removed') : t('actions.playlist.toast.added')}
+                showSeparator={index < sortedPlaylists.length - 1}
+              />
+            );
+          })
+        ))}
     </View>
   );
 }

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -210,10 +210,8 @@ export function InlinePlaylistPicker({
       setCreateError(t('actions.playlist.validation.nameRequired'));
       return;
     }
-    if (trimmed.length > NAME_MAX) {
-      setCreateError(t('actions.playlist.validation.nameTooLong'));
-      return;
-    }
+    // No length check needed: the input caps at NAME_MAX (maxLength) and trim only
+    // shortens, so the name can't exceed it.
     setSubmitting(true);
     setCreateError(null);
     // Create and add are separate operations with separate failure handling: if

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -1,0 +1,546 @@
+import { useCallback, useMemo, useState, type ComponentType } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, View, type TextInputProps } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { BoardName, Climb } from '@boardsesh/shared-schema';
+import {
+  GET_PLAYLISTS_FOR_CLIMB,
+  type GetPlaylistsForClimbQueryResponse,
+} from '@boardsesh/graphql/operations/playlists';
+import { playlistMembershipStore } from '@boardsesh/climb-actions';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { ListRow } from '../ListRow';
+import { getHttpClient } from '../../lib/graphql/client';
+import { usePlaylistsContext, type Playlist } from '../../providers/playlists-provider';
+import { useTheme } from '../../providers/theme-provider';
+import { sortPlaylistsByName } from '../../lib/sort-filter-playlists';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { borderRadius, spacing } from '../../theme/tokens';
+import { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';
+import { NAME_MAX } from './playlist-form-values';
+
+// One-tap emoji shortcuts for the compact inline create form. The full emoji
+// picker (system keyboard + description field) lives on the playlist edit
+// screen; the inline form stays lightweight so it fits the reaction overlay's
+// floating card.
+const QUICK_EMOJI = ['🔥', '💪', '🎯', '⭐', '🧗', '🪨', '🏆'] as const;
+
+type InlinePlaylistPickerProps = {
+  climb: Climb;
+  /** Angle the membership add targets (the climb's board config angle). */
+  angle: number;
+  boardName: BoardName;
+  layoutId: number;
+  /**
+   * Text input host: inject `BottomSheetTextInput` when rendered inside a
+   * `ModalSheet` (so the keyboard pushes the sheet), and the plain RN
+   * `TextInput` when rendered inside the reaction overlay. Keeps this body
+   * presentation-agnostic — it never mounts a sheet or overlay of its own,
+   * which is the whole point (#3294: stacking a second native sheet dismisses
+   * the first).
+   */
+  TextInputComponent: ComponentType<TextInputProps>;
+  /** Rendered on the left of the header when the host wants a back affordance
+   *  (the reaction overlay returns to its action list; the sheet omits it). */
+  onBack?: () => void;
+};
+
+/**
+ * Membership-aware "add to playlist" body: a toggle list (checkmark = the climb
+ * is in that playlist; tap to add or remove) plus an inline create form. Shared
+ * by the reaction overlay (`ClimbReactionMenu`) and the add-to-playlist
+ * `ModalSheet` (`AddToPlaylistSheet`).
+ *
+ * Feedback is inline, never a toast: a toast fired while a `FullWindowOverlay`
+ * or native sheet is on screen renders behind it and is invisible. Success is
+ * the optimistic checkmark itself; failures revert the optimistic state and
+ * surface an inline error line.
+ */
+export function InlinePlaylistPicker({
+  climb,
+  angle,
+  boardName,
+  layoutId,
+  TextInputComponent,
+  onBack,
+}: InlinePlaylistPickerProps) {
+  const { t } = useTranslation('climbs');
+  const { t: tc } = useTranslation('common');
+  const { systemColors, brandColors } = useTheme();
+  const queryClient = useQueryClient();
+  const { playlists, addToPlaylist, removeFromPlaylist, createPlaylist, isLoading, isAuthenticated } =
+    usePlaylistsContext();
+
+  // This climb's current memberships. The provider's membership map is empty
+  // (see use-mobile-climb-actions-data) and the shared chip store is only
+  // populated behind an opt-in setting, so fetch the single climb's memberships
+  // directly — the source of truth for the checkmarks. Optimistic writes go
+  // through `setQueryData` on this key so they survive the host unmounting and
+  // re-mounting the picker (the reaction overlay does exactly that on back).
+  const membershipKey = useMemo(
+    () => ['playlistsForClimb', boardName, layoutId, climb.uuid] as const,
+    [boardName, layoutId, climb.uuid],
+  );
+  const { data: memberUuids, isLoading: membershipLoading } = useQuery({
+    queryKey: membershipKey,
+    queryFn: async (): Promise<string[]> => {
+      const response = await getHttpClient().request<GetPlaylistsForClimbQueryResponse>(GET_PLAYLISTS_FOR_CLIMB, {
+        input: { boardType: boardName, layoutId, climbUuid: climb.uuid },
+      });
+      return response.playlistsForClimb;
+    },
+    enabled: isAuthenticated,
+    staleTime: 30 * 1000,
+  });
+
+  const members = useMemo(() => new Set(memberUuids ?? []), [memberUuids]);
+
+  const [error, setError] = useState<string | null>(null);
+
+  const sortedPlaylists = useMemo(() => sortPlaylistsByName(playlists), [playlists]);
+
+  // Write a membership set to the cache and mirror it into the shared chip store
+  // (so climb-list playlist chips reflect the change without a refetch).
+  const writeMembership = useCallback(
+    (nextUuids: string[]) => {
+      queryClient.setQueryData<string[]>(membershipKey, nextUuids);
+      playlistMembershipStore.setMembershipForClimb(climb.uuid, nextUuids);
+    },
+    [queryClient, membershipKey, climb.uuid],
+  );
+
+  // Toggle one playlist's membership. Rows are gated behind the membership load
+  // below, so the initial fetch has resolved before any toggle. Reads and writes
+  // are surgical — computed against the *latest* cache each time — so overlapping
+  // toggles (or a failure while another is in flight) never clobber each other.
+  const handleToggle = useCallback(
+    async (playlist: Playlist) => {
+      const before = queryClient.getQueryData<string[]>(membershipKey) ?? [...members];
+      const willBeMember = !before.includes(playlist.uuid);
+      setError(null);
+      writeMembership(willBeMember ? [...before, playlist.uuid] : before.filter((uuid) => uuid !== playlist.uuid));
+      try {
+        if (willBeMember) {
+          // The backend resolvers key on playlists.uuid, so the uuid (not the
+          // bigserial id) goes on the wire.
+          await addToPlaylist(playlist.uuid, climb.uuid, angle);
+        } else {
+          await removeFromPlaylist(playlist.uuid, climb.uuid);
+        }
+      } catch (toggleError) {
+        // Undo ONLY this row's change against the current cache — not a stale
+        // snapshot — so a sibling toggle that succeeded meanwhile is preserved.
+        const current = queryClient.getQueryData<string[]>(membershipKey) ?? [];
+        writeMembership(
+          willBeMember ? current.filter((uuid) => uuid !== playlist.uuid) : [...new Set([...current, playlist.uuid])],
+        );
+        setError(t(willBeMember ? 'actions.playlist.toast.addFailed' : 'actions.playlist.toast.removeFailed'));
+        if (__DEV__) {
+          console.warn('[playlist] toggle membership failed', {
+            playlistUuid: playlist.uuid,
+            climbUuid: climb.uuid,
+            add: willBeMember,
+            error: toggleError,
+          });
+        }
+      }
+    },
+    [queryClient, membershipKey, members, writeMembership, addToPlaylist, removeFromPlaylist, climb.uuid, angle, t],
+  );
+
+  // === Inline create form ===
+  const [createOpen, setCreateOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [color, setColor] = useState<string | undefined>(undefined);
+  const [icon, setIcon] = useState<string | undefined>(undefined);
+  const [submitting, setSubmitting] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const resetCreate = useCallback(() => {
+    setName('');
+    setColor(undefined);
+    setIcon(undefined);
+    setCreateError(null);
+  }, []);
+
+  const handleOpenCreate = useCallback(() => {
+    setError(null);
+    resetCreate();
+    setCreateOpen(true);
+  }, [resetCreate]);
+
+  const handleCloseCreate = useCallback(() => {
+    resetCreate();
+    setCreateOpen(false);
+  }, [resetCreate]);
+
+  const handleSubmitCreate = useCallback(async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setCreateError(t('actions.playlist.validation.nameRequired'));
+      return;
+    }
+    if (trimmed.length > NAME_MAX) {
+      setCreateError(t('actions.playlist.validation.nameTooLong'));
+      return;
+    }
+    setSubmitting(true);
+    setCreateError(null);
+    // Create and add are separate operations with separate failure handling: if
+    // the playlist is created but the add fails, we must NOT report "create
+    // failed" and leave the name in the form, or a retry creates a duplicate.
+    let created;
+    try {
+      created = await createPlaylist(trimmed, undefined, color, icon, { boardType: boardName, layoutId });
+    } catch (submitError) {
+      // Inline, not a toast — the picker (and its host overlay/sheet) stays up.
+      setCreateError(t('actions.playlist.toast.createFailed'));
+      setSubmitting(false);
+      if (__DEV__) {
+        console.warn('[playlist] inline create failed', {
+          climbUuid: climb.uuid,
+          boardName,
+          layoutId,
+          error: submitError,
+        });
+      }
+      return;
+    }
+    // Playlist exists now; close the form so a retry can't duplicate it. The new
+    // (still-unchecked) playlist is already in the list to tap if the add fails.
+    setCreateOpen(false);
+    resetCreate();
+    try {
+      await addToPlaylist(created.uuid, climb.uuid, angle);
+      // Cancel any in-flight membership fetch (it was sent before this playlist
+      // existed) so it can't overwrite the new checkmark, then optimistically add.
+      await queryClient.cancelQueries({ queryKey: membershipKey });
+      const current = queryClient.getQueryData<string[]>(membershipKey) ?? [...members];
+      writeMembership([...new Set([...current, created.uuid])]);
+    } catch (addError) {
+      setError(t('actions.playlist.toast.addFailed'));
+      if (__DEV__) {
+        console.warn('[playlist] created playlist but failed to add climb', {
+          playlistUuid: created.uuid,
+          climbUuid: climb.uuid,
+          error: addError,
+        });
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    name,
+    color,
+    icon,
+    createPlaylist,
+    boardName,
+    layoutId,
+    addToPlaylist,
+    climb.uuid,
+    angle,
+    resetCreate,
+    queryClient,
+    membershipKey,
+    members,
+    writeMembership,
+    t,
+  ]);
+
+  const inputStyle = useMemo(
+    () => [
+      styles.input,
+      { backgroundColor: systemColors.fill, color: systemColors.label, borderColor: systemColors.separator },
+    ],
+    [systemColors],
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        {onBack ? (
+          <Pressable
+            onPress={onBack}
+            accessibilityRole="button"
+            accessibilityLabel={tc('actions.back')}
+            hitSlop={8}
+            style={styles.backButton}
+          >
+            <Icon name="chevron.left" size={20} color={systemColors.label} />
+          </Pressable>
+        ) : (
+          <Icon name="playlist" size={20} color={systemColors.accent} />
+        )}
+        <Text variant="headline" style={styles.headerTitle} numberOfLines={1}>
+          {t('actions.playlist.popover.title')}
+        </Text>
+        {isAuthenticated && !createOpen ? (
+          <Pressable
+            onPress={handleOpenCreate}
+            accessibilityRole="button"
+            accessibilityLabel={t('actions.playlist.popover.createNew')}
+            hitSlop={8}
+            style={[styles.createButton, { backgroundColor: systemColors.fill }]}
+          >
+            <Icon name="plus" size={18} color={brandColors.primary} />
+          </Pressable>
+        ) : null}
+      </View>
+
+      {createOpen ? (
+        <View style={styles.createForm}>
+          <TextInputComponent
+            value={name}
+            onChangeText={(text) => {
+              setCreateError(null);
+              setName(text);
+            }}
+            placeholder={t('actions.playlist.create.namePlaceholder')}
+            placeholderTextColor={systemColors.tertiaryLabel}
+            maxLength={NAME_MAX}
+            style={inputStyle}
+            returnKeyType="done"
+            autoFocus
+            onSubmitEditing={() => {
+              void handleSubmitCreate();
+            }}
+          />
+          <View style={styles.swatchRow}>
+            {PLAYLIST_COLORS.map((swatch) => {
+              const selected = color === swatch;
+              return (
+                <Pressable
+                  key={swatch}
+                  onPress={() => setColor(selected ? undefined : swatch)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected }}
+                  style={[
+                    styles.swatch,
+                    { backgroundColor: swatch, borderColor: systemColors.separator },
+                    selected && styles.swatchSelected,
+                  ]}
+                >
+                  {selected ? <Icon name="check.small" size={14} color={iosSystemColors.white} /> : null}
+                </Pressable>
+              );
+            })}
+          </View>
+          <View style={styles.emojiRow}>
+            {QUICK_EMOJI.map((preset) => {
+              const selected = icon === preset;
+              return (
+                <Pressable
+                  key={preset}
+                  onPress={() => setIcon(selected ? undefined : preset)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected }}
+                  style={[
+                    styles.emojiChip,
+                    { backgroundColor: systemColors.fill },
+                    selected && [styles.emojiChipSelected, { borderColor: brandColors.primary }],
+                  ]}
+                >
+                  <Text style={styles.emoji} allowFontScaling={false}>
+                    {preset}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          {createError ? (
+            <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
+              {createError}
+            </Text>
+          ) : null}
+          <View style={styles.createActions}>
+            <Pressable
+              onPress={handleCloseCreate}
+              accessibilityRole="button"
+              accessibilityLabel={tc('actions.cancel')}
+              hitSlop={8}
+              style={styles.cancelButton}
+              disabled={submitting}
+            >
+              <Text variant="body" color={systemColors.secondaryLabel}>
+                {tc('actions.cancel')}
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={() => {
+                void handleSubmitCreate();
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={t('actions.playlist.create.submit')}
+              hitSlop={8}
+              style={[styles.submitButton, { backgroundColor: brandColors.primary }]}
+              disabled={submitting}
+            >
+              {submitting ? (
+                <ActivityIndicator color={iosSystemColors.white} />
+              ) : (
+                <Text variant="body" color={iosSystemColors.white} style={styles.submitLabel}>
+                  {t('actions.playlist.create.submit')}
+                </Text>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      ) : null}
+
+      {error ? (
+        <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
+          {error}
+        </Text>
+      ) : null}
+
+      {!isAuthenticated ? (
+        <View style={styles.message}>
+          <Text variant="subheadline" color={iosSystemColors.systemGray}>
+            {t('actions.playlist.popover.signInBlurb')}
+          </Text>
+        </View>
+      ) : isLoading || membershipLoading ? (
+        <View style={styles.message}>
+          <ActivityIndicator />
+        </View>
+      ) : sortedPlaylists.length === 0 ? (
+        !createOpen ? (
+          <View style={styles.message}>
+            <Text variant="subheadline" color={iosSystemColors.systemGray}>
+              {t('actions.playlist.popover.empty')}
+            </Text>
+          </View>
+        ) : null
+      ) : (
+        sortedPlaylists.map((playlist, index) => {
+          const accent = playlist.color && isValidHexColor(playlist.color) ? playlist.color : brandColors.primary;
+          const member = members.has(playlist.uuid);
+          return (
+            <ListRow
+              key={playlist.id}
+              title={playlist.name}
+              subtitle={t('multiboardList.count', { count: playlist.climbCount })}
+              leading={<Icon name="playlist" size={22} color={accent} />}
+              trailing={member ? <Icon name="check.small" size={18} color={brandColors.primary} /> : undefined}
+              onPress={() => {
+                void handleToggle(playlist);
+              }}
+              accessibilityLabel={playlist.name}
+              accessibilityHint={member ? t('actions.playlist.toast.removed') : t('actions.playlist.toast.added')}
+              showSeparator={index < sortedPlaylists.length - 1}
+            />
+          );
+        })
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[2],
+  },
+  backButton: {
+    width: spacing[6],
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    flex: 1,
+  },
+  createButton: {
+    width: spacing[8],
+    height: spacing[8],
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  createForm: {
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[3],
+    gap: spacing[3],
+  },
+  input: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    fontSize: 16,
+  },
+  swatchRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[3],
+  },
+  swatch: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  swatchSelected: {
+    borderWidth: 3,
+    borderColor: iosSystemColors.white,
+  },
+  emojiRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+  },
+  emojiChip: {
+    width: 38,
+    height: 38,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emojiChipSelected: {
+    borderWidth: 2,
+  },
+  emoji: {
+    fontSize: 20,
+  },
+  createActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    gap: spacing[3],
+    marginTop: spacing[1],
+  },
+  cancelButton: {
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+  },
+  submitButton: {
+    minWidth: 96,
+    height: spacing[10],
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing[4],
+  },
+  submitLabel: {
+    fontWeight: '600',
+  },
+  message: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing[6],
+    paddingHorizontal: spacing[4],
+  },
+  errorText: {
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[2],
+  },
+});

--- a/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { Climb } from '@boardsesh/shared-schema';
+import type { Playlist } from '@boardsesh/graphql/operations/playlists';
+
+const playlistContext = vi.hoisted(() => ({
+  playlists: [] as Playlist[],
+  addToPlaylist: vi.fn(),
+  removeFromPlaylist: vi.fn(),
+  createPlaylist: vi.fn(),
+  isLoading: false,
+  isAuthenticated: true,
+}));
+const qstate = vi.hoisted(() => ({ data: [] as string[] | undefined, loading: false }));
+const queryClientMock = vi.hoisted(() => ({
+  getQueryData: vi.fn(),
+  setQueryData: vi.fn(),
+  cancelQueries: vi.fn(async () => {}),
+}));
+const membershipStore = vi.hoisted(() => ({ setMembershipForClimb: vi.fn() }));
+
+vi.mock('react-native', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: qstate.data, isLoading: qstate.loading }),
+  useQueryClient: () => queryClientMock,
+}));
+
+vi.mock('@boardsesh/graphql/operations/playlists', () => ({ GET_PLAYLISTS_FOR_CLIMB: 'GET_PLAYLISTS_FOR_CLIMB' }));
+vi.mock('@boardsesh/climb-actions', () => ({ playlistMembershipStore: membershipStore }));
+vi.mock('../../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: vi.fn() }) }));
+
+vi.mock('../../../providers/playlists-provider', () => ({
+  usePlaylistsContext: () => playlistContext,
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    brandColors: { primary: '#6D28D9' },
+    systemColors: {
+      accent: '#6D28D9',
+      fill: '#eeeeee',
+      label: '#000',
+      secondaryLabel: '#555',
+      tertiaryLabel: '#999',
+      separator: '#ccc',
+    },
+  }),
+}));
+
+vi.mock('../../../theme/ios-colors', () => ({
+  iosSystemColors: { white: '#fff', systemRed: '#f00', systemGray: '#8E8E93' },
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  borderRadius: { full: 9999, md: 8 },
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24, 8: 32, 10: 40 },
+}));
+
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../ListRow', () => ({
+  ListRow: ({
+    title,
+    onPress,
+    trailing,
+    accessibilityHint,
+  }: {
+    title: string;
+    onPress?: () => void;
+    trailing?: ReactNode;
+    accessibilityHint?: string;
+  }) =>
+    createElement('button', { onClick: onPress, 'aria-label': title, 'data-hint': accessibilityHint }, title, trailing),
+}));
+
+import { InlinePlaylistPicker } from '../InlinePlaylistPicker';
+
+const climb = { uuid: 'climb-1', name: 'Big Move', frames: '' } as Climb;
+
+const basePlaylist = {
+  id: 'p-1',
+  uuid: 'p-1',
+  name: 'Hard Crimps',
+  climbCount: 3,
+  isPublic: false,
+  boardType: 'kilter',
+  layoutId: 1,
+  followerCount: 0,
+  isFollowedByMe: false,
+  isPinnedByMe: false,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+} satisfies Playlist;
+
+function makePlaylist(uuid: string, name: string): Playlist {
+  return { ...basePlaylist, id: uuid, uuid, name };
+}
+
+// A trivial injected text input so the component stays presentation-agnostic.
+function NameInput(props: { value?: string; onChangeText?: (text: string) => void }) {
+  return createElement('input', {
+    'aria-label': 'name-input',
+    value: props.value ?? '',
+    onChange: (event: { target: { value: string } }) => props.onChangeText?.(event.target.value),
+  });
+}
+
+function renderPicker(onBack?: () => void) {
+  return render(
+    <InlinePlaylistPicker
+      climb={climb}
+      angle={40}
+      boardName="kilter"
+      layoutId={1}
+      TextInputComponent={NameInput as never}
+      onBack={onBack}
+    />,
+  );
+}
+
+function hasCheck(button: HTMLElement): boolean {
+  return !!button.querySelector('[data-icon="check.small"]');
+}
+
+describe('InlinePlaylistPicker', () => {
+  beforeEach(() => {
+    playlistContext.playlists = [];
+    playlistContext.isLoading = false;
+    playlistContext.isAuthenticated = true;
+    playlistContext.addToPlaylist.mockReset().mockResolvedValue(undefined);
+    playlistContext.removeFromPlaylist.mockReset().mockResolvedValue(undefined);
+    playlistContext.createPlaylist.mockReset();
+    qstate.data = [];
+    qstate.loading = false;
+    queryClientMock.getQueryData.mockReset().mockReturnValue(undefined);
+    queryClientMock.setQueryData.mockReset();
+    queryClientMock.cancelQueries.mockClear();
+    membershipStore.setMembershipForClimb.mockReset();
+  });
+
+  it('shows the sign-in blurb and no create button when signed out', () => {
+    playlistContext.isAuthenticated = false;
+    const { queryByLabelText, getByText } = renderPicker();
+    expect(queryByLabelText('actions.playlist.popover.createNew')).toBeNull();
+    expect(getByText('actions.playlist.popover.signInBlurb')).not.toBeNull();
+  });
+
+  it('shows the empty state and a create button when authed with no playlists', () => {
+    const { getByText, getByLabelText } = renderPicker();
+    expect(getByText('actions.playlist.popover.empty')).not.toBeNull();
+    expect(getByLabelText('actions.playlist.popover.createNew')).not.toBeNull();
+  });
+
+  it('renders rows sorted by name with a checkmark only on member playlists', () => {
+    playlistContext.playlists = [makePlaylist('p-b', 'banana'), makePlaylist('p-a', 'Apple')];
+    qstate.data = ['p-a'];
+    const { getByLabelText } = renderPicker();
+    // 'Apple' is a member (checkmark), 'banana' is not.
+    expect(hasCheck(getByLabelText('Apple'))).toBe(true);
+    expect(hasCheck(getByLabelText('banana'))).toBe(false);
+    expect(getByLabelText('Apple').getAttribute('data-hint')).toBe('actions.playlist.toast.removed');
+    expect(getByLabelText('banana').getAttribute('data-hint')).toBe('actions.playlist.toast.added');
+  });
+
+  it('adds the climb when tapping a non-member row (optimistic + store sync)', async () => {
+    playlistContext.playlists = [makePlaylist('p-1', 'Hard Crimps')];
+    qstate.data = [];
+    const { getByLabelText } = renderPicker();
+
+    fireEvent.click(getByLabelText('Hard Crimps'));
+
+    await waitFor(() => {
+      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-1', 'climb-1', 40);
+    });
+    expect(playlistContext.removeFromPlaylist).not.toHaveBeenCalled();
+    expect(queryClientMock.setQueryData).toHaveBeenCalledWith(['playlistsForClimb', 'kilter', 1, 'climb-1'], ['p-1']);
+    expect(membershipStore.setMembershipForClimb).toHaveBeenCalledWith('climb-1', ['p-1']);
+  });
+
+  it('removes the climb when tapping a member row', async () => {
+    playlistContext.playlists = [makePlaylist('p-1', 'Hard Crimps')];
+    qstate.data = ['p-1'];
+    const { getByLabelText } = renderPicker();
+
+    fireEvent.click(getByLabelText('Hard Crimps'));
+
+    await waitFor(() => {
+      expect(playlistContext.removeFromPlaylist).toHaveBeenCalledWith('p-1', 'climb-1');
+    });
+    expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
+    expect(queryClientMock.setQueryData).toHaveBeenCalledWith(['playlistsForClimb', 'kilter', 1, 'climb-1'], []);
+  });
+
+  it('reverts the optimistic membership and surfaces an inline error on failure', async () => {
+    playlistContext.playlists = [makePlaylist('p-1', 'Hard Crimps')];
+    qstate.data = [];
+    playlistContext.addToPlaylist.mockReset().mockRejectedValueOnce(new Error('boom'));
+    const { getByLabelText, getByText } = renderPicker();
+
+    fireEvent.click(getByLabelText('Hard Crimps'));
+
+    await waitFor(() => {
+      expect(getByText('actions.playlist.toast.addFailed')).not.toBeNull();
+    });
+    // Optimistic write then revert to the previous set.
+    expect(queryClientMock.setQueryData).toHaveBeenNthCalledWith(1, expect.anything(), ['p-1']);
+    expect(queryClientMock.setQueryData).toHaveBeenNthCalledWith(2, expect.anything(), []);
+  });
+
+  it('creates a playlist inline and adds the climb to it', async () => {
+    const created = makePlaylist('p-new', 'Projects');
+    playlistContext.createPlaylist.mockResolvedValueOnce(created);
+    const { getByLabelText } = renderPicker();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.change(getByLabelText('name-input'), { target: { value: 'Projects' } });
+    fireEvent.click(getByLabelText('actions.playlist.create.submit'));
+
+    await waitFor(() => {
+      expect(playlistContext.createPlaylist).toHaveBeenCalledWith('Projects', undefined, undefined, undefined, {
+        boardType: 'kilter',
+        layoutId: 1,
+      });
+    });
+    await waitFor(() => {
+      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-new', 'climb-1', 40);
+    });
+  });
+
+  it('keeps the created playlist and reports an add error (not a create error) when the follow-up add fails', async () => {
+    const created = makePlaylist('p-new', 'Projects');
+    playlistContext.createPlaylist.mockResolvedValueOnce(created);
+    playlistContext.addToPlaylist.mockReset().mockRejectedValueOnce(new Error('add failed'));
+    const { getByLabelText, queryByLabelText, getByText } = renderPicker();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.change(getByLabelText('name-input'), { target: { value: 'Projects' } });
+    fireEvent.click(getByLabelText('actions.playlist.create.submit'));
+
+    await waitFor(() => {
+      expect(getByText('actions.playlist.toast.addFailed')).not.toBeNull();
+    });
+    // Created exactly once (no duplicate), the add was attempted, and the form
+    // closed — so a retry taps the existing row rather than re-creating.
+    expect(playlistContext.createPlaylist).toHaveBeenCalledTimes(1);
+    expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-new', 'climb-1', 40);
+    expect(queryByLabelText('actions.playlist.create.submit')).toBeNull();
+  });
+
+  it('shows a create failure inline and keeps the form open without adding', async () => {
+    playlistContext.createPlaylist.mockRejectedValueOnce(new Error('create failed'));
+    const { getByLabelText, getByText } = renderPicker();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.change(getByLabelText('name-input'), { target: { value: 'Projects' } });
+    fireEvent.click(getByLabelText('actions.playlist.create.submit'));
+
+    await waitFor(() => {
+      expect(getByText('actions.playlist.toast.createFailed')).not.toBeNull();
+    });
+    expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
+    // Form stays open (submit still present) so the user can fix and retry.
+    expect(getByLabelText('actions.playlist.create.submit')).not.toBeNull();
+  });
+
+  it('blocks create with an empty name and shows a validation error', () => {
+    const { getByLabelText, getByText } = renderPicker();
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.click(getByLabelText('actions.playlist.create.submit'));
+    expect(getByText('actions.playlist.validation.nameRequired')).not.toBeNull();
+    expect(playlistContext.createPlaylist).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
@@ -47,6 +47,10 @@ vi.mock('@tanstack/react-query', () => ({
 
 vi.mock('@boardsesh/graphql/operations/playlists', () => ({ GET_PLAYLISTS_FOR_CLIMB: 'GET_PLAYLISTS_FOR_CLIMB' }));
 vi.mock('@boardsesh/climb-actions', () => ({ playlistMembershipStore: membershipStore }));
+// The store-seed hook — the picker uses it as an instant fallback for checkmarks.
+vi.mock('../../../hooks/use-climb-playlist-memberships', () => ({
+  useClimbPlaylistMemberships: () => new Set<string>(),
+}));
 vi.mock('../../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: vi.fn() }) }));
 
 vi.mock('../../../providers/playlists-provider', () => ({

--- a/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
@@ -33,6 +33,34 @@ vi.mock('react-native', () => ({
     accessibilityLabel?: string;
   }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  FlatList: ({
+    data,
+    renderItem,
+    keyExtractor,
+    ListHeaderComponent,
+    ListEmptyComponent,
+  }: {
+    data?: readonly Playlist[];
+    renderItem?: (info: { item: Playlist; index: number }) => ReactNode;
+    keyExtractor?: (item: Playlist, index: number) => string;
+    ListHeaderComponent?: ReactNode;
+    ListEmptyComponent?: ReactNode;
+  }) =>
+    createElement(
+      'div',
+      null,
+      ListHeaderComponent,
+      data && data.length > 0
+        ? data.map((item, index) =>
+            createElement(
+              'div',
+              { key: keyExtractor ? keyExtractor(item, index) : index },
+              renderItem?.({ item, index }),
+            ),
+          )
+        : ListEmptyComponent,
+    ),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
 

--- a/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
@@ -152,6 +152,14 @@ function hasCheck(button: HTMLElement): boolean {
   return !!button.querySelector('[data-icon="check.small"]');
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe('InlinePlaylistPicker', () => {
   beforeEach(() => {
     playlistContext.playlists = [];
@@ -299,5 +307,40 @@ describe('InlinePlaylistPicker', () => {
     fireEvent.click(getByLabelText('actions.playlist.create.submit'));
     expect(getByText('actions.playlist.validation.nameRequired')).not.toBeNull();
     expect(playlistContext.createPlaylist).not.toHaveBeenCalled();
+  });
+
+  it('ignores repeat taps on a playlist row while its toggle is in flight', async () => {
+    playlistContext.playlists = [makePlaylist('p-1', 'Hard Crimps')];
+    qstate.data = [];
+    const addDeferred = deferred<void>();
+    playlistContext.addToPlaylist.mockReset().mockReturnValueOnce(addDeferred.promise);
+    const { getByLabelText } = renderPicker();
+
+    fireEvent.click(getByLabelText('Hard Crimps')); // add — in flight
+    fireEvent.click(getByLabelText('Hard Crimps')); // ignored while the first settles
+
+    await waitFor(() => expect(playlistContext.addToPlaylist).toHaveBeenCalledTimes(1));
+    expect(playlistContext.removeFromPlaylist).not.toHaveBeenCalled();
+    addDeferred.resolve();
+  });
+
+  it('aborts the create continuation when the picker unmounts mid-create', async () => {
+    const createDeferred = deferred<Playlist>();
+    playlistContext.createPlaylist.mockReturnValueOnce(createDeferred.promise);
+    const { getByLabelText, unmount } = renderPicker();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.change(getByLabelText('name-input'), { target: { value: 'Projects' } });
+    fireEvent.click(getByLabelText('actions.playlist.create.submit'));
+    await waitFor(() => expect(playlistContext.createPlaylist).toHaveBeenCalled());
+
+    // Dismiss the overlay (back / backdrop) → picker unmounts → in-flight create's
+    // continuation must abort rather than add the climb the user backed out of.
+    unmount();
+    createDeferred.resolve(makePlaylist('p-new', 'Projects'));
+    await createDeferred.promise;
+    await Promise.resolve();
+
+    expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Adding a climb to a playlist was broken on iOS. Since the native bottom-sheet migration (#3167), presenting a second native sheet dismisses the first — so tapping **Add to playlist** from the long-press menu opened a sheet that closed immediately, and creating a new playlist from the swipe sheet closed its nested form immediately (Closes #3294).

This moves playlist add/create into the **climb reaction overlay** (a `FullWindowOverlay`, not a native sheet) as an inline, membership-aware **toggle** picker with an inline create form — nothing to stack, nothing to dismiss. The **swipe / ellipsis** path keeps its bottom sheet as before, but its create-new is now inline too, so it stops closing on you.

Both surfaces share one `InlinePlaylistPicker` body; each injects its own text input (plain `TextInput` in the overlay, `BottomSheetTextInput` in the sheet) so the component never mounts a sheet or overlay of its own.

**How it works**
- Long-press a climb → **Add to playlist** swaps the reaction card to an inline list. Checkmarks show which playlists the climb is already in; tap to add or remove; the menu stays open so you can update several at once.
- **＋ New playlist** expands a compact inline form (name + colour + emoji) — no second sheet.
- Membership comes from a per-climb `GET_PLAYLISTS_FOR_CLIMB` fetch with optimistic, surgically-reverted React Query cache writes. Feedback is inline (a toast would render behind the overlay/sheet).
- Back / hardware-back / VoiceOver-escape / backdrop-tap pop the playlist view back to the action menu before dismissing, so a half-typed playlist name isn't lost.

## Release Notes

- Adding a climb to a playlist works again — press and hold a climb to add or remove it from your playlists right there, no disappearing sheet.
- Spin up a brand-new playlist in the same spot without it vanishing mid-name.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 3277 passing (added `InlinePlaylistPicker` coverage: toggle add/remove, optimistic revert, inline create incl. create-succeeds-but-add-fails, auth/empty/validation states; updated `use-climb-actions` + `AddToPlaylistSheet` tests)
- `vp run check:mobile-bundle` — OK
- `vp check` — clean on changed files
- Manual QA still needed on device (see `.boardsesh/qa-notes.md`): the reaction-menu add/remove + inline create flow and the swipe-sheet inline create, on **both iOS and Android**. Highest-risk item is the Android inline-create keyboard (input lives in a transparent `Modal` overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqXsHgS1d6HnyCNYCgxuZh