### PR TITLE
fix(mobile): populate iPad kiosk history + stats in screenshot seed

### DIFF
--- a/packages/mobile/src/lib/board-presence/__tests__/screenshot-wall-seed.test.ts
+++ b/packages/mobile/src/lib/board-presence/__tests__/screenshot-wall-seed.test.ts
@@ -36,13 +36,32 @@ describe('screenshot-wall-seed', () => {
 
   it('serves the published climbs from the feed methods', async () => {
     const client = createScreenshotBoardPresenceClient();
-    expect(await client.fetchRecentClimbs(SCREENSHOT_SEED_BOARD_ID)).toEqual([]);
-
     const climbs = [makeClimb({ climbUuid: 'a', seq: 100 }), makeClimb({ climbUuid: 'b', seq: 99 })];
     publishScreenshotWallClimbs(climbs, null);
 
     expect(await client.fetchRecentClimbs(SCREENSHOT_SEED_BOARD_ID)).toEqual(climbs);
     expect(await client.fetchHistory(SCREENSHOT_SEED_BOARD_ID)).toEqual(climbs);
+  });
+
+  it('defers the one-shot fetches until the seed is published', async () => {
+    const client = createScreenshotBoardPresenceClient();
+    // The board-presence hook calls these once at boot, before the Climbs screen
+    // publishes — they must resolve with the full data once it does, not [] early.
+    const recentPromise = client.fetchRecentClimbs(SCREENSHOT_SEED_BOARD_ID);
+    const statsPromise = client.fetchStats(SCREENSHOT_SEED_BOARD_ID);
+
+    let resolvedEarly = false;
+    void recentPromise.then(() => {
+      resolvedEarly = true;
+    });
+    await Promise.resolve();
+    expect(resolvedEarly).toBe(false);
+
+    const climbs = [makeClimb({ climbUuid: 'a', grade: '7a', seq: 100 })];
+    publishScreenshotWallClimbs(climbs, null);
+
+    expect(await recentPromise).toEqual(climbs);
+    expect((await statsPromise).hardestGrade).toBe('7a');
   });
 
   it('derives stats from the seeded climbs (hardest = the lit climb)', async () => {

--- a/packages/mobile/src/lib/board-presence/screenshot-wall-seed.ts
+++ b/packages/mobile/src/lib/board-presence/screenshot-wall-seed.ts
@@ -48,6 +48,25 @@ export function publishScreenshotWallClimbs(climbs: BoardPresenceClimb[], holder
   }
 }
 
+/**
+ * Resolve once the seed has climbs. The board-presence hook calls
+ * `fetchRecentClimbs`/`fetchStats` ONCE, at app boot — before the Climbs screen
+ * has published — so returning the (empty) seed immediately would leave the kiosk
+ * with a lit current climb but an empty history reel and 0/— stat tiles. Awaiting
+ * the first publish instead lets those one-shot fetches deliver the full history +
+ * stats whenever the Climbs screen runs (already-published → resolves at once).
+ */
+function whenSeeded(): Promise<void> {
+  if (seedClimbs.length > 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    const listener = () => {
+      listeners.delete(listener);
+      resolve();
+    };
+    listeners.add(listener);
+  });
+}
+
 function currentSeedClimb(): BoardPresenceClimb | null {
   return seedClimbs[0] ?? null;
 }
@@ -111,15 +130,19 @@ export function createScreenshotBoardPresenceClient(): MobileBoardPresenceClient
       return () => {};
     },
     async fetchRecentClimbs() {
+      await whenSeeded();
       return seedClimbs;
     },
     async fetchHistory() {
+      await whenSeeded();
       return seedClimbs;
     },
     async fetchStats() {
+      await whenSeeded();
       return seedStats();
     },
     async fetchConnection() {
+      await whenSeeded();
       return seedHolder;
     },
     async reportDisconnect() {


### PR DESCRIPTION
## Summary

Follow-up to #3476. While verifying the iPad On-the-Wall kiosk capture, found the seed's one-shot fetches run too early: the board-presence hook calls `fetchRecentClimbs`/`fetchStats` **once at app boot**, before the Climbs screen publishes the seed. So the kiosk lit the current climb but left the **history reel empty** and the **stat tiles at 0/—**.

Fix: those fetches now `await` the first publish, so they deliver the full history + stats once the Climbs screen runs (already-published resolves immediately). Screenshot-mode only — dead-strips from normal builds.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project mobile screenshot-wall-seed` — 6 pass, incl. a new "defers the one-shot fetches until the seed is published" case.
- `vp check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KV6NHZAQUPLz5EigLLd7p