### PR TITLE
fix(mobile): cut board-art image memory to stop iOS OOM watchdog kill (#3479)

### DIFF
--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -263,6 +263,43 @@ surface the previous size's bundled background paths.
 
 ---
 
+## 7. Board-art image memory: render at display size, recycle, release on background
+
+**Rule:** Board-art surfaces are the app's largest memory consumer (decoded bitmaps live in native
+heap + as GPU textures, not the JS heap) — on iOS a 4 GB device can hit the OS watchdog OOM kill in
+the foreground while browsing (#3479). Three contracts keep them in check:
+
+- **Size the overlay to the display, keep the photo full-res.** The play-drawer board passes
+  `renderWidth` (display px × `PixelRatio.get()`) so the per-climb holds overlay rasterizes at the
+  shown size instead of the board's native ~1080px, plus `backgroundVariant="full"` so the _shared_
+  board photo (one decode per board-config, reused across every climb) stays crisp. `renderWidth`
+  alone would downgrade the photo to the 416px `thumb` — only the overlay should shrink.
+- **`recyclingKey` on always-mounted board surfaces that swap climbs.** The carousel boards key on the
+  climb's `frames` so swapping releases the previous overlay instead of holding both.
+- **Release board-art on background + memory pressure.** `LayeredClimbImage` blanks its `<Image>`
+  layers when `useIsAppBackgrounded()` is true, and `useImageCacheMemoryManagement` (mounted at the
+  app root) sweeps expo-image's memory cache on background and on the OS `memoryWarning` event. The
+  `memoryWarning` path is the direct foreground lever against the iOS OOM kill. Re-decodes from disk
+  on foreground (no network).
+
+**Why:** On-device profiling (Pixel 8 Pro, Android 16) showed ~248 MB native heap idle on the feed
+and the play-drawer carousel piling a native-res (~7 MB RGBA) overlay per swiped climb into the
+cache. Display-sizing + recycling cut carousel browse-growth ~19%; background-blanking cut the
+worst case (board left open on app-switch) ~96 MB. **Ceiling:** expo-image on Android is Glide,
+whose cache/pool are sized to device RAM and resist JS `clearMemoryCache()` (the native allocator
+retains freed pages), so the common feed-backgrounded footprint is unmoved by JS — the next lever is
+native (`onTrimMemory(UI_HIDDEN) → Glide.clearMemory()`). The high MB on a 12 GB device overstates
+real risk; the OOM actually reproduces on 4 GB iPhones.
+
+**Examples in this repo:**
+
+- `packages/mobile/src/lib/app-visibility.ts` (`useIsAppBackgrounded`, one ref-counted AppState
+  listener) + `packages/mobile/src/hooks/use-image-cache-memory-management.ts` (root cache sweep).
+- `renderWidth` + `backgroundVariant` threaded through `BoardImageNative.tsx` →
+  `use-native-climb-render.ts`; applied in `play-drawer/SwipeBoardCarousel.tsx`.
+
+---
+
 ## Profiling workflow
 
 Required evidence for any list / provider / theme PR: a **before/after recording on the climbs list

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -65,6 +65,7 @@ import { spacing } from '../src/theme/tokens';
 import { glassStackScreenOptions } from '../src/theme/navigation';
 import { reportError } from '../src/lib/error-reporting';
 import { loadRequiredFonts } from '../src/lib/required-fonts';
+import { useImageCacheMemoryManagement } from '../src/hooks/use-image-cache-memory-management';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
 import { AnalyticsPersonProperties } from '../src/components/analytics/AnalyticsPersonProperties';
@@ -284,6 +285,9 @@ function ThemedNavigation({ children }: { children: ReactNode }) {
 function RootLayout() {
   const [authReady, setAuthReady] = useState(false);
   const [fontsReady, setFontsReady] = useState(false);
+
+  // Flush decoded board-art bitmaps on background / memory warning (#3479).
+  useImageCacheMemoryManagement();
 
   useEffect(() => {
     let cancelled = false;

--- a/packages/mobile/src/components/BoardImageNative.tsx
+++ b/packages/mobile/src/components/BoardImageNative.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, type ViewStyle } from 'react-native';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { useNativeClimbRender } from '../hooks/use-native-climb-render';
+import type { BackgroundVariant } from '../lib/background-image-cache';
 import { LayeredClimbImage } from './LayeredClimbImage';
 
 type BoardImageNativeProps = {
@@ -30,6 +31,19 @@ type BoardImageNativeProps = {
    * for the full-size play view (renders at native board width).
    */
   renderWidth?: number;
+  /**
+   * Force the bundled board-photo resolution independently of `renderWidth`.
+   * The play-drawer carousel passes `renderWidth` (display-sized overlay) +
+   * `backgroundVariant="full"` (crisp shared photo). See useNativeClimbRender.
+   */
+  backgroundVariant?: BackgroundVariant;
+  /**
+   * Forwarded to the holds-overlay <Image> so expo-image recycles the view and
+   * releases the previous climb's decoded overlay when this stays mounted but
+   * the climb changes (the play-drawer carousel swapping climbs). Key it on the
+   * per-climb `frames`.
+   */
+  recyclingKey?: string;
   style?: ViewStyle;
   /**
    * Drop the holds overlay's cross-fade for this render — forwarded to
@@ -68,6 +82,8 @@ const BoardImageNative = React.memo(function BoardImageNative({
   mirrored,
   filledStyle = false,
   renderWidth,
+  backgroundVariant,
+  recyclingKey,
   style,
   suppressOverlayTransition,
   overlayTestID,
@@ -80,6 +96,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
     setIds,
     filledStyle,
     renderWidth,
+    backgroundVariant,
   });
 
   const containerStyle: ViewStyle = {
@@ -95,6 +112,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
         backgroundPaths={backgroundPaths}
         missingBackgroundCount={missingBackgroundCount}
         mirrored={mirrored}
+        recyclingKey={recyclingKey}
         suppressOverlayTransition={suppressOverlayTransition}
         overlayTestID={overlayTestID}
       />

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
+import { useIsAppBackgrounded } from '../lib/app-visibility';
 
 type LayeredClimbImageProps = {
   overlayUri: string | null;
@@ -69,6 +70,20 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   // blank drawer. Gating on onLoad makes the anchor mean "the lit board is on
   // screen".
   const [overlayPainted, setOverlayPainted] = useState(false);
+
+  // While backgrounded, drop the decoded board-art bitmaps: render an empty
+  // stack so expo-image releases their GPU textures + native-heap bitmaps (the
+  // views stay mounted across a background, so without this they pin ~100 MB+
+  // that raises the OS kill risk). Re-decodes from disk on foreground (#3479).
+  const isBackgrounded = useIsAppBackgrounded();
+  // Reset the overlay-painted anchor on background so the screenshot/e2e anchor
+  // re-gates on the next real onLoad after foreground, not before the lit board.
+  useEffect(() => {
+    if (isBackgrounded) setOverlayPainted(false);
+  }, [isBackgrounded]);
+  if (isBackgrounded) {
+    return <View style={[styles.stack, mirrored && styles.mirrored]} />;
+  }
 
   return (
     <View style={[styles.stack, mirrored && styles.mirrored]}>

--- a/packages/mobile/src/components/__tests__/layered-climb-image-backgrounded.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image-backgrounded.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type ViewMockProps = { children?: ReactNode; testID?: string };
+
+vi.mock('react-native', () => ({
+  View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('expo-image', () => ({
+  Image: ({ source }: { source: { uri: string } }) => createElement('img', { src: source.uri }),
+}));
+
+// Force the backgrounded branch.
+vi.mock('../../lib/app-visibility', () => ({ useIsAppBackgrounded: () => true }));
+
+import { LayeredClimbImage } from '../LayeredClimbImage';
+
+describe('LayeredClimbImage (backgrounded)', () => {
+  it('drops every image layer while the app is backgrounded', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        backgroundPaths: ['/bundled/kilter.webp'],
+      }),
+    );
+
+    // No decoded bitmaps mounted while backgrounded — the whole stack is blank.
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('[data-testid="layered-climb-image-empty-fallback"]')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
@@ -11,13 +11,28 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('expo-image', () => ({
-  Image: ({ source, testID, transition }: { source: { uri: string }; testID?: string; transition?: number }) =>
+  Image: ({
+    source,
+    testID,
+    transition,
+    recyclingKey,
+  }: {
+    source: { uri: string };
+    testID?: string;
+    transition?: number;
+    recyclingKey?: string;
+  }) =>
     createElement('img', {
       src: source.uri,
       'data-testid': testID ?? 'expo-image',
       'data-transition': transition,
+      'data-recycling-key': recyclingKey,
     }),
 }));
+
+// These tests exercise the foregrounded render path; the backgrounded blank is
+// covered in layered-climb-image-backgrounded.test.tsx.
+vi.mock('../../lib/app-visibility', () => ({ useIsAppBackgrounded: () => false }));
 
 import { LayeredClimbImage } from '../LayeredClimbImage';
 
@@ -75,5 +90,18 @@ describe('LayeredClimbImage', () => {
     );
 
     expect(container.querySelector('img[src="file:///overlay.png"]')?.getAttribute('data-transition')).toBe('0');
+  });
+
+  it('forwards recyclingKey to the holds-overlay <Image> so the carousel recycles on climb change', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        backgroundPaths: ['/bundled/kilter.webp'],
+        recyclingKey: 'climb-frames-abc',
+      }),
+    );
+
+    const overlay = container.querySelector('img[src="file:///overlay.png"]');
+    expect(overlay?.getAttribute('data-recycling-key')).toBe('climb-frames-abc');
   });
 });

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -328,6 +328,8 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
               mirrored={mirrored}
               renderWidth={overlayRenderWidth}
               backgroundVariant="full"
+              // Climb identity (peekFrames is the neighbour's frames, not a
+              // per-frame override) so the peek overlay recycles per climb.
               recyclingKey={peekFrames}
               style={boardStyle}
             />

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   StyleSheet,
   useWindowDimensions,
+  PixelRatio,
   type LayoutChangeEvent,
   type ViewStyle,
 } from 'react-native';
@@ -114,6 +115,15 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   );
   const boardStyle = useMemo<ViewStyle | undefined>(
     () => (boardBox ? { width: boardBox.width, height: boardBox.height } : undefined),
+    [boardBox],
+  );
+  // Render the per-climb holds overlay at the displayed pixel size, not the
+  // board's native ~1080px. The board photo stays full-res (backgroundVariant
+  // "full"); only the overlay shrinks. Without this, swiping through climbs
+  // piles a native-res (~7 MB RGBA) overlay per climb into expo-image's memory
+  // cache. Clamped to native width inside useNativeClimbRender (never upscales).
+  const overlayRenderWidth = useMemo(
+    () => (boardBox ? Math.round(boardBox.width * PixelRatio.get()) : undefined),
     [boardBox],
   );
   // The carousel works in board-width units: a letterboxed (narrower) board
@@ -268,6 +278,9 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
               boardWidth={boardWidth}
               boardHeight={boardHeight}
               mirrored={mirrored}
+              renderWidth={overlayRenderWidth}
+              backgroundVariant="full"
+              recyclingKey={currentFrames}
               style={boardStyle}
               overlayTestID="play-drawer-board-overlay"
             />
@@ -284,6 +297,11 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
                 boardWidth={boardWidth}
                 boardHeight={boardHeight}
                 mirrored={mirrored}
+                renderWidth={overlayRenderWidth}
+                backgroundVariant="full"
+                // Climb identity (not the per-frame override) so the overlay
+                // recycles on swipe-to-new-climb, not on every playback frame.
+                recyclingKey={currentFrames}
                 style={boardStyle}
                 // During a swipe commit the current board's frames swap to the
                 // climb the peek was showing; that overlay is already cached, so an
@@ -308,6 +326,9 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
               boardWidth={boardWidth}
               boardHeight={boardHeight}
               mirrored={mirrored}
+              renderWidth={overlayRenderWidth}
+              backgroundVariant="full"
+              recyclingKey={peekFrames}
               style={boardStyle}
             />
           )}

--- a/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const clearMemoryCache = vi.hoisted(() => vi.fn(() => Promise.resolve(true)));
+
+// Capture each AppState handler by event name so tests can fire them and assert
+// the registered subscriptions are torn down on unmount.
+const appState = vi.hoisted(() => {
+  const handlers: Record<string, (state?: string) => void> = {};
+  const removers: Record<string, ReturnType<typeof vi.fn>> = {};
+  return {
+    handlers,
+    removers,
+    addEventListener: vi.fn((event: string, cb: (state?: string) => void) => {
+      handlers[event] = cb;
+      const remove = vi.fn();
+      removers[event] = remove;
+      return { remove };
+    }),
+    fire: (event: string, state?: string) => handlers[event]?.(state),
+  };
+});
+
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: appState.addEventListener },
+}));
+
+vi.mock('expo-image', () => ({
+  Image: { clearMemoryCache },
+}));
+
+// Control the background flag directly so the cache-flush effect can be asserted
+// without driving the real AppState store.
+const isBackgrounded = vi.hoisted(() => ({ value: false }));
+vi.mock('../../lib/app-visibility', () => ({
+  useIsAppBackgrounded: () => isBackgrounded.value,
+}));
+
+import { useImageCacheMemoryManagement } from '../use-image-cache-memory-management';
+
+describe('useImageCacheMemoryManagement', () => {
+  beforeEach(() => {
+    clearMemoryCache.mockClear();
+    appState.addEventListener.mockClear();
+    isBackgrounded.value = false;
+  });
+
+  it('does not flush while foregrounded', () => {
+    renderHook(() => useImageCacheMemoryManagement());
+    expect(clearMemoryCache).not.toHaveBeenCalled();
+  });
+
+  it('flushes the image memory cache once the app is backgrounded', () => {
+    isBackgrounded.value = true;
+    renderHook(() => useImageCacheMemoryManagement());
+    expect(clearMemoryCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes when transitioning foreground -> background', () => {
+    const { rerender } = renderHook(() => useImageCacheMemoryManagement());
+    expect(clearMemoryCache).not.toHaveBeenCalled();
+    isBackgrounded.value = true;
+    rerender();
+    expect(clearMemoryCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-flush when returning to the foreground', () => {
+    isBackgrounded.value = true;
+    const { rerender } = renderHook(() => useImageCacheMemoryManagement());
+    expect(clearMemoryCache).toHaveBeenCalledTimes(1);
+    isBackgrounded.value = false;
+    rerender();
+    // Foregrounding must NOT sweep again — the effect gates on the flag value.
+    expect(clearMemoryCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers and tears down the memoryWarning listener', () => {
+    const { unmount } = renderHook(() => useImageCacheMemoryManagement());
+    expect(appState.addEventListener).toHaveBeenCalledWith('memoryWarning', expect.any(Function));
+    appState.fire('memoryWarning');
+    expect(clearMemoryCache).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(appState.removers.memoryWarning).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
@@ -75,6 +75,18 @@ describe('useImageCacheMemoryManagement', () => {
     expect(clearMemoryCache).toHaveBeenCalledTimes(1);
   });
 
+  it('flushes again on each background across repeated background/foreground cycles', () => {
+    isBackgrounded.value = true;
+    const { rerender } = renderHook(() => useImageCacheMemoryManagement());
+    expect(clearMemoryCache).toHaveBeenCalledTimes(1);
+    isBackgrounded.value = false;
+    rerender();
+    isBackgrounded.value = true;
+    rerender();
+    // A second background sweeps again — the flag genuinely flipped.
+    expect(clearMemoryCache).toHaveBeenCalledTimes(2);
+  });
+
   it('registers and tears down the memoryWarning listener', () => {
     const { unmount } = renderHook(() => useImageCacheMemoryManagement());
     expect(appState.addEventListener).toHaveBeenCalledWith('memoryWarning', expect.any(Function));

--- a/packages/mobile/src/hooks/use-image-cache-memory-management.ts
+++ b/packages/mobile/src/hooks/use-image-cache-memory-management.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import { Image } from 'expo-image';
+import { useIsAppBackgrounded } from '../lib/app-visibility';
+
+// Sweep expo-image's in-memory decoded-bitmap cache on background and on OS
+// memory-pressure warnings. The foreground `memoryWarning` path is the direct
+// lever against the iOS OOM watchdog kill on low-RAM devices (#3479); the disk
+// cache is untouched, so foregrounding re-decodes from disk in tens of ms (no
+// network). LayeredClimbImage blanks its <Image> layers on background first,
+// returning their bitmaps to the pool this sweep then frees.
+export function useImageCacheMemoryManagement(): void {
+  const isBackgrounded = useIsAppBackgrounded();
+
+  useEffect(() => {
+    if (isBackgrounded) void Image.clearMemoryCache();
+  }, [isBackgrounded]);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('memoryWarning', () => {
+      void Image.clearMemoryCache();
+    });
+    return () => sub.remove();
+  }, []);
+}

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -71,9 +71,19 @@ type NativeClimbRenderParams = {
    * <Image> never has to downscale a large source on the main thread (the
    * cause of the iOS app hang). Omit for the full-size play view, which
    * renders at native board width. Clamped to the board width (never
-   * upscales). Also selects the bundled `thumb` background variant.
+   * upscales). Selects the bundled `thumb` background variant by default
+   * (override with `backgroundVariant`).
    */
   renderWidth?: number;
+  /**
+   * Force the bundled board-photo resolution independently of `renderWidth`.
+   * The board photo is shared per board-config (one decode across every climb
+   * on the wall), so the play-drawer carousel renders the per-climb overlay at
+   * display size (a small `renderWidth`) while keeping the photo crisp
+   * (`backgroundVariant="full"`). Defaults to `thumb` when `renderWidth` is set,
+   * `full` otherwise.
+   */
+  backgroundVariant?: BackgroundVariant;
 };
 
 type NativeClimbRenderResult = {
@@ -480,7 +490,7 @@ function getNativeModule() {
  * and the component shows backgrounds alone.
  */
 export function useNativeClimbRender(params: NativeClimbRenderParams): NativeClimbRenderResult {
-  const { frames, boardName, layoutId, sizeId, setIds, filledStyle = false, renderWidth } = params;
+  const { frames, boardName, layoutId, sizeId, setIds, filledStyle = false, renderWidth, backgroundVariant } = params;
   const {
     overrides: holdColorOverrides,
     shapes: holdShapeOverrides,
@@ -490,9 +500,11 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   } = useHoldColorOverrides();
 
   // Small surfaces that pass a renderWidth want the bundled thumb-sized
-  // background too, so neither the overlay nor the photo is a large source
-  // the main thread has to downscale.
-  const variant: BackgroundVariant = renderWidth != null ? 'thumb' : 'full';
+  // background too, so neither the overlay nor the photo is a large source the
+  // main thread has to downscale. The play-drawer carousel overrides this to
+  // 'full' so it can shrink the per-climb overlay while keeping the shared photo
+  // crisp on the full-screen board.
+  const variant: BackgroundVariant = backgroundVariant ?? (renderWidth != null ? 'thumb' : 'full');
 
   // Run the disk-cache scan once per JS context. Safe to call on every
   // render — the function self-guards via `warmupRun`.

--- a/packages/mobile/src/lib/__tests__/app-visibility.test.ts
+++ b/packages/mobile/src/lib/__tests__/app-visibility.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Capture the 'change' handler the store installs, and let `remove()` clear it
+// so the ref-counted teardown is observable. `currentState` seeds the flag on
+// each fresh install — since it's 'active' here, every test's first subscriber
+// resets the module-level flag, keeping the tests order-independent.
+const appState = vi.hoisted(() => {
+  const ref: { handler: ((state: string) => void) | null; currentState: string } = {
+    handler: null,
+    currentState: 'active',
+  };
+  return {
+    ref,
+    addEventListener: vi.fn((_event: string, cb: (state: string) => void) => {
+      ref.handler = cb;
+      return {
+        remove: vi.fn(() => {
+          ref.handler = null;
+        }),
+      };
+    }),
+    fire: (state: string) => ref.handler?.(state),
+  };
+});
+
+vi.mock('react-native', () => ({
+  AppState: {
+    addEventListener: appState.addEventListener,
+    get currentState() {
+      return appState.ref.currentState;
+    },
+  },
+}));
+
+import { useIsAppBackgrounded } from '../app-visibility';
+
+describe('app-visibility store', () => {
+  beforeEach(() => {
+    appState.addEventListener.mockClear();
+    appState.ref.currentState = 'active';
+  });
+
+  it('installs a single AppState change listener on the first subscriber', () => {
+    const { unmount } = renderHook(() => useIsAppBackgrounded());
+    expect(appState.addEventListener).toHaveBeenCalledTimes(1);
+    expect(appState.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+    unmount();
+  });
+
+  it('shares one listener across subscribers and removes it when the last unmounts', () => {
+    const first = renderHook(() => useIsAppBackgrounded());
+    const second = renderHook(() => useIsAppBackgrounded());
+    expect(appState.addEventListener).toHaveBeenCalledTimes(1);
+    first.unmount();
+    expect(appState.ref.handler).not.toBeNull();
+    second.unmount();
+    expect(appState.ref.handler).toBeNull();
+  });
+
+  it('flips to backgrounded on "background" and back on "active"', () => {
+    const { result, unmount } = renderHook(() => useIsAppBackgrounded());
+    expect(result.current).toBe(false);
+    act(() => appState.fire('background'));
+    expect(result.current).toBe(true);
+    act(() => appState.fire('active'));
+    expect(result.current).toBe(false);
+    unmount();
+  });
+
+  it('ignores the transient "inactive" state (no blank-on-app-switcher-peek)', () => {
+    const { result, unmount } = renderHook(() => useIsAppBackgrounded());
+    act(() => appState.fire('inactive'));
+    expect(result.current).toBe(false);
+    unmount();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/app-visibility.test.ts
+++ b/packages/mobile/src/lib/__tests__/app-visibility.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, cleanup } from '@testing-library/react';
 
 // Capture the 'change' handler the store installs, and let `remove()` clear it
 // so the ref-counted teardown is observable. `currentState` seeds the flag on
@@ -41,6 +41,10 @@ describe('app-visibility store', () => {
     appState.addEventListener.mockClear();
     appState.ref.currentState = 'active';
   });
+
+  // Unmount any hook a test left mounted (even if it threw before its own
+  // unmount()) so the store's ref-counted listener drains between tests.
+  afterEach(cleanup);
 
   it('installs a single AppState change listener on the first subscriber', () => {
     const { unmount } = renderHook(() => useIsAppBackgrounded());

--- a/packages/mobile/src/lib/app-visibility.ts
+++ b/packages/mobile/src/lib/app-visibility.ts
@@ -1,0 +1,45 @@
+import { useSyncExternalStore } from 'react';
+import { AppState, type NativeEventSubscription } from 'react-native';
+
+// Single source of truth for "is the app backgrounded", backed by ONE AppState
+// listener installed lazily on the first subscriber and removed when the last
+// unsubscribes. Tying the listener to React lifecycle (instead of a bare
+// module-load side effect) keeps it from accumulating across Fast Refresh
+// reloads. Only `background` flips the flag — not iOS `inactive`, a transient
+// interruption where a blank-then-reload would just flash.
+let backgrounded = false;
+const listeners = new Set<() => void>();
+let appStateSub: NativeEventSubscription | null = null;
+
+function setBackgrounded(next: boolean): void {
+  if (next === backgrounded) return;
+  backgrounded = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  if (appStateSub === null) {
+    // Seed from the current state so a component mounting while already
+    // backgrounded starts with the right flag (usually 'active' at mount).
+    backgrounded = AppState.currentState === 'background';
+    appStateSub = AppState.addEventListener('change', (state) => {
+      setBackgrounded(state === 'background');
+    });
+  }
+  return () => {
+    listeners.delete(onStoreChange);
+    if (listeners.size === 0) {
+      appStateSub?.remove();
+      appStateSub = null;
+    }
+  };
+}
+
+function getSnapshot(): boolean {
+  return backgrounded;
+}
+
+export function useIsAppBackgrounded(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
## Summary

The iOS OS watchdog is killing the app for RAM overuse (Sentry [BOARDSESH-8B](https://boardsesh.sentry.io/issues/BOARDSESH-8B), `watchdog_termination`, fatal, in foreground). Verified in Sentry: **3 of 4 events are on the 4 GB iPhone 12 mini**, all while actively browsing board art. Every board-art `<Image>` holds a full-resolution decoded buffer in expo-image's memory cache with default limits and no eviction, nothing responds to OS memory pressure, and the play-drawer carousel piles a native-res (~7 MB RGBA) holds overlay into the cache per swiped climb.

The fix for exactly this already existed as **#3150** (`perf/board-art-image-memory`), which passed CI and was OTA-compatible but was closed with only fixable review nits. This revives its three mitigations on top of `main`, with those nits fixed:

- **Flush expo-image's memory cache on the OS `memoryWarning` event and on background** (new `useImageCacheMemoryManagement`, mounted at the app root). The `memoryWarning` path is the direct foreground lever against the watchdog kill.
- **Blank board-art bitmaps while backgrounded** via a ref-counted `useIsAppBackgrounded` store gating `LayeredClimbImage`, so the still-mounted views release their GPU textures + heap bitmaps. Re-decodes from disk on foreground (no network).
- **Render the carousel overlay at display size** (`renderWidth`) while keeping the shared board photo crisp (`backgroundVariant="full"`), and `recyclingKey` the carousel boards so a swipe releases the previous climb's overlay.

Nits fixed vs #3150: the AppState listener is installed lazily + ref-counted (tied to React lifecycle — no Fast-Refresh leak, no prod try/catch); the app-visibility tests are order-independent; `LayeredClimbImage` resets its overlay anchor on background; plus new tests for `recyclingKey` forwarding and for not re-flushing on re-foreground.

**JS-only — ships over-the-air to the existing 2.1.0 binary.** No native change.

Addresses #3479.

## Release Notes

- Fixed a crash where the app could be killed for using too much memory while browsing boards — most noticeable on older iPhones.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 432 files / 3407 tests pass, including 17 across the 4 new/expanded test files (`app-visibility`, `use-image-cache-memory-management`, `layered-climb-image`, `layered-climb-image-backgrounded`).
- `vp check` — lint + format clean on all changed files.
- `vp run check:mobile-bundle` — Android Metro bundle OK.
- Remaining: on-device iOS simulator check (open play drawer, swipe ~20 climbs, background/foreground, trigger Simulator → Simulate Memory Warning; confirm board art re-appears without flash and the app stays alive).
