### PR TITLE
fix(mobile): stop Android filter-chip taps falling through to climb rows

### DIFF
--- a/packages/mobile/src/components/chrome/CollapsingTopChrome.tsx
+++ b/packages/mobile/src/components/chrome/CollapsingTopChrome.tsx
@@ -116,7 +116,8 @@ export function CollapsingTopChrome({
   if (isMaterial) {
     return (
       <View
-        pointerEvents="box-none"
+        // NOT box-none — the opaque Material band must swallow touches; see ClimbTopChrome for the RNGH mechanism.
+        pointerEvents="auto"
         style={[
           styles.materialContainer,
           {

--- a/packages/mobile/src/components/feed/HomeTopChrome.tsx
+++ b/packages/mobile/src/components/feed/HomeTopChrome.tsx
@@ -75,7 +75,11 @@ function HomeTopChromeGlass({
       {/* Frost content scrolling under the chrome band, matching the other tabs. */}
       <ProgressiveBlur style={[styles.topBlur, { height: insets.top + TOP_ISLAND_BAND }]} />
       {/* Floating header: the user-avatar island (left) and the scope menu (a glass
-          title-menu pill, centred) over the blur — matching the other tabs. */}
+          title-menu pill, centred) over the blur — matching the other tabs.
+          Deliberately box-none (unlike the opaque Material band below): the glass
+          islands float over scrollable content, and the gaps between them must keep
+          passing touches through. The islands themselves carry backgrounds, so
+          RNGH's Android hit-test still targets them. */}
       <View
         pointerEvents="box-none"
         style={[styles.headerChrome, { paddingTop: insets.top + spacing[1] }]}

--- a/packages/mobile/src/components/feed/HomeTopChrome.tsx
+++ b/packages/mobile/src/components/feed/HomeTopChrome.tsx
@@ -127,7 +127,8 @@ function HomeTopChromeMaterial({
 
   return (
     <View
-      pointerEvents="box-none"
+      // NOT box-none — the opaque Material band must swallow touches; see ClimbTopChrome for the RNGH mechanism.
+      pointerEvents="auto"
       style={[
         styles.materialContainer,
         {

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -163,7 +163,14 @@ export function ClimbTopChrome({
 
     return (
       <View
-        pointerEvents="box-none"
+        // NOT box-none: the Material band is an opaque strip and must swallow every
+        // touch in its bounds. RNGH's Android hit-test (GestureHandlerOrchestrator)
+        // sees straight through handler-less, background-less subtrees — box-none
+        // skips its background check entirely — so list-row Gesture.Tap handlers
+        // underneath steal Compose chip taps once the list has scrolled under the
+        // chrome. With `auto`, the container's background makes it the RNGH touch
+        // target and the full DOWN…UP reaches the Compose chips natively.
+        pointerEvents="auto"
         style={[
           styles.materialContainer,
           {

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -216,6 +216,11 @@ export function ClimbTopChrome({
           </View>
         ) : null}
 
+        {/* Inner wrappers stay box-none: once the outer `auto` container claims the
+            RNGH pointer, only RN's own hit-testing runs inside, where box-none just
+            means "let touches reach the controls". If an inner control ever adopts
+            an RNGH gesture it needs no change — the outer container already stops
+            the list's handlers from being recorded. */}
         {usesCustomSearch ? (
           <View pointerEvents="box-none" style={styles.materialSearchStack}>
             <View pointerEvents="box-none" style={styles.materialSearchRow}>

--- a/packages/mobile/src/components/search/FilterChipRow.android.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.android.tsx
@@ -446,6 +446,10 @@ function FilterChipRowComponent({
 const styles = StyleSheet.create({
   host: {
     width: '100%',
+    // RN Android installs a background drawable even for a transparent colour, which
+    // makes the Host itself an RNGH hit-test target (shouldHandlerlessViewBecomeTouchTarget)
+    // if a future refactor reintroduces a box-none ancestor. Zero visual effect.
+    backgroundColor: 'transparent',
   },
 });
 

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -29,16 +29,18 @@ const haptics = vi.hoisted(() => ({ light: vi.fn(), selection: vi.fn() }));
 type ViewMockProps = {
   children?: ReactNode;
   onLayout?: (event: { nativeEvent: { layout: { height: number } } }) => void;
+  pointerEvents?: string;
 };
 vi.mock('react-native', () => ({
   Keyboard: { dismiss: vi.fn() },
   Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
     createElement('button', { onClick: onPress, 'data-scrim': 'true' }, children),
-  View: ({ children, onLayout }: ViewMockProps) =>
+  View: ({ children, onLayout, pointerEvents }: ViewMockProps) =>
     createElement(
       'div',
       {
         'data-has-layout': onLayout ? 'true' : 'false',
+        'data-pointer': pointerEvents ?? '',
         onClick: onLayout ? () => onLayout({ nativeEvent: { layout: { height: 88 } } }) : undefined,
       },
       children,
@@ -552,6 +554,19 @@ describe('ClimbTopChrome', () => {
   // The Material angle control moved out of ClimbTopChrome into the persistent filter
   // chip row (FilterChipRow.android), which this component test doesn't render — the
   // angle chip is covered by the Android screenshot QA, not here.
+
+  // Regression guard for the Android tap-passthrough fix: the Material band must
+  // be pointerEvents="auto" (NOT box-none) so RNGH's Android hit-test treats the
+  // opaque chrome as a touch target — box-none let list-row Gesture.Tap handlers
+  // underneath steal Compose chip taps once the list scrolled under the chrome.
+  it('keeps the Material chrome container pointerEvents="auto" so it swallows touches over the list', () => {
+    ctrl.variant = 'material';
+    ctrl.board = typedBoard;
+    const { container } = render(<ClimbTopChrome {...makeProps()} />);
+    const materialContainer = container.querySelector('[data-has-layout="true"]') as HTMLElement;
+    expect(materialContainer).not.toBeNull();
+    expect(materialContainer.getAttribute('data-pointer')).toBe('auto');
+  });
 
   it('reports its measured height through onHeightChange via onLayout', () => {
     const onHeightChange = vi.fn();

--- a/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
+++ b/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
@@ -71,7 +71,8 @@ export function RecordTopChrome({
   if (isMaterial) {
     return (
       <View
-        pointerEvents="box-none"
+        // NOT box-none — the opaque Material band must swallow touches; see ClimbTopChrome for the RNGH mechanism.
+        pointerEvents="auto"
         style={[
           styles.materialContainer,
           {

--- a/packages/mobile/src/components/you/ProfileTopChrome.tsx
+++ b/packages/mobile/src/components/you/ProfileTopChrome.tsx
@@ -117,6 +117,8 @@ function ProfileTopChromeMaterial({
         ) : null}
       </Appbar.Header>
 
+      {/* Inner box-none is fine: the outer `auto` container already claims the RNGH
+          pointer, so this wrapper only needs RN hit-testing to reach the tabs. */}
       <View pointerEvents="box-none" style={[styles.materialTabsRow, { borderTopColor: m3.outlineVariant }]}>
         <MaterialTabs
           options={tabOptions}

--- a/packages/mobile/src/components/you/ProfileTopChrome.tsx
+++ b/packages/mobile/src/components/you/ProfileTopChrome.tsx
@@ -83,7 +83,8 @@ function ProfileTopChromeMaterial({
 
   return (
     <View
-      pointerEvents="box-none"
+      // NOT box-none — the opaque Material band must swallow touches; see ClimbTopChrome for the RNGH mechanism.
+      pointerEvents="auto"
       style={[
         styles.materialContainer,
         {


### PR DESCRIPTION
## Summary

On Android (Material variant), once the climb list scrolled so rows sat under the top chrome, tapping a filter chip (Grade, Filters, Show, …) pressed the climb row hidden underneath instead — navigating to that climb rather than opening the filter.

**Root cause** (confirmed against the vendored RNGH source, `GestureHandlerOrchestrator.kt`): react-native-gesture-handler's Android hit-tester ignores z-order and treats ViewGroups with no gesture handler and no background drawable as transparent — and its `box-none` branch skips the background check entirely. The Material top chrome was a `pointerEvents="box-none"` absolute overlay whose chips are a background-less `@expo/ui` Compose `Host`, so RNGH found nothing in the chrome, recorded the list row's `Gesture.Tap` underneath, and on release intercepted the stream — the Compose chip got ACTION_CANCEL, the row navigated. That's also why it only happened after scrolling: at list-top only content-inset padding sits under the chrome.

**Fix**: the opaque Material chrome bands now use `pointerEvents="auto"` so they swallow every touch in their bounds (`ClimbTopChrome`, `CollapsingTopChrome`, `HomeTopChrome`, `ProfileTopChrome`, `RecordTopChrome` — Material branches only; the liquid-glass islands keep `box-none` pass-through). The `FilterChipRow` Host also gets an explicit transparent background so it remains an RNGH hit-test target even if a `box-none` ancestor is ever reintroduced. Expected side effect (standard Material app-bar behaviour): a drag starting on the chrome no longer scrolls the list.

JS-only change — rides OTA, no native build needed.

## Release Notes

- Filter chips on Android now respond after you scroll the climb list, instead of opening the climb hiding underneath

## Test plan

Reproduced and verified on an Android emulator (Pixel AVD, dev-client + Metro):

- **Pre-fix repro**: scroll the climb list, tap the Grade chip → the hidden climb's detail opened (screenshotted).
- **Post-fix**: same tap opens the grade range rail; rail grade buttons select (list refetches with the grade filter); Filters chip opens the filter sheet; Show chip opens its dropdown; a climb row below the chrome still opens its detail; the list still scrolls; everything unchanged at list-top; board switcher works on a scrolled Discover tab.
- `vp run typecheck:mobile`, `vp run test:mobile` (3574 tests), `vp run check:mobile-bundle` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GH6Hs9TgYddegExhpsWm8g