### PR TITLE
feat(mobile): keep the screen awake on the On the Wall tab

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -167,6 +167,17 @@ vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({
   default: () => createElement('span', { 'data-icon': 'mci' }),
 }));
 
+// The wall tab holds a keep-awake lock (kiosk stays lit); mock the native module
+// so the wall-segment render doesn't reach for it, and assert the lock engages.
+const keepAwake = vi.hoisted(() => ({
+  activate: vi.fn().mockResolvedValue(undefined),
+  deactivate: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('expo-keep-awake', () => ({
+  activateKeepAwakeAsync: keepAwake.activate,
+  deactivateKeepAwake: keepAwake.deactivate,
+}));
+
 vi.mock('expo-router/unstable-native-tabs', () => {
   const Trigger = Object.assign(
     ({ name, hidden, children }: { name: string; hidden?: boolean; children?: ReactNode }) =>
@@ -235,6 +246,8 @@ describe('TabLayout', () => {
     cfg.wallDeviceClass = 'panel-capable';
     cfg.segments = ['(tabs)', 'home'];
     cfg.materialScreens = [];
+    keepAwake.activate.mockClear();
+    keepAwake.deactivate.mockClear();
   });
 
   it('lands on the home tab by default', () => {
@@ -412,6 +425,17 @@ describe('TabLayout', () => {
     // The surface still EXISTS for this layout, so the sidebar cell stays hidden — it
     // doesn't pop back in merely because the wall tab is open.
     expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('false');
+    // Kiosk stays lit while the wall tab is focused.
+    expect(keepAwake.activate).toHaveBeenCalledWith('wall');
+  });
+
+  it('does not hold the wall keep-awake lock off the "On the Wall" tab', () => {
+    cfg.segments = ['(tabs)', 'home'];
+
+    render(<TabLayout />);
+
+    expect(keepAwake.activate).not.toHaveBeenCalled();
+    expect(keepAwake.deactivate).toHaveBeenCalledWith('wall');
   });
 
   it('hides the sidebar wall cell when the portrait play-pane strip owns the wall surface', () => {

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -26,6 +26,7 @@ import {
   WALL_COLUMN_WIDTH,
 } from '../../src/theme/size-class';
 import { tabsActiveSegment } from '../../src/lib/route-segments';
+import { useKeepAwakeWhile } from '../../src/hooks/use-keep-awake-while';
 import { SIDEBAR_WIDTH } from '../../src/theme/layout';
 
 // Cold-start on Home: the leftmost tab carries the beta shelf and followed
@@ -103,6 +104,10 @@ export default function TabLayout() {
   // route-typed tuple (see route-segments.ts).
   const segments = useSegments();
   const onWallTab = tabsActiveSegment(segments) === 'wall';
+  // Kiosk stays lit: hold the screen awake while the "On the Wall" tab is the
+  // focused destination (iPad-only — /wall is unreachable elsewhere). Released
+  // on navigate-away and unmount so other tabs don't hold the lock.
+  useKeepAwakeWhile(onWallTab, 'wall');
   // The live wall gets a dedicated column in landscape (room for sidebar + browse
   // list + detail pane + wall) and falls back to a strip atop the pane in portrait
   // (see resolveWallSurface). Gated on a bound board so an empty column never sits

--- a/packages/mobile/src/components/play-drawer/use-play-drawer-wake-lock.ts
+++ b/packages/mobile/src/components/play-drawer/use-play-drawer-wake-lock.ts
@@ -1,17 +1,7 @@
-import { useEffect } from 'react';
-import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
+import { useKeepAwakeWhile } from '../../hooks/use-keep-awake-while';
 
 const WAKE_LOCK_TAG = 'play-drawer';
 
 export function usePlayDrawerWakeLock(isOpen: boolean): void {
-  useEffect(() => {
-    if (isOpen) {
-      activateKeepAwakeAsync(WAKE_LOCK_TAG).catch(() => {});
-    } else {
-      deactivateKeepAwake(WAKE_LOCK_TAG).catch(() => {});
-    }
-    return () => {
-      deactivateKeepAwake(WAKE_LOCK_TAG).catch(() => {});
-    };
-  }, [isOpen]);
+  useKeepAwakeWhile(isOpen, WAKE_LOCK_TAG);
 }

--- a/packages/mobile/src/hooks/__tests__/use-keep-awake-while.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-keep-awake-while.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const keepAwake = vi.hoisted(() => ({
+  activate: vi.fn().mockResolvedValue(undefined),
+  deactivate: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('expo-keep-awake', () => ({
+  activateKeepAwakeAsync: keepAwake.activate,
+  deactivateKeepAwake: keepAwake.deactivate,
+}));
+
+import { useKeepAwakeWhile } from '../use-keep-awake-while';
+
+describe('useKeepAwakeWhile', () => {
+  beforeEach(() => {
+    keepAwake.activate.mockClear();
+    keepAwake.deactivate.mockClear();
+  });
+
+  it('activates the lock for its tag when active', () => {
+    renderHook(() => useKeepAwakeWhile(true, 'wall'));
+
+    expect(keepAwake.activate).toHaveBeenCalledWith('wall');
+    expect(keepAwake.deactivate).not.toHaveBeenCalled();
+  });
+
+  it('releases the lock when active flips to false', () => {
+    const { rerender } = renderHook(({ active }) => useKeepAwakeWhile(active, 'wall'), {
+      initialProps: { active: true },
+    });
+    keepAwake.activate.mockClear();
+    keepAwake.deactivate.mockClear();
+
+    rerender({ active: false });
+
+    expect(keepAwake.deactivate).toHaveBeenCalledWith('wall');
+    expect(keepAwake.activate).not.toHaveBeenCalled();
+  });
+
+  it('releases the lock on unmount', () => {
+    const { unmount } = renderHook(() => useKeepAwakeWhile(true, 'wall'));
+    keepAwake.deactivate.mockClear();
+
+    unmount();
+
+    expect(keepAwake.deactivate).toHaveBeenCalledWith('wall');
+  });
+
+  it('does not activate while inactive', () => {
+    renderHook(() => useKeepAwakeWhile(false, 'wall'));
+
+    expect(keepAwake.activate).not.toHaveBeenCalled();
+    expect(keepAwake.deactivate).toHaveBeenCalledWith('wall');
+  });
+});

--- a/packages/mobile/src/hooks/use-keep-awake-while.ts
+++ b/packages/mobile/src/hooks/use-keep-awake-while.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
+
+// Keeps the screen awake while `active`, scoped to a named tag so multiple
+// callers (play drawer, wall kiosk) hold independent locks — the screen stays
+// awake while any tag is active. Releases on deactivate and on unmount.
+export function useKeepAwakeWhile(active: boolean, tag: string): void {
+  useEffect(() => {
+    if (active) {
+      activateKeepAwakeAsync(tag).catch(() => {});
+    } else {
+      deactivateKeepAwake(tag).catch(() => {});
+    }
+    return () => {
+      deactivateKeepAwake(tag).catch(() => {});
+    };
+  }, [active, tag]);
+}


### PR DESCRIPTION
## Summary

The iPad "On the Wall" kiosk view (`/wall`) is meant to stay visible next to the board while people climb, but iOS dims and locks the screen after the idle timeout — so the kiosk went dark mid-session.

This holds a keep-awake lock while the "On the Wall" tab is the focused destination and releases it the moment the user navigates away (so other tabs don't keep the screen lit). Implementation:

- Extracts the existing play-drawer wake-lock pattern into a generic `useKeepAwakeWhile(active, tag)` hook. `expo-keep-awake` (already installed) supports independent named tags, so the new `wall` lock coexists with the existing `play-drawer` and BLE-connection locks — the screen stays awake while any is active.
- `usePlayDrawerWakeLock` now delegates to the generic hook (no behaviour change).
- Wires `useKeepAwakeWhile(onWallTab, 'wall')` into the tab layout, reusing the `onWallTab` boolean it already computes from the route segments. Because `/wall` is unreachable on phones (`href: null` in Material tabs, `hidden` in NativeTabs), the lock only ever engages on iPad.

No new dependency and no native config change — `expo-keep-awake` autolinks with no config plugin.

## Release Notes

- On iPad, the On the Wall view now keeps the screen from dimming so the board stays visible for your whole session.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — all 3368 tests pass, including a new unit test for `useKeepAwakeWhile` (activate on active, release on flip-to-false and on unmount) and new tab-layout assertions (lock engages on the `wall` segment, not on `home`).
- `vp run check:mobile-bundle` — Metro bundle OK.
- `vp check` on the changed files — formatted, no lint/type errors.
- Manual (device, macOS, remaining): open the iPad On the Wall tab and confirm the screen doesn't dim past the idle timeout; navigate away and confirm it dims normally again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ahzmdbu2vCZAByp8iXJj11)_