### PR TITLE
ci(mobile): gate PR native builds + restore-only Gradle cache + parallel jobs

### DIFF
--- a/.github/actions/android-rn-setup/action.yml
+++ b/.github/actions/android-rn-setup/action.yml
@@ -1,0 +1,71 @@
+name: Android RN setup
+description: >
+  Shared setup for the Android PR jobs — workspace deps, JDK 21, the Android SDK,
+  a read-only Gradle cache, and `expo prebuild`. Factored out so the parallel
+  robolectric-tests and build-apk jobs can't drift. See
+  docs/android-pr-build-speed-spec.md.
+
+# No inputs: the EXPO_PUBLIC_* values the .env step reads are workflow-level `env`
+# on the caller, which composite `run` steps inherit as process environment. No
+# secrets are involved.
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@v2
+
+    - name: Install Node.js dependencies (workspace root)
+      shell: bash
+      run: bun install --frozen-lockfile
+
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
+
+    - name: Accept licenses and install SDK components
+      shell: bash
+      run: |
+        yes | sdkmanager --licenses > /dev/null 2>&1 || true
+        sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
+    - name: Restore Gradle cache (read-only, warmed by android-apk-rn.yml on main)
+      # restore, not cache: PR runs never save. Each save was a 3.4 GB entry that
+      # blew the 10 GB repo cache budget and evicted main's release/dev caches, so
+      # every new PR built cold. Reusing main's `gradle-rn-` cache (prefix also
+      # matches the dev-client `gradle-rn-dev-` cache — a harmless, additive
+      # dependency-cache hit) means a warm build without the eviction cascade.
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-rn-${{ hashFiles('packages/mobile/package.json', 'bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-rn-
+
+    - name: Write .env for Expo build-time inlining
+      shell: bash
+      working-directory: packages/mobile
+      run: |
+        cat > .env <<EOF
+        EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
+        EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
+        EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
+        EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID
+        EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID
+        EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
+        EOF
+
+    - name: Expo prebuild (generate android/)
+      shell: bash
+      working-directory: packages/mobile
+      env:
+        # Skip the tailscale probe (already short-circuited on CI, set explicitly
+        # so a misconfigured runner never pays the 2s timeout). Step-level env
+        # travels with the step into the composite.
+        TAILSCALE_HOSTS: ''
+      run: bunx expo prebuild --platform android --clean --no-install

--- a/.github/actions/android-rn-setup/action.yml
+++ b/.github/actions/android-rn-setup/action.yml
@@ -3,7 +3,7 @@ description: >
   Shared setup for the Android PR jobs — workspace deps, JDK 21, the Android SDK,
   a read-only Gradle cache, and `expo prebuild`. Factored out so the parallel
   robolectric-tests and build-apk jobs can't drift. See
-  docs/android-pr-build-speed-spec.md.
+  docs/android-pr-build-speed-spec.md (added in #3445).
 
 # No inputs: the EXPO_PUBLIC_* values the .env step reads are workflow-level `env`
 # on the caller, which composite `run` steps inherit as process environment. No

--- a/.github/actions/mobile-native-gate/action.yml
+++ b/.github/actions/mobile-native-gate/action.yml
@@ -115,11 +115,13 @@ runs:
         # so there's no ordering footgun for any future step, and the base's node
         # tree can't collide with head's. bun's global cache (~/.bun) is shared,
         # so the base install reuses already-downloaded packages.
-        BASE_DIR="${RUNNER_TEMP:-/tmp}/mobile-native-gate-base-$RANDOM"
-        rm -rf "$BASE_DIR"
+        # mktemp -d is collision-proof; the `wt` subdir doesn't exist yet, which
+        # is what `git worktree add` wants.
+        BASE_PARENT="$(mktemp -d)"
+        BASE_DIR="$BASE_PARENT/wt"
         if ! git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null \
           || ! git worktree add --detach --force "$BASE_DIR" "$BASE_SHA" 2>/dev/null; then
-          rm -rf "$BASE_DIR"
+          rm -rf "$BASE_PARENT"
           echo "should_build=true" >> "$GITHUB_OUTPUT"
           echo "::warning::Could not materialise base $BASE_SHA to diff the fingerprint — building to be safe."
           exit 0
@@ -127,7 +129,8 @@ runs:
         write_env "$BASE_DIR"
         ( cd "$BASE_DIR" && bun install --frozen-lockfile )
         BASE_FP="$(resolve_fp "$BASE_DIR")"
-        git worktree remove --force "$BASE_DIR" 2>/dev/null || rm -rf "$BASE_DIR"
+        git worktree remove --force "$BASE_DIR" 2>/dev/null || true
+        rm -rf "$BASE_PARENT"
 
         echo "platform=$PLATFORM head=$HEAD_FP base=$BASE_FP"
         if [ -n "$HEAD_FP" ] && [ -n "$BASE_FP" ] && [ "$HEAD_FP" = "$BASE_FP" ]; then

--- a/.github/actions/mobile-native-gate/action.yml
+++ b/.github/actions/mobile-native-gate/action.yml
@@ -1,0 +1,131 @@
+name: Mobile native-build gate
+description: >
+  Decide whether a PR needs a native build. Skips when no native-input file
+  changed vs the PR base, or when the resolved Expo fingerprint is unchanged vs
+  the base — the PR-side mirror of how main skips the native build for JS-only
+  merges. Runs on ubuntu for both platforms (the fingerprint resolve is
+  file-hash based; it needs neither Xcode nor the Android SDK). See
+  docs/android-pr-build-speed-spec.md.
+
+# Why a fingerprint diff and not main's fingerprint-tag lookup: main resolves the
+# fingerprint WITH Production-environment secrets (GOOGLE_MAPS_API_KEY perturbs
+# it) and skips when a `fingerprint-<platform>-<hash>` tag already shipped. A PR
+# run — a fork PR especially — can't read those secrets, so its resolve would
+# never match the shipped tags. Resolving head and base with the PR workflow's
+# own (identical) env instead makes the env cancel out, leaving only real
+# native-input changes to move the comparison.
+inputs:
+  platform:
+    description: 'Expo platform to resolve the fingerprint for (android | ios).'
+    required: true
+outputs:
+  should_build:
+    description: 'true when the native build must run; false to skip it.'
+    value: ${{ steps.decide.outputs.should_build }}
+runs:
+  using: composite
+  steps:
+    - name: Screen changed paths
+      id: changed
+      if: github.event_name == 'pull_request'
+      uses: dorny/paths-filter@v3
+      with:
+        # `native` mirrors the repo's canonical native-input set (the ios-rn-ci
+        # CocoaPods cache key). `ci` is the workflow/action plumbing itself: a
+        # change there can't move the fingerprint, so it must force a build to be
+        # exercised at all rather than get skipped by the fingerprint diff.
+        filters: |
+          native:
+            - 'packages/mobile/package.json'
+            - 'bun.lock'
+            - 'packages/mobile/app.config.ts'
+            - 'packages/mobile/plugins/**'
+            - 'packages/mobile/modules/**'
+            - 'patches/**'
+          ci:
+            - '.github/workflows/android-pr-rn.yml'
+            - '.github/workflows/ios-rn-ci.yml'
+            - '.github/actions/android-rn-setup/**'
+            - '.github/actions/mobile-native-gate/**'
+
+    - name: Decide whether to build
+      id: decide
+      shell: bash
+      env:
+        PLATFORM: ${{ inputs.platform }}
+        NATIVE_CHANGED: ${{ steps.changed.outputs.native }}
+        CI_CHANGED: ${{ steps.changed.outputs.ci }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: |
+        set -uo pipefail
+
+        # Non-PR events (branch push, manual dispatch) always build: there's no
+        # base to diff against, and this preserves the pre-gate behaviour.
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          echo "should_build=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Not a pull_request event — building."
+          exit 0
+        fi
+
+        # A change to the workflow/action plumbing must actually run the build.
+        if [ "$CI_CHANGED" = "true" ]; then
+          echo "should_build=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::CI plumbing changed — building to exercise it."
+          exit 0
+        fi
+
+        # Nothing that can move the native fingerprint changed → skip outright,
+        # without paying for a fingerprint resolve. This is the JS-only path.
+        if [ "$NATIVE_CHANGED" != "true" ]; then
+          echo "should_build=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::No native-input files changed vs base — skipping the $PLATFORM native build (JS rides OTA)."
+          exit 0
+        fi
+
+        # A native-input file changed, but that set includes bun.lock — which any
+        # web/backend dep bump churns without touching the mobile native shape.
+        # Resolve the Expo fingerprint at head and base and skip when identical.
+        # Fail open: any resolve/checkout trouble builds.
+        resolve_fp() {
+          ( cd packages/mobile \
+            && TAILSCALE_HOSTS='' bunx expo-updates runtimeversion:resolve --platform "$PLATFORM" 2>/dev/null ) \
+            | jq -r '.runtimeVersion // empty' 2>/dev/null || true
+        }
+
+        bun install --frozen-lockfile
+        # The .env is hashed into the fingerprint, so both resolves must see the
+        # same one. It's untracked, so it survives the base checkout below.
+        cat > packages/mobile/.env <<EOF
+        EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
+        EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
+        EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
+        EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID
+        EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID
+        EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
+        EOF
+
+        HEAD_FP="$(resolve_fp)"
+
+        # Resolve the base fingerprint in-place. Checking out base rewrites the
+        # working tree to main, which doesn't have this action's files yet — safe
+        # because `decide` is the composite's LAST step (nothing re-reads
+        # action.yml after this) and $GITHUB_OUTPUT lives in RUNNER_TEMP, outside
+        # the workspace, so the write below still lands. The untracked .env
+        # survives the checkout, so both resolves hash the same one.
+        if ! git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null \
+          || ! git checkout --quiet --force "$BASE_SHA" 2>/dev/null; then
+          echo "should_build=true" >> "$GITHUB_OUTPUT"
+          echo "::warning::Could not check out base $BASE_SHA to diff the fingerprint — building to be safe."
+          exit 0
+        fi
+        bun install --frozen-lockfile
+        BASE_FP="$(resolve_fp)"
+
+        echo "platform=$PLATFORM head=$HEAD_FP base=$BASE_FP"
+        if [ -n "$HEAD_FP" ] && [ -n "$BASE_FP" ] && [ "$HEAD_FP" = "$BASE_FP" ]; then
+          echo "should_build=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::$PLATFORM fingerprint unchanged vs base ($HEAD_FP) — skipping the native build (JS rides OTA)."
+        else
+          echo "should_build=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::$PLATFORM fingerprint changed (base=$BASE_FP head=$HEAD_FP) — running the native build."
+        fi

--- a/.github/actions/mobile-native-gate/action.yml
+++ b/.github/actions/mobile-native-gate/action.yml
@@ -5,7 +5,7 @@ description: >
   the base — the PR-side mirror of how main skips the native build for JS-only
   merges. Runs on ubuntu for both platforms (the fingerprint resolve is
   file-hash based; it needs neither Xcode nor the Android SDK). See
-  docs/android-pr-build-speed-spec.md.
+  docs/android-pr-build-speed-spec.md (added in #3445).
 
 # Why a fingerprint diff and not main's fingerprint-tag lookup: main resolves the
 # fingerprint WITH Production-environment secrets (GOOGLE_MAPS_API_KEY perturbs
@@ -87,15 +87,16 @@ runs:
         # Resolve the Expo fingerprint at head and base and skip when identical.
         # Fail open: any resolve/checkout trouble builds.
         resolve_fp() {
-          ( cd packages/mobile \
+          # $1 = repo root to resolve the fingerprint in.
+          ( cd "$1/packages/mobile" \
             && TAILSCALE_HOSTS='' bunx expo-updates runtimeversion:resolve --platform "$PLATFORM" 2>/dev/null ) \
             | jq -r '.runtimeVersion // empty' 2>/dev/null || true
         }
 
-        bun install --frozen-lockfile
-        # The .env is hashed into the fingerprint, so both resolves must see the
-        # same one. It's untracked, so it survives the base checkout below.
-        cat > packages/mobile/.env <<EOF
+        write_env() {
+          # $1 = repo root. The .env is hashed into the fingerprint, so head and
+          # base must resolve against a byte-identical one.
+          cat > "$1/packages/mobile/.env" <<EOF
         EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
         EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
         EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
@@ -103,23 +104,30 @@ runs:
         EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID
         EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
         EOF
+        }
 
-        HEAD_FP="$(resolve_fp)"
+        bun install --frozen-lockfile
+        write_env .
+        HEAD_FP="$(resolve_fp .)"
 
-        # Resolve the base fingerprint in-place. Checking out base rewrites the
-        # working tree to main, which doesn't have this action's files yet — safe
-        # because `decide` is the composite's LAST step (nothing re-reads
-        # action.yml after this) and $GITHUB_OUTPUT lives in RUNNER_TEMP, outside
-        # the workspace, so the write below still lands. The untracked .env
-        # survives the checkout, so both resolves hash the same one.
+        # Resolve the base fingerprint in an ISOLATED worktree so the primary
+        # checkout is never mutated: head files (incl. this action) stay in place,
+        # so there's no ordering footgun for any future step, and the base's node
+        # tree can't collide with head's. bun's global cache (~/.bun) is shared,
+        # so the base install reuses already-downloaded packages.
+        BASE_DIR="${RUNNER_TEMP:-/tmp}/mobile-native-gate-base-$RANDOM"
+        rm -rf "$BASE_DIR"
         if ! git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null \
-          || ! git checkout --quiet --force "$BASE_SHA" 2>/dev/null; then
+          || ! git worktree add --detach --force "$BASE_DIR" "$BASE_SHA" 2>/dev/null; then
+          rm -rf "$BASE_DIR"
           echo "should_build=true" >> "$GITHUB_OUTPUT"
-          echo "::warning::Could not check out base $BASE_SHA to diff the fingerprint — building to be safe."
+          echo "::warning::Could not materialise base $BASE_SHA to diff the fingerprint — building to be safe."
           exit 0
         fi
-        bun install --frozen-lockfile
-        BASE_FP="$(resolve_fp)"
+        write_env "$BASE_DIR"
+        ( cd "$BASE_DIR" && bun install --frozen-lockfile )
+        BASE_FP="$(resolve_fp "$BASE_DIR")"
+        git worktree remove --force "$BASE_DIR" 2>/dev/null || rm -rf "$BASE_DIR"
 
         echo "platform=$PLATFORM head=$HEAD_FP base=$BASE_FP"
         if [ -n "$HEAD_FP" ] && [ -n "$BASE_FP" ] && [ "$HEAD_FP" = "$BASE_FP" ]; then

--- a/.github/actions/mobile-native-gate/action.yml
+++ b/.github/actions/mobile-native-gate/action.yml
@@ -28,6 +28,10 @@ outputs:
 runs:
   using: composite
   steps:
+    # Self-contained (like android-rn-setup): a caller only has to `checkout`
+    # first, not also remember to set up bun.
+    - uses: oven-sh/setup-bun@v2
+
     - name: Decide whether to build
       id: decide
       shell: bash
@@ -35,6 +39,10 @@ runs:
         PLATFORM: ${{ inputs.platform }}
         EVENT: ${{ github.event_name }}
       run: |
+        # No `set -e`: this gate is deliberately fail-OPEN (an unexpected error
+        # should build, never block a PR), and every decision path exits via
+        # build() or skip() below — so should_build is always written. Keep that
+        # invariant if you edit this.
         set -uo pipefail
 
         build() { echo "should_build=true"  >> "$GITHUB_OUTPUT"; echo "::notice::$1 — running the $PLATFORM native build."; exit 0; }
@@ -101,7 +109,7 @@ runs:
         # is collision-proof; the `wt` subdir doesn't exist yet, which git wants.
         BASE_PARENT="$(mktemp -d)"
         BASE_DIR="$BASE_PARENT/wt"
-        git worktree add --detach --force "$BASE_DIR" "$BASE_SHA" 2>/dev/null || {
+        git worktree add --detach "$BASE_DIR" "$BASE_SHA" 2>/dev/null || {
           rm -rf "$BASE_PARENT"; build "could not materialise main to diff the fingerprint"; }
         write_env "$BASE_DIR"
         if ! ( cd "$BASE_DIR" && bun install --frozen-lockfile ); then

--- a/.github/actions/mobile-native-gate/action.yml
+++ b/.github/actions/mobile-native-gate/action.yml
@@ -1,19 +1,22 @@
 name: Mobile native-build gate
 description: >
-  Decide whether a PR needs a native build. Skips when no native-input file
-  changed vs the PR base, or when the resolved Expo fingerprint is unchanged vs
-  the base — the PR-side mirror of how main skips the native build for JS-only
-  merges. Runs on ubuntu for both platforms (the fingerprint resolve is
-  file-hash based; it needs neither Xcode nor the Android SDK). See
-  docs/android-pr-build-speed-spec.md (added in #3445).
+  Decide whether a PR or branch push needs a native build. Skips when nothing
+  that can move the Expo fingerprint changed vs main, or when the fingerprint
+  itself is unchanged vs main — the PR/branch mirror of how main skips the native
+  build for JS-only merges. Branch pushes are gated too: the push-triggered build
+  predates OTA and no longer needs to run for JS-only changes. Runs on ubuntu for
+  both platforms (the fingerprint resolve is file-hash based; it needs neither
+  Xcode nor the Android SDK). See docs/android-pr-build-speed-spec.md (added in
+  #3445).
 
 # Why a fingerprint diff and not main's fingerprint-tag lookup: main resolves the
 # fingerprint WITH Production-environment secrets (GOOGLE_MAPS_API_KEY perturbs
 # it) and skips when a `fingerprint-<platform>-<hash>` tag already shipped. A PR
 # run — a fork PR especially — can't read those secrets, so its resolve would
-# never match the shipped tags. Resolving head and base with the PR workflow's
-# own (identical) env instead makes the env cancel out, leaving only real
-# native-input changes to move the comparison.
+# never match the shipped tags. Resolving head and main with this workflow's own
+# (identical) env instead makes the env cancel out, leaving only real native-input
+# changes to move the comparison. Everything diffs against main (fetched below),
+# which is base.sha for a PR's merge ref and the merge target for a branch push.
 inputs:
   platform:
     description: 'Expo platform to resolve the fingerprint for (android | ios).'
@@ -25,77 +28,58 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Screen changed paths
-      id: changed
-      if: github.event_name == 'pull_request'
-      uses: dorny/paths-filter@v3
-      with:
-        # `native` mirrors the repo's canonical native-input set (the ios-rn-ci
-        # CocoaPods cache key). `ci` is the workflow/action plumbing itself: a
-        # change there can't move the fingerprint, so it must force a build to be
-        # exercised at all rather than get skipped by the fingerprint diff.
-        filters: |
-          native:
-            - 'packages/mobile/package.json'
-            - 'bun.lock'
-            - 'packages/mobile/app.config.ts'
-            - 'packages/mobile/plugins/**'
-            - 'packages/mobile/modules/**'
-            - 'patches/**'
-          ci:
-            - '.github/workflows/android-pr-rn.yml'
-            - '.github/workflows/ios-rn-ci.yml'
-            - '.github/actions/android-rn-setup/**'
-            - '.github/actions/mobile-native-gate/**'
-
     - name: Decide whether to build
       id: decide
       shell: bash
       env:
         PLATFORM: ${{ inputs.platform }}
-        NATIVE_CHANGED: ${{ steps.changed.outputs.native }}
-        CI_CHANGED: ${{ steps.changed.outputs.ci }}
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        EVENT: ${{ github.event_name }}
       run: |
         set -uo pipefail
 
-        # Non-PR events (branch push, manual dispatch) always build: there's no
-        # base to diff against, and this preserves the pre-gate behaviour.
-        if [ "${{ github.event_name }}" != "pull_request" ]; then
-          echo "should_build=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::Not a pull_request event — building."
-          exit 0
+        build() { echo "should_build=true"  >> "$GITHUB_OUTPUT"; echo "::notice::$1 — running the $PLATFORM native build."; exit 0; }
+        skip()  { echo "should_build=false" >> "$GITHUB_OUTPUT"; echo "::notice::$1 — skipping the $PLATFORM native build (JS rides OTA)."; exit 0; }
+
+        # Manual dispatch has no base to diff against.
+        [ "$EVENT" = "workflow_dispatch" ] && build "manual dispatch"
+
+        # Diff against main — base.sha for a PR merge ref, the merge target for a
+        # branch push. A shallow tip is enough: `git diff A B` compares the two
+        # trees directly (no merge-base needed).
+        git fetch --no-tags --depth=1 origin main 2>/dev/null || build "could not fetch main to diff against"
+        BASE_SHA="$(git rev-parse FETCH_HEAD)"
+
+        changed() { git diff --name-only "$BASE_SHA" HEAD -- "$@" 2>/dev/null; }
+
+        # A change to the workflow/action plumbing can't move the fingerprint, so
+        # it would be skipped by the diff below — force a build so it's exercised.
+        if [ -n "$(changed \
+              .github/workflows/android-pr-rn.yml .github/workflows/ios-rn-ci.yml \
+              .github/actions/android-rn-setup .github/actions/mobile-native-gate)" ]; then
+          build "CI plumbing changed"
         fi
 
-        # A change to the workflow/action plumbing must actually run the build.
-        if [ "$CI_CHANGED" = "true" ]; then
-          echo "should_build=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::CI plumbing changed — building to exercise it."
-          exit 0
+        # Path screen: nothing in the canonical native-input set (mirrors the
+        # ios-rn-ci Pods cache key) changed → skip without paying for a resolve.
+        if [ -z "$(changed \
+              packages/mobile/package.json bun.lock packages/mobile/app.config.ts \
+              packages/mobile/plugins packages/mobile/modules patches)" ]; then
+          skip "no native-input files changed vs main"
         fi
 
-        # Nothing that can move the native fingerprint changed → skip outright,
-        # without paying for a fingerprint resolve. This is the JS-only path.
-        if [ "$NATIVE_CHANGED" != "true" ]; then
-          echo "should_build=false" >> "$GITHUB_OUTPUT"
-          echo "::notice::No native-input files changed vs base — skipping the $PLATFORM native build (JS rides OTA)."
-          exit 0
-        fi
-
-        # A native-input file changed, but that set includes bun.lock — which any
+        # A candidate changed, but that set includes bun.lock — which any
         # web/backend dep bump churns without touching the mobile native shape.
-        # Resolve the Expo fingerprint at head and base and skip when identical.
-        # Fail open: any resolve/checkout trouble builds.
+        # Resolve the Expo fingerprint at HEAD and at main and skip when identical.
+        # Fail open: any resolve/install/worktree trouble builds.
         resolve_fp() {
           # $1 = repo root to resolve the fingerprint in.
           ( cd "$1/packages/mobile" \
             && TAILSCALE_HOSTS='' bunx expo-updates runtimeversion:resolve --platform "$PLATFORM" 2>/dev/null ) \
             | jq -r '.runtimeVersion // empty' 2>/dev/null || true
         }
-
         write_env() {
           # $1 = repo root. The .env is hashed into the fingerprint, so head and
-          # base must resolve against a byte-identical one.
+          # main must resolve against a byte-identical one.
           cat > "$1/packages/mobile/.env" <<EOF
         EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
         EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
@@ -106,37 +90,31 @@ runs:
         EOF
         }
 
-        bun install --frozen-lockfile
+        bun install --frozen-lockfile || build "head bun install failed"
         write_env .
         HEAD_FP="$(resolve_fp .)"
 
-        # Resolve the base fingerprint in an ISOLATED worktree so the primary
-        # checkout is never mutated: head files (incl. this action) stay in place,
-        # so there's no ordering footgun for any future step, and the base's node
-        # tree can't collide with head's. bun's global cache (~/.bun) is shared,
-        # so the base install reuses already-downloaded packages.
-        # mktemp -d is collision-proof; the `wt` subdir doesn't exist yet, which
-        # is what `git worktree add` wants.
+        # Resolve the main fingerprint in an ISOLATED worktree so the primary
+        # checkout is never mutated (head files, incl. this action, stay in place —
+        # no ordering footgun for any later step). bun's global cache (~/.bun) is
+        # shared, so the base install re-uses already-downloaded packages. mktemp -d
+        # is collision-proof; the `wt` subdir doesn't exist yet, which git wants.
         BASE_PARENT="$(mktemp -d)"
         BASE_DIR="$BASE_PARENT/wt"
-        if ! git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null \
-          || ! git worktree add --detach --force "$BASE_DIR" "$BASE_SHA" 2>/dev/null; then
-          rm -rf "$BASE_PARENT"
-          echo "should_build=true" >> "$GITHUB_OUTPUT"
-          echo "::warning::Could not materialise base $BASE_SHA to diff the fingerprint — building to be safe."
-          exit 0
-        fi
+        git worktree add --detach --force "$BASE_DIR" "$BASE_SHA" 2>/dev/null || {
+          rm -rf "$BASE_PARENT"; build "could not materialise main to diff the fingerprint"; }
         write_env "$BASE_DIR"
-        ( cd "$BASE_DIR" && bun install --frozen-lockfile )
+        if ! ( cd "$BASE_DIR" && bun install --frozen-lockfile ); then
+          git worktree remove --force "$BASE_DIR" 2>/dev/null || true; rm -rf "$BASE_PARENT"
+          build "base bun install failed"
+        fi
         BASE_FP="$(resolve_fp "$BASE_DIR")"
         git worktree remove --force "$BASE_DIR" 2>/dev/null || true
         rm -rf "$BASE_PARENT"
 
         echo "platform=$PLATFORM head=$HEAD_FP base=$BASE_FP"
         if [ -n "$HEAD_FP" ] && [ -n "$BASE_FP" ] && [ "$HEAD_FP" = "$BASE_FP" ]; then
-          echo "should_build=false" >> "$GITHUB_OUTPUT"
-          echo "::notice::$PLATFORM fingerprint unchanged vs base ($HEAD_FP) — skipping the native build (JS rides OTA)."
+          skip "$PLATFORM fingerprint unchanged vs main ($HEAD_FP)"
         else
-          echo "should_build=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::$PLATFORM fingerprint changed (base=$BASE_FP head=$HEAD_FP) — running the native build."
+          build "$PLATFORM fingerprint changed (base=$BASE_FP head=$HEAD_FP)"
         fi

--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -1,7 +1,6 @@
 name: Android PR Build (React Native)
 
-# Two jobs in one, for PRs touching packages/mobile (managed Expo, no committed
-# android/):
+# For PRs touching packages/mobile (managed Expo, no committed android/). It:
 #   1. Catches what the JS-only checks can't — a broken Expo config plugin, an
 #      app.config.ts mistake, or a Gradle/native-module compile failure — BEFORE
 #      it reaches the push-to-main android-apk-rn.yml release build.
@@ -15,6 +14,13 @@ name: Android PR Build (React Native)
 # but with a DIFFERENT signature than the production/Play build — uninstall any
 # existing com.boardsesh.app before installing it.
 #
+# Shape (see docs/android-pr-build-speed-spec.md):
+#   gate → { robolectric-tests, build-apk }
+#   - gate skips both native jobs on a JS-only PR (no native-input change / an
+#     unchanged Expo fingerprint), mirroring main's native-skip for JS-only
+#     merges. The build jobs run in parallel and share android-rn-setup, and the
+#     Gradle cache is restored read-only from the cache main already warms.
+#
 # ci.yml already runs typecheck:mobile + the mobile vitest project +
 # check:mobile-bundle on PRs, so this doesn't duplicate those. pull_request only
 # (no push trigger) so it runs exactly once per PR sync.
@@ -26,7 +32,10 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'patches/**' # bun patches to mobile deps live in root patches/, not under packages/mobile/**
       - '.github/workflows/android-pr-rn.yml'
+      - '.github/actions/android-rn-setup/**'
+      - '.github/actions/mobile-native-gate/**'
   workflow_dispatch:
 
 concurrency:
@@ -36,81 +45,59 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # The app's env.ts already defaults to the production backend/web URLs, so the
+  # test APK talks to prod without any secrets. Sentry stays off (no DSN).
+  # Workflow-level so the gate's fingerprint resolve and both build jobs read an
+  # identical set (the .env they each write is hashed into the fingerprint).
+  EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
+  EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
+  EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+  EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
+
 jobs:
-  prebuild-and-build:
+  gate:
+    # Cheap ubuntu gate that decides whether the native jobs run. It resolves the
+    # Expo fingerprint (file-hash based — no Android SDK needed), so it always
+    # reports a check even when it skips the build, which keeps a required-check
+    # config from waiting on a job that never arrives.
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-
-    env:
-      # The app's env.ts already defaults to the production backend/web URLs, so
-      # the test APK talks to prod without any secrets. Sentry stays off (no DSN).
-      EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
-      EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
-      EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
-      EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
-      EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
-      EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
-
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read # dorny/paths-filter lists PR files via the API
+    outputs:
+      should_build: ${{ steps.gate.outputs.should_build }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
 
-      - name: Install Node.js dependencies (workspace root)
-        run: bun install --frozen-lockfile
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
+      - id: gate
+        uses: ./.github/actions/mobile-native-gate
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          platform: android
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+  robolectric-tests:
+    needs: gate
+    if: needs.gate.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    # ~2.5× the observed cold-cache duration (7m32s): kills a hung Gradle daemon
+    # without flaking on a slow runner.
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Accept licenses and install SDK components
-        run: |
-          yes | sdkmanager --licenses > /dev/null 2>&1 || true
-          sdkmanager "platforms;android-36" "build-tools;36.0.0"
-
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          # Separate key prefix from the release workflow so a debug-signed cache
-          # never masks a release-build regression (and vice versa).
-          key: ${{ runner.os }}-gradle-rn-pr-${{ hashFiles('packages/mobile/package.json', 'bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-rn-pr-
-
-      - name: Write .env for Expo build-time inlining
-        working-directory: packages/mobile
-        run: |
-          cat > .env <<EOF
-          EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
-          EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
-          EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
-          EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID
-          EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID
-          EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
-          EOF
-
-      - name: Expo prebuild (generate android/)
-        working-directory: packages/mobile
-        env:
-          # Skip the tailscale probe (already short-circuited on CI, set
-          # explicitly so a misconfigured runner never pays the 2s timeout).
-          TAILSCALE_HOSTS: ''
-        run: bunx expo prebuild --platform android --clean --no-install
+      - uses: ./.github/actions/android-rn-setup
 
       - name: Run live-activity module unit tests (Robolectric)
         working-directory: packages/mobile/android
         # Robolectric/JUnit tests for the session-presence lifecycle + the
-        # foreground-service retry path. Run before the slow APK build so a
-        # regression surfaces fast. The gradle project path for an Expo local
+        # foreground-service retry path. The gradle project path for an Expo local
         # module is autolinking-derived, so discover it rather than hardcode.
         run: |
           set -euo pipefail
@@ -123,6 +110,17 @@ jobs:
           PROJECT="${PROJECTS[0]}"
           echo "Testing module project: $PROJECT"
           ./gradlew "${PROJECT}:testDebugUnitTest" --stacktrace
+
+  build-apk:
+    needs: gate
+    if: needs.gate.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/android-rn-setup
 
       - name: Build debug-signed release APK (compiles all native modules + plugins)
         working-directory: packages/mobile/android

--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -98,7 +98,7 @@ jobs:
         # module is autolinking-derived, so discover it rather than hardcode.
         run: |
           set -euo pipefail
-          mapfile -t PROJECTS < <(./gradlew -q projects | sed -n "s/.*Project '\(:[^']*live-activity[^']*\)'.*/\1/p")
+          mapfile -t PROJECTS < <(./gradlew --no-daemon -q projects | sed -n "s/.*Project '\(:[^']*live-activity[^']*\)'.*/\1/p")
           if [ "${#PROJECTS[@]}" -ne 1 ]; then
             echo "Expected exactly one live-activity Gradle project, found ${#PROJECTS[@]}:"
             printf '  %s\n' "${PROJECTS[@]}"
@@ -106,7 +106,7 @@ jobs:
           fi
           PROJECT="${PROJECTS[0]}"
           echo "Testing module project: $PROJECT"
-          ./gradlew "${PROJECT}:testDebugUnitTest" --stacktrace
+          ./gradlew "${PROJECT}:testDebugUnitTest" --no-daemon --console=plain --stacktrace
 
   build-apk:
     needs: gate
@@ -132,7 +132,7 @@ jobs:
         # (board-renderer CMake + RN/Hermes) → faster + far lower peak memory.
         # The GitHub Release sideload APK uses the same arm64-only path; Play
         # distribution still goes through the signed AAB in android-apk-rn.yml.
-        run: ./gradlew assembleRelease -PreactNativeArchitectures=arm64-v8a -PboardseshAbiFilters=arm64-v8a --stacktrace
+        run: ./gradlew assembleRelease -PreactNativeArchitectures=arm64-v8a -PboardseshAbiFilters=arm64-v8a --no-daemon --console=plain --stacktrace
 
       - name: Upload sideloadable APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -14,7 +14,7 @@ name: Android PR Build (React Native)
 # but with a DIFFERENT signature than the production/Play build — uninstall any
 # existing com.boardsesh.app before installing it.
 #
-# Shape (see docs/android-pr-build-speed-spec.md):
+# Shape (see docs/android-pr-build-speed-spec.md, added in #3445):
 #   gate → { robolectric-tests, build-apk }
 #   - gate skips both native jobs on a JS-only PR (no native-input change / an
 #     unchanged Expo fingerprint), mirroring main's native-skip for JS-only

--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -73,8 +73,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2
-
       - id: gate
         uses: ./.github/actions/mobile-native-gate
         with:

--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -67,7 +67,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      pull-requests: read # dorny/paths-filter lists PR files via the API
     outputs:
       should_build: ${{ steps.gate.outputs.should_build }}
     steps:

--- a/.github/workflows/ios-rn-ci.yml
+++ b/.github/workflows/ios-rn-ci.yml
@@ -50,15 +50,15 @@ env:
 jobs:
   gate:
     # Cheap ubuntu gate deciding whether the (expensive, macOS) build-and-test
-    # job runs. Skips it on a JS-only PR — no native-input change, or an Expo
-    # fingerprint unchanged vs base — mirroring main's native-skip for JS-only
-    # merges. Runs on ubuntu: the fingerprint resolve is file-hash based and
-    # needs no Xcode, so this spends no macOS minutes.
+    # job runs. Skips it on a JS-only PR OR branch push — no native-input change,
+    # or an Expo fingerprint unchanged vs main — mirroring main's native-skip for
+    # JS-only merges. The push-triggered build predates OTA and no longer needs to
+    # run for JS-only branches. Runs on ubuntu: the fingerprint resolve is
+    # file-hash based and needs no Xcode, so this spends no macOS minutes.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
-      pull-requests: read # dorny/paths-filter lists PR files via the API
     outputs:
       should_build: ${{ steps.gate.outputs.should_build }}
     steps:

--- a/.github/workflows/ios-rn-ci.yml
+++ b/.github/workflows/ios-rn-ci.yml
@@ -65,8 +65,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2
-
       - id: gate
         uses: ./.github/actions/mobile-native-gate
         with:

--- a/.github/workflows/ios-rn-ci.yml
+++ b/.github/workflows/ios-rn-ci.yml
@@ -13,6 +13,7 @@ on:
       - 'vite.config.ts'
       - 'scripts/prepare-rn-ios-tests.mjs'
       - '.github/workflows/ios-rn-ci.yml'
+      - '.github/actions/mobile-native-gate/**'
   push:
     branches-ignore: [main]
     paths:
@@ -26,6 +27,7 @@ on:
       - 'vite.config.ts'
       - 'scripts/prepare-rn-ios-tests.mjs'
       - '.github/workflows/ios-rn-ci.yml'
+      - '.github/actions/mobile-native-gate/**'
   workflow_dispatch:
 
 concurrency:
@@ -35,8 +37,44 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Workflow-level so the ubuntu gate's fingerprint resolve and the macOS build
+  # read an identical EXPO_PUBLIC_* set (hashed into the fingerprint via .env).
+  EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
+  EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
+  EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+  EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
+
 jobs:
+  gate:
+    # Cheap ubuntu gate deciding whether the (expensive, macOS) build-and-test
+    # job runs. Skips it on a JS-only PR — no native-input change, or an Expo
+    # fingerprint unchanged vs base — mirroring main's native-skip for JS-only
+    # merges. Runs on ubuntu: the fingerprint resolve is file-hash based and
+    # needs no Xcode, so this spends no macOS minutes.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read # dorny/paths-filter lists PR files via the API
+    outputs:
+      should_build: ${{ steps.gate.outputs.should_build }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - id: gate
+        uses: ./.github/actions/mobile-native-gate
+        with:
+          platform: ios
+
   build-and-test:
+    needs: gate
+    if: needs.gate.outputs.should_build == 'true'
     # macos-26 is GA on GitHub-hosted runners and matches the RN TestFlight
     # workflow's Xcode line; the PR workflow has passed on this label.
     runs-on: macos-26
@@ -45,12 +83,6 @@ jobs:
     env:
       WORKSPACE_PATH: packages/mobile/ios/Boardsesh.xcworkspace
       SCHEME: BoardseshTests
-      EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
-      EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
-      EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
-      EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
-      EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
-      EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
       SENTRY_DISABLE_AUTO_UPLOAD: 'true'
 
     steps:


### PR DESCRIPTION
## Summary

Implements the CI speedup spec from #3445 (design doc + full review thread there). Three fixes to the Android PR build, plus the iOS gate Marco asked for. All config; no app code.

**1. Restore-only Gradle cache** (`android-rn-setup` composite). PR runs stop saving their own 3.4 GB cache under a PR-only key that never existed on `main`; they now restore the `gradle-rn-` cache the release/dev-client builds already warm on every mobile merge. This ends the eviction cascade that was blowing the 10 GB repo budget and forcing every PR to build cold.

**2. Parallel jobs.** The single `prebuild-and-build` job becomes `robolectric-tests` + `build-apk`, running in parallel and sharing setup via the new `.github/actions/android-rn-setup` composite (no `shell:`-less steps; workflow-level `env` inherited, no secrets).

**3. Skip native builds on JS-only PRs** (Marco's call — mirrors `main`'s native-skip for JS-only merges). New `.github/actions/mobile-native-gate` composite, used by a cheap ubuntu `gate` job in **both** `android-pr-rn.yml` and `ios-rn-ci.yml`:
- **Path screen** (plain `git diff` against a shallow `main` tip — one mechanism for PRs and branch pushes, no extra permission) over the repo's canonical native-input set (the `ios-rn-ci` Pods cache key). No native-input change → skip, no resolve.
- **Fingerprint diff** when those files changed (e.g. `bun.lock` churn from a web dep bump): resolve the Expo fingerprint at head and base under the PR's own env and skip when equal. `main`'s fingerprint-**tag** lookup can't run here — it uses Production secrets a fork PR can't read — so head-vs-base under identical env is the equivalent. **Fail-open**: any resolve/checkout trouble builds, so a gate bug costs time, never correctness.
- The iOS gate runs on **ubuntu** (fingerprint resolve is file-hash based, no Xcode), so skipping spends zero macOS minutes.

**Companion fix:** added `patches/**` to `android-pr-rn.yml`'s trigger paths — it was in the release workflow but missing here, so a patch-only PR skipped the native check entirely.

### Expected effect

- JS-only mobile PRs (the majority): native builds **skip** (~30 s gate) instead of ~21 min.
- Native-input PRs: ~21 min → **~14–15 min** (warm cache + ~2 min gate).

## Blocking pre-merge item

The job renamed from `prebuild-and-build` to `gate` / `robolectric-tests` / `build-apk`, and `ios-rn-ci` gained `gate`. If any branch-protection rule requires the old names, it must be updated to the new ones or the gate goes stale. As of 2026-07-03 no ruleset-based required checks exist on `main` (`gh api repos/boardsesh/boardsesh/rules/branches/main` is empty); classic branch protection needs an admin to confirm before merge.

## Test plan

Validated locally: YAML parses; every composite `run` step has `shell: bash`; output wiring (`gate` → `should_build`) checks out; the `mobile-ci-env-parity` test doesn't cover these two workflows, so moving their env to workflow level is out of its scope. `actionlint` wasn't available in the sandbox — relying on GitHub's own workflow validation on this PR's run.

Gate behaviour to confirm on CI here and with follow-up test PRs:
- This PR touches CI plumbing → gate's `ci` filter forces a build (exercises the new jobs end-to-end).
- A JS-only mobile PR → path screen skips both Android jobs + the iOS build (~30 s).
- A web-only dep bump churning `bun.lock` → path screen escalates, fingerprint diff comes back equal → skip.

Depends on #3445 for `docs/android-pr-build-speed-spec.md` (referenced in the action comments); the doc merges with that PR.

## Release Notes

none (internal CI change)

