### PR TITLE
feat: tall/wide climb filters offline + on every Aurora board

### DIFF
--- a/packages/board-constants/src/__tests__/product-sizes.test.ts
+++ b/packages/board-constants/src/__tests__/product-sizes.test.ts
@@ -3,9 +3,12 @@ import {
   KILTER_HOMEWALL_LAYOUT_ID,
   KILTER_HOMEWALL_PRODUCT_ID,
   getLayoutName,
+  getTallWideScope,
   isKilterHomewallTallSizeId,
   isKilterHomewallWideSizeId,
 } from '../product-sizes';
+
+const EMPTY_SCOPE = { narrowerSizeIds: [], shorterSizeIds: [], hasNarrower: false, hasShorter: false };
 
 describe('getLayoutName', () => {
   it('returns the human-readable name for a known board + layoutId', () => {
@@ -41,5 +44,52 @@ describe('Kilter Homewall size filter capabilities', () => {
     for (const sizeId of [23, 24]) {
       expect(isKilterHomewallWideSizeId(sizeId)).toBe(false);
     }
+  });
+});
+
+describe('getTallWideScope', () => {
+  const sorted = (ids: number[]) => [...ids].sort((left, right) => left - right);
+
+  it('classifies the Kilter Homewall 10x12 as both tall- and wide-capable', () => {
+    const scope = getTallWideScope('kilter', 8, 25);
+    expect(scope.hasShorter).toBe(true);
+    expect(scope.hasNarrower).toBe(true);
+    // Shorter (10-high) sizes: 7x10 (17,18,19) + 10x10 (21,22,29).
+    expect(sorted(scope.shorterSizeIds)).toEqual([17, 18, 19, 21, 22, 29]);
+    // Narrower (8-wide) sizes: 7x10 (17,18,19) + 8x12 (23,24).
+    expect(sorted(scope.narrowerSizeIds)).toEqual([17, 18, 19, 23, 24]);
+  });
+
+  it('offers only tall on 8x12 (narrowest width) and only wide on 10x10 (shortest height)', () => {
+    const tallOnly = getTallWideScope('kilter', 8, 23); // 8x12
+    expect(tallOnly.hasShorter).toBe(true);
+    expect(tallOnly.hasNarrower).toBe(false);
+
+    const wideOnly = getTallWideScope('kilter', 8, 21); // 10x10
+    expect(wideOnly.hasShorter).toBe(false);
+    expect(wideOnly.hasNarrower).toBe(true);
+  });
+
+  it('offers neither on the smallest Homewall size (7x10)', () => {
+    expect(getTallWideScope('kilter', 8, 17)).toEqual(EMPTY_SCOPE);
+  });
+
+  it('generalizes to Tension Board 2 (layout 11, product 5)', () => {
+    const scope = getTallWideScope('tension', 11, 6); // 12 high x 12 wide
+    expect(scope.hasShorter).toBe(true);
+    expect(scope.hasNarrower).toBe(true);
+    expect(sorted(scope.shorterSizeIds)).toEqual([7, 9]); // 10-high sizes
+    expect(sorted(scope.narrowerSizeIds)).toEqual([8, 9]); // 8-wide sizes
+  });
+
+  it('returns an empty scope for MoonBoard (single size) and unknown boards', () => {
+    expect(getTallWideScope('moonboard', 1, 1)).toEqual(EMPTY_SCOPE);
+    expect(getTallWideScope('kilter', 99999, 25)).toEqual(EMPTY_SCOPE);
+    expect(getTallWideScope('kilter', 8, 99999)).toEqual(EMPTY_SCOPE);
+  });
+
+  it('fails closed on a mismatched (layout, size) whose products differ', () => {
+    // size 25 is product 7 (Homewall); layout 1 is product 1 (Original).
+    expect(getTallWideScope('kilter', 1, 25)).toEqual(EMPTY_SCOPE);
   });
 });

--- a/packages/board-constants/src/product-sizes.ts
+++ b/packages/board-constants/src/product-sizes.ts
@@ -112,6 +112,70 @@ export const getSizesForProduct = (boardName: BoardName, productId: number): Pro
   });
 };
 
+export type TallWideScope = {
+  /** Family size ids strictly narrower than the active size (width axis). */
+  narrowerSizeIds: number[];
+  /** Family size ids strictly shorter than the active size (height axis). */
+  shorterSizeIds: number[];
+  /** A narrower family size exists — gates the "wide" filter/chip. */
+  hasNarrower: boolean;
+  /** A shorter family size exists — gates the "tall" filter/chip. */
+  hasShorter: boolean;
+};
+
+const EMPTY_TALL_WIDE_SCOPE: TallWideScope = {
+  narrowerSizeIds: [],
+  shorterSizeIds: [],
+  hasNarrower: false,
+  hasShorter: false,
+};
+
+/**
+ * Size-relative "tall"/"wide" scope for a board's active (layout, size), the
+ * single source of truth for both filters on every board.
+ *
+ * A climb is **wide** when it can't be done on any size in the active layout's
+ * product family that is narrower than the active size, and **tall** when it
+ * can't be done on any shorter one — a caller expresses that as: the climb's
+ * `compatible_size_ids` overlaps NONE of the returned `narrowerSizeIds` /
+ * `shorterSizeIds`. Both axes are scoped to the active size's product family: a
+ * board type can mix products whose coordinate systems differ (so a climb's
+ * `compatible_size_ids` may list cross-product sizes that must not leak into the
+ * reference set), and every family size class counts — duplicate LED-kit variants
+ * (e.g. Kilter Homewall 17/18/19, all 7x10) are all "narrower".
+ *
+ * `hasNarrower` / `hasShorter` are false when the active size is the
+ * narrowest / shortest in its axis — how callers hide the Wide / Tall option so
+ * the smallest size never offers a filter that would match nothing. A board with
+ * a single size (MoonBoard, Touchstone) yields empty sets on both axes.
+ *
+ * Width = `edgeRight - edgeLeft`, height = `edgeTop - edgeBottom`.
+ */
+export const getTallWideScope = (boardName: BoardName, layoutId: number, sizeId: number): TallWideScope => {
+  const activeSize = getProductSize(boardName, sizeId);
+  const layout = getLayout(boardName, layoutId);
+  // A mismatched (layout, size) — a stale/crafted combo whose size belongs to a
+  // different product than the layout — has no coherent family; fail closed.
+  if (!activeSize || !layout || activeSize.productId !== layout.productId) return EMPTY_TALL_WIDE_SCOPE;
+
+  const activeWidth = activeSize.edgeRight - activeSize.edgeLeft;
+  const activeHeight = activeSize.edgeTop - activeSize.edgeBottom;
+
+  // Whole product family (not getSizesForProduct, which drops a Grasshopper
+  // duplicate for the picker) — the reference set needs every size class.
+  const family = Object.values(PRODUCT_SIZES[boardName] ?? {}).filter((size) => size.productId === layout.productId);
+
+  const narrowerSizeIds = family.filter((size) => size.edgeRight - size.edgeLeft < activeWidth).map((size) => size.id);
+  const shorterSizeIds = family.filter((size) => size.edgeTop - size.edgeBottom < activeHeight).map((size) => size.id);
+
+  return {
+    narrowerSizeIds,
+    shorterSizeIds,
+    hasNarrower: narrowerSizeIds.length > 0,
+    hasShorter: shorterSizeIds.length > 0,
+  };
+};
+
 export const getSetsForLayoutAndSize = (boardName: BoardName, layoutId: number, sizeId: number): SetData[] => {
   const key = `${layoutId}-${sizeId}`;
   return SETS[boardName]?.[key] ?? [];

--- a/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
@@ -1,11 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import type { SQL } from 'drizzle-orm';
-import {
-  createClimbFilters,
-  getKilterHomewallWideHoldIdsForSets,
-  resetKilterHomewallWideHoldIdsForTests,
-} from '../create-climb-filters';
+import { createClimbFilters } from '../create-climb-filters';
 import type { BoardRouteParams, ClimbSearchParams } from '../types';
 
 const params: BoardRouteParams = {
@@ -231,16 +227,23 @@ void describe('createClimbFilters: tall climbs', () => {
     angle: 40,
   };
 
-  void it('uses the climb bottom edge to find Kilter Homewall tall climbs', () => {
+  void it('excludes climbs compatible with any shorter Homewall size via compatible_size_ids', () => {
     const filters = createClimbFilters(homewallTallParams, { onlyTallClimbs: true });
 
     assert.equal(filters.tallClimbsConditions.length, 1);
     const rendered = sqlToString(filters.tallClimbsConditions[0]);
-    assert.match(rendered, /edge_bottom/);
-    assert.match(rendered, /SELECT MAX\(ps\.edge_bottom\)/);
-    assert.match(rendered, /FROM/);
-    assert.match(rendered, /MAX/);
-    assert.match(rendered, /product_id/);
+    // NOT (compatible_size_ids && ARRAY[<shorter size ids>]::int[])
+    assert.match(rendered, /NOT/);
+    assert.match(rendered, /compatible_size_ids/);
+    assert.match(rendered, /&&/);
+    assert.match(rendered, /ARRAY\[/);
+    assert.match(rendered, /::int\[\]/);
+    // The shorter (10-high) Homewall sizes: 7x10 (17,18,19) + 10x10 (21,22,29).
+    for (const shorterSizeId of [17, 18, 19, 21, 22, 29]) {
+      assert.match(rendered, new RegExp(`(^|\\D)${shorterSizeId}(\\D|$)`));
+    }
+    // No longer the old climb-bottom-edge subquery.
+    assert.doesNotMatch(rendered, /edge_bottom/);
   });
 
   void it('supports tall climbs on 8x12 Kilter Homewall sizes', () => {
@@ -248,15 +251,31 @@ void describe('createClimbFilters: tall climbs', () => {
       const filters = createClimbFilters({ ...homewallTallParams, size_id: sizeId }, { onlyTallClimbs: true });
       assert.equal(filters.tallClimbsConditions.length, 1);
       assert.notEqual(sqlToString(filters.tallClimbsConditions[0]), 'false');
-      assert.match(sqlToString(filters.tallClimbsConditions[0]), /edge_bottom/);
+      assert.match(sqlToString(filters.tallClimbsConditions[0]), /compatible_size_ids/);
     }
   });
 
-  void it('returns no results for tall climbs requests on unsupported boards or sizes', () => {
+  void it('generalizes tall climbs to other boards with a size grid (Tension Board 2)', () => {
+    // Tension Board 2 layout 11 -> product 5; size 6 = "12 high x 12 wide".
+    const filters = createClimbFilters(
+      { board_name: 'tension', layout_id: 11, size_id: 6, set_ids: [], angle: 40 },
+      { onlyTallClimbs: true },
+    );
+    assert.equal(filters.tallClimbsConditions.length, 1);
+    const rendered = sqlToString(filters.tallClimbsConditions[0]);
+    assert.notEqual(rendered, 'false');
+    assert.match(rendered, /compatible_size_ids/);
+    // The shorter (10-high) product-5 sizes are 7 and 9.
+    for (const shorterSizeId of [7, 9]) {
+      assert.match(rendered, new RegExp(`(^|\\D)${shorterSizeId}(\\D|$)`));
+    }
+  });
+
+  void it('returns no results for tall climbs on the shortest size, mismatched, or unknown boards', () => {
     const unsupportedCases = [
-      { ...homewallTallParams, size_id: 21 },
-      { ...homewallTallParams, layout_id: 1 },
-      { ...homewallTallParams, board_name: 'tension' as const },
+      { ...homewallTallParams, size_id: 21 }, // 10x10 is the shortest — no shorter size exists
+      { ...homewallTallParams, layout_id: 1 }, // size 25 (product 7) doesn't belong to layout 1 (product 1)
+      { ...homewallTallParams, board_name: 'tension' as const }, // size 25 isn't a Tension size
     ];
 
     for (const unsupportedParams of unsupportedCases) {
@@ -282,75 +301,57 @@ void describe('createClimbFilters: wide climbs', () => {
     assert.equal(filters.wideClimbsConditions.length, 0);
   });
 
-  void it('uses an individual-hold EXISTS predicate for 10x10 side expansion holds', () => {
+  void it('excludes climbs compatible with any narrower Homewall size via compatible_size_ids', () => {
     const filters = createClimbFilters(homewallWideParams, { onlyWideClimbs: true });
 
     assert.equal(filters.wideClimbsConditions.length, 1);
     const rendered = sqlToString(filters.wideClimbsConditions[0]);
-    const wideHoldIds = getKilterHomewallWideHoldIdsForSets(homewallWideParams.set_ids);
-
-    assert.equal(wideHoldIds.length, 86);
-    assert.match(rendered, /EXISTS/);
-    assert.match(rendered, /FROM\s+wide_ch/);
-    assert.match(rendered, /wide_ch\.hold_id IN/);
-    assert.match(rendered, new RegExp(String(wideHoldIds[0])));
-    assert.match(rendered, new RegExp(String(wideHoldIds[wideHoldIds.length - 1])));
-    assert.doesNotMatch(rendered, /JOIN\s+wide_bp/);
-    assert.doesNotMatch(rendered, /JOIN\s+.*wide_bh/);
-    assert.doesNotMatch(rendered, /board_product_sizes/);
-    assert.doesNotMatch(rendered, /wide_ps/);
-    assert.doesNotMatch(rendered, /small_ps/);
-    assert.doesNotMatch(rendered, /compatible_size_ids/);
+    assert.match(rendered, /NOT/);
+    assert.match(rendered, /compatible_size_ids/);
+    assert.match(rendered, /&&/);
+    assert.match(rendered, /ARRAY\[/);
+    // The narrower (8-wide) Homewall sizes: 7x10 (17,18,19) + 8x12 (23,24).
+    for (const narrowerSizeId of [17, 18, 19, 23, 24]) {
+      assert.match(rendered, new RegExp(`(^|\\D)${narrowerSizeId}(\\D|$)`));
+    }
+    // No longer the old hold-membership machinery.
+    assert.doesNotMatch(rendered, /wide_ch/);
+    assert.doesNotMatch(rendered, /hold_id/);
   });
 
-  void it('can reset cached wide hold metadata for test isolation', () => {
-    const beforeReset = getKilterHomewallWideHoldIdsForSets([26, 27]);
-    resetKilterHomewallWideHoldIdsForTests();
-    const afterReset = getKilterHomewallWideHoldIdsForSets([26, 27]);
-
-    assert.deepEqual(afterReset, beforeReset);
+  void it('is independent of selected route sets (compatible_size_ids is precomputed)', () => {
+    // The old hold-based path narrowed by set_ids; the size-grid path does not.
+    const withSets = sqlToString(
+      createClimbFilters({ ...homewallWideParams, set_ids: [26] }, { onlyWideClimbs: true }).wideClimbsConditions[0],
+    );
+    const withoutSets = sqlToString(
+      createClimbFilters({ ...homewallWideParams, set_ids: [] }, { onlyWideClimbs: true }).wideClimbsConditions[0],
+    );
+    assert.equal(withSets, withoutSets);
+    assert.notEqual(withSets, 'false');
   });
 
-  void it('narrows the wide hold list to selected route sets', () => {
-    const filters = createClimbFilters({ ...homewallWideParams, set_ids: [26] }, { onlyWideClimbs: true });
-
+  void it('generalizes wide climbs to other boards with a size grid (Tension Board 2)', () => {
+    // Tension Board 2 layout 11 -> product 5; size 6 = "12 high x 12 wide".
+    const filters = createClimbFilters(
+      { board_name: 'tension', layout_id: 11, size_id: 6, set_ids: [], angle: 40 },
+      { onlyWideClimbs: true },
+    );
     assert.equal(filters.wideClimbsConditions.length, 1);
     const rendered = sqlToString(filters.wideClimbsConditions[0]);
-    const mainlineWideHoldIds = getKilterHomewallWideHoldIdsForSets([26]);
-    const auxiliaryWideHoldIds = getKilterHomewallWideHoldIdsForSets([27]);
-
-    assert.equal(mainlineWideHoldIds.length, 30);
-    assert.equal(auxiliaryWideHoldIds.length, 56);
-    assert.match(rendered, new RegExp(String(mainlineWideHoldIds[0])));
-    assert.match(rendered, new RegExp(String(mainlineWideHoldIds[mainlineWideHoldIds.length - 1])));
-    assert.doesNotMatch(rendered, new RegExp(String(auxiliaryWideHoldIds[0])));
-  });
-
-  void it('keeps wide filtering active when selected sets mix expansion and non-expansion sets', () => {
-    const filters = createClimbFilters({ ...homewallWideParams, set_ids: [26, 28] }, { onlyWideClimbs: true });
-
-    assert.equal(filters.wideClimbsConditions.length, 1);
-    const rendered = sqlToString(filters.wideClimbsConditions[0]);
-    const mixedWideHoldIds = getKilterHomewallWideHoldIdsForSets([26, 28]);
-
-    assert.equal(mixedWideHoldIds.length, 30);
     assert.notEqual(rendered, 'false');
-    assert.match(rendered, /wide_ch\.hold_id IN/);
-    assert.match(rendered, new RegExp(String(mixedWideHoldIds[0])));
+    assert.match(rendered, /compatible_size_ids/);
+    // The narrower (8-wide) product-5 sizes are 8 and 9.
+    for (const narrowerSizeId of [8, 9]) {
+      assert.match(rendered, new RegExp(`(^|\\D)${narrowerSizeId}(\\D|$)`));
+    }
   });
 
-  void it('uses a false condition when selected sets contain no side expansion holds', () => {
-    const filters = createClimbFilters({ ...homewallWideParams, set_ids: [28, 29] }, { onlyWideClimbs: true });
-
-    assert.equal(filters.wideClimbsConditions.length, 1);
-    assert.equal(sqlToString(filters.wideClimbsConditions[0]), 'false');
-  });
-
-  void it('returns no results for wide climbs requests on unsupported boards or sizes', () => {
+  void it('returns no results for wide climbs on the narrowest size, mismatched, or unknown boards', () => {
     const unsupportedCases = [
-      { ...homewallWideParams, size_id: 17 },
-      { ...homewallWideParams, layout_id: 1 },
-      { ...homewallWideParams, board_name: 'tension' as const },
+      { ...homewallWideParams, size_id: 17 }, // 7x10 is the narrowest — no narrower size exists
+      { ...homewallWideParams, layout_id: 1 }, // size 25 (product 7) doesn't belong to layout 1 (product 1)
+      { ...homewallWideParams, board_name: 'tension' as const }, // size 25 isn't a Tension size
     ];
 
     for (const unsupportedParams of unsupportedCases) {
@@ -358,13 +359,6 @@ void describe('createClimbFilters: wide climbs', () => {
       assert.equal(filters.wideClimbsConditions.length, 1);
       assert.equal(sqlToString(filters.wideClimbsConditions[0]), 'false');
     }
-  });
-
-  void it('applies wide climbs filtering to the 10x10 Auxiliary LED Kit size', () => {
-    const filters = createClimbFilters({ ...homewallWideParams, size_id: 29, set_ids: [27] }, { onlyWideClimbs: true });
-
-    assert.equal(filters.wideClimbsConditions.length, 1);
-    assert.match(sqlToString(filters.wideClimbsConditions[0]), /EXISTS/);
   });
 
   void it('can combine tall and wide filters on 10x12 Kilter Homewall', () => {

--- a/packages/db/src/queries/climbs/create-climb-filters.ts
+++ b/packages/db/src/queries/climbs/create-climb-filters.ts
@@ -1,72 +1,15 @@
 import { type SQL, eq, gt, gte, sql, like, notLike, inArray, isNull, or, and } from 'drizzle-orm';
-import {
-  KILTER_HOMEWALL_LAYOUT_ID,
-  KILTER_HOMEWALL_PRODUCT_ID,
-  getHolePlacements,
-  getProductSize,
-  isKilterHomewallTallSizeId,
-  isKilterHomewallWideSizeId,
-  type HoldTuple,
-  type ProductSizeData,
-} from '@boardsesh/board-constants/product-sizes';
+import { getTallWideScope } from '@boardsesh/board-constants/product-sizes';
 import {
   boardClimbs,
   boardClimbStats,
   boardseshTicks,
-  boardProductSizes,
   boardClimbHolds,
   boardPlacements,
   boardHoles,
   boardBetaLinks,
 } from '../../schema/index';
 import type { BoardRouteParams, ClimbSearchParams } from './types';
-
-// Kilter Homewall constants for expansion-aware filtering (layout/product ids
-// come from @boardsesh/board-constants; these sizes/sets are db-query-local).
-const KILTER_HOMEWALL_SMALL_SIZE_ID = 17;
-const KILTER_HOMEWALL_WIDE_REFERENCE_SIZE_ID = 21;
-const KILTER_HOMEWALL_WIDE_EXPANSION_SET_IDS = [26, 27, 28, 29] as const;
-
-function isKilterHomewallWideSideExpansionHold(
-  holdPlacement: HoldTuple,
-  smallSize: ProductSizeData,
-  wideSize: ProductSizeData,
-): boolean {
-  const [, , xCoordinate, yCoordinate] = holdPlacement;
-  // Product-size edges are outer board bounds. A hold exactly on the 7x10 edge
-  // is outside that size, while a hold exactly on the 10x10 outer edge is not
-  // inside the 10x10 renderable area. Match getBoardDetails' strict bounds.
-  const isInsideWideSize =
-    xCoordinate > wideSize.edgeLeft &&
-    xCoordinate < wideSize.edgeRight &&
-    yCoordinate > wideSize.edgeBottom &&
-    yCoordinate < wideSize.edgeTop;
-  const isOutsideSmallWidth = xCoordinate <= smallSize.edgeLeft || xCoordinate >= smallSize.edgeRight;
-  return isInsideWideSize && isOutsideSmallWidth;
-}
-
-function buildKilterHomewallWideHoldIdsBySet(): ReadonlyMap<number, readonly number[]> {
-  const smallSize = getProductSize('kilter', KILTER_HOMEWALL_SMALL_SIZE_ID);
-  const wideSize = getProductSize('kilter', KILTER_HOMEWALL_WIDE_REFERENCE_SIZE_ID);
-  if (!smallSize || !wideSize) {
-    throw new Error('Kilter Homewall size metadata is missing for the wide climb filter');
-  }
-
-  const wideHoldIdsBySet = new Map(
-    KILTER_HOMEWALL_WIDE_EXPANSION_SET_IDS.map((setId) => [
-      setId,
-      getHolePlacements('kilter', KILTER_HOMEWALL_LAYOUT_ID, setId)
-        .filter((holdPlacement) => isKilterHomewallWideSideExpansionHold(holdPlacement, smallSize, wideSize))
-        .map(([holdId]) => holdId),
-    ]),
-  );
-  const wideHoldCount = [...wideHoldIdsBySet.values()].reduce((total, holdIds) => total + holdIds.length, 0);
-  if (wideHoldCount === 0) {
-    throw new Error('Kilter Homewall wide climb filter did not find any side-expansion holds');
-  }
-
-  return wideHoldIdsBySet;
-}
 
 // Escape LIKE/ILIKE metacharacters so user-supplied search text is matched
 // literally. Postgres' default escape character is backslash, so `\%`, `\_`,
@@ -76,25 +19,13 @@ function escapeLikePattern(input: string): string {
   return input.replace(/[\\%_]/g, (char) => `\\${char}`);
 }
 
-// Board constants are generated static data in the deployed bundle, so this
-// production cache is intentionally never invalidated.
-let kilterHomewallWideHoldIdsBySet: ReadonlyMap<number, readonly number[]> | null = null;
-
-function getKilterHomewallWideHoldIdsBySet(): ReadonlyMap<number, readonly number[]> {
-  kilterHomewallWideHoldIdsBySet ??= buildKilterHomewallWideHoldIdsBySet();
-  return kilterHomewallWideHoldIdsBySet;
-}
-
-export function resetKilterHomewallWideHoldIdsForTests(): void {
-  kilterHomewallWideHoldIdsBySet = null;
-}
-
-export function getKilterHomewallWideHoldIdsForSets(setIds: readonly number[]): number[] {
-  const selectedSetIds = new Set(setIds);
-  const wideHoldIdsBySet = getKilterHomewallWideHoldIdsBySet();
-  return [...selectedSetIds]
-    .flatMap((setId) => wideHoldIdsBySet.get(setId) ?? [])
-    .sort((leftHoldId, rightHoldId) => leftHoldId - rightHoldId);
+// A Postgres `ARRAY[...]::int[]` literal from a size-id list, for the tall/wide
+// `compatible_size_ids &&` overlap predicates.
+function sizeIdArrayLiteral(sizeIds: readonly number[]): SQL {
+  return sql`ARRAY[${sql.join(
+    sizeIds.map((sizeId) => sql`${sizeId}`),
+    sql`, `,
+  )}]::int[]`;
 }
 
 /**
@@ -354,64 +285,35 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
     }
   }
 
-  // Tall climbs filter condition
-  const tallClimbsConditions: SQL[] = [];
+  // Tall / Wide climbs filters. A climb is "tall"/"wide" when it can't be done
+  // on any size of the active layout's product family that is shorter/narrower
+  // than the active size — i.e. its denormalized compatible_size_ids overlaps
+  // none of the shorter/narrower family sizes. getTallWideScope is the single
+  // source of truth (shared with the mobile offline search and every UI chip);
+  // it fails closed (empty sets) when the active size is the shortest/narrowest
+  // in its axis or the (board, layout, size) is unknown/mismatched, so a
+  // stale/crafted request stays restrictive (`false`) instead of returning
+  // everything. Works on every board with a size grid — Kilter Homewall &
+  // Original, Tension Board 2, Decoy, Grasshopper — and no-ops on single-size
+  // boards (MoonBoard, Touchstone).
+  const { narrowerSizeIds, shorterSizeIds, hasNarrower, hasShorter } = getTallWideScope(
+    params.board_name,
+    params.layout_id,
+    params.size_id,
+  );
 
+  const tallClimbsConditions: SQL[] = [];
   if (searchParams.onlyTallClimbs) {
-    const isTallClimbSupportedBoard =
-      params.board_name === 'kilter' &&
-      params.layout_id === KILTER_HOMEWALL_LAYOUT_ID &&
-      isKilterHomewallTallSizeId(params.size_id);
-    if (!isTallClimbSupportedBoard) {
-      // A stale/crafted URL asked for a board-scoped filter the current board
-      // cannot satisfy. Keep the request restrictive instead of silently
-      // returning unfiltered climbs.
-      tallClimbsConditions.push(sql`false`);
-    } else {
-      tallClimbsConditions.push(
-        sql`${boardClimbs.edgeBottom} < (
-        SELECT MAX(ps.edge_bottom)
-        FROM ${boardProductSizes} ps
-        WHERE ps.board_type = ${params.board_name}
-        AND ps.product_id = ${KILTER_HOMEWALL_PRODUCT_ID}
-        AND ps.id != ${params.size_id}
-      )`,
-      );
-    }
+    tallClimbsConditions.push(
+      hasShorter ? sql`NOT (${boardClimbs.compatibleSizeIds} && ${sizeIdArrayLiteral(shorterSizeIds)})` : sql`false`,
+    );
   }
 
   const wideClimbsConditions: SQL[] = [];
-
   if (searchParams.onlyWideClimbs) {
-    const isWideClimbSupportedBoard =
-      params.board_name === 'kilter' &&
-      params.layout_id === KILTER_HOMEWALL_LAYOUT_ID &&
-      isKilterHomewallWideSizeId(params.size_id);
-    if (!isWideClimbSupportedBoard) {
-      // A stale/crafted URL asked for a board-scoped filter the current board
-      // cannot satisfy. Keep the request restrictive instead of silently
-      // returning unfiltered climbs.
-      wideClimbsConditions.push(sql`false`);
-    } else {
-      const wideHoldIds = getKilterHomewallWideHoldIdsForSets(params.set_ids);
-      if (wideHoldIds.length === 0) {
-        wideClimbsConditions.push(sql`false`);
-      } else {
-        const wideHoldIdLiterals = sql.join(
-          wideHoldIds.map((holdId) => sql`${holdId}`),
-          sql`, `,
-        );
-        // This requires at least one hold in the 10x10 side expansion over 7x10.
-        // On 10x12 boards, other holds may still use the lower 10x12-only rows.
-        wideClimbsConditions.push(sql`EXISTS (
-        SELECT 1
-        FROM ${boardClimbHolds} wide_ch
-        WHERE wide_ch.board_type = ${params.board_name}
-          AND wide_ch.climb_uuid = ${boardClimbs.uuid}
-          AND wide_ch.hold_id IN (${wideHoldIdLiterals})
-      )`);
-      }
-    }
+    wideClimbsConditions.push(
+      hasNarrower ? sql`NOT (${boardClimbs.compatibleSizeIds} && ${sizeIdArrayLiteral(narrowerSizeIds)})` : sql`false`,
+    );
   }
 
   // Beta-videos filter: keep only climbs that have at least one beta link the

--- a/packages/db/src/queries/climbs/create-climb-filters.ts
+++ b/packages/db/src/queries/climbs/create-climb-filters.ts
@@ -302,17 +302,26 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
     params.size_id,
   );
 
+  // The explicit `IS NOT NULL` guard mirrors the mobile offline path
+  // (search-climbs-local.ts) and makes the intent obvious: a climb whose
+  // compatible_size_ids is NULL isn't classifiable, so it's not tall/wide.
+  // (`NOT (NULL && …)` is already NULL — falsy in WHERE — so this is a
+  // readability/parity change, not a behavior change.)
   const tallClimbsConditions: SQL[] = [];
   if (searchParams.onlyTallClimbs) {
     tallClimbsConditions.push(
-      hasShorter ? sql`NOT (${boardClimbs.compatibleSizeIds} && ${sizeIdArrayLiteral(shorterSizeIds)})` : sql`false`,
+      hasShorter
+        ? sql`${boardClimbs.compatibleSizeIds} IS NOT NULL AND NOT (${boardClimbs.compatibleSizeIds} && ${sizeIdArrayLiteral(shorterSizeIds)})`
+        : sql`false`,
     );
   }
 
   const wideClimbsConditions: SQL[] = [];
   if (searchParams.onlyWideClimbs) {
     wideClimbsConditions.push(
-      hasNarrower ? sql`NOT (${boardClimbs.compatibleSizeIds} && ${sizeIdArrayLiteral(narrowerSizeIds)})` : sql`false`,
+      hasNarrower
+        ? sql`${boardClimbs.compatibleSizeIds} IS NOT NULL AND NOT (${boardClimbs.compatibleSizeIds} && ${sizeIdArrayLiteral(narrowerSizeIds)})`
+        : sql`false`,
     );
   }
 

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -18,11 +18,7 @@ import {
   type ClimbBoardFilterState,
   type GradeTapMeta,
 } from '@boardsesh/climb-filters';
-import {
-  KILTER_HOMEWALL_LAYOUT_ID,
-  isKilterHomewallTallSizeId,
-  isKilterHomewallWideSizeId,
-} from '@boardsesh/board-constants';
+import { getTallWideScope } from '@boardsesh/board-constants';
 import { ClimbListRow } from '../../../src/components/ClimbListRow';
 import { ClimbListRowSkeleton } from '../../../src/components/ClimbListRowSkeleton';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
@@ -55,6 +51,8 @@ import { useLastUsedGrade } from '../../../src/hooks/use-last-used-grade';
 import { useClimbListPlaylistMemberships } from '../../../src/hooks/use-climb-list-playlist-memberships';
 import { useInfiniteSearchClimbs } from '../../../src/lib/graphql/hooks/use-infinite-search-climbs';
 import { offlineAwareRequest } from '../../../src/lib/graphql/offline-request';
+import { isOfflineSearchSupported } from '../../../src/db/queries/search-climbs-local';
+import { useIsOffline } from '../../../src/hooks/use-is-offline';
 import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../src/lib/graphql/operations';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
 import { toQueueClimb, toQueueClimbs } from '../../../src/lib/climb-types';
@@ -364,6 +362,9 @@ function ClimbListInner() {
   const angle = activeBoard?.angle ?? 0;
 
   const hasBoardConfig = !!activeBoard;
+
+  // Reactive connectivity, for the offline-only empty state below.
+  const isOffline = useIsOffline();
 
   const { data: gradesData } = useGrades(boardName);
   const gradesRef = useRef(gradesData);
@@ -1035,14 +1036,18 @@ function ClimbListInner() {
     (next: boolean) => patchBoardFilters({ onlyBenchmarks: next || undefined }),
     [patchBoardFilters],
   );
-  // Tall/Wide chips: only on the Kilter homewall sizes where they apply, mirroring
-  // web (isKilterHomewall{Tall,Wide}SizeId) — Wide on 10x10, Tall on 8x12, both on
-  // 10x12. Tap toggles the filter; long-press locks it (persisted) so it survives
-  // clears — the re-pin effects below re-apply a locked filter whenever it's cleared.
+  // Tall/Wide chips appear on any board whose active size has a shorter/narrower
+  // size in its product family — Kilter Homewall & Original, Tension Board 2,
+  // Decoy, Grasshopper (getTallWideScope is the shared source of truth, matching
+  // the server filter). Tap toggles the filter; long-press locks it (persisted)
+  // so it survives clears — the re-pin effects below re-apply a locked filter
+  // whenever it's cleared.
   const { locks: dimensionLocks, setLock: setDimensionLock } = useDimensionLocks();
-  const isKilterHomewall = boardName === 'kilter' && layoutId === KILTER_HOMEWALL_LAYOUT_ID;
-  const showTallChip = isKilterHomewall && isKilterHomewallTallSizeId(sizeId);
-  const showWideChip = isKilterHomewall && isKilterHomewallWideSizeId(sizeId);
+  const { hasShorter: showTallChip, hasNarrower: showWideChip } = getTallWideScope(
+    boardName as BoardName,
+    layoutId,
+    sizeId,
+  );
   const dimensionChips = useMemo<DimensionChip[]>(() => {
     const chips: DimensionChip[] = [];
     if (showTallChip) {
@@ -1325,6 +1330,11 @@ function ClimbListInner() {
   }
 
   const isEmpty = visibleClimbs.length === 0 && !isClimbsLoading;
+  // Offline with a filter we can't answer on-device (drafts, beta, zones, hold
+  // state) — the search returns an empty result, so tell the user why instead of
+  // the generic "no climbs". Tall/wide are offline-expressible, so they don't
+  // trip this.
+  const offlineFilterUnavailable = isEmpty && isOffline && !isOfflineSearchSupported(searchInput);
 
   return (
     <View testID="climbs-screen" style={[styles.container, { backgroundColor: systemColors.background }]}>
@@ -1352,6 +1362,22 @@ function ClimbListInner() {
         ListEmptyComponent={
           showInitialSkeletons ? (
             <ClimbListSkeletonRows count={INITIAL_SKELETON_ROW_COUNT} />
+          ) : offlineFilterUnavailable ? (
+            <View style={styles.emptyContainer}>
+              <Icon name="offline.unavailable" size={48} color={iosSystemColors.systemGray4} />
+              <Text variant="headline" style={styles.emptyTitle}>
+                {t('mobile.emptyState.offlineFilter.title')}
+              </Text>
+              <Text variant="subheadline" style={styles.emptySubtitle}>
+                {t('mobile.emptyState.offlineFilter.subtitle')}
+              </Text>
+              <Button
+                title={t('mobile.emptyState.offlineFilter.cta')}
+                variant="outlined"
+                onPress={handleClearNonGradeFilters}
+                style={styles.emptyCta}
+              />
+            </View>
           ) : isEmpty ? (
             <View style={styles.emptyContainer}>
               <Icon name="search" size={48} color={iosSystemColors.systemGray4} />

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -109,6 +109,7 @@ export const iconMap = {
   'offline.download': { ios: 'icloud.and.arrow.down', android: 'cloud-download-outline' },
   'offline.downloaded': { ios: 'checkmark.icloud.fill', android: 'cloud-check-variant' },
   'offline.pending': { ios: 'icloud', android: 'cloud-outline' },
+  'offline.unavailable': { ios: 'wifi.slash', android: 'wifi-off' },
 
   // Social
   person: { ios: 'person', android: 'account-outline' },

--- a/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
@@ -5,11 +5,7 @@ import { Chip as PaperChip } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import type { BoardName, Grade } from '@boardsesh/shared-schema';
 import { getGradesForBoard } from '@boardsesh/board-config';
-import {
-  KILTER_HOMEWALL_LAYOUT_ID,
-  isKilterHomewallTallSizeId,
-  isKilterHomewallWideSizeId,
-} from '@boardsesh/board-constants';
+import { getTallWideScope } from '@boardsesh/board-constants';
 import {
   formatMinAscentsFilterCount,
   getMinAscentsFilterOptions,
@@ -271,9 +267,10 @@ export function GeneratorPickerCard({
   const { formatGradeByDifficultyId } = useGradeFormat();
   const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
 
-  const isKilterHomewall = boardName === 'kilter' && layoutId === KILTER_HOMEWALL_LAYOUT_ID;
-  const showTallClimbsFilter = isKilterHomewall && sizeId != null && isKilterHomewallTallSizeId(sizeId);
-  const showWideClimbsFilter = isKilterHomewall && sizeId != null && isKilterHomewallWideSizeId(sizeId);
+  const tallWideScope =
+    boardName != null && layoutId != null && sizeId != null ? getTallWideScope(boardName, layoutId, sizeId) : null;
+  const showTallClimbsFilter = tallWideScope?.hasShorter ?? false;
+  const showWideClimbsFilter = tallWideScope?.hasNarrower ?? false;
 
   useEffect(() => {
     if (selection.type !== 'on') return;

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
@@ -91,9 +91,9 @@ vi.mock('@boardsesh/board-config', () => ({
   ],
 }));
 vi.mock('@boardsesh/board-constants', () => ({
-  KILTER_HOMEWALL_LAYOUT_ID: 8,
-  isKilterHomewallTallSizeId: () => false,
-  isKilterHomewallWideSizeId: () => false,
+  // No shorter/narrower sizes → no tall/wide chips, keeping this analytics test
+  // focused on the other filters.
+  getTallWideScope: () => ({ narrowerSizeIds: [], shorterSizeIds: [], hasNarrower: false, hasShorter: false }),
 }));
 vi.mock('@boardsesh/climb-filters', () => ({
   formatMinAscentsFilterCount: (value: number) => String(value),

--- a/packages/mobile/src/db/queries/__tests__/search-climbs-local.test.ts
+++ b/packages/mobile/src/db/queries/__tests__/search-climbs-local.test.ts
@@ -258,16 +258,67 @@ describe('searchClimbsLocal', () => {
   });
 });
 
+describe('searchClimbsLocal: tall/wide (Kilter Homewall size grid)', () => {
+  let db: TestSqliteDb;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    await ensureMutationQueueTable(db);
+    await runMigrations(db);
+    // Active size 25 (10x12): shorter sizes = {17,18,19,21,22,29}, narrower = {17,18,19,23,24}.
+    // Each climb is compatible with 25 so it passes the base size filter.
+    await insertClimb(db, { uuid: 'tall-wide', layoutId: 8, compatibleSizeIds: [25, 26] });
+    await insertClimb(db, { uuid: 'tall-only', layoutId: 8, compatibleSizeIds: [23, 24, 25, 26] });
+    await insertClimb(db, { uuid: 'wide-only', layoutId: 8, compatibleSizeIds: [21, 22, 25, 26] });
+    await insertClimb(db, { uuid: 'neither', layoutId: 8, compatibleSizeIds: [21, 24, 25] });
+  });
+
+  const homewall = (overrides: Partial<ClimbSearchInput> = {}) => makeInput({ layoutId: 8, sizeId: 25, ...overrides });
+
+  it('tall = climbs compatible with no shorter Homewall size', async () => {
+    const result = await searchClimbsLocal(db, homewall({ onlyTallClimbs: true }));
+    expect(uuids(result).sort()).toEqual(['tall-only', 'tall-wide']);
+  });
+
+  it('wide = climbs compatible with no narrower Homewall size', async () => {
+    const result = await searchClimbsLocal(db, homewall({ onlyWideClimbs: true }));
+    expect(uuids(result).sort()).toEqual(['tall-wide', 'wide-only']);
+  });
+
+  it('tall AND wide narrows to climbs that need the largest size', async () => {
+    const result = await searchClimbsLocal(db, homewall({ onlyTallClimbs: true, onlyWideClimbs: true }));
+    expect(uuids(result)).toEqual(['tall-wide']);
+  });
+
+  it('count mirrors the tall/wide search', async () => {
+    expect(await countClimbsLocal(db, homewall({ onlyTallClimbs: true }))).toBe(2);
+    expect(await countClimbsLocal(db, homewall({ onlyWideClimbs: true }))).toBe(2);
+  });
+
+  it('fails closed on the shortest/narrowest size (the filter has no option there)', async () => {
+    // A climb that fits the 7x10 size 17 (both shortest and narrowest).
+    await insertClimb(db, { uuid: 'small', layoutId: 8, compatibleSizeIds: [17, 18, 19, 21, 25] });
+    const base = await searchClimbsLocal(db, makeInput({ layoutId: 8, sizeId: 17 }));
+    expect(uuids(base)).toContain('small');
+    const tall = await searchClimbsLocal(db, makeInput({ layoutId: 8, sizeId: 17, onlyTallClimbs: true }));
+    const wide = await searchClimbsLocal(db, makeInput({ layoutId: 8, sizeId: 17, onlyWideClimbs: true }));
+    expect(tall.climbs).toHaveLength(0);
+    expect(wide.climbs).toHaveLength(0);
+  });
+});
+
 describe('isOfflineSearchSupported', () => {
   it('supports the core filters', () => {
     expect(isOfflineSearchSupported(makeInput({ minGrade: 16, name: 'x', boulders: true }))).toBe(true);
     expect(isOfflineSearchSupported(makeInput({ holdsFilter: { hold_5: { ANY: 'include' } } }))).toBe(true);
+    // Tall/wide are expressible against the synced compatible_size_ids.
+    expect(isOfflineSearchSupported(makeInput({ onlyTallClimbs: true }))).toBe(true);
+    expect(isOfflineSearchSupported(makeInput({ onlyWideClimbs: true }))).toBe(true);
   });
 
   it('falls back for filters that need un-synced tables or the drafts path', () => {
     expect(isOfflineSearchSupported(makeInput({ onlyDrafts: true }))).toBe(false);
     expect(isOfflineSearchSupported(makeInput({ onlyWithBetaVideos: true }))).toBe(false);
-    expect(isOfflineSearchSupported(makeInput({ onlyTallClimbs: true }))).toBe(false);
     expect(
       isOfflineSearchSupported(makeInput({ zoneBox: { edgeLeft: 0, edgeRight: 10, edgeBottom: 0, edgeTop: 10 } })),
     ).toBe(false);

--- a/packages/mobile/src/db/queries/search-climbs-local.ts
+++ b/packages/mobile/src/db/queries/search-climbs-local.ts
@@ -1,7 +1,8 @@
 import type { OfflineDatabase } from '@boardsesh/offline-sync';
-import type { Climb, ClimbSearchInput } from '@boardsesh/shared-schema';
+import type { BoardName, Climb, ClimbSearchInput } from '@boardsesh/shared-schema';
 import { isNoMatch } from '@boardsesh/shared-schema';
 import { isSizeScopedBoard } from '@boardsesh/board-config';
+import { getTallWideScope } from '@boardsesh/board-constants';
 import { getGradeLabel, getClimbStars } from '../../lib/grade-label';
 
 /**
@@ -97,10 +98,11 @@ function parseHoldsFilter(holdsFilter: unknown): HoldFilters {
  */
 export function isOfflineSearchSupported(input: ClimbSearchInput): boolean {
   // projectsOnly, boulders/routes, benchmarks, name, setter, grade range, min
-  // ascents/rating, present-hold, and personal-progress filters are all supported.
+  // ascents/rating, present-hold, tall/wide (via the synced compatible_size_ids,
+  // see buildJoinAndWhere), and personal-progress filters are all supported.
   // These need tables we don't sync (or the drafts owner path), so fall back:
   if (input.onlyDrafts) return false;
-  if (input.onlyTallClimbs || input.onlyWideClimbs || input.onlyWithBetaVideos) return false;
+  if (input.onlyWithBetaVideos) return false;
   if (input.zoneBox) return false;
   const { hasHoldState } = parseHoldsFilter(input.holdsFilter);
   if (hasHoldState) return false;
@@ -227,6 +229,36 @@ function buildJoinAndWhere(input: ClimbSearchInput): JoinAndWhere {
   }
   for (const holdId of notHolds) {
     push(`c.frames NOT LIKE ? ESCAPE '\\'`, `%p${holdId}r%`);
+  }
+
+  // Tall / Wide (size-grid) filters over the synced compatible_size_ids —
+  // mirrors the server (create-climb-filters.ts) so an online and offline search
+  // return the same rows. getTallWideScope fails closed (empty sets) when the
+  // active size is the shortest/narrowest in its axis or the board has no grid,
+  // so the filter then matches nothing (`0 = 1`), exactly like the server's
+  // `false`. The `IS NOT NULL` guard matches the server's `NOT (NULL && …)` NULL
+  // handling (a null array is not tall/wide) — json_each(NULL) would otherwise
+  // yield an empty set that a bare NOT EXISTS reads as a match.
+  if (input.onlyTallClimbs || input.onlyWideClimbs) {
+    const { narrowerSizeIds, shorterSizeIds, hasNarrower, hasShorter } = getTallWideScope(
+      boardType as BoardName,
+      input.layoutId,
+      input.sizeId,
+    );
+    const pushSizeGridFilter = (enabled: boolean | null | undefined, hasSmaller: boolean, smallerSizeIds: number[]) => {
+      if (!enabled) return;
+      if (!hasSmaller) {
+        push('0 = 1');
+        return;
+      }
+      const placeholders = smallerSizeIds.map(() => '?').join(', ');
+      push(
+        `c.compatible_size_ids IS NOT NULL AND NOT EXISTS (SELECT 1 FROM json_each(c.compatible_size_ids) WHERE value IN (${placeholders}))`,
+        ...smallerSizeIds,
+      );
+    };
+    pushSizeGridFilter(input.onlyTallClimbs, hasShorter, shorterSizeIds);
+    pushSizeGridFilter(input.onlyWideClimbs, hasNarrower, narrowerSizeIds);
   }
 
   // Personal progress against local ticks (device is single-user).

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -559,6 +559,11 @@
       "noMatches": {
         "title": "No matches",
         "description": "Nothing matches \"{{query}}\""
+      },
+      "offlineFilter": {
+        "title": "This filter needs a signal",
+        "subtitle": "Drafts, beta, zones, and hold filters only work online. Clear it to keep browsing your downloaded board.",
+        "cta": "Clear filter"
       }
     },
     "detail": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -559,6 +559,11 @@
       "noMatches": {
         "title": "Sin resultados",
         "description": "Nada coincide con \"{{query}}\""
+      },
+      "offlineFilter": {
+        "title": "Este filtro necesita conexión",
+        "subtitle": "Los borradores, las betas, las zonas y los filtros de presas solo funcionan con conexión. Bórralo para seguir explorando tu plafón descargado.",
+        "cta": "Borrar filtro"
       }
     },
     "detail": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -559,6 +559,11 @@
       "noMatches": {
         "title": "Aucun résultat",
         "description": "Rien ne correspond à \"{{query}}\""
+      },
+      "offlineFilter": {
+        "title": "Ce filtre nécessite une connexion",
+        "subtitle": "Les brouillons, les betas, les zones et les filtres de prises ne fonctionnent qu'en ligne. Efface-le pour continuer à parcourir hors ligne.",
+        "cta": "Effacer le filtre"
       }
     },
     "detail": {

--- a/packages/web/app/components/playlist-generator/generator-options-form.tsx
+++ b/packages/web/app/components/playlist-generator/generator-options-form.tsx
@@ -37,11 +37,7 @@ import {
 } from './types';
 import styles from './generator-options-form.module.css';
 
-import {
-  KILTER_HOMEWALL_LAYOUT_ID,
-  isKilterHomewallTallSizeId,
-  isKilterHomewallWideSizeId,
-} from '@/app/lib/board-constants';
+import { getTallWideScope } from '@/app/lib/board-constants';
 
 const qualityBucketRowSx: SxProps<Theme> = {
   alignItems: 'stretch',
@@ -85,10 +81,13 @@ const GeneratorOptionsForm: React.FC<GeneratorOptionsFormProps> = ({
     label: t(`generator.climbBiasOptions.${value}`),
   }));
 
-  // Check if we should show the tall climbs filter.
-  const isKilterHomewall = boardDetails.board_name === 'kilter' && boardDetails.layout_id === KILTER_HOMEWALL_LAYOUT_ID;
-  const showTallClimbsFilter = isKilterHomewall && isKilterHomewallTallSizeId(boardDetails.size_id);
-  const showWideClimbsFilter = isKilterHomewall && isKilterHomewallWideSizeId(boardDetails.size_id);
+  // Tall/Wide filters show on any board whose active size has a shorter/narrower
+  // size in its product family (getTallWideScope — shared with mobile + server).
+  const { hasShorter: showTallClimbsFilter, hasNarrower: showWideClimbsFilter } = getTallWideScope(
+    boardDetails.board_name,
+    boardDetails.layout_id,
+    boardDetails.size_id,
+  );
 
   // Helper to update options
   const updateOption = <K extends keyof GeneratorOptions>(key: K, value: GeneratorOptions[K]) => {

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -42,11 +42,7 @@ import CollapsibleSection, {
 import { useTranslation } from 'react-i18next';
 import styles from './accordion-search-form.module.css';
 
-import {
-  KILTER_HOMEWALL_LAYOUT_ID,
-  isKilterHomewallTallSizeId,
-  isKilterHomewallWideSizeId,
-} from '@/app/lib/board-constants';
+import { getTallWideScope } from '@/app/lib/board-constants';
 
 type AccordionSearchFormProps = {
   boardDetails: BoardDetails;
@@ -62,9 +58,13 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
   const [showSort, setShowSort] = useState(false);
   const summaryLabels = createSearchSummaryLabels(t);
 
-  const isKilterHomewall = boardDetails.board_name === 'kilter' && boardDetails.layout_id === KILTER_HOMEWALL_LAYOUT_ID;
-  const showTallClimbsFilter = isKilterHomewall && isKilterHomewallTallSizeId(boardDetails.size_id);
-  const showWideClimbsFilter = isKilterHomewall && isKilterHomewallWideSizeId(boardDetails.size_id);
+  // Tall/Wide filters show on any board whose active size has a shorter/narrower
+  // size in its product family (getTallWideScope — shared with mobile + server).
+  const { hasShorter: showTallClimbsFilter, hasNarrower: showWideClimbsFilter } = getTallWideScope(
+    boardDetails.board_name,
+    boardDetails.layout_id,
+    boardDetails.size_id,
+  );
   const minRatingPickerValue = getMinRatingPickerValue(uiSearchParams.minRating);
 
   let statusValue: 'any' | 'drafts' | 'established' | 'projects' = 'any';


### PR DESCRIPTION
## What & why

Testing offline mode, a downloaded Kilter Homewall board showed **no climbs** in airplane mode — because the **Tall Climbs** filter was on, and tall/wide weren't expressible against the local SQLite tables, so the offline search short-circuited to an empty result (rendered as a silent "no climbs").

Root fix: derive tall/wide from the **already-synced, GIN-indexed `compatible_size_ids`** instead of an edge-threshold subquery (tall) and an `EXISTS(board_climb_holds …)` (wide). This makes both filters:

- **Work offline** — no new synced column, no `board_climb_holds` sync.
- **Generalize to every board with a size grid** — Kilter Original, Tension Board 2, Decoy, Grasshopper — not just the Kilter Homewall. Single-size boards (MoonBoard, Touchstone) opt out automatically.
- **Run online and offline off one shared definition** (`getTallWideScope`), so results match.

### Definition (size-relative, product-scoped)

For the active `(board, layout, size)`: **wide** = the climb's `compatible_size_ids` overlaps no *narrower* size in the layout's product family; **tall** = overlaps no *shorter* size. The Tall/Wide chip only shows when a narrower/shorter size exists, so the smallest size in each axis offers nothing. Reference sets are scoped to the active size's product (a board's `compatible_size_ids` can list cross-product sizes).

## Performance

Wide previously did a per-climb nested-loop semi-join into the large `board_climb_holds` table. The new predicate uses the `compatible_size_ids` GIN index for the base scope and applies tall/wide as a cheap array filter — **no `board_climb_holds` access**. `EXPLAIN ANALYZE` on prod (Kilter Homewall, size 25, wide):

| | Execution | Buffers | board_climb_holds |
|---|---|---|---|
| Old (`EXISTS board_climb_holds`) | ~568 ms | ~206k hits | nested-loop per climb |
| New (`NOT compatible_size_ids &&`) | ~173 ms | ~19k hits | none |

## Correctness / parity

Tall is a strict **superset** of the old edge filter: the +613 extra climbs (Homewall) have their lowest hold exactly on the short board's floor (`edge_bottom = 24`). Those holds aren't rendered/reachable on the shorter board (strict bounds), so they genuinely need the taller size — consistent with how `compatible_size_ids` and the renderer treat boundary holds. No climb is dropped. Validated on prod: Kilter Homewall 11,869 wide / 12,637 tall, Tension Board 2 14,252 / 24,319, Grasshopper 7,562 / 17,445 — all sane populations.

## Also

Offline empty-state: when offline **and** a still-unsupported filter is active (drafts, beta videos, zones, hold-state), the climbs list now says the filter needs a connection with a one-tap **Clear**, instead of a generic "no climbs". (en-US/es/fr.)

## Test plan

- `getTallWideScope` unit tests (board-constants): grid cells, Tension generalization, single-size/MoonBoard, mismatched-product fail-closed.
- Online `create-climb-filters` tests rewritten for the `compatible_size_ids` SQL + generalization.
- Offline `search-climbs-local` tests: tall/wide over `compatible_size_ids`, `isOfflineSearchSupported` now true for tall/wide.
- Full suites green: mobile (3699), web (changed components), db unit, i18n catalog parity, `vp check`, typecheck (mobile/web/db).

## Release Notes

Filter for **tall and wide climbs on more boards** — Kilter Original, Tension Board 2, Decoy and Grasshopper now show the Tall/Wide chips, not just the Kilter Homewall. And they work **with no signal**: once you've downloaded a board, tall/wide filtering runs on-device. Flip on a filter that still needs a connection (drafts, beta, zones, holds) while offline and the screen now tells you why, with a tap to clear it, instead of just coming up empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFXvVk8uYmiju11gwEdmTp