### PR TITLE
fix(mobile): capture iPad App Store screenshots via a sidebar-tap flow

### DIFF
--- a/packages/mobile/.maestro/app-store-ipad.yaml
+++ b/packages/mobile/.maestro/app-store-ipad.yaml
@@ -1,0 +1,72 @@
+appId: com.boardsesh.app
+name: app-store screenshots (iPad)
+---
+# iPad App Store hero shots against the prod backend + curated test user.
+#
+# Why this differs from the iPhone flow (app-store.yaml): the iPad CANNOT be driven
+# by deep links. On the iPad simulator every `openurl com.boardsesh.app://…` pops the
+# "Open in 'Boardsesh'?" scheme-confirm dialog and the URL is never delivered to the
+# app's router — navigation just never happens (verified: an all-deep-link run on
+# iPad produced 11 byte-identical "stuck on home + dialog" frames, while the same
+# flow on iPhone navigated 10 distinct screens). iPhone remembers the confirm after
+# the first prime; iPad does not.
+#
+# So the iPad navigates via the persistent left SIDEBAR using coordinate taps — the
+# same gesture-tap mechanism the rest of this RN/Fabric build needs (the accessibility
+# tree doesn't expose plain RN views, only native inputs + system dialogs). No
+# `openurl`, so no dialog. The orchestrator selects this flow for iPad devices (see
+# iosSourceFlowFile in scripts/mobile-screenshots.ts).
+#
+# The ${TAP_*} points are substituted per device by the orchestrator
+# (renderMaestroFlowForIosDevice): the sidebar is laid out in fixed logical points,
+# but Maestro taps are a percentage of the current screen, and the 13" and 11" iPad
+# have different landscape heights — so each item's percentage is computed from its
+# logical anchor and the device's pixel height. Do NOT hardcode percentages here.
+#
+# The wall kiosk is seeded from the active board's REAL climbs when the Climbs list
+# mounts (src/lib/board-presence/screenshot-wall-seed.ts), so Climbs is visited BEFORE
+# On the Wall. The active board is auto-activated on boot (ScreenshotBoardAutoActivator),
+# and the build auto-signs-in and lands on home — the orchestrator gates on
+# `$screen /home` before running this flow.
+- setOrientation: ${MAESTRO_DEVICE_ORIENTATION}
+- waitForAnimationToEnd
+
+# Climbs — the browse list. Visited FIRST because mounting it seeds the wall kiosk.
+- tapOn:
+    point: ${TAP_CLIMBS}
+- waitForAnimationToEnd
+- waitForAnimationToEnd
+- takeScreenshot: 02-climbs
+
+# Home — the "Everyone" feed, with the persistent wall rail now showing the lit climb.
+- tapOn:
+    point: ${TAP_HOME}
+- waitForAnimationToEnd
+- takeScreenshot: 01-home
+
+# On the Wall — the wall-mounted kiosk HERO: the lit board + the current climb big and
+# readable from across the gym. The board-presence feed is seeded above.
+- tapOn:
+    point: ${TAP_WALL}
+- waitForAnimationToEnd
+- waitForAnimationToEnd
+- takeScreenshot: 00-wall
+
+# Record — the workout generator (a workout is pre-selected in screenshot mode via
+# EXPO_PUBLIC_SCREENSHOT_WORKOUT).
+- tapOn:
+    point: ${TAP_RECORD}
+- waitForAnimationToEnd
+- takeScreenshot: 03-workout-generator
+
+# Discover — the playlist library (smart "Your Picks" + saved playlists).
+- tapOn:
+    point: ${TAP_DISCOVER}
+- waitForAnimationToEnd
+- takeScreenshot: 04-discover
+
+# Profile — progress / stats (charts).
+- tapOn:
+    point: ${TAP_PROFILE}
+- waitForAnimationToEnd
+- takeScreenshot: 05-profile

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -147,26 +147,10 @@ name: app-store screenshots
 - waitForAnimationToEnd
 - takeScreenshot: 07-playlist-detail
 
-# On the Wall (iPad only) — the wall-mounted kiosk: the current climb big and readable
-# from across the gym, who's on it, the session's hardest send, and the history reel. In
-# screenshot mode the board-presence feed is seeded from the active board's REAL climbs
-# (see src/lib/board-presence/screenshot-wall-seed.ts), so the holds light up instead of
-# the empty "Connect a board" state. `/wall` is an iPad-ONLY route (hidden on iPhone), so
-# this whole block is gated on the device class the orchestrator bakes in
-# (${__MAESTRO_IS_IPAD__} → true on iPads, false on iPhones) — an iPhone run skips it and
-# never writes a junk shot into the iPhone folder. Runs BEFORE the board-view shots below
-# because those open the play drawer, which overlays the whole app.
-- runFlow:
-    when:
-      true: ${__MAESTRO_IS_IPAD__}
-    commands:
-      - openLink: com.boardsesh.app://wall
-      - tapOn:
-          text: 'Open'
-          optional: true
-      - waitForAnimationToEnd
-      - waitForAnimationToEnd
-      - takeScreenshot: 00-wall
+# NOTE: this flow is iPhone-only. iPad deep links don't navigate on the simulator
+# (the scheme-confirm dialog swallows the openurl), so iPad captures — including the
+# On the Wall kiosk — run from app-store-ipad.yaml via sidebar taps, which the
+# orchestrator selects for iPad devices (iosSourceFlowFile).
 
 # Board view — the signature feature: the wall with holds lit. The screenshot-mode param
 # auto-opens the first climb's play drawer (no coordinate tap). LAST, because the play

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -7,6 +7,8 @@ import { join } from 'node:path';
 import {
   buildScreenshotEnv,
   deviceSlug,
+  iosSourceFlowFile,
+  ipadSidebarTapPoint,
   isIpadScreenshotDevice,
   metroDevClientUrl,
   parseArgs,
@@ -303,53 +305,85 @@ describe('renderMaestroFlowForIosDevice', () => {
     }
   });
 
-  it('renders the iPad-class gate to true on iPad and false on iPhone', () => {
-    const ipadDevice: IosScreenshotDevice = {
+  it('resolves iPad sidebar tap points from each device landscape height', () => {
+    const ipad13: IosScreenshotDevice = {
       name: 'iPad Pro 13-inch (M5)',
       typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M5-12GB',
       orientation: 'LANDSCAPE_LEFT',
     };
-    const phoneDevice: IosScreenshotDevice = {
-      name: 'iPhone 16 Pro Max',
-      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max',
-      orientation: 'PORTRAIT',
+    const ipad11: IosScreenshotDevice = {
+      name: 'iPad Pro 11-inch (M5)',
+      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-11-inch-M5-12GB',
+      orientation: 'LANDSCAPE_LEFT',
     };
-    const flowSource =
-      '- runFlow:\n    when:\n      true: ${__MAESTRO_IS_IPAD__}\n    commands:\n      - takeScreenshot: 00-wall\n';
+    const flow = '- tapOn:\n    point: ${TAP_CLIMBS}\n- tapOn:\n    point: ${TAP_PROFILE}\n';
 
-    const ipadRendered = renderMaestroFlowForIosDevice(flowSource, ipadDevice);
-    expect(ipadRendered).toContain('true: ${true}');
-    expect(ipadRendered).not.toContain('__MAESTRO_IS_IPAD__');
-
-    const phoneRendered = renderMaestroFlowForIosDevice(flowSource, phoneDevice);
-    expect(phoneRendered).toContain('true: ${false}');
-    expect(phoneRendered).not.toContain('__MAESTRO_IS_IPAD__');
+    // Climbs anchors at logical 144pt (=288px @2x): 288/2064 ≈ 14% on the 13",
+    // 288/1668 ≈ 17% on the shorter 11". Same item, different percentage per device.
+    // Maestro needs whole-number percentages, so the point is rounded.
+    const rendered13 = renderMaestroFlowForIosDevice(flow, ipad13);
+    const rendered11 = renderMaestroFlowForIosDevice(flow, ipad11);
+    expect(rendered13).toContain('point: 3%,14%');
+    expect(rendered11).toContain('point: 3%,17%');
+    // Profile is bottom-anchored — near the bottom on both, but not identical.
+    expect(rendered13).toContain('point: 3%,94%');
+    expect(rendered11).toContain('point: 3%,93%');
+    expect(rendered13).not.toContain('${TAP_');
+    expect(rendered11).not.toContain('${TAP_');
   });
 
-  it('gates the real app-store wall shot on the iPad device class', () => {
-    const ipadDevice: IosScreenshotDevice = {
-      name: 'iPad Pro 13-inch (M5)',
-      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M5-12GB',
-      orientation: 'LANDSCAPE_LEFT',
-    };
+  it('leaves iPad tap placeholders unresolved on a non-iPad device (the flow never runs there)', () => {
     const phoneDevice: IosScreenshotDevice = {
       name: 'iPhone 16 Pro Max',
       typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max',
       orientation: 'PORTRAIT',
     };
-    const flowSource = readFileSync('packages/mobile/.maestro/app-store.yaml', 'utf8');
-    // The flow ships the placeholder and the iPad-only wall capture.
-    expect(flowSource).toContain('__MAESTRO_IS_IPAD__');
-    expect(flowSource).toContain('takeScreenshot: 00-wall');
-    expect(flowSource).toContain('com.boardsesh.app://wall');
+    expect(ipadSidebarTapPoint('TAP_CLIMBS', phoneDevice)).toBeNull();
+    expect(renderMaestroFlowForIosDevice('point: ${TAP_CLIMBS}', phoneDevice)).toContain('${TAP_CLIMBS}');
+  });
 
-    // Rendered per device, the wall gate resolves to a concrete boolean and the
-    // placeholder is gone (so neither run leaves an unresolved token).
-    expect(renderMaestroFlowForIosDevice(flowSource, ipadDevice)).toContain('true: ${true}');
-    expect(renderMaestroFlowForIosDevice(flowSource, phoneDevice)).toContain('true: ${false}');
-    for (const device of [ipadDevice, phoneDevice]) {
-      expect(renderMaestroFlowForIosDevice(flowSource, device)).not.toContain('__MAESTRO_IS_IPAD__');
-    }
+  it('the iPad flow uses only ${TAP_*} placeholders, never hardcoded percentages', () => {
+    const ipadFlow = readFileSync('packages/mobile/.maestro/app-store-ipad.yaml', 'utf8');
+    expect(ipadFlow).toContain('point: ${TAP_CLIMBS}');
+    expect(ipadFlow).toContain('point: ${TAP_WALL}');
+    // No literal "N%,M%" tap points — those wouldn't transfer between iPad sizes.
+    expect(ipadFlow).not.toMatch(/point:\s*'?\d/);
+  });
+});
+
+describe('iosSourceFlowFile', () => {
+  const ipadDevice: IosScreenshotDevice = {
+    name: 'iPad Pro 13-inch (M5)',
+    typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M5-12GB',
+    orientation: 'LANDSCAPE_LEFT',
+  };
+  const phoneDevice: IosScreenshotDevice = {
+    name: 'iPhone 16 Pro Max',
+    typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max',
+    orientation: 'PORTRAIT',
+  };
+
+  it('routes the app-store flow to the iPad tap flow for iPad, and the shared flow for iPhone', () => {
+    expect(iosSourceFlowFile(makeOptions({ flow: 'app-store' }), ipadDevice)).toMatch(/app-store-ipad\.yaml$/);
+    const phoneFlow = iosSourceFlowFile(makeOptions({ flow: 'app-store' }), phoneDevice);
+    expect(phoneFlow).toMatch(/app-store\.yaml$/);
+    expect(phoneFlow).not.toMatch(/app-store-ipad\.yaml$/);
+  });
+
+  it('falls back to the shared flow on iPad when no iPad variant exists (onboarding)', () => {
+    expect(iosSourceFlowFile(makeOptions({ flow: 'onboarding' }), ipadDevice)).toMatch(/onboarding\.yaml$/);
+  });
+
+  it('the iPad flow is tap-driven (no openurl) and captures the wall kiosk; iPhone stays deep-link driven', () => {
+    const ipadFlow = readFileSync('packages/mobile/.maestro/app-store-ipad.yaml', 'utf8');
+    expect(ipadFlow).toContain('takeScreenshot: 00-wall');
+    expect(ipadFlow).toContain('point:');
+    expect(ipadFlow).not.toContain('openLink:');
+
+    const phoneFlow = readFileSync('packages/mobile/.maestro/app-store.yaml', 'utf8');
+    expect(phoneFlow).toContain('openLink: com.boardsesh.app://climbs');
+    expect(phoneFlow).not.toContain('__MAESTRO_IS_IPAD__');
+    expect(phoneFlow).not.toContain('://wall');
   });
 });
 

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -64,12 +64,33 @@ const LOG = '[mobile:screenshots]';
 const APP_ID = 'com.boardsesh.app';
 const DEV_CLIENT_URL_SCHEME = 'exp+boardsesh';
 const MAESTRO_DEVICE_ORIENTATION_PLACEHOLDER = '${MAESTRO_DEVICE_ORIENTATION}';
-// Substituted to the literal `true`/`false` per device, inside a flow `${…}`
-// condition, so an iPad-only capture step (`when: { true: ${__MAESTRO_IS_IPAD__} }`)
-// runs on iPads and is skipped on iPhones — same render-time substitution the
-// orientation placeholder uses (Maestro `test` reads `${VAR}` only from `-e`, not
-// a flow's own text, so substitution is the reliable path).
-const MAESTRO_IS_IPAD_PLACEHOLDER = '__MAESTRO_IS_IPAD__';
+
+// The iPad tap flow (app-store-ipad.yaml) navigates via the left SIDEBAR with
+// coordinate taps. The sidebar is laid out in LOGICAL POINTS (identical on every
+// iPad), but Maestro `point:` taps are percentages of the CURRENT screen — and the
+// 13" and 11" iPad have different landscape pixel heights, so the same item sits at
+// a different percentage on each. So the flow carries a `${TAP_*}` placeholder per
+// item and the orchestrator substitutes the concrete `x%,y%` computed from the
+// item's logical anchor and THIS device's pixel height. (All iPad simulators are
+// @2x, so logical points → pixels is ×2.)
+const IPAD_SIDEBAR_TAP_X_PERCENT = 3;
+// Vertical anchor of each top-anchored sidebar item, in logical points from the top.
+const IPAD_SIDEBAR_TOP_ITEM_PT: Record<string, number> = {
+  TAP_HOME: 72,
+  TAP_CLIMBS: 144,
+  TAP_RECORD: 206,
+  TAP_WALL: 278,
+  TAP_DISCOVER: 361,
+};
+// Profile is pinned to the BOTTOM of the sidebar, this many logical points up from
+// the bottom screen edge.
+const IPAD_SIDEBAR_PROFILE_FROM_BOTTOM_PT = 62;
+// Landscape pixel height per iPad, keyed by device slug (matches the sizes the
+// screenshot dimension gate accepts).
+const IPAD_LANDSCAPE_HEIGHT_PX: Record<string, number> = {
+  'ipad-pro-13-inch-m5': 2064,
+  'ipad-pro-11-inch-m5': 1668,
+};
 const DEFAULT_ANDROID_DEVICE = 'Pixel 2';
 const DEFAULT_ANDROID_APK = resolve(
   MOBILE_DIR,
@@ -615,10 +636,52 @@ export function isIpadScreenshotDevice(screenshotDevice: IosScreenshotDevice): b
   return screenshotDevice.typeId.includes('iPad');
 }
 
+/**
+ * The Maestro flow source for an iOS device. iPad deep links don't navigate on
+ * the simulator — the "Open in 'Boardsesh'?" scheme-confirm dialog swallows every
+ * `openurl` — so iPad drives navigation via sidebar coordinate taps from a
+ * dedicated `<flow>-ipad.yaml`. Falls back to the shared `<flow>[-ios].yaml`
+ * (iPhone's deep-link flow) when no iPad variant exists.
+ */
+export function iosSourceFlowFile(options: ScreenshotOptions, screenshotDevice: IosScreenshotDevice): string {
+  if (isIpadScreenshotDevice(screenshotDevice)) {
+    const ipadFlowFile = join(MAESTRO_DIR, `${options.flow}-ipad.yaml`);
+    if (existsSync(ipadFlowFile)) return ipadFlowFile;
+  }
+  return flowFileForPlatform(options, 'ios');
+}
+
+/**
+ * The `x%,y%` Maestro tap point for an iPad sidebar item, computed from its logical
+ * anchor and the device's landscape pixel height (iPad simulators are @2x, so
+ * `logicalPt × 2` = pixels). Top items are anchored from the top; Profile from the
+ * bottom. Returns null for a non-iPad device or an unknown iPad height.
+ */
+export function ipadSidebarTapPoint(placeholder: string, screenshotDevice: IosScreenshotDevice): string | null {
+  const heightPx = IPAD_LANDSCAPE_HEIGHT_PX[deviceSlug(screenshotDevice.name)];
+  if (heightPx === undefined) return null;
+  const topAnchorPt = IPAD_SIDEBAR_TOP_ITEM_PT[placeholder];
+  const yPercent =
+    topAnchorPt !== undefined
+      ? ((topAnchorPt * 2) / heightPx) * 100
+      : placeholder === 'TAP_PROFILE'
+        ? ((heightPx - IPAD_SIDEBAR_PROFILE_FROM_BOTTOM_PT * 2) / heightPx) * 100
+        : null;
+  if (yPercent === null) return null;
+  // Maestro `point:` percentages must be whole numbers (it throws on a decimal). The
+  // sidebar touch targets are ~44pt (~5%), so rounding is well within tolerance.
+  return `${IPAD_SIDEBAR_TAP_X_PERCENT}%,${Math.round(yPercent)}%`;
+}
+
 export function renderMaestroFlowForIosDevice(flowSource: string, screenshotDevice: IosScreenshotDevice): string {
-  return flowSource
-    .replaceAll(MAESTRO_DEVICE_ORIENTATION_PLACEHOLDER, screenshotDevice.orientation)
-    .replaceAll(MAESTRO_IS_IPAD_PLACEHOLDER, isIpadScreenshotDevice(screenshotDevice) ? 'true' : 'false');
+  let rendered = flowSource.replaceAll(MAESTRO_DEVICE_ORIENTATION_PLACEHOLDER, screenshotDevice.orientation);
+  for (const placeholder of [...Object.keys(IPAD_SIDEBAR_TOP_ITEM_PT), 'TAP_PROFILE']) {
+    const point = ipadSidebarTapPoint(placeholder, screenshotDevice);
+    if (point !== null) {
+      rendered = rendered.replaceAll(`\${${placeholder}}`, point);
+    }
+  }
+  return rendered;
 }
 
 export function rotationDegreesForIosOrientation(orientation: IosDeviceOrientation): number | null {
@@ -630,7 +693,7 @@ function renderedFlowFileForIosDevice(
   screenshotDevice: IosScreenshotDevice,
   captureDir: string,
 ): string {
-  const flowFile = flowFileForPlatform(options, 'ios');
+  const flowFile = iosSourceFlowFile(options, screenshotDevice);
   if (!existsSync(flowFile)) return flowFile;
   const renderedFlowFile = join(captureDir, `${options.flow}-${deviceSlug(screenshotDevice.name)}.yaml`);
   writeFileSync(renderedFlowFile, renderMaestroFlowForIosDevice(readFileSync(flowFile, 'utf8'), screenshotDevice));
@@ -724,16 +787,30 @@ function captureIosDevice(
     // there before Maestro runs — this is what login.yaml's readiness wait used to
     // do (now deleted; there's no login screen to gate on).
     console.log(`${LOG} Waiting for the app to auto-sign-in and reach home...`);
-    if (!waitForHomeReady(homeReadyBaseline, 45)) {
-      console.log(`${LOG} Plain launch did not reach home; retrying with the explicit dev-client URL...`);
-      runCapture('xcrun', ['simctl', 'openurl', device.udid, metroDevClientUrl()]);
+    // iPad cold-boots + first-bundle-loads slower, so give the plain launch more time
+    // before the retry.
+    const isIpad = isIpadScreenshotDevice(screenshotDevice);
+    if (!waitForHomeReady(homeReadyBaseline, isIpad ? 90 : 45)) {
+      if (isIpad) {
+        // iPad: re-launch PLAINLY — never `openurl`. The "Open in 'Boardsesh'?" confirm
+        // that an openurl raises is never dismissed on iPad (the URL isn't delivered to
+        // the app), and it then blocks the entire sidebar-tap flow. A fresh launch just
+        // re-triggers the dev-client's auto-connect + auto-sign-in, no dialog.
+        console.log(`${LOG} Plain launch did not reach home; terminating and re-launching (iPad, no openurl)...`);
+        runCapture('xcrun', ['simctl', 'terminate', device.udid, APP_ID]);
+        runCapture('xcrun', ['simctl', 'launch', device.udid, APP_ID]);
+      } else {
+        console.log(`${LOG} Plain launch did not reach home; retrying with the explicit dev-client URL...`);
+        runCapture('xcrun', ['simctl', 'openurl', device.udid, metroDevClientUrl()]);
+      }
     }
     if (!waitForHomeReady(homeReadyBaseline)) {
       console.error(`${LOG} FAILED: app did not reach the home screen (auto sign-in / bundle load).`);
+      dumpMetroLogTail();
       return 1;
     }
 
-    const sourceFlowFile = flowFileForPlatform(options, 'ios');
+    const sourceFlowFile = iosSourceFlowFile(options, screenshotDevice);
     if (!existsSync(sourceFlowFile)) {
       console.error(`${LOG} FAILED: flow not found: ${sourceFlowFile}`);
       return 1;
@@ -1105,16 +1182,40 @@ export function portInUse(port: number): boolean {
  * group; `CI=1` keeps expo non-interactive (no keypress menu / TTY expectations).
  */
 export function startMetro(env: NodeJS.ProcessEnv): ChildProcess {
-  // Pipe Metro's output through `tee` to METRO_LOG_PATH so waitForHomeReady can poll
-  // it for the app's "$screen /home" marker — the JS console logs land in Metro's
-  // stdout, NOT the device's unified log. `2>&1 | tee` keeps the output in the run
-  // log too; `tee` (no -a) truncates the file, so each run starts clean.
-  return spawn('sh', ['-c', `bunx expo start --port ${METRO_PORT} 2>&1 | tee ${METRO_LOG_PATH}`], {
+  // Write Metro's output straight to METRO_LOG_PATH via a shell redirect (NOT a
+  // `tee` into the orchestrator's inherited stdout). waitForHomeReady polls that
+  // file for the app's "$screen /home" marker — the JS console logs land in Metro's
+  // stdout, NOT the device's unified log. The old `2>&1 | tee` with `stdio:'inherit'`
+  // made this detached process share the runner's stdout, which throws
+  // ERR_STREAM_UNABLE_TO_PIPE when that stream hits backpressure/close and silently
+  // stalls the log file mid-run — so the marker never lands and the slower-booting
+  // iPad shards time out at "did not reach the home screen". `> FILE 2>&1` (no `-a`,
+  // so it truncates for a clean run) plus `stdio:'ignore'` keeps the child off the
+  // parent's fds. Trade-off: Metro no longer streams into the live CI run log —
+  // dumpMetroLogTail surfaces it on a reach-home failure instead.
+  return spawn('sh', ['-c', `bunx expo start --port ${METRO_PORT} > ${METRO_LOG_PATH} 2>&1`], {
     cwd: MOBILE_DIR,
     env: { ...env, CI: '1' },
-    stdio: 'inherit',
+    stdio: 'ignore',
     detached: true,
   });
+}
+
+/**
+ * Dump the tail of the Metro log to the run output. Metro no longer streams into
+ * the live CI log (see startMetro), so on a reach-home failure this is how the
+ * app-side console output (auth errors, a redbox, a missing `$screen /home`) is
+ * surfaced for debugging.
+ */
+function dumpMetroLogTail(lines = 80): void {
+  if (!existsSync(METRO_LOG_PATH)) {
+    console.error(`${LOG} (no Metro log at ${METRO_LOG_PATH} to dump)`);
+    return;
+  }
+  const tail = readFileSync(METRO_LOG_PATH, 'utf8').split('\n').slice(-lines).join('\n');
+  console.error(
+    `${LOG} --- last ${lines} lines of Metro log (${METRO_LOG_PATH}) ---\n${tail}\n${LOG} --- end Metro log ---`,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

2.2 is the first release to ship iPad, so we need iPad App Store screenshots — but they've **never captured in CI**. This makes them work. Two iPad-specific root causes:

**1. iPad shards timed out at reach-home.** `startMetro` tee'd Metro's stdout through the orchestrator's inherited stdio, which throws `ERR_STREAM_UNABLE_TO_PIPE` under backpressure and silently stalls the log file — so the `$screen /home` readiness marker never landed and every (slower-booting) iPad shard failed. Now Metro writes straight to the log file via a shell redirect (`> FILE 2>&1`, `stdio: 'ignore'`), with a log-tail dump on failure. The iPad plain launch also gets more time, and its retry is a plain **re-launch** — never `openurl` (which pops the dialog below).

**2. Deep links don't navigate on the iPad simulator.** Every `openurl com.boardsesh.app://…` pops the "Open in Boardsesh?" scheme-confirm dialog and the URL is never delivered to the app's router. Verified: an all-deep-link iPad run produced **11 byte-identical "stuck on home + dialog" frames**, while the same flow on iPhone navigated 10 distinct screens (iPhone remembers the confirm; iPad doesn't).

**Fix:** a dedicated **`app-store-ipad.yaml`** that navigates the persistent left sidebar via coordinate taps — no `openurl`, no dialog. The orchestrator selects it for iPad devices (`iosSourceFlowFile`); iPhone keeps the deep-link flow unchanged. The sidebar sits at fixed logical points but Maestro taps are a screen percentage, and the 13"/11" iPad differ in landscape height — so each `${TAP_*}` point is computed per device from its logical anchor and pixel height (rounded; Maestro rejects decimal percentages).

Captures the **On the Wall kiosk** (lit-board hero) + home, climbs, workout, discover, profile. **Verified locally on both the 13" and 11" iPad** — all 6 shots distinct and correct, kiosk lit ("Moon Landing" V3). Depends on the wall seed from #3476/#3477.

## Release Notes

- [x] No release note needed (internal / tooling change)

## Test plan

- `vp test run mobile-screenshots.test` — 39 pass, incl. `iosSourceFlowFile` routing + per-device `${TAP_*}` computation (14% on 13" vs 17% on 11%, etc.).
- `vp check` — clean.
- Local capture on **iPad Pro 13" (M5)** and **iPad Pro 11" (M5)**: 6 distinct shots each, kiosk renders the lit board.

## After merge
Re-run `mobile-screenshots-ios` (upload: true) — the iPad shards should now produce the full set and upload to the 2.2 App Store version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KV6NHZAQUPLz5EigLLd7p