### PR TITLE
feat(web): make home hero drive app installs; swap beta/boards rails

### DIFF
--- a/packages/shared/i18n/locales/en-US/marketing.json
+++ b/packages/shared/i18n/locales/en-US/marketing.json
@@ -30,8 +30,9 @@
     "hero": {
       "title": "Get on the board!",
       "subtitle": "Track your sends across Kilter, Tension, and MoonBoard.",
-      "ctaStart": "Start climbing",
-      "ctaContinue": "Continue climbing"
+      "ctaInstallIos": "Install from App Store",
+      "ctaInstallAndroid": "Get it on Google Play",
+      "ctaUpdate": "Update the app"
     },
     "onboardingHeader": "Make it yours",
     "install": {

--- a/packages/shared/i18n/locales/es/marketing.json
+++ b/packages/shared/i18n/locales/es/marketing.json
@@ -30,8 +30,9 @@
     "hero": {
       "title": "¡A escalar!",
       "subtitle": "Registra tus encadenes en Kilter, Tension y MoonBoard.",
-      "ctaStart": "Empezar a escalar",
-      "ctaContinue": "Seguir escalando"
+      "ctaInstallIos": "Descárgala en el App Store",
+      "ctaInstallAndroid": "Disponible en Google Play",
+      "ctaUpdate": "Actualiza la app"
     },
     "onboardingHeader": "Hazlo tuyo",
     "install": {

--- a/packages/shared/i18n/locales/fr/marketing.json
+++ b/packages/shared/i18n/locales/fr/marketing.json
@@ -30,8 +30,9 @@
     "hero": {
       "title": "Au mur !",
       "subtitle": "Notez vos croix sur Kilter, Tension et MoonBoard.",
-      "ctaStart": "Commencer à grimper",
-      "ctaContinue": "Reprendre la grimpe"
+      "ctaInstallIos": "Télécharger sur l'App Store",
+      "ctaInstallAndroid": "Disponible sur Google Play",
+      "ctaUpdate": "Mettre à jour l'appli"
     },
     "onboardingHeader": "Faites-en votre app",
     "install": {

--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -159,7 +159,7 @@ describe('HomePageContent', () => {
       expect(openSpy).toHaveBeenCalledWith(IOS_APP_STORE_URL, '_blank', 'noopener,noreferrer');
       expect(mockTrack).toHaveBeenCalledWith(
         'App Install Click',
-        expect.objectContaining({ platform: 'ios', placement: 'hero', mode: 'update' }),
+        expect.objectContaining({ platform: 'ios', source: 'app-store', placement: 'hero', mode: 'update' }),
       );
     });
 
@@ -174,7 +174,7 @@ describe('HomePageContent', () => {
       expect(openSpy).toHaveBeenCalledWith(ANDROID_PLAY_STORE_URL, '_blank', 'noopener,noreferrer');
       expect(mockTrack).toHaveBeenCalledWith(
         'App Install Click',
-        expect.objectContaining({ platform: 'android', placement: 'hero', mode: 'update' }),
+        expect.objectContaining({ platform: 'android', source: 'google-play', placement: 'hero', mode: 'update' }),
       );
     });
   });

--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -2,13 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import enMarketing from '@boardsesh/i18n/locales/en-US/marketing.json';
-import type { ActiveSessionInfo } from '@/app/components/persistent-session/types';
+import { IOS_APP_STORE_URL, ANDROID_PLAY_STORE_URL } from '@/app/lib/store-urls';
 
 // --- Mocks ---
 
-// Resolve real en-US copy so assertions like /continue climbing/i still match
-// after the page started reading from i18n catalogs. Falls back to the raw
-// key, which surfaces missing keys clearly if a regex stops matching.
+// Resolve real en-US copy so assertions against the hero CTA still match after
+// the page started reading from i18n catalogs. Falls back to the raw key, which
+// surfaces missing keys clearly if a regex stops matching.
 function resolveMarketingKey(key: string): string {
   const segments = key.split('.');
   let node: unknown = enMarketing;
@@ -29,10 +29,14 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+const mockTrack = vi.fn();
+vi.mock('@/app/lib/analytics', () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
 import HomePageContent from '../home-page-content';
 
 const mockPush = vi.fn();
-const mockSetClimbSessionCookie = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush, replace: vi.fn(), back: vi.fn() }),
   usePathname: () => '/',
@@ -48,19 +52,8 @@ vi.mock('@/app/lib/ble/capacitor-utils', () => ({
   waitForCapacitor: () => mockWaitForCapacitor(),
 }));
 
-vi.mock('@/app/lib/climb-session-cookie', () => ({
-  setClimbSessionCookie: (...args: unknown[]) => mockSetClimbSessionCookie(...args),
-}));
-
 vi.mock('next-auth/react', () => ({
   useSession: () => ({ data: null, status: 'unauthenticated' }),
-}));
-
-let mockActiveSession: ActiveSessionInfo | null = null;
-vi.mock('@/app/components/persistent-session', () => ({
-  usePersistentSession: () => ({ activeSession: mockActiveSession }),
-  usePersistentSessionState: () => ({ activeSession: mockActiveSession }),
-  usePersistentSessionActions: () => ({}),
 }));
 
 vi.mock('@/app/components/session-creation/start-sesh-drawer', () => ({
@@ -85,171 +78,91 @@ vi.mock('@/app/components/beta-videos/home-recent-beta-section', () => ({
 
 // --- Helpers ---
 
-function makeActiveSession(overrides: Partial<ActiveSessionInfo> = {}): ActiveSessionInfo {
-  return {
-    sessionId: 'session-123',
-    boardPath: '/b/kilter-original-12x12/40/list',
-    boardDetails: {} as ActiveSessionInfo['boardDetails'],
-    parsedParams: {
-      board_name: 'kilter',
-      layout_id: 1,
-      size_id: 10,
-      set_ids: [1, 2],
-      angle: 40,
-    },
-    ...overrides,
-  };
-}
-
 const defaultProps = {
   boardConfigs: {} as React.ComponentProps<typeof HomePageContent>['boardConfigs'],
 };
 
+const ANDROID_UA =
+  'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Mobile Safari/537.36';
+const IOS_SAFARI_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+const originalUA = Object.getOwnPropertyDescriptor(window.navigator, 'userAgent');
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(window.navigator, 'userAgent', { value: ua, configurable: true });
+}
+
 // --- Tests ---
 
 describe('HomePageContent', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    mockActiveSession = null;
+    mockIsNativeApp.mockReturnValue(false);
+    mockIsCapacitorWebView.mockReturnValue(false);
+    mockWaitForCapacitor.mockResolvedValue(false);
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
   });
 
-  describe('hero button without active session', () => {
-    it('shows "Start climbing" when no active session', () => {
-      render(<HomePageContent {...defaultProps} />);
-      expect(screen.getByRole('button', { name: /start climbing/i })).toBeTruthy();
-    });
+  afterEach(() => {
+    openSpy.mockRestore();
+    if (originalUA) {
+      Object.defineProperty(window.navigator, 'userAgent', originalUA);
+    }
+  });
 
-    it('opens the session creation drawer on click', async () => {
+  describe('hero install CTA', () => {
+    it('shows the App Store install CTA on iOS/desktop web and opens the store on click', async () => {
+      setUserAgent(IOS_SAFARI_UA);
       render(<HomePageContent {...defaultProps} />);
-      fireEvent.click(screen.getByRole('button', { name: /start climbing/i }));
-      // Drawer mounts asynchronously via useEffect after state change
-      await waitFor(() => {
-        expect(screen.getByTestId('start-sesh-drawer')).toBeTruthy();
-      });
+
+      const button = await screen.findByRole('button', { name: /install from app store/i });
+      fireEvent.click(button);
+
+      expect(openSpy).toHaveBeenCalledWith(IOS_APP_STORE_URL, '_blank', 'noopener,noreferrer');
+      expect(mockTrack).toHaveBeenCalledWith(
+        'App Install Click',
+        expect.objectContaining({ platform: 'ios', source: 'app-store', placement: 'hero', mode: 'install' }),
+      );
+      // The hero no longer starts a sesh — the drawer must stay closed and no
+      // client navigation should fire.
+      expect(screen.queryByTestId('start-sesh-drawer')).toBeNull();
       expect(mockPush).not.toHaveBeenCalled();
     });
-  });
 
-  describe('hero button with active session', () => {
-    it('shows "Continue climbing" when active session exists', () => {
-      mockActiveSession = makeActiveSession();
+    it('shows the Google Play install CTA on Android web and opens Play on click', async () => {
+      setUserAgent(ANDROID_UA);
       render(<HomePageContent {...defaultProps} />);
-      expect(screen.getByRole('button', { name: /continue climbing/i })).toBeTruthy();
+
+      const button = await screen.findByRole('button', { name: /get it on google play/i });
+      fireEvent.click(button);
+
+      expect(openSpy).toHaveBeenCalledWith(ANDROID_PLAY_STORE_URL, '_blank', 'noopener,noreferrer');
+      expect(mockTrack).toHaveBeenCalledWith(
+        'App Install Click',
+        expect.objectContaining({ platform: 'android', source: 'google-play', placement: 'hero', mode: 'install' }),
+      );
     });
 
-    it('navigates to climb list for /b/ slug paths', () => {
-      mockActiveSession = makeActiveSession({
-        boardPath: '/b/kilter-original-12x12/40/list',
-        parsedParams: {
-          board_name: 'kilter',
-          layout_id: 1,
-          size_id: 10,
-          set_ids: [1, 2],
-          angle: 40,
-        },
-      });
+    it('shows an update CTA for the retired native app, pointed at the same store', async () => {
+      setUserAgent(IOS_SAFARI_UA);
+      mockIsNativeApp.mockReturnValue(true);
       render(<HomePageContent {...defaultProps} />);
-      fireEvent.click(screen.getByRole('button', { name: /continue climbing/i }));
-      expect(mockSetClimbSessionCookie).toHaveBeenCalledWith('session-123');
-      expect(mockPush).toHaveBeenCalledWith('/b/kilter-original-12x12/40/list');
-    });
 
-    it('extracts slug correctly regardless of trailing path segments', () => {
-      mockActiveSession = makeActiveSession({
-        boardPath: '/b/tension-tb2-original/25/view/some-uuid',
-        parsedParams: {
-          board_name: 'tension',
-          layout_id: 2,
-          size_id: 5,
-          set_ids: [3],
-          angle: 25,
-        },
-      });
-      render(<HomePageContent {...defaultProps} />);
-      fireEvent.click(screen.getByRole('button', { name: /continue climbing/i }));
-      expect(mockSetClimbSessionCookie).toHaveBeenCalledWith('session-123');
-      expect(mockPush).toHaveBeenCalledWith('/b/tension-tb2-original/25/list');
-    });
+      const button = await screen.findByRole('button', { name: /update the app/i });
+      fireEvent.click(button);
 
-    it('navigates directly to boardPath for legacy/custom paths', () => {
-      mockActiveSession = makeActiveSession({
-        boardPath: '/kilter/1/10/1,2/40',
-      });
-      render(<HomePageContent {...defaultProps} />);
-      fireEvent.click(screen.getByRole('button', { name: /continue climbing/i }));
-      expect(mockSetClimbSessionCookie).toHaveBeenCalledWith('session-123');
-      expect(mockPush).toHaveBeenCalledWith('/kilter/1/10/1,2/40');
-    });
-
-    it('does not open the session creation drawer when active session exists', () => {
-      mockActiveSession = makeActiveSession();
-      render(<HomePageContent {...defaultProps} />);
-      fireEvent.click(screen.getByRole('button', { name: /continue climbing/i }));
-      expect(screen.queryByTestId('start-sesh-drawer')).toBeNull();
-    });
-
-    it('uses parsedParams.angle for the URL, not the angle in boardPath', () => {
-      mockActiveSession = makeActiveSession({
-        boardPath: '/b/my-board/40/list',
-        parsedParams: {
-          board_name: 'kilter',
-          layout_id: 1,
-          size_id: 10,
-          set_ids: [1],
-          angle: 45,
-        },
-      });
-      render(<HomePageContent {...defaultProps} />);
-      fireEvent.click(screen.getByRole('button', { name: /continue climbing/i }));
-      // Should use parsedParams.angle (45), not the 40 from boardPath
-      expect(mockSetClimbSessionCookie).toHaveBeenCalledWith('session-123');
-      expect(mockPush).toHaveBeenCalledWith('/b/my-board/45/list');
-    });
-
-    it('handles negative angles correctly', () => {
-      mockActiveSession = makeActiveSession({
-        boardPath: '/b/tension-board/-20/list',
-        parsedParams: {
-          board_name: 'tension',
-          layout_id: 1,
-          size_id: 10,
-          set_ids: [1],
-          angle: -20,
-        },
-      });
-      render(<HomePageContent {...defaultProps} />);
-      fireEvent.click(screen.getByRole('button', { name: /continue climbing/i }));
-      expect(mockSetClimbSessionCookie).toHaveBeenCalledWith('session-123');
-      expect(mockPush).toHaveBeenCalledWith('/b/tension-board/-20/list');
+      expect(openSpy).toHaveBeenCalledWith(IOS_APP_STORE_URL, '_blank', 'noopener,noreferrer');
+      expect(mockTrack).toHaveBeenCalledWith(
+        'App Install Click',
+        expect.objectContaining({ placement: 'hero', mode: 'update' }),
+      );
     });
   });
 
   describe('install app card', () => {
-    const originalUA = Object.getOwnPropertyDescriptor(window.navigator, 'userAgent');
-    const ANDROID_UA =
-      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Mobile Safari/537.36';
-    const IOS_SAFARI_UA =
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
-
-    function setUserAgent(ua: string) {
-      Object.defineProperty(window.navigator, 'userAgent', {
-        value: ua,
-        configurable: true,
-      });
-    }
-
-    beforeEach(() => {
-      mockIsNativeApp.mockReturnValue(false);
-      mockIsCapacitorWebView.mockReturnValue(false);
-      mockWaitForCapacitor.mockResolvedValue(false);
-    });
-
-    afterEach(() => {
-      if (originalUA) {
-        Object.defineProperty(window.navigator, 'userAgent', originalUA);
-      }
-    });
-
     it('shows the iOS App Store CTA on a regular browser', async () => {
       setUserAgent(IOS_SAFARI_UA);
       render(<HomePageContent {...defaultProps} />);
@@ -299,8 +212,12 @@ describe('HomePageContent', () => {
   });
 
   describe('SSR popular configs', () => {
-    it('passes initialPopularConfigs to BoardDiscoveryScroll when provided', () => {
-      // BoardDiscoveryScroll is mocked, so we just verify the component renders without error
+    it('renders the hero install CTA when initialPopularConfigs are provided', async () => {
+      // BoardDiscoveryScroll is mocked, so we just verify the component renders
+      // without error and still surfaces the hero CTA. Pin the UA so the CTA
+      // label is deterministic (userAgent lives on the prototype, so the
+      // per-test restore can't reset it between cases).
+      setUserAgent(IOS_SAFARI_UA);
       const initialConfigs = [
         {
           boardType: 'kilter',
@@ -319,7 +236,7 @@ describe('HomePageContent', () => {
       ];
 
       render(<HomePageContent {...defaultProps} initialPopularConfigs={initialConfigs} />);
-      expect(screen.getByRole('button', { name: /start climbing/i })).toBeTruthy();
+      expect(await screen.findByRole('button', { name: /install from app store/i })).toBeTruthy();
     });
   });
 });

--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -87,7 +87,11 @@ const ANDROID_UA =
 const IOS_SAFARI_UA =
   'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
 
-const originalUA = Object.getOwnPropertyDescriptor(window.navigator, 'userAgent');
+// `userAgent` lives on Navigator.prototype, so getOwnPropertyDescriptor returns
+// undefined and there's no own-property descriptor to hand back. Capture the
+// string value instead and always redefine it in afterEach so the UA never
+// bleeds between cases.
+const ORIGINAL_UA = window.navigator.userAgent;
 
 function setUserAgent(ua: string) {
   Object.defineProperty(window.navigator, 'userAgent', { value: ua, configurable: true });
@@ -108,9 +112,7 @@ describe('HomePageContent', () => {
 
   afterEach(() => {
     openSpy.mockRestore();
-    if (originalUA) {
-      Object.defineProperty(window.navigator, 'userAgent', originalUA);
-    }
+    setUserAgent(ORIGINAL_UA);
   });
 
   describe('hero install CTA', () => {
@@ -146,7 +148,7 @@ describe('HomePageContent', () => {
       );
     });
 
-    it('shows an update CTA for the retired native app, pointed at the same store', async () => {
+    it('shows an update CTA for a retired iOS native app, pointed at the App Store', async () => {
       setUserAgent(IOS_SAFARI_UA);
       mockIsNativeApp.mockReturnValue(true);
       render(<HomePageContent {...defaultProps} />);
@@ -157,7 +159,22 @@ describe('HomePageContent', () => {
       expect(openSpy).toHaveBeenCalledWith(IOS_APP_STORE_URL, '_blank', 'noopener,noreferrer');
       expect(mockTrack).toHaveBeenCalledWith(
         'App Install Click',
-        expect.objectContaining({ placement: 'hero', mode: 'update' }),
+        expect.objectContaining({ platform: 'ios', placement: 'hero', mode: 'update' }),
+      );
+    });
+
+    it('shows an update CTA for a retired Android native app, pointed at Google Play', async () => {
+      setUserAgent(ANDROID_UA);
+      mockIsNativeApp.mockReturnValue(true);
+      render(<HomePageContent {...defaultProps} />);
+
+      const button = await screen.findByRole('button', { name: /update the app/i });
+      fireEvent.click(button);
+
+      expect(openSpy).toHaveBeenCalledWith(ANDROID_PLAY_STORE_URL, '_blank', 'noopener,noreferrer');
+      expect(mockTrack).toHaveBeenCalledWith(
+        'App Install Click',
+        expect.objectContaining({ platform: 'android', placement: 'hero', mode: 'update' }),
       );
     });
   });
@@ -215,8 +232,7 @@ describe('HomePageContent', () => {
     it('renders the hero install CTA when initialPopularConfigs are provided', async () => {
       // BoardDiscoveryScroll is mocked, so we just verify the component renders
       // without error and still surfaces the hero CTA. Pin the UA so the CTA
-      // label is deterministic (userAgent lives on the prototype, so the
-      // per-test restore can't reset it between cases).
+      // label is deterministic.
       setUserAgent(IOS_SAFARI_UA);
       const initialConfigs = [
         {

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -249,8 +249,10 @@ export default function HomePageContent({
   const [createBoardMounted, setCreateBoardMounted] = useState(false);
   const [installPlatform, setInstallPlatform] = useState<InstallPlatform>('unknown');
   // Which store a legacy native straggler installed from, so the hero "update"
-  // CTA points at the right place. Defaults to iOS; corrected from the UA when
-  // a native build is detected.
+  // CTA points at the right place. Only read once installPlatform === 'native',
+  // and set in the same effect pass that flips the platform to 'native', so the
+  // 'ios' seed here is never actually observed by the hero — it just keeps the
+  // state typed.
   const [nativeStore, setNativeStore] = useState<HeroInstallStore>('ios');
 
   useEffect(() => {

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -21,6 +21,7 @@ import Skeleton from '@mui/material/Skeleton';
 import SvgIcon from '@mui/material/SvgIcon';
 import { isNativeApp, isCapacitorWebView, waitForCapacitor } from '@/app/lib/ble/capacitor-utils';
 import { IOS_APP_STORE_URL, ANDROID_PLAY_STORE_URL } from '@/app/lib/store-urls';
+import { resolveHeroInstall, type InstallPlatform, type HeroInstallStore } from '@/app/lib/hero-install';
 import { useSession } from 'next-auth/react';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import { useTranslation } from 'react-i18next';
@@ -160,30 +161,6 @@ function OnboardingCard({ icon, title, description, onClick, accent = 'action' }
       </CardActionArea>
     </Card>
   );
-}
-
-type InstallPlatform = 'unknown' | 'native' | 'android-web' | 'other-web';
-
-type HeroInstallStore = 'ios' | 'android';
-type HeroInstall = { mode: 'install' | 'update'; store: HeroInstallStore };
-
-// Maps the detected platform to the hero CTA. Web visitors get a store install
-// button; the last stragglers still on the retired Capacitor build (we ship a
-// React Native app now) get an "update" nudge to whichever store they came
-// from. The pre-detection 'unknown' state renders the App Store install so the
-// hero CTA is real and clickable on first paint — it corrects to Play Store /
-// update once the platform check runs on mount.
-function resolveHeroInstall(platform: InstallPlatform, nativeStore: HeroInstallStore): HeroInstall {
-  switch (platform) {
-    case 'android-web':
-      return { mode: 'install', store: 'android' };
-    case 'native':
-      return { mode: 'update', store: nativeStore };
-    case 'unknown':
-    case 'other-web':
-    default:
-      return { mode: 'install', store: 'ios' };
-  }
 }
 
 function InstallAppShadowCard() {

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -9,7 +9,8 @@ import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardActionArea from '@mui/material/CardActionArea';
-import PlayArrowRounded from '@mui/icons-material/PlayArrowRounded';
+import InstallMobileOutlined from '@mui/icons-material/InstallMobileOutlined';
+import SystemUpdateOutlined from '@mui/icons-material/SystemUpdateOutlined';
 import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
 import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
 import BluetoothOutlined from '@mui/icons-material/BluetoothOutlined';
@@ -24,7 +25,6 @@ import { useSession } from 'next-auth/react';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import { useTranslation } from 'react-i18next';
 import { themeTokens } from '@/app/theme/theme-config';
-import { usePersistentSession } from '@/app/components/persistent-session';
 import BoardDiscoveryScroll from '@/app/components/board-scroll/board-discovery-scroll';
 import { constructBoardSlugListUrl, constructClimbListWithSlugs, tryConstructSlugListUrl } from '@/app/lib/url-utils';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
@@ -33,7 +33,6 @@ import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import type { RecentBetaLinkRow } from '@/app/lib/server-recent-beta-links';
 import HomeRecentBetaSection from '@/app/components/beta-videos/home-recent-beta-section';
 import { track } from '@/app/lib/analytics';
-import { setClimbSessionCookie } from '@/app/lib/climb-session-cookie';
 import { useOnboardingTourOptional } from '@/app/components/onboarding/onboarding-tour-provider';
 import { TOUR_OPEN_START_SESH_EVENT } from '@/app/components/onboarding/onboarding-tour-events';
 
@@ -165,6 +164,28 @@ function OnboardingCard({ icon, title, description, onClick, accent = 'action' }
 
 type InstallPlatform = 'unknown' | 'native' | 'android-web' | 'other-web';
 
+type HeroInstallStore = 'ios' | 'android';
+type HeroInstall = { mode: 'install' | 'update'; store: HeroInstallStore };
+
+// Maps the detected platform to the hero CTA. Web visitors get a store install
+// button; the last stragglers still on the retired Capacitor build (we ship a
+// React Native app now) get an "update" nudge to whichever store they came
+// from. The pre-detection 'unknown' state renders the App Store install so the
+// hero CTA is real and clickable on first paint — it corrects to Play Store /
+// update once the platform check runs on mount.
+function resolveHeroInstall(platform: InstallPlatform, nativeStore: HeroInstallStore): HeroInstall {
+  switch (platform) {
+    case 'android-web':
+      return { mode: 'install', store: 'android' };
+    case 'native':
+      return { mode: 'update', store: nativeStore };
+    case 'unknown':
+    case 'other-web':
+    default:
+      return { mode: 'install', store: 'ios' };
+  }
+}
+
 function InstallAppShadowCard() {
   return (
     <Card
@@ -242,7 +263,6 @@ export default function HomePageContent({
   const { t } = useTranslation('marketing');
   const { status } = useSession();
   const router = useLocaleRouter();
-  const { activeSession } = usePersistentSession();
   const onboardingTour = useOnboardingTourOptional();
   const [seshDrawerOpen, setSeshDrawerOpen] = useState(false);
   const [findClimbersOpen, setFindClimbersOpen] = useState(false);
@@ -251,10 +271,15 @@ export default function HomePageContent({
   const [findClimbersMounted, setFindClimbersMounted] = useState(false);
   const [createBoardMounted, setCreateBoardMounted] = useState(false);
   const [installPlatform, setInstallPlatform] = useState<InstallPlatform>('unknown');
+  // Which store a legacy native straggler installed from, so the hero "update"
+  // CTA points at the right place. Defaults to iOS; corrected from the UA when
+  // a native build is detected.
+  const [nativeStore, setNativeStore] = useState<HeroInstallStore>('ios');
 
   useEffect(() => {
     let cancelled = false;
     const classifyWeb = () => (/Android/i.test(navigator.userAgent) ? 'android-web' : 'other-web');
+    const classifyNativeStore = (): HeroInstallStore => (/Android/i.test(navigator.userAgent) ? 'android' : 'ios');
 
     // App-store screenshot tests set this flag so the install CTA matches
     // what users see in the actual iOS build (i.e. nothing).
@@ -264,11 +289,13 @@ export default function HomePageContent({
       sessionStorage.getItem('boardsesh:e2e-suppress-install-card') === '1'
     ) {
       setInstallPlatform('native');
+      setNativeStore(classifyNativeStore());
       return;
     }
 
     if (isNativeApp()) {
       setInstallPlatform('native');
+      setNativeStore(classifyNativeStore());
       return;
     }
 
@@ -279,7 +306,12 @@ export default function HomePageContent({
       waitForCapacitor()
         .then((appeared) => {
           if (cancelled) return;
-          setInstallPlatform(appeared && isNativeApp() ? 'native' : classifyWeb());
+          if (appeared && isNativeApp()) {
+            setInstallPlatform('native');
+            setNativeStore(classifyNativeStore());
+          } else {
+            setInstallPlatform(classifyWeb());
+          }
         })
         .catch(() => {
           if (!cancelled) setInstallPlatform(classifyWeb());
@@ -362,6 +394,18 @@ export default function HomePageContent({
     [router],
   );
 
+  // Hero CTA now drives app installs instead of starting a sesh. Store target,
+  // label, and icon all follow the detected platform.
+  const heroInstall = resolveHeroInstall(installPlatform, nativeStore);
+  const heroInstallUrl = heroInstall.store === 'android' ? ANDROID_PLAY_STORE_URL : IOS_APP_STORE_URL;
+  const HeroInstallIcon = heroInstall.mode === 'update' ? SystemUpdateOutlined : InstallMobileOutlined;
+  const heroInstallLabel =
+    heroInstall.mode === 'update'
+      ? t('home.hero.ctaUpdate')
+      : heroInstall.store === 'android'
+        ? t('home.hero.ctaInstallAndroid')
+        : t('home.hero.ctaInstallIos');
+
   return (
     // Page-level translate="no" was removed because it blocked browser
     // translation of every static UI label on this page. The error boundary
@@ -387,7 +431,7 @@ export default function HomePageContent({
           gap: 3,
         }}
       >
-        {/* Hero: Start Climbing CTA */}
+        {/* Hero: Install-the-app CTA */}
         <Box
           sx={{
             display: 'flex',
@@ -413,21 +457,15 @@ export default function HomePageContent({
           <Button
             variant="contained"
             size="large"
-            startIcon={<PlayArrowRounded />}
+            startIcon={<HeroInstallIcon />}
             onClick={() => {
-              if (activeSession) {
-                let url: string;
-                if (activeSession.boardPath.startsWith('/b/')) {
-                  const segments = activeSession.boardPath.split('/');
-                  url = constructBoardSlugListUrl(segments[2], activeSession.parsedParams.angle);
-                } else {
-                  url = activeSession.boardPath;
-                }
-                setClimbSessionCookie(activeSession.sessionId);
-                router.push(url);
-              } else {
-                setSeshDrawerOpen(true);
-              }
+              track('App Install Click', {
+                platform: heroInstall.store,
+                source: heroInstall.store === 'android' ? 'google-play' : 'app-store',
+                placement: 'hero',
+                mode: heroInstall.mode,
+              });
+              window.open(heroInstallUrl, '_blank', 'noopener,noreferrer');
             }}
             sx={{
               mt: 1,
@@ -457,9 +495,13 @@ export default function HomePageContent({
               },
             }}
           >
-            {activeSession ? t('home.hero.ctaContinue') : t('home.hero.ctaStart')}
+            {heroInstallLabel}
           </Button>
         </Box>
+
+        {/* Recent beta videos from across the community — leads the discovery
+            rail so the community signal is the first thing below the hero */}
+        <HomeRecentBetaSection initialRecentBeta={initialRecentBeta} />
 
         {/* Board Discovery - Find nearby + Custom + My boards + Popular configs */}
         <BoardDiscoveryScroll
@@ -468,10 +510,6 @@ export default function HomePageContent({
           onCustomClick={handleCustomClick}
           initialPopularConfigs={initialPopularConfigs}
         />
-
-        {/* Recent beta videos from across the community — sits high in the page
-            so the community signal isn't buried under the onboarding stack */}
-        <HomeRecentBetaSection initialRecentBeta={initialRecentBeta} />
 
         {/* Onboarding Cards */}
         <Box

--- a/packages/web/app/lib/__tests__/hero-install.test.ts
+++ b/packages/web/app/lib/__tests__/hero-install.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { resolveHeroInstall } from '../hero-install';
+
+describe('resolveHeroInstall', () => {
+  it('renders the App Store install for the pre-detection "unknown" first-paint state', () => {
+    // Load-bearing: this is what a crawler / SSR snapshot and the very first
+    // client paint see, before the on-mount platform check runs.
+    expect(resolveHeroInstall('unknown', 'ios')).toEqual({ mode: 'install', store: 'ios' });
+    // nativeStore is irrelevant unless the platform is 'native'.
+    expect(resolveHeroInstall('unknown', 'android')).toEqual({ mode: 'install', store: 'ios' });
+  });
+
+  it('renders the App Store install for iOS / desktop web', () => {
+    expect(resolveHeroInstall('other-web', 'ios')).toEqual({ mode: 'install', store: 'ios' });
+  });
+
+  it('renders the Google Play install for Android web', () => {
+    expect(resolveHeroInstall('android-web', 'ios')).toEqual({ mode: 'install', store: 'android' });
+  });
+
+  it('renders an update CTA for a retired native app, pointed at the store it came from', () => {
+    expect(resolveHeroInstall('native', 'ios')).toEqual({ mode: 'update', store: 'ios' });
+    expect(resolveHeroInstall('native', 'android')).toEqual({ mode: 'update', store: 'android' });
+  });
+});

--- a/packages/web/app/lib/hero-install.ts
+++ b/packages/web/app/lib/hero-install.ts
@@ -5,16 +5,12 @@ export type InstallPlatform = 'unknown' | 'native' | 'android-web' | 'other-web'
 export type HeroInstallStore = 'ios' | 'android';
 export type HeroInstall = { mode: 'install' | 'update'; store: HeroInstallStore };
 
-/**
- * Maps the detected platform to the home hero CTA.
- *
- * Web visitors get a store install button; the last stragglers still on the
- * retired Capacitor build (we ship a React Native app now) get an "update"
- * nudge to whichever store they came from. The pre-detection 'unknown' state
- * renders the App Store install so the hero CTA is real and clickable on first
- * paint (this is also what a crawler / SSR snapshot sees) — it corrects to Play
- * Store / update once the platform check runs on mount.
- */
+// Maps the detected platform to the home hero CTA. 'unknown' (pre-detection
+// first paint, also what a crawler / SSR snapshot sees) and 'other-web' both
+// get the App Store install; Android web gets Play; a retired native straggler
+// (we ship a React Native app now) gets an "update" nudge to the store it came
+// from. No `default` case — a new InstallPlatform member should fail the
+// typecheck here until it's handled explicitly.
 export function resolveHeroInstall(platform: InstallPlatform, nativeStore: HeroInstallStore): HeroInstall {
   switch (platform) {
     case 'android-web':
@@ -23,7 +19,6 @@ export function resolveHeroInstall(platform: InstallPlatform, nativeStore: HeroI
       return { mode: 'update', store: nativeStore };
     case 'unknown':
     case 'other-web':
-    default:
       return { mode: 'install', store: 'ios' };
   }
 }

--- a/packages/web/app/lib/hero-install.ts
+++ b/packages/web/app/lib/hero-install.ts
@@ -1,0 +1,29 @@
+// Platform classification for the home hero + onboarding install card.
+// 'unknown' is the pre-detection state before the on-mount UA/native check runs.
+export type InstallPlatform = 'unknown' | 'native' | 'android-web' | 'other-web';
+
+export type HeroInstallStore = 'ios' | 'android';
+export type HeroInstall = { mode: 'install' | 'update'; store: HeroInstallStore };
+
+/**
+ * Maps the detected platform to the home hero CTA.
+ *
+ * Web visitors get a store install button; the last stragglers still on the
+ * retired Capacitor build (we ship a React Native app now) get an "update"
+ * nudge to whichever store they came from. The pre-detection 'unknown' state
+ * renders the App Store install so the hero CTA is real and clickable on first
+ * paint (this is also what a crawler / SSR snapshot sees) — it corrects to Play
+ * Store / update once the platform check runs on mount.
+ */
+export function resolveHeroInstall(platform: InstallPlatform, nativeStore: HeroInstallStore): HeroInstall {
+  switch (platform) {
+    case 'android-web':
+      return { mode: 'install', store: 'android' };
+    case 'native':
+      return { mode: 'update', store: nativeStore };
+    case 'unknown':
+    case 'other-web':
+    default:
+      return { mode: 'install', store: 'ios' };
+  }
+}


### PR DESCRIPTION
## Summary

Reworks the top of the web home page:

- **Hero CTA now drives app installs** instead of starting a sesh. The button is platform-aware:
  - iOS / desktop web → **Install from App Store**
  - Android web → **Get it on Google Play**
  - Legacy native app (retired Capacitor build — we ship a React Native app now) → **Update the app**, pointed at whichever store that straggler installed from.

  During the brief pre-detection window the CTA renders the App Store install so it's real and clickable on first paint, then corrects to Play Store / update once the platform check runs on mount. Clicks fire an `App Install Click` analytics event tagged `placement: 'hero'` + `mode`.
- **Swapped the discovery rails**: *Fresh beta* now leads, *Boards near you* follows.

The existing "Get the Boardsesh app" install card lower in the onboarding stack is unchanged (kept per request), so web visitors see the CTA in both spots.

Removed the now-dead active-session "Continue climbing" hero path (and its unused `usePersistentSession` / `setClimbSessionCookie` imports). The Start-a-sesh drawer is still reachable from the "Connect your board" onboarding card and the product tour.

### Notes
- `home.hero.ctaStart` / `ctaContinue` were deleted from all three locale catalogs (en-US, es, fr) and replaced with `ctaInstallIos` / `ctaInstallAndroid` / `ctaUpdate` — the orphaned-key check fails otherwise.
- The App Store screenshot flag (`boardsesh:e2e-suppress-install-card`) still hides the onboarding install *card*; the hero now shows the "Update the app" CTA in that mode. The RN app doesn't render this web page, so this only affects any residual web screenshot.

## Release Notes

- The home screen now points you straight to the app in the App Store or Google Play.

## Test plan

- `vp check` on all changed files — clean.
- `vp run typecheck:web` — passes.
- `vp run check:i18n` and `vp run check:i18n:orphans` — clean (no hardcoded strings, no orphaned keys).
- i18n catalog-completeness test — 28 passed (locale parity for the new keys).
- Rewrote `home-page-content.test.tsx` to cover the new hero: iOS install → App Store URL, Android install → Play URL, native → "Update the app", each firing the right `App Install Click` event and *not* opening the sesh drawer / navigating. `SKIP_TEST_INFRA=1 vp test run … home-page-content.test.tsx` → 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RknoTDCvyPTKi2r8y87wm8