### PR TITLE
feat(mobile): move the angle chip into the filter row (Android)

### DIFF
--- a/packages/mobile/src/components/chrome/BoardSwitcherButton.tsx
+++ b/packages/mobile/src/components/chrome/BoardSwitcherButton.tsx
@@ -21,10 +21,10 @@ type BoardSwitcherButtonProps = {
 };
 
 /**
- * The Material variant's board switcher: the active board label ("Kilter • M •
- * 45°", or "Garage Wall • 40°" for a named board) shown as the app-bar title
- * with a trailing down-caret affordance, so it reads as a tappable context
- * switcher rather than the static subtitle it replaces. It is the flat M3
+ * The Material variant's board switcher: the active board label ("Kilter • M", or
+ * "Garage Wall" for a named board — angle omitted, it rides its own filter chip)
+ * shown as the app-bar title with a trailing down-caret affordance, so it reads as
+ * a tappable context switcher rather than the static subtitle it replaces. It is the flat M3
  * counterpart of the liquid-glass `BoardToolbarAction` — reads the active board
  * itself, renders nothing when none is set, and fires the haptic here while the
  * caller injects what a tap does. Lives where `Appbar.Content` did, `flex: 1`.
@@ -33,7 +33,9 @@ export function BoardSwitcherButton({ onPress, accessibilityHint, badge = false 
   const { systemColors, brandColors } = useTheme();
   const { data: activeBoard } = useActiveBoard();
 
-  const boardLabel = useMemo(() => formatActiveBoardLabel(activeBoard), [activeBoard]);
+  // Drop the angle from the title — it now rides as its own chip in the filter row,
+  // so repeating it here would show the angle twice in the same header band.
+  const boardLabel = useMemo(() => formatActiveBoardLabel(activeBoard, { includeAngle: false }), [activeBoard]);
 
   const handlePress = useCallback(() => {
     hapticLight();

--- a/packages/mobile/src/components/chrome/MaterialBoardActions.tsx
+++ b/packages/mobile/src/components/chrome/MaterialBoardActions.tsx
@@ -5,53 +5,23 @@
 // them. They are the flat M3 counterparts of the liquid-glass `AngleToolbarAction`
 // / `LightbulbToolbarAction` islands — each reads its own state and renders
 // nothing when it doesn't apply (no adjustable board / no bluetooth).
+//
+// The Climbs angle lives as the first chip in the native filter chip row
+// (`FilterChipRow.android`), not here — the app bar keeps only the create action.
+// `MaterialAngleAction` remains for Discover's `CollapsingTopChrome`.
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { Appbar, Chip } from 'react-native-paper';
+import { Appbar } from 'react-native-paper';
 import { useTheme } from '../../providers/theme-provider';
-import { useActiveBoard, useSetActiveBoard } from '../../lib/graphql/use-active-board';
 import { hapticLight } from '../../lib/haptics';
 import { useLightbulbControl } from '../ble/use-lightbulb-control';
 import { useBleControlSheet } from '../../providers/ble-control-sheet-provider';
 import { Text } from '../Text';
 import { iconMap } from '../icon-map';
 import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
-
-/**
- * Shared angle state for the Material angle controls: reads the active board, owns
- * the selector sheet's open state, and writes the chosen angle back (re-grading the
- * list).
- *
- * Each consumer gets its OWN instance (and its own `visible` state) — that's by
- * design, not a bug: `MaterialAngleAction` (Discover's app bar) and
- * `MaterialAngleChip` (the Climbs quick row) never co-render on the same screen
- * (Climbs dropped the app-bar action when the angle moved to the chip row), so
- * there is no shared sheet-open state to diverge.
- */
-function useMaterialAngleControl() {
-  const { data: activeBoard } = useActiveBoard();
-  const setActiveBoard = useSetActiveBoard();
-  const [visible, setVisible] = useState(false);
-
-  const canAdjust = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
-  const open = useCallback(() => {
-    if (!activeBoard || activeBoard.isAngleAdjustable === false || activeBoard.angle == null) return;
-    hapticLight();
-    setVisible(true);
-  }, [activeBoard]);
-  const close = useCallback(() => setVisible(false), []);
-  const change = useCallback(
-    (newAngle: number) => {
-      if (!activeBoard || activeBoard.isAngleAdjustable === false || newAngle === activeBoard.angle) return;
-      void setActiveBoard({ ...activeBoard, angle: newAngle });
-    },
-    [activeBoard, setActiveBoard],
-  );
-
-  return { activeBoard, canAdjust, visible, open, close, change };
-}
+import { useMaterialAngleControl } from './use-material-angle-control';
 
 export function MaterialAngleAction() {
   const { systemColors } = useTheme();
@@ -72,41 +42,6 @@ export function MaterialAngleAction() {
   return (
     <>
       <Appbar.Action icon={angleIcon} onPress={open} accessibilityLabel={tSession('mobile.angleSelector.title')} />
-      <AngleSelectorSheet
-        visible={visible}
-        onClose={close}
-        boardName={activeBoard.boardType}
-        layoutId={activeBoard.layoutId}
-        currentAngle={activeBoard.angle}
-        onAngleChange={change}
-      />
-    </>
-  );
-}
-
-/**
- * The Material angle control as an M3 quick-row chip (Climbs). Angle re-grades the
- * whole list, so it belongs with the other list parameters (grade / filters) one
- * tap away, not buried — and it keeps the over-budget app bar lean. Renders nothing
- * for fixed-angle boards (or none).
- */
-export function MaterialAngleChip() {
-  const { t: tSession } = useTranslation('session');
-  const { activeBoard, canAdjust, visible, open, close, change } = useMaterialAngleControl();
-
-  if (!activeBoard || !canAdjust) return null;
-
-  return (
-    <>
-      <Chip
-        compact
-        mode="outlined"
-        onPress={open}
-        accessibilityLabel={tSession('mobile.angleSelector.title')}
-        textStyle={styles.materialChipText}
-      >
-        {`${activeBoard.angle}°`}
-      </Chip>
       <AngleSelectorSheet
         visible={visible}
         onClose={close}
@@ -158,8 +93,5 @@ const styles = StyleSheet.create({
   materialAngleText: {
     fontWeight: '700',
     textAlign: 'center',
-  },
-  materialChipText: {
-    fontWeight: '700',
   },
 });

--- a/packages/mobile/src/components/chrome/__tests__/board-switcher-button.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/board-switcher-button.test.tsx
@@ -101,25 +101,26 @@ describe('BoardSwitcherButton', () => {
     expect(button(container)).toBeNull();
   });
 
-  it('renders the board label with a caret and fires onPress with a haptic', () => {
+  it('renders the board label (angle omitted) with a caret and fires onPress with a haptic', () => {
     ctrl.board = typedBoard;
     const onPress = vi.fn();
     const { container } = render(createElement(BoardSwitcherButton, { onPress }));
     const target = button(container);
-    expect(target?.getAttribute('data-label')).toBe('Display:kilter • M • 40°');
+    // The angle rides its own filter chip now, so the title omits "• 40°".
+    expect(target?.getAttribute('data-label')).toBe('Display:kilter • M');
     expect(container.querySelector('[data-icon="chevron.down"]')).not.toBeNull();
     fireEvent.click(target!);
     expect(onPress).toHaveBeenCalledTimes(1);
     expect(haptics.light).toHaveBeenCalledTimes(1);
   });
 
-  it('leads with the custom board name for a named board', () => {
+  it('leads with the custom board name for a named board (angle omitted)', () => {
     ctrl.board = namedBoard;
     const { container } = render(createElement(BoardSwitcherButton, { onPress: vi.fn() }));
-    expect(button(container)?.getAttribute('data-label')).toBe('Garage Wall • 25°');
+    expect(button(container)?.getAttribute('data-label')).toBe('Garage Wall');
   });
 
-  it('renders a named board with no angle (label has no separator)', () => {
+  it('renders a named board with no angle', () => {
     ctrl.board = namedBoardNoAngle;
     const { container } = render(createElement(BoardSwitcherButton, { onPress: vi.fn() }));
     expect(button(container)?.getAttribute('data-label')).toBe('Garage Wall');

--- a/packages/mobile/src/components/chrome/__tests__/use-material-angle-control.test.ts
+++ b/packages/mobile/src/components/chrome/__tests__/use-material-angle-control.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+type Board = Pick<UserBoard, 'angle' | 'isAngleAdjustable' | 'boardType' | 'layoutId'>;
+
+const ctrl = vi.hoisted(() => ({ board: null as Board | null, setActiveBoard: vi.fn() }));
+const haptics = vi.hoisted(() => ({ light: vi.fn() }));
+
+vi.mock('../../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: ctrl.board }),
+  useSetActiveBoard: () => ctrl.setActiveBoard,
+}));
+vi.mock('../../../lib/haptics', () => ({ hapticLight: haptics.light }));
+
+import { useMaterialAngleControl } from '../use-material-angle-control';
+
+const adjustableBoard: Board = { angle: 40, isAngleAdjustable: true, boardType: 'kilter', layoutId: 1 };
+
+describe('useMaterialAngleControl', () => {
+  beforeEach(() => {
+    ctrl.board = null;
+    ctrl.setActiveBoard.mockReset();
+    haptics.light.mockReset();
+  });
+
+  it('reports canAdjust for an adjustable board with an angle', () => {
+    ctrl.board = adjustableBoard;
+    const { result } = renderHook(() => useMaterialAngleControl());
+    expect(result.current.canAdjust).toBe(true);
+  });
+
+  it('is not adjustable for a fixed-angle board', () => {
+    ctrl.board = { ...adjustableBoard, isAngleAdjustable: false };
+    const { result } = renderHook(() => useMaterialAngleControl());
+    expect(result.current.canAdjust).toBe(false);
+  });
+
+  it('is not adjustable when the angle is missing', () => {
+    ctrl.board = { ...adjustableBoard, angle: null as unknown as number };
+    const { result } = renderHook(() => useMaterialAngleControl());
+    expect(result.current.canAdjust).toBe(false);
+  });
+
+  it('opens the sheet with a haptic', () => {
+    ctrl.board = adjustableBoard;
+    const { result } = renderHook(() => useMaterialAngleControl());
+    act(() => result.current.open());
+    expect(result.current.visible).toBe(true);
+    expect(haptics.light).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open (or fire a haptic) for a fixed-angle board', () => {
+    ctrl.board = { ...adjustableBoard, isAngleAdjustable: false };
+    const { result } = renderHook(() => useMaterialAngleControl());
+    act(() => result.current.open());
+    expect(result.current.visible).toBe(false);
+    expect(haptics.light).not.toHaveBeenCalled();
+  });
+
+  it('closes the sheet', () => {
+    ctrl.board = adjustableBoard;
+    const { result } = renderHook(() => useMaterialAngleControl());
+    act(() => result.current.open());
+    act(() => result.current.close());
+    expect(result.current.visible).toBe(false);
+  });
+
+  it('persists a new angle via setActiveBoard', () => {
+    ctrl.board = adjustableBoard;
+    const { result } = renderHook(() => useMaterialAngleControl());
+    act(() => result.current.change(45));
+    expect(ctrl.setActiveBoard).toHaveBeenCalledWith({ ...adjustableBoard, angle: 45 });
+  });
+
+  it('ignores a no-op change to the current angle', () => {
+    ctrl.board = adjustableBoard;
+    const { result } = renderHook(() => useMaterialAngleControl());
+    act(() => result.current.change(40));
+    expect(ctrl.setActiveBoard).not.toHaveBeenCalled();
+  });
+
+  it('ignores a change for a fixed-angle board', () => {
+    ctrl.board = { ...adjustableBoard, isAngleAdjustable: false };
+    const { result } = renderHook(() => useMaterialAngleControl());
+    act(() => result.current.change(45));
+    expect(ctrl.setActiveBoard).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/chrome/index.ts
+++ b/packages/mobile/src/components/chrome/index.ts
@@ -6,4 +6,4 @@ export { LightbulbToolbarAction } from './LightbulbToolbarAction';
 export { CollapsingLargeTitleHeader } from './CollapsingLargeTitleHeader';
 export { CollapsingTopChrome } from './CollapsingTopChrome';
 export { DiscoverTopChrome } from './DiscoverTopChrome';
-export { MaterialAngleAction, MaterialAngleChip, MaterialLightbulbAction } from './MaterialBoardActions';
+export { MaterialAngleAction, MaterialLightbulbAction } from './MaterialBoardActions';

--- a/packages/mobile/src/components/chrome/use-material-angle-control.ts
+++ b/packages/mobile/src/components/chrome/use-material-angle-control.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from 'react';
+import { useActiveBoard, useSetActiveBoard } from '../../lib/graphql/use-active-board';
+import { hapticLight } from '../../lib/haptics';
+
+/**
+ * Shared angle state for the Material angle controls: reads the active board, owns
+ * the selector sheet's open state, and writes the chosen angle back (re-grading the
+ * list).
+ *
+ * Each consumer gets its OWN instance (and its own `visible` state) — that's by
+ * design, not a bug: `MaterialAngleAction` (Discover's app bar) and the Climbs
+ * filter-row angle chip never co-render on the same screen, so there is no shared
+ * sheet-open state to diverge.
+ */
+export function useMaterialAngleControl() {
+  const { data: activeBoard } = useActiveBoard();
+  const setActiveBoard = useSetActiveBoard();
+  const [visible, setVisible] = useState(false);
+
+  const canAdjust = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
+  const open = useCallback(() => {
+    if (!activeBoard || activeBoard.isAngleAdjustable === false || activeBoard.angle == null) return;
+    hapticLight();
+    setVisible(true);
+  }, [activeBoard]);
+  const close = useCallback(() => setVisible(false), []);
+  const change = useCallback(
+    (newAngle: number) => {
+      if (!activeBoard || activeBoard.isAngleAdjustable === false || newAngle === activeBoard.angle) return;
+      void setActiveBoard({ ...activeBoard, angle: newAngle });
+    },
+    [activeBoard, setActiveBoard],
+  );
+
+  return { activeBoard, canAdjust, visible, open, close, change };
+}

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -16,12 +16,11 @@ import { Appbar, Chip } from 'react-native-paper';
 import type { Grade } from '@boardsesh/shared-schema';
 import type { GradeBound, GradeTapMeta } from '@boardsesh/climb-filters';
 import { useTheme } from '../../providers/theme-provider';
-import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { selectByVariant } from '../../theme/variants';
 import { spacing } from '../../theme/tokens';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { iconMap } from '../icon-map';
-import { BoardSwitcherButton, CollapsingTopChrome, MaterialAngleChip, TOP_ACTION_SIZE } from '../chrome';
+import { BoardSwitcherButton, CollapsingTopChrome, TOP_ACTION_SIZE } from '../chrome';
 import { GradeRangeRail } from '../grade';
 import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
 import { WallStatusCapsule } from '../queue-control/WallStatusCapsule';
@@ -116,14 +115,8 @@ export function ClimbTopChrome({
 }: ClimbTopChromeProps) {
   const { t } = useTranslation('climbs');
   const { systemColors, variant } = useTheme();
-  const { data: activeBoard } = useActiveBoard();
   const insets = useSafeAreaInsets();
   const usesCustomSearch = searchMode === 'custom';
-  // The Material angle control moved out of the (over-budget) app bar into the
-  // quick row beside the grade/filter chips. Gate the quick row on it OR a filter
-  // summary so the row never renders an empty gap.
-  const angleAdjustable = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
-
   // "On the wall" capsule: own the gate here so a falsy centre slot falls back to
   // the title, and the capsule gets a clean mount/unmount (entering/exiting fade).
   // Only present when a board feed lights a climb that differs from the user's own
@@ -259,24 +252,25 @@ export function ClimbTopChrome({
                 default; it sits directly under the search field, like Liquid Glass. */}
             {showPersistentChips ? filterChrome : null}
 
-            {angleAdjustable || visibleFilterSummary ? (
+            {/* The angle now rides as the first chip in the persistent chip row above
+                (FilterChipRow.android); the quick row only carries the condensed filter
+                summary, which shows only when the top-chrome filters are active (i.e.
+                the persistent chip row is off). */}
+            {visibleFilterSummary ? (
               <View pointerEvents="box-none" style={styles.materialQuickRow}>
-                <MaterialAngleChip />
-                {visibleFilterSummary ? (
-                  <Chip
-                    compact
-                    mode="flat"
-                    icon={iconMap.filter.android}
-                    onPress={visibleFilterSummary.onClear}
-                    onClose={visibleFilterSummary.onClear}
-                    closeIcon={iconMap.close.android}
-                    accessibilityLabel={visibleFilterSummary.text}
-                    style={styles.materialChip}
-                    textStyle={styles.materialChipText}
-                  >
-                    {visibleFilterSummary.text}
-                  </Chip>
-                ) : null}
+                <Chip
+                  compact
+                  mode="flat"
+                  icon={iconMap.filter.android}
+                  onPress={visibleFilterSummary.onClear}
+                  onClose={visibleFilterSummary.onClear}
+                  closeIcon={iconMap.close.android}
+                  accessibilityLabel={visibleFilterSummary.text}
+                  style={styles.materialChip}
+                  textStyle={styles.materialChipText}
+                >
+                  {visibleFilterSummary.text}
+                </Chip>
               </View>
             ) : null}
 

--- a/packages/mobile/src/components/search/FilterChipRow.android.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.android.tsx
@@ -47,6 +47,8 @@ import { POPULARITY_BUCKETS, RATING_BUCKETS } from '../../lib/filter-chip-menus'
 import { useTheme } from '../../providers/theme-provider';
 import { spacing } from '../../theme/tokens';
 import { filterChipBrandColors } from '../../theme/expo-ui-modifiers';
+import { useMaterialAngleControl } from '../chrome/use-material-angle-control';
+import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
 import { popularityChipLabel, ratingChipLabel } from './FilterChipRow.logic';
 import type { DimensionChip, FilterChipRowProps } from './FilterChipRow.types';
 
@@ -252,6 +254,19 @@ function FilterChipRowComponent({
   const { brandColors, colorScheme } = useTheme();
   const chipColors = filterChipBrandColors(brandColors);
 
+  // Angle rides as the first chip: it re-grades the whole list, so it belongs with
+  // the other list-refinement chips rather than in the app bar. Self-contained (reads
+  // the active board, owns its own selector sheet); renders nothing for fixed-angle
+  // boards. Android only — iOS keeps its toolbar angle island (see FilterChipRow.ios).
+  const {
+    activeBoard,
+    canAdjust: canAdjustAngle,
+    visible: angleSheetVisible,
+    open: openAngle,
+    close: closeAngle,
+    change: changeAngle,
+  } = useMaterialAngleControl();
+
   const currentRecentKey = getFilterKey(currentFilters, currentSearchText);
   const hasActivePopularity = minAscents != null;
   const hasActiveRating = minRating != null;
@@ -262,151 +277,169 @@ function FilterChipRowComponent({
       : t('mobile.filter.title');
 
   return (
-    // `colorScheme` keeps the Compose MaterialTheme on our in-app Light/Dark toggle.
-    // `matchContents={{ vertical: true }}` (NOT the boolean form) fills the parent
-    // width so the Row's `fillMaxWidth()` has a bounded width to scroll within, while
-    // height tracks the chip content — mirrors SwitchRow/SegmentedControl.
-    <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
-      <Row
-        modifiers={[fillMaxWidth(), horizontalScroll(), padding(spacing[4], spacing[2], spacing[4], spacing[2])]}
-        verticalAlignment="center"
-        horizontalArrangement={{ spacedBy: spacing[2] }}
-      >
-        {/* Filters · N → the long-tail sheet. Action chip, no menu. */}
-        <ActionChip
-          label={filtersLabel}
-          selected={activeFilterCount > 0}
-          colors={chipColors}
-          iconSource={ICON.tune}
-          onPress={onOpenFilters}
-        />
+    <>
+      {/* `colorScheme` keeps the Compose MaterialTheme on our in-app Light/Dark toggle.
+          `matchContents={{ vertical: true }}` (NOT the boolean form) fills the parent
+          width so the Row's `fillMaxWidth()` has a bounded width to scroll within, while
+          height tracks the chip content — mirrors SwitchRow/SegmentedControl. */}
+      <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
+        <Row
+          modifiers={[fillMaxWidth(), horizontalScroll(), padding(spacing[4], spacing[2], spacing[4], spacing[2])]}
+          verticalAlignment="center"
+          horizontalArrangement={{ spacedBy: spacing[2] }}
+        >
+          {/* Angle → the angle picker. First chip; re-grades the list on change. Action
+              chip, no menu; outlined like the resting filters. Hidden for fixed-angle boards. */}
+          {canAdjustAngle && activeBoard ? (
+            <ActionChip label={`${activeBoard.angle}°`} selected={false} colors={chipColors} onPress={openAngle} />
+          ) : null}
 
-        {/* Recent ▾ — hidden when there are none. */}
-        {recentFilters.length > 0 ? (
-          <MenuChip
-            label={t('mobile.search.recentFilters')}
-            selected={false}
+          {/* Filters · N → the long-tail sheet. Action chip, no menu. */}
+          <ActionChip
+            label={filtersLabel}
+            selected={activeFilterCount > 0}
             colors={chipColors}
-            iconSource={ICON.history}
-            renderItems={(close) => (
-              <>
-                {recentFilters.map((recent) => (
+            iconSource={ICON.tune}
+            onPress={onOpenFilters}
+          />
+
+          {/* Recent ▾ — hidden when there are none. */}
+          {recentFilters.length > 0 ? (
+            <MenuChip
+              label={t('mobile.search.recentFilters')}
+              selected={false}
+              colors={chipColors}
+              iconSource={ICON.history}
+              renderItems={(close) => (
+                <>
+                  {recentFilters.map((recent) => (
+                    <MenuItem
+                      key={recent.id}
+                      label={recent.label}
+                      checked={getFilterKey(recent.filters, recent.searchText) === currentRecentKey}
+                      onClick={() => {
+                        onApplyRecent(recent.filters, recent.searchText);
+                        close();
+                      }}
+                    />
+                  ))}
+                  <HorizontalDivider />
                   <MenuItem
-                    key={recent.id}
-                    label={recent.label}
-                    checked={getFilterKey(recent.filters, recent.searchText) === currentRecentKey}
+                    label={t('mobile.search.clearRecentSearches')}
+                    checked={false}
+                    textColor={brandColors.error}
                     onClick={() => {
-                      onApplyRecent(recent.filters, recent.searchText);
+                      onClearRecent();
                       close();
                     }}
                   />
-                ))}
-                <HorizontalDivider />
+                </>
+              )}
+            />
+          ) : null}
+
+          {/* Grade → the range rail overlay. Action chip, no menu; tap toggles the rail. */}
+          <ActionChip
+            label={gradeLabel}
+            selected={gradeActive}
+            colors={chipColors}
+            onPress={gradeRailOpen ? onCloseGrade : onOpenGrade}
+          />
+
+          {/* Show ▾ — hide-sent (auth-gated) + benchmarks. The controlled menu stays
+            OPEN while toggling (these items don't call close()). */}
+          <MenuChip
+            label={t('mobile.search.chips.show')}
+            selected={hideCompleted || onlyBenchmarks}
+            colors={chipColors}
+            renderItems={() => (
+              <>
+                {canHideCompleted ? (
+                  <MenuItem
+                    label={t('mobile.filter.hideSent')}
+                    checked={hideCompleted}
+                    onClick={() => onToggleHideCompleted(!hideCompleted)}
+                  />
+                ) : null}
                 <MenuItem
-                  label={t('mobile.search.clearRecentSearches')}
-                  checked={false}
-                  textColor={brandColors.error}
-                  onClick={() => {
-                    onClearRecent();
-                    close();
-                  }}
+                  label={t('mobile.filter.benchmark')}
+                  checked={onlyBenchmarks}
+                  onClick={() => onToggleBenchmarks(!onlyBenchmarks)}
                 />
               </>
             )}
           />
-        ) : null}
 
-        {/* Grade → the range rail overlay. Action chip, no menu; tap toggles the rail. */}
-        <ActionChip
-          label={gradeLabel}
-          selected={gradeActive}
-          colors={chipColors}
-          onPress={gradeRailOpen ? onCloseGrade : onOpenGrade}
-        />
-
-        {/* Show ▾ — hide-sent (auth-gated) + benchmarks. The controlled menu stays
-            OPEN while toggling (these items don't call close()). */}
-        <MenuChip
-          label={t('mobile.search.chips.show')}
-          selected={hideCompleted || onlyBenchmarks}
-          colors={chipColors}
-          renderItems={() => (
-            <>
-              {canHideCompleted ? (
-                <MenuItem
-                  label={t('mobile.filter.hideSent')}
-                  checked={hideCompleted}
-                  onClick={() => onToggleHideCompleted(!hideCompleted)}
-                />
-              ) : null}
-              <MenuItem
-                label={t('mobile.filter.benchmark')}
-                checked={onlyBenchmarks}
-                onClick={() => onToggleBenchmarks(!onlyBenchmarks)}
-              />
-            </>
-          )}
-        />
-
-        {/* Tall / Wide — board-shape chips for the current Kilter homewall size
+          {/* Tall / Wide — board-shape chips for the current Kilter homewall size
             (empty otherwise). Tap opens a menu: filter toggle + lock/unlock. */}
-        {dimensionChips.map((dimension) => (
-          <DimensionChipView
-            key={dimension.key}
-            dimension={dimension}
-            label={dimension.key === 'tall' ? t('mobile.search.chips.tall') : t('mobile.search.chips.wide')}
-            toggleLabel={dimension.key === 'tall' ? t('mobile.filter.tall') : t('mobile.filter.wide')}
+          {dimensionChips.map((dimension) => (
+            <DimensionChipView
+              key={dimension.key}
+              dimension={dimension}
+              label={dimension.key === 'tall' ? t('mobile.search.chips.tall') : t('mobile.search.chips.wide')}
+              toggleLabel={dimension.key === 'tall' ? t('mobile.filter.tall') : t('mobile.filter.wide')}
+              colors={chipColors}
+              lockLabel={t('mobile.search.chips.lock')}
+              unlockLabel={t('mobile.search.chips.unlock')}
+            />
+          ))}
+
+          {/* Popularity ▾ — single-choice min-ascents buckets. */}
+          <MenuChip
+            label={hasActivePopularity ? popularityChipLabel(minAscents, t) : t('mobile.filter.popularity')}
+            selected={hasActivePopularity}
             colors={chipColors}
-            lockLabel={t('mobile.search.chips.lock')}
-            unlockLabel={t('mobile.search.chips.unlock')}
+            renderItems={(close) => (
+              <>
+                {POPULARITY_BUCKETS.map((bucket) => (
+                  <MenuItem
+                    key={bucket ?? 'any'}
+                    label={popularityChipLabel(bucket, t)}
+                    checked={bucket === minAscents}
+                    onClick={() => {
+                      onChangePopularity(bucket);
+                      close();
+                    }}
+                  />
+                ))}
+              </>
+            )}
           />
-        ))}
 
-        {/* Popularity ▾ — single-choice min-ascents buckets. */}
-        <MenuChip
-          label={hasActivePopularity ? popularityChipLabel(minAscents, t) : t('mobile.filter.popularity')}
-          selected={hasActivePopularity}
-          colors={chipColors}
-          renderItems={(close) => (
-            <>
-              {POPULARITY_BUCKETS.map((bucket) => (
-                <MenuItem
-                  key={bucket ?? 'any'}
-                  label={popularityChipLabel(bucket, t)}
-                  checked={bucket === minAscents}
-                  onClick={() => {
-                    onChangePopularity(bucket);
-                    close();
-                  }}
-                />
-              ))}
-            </>
-          )}
+          {/* Min rating ▾ — single-choice star buckets. */}
+          <MenuChip
+            label={hasActiveRating ? ratingChipLabel(minRating, t) : t('mobile.filter.minRating')}
+            selected={hasActiveRating}
+            colors={chipColors}
+            renderItems={(close) => (
+              <>
+                {RATING_BUCKETS.map((bucket) => (
+                  <MenuItem
+                    key={bucket ?? 'any'}
+                    label={ratingChipLabel(bucket, t)}
+                    checked={bucket === minRating}
+                    onClick={() => {
+                      onChangeRating(bucket);
+                      close();
+                    }}
+                  />
+                ))}
+              </>
+            )}
+          />
+        </Row>
+      </Host>
+      {canAdjustAngle && activeBoard ? (
+        <AngleSelectorSheet
+          visible={angleSheetVisible}
+          onClose={closeAngle}
+          boardName={activeBoard.boardType}
+          layoutId={activeBoard.layoutId}
+          currentAngle={activeBoard.angle}
+          onAngleChange={changeAngle}
         />
-
-        {/* Min rating ▾ — single-choice star buckets. */}
-        <MenuChip
-          label={hasActiveRating ? ratingChipLabel(minRating, t) : t('mobile.filter.minRating')}
-          selected={hasActiveRating}
-          colors={chipColors}
-          renderItems={(close) => (
-            <>
-              {RATING_BUCKETS.map((bucket) => (
-                <MenuItem
-                  key={bucket ?? 'any'}
-                  label={ratingChipLabel(bucket, t)}
-                  checked={bucket === minRating}
-                  onClick={() => {
-                    onChangeRating(bucket);
-                    close();
-                  }}
-                />
-              ))}
-            </>
-          )}
-        />
-      </Row>
-    </Host>
+      ) : null}
+    </>
   );
 }
 

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -370,10 +370,6 @@ const createAction = (root: HTMLElement) =>
   root.querySelector('[data-pressable="mobile.create.fab.ariaLabel"]') as HTMLButtonElement | null;
 const angleAction = (root: HTMLElement) =>
   root.querySelector('[data-pressable="mobile.angleSelector.title"]') as HTMLButtonElement | null;
-// Material variant: the angle is an M3 quick-row chip (Paper Chip), not a glass
-// toolbar action — the paper mock renders it as `[data-chip="<a11y label>"]`.
-const materialAngleChip = (root: HTMLElement) =>
-  root.querySelector('[data-chip="mobile.angleSelector.title"]') as HTMLButtonElement | null;
 const lightbulb = (root: HTMLElement) =>
   (root.querySelector('[data-pressable="ble.connectBoard"]') ??
     root.querySelector('[data-pressable="lightControl.disconnect"]')) as HTMLButtonElement | null;
@@ -553,31 +549,9 @@ describe('ClimbTopChrome', () => {
     expect(lightbulb(container)).toBeNull();
   });
 
-  it('renders the angle as a Material quick-row chip (not an app-bar action)', () => {
-    ctrl.variant = 'material';
-    ctrl.board = typedBoard;
-    const { container } = render(<ClimbTopChrome {...makeProps()} />);
-    const chip = materialAngleChip(container);
-    expect(chip).not.toBeNull();
-    expect(chip?.textContent).toContain('40°');
-  });
-
-  it('omits the Material angle chip for fixed-angle boards', () => {
-    ctrl.variant = 'material';
-    ctrl.board = { ...typedBoard, isAngleAdjustable: false };
-    const { container } = render(<ClimbTopChrome {...makeProps()} />);
-    expect(materialAngleChip(container)).toBeNull();
-  });
-
-  it('opens the angle sheet from the Material chip and persists the selection', () => {
-    ctrl.variant = 'material';
-    ctrl.board = typedBoard;
-    const { container } = render(<ClimbTopChrome {...makeProps()} />);
-    fireEvent.click(materialAngleChip(container)!);
-    expect(container.querySelector('[data-angle-selector]')).not.toBeNull();
-    fireEvent.click(container.querySelector('[data-angle-selector]') as HTMLButtonElement);
-    expect(ctrl.setActiveBoard).toHaveBeenCalledWith({ ...typedBoard, angle: 45 });
-  });
+  // The Material angle control moved out of ClimbTopChrome into the persistent filter
+  // chip row (FilterChipRow.android), which this component test doesn't render — the
+  // angle chip is covered by the Android screenshot QA, not here.
 
   it('reports its measured height through onHeightChange via onLayout', () => {
     const onHeightChange = vi.fn();
@@ -611,7 +585,9 @@ describe('ClimbTopChrome', () => {
     // label shows as the title with a down-caret affordance. Assert the hint too
     // so this pins the BoardSwitcherButton specifically, not any [data-capsule].
     const switcher = capsule(container);
-    expect(switcher?.getAttribute('data-capsule')).toBe('Display:kilter • 12x12 • 40°');
+    // The Material board switcher drops the angle from the title (it rides its own
+    // filter chip now), so the label is the board name + size without "• 40°".
+    expect(switcher?.getAttribute('data-capsule')).toBe('Display:kilter • 12x12');
     expect(switcher?.getAttribute('data-hint')).toBe('mobile.search.boardSwitcherHint');
     expect(container.querySelector('[data-icon="chevron.down"]')).not.toBeNull();
     expect(container.querySelector('[data-search-field]')).not.toBeNull();

--- a/packages/mobile/src/lib/boards/__tests__/active-board-label.test.ts
+++ b/packages/mobile/src/lib/boards/__tests__/active-board-label.test.ts
@@ -56,4 +56,30 @@ describe('formatActiveBoardLabel', () => {
       }),
     ).toBe('Display:kilter • 0°');
   });
+
+  it('omits the angle segment when includeAngle is false', () => {
+    expect(
+      formatActiveBoardLabel(
+        {
+          name: 'Garage Wall',
+          angle: 40,
+          boardType: 'kilter',
+          sizeName: '12x12',
+          layoutName: 'Homewall',
+        },
+        { includeAngle: false },
+      ),
+    ).toBe('Garage Wall');
+    expect(
+      formatActiveBoardLabel(
+        {
+          angle: 45,
+          boardType: 'tension',
+          sizeName: '12x12',
+          layoutName: 'Spray',
+        },
+        { includeAngle: false },
+      ),
+    ).toBe('Display:tension • 12x12');
+  });
 });

--- a/packages/mobile/src/lib/boards/active-board-label.ts
+++ b/packages/mobile/src/lib/boards/active-board-label.ts
@@ -8,10 +8,20 @@ type BoardLabelFields = {
   layoutName?: string | null;
 };
 
-export function formatActiveBoardLabel(activeBoard: BoardLabelFields | null | undefined): string | null {
+type BoardLabelOptions = {
+  /** Append the angle segment (e.g. "• 40°"). Default true. Set false where the
+   *  angle is surfaced separately (the Material board switcher — the angle rides
+   *  its own filter chip), to avoid showing it twice. */
+  includeAngle?: boolean;
+};
+
+export function formatActiveBoardLabel(
+  activeBoard: BoardLabelFields | null | undefined,
+  { includeAngle = true }: BoardLabelOptions = {},
+): string | null {
   if (!activeBoard) return null;
 
-  const angleLabel = activeBoard.angle != null ? `${activeBoard.angle}°` : null;
+  const angleLabel = includeAngle && activeBoard.angle != null ? `${activeBoard.angle}°` : null;
   const customName = activeBoard.name?.trim();
   const hasCustomName = customName != null && customName.length > 0;
   const labelParts = hasCustomName


### PR DESCRIPTION
## Summary

On the Android/Material Climbs screen the angle (40°) had its **own dedicated row** below the filter chips, and was shown a **second time** as static text in the app-bar title — where that copy wasn't even the tappable control (tapping the title opens the board sheet). Four stacked chrome bands before the first climb, and the angle appeared twice with mismatched affordances.

The angle **re-grades the whole list**, so it's a list-refinement parameter in the same family as Grade / Show / Popularity / Min rating. This moves it to the **first chip in the persistent filter chip row**, deletes the standalone quick row, and drops `• 40°` from the Material board title so the angle appears exactly once, with its filter siblings.

App bar: `[avatar]  High Point Climbing… ⌄     +`
Chip row: `[40°]  Filters  Grade  Show  Popularity  Min rating …`

This placement was chosen after a Material Design 3 design review, which advised **against** docking the angle next to the unrelated `+` create action (a category error) and flagged a bare number in the app bar as ambiguous.

### What changed
- Extracted `useMaterialAngleControl` into its own hook so the native Compose chip row can drive the angle sheet without pulling in react-native-paper.
- `FilterChipRow.android` renders the angle as the first `ActionChip` and hosts the `AngleSelectorSheet`. **Android-only** — iOS keeps its Liquid Glass toolbar angle island (`FilterChipRow.ios` untouched), so there's no double display.
- `formatActiveBoardLabel` gained an `includeAngle` option; `BoardSwitcherButton` passes `includeAngle: false`. The glass title and the board sheet header keep the angle.
- Removed the now-dead `MaterialAngleChip` and the standalone `materialQuickRow` angle path in `ClimbTopChrome`.

## Release Notes

- The board angle now sits with your other filters at the top of the climb list instead of taking up its own line — one less row between you and the climbs.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 3414 passed (updated `board-switcher-button`, `climb-top-chrome`, `active-board-label` specs)
- `vp run check:mobile-bundle` — Android bundle OK
- Android emulator (dev-client + Metro), Climbs tab with a Tension board: verified the `40°` chip is the **first** chip in the filter row, the standalone angle row is gone, and the title has no `• 40°`. Tapping the chip opens the angle picker and re-grades the list.
- iOS unchanged (separate `FilterChipRow.ios`, keeps its toolbar angle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vkfphie4HTR5viBzG68yu1