### PR TITLE
fix(mobile): avoid double deactivateKeepAwake call on keep-awake transition

### DIFF
--- a/packages/mobile/src/hooks/use-keep-awake-while.ts
+++ b/packages/mobile/src/hooks/use-keep-awake-while.ts
@@ -1,16 +1,23 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 
 // Keeps the screen awake while `active`, scoped to a named tag so multiple
 // callers (play drawer, wall kiosk) hold independent locks — the screen stays
 // awake while any tag is active. Releases on deactivate and on unmount.
 export function useKeepAwakeWhile(active: boolean, tag: string): void {
+  // Cleanup already releases the lock on every active:true -> false
+  // transition, so the initial-mount case (no prior effect to clean up) is
+  // the only time an explicit release is needed here.
+  const isFirstRender = useRef(true);
+
   useEffect(() => {
     if (active) {
       activateKeepAwakeAsync(tag).catch(() => {});
-    } else {
+    } else if (isFirstRender.current) {
       deactivateKeepAwake(tag).catch(() => {});
     }
+    isFirstRender.current = false;
+
     return () => {
       deactivateKeepAwake(tag).catch(() => {});
     };


### PR DESCRIPTION
## Summary

- `useKeepAwakeWhile` called `deactivateKeepAwake(tag)` twice on an `active: true -> false` transition: once from the effect's `else` branch and once from the previous effect's cleanup. Functionally harmless (expo-keep-awake is idempotent) but redundant.
- The effect now only makes the explicit `deactivateKeepAwake` call on the very first render when `active` starts `false` (tracked via a `useRef` first-render flag) — every subsequent `true -> false` transition is released solely by the cleanup function, which already runs at that point.
- No behavior change: all existing `use-keep-awake-while.test.ts` expectations (activate on mount, deactivate on transition, deactivate on unmount, deactivate when mounted inactive) still hold.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project mobile` (existing `use-keep-awake-while.test.ts` suite covers mount/transition/unmount behavior)
- `vp run typecheck:mobile`


---
_Generated by [Claude Code](https://claude.ai/code/session_01LgvPRf7ys7kHuphm8hrHv4)_