### PR TITLE
fix(db): keep the stronger problem on a MoonBoard holds collision

### DIFF
--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -9,6 +9,7 @@ import { fingerprintFromHolds } from './moonboard-2024-helpers.js';
 import {
   HOLDSETUP_TO_LAYOUT,
   catalogProblemToClimbs,
+  isBetterCatalogClimb,
   type MoonBoardCatalogFile,
   type MappedCatalogClimb,
 } from './moonboard-catalog-helpers.js';
@@ -178,9 +179,13 @@ async function importMoonBoardCatalog() {
 
       console.info(`\n📖 ${file} — holdsetup ${dump.holdsetup} → layout ${layoutId}, ${dump.problems.length} problems`);
 
-      // Dedupe in memory (last wins) keyed per conflict target so a single batch
-      // never proposes the same target twice ("ON CONFLICT cannot affect row a
-      // second time").
+      // Dedupe in memory keyed per conflict target so a single batch never
+      // proposes the same target twice ("ON CONFLICT cannot affect row a second
+      // time"). When two problems share the same holds+angle (so they resolve to
+      // one target UUID) we keep the STRONGER problem (isBetterCatalogClimb: more
+      // repeats, then benchmark) instead of last-wins — otherwise a junk duplicate
+      // can clobber a real benchmark's ascent count and benchmark flag.
+      const bestByUuid = new Map<string, MappedCatalogClimb>();
       const climbByUuid = new Map<string, typeof boardClimbs.$inferInsert>();
       const statsByUuid = new Map<string, typeof boardClimbStats.$inferInsert>();
       const holdsByKey = new Map<string, typeof boardClimbHolds.$inferInsert>();
@@ -197,8 +202,16 @@ async function importMoonBoardCatalog() {
         }
         for (const mapped of climbs) {
           const { uuid, matched: matchedExisting } = resolveUuid(mapped, existingIndex);
-          if (matchedExisting) matched++;
-          else inserted++;
+          const incumbent = bestByUuid.get(uuid);
+          if (incumbent) {
+            // Same holds+angle as an already-seen problem — keep the stronger one.
+            if (!isBetterCatalogClimb(mapped, incumbent)) continue;
+          } else if (matchedExisting) {
+            matched++;
+          } else {
+            inserted++;
+          }
+          bestByUuid.set(uuid, mapped);
 
           climbByUuid.set(uuid, {
             uuid,

--- a/packages/db/scripts/moonboard-catalog-helpers.test.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.test.ts
@@ -13,6 +13,7 @@ import {
   isImportableConfig,
   mapCatalogConfig,
   catalogProblemToClimbs,
+  isBetterCatalogClimb,
   type MoonBoardCatalogProblem,
 } from './moonboard-catalog-helpers.js';
 
@@ -171,4 +172,33 @@ void test('unmappable grades map to undefined difficulty', () => {
     { layoutId: 3, angle: 40 },
   );
   assert.equal(mapped.difficultyId, undefined);
+});
+
+void test('isBetterCatalogClimb keeps the stronger of two same-holds problems', () => {
+  const cfg = PORRIDGE.configurations![1];
+  // Mirrors the real "birthday cake trail mix" (38,683 repeats, benchmark) vs the
+  // junk duplicate "name" (19 repeats, not a benchmark) — identical holds+angle.
+  const real = mapCatalogConfig(
+    { ...PORRIDGE, name: 'birthday cake trail mix' },
+    { ...cfg, repeats: 38683, isBenchmark: true },
+    { layoutId: 3, angle: 40 },
+  );
+  const junk = mapCatalogConfig(
+    { ...PORRIDGE, name: 'name' },
+    { ...cfg, repeats: 19, isBenchmark: false },
+    { layoutId: 3, angle: 40 },
+  );
+
+  // More repeats wins, regardless of processing order.
+  assert.equal(isBetterCatalogClimb(real, junk), true);
+  assert.equal(isBetterCatalogClimb(junk, real), false);
+
+  // Tie on repeats → benchmark wins.
+  const benchTie = mapCatalogConfig(PORRIDGE, { ...cfg, repeats: 100, isBenchmark: true }, { layoutId: 3, angle: 40 });
+  const plainTie = mapCatalogConfig(PORRIDGE, { ...cfg, repeats: 100, isBenchmark: false }, { layoutId: 3, angle: 40 });
+  assert.equal(isBetterCatalogClimb(benchTie, plainTie), true);
+  assert.equal(isBetterCatalogClimb(plainTie, benchTie), false);
+
+  // Fully equal → keep incumbent (stable, deterministic re-runs).
+  assert.equal(isBetterCatalogClimb(plainTie, plainTie), false);
 });

--- a/packages/db/scripts/moonboard-catalog-helpers.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.ts
@@ -213,3 +213,24 @@ export function catalogProblemToClimbs(problem: MoonBoardCatalogProblem, layoutI
   }
   return climbs;
 }
+
+/**
+ * Two distinct catalog problems can share the exact same holds at the same
+ * layout+angle (e.g. the real "birthday cake trail mix", 38,683 repeats, and a
+ * junk duplicate literally named "name" with 19 repeats). They collapse onto one
+ * Boardsesh climb (same hold fingerprint → same merged UUID), so the importer must
+ * decide which one's stats win instead of taking whichever it processed last.
+ *
+ * Prefer the stronger community signal: more ascents (repeats) wins; on a tie a
+ * benchmark beats a non-benchmark; otherwise keep the incumbent (stable, so a
+ * re-run is deterministic). Returns true if `candidate` should replace `incumbent`.
+ */
+export function isBetterCatalogClimb(candidate: MappedCatalogClimb, incumbent: MappedCatalogClimb): boolean {
+  if (candidate.ascensionistCount !== incumbent.ascensionistCount) {
+    return candidate.ascensionistCount > incumbent.ascensionistCount;
+  }
+  if (candidate.isBenchmark !== incumbent.isBenchmark) {
+    return candidate.isBenchmark;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Follow-up to #3461. After the `upstream` re-import restored MoonBoard ascent counts, **Birthday Cake Trail Mix @40** — the flagship climb from #3461 — still read wrong: `upstream = 19`, no benchmark flag, instead of its real **38,683 repeats**.

Root cause is a pre-existing importer bug the re-import surfaced: two distinct catalog problems can share the **exact same holds** at the same layout+angle, so they collapse onto one Boardsesh climb (same hold fingerprint → same merged UUID). The catalog importer deduped **last-write-wins**, so a junk duplicate clobbered the real problem:

| Moon problem id | name | @40 config | repeats | benchmark |
|---|---|---|---|---|
| 509834 | `birthday cake trail mix` | 6B+ | **38,683** | ✅ |
| 512355 | `name` (junk dup, same 8 holds) | 6B+ | 19 | ❌ |

`512355` was processed last, so it won — leaving the benchmark reading 19 ascents.

### Fix

Add `isBetterCatalogClimb` (more repeats wins; a benchmark breaks a tie; otherwise keep the incumbent so re-runs stay deterministic) and pick the winner per conflict target before building the insert batch. On the next import run the `upstream` monotonic merge restores the real count.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- New unit test `isBetterCatalogClimb keeps the stronger of two same-holds problems` (mirrors the real Birthday Cake vs. junk-duplicate collision, both orderings, benchmark tie-break, stable-on-equal). Full `moonboard-catalog-helpers` suite: 14/14 pass (`tsx --test`).
- `vp check` on the changed files: no format/lint/type errors.
- Verifying against prod after merge: re-run `db:import-moonboard-catalog`, confirm Birthday Cake Trail Mix @40 reads `upstream = 38,683` (total 38,686 with its 3 Boardsesh ticks) and its benchmark flag returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nf1YnxDDCHepQTP9RA2t5s
