### PR TITLE
chore(mobile): 2.2 App Store What's New + iPad On-the-Wall kiosk screenshot

### DIFF
--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,17 +1,16 @@
-The full MoonBoard catalog is in, hold colours are yours to tune, and boards light up more reliably on iPhone.
+This update is all about steadier Bluetooth, plus a new way to show off your wall on iPad.
 
-New:
-- The full MoonBoard catalog landed: thousands more problems with real grades, star ratings and send counts, plus the Mini 2025 and original 2010 boards. Original MoonBoard LED hardware lights up over Bluetooth too.
-- See who's on the wall at a glance: when a crewmate lights up a different climb, their face and that climb show in a capsule up top, while the bottom bar stays your own queue.
-- Tap any climb in a circuit or playlist and the whole list drops into your queue in order. Swipe back to revisit the boulders above, not just jump to the next.
-- Mix your own hold colours with a real colour picker, preview them through red-green and blue-yellow colour blindness, and pick a new octagon marker shape. MoonBoard hold circles are bigger and easier to read, too.
-- Sort your logbook by Hardest top to bottom, with the community consensus grade shown next to the one you logged.
+Steadier on the wall:
+- iOS 26.5: fixed Kilter and Tension boards not lighting up, so no more blank board mid-session or connect-then-disconnect churn.
+- Queued a climb from a different board? Your wall no longer flashes dark. Boardsesh skips it and lights the next one that fits your setup.
+- Clear a MoonBoard's lights straight from the app over Bluetooth.
 
-Fixed:
-- Kilter and Tension light up reliably on iPhone: climbs send to the wall instead of the board connecting but staying dark.
-- MoonBoard lights up on iPhone, recovers after a flaky Bluetooth moment, and now drives from the Dynamic Island.
-- Fixed an iOS freeze where the app could stop responding to taps after opening and closing sheets.
-- Filter by setter, hold type or board region again. The pickers open full screen and the whole sheet scrolls.
-- Live sessions reconnect after your login refreshes, and pause then refetch when you drop offline and come back.
+New, On the Wall on iPad:
+- Mount an iPad by the wall for a full-screen view of what's lit right now, who's on it, and the session's hardest send, readable from across the room. Step back and forth through the wall's history and tap to relight a climb someone bumped. The screen stays awake for the whole session.
+
+Also:
+- Hide MoonBoard climbs set on holds you don't own: deselect a set and those problems drop out of your results.
+- MoonBoard sends now add to a climb's community repeat count instead of wiping it, so benchmarks show their real numbers and sort back to the top.
+- Add a climb to a playlist by pressing and holding it, and spin up a new playlist right there without the sheet vanishing mid-name.
 
 Free, no ads, open source.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,17 +1,16 @@
-Está el catálogo completo de MoonBoard, puedes ajustar a tu gusto los colores de las presas y los plafones se encienden de forma más fiable en el iPhone.
+Esta actualización va de Bluetooth más estable, y de una forma nueva de lucir tu muro en el iPad.
 
-Nuevo:
-- Ya está el catálogo completo de MoonBoard: miles de bloques más con grados reales, valoraciones por estrellas y número de encadenes, además del Mini 2025 y el original de 2010. El hardware LED del MoonBoard original también se enciende por Bluetooth.
-- Mira de un vistazo quién está en el muro: cuando alguien de tu peña enciende otra vía, su cara y esa vía aparecen en una cápsula arriba, mientras la barra de abajo sigue siendo tu propia cola.
-- Toca cualquier vía de un circuito o una playlist y la lista entera entra en tu cola en orden. Desliza hacia atrás para volver a los bloques anteriores, no solo saltar al siguiente.
-- Crea tus propios colores de presa con un selector de color de verdad, previsualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.
-- Ordena tu logbook por Más difícil de arriba abajo, con el grado de consenso de la comunidad junto al que tú apuntaste.
+Más estable en el muro:
+- iOS 26.5: arreglado que los plafones Kilter y Tension no se encendieran, sin pantallas en blanco a media sesión ni el baile de conectar y desconectar.
+- ¿Metiste en la cola una vía de otro plafón? Tu muro ya no parpadea a oscuras: Boardsesh la salta y enciende la siguiente que encaje con tu montaje.
+- Apaga las luces de tu MoonBoard directamente desde la app por Bluetooth.
 
-Arreglado:
-- Kilter y Tension se encienden de forma fiable en el iPhone: las vías se envían al muro en vez de que el plafón conecte y se quede apagado.
-- El MoonBoard se enciende en el iPhone, se recupera tras un fallo puntual de Bluetooth y ahora se controla desde el Dynamic Island.
-- Arreglado un bloqueo en iOS en el que la app podía dejar de responder a los toques tras abrir y cerrar paneles.
-- Vuelve a filtrar por setter, tipo de presa o región del plafón. Los selectores se abren a pantalla completa y todo el panel se desplaza.
-- Las sesiones en vivo se reconectan cuando se refresca tu sesión, y se pausan y recargan cuando te quedas sin conexión y vuelves.
+Nuevo, En el muro en iPad:
+- Monta un iPad junto al muro para ver a pantalla completa lo que está encendido ahora mismo, quién lo está haciendo y el encadene más duro de la sesión, legible desde el otro lado de la sala. Avanza y retrocede por el historial del muro y toca para volver a encender una vía que alguien haya cambiado. La pantalla no se apaga en toda la sesión.
+
+Además:
+- Oculta las vías de MoonBoard montadas sobre presas que no tienes: deselecciona un set y esos bloques desaparecen de tus resultados.
+- Los encadenes de MoonBoard ahora suman al número de repeticiones de la comunidad en vez de borrarlo, así los benchmarks muestran sus cifras reales y vuelven a lo más alto.
+- Añade una vía a una playlist manteniéndola pulsada, y crea una playlist nueva ahí mismo sin que el panel desaparezca a medias.
 
 Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -1,17 +1,16 @@
-Está el catálogo completo de MoonBoard, puedes ajustar a tu gusto los colores de las presas y los plafones se encienden de forma más fiable en el iPhone.
+Esta actualización va de Bluetooth más estable, y de una forma nueva de lucir tu muro en el iPad.
 
-Nuevo:
-- Ya está el catálogo completo de MoonBoard: miles de bloques más con grados reales, valoraciones por estrellas y número de encadenes, además del Mini 2025 y el original de 2010. El hardware LED del MoonBoard original también se enciende por Bluetooth.
-- Mira de un vistazo quién está en el muro: cuando alguien de tu peña enciende otra vía, su cara y esa vía aparecen en una cápsula arriba, mientras la barra de abajo sigue siendo tu propia cola.
-- Toca cualquier vía de un circuito o una playlist y la lista entera entra en tu cola en orden. Desliza hacia atrás para volver a los bloques anteriores, no solo saltar al siguiente.
-- Crea tus propios colores de presa con un selector de color de verdad, previsualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.
-- Ordena tu logbook por Más difícil de arriba abajo, con el grado de consenso de la comunidad junto al que tú apuntaste.
+Más estable en el muro:
+- iOS 26.5: arreglado que los plafones Kilter y Tension no se encendieran, sin pantallas en blanco a media sesión ni el baile de conectar y desconectar.
+- ¿Metiste en la cola una vía de otro plafón? Tu muro ya no parpadea a oscuras: Boardsesh la salta y enciende la siguiente que encaje con tu montaje.
+- Apaga las luces de tu MoonBoard directamente desde la app por Bluetooth.
 
-Arreglado:
-- Kilter y Tension se encienden de forma fiable en el iPhone: las vías se envían al muro en vez de que el plafón conecte y se quede apagado.
-- El MoonBoard se enciende en el iPhone, se recupera tras un fallo puntual de Bluetooth y ahora se controla desde el Dynamic Island.
-- Arreglado un bloqueo en iOS en el que la app podía dejar de responder a los toques tras abrir y cerrar paneles.
-- Vuelve a filtrar por setter, tipo de presa o región del plafón. Los selectores se abren a pantalla completa y todo el panel se desplaza.
-- Las sesiones en vivo se reconectan cuando se refresca tu sesión, y se pausan y recargan cuando te quedas sin conexión y vuelves.
+Nuevo, En el muro en iPad:
+- Monta un iPad junto al muro para ver a pantalla completa lo que está encendido ahora mismo, quién lo está haciendo y el encadene más duro de la sesión, legible desde el otro lado de la sala. Avanza y retrocede por el historial del muro y toca para volver a encender una vía que alguien haya cambiado. La pantalla no se apaga en toda la sesión.
+
+Además:
+- Oculta las vías de MoonBoard montadas sobre presas que no tienes: deselecciona un set y esos bloques desaparecen de tus resultados.
+- Los encadenes de MoonBoard ahora suman al número de repeticiones de la comunidad en vez de borrarlo, así los benchmarks muestran sus cifras reales y vuelven a lo más alto.
+- Añade una vía a una playlist manteniéndola pulsada, y crea una playlist nueva ahí mismo sin que el panel desaparezca a medias.
 
 Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,17 +1,16 @@
-Le catalogue MoonBoard complet est là, tu règles les couleurs de prises à ta main, et les boards s'allument plus fiablement sur iPhone.
+Cette mise à jour, c'est surtout du Bluetooth plus stable, et une nouvelle façon de mettre ton mur en valeur sur iPad.
 
-Nouveau :
-- Le catalogue MoonBoard complet est arrivé : des milliers de blocs en plus avec de vraies cotations, des notes en étoiles et le nombre de sends, plus le Mini 2025 et l'original de 2010. Le matériel LED du MoonBoard d'origine s'allume aussi en Bluetooth.
-- Vois d'un coup d'œil qui est sur le mur : quand un pote allume une autre voie, son visage et cette voie s'affichent dans une capsule en haut, pendant que la barre du bas reste ta propre file.
-- Touche n'importe quelle voie d'un circuit ou d'une playlist et toute la liste passe dans ta file dans l'ordre. Reviens en arrière d'un glissement pour repasser sur les blocs précédents, pas seulement sauter au suivant.
-- Compose tes propres couleurs de prise avec un vrai sélecteur de couleur, prévisualise-les en daltonisme rouge-vert et bleu-jaune, et choisis une nouvelle forme de marqueur octogonale. Les cercles des prises MoonBoard sont aussi plus gros et plus lisibles.
-- Trie ton logbook par Plus dur de haut en bas, avec la cotation consensus de la communauté à côté de celle que tu as notée.
+Plus stable sur le mur :
+- iOS 26.5 : corrigé les boards Kilter et Tension qui ne s'allumaient plus, fini le mur vide en pleine séance et le yo-yo connexion-déconnexion.
+- Une voie d'une autre board dans ta file ? Ton mur ne clignote plus dans le noir : Boardsesh la saute et allume la suivante qui correspond à ton install.
+- Éteins les lumières de ton MoonBoard directement depuis l'appli en Bluetooth.
 
-Corrigé :
-- Kilter et Tension s'allument de façon fiable sur iPhone : les voies partent au mur au lieu de rester éteintes une fois connecté.
-- Le MoonBoard s'allume sur iPhone, récupère après un accroc Bluetooth, et se pilote maintenant depuis la Dynamic Island.
-- Corrigé un gel sur iOS où l'appli pouvait ne plus répondre aux touchers après l'ouverture et la fermeture de panneaux.
-- Filtre à nouveau par ouvreur, type de prise ou région du mur. Les sélecteurs s'ouvrent en plein écran et tout le panneau défile.
-- Les sessions live se reconnectent après le rafraîchissement de ta connexion, et se mettent en pause puis se rechargent quand tu perds le réseau puis reviens.
+Nouveau, Sur le mur sur iPad :
+- Pose un iPad près du mur pour voir en plein écran ce qui est allumé en ce moment, qui est dessus et la plus grosse croix de la séance, lisible depuis l'autre bout de la salle. Reviens en arrière et en avant dans l'historique du mur et touche pour rallumer une voie que quelqu'un a changée. L'écran reste allumé toute la séance.
+
+Aussi :
+- Masque les voies MoonBoard montées sur des prises que tu n'as pas : désélectionne un set et ces blocs disparaissent de tes résultats.
+- Les croix sur MoonBoard s'ajoutent maintenant au nombre de répétitions de la communauté au lieu de l'effacer, donc les benchmarks affichent leurs vrais chiffres et remontent en haut.
+- Ajoute une voie à une playlist en appuyant longuement dessus, et crée une nouvelle playlist ici même sans que le panneau disparaisse en plein milieu.
 
 Gratuit, sans pub, open source.

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -147,6 +147,27 @@ name: app-store screenshots
 - waitForAnimationToEnd
 - takeScreenshot: 07-playlist-detail
 
+# On the Wall (iPad only) — the wall-mounted kiosk: the current climb big and readable
+# from across the gym, who's on it, the session's hardest send, and the history reel. In
+# screenshot mode the board-presence feed is seeded from the active board's REAL climbs
+# (see src/lib/board-presence/screenshot-wall-seed.ts), so the holds light up instead of
+# the empty "Connect a board" state. `/wall` is an iPad-ONLY route (hidden on iPhone), so
+# this whole block is gated on the device class the orchestrator bakes in
+# (${__MAESTRO_IS_IPAD__} → true on iPads, false on iPhones) — an iPhone run skips it and
+# never writes a junk shot into the iPhone folder. Runs BEFORE the board-view shots below
+# because those open the play drawer, which overlays the whole app.
+- runFlow:
+    when:
+      true: ${__MAESTRO_IS_IPAD__}
+    commands:
+      - openLink: com.boardsesh.app://wall
+      - tapOn:
+          text: 'Open'
+          optional: true
+      - waitForAnimationToEnd
+      - waitForAnimationToEnd
+      - takeScreenshot: 00-wall
+
 # Board view — the signature feature: the wall with holds lit. The screenshot-mode param
 # auto-opens the first climb's play drawer (no coordinate tap). LAST, because the play
 # drawer overlays the app and would bleed into later shots.

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -58,6 +58,7 @@ import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../src/lib/
 import { getHttpClient } from '../../../src/lib/graphql/client';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
 import { toQueueClimb, toQueueClimbs } from '../../../src/lib/climb-types';
+import { publishScreenshotWallClimbs } from '../../../src/lib/board-presence/screenshot-wall-seed';
 import { parseSetIdsParam, prewarmCreateBoardHolds } from '../../../src/lib/create-board-holds';
 import { useActiveBoard, useSetActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { OnboardingTipBanner } from '../../../src/components/onboarding/OnboardingTipBanner';
@@ -785,6 +786,36 @@ function ClimbListInner() {
     screenshotBoardSheetOpenedRef.current = true;
     openBoardSheet();
   }, [screenshotOpenBoardSheet, activeBoard, openBoardSheet]);
+
+  // Screenshot mode: seed the iPad "On the Wall" kiosk from this board's real
+  // climbs (published to a module store the board-presence provider's seed client
+  // serves). Reusing the same climbs the board-view shot lights guarantees the
+  // seeded frames light the real holds for whatever board the capture user
+  // follows — no board-specific hardcoded frames that would render dark. Runs on
+  // the plain `/climbs` list (no deep-link param) so the seed is ready before the
+  // flow reaches the wall tab; dead-strips in normal builds.
+  useEffect(() => {
+    if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE !== '1') return;
+    if (!activeBoard || !searchReady || visibleClimbs.length === 0) return;
+    const nowMs = Date.now();
+    const seeded = visibleClimbs.slice(0, 6).map((climb, index) => ({
+      climbUuid: climb.uuid,
+      name: climb.name,
+      grade: climb.difficulty,
+      gradeColor: null,
+      frames: climb.frames,
+      angle: activeBoard.angle ?? climb.angle,
+      setter: climb.setter_username,
+      sentByDisplayName: null,
+      sentByAvatarUrl: null,
+      sentByUserId: null,
+      // Stagger the timestamps a few minutes apart so the history reads like a
+      // real session rather than a burst.
+      sentAt: new Date(nowMs - index * 4 * 60_000).toISOString(),
+      seq: 100 - index,
+    }));
+    publishScreenshotWallClimbs(seeded, null);
+  }, [activeBoard, searchReady, visibleClimbs]);
 
   const handleAddToQueue = useCallback(
     (climb: Climb) => {

--- a/packages/mobile/src/lib/board-presence/__tests__/screenshot-wall-seed.test.ts
+++ b/packages/mobile/src/lib/board-presence/__tests__/screenshot-wall-seed.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import type { BoardPresenceClimb, BoardPresenceEvent } from '@boardsesh/shared-schema';
+import {
+  SCREENSHOT_SEED_BOARD_ID,
+  createScreenshotBoardPresenceClient,
+  publishScreenshotWallClimbs,
+} from '../screenshot-wall-seed';
+
+function makeClimb(overrides: Partial<BoardPresenceClimb> = {}): BoardPresenceClimb {
+  return {
+    climbUuid: 'climb-1',
+    name: 'Birthday Cake Trail Mix',
+    grade: '6b+',
+    frames: 'p1080r15p1081r12',
+    angle: 40,
+    setter: 'setter-a',
+    sentByDisplayName: null,
+    sentByAvatarUrl: null,
+    sentByUserId: null,
+    sentAt: '2026-07-06T00:00:00.000Z',
+    seq: 100,
+    ...overrides,
+  };
+}
+
+// Module-level seed state persists across tests; reset it so each case starts clean.
+afterEach(() => {
+  publishScreenshotWallClimbs([], null);
+});
+
+describe('screenshot-wall-seed', () => {
+  it('exposes a non-null sentinel board id so the wall reads as live', () => {
+    expect(typeof SCREENSHOT_SEED_BOARD_ID).toBe('number');
+    expect(SCREENSHOT_SEED_BOARD_ID).not.toBeNull();
+  });
+
+  it('serves the published climbs from the feed methods', async () => {
+    const client = createScreenshotBoardPresenceClient();
+    expect(await client.fetchRecentClimbs(SCREENSHOT_SEED_BOARD_ID)).toEqual([]);
+
+    const climbs = [makeClimb({ climbUuid: 'a', seq: 100 }), makeClimb({ climbUuid: 'b', seq: 99 })];
+    publishScreenshotWallClimbs(climbs, null);
+
+    expect(await client.fetchRecentClimbs(SCREENSHOT_SEED_BOARD_ID)).toEqual(climbs);
+    expect(await client.fetchHistory(SCREENSHOT_SEED_BOARD_ID)).toEqual(climbs);
+  });
+
+  it('derives stats from the seeded climbs (hardest = the lit climb)', async () => {
+    const client = createScreenshotBoardPresenceClient();
+    const climbs = [makeClimb({ climbUuid: 'a', grade: '7a', seq: 100 }), makeClimb({ climbUuid: 'b', seq: 99 })];
+    publishScreenshotWallClimbs(climbs, null);
+
+    const stats = await client.fetchStats(SCREENSHOT_SEED_BOARD_ID);
+    expect(stats.climbsSentCount).toBe(2);
+    expect(stats.distinctClimbersCount).toBe(1);
+    expect(stats.hardestGrade).toBe('7a');
+    expect(stats.hardestSend?.climbUuid).toBe('a');
+  });
+
+  it('emits the current climb on subscribe and re-emits on later publishes', () => {
+    const client = createScreenshotBoardPresenceClient();
+    const events: BoardPresenceEvent[] = [];
+
+    // Publish before subscribing: the initial emit should deliver it.
+    publishScreenshotWallClimbs([makeClimb({ climbUuid: 'first', seq: 100 })], null);
+    const unsubscribe = client.subscribeNowPlaying(SCREENSHOT_SEED_BOARD_ID, (event) => events.push(event));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ __typename: 'BoardClimbSet', climb: expect.objectContaining({ climbUuid: 'first' }) });
+
+    // A later publish re-emits to the live subscriber.
+    publishScreenshotWallClimbs([makeClimb({ climbUuid: 'second', seq: 101 })], null);
+    expect(events).toHaveLength(2);
+    expect(events[1]).toEqual({ __typename: 'BoardClimbSet', climb: expect.objectContaining({ climbUuid: 'second' }) });
+
+    // After unsubscribe, further publishes are not delivered.
+    unsubscribe();
+    publishScreenshotWallClimbs([makeClimb({ climbUuid: 'third', seq: 102 })], null);
+    expect(events).toHaveLength(2);
+  });
+
+  it('emits nothing when the seed is empty', () => {
+    const client = createScreenshotBoardPresenceClient();
+    const events: BoardPresenceEvent[] = [];
+    client.subscribeNowPlaying(SCREENSHOT_SEED_BOARD_ID, (event) => events.push(event));
+    expect(events).toHaveLength(0);
+  });
+});

--- a/packages/mobile/src/lib/board-presence/screenshot-wall-seed.ts
+++ b/packages/mobile/src/lib/board-presence/screenshot-wall-seed.ts
@@ -1,0 +1,147 @@
+// Screenshot mode ONLY: a mobile-local seed for the iPad "On the Wall" kiosk, so
+// the App Store capture shows a lit climb + recent history instead of the empty
+// "Connect a board" state.
+//
+// This is the ONE deliberate exception to screenshot-mode's "presentation switch,
+// not a data-mocking layer" rule (see `../screenshot-mode.ts`): the wall feed is a
+// live graphql-ws subscription keyed on a `boardId` that only a BLE bind can set,
+// and the simulator has no Bluetooth — so there is no seeded-backend path to a lit
+// wall. Instead of hitting the backend, the mobile board-presence provider swaps in
+// the seed client below when `EXPO_PUBLIC_SCREENSHOT_MODE === '1'`.
+//
+// The seed climbs are REAL climbs from the active board's list, published by the
+// Climbs screen (see `app/(tabs)/climbs/index.tsx`). Because they carry the real
+// `frames` for whatever board the capture user follows, the kiosk lights the real
+// holds — no hardcoded, board-specific frame string that would render dark on a
+// different board (the known lit-climb gotcha).
+//
+// Everything here is reached only from inlined `EXPO_PUBLIC_SCREENSHOT_MODE === '1'`
+// branches, so babel/terser dead-strips the whole module from normal builds.
+
+import type { BoardConnectionHolder, BoardPresenceClimb, BoardPresenceStats } from '@boardsesh/shared-schema';
+import type { MobileBoardPresenceClient } from './board-presence-client';
+
+/**
+ * Sentinel `boardId` that flips the wall "live" (`WallScreen`'s `isWallLive`
+ * gate is `boardId !== null`) in screenshot mode. The seed client ignores it and
+ * never reaches a backend, so any non-null value works.
+ */
+export const SCREENSHOT_SEED_BOARD_ID = 999_000;
+
+type SeedListener = () => void;
+
+let seedClimbs: BoardPresenceClimb[] = [];
+let seedHolder: BoardConnectionHolder | null = null;
+const listeners = new Set<SeedListener>();
+
+/**
+ * Publish the climbs to show on the wall (newest first — index 0 is the lit
+ * climb). Called from the Climbs screen with the active board's real climbs. The
+ * seed persists at module scope, so it survives the Climbs screen unmounting when
+ * the flow deep-links to the wall tab.
+ */
+export function publishScreenshotWallClimbs(climbs: BoardPresenceClimb[], holder: BoardConnectionHolder | null): void {
+  seedClimbs = climbs;
+  seedHolder = holder;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function currentSeedClimb(): BoardPresenceClimb | null {
+  return seedClimbs[0] ?? null;
+}
+
+function seedStats(): BoardPresenceStats {
+  const hardest = currentSeedClimb();
+  return {
+    climbsSentCount: seedClimbs.length,
+    // Someone lit these climbs, so show at least one climber rather than a
+    // jarring "0" on the tile when no explicit holder is seeded.
+    distinctClimbersCount: seedClimbs.length > 0 ? 1 : 0,
+    hardestGrade: hardest?.grade ?? null,
+    hardestSend: hardest
+      ? {
+          climbUuid: hardest.climbUuid,
+          name: hardest.name,
+          grade: hardest.grade ?? '',
+          sentByUserId: seedHolder?.userId ?? '',
+          sentByDisplayName: hardest.sentByDisplayName,
+          sentByAvatarUrl: hardest.sentByAvatarUrl,
+          sentAt: hardest.sentAt,
+        }
+      : null,
+    topGrade: hardest?.grade ?? null,
+    lastSentAt: hardest?.sentAt ?? null,
+  };
+}
+
+/**
+ * A `MobileBoardPresenceClient` that serves the module seed instead of a
+ * graphql-ws transport. Every feed method reads the published climbs; the
+ * resolve/report methods are inert stubs (BLE never connects in the simulator).
+ */
+export function createScreenshotBoardPresenceClient(): MobileBoardPresenceClient {
+  const resolvedBoard = {
+    boardId: SCREENSHOT_SEED_BOARD_ID,
+    boardName: 'kilter',
+    boardType: 'kilter',
+    layoutId: 0,
+    sizeId: 0,
+    setIds: '',
+  };
+  return {
+    subscribeNowPlaying(_boardId, onEvent) {
+      const emit = () => {
+        const climb = currentSeedClimb();
+        if (climb) {
+          onEvent({ __typename: 'BoardClimbSet', climb });
+        }
+      };
+      // Emit whatever is already seeded, then re-emit on every later publish so
+      // the wall lights up whether the Climbs screen ran before or after this
+      // subscription attached.
+      emit();
+      listeners.add(emit);
+      return () => {
+        listeners.delete(emit);
+      };
+    },
+    onReconnect() {
+      return () => {};
+    },
+    async fetchRecentClimbs() {
+      return seedClimbs;
+    },
+    async fetchHistory() {
+      return seedClimbs;
+    },
+    async fetchStats() {
+      return seedStats();
+    },
+    async fetchConnection() {
+      return seedHolder;
+    },
+    async reportDisconnect() {
+      return true;
+    },
+    async reportClimb() {
+      return true;
+    },
+    async resolveBoardForSerial() {
+      return resolvedBoard;
+    },
+    async resolveBoardForUuid() {
+      return resolvedBoard;
+    },
+    async resolveBoardForConfig() {
+      return resolvedBoard;
+    },
+    async resolveBoardCandidatesForSerial() {
+      return { board: resolvedBoard };
+    },
+    async chooseBoardForSerial() {
+      return resolvedBoard;
+    },
+  };
+}

--- a/packages/mobile/src/lib/screenshot-mode.ts
+++ b/packages/mobile/src/lib/screenshot-mode.ts
@@ -14,6 +14,14 @@ import { isSupportedLocale, type Locale } from '@boardsesh/i18n';
  * `boardsesh:e2e-suppress-install-card`): a presentation-stability switch, not a
  * data-mocking layer — the seeded backend stays the source of truth.
  *
+ * The ONE deliberate exception is the iPad "On the Wall" kiosk (see
+ * `lib/board-presence/screenshot-wall-seed.ts`): the wall feed is a live
+ * graphql-ws subscription keyed on a `boardId` only a BLE bind can set, and the
+ * simulator has no Bluetooth, so there is no seeded-backend path to a lit wall.
+ * That seed reuses the active board's REAL climbs (real frames), and — like every
+ * flag here — is reached only from inlined `EXPO_PUBLIC_SCREENSHOT_MODE === '1'`
+ * branches, so it dead-strips from normal builds.
+ *
  * The boolean is intentionally NOT exported from here. Each consumer inlines the
  * raw comparison directly in its guard / ternary condition:
  *

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -34,6 +34,10 @@ import {
   createMobileBoardPresenceClient,
   type MobileBoardPresenceClient,
 } from '../lib/board-presence/board-presence-client';
+import {
+  createScreenshotBoardPresenceClient,
+  SCREENSHOT_SEED_BOARD_ID,
+} from '../lib/board-presence/screenshot-wall-seed';
 import { getWsClient } from '../lib/graphql/ws-client';
 import { track } from '../lib/analytics';
 import { BoardDisambiguationSheet } from '../components/board-discovery/BoardDisambiguationSheet';
@@ -103,7 +107,14 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
   // kept (constant true here) so consumers and the outside-provider fallback can
   // still branch on provider availability.
   const enabled = true;
-  const [boardId, setBoardId] = useState<number | null>(null);
+  // Screenshot mode: bind a sentinel board on boot so the iPad "On the Wall"
+  // kiosk renders live (its `isWallLive` gate is `boardId !== null`) with the
+  // seeded feed below, instead of the empty "Connect a board" state. The simulator
+  // has no Bluetooth to set a real boardId. Dead-strips in normal builds (inlined
+  // gate), which keep the null start.
+  const [boardId, setBoardId] = useState<number | null>(
+    process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' ? SCREENSHOT_SEED_BOARD_ID : null,
+  );
   // When a serial maps to several boards the user must pick which wall they're
   // at. We hold the candidates + serial here and surface a picker; binding waits
   // for the choice.
@@ -113,8 +124,16 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
   } | null>(null);
 
   // The injected transport, built once. Presence is always-on, so the shared
-  // hook always has a client to attach its subscription to.
-  const client = useMemo<MobileBoardPresenceClient | null>(() => createMobileBoardPresenceClient(getWsClient), []);
+  // hook always has a client to attach its subscription to. Screenshot builds
+  // swap in a seed client that serves canned real climbs (no graphql-ws), so the
+  // kiosk lights up in the simulator; the branch dead-strips in normal builds.
+  const client = useMemo<MobileBoardPresenceClient | null>(
+    () =>
+      process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1'
+        ? createScreenshotBoardPresenceClient()
+        : createMobileBoardPresenceClient(getWsClient),
+    [],
+  );
   const clientRef = useRef(client);
   clientRef.current = client;
 

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import {
   buildScreenshotEnv,
   deviceSlug,
+  isIpadScreenshotDevice,
   metroDevClientUrl,
   parseArgs,
   renderMaestroFlowForIosDevice,
@@ -300,6 +301,74 @@ describe('renderMaestroFlowForIosDevice', () => {
       expect(flowSource).toContain('${MAESTRO_DEVICE_ORIENTATION}');
       expect(renderMaestroFlowForIosDevice(flowSource, ipadDevice)).toContain('- setOrientation: LANDSCAPE_LEFT');
     }
+  });
+
+  it('renders the iPad-class gate to true on iPad and false on iPhone', () => {
+    const ipadDevice: IosScreenshotDevice = {
+      name: 'iPad Pro 13-inch (M5)',
+      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M5-12GB',
+      orientation: 'LANDSCAPE_LEFT',
+    };
+    const phoneDevice: IosScreenshotDevice = {
+      name: 'iPhone 16 Pro Max',
+      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max',
+      orientation: 'PORTRAIT',
+    };
+    const flowSource =
+      '- runFlow:\n    when:\n      true: ${__MAESTRO_IS_IPAD__}\n    commands:\n      - takeScreenshot: 00-wall\n';
+
+    const ipadRendered = renderMaestroFlowForIosDevice(flowSource, ipadDevice);
+    expect(ipadRendered).toContain('true: ${true}');
+    expect(ipadRendered).not.toContain('__MAESTRO_IS_IPAD__');
+
+    const phoneRendered = renderMaestroFlowForIosDevice(flowSource, phoneDevice);
+    expect(phoneRendered).toContain('true: ${false}');
+    expect(phoneRendered).not.toContain('__MAESTRO_IS_IPAD__');
+  });
+
+  it('gates the real app-store wall shot on the iPad device class', () => {
+    const ipadDevice: IosScreenshotDevice = {
+      name: 'iPad Pro 13-inch (M5)',
+      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M5-12GB',
+      orientation: 'LANDSCAPE_LEFT',
+    };
+    const phoneDevice: IosScreenshotDevice = {
+      name: 'iPhone 16 Pro Max',
+      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max',
+      orientation: 'PORTRAIT',
+    };
+    const flowSource = readFileSync('packages/mobile/.maestro/app-store.yaml', 'utf8');
+    // The flow ships the placeholder and the iPad-only wall capture.
+    expect(flowSource).toContain('__MAESTRO_IS_IPAD__');
+    expect(flowSource).toContain('takeScreenshot: 00-wall');
+    expect(flowSource).toContain('com.boardsesh.app://wall');
+
+    // Rendered per device, the wall gate resolves to a concrete boolean and the
+    // placeholder is gone (so neither run leaves an unresolved token).
+    expect(renderMaestroFlowForIosDevice(flowSource, ipadDevice)).toContain('true: ${true}');
+    expect(renderMaestroFlowForIosDevice(flowSource, phoneDevice)).toContain('true: ${false}');
+    for (const device of [ipadDevice, phoneDevice]) {
+      expect(renderMaestroFlowForIosDevice(flowSource, device)).not.toContain('__MAESTRO_IS_IPAD__');
+    }
+  });
+});
+
+describe('isIpadScreenshotDevice', () => {
+  it('is true for iPad simulator types and false for iPhone', () => {
+    expect(
+      isIpadScreenshotDevice({
+        name: 'iPad Pro 11-inch (M5)',
+        typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-11-inch-M5-12GB',
+        orientation: 'LANDSCAPE_LEFT',
+      }),
+    ).toBe(true);
+    expect(
+      isIpadScreenshotDevice({
+        name: 'iPhone 16 Pro Max',
+        typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max',
+        orientation: 'PORTRAIT',
+      }),
+    ).toBe(false);
   });
 });
 

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -64,6 +64,12 @@ const LOG = '[mobile:screenshots]';
 const APP_ID = 'com.boardsesh.app';
 const DEV_CLIENT_URL_SCHEME = 'exp+boardsesh';
 const MAESTRO_DEVICE_ORIENTATION_PLACEHOLDER = '${MAESTRO_DEVICE_ORIENTATION}';
+// Substituted to the literal `true`/`false` per device, inside a flow `${…}`
+// condition, so an iPad-only capture step (`when: { true: ${__MAESTRO_IS_IPAD__} }`)
+// runs on iPads and is skipped on iPhones — same render-time substitution the
+// orientation placeholder uses (Maestro `test` reads `${VAR}` only from `-e`, not
+// a flow's own text, so substitution is the reliable path).
+const MAESTRO_IS_IPAD_PLACEHOLDER = '__MAESTRO_IS_IPAD__';
 const DEFAULT_ANDROID_DEVICE = 'Pixel 2';
 const DEFAULT_ANDROID_APK = resolve(
   MOBILE_DIR,
@@ -605,8 +611,14 @@ function flowFileForPlatform(options: ScreenshotOptions, platform: 'ios' | 'andr
   return join(MAESTRO_DIR, `${options.flow}.yaml`);
 }
 
+export function isIpadScreenshotDevice(screenshotDevice: IosScreenshotDevice): boolean {
+  return screenshotDevice.typeId.includes('iPad');
+}
+
 export function renderMaestroFlowForIosDevice(flowSource: string, screenshotDevice: IosScreenshotDevice): string {
-  return flowSource.replaceAll(MAESTRO_DEVICE_ORIENTATION_PLACEHOLDER, screenshotDevice.orientation);
+  return flowSource
+    .replaceAll(MAESTRO_DEVICE_ORIENTATION_PLACEHOLDER, screenshotDevice.orientation)
+    .replaceAll(MAESTRO_IS_IPAD_PLACEHOLDER, isIpadScreenshotDevice(screenshotDevice) ? 'true' : 'false');
 }
 
 export function rotationDegreesForIosOrientation(orientation: IosDeviceOrientation): number | null {


### PR DESCRIPTION
## Summary

Prep the **2.2** App Store submission: refresh the "What's New" copy and add an iPad screenshot that features the new On-the-Wall kiosk.

**What's New (App Store `release_notes.txt`, all 4 locales).** Rewritten for 2.2, led by the Bluetooth stability fixes (per request — the Rogue gym timer is intentionally left out, it's not shipping yet):
- iOS 26.5 Kilter/Tension lighting fix (#3365), cross-board wall-dark skip (#3454), MoonBoard Clear Lights (#3455)
- iPad **On the Wall** kiosk (#3457/#3453/#3465)
- MoonBoard holds-you-own filter (#3320), preserved community repeat counts (#3461), playlist quick-add (#3452)
- `es-MX` kept byte-identical to `es-ES`; all four under Apple's 4000-char limit.

**iPad kiosk screenshot.** The screenshot tooling already captures both iPads, but the kiosk reads a live board-presence feed keyed on a BLE-bound `boardId` — with no Bluetooth in the simulator it renders the empty "Connect a board" state. So in screenshot mode only:
- `MobileBoardPresenceProvider` binds a sentinel board and swaps in a **seed client** (no graphql-ws).
- The Climbs screen publishes the active board's **real climbs** to the seed — real `frames` light the real holds, so it works for whatever board the capture user follows (no board-specific hardcoded frames that would render dark).
- All behind inlined `EXPO_PUBLIC_SCREENSHOT_MODE === '1'` guards → dead-strips from normal builds. Documented as the one deliberate exception in `screenshot-mode.ts`.

**Maestro.** Added an iPad-only `://wall` capture (`00-wall`) to the shared app-store flow, gated on a render-time device-class token so an iPhone run skips it (no junk shot in the iPhone folder).

## Release Notes

- [x] No release note needed (internal / technical change)

<!-- Store "What's New" text lives in fastlane/metadata; the in-app changelog is owned by the OTA workflow. This PR changes only store metadata + screenshot-mode tooling, no in-app runtime behaviour. -->

## Test plan

- `vp check` (lint/format) — clean on all changed files.
- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — new `screenshot-wall-seed` tests (5) + board-presence/wall suites (153) + climbs (36) all pass.
- `vp test run mobile-screenshots.test` — orchestrator device-class gating (35) pass.
- `vp run check:mobile-bundle` — new import resolves; bundle OK.
- Local iPad capture (`vp run mobile:screenshots --devices ipads`) to confirm the kiosk shows a **lit** climb — see comment below.

## Post-merge (manual)

1. Create the **2.2** version in App Store Connect (Prepare for Submission) — the metadata/screenshot lanes only write into an editable version.
2. Actions → **Mobile Screenshots (iOS)** with `upload: true`, then **Mobile Store Metadata** (`platform: ios`).
3. Attach the 2.2 TestFlight build, confirm, Submit for Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KV6NHZAQUPLz5EigLLd7p