### PR TITLE
fix(mobile): route remaining climb reads through the offline interceptor

### DIFF
--- a/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
+++ b/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
@@ -49,7 +49,7 @@ import { useBoardPresenceControls } from '../../providers/board-presence-provide
 import { track } from '../../lib/analytics';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
-import { getHttpClient } from '../../lib/graphql/client';
+import { offlineAwareRequest } from '../../lib/graphql/offline-request';
 import { GET_CLIMB, type GetClimbQueryResponse } from '../../lib/graphql/operations';
 import { boardPresenceClimbToClimb } from '../../lib/board-presence/presence-climb';
 import { withAlpha } from '../../theme/colors';
@@ -347,15 +347,14 @@ function NowOnTheWallPanelComponent(
 
       let climbRequest = actionClimbRequestRef.current.get(cacheKey);
       if (!climbRequest) {
-        climbRequest = getHttpClient()
-          .request<GetClimbQueryResponse>(GET_CLIMB, {
-            boardName: actionBoardConfig.boardName,
-            layoutId: actionBoardConfig.layoutId,
-            sizeId: actionBoardConfig.sizeId,
-            setIds: actionBoardConfig.setIds,
-            angle: actionBoardConfig.angle,
-            climbUuid: presenceClimb.climbUuid,
-          })
+        climbRequest = offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, {
+          boardName: actionBoardConfig.boardName,
+          layoutId: actionBoardConfig.layoutId,
+          sizeId: actionBoardConfig.sizeId,
+          setIds: actionBoardConfig.setIds,
+          angle: actionBoardConfig.angle,
+          climbUuid: presenceClimb.climbUuid,
+        })
           .then((response): Climb | null => {
             if (!response.climb) {
               console.warn('Board-sheet climb action returned no climb', presenceClimb.climbUuid);

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/select-climbs-for-plan.test.ts
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/select-climbs-for-plan.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Climb, UserBoard } from '@boardsesh/shared-schema';
+import { SEARCH_CLIMBS } from '../../../../lib/graphql/operations';
+import type { PreviewFetchContext } from '../workout-preview-pool';
+
+// Keep expo-crypto (pulled in via workout-preview-pool → climb-to-queue-item)
+// out of the node test environment — it drags in raw react-native source.
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'qi-0' }));
+
+// fetchGradePool must go through the offline interceptor (issue #3472) so
+// "plan my session" works offline on a downloaded board — not getHttpClient()
+// directly, which bypasses local SQLite.
+vi.mock('../../../../lib/graphql/offline-request', () => ({
+  offlineAwareRequest: vi.fn(),
+}));
+
+import { offlineAwareRequest } from '../../../../lib/graphql/offline-request';
+import { buildClimbSearchInput, fetchGradePool } from '../select-climbs-for-plan';
+
+const offlineAwareRequestMock = vi.mocked(offlineAwareRequest);
+
+const ctx: PreviewFetchContext = {
+  board: { boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 } as UserBoard,
+  isAuthenticated: false,
+};
+
+describe('fetchGradePool', () => {
+  beforeEach(() => {
+    offlineAwareRequestMock.mockReset();
+  });
+
+  it('routes SEARCH_CLIMBS through the offline interceptor with the built input', async () => {
+    const climbs = [{ uuid: 'climb-1' } as Climb];
+    offlineAwareRequestMock.mockResolvedValue({ searchClimbs: { climbs, hasMore: false } });
+
+    const pool = await fetchGradePool(15, ctx);
+
+    expect(offlineAwareRequestMock).toHaveBeenCalledExactlyOnceWith(SEARCH_CLIMBS, {
+      input: buildClimbSearchInput(15, ctx),
+    });
+    expect(pool).toEqual(climbs);
+  });
+
+  it('returns the empty pool from the offline fallback', async () => {
+    offlineAwareRequestMock.mockResolvedValue({ searchClimbs: { climbs: [], hasMore: false } });
+
+    await expect(fetchGradePool(15, ctx)).resolves.toEqual([]);
+  });
+});

--- a/packages/mobile/src/components/session-screen/pre-session/select-climbs-for-plan.ts
+++ b/packages/mobile/src/components/session-screen/pre-session/select-climbs-for-plan.ts
@@ -1,7 +1,7 @@
 import type { Climb, ClimbSearchInput, UserBoard } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import type { PlannedClimbSlot } from '@boardsesh/playlist-generator';
-import { getHttpClient } from '../../../lib/graphql/client';
+import { offlineAwareRequest } from '../../../lib/graphql/offline-request';
 import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../lib/graphql/operations';
 import {
   buildPools,
@@ -61,7 +61,7 @@ export function buildClimbSearchInput(grade: number, ctx: PreviewFetchContext): 
  */
 export async function fetchGradePool(grade: number, ctx: PreviewFetchContext): Promise<Climb[]> {
   const input = buildClimbSearchInput(grade, ctx);
-  const response = await getHttpClient().request<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input });
+  const response = await offlineAwareRequest<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input });
   return response.searchClimbs.climbs.slice();
 }
 

--- a/packages/mobile/src/lib/graphql/__tests__/offline-request.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/offline-request.test.ts
@@ -252,6 +252,36 @@ describe('offlineAwareRequest — GET_CLIMB', () => {
     expect(result).toEqual({ climb: null });
     expect(request).not.toHaveBeenCalled();
   });
+
+  it('retries a local miss over the network while online (row not synced yet, e.g. a live presence climb)', async () => {
+    setOnline(true);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+    getClimbLocal.mockResolvedValue(null);
+    const result = await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, climbVars);
+    expect(result.climb?.uuid).toBe('net-detail');
+    expect(getClimbLocal).toHaveBeenCalled();
+    expect(request).toHaveBeenCalledWith(GET_CLIMB, climbVars);
+  });
+
+  it('lets a local miss stand while offline — { climb: null }, no doomed network call', async () => {
+    setOnline(false);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+    getClimbLocal.mockResolvedValue(null);
+    const result = await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, climbVars);
+    expect(result).toEqual({ climb: null });
+    expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe('offlineAwareRequest — empty search results are answers, not misses', () => {
+  it('does not retry an empty local SEARCH_CLIMBS result over the network', async () => {
+    setOnline(true);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+    searchClimbsLocal.mockResolvedValue({ climbs: [], hasMore: false });
+    const result = await offlineAwareRequest<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input: searchInput });
+    expect(result).toEqual({ searchClimbs: { climbs: [], hasMore: false } });
+    expect(request).not.toHaveBeenCalled();
+  });
 });
 
 describe('offlineAwareRequest — unregistered document', () => {

--- a/packages/mobile/src/lib/graphql/offline-request.ts
+++ b/packages/mobile/src/lib/graphql/offline-request.ts
@@ -46,6 +46,11 @@ type OfflineOperation<TVariables, TResponse> = {
   // Returns the RAW GraphQL response shape (as if the server had answered).
   resolveLocal: (db: SQLiteDatabase, variables: TVariables) => Promise<TResponse>;
   offlineFallback: () => TResponse;
+  // A local result that should be retried over the network while online: a
+  // known-key read that missed because the row hasn't synced yet (e.g. a live
+  // presence event referencing a climb newer than the board download). An
+  // empty search result is a real answer, not a miss — search ops omit this.
+  isLocalMiss?: (response: TResponse) => boolean;
 };
 
 // Generics erased at storage; `never` params keep the assignment legal
@@ -91,6 +96,7 @@ registerOfflineOperation<GetClimbQueryVariables, GetClimbQueryResponse>({
     }),
   }),
   offlineFallback: () => ({ climb: null }),
+  isLocalMiss: (response) => response.climb === null,
 });
 
 /**
@@ -111,9 +117,15 @@ export async function offlineAwareRequest<TResponse>(document: string, variables
     // the offline fallback below still applies either way. `as never` re-narrows
     // the storage-erased generics — see the OFFLINE_OPERATIONS declaration.
     if (db && variables !== undefined && (await operation.canServeLocal(db, variables as never))) {
-      return (await operation.resolveLocal(db, variables as never)) as TResponse;
+      const localResponse = (await operation.resolveLocal(db, variables as never)) as TResponse;
+      // A known-key miss falls through to the network while online — the row
+      // may simply not have synced yet. Offline, the miss stands (it has the
+      // same shape as offlineFallback).
+      const retryOverNetwork = operation.isLocalMiss?.(localResponse) === true && onlineManager.isOnline();
+      if (!retryOverNetwork) return localResponse;
+    } else if (!onlineManager.isOnline()) {
+      return operation.offlineFallback() as TResponse;
     }
-    if (!onlineManager.isOnline()) return operation.offlineFallback() as TResponse;
   }
   return getHttpClient().request<TResponse>(document, variables);
 }

--- a/packages/mobile/src/providers/queue/use-queue-regrade.ts
+++ b/packages/mobile/src/providers/queue/use-queue-regrade.ts
@@ -3,7 +3,7 @@ import { isPlaylistPeekQueueItemUuid } from '@boardsesh/queue';
 import type { ClimbQueueItem, ClimbRegradePatch, PlaylistSuggestionSource, QueueAction } from '@boardsesh/queue';
 import { findNextQueueItemWithSuggestions } from '@boardsesh/play-view';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { getHttpClient } from '../../lib/graphql/client';
+import { offlineAwareRequest } from '../../lib/graphql/offline-request';
 import { GET_CLIMB, type GetClimbQueryResponse } from '../../lib/graphql/operations';
 
 type UseQueueRegradeParams = {
@@ -79,11 +79,10 @@ export function useQueueRegrade({
 
     let cancelled = false;
     void (async () => {
-      const client = getHttpClient();
       const patches = await Promise.all(
         targetUuids.map(async (climbUuid) => {
           try {
-            const response = await client.request<GetClimbQueryResponse>(GET_CLIMB, {
+            const response = await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, {
               boardName: boardType,
               layoutId,
               sizeId,


### PR DESCRIPTION
## Summary

Closes #3472.

Three mobile call sites requested documents that are registered in the offline interceptor (`offline-request.ts`) but called `getHttpClient().request` directly, bypassing local SQLite — so they failed offline even on a fully downloaded board. All three now go through `offlineAwareRequest`, which serves local data when the board is downloaded and falls through to the network otherwise:

- `providers/queue/use-queue-regrade.ts` — GET_CLIMB per angle: changing the queue angle offline rejected and kept stale grades, even though `getClimbLocal` answers per-angle.
- `components/session-screen/pre-session/select-climbs-for-plan.ts` — SEARCH_CLIMBS: "plan my session" failed offline. Filters that aren't expressible on-device (`hideAttempted` etc.) still short-circuit to the network via `isOfflineSearchSupported`, so online behaviour is unchanged.
- `components/board-presence/NowOnTheWallPanel.tsx` — GET_CLIMB presence hydration. The issue asked to decide local-first vs deliberately network-only: **local-first**. The request is scoped to the user's own active board config (`actionBoardConfigForPresenceClimb` only overrides the angle), so there's no cross-board dimension and a downloaded board can serve it; undownloaded boards fall through to the network exactly as before.

With the `offline-board-downloads` flag off, `offlineAwareRequest` degrades to plain HTTP, so this is behavior-neutral for everyone outside the flag.

Adds a regression test pinning `fetchGradePool` to the interceptor (nothing previously tested its request wiring). The other two call sites are covered by existing component tests plus the interceptor suite.

## Release Notes

- Downloaded boards now work fully offline: changing the queue angle keeps grades accurate, "plan my session" builds from your downloaded climbs, and wall-panel climbs load without a connection

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 450 files / 3,576 tests passed, including the existing NowOnTheWallPanel, board-sheet, and offline-request suites (no mock churn: the offline flag defaults off in tests, so the interceptor degrades to the mocked HTTP client)
- `vp run check:mobile-bundle` — Android bundle OK
- New `select-climbs-for-plan.test.ts` asserts `fetchGradePool` routes SEARCH_CLIMBS through `offlineAwareRequest`
- QA notes for manual offline flows in `.boardsesh/qa-notes.md` (download board → airplane mode → angle change / session plan / wall panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhY2A4gL9RzPBQxH85RQJB