### PR TITLE
fix(mobile): light the iPad wall kiosk without navigation + screenshot pipeline hardening

### DIFF
--- a/.github/workflows/mobile-screenshots-ios.yml
+++ b/.github/workflows/mobile-screenshots-ios.yml
@@ -252,7 +252,7 @@ jobs:
         run: |
           set -euo pipefail
           url="https://github.com/mobile-dev-inc/maestro/releases/download/cli-${MAESTRO_VERSION}/maestro.zip"
-          curl -fsSL "$url" -o maestro.zip
+          curl -fsSL --retry 5 --retry-all-errors "$url" -o maestro.zip
           echo "${MAESTRO_SHA256}  maestro.zip" | shasum -a 256 -c -
           unzip -q maestro.zip -d "$HOME/.maestro-dist"
           echo "$HOME/.maestro-dist/maestro/bin" >> "$GITHUB_PATH"

--- a/packages/mobile/.maestro/app-store-ipad.yaml
+++ b/packages/mobile/.maestro/app-store-ipad.yaml
@@ -6,67 +6,118 @@ name: app-store screenshots (iPad)
 # Why this differs from the iPhone flow (app-store.yaml): the iPad CANNOT be driven
 # by deep links. On the iPad simulator every `openurl com.boardsesh.app://…` pops the
 # "Open in 'Boardsesh'?" scheme-confirm dialog and the URL is never delivered to the
-# app's router — navigation just never happens (verified: an all-deep-link run on
-# iPad produced 11 byte-identical "stuck on home + dialog" frames, while the same
-# flow on iPhone navigated 10 distinct screens). iPhone remembers the confirm after
+# app's router — navigation just never happens. iPhone remembers the confirm after
 # the first prime; iPad does not.
 #
-# So the iPad navigates via the persistent left SIDEBAR using coordinate taps — the
-# same gesture-tap mechanism the rest of this RN/Fabric build needs (the accessibility
-# tree doesn't expose plain RN views, only native inputs + system dialogs). No
-# `openurl`, so no dialog. The orchestrator selects this flow for iPad devices (see
-# iosSourceFlowFile in scripts/mobile-screenshots.ts).
+# So the iPad navigates via the persistent left SIDEBAR. Each item is a real
+# accessibility element (IpadSidebar sets accessibilityLabel, a locale-independent
+# `testID` of ipad-sidebar-<segment>, and accessibilityState.selected on the active
+# item), so every step taps by id and then waits for `selected: true` — PROOF the
+# navigation took effect, wrapped in a retry that re-taps if it didn't. The previous
+# coordinate-tap flow had no such proof: on the 11" iPad the first tap after the
+# rotation relayout was silently swallowed, and 02-climbs shipped byte-identical to
+# 01-home with a dark wall hero (the orchestrator now also fails the run on
+# byte-identical captures).
 #
-# The ${TAP_*} points are substituted per device by the orchestrator
-# (renderMaestroFlowForIosDevice): the sidebar is laid out in fixed logical points,
-# but Maestro taps are a percentage of the current screen, and the 13" and 11" iPad
-# have different landscape heights — so each item's percentage is computed from its
-# logical anchor and the device's pixel height. Do NOT hardcode percentages here.
-#
-# The wall kiosk is seeded from the active board's REAL climbs when the Climbs list
-# mounts (src/lib/board-presence/screenshot-wall-seed.ts), so Climbs is visited BEFORE
-# On the Wall. The active board is auto-activated on boot (ScreenshotBoardAutoActivator),
-# and the build auto-signs-in and lands on home — the orchestrator gates on
-# `$screen /home` before running this flow.
+# The wall kiosk seed (the active board's real climbs) is published at the root by
+# ScreenshotBoardAutoActivator as soon as the board activates, so the wall shot no
+# longer depends on the Climbs screen mounting first. Climbs is still visited first:
+# it re-publishes the same seed (idempotent) and gives the wall panel time to render.
+# The build auto-signs-in and lands on home — the orchestrator gates on reach-home
+# before running this flow.
 - setOrientation: ${MAESTRO_DEVICE_ORIENTATION}
 - waitForAnimationToEnd
+# The sidebar must be mounted and interactive before the first tap — the first tap
+# after the rotation relayout is the one that got swallowed in CI.
+- extendedWaitUntil:
+    visible:
+      id: "ipad-sidebar-climbs"
+    timeout: 15000
 
-# Climbs — the browse list. Visited FIRST because mounting it seeds the wall kiosk.
-- tapOn:
-    point: ${TAP_CLIMBS}
+# Climbs — the browse list.
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn:
+          id: "ipad-sidebar-climbs"
+      - extendedWaitUntil:
+          visible:
+            id: "ipad-sidebar-climbs"
+            selected: true
+          timeout: 5000
 - waitForAnimationToEnd
 - waitForAnimationToEnd
 - takeScreenshot: 02-climbs
 
-# Home — the "Everyone" feed, with the persistent wall rail now showing the lit climb.
-- tapOn:
-    point: ${TAP_HOME}
+# Home — the "Everyone" feed, with the persistent wall rail showing the lit climb.
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn:
+          id: "ipad-sidebar-home"
+      - extendedWaitUntil:
+          visible:
+            id: "ipad-sidebar-home"
+            selected: true
+          timeout: 5000
 - waitForAnimationToEnd
 - takeScreenshot: 01-home
 
-# On the Wall — the wall-mounted kiosk HERO: the lit board + the current climb big and
-# readable from across the gym. The board-presence feed is seeded above.
-- tapOn:
-    point: ${TAP_WALL}
+# On the Wall — the wall-mounted kiosk HERO: the lit board + the current climb big
+# and readable from across the gym.
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn:
+          id: "ipad-sidebar-wall"
+      - extendedWaitUntil:
+          visible:
+            id: "ipad-sidebar-wall"
+            selected: true
+          timeout: 5000
 - waitForAnimationToEnd
 - waitForAnimationToEnd
 - takeScreenshot: 00-wall
 
 # Record — the workout generator (a workout is pre-selected in screenshot mode via
 # EXPO_PUBLIC_SCREENSHOT_WORKOUT).
-- tapOn:
-    point: ${TAP_RECORD}
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn:
+          id: "ipad-sidebar-record"
+      - extendedWaitUntil:
+          visible:
+            id: "ipad-sidebar-record"
+            selected: true
+          timeout: 5000
 - waitForAnimationToEnd
 - takeScreenshot: 03-workout-generator
 
 # Discover — the playlist library (smart "Your Picks" + saved playlists).
-- tapOn:
-    point: ${TAP_DISCOVER}
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn:
+          id: "ipad-sidebar-discover"
+      - extendedWaitUntil:
+          visible:
+            id: "ipad-sidebar-discover"
+            selected: true
+          timeout: 5000
 - waitForAnimationToEnd
 - takeScreenshot: 04-discover
 
 # Profile — progress / stats (charts).
-- tapOn:
-    point: ${TAP_PROFILE}
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn:
+          id: "ipad-sidebar-profile"
+      - extendedWaitUntil:
+          visible:
+            id: "ipad-sidebar-profile"
+            selected: true
+          timeout: 5000
 - waitForAnimationToEnd
 - takeScreenshot: 05-profile

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -56,12 +56,19 @@ name: app-store screenshots
 # real openLink below navigates cleanly (it's also why Discover needs no special handling
 # any more). The first openurl always pops it (wait + tap); the repeat mops up any
 # re-prompts (optional, after a settle so the dialog has appeared). iOS then remembers it.
+#
+# Both prime steps are OPTIONAL: on a fresh simulator (every CI run) the first openurl
+# always pops the dialog, but a reused local simulator may already remember the confirm
+# from an earlier run and never pop it — a hard wait here failed the whole flow on
+# exactly that (the repeat below still mops up any late re-prompts).
 - openLink: com.boardsesh.app://home
 - extendedWaitUntil:
     visible: 'Open'
     timeout: 12000
+    optional: true
 - tapOn:
     text: 'Open'
+    optional: true
 - waitForAnimationToEnd
 - repeat:
     times: 3

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -58,7 +58,10 @@ import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../src/lib/
 import { getHttpClient } from '../../../src/lib/graphql/client';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
 import { toQueueClimb, toQueueClimbs } from '../../../src/lib/climb-types';
-import { publishScreenshotWallClimbs } from '../../../src/lib/board-presence/screenshot-wall-seed';
+import {
+  buildScreenshotWallSeed,
+  publishScreenshotWallClimbs,
+} from '../../../src/lib/board-presence/screenshot-wall-seed';
 import { parseSetIdsParam, prewarmCreateBoardHolds } from '../../../src/lib/create-board-holds';
 import { useActiveBoard, useSetActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { OnboardingTipBanner } from '../../../src/components/onboarding/OnboardingTipBanner';
@@ -797,24 +800,7 @@ function ClimbListInner() {
   useEffect(() => {
     if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE !== '1') return;
     if (!activeBoard || !searchReady || visibleClimbs.length === 0) return;
-    const nowMs = Date.now();
-    const seeded = visibleClimbs.slice(0, 6).map((climb, index) => ({
-      climbUuid: climb.uuid,
-      name: climb.name,
-      grade: climb.difficulty,
-      gradeColor: null,
-      frames: climb.frames,
-      angle: activeBoard.angle ?? climb.angle,
-      setter: climb.setter_username,
-      sentByDisplayName: null,
-      sentByAvatarUrl: null,
-      sentByUserId: null,
-      // Stagger the timestamps a few minutes apart so the history reads like a
-      // real session rather than a burst.
-      sentAt: new Date(nowMs - index * 4 * 60_000).toISOString(),
-      seq: 100 - index,
-    }));
-    publishScreenshotWallClimbs(seeded, null);
+    publishScreenshotWallClimbs(buildScreenshotWallSeed(visibleClimbs, activeBoard.angle ?? null), null);
   }, [activeBoard, searchReady, visibleClimbs]);
 
   const handleAddToQueue = useCallback(

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -160,7 +160,7 @@ function ClimbListInner() {
   }>();
   const { t } = useTranslation('climbs');
   const { t: tCommon } = useTranslation('common');
-  const { openClimbActions, openAddToPlaylist, openBoardSheet } = useDrawerHost();
+  const { openClimbActions, openAddToPlaylist, openBoardSheet, usesDetailPane } = useDrawerHost();
   // One-time board-history reveal: armed when the user binds a board from the
   // onboarding hand-off and consumed on focus (see the useFocusEffect below).
   // Declared here so handleOpenBoardDetail can clear it — tapping the board
@@ -777,6 +777,24 @@ function ClimbListInner() {
     screenshotOpenedForBoardRef.current = activeBoard.uuid;
     handleClimbPress(firstClimb);
   }, [screenshotOpenFirst, searchReady, visibleClimbs, handleClimbPress, screenshotTargetBoard, activeBoard]);
+
+  // Screenshot mode, iPad master-detail only: the plain `/climbs` list shot must
+  // also LIGHT the detail pane — with nothing selected it reads as a dead black
+  // column in the App Store shot. Activating the first climb fills the pane
+  // beside the list (and it stays lit for the later Home/Discover shots). Gated
+  // on `usesDetailPane` because on iPhone the same activation opens the play
+  // drawer OVER the list; `screenshotOpenFirst` runs its own activation, so this
+  // yields to it. Dead-strips in normal builds.
+  const screenshotPaneLitRef = useRef(false);
+  useEffect(() => {
+    if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE !== '1') return;
+    if (screenshotOpenFirst || !usesDetailPane || screenshotPaneLitRef.current) return;
+    if (!activeBoard || !searchReady) return;
+    const firstClimb = visibleClimbs[0];
+    if (!firstClimb) return;
+    screenshotPaneLitRef.current = true;
+    handleClimbPress(firstClimb);
+  }, [screenshotOpenFirst, usesDetailPane, activeBoard, searchReady, visibleClimbs, handleClimbPress]);
 
   // Screenshot mode: deterministically open the board-presence "now on the wall"
   // sheet (the onboarding hero shot) once the active board resolves, instead of a

--- a/packages/mobile/src/components/analytics/AnalyticsScreenTracker.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsScreenTracker.tsx
@@ -28,11 +28,12 @@ export function AnalyticsScreenTracker(): null {
         const pingUntilDelivered = async () => {
           for (let attempt = 0; attempt < 3; attempt += 1) {
             try {
-              await fetch(readyUrl);
-              return;
+              const readinessResponse = await fetch(readyUrl);
+              if (readinessResponse.ok) return;
             } catch {
-              await new Promise((resolveDelay) => setTimeout(resolveDelay, 2000));
+              // Retry below.
             }
+            await new Promise((resolveDelay) => setTimeout(resolveDelay, 2000));
           }
         };
         void pingUntilDelivered();

--- a/packages/mobile/src/components/analytics/AnalyticsScreenTracker.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsScreenTracker.tsx
@@ -18,12 +18,24 @@ export function AnalyticsScreenTracker(): null {
     trackScreen(path);
     // Screenshot mode: tell the capture orchestrator we reached home directly (not
     // via Metro's `$screen /home` log, which intermittently stops forwarding mid-run
-    // with ERR_STREAM_UNABLE_TO_PIPE). Fire-and-forget GET to its readiness server;
-    // the inlined guard dead-strips this in normal builds.
+    // with ERR_STREAM_UNABLE_TO_PIPE). A few retried GETs to its readiness server —
+    // a single fire-and-forget fetch loses the signal to any transient hiccup, and
+    // this ping only matters when the Metro marker is already lost. The inlined
+    // guard dead-strips this in normal builds.
     if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' && path === '/home') {
       const readyUrl = process.env.EXPO_PUBLIC_SCREENSHOT_READY_URL;
       if (readyUrl) {
-        void fetch(readyUrl).catch(() => {});
+        const pingUntilDelivered = async () => {
+          for (let attempt = 0; attempt < 3; attempt += 1) {
+            try {
+              await fetch(readyUrl);
+              return;
+            } catch {
+              await new Promise((resolveDelay) => setTimeout(resolveDelay, 2000));
+            }
+          }
+        };
+        void pingUntilDelivered();
       }
     }
   }, [segments]);

--- a/packages/mobile/src/components/analytics/AnalyticsScreenTracker.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsScreenTracker.tsx
@@ -33,7 +33,9 @@ export function AnalyticsScreenTracker(): null {
             } catch {
               // Retry below.
             }
-            await new Promise((resolveDelay) => setTimeout(resolveDelay, 2000));
+            if (attempt < 2) {
+              await new Promise((resolveDelay) => setTimeout(resolveDelay, 2000));
+            }
           }
         };
         void pingUntilDelivered();

--- a/packages/mobile/src/components/navigation/IpadSidebar.tsx
+++ b/packages/mobile/src/components/navigation/IpadSidebar.tsx
@@ -80,6 +80,10 @@ function SidebarItem({
       accessibilityRole="tab"
       accessibilityState={{ selected: focused }}
       accessibilityLabel={destination.label}
+      // Locale-independent handle for the App Store screenshot flow
+      // (.maestro/app-store-ipad.yaml): it taps `id: ipad-sidebar-<segment>` and
+      // then waits for `selected: true` as proof the navigation took effect.
+      testID={`ipad-sidebar-${destination.segment}`}
       style={styles.item}
     >
       <View style={[styles.iconPill, active ? { backgroundColor: systemColors.fill } : null]}>

--- a/packages/mobile/src/components/screenshot-board-auto-activator.tsx
+++ b/packages/mobile/src/components/screenshot-board-auto-activator.tsx
@@ -1,5 +1,11 @@
-import { useEffect } from 'react';
-import { useMyBoards } from '../lib/graphql/hooks';
+import { useEffect, useMemo } from 'react';
+import { DEFAULT_CLIMB_FILTER_STATE, toClimbSearchInput } from '@boardsesh/climb-filters';
+import {
+  buildScreenshotWallSeed,
+  publishScreenshotWallClimbs,
+  SCREENSHOT_WALL_SEED_COUNT,
+} from '../lib/board-presence/screenshot-wall-seed';
+import { useMyBoards, useSearchClimbs } from '../lib/graphql/hooks';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
 import { useAuth } from '../providers/auth-provider';
 
@@ -16,6 +22,12 @@ import { useAuth } from '../providers/auth-provider';
  * Because it keeps `useActiveBoard` observed, the activated board is never
  * garbage-collected, and if anything clears it (e.g. a sign-out cleanup on a boot
  * AppState race) the effect re-runs and re-activates.
+ *
+ * Also publishes the wall-kiosk seed (the active board's first climbs) from
+ * here, at the root, so the iPad "On the Wall" hero lights up even if the
+ * Maestro flow never reaches the Climbs screen — its sidebar coordinate tap has
+ * missed on the 11" iPad, which shipped a "WALL IS DARK" App Store shot. The
+ * Climbs screen still re-publishes the same seed when it mounts (idempotent).
  *
  * Mount only behind an inlined `EXPO_PUBLIC_SCREENSHOT_MODE === '1'` check so it
  * dead-strips in normal builds and never runs for real users.
@@ -37,6 +49,35 @@ export function ScreenshotBoardAutoActivator(): null {
     console.log(`[screenshot] auto-activating board ${firstBoard.uuid} (${firstBoard.boardType})`);
     void setActiveBoard(firstBoard);
   }, [isAuthenticated, activeBoard, boardConnection, setActiveBoard]);
+
+  // Same default-filter search the Climbs list runs, sized to the seed — so the
+  // wall lights the same climbs the Climbs screen would publish.
+  const wallSeedSearchInput = useMemo(() => {
+    if (!activeBoard) return null;
+    return toClimbSearchInput(
+      DEFAULT_CLIMB_FILTER_STATE,
+      {
+        boardName: activeBoard.boardType,
+        layoutId: activeBoard.layoutId,
+        sizeId: activeBoard.sizeId,
+        setIds: activeBoard.setIds ?? '',
+        angle: activeBoard.angle ?? 0,
+      },
+      { page: 0, pageSize: SCREENSHOT_WALL_SEED_COUNT },
+    );
+  }, [activeBoard]);
+  const { data: wallSeedSearch } = useSearchClimbs(
+    wallSeedSearchInput ?? { boardName: '', layoutId: 0, sizeId: 0, setIds: '', angle: 0, page: 0, pageSize: 0 },
+    wallSeedSearchInput !== null,
+  );
+
+  useEffect(() => {
+    const seedClimbs = wallSeedSearch?.climbs;
+    if (!activeBoard || !seedClimbs || seedClimbs.length === 0) return;
+    // Logged for the same Metro-tee debuggability as the activation above.
+    console.log(`[screenshot] wall seed published from auto-activator (${seedClimbs.length} climbs)`);
+    publishScreenshotWallClimbs(buildScreenshotWallSeed(seedClimbs, activeBoard.angle ?? null), null);
+  }, [wallSeedSearch, activeBoard]);
 
   return null;
 }

--- a/packages/mobile/src/components/screenshot-board-auto-activator.tsx
+++ b/packages/mobile/src/components/screenshot-board-auto-activator.tsx
@@ -8,6 +8,21 @@ import {
 import { useMyBoards, useSearchClimbs } from '../lib/graphql/hooks';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
 import { useAuth } from '../providers/auth-provider';
+import type { ClimbSearchInput } from '@boardsesh/shared-schema';
+
+// Query-key placeholder for the frames before the active board resolves. The
+// paired `enabled: false` means React Query never runs the fetch — the object
+// is only hashed into the key — so the zero board values are never sent
+// anywhere. Hoisted so every disabled render hashes the identical key.
+const WALL_SEED_SEARCH_DISABLED_INPUT: ClimbSearchInput = {
+  boardName: '',
+  layoutId: 0,
+  sizeId: 0,
+  setIds: '',
+  angle: 0,
+  page: 0,
+  pageSize: 0,
+};
 
 /**
  * Screenshot builds only: make the signed-in user's first saved board (Marco's
@@ -67,7 +82,7 @@ export function ScreenshotBoardAutoActivator(): null {
     );
   }, [activeBoard]);
   const { data: wallSeedSearch } = useSearchClimbs(
-    wallSeedSearchInput ?? { boardName: '', layoutId: 0, sizeId: 0, setIds: '', angle: 0, page: 0, pageSize: 0 },
+    wallSeedSearchInput ?? WALL_SEED_SEARCH_DISABLED_INPUT,
     wallSeedSearchInput !== null,
   );
 

--- a/packages/mobile/src/lib/board-presence/screenshot-wall-seed.ts
+++ b/packages/mobile/src/lib/board-presence/screenshot-wall-seed.ts
@@ -10,7 +10,8 @@
 // the seed client below when `EXPO_PUBLIC_SCREENSHOT_MODE === '1'`.
 //
 // The seed climbs are REAL climbs from the active board's list, published by the
-// Climbs screen (see `app/(tabs)/climbs/index.tsx`). Because they carry the real
+// root ScreenshotBoardAutoActivator as soon as the board activates (and
+// re-published by the Climbs screen when it mounts). Because they carry the real
 // `frames` for whatever board the capture user follows, the kiosk lights the real
 // holds — no hardcoded, board-specific frame string that would render dark on a
 // different board (the known lit-climb gotcha).
@@ -18,8 +19,39 @@
 // Everything here is reached only from inlined `EXPO_PUBLIC_SCREENSHOT_MODE === '1'`
 // branches, so babel/terser dead-strips the whole module from normal builds.
 
-import type { BoardConnectionHolder, BoardPresenceClimb, BoardPresenceStats } from '@boardsesh/shared-schema';
+import type { BoardConnectionHolder, BoardPresenceClimb, BoardPresenceStats, Climb } from '@boardsesh/shared-schema';
 import type { MobileBoardPresenceClient } from './board-presence-client';
+
+/** How many of the active board's climbs the wall kiosk history is seeded with. */
+export const SCREENSHOT_WALL_SEED_COUNT = 6;
+
+/**
+ * Map the active board's real climbs (the first page of the default search) to
+ * the wall-seed shape. Shared by the Climbs screen and the root
+ * ScreenshotBoardAutoActivator so the kiosk lights the same holds no matter
+ * which publisher runs first — the iPad capture must not depend on the Climbs
+ * screen ever mounting (its sidebar tap has missed on the 11" iPad, shipping a
+ * "WALL IS DARK" hero shot).
+ */
+export function buildScreenshotWallSeed(climbs: Climb[], boardAngle: number | null): BoardPresenceClimb[] {
+  const nowMs = Date.now();
+  return climbs.slice(0, SCREENSHOT_WALL_SEED_COUNT).map((climb, index) => ({
+    climbUuid: climb.uuid,
+    name: climb.name,
+    grade: climb.difficulty,
+    gradeColor: null,
+    frames: climb.frames,
+    angle: boardAngle ?? climb.angle,
+    setter: climb.setter_username,
+    sentByDisplayName: null,
+    sentByAvatarUrl: null,
+    sentByUserId: null,
+    // Stagger the timestamps a few minutes apart so the history reads like a
+    // real session rather than a burst.
+    sentAt: new Date(nowMs - index * 4 * 60_000).toISOString(),
+    seq: 100 - index,
+  }));
+}
 
 /**
  * Sentinel `boardId` that flips the wall "live" (`WallScreen`'s `isWallLive`
@@ -36,9 +68,9 @@ const listeners = new Set<SeedListener>();
 
 /**
  * Publish the climbs to show on the wall (newest first — index 0 is the lit
- * climb). Called from the Climbs screen with the active board's real climbs. The
- * seed persists at module scope, so it survives the Climbs screen unmounting when
- * the flow deep-links to the wall tab.
+ * climb). Called from ScreenshotBoardAutoActivator (root) and the Climbs screen
+ * with the active board's real climbs. The seed persists at module scope, so it
+ * survives any screen unmounting before the flow reaches the wall tab.
  */
 export function publishScreenshotWallClimbs(climbs: BoardPresenceClimb[], holder: BoardConnectionHolder | null): void {
   seedClimbs = climbs;

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -133,16 +133,28 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
           // Diagnostics land in Metro's stdout (which the capture orchestrator tees to
           // a log it polls), so a silent sign-in failure is no longer invisible in CI.
           if (SCREENSHOT_USER_EMAIL && SCREENSHOT_USER_PASSWORD) {
-            const screenshotSignIn = await authSignInWithCredentials(SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD);
-            if (screenshotSignIn.success) {
-              console.info('[screenshot] auto sign-in succeeded; rendering straight into home');
-              setIsAuthenticated(true);
-              return;
+            // Retried in-app because a transient network failure here (seen in CI as
+            // `status=null error=network`) otherwise burns one of the orchestrator's
+            // full 120-second relaunch cycles just to attempt the same call again.
+            for (let attempt = 1; attempt <= 3; attempt += 1) {
+              const screenshotSignIn = await authSignInWithCredentials(SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD);
+              if (screenshotSignIn.success) {
+                console.info('[screenshot] auto sign-in succeeded; rendering straight into home');
+                setIsAuthenticated(true);
+                return;
+              }
+              console.warn(
+                `[screenshot] auto sign-in FAILED (attempt ${attempt}/3) — ` +
+                  `status=${screenshotSignIn.status ?? 'null'} error=${screenshotSignIn.error}` +
+                  ` (emailLen=${SCREENSHOT_USER_EMAIL.length} passwordLen=${SCREENSHOT_USER_PASSWORD.length})`,
+              );
+              // Bad credentials (4xx) will not get better; only retry what can
+              // heal — network failures (status null) and transient 5xx.
+              if (screenshotSignIn.status !== null && screenshotSignIn.status < 500) break;
+              if (attempt < 3) {
+                await new Promise((resolveDelay) => setTimeout(resolveDelay, attempt * 2000));
+              }
             }
-            console.warn(
-              `[screenshot] auto sign-in FAILED — status=${screenshotSignIn.status ?? 'null'} error=${screenshotSignIn.error}` +
-                ` (emailLen=${SCREENSHOT_USER_EMAIL.length} passwordLen=${SCREENSHOT_USER_PASSWORD.length})`,
-            );
           } else {
             console.warn(
               `[screenshot] auto sign-in SKIPPED — credentials not inlined into the bundle` +

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -169,6 +169,10 @@ type DrawerHostValue = {
   /** Props for the iPad "Now on the wall" column (regular landscape); null while
    *  no board is resolved. Consumed by `IpadWallColumn` in the shell. */
   boardPanelProps: NowOnTheWallColumnProps | null;
+  /** True when `openPlayDrawer` lands in the iPad shell's persistent right-column
+   *  pane (regular-width master-detail) rather than the `/play` route / bottom
+   *  sheet — a selection fills the pane beside the list instead of covering it. */
+  usesDetailPane: boolean;
 };
 
 const DrawerHostContext = createContext<DrawerHostValue | null>(null);
@@ -767,6 +771,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       openBoardSheet,
       playDrawerPaneProps,
       boardPanelProps,
+      usesDetailPane,
     }),
     [
       storedActiveBoardConfig,
@@ -780,6 +785,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       openBoardSheet,
       playDrawerPaneProps,
       boardPanelProps,
+      usesDetailPane,
     ],
   );
 

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -7,12 +7,12 @@ import { join } from 'node:path';
 import {
   buildScreenshotEnv,
   deviceSlug,
+  findDuplicateScreenshotGroups,
   iosSourceFlowFile,
   ipadSidebarTapPoint,
   isIpadScreenshotDevice,
   metroDevClientUrl,
   parseArgs,
-  READINESS_LOG_PATH,
   renderMaestroFlowForIosDevice,
   resolveAppStoreLocaleTargets,
   resolveIosScreenshotDevices,
@@ -231,13 +231,50 @@ describe('buildScreenshotEnv', () => {
 
 describe('screenshotReadinessCount', () => {
   it('counts each home-reached ping line the readiness server appended', () => {
-    writeFileSync(READINESS_LOG_PATH, '');
-    expect(screenshotReadinessCount()).toBe(0);
-    writeFileSync(READINESS_LOG_PATH, 'x\n');
-    expect(screenshotReadinessCount()).toBe(1);
-    // Blank trailing lines don't inflate the count (the wait compares against a baseline).
-    writeFileSync(READINESS_LOG_PATH, 'x\nx\n');
-    expect(screenshotReadinessCount()).toBe(2);
+    // A private temp log — writing the real READINESS_LOG_PATH could poison a
+    // capture run happening on the same machine.
+    const tempDir = mkdtempSync(join(tmpdir(), 'boardsesh-readiness-'));
+    const logPath = join(tempDir, 'ready.log');
+    try {
+      expect(screenshotReadinessCount(logPath)).toBe(0);
+      writeFileSync(logPath, '');
+      expect(screenshotReadinessCount(logPath)).toBe(0);
+      writeFileSync(logPath, 'x\n');
+      expect(screenshotReadinessCount(logPath)).toBe(1);
+      // Blank trailing lines don't inflate the count (the wait compares against a baseline).
+      writeFileSync(logPath, 'x\nx\n');
+      expect(screenshotReadinessCount(logPath)).toBe(2);
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('findDuplicateScreenshotGroups', () => {
+  it('flags byte-identical captures and leaves distinct ones alone', () => {
+    const captureDir = mkdtempSync(join(tmpdir(), 'boardsesh-dup-shots-'));
+    try {
+      // The iPad 11" failure shape: the Climbs tap never navigated, so
+      // 02-climbs came out as a pixel-perfect copy of 01-home.
+      writeFileSync(join(captureDir, '01-home.png'), 'home-frame-bytes');
+      writeFileSync(join(captureDir, '02-climbs.png'), 'home-frame-bytes');
+      writeFileSync(join(captureDir, '00-wall.png'), 'wall-frame-bytes');
+      writeFileSync(join(captureDir, 'notes.txt'), 'home-frame-bytes');
+      expect(findDuplicateScreenshotGroups(captureDir)).toEqual([['01-home.png', '02-climbs.png']]);
+    } finally {
+      rmSync(captureDir, { force: true, recursive: true });
+    }
+  });
+
+  it('returns no groups when every capture is distinct', () => {
+    const captureDir = mkdtempSync(join(tmpdir(), 'boardsesh-dup-shots-'));
+    try {
+      writeFileSync(join(captureDir, '01-home.png'), 'home-frame-bytes');
+      writeFileSync(join(captureDir, '02-climbs.png'), 'climbs-frame-bytes');
+      expect(findDuplicateScreenshotGroups(captureDir)).toEqual([]);
+    } finally {
+      rmSync(captureDir, { force: true, recursive: true });
+    }
   });
 });
 

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -9,7 +9,6 @@ import {
   deviceSlug,
   findDuplicateScreenshotGroups,
   iosSourceFlowFile,
-  ipadSidebarTapPoint,
   isIpadScreenshotDevice,
   metroDevClientUrl,
   parseArgs,
@@ -362,49 +361,21 @@ describe('renderMaestroFlowForIosDevice', () => {
     }
   });
 
-  it('resolves iPad sidebar tap points from each device landscape height', () => {
-    const ipad13: IosScreenshotDevice = {
-      name: 'iPad Pro 13-inch (M5)',
-      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M5-12GB',
-      orientation: 'LANDSCAPE_LEFT',
-    };
-    const ipad11: IosScreenshotDevice = {
-      name: 'iPad Pro 11-inch (M5)',
-      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-11-inch-M5-12GB',
-      orientation: 'LANDSCAPE_LEFT',
-    };
-    const flow = '- tapOn:\n    point: ${TAP_CLIMBS}\n- tapOn:\n    point: ${TAP_PROFILE}\n';
-
-    // Climbs anchors at logical 144pt (=288px @2x): 288/2064 ≈ 14% on the 13",
-    // 288/1668 ≈ 17% on the shorter 11". Same item, different percentage per device.
-    // Maestro needs whole-number percentages, so the point is rounded.
-    const rendered13 = renderMaestroFlowForIosDevice(flow, ipad13);
-    const rendered11 = renderMaestroFlowForIosDevice(flow, ipad11);
-    expect(rendered13).toContain('point: 3%,14%');
-    expect(rendered11).toContain('point: 3%,17%');
-    // Profile is bottom-anchored — near the bottom on both, but not identical.
-    expect(rendered13).toContain('point: 3%,94%');
-    expect(rendered11).toContain('point: 3%,93%');
-    expect(rendered13).not.toContain('${TAP_');
-    expect(rendered11).not.toContain('${TAP_');
-  });
-
-  it('leaves iPad tap placeholders unresolved on a non-iPad device (the flow never runs there)', () => {
-    const phoneDevice: IosScreenshotDevice = {
-      name: 'iPhone 16 Pro Max',
-      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max',
-      orientation: 'PORTRAIT',
-    };
-    expect(ipadSidebarTapPoint('TAP_CLIMBS', phoneDevice)).toBeNull();
-    expect(renderMaestroFlowForIosDevice('point: ${TAP_CLIMBS}', phoneDevice)).toContain('${TAP_CLIMBS}');
-  });
-
-  it('the iPad flow uses only ${TAP_*} placeholders, never hardcoded percentages', () => {
+  it('the iPad flow taps sidebar items by testID and verifies the selected state — no coordinate taps', () => {
     const ipadFlow = readFileSync('packages/mobile/.maestro/app-store-ipad.yaml', 'utf8');
-    expect(ipadFlow).toContain('point: ${TAP_CLIMBS}');
-    expect(ipadFlow).toContain('point: ${TAP_WALL}');
-    // No literal "N%,M%" tap points — those wouldn't transfer between iPad sizes.
-    expect(ipadFlow).not.toMatch(/point:\s*'?\d/);
+    // Every destination is tapped via its locale-independent id (IpadSidebar's
+    // `ipad-sidebar-<segment>` testID)...
+    for (const segment of ['home', 'climbs', 'record', 'wall', 'discover', 'profile']) {
+      expect(ipadFlow).toContain(`id: "ipad-sidebar-${segment}"`);
+    }
+    // ...and each navigation is verified via the item's selected accessibility
+    // state, so a silently-swallowed tap (the 11" dark-wall failure) re-taps
+    // instead of screenshotting the wrong screen.
+    expect(ipadFlow).toContain('selected: true');
+    expect(ipadFlow).toContain('retry:');
+    // No blind coordinate taps — they carried no proof the navigation happened.
+    expect(ipadFlow).not.toContain('point:');
+    expect(ipadFlow).not.toContain('${TAP_');
   });
 });
 
@@ -434,7 +405,7 @@ describe('iosSourceFlowFile', () => {
   it('the iPad flow is tap-driven (no openurl) and captures the wall kiosk; iPhone stays deep-link driven', () => {
     const ipadFlow = readFileSync('packages/mobile/.maestro/app-store-ipad.yaml', 'utf8');
     expect(ipadFlow).toContain('takeScreenshot: 00-wall');
-    expect(ipadFlow).toContain('point:');
+    expect(ipadFlow).toContain('tapOn:');
     expect(ipadFlow).not.toContain('openLink:');
 
     const phoneFlow = readFileSync('packages/mobile/.maestro/app-store.yaml', 'utf8');

--- a/scripts/mobile-android-shots.ts
+++ b/scripts/mobile-android-shots.ts
@@ -318,6 +318,7 @@ function screenshotEnvOptions(options: ShotsOptions): ScreenshotOptions {
     workout: null,
     appPath: null,
     shutdown: false,
+    orientation: null,
   };
 }
 

--- a/scripts/mobile-android-shots.ts
+++ b/scripts/mobile-android-shots.ts
@@ -462,7 +462,7 @@ async function runFullPipeline(options: ShotsOptions): Promise<number> {
     adb(serial, ['shell', `am start -a android.intent.action.VIEW -d '${metroDevClientUrl()}'`], env);
 
     if (options.screenshotMode) {
-      if (waitForHomeReady(baseline, 240)) {
+      if (waitForHomeReady(baseline, 0, 240)) {
         console.log(`${LOG} App reached home.`);
       } else {
         console.warn(

--- a/scripts/mobile-ios-shots.ts
+++ b/scripts/mobile-ios-shots.ts
@@ -391,6 +391,7 @@ function screenshotEnvOptions(options: ShotsOptions): ScreenshotOptions {
     workout: null,
     appPath: options.appPath,
     shutdown: false,
+    orientation: null,
   };
 }
 

--- a/scripts/mobile-ios-shots.ts
+++ b/scripts/mobile-ios-shots.ts
@@ -552,7 +552,7 @@ async function runFullPipeline(options: ShotsOptions): Promise<number> {
     if (launch.status !== 0) throw new Error(`simctl launch exited ${launch.status}`);
 
     if (options.screenshotMode) {
-      if (waitForHomeReady(baseline, 240)) {
+      if (waitForHomeReady(baseline, 0, 240)) {
         console.log(`${LOG} App reached home.`);
       } else {
         console.warn(

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -1275,7 +1275,10 @@ export function startReadinessServer(): ChildProcess {
   // Verify the child actually bound. Its stdio is 'ignore', so a bind failure
   // (port already taken, child crash) would otherwise be silent and reach-home
   // would quietly degrade to the Metro marker alone — the exact single-signal
-  // fragility this server exists to remove.
+  // fragility this server exists to remove. The up-to-5s wait blocks
+  // synchronously ON PURPOSE: this orchestrator is fully synchronous
+  // (spawnSync everywhere), and nothing useful can happen before the second
+  // reach-home signal is known to be live.
   let bound = false;
   for (let attempt = 0; attempt < 10 && !bound; attempt += 1) {
     sleepSeconds(0.5);

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -36,6 +36,7 @@
  */
 
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -594,6 +595,35 @@ export function clearStatusBar(udid: string): void {
   runCapture('xcrun', ['simctl', 'status_bar', udid, 'clear']);
 }
 
+/**
+ * Group the captured PNGs by content hash and return every group with more than
+ * one file. Two byte-identical captures mean a navigation step silently failed
+ * and the flow screenshotted the same screen twice — seen on the iPad 11",
+ * where the Climbs sidebar tap missed and `02-climbs.png` shipped as a
+ * pixel-perfect copy of `01-home.png`. Distinct screens never hash equal (the
+ * status bar is frozen at 9:41, but screen content always differs), so any
+ * duplicate is a real capture failure and the shard should fail loudly instead
+ * of uploading a duplicate to the store.
+ */
+export function findDuplicateScreenshotGroups(captureDir: string): string[][] {
+  const pngs = readdirSync(captureDir)
+    .filter((file) => file.toLowerCase().endsWith('.png'))
+    .sort();
+  const filesByHash = new Map<string, string[]>();
+  for (const png of pngs) {
+    const digest = createHash('sha256')
+      .update(readFileSync(join(captureDir, png)))
+      .digest('hex');
+    const group = filesByHash.get(digest);
+    if (group) {
+      group.push(png);
+    } else {
+      filesByHash.set(digest, [png]);
+    }
+  }
+  return [...filesByHash.values()].filter((group) => group.length > 1);
+}
+
 function collectScreenshots(
   captureDir: string,
   platform: 'ios' | 'android',
@@ -878,6 +908,16 @@ function captureIosDevice(
     const normalizeStatus = normalizeCapturedIosScreenshots(captureDir, screenshotDevice);
     if (normalizeStatus !== 0) return normalizeStatus;
 
+    const duplicateGroups = findDuplicateScreenshotGroups(captureDir);
+    if (duplicateGroups.length > 0) {
+      for (const group of duplicateGroups) {
+        console.error(
+          `${LOG} FAILED: byte-identical captures ${group.join(' = ')} — a navigation step did not take effect.`,
+        );
+      }
+      return 1;
+    }
+
     const saved = collectScreenshots(captureDir, 'ios', device.name, localeTarget.appStoreLocales);
     if (saved.length === 0) {
       console.error(`${LOG} WARNING: flow completed but no PNGs were captured.`);
@@ -962,6 +1002,16 @@ function runAndroid(options: ScreenshotOptions): number {
     if (maestroStatus !== 0) {
       console.error(`${LOG} FAILED: Maestro exited with ${maestroStatus}.`);
       return maestroStatus;
+    }
+
+    const duplicateGroups = findDuplicateScreenshotGroups(captureDir);
+    if (duplicateGroups.length > 0) {
+      for (const group of duplicateGroups) {
+        console.error(
+          `${LOG} FAILED: byte-identical captures ${group.join(' = ')} — a navigation step did not take effect.`,
+        );
+      }
+      return 1;
     }
 
     const saved = collectScreenshots(captureDir, 'android', deviceName);
@@ -1225,8 +1275,10 @@ export function portInUse(port: number): boolean {
 // home. The reach-home wait counts new lines alongside the Metro `$screen /home`
 // marker — a signal that survives Metro's log forwarding dying.
 export const READINESS_LOG_PATH = join(tmpdir(), 'boardsesh-screenshot-ready.log');
-export function screenshotReadinessCount(): number {
-  const log = existsSync(READINESS_LOG_PATH) ? readFileSync(READINESS_LOG_PATH, 'utf8') : '';
+// `logPath` is parameterized for tests only, so they never touch the real log a
+// concurrent capture run might be counting.
+export function screenshotReadinessCount(logPath: string = READINESS_LOG_PATH): number {
+  const log = existsSync(logPath) ? readFileSync(logPath, 'utf8') : '';
   return log.split('\n').filter((line) => line.length > 0).length;
 }
 
@@ -1257,14 +1309,37 @@ function readinessServerReachable(): boolean {
  */
 export function startReadinessServer(): ChildProcess {
   writeFileSync(READINESS_LOG_PATH, '');
-  const serverCode =
-    `const h=require('http'),f=require('fs');` +
-    `h.createServer((q,s)=>{if(q.url&&q.url.indexOf('/ready')===0){f.appendFileSync(${JSON.stringify(READINESS_LOG_PATH)},'x\\n');}s.statusCode=204;s.end();})` +
-    `.listen(${SCREENSHOT_READY_PORT},'0.0.0.0');`;
+  const serverCode = [
+    `const http = require('http');`,
+    `const fs = require('fs');`,
+    `http.createServer((request, response) => {`,
+    `  if (request.url && request.url.indexOf('/ready') === 0) {`,
+    `    fs.appendFileSync(${JSON.stringify(READINESS_LOG_PATH)}, 'x\\n');`,
+    `  }`,
+    `  response.statusCode = 204;`,
+    `  response.end();`,
+    `}).listen(${SCREENSHOT_READY_PORT}, '0.0.0.0');`,
+  ].join('\n');
   const server = spawn(process.execPath, ['-e', serverCode], { stdio: 'ignore', detached: true });
   // Don't let the child keep the orchestrator's event loop alive at exit.
   server.unref();
-  console.log(`${LOG} Readiness server started (pid ${server.pid ?? '?'}) on port ${SCREENSHOT_READY_PORT}.`);
+  // Verify the child actually bound. Its stdio is 'ignore', so a bind failure
+  // (port already taken, child crash) would otherwise be silent and reach-home
+  // would quietly degrade to the Metro marker alone — the exact single-signal
+  // fragility this server exists to remove.
+  let bound = false;
+  for (let attempt = 0; attempt < 10 && !bound; attempt += 1) {
+    sleepSeconds(0.5);
+    bound = readinessServerReachable();
+  }
+  if (bound) {
+    console.log(`${LOG} Readiness server started (pid ${server.pid ?? '?'}) on port ${SCREENSHOT_READY_PORT}.`);
+  } else {
+    console.warn(
+      `${LOG} WARNING: readiness server never responded on port ${SCREENSHOT_READY_PORT} — is the port in use? ` +
+        `Reach-home will rely on the Metro '$screen /home' marker alone.`,
+    );
+  }
   return server;
 }
 

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -72,32 +72,6 @@ const APP_ID = 'com.boardsesh.app';
 const DEV_CLIENT_URL_SCHEME = 'exp+boardsesh';
 const MAESTRO_DEVICE_ORIENTATION_PLACEHOLDER = '${MAESTRO_DEVICE_ORIENTATION}';
 
-// The iPad tap flow (app-store-ipad.yaml) navigates via the left SIDEBAR with
-// coordinate taps. The sidebar is laid out in LOGICAL POINTS (identical on every
-// iPad), but Maestro `point:` taps are percentages of the CURRENT screen — and the
-// 13" and 11" iPad have different landscape pixel heights, so the same item sits at
-// a different percentage on each. So the flow carries a `${TAP_*}` placeholder per
-// item and the orchestrator substitutes the concrete `x%,y%` computed from the
-// item's logical anchor and THIS device's pixel height. (All iPad simulators are
-// @2x, so logical points → pixels is ×2.)
-const IPAD_SIDEBAR_TAP_X_PERCENT = 3;
-// Vertical anchor of each top-anchored sidebar item, in logical points from the top.
-const IPAD_SIDEBAR_TOP_ITEM_PT: Record<string, number> = {
-  TAP_HOME: 72,
-  TAP_CLIMBS: 144,
-  TAP_RECORD: 206,
-  TAP_WALL: 278,
-  TAP_DISCOVER: 361,
-};
-// Profile is pinned to the BOTTOM of the sidebar, this many logical points up from
-// the bottom screen edge.
-const IPAD_SIDEBAR_PROFILE_FROM_BOTTOM_PT = 62;
-// Landscape pixel height per iPad, keyed by device slug (matches the sizes the
-// screenshot dimension gate accepts).
-const IPAD_LANDSCAPE_HEIGHT_PX: Record<string, number> = {
-  'ipad-pro-13-inch-m5': 2064,
-  'ipad-pro-11-inch-m5': 1668,
-};
 const DEFAULT_ANDROID_DEVICE = 'Pixel 2';
 const DEFAULT_ANDROID_APK = resolve(
   MOBILE_DIR,
@@ -691,37 +665,12 @@ export function iosSourceFlowFile(options: ScreenshotOptions, screenshotDevice: 
   return flowFileForPlatform(options, 'ios');
 }
 
-/**
- * The `x%,y%` Maestro tap point for an iPad sidebar item, computed from its logical
- * anchor and the device's landscape pixel height (iPad simulators are @2x, so
- * `logicalPt × 2` = pixels). Top items are anchored from the top; Profile from the
- * bottom. Returns null for a non-iPad device or an unknown iPad height.
- */
-export function ipadSidebarTapPoint(placeholder: string, screenshotDevice: IosScreenshotDevice): string | null {
-  const heightPx = IPAD_LANDSCAPE_HEIGHT_PX[deviceSlug(screenshotDevice.name)];
-  if (heightPx === undefined) return null;
-  const topAnchorPt = IPAD_SIDEBAR_TOP_ITEM_PT[placeholder];
-  const yPercent =
-    topAnchorPt !== undefined
-      ? ((topAnchorPt * 2) / heightPx) * 100
-      : placeholder === 'TAP_PROFILE'
-        ? ((heightPx - IPAD_SIDEBAR_PROFILE_FROM_BOTTOM_PT * 2) / heightPx) * 100
-        : null;
-  if (yPercent === null) return null;
-  // Maestro `point:` percentages must be whole numbers (it throws on a decimal). The
-  // sidebar touch targets are ~44pt (~5%), so rounding is well within tolerance.
-  return `${IPAD_SIDEBAR_TAP_X_PERCENT}%,${Math.round(yPercent)}%`;
-}
-
+// The iPad flow taps sidebar items by their locale-independent testID
+// (`ipad-sidebar-<segment>`, see IpadSidebar) and verifies each navigation via
+// the item's `selected` accessibility state — no per-device coordinate math.
+// Only the orientation placeholder needs substituting per device.
 export function renderMaestroFlowForIosDevice(flowSource: string, screenshotDevice: IosScreenshotDevice): string {
-  let rendered = flowSource.replaceAll(MAESTRO_DEVICE_ORIENTATION_PLACEHOLDER, screenshotDevice.orientation);
-  for (const placeholder of [...Object.keys(IPAD_SIDEBAR_TOP_ITEM_PT), 'TAP_PROFILE']) {
-    const point = ipadSidebarTapPoint(placeholder, screenshotDevice);
-    if (point !== null) {
-      rendered = rendered.replaceAll(`\${${placeholder}}`, point);
-    }
-  }
-  return rendered;
+  return flowSource.replaceAll(MAESTRO_DEVICE_ORIENTATION_PLACEHOLDER, screenshotDevice.orientation);
 }
 
 export function rotationDegreesForIosOrientation(orientation: IosDeviceOrientation): number | null {


### PR DESCRIPTION
## Summary

The App Store screenshot workflow failed 62% of its last 30 runs, and every iPad Pro 11-inch shot shipped with a dark board ("WALL IS DARK") plus a `02-climbs.png` that was a byte-identical copy of `01-home.png`. This PR fixes the iPad failure at its root and lands the remaining reliability work from the #3492 review.

### iPad 11" dark wall — root cause and fix

Artifacts from run 28781735332 show the 11"'s first sidebar tap (Climbs) silently never navigated on every locale, while the 13" was fine. The wall kiosk seed was only published when the Climbs screen mounted, so the hero shot rendered unlit holds.

Three layers of fix, so no single tap can sink a shard again:

1. **The wall no longer depends on navigation.** `ScreenshotBoardAutoActivator` (root-mounted, screenshot-mode only) now runs the same default-filter climb search the Climbs list uses and publishes the wall seed as soon as the active board resolves. Shared mapping lives in `buildScreenshotWallSeed` (`screenshot-wall-seed.ts`); the Climbs screen re-publishes the same seed (idempotent).
2. **Sidebar taps are now verifiable.** The #3484 note said Maestro couldn't see RN views — re-tested with `maestro hierarchy`: labeled pressables ARE exposed, including their `selected` accessibility state. `IpadSidebar` items now carry a locale-independent `testID` (`ipad-sidebar-<segment>`), and `app-store-ipad.yaml` taps by id, waits for `selected: true` as proof the navigation took effect, and re-taps via `retry` if it didn't. All per-device coordinate-tap math (`ipadSidebarTapPoint`, anchor tables) is deleted.
3. **Bad captures fail loudly.** `collectScreenshots` now fails the run when two captures are byte-identical — the exact 11" failure shape — instead of shipping a duplicate to App Store Connect.
4. **The master-detail pane is lit in every iPad shot.** On the plain `/climbs` list the detail pane used to sit as a dead black column (nothing selected). In screenshot mode the Climbs screen now activates the first climb when the pane layout is up (`usesDetailPane`, newly exposed from the drawer host) — the pane shows a lit board beside the list and stays lit for the Home/Discover shots. iPhone is untouched (there the same activation would cover the list with the play drawer).

### Reach-home / flake hardening (residual #3492 review findings)

- `waitForHomeReady(baseline, 240)` in `mobile-ios-shots.ts` / `mobile-android-shots.ts` passed the timeout into the new `readyBaseline` slot (unsatisfiable) — now `(baseline, 0, 240)`.
- The readiness server's bind is verified via `/probe` after spawn (its stdio is `ignore`, so a port conflict used to be silent); inline server code de-minified per repo naming rules.
- The app retries the reach-home readiness ping (3×, 2s apart) instead of one fire-and-forget fetch.
- Screenshot auto sign-in retries transient failures (network / 5xx, 3× with backoff) — previously one `error=network` blip cost a full 120s relaunch cycle (seen in run 28579610631).
- `screenshotReadinessCount` tests use a private temp log instead of writing the real one.
- The Maestro download curl in CI retries (`--retry 5 --retry-all-errors`).
- The iPhone flow's prime-dialog steps are `optional:` — a reused local simulator remembers the scheme confirm and the "Open" dialog never pops, which used to fail the whole flow (CI runners are always fresh and still prime).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Local `vp run mobile:screenshots` on iPad Pro 11-inch (M5), en-US, prod backend — three runs across the iterations: `00-wall` renders the lit hero (ON THE WALL NOW · V3 Moon Landing), `02-climbs` shows the climb list with the first climb selected and its lit board filling the detail pane, `01-home` shows the same lit pane, all six frames distinct, every id-tap `selected`-state assertion passed.
- Local `vp run mobile:screenshots` on iPhone 16 Pro Max, en-US: 10 distinct frames, duplicate guard green (and the remembered-dialog case reproduced + fixed).
- `vp run typecheck:mobile`, `vp run test:mobile` (3423 tests), scripts tests (41, incl. new duplicate-guard + flow-shape tests), `vp check` clean on touched files.
- Full 9-shard `workflow_dispatch` on this branch (no upload): link in comments once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KV6NHZAQUPLz5EigLLd7p
