### PR TITLE
fix(web): clear bluetooth toast dedup ref on disconnect

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -723,6 +723,82 @@ describe('BluetoothProvider', () => {
       });
       expect(mockShowMessage).toHaveBeenCalledTimes(2);
     });
+
+    it('reports a spill again after an intervening compatible climb write throws', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockSendFramesToBoard.mockResolvedValue(true);
+      const spill = makeSpillItem('spill', 'kilter', 8);
+      const compatible = makeSpillItem('ok', 'kilter', 1);
+      mockCurrentClimbQueueItem = spill;
+      mockQueue = [spill, compatible];
+      mockBluetoothState.isConnected = true;
+
+      const { rerender } = renderHook(() => useBluetoothContext(), { wrapper: createWrapper() });
+      await act(async () => {});
+      expect(mockShowMessage).toHaveBeenCalledTimes(1);
+
+      // The intervening compatible climb's write throws (e.g. a mid-send GATT
+      // drop). The dedup ref is cleared synchronously the moment the loop moves
+      // past the incompatible branch — before this awaited call even starts —
+      // so the clear must survive regardless of how this write resolves.
+      mockSendFramesToBoard.mockRejectedValueOnce(new Error('Bluetooth write failed'));
+      mockCurrentClimbQueueItem = compatible;
+      await act(async () => {
+        rerender();
+      });
+      await vi.waitFor(() =>
+        expect(mockTrack).toHaveBeenCalledWith(
+          'Climb Sent to Board Failure',
+          expect.objectContaining({ climbUuid: 'c-ok', failureReason: 'write_aborted' }),
+        ),
+      );
+
+      // Returning to the spill climb must still re-toast/re-advance — proving
+      // the dedup reset was unaffected by the intervening write's failure.
+      mockCurrentClimbQueueItem = spill;
+      await act(async () => {
+        rerender();
+      });
+      expect(mockShowMessage).toHaveBeenCalledTimes(2);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('reports a spill again after an intervening compatible climb write fails (resolves false)', async () => {
+      mockSendFramesToBoard.mockResolvedValue(true);
+      const spill = makeSpillItem('spill', 'kilter', 8);
+      const compatible = makeSpillItem('ok', 'kilter', 1);
+      mockCurrentClimbQueueItem = spill;
+      mockQueue = [spill, compatible];
+      mockBluetoothState.isConnected = true;
+
+      const { rerender } = renderHook(() => useBluetoothContext(), { wrapper: createWrapper() });
+      await act(async () => {});
+      expect(mockShowMessage).toHaveBeenCalledTimes(1);
+
+      // Mirrors the hook's real failing path: set the shared failure-reason ref
+      // synchronously and resolve false, rather than throwing.
+      mockSendFramesToBoard.mockImplementationOnce(async () => {
+        mockSendFailureReasonRef.current = 'disconnected';
+        return false;
+      });
+      mockCurrentClimbQueueItem = compatible;
+      await act(async () => {
+        rerender();
+      });
+      await vi.waitFor(() =>
+        expect(mockTrack).toHaveBeenCalledWith(
+          'Climb Sent to Board Failure',
+          expect.objectContaining({ climbUuid: 'c-ok', failureReason: 'disconnected' }),
+        ),
+      );
+
+      mockCurrentClimbQueueItem = spill;
+      await act(async () => {
+        rerender();
+      });
+      expect(mockShowMessage).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('rapid-swiping serialization', () => {

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -517,6 +517,81 @@ describe('useBoardBluetooth', () => {
       expect(mockShowMessage).toHaveBeenCalledTimes(2);
     });
 
+    it('re-arms the incompatible toast after an unexpected disconnect (write-triggered)', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      // Real BoardDetails carry a number[] set_ids; the shared mock lies with a
+      // string, so use array set_ids here (boardIdentityKey joins the array).
+      const arraySetIdsDetails = {
+        ...mockBoardDetails,
+        set_ids: [1, 2],
+      } as unknown as Parameters<typeof useBoardBluetooth>[0]['boardDetails'];
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: arraySetIdsDetails }));
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      const spillContext = { climbUuid: 'spill-1', climbBoardType: 'kilter', climbLayoutId: 8 };
+
+      // First send of the incompatible climb toasts once.
+      await act(async () => {
+        await result.current.sendFramesToBoard('p1r12', false, undefined, spillContext);
+      });
+      expect(mockShowMessage).toHaveBeenCalledTimes(1);
+
+      // A write to a DIFFERENT, compatible climb fails with a disconnect-shaped
+      // error — this drives the catch block's handleDisconnection() call
+      // (classifyBleFailureReason -> 'disconnected'), simulating a GATT drop
+      // that happens before any success-clear site is reached.
+      mockAdapter.write.mockRejectedValueOnce(new DOMException('GATT Server is disconnected.', 'NetworkError'));
+      await act(async () => {
+        await result.current.sendFramesToBoard('p4131r42', false, undefined, {
+          climbUuid: 'ok-1',
+          climbBoardType: 'kilter',
+          climbLayoutId: 1,
+        });
+      });
+      expect(result.current.isConnected).toBe(false);
+      mockShowMessage.mockClear();
+
+      // Reconnect and resend the ORIGINAL spill climb: previously the stale ref
+      // would suppress this toast because it still pointed at 'spill-1'.
+      await act(async () => {
+        await result.current.connect();
+      });
+      await act(async () => {
+        await result.current.sendFramesToBoard('p1r12', false, undefined, spillContext);
+      });
+      expect(mockShowMessage).toHaveBeenCalledTimes(1);
+
+      errorSpy.mockRestore();
+    });
+
+    it('re-arms the incompatible toast after an explicit disconnect()', async () => {
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      const spillContext = { climbUuid: 'spill-1', climbBoardType: 'kilter', climbLayoutId: 8 };
+      await act(async () => {
+        await result.current.sendFramesToBoard('p1r12', false, undefined, spillContext);
+      });
+      expect(mockShowMessage).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await result.current.disconnect();
+      });
+      mockShowMessage.mockClear();
+
+      await act(async () => {
+        await result.current.connect();
+      });
+      await act(async () => {
+        await result.current.sendFramesToBoard('p1r12', false, undefined, spillContext);
+      });
+      expect(mockShowMessage).toHaveBeenCalledTimes(1);
+    });
+
     it('refuses silently when the caller suppresses the toast (play-drawer path)', async () => {
       const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
       await act(async () => {

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -254,11 +254,8 @@ export function useBoardBluetooth({
   // Dedups the cross-board toast per climb: the play-drawer playback loop and
   // the AutoSender both re-invoke sendFramesToBoard for the same climb, and
   // one toast per climb is enough. Cleared on any successful send so a later
-  // board switch back to a mismatched config re-surfaces the message. Also
-  // cleared on disconnect (both the unexpected drop in handleDisconnection
-  // and the explicit user-initiated disconnect()) — a fresh connection should
-  // always get its own first toast for a climb, even one already flagged
-  // incompatible on the previous connection.
+  // board switch back to a mismatched config re-surfaces the message.
+  // Also cleared on both disconnect paths (handleDisconnection, disconnect()) so a fresh connection re-arms it.
   const lastIncompatibleToastUuidRef = useRef<string | null>(null);
 
   // Device picker state for custom Capacitor scanning.
@@ -303,12 +300,7 @@ export function useBoardBluetooth({
     const connectedAt = connectedAtRef.current;
     connectedAtRef.current = null;
     configuredBoardKeyRef.current = null;
-    // A fresh connection should get its own first incompatible-climb toast,
-    // even for a climb already flagged on the connection we just lost —
-    // otherwise a write that fails mid-session (e.g. the catch block below
-    // calling handleDisconnection on a 'disconnected' classification) can
-    // leave this ref pointing at a stale climb and wrongly suppress the
-    // toast after reconnect.
+    // A fresh connection re-arms the incompatible-climb toast, even for a climb already flagged before this drop.
     lastIncompatibleToastUuidRef.current = null;
     if (connectedAt !== null) {
       const connectionDurationSec = Math.max(0, Math.round((Date.now() - connectedAt) / 1000));
@@ -825,9 +817,7 @@ export function useBoardBluetooth({
     // later genuine drop can prompt again, and forget the board so a later tap
     // opens the picker rather than silently grabbing this board back.
     boardTakenPromptShownRef.current = false;
-    // Symmetric with the take-back guard above: a deliberate disconnect should
-    // equally allow the incompatible-climb toast to resurface on the next
-    // connection instead of staying suppressed from this session.
+    // Symmetric with the take-back guard above: re-arm the incompatible-climb toast for the next connection.
     lastIncompatibleToastUuidRef.current = null;
     setLastConnectedBoard(null);
     setIsConnected(false);

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -254,7 +254,11 @@ export function useBoardBluetooth({
   // Dedups the cross-board toast per climb: the play-drawer playback loop and
   // the AutoSender both re-invoke sendFramesToBoard for the same climb, and
   // one toast per climb is enough. Cleared on any successful send so a later
-  // board switch back to a mismatched config re-surfaces the message.
+  // board switch back to a mismatched config re-surfaces the message. Also
+  // cleared on disconnect (both the unexpected drop in handleDisconnection
+  // and the explicit user-initiated disconnect()) — a fresh connection should
+  // always get its own first toast for a climb, even one already flagged
+  // incompatible on the previous connection.
   const lastIncompatibleToastUuidRef = useRef<string | null>(null);
 
   // Device picker state for custom Capacitor scanning.
@@ -299,6 +303,13 @@ export function useBoardBluetooth({
     const connectedAt = connectedAtRef.current;
     connectedAtRef.current = null;
     configuredBoardKeyRef.current = null;
+    // A fresh connection should get its own first incompatible-climb toast,
+    // even for a climb already flagged on the connection we just lost —
+    // otherwise a write that fails mid-session (e.g. the catch block below
+    // calling handleDisconnection on a 'disconnected' classification) can
+    // leave this ref pointing at a stale climb and wrongly suppress the
+    // toast after reconnect.
+    lastIncompatibleToastUuidRef.current = null;
     if (connectedAt !== null) {
       const connectionDurationSec = Math.max(0, Math.round((Date.now() - connectedAt) / 1000));
       track('Bluetooth Disconnected', {
@@ -814,6 +825,10 @@ export function useBoardBluetooth({
     // later genuine drop can prompt again, and forget the board so a later tap
     // opens the picker rather than silently grabbing this board back.
     boardTakenPromptShownRef.current = false;
+    // Symmetric with the take-back guard above: a deliberate disconnect should
+    // equally allow the incompatible-climb toast to resurface on the next
+    // connection instead of staying suppressed from this session.
+    lastIncompatibleToastUuidRef.current = null;
     setLastConnectedBoard(null);
     setIsConnected(false);
     onConnectionChange?.(false);

--- a/packages/web/app/lib/data/__tests__/queries.test.ts
+++ b/packages/web/app/lib/data/__tests__/queries.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('next/cache', () => ({
+  unstable_cache:
+    <T extends (...args: unknown[]) => unknown>(fn: T) =>
+    (...args: Parameters<T>) =>
+      fn(...args),
+}));
+
+const mockSqlTag = vi.fn();
+const rowsFromResultMock = <T>(result: unknown): T[] => {
+  if (Array.isArray(result)) return result as T[];
+  throw new TypeError('Expected postgres-js query result to be a row array');
+};
+vi.mock('@/app/lib/db/db', () => ({
+  sql: mockSqlTag,
+  rowsFromResult: rowsFromResultMock,
+}));
+
+import { getClimb } from '../queries';
+
+describe('getClimb', () => {
+  beforeEach(() => {
+    mockSqlTag.mockReset();
+  });
+
+  it('maps layoutId, boardType, and derives difficulty/is_no_match from characteristics', async () => {
+    mockSqlTag.mockResolvedValueOnce([
+      {
+        uuid: 'climb-uuid-1',
+        setter_username: 'setter1',
+        userId: 'user-1',
+        name: 'Test Climb',
+        description: null,
+        layoutId: 8,
+        boardType: 'kilter',
+        frames: 'p1r12p2r13',
+        framesCount: 1,
+        framesPace: 0,
+        angle: 40,
+        ascensionist_count: 12,
+        difficulty_id: 20,
+        quality_average: '2.50',
+        difficulty_error: '0.10',
+        benchmark_difficulty: null,
+        is_draft: false,
+        created_at: '2024-01-01T00:00:00.000Z',
+        published_at: '2024-01-02T00:00:00.000Z',
+        characteristics: ['no_match'],
+      },
+    ]);
+
+    const climb = await getClimb({
+      board_name: 'kilter',
+      layout_id: 8,
+      size_id: 10,
+      set_ids: [1, 2],
+      angle: 40,
+      climb_uuid: 'climb-uuid-1',
+    });
+
+    expect(mockSqlTag).toHaveBeenCalledTimes(1);
+    expect(climb.uuid).toBe('climb-uuid-1');
+    expect(climb.layoutId).toBe(8);
+    expect(climb.boardType).toBe('kilter');
+    expect(climb.difficulty).toBe('6c/V5');
+    expect(climb.is_no_match).toBe(true);
+    expect(climb.ascensionist_count).toBe(12);
+  });
+
+  it('derives is_no_match from the description prefix when characteristics is null', async () => {
+    mockSqlTag.mockResolvedValueOnce([
+      {
+        uuid: 'climb-uuid-2',
+        setter_username: 'setter2',
+        userId: null,
+        name: 'Legacy Climb',
+        description: 'No match\nSome beta notes',
+        layoutId: 1,
+        boardType: 'kilter',
+        frames: 'p1r12',
+        framesCount: 1,
+        framesPace: 0,
+        angle: 40,
+        ascensionist_count: 0,
+        difficulty_id: null,
+        quality_average: null,
+        difficulty_error: null,
+        benchmark_difficulty: null,
+        is_draft: false,
+        created_at: '2024-01-01T00:00:00.000Z',
+        published_at: null,
+        characteristics: null,
+      },
+    ]);
+
+    const climb = await getClimb({
+      board_name: 'kilter',
+      layout_id: 1,
+      size_id: 10,
+      set_ids: [1, 2],
+      angle: 40,
+      climb_uuid: 'climb-uuid-2',
+    });
+
+    expect(climb.layoutId).toBe(1);
+    expect(climb.boardType).toBe('kilter');
+    expect(climb.difficulty).toBe('');
+    expect(climb.is_no_match).toBe(true);
+  });
+
+  it('is_no_match is false when characteristics has no no_match token and the description does not start with "no match"', async () => {
+    mockSqlTag.mockResolvedValueOnce([
+      {
+        uuid: 'climb-uuid-3',
+        setter_username: 'setter3',
+        userId: null,
+        name: 'Normal Climb',
+        description: 'Great warmup',
+        layoutId: 1,
+        boardType: 'tension',
+        frames: 'p1r12',
+        framesCount: 1,
+        framesPace: 0,
+        angle: 40,
+        ascensionist_count: 3,
+        difficulty_id: 22,
+        quality_average: '3.00',
+        difficulty_error: '0.00',
+        benchmark_difficulty: null,
+        is_draft: false,
+        created_at: '2024-01-01T00:00:00.000Z',
+        published_at: '2024-01-01T00:00:00.000Z',
+        characteristics: ['method_footless'],
+      },
+    ]);
+
+    const climb = await getClimb({
+      board_name: 'tension',
+      layout_id: 1,
+      size_id: 10,
+      set_ids: [1],
+      angle: 40,
+      climb_uuid: 'climb-uuid-3',
+    });
+
+    expect(climb.boardType).toBe('tension');
+    expect(climb.difficulty).toBe('7a/V6');
+    expect(climb.is_no_match).toBe(false);
+  });
+});

--- a/packages/web/app/lib/data/__tests__/queries.test.ts
+++ b/packages/web/app/lib/data/__tests__/queries.test.ts
@@ -1,5 +1,15 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { getClimb } from '../queries';
+
+const { mockSqlTag, rowsFromResultMock } = vi.hoisted(() => {
+  const mockSqlTag = vi.fn();
+  const rowsFromResultMock = <T>(result: unknown): T[] => {
+    if (Array.isArray(result)) return result as T[];
+    throw new TypeError('Expected postgres-js query result to be a row array');
+  };
+  return { mockSqlTag, rowsFromResultMock };
+});
 
 vi.mock('server-only', () => ({}));
 
@@ -10,17 +20,10 @@ vi.mock('next/cache', () => ({
       fn(...args),
 }));
 
-const mockSqlTag = vi.fn();
-const rowsFromResultMock = <T>(result: unknown): T[] => {
-  if (Array.isArray(result)) return result as T[];
-  throw new TypeError('Expected postgres-js query result to be a row array');
-};
 vi.mock('@/app/lib/db/db', () => ({
   sql: mockSqlTag,
   rowsFromResult: rowsFromResultMock,
 }));
-
-import { getClimb } from '../queries';
 
 describe('getClimb', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Follow-up on three "minor, non-blocking" notes from a prior review:

- `fetchClimbFromDb` (`packages/web/app/lib/data/queries.ts`) recently gained `layoutId`/`boardType` columns with zero test coverage — `queries.ts` had no test file at all. Added `packages/web/app/lib/data/__tests__/queries.test.ts`, reusing the existing raw-`sql`/`rowsFromResult` mocking pattern from `dynamic-og-data.test.ts`, covering the new columns plus the `difficulty`/`is_no_match` derivation.
- `lastIncompatibleToastUuidRef` in `use-board-bluetooth.ts` was only cleared on a *successful* send. The original note assumed "the disconnect flow resets state independently" — investigation showed this was false: neither `handleDisconnection` (unexpected drop) nor `disconnect()` (user-initiated) cleared it. Concretely: an incompatible-climb toast fires for climb X, a later write to a *different* climb throws with a GATT-drop error, `handleDisconnection()` tears down the connection, the user reconnects and resends climb X — the stale ref wrongly suppressed the toast on the fresh connection. Fixed by clearing the ref in both disconnect paths, with two regression tests.
- `lastSkipReportedUuidRef` spill-dedup in `bluetooth-context.tsx` clears unconditionally *before* the intervening compatible climb's write is awaited. Investigation confirmed this is correct and intentional (clearing only on success would leave the dedup permanently stuck after any failed intervening write). No code change — added two regression tests locking in the behavior so a future refactor can't silently regress it.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project web` — new/updated tests in `queries.test.ts`, `use-board-bluetooth.test.ts`, and `bluetooth-context.test.tsx` all pass.
- `vp run typecheck:web` — clean.
- `vp check` — clean (scoped to the touched files; an unrelated pre-existing formatting issue in a mobile test file was left untouched).
- Confirmed the two new `use-board-bluetooth.test.ts` regression tests fail without the fix and pass with it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WCGTFZikySPRgxr1AFoma2)_