### PR TITLE
fix(mobile): MoonBoard clear-all over BLE + unit-testable write flow-control

### DIFF
--- a/docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md
+++ b/docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md
@@ -42,6 +42,7 @@ Each claim is tagged so you can separate what was observed in the app from what 
 | Per-board LED version?                 | **Yes.** Boards persist a `led_version`; the app tracks LED hardware generation per board.                              | ✅  |
 | LED payload format                     | ASCII `l#<marker><pos>,<marker><pos>,…#` over the chosen write characteristic.                                          | 🔁  |
 | LED position numbering                 | Column-major **serpentine** over the 11×18 grid (positions 0–197).                                                      | 🔁  |
+| Clearing the board                     | Empty frame `l##` clears all LEDs (community firmware); Boardsesh sends it only on a deliberate clear (§5.5).            | 🔁❓ |
 | Two extra 128-bit UUIDs in the binary  | Present, but match **neither** BLE service family; they live in the app's `uuid`-package / SDK realm, not the LED path. | ❓  |
 
 ---
@@ -211,6 +212,14 @@ The position index is a property of the **physical LED string**, so it is identi
 🔁 The ASCII string is split into BLE writes. The classic transport size is **20 bytes per write** (`MAX_BLUETOOTH_MESSAGE_SIZE` in `transport.ts`); chunking is a transport detail and does not change the message.
 
 **Write type depends on the controller generation.** The newer Nordic-UART RX characteristic (`6e400002`) supports **Write Without Response**. The original RedBearLab write characteristic (`713d0003`), however, advertises only the plain `.write` property — on iOS, CoreBluetooth **silently drops** a write-without-response to a characteristic that lacks the no-response property, leaving the wall dark. So an interoperable iOS client must use **write-with-response** for the RedBearLab box (pacing on the GATT write ack), and may use write-without-response for the Nordic-UART boards. Android's GATT stack issues no-response writes regardless of the advertised property, so the same write call works on both there. Boardsesh implements exactly this gating (`BoardBleEncoding.preferredWriteType` in `packages/mobile/modules/live-activity/ios/`): MoonBoard falls back to write-with-response whenever the chosen write characteristic doesn't advertise `.writeWithoutResponse`.
+
+### 5.5 Clearing the board
+
+🔁 A frame with no holds — `l##` (the prefix and suffix with an empty payload) — is the clear-all. The ArduinoMoonBoardLED community firmware clears every LED at the start of each incoming frame before lighting the holds it names, so an empty frame darks the whole wall.
+
+❓ Unconfirmed on official Moon controllers (flagged for a live BLE capture); at worst it is a no-op there.
+
+Boardsesh sends `l##` **only on a deliberate clear** (the "Turn off all lights" control, or advancing the queue past the last compatible climb). A climb whose holds all drop out (unrecognised roles / out-of-range ids) is **never** cleared this way — it refuses to write and surfaces an incompatible-climb error instead, so a corrupt climb can't silently dark the wall.
 
 ---
 

--- a/docs/ui/12-bluetooth.md
+++ b/docs/ui/12-bluetooth.md
@@ -57,7 +57,7 @@ The BLE connection is managed by `useBoardBluetooth` hook and exposed via `Bluet
 
 **MoonBoard:**
 
-1. Empty frames are skipped (MoonBoard packet format doesn't support "clear").
+1. Empty frames send MoonBoard's clear-all `l##` frame (deliberate clear only — verified against the ArduinoMoonBoardLED community firmware, which clears every LED on each incoming frame; unverified on official Moon controllers, where it is at worst a no-op). An all-placements-skipped climb still refuses to write rather than fall through to this clear.
 2. `getMoonboardBluetoothPacket(frames)` produces the packet.
 3. If all placements are skipped, shows error snackbar and returns `false`.
 4. Partial skips are logged to Sentry.

--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -1,0 +1,660 @@
+import CoreBluetooth
+import XCTest
+
+// MARK: - Fakes
+
+/// A `WritableBlePeripheral` with no CoreBluetooth backing. `canSendScript`
+/// pops one value per read of `canSendWriteWithoutResponse` (mirroring the way
+/// the real property can flip between the BLE manager's reads), falling back to
+/// `canSendDefault` once the script is drained.
+@available(iOS 17.0, *)
+final class FakeWritablePeripheral: WritableBlePeripheral {
+    let identifier: UUID
+    let name: String?
+    var canSendDefault: Bool
+    var canSendScript: [Bool]
+    var maxWriteValueLength: Int
+    private(set) var writtenChunks: [(data: Data, type: CBCharacteristicWriteType)] = []
+    private(set) var canSendReadCount = 0
+
+    init(
+        identifier: UUID = UUID(),
+        name: String? = "Test Board",
+        canSendDefault: Bool = true,
+        canSendScript: [Bool] = [],
+        maxWriteValueLength: Int = 20
+    ) {
+        self.identifier = identifier
+        self.name = name
+        self.canSendDefault = canSendDefault
+        self.canSendScript = canSendScript
+        self.maxWriteValueLength = maxWriteValueLength
+    }
+
+    var canSendWriteWithoutResponse: Bool {
+        canSendReadCount += 1
+        if !canSendScript.isEmpty {
+            return canSendScript.removeFirst()
+        }
+        return canSendDefault
+    }
+
+    func maximumWriteValueLength(for _: CBCharacteristicWriteType) -> Int {
+        maxWriteValueLength
+    }
+
+    func writeValue(_ data: Data, for _: CBCharacteristic, type: CBCharacteristicWriteType) {
+        writtenChunks.append((data: data, type: type))
+    }
+}
+
+/// One-shot fake. `fire()` runs the handler inline exactly once, and never once
+/// cancelled — modelling a `DispatchWorkItem` that already ran or was cancelled.
+@available(iOS 17.0, *)
+final class FakeOneShotTimer: BleOneShotTimer {
+    let label: String
+    let delay: TimeInterval
+    private let handler: () -> Void
+    private(set) var cancelled = false
+    private(set) var fired = false
+
+    init(label: String, delay: TimeInterval, handler: @escaping () -> Void) {
+        self.label = label
+        self.delay = delay
+        self.handler = handler
+    }
+
+    func cancel() {
+        cancelled = true
+    }
+
+    func fire() {
+        guard !cancelled, !fired else { return }
+        fired = true
+        handler()
+    }
+}
+
+/// Repeating fake mirroring `DispatchSourceTimer`. `fire()` runs the stored
+/// handler inline (inert once cancelled). `fire(ignoringCancellation: true)`
+/// simulates a tick already enqueued when `cancel()` ran, exercising the
+/// manager's `===` identity self-guard.
+@available(iOS 17.0, *)
+final class FakeRepeatingTimer: BleRepeatingTimer {
+    private(set) var interval: TimeInterval?
+    private(set) var leeway: DispatchTimeInterval?
+    private(set) var activated = false
+    private(set) var cancelled = false
+    private var handler: (() -> Void)?
+
+    func setEventHandler(_ handler: @escaping () -> Void) {
+        self.handler = handler
+    }
+
+    func schedule(interval: TimeInterval, leeway: DispatchTimeInterval) {
+        self.interval = interval
+        self.leeway = leeway
+    }
+
+    func activate() {
+        activated = true
+    }
+
+    func cancel() {
+        cancelled = true
+    }
+
+    func fire(ignoringCancellation: Bool = false) {
+        guard let handler else { return }
+        if cancelled, !ignoringCancellation { return }
+        handler()
+    }
+}
+
+@available(iOS 17.0, *)
+final class FakeBleTimerScheduler: BleTimerScheduling {
+    private(set) var oneShotTimers: [FakeOneShotTimer] = []
+    private(set) var repeatingTimers: [FakeRepeatingTimer] = []
+
+    func scheduleOneShot(after delay: TimeInterval, label: String, _ handler: @escaping () -> Void) -> BleOneShotTimer {
+        let timer = FakeOneShotTimer(label: label, delay: delay, handler: handler)
+        oneShotTimers.append(timer)
+        return timer
+    }
+
+    func makeRepeatingTimer() -> BleRepeatingTimer {
+        let timer = FakeRepeatingTimer()
+        repeatingTimers.append(timer)
+        return timer
+    }
+
+    func oneShots(label: String) -> [FakeOneShotTimer] {
+        oneShotTimers.filter { $0.label == label }
+    }
+
+    func lastOneShot(label: String) -> FakeOneShotTimer? {
+        oneShots(label: label).last
+    }
+}
+
+// MARK: - Tests
+
+/// Characterization suite for the `BoardBleManager` write flow-control path
+/// (#3366). Every action is funnelled through `testHooks.sync {}` so the BLE
+/// serial queue's dispatch-specific reentrancy runs nested hops inline; the fake
+/// timers fire inline. No `XCTestExpectation`, no sleeps.
+@available(iOS 17.0, *)
+final class BoardBleWriteFlowTests: XCTestCase {
+    private var scheduler: FakeBleTimerScheduler!
+    private var manager: BoardBleManager!
+    private var cancelledPeripheralIds: [UUID] = []
+    private let uartWriteCharacteristicUuid = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
+
+    override func setUp() {
+        super.setUp()
+        cancelledPeripheralIds = []
+        scheduler = FakeBleTimerScheduler()
+        manager = BoardBleManager(timerScheduler: scheduler, createCentralManagerEagerly: false)
+        let hooks = manager.testHooks
+        hooks.sync {
+            // A dev machine's app-group defaults could leak a persisted config.
+            hooks.setConfiguration(nil)
+            // Intercept the sole concrete cancelPeripheralConnection call so a
+            // fake peripheral never has to be a CBPeripheral and no
+            // CBCentralManager is instantiated.
+            hooks.setCancelPeripheralConnectionOverride { [weak self] peripheral in
+                self?.cancelledPeripheralIds.append(peripheral.identifier)
+            }
+        }
+    }
+
+    override func tearDown() {
+        manager.testHooks.sync {
+            manager.testHooks.setCancelPeripheralConnectionOverride(nil)
+        }
+        manager = nil
+        scheduler = nil
+        super.tearDown()
+    }
+
+    private func makeCharacteristic(properties: CBCharacteristicProperties = .writeWithoutResponse) -> CBMutableCharacteristic {
+        CBMutableCharacteristic(
+            type: uartWriteCharacteristicUuid,
+            properties: properties,
+            value: nil,
+            permissions: [.writeable]
+        )
+    }
+
+    private func moonboardConfiguration() -> BoardBleConfiguration {
+        BoardBleConfiguration(
+            boardName: "moonboard",
+            layoutId: 0,
+            sizeId: 0,
+            apiLevel: nil,
+            deviceName: nil,
+            colorOverrides: [:],
+            numRows: nil
+        )
+    }
+
+    /// Fire the most recently scheduled one-shot with `label`, on the BLE queue.
+    private func fireLatestOneShot(label: String) {
+        manager.testHooks.sync {
+            guard let timer = scheduler.lastOneShot(label: label) else {
+                XCTFail("expected a scheduled \(label) timer")
+                return
+            }
+            timer.fire()
+        }
+    }
+
+    // 1
+    func testHappyPathWritesChunksSequentiallyWithChunkDelay() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: true, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+        let payload = Data((0 ..< 50).map { UInt8($0) })
+
+        var completionError: Error?
+        var completionTelemetry: BoardBleWriteTelemetry?
+        var completionCount = 0
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { error, telemetry in
+                completionError = error
+                completionTelemetry = telemetry
+                completionCount += 1
+            }
+        }
+
+        // Only the first chunk goes out synchronously; the rest pace on chunkDelay.
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(completionCount, 0)
+
+        fireLatestOneShot(label: "chunkDelay") // -> chunk 2
+        fireLatestOneShot(label: "chunkDelay") // -> chunk 3
+        fireLatestOneShot(label: "chunkDelay") // -> completion
+
+        XCTAssertEqual(peripheral.writtenChunks.count, 3)
+        XCTAssertEqual(peripheral.writtenChunks[0].data, payload.subdata(in: 0 ..< 20))
+        XCTAssertEqual(peripheral.writtenChunks[1].data, payload.subdata(in: 20 ..< 40))
+        XCTAssertEqual(peripheral.writtenChunks[2].data, payload.subdata(in: 40 ..< 50))
+        XCTAssertTrue(peripheral.writtenChunks.allSatisfy { $0.type == .withoutResponse })
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertNil(completionError)
+        XCTAssertEqual(completionTelemetry?.chunkCount, 3)
+        XCTAssertEqual(completionTelemetry?.parkCount, 0)
+        XCTAssertEqual(completionTelemetry?.writeType, "withoutResponse")
+    }
+
+    // 2
+    func testParkedWriteResumesViaPollerWhenCanSendFlipsWithoutDelegate() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        var completionTelemetry: BoardBleWriteTelemetry?
+        var completionCount = 0
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { _, telemetry in
+                completionTelemetry = telemetry
+                completionCount += 1
+            }
+        }
+
+        // Parked: no chunk, poller activated, watchdog armed, resume pending.
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+        XCTAssertEqual(scheduler.repeatingTimers.count, 1)
+        XCTAssertTrue(scheduler.repeatingTimers[0].activated)
+        XCTAssertNotNil(scheduler.lastOneShot(label: "writeResumeWatchdog"))
+        XCTAssertTrue(hooks.sync { hooks.hasPendingWriteResume })
+
+        // Tick while still false: stays parked.
+        hooks.sync { scheduler.repeatingTimers[0].fire() }
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+        XCTAssertTrue(hooks.sync { hooks.hasPendingWriteResume })
+
+        // Flip true and tick: resumes via the poller and finishes.
+        peripheral.canSendDefault = true
+        hooks.sync { scheduler.repeatingTimers[0].fire() }
+        fireLatestOneShot(label: "chunkDelay")
+
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(completionTelemetry?.lastResumeSource, "poll")
+        XCTAssertEqual(completionTelemetry?.parkCount, 1)
+        XCTAssertEqual(completionTelemetry?.peripheralIsReadyFired, false)
+        XCTAssertEqual(completionTelemetry?.watchdogTripped, false)
+        XCTAssertTrue(scheduler.repeatingTimers[0].cancelled)
+        XCTAssertTrue(scheduler.lastOneShot(label: "writeResumeWatchdog")?.cancelled ?? false)
+    }
+
+    // 3
+    func testPeripheralIsReadyCallbackResumesAndCancelsPoller() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        var completionTelemetry: BoardBleWriteTelemetry?
+        var completionCount = 0
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { _, telemetry in
+                completionTelemetry = telemetry
+                completionCount += 1
+            }
+        }
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+
+        // The delegate callback resumes the parked write, cancelling the poller
+        // without any tick having fired.
+        peripheral.canSendDefault = true
+        hooks.firePeripheralIsReady()
+        fireLatestOneShot(label: "chunkDelay")
+
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(completionTelemetry?.lastResumeSource, "callback")
+        XCTAssertEqual(completionTelemetry?.peripheralIsReadyFired, true)
+        XCTAssertTrue(scheduler.repeatingTimers[0].cancelled)
+
+        // A stale tick from the cancelled poller (already enqueued when cancel
+        // ran) writes nothing: the `===` identity guard bails.
+        hooks.sync { scheduler.repeatingTimers[0].fire(ignoringCancellation: true) }
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+    }
+
+    // 4
+    func testSynchronousReparkInstallsFreshPollerAndWatchdog() {
+        let hooks = manager.testHooks
+        // park read = false, poller-tick read = true, writeChunk re-read = false.
+        let peripheral = FakeWritablePeripheral(
+            canSendDefault: true,
+            canSendScript: [false, true, false],
+            maxWriteValueLength: 20
+        )
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        var completionTelemetry: BoardBleWriteTelemetry?
+        var completionCount = 0
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { _, telemetry in
+                completionTelemetry = telemetry
+                completionCount += 1
+            }
+        }
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+        XCTAssertEqual(scheduler.repeatingTimers.count, 1)
+        XCTAssertTrue(scheduler.repeatingTimers[0].activated)
+
+        // Poller#1 tick reads true -> resume -> writeChunk re-reads false -> re-park.
+        hooks.sync { scheduler.repeatingTimers[0].fire() }
+
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+        XCTAssertEqual(completionCount, 0)
+        XCTAssertEqual(hooks.sync { hooks.currentTelemetry?.parkCount }, 2)
+        // A fresh poller + watchdog replaced the retired pair.
+        XCTAssertEqual(scheduler.repeatingTimers.count, 2)
+        XCTAssertTrue(scheduler.repeatingTimers[0].cancelled)
+        XCTAssertTrue(scheduler.repeatingTimers[1].activated)
+        XCTAssertFalse(scheduler.repeatingTimers[1].cancelled)
+        let resumeWatchdogs = scheduler.oneShots(label: "writeResumeWatchdog")
+        XCTAssertEqual(resumeWatchdogs.count, 2)
+        XCTAssertTrue(resumeWatchdogs[0].cancelled)
+        XCTAssertFalse(resumeWatchdogs[1].cancelled)
+        XCTAssertTrue(hooks.sync { hooks.hasPendingWriteResume })
+
+        // Second poller tick with canSend truly true completes the write.
+        peripheral.canSendDefault = true
+        hooks.sync { scheduler.repeatingTimers[1].fire() }
+        fireLatestOneShot(label: "chunkDelay")
+
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(completionTelemetry?.lastResumeSource, "poll")
+    }
+
+    // 5
+    func testWatchdogTripRecordsCanSendAtTripFalseAndFailsWritesWithTimeout() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        var completionError: Error?
+        var completionTelemetry: BoardBleWriteTelemetry?
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { error, telemetry in
+                completionError = error
+                completionTelemetry = telemetry
+            }
+        }
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+
+        fireLatestOneShot(label: "writeResumeWatchdog")
+
+        XCTAssertEqual(completionError as? BoardBleError, .writeTimedOut)
+        XCTAssertEqual(completionTelemetry?.watchdogTripped, true)
+        XCTAssertEqual(completionTelemetry?.canSendAtTrip, false)
+        XCTAssertTrue(scheduler.repeatingTimers[0].cancelled)
+        XCTAssertEqual(hooks.sync { hooks.writeStallRecoveries }, 1)
+        XCTAssertEqual(hooks.sync { hooks.writeStallRecoveringPeripheralId }, peripheral.identifier)
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertNotNil(scheduler.lastOneShot(label: "writeStallRecoveryWatchdog"))
+    }
+
+    // 6
+    func testWatchdogTripRecordsCanSendAtTripTrueWhenPollerMissedFlip() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        var completionTelemetry: BoardBleWriteTelemetry?
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { _, telemetry in
+                completionTelemetry = telemetry
+            }
+        }
+
+        // The property flipped true but no poller tick observed it.
+        peripheral.canSendDefault = true
+        fireLatestOneShot(label: "writeResumeWatchdog")
+
+        XCTAssertEqual(completionTelemetry?.watchdogTripped, true)
+        XCTAssertEqual(completionTelemetry?.canSendAtTrip, true)
+    }
+
+    // 7
+    func testWatchdogTripWithPeripheralGoneOmitsCanSendAtTrip() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        var completionError: Error?
+        var completionTelemetry: BoardBleWriteTelemetry?
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { error, telemetry in
+                completionError = error
+                completionTelemetry = telemetry
+            }
+        }
+
+        // The peripheral vanished before the watchdog ran.
+        hooks.sync { hooks.setConnection(peripheral: nil, characteristic: nil) }
+        fireLatestOneShot(label: "writeResumeWatchdog")
+
+        XCTAssertEqual(completionError as? BoardBleError, .writeTimedOut)
+        XCTAssertEqual(completionTelemetry?.watchdogTripped, true)
+        XCTAssertNil(completionTelemetry?.canSendAtTrip)
+        // No link to cycle: the intentional-cancel path is not taken and the
+        // recovery budget is untouched.
+        XCTAssertTrue(cancelledPeripheralIds.isEmpty)
+        XCTAssertEqual(hooks.sync { hooks.writeStallRecoveries }, 0)
+    }
+
+    // 8
+    func testWatchdogTripBeyondRecoveryBudgetFailsWithRecoveryFailedAndEmitsDisconnect() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        var disconnectDeviceId: String?
+        var disconnectBody: [String: Any]?
+        var completionError: Error?
+
+        hooks.sync {
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: { deviceId, body in
+                    disconnectDeviceId = deviceId
+                    disconnectBody = body
+                },
+                onConnected: nil
+            )
+            // Already at the recovery budget: the next stall gives up.
+            hooks.setWriteStallRecoveries(2)
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { error, _ in
+                completionError = error
+            }
+        }
+
+        fireLatestOneShot(label: "writeResumeWatchdog")
+
+        XCTAssertEqual(completionError as? BoardBleError, .writeRecoveryFailed)
+        XCTAssertEqual(disconnectDeviceId, peripheral.identifier.uuidString)
+        XCTAssertEqual(disconnectBody?["context"] as? String, "write_stall_budget_exhausted")
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(hooks.sync { hooks.writeStallRecoveries }, 0)
+        XCTAssertNil(hooks.sync { hooks.writeStallRecoveringPeripheralId })
+    }
+
+    // 9
+    func testFailQueuedWritesCancelsPollerWatchdogAndSettlesAllCompletions() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+        let head = Data((0 ..< 10).map { UInt8($0) })
+        let second = Data((100 ..< 108).map { UInt8($0) })
+
+        var headError: Error?
+        var headTelemetry: BoardBleWriteTelemetry?
+        var headSettled = false
+        var secondError: Error?
+        var secondTelemetryWasNil = false
+        var secondSettled = false
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: head) { error, telemetry in
+                headError = error
+                headTelemetry = telemetry
+                headSettled = true
+            }
+            manager.write(data: second) { error, telemetry in
+                secondError = error
+                secondTelemetryWasNil = telemetry == nil
+                secondSettled = true
+            }
+        }
+        // Head parked, second queued behind it.
+        XCTAssertTrue(hooks.sync { hooks.hasPendingWriteResume })
+        XCTAssertEqual(hooks.sync { hooks.writeQueueDepth }, 2)
+        let generationBeforeCancel = hooks.sync { hooks.writeGeneration }
+
+        manager.cancelWrites()
+        // cancelWrites hops through runOnBleQueue; settle it with a barrier.
+        hooks.sync {}
+
+        XCTAssertTrue(headSettled)
+        XCTAssertEqual(headError as? BoardBleError, .writeCancelled)
+        XCTAssertEqual(headTelemetry?.parkCount, 1)
+        XCTAssertTrue(secondSettled)
+        XCTAssertEqual(secondError as? BoardBleError, .writeCancelled)
+        XCTAssertTrue(secondTelemetryWasNil)
+        XCTAssertTrue(scheduler.repeatingTimers[0].cancelled)
+        XCTAssertTrue(scheduler.lastOneShot(label: "writeResumeWatchdog")?.cancelled ?? false)
+        XCTAssertFalse(hooks.sync { hooks.hasPendingWriteResume })
+        XCTAssertFalse(hooks.sync { hooks.isWriting })
+        XCTAssertGreaterThan(hooks.sync { hooks.writeGeneration }, generationBeforeCancel)
+
+        // A fresh write on the same (still-connected) peripheral proceeds.
+        peripheral.canSendDefault = true
+        let fresh = Data((0 ..< 5).map { UInt8($0) })
+        hooks.sync {
+            manager.write(data: fresh) { _, _ in }
+        }
+        fireLatestOneShot(label: "chunkDelay")
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(peripheral.writtenChunks[0].data, fresh)
+    }
+
+    // 10
+    func testStalePollerTickAfterCancelIsInert() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { _, _ in }
+        }
+        manager.cancelWrites()
+        hooks.sync {}
+
+        // The poller was cancelled by failQueuedWrites; a tick already enqueued
+        // at cancel time must write nothing even with canSend flipped true.
+        peripheral.canSendDefault = true
+        hooks.sync { scheduler.repeatingTimers[0].fire(ignoringCancellation: true) }
+
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+    }
+
+    // 11
+    func testStaleResumeClosureAfterGenerationBumpIsInert() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { _, _ in }
+        }
+        let staleResume = hooks.sync { hooks.capturedPendingWriteResume }
+        XCTAssertNotNil(staleResume)
+
+        manager.cancelWrites()
+        hooks.sync {}
+
+        // Invoking the stale continuation after the write-generation bump: the
+        // generation guard in writeChunk bails.
+        peripheral.canSendDefault = true
+        hooks.sync { staleResume?() }
+        // Barrier for the defensive bleQueue.async reschedule in writeChunk.
+        hooks.sync {}
+
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+        XCTAssertFalse(hooks.sync { hooks.isWriting })
+    }
+
+    // 12
+    func testWithResponseWritePacesOnAckAndArmsAckWatchdog() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: true, maxWriteValueLength: 20)
+        // MoonBoard + `.write`-only characteristic -> the with-response path.
+        let characteristic = makeCharacteristic(properties: .write)
+        let payload = Data((0 ..< 40).map { UInt8($0) })
+
+        var completionError: Error?
+        var completionTelemetry: BoardBleWriteTelemetry?
+        var completionCount = 0
+
+        hooks.sync {
+            hooks.setConfiguration(moonboardConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { error, telemetry in
+                completionError = error
+                completionTelemetry = telemetry
+                completionCount += 1
+            }
+        }
+
+        // First chunk out with-response; paced on the ack, not chunkDelay.
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(peripheral.writtenChunks[0].type, .withResponse)
+        XCTAssertEqual(peripheral.writtenChunks[0].data.count, 20)
+        XCTAssertNotNil(scheduler.lastOneShot(label: "writeAckWatchdog"))
+        XCTAssertEqual(completionCount, 0)
+
+        hooks.fireWriteAck(error: nil) // -> chunk 2
+        XCTAssertEqual(peripheral.writtenChunks.count, 2)
+
+        hooks.fireWriteAck(error: nil) // -> completion
+        XCTAssertEqual(peripheral.writtenChunks.count, 2)
+        XCTAssertTrue(peripheral.writtenChunks.allSatisfy { $0.type == .withResponse })
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertNil(completionError)
+        XCTAssertEqual(completionTelemetry?.writeType, "withResponse")
+    }
+}

--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -351,6 +351,10 @@ final class BoardBleWriteFlowTests: XCTestCase {
         // Poller#1 tick reads true -> resume -> writeChunk re-reads false -> re-park.
         hooks.sync { scheduler.repeatingTimers[0].fire() }
 
+        // Every scripted read was consumed exactly where expected — a leftover
+        // entry means a read the scenario never made (the default would then
+        // silently answer later reads and mask it).
+        XCTAssertTrue(peripheral.canSendScript.isEmpty)
         XCTAssertTrue(peripheral.writtenChunks.isEmpty)
         XCTAssertEqual(completionCount, 0)
         XCTAssertEqual(hooks.sync { hooks.currentTelemetry?.parkCount }, 2)

--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -15,7 +15,6 @@ final class FakeWritablePeripheral: WritableBlePeripheral {
     var canSendScript: [Bool]
     var maxWriteValueLength: Int
     private(set) var writtenChunks: [(data: Data, type: CBCharacteristicWriteType)] = []
-    private(set) var canSendReadCount = 0
 
     init(
         identifier: UUID = UUID(),
@@ -32,7 +31,6 @@ final class FakeWritablePeripheral: WritableBlePeripheral {
     }
 
     var canSendWriteWithoutResponse: Bool {
-        canSendReadCount += 1
         if !canSendScript.isEmpty {
             return canSendScript.removeFirst()
         }
@@ -53,14 +51,12 @@ final class FakeWritablePeripheral: WritableBlePeripheral {
 @available(iOS 17.0, *)
 final class FakeOneShotTimer: BleOneShotTimer {
     let label: String
-    let delay: TimeInterval
     private let handler: () -> Void
     private(set) var cancelled = false
     private(set) var fired = false
 
-    init(label: String, delay: TimeInterval, handler: @escaping () -> Void) {
+    init(label: String, handler: @escaping () -> Void) {
         self.label = label
-        self.delay = delay
         self.handler = handler
     }
 
@@ -81,8 +77,6 @@ final class FakeOneShotTimer: BleOneShotTimer {
 /// manager's `===` identity self-guard.
 @available(iOS 17.0, *)
 final class FakeRepeatingTimer: BleRepeatingTimer {
-    private(set) var interval: TimeInterval?
-    private(set) var leeway: DispatchTimeInterval?
     private(set) var activated = false
     private(set) var cancelled = false
     private var handler: (() -> Void)?
@@ -91,10 +85,7 @@ final class FakeRepeatingTimer: BleRepeatingTimer {
         self.handler = handler
     }
 
-    func schedule(interval: TimeInterval, leeway: DispatchTimeInterval) {
-        self.interval = interval
-        self.leeway = leeway
-    }
+    func schedule(interval _: TimeInterval, leeway _: DispatchTimeInterval) {}
 
     func activate() {
         activated = true
@@ -116,8 +107,8 @@ final class FakeBleTimerScheduler: BleTimerScheduling {
     private(set) var oneShotTimers: [FakeOneShotTimer] = []
     private(set) var repeatingTimers: [FakeRepeatingTimer] = []
 
-    func scheduleOneShot(after delay: TimeInterval, label: String, _ handler: @escaping () -> Void) -> BleOneShotTimer {
-        let timer = FakeOneShotTimer(label: label, delay: delay, handler: handler)
+    func scheduleOneShot(after _: TimeInterval, label: String, _ handler: @escaping () -> Void) -> BleOneShotTimer {
+        let timer = FakeOneShotTimer(label: label, handler: handler)
         oneShotTimers.append(timer)
         return timer
     }

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -155,10 +155,21 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertEqual(result.totalPlacements, 3)
     }
 
-    func testMoonboardPacketIsEmptyWhenNothingEncodes() {
-        // No clear-all: an empty or all-skipped frame must produce no packet so
-        // the BLE manager refuses to write and leaves the wall lit as-is.
-        XCTAssertTrue(BoardBleEncoding.makeMoonboardPacket(frames: "").packet.isEmpty)
+    func testMoonboardPacketClearsForEmptyFrames() {
+        // Empty frames = deliberate clear-all: `l##` clears every LED on community
+        // firmware (JS parity). totalPlacements 0 (nothing to skip) is what keeps
+        // the caller's all-skipped guard from refusing it.
+        let result = BoardBleEncoding.makeMoonboardPacket(frames: "")
+        XCTAssertEqual(String(decoding: result.packet, as: UTF8.self), "l##")
+        XCTAssertEqual(result.totalPlacements, 0)
+        XCTAssertEqual(result.skippedRoleCount, 0)
+        XCTAssertEqual(result.skippedPositionCount, 0)
+    }
+
+    func testMoonboardPacketIsEmptyWhenAllPlacementsSkipped() {
+        // A non-empty climb whose holds all drop (role 45 is not a MoonBoard LED
+        // role) must produce no packet so the BLE manager refuses to write and
+        // leaves the wall lit as-is — never falls through to the clear-all frame.
         XCTAssertTrue(BoardBleEncoding.makeMoonboardPacket(frames: "p1r45").packet.isEmpty)
     }
 

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -173,6 +173,15 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertTrue(BoardBleEncoding.makeMoonboardPacket(frames: "p1r45").packet.isEmpty)
     }
 
+    func testMoonboardPacketIsEmptyForMalformedFrames() {
+        // Corrupt/truncated frames that PARSE to nothing are not a clear: the
+        // clear-all gate is the raw empty string, so these must hit the
+        // zero-encodable refusal (empty packet), never emit `l##` (#3420).
+        XCTAssertTrue(BoardBleEncoding.makeMoonboardPacket(frames: "p12").packet.isEmpty)
+        XCTAssertTrue(BoardBleEncoding.makeMoonboardPacket(frames: "pXr42").packet.isEmpty)
+        XCTAssertTrue(BoardBleEncoding.makeMoonboardPacket(frames: "garbage").packet.isEmpty)
+    }
+
     func testMoonboardSerialPositionMirrorsGridMath() {
         XCTAssertEqual(BoardBleEncoding.moonboardSerialPosition(holdId: 1), 0)
         XCTAssertEqual(BoardBleEncoding.moonboardSerialPosition(holdId: 2), 35)

--- a/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
@@ -360,14 +360,14 @@ enum BoardBleEncoding {
     }
 
     static func makeMoonboardPacket(frames: String, numRows: Int? = nil) -> BoardBlePacketResult {
-        let parsedFrames = parseFrames(frames)
-
         // `l##` (empty frame) is MoonBoard's clear-all: community firmware
         // (ArduinoMoonBoardLED) clears every LED on each incoming frame; unverified
-        // on official Moon controllers (at worst a no-op). Sent only on a
-        // deliberate clear (empty frames) — never as a fallback for an all-skipped
-        // climb, which must surface an error instead of silently darking the board.
-        if parsedFrames.isEmpty {
+        // on official Moon controllers (at worst a no-op). Gate on the RAW string —
+        // only the deliberate-clear input (`frames == ""`) may produce `l##`. A
+        // non-empty frames string that parses to nothing (corrupt/truncated data)
+        // must fall through to the zero-encodable refusal below, matching the JS
+        // builder's `isClear` contract.
+        if frames.isEmpty {
             return BoardBlePacketResult(
                 packet: Data((moonboardFramePrefix + moonboardFrameSuffix).utf8),
                 skippedPositionCount: 0,
@@ -376,6 +376,7 @@ enum BoardBleEncoding {
             )
         }
 
+        let parsedFrames = parseFrames(frames)
         var encodedHolds: [String] = []
         var skippedRoleCount = 0
         var skippedPositionCount = 0
@@ -392,11 +393,11 @@ enum BoardBleEncoding {
             encodedHolds.append("\(roleLetter)\(position)")
         }
 
-        // All placements skipped → refuse: a non-empty climb whose holds all
-        // dropped (unrecognised roles or out-of-range ids) must not fall through
-        // to `l##` (that's the deliberate clear-all above), so return an empty
-        // packet and let the caller refuse to write — matching
-        // dispatchMoonboardPacket on the JS side.
+        // Zero encodable holds on a non-empty climb → refuse: whether every
+        // placement was skipped (unrecognised roles, out-of-range ids) or the
+        // frames string parsed to nothing at all, falling through to `l##` would
+        // silently dark the wall, so return an empty packet and let the caller
+        // refuse to write — matching dispatchMoonboardPacket on the JS side.
         guard !encodedHolds.isEmpty else {
             return BoardBlePacketResult(
                 packet: Data(),

--- a/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
@@ -360,11 +360,26 @@ enum BoardBleEncoding {
     }
 
     static func makeMoonboardPacket(frames: String, numRows: Int? = nil) -> BoardBlePacketResult {
+        let parsedFrames = parseFrames(frames)
+
+        // `l##` (empty frame) is MoonBoard's clear-all: community firmware
+        // (ArduinoMoonBoardLED) clears every LED on each incoming frame; unverified
+        // on official Moon controllers (at worst a no-op). Sent only on a
+        // deliberate clear (empty frames) — never as a fallback for an all-skipped
+        // climb, which must surface an error instead of silently darking the board.
+        if parsedFrames.isEmpty {
+            return BoardBlePacketResult(
+                packet: Data((moonboardFramePrefix + moonboardFrameSuffix).utf8),
+                skippedPositionCount: 0,
+                skippedRoleCount: 0,
+                totalPlacements: 0
+            )
+        }
+
         var encodedHolds: [String] = []
         var skippedRoleCount = 0
         var skippedPositionCount = 0
 
-        let parsedFrames = parseFrames(frames)
         for frame in parsedFrames {
             guard let roleLetter = moonboardRoleMap[frame.roleCode] else {
                 skippedRoleCount += 1
@@ -377,10 +392,11 @@ enum BoardBleEncoding {
             encodedHolds.append("\(roleLetter)\(position)")
         }
 
-        // No clear-all for MoonBoard: an empty `l##` frame is a no-op on the
-        // controller, so when nothing encodes (unrecognised roles, out-of-range
-        // ids, or no holds) return an empty packet and let the caller refuse to
-        // write — matching dispatchMoonboardPacket on the JS side.
+        // All placements skipped → refuse: a non-empty climb whose holds all
+        // dropped (unrecognised roles or out-of-range ids) must not fall through
+        // to `l##` (that's the deliberate clear-all above), so return an empty
+        // packet and let the caller refuse to write — matching
+        // dispatchMoonboardPacket on the JS side.
         guard !encodedHolds.isEmpty else {
             return BoardBlePacketResult(
                 packet: Data(),

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -709,18 +709,23 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         guard let configuration else { return }
         guard connectedPeripheral != nil, writeCharacteristic != nil else { return }
 
-        // MoonBoard has no clear-all command (an empty `l##` frame is a no-op on
-        // the controller and the JS layer refuses to send it), so leave the wall
-        // lit as-is rather than writing an Aurora clear packet to it.
-        if configuration.boardName == "moonboard" { return }
-
-        let result = BoardBleEncoding.makeAuroraPacket(
-            frames: "",
-            placementPositions: [:],
-            boardName: configuration.boardName,
-            apiLevel: apiLevelOnBleQueue(configuration: configuration),
-            colorOverrides: configuration.colorOverrides
-        )
+        // `l##` (empty frame) is MoonBoard's clear-all: community firmware
+        // (ArduinoMoonBoardLED) clears every LED on each incoming frame; unverified
+        // on official Moon controllers (at worst a no-op). Aurora clears via its
+        // own empty-frames packet. Either way a deliberate clear darks the wall,
+        // matching the JS clear path.
+        let result: BoardBlePacketResult
+        if configuration.boardName == "moonboard" {
+            result = BoardBleEncoding.makeMoonboardPacket(frames: "", numRows: configuration.numRows)
+        } else {
+            result = BoardBleEncoding.makeAuroraPacket(
+                frames: "",
+                placementPositions: [:],
+                boardName: configuration.boardName,
+                apiLevel: apiLevelOnBleQueue(configuration: configuration),
+                colorOverrides: configuration.colorOverrides
+            )
+        }
 
         guard !result.packet.isEmpty else { return }
         writeOnBleQueue(data: result.packet) { [weak self] error, _ in
@@ -746,9 +751,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // 18-row standard-wall default.
             let result = BoardBleEncoding.makeMoonboardPacket(frames: item.frames, numRows: configuration.numRows)
             guard !result.packet.isEmpty else {
-                // Every hold was unrecognised/out-of-range, or the climb has no
-                // holds. Refuse to write rather than dark the wall — there is no
-                // MoonBoard clear-all.
+                // A non-empty climb whose holds all dropped (unrecognised/out-of-
+                // range) → refuse to write rather than dark the wall. Only a
+                // deliberate empty-frames item clears (via `l##`, Aurora parity);
+                // makeMoonboardPacket returns an empty packet for this all-skipped
+                // case so it never reaches the wall.
                 logger.warning("Skipping MoonBoard BLE write: no encodable holds for climb \(item.climbUuid, privacy: .public)")
                 return
             }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -79,7 +79,7 @@ struct BoardBleWriteTelemetry {
     }
 }
 
-enum BoardBleError: LocalizedError, Equatable {
+enum BoardBleError: LocalizedError {
     case bluetoothUnavailable
     case deviceNotFound
     case connectTimedOut
@@ -258,9 +258,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     #if DEBUG || BOARDSESH_TESTS
     /// Test-only interception of the single concrete `cancelPeripheralConnection`
     /// call site so a fake peripheral never has to be a real `CBPeripheral` and no
-    /// `CBCentralManager` is instantiated. nil in production/dev; only the write
-    /// flow-control test suite sets it.
-    var cancelPeripheralConnectionOverrideForTesting: ((WritableBlePeripheral) -> Void)?
+    /// `CBCentralManager` is instantiated. nil in production/dev; set only through
+    /// `TestHooks.setCancelPeripheralConnectionOverride` (same-file extension).
+    private var cancelPeripheralConnectionOverrideForTesting: ((WritableBlePeripheral) -> Void)?
     #endif
 
     private var onScanResult: ((BoardBleScanResult) -> Void)?
@@ -275,19 +275,28 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// wall. Payload: (deviceId, deviceName).
     private var onConnected: ((String, String?) -> Void)?
 
-    /// Production must use `BoardBleManager.shared`, which calls this with the
-    /// default arguments — reproducing the original `override private init()`
-    /// exactly: the real GCD `DispatchBleTimerScheduler` and an eagerly created
-    /// `CBCentralManager`. Tests construct isolated instances with a fake
-    /// scheduler and `createCentralManagerEagerly: false` so no CoreBluetooth
-    /// stack (or permission prompt) spins up.
-    init(timerScheduler: BleTimerScheduling? = nil, createCentralManagerEagerly: Bool = true) {
+    /// `private` keeps the singleton compiler-enforced: a second live instance
+    /// would register a second `CBCentralManager` with the same restoration
+    /// identifier and split connection state across two delegates.
+    override private init() {
         super.init()
-        // Assign before the lazy `timerScheduler` default (or anything else) can
-        // touch it — nothing in this initializer reads the scheduler.
-        if let timerScheduler {
-            self.timerScheduler = timerScheduler
-        }
+        completeInit(createCentralManagerEagerly: true)
+    }
+
+    #if DEBUG || BOARDSESH_TESTS
+    /// Test-only isolated instance: a fake scheduler plus
+    /// `createCentralManagerEagerly: false` means no CoreBluetooth stack (or
+    /// permission prompt) ever spins up. Production must use `.shared`.
+    init(timerScheduler: BleTimerScheduling, createCentralManagerEagerly: Bool) {
+        super.init()
+        // Assign before the lazy `timerScheduler` default (or anything else)
+        // can touch it — nothing in completeInit reads the scheduler.
+        self.timerScheduler = timerScheduler
+        completeInit(createCentralManagerEagerly: createCentralManagerEagerly)
+    }
+    #endif
+
+    private func completeInit(createCentralManagerEagerly: Bool) {
         bleQueue.setSpecific(key: bleQueueKey, value: ())
         runOnBleQueueSync {
             configuration = readConfiguration()

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -79,7 +79,7 @@ struct BoardBleWriteTelemetry {
     }
 }
 
-enum BoardBleError: LocalizedError {
+enum BoardBleError: LocalizedError, Equatable {
     case bluetoothUnavailable
     case deviceNotFound
     case connectTimedOut
@@ -192,7 +192,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // device; without this gate every repeat advertisement would cross the
     // native→JS bridge. Cleared on every startScan so a fresh scan re-emits.
     private var emittedScanResults: [String: String] = [:]
-    private var connectedPeripheral: CBPeripheral?
+    private var connectedPeripheral: WritableBlePeripheral?
     private var writeCharacteristic: CBCharacteristic?
     private var pendingConnectCompletion: ((Result<Void, Error>) -> Void)?
     private var connectTimeoutWorkItem: DispatchWorkItem?
@@ -210,12 +210,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var writeGeneration: UInt64 = 0
     private var isWriting = false
     private var pendingWriteResume: (() -> Void)?
-    private var pendingWriteResumeWatchdog: DispatchWorkItem?
+    private var pendingWriteResumeWatchdog: BleOneShotTimer?
     // Poller behind the parked write (#3230): re-checks
     // `canSendWriteWithoutResponse` while `pendingWriteResume` is set, because
     // iOS 26.5 can flip the property without ever delivering the
     // `peripheralIsReady` delegate. Cancelled wherever the watchdog is.
-    private var writeResumePoller: DispatchSourceTimer?
+    private var writeResumePoller: BleRepeatingTimer?
     // Telemetry for the request currently being written (#3230). Requests are
     // strictly serial (`isWriting`), so one slot suffices: seeded when a request
     // starts, finalized at whichever settle point delivers its completion.
@@ -225,7 +225,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // characteristic advertises only `.write`). The `didWriteValueFor` ack is
     // the resume signal — the with-response analogue of `pendingWriteResume`.
     private var pendingWriteAck: (() -> Void)?
-    private var pendingWriteAckWatchdog: DispatchWorkItem?
+    private var pendingWriteAckWatchdog: BleOneShotTimer?
     // Write-stall recovery (#3181). `writeStallRecoveries` counts consecutive
     // stalls (reset on any drained write). `writeStallRecoveringPeripheralId` is
     // the board whose congested link we deliberately cycled; it is set across the
@@ -243,10 +243,25 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // stays on), this fires so the window can't strand forever (wall dark, JS
     // still "connected"). Cancelled the moment the reconnect actually starts —
     // from there the reconnect's own connect timeout owns the deadline (#3181).
-    private var writeStallRecoveryWatchdog: DispatchWorkItem?
+    private var writeStallRecoveryWatchdog: BleOneShotTimer?
     private var configuration: BoardBleConfiguration?
     private lazy var readyWaiters = WaiterPool(queue: bleQueue)
     private lazy var drainWaiters = WaiterPool(queue: bleQueue)
+
+    /// Injectable factory for the write flow-control timers (#3366). Production
+    /// (`.shared`, or any default-arg init) uses the GCD-backed
+    /// `DispatchBleTimerScheduler` — byte-for-byte the pre-refactor inline code.
+    /// An init that supplies a scheduler assigns it before this lazy default can
+    /// be touched, so tests get their fake instead.
+    private lazy var timerScheduler: BleTimerScheduling = DispatchBleTimerScheduler(queue: bleQueue)
+
+    #if DEBUG || BOARDSESH_TESTS
+    /// Test-only interception of the single concrete `cancelPeripheralConnection`
+    /// call site so a fake peripheral never has to be a real `CBPeripheral` and no
+    /// `CBCentralManager` is instantiated. nil in production/dev; only the write
+    /// flow-control test suite sets it.
+    var cancelPeripheralConnectionOverrideForTesting: ((WritableBlePeripheral) -> Void)?
+    #endif
 
     private var onScanResult: ((BoardBleScanResult) -> Void)?
     // Second arg carries the disconnect reason (CoreBluetooth NSError code/domain/
@@ -260,12 +275,25 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// wall. Payload: (deviceId, deviceName).
     private var onConnected: ((String, String?) -> Void)?
 
-    override private init() {
+    /// Production must use `BoardBleManager.shared`, which calls this with the
+    /// default arguments — reproducing the original `override private init()`
+    /// exactly: the real GCD `DispatchBleTimerScheduler` and an eagerly created
+    /// `CBCentralManager`. Tests construct isolated instances with a fake
+    /// scheduler and `createCentralManagerEagerly: false` so no CoreBluetooth
+    /// stack (or permission prompt) spins up.
+    init(timerScheduler: BleTimerScheduling? = nil, createCentralManagerEagerly: Bool = true) {
         super.init()
+        // Assign before the lazy `timerScheduler` default (or anything else) can
+        // touch it — nothing in this initializer reads the scheduler.
+        if let timerScheduler {
+            self.timerScheduler = timerScheduler
+        }
         bleQueue.setSpecific(key: bleQueueKey, value: ())
         runOnBleQueueSync {
             configuration = readConfiguration()
-            _ = centralManager
+            if createCentralManagerEagerly {
+                _ = centralManager
+            }
         }
     }
 
@@ -646,7 +674,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         intentionalDisconnectGenerations[peripheral.identifier] = connectionGeneration
         peripheralGenerations[peripheral.identifier] = connectionGeneration
-        centralManager.cancelPeripheralConnection(peripheral)
+        cancelPeripheralConnection(peripheral)
         writeCharacteristic = nil
         connectedPeripheral = nil
         completion?()
@@ -1144,6 +1172,14 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        handlePeripheralIsReadyOnBleQueue()
+    }
+
+    /// Body of `peripheralIsReady(toSendWriteWithoutResponse:)`, extracted so the
+    /// write flow-control tests can drive it without a real `CBPeripheral`
+    /// (#3366). The delegate already ignored the peripheral arg, so this is a
+    /// pure move. Runs on `bleQueue` (CoreBluetooth delivers the delegate there).
+    func handlePeripheralIsReadyOnBleQueue() {
         // Recorded even when nothing is parked: the diagnostic question for
         // #3230 is whether iOS delivered this delegate at all during a request.
         currentWriteTelemetry?.peripheralIsReadyFired = true
@@ -1190,7 +1226,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// guard (and, beyond those, `writeChunk`'s generation guards).
     private func startWriteResumePollerOnBleQueue() {
         writeResumePoller?.cancel()
-        let poller = DispatchSource.makeTimerSource(queue: bleQueue)
+        let poller = timerScheduler.makeRepeatingTimer()
         poller.setEventHandler { [weak self, weak poller] in
             guard let self, let poller, self.writeResumePoller === poller else { return }
             guard self.pendingWriteResume != nil else {
@@ -1206,8 +1242,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             self.resumeParkedWrite(source: "poll")
         }
         poller.schedule(
-            deadline: .now() + writeResumePollInterval,
-            repeating: writeResumePollInterval,
+            interval: writeResumePollInterval,
             leeway: .milliseconds(20)
         )
         writeResumePoller = poller
@@ -1220,6 +1255,14 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // already nil'd it) no-ops. Stale-generation acks are caught by
     // `writeChunk`'s generation guard when the continuation re-enters.
     func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        handleDidWriteValueOnBleQueue(error: error)
+    }
+
+    /// Body of `didWriteValueFor`, extracted so the write flow-control tests can
+    /// drive the with-response ack path without a real `CBPeripheral` (#3366).
+    /// The delegate used only `error` (never the peripheral/characteristic), so
+    /// this is a pure move. Runs on `bleQueue`.
+    func handleDidWriteValueOnBleQueue(error: Error?) {
         pendingWriteAckWatchdog?.cancel()
         pendingWriteAckWatchdog = nil
         let ack = pendingWriteAck
@@ -1291,7 +1334,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     private func connectionDiagnosticsOnBleQueue(
-        peripheral: CBPeripheral,
+        peripheral: WritableBlePeripheral,
         characteristic: CBCharacteristic
     ) -> BoardBleConnectionDiagnostics {
         let properties = characteristic.properties
@@ -1445,7 +1488,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 // field: true would mean the poller missed a flip (logic bug);
                 // false proves the wedge that only a link cycle clears; absent
                 // means the peripheral was already gone when the watchdog ran.
-                let watchdog = DispatchWorkItem { [weak self] in
+                pendingWriteResumeWatchdog?.cancel()
+                pendingWriteResumeWatchdog = timerScheduler.scheduleOneShot(after: writeResumeTimeout, label: "writeResumeWatchdog") { [weak self] in
                     guard let self, self.pendingWriteResume != nil else { return }
                     // Tri-state on purpose: true = the poller missed a flip
                     // (logic bug), false = wedged buffer on a live link, nil
@@ -1457,15 +1501,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                     self.logger.error("BLE write stalled: peripheral never became ready for write-without-response (canSendAtTrip=\(String(describing: canSendAtTrip), privacy: .public)); attempting recovery")
                     self.handleWriteStall()
                 }
-                pendingWriteResumeWatchdog?.cancel()
-                pendingWriteResumeWatchdog = watchdog
-                bleQueue.asyncAfter(deadline: .now() + writeResumeTimeout, execute: watchdog)
                 startWriteResumePollerOnBleQueue()
                 return
             }
 
             peripheral.writeValue(request.chunks[chunkIndex], for: characteristic, type: .withoutResponse)
-            bleQueue.asyncAfter(deadline: .now() + chunkDelay) { [weak self] in
+            _ = timerScheduler.scheduleOneShot(after: chunkDelay, label: "chunkDelay") { [weak self] in
                 self?.writeChunk(
                     requestIndex: requestIndex,
                     chunkIndex: chunkIndex + 1,
@@ -1492,15 +1533,13 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
         // Watchdog mirrors the without-response stall path: if the board never
         // acks within writeResumeTimeout, recover by cycling the link (#3181).
-        let ackWatchdog = DispatchWorkItem { [weak self] in
+        pendingWriteAckWatchdog?.cancel()
+        pendingWriteAckWatchdog = timerScheduler.scheduleOneShot(after: writeResumeTimeout, label: "writeAckWatchdog") { [weak self] in
             guard let self, self.pendingWriteAck != nil else { return }
             self.currentWriteTelemetry?.watchdogTripped = true
             self.logger.error("BLE write stalled: peripheral never acked write-with-response; attempting recovery")
             self.handleWriteStall()
         }
-        pendingWriteAckWatchdog?.cancel()
-        pendingWriteAckWatchdog = ackWatchdog
-        bleQueue.asyncAfter(deadline: .now() + writeResumeTimeout, execute: ackWatchdog)
         peripheral.writeValue(request.chunks[chunkIndex], for: characteristic, type: .withResponse)
     }
 
@@ -1612,7 +1651,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // recovery arm cancels this and hands the deadline to the reconnect's own
         // connect timeout; if didDisconnect never lands, this fails closed.
         let recoveringId = peripheral.identifier
-        let recoveryWatchdog = DispatchWorkItem { [weak self] in
+        writeStallRecoveryWatchdog?.cancel()
+        writeStallRecoveryWatchdog = timerScheduler.scheduleOneShot(after: connectTimeout, label: "writeStallRecoveryWatchdog") { [weak self] in
             guard let self, self.writeStallRecoveringPeripheralId == recoveringId else { return }
             self.logger.error("BLE write-stall recovery stalled before reconnect (no didDisconnect); surfacing disconnect for \(recoveringId.uuidString, privacy: .public)")
             self.writeStallRecoveringPeripheralId = nil
@@ -1621,22 +1661,38 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             self.connectedPeripheral = nil
             self.onDisconnect?(recoveringId.uuidString, ["context": "write_stall_recovery_timeout"])
         }
-        writeStallRecoveryWatchdog?.cancel()
-        writeStallRecoveryWatchdog = recoveryWatchdog
-        bleQueue.asyncAfter(deadline: .now() + connectTimeout, execute: recoveryWatchdog)
     }
 
     /// Intentionally drop the current link: bump the generation, mark the
     /// disconnect intentional (so didDisconnectPeripheral suppresses the
     /// onDisconnect-to-JS and invalidates the old link's stale callbacks), cancel,
     /// and null the connection. Shared by the write-stall recovery paths (#3181).
-    private func cancelConnectionIntentionallyOnBleQueue(_ peripheral: CBPeripheral) {
+    private func cancelConnectionIntentionallyOnBleQueue(_ peripheral: WritableBlePeripheral) {
         connectionGeneration += 1
         intentionalDisconnectGenerations[peripheral.identifier] = connectionGeneration
         peripheralGenerations[peripheral.identifier] = connectionGeneration
-        centralManager.cancelPeripheralConnection(peripheral)
+        cancelPeripheralConnection(peripheral)
         writeCharacteristic = nil
         connectedPeripheral = nil
+    }
+
+    /// The single concrete `CBCentralManager.cancelPeripheralConnection` call
+    /// site. Every `WritableBlePeripheral` is a `CBPeripheral` outside tests, so
+    /// in production this is exactly the old inline call. The test override lets
+    /// the write flow-control suite observe intentional cancels without a real
+    /// CoreBluetooth peripheral.
+    private func cancelPeripheralConnection(_ peripheral: WritableBlePeripheral) {
+        #if DEBUG || BOARDSESH_TESTS
+        if let overrideForTesting = cancelPeripheralConnectionOverrideForTesting {
+            overrideForTesting(peripheral)
+            return
+        }
+        #endif
+        guard let concretePeripheral = peripheral as? CBPeripheral else {
+            assertionFailure("WritableBlePeripheral is always CBPeripheral outside tests")
+            return
+        }
+        centralManager.cancelPeripheralConnection(concretePeripheral)
     }
 
     private func readConfiguration() -> BoardBleConfiguration? {
@@ -1677,3 +1733,69 @@ private extension Data {
         self = Data(bytes)
     }
 }
+
+#if DEBUG || BOARDSESH_TESTS
+extension BoardBleManager {
+    /// Test-only seam into the write flow-control internals (#3366). Reaches the
+    /// manager's `private` state via same-file extension access, so the write
+    /// flow-control suite can set up an isolated connection, drive the timers /
+    /// delegate callbacks the fakes replace, and read back the resulting state
+    /// without touching CoreBluetooth. Never compiled into release builds.
+    struct TestHooks {
+        fileprivate let manager: BoardBleManager
+
+        /// Run `body` on the BLE serial queue synchronously. Nested manager hops
+        /// (`runOnBleQueue`) execute inline under this, so a whole action settles
+        /// before the call returns — the suite's determinism relies on it.
+        func sync<T>(_ body: () -> T) -> T {
+            manager.runOnBleQueueSync(body)
+        }
+
+        /// Directly seed the connection the write path guards on. No CoreBluetooth
+        /// side effects, unlike the real connect flow.
+        func setConnection(peripheral: WritableBlePeripheral?, characteristic: CBCharacteristic?) {
+            manager.connectedPeripheral = peripheral
+            manager.writeCharacteristic = characteristic
+        }
+
+        /// Set the in-memory board configuration WITHOUT the app-group persistence
+        /// `configure()` performs — so a dev machine's stored config can't leak in.
+        func setConfiguration(_ configuration: BoardBleConfiguration?) {
+            manager.configuration = configuration
+        }
+
+        /// Seed the consecutive-stall counter to exercise the recovery-budget
+        /// boundary in `handleWriteStall`.
+        func setWriteStallRecoveries(_ count: Int) {
+            manager.writeStallRecoveries = count
+        }
+
+        /// Intercept the single concrete `cancelPeripheralConnection` call so a
+        /// fake peripheral never has to be a real `CBPeripheral`.
+        func setCancelPeripheralConnectionOverride(_ handler: ((WritableBlePeripheral) -> Void)?) {
+            manager.cancelPeripheralConnectionOverrideForTesting = handler
+        }
+
+        /// Fire the `peripheralIsReady(toSendWriteWithoutResponse:)` delegate body.
+        func firePeripheralIsReady() {
+            manager.runOnBleQueueSync { manager.handlePeripheralIsReadyOnBleQueue() }
+        }
+
+        /// Fire the `didWriteValueFor` delegate body (with-response ack path).
+        func fireWriteAck(error: Error?) {
+            manager.runOnBleQueueSync { manager.handleDidWriteValueOnBleQueue(error: error) }
+        }
+
+        var hasPendingWriteResume: Bool { manager.pendingWriteResume != nil }
+        var capturedPendingWriteResume: (() -> Void)? { manager.pendingWriteResume }
+        var isWriting: Bool { manager.isWriting }
+        var writeQueueDepth: Int { manager.writeQueue.count }
+        var writeGeneration: UInt64 { manager.writeGeneration }
+        var currentTelemetry: BoardBleWriteTelemetry? { manager.currentWriteTelemetry }
+        var writeStallRecoveries: Int { manager.writeStallRecoveries }
+        var writeStallRecoveringPeripheralId: UUID? { manager.writeStallRecoveringPeripheralId }
+    }
+
+    var testHooks: TestHooks { TestHooks(manager: self) }
+}
+#endif

--- a/packages/mobile/modules/live-activity/ios/BoardBleWriteSeams.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleWriteSeams.swift
@@ -1,0 +1,106 @@
+import CoreBluetooth
+import Foundation
+
+/// The slice of `CBPeripheral` the write flow-control path uses (#3366).
+/// `CBPeripheral` conforms via an empty extension — zero behavior change; the
+/// seam exists only so tests can inject a fake peripheral without standing up a
+/// real CoreBluetooth stack.
+protocol WritableBlePeripheral: AnyObject {
+    var identifier: UUID { get }
+    var name: String? { get }
+    var canSendWriteWithoutResponse: Bool { get }
+    func maximumWriteValueLength(for type: CBCharacteristicWriteType) -> Int
+    func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType)
+}
+
+extension CBPeripheral: WritableBlePeripheral {}
+
+/// One-shot cancellable timer. Production wraps a `DispatchWorkItem` scheduled
+/// via `queue.asyncAfter`; `cancel()` forwards to the work item's `cancel()`.
+protocol BleOneShotTimer: AnyObject {
+    func cancel()
+}
+
+/// Repeating timer mirroring `DispatchSourceTimer`'s lifecycle
+/// (`setEventHandler` → `schedule` → `activate`; `cancel`). `AnyObject` so the
+/// `===` identity guard behind the write-resume poller keeps working.
+protocol BleRepeatingTimer: AnyObject {
+    func setEventHandler(_ handler: @escaping () -> Void)
+    func schedule(interval: TimeInterval, leeway: DispatchTimeInterval)
+    func activate()
+    func cancel()
+}
+
+/// Factory for the write flow-control timers. Production hands back GCD-backed
+/// timers scheduled on the BLE queue; tests hand back fakes they fire inline.
+protocol BleTimerScheduling: AnyObject {
+    /// `label` names the call site ("writeResumeWatchdog" | "chunkDelay" |
+    /// "writeAckWatchdog" | "writeStallRecoveryWatchdog"); tests key on it.
+    func scheduleOneShot(after delay: TimeInterval, label: String, _ handler: @escaping () -> Void) -> BleOneShotTimer
+    func makeRepeatingTimer() -> BleRepeatingTimer
+}
+
+/// Production scheduler: wraps GCD exactly as the pre-#3366 inline code did, so
+/// swapping the manager's timer construction onto this seam is byte-for-byte
+/// behavior-preserving.
+///
+/// - one-shot: `DispatchWorkItem(block: handler)` scheduled with
+///   `queue.asyncAfter(deadline: .now() + delay, execute:)`; `cancel()` →
+///   `workItem.cancel()`.
+/// - repeating: a `DispatchSource.makeTimerSource(queue:)` whose
+///   `setEventHandler` / `activate` / `cancel` are forwarded 1:1, and whose
+///   `schedule(interval:leeway:)` maps to
+///   `timer.schedule(deadline: .now() + interval, repeating: interval, leeway:)`.
+final class DispatchBleTimerScheduler: BleTimerScheduling {
+    private let queue: DispatchQueue
+
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
+
+    func scheduleOneShot(after delay: TimeInterval, label _: String, _ handler: @escaping () -> Void) -> BleOneShotTimer {
+        let workItem = DispatchWorkItem(block: handler)
+        queue.asyncAfter(deadline: .now() + delay, execute: workItem)
+        return DispatchBleOneShotTimer(workItem: workItem)
+    }
+
+    func makeRepeatingTimer() -> BleRepeatingTimer {
+        DispatchBleRepeatingTimer(timer: DispatchSource.makeTimerSource(queue: queue))
+    }
+}
+
+private final class DispatchBleOneShotTimer: BleOneShotTimer {
+    private let workItem: DispatchWorkItem
+
+    init(workItem: DispatchWorkItem) {
+        self.workItem = workItem
+    }
+
+    func cancel() {
+        workItem.cancel()
+    }
+}
+
+private final class DispatchBleRepeatingTimer: BleRepeatingTimer {
+    private let timer: DispatchSourceTimer
+
+    init(timer: DispatchSourceTimer) {
+        self.timer = timer
+    }
+
+    func setEventHandler(_ handler: @escaping () -> Void) {
+        timer.setEventHandler(handler: handler)
+    }
+
+    func schedule(interval: TimeInterval, leeway: DispatchTimeInterval) {
+        timer.schedule(deadline: .now() + interval, repeating: interval, leeway: leeway)
+    }
+
+    func activate() {
+        timer.activate()
+    }
+
+    func cancel() {
+        timer.cancel()
+    }
+}

--- a/packages/mobile/src/components/__tests__/ble-control-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/ble-control-sheet.test.tsx
@@ -40,7 +40,6 @@ const baseProps = {
   visible: true,
   onReassert: vi.fn(),
   onClearLights: vi.fn(),
-  supportsClearLights: true,
   onDisconnect: vi.fn(),
   onClose: vi.fn(),
 };
@@ -85,11 +84,10 @@ describe('BleControlSheet', () => {
     expect(baseProps.onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('hides the turn-off row when the board cannot encode a clear frame (MoonBoard)', () => {
-    const { queryByText, getByText } = render(<BleControlSheet {...baseProps} supportsClearLights={false} />);
-    expect(queryByText('lightControl.turnOffAll')).toBeNull();
-    // The other controls stay available.
-    expect(getByText('ble.relightBoard')).toBeDefined();
-    expect(getByText('lightControl.disconnect')).toBeDefined();
+  it('always renders the turn-off row (every board now has a clear-all, incl. MoonBoard)', () => {
+    // MoonBoard clears via its `l##` empty frame (#3420), so the row is no longer
+    // board-gated — it shows on every connected board.
+    const { getByText } = render(<BleControlSheet {...baseProps} />);
+    expect(getByText('lightControl.turnOffAll')).toBeDefined();
   });
 });

--- a/packages/mobile/src/components/ble/BleControlSheet.tsx
+++ b/packages/mobile/src/components/ble/BleControlSheet.tsx
@@ -14,13 +14,6 @@ type BleControlSheetProps = {
   onReassert: () => void;
   /** Clear every LED on the wall, keeping the connection alive. */
   onClearLights: () => void;
-  /**
-   * Whether the connected board can encode a clear-all frame. MoonBoard's
-   * protocol has no "clear" packet (an empty frame is a deliberate no-op in
-   * sendFramesToBoard, matching web), so the row is hidden rather than left
-   * as a silent dead tap.
-   */
-  supportsClearLights: boolean;
   /** Drop the BLE connection. */
   onDisconnect: () => void;
   onClose: () => void;
@@ -29,14 +22,7 @@ type BleControlSheetProps = {
 // Secondary BLE controls (Re-light / Turn off all lights / Disconnect) revealed
 // by long-pressing the lightbulb — keeps the destructive Disconnect behind a
 // labelled menu.
-function BleControlSheet({
-  visible,
-  onReassert,
-  onClearLights,
-  supportsClearLights,
-  onDisconnect,
-  onClose,
-}: BleControlSheetProps) {
+function BleControlSheet({ visible, onReassert, onClearLights, onDisconnect, onClose }: BleControlSheetProps) {
   const { t: tSettings } = useTranslation('settings');
   const { t: tCommon } = useTranslation('common');
   const { brandColors, systemColors } = useTheme();
@@ -67,14 +53,12 @@ function BleControlSheet({
           onPress={handleReassert}
           showSeparator
         />
-        {supportsClearLights && (
-          <ListRow
-            title={tCommon('lightControl.turnOffAll')}
-            leading={<Icon name="lightbulb.slash" size={22} color={systemColors.secondaryLabel} />}
-            onPress={handleClearLights}
-            showSeparator
-          />
-        )}
+        <ListRow
+          title={tCommon('lightControl.turnOffAll')}
+          leading={<Icon name="lightbulb.slash" size={22} color={systemColors.secondaryLabel} />}
+          onPress={handleClearLights}
+          showSeparator
+        />
         <ListRow
           title={tCommon('lightControl.disconnect')}
           leading={<Icon name="bluetooth.off" size={22} color={iosSystemColors.systemRed} />}

--- a/packages/mobile/src/components/ble/BleControlSheetHost.tsx
+++ b/packages/mobile/src/components/ble/BleControlSheetHost.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { toBoardName } from '@boardsesh/board-config';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
-import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { disconnectAllBluetooth } from '../../lib/ble/bluetooth-status-store';
 import { BleControlSheet } from './BleControlSheet';
 
@@ -18,12 +16,9 @@ type BleControlSheetHostProps = {
  *   - inside the play route (PlayDrawer) so the lightbulb's sheet presents ABOVE
  *     the route instead of behind it (an @expo/ui sheet presents off the VC that
  *     owns its subtree; a root-only instance lands under the modal player).
- * supportsClearLights keys off the CONNECTED (active) board's protocol, not the
- * displayed climb's board, so it's correct wherever this is mounted.
  */
 export function BleControlSheetHost({ visible, onClose }: BleControlSheetHostProps) {
   const bluetooth = useOptionalBluetoothContext();
-  const { data: activeBoard } = useActiveBoard();
   const isConnected = bluetooth?.isConnected ?? false;
 
   // Close if the link drops while the sheet is open — otherwise it lingers
@@ -48,8 +43,6 @@ export function BleControlSheetHost({ visible, onClose }: BleControlSheetHostPro
       visible={visible}
       onReassert={handleReassert}
       onClearLights={handleClearLights}
-      // MoonBoard's protocol has no clear-all frame; hide the row there.
-      supportsClearLights={toBoardName(activeBoard?.boardType) !== 'moonboard'}
       onDisconnect={disconnectAllBluetooth}
       onClose={onClose}
     />

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -672,8 +672,8 @@ describe('useBoardBluetooth', () => {
   });
 
   it('fires Board Lights Cleared (not Climb Sent to Board Success) on a MoonBoard deliberate clear (#3420)', async () => {
-    // Empty frames deliberately sends `l##` (totalPlacements 0), so the clear is
-    // written and tracked as a clear — never as a climb send.
+    // Empty frames sends `l##` (isClear), and sendSource 'clear' marks it a
+    // user-initiated clear — tracked as a clear, never as a climb send.
     const fakeAdapter = makeFakeAdapter();
     vi.mocked(createBluetoothAdapter).mockReturnValue(
       fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
@@ -683,6 +683,7 @@ describe('useBoardBluetooth', () => {
       skippedRoleCount: 0,
       skippedPositionCount: 0,
       totalPlacements: 0,
+      isClear: true,
     });
 
     const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
@@ -691,13 +692,44 @@ describe('useBoardBluetooth', () => {
     });
     let cleared: boolean | undefined;
     await act(async () => {
-      cleared = await result.current.sendFramesToBoard('');
+      cleared = await result.current.sendFramesToBoard('', false, undefined, { sendSource: 'clear' });
     });
 
     expect(cleared).toBe(true);
     expect(fakeAdapter.write).toHaveBeenCalled();
     const clearedCall = mockTrack.mock.calls.find(([name]) => name === 'Board Lights Cleared');
-    expect(clearedCall?.[1]).toMatchObject({ boardName: 'moonboard', layoutId: 1, sizeId: 1 });
+    expect(clearedCall?.[1]).toMatchObject({ boardName: 'moonboard', layoutId: 1, sizeId: 1, sendSource: 'clear' });
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Success')).toBeUndefined();
+  });
+
+  it('clears the wall silently for auto-sent empty frames — no clear or success event (#3420)', async () => {
+    // A queue/presence climb whose frames are empty still overwrites the wall
+    // (Aurora parity) but is not a user clear action: the write goes out and
+    // neither Board Lights Cleared nor Climb Sent to Board Success fires.
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new TextEncoder().encode('l##'),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 0,
+      isClear: true,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+    let sent: boolean | undefined;
+    await act(async () => {
+      sent = await result.current.sendFramesToBoard('');
+    });
+
+    expect(sent).toBe(true);
+    expect(fakeAdapter.write).toHaveBeenCalled();
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Board Lights Cleared')).toBeUndefined();
     expect(mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Success')).toBeUndefined();
   });
 
@@ -1289,6 +1321,7 @@ describe('dispatchMoonboardPacket', () => {
       totalPlacements: 2,
       skippedRoleCount: 0,
       skippedPositionCount: 0,
+      isClear: false,
     });
     const write = vi.fn().mockResolvedValue(undefined);
 
@@ -1306,6 +1339,7 @@ describe('dispatchMoonboardPacket', () => {
       totalPlacements: 1,
       skippedRoleCount: 0,
       skippedPositionCount: 0,
+      isClear: false,
     });
     const write = vi.fn().mockResolvedValue(undefined);
 
@@ -1324,6 +1358,7 @@ describe('dispatchMoonboardPacket', () => {
       totalPlacements: 0,
       skippedRoleCount: 0,
       skippedPositionCount: 0,
+      isClear: true,
     });
     const write = vi.fn().mockResolvedValue(undefined);
 
@@ -1340,6 +1375,7 @@ describe('dispatchMoonboardPacket', () => {
       totalPlacements: 1,
       skippedRoleCount: 0,
       skippedPositionCount: 0,
+      isClear: false,
     });
     const write = vi.fn().mockResolvedValue(undefined);
     const controller = new AbortController();
@@ -1358,10 +1394,30 @@ describe('dispatchMoonboardPacket', () => {
       totalPlacements: 2,
       skippedRoleCount: 2,
       skippedPositionCount: 0,
+      isClear: false,
     });
     const write = vi.fn().mockResolvedValue(undefined);
 
     const result = await dispatchMoonboardPacket('p1r99p2r98', write);
+
+    expect(result).toBe(false);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('returns false and never writes for a degenerate non-empty frames string (#3420)', async () => {
+    // A corrupt frames string like 'p' parses to zero placements, so the
+    // builder emits `l##` with isClear false — writing it would dark the wall
+    // on a climb send, so the zero-encodable guard must refuse.
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new TextEncoder().encode('l##'),
+      totalPlacements: 0,
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      isClear: false,
+    });
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    const result = await dispatchMoonboardPacket('p', write);
 
     expect(result).toBe(false);
     expect(write).not.toHaveBeenCalled();
@@ -1374,6 +1430,7 @@ describe('dispatchMoonboardPacket', () => {
       totalPlacements: 2,
       skippedRoleCount: 1,
       skippedPositionCount: 0,
+      isClear: false,
     });
     const write = vi.fn().mockResolvedValue(undefined);
 

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -671,6 +671,36 @@ describe('useBoardBluetooth', () => {
     });
   });
 
+  it('fires Board Lights Cleared (not Climb Sent to Board Success) on a MoonBoard deliberate clear (#3420)', async () => {
+    // Empty frames deliberately sends `l##` (totalPlacements 0), so the clear is
+    // written and tracked as a clear — never as a climb send.
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new TextEncoder().encode('l##'),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 0,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+    let cleared: boolean | undefined;
+    await act(async () => {
+      cleared = await result.current.sendFramesToBoard('');
+    });
+
+    expect(cleared).toBe(true);
+    expect(fakeAdapter.write).toHaveBeenCalled();
+    const clearedCall = mockTrack.mock.calls.find(([name]) => name === 'Board Lights Cleared');
+    expect(clearedCall?.[1]).toMatchObject({ boardName: 'moonboard', layoutId: 1, sizeId: 1 });
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Success')).toBeUndefined();
+  });
+
   it('attaches write diagnostics alongside failureReason on a failed send (#3230)', async () => {
     const writeDiagnostics: BleWriteDiagnostics = {
       chunkSize: 244,
@@ -1284,13 +1314,23 @@ describe('dispatchMoonboardPacket', () => {
     expect(result).toBe(true);
   });
 
-  it('returns undefined and skips write when frames is empty', async () => {
-    const write = vi.fn();
+  it('writes the deliberate clear-all `l##` packet and returns true for empty frames (#3420)', async () => {
+    // getMoonboardBluetoothPacket('') returns the clear-all packet with
+    // totalPlacements 0, so the all-skipped guard never trips and the clear is
+    // written — MoonBoard's deliberate clear path (web parity).
+    const clearPacket = new TextEncoder().encode('l##');
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: clearPacket,
+      totalPlacements: 0,
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+    });
+    const write = vi.fn().mockResolvedValue(undefined);
 
     const result = await dispatchMoonboardPacket('', write);
 
-    expect(result).toBeUndefined();
-    expect(write).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+    expect(write).toHaveBeenCalledWith(clearPacket, undefined);
   });
 
   it('forwards the AbortSignal to write()', async () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -702,6 +702,31 @@ describe('useBoardBluetooth', () => {
     expect(mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Success')).toBeUndefined();
   });
 
+  it('fires Board Lights Cleared on an Aurora deliberate clear (#3420)', async () => {
+    // The Aurora clear branch is separate from dispatchMoonboardPacket, so its
+    // sendSource-gated tracking needs its own pin.
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetAuroraBluetoothPacket.mockReturnValue({ packet: new Uint8Array([0x01, 0x02]) });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+    let cleared: boolean | undefined;
+    await act(async () => {
+      cleared = await result.current.sendFramesToBoard('', false, undefined, { sendSource: 'clear' });
+    });
+
+    expect(cleared).toBe(true);
+    expect(fakeAdapter.write).toHaveBeenCalled();
+    const clearedCall = mockTrack.mock.calls.find(([name]) => name === 'Board Lights Cleared');
+    expect(clearedCall?.[1]).toMatchObject({ boardName: 'kilter', sendSource: 'clear' });
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Success')).toBeUndefined();
+  });
+
   it('clears the wall silently for auto-sent empty frames — no clear or success event (#3420)', async () => {
     // A queue/presence climb whose frames are empty still overwrites the wall
     // (Aurora parity) but is not a user clear action: the write goes out and

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -93,20 +93,23 @@ export function bleWriteDiagnosticsProperties(
 
 // Exported for testing — isolates the .packet extraction so regressions are caught.
 //
+// Empty frames now deliberately send MoonBoard's clear-all `l##` frame:
+// getMoonboardBluetoothPacket('') returns totalPlacements 0, so the all-skipped
+// guard below never trips and the clear packet is written — web parity
+// (use-board-bluetooth.ts).
+//
 // Returns:
-//  - undefined when there are no frames (nothing to send)
-//  - false when every placement was skipped (the packet builder still emits the
-//    "clear all" packet `l##`, so writing it would silently dark the board while
+//  - false when every placement was skipped for a non-empty climb (the packet
+//    builder still emits `l##`, so writing it would silently dark the board while
 //    the caller reported success). The caller surfaces the incompatible-climb
-//    error instead of writing — web parity (use-board-bluetooth.ts:348-363).
+//    error instead of writing.
 //  - true after a successful write.
 export async function dispatchMoonboardPacket(
   frames: string,
   write: BluetoothAdapter['write'],
   signal?: AbortSignal,
   numRows?: number,
-): Promise<boolean | undefined> {
-  if (!frames) return undefined;
+): Promise<boolean> {
   const { packet, skippedRoleCount, skippedPositionCount, totalPlacements } = getMoonboardBluetoothPacket(
     frames,
     numRows,
@@ -228,7 +231,8 @@ export const convertToMirroredFramesString = (frames: string, holdsData: HoldPla
  * (e.g. a manual mirror re-send) just omit it.
  */
 export type BleSendContext = {
-  /** Where the send came from: the queue auto-sender, an undo, or a clear. */
+  /** Where the send came from: the queue auto-sender, an undo, or a deliberate
+   *  clear (passed by clearBoard). */
   sendSource: 'auto' | 'undo' | 'clear';
   targetQueueItemUuid?: string;
   climbUuid?: string;
@@ -511,6 +515,25 @@ export function useBoardBluetooth({
           sendAdapter = adapterRef.current;
 
           if (boardName === 'moonboard') {
+            // Empty frames = deliberate clear-all. `l##` (empty frame) is
+            // MoonBoard's clear-all: community firmware (ArduinoMoonBoardLED)
+            // clears every LED on each incoming frame; unverified on official Moon
+            // controllers (at worst a no-op). Sent only on a deliberate clear —
+            // never as a fallback for an all-skipped climb, which surfaces an error
+            // below instead of silently darking the board.
+            if (frames === '') {
+              const cleared = await dispatchMoonboardPacket(
+                '',
+                adapterRef.current.write.bind(adapterRef.current),
+                combinedSignal,
+                moonNumRows,
+              );
+              if (cleared) {
+                track(SHARED_EVENTS.BoardLightsCleared, boardAnalyticsProperties);
+              }
+              return cleared;
+            }
+
             const sent = await dispatchMoonboardPacket(
               frames,
               adapterRef.current.write.bind(adapterRef.current),
@@ -518,10 +541,11 @@ export function useBoardBluetooth({
               moonNumRows,
             );
             // false = every placement was skipped (unrecognised/corrupt hold
-            // data). The packet builder would emit a "clear all" packet, darking
-            // the board, so dispatchMoonboardPacket refuses to write. Surface the
-            // same incompatible-climb error the Aurora branch uses instead of
-            // letting the AutoSender buzz success on a dark board.
+            // data) for a non-empty climb. The packet builder would emit the
+            // clear-all packet `l##`, darking the board, so dispatchMoonboardPacket
+            // refuses to write. Surface the same incompatible-climb error the
+            // Aurora branch uses instead of letting the AutoSender buzz success on
+            // a dark board.
             if (sent === false) {
               console.warn('[BLE] All MoonBoard placements skipped — climb has unrecognised hold data');
               Alert.alert(t('ble.sendFailedTitle'), t('ble.errorIncompatible'));
@@ -544,6 +568,7 @@ export function useBoardBluetooth({
           if (frames === '') {
             const clearResult = getAuroraBluetoothPacket('', {}, boardName as AuroraBoardName, apiLevelRef.current);
             await adapterRef.current.write(clearResult.packet, combinedSignal);
+            track(SHARED_EVENTS.BoardLightsCleared, boardAnalyticsProperties);
             return true;
           }
 

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -93,16 +93,15 @@ export function bleWriteDiagnosticsProperties(
 
 // Exported for testing — isolates the .packet extraction so regressions are caught.
 //
-// Empty frames now deliberately send MoonBoard's clear-all `l##` frame:
-// getMoonboardBluetoothPacket('') returns totalPlacements 0, so the all-skipped
-// guard below never trips and the clear packet is written — web parity
-// (use-board-bluetooth.ts).
+// Empty frames deliberately send MoonBoard's clear-all `l##` frame (the builder
+// marks that result `isClear`) — web parity (use-board-bluetooth.ts).
 //
 // Returns:
-//  - false when every placement was skipped for a non-empty climb (the packet
-//    builder still emits `l##`, so writing it would silently dark the board while
-//    the caller reported success). The caller surfaces the incompatible-climb
-//    error instead of writing.
+//  - false when a non-clear send encodes zero holds — every placement skipped,
+//    or a degenerate frames string that parses to no placements. The builder
+//    still emits `l##` for those, so writing it would silently dark the board
+//    while the caller reported success; the caller surfaces the
+//    incompatible-climb error instead.
 //  - true after a successful write.
 export async function dispatchMoonboardPacket(
   frames: string,
@@ -110,12 +109,12 @@ export async function dispatchMoonboardPacket(
   signal?: AbortSignal,
   numRows?: number,
 ): Promise<boolean> {
-  const { packet, skippedRoleCount, skippedPositionCount, totalPlacements } = getMoonboardBluetoothPacket(
+  const { packet, skippedRoleCount, skippedPositionCount, totalPlacements, isClear } = getMoonboardBluetoothPacket(
     frames,
     numRows,
   );
-  const skippedCount = skippedRoleCount + skippedPositionCount;
-  if (totalPlacements > 0 && skippedCount === totalPlacements) {
+  const encodedCount = totalPlacements - skippedRoleCount - skippedPositionCount;
+  if (!isClear && encodedCount === 0) {
     return false;
   }
   await write(packet, signal);
@@ -515,38 +514,19 @@ export function useBoardBluetooth({
           sendAdapter = adapterRef.current;
 
           if (boardName === 'moonboard') {
-            // Empty frames = deliberate clear-all. `l##` (empty frame) is
-            // MoonBoard's clear-all: community firmware (ArduinoMoonBoardLED)
-            // clears every LED on each incoming frame; unverified on official Moon
-            // controllers (at worst a no-op). Sent only on a deliberate clear —
-            // never as a fallback for an all-skipped climb, which surfaces an error
-            // below instead of silently darking the board.
-            if (frames === '') {
-              const cleared = await dispatchMoonboardPacket(
-                '',
-                adapterRef.current.write.bind(adapterRef.current),
-                combinedSignal,
-                moonNumRows,
-              );
-              if (cleared) {
-                track(SHARED_EVENTS.BoardLightsCleared, boardAnalyticsProperties);
-              }
-              return cleared;
-            }
-
             const sent = await dispatchMoonboardPacket(
               frames,
               adapterRef.current.write.bind(adapterRef.current),
               combinedSignal,
               moonNumRows,
             );
-            // false = every placement was skipped (unrecognised/corrupt hold
-            // data) for a non-empty climb. The packet builder would emit the
+            // false = the climb encoded zero holds (every placement skipped, or
+            // a degenerate frames string). The packet builder would emit the
             // clear-all packet `l##`, darking the board, so dispatchMoonboardPacket
             // refuses to write. Surface the same incompatible-climb error the
             // Aurora branch uses instead of letting the AutoSender buzz success on
             // a dark board.
-            if (sent === false) {
+            if (!sent) {
               console.warn('[BLE] All MoonBoard placements skipped — climb has unrecognised hold data');
               Alert.alert(t('ble.sendFailedTitle'), t('ble.errorIncompatible'));
               track(SHARED_EVENTS.ClimbSentToBoardFailure, {
@@ -555,20 +535,34 @@ export function useBoardBluetooth({
               });
               return false;
             }
-            if (sent) {
-              track(SHARED_EVENTS.ClimbSentToBoardSuccess, {
-                ...boardAnalyticsProperties,
-                ...bleWriteDiagnosticsProperties(await fetchWriteDiagnostics()),
-              });
+            if (frames === '') {
+              // Deliberate clear-all just went out as `l##`: community firmware
+              // (ArduinoMoonBoardLED) clears every LED on each incoming frame;
+              // unverified on official Moon controllers (at worst a no-op). Only a
+              // user-initiated clear counts as "lights cleared" — an auto-sent
+              // climb with empty frames darks the wall (Aurora parity) but is not
+              // a clear action.
+              if (sendContext?.sendSource === 'clear') {
+                track(SHARED_EVENTS.BoardLightsCleared, boardAnalyticsProperties);
+              }
+              return true;
             }
-            return sent;
+            track(SHARED_EVENTS.ClimbSentToBoardSuccess, {
+              ...boardAnalyticsProperties,
+              ...bleWriteDiagnosticsProperties(await fetchWriteDiagnostics()),
+            });
+            return true;
           }
 
-          // Empty frames = "clear all LEDs" for Aurora boards
+          // Empty frames = "clear all LEDs" for Aurora boards. Only a
+          // user-initiated clear is tracked; auto-sent empty frames clear the
+          // wall (long-standing Aurora behaviour) without counting as one.
           if (frames === '') {
             const clearResult = getAuroraBluetoothPacket('', {}, boardName as AuroraBoardName, apiLevelRef.current);
             await adapterRef.current.write(clearResult.packet, combinedSignal);
-            track(SHARED_EVENTS.BoardLightsCleared, boardAnalyticsProperties);
+            if (sendContext?.sendSource === 'clear') {
+              track(SHARED_EVENTS.BoardLightsCleared, boardAnalyticsProperties);
+            }
             return true;
           }
 

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -715,8 +715,13 @@ describe('BluetoothProvider spill skip', () => {
     await act(async () => {});
 
     expect(queue.setCurrentClimb).not.toHaveBeenCalled();
-    // clearBoard sends empty frames to dark the wall.
-    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('');
+    // clearBoard sends empty frames (tagged as a deliberate clear) to dark the wall.
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+      '',
+      false,
+      undefined,
+      expect.objectContaining({ sendSource: 'clear' }),
+    );
     expect(toast.showToast).toHaveBeenCalledTimes(1);
     const skipCall = analytics.track.mock.calls.find(([name]) => name === 'BLE Queue Climb Skipped');
     expect(skipCall?.[1]).toMatchObject({ skippedClimbUuid: 'spill', advancedToClimbUuid: null });

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -806,7 +806,12 @@ describe('BluetoothProvider spill skip', () => {
 
     // No advance, wall cleared locally, user still told + telemetry marked in-session.
     expect(queue.setCurrentClimb).not.toHaveBeenCalled();
-    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('');
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+      '',
+      false,
+      undefined,
+      expect.objectContaining({ sendSource: 'clear' }),
+    );
     expect(toast.showToast).toHaveBeenCalledTimes(1);
     const skipCall = analytics.track.mock.calls.find(([name]) => name === 'BLE Queue Climb Skipped');
     expect(skipCall?.[1]).toMatchObject({ skippedClimbUuid: 'spill', inSession: true });

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -716,12 +716,7 @@ describe('BluetoothProvider spill skip', () => {
 
     expect(queue.setCurrentClimb).not.toHaveBeenCalled();
     // clearBoard sends empty frames (tagged as a deliberate clear) to dark the wall.
-    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
-      '',
-      false,
-      undefined,
-      expect.objectContaining({ sendSource: 'clear' }),
-    );
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('');
     expect(toast.showToast).toHaveBeenCalledTimes(1);
     const skipCall = analytics.track.mock.calls.find(([name]) => name === 'BLE Queue Climb Skipped');
     expect(skipCall?.[1]).toMatchObject({ skippedClimbUuid: 'spill', advancedToClimbUuid: null });
@@ -806,12 +801,7 @@ describe('BluetoothProvider spill skip', () => {
 
     // No advance, wall cleared locally, user still told + telemetry marked in-session.
     expect(queue.setCurrentClimb).not.toHaveBeenCalled();
-    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
-      '',
-      false,
-      undefined,
-      expect.objectContaining({ sendSource: 'clear' }),
-    );
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('');
     expect(toast.showToast).toHaveBeenCalledTimes(1);
     const skipCall = analytics.track.mock.calls.find(([name]) => name === 'BLE Queue Climb Skipped');
     expect(skipCall?.[1]).toMatchObject({ skippedClimbUuid: 'spill', inSession: true });

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -1075,17 +1075,19 @@ export function BluetoothProvider({
       // Party: never advance — the current climb is shared session state, and a
       // member whose wall can't light it must not hijack the queue for everyone.
       // Just clear this wall so it doesn't keep showing the previous climb.
+      // Untagged internal clear (no sendSource): the user didn't press Clear
+      // Lights, so this must not count towards Board Lights Cleared.
       if (sessionIdRef.current != null) {
-        void clearBoard();
+        void sendFramesToBoard('');
         return;
       }
       if (next) {
         setCurrentClimb(next);
       } else {
-        void clearBoard();
+        void sendFramesToBoard('');
       }
     },
-    [setCurrentClimb, showToast, clearBoard, t],
+    [setCurrentClimb, showToast, sendFramesToBoard, t],
   );
 
   // Bumped by `reassertWall()` to force the auto-sender to re-push the current

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -1037,7 +1037,10 @@ export function BluetoothProvider({
     return true;
   }, [sendFramesToBoard]);
 
-  const clearBoard = useCallback(() => sendFramesToBoard(''), [sendFramesToBoard]);
+  const clearBoard = useCallback(
+    () => sendFramesToBoard('', false, undefined, { sendSource: 'clear' }),
+    [sendFramesToBoard],
+  );
 
   // Advance the queue past a "spill" climb (one set for a different board/layout
   // than the connected board) instead of dark-firing the wall, and tell the user.

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -114,6 +114,11 @@ export const SHARED_EVENTS = {
   BlePickerDevicesResolved: 'BLE Picker Devices Resolved',
   ClimbSentToBoardSuccess: 'Climb Sent to Board Success',
   ClimbSentToBoardFailure: 'Climb Sent to Board Failure',
+  // Fired on a successful deliberate clear-all write (both Aurora and MoonBoard,
+  // the latter via its `l##` empty frame — see #3420). Props: boardName,
+  // layoutId, sizeId, boardId?, sendSource?, mirrored, connectedViaMismatchOverride
+  // (web sends at least boardName).
+  BoardLightsCleared: 'Board Lights Cleared',
   // A queued climb set for a DIFFERENT board/layout than the connected board was
   // skipped instead of dark-firing the wall. Props: skippedClimbUuid,
   // skippedCount, advancedToClimbUuid (null when no compatible climb remained),

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -114,10 +114,12 @@ export const SHARED_EVENTS = {
   BlePickerDevicesResolved: 'BLE Picker Devices Resolved',
   ClimbSentToBoardSuccess: 'Climb Sent to Board Success',
   ClimbSentToBoardFailure: 'Climb Sent to Board Failure',
-  // Fired on a successful deliberate clear-all write (both Aurora and MoonBoard,
-  // the latter via its `l##` empty frame — see #3420). Props: boardName,
-  // layoutId, sizeId, boardId?, sendSource?, mirrored, connectedViaMismatchOverride
-  // (web sends at least boardName).
+  // Fired on a successful USER-INITIATED clear-all write (sendSource 'clear';
+  // both Aurora and MoonBoard, the latter via its `l##` empty frame — #3420).
+  // Internal clears (spill skip, auto-sent empty frames) are untagged and do
+  // not fire this. Props: mobile sends its full board analytics set (boardName,
+  // layoutId, sizeId, mirrored, boardId?, connectedViaMismatchOverride,
+  // sendSource); web sends boardName, layoutId, sizeId.
   BoardLightsCleared: 'Board Lights Cleared',
   // A queued climb set for a DIFFERENT board/layout than the connected board was
   // skipped instead of dark-firing the wall. Props: skippedClimbUuid,

--- a/packages/shared/ble-protocol/src/__tests__/moonboard.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/moonboard.test.ts
@@ -108,6 +108,17 @@ describe('getMoonboardBluetoothPacket', () => {
     const result = getMoonboardBluetoothPacket('p1r42p2r43p198r44');
     expect(new TextDecoder().decode(result.packet)).toBe('l#S0,P35,E197#');
   });
+
+  it('sends the deliberate clear-all `l##` frame for empty frames (#3420)', () => {
+    // Empty frames is the deliberate clear path: `l##` clears every LED on
+    // community firmware. totalPlacements 0 (nothing to skip) is what lets the
+    // caller's all-skipped guard pass this through instead of refusing to write.
+    const result = getMoonboardBluetoothPacket('');
+    expect(new TextDecoder().decode(result.packet)).toBe('l##');
+    expect(result.totalPlacements).toBe(0);
+    expect(result.skippedRoleCount).toBe(0);
+    expect(result.skippedPositionCount).toBe(0);
+  });
 });
 
 // =============================================================================

--- a/packages/shared/ble-protocol/src/__tests__/moonboard.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/moonboard.test.ts
@@ -92,6 +92,9 @@ describe('getMoonboardBluetoothPacket', () => {
     const decoded = new TextDecoder().decode(result.packet);
     expect(decoded).toBe('l##');
     expect(result.skippedRoleCount).toBe(1);
+    // The bytes match the clear frame but this is NOT a clear — consumers must
+    // refuse to write it (zero encodable holds on a non-clear send).
+    expect(result.isClear).toBe(false);
   });
 
   it('encodes valid holds and skips invalid role codes', () => {
@@ -111,13 +114,24 @@ describe('getMoonboardBluetoothPacket', () => {
 
   it('sends the deliberate clear-all `l##` frame for empty frames (#3420)', () => {
     // Empty frames is the deliberate clear path: `l##` clears every LED on
-    // community firmware. totalPlacements 0 (nothing to skip) is what lets the
-    // caller's all-skipped guard pass this through instead of refusing to write.
+    // community firmware. Only this input marks the result isClear — the flag
+    // consumers use to let the clear through their zero-encodable refusal.
     const result = getMoonboardBluetoothPacket('');
     expect(new TextDecoder().decode(result.packet)).toBe('l##');
     expect(result.totalPlacements).toBe(0);
     expect(result.skippedRoleCount).toBe(0);
     expect(result.skippedPositionCount).toBe(0);
+    expect(result.isClear).toBe(true);
+  });
+
+  it('never marks a degenerate non-empty frames string as a clear (#3420)', () => {
+    // Separator-only input parses to zero placements and produces the same
+    // `l##` bytes, but isClear false tells consumers to refuse the write
+    // instead of silently darking the wall on a corrupt climb.
+    const result = getMoonboardBluetoothPacket('p');
+    expect(new TextDecoder().decode(result.packet)).toBe('l##');
+    expect(result.totalPlacements).toBe(0);
+    expect(result.isClear).toBe(false);
   });
 });
 

--- a/packages/shared/ble-protocol/src/moonboard.ts
+++ b/packages/shared/ble-protocol/src/moonboard.ts
@@ -17,6 +17,14 @@ export type MoonboardPacketResult = {
   skippedRoleCount: number;
   skippedPositionCount: number;
   totalPlacements: number;
+  /**
+   * True only for the deliberate clear-all input (`frames === ''`), whose
+   * packet is the bare `l##` frame. Consumers must refuse to write whenever
+   * `!isClear` and nothing encoded (all placements skipped, or a degenerate
+   * non-empty frames string that parses to zero placements) — writing `l##`
+   * there would silently dark the wall while the send reported success.
+   */
+  isClear: boolean;
 };
 
 // Note: UART_SERVICE_UUID is available from './transport' — not re-exported
@@ -56,20 +64,6 @@ export function getMoonboardBluetoothPacket(
   frames: string,
   numRows: number = MOONBOARD_GRID.numRows,
 ): MoonboardPacketResult {
-  // `l##` (empty frame) is MoonBoard's clear-all: community firmware
-  // (ArduinoMoonBoardLED) clears every LED on each incoming frame; unverified on
-  // official Moon controllers (at worst a no-op). Sent only on a deliberate clear
-  // — never as a fallback for an all-skipped climb, which must surface an error
-  // instead of silently darking the board.
-  if (frames === '') {
-    return {
-      packet: new TextEncoder().encode(`${MOONBOARD_FRAME_PREFIX}${MOONBOARD_FRAME_SUFFIX}`),
-      skippedRoleCount: 0,
-      skippedPositionCount: 0,
-      totalPlacements: 0,
-    };
-  }
-
   const encodedHolds: string[] = [];
   let skippedRoleCount = 0;
   let skippedPositionCount = 0;
@@ -99,10 +93,16 @@ export function getMoonboardBluetoothPacket(
 
   const holdPayload = encodedHolds.join(',');
 
+  // `l##` (empty holdPayload) is MoonBoard's clear-all: community firmware
+  // (ArduinoMoonBoardLED) clears every LED on each incoming frame; unverified on
+  // official Moon controllers (at worst a no-op). Only the deliberate-clear input
+  // (frames === '') marks the result `isClear` — a climb that merely encodes to
+  // nothing produces the same bytes but must be refused by the caller.
   return {
     packet: new TextEncoder().encode(`${MOONBOARD_FRAME_PREFIX}${holdPayload}${MOONBOARD_FRAME_SUFFIX}`),
     skippedRoleCount,
     skippedPositionCount,
     totalPlacements: frameParts.length,
+    isClear: frames === '',
   };
 }

--- a/packages/shared/ble-protocol/src/moonboard.ts
+++ b/packages/shared/ble-protocol/src/moonboard.ts
@@ -56,6 +56,20 @@ export function getMoonboardBluetoothPacket(
   frames: string,
   numRows: number = MOONBOARD_GRID.numRows,
 ): MoonboardPacketResult {
+  // `l##` (empty frame) is MoonBoard's clear-all: community firmware
+  // (ArduinoMoonBoardLED) clears every LED on each incoming frame; unverified on
+  // official Moon controllers (at worst a no-op). Sent only on a deliberate clear
+  // — never as a fallback for an all-skipped climb, which must surface an error
+  // instead of silently darking the board.
+  if (frames === '') {
+    return {
+      packet: new TextEncoder().encode(`${MOONBOARD_FRAME_PREFIX}${MOONBOARD_FRAME_SUFFIX}`),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 0,
+    };
+  }
+
   const encodedHolds: string[] = [];
   let skippedRoleCount = 0;
   let skippedPositionCount = 0;

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -644,7 +644,7 @@ describe('BluetoothProvider', () => {
 
       expect(mockSetCurrentClimbQueueItem).not.toHaveBeenCalled();
       // clearBoard sends empty frames to dark the wall.
-      expect(mockSendFramesToBoard).toHaveBeenCalledWith('');
+      expect(mockSendFramesToBoard).toHaveBeenCalledWith('', false, undefined, { sendSource: 'clear' });
       expect(mockTrack).toHaveBeenCalledWith(
         'BLE Queue Climb Skipped',
         expect.objectContaining({ skippedClimbUuid: 'c-spill', advancedToClimbUuid: null }),
@@ -663,7 +663,7 @@ describe('BluetoothProvider', () => {
       await act(async () => {});
 
       expect(mockSetCurrentClimbQueueItem).not.toHaveBeenCalled();
-      expect(mockSendFramesToBoard).toHaveBeenCalledWith('');
+      expect(mockSendFramesToBoard).toHaveBeenCalledWith('', false, undefined, { sendSource: 'clear' });
       expect(mockTrack).toHaveBeenCalledWith(
         'BLE Queue Climb Skipped',
         expect.objectContaining({ skippedClimbUuid: 'c-spill', inSession: true }),

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -644,7 +644,7 @@ describe('BluetoothProvider', () => {
 
       expect(mockSetCurrentClimbQueueItem).not.toHaveBeenCalled();
       // clearBoard sends empty frames to dark the wall.
-      expect(mockSendFramesToBoard).toHaveBeenCalledWith('', false, undefined, { sendSource: 'clear' });
+      expect(mockSendFramesToBoard).toHaveBeenCalledWith('');
       expect(mockTrack).toHaveBeenCalledWith(
         'BLE Queue Climb Skipped',
         expect.objectContaining({ skippedClimbUuid: 'c-spill', advancedToClimbUuid: null }),
@@ -663,7 +663,7 @@ describe('BluetoothProvider', () => {
       await act(async () => {});
 
       expect(mockSetCurrentClimbQueueItem).not.toHaveBeenCalled();
-      expect(mockSendFramesToBoard).toHaveBeenCalledWith('', false, undefined, { sendSource: 'clear' });
+      expect(mockSendFramesToBoard).toHaveBeenCalledWith('');
       expect(mockTrack).toHaveBeenCalledWith(
         'BLE Queue Climb Skipped',
         expect.objectContaining({ skippedClimbUuid: 'c-spill', inSession: true }),

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-moonboard.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-moonboard.test.ts
@@ -52,10 +52,11 @@ describe('getMoonboardBluetoothPacket', () => {
   });
 
   it('sends the deliberate clear-all `l##` frame for empty frames (#3420)', () => {
-    const { packet, totalPlacements } = getMoonboardBluetoothPacket('');
+    const { packet, totalPlacements, isClear } = getMoonboardBluetoothPacket('');
 
     expect(new TextDecoder().decode(packet)).toBe('l##');
     expect(totalPlacements).toBe(0);
+    expect(isClear).toBe(true);
   });
 
   it('skips unsupported Moonboard hold state codes gracefully', () => {

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-moonboard.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-moonboard.test.ts
@@ -51,6 +51,13 @@ describe('getMoonboardBluetoothPacket', () => {
     expect(new TextDecoder().decode(packet)).toBe('l#S0,P35,E197#');
   });
 
+  it('sends the deliberate clear-all `l##` frame for empty frames (#3420)', () => {
+    const { packet, totalPlacements } = getMoonboardBluetoothPacket('');
+
+    expect(new TextDecoder().decode(packet)).toBe('l##');
+    expect(totalPlacements).toBe(0);
+  });
+
   it('skips unsupported Moonboard hold state codes gracefully', () => {
     const { packet, skippedRoleCount, totalPlacements } = getMoonboardBluetoothPacket('p1r45');
 

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -359,6 +359,30 @@ describe('useBoardBluetooth', () => {
     expect(mockAdapter.write).toHaveBeenCalledWith(new Uint8Array([9, 8, 7]), undefined);
   });
 
+  it('clear-all writes the MoonBoard clear packet; only user-initiated clears are tracked (#3420)', async () => {
+    const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockMoonboardDetails }));
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    // Auto-sent empty frames: the wall clears silently — no Board Lights Cleared.
+    await act(async () => {
+      await result.current.sendFramesToBoard('');
+    });
+    expect(mockGetMoonboardBluetoothPacket).toHaveBeenCalledWith('', 18);
+    expect(mockAdapter.write).toHaveBeenCalledWith(new Uint8Array([9, 8, 7]), undefined);
+    expect(mockTrack.mock.calls.find(([eventName]) => eventName === 'Board Lights Cleared')).toBeUndefined();
+
+    // User-initiated clear (sendSource 'clear'): same write, tracked.
+    let clearResult: boolean | undefined;
+    await act(async () => {
+      clearResult = await result.current.sendFramesToBoard('', false, undefined, { sendSource: 'clear' });
+    });
+    expect(clearResult).toBe(true);
+    const clearedCall = mockTrack.mock.calls.find(([eventName]) => eventName === 'Board Lights Cleared');
+    expect(clearedCall?.[1]).toMatchObject({ boardName: 'moonboard' });
+  });
+
   it('calls onConnectionChange callback', async () => {
     const onConnectionChange = vi.fn();
 

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -718,17 +718,19 @@ export function BluetoothProvider({
         'info',
       );
 
+      // Untagged internal clear (no sendSource): the user didn't press the
+      // clear control, so this must not count towards Board Lights Cleared.
       if (sessionIdRef.current != null) {
-        void clearBoard();
+        void sendFramesToBoard('');
         return;
       }
       if (next) {
         queueActionsRef.current?.setCurrentClimbQueueItem(next);
       } else {
-        void clearBoard();
+        void sendFramesToBoard('');
       }
     },
-    [boardDetails, clearBoard, showMessage, t],
+    [boardDetails, sendFramesToBoard, showMessage, t],
   );
 
   // Stop any active light show the moment the board disconnects so a

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -680,7 +680,10 @@ export function BluetoothProvider({
   );
 
   const [partyMode, setPartyMode] = useState<'off' | 'glyphs' | 'disco'>('off');
-  const clearBoard = useCallback(() => sendFramesToBoard(''), [sendFramesToBoard]);
+  const clearBoard = useCallback(
+    () => sendFramesToBoard('', false, undefined, { sendSource: 'clear' }),
+    [sendFramesToBoard],
+  );
 
   // Skip-spill handler: solo advances the queue past the incompatible climb;
   // party only clears this wall — the shared current climb must not be

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -43,7 +43,9 @@ export type BleSendContext = {
    * climb (play-drawer playback), whose skip toast already covers the user. */
   suppressIncompatibleToast?: boolean;
   /** 'clear' marks a user-initiated clear-all so it's tracked as one (#3420);
-   * auto-sent empty frames clear the wall without counting as a clear action. */
+   * auto-sent empty frames clear the wall without counting as a clear action.
+   * Deliberately narrower than mobile's 'auto' | 'undo' | 'clear' union — web
+   * only distinguishes clears; widen it if a caller ever needs the others. */
   sendSource?: 'clear';
 };
 

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -373,9 +373,10 @@ export function useBoardBluetooth({
   }, []);
 
   // Function to send frames string to the board.
-  // An empty `frames` string is the "clear all LEDs" path: Aurora's packet
-  // builder already returns a zero-length placement set, which the board
-  // interprets as "no LEDs lit", overwriting whatever was on the wall.
+  // An empty `frames` string is the "clear all LEDs" path on both board
+  // families: Aurora's packet builder returns a zero-length placement set the
+  // board reads as "no LEDs lit", and MoonBoard's `l##` empty frame clears every
+  // LED on community firmware — either way whatever was on the wall is overwritten.
   const sendFramesToBoard = useCallback(
     async (frames: string, mirrored: boolean = false, signal?: AbortSignal, sendContext?: BleSendContext) => {
       if (!adapterRef.current || !boardDetails) return;
@@ -404,12 +405,27 @@ export function useBoardBluetooth({
         }
 
         if (boardDetails.board_name === 'moonboard') {
-          // MoonBoard's packet format isn't designed to encode "clear" via an
-          // empty frame string — skip the write rather than send a malformed
-          // packet to the board.
-          if (!frames) return;
           // Mini boards wire a 12-row LED strip; the standard board is 18 rows.
           const moonNumRows = getMoonBoardGeometryByLayoutId(boardDetails.layout_id).numRows;
+
+          // Empty frames = deliberate clear-all. `l##` (empty frame) is
+          // MoonBoard's clear-all: community firmware (ArduinoMoonBoardLED) clears
+          // every LED on each incoming frame; unverified on official Moon
+          // controllers (at worst a no-op). Sent only on a deliberate clear —
+          // never as a fallback for an all-skipped climb, which surfaces an error
+          // below instead of silently darking the board.
+          if (frames === '') {
+            const moonClearResult = getMoonboardBluetoothPacket('', moonNumRows);
+            await serialisedWrite(adapterRef.current, moonClearResult.packet, signal);
+            track(SHARED_EVENTS.BoardLightsCleared, {
+              boardName: boardDetails.board_name,
+              layoutId: boardDetails.layout_id,
+              sizeId: boardDetails.size_id,
+            });
+            void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
+            return true;
+          }
+
           const moonResult = getMoonboardBluetoothPacket(frames, moonNumRows);
           const moonSkipped = moonResult.skippedRoleCount + moonResult.skippedPositionCount;
 
@@ -460,6 +476,11 @@ export function useBoardBluetooth({
         if (frames === '') {
           const clearResult = getAuroraBluetoothPacket('', {}, boardDetails.board_name, apiLevelRef.current);
           await serialisedWrite(adapterRef.current, clearResult.packet, signal);
+          track(SHARED_EVENTS.BoardLightsCleared, {
+            boardName: boardDetails.board_name,
+            layoutId: boardDetails.layout_id,
+            sizeId: boardDetails.size_id,
+          });
           void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
           lastIncompatibleToastUuidRef.current = null;
           return true;

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -42,6 +42,9 @@ export type BleSendContext = {
   /** Refuse silently: for callers racing the AutoSender on the same current
    * climb (play-drawer playback), whose skip toast already covers the user. */
   suppressIncompatibleToast?: boolean;
+  /** 'clear' marks a user-initiated clear-all so it's tracked as one (#3420);
+   * auto-sent empty frames clear the wall without counting as a clear action. */
+  sendSource?: 'clear';
 };
 
 // Module-level cache for Aurora LED placements loader to avoid repeated dynamic import overhead
@@ -376,7 +379,10 @@ export function useBoardBluetooth({
   // An empty `frames` string is the "clear all LEDs" path on both board
   // families: Aurora's packet builder returns a zero-length placement set the
   // board reads as "no LEDs lit", and MoonBoard's `l##` empty frame clears every
-  // LED on community firmware — either way whatever was on the wall is overwritten.
+  // LED on community firmware (unverified on official Moon controllers; at worst
+  // a no-op) — either way whatever was on the wall is overwritten. Pass
+  // `sendSource: 'clear'` for a user-initiated clear so it's tracked as one;
+  // auto-sent empty frames clear the wall without counting as a clear action.
   const sendFramesToBoard = useCallback(
     async (frames: string, mirrored: boolean = false, signal?: AbortSignal, sendContext?: BleSendContext) => {
       if (!adapterRef.current || !boardDetails) return;
@@ -404,34 +410,40 @@ export function useBoardBluetooth({
           return false;
         }
 
-        if (boardDetails.board_name === 'moonboard') {
-          // Mini boards wire a 12-row LED strip; the standard board is 18 rows.
-          const moonNumRows = getMoonBoardGeometryByLayoutId(boardDetails.layout_id).numRows;
-
-          // Empty frames = deliberate clear-all. `l##` (empty frame) is
-          // MoonBoard's clear-all: community firmware (ArduinoMoonBoardLED) clears
-          // every LED on each incoming frame; unverified on official Moon
-          // controllers (at worst a no-op). Sent only on a deliberate clear —
-          // never as a fallback for an all-skipped climb, which surfaces an error
-          // below instead of silently darking the board.
-          if (frames === '') {
-            const moonClearResult = getMoonboardBluetoothPacket('', moonNumRows);
-            await serialisedWrite(adapterRef.current, moonClearResult.packet, signal);
+        // The clear-all path is family-agnostic apart from the packet builder.
+        if (frames === '') {
+          const clearPacket =
+            boardDetails.board_name === 'moonboard'
+              ? getMoonboardBluetoothPacket('', getMoonBoardGeometryByLayoutId(boardDetails.layout_id).numRows).packet
+              : getAuroraBluetoothPacket('', {}, boardDetails.board_name, apiLevelRef.current).packet;
+          await serialisedWrite(adapterRef.current, clearPacket, signal);
+          if (sendContext?.sendSource === 'clear') {
             track(SHARED_EVENTS.BoardLightsCleared, {
               boardName: boardDetails.board_name,
               layoutId: boardDetails.layout_id,
               sizeId: boardDetails.size_id,
             });
-            void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
-            return true;
           }
+          void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
+          lastIncompatibleToastUuidRef.current = null;
+          return true;
+        }
+
+        if (boardDetails.board_name === 'moonboard') {
+          // Mini boards wire a 12-row LED strip; the standard board is 18 rows.
+          const moonNumRows = getMoonBoardGeometryByLayoutId(boardDetails.layout_id).numRows;
 
           const moonResult = getMoonboardBluetoothPacket(frames, moonNumRows);
           const moonSkipped = moonResult.skippedRoleCount + moonResult.skippedPositionCount;
+          const moonEncoded = moonResult.totalPlacements - moonSkipped;
 
-          if (moonSkipped > 0 && moonResult.totalPlacements === moonSkipped) {
+          // Zero encodable holds on a non-empty climb — every placement skipped,
+          // or a degenerate frames string that parses to no placements. The
+          // builder still emits the clear-all `l##` for those, so refuse rather
+          // than silently dark the wall while reporting success.
+          if (moonEncoded === 0) {
             Sentry.captureMessage(
-              `[BLE] All ${moonResult.totalPlacements} MoonBoard placements skipped — climb data may be corrupted`,
+              `[BLE] MoonBoard climb encoded no holds (${moonSkipped} of ${moonResult.totalPlacements} placements skipped) — climb data may be corrupted`,
               {
                 level: 'warning',
                 tags: { board: 'moonboard' },
@@ -465,22 +477,6 @@ export function useBoardBluetooth({
           }
 
           await serialisedWrite(adapterRef.current, moonResult.packet, signal);
-          void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
-          lastIncompatibleToastUuidRef.current = null;
-          return true;
-        }
-
-        // Empty frames is the "clear all LEDs" path. Skip mirroring and the
-        // LED-placement load entirely — the Aurora packet builder produces a
-        // standalone clear packet that doesn't depend on placement data.
-        if (frames === '') {
-          const clearResult = getAuroraBluetoothPacket('', {}, boardDetails.board_name, apiLevelRef.current);
-          await serialisedWrite(adapterRef.current, clearResult.packet, signal);
-          track(SHARED_EVENTS.BoardLightsCleared, {
-            boardName: boardDetails.board_name,
-            layoutId: boardDetails.layout_id,
-            sizeId: boardDetails.size_id,
-          });
           void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
           lastIncompatibleToastUuidRef.current = null;
           return true;

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -9,12 +9,28 @@ const TEST_TARGET_NAME = 'BoardseshTests';
 const APP_TARGET_NAME = 'Boardsesh';
 const BUNDLE_IDENTIFIER = 'com.boardsesh.app.tests';
 const DEPLOYMENT_TARGET = '17.0';
-const SWIFT_FLAGS = '"$(inherited) -D WIDGET_EXTENSION"';
+const SWIFT_FLAGS = '"$(inherited) -D WIDGET_EXTENSION -D BOARDSESH_TESTS"';
 
 const TEST_SOURCE_FILES = [
   {
     sourcePath: '../ios-tests/LiveActivityWidgetTests.swift',
     projectPath: 'BoardseshTests/LiveActivityWidgetTests.swift',
+  },
+  {
+    sourcePath: '../ios-tests/BoardBleWriteFlowTests.swift',
+    projectPath: 'BoardseshTests/BoardBleWriteFlowTests.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/BoardBleManager.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/BoardBleManager.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/BoardBleWriteSeams.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/BoardBleWriteSeams.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/WaiterPool.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/WaiterPool.swift',
   },
   {
     sourcePath: '../modules/live-activity/ios/ClimbSessionAttributes.swift',


### PR DESCRIPTION
## Summary

Two BLE issues in one PR (plus verification of a third):

**MoonBoard "clear board" was a silent no-op (Closes #3420).** A deliberate clear did nothing on MoonBoard: the JS transport returned early on empty frames, native iOS skipped the `moonboard` branch, and the two sides documented contradictory beliefs about the empty `l##` frame. Now a deliberate clear sends `l##` on every path (shared JS builder, mobile, web, native iOS queue path) and the Clear Lights row is no longer hidden for MoonBoard. Evidence: community firmware (ArduinoMoonBoardLED, built against the official app) clears every LED on each incoming frame; unverified on official Moon controllers — at worst it's a no-op, i.e. today's behaviour. Spec §5.5 documents the contract with provenance tags.

The deliberate-vs-accidental distinction is structural: `MoonboardPacketResult.isClear` is true only for the empty-string input, and every consumer refuses to write when `!isClear` and zero holds encoded — so an all-skipped or corrupt/degenerate climb can never dark the wall as a fake "success". The Swift builder gates on the raw empty string for the same reason (malformed frames that parse to nothing hit the refusal, not the clear). A new shared `Board Lights Cleared` analytics event fires only for user-initiated clears (`sendSource: 'clear'`) on both board families.

**`BoardBleManager` write flow-control is now unit-testable (Closes #3366).** The park / poll-resume / watchdog / stall-recovery state machine from #3365 gets the seam that PR's review asked for: a `WritableBlePeripheral` protocol (CBPeripheral conforms via empty extension) plus injectable one-shot/repeating timer scheduling, with the production `DispatchBleTimerScheduler` wrapping the previous GCD code 1:1. Twelve deterministic XCTests (no sleeps, no expectations) cover chunk sequencing, poll vs callback resume, the synchronous re-park capture-and-nil ordering, the watchdog `canSendAtTrip` tri-state, recovery-budget exhaustion, `failQueuedWrites`, stale poller/resume guards, and with-response ack pacing. The refactor is behaviour-preserving by construction: closure bodies moved verbatim, no control-flow restructuring, the production singleton stays compiler-enforced (`private init`; the DI init is `#if DEBUG || BOARDSESH_TESTS`).

**#3391 (iOS disconnect reason dropped)** turned out to be already fixed on main by #3289 — verified end-to-end (native error threading → adapter → `disconnectIosCode` on the event, with a test pinning it) and closed with a comment; no code here.

An 8-angle adversarial review ran over the diff; the confirmed findings (Swift clear-gate breadth, degenerate-frames hole, clear-event attribution, singleton de-privatization) were fixed in the third commit.

⚠️ Contains native iOS changes — ships in the next native build, not OTA. Hardware verification of `l##` on an official Moon controller is the remaining open item (safe either way: worst case the clear stays a no-op, exactly as before).

## Release Notes

- Turn off your MoonBoard's lights from the app — the Clear Lights button now works on MoonBoard walls.

## Test plan

- `vp run typecheck` / `typecheck:mobile` — pass
- `vp run test:mobile` — 3276 tests pass; `vp run test:web` — 4992 pass (one unrelated flaky auth test passes in isolation)
- BLE-focused suites (shared ble-protocol, mobile ble, provider mismatch-switch, web bluetooth-control): 866 tests pass
- Swift: `BoardseshTests` scheme, 47 tests pass locally on iPhone 17 Pro simulator (12 new write-flow + new clear/malformed-frames pins); CI runs the same suite via `ios-rn-ci.yml`
- `vp run check:mobile-bundle` — OK; `vp check` clean on all changed files
- New regression pins: degenerate non-empty frames refused on JS and Swift; auto-sent empty frames clear silently (no success/clear events); all-skipped refusal unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2zzsVpii6H7EKeAPsq4fk