### PR TITLE
feat(android): trim Glide memory on UI_HIDDEN

### DIFF
--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -106,15 +106,20 @@ jobs:
         # than hardcode.
         run: |
           set -euo pipefail
-          mapfile -t PROJECTS < <(./gradlew --no-daemon -q projects | sed -n "s/.*Project '\(:[^']*\(live-activity\|memory-trim\)[^']*\)'.*/\1/p")
-          if [ "${#PROJECTS[@]}" -ne 2 ]; then
-            echo "Expected exactly two tested module Gradle projects (live-activity, memory-trim), found ${#PROJECTS[@]}:"
-            printf '  %s\n' "${PROJECTS[@]}"
-            exit 1
-          fi
-          for PROJECT in "${PROJECTS[@]}"; do
-            echo "Testing module project: $PROJECT"
-            ./gradlew "${PROJECT}:testDebugUnitTest" --no-daemon --console=plain --stacktrace
+          # One entry per local module that ships Kotlin unit tests. Adding a
+          # module here is the only change needed — each name is discovered
+          # and must resolve to exactly one Gradle project.
+          TESTED_MODULES=(live-activity memory-trim)
+          ALL_PROJECTS=$(./gradlew --no-daemon -q projects)
+          for MODULE in "${TESTED_MODULES[@]}"; do
+            mapfile -t PROJECTS < <(printf '%s\n' "$ALL_PROJECTS" | sed -n "s/.*Project '\(:[^']*${MODULE}[^']*\)'.*/\1/p")
+            if [ "${#PROJECTS[@]}" -ne 1 ]; then
+              echo "Expected exactly one Gradle project for module '${MODULE}', found ${#PROJECTS[@]}:"
+              printf '  %s\n' "${PROJECTS[@]}"
+              exit 1
+            fi
+            echo "Testing module project: ${PROJECTS[0]}"
+            ./gradlew "${PROJECTS[0]}:testDebugUnitTest" --no-daemon --console=plain --stacktrace
           done
 
   build-apk:

--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -97,22 +97,25 @@ jobs:
 
       - uses: ./.github/actions/android-rn-setup
 
-      - name: Run live-activity module unit tests (Robolectric)
+      - name: Run local-module unit tests (Robolectric/JUnit)
         working-directory: packages/mobile/android
-        # Robolectric/JUnit tests for the session-presence lifecycle + the
-        # foreground-service retry path. The gradle project path for an Expo local
-        # module is autolinking-derived, so discover it rather than hardcode.
+        # Robolectric/JUnit tests for local Expo modules that ship them:
+        # live-activity (session-presence lifecycle + foreground-service retry)
+        # and memory-trim (Glide trim-level policy). The gradle project path for
+        # an Expo local module is autolinking-derived, so discover it rather
+        # than hardcode.
         run: |
           set -euo pipefail
-          mapfile -t PROJECTS < <(./gradlew --no-daemon -q projects | sed -n "s/.*Project '\(:[^']*live-activity[^']*\)'.*/\1/p")
-          if [ "${#PROJECTS[@]}" -ne 1 ]; then
-            echo "Expected exactly one live-activity Gradle project, found ${#PROJECTS[@]}:"
+          mapfile -t PROJECTS < <(./gradlew --no-daemon -q projects | sed -n "s/.*Project '\(:[^']*\(live-activity\|memory-trim\)[^']*\)'.*/\1/p")
+          if [ "${#PROJECTS[@]}" -ne 2 ]; then
+            echo "Expected exactly two tested module Gradle projects (live-activity, memory-trim), found ${#PROJECTS[@]}:"
             printf '  %s\n' "${PROJECTS[@]}"
             exit 1
           fi
-          PROJECT="${PROJECTS[0]}"
-          echo "Testing module project: $PROJECT"
-          ./gradlew "${PROJECT}:testDebugUnitTest" --no-daemon --console=plain --stacktrace
+          for PROJECT in "${PROJECTS[@]}"; do
+            echo "Testing module project: $PROJECT"
+            ./gradlew "${PROJECT}:testDebugUnitTest" --no-daemon --console=plain --stacktrace
+          done
 
   build-apk:
     needs: gate

--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -287,8 +287,13 @@ and the play-drawer carousel piling a native-res (~7 MB RGBA) overlay per swiped
 cache. Display-sizing + recycling cut carousel browse-growth ~19%; background-blanking cut the
 worst case (board left open on app-switch) ~96 MB. **Ceiling:** expo-image on Android is Glide,
 whose cache/pool are sized to device RAM and resist JS `clearMemoryCache()` (the native allocator
-retains freed pages), so the common feed-backgrounded footprint is unmoved by JS — the next lever is
-native (`onTrimMemory(UI_HIDDEN) → Glide.clearMemory()`). The high MB on a 12 GB device overstates
+retains freed pages), so the common feed-backgrounded footprint is unmoved by JS. The native lever
+is implemented: `modules/memory-trim/` registers a `ComponentCallbacks2` that full-clears Glide
+(memory cache + bitmap/array pools) on `onTrimMemory(UI_HIDDEN..39)` — the window where stock
+Glide only half-trims (it already full-clears at `BACKGROUND(40)+`). The module is side-effect-only
+and activated by a JS import in `app/_layout.tsx` (Expo modules are created lazily on first JS
+access — without the import its OnCreate never runs). Verify via
+`adb logcat -s MemoryTrim`. The high MB on a 12 GB device overstates
 real risk; the OOM actually reproduces on 4 GB iPhones.
 
 **Examples in this repo:**
@@ -297,6 +302,8 @@ real risk; the OOM actually reproduces on 4 GB iPhones.
   listener) + `packages/mobile/src/hooks/use-image-cache-memory-management.ts` (root cache sweep).
 - `renderWidth` + `backgroundVariant` threaded through `BoardImageNative.tsx` →
   `use-native-climb-render.ts`; applied in `play-drawer/SwipeBoardCarousel.tsx`.
+- `packages/mobile/modules/memory-trim/` (Android-only) — native Glide full-clear at
+  `TRIM_MEMORY_UI_HIDDEN`; policy in `MemoryTrimPolicy.kt`, activation import in `app/_layout.tsx`.
 
 ---
 

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -77,6 +77,10 @@ import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 import { AccessoryOnboardingTip } from '../src/components/onboarding/AccessoryOnboardingTip';
 import { FreezeDebugOverlay } from '../src/components/FreezeDebugOverlay';
 import { DATABASE_NAME, initializeDatabase } from '../src/db';
+// Side-effect import: instantiates the Android-only MemoryTrim native module
+// (expo-modules-core creates modules lazily on first JS access), whose Kotlin
+// OnCreate registers the Glide trim-on-UI_HIDDEN callback. No-op on iOS.
+import '../modules/memory-trim/src/index';
 
 void SplashScreen.preventAutoHideAsync();
 

--- a/packages/mobile/modules/memory-trim/android/build.gradle
+++ b/packages/mobile/modules/memory-trim/android/build.gradle
@@ -35,4 +35,10 @@ dependencies {
   // build/runtime risk here — keep this version in lockstep with expo-image's
   // GLIDE_VERSION whenever expo-image is upgraded.
   compileOnly 'com.github.bumptech.glide:glide:5.0.5'
+
+  // JVM unit tests for the trim-level policy (which onTrimMemory levels we
+  // full-clear vs leave to stock Glide). Run via :…:testDebugUnitTest in
+  // .github/workflows/android-pr-rn.yml; the repo's `vp` flow has no Kotlin
+  // test runner.
+  testImplementation 'junit:junit:4.13.2'
 }

--- a/packages/mobile/modules/memory-trim/android/build.gradle
+++ b/packages/mobile/modules/memory-trim/android/build.gradle
@@ -1,0 +1,38 @@
+plugins {
+  id 'com.android.library'
+  // Canonical Expo local-module plugin: applies Kotlin + provides
+  // expo-modules-core (Module/ModuleDefinition API) on the compile classpath,
+  // version-proof. Groovy (not .kts) so the library defaultConfig
+  // versionCode/versionName the plugin requires can be set.
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'com.boardsesh'
+version = '1.0.0'
+
+android {
+  namespace 'expo.modules.memorytrim'
+  compileSdk 36
+
+  defaultConfig {
+    minSdk 24
+    // Required by expo-module-gradle-plugin's publication setup.
+    versionCode 1
+    versionName '1.0.0'
+  }
+}
+
+dependencies {
+  // Glide is provided AT RUNTIME by expo-image, which declares
+  //   api "com.github.bumptech.glide:glide:5.0.5"
+  // in node_modules/expo-image/android/build.gradle. Because that's an `api`
+  // (not `implementation`) dependency, Glide 5.0.5 is already exposed on the
+  // merged app classpath. This module only needs the Glide *types* at compile
+  // time to call Glide.get(app).clearMemory()/trimMemory(), so we use
+  // `compileOnly` at the exact same version: it compiles against the same Glide
+  // the app runs, without bundling a second (potentially version-skewed) copy of
+  // Glide into the APK. Version skew with expo-image's bundled Glide is the main
+  // build/runtime risk here — keep this version in lockstep with expo-image's
+  // GLIDE_VERSION whenever expo-image is upgraded.
+  compileOnly 'com.github.bumptech.glide:glide:5.0.5'
+}

--- a/packages/mobile/modules/memory-trim/android/src/main/java/expo/modules/memorytrim/MemoryTrimModule.kt
+++ b/packages/mobile/modules/memory-trim/android/src/main/java/expo/modules/memorytrim/MemoryTrimModule.kt
@@ -1,0 +1,91 @@
+package expo.modules.memorytrim
+
+import android.app.Application
+import android.content.ComponentCallbacks2
+import android.content.res.Configuration
+import android.os.Handler
+import android.os.Looper
+import com.bumptech.glide.Glide
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+/**
+ * Android-only, side-effect-only module. It has no JS-callable API: on native
+ * module-registry init (app launch) its OnCreate registers a
+ * [ComponentCallbacks2] on the application, so the Android framework calls back
+ * on memory pressure. This is the "next lever" from docs/react-native-performance.md
+ * rule 7 — JS Image.clearMemoryCache() can't move Glide's native bitmap cache /
+ * pool.
+ *
+ * Glide self-registers its own ComponentCallbacks2 (Glide.get() calls
+ * registerComponentCallbacks on the application), so foreground pressure levels
+ * (< UI_HIDDEN) and the BACKGROUND(40)+ full clear are already handled by stock
+ * Glide. The one gap this module fills: at TRIM_MEMORY_UI_HIDDEN(20)..39 stock
+ * Glide only trims its memory cache to HALF, keeping the other half plus the
+ * bitmap/array pools alive while the app is backgrounded. We full-clear at
+ * UI_HIDDEN instead, so board-art bitmaps are released the moment the UI hides
+ * rather than when the system escalates to BACKGROUND.
+ */
+class MemoryTrimModule : Module() {
+    // Held so OnDestroy can unregister the exact same instance we registered.
+    private var registeredApplication: Application? = null
+    private var memoryCallbacks: ComponentCallbacks2? = null
+
+    override fun definition() = ModuleDefinition {
+        Name("MemoryTrim")
+
+        OnCreate {
+            val application = appContext.reactContext?.applicationContext as? Application
+                ?: return@OnCreate
+
+            val callbacks = object : ComponentCallbacks2 {
+                override fun onConfigurationChanged(newConfig: Configuration) {
+                    // Not a memory signal — nothing to trim.
+                }
+
+                @Deprecated("Deprecated in Android 14 (API 34); still delivered on older devices.")
+                override fun onLowMemory() {
+                    // Legacy critical-memory signal on older devices. Stock Glide's own
+                    // callback also full-clears here; required override, kept consistent.
+                    clearGlideMemoryOnMain(application)
+                }
+
+                override fun onTrimMemory(level: Int) {
+                    if (level >= ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
+                        // UI hidden (backgrounded): the bitmap cache is dead weight —
+                        // drop all of it now instead of Glide's stock half-trim.
+                        clearGlideMemoryOnMain(application)
+                    }
+                    // Foreground levels (< UI_HIDDEN): stock Glide's self-registered
+                    // callback already calls trimMemory(level); doing it here too would
+                    // just double-trim.
+                }
+            }
+
+            application.registerComponentCallbacks(callbacks)
+            registeredApplication = application
+            memoryCallbacks = callbacks
+        }
+
+        OnDestroy {
+            memoryCallbacks?.let { registeredApplication?.unregisterComponentCallbacks(it) }
+            memoryCallbacks = null
+            registeredApplication = null
+        }
+    }
+
+    /**
+     * Glide.clearMemory() asserts it runs on the main thread. onTrimMemory /
+     * onLowMemory are already delivered on the main thread, but hop to the main
+     * looper defensively so any future call site can't trip the assertion.
+     */
+    private fun clearGlideMemoryOnMain(application: Application) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            Glide.get(application).clearMemory()
+        } else {
+            Handler(Looper.getMainLooper()).post {
+                Glide.get(application).clearMemory()
+            }
+        }
+    }
+}

--- a/packages/mobile/modules/memory-trim/android/src/main/java/expo/modules/memorytrim/MemoryTrimModule.kt
+++ b/packages/mobile/modules/memory-trim/android/src/main/java/expo/modules/memorytrim/MemoryTrimModule.kt
@@ -17,14 +17,11 @@ import expo.modules.kotlin.modules.ModuleDefinition
  * rule 7 — JS Image.clearMemoryCache() can't move Glide's native bitmap cache /
  * pool.
  *
- * Glide self-registers its own ComponentCallbacks2 (Glide.get() calls
- * registerComponentCallbacks on the application), so foreground pressure levels
- * (< UI_HIDDEN) and the BACKGROUND(40)+ full clear are already handled by stock
- * Glide. The one gap this module fills: at TRIM_MEMORY_UI_HIDDEN(20)..39 stock
- * Glide only trims its memory cache to HALF, keeping the other half plus the
- * bitmap/array pools alive while the app is backgrounded. We full-clear at
- * UI_HIDDEN instead, so board-art bitmaps are released the moment the UI hides
- * rather than when the system escalates to BACKGROUND.
+ * Scope is deliberately narrow: [MemoryTrimPolicy] documents what stock Glide
+ * already handles itself and limits this module to the one gap — a full clear
+ * in the TRIM_MEMORY_UI_HIDDEN(20)..39 window, so board-art bitmaps are
+ * released the moment the UI hides rather than when the system escalates to
+ * BACKGROUND(40).
  */
 class MemoryTrimModule : Module() {
     // Held so OnDestroy can unregister the exact same instance we registered.
@@ -43,22 +40,20 @@ class MemoryTrimModule : Module() {
                     // Not a memory signal — nothing to trim.
                 }
 
-                @Deprecated("Deprecated in Android 14 (API 34); still delivered on older devices.")
+                @Suppress("OVERRIDE_DEPRECATION")
                 override fun onLowMemory() {
-                    // Legacy critical-memory signal on older devices. Stock Glide's own
-                    // callback also full-clears here; required override, kept consistent.
-                    clearGlideMemoryOnMain(application)
+                    // Required override. Stock Glide's own callback already full-clears
+                    // on this legacy signal — nothing to add.
                 }
 
                 override fun onTrimMemory(level: Int) {
-                    if (level >= ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
+                    if (MemoryTrimPolicy.shouldFullClear(level)) {
                         // UI hidden (backgrounded): the bitmap cache is dead weight —
                         // drop all of it now instead of Glide's stock half-trim.
+                        // Outside this window stock Glide's self-registered callback
+                        // already trims/clears; acting here would double-trim.
                         clearGlideMemoryOnMain(application)
                     }
-                    // Foreground levels (< UI_HIDDEN): stock Glide's self-registered
-                    // callback already calls trimMemory(level); doing it here too would
-                    // just double-trim.
                 }
             }
 

--- a/packages/mobile/modules/memory-trim/android/src/main/java/expo/modules/memorytrim/MemoryTrimModule.kt
+++ b/packages/mobile/modules/memory-trim/android/src/main/java/expo/modules/memorytrim/MemoryTrimModule.kt
@@ -5,6 +5,7 @@ import android.content.ComponentCallbacks2
 import android.content.res.Configuration
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import com.bumptech.glide.Glide
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -24,6 +25,10 @@ import expo.modules.kotlin.modules.ModuleDefinition
  * BACKGROUND(40).
  */
 class MemoryTrimModule : Module() {
+    private companion object {
+        const val TAG = "MemoryTrim"
+    }
+
     // Held so OnDestroy can unregister the exact same instance we registered.
     private var registeredApplication: Application? = null
     private var memoryCallbacks: ComponentCallbacks2? = null
@@ -33,7 +38,11 @@ class MemoryTrimModule : Module() {
 
         OnCreate {
             val application = appContext.reactContext?.applicationContext as? Application
-                ?: return@OnCreate
+            if (application == null) {
+                Log.w(TAG, "OnCreate: no application context; trim callbacks not registered")
+                return@OnCreate
+            }
+            Log.d(TAG, "OnCreate: registering trim callbacks")
 
             val callbacks = object : ComponentCallbacks2 {
                 override fun onConfigurationChanged(newConfig: Configuration) {
@@ -52,6 +61,7 @@ class MemoryTrimModule : Module() {
                         // drop all of it now instead of Glide's stock half-trim.
                         // Outside this window stock Glide's self-registered callback
                         // already trims/clears; acting here would double-trim.
+                        Log.d(TAG, "onTrimMemory(level=$level): full Glide clear")
                         clearGlideMemoryOnMain(application)
                     }
                 }

--- a/packages/mobile/modules/memory-trim/android/src/main/java/expo/modules/memorytrim/MemoryTrimPolicy.kt
+++ b/packages/mobile/modules/memory-trim/android/src/main/java/expo/modules/memorytrim/MemoryTrimPolicy.kt
@@ -1,0 +1,23 @@
+package expo.modules.memorytrim
+
+import android.content.ComponentCallbacks2
+
+/**
+ * Decides which onTrimMemory levels this module full-clears Glide for.
+ *
+ * Stock Glide self-registers its own ComponentCallbacks2 (Glide.get() calls
+ * registerComponentCallbacks on the application) and already handles:
+ * - foreground pressure (< UI_HIDDEN): proportional trimMemory(level)
+ * - BACKGROUND(40)+: full clearMemory()
+ * - onLowMemory: full clearMemory()
+ *
+ * The one gap is TRIM_MEMORY_UI_HIDDEN(20)..39, where stock Glide only trims
+ * its memory cache to HALF, keeping the other half plus the bitmap/array pools
+ * alive while the app is backgrounded. Only that window needs our full clear;
+ * everything else would double-trim what Glide already does.
+ */
+object MemoryTrimPolicy {
+    fun shouldFullClear(level: Int): Boolean =
+        level >= ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN &&
+            level < ComponentCallbacks2.TRIM_MEMORY_BACKGROUND
+}

--- a/packages/mobile/modules/memory-trim/android/src/test/java/expo/modules/memorytrim/MemoryTrimPolicyTest.kt
+++ b/packages/mobile/modules/memory-trim/android/src/test/java/expo/modules/memorytrim/MemoryTrimPolicyTest.kt
@@ -1,0 +1,28 @@
+package expo.modules.memorytrim
+
+import android.content.ComponentCallbacks2
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MemoryTrimPolicyTest {
+    @Test
+    fun `foreground pressure levels are left to stock Glide`() {
+        assertFalse(MemoryTrimPolicy.shouldFullClear(ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE))
+        assertFalse(MemoryTrimPolicy.shouldFullClear(ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW))
+        assertFalse(MemoryTrimPolicy.shouldFullClear(ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL))
+    }
+
+    @Test
+    fun `ui hidden window full-clears`() {
+        assertTrue(MemoryTrimPolicy.shouldFullClear(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN))
+        assertTrue(MemoryTrimPolicy.shouldFullClear(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND - 1))
+    }
+
+    @Test
+    fun `background and above are left to stock Glide's own full clear`() {
+        assertFalse(MemoryTrimPolicy.shouldFullClear(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND))
+        assertFalse(MemoryTrimPolicy.shouldFullClear(ComponentCallbacks2.TRIM_MEMORY_MODERATE))
+        assertFalse(MemoryTrimPolicy.shouldFullClear(ComponentCallbacks2.TRIM_MEMORY_COMPLETE))
+    }
+}

--- a/packages/mobile/modules/memory-trim/expo-module.config.json
+++ b/packages/mobile/modules/memory-trim/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["expo.modules.memorytrim.MemoryTrimModule"]
+  }
+}

--- a/packages/mobile/modules/memory-trim/package.json
+++ b/packages/mobile/modules/memory-trim/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@boardsesh/memory-trim-module",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Android-only native module that trims Glide's image memory cache when the app UI is hidden",
+  "license": "MIT",
+  "main": "src/index.ts"
+}

--- a/packages/mobile/modules/memory-trim/package.json
+++ b/packages/mobile/modules/memory-trim/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "description": "Android-only native module that trims Glide's image memory cache when the app UI is hidden",
   "license": "MIT",
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "peerDependencies": {
+    "expo-modules-core": "*"
+  }
 }

--- a/packages/mobile/modules/memory-trim/src/index.ts
+++ b/packages/mobile/modules/memory-trim/src/index.ts
@@ -3,11 +3,10 @@ import { requireOptionalNativeModule } from 'expo-modules-core';
 // Side-effect-only Android module. Its Kotlin OnCreate registers a
 // ComponentCallbacks2 that trims Glide's native image-memory cache when the app
 // UI is hidden (see android/.../MemoryTrimModule.kt). There is no JS API to
-// call — the module activates itself at native module-registry init, so nothing
-// needs to import this to make it work.
-//
-// Exported only so the package has a valid entry point and callers can
-// null-check that the module is linked into the running binary.
+// call, but expo-modules-core creates native modules LAZILY on first JS access
+// — verified on-device: without this require the Kotlin OnCreate never runs and
+// no trim callback is registered. The app must import this entry point once at
+// startup (app/_layout.tsx does) to activate the module.
 // requireOptionalNativeModule returns null (silently) on iOS (this module is
 // Android-only), in Expo Go, or in a dev client built before this module
 // existed.

--- a/packages/mobile/modules/memory-trim/src/index.ts
+++ b/packages/mobile/modules/memory-trim/src/index.ts
@@ -1,0 +1,14 @@
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+// Side-effect-only Android module. Its Kotlin OnCreate registers a
+// ComponentCallbacks2 that trims Glide's native image-memory cache when the app
+// UI is hidden (see android/.../MemoryTrimModule.kt). There is no JS API to
+// call — the module activates itself at native module-registry init, so nothing
+// needs to import this to make it work.
+//
+// Exported only so the package has a valid entry point and callers can
+// null-check that the module is linked into the running binary.
+// requireOptionalNativeModule returns null (silently) on iOS (this module is
+// Android-only), in Expo Go, or in a dev client built before this module
+// existed.
+export const memoryTrimNative = requireOptionalNativeModule('MemoryTrim');


### PR DESCRIPTION
## Summary

Implements the native lever named in docs/react-native-performance.md rule 7: an Android-only Expo local module (`modules/memory-trim`) that registers a `ComponentCallbacks2` and full-clears Glide's image memory (memory cache + bitmap/array pools) when the app UI is hidden.

Honest scope: stock Glide self-registers its own trim handling — foreground levels get proportional trims, and `BACKGROUND(40)+` / `onLowMemory` already full-clear. The one gap is `TRIM_MEMORY_UI_HIDDEN(20)..39`, where stock Glide only half-trims its memory cache; this module full-clears there so board-art bitmaps are released the moment the user switches apps. The policy is isolated in `MemoryTrimPolicy` (JUnit-tested, wired into the robolectric-tests CI job).

Non-obvious activation detail: expo-modules-core creates native modules **lazily on first JS access**, so a side-effect-only module's `OnCreate` never runs on its own — `app/_layout.tsx` imports the module's entry point once at startup (no-op on iOS). Found on-device; without the import the callback simply never registers.

Fingerprint impact (verified via `expo-updates runtimeversion:resolve`, module absent vs present):
- **iOS: byte-identical** (`platforms: ["android"]`, no apple sources, no config plugin)
- **Android: changes** (expected). Once merged, Android binaries on the old fingerprint stop receiving new OTAs until the next Android store build ships — worth timing the merge accordingly.

Glide pinned `compileOnly` to expo-image's `GLIDE_VERSION` (5.0.5); build.gradle documents the lockstep requirement.

## Release Notes

- Boardsesh frees up memory as soon as you switch away from the app on Android

## Test plan

- **On-device (x86_64 emulator, locally built dev-client APK):** logcat shows `OnCreate: registering trim callbacks` at launch; backgrounding fires `onTrimMemory(level=20): full Glide clear`; `dumpsys meminfo` Native Heap PSS 653.7 → 638.6 MB, TOTAL PSS 939.4 → 919.2 MB (~20 MB released on a lightly warmed dev build)
- `./gradlew :boardsesh-memory-trim-module:compileDebugKotlin` + `:testDebugUnitTest` — green against expo-modules-core 57.0.2 + Glide 5.0.5
- `vp run typecheck:mobile`, `vp run check:mobile-bundle` — green
- QA review decompiled Glide 5.0.5 to verify the main-thread assertion handling and threshold semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rRcNZWqQX2seq9uuaHcHF