### PR TITLE
feat(mobile): add an iPad "On the Wall" tab and sheet the wall panel on small iPads

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -170,6 +170,26 @@ waits out the whole transition and is disabled in screenshot mode.
   boards → pushed routes (rule 3); setters is a searchable list route.
 - **Onboarding** — immersive cover, not over the live tab bar → `fullScreenModal`.
 
+## iPad-only tab destinations (sidebar rail, never a phone tab)
+
+To add a `(tabs)` destination that appears only on the iPad sidebar rail and NEVER as a phone
+bottom tab (e.g. `/wall`, the "On the Wall" tab — `app/(tabs)/wall/`):
+
+- Register it as a keyed `<Tabs.Screen name="wall" options={{ href: null }} />` in the shared
+  `tabScreens` array (`app/(tabs)/_layout.tsx`). It **must** be a `(tabs)` route so it renders in
+  the iPad shell's content pane (keeping the sidebar + play/wall panes); a root route would cover
+  them.
+- `href: null` is meant to hide it from the bar — but expo-router turns it into
+  `tabBarItemStyle: { display: 'none' }` and **strips the `href` key**, so a _custom_ tab bar still
+  renders it unless it filters. `MaterialTabBar` skips
+  `StyleSheet.flatten(options.tabBarItemStyle)?.display === 'none'`.
+- Add `<NativeTabs.Trigger name="wall" hidden />` (the `hidden` prop) so the iOS-26 glass bar
+  declares the route but shows no 6th tab (a 6th would spill into "More" and clash with the
+  `role="search"` slot).
+- Add a `SidebarDestination` in `IpadSidebar.tsx`; `tabsActiveSegment` (route-segments.ts) already
+  highlights it. Suppress any ambient duplicate of the same content (e.g. the wall column) while
+  the destination is the focused segment.
+
 ## See also
 
 - `docs/react-native-performance.md` — list/provider/gesture performance rules.

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -33,7 +33,14 @@ const cfg = vi.hoisted(() => ({
   // The column also needs a resolved active board (the panel renders its config);
   // boardId can be set from BLE without one, so the layout gates on this too.
   activeBoard: null as { uuid: string } | null,
-  materialScreens: [] as Array<{ name: string; options?: { lazy?: boolean } }>,
+  // Launch-fixed device-size class: 'panel-capable' (11" Pro / 13") keeps the wall
+  // panel; 'sheet-only' (mini / base 11" / Air) collapses it to the sheet + tab.
+  // Default panel-capable so the width-driven wall-surface tests still hold.
+  wallDeviceClass: 'panel-capable' as 'panel-capable' | 'sheet-only',
+  // Focused route segments — drives the wall-tab redundancy rule (the ambient
+  // column is hidden while the "On the Wall" tab is the focused destination).
+  segments: ['(tabs)', 'home'] as readonly string[],
+  materialScreens: [] as Array<{ name: string; options?: { lazy?: boolean; href?: string | null } }>,
 }));
 
 vi.mock('react-native', () => ({
@@ -86,6 +93,7 @@ vi.mock('../../../src/hooks/use-device-layout', () => ({
     widthClass: cfg.widthClass,
     expanded: false,
     isPad: cfg.widthClass === 'regular' || cfg.isPad,
+    wallDeviceClass: cfg.wallDeviceClass,
   }),
 }));
 
@@ -148,7 +156,7 @@ vi.mock('expo-router', () => {
     },
   );
 
-  return { Tabs };
+  return { Tabs, useSegments: () => cfg.segments };
 });
 
 vi.mock('../../../src/components/navigation/MaterialTabBar', () => ({
@@ -161,8 +169,9 @@ vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({
 
 vi.mock('expo-router/unstable-native-tabs', () => {
   const Trigger = Object.assign(
-    ({ name, children }: { name: string; children?: ReactNode }) =>
-      createElement('section', { 'data-trigger': name }, children),
+    ({ name, hidden, children }: { name: string; hidden?: boolean; children?: ReactNode }) =>
+      // Model NativeTabs: a `hidden` trigger declares the route but is not a tab.
+      hidden ? null : createElement('section', { 'data-trigger': name }, children),
     {
       Icon: () => createElement('span', { 'data-icon': 'true' }),
       Label: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
@@ -223,6 +232,8 @@ describe('TabLayout', () => {
     cfg.boardPresenceEnabled = false;
     cfg.boardPresenceBoardId = null;
     cfg.activeBoard = null;
+    cfg.wallDeviceClass = 'panel-capable';
+    cfg.segments = ['(tabs)', 'home'];
     cfg.materialScreens = [];
   });
 
@@ -248,6 +259,7 @@ describe('TabLayout', () => {
       'home',
       'climbs',
       'record',
+      'wall',
       'discover',
       'profile',
     ]);
@@ -267,6 +279,7 @@ describe('TabLayout', () => {
       'home',
       'climbs',
       'record',
+      'wall',
       'discover',
       'profile',
     ]);
@@ -291,12 +304,13 @@ describe('TabLayout', () => {
       'home',
       'climbs',
       'record',
+      'wall',
       'discover',
       'profile',
     ]);
   });
 
-  it('renders the iPad sidebar shell at regular width and registers all five tabs', () => {
+  it('renders the iPad sidebar shell at regular width and registers all six tabs (wall hidden from the bar)', () => {
     // Regular-width iPad takes the sidebar branch before the native/Material tab
     // bars: the glass sidebar carries navigation and the native iOS 26 tab bar is
     // gone, but the Tabs navigator still registers every tab screen.
@@ -316,9 +330,13 @@ describe('TabLayout', () => {
       'home',
       'climbs',
       'record',
+      'wall',
       'discover',
       'profile',
     ]);
+    // The wall screen registers with href:null so it never shows as a Material tab
+    // button (MaterialTabBar filters the resulting display:none item).
+    expect(cfg.materialScreens.find((screen) => screen.name === 'wall')?.options).toMatchObject({ href: null });
   });
 
   it('suppresses the detail pane on the tightest regular portraits, keeping the list full width', () => {
@@ -354,6 +372,43 @@ describe('TabLayout', () => {
     // pixel widths of each are covered by size-class.test.ts (resolveDetailPaneWidth,
     // WALL_COLUMN_WIDTH), so assert the surfaces are present, not their arithmetic.
     expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();
+  });
+
+  it('collapses the wall column to the sheet on a small (sheet-only) iPad, even in landscape', () => {
+    // iPad mini / base 11" / Air 11": physically below the 11" Pro, so the wall panel
+    // is dropped even though the window is wide enough for a column — the wall reaches
+    // the user via the BoardSheet peek + the "On the Wall" tab instead, like the phone.
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 1366;
+    cfg.wallDeviceClass = 'sheet-only';
+    cfg.boardPresenceEnabled = true;
+    cfg.boardPresenceBoardId = 1;
+    cfg.activeBoard = { uuid: 'board-1' };
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
+    // No rich wall surface on this device → the ambient sidebar cell stays the launcher.
+    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
+  });
+
+  it('hides the wall column while the "On the Wall" tab is the focused destination', () => {
+    // Panel-capable landscape with a bound board would show the column, but on the
+    // wall tab the same feed is already the content pane — so the ambient column
+    // steps aside (no two live copies of the feed).
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 1366;
+    cfg.boardPresenceEnabled = true;
+    cfg.boardPresenceBoardId = 1;
+    cfg.activeBoard = { uuid: 'board-1' };
+    cfg.segments = ['(tabs)', 'wall'];
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
+    // The surface still EXISTS for this layout, so the sidebar cell stays hidden — it
+    // doesn't pop back in merely because the wall tab is open.
+    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('false');
   });
 
   it('hides the sidebar wall cell when the portrait play-pane strip owns the wall surface', () => {

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps } from 'react';
 import { Platform, StyleSheet, View, useWindowDimensions, type ColorValue } from 'react-native';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
-import { Tabs } from 'expo-router';
+import { Tabs, useSegments } from 'expo-router';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useTranslation } from 'react-i18next';
 import { useBluetoothConnectedStatus } from '../../src/lib/ble/bluetooth-status-store';
@@ -20,11 +20,12 @@ import { IpadWallColumn } from '../../src/components/board-presence/IpadWallColu
 import { useBoardPresenceControls } from '../../src/providers/board-presence-provider';
 import { useActiveBoard } from '../../src/lib/graphql/use-active-board';
 import {
-  resolveWallSurface,
+  resolveEffectiveWallSurface,
   resolveDetailPaneSurface,
   resolveDetailPaneWidth,
   WALL_COLUMN_WIDTH,
 } from '../../src/theme/size-class';
+import { tabsActiveSegment } from '../../src/lib/route-segments';
 import { SIDEBAR_WIDTH } from '../../src/theme/layout';
 
 // Cold-start on Home: the leftmost tab carries the beta shelf and followed
@@ -96,6 +97,12 @@ export default function TabLayout() {
   // reserved for the Phase-3 master+detail Climbs browser; see size-class.ts.)
   const deviceLayout = useDeviceLayout();
   const { width: windowWidth } = useWindowDimensions();
+  // The focused tab drives the wall-redundancy rule below: when the "On the
+  // Wall" destination is open, the ambient column is suppressed so the same feed
+  // isn't shown twice. `tabsActiveSegment` reads segment 1 without indexing the
+  // route-typed tuple (see route-segments.ts).
+  const segments = useSegments();
+  const onWallTab = tabsActiveSegment(segments) === 'wall';
   // The live wall gets a dedicated column in landscape (room for sidebar + browse
   // list + detail pane + wall) and falls back to a strip atop the pane in portrait
   // (see resolveWallSurface). Gated on a bound board so an empty column never sits
@@ -107,9 +114,15 @@ export default function TabLayout() {
   // serial before/without an active board, so gate on the active board too — else
   // the column View reserves 300pt while `IpadWallColumn` renders null (dead space).
   const { data: activeBoard } = useActiveBoard();
-  const wallSurface = resolveWallSurface({
+  // Below the device-size floor (iPad mini / base 11" / Air 11" — see
+  // WALL_PANEL_MIN_DEVICE_LONG_SIDE) `resolveEffectiveWallSurface` collapses the
+  // column AND the strip to `none`; those devices reach the wall through the
+  // BoardSheet peek and the "On the Wall" tab, like the phone. Only the 11" Pro
+  // and 13" iPads keep the persistent panel.
+  const wallSurface = resolveEffectiveWallSurface({
     width: windowWidth,
     widthClass: deviceLayout.widthClass,
+    wallDeviceClass: deviceLayout.wallDeviceClass,
     sidebarWidth: SIDEBAR_WIDTH,
   });
   const showWallColumn =
@@ -171,6 +184,18 @@ export default function TabLayout() {
       }}
     />,
     <Tabs.Screen
+      key="wall"
+      name="wall"
+      // iPad-only "On the Wall" destination. `href: null` hides it from the JS
+      // Material tab bar (expo-router turns it into tabBarItemStyle:{display:'none'},
+      // which MaterialTabBar filters) and there's no NativeTabs.Trigger below, so it
+      // never appears as a 6th bottom tab on any phone. It's registered here anyway
+      // so the single JS Tabs navigator can route /wall INSIDE the shell content
+      // (keeping the sidebar + panes), reached from the iPad sidebar rail row; a root
+      // route would cover the shell instead.
+      options={{ href: null, title: t('mobile.nav.wall') }}
+    />,
+    <Tabs.Screen
       key="discover"
       name="discover"
       options={{
@@ -226,8 +251,10 @@ export default function TabLayout() {
         ) : null}
         {/* Dedicated "Now on the wall" column — landscape only, where the width
             budget leaves room for it (see resolveWallSurface). In portrait the wall
-            rides a strip atop the pane (IpadPlayPane) instead. */}
-        {isRegular && showWallColumn ? (
+            rides a strip atop the pane (IpadPlayPane) instead. Hidden while the
+            "On the Wall" tab is the focused destination — it shows the same feed,
+            so two live copies would be redundant. */}
+        {isRegular && showWallColumn && !onWallTab ? (
           <View
             key="wall"
             style={[styles.wallColumn, { width: WALL_COLUMN_WIDTH, borderLeftColor: systemColors.separator }]}
@@ -281,6 +308,11 @@ export default function TabLayout() {
           <NativeTabs.Trigger.Badge selectedBackgroundColor={brandColors.success}> </NativeTabs.Trigger.Badge>
         ) : null}
       </NativeTabs.Trigger>
+
+      {/* /wall is a (tabs) route (the iPad sidebar routes to it), so it must be
+          declared to NativeTabs — but `hidden` keeps it off the iPhone glass bar,
+          where a 6th tab would spill into "More" and clash with the search slot. */}
+      <NativeTabs.Trigger name="wall" hidden />
 
       <NativeTabs.Trigger name="discover">
         <NativeTabs.Trigger.Icon sf="bookmark" md="bookmarks" />

--- a/packages/mobile/app/(tabs)/wall/_layout.tsx
+++ b/packages/mobile/app/(tabs)/wall/_layout.tsx
@@ -1,0 +1,18 @@
+import { Stack } from 'expo-router';
+import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+
+/**
+ * The "On the Wall" tab. iPad-only — it's registered as an `href: null` tab screen
+ * (hidden from every phone tab bar) and reached from the iPad sidebar rail; see
+ * `app/(tabs)/_layout.tsx`. A single inline `index` for now; the Stack gives future
+ * deep links / sub-routes (a full leaderboard, a per-climb wall detail) a home.
+ */
+export default function WallLayout() {
+  const screenOptions = useStackScreenOptions();
+
+  return (
+    <Stack screenOptions={screenOptions}>
+      <Stack.Screen name="index" options={{ headerShown: false }} />
+    </Stack>
+  );
+}

--- a/packages/mobile/app/(tabs)/wall/index.tsx
+++ b/packages/mobile/app/(tabs)/wall/index.tsx
@@ -1,0 +1,10 @@
+import { WallScreen } from '../../../src/components/board-presence/WallScreen';
+
+/**
+ * The "On the Wall" tab screen: what's lit on the board right now, plus the
+ * session stats, leaderboard, and history. iPad-only (routed from the sidebar);
+ * the layout adapts to portrait (single column) and landscape (focal + list).
+ */
+export default function WallIndex() {
+  return <WallScreen />;
+}

--- a/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
+++ b/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
@@ -52,6 +52,7 @@ import { useGradeFormat } from '../../hooks/use-grade-format';
 import { getHttpClient } from '../../lib/graphql/client';
 import { GET_CLIMB, type GetClimbQueryResponse } from '../../lib/graphql/operations';
 import { boardPresenceClimbToClimb } from '../../lib/board-presence/presence-climb';
+import { computeSessionRanking, type SessionRankingEntry } from '../../lib/board-presence/session-ranking';
 import { withAlpha } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 
@@ -142,8 +143,19 @@ function setActionClimbCacheEntry(cache: Map<string, Climb>, key: string, climb:
 }
 
 export type NowOnTheWallPanelProps = {
-  /** 'sheet' renders inside the native modal (BottomSheetFlatList); 'column' renders inline (FlatList). */
-  variant: 'sheet' | 'column';
+  /**
+   * 'sheet' renders inside the native modal (BottomSheetFlatList); 'column' and
+   * 'screen' render inline (plain FlatList) and own both safe-area insets. 'screen'
+   * is the full-width "On the Wall" tab — it additionally shows the client-derived
+   * "This session" leaderboard under the stats.
+   */
+  variant: 'sheet' | 'column' | 'screen';
+  /**
+   * Show the live hero (the currently-lit climb) as the first list row. Default
+   * true. The landscape wall tab sets it false because a dedicated focal pane
+   * (`WallFocalClimb`) already owns the lit climb, so the list starts at the stats.
+   */
+  showHero?: boolean;
   /** The active board label, shown as the panel title. */
   boardLabel: string | null;
   /**
@@ -169,6 +181,7 @@ export type NowOnTheWallPanelProps = {
 function NowOnTheWallPanelComponent(
   {
     variant,
+    showHero = true,
     boardLabel,
     boardConfig,
     onClose,
@@ -227,6 +240,10 @@ function NowOnTheWallPanelComponent(
         : history,
     [currentClimb, history],
   );
+
+  // Client-derived "This session" leaderboard from the loaded history window.
+  // Cheap + memoized; only rendered on the full-screen tab (variant 'screen').
+  const sessionRanking = useMemo(() => computeSessionRanking(history), [history]);
 
   // "Load older" — pages further back through the durable history log, past
   // the live feed's in-memory HISTORY_CAP window.
@@ -533,35 +550,36 @@ function NowOnTheWallPanelComponent(
   const listHeader = useMemo(
     () => (
       <View>
-        {canUseInteractiveRows && rowBoard && currentClimb ? (
-          <InteractiveHeroRow
-            climb={currentClimb}
-            rowBoard={rowBoard}
-            boardConfig={boardConfig}
-            labelColor={systemColors.label}
-            secondaryColor={systemColors.secondaryLabel}
-            accentColor={brandColors.warning}
-            surfaceColor={systemColors.secondaryBackground}
-            formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
-            gradeColor={getGradeColor(currentClimb.grade ?? '') ?? DEFAULT_GRADE_COLOR}
-            isActionLoading={heroActionLoading}
-            onPress={onClimbPress ? handleInteractiveClimbPress : undefined}
-            onAddToQueue={handleInteractiveAddToQueue}
-            onOpenPlaylist={handleInteractiveOpenPlaylist}
-            onOpenActions={handleInteractiveOpenActions}
-          />
-        ) : (
-          <NowOnTheWallHero
-            climb={currentClimb}
-            boardConfig={boardConfig}
-            labelColor={systemColors.label}
-            secondaryColor={systemColors.secondaryLabel}
-            accentColor={brandColors.warning}
-            surfaceColor={systemColors.secondaryBackground}
-            formattedGrade={currentClimb?.grade ? formatGrade(currentClimb.grade) : null}
-            gradeColor={getGradeColor(currentClimb?.grade ?? '') ?? DEFAULT_GRADE_COLOR}
-          />
-        )}
+        {showHero &&
+          (canUseInteractiveRows && rowBoard && currentClimb ? (
+            <InteractiveHeroRow
+              climb={currentClimb}
+              rowBoard={rowBoard}
+              boardConfig={boardConfig}
+              labelColor={systemColors.label}
+              secondaryColor={systemColors.secondaryLabel}
+              accentColor={brandColors.warning}
+              surfaceColor={systemColors.secondaryBackground}
+              formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
+              gradeColor={getGradeColor(currentClimb.grade ?? '') ?? DEFAULT_GRADE_COLOR}
+              isActionLoading={heroActionLoading}
+              onPress={onClimbPress ? handleInteractiveClimbPress : undefined}
+              onAddToQueue={handleInteractiveAddToQueue}
+              onOpenPlaylist={handleInteractiveOpenPlaylist}
+              onOpenActions={handleInteractiveOpenActions}
+            />
+          ) : (
+            <NowOnTheWallHero
+              climb={currentClimb}
+              boardConfig={boardConfig}
+              labelColor={systemColors.label}
+              secondaryColor={systemColors.secondaryLabel}
+              accentColor={brandColors.warning}
+              surfaceColor={systemColors.secondaryBackground}
+              formattedGrade={currentClimb?.grade ? formatGrade(currentClimb.grade) : null}
+              gradeColor={getGradeColor(currentClimb?.grade ?? '') ?? DEFAULT_GRADE_COLOR}
+            />
+          ))}
         {stats ? (
           <View style={styles.statsBlock}>
             <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionHeader}>
@@ -610,6 +628,28 @@ function NowOnTheWallPanelComponent(
             ) : null}
           </View>
         ) : null}
+        {/* Client-derived "This session" leaderboard — full-screen wall tab only,
+            and only worth showing once at least two climbers have sent. The
+            backend hardest-send crown above tells the grade story; this ranks by
+            who's been most active on the loaded history window. */}
+        {variant === 'screen' && sessionRanking.length >= 2 ? (
+          <View style={styles.statsBlock}>
+            <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionHeader}>
+              {t('mobile.boardPresence.sessionLeaderboardHeader')}
+            </Text>
+            {sessionRanking.map((entry, index) => (
+              <SessionRankRow
+                key={entry.key}
+                rank={index + 1}
+                entry={entry}
+                labelColor={systemColors.label}
+                secondaryColor={systemColors.secondaryLabel}
+                surfaceColor={systemColors.secondaryBackground}
+                sendsLabel={t('mobile.boardPresence.sessionSends', { count: entry.sendCount })}
+              />
+            ))}
+          </View>
+        ) : null}
         {visibleHistory.length > 0 ? (
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionHeader}>
             {t('mobile.boardPresence.historyHeader')}
@@ -618,6 +658,9 @@ function NowOnTheWallPanelComponent(
       </View>
     ),
     [
+      variant,
+      showHero,
+      sessionRanking,
       currentClimb,
       boardConfig,
       stats,
@@ -687,9 +730,9 @@ function NowOnTheWallPanelComponent(
   const listContentContainerStyle = useMemo(() => ({ paddingBottom: spacing[4] }), []);
 
   // Sheet mode sits inside the native sheet chrome (which owns the bottom safe
-  // area), so the footer only needs its own spacing. The inline column renders at
-  // the top of the shell with no chrome, so it owns both safe-area insets.
-  const headerTopPadding = variant === 'column' ? insets.top + spacing[2] : 0;
+  // area), so the footer only needs its own spacing. The inline column and the
+  // full-screen tab render with no chrome, so they own both safe-area insets.
+  const headerTopPadding = variant === 'sheet' ? 0 : insets.top + spacing[2];
   const footerBottomPadding = variant === 'sheet' ? spacing[3] : insets.bottom + spacing[3];
 
   const refreshControl = (
@@ -748,6 +791,9 @@ function NowOnTheWallPanelComponent(
           onEndReached={hasMore ? handleEndReached : undefined}
           onEndReachedThreshold={0.6}
           onScrollBeginDrag={handleScrollBeginDrag}
+          // Fill the bounded height between the header and the switch-board footer
+          // (the inline column and the full-screen tab both render in a flex parent).
+          style={styles.fillList}
           contentContainerStyle={listContentContainerStyle}
           refreshControl={refreshControl}
         />
@@ -1247,6 +1293,32 @@ function HardestSendRow({
   );
 }
 
+type SessionRankRowProps = {
+  rank: number;
+  entry: SessionRankingEntry;
+  labelColor: ColorValue;
+  secondaryColor: ColorValue;
+  surfaceColor: ColorValue;
+  sendsLabel: string;
+};
+
+function SessionRankRow({ rank, entry, labelColor, secondaryColor, surfaceColor, sendsLabel }: SessionRankRowProps) {
+  return (
+    <View style={[styles.sessionRankRow, { backgroundColor: surfaceColor }]}>
+      <Text variant="subheadline" color={secondaryColor} style={styles.sessionRankNumber}>
+        {String(rank)}
+      </Text>
+      <PressableAvatar userId={entry.userId} uri={entry.avatarUrl} name={entry.displayName} size={30} />
+      <Text variant="subheadline" color={labelColor} numberOfLines={1} style={styles.sessionRankName}>
+        {entry.displayName}
+      </Text>
+      <Text variant="footnote" color={secondaryColor} numberOfLines={1}>
+        {sendsLabel}
+      </Text>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   header: {
     flexDirection: 'row',
@@ -1266,6 +1338,9 @@ const styles = StyleSheet.create({
     flex: 1,
     marginHorizontal: spacing[2],
     textAlign: 'center',
+  },
+  fillList: {
+    flex: 1,
   },
   hero: {
     flexDirection: 'row',
@@ -1363,6 +1438,26 @@ const styles = StyleSheet.create({
     gap: 2,
   },
   hardestName: {
+    fontWeight: '600',
+  },
+  sessionRankRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    marginHorizontal: spacing[4],
+    marginTop: spacing[2],
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[3],
+    borderRadius: borderRadius.md,
+  },
+  sessionRankNumber: {
+    minWidth: 18,
+    textAlign: 'center',
+    fontVariant: ['tabular-nums'],
+    fontWeight: '700',
+  },
+  sessionRankName: {
+    flex: 1,
     fontWeight: '600',
   },
   historyRow: {

--- a/packages/mobile/src/components/board-presence/WallEmptyState.tsx
+++ b/packages/mobile/src/components/board-presence/WallEmptyState.tsx
@@ -1,0 +1,74 @@
+import { memo, useCallback } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Icon } from '../Icon';
+import { Text } from '../Text';
+import { Button } from '../Button';
+import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
+import { useTheme } from '../../providers/theme-provider';
+import { hapticSelection } from '../../lib/haptics';
+import { spacing } from '../../theme/tokens';
+
+/**
+ * The "On the Wall" tab's empty state — shown whenever no board is bound over
+ * Bluetooth, which is the common case. Climber voice, a board-shaped bulb glyph
+ * (no AI art), and a single CTA that opens the existing device picker via the
+ * Bluetooth context's `connect()`. When no Bluetooth context is mounted the CTA
+ * is hidden (nothing to connect to).
+ */
+function WallEmptyStateComponent() {
+  const { t } = useTranslation('session');
+  const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const bluetooth = useOptionalBluetoothContext();
+
+  const handleConnect = useCallback(() => {
+    hapticSelection();
+    void bluetooth?.connect();
+  }, [bluetooth]);
+
+  return (
+    <View style={[styles.root, { paddingTop: insets.top + spacing[10], paddingBottom: insets.bottom + spacing[8] }]}>
+      <Icon name="lightbulb" size={48} color={systemColors.tertiaryLabel} />
+      <Text variant="title2" color={systemColors.label} style={styles.title}>
+        {t('mobile.boardPresence.wallEmptyTitle')}
+      </Text>
+      <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.body}>
+        {t('mobile.boardPresence.wallEmptyBody')}
+      </Text>
+      {bluetooth ? (
+        <View style={styles.cta}>
+          <Button
+            title={t('mobile.boardPresence.wallEmptyCta')}
+            variant="filled"
+            icon="lightbulb"
+            onPress={handleConnect}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export const WallEmptyState = memo(WallEmptyStateComponent);
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[8],
+  },
+  title: {
+    textAlign: 'center',
+  },
+  body: {
+    textAlign: 'center',
+    maxWidth: 420,
+  },
+  cta: {
+    marginTop: spacing[4],
+  },
+});

--- a/packages/mobile/src/components/board-presence/WallFocalClimb.tsx
+++ b/packages/mobile/src/components/board-presence/WallFocalClimb.tsx
@@ -9,6 +9,7 @@ import { BoardDriverAvatar } from './BoardDriverAvatar';
 import { Icon } from '../Icon';
 import { Text } from '../Text';
 import { getBoardRenderData } from '../../lib/board-details';
+import { parseSetIds } from '../../lib/board-presence/parse-set-ids';
 import { computeContainedBoardSize } from '../play-drawer/play-drawer-layout';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { useTheme } from '../../providers/theme-provider';
@@ -27,19 +28,6 @@ import { spacing, borderRadius } from '../../theme/tokens';
  * which would crop or letterbox several boards. Recomputed on every width change
  * (rotation / Split View); the contained size is not memoized across a resize.
  */
-function setIdsToNumbers(setIds: string): number[] {
-  return (
-    setIds
-      .split(',')
-      .map((setIdText) => setIdText.trim())
-      // Drop empty tokens BEFORE Number(): Number('') is 0 (finite), so an empty
-      // setIds string would otherwise yield [0] and slip past the length===0 guard.
-      .filter((setIdText) => setIdText.length > 0)
-      .map((setIdText) => Number(setIdText))
-      .filter((setIdValue) => Number.isFinite(setIdValue))
-  );
-}
-
 function WallFocalClimbComponent({ boardConfig }: { boardConfig: BoardConfig | null }) {
   const { t } = useTranslation('session');
   const { systemColors, brandColors } = useTheme();
@@ -54,7 +42,7 @@ function WallFocalClimbComponent({ boardConfig }: { boardConfig: BoardConfig | n
 
   const renderData = useMemo(() => {
     if (!boardConfig) return null;
-    const setIds = setIdsToNumbers(boardConfig.setIds);
+    const setIds = parseSetIds(boardConfig.setIds);
     if (setIds.length === 0) return null;
     return getBoardRenderData({
       boardName: boardConfig.boardName as BoardName,

--- a/packages/mobile/src/components/board-presence/WallFocalClimb.tsx
+++ b/packages/mobile/src/components/board-presence/WallFocalClimb.tsx
@@ -28,10 +28,16 @@ import { spacing, borderRadius } from '../../theme/tokens';
  * (rotation / Split View); the contained size is not memoized across a resize.
  */
 function setIdsToNumbers(setIds: string): number[] {
-  return setIds
-    .split(',')
-    .map((setIdText) => Number(setIdText))
-    .filter((setIdValue) => Number.isFinite(setIdValue));
+  return (
+    setIds
+      .split(',')
+      .map((setIdText) => setIdText.trim())
+      // Drop empty tokens BEFORE Number(): Number('') is 0 (finite), so an empty
+      // setIds string would otherwise yield [0] and slip past the length===0 guard.
+      .filter((setIdText) => setIdText.length > 0)
+      .map((setIdText) => Number(setIdText))
+      .filter((setIdValue) => Number.isFinite(setIdValue))
+  );
 }
 
 function WallFocalClimbComponent({ boardConfig }: { boardConfig: BoardConfig | null }) {

--- a/packages/mobile/src/components/board-presence/WallFocalClimb.tsx
+++ b/packages/mobile/src/components/board-presence/WallFocalClimb.tsx
@@ -1,0 +1,187 @@
+import { memo, useCallback, useMemo, useState } from 'react';
+import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { useBoardPresenceCurrent } from '@boardsesh/board-presence-react';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { BoardImageNative } from '../BoardImageNative';
+import { BoardDriverAvatar } from './BoardDriverAvatar';
+import { Icon } from '../Icon';
+import { Text } from '../Text';
+import { getBoardRenderData } from '../../lib/board-details';
+import { computeContainedBoardSize } from '../play-drawer/play-drawer-layout';
+import type { BoardConfig } from '../../providers/drawer-host-provider';
+import { useTheme } from '../../providers/theme-provider';
+import { useGradeFormat } from '../../hooks/use-grade-format';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+/**
+ * The landscape wall tab's leading focal pane: a large contain-fit render of the
+ * currently-lit climb with its name / grade / who lit it, or a dim placeholder
+ * when the wall is dark. Non-scrolling — it stays put as the "what's lit RIGHT
+ * NOW" anchor while the trailing list scrolls.
+ *
+ * The board art MUST contain-fit (board aspect ratios span ~0.43 tall Kilter to
+ * ~1.81 wide Kilter), so the box is measured with `onLayout` and the art sized
+ * via `computeContainedBoardSize` — never a fixed `aspectRatio` on the container,
+ * which would crop or letterbox several boards. Recomputed on every width change
+ * (rotation / Split View); the contained size is not memoized across a resize.
+ */
+function setIdsToNumbers(setIds: string): number[] {
+  return setIds
+    .split(',')
+    .map((setIdText) => Number(setIdText))
+    .filter((setIdValue) => Number.isFinite(setIdValue));
+}
+
+function WallFocalClimbComponent({ boardConfig }: { boardConfig: BoardConfig | null }) {
+  const { t } = useTranslation('session');
+  const { systemColors, brandColors } = useTheme();
+  const { formatGrade } = useGradeFormat();
+  const { currentClimb } = useBoardPresenceCurrent();
+
+  const [box, setBox] = useState<{ width: number; height: number } | null>(null);
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    setBox((prev) => (prev && prev.width === width && prev.height === height ? prev : { width, height }));
+  }, []);
+
+  const renderData = useMemo(() => {
+    if (!boardConfig) return null;
+    const setIds = setIdsToNumbers(boardConfig.setIds);
+    if (setIds.length === 0) return null;
+    return getBoardRenderData({
+      boardName: boardConfig.boardName as BoardName,
+      layoutId: boardConfig.layoutId,
+      sizeId: boardConfig.sizeId,
+      setIds,
+    });
+  }, [boardConfig]);
+
+  const contained =
+    box && renderData
+      ? computeContainedBoardSize(box.width, box.height, renderData.boardWidth / renderData.boardHeight)
+      : null;
+
+  const litBy = currentClimb?.sentByDisplayName?.trim() || null;
+  const setter = currentClimb?.setter?.trim();
+  const grade = currentClimb?.grade ? formatGrade(currentClimb.grade) : null;
+  const gradeColor = getGradeColor(currentClimb?.grade ?? '') ?? DEFAULT_GRADE_COLOR;
+
+  return (
+    <View style={styles.root}>
+      <View style={styles.artBox} onLayout={handleLayout}>
+        {currentClimb && boardConfig && renderData ? (
+          // Lit climb: render the art once the box is measured. For the pre-measure
+          // frame (box null → contained null) render nothing, NOT the dark
+          // placeholder — otherwise the pane briefly claims the wall is dark while a
+          // climb is actually lit.
+          contained ? (
+            <BoardImageNative
+              frames={currentClimb.frames ?? ''}
+              boardName={boardConfig.boardName as BoardName}
+              layoutId={boardConfig.layoutId}
+              sizeId={boardConfig.sizeId}
+              setIds={boardConfig.setIds}
+              boardWidth={renderData.boardWidth}
+              boardHeight={renderData.boardHeight}
+              style={{
+                width: contained.width,
+                height: contained.height,
+                borderRadius: borderRadius.lg,
+                overflow: 'hidden',
+              }}
+            />
+          ) : null
+        ) : (
+          <View style={styles.darkWall}>
+            <Icon name="lightbulb" size={40} color={systemColors.tertiaryLabel} />
+            <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.darkText}>
+              {t('mobile.boardPresence.wallDark')}
+            </Text>
+          </View>
+        )}
+      </View>
+      {currentClimb ? (
+        <View style={styles.meta}>
+          <View style={styles.nameRow}>
+            <Text variant="title3" color={systemColors.label} numberOfLines={1} style={styles.name}>
+              {currentClimb.name ?? ''}
+            </Text>
+            {grade ? (
+              <Text variant="title3" style={[styles.grade, { color: gradeColor }]}>
+                {grade}
+              </Text>
+            ) : null}
+          </View>
+          {setter ? (
+            <Text variant="caption1" color={systemColors.secondaryLabel} numberOfLines={1}>
+              {t('mobile.boardPresence.setByLine', { setter })}
+            </Text>
+          ) : null}
+          {litBy ? (
+            <View style={styles.driverRow}>
+              <BoardDriverAvatar
+                size={22}
+                userId={currentClimb.sentByUserId}
+                uri={currentClimb.sentByAvatarUrl}
+                name={litBy}
+                status="connected"
+                accessibilityLabel={t('mobile.boardPresence.drivenByA11y', { name: litBy })}
+              />
+              <Text variant="caption1" color={brandColors.warning} numberOfLines={1} style={styles.driverName}>
+                {litBy}
+              </Text>
+            </View>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export const WallFocalClimb = memo(WallFocalClimbComponent);
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    padding: spacing[4],
+    gap: spacing[3],
+  },
+  artBox: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  darkWall: {
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  darkText: {
+    textAlign: 'center',
+  },
+  meta: {
+    gap: 2,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  name: {
+    flex: 1,
+  },
+  grade: {
+    fontVariant: ['tabular-nums'],
+    fontWeight: '700',
+  },
+  driverRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingTop: 2,
+  },
+  driverName: {
+    flexShrink: 1,
+  },
+});

--- a/packages/mobile/src/components/board-presence/WallScreen.tsx
+++ b/packages/mobile/src/components/board-presence/WallScreen.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useState, type ReactNode } from 'react';
 import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
 import { NowOnTheWallPanel } from './NowOnTheWallPanel';
 import { WallFocalClimb } from './WallFocalClimb';
@@ -36,22 +36,32 @@ function WallScreenComponent() {
   const isWallLive = enabled && boardId !== null;
   const twoPane = containerWidth >= REGULAR_WIDTH_BREAKPOINT;
 
+  let content: ReactNode;
+  if (!isWallLive) {
+    content = <WallEmptyState />;
+  } else if (!boardPanelProps) {
+    // Bound over Bluetooth, but the active board config hasn't resolved yet — a
+    // neutral blank (the themed background), never the "Connect a board" CTA, which
+    // would be wrong for someone who just connected.
+    content = null;
+  } else if (twoPane) {
+    content = (
+      <View style={styles.row}>
+        <View style={[styles.focal, { borderRightColor: systemColors.separator }]}>
+          <WallFocalClimb boardConfig={boardPanelProps.boardConfig} />
+        </View>
+        <View style={styles.list}>
+          <NowOnTheWallPanel variant="screen" showHero={false} {...boardPanelProps} />
+        </View>
+      </View>
+    );
+  } else {
+    content = <NowOnTheWallPanel variant="screen" {...boardPanelProps} />;
+  }
+
   return (
     <View style={[styles.root, { backgroundColor: systemColors.background }]} onLayout={handleLayout}>
-      {!isWallLive || !boardPanelProps ? (
-        <WallEmptyState />
-      ) : twoPane ? (
-        <View style={styles.row}>
-          <View style={[styles.focal, { borderRightColor: systemColors.separator }]}>
-            <WallFocalClimb boardConfig={boardPanelProps.boardConfig} />
-          </View>
-          <View style={styles.list}>
-            <NowOnTheWallPanel variant="screen" showHero={false} {...boardPanelProps} />
-          </View>
-        </View>
-      ) : (
-        <NowOnTheWallPanel variant="screen" {...boardPanelProps} />
-      )}
+      {content}
     </View>
   );
 }

--- a/packages/mobile/src/components/board-presence/WallScreen.tsx
+++ b/packages/mobile/src/components/board-presence/WallScreen.tsx
@@ -1,0 +1,74 @@
+import { memo, useCallback, useState } from 'react';
+import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
+import { NowOnTheWallPanel } from './NowOnTheWallPanel';
+import { WallFocalClimb } from './WallFocalClimb';
+import { WallEmptyState } from './WallEmptyState';
+import { useDrawerHost } from '../../providers/drawer-host-provider';
+import { useBoardPresenceControls } from '../../providers/board-presence-provider';
+import { useTheme } from '../../providers/theme-provider';
+import { REGULAR_WIDTH_BREAKPOINT } from '../../theme/size-class';
+
+/**
+ * The "On the Wall" tab body. iPad-only destination (routed from the sidebar), so
+ * it always renders inside the regular-width shell content pane. Its layout is
+ * driven by its OWN measured width (not the window, which is wider than the
+ * content pane, and not an orientation API): at/above the regular breakpoint it
+ * splits into a leading focal pane (the lit climb) + a trailing scrolling list
+ * (stats + "This session" leaderboard + history); below it — a narrow Split View
+ * window, or the content pane once the play pane takes its share — it falls back
+ * to the single-column composition so nothing gets crushed.
+ *
+ * The wall is live only when a board is bound over Bluetooth, matching
+ * `SidebarWallCell` and the shell column. `boardPanelProps` is non-null whenever a
+ * board is merely stored, so the empty state gates on the presence controls.
+ */
+function WallScreenComponent() {
+  const { systemColors } = useTheme();
+  const { boardPanelProps } = useDrawerHost();
+  const { enabled, boardId } = useBoardPresenceControls();
+
+  const [containerWidth, setContainerWidth] = useState(0);
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextWidth = event.nativeEvent.layout.width;
+    setContainerWidth((prev) => (prev === nextWidth ? prev : nextWidth));
+  }, []);
+
+  const isWallLive = enabled && boardId !== null;
+  const twoPane = containerWidth >= REGULAR_WIDTH_BREAKPOINT;
+
+  return (
+    <View style={[styles.root, { backgroundColor: systemColors.background }]} onLayout={handleLayout}>
+      {!isWallLive || !boardPanelProps ? (
+        <WallEmptyState />
+      ) : twoPane ? (
+        <View style={styles.row}>
+          <View style={[styles.focal, { borderRightColor: systemColors.separator }]}>
+            <WallFocalClimb boardConfig={boardPanelProps.boardConfig} />
+          </View>
+          <View style={styles.list}>
+            <NowOnTheWallPanel variant="screen" showHero={false} {...boardPanelProps} />
+          </View>
+        </View>
+      ) : (
+        <NowOnTheWallPanel variant="screen" {...boardPanelProps} />
+      )}
+    </View>
+  );
+}
+
+export const WallScreen = memo(WallScreenComponent);
+
+const styles = StyleSheet.create({
+  root: { flex: 1 },
+  row: { flex: 1, flexDirection: 'row' },
+  // The focal pane leads at ~48% but caps so the extra width on a 13" goes to the
+  // readable list, not an oversized board (mirrors Apple Photos/Files).
+  focal: {
+    flexBasis: '48%',
+    flexGrow: 0,
+    flexShrink: 0,
+    maxWidth: 520,
+    borderRightWidth: StyleSheet.hairlineWidth,
+  },
+  list: { flex: 1 },
+});

--- a/packages/mobile/src/components/board-presence/__tests__/WallScreen.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/WallScreen.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, useEffect, type ReactNode } from 'react';
+
+const cfg = vi.hoisted(() => ({
+  enabled: true,
+  boardId: 1 as number | null,
+  boardPanelProps: {
+    boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 1, setIds: '1', angle: 40 },
+    boardLabel: 'Kilter',
+  } as Record<string, unknown> | null,
+  // The width the root View reports via onLayout — WallScreen picks two-pane at >=700.
+  layoutWidth: 400,
+}));
+
+vi.mock('react-native', () => ({
+  // Fire onLayout from an effect so the width-driven branch is exercised (jsdom has
+  // no real layout pass). Only WallScreen's root View passes onLayout.
+  View: ({
+    children,
+    onLayout,
+  }: {
+    children?: ReactNode;
+    onLayout?: (event: { nativeEvent: { layout: { width: number; height: number } } }) => void;
+  }) => {
+    useEffect(() => {
+      if (onLayout) onLayout({ nativeEvent: { layout: { width: cfg.layoutWidth, height: 800 } } });
+    }, [onLayout]);
+    return createElement('div', null, children);
+  },
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('../NowOnTheWallPanel', () => ({
+  NowOnTheWallPanel: (props: { showHero?: boolean }) =>
+    createElement('div', { 'data-panel': 'true', 'data-show-hero': String(props.showHero ?? true) }),
+}));
+vi.mock('../WallFocalClimb', () => ({
+  WallFocalClimb: () => createElement('div', { 'data-focal': 'true' }),
+}));
+vi.mock('../WallEmptyState', () => ({
+  WallEmptyState: () => createElement('div', { 'data-empty': 'true' }),
+}));
+
+vi.mock('../../../providers/drawer-host-provider', () => ({
+  useDrawerHost: () => ({ boardPanelProps: cfg.boardPanelProps }),
+}));
+vi.mock('../../../providers/board-presence-provider', () => ({
+  useBoardPresenceControls: () => ({ enabled: cfg.enabled, boardId: cfg.boardId }),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { background: '#000', separator: '#333' } }),
+}));
+
+import { WallScreen } from '../WallScreen';
+
+describe('WallScreen', () => {
+  beforeEach(() => {
+    cfg.enabled = true;
+    cfg.boardId = 1;
+    cfg.boardPanelProps = {
+      boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 1, setIds: '1', angle: 40 },
+      boardLabel: 'Kilter',
+    };
+    cfg.layoutWidth = 400;
+  });
+
+  it('shows the connect empty state when no board is bound', () => {
+    cfg.boardId = null;
+    const { container } = render(<WallScreen />);
+    expect(container.querySelector('[data-empty="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-panel="true"]')).toBeNull();
+    expect(container.querySelector('[data-focal="true"]')).toBeNull();
+  });
+
+  it('shows the empty state when board presence is disabled', () => {
+    cfg.enabled = false;
+    const { container } = render(<WallScreen />);
+    expect(container.querySelector('[data-empty="true"]')).not.toBeNull();
+  });
+
+  it('renders a single-column panel (hero shown, no focal) in a narrow pane', () => {
+    cfg.layoutWidth = 400;
+    const { container } = render(<WallScreen />);
+    expect(container.querySelector('[data-empty="true"]')).toBeNull();
+    expect(container.querySelector('[data-focal="true"]')).toBeNull();
+    const panel = container.querySelector('[data-panel="true"]');
+    expect(panel).not.toBeNull();
+    expect(panel?.getAttribute('data-show-hero')).toBe('true');
+  });
+
+  it('splits into a focal pane + hero-less list at/above the regular breakpoint', () => {
+    cfg.layoutWidth = 900;
+    const { container } = render(<WallScreen />);
+    expect(container.querySelector('[data-focal="true"]')).not.toBeNull();
+    const panel = container.querySelector('[data-panel="true"]');
+    expect(panel).not.toBeNull();
+    // The focal pane owns the lit climb, so the trailing list drops its hero.
+    expect(panel?.getAttribute('data-show-hero')).toBe('false');
+  });
+});

--- a/packages/mobile/src/components/board-presence/__tests__/WallScreen.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/WallScreen.test.tsx
@@ -80,6 +80,16 @@ describe('WallScreen', () => {
     expect(container.querySelector('[data-empty="true"]')).not.toBeNull();
   });
 
+  it('renders a neutral blank (not the connect CTA) while a bound board config is still resolving', () => {
+    // Bound over Bluetooth (enabled + boardId) but boardPanelProps not yet resolved:
+    // the connect CTA would be wrong for someone who just connected.
+    cfg.boardPanelProps = null;
+    const { container } = render(<WallScreen />);
+    expect(container.querySelector('[data-empty="true"]')).toBeNull();
+    expect(container.querySelector('[data-panel="true"]')).toBeNull();
+    expect(container.querySelector('[data-focal="true"]')).toBeNull();
+  });
+
   it('renders a single-column panel (hero shown, no focal) in a narrow pane', () => {
     cfg.layoutWidth = 400;
     const { container } = render(<WallScreen />);

--- a/packages/mobile/src/components/navigation/IpadSidebar.tsx
+++ b/packages/mobile/src/components/navigation/IpadSidebar.tsx
@@ -113,6 +113,9 @@ function IpadSidebarComponent({ showWallCell = true }: { showWallCell?: boolean 
       { segment: 'home', href: '/home', icon: 'home', label: t('mobile.nav.home') },
       { segment: 'climbs', href: '/climbs', icon: 'search', label: t('mobile.nav.climbs') },
       { segment: 'record', href: '/record', icon: 'record', label: tSession('mobile.session.recordTab') },
+      // The "On the Wall" destination sits with Record — the two "I'm at the
+      // board" activities. iPad-only: it's a rail row here, never a phone tab.
+      { segment: 'wall', href: '/wall', icon: 'lightbulb', label: t('mobile.nav.wall') },
       { segment: 'discover', href: '/discover', icon: 'discover', label: tPlaylists('bottomTabBar.discover') },
     ],
     [t, tSession, tPlaylists],

--- a/packages/mobile/src/components/navigation/MaterialTabBar.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabBar.tsx
@@ -52,6 +52,12 @@ export function MaterialTabBar({ state, descriptors, navigation, insets }: Botto
     >
       {state.routes.map((route, index) => {
         const { options } = descriptors[route.key];
+        // expo-router turns a screen's `href: null` into `tabBarItemStyle:
+        // { display: 'none' }` (the iPad-only /wall destination). This custom bar
+        // renders every route in `state.routes`, so without this filter a hidden
+        // route would show as a phone tab button. Skip it — the default RN tab bar
+        // hides it via `tabBarButton`, which a custom bar doesn't honor.
+        if (StyleSheet.flatten(options.tabBarItemStyle)?.display === 'none') return null;
         const focused = state.index === index;
         const label = typeof options.title === 'string' ? options.title : route.name;
         const iconColor = focused ? activeIconColor : inactiveColor;

--- a/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
+++ b/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
@@ -18,6 +18,7 @@ vi.mock('react-native', () => ({
     hairlineWidth: 1,
     absoluteFill: { position: 'absolute' },
     create: (styles: unknown) => styles,
+    flatten: (style: unknown) => (Array.isArray(style) ? Object.assign({}, ...style) : style),
   },
   View: ({
     children,
@@ -249,6 +250,39 @@ describe('MaterialTabBar', () => {
         type: 'tabLongPress',
         target: 'route-b',
       });
+    });
+  });
+
+  describe('hidden (href:null) routes', () => {
+    it('does not render a route whose tabBarItemStyle is display:none', () => {
+      // expo-router turns a screen's `href: null` into tabBarItemStyle:{display:'none'}
+      // (the iPad-only /wall destination). This custom bar renders every route in
+      // state.routes, so it must filter that item or it would show as a phone tab.
+      const routes = [
+        { key: 'a', name: 'home' },
+        { key: 'wall', name: 'wall' },
+        { key: 'b', name: 'profile' },
+      ];
+      const props = {
+        state: { routes, index: 0 },
+        descriptors: {
+          a: { options: { title: 'Home' } },
+          wall: { options: { title: 'On the Wall', tabBarItemStyle: { display: 'none' } } },
+          b: { options: { title: 'Profile' } },
+        },
+        navigation: {
+          emit: vi.fn(() => ({ defaultPrevented: false })),
+          navigate: vi.fn(),
+        },
+        insets: { bottom: 0, top: 0, left: 0, right: 0 },
+      };
+      const { getAllByRole, queryByLabelText } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
+      expect(getAllByRole('tab')).toHaveLength(2);
+      expect(queryByLabelText('On the Wall')).toBeNull();
+      expect(queryByLabelText('Home')).not.toBeNull();
+      expect(queryByLabelText('Profile')).not.toBeNull();
     });
   });
 

--- a/packages/mobile/src/components/play-drawer/IpadPlayPane.tsx
+++ b/packages/mobile/src/components/play-drawer/IpadPlayPane.tsx
@@ -33,7 +33,8 @@ function IpadPlayPaneComponent() {
   const { width } = useWindowDimensions();
   const { widthClass, wallDeviceClass } = useDeviceLayout();
   const { enabled, boardId } = useBoardPresenceControls();
-  const onWallTab = tabsActiveSegment(useSegments()) === 'wall';
+  const segments = useSegments();
+  const onWallTab = tabsActiveSegment(segments) === 'wall';
 
   // In portrait/narrow regular there's no room for a wall column, so the wall
   // lives as a strip atop the pane. It shows only when board presence is active,

--- a/packages/mobile/src/components/play-drawer/IpadPlayPane.tsx
+++ b/packages/mobile/src/components/play-drawer/IpadPlayPane.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { View, StyleSheet, useWindowDimensions } from 'react-native';
+import { useSegments } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PlayDrawer } from './PlayDrawer';
@@ -8,7 +9,8 @@ import { WallStrip } from '../board-presence/WallStrip';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useBoardPresenceControls } from '../../providers/board-presence-provider';
 import { useDeviceLayout } from '../../hooks/use-device-layout';
-import { resolveWallSurface } from '../../theme/size-class';
+import { resolveEffectiveWallSurface } from '../../theme/size-class';
+import { tabsActiveSegment } from '../../lib/route-segments';
 import { SIDEBAR_WIDTH } from '../../theme/layout';
 import { spacing } from '../../theme/tokens';
 
@@ -29,14 +31,18 @@ function IpadPlayPaneComponent() {
   const insets = useSafeAreaInsets();
   const { t } = useTranslation('session');
   const { width } = useWindowDimensions();
-  const { widthClass } = useDeviceLayout();
+  const { widthClass, wallDeviceClass } = useDeviceLayout();
   const { enabled, boardId } = useBoardPresenceControls();
+  const onWallTab = tabsActiveSegment(useSegments()) === 'wall';
 
   // In portrait/narrow regular there's no room for a wall column, so the wall
-  // lives as a strip atop the pane. It shows only when board presence is active;
-  // when it does, the strip owns the top inset (PlayDrawer skips it).
-  const wallSurface = resolveWallSurface({ width, widthClass, sidebarWidth: SIDEBAR_WIDTH });
-  const showStrip = wallSurface === 'strip' && enabled && boardId !== null;
+  // lives as a strip atop the pane. It shows only when board presence is active,
+  // the device is large enough for the panel at all (sheet-only devices collapse
+  // it — same gate the shell uses), and the "On the Wall" tab isn't already the
+  // focused destination. When it shows, the strip owns the top inset (PlayDrawer
+  // skips it).
+  const wallSurface = resolveEffectiveWallSurface({ width, widthClass, wallDeviceClass, sidebarWidth: SIDEBAR_WIDTH });
+  const showStrip = wallSurface === 'strip' && enabled && boardId !== null && !onWallTab;
 
   // No board resolved yet — the pane has no selection to show.
   if (!playDrawerPaneProps) {

--- a/packages/mobile/src/components/play-drawer/__tests__/IpadPlayPane.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/IpadPlayPane.test.tsx
@@ -9,6 +9,10 @@ import { createElement, type ReactNode } from 'react';
 const cfg = vi.hoisted(() => ({
   width: 834,
   widthClass: 'regular' as 'compact' | 'regular',
+  // 'panel-capable' (11" Pro / 13") keeps the strip/column; 'sheet-only' collapses it.
+  wallDeviceClass: 'panel-capable' as 'panel-capable' | 'sheet-only',
+  // Focused route — the strip is suppressed while the "On the Wall" tab is open.
+  segments: ['(tabs)', 'record'] as readonly string[],
   presenceEnabled: true,
   presenceBoardId: 1 as number | null,
   paneProps: { boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 1, setIds: '1', angle: 40 } } as Record<
@@ -27,6 +31,7 @@ vi.mock('react-native', () => ({
   PlatformColor: (name: string) => name,
 }));
 
+vi.mock('expo-router', () => ({ useSegments: () => cfg.segments }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 24, bottom: 0, left: 0, right: 0 }),
@@ -61,7 +66,7 @@ vi.mock('../../../providers/board-presence-provider', () => ({
 }));
 
 vi.mock('../../../hooks/use-device-layout', () => ({
-  useDeviceLayout: () => ({ widthClass: cfg.widthClass, expanded: false }),
+  useDeviceLayout: () => ({ widthClass: cfg.widthClass, expanded: false, wallDeviceClass: cfg.wallDeviceClass }),
 }));
 
 import { IpadPlayPane } from '../IpadPlayPane';
@@ -70,6 +75,8 @@ describe('IpadPlayPane wall surface', () => {
   beforeEach(() => {
     cfg.width = 834;
     cfg.widthClass = 'regular';
+    cfg.wallDeviceClass = 'panel-capable';
+    cfg.segments = ['(tabs)', 'record'];
     cfg.presenceEnabled = true;
     cfg.presenceBoardId = 1;
     cfg.paneProps = { boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 1, setIds: '1', angle: 40 } };
@@ -92,6 +99,23 @@ describe('IpadPlayPane wall surface', () => {
 
   it('shows no strip when board presence is not bound, keeping the pane top inset', () => {
     cfg.presenceBoardId = null;
+    const { container } = render(<IpadPlayPane />);
+    expect(container.querySelector('[data-wall-strip="true"]')).toBeNull();
+    expect(captured.playDrawerProps?.paneTopInset).toBe(true);
+  });
+
+  it('shows no strip on a small (sheet-only) iPad — the wall collapses to the sheet', () => {
+    // Same 834pt portrait that would dock a strip, but the device is below the 11"
+    // Pro floor, so the wall is sheet-only (matches the shell gate).
+    cfg.wallDeviceClass = 'sheet-only';
+    const { container } = render(<IpadPlayPane />);
+    expect(container.querySelector('[data-wall-strip="true"]')).toBeNull();
+    expect(captured.playDrawerProps?.paneTopInset).toBe(true);
+  });
+
+  it('shows no strip while the "On the Wall" tab is the focused destination', () => {
+    // The tab already shows the wall feed, so the ambient strip steps aside.
+    cfg.segments = ['(tabs)', 'wall'];
     const { container } = render(<IpadPlayPane />);
     expect(container.querySelector('[data-wall-strip="true"]')).toBeNull();
     expect(captured.playDrawerProps?.paneTopInset).toBe(true);

--- a/packages/mobile/src/hooks/use-device-layout.ts
+++ b/packages/mobile/src/hooks/use-device-layout.ts
@@ -1,6 +1,11 @@
 import { useMemo } from 'react';
-import { Platform, useWindowDimensions } from 'react-native';
-import { resolveDeviceLayout, type DeviceLayout } from '../theme/size-class';
+import { Dimensions, Platform, useWindowDimensions } from 'react-native';
+import {
+  resolveDeviceLayout,
+  resolveWallDeviceClass,
+  type DeviceLayout,
+  type WallDeviceClass,
+} from '../theme/size-class';
 
 /**
  * The adaptive shell's size class, recomputed as the app window resizes —
@@ -15,10 +20,24 @@ import { resolveDeviceLayout, type DeviceLayout } from '../theme/size-class';
  * narrow split is `compact` but must NOT swap to NativeTabs, or the boundary
  * cross would remount the navigator). It is launch-fixed (`Platform.isPad`),
  * unlike `widthClass`, which is live.
+ *
+ * `wallDeviceClass` is the other launch-fixed axis: whether the device is
+ * physically large enough for the persistent wall panel, from the screen long
+ * side (see `resolveWallDeviceClass`). It's read from `Dimensions.get('screen')`
+ * — the PHYSICAL screen, not the app window (which shrinks under Split View /
+ * Stage Manager) — and rotation-invariant via `max`, so it's memoized once.
  */
-export function useDeviceLayout(): DeviceLayout & { isPad: boolean } {
+export function useDeviceLayout(): DeviceLayout & { isPad: boolean; wallDeviceClass: WallDeviceClass } {
   const { width } = useWindowDimensions();
   // `Platform.isPad` is iOS-only (undefined on Android), so guard on the OS too.
   const isPad = Platform.OS === 'ios' && Platform.isPad === true;
-  return useMemo(() => ({ ...resolveDeviceLayout({ width, isPad }), isPad }), [width, isPad]);
+  const screenLongSide = useMemo(() => {
+    const screen = Dimensions.get('screen');
+    return Math.max(screen.width, screen.height);
+  }, []);
+  const wallDeviceClass = resolveWallDeviceClass({ screenLongSide, isPad });
+  return useMemo(
+    () => ({ ...resolveDeviceLayout({ width, isPad }), isPad, wallDeviceClass }),
+    [width, isPad, wallDeviceClass],
+  );
 }

--- a/packages/mobile/src/lib/board-presence/__tests__/parse-set-ids.test.ts
+++ b/packages/mobile/src/lib/board-presence/__tests__/parse-set-ids.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { parseSetIds } from '../parse-set-ids';
+
+describe('parseSetIds', () => {
+  it('parses a comma-separated list', () => {
+    expect(parseSetIds('1,2,3')).toEqual([1, 2, 3]);
+  });
+
+  it('parses a single id', () => {
+    expect(parseSetIds('12')).toEqual([12]);
+  });
+
+  it('returns [] for an empty string (not [0])', () => {
+    // Regression guard: Number('') is 0 (finite), so a naive parse would yield [0]
+    // and slip past a length===0 fallback, rendering an invalid board.
+    expect(parseSetIds('')).toEqual([]);
+  });
+
+  it('drops empty tokens from trailing/duplicate commas', () => {
+    expect(parseSetIds('1,,2,')).toEqual([1, 2]);
+  });
+
+  it('trims whitespace around ids', () => {
+    expect(parseSetIds(' 3 , 4 ')).toEqual([3, 4]);
+  });
+
+  it('drops non-numeric tokens', () => {
+    expect(parseSetIds('1,abc,2')).toEqual([1, 2]);
+  });
+});

--- a/packages/mobile/src/lib/board-presence/__tests__/session-ranking.test.ts
+++ b/packages/mobile/src/lib/board-presence/__tests__/session-ranking.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
+import { computeSessionRanking } from '../session-ranking';
+
+// computeSessionRanking only reads the sender + seq fields, so a partial cast
+// keeps the fixtures readable without stubbing the whole BoardPresenceClimb shape.
+function climb(fields: {
+  sentByUserId?: string | null;
+  sentByDisplayName?: string | null;
+  sentByAvatarUrl?: string | null;
+  seq: number;
+}): BoardPresenceClimb {
+  return fields as unknown as BoardPresenceClimb;
+}
+
+describe('computeSessionRanking', () => {
+  it('groups sends by climber and ranks by send count', () => {
+    const ranking = computeSessionRanking([
+      climb({ sentByUserId: 'u1', sentByDisplayName: 'Ana', seq: 1 }),
+      climb({ sentByUserId: 'u2', sentByDisplayName: 'Bo', seq: 2 }),
+      climb({ sentByUserId: 'u1', sentByDisplayName: 'Ana', seq: 3 }),
+    ]);
+    expect(ranking.map((entry) => [entry.displayName, entry.sendCount])).toEqual([
+      ['Ana', 2],
+      ['Bo', 1],
+    ]);
+  });
+
+  it('breaks send-count ties toward the most recent send (highest seq)', () => {
+    const ranking = computeSessionRanking([
+      climb({ sentByUserId: 'u1', sentByDisplayName: 'Ana', seq: 1 }),
+      climb({ sentByUserId: 'u2', sentByDisplayName: 'Bo', seq: 5 }),
+    ]);
+    expect(ranking.map((entry) => entry.displayName)).toEqual(['Bo', 'Ana']);
+    expect(ranking[0].latestSeq).toBe(5);
+  });
+
+  it('skips anonymous sends with no display name', () => {
+    const ranking = computeSessionRanking([
+      climb({ sentByUserId: null, sentByDisplayName: null, seq: 1 }),
+      climb({ sentByUserId: null, sentByDisplayName: '   ', seq: 2 }),
+      climb({ sentByUserId: 'u1', sentByDisplayName: 'Ana', seq: 3 }),
+    ]);
+    expect(ranking).toHaveLength(1);
+    expect(ranking[0].displayName).toBe('Ana');
+  });
+
+  it('groups userless climbers by trimmed display name', () => {
+    const ranking = computeSessionRanking([
+      climb({ sentByUserId: null, sentByDisplayName: 'Guest', seq: 1 }),
+      climb({ sentByUserId: null, sentByDisplayName: 'Guest', seq: 2 }),
+    ]);
+    expect(ranking).toHaveLength(1);
+    expect(ranking[0].sendCount).toBe(2);
+    expect(ranking[0].userId).toBeNull();
+  });
+
+  it('caps the leaderboard at the limit', () => {
+    const history = Array.from({ length: 8 }, (_unused, index) =>
+      climb({ sentByUserId: `u${index}`, sentByDisplayName: `C${index}`, seq: index }),
+    );
+    expect(computeSessionRanking(history, 3)).toHaveLength(3);
+  });
+
+  it('returns an empty ranking for an empty history', () => {
+    expect(computeSessionRanking([])).toEqual([]);
+  });
+});

--- a/packages/mobile/src/lib/board-presence/parse-set-ids.ts
+++ b/packages/mobile/src/lib/board-presence/parse-set-ids.ts
@@ -1,0 +1,18 @@
+/**
+ * Parse a board config's comma-separated `setIds` string into the number[] that
+ * `getBoardRenderData` / `getBoardAspectRatio` expect.
+ *
+ * Empty tokens are dropped BEFORE `Number()` on purpose: `Number('')` is `0` (a
+ * finite value), so an empty or trailing-comma string would otherwise yield a
+ * bogus `[0]` and slip past a `length === 0` guard, calling the render helpers
+ * with an invalid set. Trimming + dropping empties makes `''` → `[]` so callers
+ * fall back cleanly. Pure, so it unit-tests without react-native.
+ */
+export function parseSetIds(setIds: string): number[] {
+  return setIds
+    .split(',')
+    .map((setIdText) => setIdText.trim())
+    .filter((setIdText) => setIdText.length > 0)
+    .map((setIdText) => Number(setIdText))
+    .filter((setIdValue) => Number.isFinite(setIdValue));
+}

--- a/packages/mobile/src/lib/board-presence/session-ranking.ts
+++ b/packages/mobile/src/lib/board-presence/session-ranking.ts
@@ -1,0 +1,57 @@
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
+
+export type SessionRankingEntry = {
+  /** Stable grouping key — the climber's userId when known, else their name. */
+  key: string;
+  userId: string | null;
+  displayName: string;
+  avatarUrl: string | null;
+  sendCount: number;
+  /**
+   * Highest board-presence `seq` the climber appears at — the tie-break, so an
+   * equal send count is broken toward the most recently active climber.
+   */
+  latestSeq: number;
+};
+
+/**
+ * A per-climber "This session" leaderboard derived purely on the client from the
+ * loaded board-presence history window: who has lit the most climbs on this wall,
+ * ranked by send count then by most recent send (`seq`).
+ *
+ * Deliberately NOT grade-ranked. The presence feed carries only a display grade
+ * string (e.g. "V5" / "7a"), with no reliable client-side ordering across boards
+ * and angles — the "hardest" story is told by the backend `hardestSend` crown
+ * (`BoardPresenceStats`) instead. Because this only sees the loaded pages, it is
+ * a session-window view, not an all-time ranking, and callers must label it as
+ * such ("This session").
+ *
+ * Sends with no attributed climber (no display name) are skipped — an anonymous
+ * send can't rank. Pure and O(n), so it memoizes on the history array and unit-
+ * tests without react-native.
+ */
+export function computeSessionRanking(history: readonly BoardPresenceClimb[], limit = 5): SessionRankingEntry[] {
+  const byClimber = new Map<string, SessionRankingEntry>();
+  for (const climb of history) {
+    const displayName = climb.sentByDisplayName?.trim();
+    if (!displayName) continue;
+    const key = climb.sentByUserId ?? `name:${displayName}`;
+    const existing = byClimber.get(key);
+    if (existing) {
+      existing.sendCount += 1;
+      if (climb.seq > existing.latestSeq) existing.latestSeq = climb.seq;
+    } else {
+      byClimber.set(key, {
+        key,
+        userId: climb.sentByUserId ?? null,
+        displayName,
+        avatarUrl: climb.sentByAvatarUrl ?? null,
+        sendCount: 1,
+        latestSeq: climb.seq,
+      });
+    }
+  }
+  return [...byClimber.values()]
+    .sort((left, right) => right.sendCount - left.sendCount || right.latestSeq - left.latestSeq)
+    .slice(0, limit);
+}

--- a/packages/mobile/src/theme/__tests__/size-class.test.ts
+++ b/packages/mobile/src/theme/__tests__/size-class.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect } from 'vitest';
 import {
   resolveDeviceLayout,
   resolveWallSurface,
+  resolveWallDeviceClass,
+  resolveEffectiveWallSurface,
   resolveDetailPaneSurface,
   resolveDetailPaneWidth,
   REGULAR_WIDTH_BREAKPOINT,
   EXPANDED_WIDTH_BREAKPOINT,
+  WALL_PANEL_MIN_DEVICE_LONG_SIDE,
 } from '../size-class';
 
 const SIDEBAR_WIDTH = 96;
@@ -78,6 +81,54 @@ describe('resolveWallSurface', () => {
     // balancedContentWidth = (width - 96 - 300) / 2; column requires >= 390 → width >= 1176.
     expect(resolveWallSurface({ width: 1175, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('strip');
     expect(resolveWallSurface({ width: 1176, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('column');
+  });
+});
+
+describe('resolveWallDeviceClass', () => {
+  it('is always sheet-only off iPad, whatever the screen size', () => {
+    // Phones never mount the persistent wall panel — the wall lives in the sheet.
+    for (const screenLongSide of [844, 932, 1133, 1366]) {
+      expect(resolveWallDeviceClass({ screenLongSide, isPad: false })).toBe('sheet-only');
+    }
+  });
+
+  it('keeps the small iPads on the sheet: mini, base 10.9/11" and Air 11"', () => {
+    // Below the 11" Pro's long side (1194): iPad mini (1133), base iPad and Air
+    // 11" (1180), and one point under the floor.
+    for (const screenLongSide of [1133, 1180, WALL_PANEL_MIN_DEVICE_LONG_SIDE - 1]) {
+      expect(resolveWallDeviceClass({ screenLongSide, isPad: true })).toBe('sheet-only');
+    }
+  });
+
+  it('keeps the panel on the 11" Pro and every 13"', () => {
+    // 11" Pro (1194 / M4 1210) and all 13" (12.9" 1366, M4 13" 1376).
+    for (const screenLongSide of [WALL_PANEL_MIN_DEVICE_LONG_SIDE, 1210, 1366, 1376]) {
+      expect(resolveWallDeviceClass({ screenLongSide, isPad: true })).toBe('panel-capable');
+    }
+  });
+});
+
+describe('resolveEffectiveWallSurface', () => {
+  it('collapses the wall to none on a sheet-only device, at any width', () => {
+    // A small iPad in landscape would otherwise get a column; the device floor
+    // forces the sheet + "On the Wall" tab instead.
+    for (const width of [834, 1194, 1366]) {
+      expect(
+        resolveEffectiveWallSurface({
+          width,
+          widthClass: 'regular',
+          wallDeviceClass: 'sheet-only',
+          sidebarWidth: SIDEBAR_WIDTH,
+        }),
+      ).toBe('none');
+    }
+  });
+
+  it('defers to the live width logic on a panel-capable device', () => {
+    const capable = { wallDeviceClass: 'panel-capable' as const, sidebarWidth: SIDEBAR_WIDTH };
+    expect(resolveEffectiveWallSurface({ width: 1366, widthClass: 'regular', ...capable })).toBe('column');
+    expect(resolveEffectiveWallSurface({ width: 834, widthClass: 'regular', ...capable })).toBe('strip');
+    expect(resolveEffectiveWallSurface({ width: 932, widthClass: 'compact', ...capable })).toBe('none');
   });
 });
 

--- a/packages/mobile/src/theme/size-class.ts
+++ b/packages/mobile/src/theme/size-class.ts
@@ -19,6 +19,21 @@ export const REGULAR_WIDTH_BREAKPOINT = 700;
 /** At/above this width a regular layout also fits a master + detail pane. */
 export const EXPANDED_WIDTH_BREAKPOINT = 1024;
 
+/**
+ * An iPad whose physical screen long side is below this drops the persistent
+ * "Now on the wall" panel (landscape column / portrait strip) and reaches the
+ * wall through the phone-style bottom SHEET instead — the "smaller than the
+ * 11-inch iPad Pro" line. This is a DEVICE-SIZE question the live width axis
+ * physically can't answer: an iPad mini and an 11" Pro are both
+ * Regular/Regular fullscreen, so no `UITraitCollection` separates them.
+ *
+ * 1194 = the 11" Pro's long side. Below it — iPad mini (1133), base iPad
+ * 10.9/11" and Air 11" (1180), and legacy small iPads — the wall is sheet-only;
+ * the 11" Pro (1194/1210) and every 13" (1366/1376) keep the panel. (1180 is
+ * the one-line knob if you later want to keep the panel on the base 11" class.)
+ */
+export const WALL_PANEL_MIN_DEVICE_LONG_SIDE = 1194;
+
 export type WidthClass = 'compact' | 'regular';
 
 export type DeviceLayout = {
@@ -38,6 +53,32 @@ export function resolveDeviceLayout({ width, isPad }: { width: number; isPad: bo
     return { widthClass: 'compact', expanded: false };
   }
   return { widthClass: 'regular', expanded: width >= EXPANDED_WIDTH_BREAKPOINT };
+}
+
+/**
+ * `panel-capable` — the device is physically large enough for the persistent
+ * wall panel. `sheet-only` — it isn't, so the wall falls back to the phone-style
+ * bottom sheet. A launch-fixed axis, orthogonal to the live width class.
+ */
+export type WallDeviceClass = 'panel-capable' | 'sheet-only';
+
+/**
+ * Resolve the wall device class from the physical screen long side (see
+ * {@link WALL_PANEL_MIN_DEVICE_LONG_SIDE}). Non-iPad is always `sheet-only` —
+ * phones never mount the panel — so this is only consulted on iPad. Pure (the
+ * long side is injected), so it unit-tests without react-native like the width
+ * resolvers; the React wrapper reads `Dimensions.get('screen')` in
+ * `use-device-layout.ts`.
+ */
+export function resolveWallDeviceClass({
+  screenLongSide,
+  isPad,
+}: {
+  screenLongSide: number;
+  isPad: boolean;
+}): WallDeviceClass {
+  if (!isPad || screenLongSide < WALL_PANEL_MIN_DEVICE_LONG_SIDE) return 'sheet-only';
+  return 'panel-capable';
 }
 
 /**
@@ -86,6 +127,29 @@ export function resolveWallSurface({
   if (widthClass !== 'regular') return 'none';
   const balancedContentWidth = (width - sidebarWidth - WALL_COLUMN_WIDTH) / 2;
   return balancedContentWidth >= WALL_COLUMN_BALANCED_CONTENT_FLOOR ? 'column' : 'strip';
+}
+
+/**
+ * The wall surface after the device-size floor is applied: a `sheet-only` device
+ * never mounts the column or strip (the wall lives in the bottom sheet + the
+ * "On the Wall" tab instead), so it always resolves to `none`; a `panel-capable`
+ * device defers to the live width logic in {@link resolveWallSurface}. The one
+ * gate the shell and the play pane both consult, so they never diverge. Pure —
+ * `wallDeviceClass` and the sidebar width are injected — for unit testing.
+ */
+export function resolveEffectiveWallSurface({
+  width,
+  widthClass,
+  wallDeviceClass,
+  sidebarWidth,
+}: {
+  width: number;
+  widthClass: WidthClass;
+  wallDeviceClass: WallDeviceClass;
+  sidebarWidth: number;
+}): WallSurface {
+  if (wallDeviceClass === 'sheet-only') return 'none';
+  return resolveWallSurface({ width, widthClass, sidebarWidth });
 }
 
 /** Minimum width the persistent detail (play) pane needs to be useful — the floor

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -192,6 +192,7 @@
       "home": "Home",
       "boards": "Boards",
       "climbs": "Climbs",
+      "wall": "On the Wall",
       "profile": "Profile",
       "holdFilter": "Hold types",
       "zoneFilter": "Board region",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -432,7 +432,14 @@
       "actionLoading": "Loading climb",
       "actionFailed": "Couldn't load that climb. Try again.",
       "loadingMore": "Loading more history",
-      "loadMore": "Load more"
+      "loadMore": "Load more",
+      "wallEmptyTitle": "Nobody's on the wall",
+      "wallEmptyBody": "Connect to your board over Bluetooth to see what's lit, who's crushing it, and the session's hardest send.",
+      "wallEmptyCta": "Connect a board",
+      "wallDark": "Nothing lit right now",
+      "sessionLeaderboardHeader": "This session",
+      "sessionSends_one": "{{count}} send",
+      "sessionSends_other": "{{count}} sends"
     },
     "toast": {
       "sessionEnded": "Session ended"

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -393,6 +393,7 @@
       "home": "Inicio",
       "boards": "Plafones",
       "climbs": "Bloques",
+      "wall": "En el muro",
       "profile": "Perfil",
       "holdFilter": "Tipos de presa",
       "zoneFilter": "Zona del muro",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -432,7 +432,14 @@
       "actionLoading": "Cargando el bloque",
       "actionFailed": "No se pudo cargar ese bloque. Inténtalo de nuevo.",
       "loadingMore": "Cargando más historial",
-      "loadMore": "Cargar más"
+      "loadMore": "Cargar más",
+      "wallEmptyTitle": "No hay nadie en el muro",
+      "wallEmptyBody": "Conéctate a tu plafón por Bluetooth para ver qué está encendido, quién está reventando y el encadene más duro de la sesión.",
+      "wallEmptyCta": "Conectar un plafón",
+      "wallDark": "Nada encendido ahora mismo",
+      "sessionLeaderboardHeader": "Esta sesión",
+      "sessionSends_one": "{{count}} encadene",
+      "sessionSends_other": "{{count}} encadenes"
     },
     "toast": {
       "sessionEnded": "Sesión terminada"

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -192,6 +192,7 @@
       "home": "Accueil",
       "boards": "Boards",
       "climbs": "Blocs",
+      "wall": "Sur le mur",
       "profile": "Profil",
       "holdFilter": "Types de prise",
       "zoneFilter": "Zone du mur",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -432,7 +432,14 @@
       "actionLoading": "Chargement du bloc",
       "actionFailed": "Impossible de charger ce bloc. Réessayez.",
       "loadingMore": "Chargement de l'historique",
-      "loadMore": "Charger plus"
+      "loadMore": "Charger plus",
+      "wallEmptyTitle": "Personne sur le mur",
+      "wallEmptyBody": "Connecte-toi à ta board en Bluetooth pour voir ce qui est allumé, qui déroule et la plus grosse croix de la séance.",
+      "wallEmptyCta": "Connecter une board",
+      "wallDark": "Rien d'allumé pour l'instant",
+      "sessionLeaderboardHeader": "Cette séance",
+      "sessionSends_one": "{{count}} croix",
+      "sessionSends_other": "{{count}} croix"
     },
     "toast": {
       "sessionEnded": "Session terminée"


### PR DESCRIPTION
## Summary

Two iPad improvements, both reusing the existing board-presence system:

1. **Small iPads shed the cramped wall panel.** On iPads smaller than the 11" Pro (mini, base 10.9/11", Air 11") the persistent "Now on the wall" side panel is dropped; the wall reaches you through the bottom sheet + the new tab, exactly like the phone. The 11" Pro and every 13" keep the panel. It's a new launch-fixed device-size axis (`resolveWallDeviceClass`, screen long side ≥ 1194pt) composed as a pure AND-narrowing gate over the untouched window-width logic in `size-class.ts`, so phones and Split View / Stage Manager are provably unregressed (the gate can only downgrade the wall surface, never widen it).

2. **A new iPad-only "On the Wall" tab.** A sidebar destination — registered as an `href: null` tab route so it's hidden from every phone tab bar (Material bar filters the resulting `display:none` item; the native glass bar gets a `hidden` trigger) — showing what's lit on the board right now, the session stats, a "This session" leaderboard, and the history feed. It adapts to **portrait** (single column) and **landscape** (focal board art + scrolling list) from its **own measured width** (not the window, not an orientation API), so a narrow Split View window falls back to single column. The board art contain-fits across the full 0.43–1.81 board aspect-ratio range, so a tall MoonBoard and a wide Kilter both look right.

Design was set by an HIG design panel; the small-iPad threshold (1194 vs 1180), iPad-only scope, leaderboard shape, and play-pane behaviour were confirmed with the maintainer. `NowOnTheWallPanel` gained a `variant="screen"` and the "This session" leaderboard is a pure client-side selector (`session-ranking.ts`) ranked by send count then recency — the grade story stays the backend hardest-send crown, since the presence feed has no reliable client-side grade ordering.

## Release Notes

- See what's lit on the wall from your iPad — a new On the Wall tab with the current climb, who's crushing it, the session's hardest send, and recent history, in portrait or landscape
- Smaller iPads now open the board history as a sheet, so the browse list keeps the full screen

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 3310 pass. New unit tests: `size-class` (device-class + effective-surface boundaries), `session-ranking` (grouping/tie-break/limit), `WallScreen` (empty vs live, portrait/landscape at 700), `MaterialTabBar` (hidden `href:null` route filtered). Updated `tab-layout` + `IpadPlayPane` for the device gate and wall-tab suppression.
- `@boardsesh/i18n` catalog parity — 28 pass (new `common.mobile.nav.wall` + `session.mobile.boardPresence.*` keys in en-US / es / fr; Spanish uses "muro" for the wall to match the shipped board-presence copy, French "croix"/"allumer")
- `vp check` — lint/format clean
- `vp run check:mobile-bundle` — iOS + Android bundles OK (new `/wall` route + `variant="screen"`)
- Adversarial multi-agent review of the diff — 2 low findings, both fixed (single-send plural grammar; a pre-measure focal frame that briefly read "dark" while a climb was lit)

**Still needs on-device visual QA** (invisible to vitest): the `/wall` tab in portrait/landscape on 11" Pro vs 13", the sheet-vs-panel split on mini / base 11" / Air 11", contain-fit on the widest (1.81) and tallest (0.43) boards, and a Split View resize on the wall tab degrading to single column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vj28m82VgJhvszfnJ8NME
