### PR TITLE
fix(web): re-light the previous climb after a spill clears the wall

### DIFF
--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -835,4 +835,42 @@ describe('BluetoothProvider spill skip', () => {
     await act(async () => {});
     expect(litSends()).toBe(2);
   });
+
+  it('drops the connect-initial-send seed when a spill clears the wall', async () => {
+    // Regression: connect-and-light seeds the dedup so the freshly mounted
+    // AutoSender doesn't repeat connect()'s initial write. If a spill lands
+    // during the handshake and clears the wall (party: the skip never
+    // advances, it only clears), consuming that seed later would set the
+    // signature WITHOUT a write — dark wall + false confirm.
+    queue.sessionId = 'party-1';
+    const lit = makeBoardItem('lit', 'kilter', 1);
+    const spill = makeBoardItem('spill', 'tension', 1);
+    // Simulate connect(initialFrames) having just written the lit climb.
+    bluetooth.state.connectInitialSendRef.current = {
+      frames: 'frames-lit',
+      mirrored: false,
+      colorSignature: 'default',
+    };
+    queue.currentClimbQueueItem = spill;
+    queue.queue = [spill, lit];
+
+    const { rerender } = renderProvider(KILTER_PROPS);
+    await act(async () => {});
+
+    // The spill was skipped (wall cleared) and the stale seed dropped with it.
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('');
+    expect(bluetooth.state.connectInitialSendRef.current).toBeNull();
+
+    // The lit climb becoming current must produce a real write, not a
+    // seed-satisfied silent confirm.
+    queue.currentClimbQueueItem = lit;
+    rerender(createElement(BluetoothProvider, { ...KILTER_PROPS, children: createElement('div', null) }));
+    await act(async () => {});
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+      'frames-lit',
+      false,
+      expect.anything(),
+      expect.objectContaining({ sendSource: 'auto', climbUuid: 'lit' }),
+    );
+  });
 });

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -806,4 +806,33 @@ describe('BluetoothProvider spill skip', () => {
     const skipCall = analytics.track.mock.calls.find(([name]) => name === 'BLE Queue Climb Skipped');
     expect(skipCall?.[1]).toMatchObject({ skippedClimbUuid: 'spill', inSession: true });
   });
+
+  it('physically re-lights the previously lit climb after a spill cleared the wall', async () => {
+    // Regression: the skip handler clears the wall, so the send-signature
+    // dedup must not treat the previously lit climb as "already on the wall"
+    // when the user returns to it — that would leave the wall dark while
+    // still firing wall-confirm.
+    const lit = makeBoardItem('lit', 'kilter', 1);
+    const spill = makeBoardItem('spill', 'tension', 1);
+    queue.currentClimbQueueItem = lit;
+    queue.queue = [lit, spill];
+
+    const { rerender } = renderProvider(KILTER_PROPS);
+    await act(async () => {});
+    const litSends = () =>
+      (bluetooth.state.sendFramesToBoard.mock.calls as unknown[][]).filter((call) => call[0] === 'frames-lit').length;
+    expect(litSends()).toBe(1);
+
+    // Spill becomes current with nothing compatible after it → wall cleared.
+    queue.currentClimbQueueItem = spill;
+    rerender(createElement(BluetoothProvider, { ...KILTER_PROPS, children: createElement('div', null) }));
+    await act(async () => {});
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('');
+
+    // Returning to the previously lit climb must re-write it, not dedup.
+    queue.currentClimbQueueItem = lit;
+    rerender(createElement(BluetoothProvider, { ...KILTER_PROPS, children: createElement('div', null) }));
+    await act(async () => {});
+    expect(litSends()).toBe(2);
+  });
 });

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -302,8 +302,11 @@ function BluetoothAutoSender({
             // The skip handler may clearBoard(), so whatever the dedup ref
             // remembers is no longer on the wall — drop it, or returning to
             // the previously lit climb would hit the byte-identical skip and
-            // leave the wall dark while still firing onWallConfirmed.
+            // leave the wall dark while still firing onWallConfirmed. Same for
+            // the connect-initial-send seed: consuming it after the clear
+            // would set the signature without a write (dark wall again).
             lastSentSignatureRef.current = null;
+            connectInitialSendRef.current = null;
             if (lastSkipReportedUuidRef.current !== item.uuid) {
               lastSkipReportedUuidRef.current = item.uuid;
               const { item: nextItem, skippedCount } = findNextCompatibleQueueItem(

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -299,6 +299,11 @@ function BluetoothAutoSender({
           // effect deps). Only a KNOWN mismatch is skipped; unknown/missing
           // metadata is sent as today.
           if (classifyClimbBoardCompatibility(activeConfigRef.current, item.climb) === 'incompatible') {
+            // The skip handler may clearBoard(), so whatever the dedup ref
+            // remembers is no longer on the wall — drop it, or returning to
+            // the previously lit climb would hit the byte-identical skip and
+            // leave the wall dark while still firing onWallConfirmed.
+            lastSentSignatureRef.current = null;
             if (lastSkipReportedUuidRef.current !== item.uuid) {
               lastSkipReportedUuidRef.current = item.uuid;
               const { item: nextItem, skippedCount } = findNextCompatibleQueueItem(

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -799,6 +799,52 @@ describe('BluetoothProvider', () => {
       });
       expect(mockShowMessage).toHaveBeenCalledTimes(2);
     });
+
+    it('physically re-lights the previously lit climb after a spill cleared the wall', async () => {
+      // Regression: the skip handler clears the wall, so the send-signature
+      // dedup must not treat the previously lit climb as "already on the wall"
+      // when the user returns to it — that would leave the wall dark while
+      // still firing wall-confirm.
+      mockSendFramesToBoard.mockResolvedValue(true);
+      const lit: MockQueueItem = {
+        uuid: 'lit',
+        climb: { uuid: 'c-lit', frames: 'p9r12', mirrored: false, name: 'Lit', boardType: 'kilter', layoutId: 1 },
+      };
+      const spill = makeSpillItem('spill', 'kilter', 8);
+      mockCurrentClimbQueueItem = lit;
+      mockQueue = [lit, spill];
+      mockBluetoothState.isConnected = true;
+
+      const { rerender } = renderHook(() => useBluetoothContext(), { wrapper: createWrapper() });
+      await act(async () => {
+        await vi.waitFor(() =>
+          expect(mockSendFramesToBoard).toHaveBeenCalledWith(
+            'p9r12',
+            false,
+            expect.anything(),
+            expect.objectContaining({ climbUuid: 'c-lit' }),
+          ),
+        );
+      });
+
+      // Spill becomes current with nothing compatible after it → wall cleared.
+      mockCurrentClimbQueueItem = spill;
+      await act(async () => {
+        rerender();
+      });
+      expect(mockSendFramesToBoard).toHaveBeenCalledWith('');
+
+      // Returning to the previously lit climb must re-write it, not dedup.
+      const litSendsBefore = mockSendFramesToBoard.mock.calls.filter(([frames]) => frames === 'p9r12').length;
+      mockCurrentClimbQueueItem = lit;
+      await act(async () => {
+        rerender();
+      });
+      await vi.waitFor(() => {
+        const litSendsAfter = mockSendFramesToBoard.mock.calls.filter(([frames]) => frames === 'p9r12').length;
+        expect(litSendsAfter).toBe(litSendsBefore + 1);
+      });
+    });
   });
 
   describe('rapid-swiping serialization', () => {

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -616,6 +616,38 @@ describe('useBoardBluetooth', () => {
       expect(mockShowMessage).toHaveBeenCalledTimes(1);
     });
 
+    it('re-toasts the same climb when it is also incompatible with the next board', async () => {
+      // The hook outlives route changes; the dedup key is board-scoped so the
+      // first refusal on the NEW board toasts even though the climb uuid is
+      // unchanged (and regardless of effect ordering on the switch commit).
+      const homewallDetails = {
+        ...(mockBoardDetails as unknown as Record<string, unknown>),
+        layout_id: 8,
+      } as unknown as Parameters<typeof useBoardBluetooth>[0]['boardDetails'];
+
+      const { result, rerender } = renderHook(({ details }) => useBoardBluetooth({ boardDetails: details }), {
+        initialProps: { details: mockBoardDetails },
+      });
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Tension climb: incompatible with kilter layout 1 AND kilter layout 8.
+      const spillContext = { climbUuid: 'spill-x', climbBoardType: 'tension', climbLayoutId: 1 };
+      await act(async () => {
+        await result.current.sendFramesToBoard('p1r12', false, undefined, spillContext);
+        await result.current.sendFramesToBoard('p1r12', false, undefined, spillContext);
+      });
+      expect(mockShowMessage).toHaveBeenCalledTimes(1);
+
+      // Switch to the Homewall config — same climb, still incompatible.
+      rerender({ details: homewallDetails });
+      await act(async () => {
+        await result.current.sendFramesToBoard('p1r12', false, undefined, spillContext);
+      });
+      expect(mockShowMessage).toHaveBeenCalledTimes(2);
+    });
+
     it('refuses silently when the caller suppresses the toast (play-drawer path)', async () => {
       const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
       await act(async () => {

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -290,6 +290,11 @@ function BluetoothAutoSender({
           // skipped (unknown metadata sends as today), and no onWallConfirmed —
           // the climb never reached the wall.
           if (classifyClimbBoardCompatibility(activeConfigRef.current, item.climb) === 'incompatible') {
+            // The skip handler may clearBoard(), so whatever the dedup ref
+            // remembers is no longer on the wall — drop it, or returning to
+            // the previously lit climb would hit the byte-identical skip and
+            // leave the wall dark while still firing onWallConfirmed.
+            lastSentSignatureRef.current = null;
             if (lastSkipReportedUuidRef.current !== item.uuid) {
               lastSkipReportedUuidRef.current = item.uuid;
               const { item: nextItem, skippedCount } = findNextCompatibleQueueItem(

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -262,6 +262,12 @@ export function useBoardBluetooth({
   // board switch back to a mismatched config re-surfaces the message.
   // Also cleared on both disconnect paths (handleDisconnection, disconnect()) so a fresh connection re-arms it.
   const lastIncompatibleToastUuidRef = useRef<string | null>(null);
+  // The hook outlives route changes (root provider), so also re-arm on a board
+  // switch — the same climb can be incompatible with the NEW board too and
+  // deserves a fresh toast there.
+  useEffect(() => {
+    lastIncompatibleToastUuidRef.current = null;
+  }, [boardDetails]);
 
   // Device picker state for custom Capacitor scanning.
   // pickerRejectRef holds the pending promise's reject so unmount cleanup

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -256,18 +256,14 @@ export function useBoardBluetooth({
   // a failing call resolving and the AutoSender's same-microtask read.
   const lastSendFailureReasonRef = useRef<BleSendFailureReason | null>(null);
 
-  // Dedups the cross-board toast per climb: the play-drawer playback loop and
-  // the AutoSender both re-invoke sendFramesToBoard for the same climb, and
-  // one toast per climb is enough. Cleared on any successful send so a later
-  // board switch back to a mismatched config re-surfaces the message.
-  // Also cleared on both disconnect paths (handleDisconnection, disconnect()) so a fresh connection re-arms it.
+  // Dedups the cross-board toast per board+climb: the play-drawer playback
+  // loop and the AutoSender both re-invoke sendFramesToBoard for the same
+  // climb, and one toast per climb per board is enough. Keyed on board
+  // identity (not reset via effect — child send effects run before this
+  // hook's effects on a board-switch commit, so an effect reset would race),
+  // cleared on any successful send, and cleared on both disconnect paths
+  // (handleDisconnection, disconnect()) so a fresh connection re-arms it.
   const lastIncompatibleToastUuidRef = useRef<string | null>(null);
-  // The hook outlives route changes (root provider), so also re-arm on a board
-  // switch — the same climb can be incompatible with the NEW board too and
-  // deserves a fresh toast there.
-  useEffect(() => {
-    lastIncompatibleToastUuidRef.current = null;
-  }, [boardDetails]);
 
   // Device picker state for custom Capacitor scanning.
   // pickerRejectRef holds the pending promise's reject so unmount cleanup
@@ -411,8 +407,9 @@ export function useBoardBluetooth({
           ) === 'incompatible'
         ) {
           // Contextless callers dedup under a sentinel so a retry loop can't
-          // spam the toast; the ref clears on any successful send.
-          const toastKey = climbUuid ?? '__no-uuid__';
+          // spam the toast; the ref clears on any successful send. Board scope
+          // matches the guard's granularity (name + layout).
+          const toastKey = `${boardDetails.board_name}-${boardDetails.layout_id}::${climbUuid ?? '__no-uuid__'}`;
           if (!sendContext?.suppressIncompatibleToast && lastIncompatibleToastUuidRef.current !== toastKey) {
             lastIncompatibleToastUuidRef.current = toastKey;
             showMessage(t('bluetooth.incompatibleClimb'), 'error');

--- a/packages/web/app/components/board-page/light-control-drawer.tsx
+++ b/packages/web/app/components/board-page/light-control-drawer.tsx
@@ -98,6 +98,9 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
   const isMoonboard = boardDetails.board_name === 'moonboard';
   const climbFrames = currentClimbQueueItem?.climb.frames ?? '';
   const climbMirrored = !!currentClimbQueueItem?.climb.mirrored;
+  const climbUuid = currentClimbQueueItem?.climb.uuid;
+  const climbBoardType = currentClimbQueueItem?.climb.boardType;
+  const climbLayoutId = currentClimbQueueItem?.climb.layoutId;
   const hasClimbLoaded = climbFrames.length > 0;
 
   const [colorDialogOpen, setColorDialogOpen] = useState(false);
@@ -226,9 +229,9 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
         .map((id) => `p${id}r${stateCodes[Math.floor(Math.random() * stateCodes.length)]}`)
         .join('');
       const result = await sendFramesToBoard(`${baseFrames}${handFrames}`, climbMirrored, undefined, {
-        climbUuid: currentClimbQueueItem?.climb.uuid,
-        climbBoardType: currentClimbQueueItem?.climb.boardType,
-        climbLayoutId: currentClimbQueueItem?.climb.layoutId,
+        climbUuid,
+        climbBoardType,
+        climbLayoutId,
       });
       inFlight = false;
       // The effect may have been torn down while the write was in flight — don't
@@ -256,7 +259,9 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
     boardDetails.board_name,
     climbFrames,
     climbMirrored,
-    currentClimbQueueItem,
+    climbUuid,
+    climbBoardType,
+    climbLayoutId,
     sendFramesToBoard,
     setPartyMode,
     showMessage,


### PR DESCRIPTION
## Summary

Follow-up to #3454, from an adversarial post-merge review of the diff.

**The bug (both platforms):** when the new spill guard clears the wall (party member receives a cross-board climb, or solo with no compatible climb left), the AutoSender's byte-identical send dedup (`lastSentSignatureRef`) still remembered the previously lit climb. Returning to that climb — the mainline "get back on my project" flow in a mixed-wall party — hit the "same pixels already on the wall" branch: no BLE write, wall stays dark, yet wall-confirm still fired (drawer lightbulb dismissed, party confirm broadcast, presence reported the climb as lit). Only a lightbulb reassert or switching climbs recovered. Fix: drop the send signature in the skip branch on web and mobile. The regression tests were verified to fail without the fix.

Two smaller items from the same review:

- **Toast dedup across board switches:** the BLE hook outlives route changes, so a climb refused on board A was silently refused on board B (also incompatible) with no toast. The dedup ref now re-arms whenever `boardDetails` changes.
- **Disco strobe restart churn:** the disco effect depended on the whole `currentClimbQueueItem` object; reducer actions that recreate the item without changing frames (regrade on angle change, queue item replace) tore down and restarted the interval. It now depends on the three identity primitives it actually reads.

Review items deliberately not addressed (noted for the record): `advancedToClimbUuid` telemetry reports the computed next item even in party mode where no advance happens (dashboards should cross-filter on `inSession`), and the skip→advance queue snapshot race from the #3454 review remains follow-up material.

## Release Notes

- Fixed a case where getting back on your climb after a mate queued one for a different wall left the board dark until you re-tapped the lightbulb

## Test plan

- New regression tests on both platforms: light a climb → spill clears the wall → return to the climb → a physical re-send must happen (web `bluetooth-context.test.tsx`, mobile `bluetooth-provider-mismatch-switch.test.tsx`). Confirmed the web test fails with the fix line removed.
- `vp test run` on all touched suites (607 web BLE/board-page/play-view + 18 mobile spill tests green), `vp run typecheck:web` / `typecheck:mobile`, `vp check` on changed files — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2W1ZcyJNXA7HzA4wFep85