### PR TITLE
fix(mobile): retry full GATT discovery + record exposed services on MoonBoard BLE service_missing

### DIFF
--- a/packages/mobile/ios-tests/BoardBleServiceDiscoveryTests.swift
+++ b/packages/mobile/ios-tests/BoardBleServiceDiscoveryTests.swift
@@ -1,0 +1,72 @@
+import CoreBluetooth
+import XCTest
+
+/// Unit tests for the pure service-discovery decision that backs
+/// `didDiscoverServices` (#3480): prefer Nordic UART, fall back to the original
+/// RedBearLab service, and — when a targeted probe finds neither — retry a full
+/// GATT discovery ONCE (defeating a stale/partial iOS cache) before failing.
+@available(iOS 17.0, *)
+final class BoardBleServiceDiscoveryTests: XCTestCase {
+    private var scheduler: FakeBleTimerScheduler!
+    private var manager: BoardBleManager!
+
+    // Mirrors the constants baked into BoardBleManager.
+    private let uartServiceUuid = CBUUID(string: "6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
+    private let redBearLabServiceUuid = CBUUID(string: "713D0000-503E-4C75-BA94-3148F18D941E")
+    private let unrelatedServiceUuid = CBUUID(string: "180A") // Device Information
+
+    override func setUp() {
+        super.setUp()
+        scheduler = FakeBleTimerScheduler()
+        manager = BoardBleManager(timerScheduler: scheduler, createCentralManagerEagerly: false)
+    }
+
+    override func tearDown() {
+        manager = nil
+        scheduler = nil
+        super.tearDown()
+    }
+
+    private func decide(_ discovered: [CBUUID], retried: Bool) -> BoardBleManager.ServiceDiscoveryDecision {
+        manager.testHooks.serviceDiscoveryDecision(
+            discoveredServiceUuids: discovered,
+            hasRetriedFullDiscovery: retried
+        )
+    }
+
+    func testProbeOrderPrefersUartThenRedBearLab() {
+        XCTAssertEqual(manager.testHooks.writeServiceUuidsForTesting, [uartServiceUuid, redBearLabServiceUuid])
+    }
+
+    func testSelectsUartWhenPresent() {
+        XCTAssertEqual(decide([uartServiceUuid], retried: false), .select(uartServiceUuid))
+    }
+
+    func testSelectsRedBearLabWhenOnlyItIsPresent() {
+        XCTAssertEqual(decide([redBearLabServiceUuid], retried: false), .select(redBearLabServiceUuid))
+    }
+
+    func testPrefersUartWhenBothPresent() {
+        XCTAssertEqual(
+            decide([redBearLabServiceUuid, uartServiceUuid], retried: false),
+            .select(uartServiceUuid)
+        )
+    }
+
+    func testRetriesFullDiscoveryOnFirstMiss() {
+        XCTAssertEqual(decide([], retried: false), .retryFullDiscovery)
+        // Unrelated services (a decoy peripheral / third controller gen) are
+        // still a miss for OUR write services, so we still retry once.
+        XCTAssertEqual(decide([unrelatedServiceUuid], retried: false), .retryFullDiscovery)
+    }
+
+    func testFailsOnSecondMissAfterRetry() {
+        XCTAssertEqual(decide([], retried: true), .fail)
+        XCTAssertEqual(decide([unrelatedServiceUuid], retried: true), .fail)
+    }
+
+    func testSelectsEvenAfterRetryWhenServiceFinallyAppears() {
+        // The full re-discovery surfaced the service the targeted probe missed.
+        XCTAssertEqual(decide([uartServiceUuid], retried: true), .select(uartServiceUuid))
+    }
+}

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -206,6 +206,22 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var intentionalDisconnectGenerations: [UUID: UInt64] = [:]
     private var peripheralGenerations: [UUID: UInt64] = [:]
     private var connectionGeneration: UInt64 = 0
+    // Peripherals whose targeted service probe (discoverServices([uart,
+    // redBearLab])) found neither write service and for which we've already
+    // retried once with a full (nil) discovery. iOS can serve a stale/partial
+    // GATT cache for a targeted probe, reporting a service absent that the board
+    // actually exposes; a full re-read defeats that. The set bounds the retry to
+    // ONE attempt so a board that genuinely exposes neither service still fails
+    // instead of looping. Reset at the start of each fresh targeted discovery
+    // (didConnect / state restoration) and on teardown. See #3480.
+    private var retriedFullServiceDiscovery: Set<UUID> = []
+    // Service UUIDs actually discovered on the peripheral when a connect failed
+    // during service/characteristic discovery. Stashed so JS can attach it to
+    // the Sentry `service_missing` report (getLastConnectDiagnostics) — the
+    // failure alone can't say whether the board exposed NOTHING (stale cache /
+    // decoy peripheral) or an unknown third controller generation. Clear-on-read
+    // via takeLastConnectFailureDiagnostics(). See #3480.
+    private var lastConnectFailureDiscoveredServices: [String]?
     private var writeQueue: [WriteRequest] = []
     private var writeGeneration: UInt64 = 0
     private var isWriting = false
@@ -328,6 +344,18 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             let deviceId = peripheral.identifier.uuidString
             let diagnostics = connectionDiagnosticsOnBleQueue(peripheral: peripheral, characteristic: characteristic)
             return (deviceId, discoveredNames[deviceId] ?? peripheral.name, diagnostics)
+        }
+    }
+
+    /// Service UUIDs discovered on the peripheral for the most recent connect
+    /// that failed in service/characteristic discovery, or nil if there is no
+    /// such failure to report. Clear-on-read so a single failure is attributed
+    /// to a single analytics event. Exposed to JS as `getLastConnectDiagnostics`
+    /// (read right after a `connect` rejection). See #3480.
+    func takeLastConnectFailureDiagnostics() -> [String]? {
+        runOnBleQueueSync {
+            defer { lastConnectFailureDiscoveredServices = nil }
+            return lastConnectFailureDiscoveredServices
         }
     }
 
@@ -925,6 +953,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             peripheralGenerations[peripheral.identifier] = connectionGeneration
             connectedPeripheral = peripheral
             logger.info("Restored BLE peripheral \(deviceId, privacy: .public)")
+            retriedFullServiceDiscovery.remove(peripheral.identifier)
             peripheral.discoverServices(writeServiceUuids())
         case .connecting:
             // The restored connect request is still pending; didConnect will
@@ -987,6 +1016,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
         peripheral.delegate = self
+        retriedFullServiceDiscovery.remove(peripheral.identifier)
         peripheral.discoverServices(writeServiceUuids())
     }
 
@@ -1079,6 +1109,31 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         [uartServiceUuid, redBearLabServiceUuid]
     }
 
+    /// Outcome of a `didDiscoverServices` callback.
+    enum ServiceDiscoveryDecision: Equatable {
+        /// A known write service is present — discover its write characteristic.
+        case select(CBUUID)
+        /// Neither write service present on a targeted probe; re-read the whole
+        /// GATT table once (defeats a stale/partial iOS cache) before giving up.
+        case retryFullDiscovery
+        /// Neither write service present even after a full re-discovery — fail.
+        case fail
+    }
+
+    /// Pure decision for `didDiscoverServices`, split out so the retry/fallback
+    /// logic is unit-testable without a real `CBPeripheral` (#3480). Prefers the
+    /// Nordic UART service, falling back to the original RedBearLab one, matching
+    /// `writeServiceUuids()` ordering.
+    func serviceDiscoveryDecision(
+        discoveredServiceUuids: [CBUUID],
+        hasRetriedFullDiscovery: Bool
+    ) -> ServiceDiscoveryDecision {
+        if let match = writeServiceUuids().first(where: { discoveredServiceUuids.contains($0) }) {
+            return .select(match)
+        }
+        return hasRetriedFullDiscovery ? .fail : .retryFullDiscovery
+    }
+
     /// The write characteristic UUID paired with a discovered service UUID.
     private func writeCharacteristicUuid(for serviceUuid: CBUUID) -> CBUUID {
         serviceUuid == redBearLabServiceUuid ? redBearLabWriteCharacteristicUuid : uartWriteCharacteristicUuid
@@ -1097,16 +1152,29 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
 
         // Prefer the Nordic UART service; fall back to RedBearLab for the
-        // original MoonBoard LED box. writeServiceUuids() is ordered, so the
-        // compactMap keeps that preference.
-        guard let service = writeServiceUuids().compactMap({ uuid in
-            peripheral.services?.first(where: { $0.uuid == uuid })
-        }).first else {
+        // original MoonBoard LED box. If a targeted probe finds neither, iOS may
+        // be serving a stale/partial GATT cache — re-read the whole table once
+        // before failing (#3480).
+        let discoveredUuids = (peripheral.services ?? []).map { $0.uuid }
+        switch serviceDiscoveryDecision(
+            discoveredServiceUuids: discoveredUuids,
+            hasRetriedFullDiscovery: retriedFullServiceDiscovery.contains(peripheral.identifier)
+        ) {
+        case .select(let serviceUuid):
+            guard let service = peripheral.services?.first(where: { $0.uuid == serviceUuid }) else {
+                // The decision was computed from this same services list, so the
+                // service should still be here; treat a race as a plain miss.
+                failConnectionSetup(peripheral, error: BoardBleError.uartServiceMissing)
+                return
+            }
+            peripheral.discoverCharacteristics([writeCharacteristicUuid(for: service.uuid)], for: service)
+        case .retryFullDiscovery:
+            retriedFullServiceDiscovery.insert(peripheral.identifier)
+            logger.info("BLE service probe found neither UART nor RedBearLab for \(peripheral.identifier.uuidString, privacy: .public); retrying full GATT discovery")
+            peripheral.discoverServices(nil)
+        case .fail:
             failConnectionSetup(peripheral, error: BoardBleError.uartServiceMissing)
-            return
         }
-
-        peripheral.discoverCharacteristics([writeCharacteristicUuid(for: service.uuid)], for: service)
     }
 
     /// A connection that reached service discovery but can't become
@@ -1116,7 +1184,14 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// (picker connect / widget reconnect); during state restoration there is
     /// no pending completion and the teardown itself is the fix.
     private func failConnectionSetup(_ peripheral: CBPeripheral, error: Error) {
-        logger.error("BLE connection setup failed for \(peripheral.identifier.uuidString, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        // Record what the board DID expose so a service_missing report can tell
+        // "nothing discovered" (stale cache / decoy peripheral) apart from an
+        // unknown third controller generation (#3480). Read by JS via
+        // getLastConnectDiagnostics right after the connect rejection.
+        let discoveredServices = (peripheral.services ?? []).map { $0.uuid.uuidString }
+        lastConnectFailureDiscoveredServices = discoveredServices
+        logger.error("BLE connection setup failed for \(peripheral.identifier.uuidString, privacy: .public): \(error.localizedDescription, privacy: .public) discoveredServices=[\(discoveredServices.joined(separator: ","), privacy: .public)]")
+        retriedFullServiceDiscovery.remove(peripheral.identifier)
         peripheralGenerations.removeValue(forKey: peripheral.identifier)
         if connectedPeripheral?.identifier == peripheral.identifier {
             connectedPeripheral = nil
@@ -1794,6 +1869,22 @@ extension BoardBleManager {
         func fireWriteAck(error: Error?) {
             manager.runOnBleQueueSync { manager.handleDidWriteValueOnBleQueue(error: error) }
         }
+
+        /// Exercise the pure service-discovery decision (retry-then-fail
+        /// fallback) without a real `CBPeripheral` (#3480).
+        func serviceDiscoveryDecision(
+            discoveredServiceUuids: [CBUUID],
+            hasRetriedFullDiscovery: Bool
+        ) -> BoardBleManager.ServiceDiscoveryDecision {
+            manager.serviceDiscoveryDecision(
+                discoveredServiceUuids: discoveredServiceUuids,
+                hasRetriedFullDiscovery: hasRetriedFullDiscovery
+            )
+        }
+
+        /// The Nordic UART and RedBearLab write-service UUIDs, in probe order,
+        /// so tests can assert the decision without hardcoding them.
+        var writeServiceUuidsForTesting: [CBUUID] { manager.writeServiceUuids() }
 
         var hasPendingWriteResume: Bool { manager.pendingWriteResume != nil }
         var capturedPendingWriteResume: (() -> Void)? { manager.pendingWriteResume }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -1124,7 +1124,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// logic is unit-testable without a real `CBPeripheral` (#3480). Prefers the
     /// Nordic UART service, falling back to the original RedBearLab one, matching
     /// `writeServiceUuids()` ordering.
-    func serviceDiscoveryDecision(
+    private func serviceDiscoveryDecision(
         discoveredServiceUuids: [CBUUID],
         hasRetriedFullDiscovery: Bool
     ) -> ServiceDiscoveryDecision {
@@ -1161,6 +1161,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             hasRetriedFullDiscovery: retriedFullServiceDiscovery.contains(peripheral.identifier)
         ) {
         case .select(let serviceUuid):
+            // Discovery resolved for this connection — drop any retry marker so it
+            // doesn't linger for the peripheral's lifetime (symmetry with the
+            // didConnect / failConnectionSetup cleanups).
+            retriedFullServiceDiscovery.remove(peripheral.identifier)
             guard let service = peripheral.services?.first(where: { $0.uuid == serviceUuid }) else {
                 // The decision was computed from this same services list, so the
                 // service should still be here; treat a race as a plain miss.

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -168,6 +168,17 @@ public class BoardBleModule: Module {
             }
         }
 
+        // Diagnostics for the most recent failed JS connect (#3480). Read right
+        // after a `connect` rejection so the JS layer can attach the services the
+        // board actually exposed to the Sentry `service_missing` report. Clear-on-
+        // read (the manager clears its stash), mirroring getLastWriteDiagnostics.
+        AsyncFunction("getLastConnectDiagnostics") { () -> [String: Any]? in
+            guard let discoveredServices = BoardBleManager.shared.takeLastConnectFailureDiagnostics() else {
+                return nil
+            }
+            return ["discoveredServices": discoveredServices]
+        }
+
         AsyncFunction("cancelWrites") { () -> Void in
             BoardBleManager.shared.cancelWrites()
         }

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -78,6 +78,18 @@ export type NativeBleWriteDiagnostics = {
   durationMs: number;
 };
 
+/**
+ * Diagnostics for a connect that failed during GATT service/characteristic
+ * discovery (#3480). Fetched via `getLastConnectDiagnostics` right after a
+ * rejected `connect`, so a `service_missing` report can distinguish "the board
+ * exposed nothing" (stale iOS cache / decoy peripheral → empty array) from an
+ * unknown third controller generation (unfamiliar service UUIDs).
+ */
+export type NativeBleConnectDiagnostics = {
+  /** Service UUIDs actually discovered on the peripheral before it failed. */
+  discoveredServices: string[];
+};
+
 export type NativeBleConfigureBoardOptions = {
   boardName: string;
   layoutId: number;
@@ -123,6 +135,14 @@ type BoardBleNativeModule = {
    * (an OTA JS update can run against an older binary).
    */
   getLastWriteDiagnostics?(): Promise<NativeBleWriteDiagnostics | null>;
+  /**
+   * Diagnostics of the most recent failed JS connect, for tagging a
+   * `service_missing` failure with the services the board actually exposed (a
+   * rejected promise can't carry them). Only present on newer binaries — gate
+   * on `typeof getLastConnectDiagnostics === 'function'` (an OTA JS update can
+   * run against an older binary). See #3480.
+   */
+  getLastConnectDiagnostics?(): Promise<NativeBleConnectDiagnostics | null>;
   addListener(event: 'scanResult', listener: (payload: NativeBleScanEvent) => void): EventSubscription;
   addListener(event: 'disconnected', listener: (payload: NativeBleDisconnectEvent) => void): EventSubscription;
   addListener(event: 'connected', listener: (payload: NativeBleConnectedEvent) => void): EventSubscription;

--- a/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
@@ -657,13 +657,15 @@ describe('NativeIosBleAdapter connect diagnostics (#3480)', () => {
 
     // First attempt fails and stashes diagnostics.
     nativeMock.connect.mockRejectedValueOnce(new Error('UART service was not found'));
+    const firstAttempt = driveConnect(adapter, 'A1B2C3');
     await vi.runAllTimersAsync();
-    await driveConnect(adapter, 'A1B2C3');
+    await firstAttempt;
     await expect(adapter.getLastConnectDiagnostics()).resolves.toEqual({ discoveredServices: [] });
 
     // Second attempt succeeds — the stale diagnostics must be dropped.
-    await driveConnect(adapter, 'A1B2C3');
+    const secondAttempt = driveConnect(adapter, 'A1B2C3');
     await vi.runAllTimersAsync();
+    await secondAttempt;
     await expect(adapter.getLastConnectDiagnostics()).resolves.toBeNull();
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
@@ -601,3 +601,69 @@ describe('NativeIosBleAdapter write diagnostics', () => {
     await expect(adapter.getLastWriteDiagnostics()).resolves.toBeNull();
   });
 });
+
+describe('NativeIosBleAdapter connect diagnostics (#3480)', () => {
+  afterEach(() => {
+    delete (nativeMock as Record<string, unknown>).getLastConnectDiagnostics;
+  });
+
+  // Drive requestAndConnect to the point native.connect is invoked by
+  // auto-selecting a device advertising the target serial.
+  const driveConnect = (adapter: NativeIosBleAdapter, serial: string): Promise<unknown> => {
+    const promise = adapter.requestAndConnect(serial).catch((error: Error) => error);
+    void Promise.resolve().then(() => {
+      scanListeners[0]?.({
+        device: { deviceId: 'dev-1', name: `Kilter Board#${serial}@3` },
+        localName: `Kilter Board#${serial}@3`,
+        rssi: -55,
+      });
+    });
+    return promise;
+  };
+
+  it('fetches the native stash and rethrows when a connect rejects on a newer binary', async () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    const connectError = new Error('UART service was not found');
+    nativeMock.connect.mockRejectedValueOnce(connectError);
+    const getStash = vi.fn().mockResolvedValue({ discoveredServices: ['AURORA-UUID'] });
+    (nativeMock as Record<string, unknown>).getLastConnectDiagnostics = getStash;
+
+    const connectPromise = driveConnect(adapter, 'A1B2C3');
+    await vi.runAllTimersAsync();
+
+    expect(await connectPromise).toBe(connectError);
+    expect(getStash).toHaveBeenCalledOnce();
+    await expect(adapter.getLastConnectDiagnostics()).resolves.toEqual({ discoveredServices: ['AURORA-UUID'] });
+  });
+
+  it('rethrows without a stash fetch when a connect rejects on an old binary', async () => {
+    // Default native mock has no getLastConnectDiagnostics — the old-binary case
+    // where the reject path must not attempt (or throw from) a fetch.
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    const connectError = new Error('UART service was not found');
+    nativeMock.connect.mockRejectedValueOnce(connectError);
+
+    const connectPromise = driveConnect(adapter, 'A1B2C3');
+    await vi.runAllTimersAsync();
+
+    expect(await connectPromise).toBe(connectError);
+    await expect(adapter.getLastConnectDiagnostics()).resolves.toBeNull();
+  });
+
+  it('clears stale connect diagnostics on a subsequent successful connect', async () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    const getStash = vi.fn().mockResolvedValue({ discoveredServices: [] });
+    (nativeMock as Record<string, unknown>).getLastConnectDiagnostics = getStash;
+
+    // First attempt fails and stashes diagnostics.
+    nativeMock.connect.mockRejectedValueOnce(new Error('UART service was not found'));
+    await vi.runAllTimersAsync();
+    await driveConnect(adapter, 'A1B2C3');
+    await expect(adapter.getLastConnectDiagnostics()).resolves.toEqual({ discoveredServices: [] });
+
+    // Second attempt succeeds — the stale diagnostics must be dropped.
+    await driveConnect(adapter, 'A1B2C3');
+    await vi.runAllTimersAsync();
+    await expect(adapter.getLastConnectDiagnostics()).resolves.toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -92,6 +92,13 @@ vi.mock('../adapter', () => ({
   RNBleAdapter: vi.fn(),
 }));
 
+// Spy on reportHandledError (keep the real noise-policy/other exports) so a
+// connect failure's Sentry tags can be asserted (#3480).
+vi.mock('../../error-reporting', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../error-reporting')>();
+  return { ...actual, reportHandledError: vi.fn() };
+});
+
 // adapter-factory pulls in modules/live-activity/src/index, which pulls in
 // expo-modules-core, which references the React Native `__DEV__` global at
 // import time. Short-circuiting the factory here avoids that chain — the
@@ -121,6 +128,7 @@ import {
   useBoardBluetooth,
 } from '../use-board-bluetooth';
 import type { BleWriteDiagnostics } from '../types';
+import { reportHandledError } from '../../error-reporting';
 
 // ── Factory helpers ────────────────────────────────────────────────────────
 
@@ -262,6 +270,85 @@ describe('useBoardBluetooth', () => {
     });
 
     expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
+  });
+
+  it('tags a service_missing failure with the services the board exposed (#3480)', async () => {
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockRejectedValue(new Error('UART service was not found')),
+    });
+    // Newer binary: the adapter can report what the board actually exposed.
+    (fakeAdapter as Record<string, unknown>).getLastConnectDiagnostics = vi
+      .fn()
+      .mockResolvedValue({ discoveredServices: ['180a', '180f'] });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.serviceMissing');
+    expect(reportHandledError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: {
+          source: 'ble-connect',
+          failure_category: 'service_missing',
+          ble_discovered_services: '180a,180f',
+        },
+      }),
+    );
+  });
+
+  it('tags service_missing with "none" when the board exposed no services (#3480)', async () => {
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockRejectedValue(new Error('UART service was not found')),
+    });
+    (fakeAdapter as Record<string, unknown>).getLastConnectDiagnostics = vi
+      .fn()
+      .mockResolvedValue({ discoveredServices: [] });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(reportHandledError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({ ble_discovered_services: 'none' }),
+      }),
+    );
+  });
+
+  it('omits the discovered-services tag on an old binary without the accessor (#3480)', async () => {
+    // No getLastConnectDiagnostics on the adapter → no tag, but still reports.
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockRejectedValue(new Error('UART service was not found')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(reportHandledError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: { source: 'ble-connect', failure_category: 'service_missing' },
+      }),
+    );
   });
 
   it('serialises overlapping sendFramesToBoard calls so chunks never interleave', async () => {

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -13,6 +13,7 @@ import {
 import type {
   BluetoothAdapter,
   BleConnection,
+  BleConnectDiagnostics,
   BleDisconnectInfo,
   BleWriteDiagnostics,
   BoardScanFamily,
@@ -71,6 +72,12 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
   // Transport diagnostics of the most recently settled write (#3230): the
   // resolved value on success, the native module's stash after a reject.
   private lastWriteDiagnostics: BleWriteDiagnostics | null = null;
+  // Diagnostics of the most recent failed connect (#3480): the services the
+  // board actually exposed, fetched from the native module's stash after a
+  // rejected connect (an Expo reject can't carry them). Held until the next
+  // connect attempt so both the failure analytics event and the Sentry report
+  // can read it.
+  private lastConnectDiagnostics: BleConnectDiagnostics | null = null;
 
   constructor(
     private readonly devicePicker: DevicePickerFn,
@@ -225,7 +232,21 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       }
     }
 
-    await native.connect(selectedDeviceId);
+    // Fresh attempt: drop any stale connect diagnostics so a later read can't
+    // re-attribute a previous failure to this connect.
+    this.lastConnectDiagnostics = null;
+    try {
+      await native.connect(selectedDeviceId);
+    } catch (error) {
+      // A rejected connect can't carry structured data (Expo), so on failure
+      // fetch the services the board actually exposed from the module stash for
+      // the service_missing report (#3480). Absent on older binaries (OTA JS can
+      // outrun the native build) — then there's simply nothing to fetch.
+      if (typeof native.getLastConnectDiagnostics === 'function') {
+        this.lastConnectDiagnostics = await native.getLastConnectDiagnostics().catch(() => null);
+      }
+      throw error;
+    }
 
     this.trackConnectedDevice(selectedDeviceId);
 
@@ -337,6 +358,13 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
   // analytics event and the Sentry report), so reads must not consume it.
   async getLastWriteDiagnostics(): Promise<BleWriteDiagnostics | null> {
     return this.lastWriteDiagnostics;
+  }
+
+  // Diagnostics of the most recent failed connect (#3480), held until the next
+  // connect attempt so the failure can feed several consumers (analytics event,
+  // Sentry report) without a read consuming it.
+  async getLastConnectDiagnostics(): Promise<BleConnectDiagnostics | null> {
+    return this.lastConnectDiagnostics;
   }
 
   onDisconnect(callback: (info?: BleDisconnectInfo) => void): () => void {

--- a/packages/mobile/src/lib/ble/types.ts
+++ b/packages/mobile/src/lib/ble/types.ts
@@ -64,6 +64,18 @@ export type BleWriteDiagnostics = {
   durationMs?: number;
 };
 
+// Diagnostics for a connect that failed during GATT discovery (#3480), for
+// tagging the `service_missing` failure. Populated only by native iOS; a
+// rejected connect promise can't carry it, so the adapter stashes it and the
+// hook reads it right after the failure.
+export type BleConnectDiagnostics = {
+  // Service UUIDs the peripheral actually exposed before discovery failed.
+  // Empty means the board advertised no known write service (stale iOS GATT
+  // cache or a decoy peripheral matched by name); unfamiliar UUIDs point at a
+  // controller generation we don't handle yet.
+  discoveredServices?: string[];
+};
+
 export type BluetoothAdapter = {
   isAvailable(): Promise<boolean>;
   requestAndConnect(targetSerial?: string): Promise<BleConnection>;
@@ -74,4 +86,7 @@ export type BluetoothAdapter = {
   // (success or failure), for analytics tagging. Optional: web-era adapters
   // and old binaries don't report any.
   getLastWriteDiagnostics?(): Promise<BleWriteDiagnostics | null>;
+  // Diagnostics of the adapter's most recent failed connect, for tagging a
+  // service_missing report. Optional: only native iOS reports it.
+  getLastConnectDiagnostics?(): Promise<BleConnectDiagnostics | null>;
 };

--- a/packages/mobile/src/lib/ble/types.ts
+++ b/packages/mobile/src/lib/ble/types.ts
@@ -69,11 +69,12 @@ export type BleWriteDiagnostics = {
 // rejected connect promise can't carry it, so the adapter stashes it and the
 // hook reads it right after the failure.
 export type BleConnectDiagnostics = {
-  // Service UUIDs the peripheral actually exposed before discovery failed.
-  // Empty means the board advertised no known write service (stale iOS GATT
-  // cache or a decoy peripheral matched by name); unfamiliar UUIDs point at a
-  // controller generation we don't handle yet.
-  discoveredServices?: string[];
+  // Service UUIDs the peripheral actually exposed before discovery failed. The
+  // native module always reports this (possibly empty) when it hands back a
+  // diagnostics object, so it's required. Empty means the board advertised no
+  // known write service (stale iOS GATT cache or a decoy peripheral matched by
+  // name); unfamiliar UUIDs point at a controller generation we don't handle yet.
+  discoveredServices: string[];
 };
 
 export type BluetoothAdapter = {

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -730,6 +730,11 @@ export function useBoardBluetooth({
 
       setLoading(true);
 
+      // Hoisted so the catch can read the adapter's post-mortem connect
+      // diagnostics (which services the board exposed) for a service_missing
+      // report (#3480); `adapter` itself is block-scoped to the try.
+      let connectAdapter: BluetoothAdapter | null = null;
+
       try {
         const permissionsGranted = await requestBleRuntimePermissions({ requestNotificationPermission: true });
         if (!permissionsGranted) {
@@ -738,6 +743,7 @@ export function useBoardBluetooth({
         }
 
         const adapter = createBluetoothAdapter(devicePicker, scanFamilyForBoard(boardName));
+        connectAdapter = adapter;
 
         const available = await adapter.isAvailable();
         if (!available) {
@@ -893,9 +899,25 @@ export function useBoardBluetooth({
           console.warn('Bluetooth device selection cancelled by user');
         } else {
           console.error('Error connecting to Bluetooth:', error);
+          // For service_missing, tag the report with the services the board
+          // actually exposed so the next occurrence is diagnosable: empty means
+          // nothing was discovered (stale iOS GATT cache or a decoy peripheral),
+          // unfamiliar UUIDs point at an unhandled controller generation (#3480).
+          let discoveredServicesTag: string | undefined;
+          if (failureCategory === 'service_missing') {
+            const connectDiagnostics = await connectAdapter?.getLastConnectDiagnostics?.().catch(() => null);
+            const discoveredServices = connectDiagnostics?.discoveredServices;
+            if (discoveredServices) {
+              discoveredServicesTag = discoveredServices.length > 0 ? discoveredServices.join(',') : 'none';
+            }
+          }
           reportHandledError(error, {
             level: reportLevel,
-            tags: { source: 'ble-connect', failure_category: failureCategory },
+            tags: {
+              source: 'ble-connect',
+              failure_category: failureCategory,
+              ...(discoveredServicesTag ? { ble_discovered_services: discoveredServicesTag } : {}),
+            },
           });
         }
         setIsConnected(false);

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -21,6 +21,10 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/BoardBleWriteFlowTests.swift',
   },
   {
+    sourcePath: '../ios-tests/BoardBleServiceDiscoveryTests.swift',
+    projectPath: 'BoardseshTests/BoardBleServiceDiscoveryTests.swift',
+  },
+  {
     sourcePath: '../modules/live-activity/ios/BoardBleManager.swift',
     projectPath: 'BoardseshTests/LiveActivitySources/BoardBleManager.swift',
   },


### PR DESCRIPTION
## Summary

MoonBoard BLE connect on native iOS was failing with `Error: UART service was not found` (Sentry [BOARDSESH-8Y](https://boardsesh.sentry.io/issues/7593464485/)) — 1 user, 2 events, iOS 26.0.1, release `2.1.0+3`.

The obvious hypothesis (code only looked for Nordic UART, missed the original RedBearLab controller generation) was already handled: #3233 added the dual-service probe across every layer and merged **before** the `2.1.0` bump, so the shipped binary already probed both `6e400001` (UART) and `713d0000` (RedBearLab). The failure means native discovery found **neither** service on the connected peripheral — most consistent with a **stale/partial iOS GATT cache** served for a targeted `discoverServices([...])` (the documented iOS failure mode; a phone reboot clears it). A decoy peripheral matched by name during the unfiltered MoonBoard scan is the secondary suspect. Today the failure records nothing about what the board *did* expose, so it can't be diagnosed further.

This change:

- **Retries once with a full `discoverServices(nil)`** when the targeted probe finds neither write service, forcing iOS to re-read the whole GATT table before giving up. Bounded to a single retry per connection so a board that genuinely exposes neither service still fails instead of looping.
- **Records the services the board actually exposed** on a failed connect. JS reads them via a new `getLastConnectDiagnostics` (mirroring `getLastWriteDiagnostics`) and tags the `service_missing` Sentry report with `ble_discovered_services` — `none` when the board exposed nothing (stale cache / decoy), the UUID list when it exposed something we don't handle (an unknown controller generation).
- The retry/fallback decision is split into a pure `serviceDiscoveryDecision` helper so it's unit-testable without a real `CBPeripheral`.

The connect rejection message is unchanged (`UART service was not found`), so Sentry grouping and the `classifyBleFailure` regex are unaffected; the diagnostic rides a tag.

This is a **native change** (new fingerprint) — it ships in the next TestFlight/App Store build, not via OTA. The real-hardware proof will be the enriched `ble_discovered_services` tag on the next production occurrence.

Addresses #3480

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 3402 passed. New coverage: Swift `BoardBleServiceDiscoveryTests` (decision: select UART / select RedBearLab / prefer UART / retry-on-first-miss / fail-after-retry / select-after-retry), adapter `getLastConnectDiagnostics` stash + reset, hook `ble_discovered_services` tag (UUID list / `none` / omitted on old binary).
- `vp check` on all changed files — clean.
- Swift compiles + runs in `ios-rn-ci.yml` (triggers on `packages/mobile/**` + `scripts/prepare-rn-ios-tests.mjs`, both touched). End-to-end BLE can't run in a simulator (no CoreBluetooth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZtNj5scNd6fy1Ckc17aX3
