### PR TITLE
fix(mobile): guard @expo/ui Android sheet partialExpand against native skew

### DIFF
--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -49,6 +49,23 @@ install, since the device couldn't verify the manifest came from us.
    version, decoupled from OTA compatibility. Resolve the current value with
    `bunx expo-updates runtimeversion:resolve --platform ios|android` (from `packages/mobile/`).
 
+### Invariant: OTA JS must not call native methods newer than the min shipped binary
+
+The fingerprint gate only protects you when the JS change is matched by a native change. It does
+**not** catch a JS-only change that starts calling a native method the shipped binary doesn't have —
+e.g. bumping a native module's JS (or the module itself, if its native side ships separately) so the
+JS invokes a newer imperative native method. The fingerprint is unchanged (JS-only), so the OTA lands
+on old binaries whose native layer predates the method, and the call fails at runtime.
+
+This is exactly how #3478 happened: `@expo/ui`'s Android bottom sheet calls `partialExpand()` /
+`expand()` on the native `ModalBottomSheetView`. A production OTA pushed JS that calls them onto a
+store binary built against an older `@expo/ui`, and the unregistered AsyncFunction rejected — a
+crash-reported unhandled rejection.
+
+Rule: any imperative native call that could be OTA-ahead of the native binary must be guarded (a
+`.catch` / capability probe / `requireOptionalNativeModule` null-check) so it degrades to a no-op
+instead of throwing. For `@expo/ui` sheets the guard lives in `patches/@expo%2Fui@57.0.3.patch`.
+
 ## Publishing a production update
 
 **Automatic.** Every push to `main` that touches the mobile app runs

--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -71,7 +71,7 @@ in a higher window, not native sheets.
 
 **How a dismiss "settles."** The coordinator needs to know when a dismiss animation has
 really finished before it starts the next transition. On **iOS** that's the accurate native
-signal: our `@expo/ui` patch (`patches/@expo%2Fui@56.0.18.patch`) forwards SwiftUI's
+signal: our `@expo/ui` patch (`patches/@expo%2Fui@57.0.3.patch`) forwards SwiftUI's
 post-animation `.sheet(onDismiss:)` out of the community wrapper as `onFullyDismissed`, which
 `useManagedSheet` routes into `coordinator.notifyFullyDismissed`. So a surface that renders the
 raw `BottomSheetModal`/`BottomSheet` must pass `onFullyDismissed={managed.onFullyDismissed}` (the
@@ -81,6 +81,15 @@ is the fallback: it's the only settle signal on **Android** (Compose has no post
 and on iOS it's the ceiling for the rare case the native event never arrives (a Host torn down
 mid-animation). A `__DEV__` warning fires only when the ceiling beats a native signal that was
 expected (an iOS dismiss of a still-registered sheet).
+
+The same patch also guards the **Android** re-snap path: `snapToIndex` on an already-open
+multi-detent sheet fires `expand()` / `partialExpand()` fire-and-forget on the native
+`ModalBottomSheetView`. A store binary whose native `@expo/ui` predates one of those
+AsyncFunctions rejects the call ("No handler registered for AsyncFunction …"), which — being
+unawaited — surfaces as a crash-reported unhandled rejection (#3478). The patch attaches a
+`.catch` so it no-ops on those binaries and never reaches a native build that has the method.
+This is the OTA-ahead-of-native invariant in `docs/mobile-ota-updates.md`: OTA JS must not call
+native `@expo/ui` methods newer than the min shipped binary without a guard.
 
 **iOS sizing — the single-flex-child contract.** Hand the native `@expo/ui` sheet exactly ONE
 flex child; multiple direct children make it size to content and collapse a `flex: 1` scroll body.

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -28,11 +28,16 @@ export const isSentryEnabled = !!sentryDsn && !__DEV__;
 // AsyncFunction on the `ModalBottomSheetView` native view, so the call rejects
 // ("No handler registered for AsyncFunction '<method>' on view 'ModalBottomSheetView'")
 // and, being unawaited, surfaces as an onunhandledrejection. The op is a no-op on those
-// binaries (the sheet is already at that detent), so only the Sentry noise is worth
-// dropping. Match the view name + method (never a bare `partialExpand` substring) so no
-// unrelated error is ever dropped; cover `expand` too — same mechanism, even though only
-// `partialExpand` rejects on today's fleet. See docs/mobile-ota-updates.md: this is a
-// JS-only change, so it keeps the same fingerprint and rides the OTA to shipped binaries.
+// binaries (the sheet is already at that detent).
+//
+// The real fix guards the call at source: `patches/@expo%2Fui@57.0.3.patch` attaches a
+// `.catch` to both calls in BottomSheet.android.tsx (issue #3478), so once a binary pulls
+// that OTA the rejection never fires. This filter is now belt-and-braces: it still drops
+// the report from binaries running the pre-patch OTA bundle, and from the tail of old
+// binaries before the next native build ships. Match the view name + method (never a bare
+// `partialExpand` substring) so no unrelated error is ever dropped; cover `expand` too —
+// same mechanism, even though only `partialExpand` rejects on today's fleet. See
+// docs/mobile-ota-updates.md: JS-only, so it keeps the same fingerprint and rides the OTA.
 const EXPO_UI_SHEET_NO_HANDLER =
   /Call to function 'ModalBottomSheetView\.(?:partialExpand|expand)' has been rejected|No handler registered for AsyncFunction '(?:partialExpand|expand)' on view 'ModalBottomSheetView'/;
 

--- a/patches/@expo%2Fui@57.0.3.patch
+++ b/patches/@expo%2Fui@57.0.3.patch
@@ -1,5 +1,5 @@
 diff --git a/build/community/bottom-sheet/types.d.ts b/build/community/bottom-sheet/types.d.ts
-index 72fc6be..d1cf11e 100644
+index 72fc6becbc414c318799e28103d15484ed86f703..d1cf11e93b0c0d8dc77abddaafc89e14d34faccc 100644
 --- a/build/community/bottom-sheet/types.d.ts
 +++ b/build/community/bottom-sheet/types.d.ts
 @@ -159,6 +159,14 @@ export interface BottomSheetProps {
@@ -17,22 +17,59 @@ index 72fc6be..d1cf11e 100644
      /**
       * Whether the sheet can be dismissed by panning down.
       * @default false
+diff --git a/src/community/bottom-sheet/BottomSheet.android.tsx b/src/community/bottom-sheet/BottomSheet.android.tsx
+index f60ae61bf0c9023d41c55cdca2d9af0de7291a92..4e64d1a89518f9c22c0f9f3fb4473ae73ca99d40 100644
+--- a/src/community/bottom-sheet/BottomSheet.android.tsx
++++ b/src/community/bottom-sheet/BottomSheet.android.tsx
+@@ -11,6 +11,20 @@ import { RNHostView } from '../../jetpack-compose/RNHostView';
+ 
+ export { useBottomSheet } from './context';
+ 
++// `expand()` / `partialExpand()` are native AsyncFunctions on `ModalBottomSheetView`.
++// A store binary whose native ExpoUI layer predates a method rejects the call with
++// "No handler registered for AsyncFunction '<method>' on view 'ModalBottomSheetView'".
++// These calls are fire-and-forget, so an unhandled rejection would surface as a global
++// onunhandledrejection (crash report + noise) even though the re-snap is a harmless
++// no-op on those binaries. Swallow it: the sheet stays where it is, which is the
++// existing behaviour, and never wrongly expands a collapse. On binaries whose native
++// layer has the method this never rejects. (boardsesh patch — see issue #3478.)
++function swallowMissingNativeHandler(error: unknown): void {
++  // Never rejects on a dev build (current native layer has the method), so a warning
++  // here means something genuinely unexpected — surface it in dev, stay silent in prod.
++  if (__DEV__) console.warn('[bottom-sheet] native snap call rejected:', error);
++}
++
+ function extractBackgroundColor(
+   backgroundStyle: BottomSheetProps['backgroundStyle']
+ ): string | undefined {
+@@ -143,9 +157,9 @@ export function BottomSheet(props: BottomSheetProps) {
+         // Native ModalBottomSheet has two states: partial (~50%) and expanded (full).
+         // Map index 0 → partialExpand(), last index → expand().
+         if (clampedIndex === maxIndex) {
+-          sheetRef.current?.expand();
++          sheetRef.current?.expand()?.catch(swallowMissingNativeHandler);
+         } else {
+-          sheetRef.current?.partialExpand();
++          sheetRef.current?.partialExpand()?.catch(swallowMissingNativeHandler);
+         }
+         pendingIndexRef.current = null;
+       }
 diff --git a/src/community/bottom-sheet/BottomSheet.ios.tsx b/src/community/bottom-sheet/BottomSheet.ios.tsx
-index 0dd7d25..5bef3f2 100644
+index 9908630d50d9a405688ae60c88f5e6638948420d..75f4219b6ce2a72a90ec442329241c83b97af04f 100644
 --- a/src/community/bottom-sheet/BottomSheet.ios.tsx
 +++ b/src/community/bottom-sheet/BottomSheet.ios.tsx
 @@ -86,6 +86,7 @@ export function BottomSheet(props: BottomSheetProps) {
+     index: indexProp = 0,
      onChange,
      onClose,
-     onDismiss,
 +    onFullyDismissed,
+     onDismiss,
      enablePanDownToClose = false,
      enableDynamicSizing = true,
-     handleComponent,
 @@ -108,6 +109,15 @@ export function BottomSheet(props: BottomSheetProps) {
+   const onCloseRef = useRef(onClose);
    onCloseRef.current = onClose;
    const onDismissRef = useRef(onDismiss);
-   onDismissRef.current = onDismiss;
 +  const onFullyDismissedRef = useRef(onFullyDismissed);
 +  onFullyDismissedRef.current = onFullyDismissed;
 +
@@ -42,19 +79,19 @@ index 0dd7d25..5bef3f2 100644
 +  const handleNativeDismiss = useCallback(() => {
 +    onFullyDismissedRef.current?.();
 +  }, []);
+   onDismissRef.current = onDismiss;
  
    const detents = useMemo<PresentationDetent[]>(() => {
-     if (!snapPointsProp || snapPointsProp.length === 0) return ['medium', 'large'];
 @@ -234,6 +244,7 @@ export function BottomSheet(props: BottomSheetProps) {
+         <Host style={{ position: 'absolute', width }} pointerEvents="none">
            <NativeBottomSheet
              isPresented={isPresented}
-             onIsPresentedChange={handlePresentedChange}
 +            onDismiss={handleNativeDismiss}
+             onIsPresentedChange={handlePresentedChange}
              fitToContents={fitToContents}>
              <Group modifiers={modifiers}>
-               <RNHostView matchContents={fitToContents}>
 diff --git a/src/community/bottom-sheet/types.ts b/src/community/bottom-sheet/types.ts
-index d7372fc..efcf425 100644
+index d7372fcb72e3717329ee8df4e27e2f537f17decb..efcf4256103d5b9f1a068e32778a92efc6fa30bc 100644
 --- a/src/community/bottom-sheet/types.ts
 +++ b/src/community/bottom-sheet/types.ts
 @@ -178,6 +178,15 @@ export interface BottomSheetProps {


### PR DESCRIPTION
## Summary

Fixes the top production error by user count (Sentry [BOARDSESH-6V](https://boardsesh.sentry.io/issues/BOARDSESH-6V): 108 users, 725 events, Android-only).

`@expo/ui`'s Android community bottom sheet fires `expand()` / `partialExpand()` **fire-and-forget** on the native `ModalBottomSheetView` inside `snapToIndex` (only when a multi-detent sheet is re-snapped while already open — e.g. picking a different board in `BoardDetailSheet`). A store binary whose native `@expo/ui` predates one of those AsyncFunctions rejects the call (`No handler registered for AsyncFunction 'partialExpand' on view 'ModalBottomSheetView'`), and — being unawaited — it surfaces as a crash-reported unhandled rejection. The re-snap itself is a harmless no-op on those binaries.

**Fix (OTA safety net):** guard both calls at source in `patches/@expo%2Fui@57.0.3.patch` — attach a `.catch` so a missing native handler no-ops instead of throwing. This ships over OTA (Metro bundles `@expo/ui`'s `src`), so binaries that pull the update stop crashing immediately. This is strictly better than the existing Sentry filter because it stops the rejection at the source — it never reaches Sentry **or** PostHog **or** the dev overlay.

Chose a **no-op over falling back to `expand()`**: `expand()` can also be missing on the oldest binaries (the Sentry regex already matched both), so a fallback could itself reject, and a no-op never *wrongly* expands a collapse.

**Permanent native fix:** the repo is already pinned to `@expo/ui@57.0.3` (SDK 57), which registers the methods natively — so the next store build (2.2.0) retires the crash for good. No version bump or native change needed here.

Also:
- `packages/mobile/src/lib/sentry.ts` — kept the `beforeSend` filter as belt-and-braces (it still drops the report from pre-patch OTA bundles and the tail of old binaries) and updated the comment to reflect that the call is now guarded at source.
- Docs — fixed a stale `56.0.18` patch reference in `mobile-sheets-vs-routes.md`, and recorded the OTA-ahead-of-native invariant (issue point 3 / #3275) in `mobile-ota-updates.md`.

Addresses #3478 (fully retired once the SDK 57 store build ships).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 429 files / 3396 tests pass (incl. existing `sentry.ts` filter tests).
- `vp run check:mobile-bundle` — Android bundle builds OK, confirming the regenerated patch applies cleanly against `57.0.3`.
- The unhandled rejection can't be reproduced on a current SDK 57 simulator (the method exists there); it only fires on the old 2.1.0 native layer. The guard is verified by patch-applies + bundle-builds, and by reasoning that a `.catch` on the fire-and-forget promise can't surface as an unhandled rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVy5cPM2dynPMPz6KiNKFs