### PR TITLE
fix(mobile): fall back to bundle-done when the screenshot reach-home marker is lost

### DIFF
--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -10,6 +10,8 @@ import {
   iosSourceFlowFile,
   ipadSidebarTapPoint,
   isIpadScreenshotDevice,
+  METRO_LOG_PATH,
+  metroBundleFinished,
   metroDevClientUrl,
   parseArgs,
   renderMaestroFlowForIosDevice,
@@ -348,6 +350,23 @@ describe('renderMaestroFlowForIosDevice', () => {
     expect(ipadFlow).toContain('point: ${TAP_WALL}');
     // No literal "N%,M%" tap points — those wouldn't transfer between iPad sizes.
     expect(ipadFlow).not.toMatch(/point:\s*'?\d/);
+  });
+});
+
+describe('metroBundleFinished', () => {
+  afterEach(() => {
+    rmSync(METRO_LOG_PATH, { force: true });
+  });
+
+  it('is false without a log and true once Metro logs a completed bundle', () => {
+    rmSync(METRO_LOG_PATH, { force: true });
+    expect(metroBundleFinished()).toBe(false);
+
+    writeFileSync(METRO_LOG_PATH, 'Starting Metro Bundler\nWaiting on http://localhost:8081\n');
+    expect(metroBundleFinished()).toBe(false);
+
+    writeFileSync(METRO_LOG_PATH, 'iOS Bundled 31912ms node_modules/.../entry.js (4662 modules)\n');
+    expect(metroBundleFinished()).toBe(true);
   });
 });
 

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -805,9 +805,22 @@ function captureIosDevice(
       }
     }
     if (!waitForHomeReady(homeReadyBaseline)) {
-      console.error(`${LOG} FAILED: app did not reach the home screen (auto sign-in / bundle load).`);
-      dumpMetroLogTail();
-      return 1;
+      // The readiness marker never landed. If Metro finished the JS bundle, the app
+      // has had the full timeout to auto-sign-in and reach home — the missing marker
+      // is almost always Metro's log-forwarding pipe dying with
+      // ERR_STREAM_UNABLE_TO_PIPE, not the app failing to boot. Proceed instead of
+      // failing the shard (a genuinely stuck app is caught downstream when the flow's
+      // deep links / taps land on a blank screen). If the bundle never even finished,
+      // this is a real failure.
+      if (metroBundleFinished()) {
+        console.warn(
+          `${LOG} Home marker not seen, but Metro finished the bundle — proceeding (Metro log forwarding likely broke; the app auto-signs-in and reaches home).`,
+        );
+      } else {
+        console.error(`${LOG} FAILED: app did not reach the home screen (auto sign-in / bundle load).`);
+        dumpMetroLogTail();
+        return 1;
+      }
     }
 
     const sourceFlowFile = iosSourceFlowFile(options, screenshotDevice);
@@ -1221,6 +1234,20 @@ function dumpMetroLogTail(lines = 80): void {
   console.error(
     `${LOG} --- last ${lines} lines of Metro log (${METRO_LOG_PATH}) ---\n${tail}\n${LOG} --- end Metro log ---`,
   );
+}
+
+/**
+ * Whether Metro logged a completed JS bundle for the app (`… Bundled 12345ms …`).
+ * The `$screen /home` readiness marker rides Metro's forwarding of the app's
+ * console.log to Metro stdout, which intermittently dies mid-run with
+ * `ERR_STREAM_UNABLE_TO_PIPE` — after which no further app logs (including the
+ * marker) are captured, even though the screenshot build still auto-signs-in and
+ * reaches home. The "Bundled" line lands BEFORE that break, so it's a reliable
+ * signal that the JS loaded and home is imminent — the reach-home fallback.
+ */
+export function metroBundleFinished(): boolean {
+  const metroLog = existsSync(METRO_LOG_PATH) ? readFileSync(METRO_LOG_PATH, 'utf8') : '';
+  return /Bundled \d+ms/.test(metroLog);
 }
 
 /**


### PR DESCRIPTION
## Summary

Third and final robustness fix for the iOS screenshot capture (follows #3484, #3485). Even with the log now line-buffered (#3485), the upload run still flaked ~2 shards per run — iPhone and iPad alike.

Root cause (now visible in the log dump): **`ERR_STREAM_UNABLE_TO_PIPE` is Metro's own error**, thrown after the bundle finishes when its log-forwarding pipe breaks. Once it fires, no further app console.logs are captured — so the `$screen /home` marker never lands and the shard fails at "did not reach the home screen", **even though the screenshot build did auto-sign-in and reach home**.

Fix: the `… Bundled 12345ms …` line lands *before* the pipe breaks, so it's a reliable "JS loaded" signal. When the marker times out but the bundle finished (and the app has had the full reach-home window to sign in + render), **proceed** instead of failing the shard. A genuinely stuck app is still caught downstream when the flow's taps/links hit a blank screen; a bundle that never finished stays a hard failure.

## Release Notes

- [x] No release note needed (internal / tooling change)

## Test plan
- `vp test run mobile-screenshots.test` — 40 pass, incl. a new `metroBundleFinished` case.
- `vp check` — clean.

## After merge
Re-run `mobile-screenshots-ios` (upload: true) — shards should stop flaking on the Metro log-forwarding race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KV6NHZAQUPLz5EigLLd7p