### PR TITLE
fix(db): acquire all 0144 table locks up front to avoid deploy deadlock

### DIFF
--- a/packages/db/drizzle/0144_offline_sync_backend.sql
+++ b/packages/db/drizzle/0144_offline_sync_backend.sql
@@ -6,6 +6,49 @@
 -- the generated snapshot, but reach the same schema through nullable adds,
 -- explicit sequences, batched backfills, and final NOT NULL/default changes.
 
+-- Take every table lock this migration needs up front, before any slow work.
+-- The first production run deadlocked (40P01): the ALTER on board_climb_stats
+-- held its AccessExclusiveLock through the ~2 minute backfill, then the ALTER
+-- on board_climbs queued behind a live app query that held board_climbs and
+-- was itself waiting on board_climb_stats. Acquiring all locks in one
+-- retry-protected step means we never wait for a new lock while sitting on an
+-- old one with traffic interleaved. lock_timeout bounds each attempt and the
+-- subtransaction rollback releases partial acquisitions before retrying, so
+-- the migration can't deadlock against app queries — it just queues.
+-- boardsesh_ticks and playlists only receive triggers/indexes here, so they
+-- get SHARE ROW EXCLUSIVE (blocks writes, keeps reads flowing) instead of
+-- ACCESS EXCLUSIVE.
+DO $$
+DECLARE
+  attempts integer := 0;
+BEGIN
+  LOOP
+    attempts := attempts + 1;
+    BEGIN
+      SET LOCAL lock_timeout = '3s';
+      LOCK TABLE
+        "board_climb_stats",
+        "board_climbs",
+        "user_favorites",
+        "playlist_climbs",
+        "user_playlist_pins",
+        "playlist_follows",
+        "setter_follows",
+        "user_follows"
+      IN ACCESS EXCLUSIVE MODE;
+      LOCK TABLE "boardsesh_ticks", "playlists" IN SHARE ROW EXCLUSIVE MODE;
+      SET LOCAL lock_timeout = '0';
+      RETURN;
+    EXCEPTION WHEN lock_not_available OR deadlock_detected THEN
+      IF attempts >= 40 THEN
+        RAISE;
+      END IF;
+      PERFORM pg_sleep(1);
+    END;
+  END LOOP;
+END $$;
+--> statement-breakpoint
+
 CREATE TABLE "sync_deletions" (
 	"id" bigserial PRIMARY KEY NOT NULL,
 	"table_name" text NOT NULL,


### PR DESCRIPTION
## Summary

The main deploy failed running migration `0144_offline_sync_backend` against prod: [run 28835722106](https://github.com/boardsesh/boardsesh/actions/runs/28835722106/job/85519506323).

**Root cause:** the whole migration runs in one transaction. The `ALTER TABLE board_climb_stats` took an `AccessExclusiveLock`, the batched backfill then held it for ~2 minutes, and when the migration next requested the exclusive lock on `board_climbs`, a live app query already held a share lock on `board_climbs` and was itself waiting on `board_climb_stats`. Postgres killed the migration as the deadlock victim (`40P01`). The transaction rolled back atomically, so nothing partially applied — 0144 is still unapplied on prod.

**Fix:** acquire every table lock the migration needs in a single retry-protected `DO` block as the very first statement, before any slow work. Once all locks are held, app queries just queue behind the migration instead of interleaving into a deadlock cycle. Details:

- `lock_timeout = '3s'` bounds each acquisition attempt; on `lock_not_available` or `deadlock_detected` the subtransaction rollback releases any partially acquired locks, sleeps 1s, and retries (up to 40 attempts) so the migration can't livelock or deadlock against traffic.
- Tables that are `ALTER`ed get `ACCESS EXCLUSIVE` (they'd need it anyway); `boardsesh_ticks` and `playlists` only receive triggers/indexes, so they take `SHARE ROW EXCLUSIVE` and reads keep flowing.
- `lock_timeout` is reset to `0` after acquisition so the long backfills aren't subject to it.

Editing the merged migration in place is safe: the drizzle migrator gates on `created_at`, not file hash, and the failed prod run left no trace of 0144.

**Validation:** executed the lock block against a scratch Postgres 18 with stub tables — runs clean, locks acquired, `lock_timeout` back to `0` afterwards.

Once merged, the push to `main` triggers `production-deploy.yml` and the migration re-runs.

## Release Notes

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AWDbJpReVSk83DsgvrzQg