### PR TITLE
fix(mobile): revert broken bundle-done fallback; retry reach-home for flaky Metro connect

### DIFF
--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -10,8 +10,6 @@ import {
   iosSourceFlowFile,
   ipadSidebarTapPoint,
   isIpadScreenshotDevice,
-  METRO_LOG_PATH,
-  metroBundleFinished,
   metroDevClientUrl,
   parseArgs,
   renderMaestroFlowForIosDevice,
@@ -350,23 +348,6 @@ describe('renderMaestroFlowForIosDevice', () => {
     expect(ipadFlow).toContain('point: ${TAP_WALL}');
     // No literal "N%,M%" tap points — those wouldn't transfer between iPad sizes.
     expect(ipadFlow).not.toMatch(/point:\s*'?\d/);
-  });
-});
-
-describe('metroBundleFinished', () => {
-  afterEach(() => {
-    rmSync(METRO_LOG_PATH, { force: true });
-  });
-
-  it('is false without a log and true once Metro logs a completed bundle', () => {
-    rmSync(METRO_LOG_PATH, { force: true });
-    expect(metroBundleFinished()).toBe(false);
-
-    writeFileSync(METRO_LOG_PATH, 'Starting Metro Bundler\nWaiting on http://localhost:8081\n');
-    expect(metroBundleFinished()).toBe(false);
-
-    writeFileSync(METRO_LOG_PATH, 'iOS Bundled 31912ms node_modules/.../entry.js (4662 modules)\n');
-    expect(metroBundleFinished()).toBe(true);
   });
 });
 

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -805,22 +805,9 @@ function captureIosDevice(
       }
     }
     if (!waitForHomeReady(homeReadyBaseline)) {
-      // The readiness marker never landed. If Metro finished the JS bundle, the app
-      // has had the full timeout to auto-sign-in and reach home — the missing marker
-      // is almost always Metro's log-forwarding pipe dying with
-      // ERR_STREAM_UNABLE_TO_PIPE, not the app failing to boot. Proceed instead of
-      // failing the shard (a genuinely stuck app is caught downstream when the flow's
-      // deep links / taps land on a blank screen). If the bundle never even finished,
-      // this is a real failure.
-      if (metroBundleFinished()) {
-        console.warn(
-          `${LOG} Home marker not seen, but Metro finished the bundle — proceeding (Metro log forwarding likely broke; the app auto-signs-in and reaches home).`,
-        );
-      } else {
-        console.error(`${LOG} FAILED: app did not reach the home screen (auto sign-in / bundle load).`);
-        dumpMetroLogTail();
-        return 1;
-      }
+      console.error(`${LOG} FAILED: app did not reach the home screen (auto sign-in / bundle load).`);
+      dumpMetroLogTail();
+      return 1;
     }
 
     const sourceFlowFile = iosSourceFlowFile(options, screenshotDevice);
@@ -1234,20 +1221,6 @@ function dumpMetroLogTail(lines = 80): void {
   console.error(
     `${LOG} --- last ${lines} lines of Metro log (${METRO_LOG_PATH}) ---\n${tail}\n${LOG} --- end Metro log ---`,
   );
-}
-
-/**
- * Whether Metro logged a completed JS bundle for the app (`… Bundled 12345ms …`).
- * The `$screen /home` readiness marker rides Metro's forwarding of the app's
- * console.log to Metro stdout, which intermittently dies mid-run with
- * `ERR_STREAM_UNABLE_TO_PIPE` — after which no further app logs (including the
- * marker) are captured, even though the screenshot build still auto-signs-in and
- * reaches home. The "Bundled" line lands BEFORE that break, so it's a reliable
- * signal that the JS loaded and home is imminent — the reach-home fallback.
- */
-export function metroBundleFinished(): boolean {
-  const metroLog = existsSync(METRO_LOG_PATH) ? readFileSync(METRO_LOG_PATH, 'utf8') : '';
-  return /Bundled \d+ms/.test(metroLog);
 }
 
 /**

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -787,24 +787,31 @@ function captureIosDevice(
     // there before Maestro runs — this is what login.yaml's readiness wait used to
     // do (now deleted; there's no login screen to gate on).
     console.log(`${LOG} Waiting for the app to auto-sign-in and reach home...`);
-    // iPad cold-boots + first-bundle-loads slower, so give the plain launch more time
-    // before the retry.
+    // The dev-client's auto-connect to Metro is intermittently flaky in CI — the app
+    // lands on the "Searching for development servers" launcher (or the "Failed to
+    // load app" error) instead of loading the JS. When that happens, re-launch and try
+    // again; each fresh launch re-attempts the connect, and a shard that never recovers
+    // fails hard (rather than capturing the launcher) so it can be re-run.
+    // iPad cold-boots slower, so give the first launch more time.
     const isIpad = isIpadScreenshotDevice(screenshotDevice);
-    if (!waitForHomeReady(homeReadyBaseline, isIpad ? 90 : 45)) {
+    let reachedHome = waitForHomeReady(homeReadyBaseline, isIpad ? 90 : 45);
+    for (let attempt = 1; attempt <= 3 && !reachedHome; attempt += 1) {
       if (isIpad) {
         // iPad: re-launch PLAINLY — never `openurl`. The "Open in 'Boardsesh'?" confirm
-        // that an openurl raises is never dismissed on iPad (the URL isn't delivered to
-        // the app), and it then blocks the entire sidebar-tap flow. A fresh launch just
-        // re-triggers the dev-client's auto-connect + auto-sign-in, no dialog.
-        console.log(`${LOG} Plain launch did not reach home; terminating and re-launching (iPad, no openurl)...`);
+        // an openurl raises is never delivered/dismissed on iPad and then blocks the
+        // whole sidebar-tap flow. A fresh launch re-triggers auto-connect, no dialog.
+        console.log(`${LOG} Not home yet; terminating and re-launching (iPad attempt ${attempt}/3)...`);
         runCapture('xcrun', ['simctl', 'terminate', device.udid, APP_ID]);
         runCapture('xcrun', ['simctl', 'launch', device.udid, APP_ID]);
       } else {
-        console.log(`${LOG} Plain launch did not reach home; retrying with the explicit dev-client URL...`);
+        // iPhone: force the connect with the explicit dev-client URL (its deep-link
+        // confirm is dismissed + remembered on iPhone, so it's safe and more reliable).
+        console.log(`${LOG} Not home yet; forcing the dev-client URL (iPhone attempt ${attempt}/3)...`);
         runCapture('xcrun', ['simctl', 'openurl', device.udid, metroDevClientUrl()]);
       }
+      reachedHome = waitForHomeReady(homeReadyBaseline, 75);
     }
-    if (!waitForHomeReady(homeReadyBaseline)) {
+    if (!reachedHome) {
       console.error(`${LOG} FAILED: app did not reach the home screen (auto sign-in / bundle load).`);
       dumpMetroLogTail();
       return 1;


### PR DESCRIPTION
## Summary

**Reverts #3486 and replaces it.** #3486's "bundle-done fallback" was wrong: the reach-home failures aren't a lost marker — the app genuinely **isn't loading from Metro** in CI (it lands on the dev-client "Searching for development servers" launcher, or "Failed to load app from localhost:8081"). The fallback saw "Metro finished bundling" and proceeded anyway, so it **captured the launcher/error screen and uploaded broken screenshots to App Store Connect.**

This PR:
1. **Reverts the fallback** — a shard that never reaches home now fails hard (so it can be re-run) instead of capturing a broken frame. No more broken uploads.
2. **Retries the reach-home launch up to 3×** — the dev-client auto-connect is intermittently flaky; each fresh re-launch re-attempts it (iPad: plain terminate+launch, so no `openurl` dialog; iPhone: the dev-client URL). A transient connect failure recovers; a persistent one still fails hard.

The iPad **capture flow itself is solid** — every shard that reaches home produces the correct 6-shot set with the lit kiosk. This is purely the app-load flakiness.

## Release Notes

- [x] No release note needed (internal / tooling change)

## Test plan
- `vp test run mobile-screenshots.test` — pass.
- After merge: run `mobile-screenshots-ios` (upload: true); re-run any failed shards until all 9 pass with real content, which overwrites the broken ASC screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KV6NHZAQUPLz5EigLLd7p