### PR TITLE
feat: add GLEDOPTO GL-C-015WL-D firmware variant for the Kilter LED string

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -26,6 +26,8 @@ jobs:
             name: waveshare-7inch
           - env: esp32dev
             name: esp32-legacy
+          - env: gledopto-c015
+            name: gledopto-c015
 
     steps:
       - name: Checkout repository
@@ -104,6 +106,7 @@ jobs:
           | firmware-tdisplay-s3.bin | LilyGo T-Display S3 |
           | firmware-waveshare-7inch.bin | Waveshare 7" touch display |
           | firmware-esp32-legacy.bin | Legacy ESP32 |
+          | firmware-gledopto-c015.bin | GLEDOPTO GL-C-015WL-D (WLED-style ESP32) |
 
           ### How to Flash via OTA
           1. Download the .bin file matching your hardware

--- a/embedded/README.md
+++ b/embedded/README.md
@@ -108,12 +108,14 @@ party-mode GraphQL, then lights the string.
   group 1 — order is `V+ | IO16 | GND`). This is GPIO16, which the firmware drives.
 - **Power**: the strip's V+/GND can run off the controller's output terminals
   (rated 10 A per channel / 15 A total). The output `V+` is **gated behind a
-  high-side MOSFET on GPIO12** (WLED's "Relay GPIO 12"); the firmware drives it
-  high at boot (`-D LED_POWER_ENABLE_PIN=12`), so the terminal carries the input
-  voltage once the controller has started. Older firmware builds never drove
-  GPIO12 and the output `V+` read ~0 V — reflash if you see that. For strings
-  that draw more than the terminal rating, run V+/GND straight from the PSU to
-  the strip instead.
+  high-side MOSFET on GPIO18** (active high — found by a pin sweep on real
+  hardware; GLEDOPTO's manual documents GPIO12 for other revisions of the
+  family). The firmware drives both high at boot (`-D LED_POWER_ENABLE_PIN=18`,
+  `-D LED_POWER_ENABLE_PIN_2=12`), so the terminal carries the input voltage
+  once the controller has started. Older firmware builds never drove the enable
+  pin and the output `V+` read ~0 V — reflash if you see that. For strings that
+  draw more than the terminal rating, run V+/GND straight from the PSU to the
+  strip instead.
 - **Tie all grounds common** — PSU `−` ↔ controller `GND` ↔ strip `GND`. The data
   line needs a shared ground reference or nothing lights, even with power present.
   (Automatic when the strip is powered from the controller's own terminals.)

--- a/embedded/README.md
+++ b/embedded/README.md
@@ -106,13 +106,17 @@ party-mode GraphQL, then lights the string.
 
 - **Data** → the controller's **`IO16`** output terminal (the middle pin of output
   group 1 — order is `V+ | IO16 | GND`). This is GPIO16, which the firmware drives.
-- **Power the strip's V+/GND directly from the LED power supply** — at the strip's
-  own voltage (this string is 12 V). ⚠️ **Do NOT rely on the controller's output
-  `V+` terminal**: on this board the barrel/input V+ reads a correct 12 V but the
-  output `V+` stays dead (~0 V — it's gated behind an enable/relay pin the firmware
-  doesn't drive). Run V+/GND straight from the PSU to the strip.
+- **Power**: the strip's V+/GND can run off the controller's output terminals
+  (rated 10 A per channel / 15 A total). The output `V+` is **gated behind a
+  high-side MOSFET on GPIO12** (WLED's "Relay GPIO 12"); the firmware drives it
+  high at boot (`-D LED_POWER_ENABLE_PIN=12`), so the terminal carries the input
+  voltage once the controller has started. Older firmware builds never drove
+  GPIO12 and the output `V+` read ~0 V — reflash if you see that. For strings
+  that draw more than the terminal rating, run V+/GND straight from the PSU to
+  the strip instead.
 - **Tie all grounds common** — PSU `−` ↔ controller `GND` ↔ strip `GND`. The data
   line needs a shared ground reference or nothing lights, even with power present.
+  (Automatic when the strip is powered from the controller's own terminals.)
 - USB-C powers only the ESP32 (flashing/serial); it never powers the LED rail.
 
 **Chipset / color order** are build flags, defaulting to `WS2811` / `RGB` (both

--- a/embedded/README.md
+++ b/embedded/README.md
@@ -87,6 +87,44 @@ Main firmware for controlling Kilter/Tension climbing board LEDs. Features:
 - **GraphQL-WS Client**: Real-time sync with Boardsesh backend
 - **Web Config**: HTTP server for WiFi and device setup
 
+#### Build variants
+
+`board-controller` builds for several boards via PlatformIO envs (see
+`projects/board-controller/platformio.ini`): `esp32s3dev` (default),
+`esp32s3dev-proxy`, `tdisplay-s3`, `waveshare-7inch`, `waveshare-amoled-216`,
+`esp32dev` (legacy), and **`gledopto-c015`** (below).
+
+#### GLEDOPTO GL-C-015WL-D variant
+
+`gledopto-c015` targets the [GLEDOPTO GL-C-015WL-D](https://gledopto.com/h-pd-125.html) —
+a cheap WLED-style controller (classic ESP32, 4 MB flash, DC 5–24 V in) used as a
+standalone LED driver for a Kilter board. No display, no proxy; it decodes climbs
+over BLE (the board appears to the Kilter app as `Kilter Board#123456@3`) and via
+party-mode GraphQL, then lights the string.
+
+**Wiring** (Setter-Closet-style WS2811 pixel-node string — 3 wires: V+/GND/data):
+
+- Data → **GPIO16** (the controller's primary "D1" output).
+- V+ / GND → the controller's LED power output (the Kilter string is 5 V).
+
+**Chipset / color order** are build flags, defaulting to `WS2811` / `GRB`. They're
+consumed by `libs/led-controller/src/led_controller.cpp`. If the first flash looks
+wrong, adjust in `platformio.ini`:
+
+- Colors swapped (red shows as green/blue) → `-D LED_COLOR_ORDER=RGB`.
+- Nothing lights at all → `-D GLEDOPTO_LED_PIN=2` (the "D2" output).
+- Flicker / wrong pixels → `-D LED_CHIPSET=WS2812B`.
+- String length → `-D NUM_LEDS=<n>` (default 200, max 500).
+
+**Build & flash** (over the controller's USB/UART download port):
+
+```bash
+cd embedded/projects/board-controller
+pio run -e gledopto-c015              # build
+pio run -e gledopto-c015 -t upload   # flash
+pio device monitor                   # serial (confirms "LED_PIN = 16" + startup blink)
+```
+
 ### moonboard-dev-server
 
 Development firmware for MoonBoard BLE decoding and browser-based previewing. Features:

--- a/embedded/README.md
+++ b/embedded/README.md
@@ -102,19 +102,33 @@ standalone LED driver for a Kilter board. No display, no proxy; it decodes climb
 over BLE (the board appears to the Kilter app as `Kilter Board#123456@3`) and via
 party-mode GraphQL, then lights the string.
 
-**Wiring** (Setter-Closet-style WS2811 pixel-node string — 3 wires: V+/GND/data):
+**Wiring** (verified with a 12 V WS2811 pixel string; 3 wires: V+/GND/data):
 
-- Data → **GPIO16** (the controller's primary "D1" output).
-- V+ / GND → the controller's LED power output (the Kilter string is 5 V).
+- **Data** → the controller's **`IO16`** output terminal (the middle pin of output
+  group 1 — order is `V+ | IO16 | GND`). This is GPIO16, which the firmware drives.
+- **Power the strip's V+/GND directly from the LED power supply** — at the strip's
+  own voltage (this string is 12 V). ⚠️ **Do NOT rely on the controller's output
+  `V+` terminal**: on this board the barrel/input V+ reads a correct 12 V but the
+  output `V+` stays dead (~0 V — it's gated behind an enable/relay pin the firmware
+  doesn't drive). Run V+/GND straight from the PSU to the strip.
+- **Tie all grounds common** — PSU `−` ↔ controller `GND` ↔ strip `GND`. The data
+  line needs a shared ground reference or nothing lights, even with power present.
+- USB-C powers only the ESP32 (flashing/serial); it never powers the LED rail.
 
-**Chipset / color order** are build flags, defaulting to `WS2811` / `GRB`. They're
-consumed by `libs/led-controller/src/led_controller.cpp`. If the first flash looks
-wrong, adjust in `platformio.ini`:
+**Chipset / color order** are build flags, defaulting to `WS2811` / `RGB` (both
+verified on the Setter-Closet 12 V string). They're consumed by
+`libs/led-controller/src/led_controller.cpp`. If a different string looks wrong,
+adjust in `platformio.ini`:
 
-- Colors swapped (red shows as green/blue) → `-D LED_COLOR_ORDER=RGB`.
-- Nothing lights at all → `-D GLEDOPTO_LED_PIN=2` (the "D2" output).
+- Red/green swapped → `-D LED_COLOR_ORDER=GRB`.
+- Nothing lights (and power/ground are confirmed good) → try `-D GLEDOPTO_LED_PIN=2`
+  (the "D2"/`IO2` output).
 - Flicker / wrong pixels → `-D LED_CHIPSET=WS2812B`.
 - String length → `-D NUM_LEDS=<n>` (default 200, max 500).
+
+**Bench-supply tip:** if the supply reads its set voltage at the input but the LEDs
+are dead, check the current limit isn't clamped near 0 A (that collapses the output
+to ~0.2 V), and that barrel polarity is center-positive.
 
 **Build & flash** (over the controller's USB/UART download port):
 

--- a/embedded/libs/graphql-ws-client/src/graphql_ws_client.cpp
+++ b/embedded/libs/graphql-ws-client/src/graphql_ws_client.cpp
@@ -395,7 +395,11 @@ void GraphQLWSClient::handleLedUpdate(JsonObject& data) {
         }
     }
 
-    // Always render LEDs (it's imperceptible to users)
+    // Each LedUpdate carries the FULL LED state for a climb, so clear the
+    // previous climb before applying the new one (same contract as the BLE
+    // path in nordic_uart_ble.cpp). Without this, switching climbs from the
+    // web queue accumulates holds from the previous climb on the strip.
+    LEDs.clear();
     LEDs.setLeds(ledCommands, count);
     LEDs.show();
 

--- a/embedded/libs/led-controller/src/led_controller.cpp
+++ b/embedded/libs/led-controller/src/led_controller.cpp
@@ -1,5 +1,28 @@
 #include "led_controller.h"
 
+// FastLED needs the chipset, data pin, and color order as compile-time tokens,
+// so they are resolved from build flags here rather than passed at runtime.
+// Defaults match the original Aurora/Kilter wiring; per-board build variants
+// override them (e.g. the GLEDOPTO GL-C-015WL-D drives WS2811 nodes on GPIO16).
+#ifndef LED_CHIPSET
+#define LED_CHIPSET WS2812B
+#endif
+#ifndef LED_COLOR_ORDER
+#define LED_COLOR_ORDER GRB
+#endif
+
+#if defined(TDISPLAY_LED_PIN)
+#define LED_DATA_PIN TDISPLAY_LED_PIN
+#elif defined(WAVESHARE_LED_PIN)
+#define LED_DATA_PIN WAVESHARE_LED_PIN
+#elif defined(WAVESHARE_AMOLED_LED_PIN)
+#define LED_DATA_PIN WAVESHARE_AMOLED_LED_PIN
+#elif defined(GLEDOPTO_LED_PIN)
+#define LED_DATA_PIN GLEDOPTO_LED_PIN
+#else
+#define LED_DATA_PIN 5
+#endif
+
 LedController LEDs;
 
 LedController::LedController() : numLeds(0), brightness(128), initialized(false) {
@@ -9,15 +32,11 @@ LedController::LedController() : numLeds(0), brightness(128), initialized(false)
 void LedController::begin(uint8_t pin, uint16_t count) {
     numLeds = min(count, (uint16_t)MAX_LEDS);
 
-    // FastLED.addLeds requires compile-time pin constant
-    // Use conditional compilation for different board configurations
-#ifdef TDISPLAY_LED_PIN
-    // T-Display-S3: Use GPIO 43 (avoids LCD_RST on GPIO 5)
-    FastLED.addLeds<WS2812B, TDISPLAY_LED_PIN, GRB>(leds, numLeds);
-#else
-    // Default: Use GPIO 5
-    FastLED.addLeds<WS2812B, 5, GRB>(leds, numLeds);
-#endif
+    // FastLED.addLeds requires compile-time constants; chipset, pin, and color
+    // order are resolved from build flags at the top of this file. The runtime
+    // `pin` argument is retained for API compatibility but does not select the
+    // pin (FastLED templates it).
+    FastLED.addLeds<LED_CHIPSET, LED_DATA_PIN, LED_COLOR_ORDER>(leds, numLeds);
 
     FastLED.setBrightness(brightness);
 

--- a/embedded/libs/led-controller/src/led_controller.cpp
+++ b/embedded/libs/led-controller/src/led_controller.cpp
@@ -17,6 +17,10 @@ void LedController::begin(uint16_t count) {
     pinMode(LED_POWER_ENABLE_PIN, OUTPUT);
     digitalWrite(LED_POWER_ENABLE_PIN, HIGH);
 #endif
+#ifdef LED_POWER_ENABLE_PIN_2
+    pinMode(LED_POWER_ENABLE_PIN_2, OUTPUT);
+    digitalWrite(LED_POWER_ENABLE_PIN_2, HIGH);
+#endif
 
     // FastLED.addLeds requires compile-time constants; chipset, pin, and color
     // order are resolved from build flags in led_controller.h.

--- a/embedded/libs/led-controller/src/led_controller.cpp
+++ b/embedded/libs/led-controller/src/led_controller.cpp
@@ -9,7 +9,7 @@ LedController::LedController() : numLeds(0), brightness(128), initialized(false)
     memset(leds, 0, sizeof(leds));
 }
 
-void LedController::begin(uint8_t pin, uint16_t count) {
+void LedController::begin(uint16_t count) {
     numLeds = min(count, (uint16_t)MAX_LEDS);
 
 #ifdef LED_POWER_ENABLE_PIN
@@ -19,9 +19,7 @@ void LedController::begin(uint8_t pin, uint16_t count) {
 #endif
 
     // FastLED.addLeds requires compile-time constants; chipset, pin, and color
-    // order are resolved from build flags at the top of this file. The runtime
-    // `pin` argument is retained for API compatibility but does not select the
-    // pin (FastLED templates it).
+    // order are resolved from build flags in led_controller.h.
     FastLED.addLeds<LED_CHIPSET, LED_DATA_PIN, LED_COLOR_ORDER>(leds, numLeds);
 
     FastLED.setBrightness(brightness);

--- a/embedded/libs/led-controller/src/led_controller.cpp
+++ b/embedded/libs/led-controller/src/led_controller.cpp
@@ -12,6 +12,12 @@ LedController::LedController() : numLeds(0), brightness(128), initialized(false)
 void LedController::begin(uint8_t pin, uint16_t count) {
     numLeds = min(count, (uint16_t)MAX_LEDS);
 
+#ifdef LED_POWER_ENABLE_PIN
+    // Energize the gated LED output V+ terminal (see led_controller.h).
+    pinMode(LED_POWER_ENABLE_PIN, OUTPUT);
+    digitalWrite(LED_POWER_ENABLE_PIN, HIGH);
+#endif
+
     // FastLED.addLeds requires compile-time constants; chipset, pin, and color
     // order are resolved from build flags at the top of this file. The runtime
     // `pin` argument is retained for API compatibility but does not select the

--- a/embedded/libs/led-controller/src/led_controller.cpp
+++ b/embedded/libs/led-controller/src/led_controller.cpp
@@ -1,27 +1,7 @@
 #include "led_controller.h"
 
-// FastLED needs the chipset, data pin, and color order as compile-time tokens,
-// so they are resolved from build flags here rather than passed at runtime.
-// Defaults match the original Aurora/Kilter wiring; per-board build variants
-// override them (e.g. the GLEDOPTO GL-C-015WL-D drives WS2811 nodes on GPIO16).
-#ifndef LED_CHIPSET
-#define LED_CHIPSET WS2812B
-#endif
-#ifndef LED_COLOR_ORDER
-#define LED_COLOR_ORDER GRB
-#endif
-
-#if defined(TDISPLAY_LED_PIN)
-#define LED_DATA_PIN TDISPLAY_LED_PIN
-#elif defined(WAVESHARE_LED_PIN)
-#define LED_DATA_PIN WAVESHARE_LED_PIN
-#elif defined(WAVESHARE_AMOLED_LED_PIN)
-#define LED_DATA_PIN WAVESHARE_AMOLED_LED_PIN
-#elif defined(GLEDOPTO_LED_PIN)
-#define LED_DATA_PIN GLEDOPTO_LED_PIN
-#else
-#define LED_DATA_PIN 5
-#endif
+// LED_CHIPSET / LED_DATA_PIN / LED_COLOR_ORDER are resolved from build flags in
+// led_controller.h (the single source of truth).
 
 LedController LEDs;
 

--- a/embedded/libs/led-controller/src/led_controller.h
+++ b/embedded/libs/led-controller/src/led_controller.h
@@ -7,9 +7,9 @@
 // LED hardware configuration — the single source of truth, resolved from build
 // flags at compile time. FastLED needs chipset, data pin, and color order as
 // compile-time tokens, so they live here: led_controller.cpp's addLeds<> call
-// consumes them, and the project's board_config.h aliases LED_PIN/LED_TYPE/
-// COLOR_ORDER to them for logging and declarative config. Override per board
-// variant with -D LED_CHIPSET / -D LED_COLOR_ORDER / a *_LED_PIN flag.
+// consumes them, and consumers (e.g. main.cpp logging) include this header and
+// read LED_DATA_PIN directly. Override per board variant with -D LED_CHIPSET /
+// -D LED_COLOR_ORDER / a *_LED_PIN flag.
 #ifndef LED_CHIPSET
 #define LED_CHIPSET WS2812B
 #endif

--- a/embedded/libs/led-controller/src/led_controller.h
+++ b/embedded/libs/led-controller/src/led_controller.h
@@ -67,7 +67,9 @@ class LedController {
   public:
     LedController();
 
-    void begin(uint8_t pin, uint16_t numLeds);
+    // The data pin is the compile-time LED_DATA_PIN (FastLED templates it);
+    // begin() only takes the strip length.
+    void begin(uint16_t numLeds);
 
     void setLed(int index, CRGB color);
     void setLed(int index, uint8_t r, uint8_t g, uint8_t b);

--- a/embedded/libs/led-controller/src/led_controller.h
+++ b/embedded/libs/led-controller/src/led_controller.h
@@ -29,6 +29,15 @@
 #define LED_DATA_PIN 5
 #endif
 
+// Some WLED-style controllers gate the LED output V+ terminal behind a
+// high-side MOSFET "relay" on a GPIO (WLED's "Relay GPIO"). Define
+// LED_POWER_ENABLE_PIN to drive that pin HIGH in begin() so the output
+// terminal is energized; without it the strip's V+ terminal stays at ~0V.
+// On the GLEDOPTO GL-C-015WL-D/016WL-D this is GPIO12 (active high, per the
+// official manual's "Relay GPIO 12, uncheck Invert"). GPIO12 is the ESP32
+// MTDI strapping pin, so it must only be driven high AFTER boot — begin()
+// runs from setup(), which is safe; never strap it high in hardware.
+
 #define MAX_LEDS 500
 
 /**

--- a/embedded/libs/led-controller/src/led_controller.h
+++ b/embedded/libs/led-controller/src/led_controller.h
@@ -31,12 +31,14 @@
 
 // Some WLED-style controllers gate the LED output V+ terminal behind a
 // high-side MOSFET "relay" on a GPIO (WLED's "Relay GPIO"). Define
-// LED_POWER_ENABLE_PIN to drive that pin HIGH in begin() so the output
-// terminal is energized; without it the strip's V+ terminal stays at ~0V.
-// On the GLEDOPTO GL-C-015WL-D/016WL-D this is GPIO12 (active high, per the
-// official manual's "Relay GPIO 12, uncheck Invert"). GPIO12 is the ESP32
-// MTDI strapping pin, so it must only be driven high AFTER boot — begin()
-// runs from setup(), which is safe; never strap it high in hardware.
+// LED_POWER_ENABLE_PIN (and optionally LED_POWER_ENABLE_PIN_2) to drive the
+// pin(s) HIGH in begin() so the output terminal is energized; without it the
+// strip's V+ terminal stays at ~0V. On the GLEDOPTO GL-C-015WL-D the enable
+// pin is GPIO18 (active high — verified with a pin sweep on real hardware);
+// GLEDOPTO's manual documents GPIO12 for other revisions of the family, so
+// the gledopto env drives both. GPIO12 is the ESP32 MTDI strapping pin, so
+// it must only be driven high AFTER boot — begin() runs from setup(), which
+// is safe; never strap it high in hardware.
 
 #define MAX_LEDS 500
 

--- a/embedded/libs/led-controller/src/led_controller.h
+++ b/embedded/libs/led-controller/src/led_controller.h
@@ -4,6 +4,31 @@
 #include <Arduino.h>
 #include <FastLED.h>
 
+// LED hardware configuration — the single source of truth, resolved from build
+// flags at compile time. FastLED needs chipset, data pin, and color order as
+// compile-time tokens, so they live here: led_controller.cpp's addLeds<> call
+// consumes them, and the project's board_config.h aliases LED_PIN/LED_TYPE/
+// COLOR_ORDER to them for logging and declarative config. Override per board
+// variant with -D LED_CHIPSET / -D LED_COLOR_ORDER / a *_LED_PIN flag.
+#ifndef LED_CHIPSET
+#define LED_CHIPSET WS2812B
+#endif
+#ifndef LED_COLOR_ORDER
+#define LED_COLOR_ORDER GRB
+#endif
+
+#if defined(TDISPLAY_LED_PIN)
+#define LED_DATA_PIN TDISPLAY_LED_PIN
+#elif defined(WAVESHARE_LED_PIN)
+#define LED_DATA_PIN WAVESHARE_LED_PIN
+#elif defined(WAVESHARE_AMOLED_LED_PIN)
+#define LED_DATA_PIN WAVESHARE_AMOLED_LED_PIN
+#elif defined(GLEDOPTO_LED_PIN)
+#define LED_DATA_PIN GLEDOPTO_LED_PIN
+#else
+#define LED_DATA_PIN 5
+#endif
+
 #define MAX_LEDS 500
 
 /**

--- a/embedded/libs/nordic-uart-ble/src/nordic_uart_ble.cpp
+++ b/embedded/libs/nordic-uart-ble/src/nordic_uart_ble.cpp
@@ -219,10 +219,11 @@ void NordicUartBLE::onWrite(NimBLECharacteristic* characteristic, NimBLEConnInfo
         LEDs.clear();
         if (commands.size() > 0) {
             LEDs.setLeds(commands.data(), commands.size());
+            Logger.logln("BLE: Updated %zu LEDs from Bluetooth", commands.size());
+        } else {
+            Logger.logln("BLE: Cleared board from Bluetooth");
         }
         LEDs.show();
-
-        Logger.logln("BLE: Updated %zu LEDs from Bluetooth", commands.size());
 
         // If callback is set, forward to backend
         if (ledDataCallback && commands.size() > 0) {

--- a/embedded/libs/nordic-uart-ble/src/nordic_uart_ble.cpp
+++ b/embedded/libs/nordic-uart-ble/src/nordic_uart_ble.cpp
@@ -225,7 +225,9 @@ void NordicUartBLE::onWrite(NimBLECharacteristic* characteristic, NimBLEConnInfo
         }
         LEDs.show();
 
-        // If callback is set, forward to backend
+        // Forward to the backend only for non-empty climbs: the callback's job
+        // is climb matching, and an empty clear-board frame has nothing to
+        // match (the backend has no clear event to publish either).
         if (ledDataCallback && commands.size() > 0) {
             ledDataCallback(commands.data(), commands.size(), protocol.getAngle());
         }

--- a/embedded/libs/nordic-uart-ble/src/nordic_uart_ble.cpp
+++ b/embedded/libs/nordic-uart-ble/src/nordic_uart_ble.cpp
@@ -209,20 +209,24 @@ void NordicUartBLE::onWrite(NimBLECharacteristic* characteristic, NimBLEConnInfo
     bool complete = protocol.processPacket((const uint8_t*)value.data(), value.length());
 
     if (complete) {
-        // Get decoded LED commands
+        // Each complete Aurora frame is the FULL LED state for a climb, so clear
+        // the previous climb before applying the new one. Without this, swiping
+        // between climbs accumulates LEDs on the strip and they never turn off.
+        // (An empty frame therefore clears the board, which is the correct
+        // behaviour for a "clear board" command.)
         const std::vector<LedCommand>& commands = protocol.getLedCommands();
 
+        LEDs.clear();
         if (commands.size() > 0) {
-            // Update LEDs directly
             LEDs.setLeds(commands.data(), commands.size());
-            LEDs.show();
+        }
+        LEDs.show();
 
-            Logger.logln("BLE: Updated %zu LEDs from Bluetooth", commands.size());
+        Logger.logln("BLE: Updated %zu LEDs from Bluetooth", commands.size());
 
-            // If callback is set, forward to backend
-            if (ledDataCallback) {
-                ledDataCallback(commands.data(), commands.size(), protocol.getAngle());
-            }
+        // If callback is set, forward to backend
+        if (ledDataCallback && commands.size() > 0) {
+            ledDataCallback(commands.data(), commands.size(), protocol.getAngle());
         }
     }
 

--- a/embedded/projects/board-controller/platformio.ini
+++ b/embedded/projects/board-controller/platformio.ini
@@ -241,6 +241,7 @@ build_flags =
     -D GLEDOPTO_LED_PIN=16
     ; WS2811 pixel nodes. Override to WS2812B or SK6812 if the string differs.
     -D LED_CHIPSET=WS2811
-    ; Verify on hardware; flip to RGB if red/green/blue come out swapped.
-    -D LED_COLOR_ORDER=GRB
+    ; RGB confirmed on hardware (Setter-Closet 12V WS2811 string). GRB shows
+    ; red/green swapped. Override to GRB if a different string needs it.
+    -D LED_COLOR_ORDER=RGB
     -D FIRMWARE_BUILD_ENV=\"gledopto-c015\"

--- a/embedded/projects/board-controller/platformio.ini
+++ b/embedded/projects/board-controller/platformio.ini
@@ -239,6 +239,11 @@ build_flags =
     ${env.build_flags}
     ; GL-C-015WL-D primary data output. Try 2 (the "D2" channel) if no output.
     -D GLEDOPTO_LED_PIN=16
+    ; The board gates the LED output V+ terminal behind a high-side MOSFET
+    ; ("Relay GPIO 12, uncheck Invert" in the GLEDOPTO manual). Drive it high
+    ; so the output terminal actually has power. Without this, output V+ reads
+    ; ~0V and the strip must be powered directly from the PSU.
+    -D LED_POWER_ENABLE_PIN=12
     ; WS2811 pixel nodes. Override to WS2812B or SK6812 if the string differs.
     -D LED_CHIPSET=WS2811
     ; RGB confirmed on hardware (Setter-Closet 12V WS2811 string). GRB shows

--- a/embedded/projects/board-controller/platformio.ini
+++ b/embedded/projects/board-controller/platformio.ini
@@ -222,3 +222,25 @@ board_build.partitions = min_spiffs.csv
 build_flags =
     ${env.build_flags}
     -D FIRMWARE_BUILD_ENV=\"esp32dev\"
+
+; ============================================
+; GLEDOPTO GL-C-015WL-D (classic ESP32, 4MB, WLED-style controller)
+; Standalone LED controller for a Kilter WS2811 pixel-node string.
+; Data output on GPIO16 (GL-C-015WL-D's primary "D1" channel).
+; Flash over the controller's USB/UART download port.
+; ============================================
+[env:gledopto-c015]
+board = esp32dev
+board_build.mcu = esp32
+board_build.f_cpu = 240000000L
+board_build.partitions = min_spiffs.csv
+
+build_flags =
+    ${env.build_flags}
+    ; GL-C-015WL-D primary data output. Try 2 (the "D2" channel) if no output.
+    -D GLEDOPTO_LED_PIN=16
+    ; WS2811 pixel nodes. Override to WS2812B or SK6812 if the string differs.
+    -D LED_CHIPSET=WS2811
+    ; Verify on hardware; flip to RGB if red/green/blue come out swapped.
+    -D LED_COLOR_ORDER=GRB
+    -D FIRMWARE_BUILD_ENV=\"gledopto-c015\"

--- a/embedded/projects/board-controller/platformio.ini
+++ b/embedded/projects/board-controller/platformio.ini
@@ -239,11 +239,13 @@ build_flags =
     ${env.build_flags}
     ; GL-C-015WL-D primary data output. Try 2 (the "D2" channel) if no output.
     -D GLEDOPTO_LED_PIN=16
-    ; The board gates the LED output V+ terminal behind a high-side MOSFET
-    ; ("Relay GPIO 12, uncheck Invert" in the GLEDOPTO manual). Drive it high
-    ; so the output terminal actually has power. Without this, output V+ reads
-    ; ~0V and the strip must be powered directly from the PSU.
-    -D LED_POWER_ENABLE_PIN=12
+    ; The board gates the LED output V+ terminal behind a high-side MOSFET.
+    ; Drive the enable pin high or output V+ reads ~0V and the strip must be
+    ; powered directly from the PSU. GPIO18 verified on real hardware via a
+    ; pin sweep (12V when high, ~0.6V when low); GPIO12 is what the GLEDOPTO
+    ; manual documents ("Relay GPIO 12") for other revisions — drive both.
+    -D LED_POWER_ENABLE_PIN=18
+    -D LED_POWER_ENABLE_PIN_2=12
     ; WS2811 pixel nodes. Override to WS2812B or SK6812 if the string differs.
     -D LED_CHIPSET=WS2811
     ; RGB confirmed on hardware (Setter-Closet 12V WS2811 string). GRB shows

--- a/embedded/projects/board-controller/src/config/board_config.h
+++ b/embedded/projects/board-controller/src/config/board_config.h
@@ -6,39 +6,17 @@
 // Device identification
 #define DEVICE_NAME "Boardsesh Controller"
 
-// LED configuration
-// Note: GPIO 5 conflicts with LCD_RST on T-Display-S3.
-// Use TDISPLAY_LED_PIN, WAVESHARE_LED_PIN, WAVESHARE_AMOLED_LED_PIN, or
-// GLEDOPTO_LED_PIN build flags to override the data pin per board variant.
-// Keep this cascade in sync with led_controller.cpp's LED_DATA_PIN cascade.
-#ifdef TDISPLAY_LED_PIN
-#define LED_PIN TDISPLAY_LED_PIN
-#elif defined(WAVESHARE_LED_PIN)
-#define LED_PIN WAVESHARE_LED_PIN
-#elif defined(WAVESHARE_AMOLED_LED_PIN)
-#define LED_PIN WAVESHARE_AMOLED_LED_PIN
-#elif defined(GLEDOPTO_LED_PIN)
-#define LED_PIN GLEDOPTO_LED_PIN
-#else
-#define LED_PIN 5  // GPIO pin for LED data (default for non-display builds)
-#endif
+// LED configuration.
+// The data pin, chipset, and color order are single-sourced from the
+// led-controller library (LED_DATA_PIN / LED_CHIPSET / LED_COLOR_ORDER in
+// led_controller.h, resolved from build flags per board variant — see the
+// *_LED_PIN / LED_CHIPSET / LED_COLOR_ORDER flags there). Consumers include
+// led_controller.h and read LED_DATA_PIN directly.
 
 // Number of LEDs on the string. Override per variant with -D NUM_LEDS=<n>.
 #ifndef NUM_LEDS
 #define NUM_LEDS 200
 #endif
-
-// LED chipset + color order. The actual FastLED driver in led_controller.cpp
-// consumes the LED_CHIPSET / LED_COLOR_ORDER build flags; these mirror them so
-// the declarative config and the driver stay in agreement.
-#ifndef LED_CHIPSET
-#define LED_CHIPSET WS2812B
-#endif
-#ifndef LED_COLOR_ORDER
-#define LED_COLOR_ORDER GRB
-#endif
-#define LED_TYPE LED_CHIPSET         // LED strip type
-#define COLOR_ORDER LED_COLOR_ORDER  // Color order
 
 // Default brightness (0-255)
 #define DEFAULT_BRIGHTNESS 128

--- a/embedded/projects/board-controller/src/config/board_config.h
+++ b/embedded/projects/board-controller/src/config/board_config.h
@@ -7,20 +7,38 @@
 #define DEVICE_NAME "Boardsesh Controller"
 
 // LED configuration
-// Note: GPIO 5 conflicts with LCD_RST on T-Display-S3
-// Use TDISPLAY_LED_PIN, WAVESHARE_LED_PIN, or WAVESHARE_AMOLED_LED_PIN build flag to override for display builds
+// Note: GPIO 5 conflicts with LCD_RST on T-Display-S3.
+// Use TDISPLAY_LED_PIN, WAVESHARE_LED_PIN, WAVESHARE_AMOLED_LED_PIN, or
+// GLEDOPTO_LED_PIN build flags to override the data pin per board variant.
+// Keep this cascade in sync with led_controller.cpp's LED_DATA_PIN cascade.
 #ifdef TDISPLAY_LED_PIN
 #define LED_PIN TDISPLAY_LED_PIN
 #elif defined(WAVESHARE_LED_PIN)
 #define LED_PIN WAVESHARE_LED_PIN
 #elif defined(WAVESHARE_AMOLED_LED_PIN)
 #define LED_PIN WAVESHARE_AMOLED_LED_PIN
+#elif defined(GLEDOPTO_LED_PIN)
+#define LED_PIN GLEDOPTO_LED_PIN
 #else
 #define LED_PIN 5  // GPIO pin for LED data (default for non-display builds)
 #endif
-#define NUM_LEDS 200      // Total number of LEDs
-#define LED_TYPE WS2812B  // LED strip type
-#define COLOR_ORDER GRB   // Color order
+
+// Number of LEDs on the string. Override per variant with -D NUM_LEDS=<n>.
+#ifndef NUM_LEDS
+#define NUM_LEDS 200
+#endif
+
+// LED chipset + color order. The actual FastLED driver in led_controller.cpp
+// consumes the LED_CHIPSET / LED_COLOR_ORDER build flags; these mirror them so
+// the declarative config and the driver stay in agreement.
+#ifndef LED_CHIPSET
+#define LED_CHIPSET WS2812B
+#endif
+#ifndef LED_COLOR_ORDER
+#define LED_COLOR_ORDER GRB
+#endif
+#define LED_TYPE LED_CHIPSET         // LED strip type
+#define COLOR_ORDER LED_COLOR_ORDER  // Color order
 
 // Default brightness (0-255)
 #define DEFAULT_BRIGHTNESS 128

--- a/embedded/projects/board-controller/src/main.cpp
+++ b/embedded/projects/board-controller/src/main.cpp
@@ -545,7 +545,7 @@ void setup() {
 
     // Initialize LEDs
     Logger.logln("Initializing LEDs on pin %d...", LED_DATA_PIN);
-    LEDs.begin(LED_DATA_PIN, NUM_LEDS);
+    LEDs.begin(NUM_LEDS);
     LEDs.setBrightness(Config.getInt("brightness", DEFAULT_BRIGHTNESS));
 
     // Startup animation (brief to confirm LEDs working)

--- a/embedded/projects/board-controller/src/main.cpp
+++ b/embedded/projects/board-controller/src/main.cpp
@@ -509,7 +509,7 @@ void setup() {
 
     Logger.logln("=================================");
     Logger.logln("%s v%s", DEVICE_NAME, FIRMWARE_VERSION);
-    Logger.logln("LED_PIN = %d", LED_PIN);
+    Logger.logln("LED_PIN = %d", LED_DATA_PIN);
 #ifdef ENABLE_BLE_PROXY
     Logger.logln("BLE Proxy: Enabled");
 #endif
@@ -544,8 +544,8 @@ void setup() {
 #endif
 
     // Initialize LEDs
-    Logger.logln("Initializing LEDs on pin %d...", LED_PIN);
-    LEDs.begin(LED_PIN, NUM_LEDS);
+    Logger.logln("Initializing LEDs on pin %d...", LED_DATA_PIN);
+    LEDs.begin(LED_DATA_PIN, NUM_LEDS);
     LEDs.setBrightness(Config.getInt("brightness", DEFAULT_BRIGHTNESS));
 
     // Startup animation (brief to confirm LEDs working)

--- a/embedded/projects/moonboard-dev-server/src/main.cpp
+++ b/embedded/projects/moonboard-dev-server/src/main.cpp
@@ -636,7 +636,7 @@ void setup() {
 
     Config.begin();
 
-    LEDs.begin(LED_PIN, NUM_LEDS);
+    LEDs.begin(NUM_LEDS);
     LEDs.setBrightness(Config.getInt("brightness", DEFAULT_BRIGHTNESS));
     LEDs.clear();
     LEDs.show();

--- a/embedded/test/lib/mocks/src/ArduinoJson.h
+++ b/embedded/test/lib/mocks/src/ArduinoJson.h
@@ -159,8 +159,8 @@ class JsonObject {
 
     JsonVariant& operator[](const char* key) {
         if (!variant_) {
-            nullVariant() = JsonVariant();
-            return nullVariant();
+            sharedNullSlot() = JsonVariant();
+            return sharedNullSlot();
         }
         variant_->objectVal_[key].parent_ = variant_;
         return variant_->objectVal_[key];
@@ -174,7 +174,7 @@ class JsonObject {
     // The slot is a single static shared by every null subscript: do NOT hold
     // the returned reference across another null-JsonObject access — the next
     // access resets it and the held reference silently aliases the new read.
-    static JsonVariant& nullVariant() {
+    static JsonVariant& sharedNullSlot() {
         static JsonVariant nullSlot;
         return nullSlot;
     }

--- a/embedded/test/lib/mocks/src/ArduinoJson.h
+++ b/embedded/test/lib/mocks/src/ArduinoJson.h
@@ -171,6 +171,9 @@ class JsonObject {
 
     // Fallback storage so operator[] on a null JsonObject still has something
     // to reference (reset on each access; mirrors reading a missing value).
+    // The slot is a single static shared by every null subscript: do NOT hold
+    // the returned reference across another null-JsonObject access — the next
+    // access resets it and the held reference silently aliases the new read.
     static JsonVariant& nullVariant() {
         static JsonVariant nullSlot;
         return nullSlot;

--- a/embedded/test/lib/mocks/src/ArduinoJson.h
+++ b/embedded/test/lib/mocks/src/ArduinoJson.h
@@ -120,8 +120,11 @@ class JsonVariant {
     }
     JsonVariant& operator=(const JsonDocument& doc);  // Forward declaration, defined after JsonDocument
 
-    // Object/Array accessors
-    JsonVariant operator[](const char* key);
+    // Object/Array accessors. The non-const key accessor returns a reference
+    // into the object map (like real ArduinoJson) so wrappers built from the
+    // result (JsonObject/JsonArray hold a pointer) stay valid while the
+    // document is alive.
+    JsonVariant& operator[](const char* key);
     JsonVariant operator[](int index);
     const JsonVariant operator[](const char* key) const;
     const JsonVariant operator[](int index) const;
@@ -154,15 +157,24 @@ class JsonObject {
             v->type_ = JsonVariant::TypeObject;
     }
 
-    JsonVariant operator[](const char* key) {
-        if (!variant_)
-            return JsonVariant();
+    JsonVariant& operator[](const char* key) {
+        if (!variant_) {
+            nullVariant() = JsonVariant();
+            return nullVariant();
+        }
         variant_->objectVal_[key].parent_ = variant_;
         return variant_->objectVal_[key];
     }
 
     bool isNull() const { return variant_ == nullptr; }
     operator bool() const { return variant_ != nullptr; }
+
+    // Fallback storage so operator[] on a null JsonObject still has something
+    // to reference (reset on each access; mirrors reading a missing value).
+    static JsonVariant& nullVariant() {
+        static JsonVariant nullSlot;
+        return nullSlot;
+    }
 
     // Iterator support for range-based for loops
     class iterator {
@@ -303,7 +315,7 @@ template <> inline JsonObject JsonVariant::add<JsonObject>() {
 }
 
 // JsonVariant implementations
-inline JsonVariant JsonVariant::operator[](const char* key) {
+inline JsonVariant& JsonVariant::operator[](const char* key) {
     if (type_ != TypeObject)
         type_ = TypeObject;
     objectVal_[key].parent_ = this;
@@ -342,7 +354,7 @@ class JsonDocument {
   public:
     JsonDocument() {}
 
-    JsonVariant operator[](const char* key) {
+    JsonVariant& operator[](const char* key) {
         root_.type_ = JsonVariant::TypeObject;
         root_.objectVal_[key].parent_ = &root_;
         return root_.objectVal_[key];

--- a/embedded/test/test_graphql_ws_client/test_graphql_ws_client.cpp
+++ b/embedded/test/test_graphql_ws_client/test_graphql_ws_client.cpp
@@ -10,6 +10,7 @@
 #include <WebSocketsClient.h>
 #include <cstring>
 #include <graphql_ws_client.h>
+#include <led_controller.h>
 #include <unity.h>
 
 // Access the global WebSocket mock through GraphQL client
@@ -137,6 +138,69 @@ void test_display_hash_unchanged_by_send(void) {
     client->sendLedPositions(commands, 2, 40);
 
     // Display hash should remain 0 since it's only updated from backend
+    TEST_ASSERT_EQUAL_UINT32(0, client->getCurrentDisplayHash());
+}
+
+// =============================================================================
+// LED Update Tests
+// =============================================================================
+
+// Append one LED command object to the update's "commands" array. Set fields
+// immediately per element (the mock's vector can reallocate on the next add).
+static void addLedCommand(JsonArray commands, int position, int r, int g, int b) {
+    JsonObject command = commands.add<JsonObject>();
+    command["position"] = position;
+    command["r"] = r;
+    command["g"] = g;
+    command["b"] = b;
+}
+
+// Regression test: each LedUpdate carries the FULL LED state for a climb, so
+// switching climbs from the web queue must clear the previous climb's holds
+// instead of accumulating them on the strip (same contract as the BLE path).
+void test_led_update_clears_previous_climb_leds(void) {
+    LEDs.begin(5, 50);
+    CRGB* strip = CFastLED::getLeds();
+    TEST_ASSERT_NOT_NULL(strip);
+
+    JsonDocument climbA;
+    JsonArray commandsA = climbA["commands"].to<JsonArray>();
+    addLedCommand(commandsA, 1, 255, 0, 0);
+    addLedCommand(commandsA, 2, 0, 255, 0);
+    JsonObject climbAData = climbA.as<JsonObject>();
+    client->handleLedUpdate(climbAData);
+
+    TEST_ASSERT_TRUE(strip[1] != CRGB(0, 0, 0));
+    TEST_ASSERT_TRUE(strip[2] != CRGB(0, 0, 0));
+    TEST_ASSERT_TRUE(client->getCurrentDisplayHash() != 0);
+
+    JsonDocument climbB;
+    JsonArray commandsB = climbB["commands"].to<JsonArray>();
+    addLedCommand(commandsB, 3, 0, 0, 255);
+    JsonObject climbBData = climbB.as<JsonObject>();
+    client->handleLedUpdate(climbBData);
+
+    TEST_ASSERT_TRUE(strip[3] != CRGB(0, 0, 0));
+    TEST_ASSERT_TRUE(strip[1] == CRGB(0, 0, 0));
+    TEST_ASSERT_TRUE(strip[2] == CRGB(0, 0, 0));
+}
+
+void test_led_update_without_commands_clears_all_leds(void) {
+    LEDs.begin(5, 50);
+    CRGB* strip = CFastLED::getLeds();
+
+    JsonDocument climb;
+    JsonArray commands = climb["commands"].to<JsonArray>();
+    addLedCommand(commands, 4, 255, 255, 255);
+    JsonObject climbData = climb.as<JsonObject>();
+    client->handleLedUpdate(climbData);
+    TEST_ASSERT_TRUE(strip[4] != CRGB(0, 0, 0));
+
+    JsonDocument clearUpdate;
+    JsonObject clearData = clearUpdate.as<JsonObject>();
+    client->handleLedUpdate(clearData);
+
+    TEST_ASSERT_TRUE(strip[4] == CRGB(0, 0, 0));
     TEST_ASSERT_EQUAL_UINT32(0, client->getCurrentDisplayHash());
 }
 
@@ -366,6 +430,10 @@ int main(int argc, char** argv) {
     // Display hash tests
     RUN_TEST(test_initial_display_hash_zero);
     RUN_TEST(test_display_hash_unchanged_by_send);
+
+    // LED update tests
+    RUN_TEST(test_led_update_clears_previous_climb_leds);
+    RUN_TEST(test_led_update_without_commands_clears_all_leds);
 
     // Message callback tests
     RUN_TEST(test_set_message_callback_stores_callback);

--- a/embedded/test/test_graphql_ws_client/test_graphql_ws_client.cpp
+++ b/embedded/test/test_graphql_ws_client/test_graphql_ws_client.cpp
@@ -159,7 +159,7 @@ static void addLedCommand(JsonArray commands, int position, int r, int g, int b)
 // switching climbs from the web queue must clear the previous climb's holds
 // instead of accumulating them on the strip (same contract as the BLE path).
 void test_led_update_clears_previous_climb_leds(void) {
-    LEDs.begin(5, 50);
+    LEDs.begin(50);
     CRGB* strip = CFastLED::getLeds();
     TEST_ASSERT_NOT_NULL(strip);
 
@@ -186,7 +186,7 @@ void test_led_update_clears_previous_climb_leds(void) {
 }
 
 void test_led_update_without_commands_clears_all_leds(void) {
-    LEDs.begin(5, 50);
+    LEDs.begin(50);
     CRGB* strip = CFastLED::getLeds();
 
     JsonDocument climb;

--- a/embedded/test/test_graphql_ws_client/test_graphql_ws_client.cpp
+++ b/embedded/test/test_graphql_ws_client/test_graphql_ws_client.cpp
@@ -185,6 +185,27 @@ void test_led_update_clears_previous_climb_leds(void) {
     TEST_ASSERT_TRUE(strip[2] == CRGB(0, 0, 0));
 }
 
+void test_led_update_with_empty_commands_array_clears_all_leds(void) {
+    LEDs.begin(50);
+    CRGB* strip = CFastLED::getLeds();
+
+    JsonDocument climb;
+    JsonArray commands = climb["commands"].to<JsonArray>();
+    addLedCommand(commands, 6, 255, 0, 0);
+    JsonObject climbData = climb.as<JsonObject>();
+    client->handleLedUpdate(climbData);
+    TEST_ASSERT_TRUE(strip[6] != CRGB(0, 0, 0));
+
+    // Explicit "commands": [] (as opposed to the key being absent)
+    JsonDocument clearUpdate;
+    clearUpdate["commands"].to<JsonArray>();
+    JsonObject clearData = clearUpdate.as<JsonObject>();
+    client->handleLedUpdate(clearData);
+
+    TEST_ASSERT_TRUE(strip[6] == CRGB(0, 0, 0));
+    TEST_ASSERT_EQUAL_UINT32(0, client->getCurrentDisplayHash());
+}
+
 void test_led_update_without_commands_clears_all_leds(void) {
     LEDs.begin(50);
     CRGB* strip = CFastLED::getLeds();
@@ -433,6 +454,7 @@ int main(int argc, char** argv) {
 
     // LED update tests
     RUN_TEST(test_led_update_clears_previous_climb_leds);
+    RUN_TEST(test_led_update_with_empty_commands_array_clears_all_leds);
     RUN_TEST(test_led_update_without_commands_clears_all_leds);
 
     // Message callback tests

--- a/embedded/test/test_led_controller/test_led_controller.cpp
+++ b/embedded/test/test_led_controller/test_led_controller.cpp
@@ -30,17 +30,17 @@ void test_initial_state(void) {
 }
 
 void test_begin_sets_num_leds(void) {
-    controller->begin(5, 100);
+    controller->begin(100);
     TEST_ASSERT_EQUAL(100, controller->getNumLeds());
 }
 
 void test_begin_caps_at_max_leds(void) {
-    controller->begin(5, 600);  // More than MAX_LEDS (500)
+    controller->begin(600);  // More than MAX_LEDS (500)
     TEST_ASSERT_EQUAL(MAX_LEDS, controller->getNumLeds());
 }
 
 void test_begin_with_zero_leds(void) {
-    controller->begin(5, 0);
+    controller->begin(0);
     TEST_ASSERT_EQUAL(0, controller->getNumLeds());
 }
 
@@ -49,32 +49,32 @@ void test_begin_with_zero_leds(void) {
 // =============================================================================
 
 void test_setLed_with_crgb(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->setLed(0, CRGB(255, 128, 64));
     // No crash means success - we can't directly inspect internal state
     TEST_ASSERT_TRUE(true);
 }
 
 void test_setLed_with_rgb_values(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->setLed(5, 100, 150, 200);
     TEST_ASSERT_TRUE(true);
 }
 
 void test_setLed_negative_index_ignored(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->setLed(-1, CRGB(255, 0, 0));  // Should not crash
     TEST_ASSERT_TRUE(true);
 }
 
 void test_setLed_index_at_boundary(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->setLed(9, CRGB(255, 0, 0));  // Last valid index
     TEST_ASSERT_TRUE(true);
 }
 
 void test_setLed_index_beyond_boundary_ignored(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->setLed(10, CRGB(255, 0, 0));   // Beyond boundary
     controller->setLed(100, CRGB(255, 0, 0));  // Way beyond boundary
     TEST_ASSERT_TRUE(true);
@@ -85,7 +85,7 @@ void test_setLed_index_beyond_boundary_ignored(void) {
 // =============================================================================
 
 void test_setLeds_single_command(void) {
-    controller->begin(5, 100);
+    controller->begin(100);
 
     LedCommand commands[1] = {{10, 255, 128, 64}};
 
@@ -94,7 +94,7 @@ void test_setLeds_single_command(void) {
 }
 
 void test_setLeds_multiple_commands(void) {
-    controller->begin(5, 100);
+    controller->begin(100);
 
     LedCommand commands[5] = {{0, 255, 0, 0}, {1, 0, 255, 0}, {2, 0, 0, 255}, {3, 255, 255, 0}, {4, 0, 255, 255}};
 
@@ -103,7 +103,7 @@ void test_setLeds_multiple_commands(void) {
 }
 
 void test_setLeds_with_out_of_bounds_positions(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
 
     LedCommand commands[3] = {
         {5, 255, 0, 0},   // Valid
@@ -116,7 +116,7 @@ void test_setLeds_with_out_of_bounds_positions(void) {
 }
 
 void test_setLeds_empty_array(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
 
     LedCommand commands[1] = {{0, 0, 0, 0}};
     controller->setLeds(commands, 0);  // Count is 0
@@ -124,7 +124,7 @@ void test_setLeds_empty_array(void) {
 }
 
 void test_setLeds_large_batch(void) {
-    controller->begin(5, 200);
+    controller->begin(200);
 
     LedCommand commands[100];
     for (int i = 0; i < 100; i++) {
@@ -143,19 +143,19 @@ void test_setLeds_large_batch(void) {
 // =============================================================================
 
 void test_setBrightness(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->setBrightness(200);
     TEST_ASSERT_EQUAL(200, controller->getBrightness());
 }
 
 void test_setBrightness_min_value(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->setBrightness(0);
     TEST_ASSERT_EQUAL(0, controller->getBrightness());
 }
 
 void test_setBrightness_max_value(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->setBrightness(255);
     TEST_ASSERT_EQUAL(255, controller->getBrightness());
 }
@@ -169,21 +169,21 @@ void test_getBrightness_default(void) {
 // =============================================================================
 
 void test_clear_does_not_crash(void) {
-    controller->begin(5, 50);
+    controller->begin(50);
     controller->setLed(0, CRGB(255, 255, 255));
     controller->clear();
     TEST_ASSERT_TRUE(true);
 }
 
 void test_show_does_not_crash(void) {
-    controller->begin(5, 50);
+    controller->begin(50);
     controller->setLed(0, CRGB(255, 255, 255));
     controller->show();
     TEST_ASSERT_TRUE(true);
 }
 
 void test_clear_show_sequence(void) {
-    controller->begin(5, 50);
+    controller->begin(50);
     controller->setLed(0, CRGB(255, 0, 0));
     controller->show();
     controller->clear();
@@ -196,31 +196,31 @@ void test_clear_show_sequence(void) {
 // =============================================================================
 
 void test_blink_default_parameters(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->blink(255, 0, 0);  // 3 blinks, 100ms delay by default
     TEST_ASSERT_TRUE(true);
 }
 
 void test_blink_custom_count(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->blink(0, 255, 0, 5);  // 5 blinks
     TEST_ASSERT_TRUE(true);
 }
 
 void test_blink_custom_delay(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->blink(0, 0, 255, 2, 50);  // 2 blinks, 50ms delay
     TEST_ASSERT_TRUE(true);
 }
 
 void test_blink_zero_leds(void) {
-    controller->begin(5, 0);           // No LEDs
+    controller->begin(0);           // No LEDs
     controller->blink(255, 255, 255);  // Should not crash
     TEST_ASSERT_TRUE(true);
 }
 
 void test_blink_zero_count(void) {
-    controller->begin(5, 10);
+    controller->begin(10);
     controller->blink(255, 255, 255, 0);  // 0 blinks
     TEST_ASSERT_TRUE(true);
 }
@@ -239,9 +239,9 @@ void test_operations_before_begin(void) {
 }
 
 void test_multiple_begin_calls(void) {
-    controller->begin(5, 50);
+    controller->begin(50);
     controller->setLed(0, CRGB(255, 0, 0));
-    controller->begin(6, 100);  // Reinitialize
+    controller->begin(100);  // Reinitialize
     TEST_ASSERT_EQUAL(100, controller->getNumLeds());
 }
 

--- a/embedded/test/test_nordic_uart_ble/test_nordic_uart_ble.cpp
+++ b/embedded/test/test_nordic_uart_ble/test_nordic_uart_ble.cpp
@@ -387,6 +387,104 @@ void test_clear_last_sent_hash(void) {
 }
 
 // =============================================================================
+// Aurora Frame → LED Strip Tests
+// =============================================================================
+
+// Build a complete Aurora V3 single-packet frame ('T') lighting the given
+// (position, packed RRRGGGBB color) pairs. An empty list produces a valid
+// zero-LED frame (the app's "clear board" command).
+static std::vector<uint8_t> buildV3Frame(const std::vector<std::pair<uint16_t, uint8_t>>& ledsToLight) {
+    std::vector<uint8_t> data;
+    data.push_back('T');  // CMD_V3_PACKET_ONLY
+    for (const auto& led : ledsToLight) {
+        data.push_back(led.first & 0xFF);
+        data.push_back((led.first >> 8) & 0xFF);
+        data.push_back(led.second);
+    }
+
+    uint8_t checksum = 0;
+    for (uint8_t byte : data) {
+        checksum = (checksum + byte) & 0xFF;
+    }
+    checksum ^= 0xFF;
+
+    std::vector<uint8_t> frame;
+    frame.push_back(0x01);  // SOH
+    frame.push_back((uint8_t)data.size());
+    frame.push_back(checksum);
+    frame.push_back(0x02);  // STX
+    frame.insert(frame.end(), data.begin(), data.end());
+    frame.push_back(0x03);  // ETX
+    return frame;
+}
+
+static NimBLECharacteristic* connectAndGetRxCharacteristic() {
+    ble_gap_conn_desc desc;
+    memset(&desc, 0, sizeof(desc));
+    desc.conn_handle = 1;
+    NimBLEDevice::getServer()->mockConnect(&desc);
+
+    NimBLEService* service = NimBLEDevice::getServer()->getServiceByUUID(NUS_SERVICE_UUID);
+    return service ? service->getCharacteristic(NUS_RX_CHARACTERISTIC) : nullptr;
+}
+
+// Regression test: each complete Aurora frame is the FULL LED state for a
+// climb, so switching climbs must clear the previous climb's holds instead of
+// accumulating them on the strip.
+void test_new_climb_frame_clears_previous_climb_leds(void) {
+    LEDs.begin(5, 50);
+    ble->setLedDataCallback(testLedDataCallback);
+    ble->begin("Test Device");
+
+    NimBLECharacteristic* rxChar = connectAndGetRxCharacteristic();
+    TEST_ASSERT_NOT_NULL(rxChar);
+
+    CRGB* strip = CFastLED::getLeds();
+    TEST_ASSERT_NOT_NULL(strip);
+
+    // Climb A lights LEDs 1 and 2 (0xE0 = full red in RRRGGGBB)
+    std::vector<uint8_t> climbA = buildV3Frame({{1, 0xE0}, {2, 0xE0}});
+    rxChar->mockWrite(climbA.data(), climbA.size());
+
+    TEST_ASSERT_TRUE(strip[1] != CRGB(0, 0, 0));
+    TEST_ASSERT_TRUE(strip[2] != CRGB(0, 0, 0));
+    TEST_ASSERT_EQUAL(1, ledDataCallbackCount);
+    TEST_ASSERT_EQUAL(2, lastLedCommands.size());
+
+    // Climb B lights LED 3 only — LEDs 1 and 2 must turn off
+    std::vector<uint8_t> climbB = buildV3Frame({{3, 0xE0}});
+    rxChar->mockWrite(climbB.data(), climbB.size());
+
+    TEST_ASSERT_TRUE(strip[3] != CRGB(0, 0, 0));
+    TEST_ASSERT_TRUE(strip[1] == CRGB(0, 0, 0));
+    TEST_ASSERT_TRUE(strip[2] == CRGB(0, 0, 0));
+    TEST_ASSERT_EQUAL(2, ledDataCallbackCount);
+}
+
+void test_empty_frame_clears_all_leds(void) {
+    LEDs.begin(5, 50);
+    ble->setLedDataCallback(testLedDataCallback);
+    ble->begin("Test Device");
+
+    NimBLECharacteristic* rxChar = connectAndGetRxCharacteristic();
+    TEST_ASSERT_NOT_NULL(rxChar);
+
+    CRGB* strip = CFastLED::getLeds();
+
+    std::vector<uint8_t> climb = buildV3Frame({{4, 0xE0}});
+    rxChar->mockWrite(climb.data(), climb.size());
+    TEST_ASSERT_TRUE(strip[4] != CRGB(0, 0, 0));
+
+    // Zero-LED frame = "clear board" from the app
+    std::vector<uint8_t> clearFrame = buildV3Frame({});
+    rxChar->mockWrite(clearFrame.data(), clearFrame.size());
+
+    TEST_ASSERT_TRUE(strip[4] == CRGB(0, 0, 0));
+    // The clear is not forwarded to the backend (only non-empty climbs are)
+    TEST_ASSERT_EQUAL(1, ledDataCallbackCount);
+}
+
+// =============================================================================
 // Disconnect Client Tests
 // =============================================================================
 
@@ -596,6 +694,9 @@ int main(int argc, char** argv) {
     RUN_TEST(test_should_send_led_data_true_for_different_hash);
     RUN_TEST(test_should_send_led_data_true_when_no_device);
     RUN_TEST(test_clear_last_sent_hash);
+
+    RUN_TEST(test_new_climb_frame_clears_previous_climb_leds);
+    RUN_TEST(test_empty_frame_clears_all_leds);
 
     // Disconnect client tests
     RUN_TEST(test_disconnect_client_when_connected);

--- a/embedded/test/test_nordic_uart_ble/test_nordic_uart_ble.cpp
+++ b/embedded/test/test_nordic_uart_ble/test_nordic_uart_ble.cpp
@@ -432,7 +432,7 @@ static NimBLECharacteristic* connectAndGetRxCharacteristic() {
 // climb, so switching climbs must clear the previous climb's holds instead of
 // accumulating them on the strip.
 void test_new_climb_frame_clears_previous_climb_leds(void) {
-    LEDs.begin(5, 50);
+    LEDs.begin(50);
     ble->setLedDataCallback(testLedDataCallback);
     ble->begin("Test Device");
 
@@ -462,7 +462,7 @@ void test_new_climb_frame_clears_previous_climb_leds(void) {
 }
 
 void test_empty_frame_clears_all_leds(void) {
-    LEDs.begin(5, 50);
+    LEDs.begin(50);
     ble->setLedDataCallback(testLedDataCallback);
     ble->begin("Test Device");
 


### PR DESCRIPTION
## Summary

Adds a `gledopto-c015` PlatformIO build variant to the `board-controller` firmware, targeting the **GLEDOPTO GL-C-015WL-D** — a cheap WLED-style ESP32 controller (classic ESP32, 4 MB flash, DC 5–24 V in, addressable data on GPIO16) used as a standalone driver for a Kilter board's LED string. Reuses every shared lib (Aurora BLE decode, Nordic-UART board emulation, party-mode GraphQL, web config); only hardware config is new.

**✅ Verified on real hardware** (GL-C-015WL-D + a 12 V WS2811 string): flashed over USB-C, board boots on GPIO16, connects over BLE as `Kilter Board#123456@3`, and climbs light the correct holds in the correct colors and clear between climbs.

### What changed
- **`platformio.ini`** — new `[env:gledopto-c015]` (esp32dev/classic ESP32, `min_spiffs.csv`, `GLEDOPTO_LED_PIN=16`, `LED_POWER_ENABLE_PIN=18` + `LED_POWER_ENABLE_PIN_2=12`, `LED_CHIPSET=WS2811`, `LED_COLOR_ORDER=RGB`). Chipset/order/pin/count are all build flags.
- **`led_controller.{h,cpp}`** — pin/chipset/color-order single-sourced from build flags (also fixed a latent bug where the Waveshare LED-pin flags were defined but ignored). New opt-in `LED_POWER_ENABLE_PIN`(`_2`) flags, driven HIGH in `begin()`. `begin()` also dropped its dead `pin` parameter (review feedback — FastLED templates the compile-time pin, so the runtime arg was silently ignored).
- **Output V+ power fix (GPIO18 relay, ✅ verified on hardware).** The GL-C-015WL-D gates its LED output `V+` terminal behind a high-side MOSFET — that's why the terminal read ~0 V and the strip previously had to be power-bypassed straight from the PSU (stock WLED ships with its "Relay GPIO" preconfigured, which is why the terminal works out of the box). A pin sweep on the real unit (interactive finder firmware + multimeter) found the enable is **GPIO18, active high** on this revision: 12 V with GPIO18 high, ~0.6 V low. GLEDOPTO's manual documents "Relay GPIO 12" for the family, so the firmware drives **both** 18 and 12 HIGH at LED init via `LED_POWER_ENABLE_PIN`/`LED_POWER_ENABLE_PIN_2` (safely after boot — GPIO12 is the MTDI strapping pin and must not be high at reset).
- **`nordic_uart_ble.cpp`** — **clear the LED buffer before each Aurora frame.** Every complete frame is the full climb, but the handler previously added LEDs without clearing, so swiping climbs accumulated LEDs that never turned off. Shared fix — improves every LED variant.
- **`graphql_ws_client.cpp`** — the **same clear-before-set fix for the party-mode path**: `handleLedUpdate` applied backend LED commands without clearing, so switching climbs from the web queue accumulated holds exactly like the BLE bug above.
- **Regression tests** for both clear paths (BLE Aurora frames + GraphQL LedUpdate, incl. the empty "clear board" frames), verified to fail on the pre-fix code. The ArduinoJson test mock's object accessors now return references (matching real ArduinoJson v7) so wrappers built from `operator[]` no longer dangle.
- **`firmware-build.yml`** — build + release the `gledopto-c015` binary alongside the others.
- **`README.md`** — GLEDOPTO variant docs: wiring (data on `IO16`, output `V+` now powered via the GPIO18 relay fix, common grounds), PSU bypass guidance for strings above the 10 A/channel terminal rating, bench-supply + color/pin/chipset troubleshooting.

Defaults for all other envs resolve to the previous `WS2812B, 5/43, GRB` — no behavior change except the Waveshare pin fix and the (correct) clear-between-climbs behavior.

## Release Notes

- [x] No release note needed (internal / technical change)

<!-- Firmware for a DIY hardware controller; not shipped in the mobile app's What's New. -->

## Test plan

- `pio run -e gledopto-c015` and `pio run -e esp32s3dev` → build clean.
- `pio test -e native` → full native suite passes (incl. the new clear-between-climbs regression tests for both the BLE and party-mode paths).
- **Hardware:** flashed a real GL-C-015WL-D over USB-C (CH340; auto-reset, no BOOT button). Confirmed via serial `LED_PIN = 16` + BLE `Updated N LEDs`. A multi-pin self-test confirmed GPIO16 is the right data pin and RGB is the right color order. Sending climbs from the app lights the correct holds/colors; swiping between climbs now clears the previous one. Wiring: 12 V WS2811 powered directly from the PSU, data on `IO16`, common ground.
- **Hardware, verified 2026-07-06 on the real unit:** GPIO18 pin sweep confirmed the V+ gate (12 V high / ~0.6 V low); after reflash the output terminal carries the input voltage, the app connects over BLE, climbs light/switch/clear correctly. Remaining before wall install: set `-D NUM_LEDS` to the real string length if it exceeds 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNi2igPzdp7KxGsMmbbdpQ
