### PR TITLE
fix(mobile): play drawer occasionally opens with unlit holds on Android

### DIFF
--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// In-flight render race regression (play-drawer "unlit holds"): a slow native
+// render must not clobber nativeRender state after the hook's props have moved
+// to a different climb, or the key-match guard nulls overlayUri for the current
+// climb with nothing left to re-fire the effect.
+
+vi.mock('expo-file-system', () => ({
+  Directory: vi.fn(() => ({ exists: false, list: () => [] })),
+  Paths: { cache: { uri: 'file:///cache/' } },
+}));
+
+vi.mock('../../lib/board-details', () => ({
+  getBoardRenderData: vi.fn(() => ({
+    boardWidth: 1000,
+    boardHeight: 1200,
+    holdsData: [{ id: 1, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }],
+  })),
+}));
+
+vi.mock('../../lib/background-image-cache', () => ({
+  tryGetBackgroundPathsSync: vi.fn(() => ({ paths: ['file:///bg.png'], missingCount: 0 })),
+  ensureBackgroundsCached: vi.fn(async () => ({ paths: ['file:///bg.png'], missingCount: 0 })),
+}));
+
+vi.mock('../../lib/error-reporting', () => ({
+  reportError: vi.fn(),
+}));
+
+vi.mock('../../lib/hold-color-overrides', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../lib/hold-color-overrides')>();
+  // Referentially STABLE value: `overrides`/`shapes` are effect deps in the
+  // hook, so a fresh object per render would re-fire the overlay effect every
+  // render and self-heal the exact stale-clobber this suite exists to catch.
+  const stableOverrides = {
+    overrides: {},
+    shapes: {},
+    brushThickness: original.DEFAULT_HOLD_BRUSH_THICKNESS,
+    shapeSize: original.DEFAULT_HOLD_SHAPE_SIZE,
+    renderSignature: original.DEFAULT_HOLD_COLOR_SIGNATURE,
+  };
+  return {
+    ...original,
+    useHoldColorOverrides: () => stableOverrides,
+  };
+});
+
+// Controllable native renderer: each call returns a deferred we resolve from
+// the test, keyed by the cacheKey argument. Injected via the test-only setter
+// because the hook loads the real module through a literal CJS require() that
+// the vitest mock registry can't intercept.
+const pendingRenders = new Map<string, { resolve: (uri: string) => void }>();
+const fakeNativeModule = {
+  // Availability flag getNativeModule() checks; the hook calls the top-level
+  // renderHoldsOverlay wrapper, not this object.
+  boardRendererNative: {},
+  renderHoldsOverlay: vi.fn(
+    (_configJson: string, cacheKey: string) =>
+      new Promise<string>((resolve) => {
+        pendingRenders.set(cacheKey, { resolve });
+      }),
+  ),
+};
+
+const {
+  useNativeClimbRender,
+  buildCacheKey,
+  _renderedOverlaysForTests,
+  _inflightRendersForTests,
+  _setNativeModuleForTests,
+} = await import('../use-native-climb-render');
+
+const BASE = {
+  boardName: 'kilter' as const,
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '26,27',
+  filledStyle: false,
+};
+
+const FRAMES_SLOW = 'p1100r12p1200r13';
+const FRAMES_CACHED = 'p1300r12p1400r15';
+
+function cacheKeyFor(frames: string): string {
+  return buildCacheKey(BASE.boardName, BASE.layoutId, BASE.sizeId, BASE.setIds, frames, BASE.filledStyle);
+}
+
+describe('useNativeClimbRender in-flight race', () => {
+  beforeEach(() => {
+    pendingRenders.clear();
+    _renderedOverlaysForTests.clear();
+    _inflightRendersForTests.clear();
+    _setNativeModuleForTests(fakeNativeModule as unknown as Parameters<typeof _setNativeModuleForTests>[0]);
+  });
+
+  it('discards a slow render resolution after props moved to a cached climb', async () => {
+    const slowKey = cacheKeyFor(FRAMES_SLOW);
+    const cachedKey = cacheKeyFor(FRAMES_CACHED);
+    _renderedOverlaysForTests.set(cachedKey, 'file:///overlay-cached.png');
+
+    const { result, rerender } = renderHook(
+      (props: { frames: string }) => useNativeClimbRender({ ...BASE, ...props }),
+      { initialProps: { frames: FRAMES_SLOW } },
+    );
+
+    // Slow climb: render kicked off, nothing to show yet.
+    await waitFor(() => expect(pendingRenders.has(slowKey)).toBe(true));
+    expect(result.current.overlayUri).toBeNull();
+
+    // Swipe to a climb whose overlay is already cached — sync branch shows it.
+    rerender({ frames: FRAMES_CACHED });
+    await waitFor(() => expect(result.current.overlayUri).toBe('file:///overlay-cached.png'));
+
+    // The slow render finally resolves. It must NOT clobber the current climb.
+    await act(async () => {
+      pendingRenders.get(slowKey)?.resolve('file:///overlay-slow.png');
+      await Promise.resolve();
+    });
+    expect(result.current.overlayUri).toBe('file:///overlay-cached.png');
+
+    // The late result still landed in the cache for an instant hit on swipe-back.
+    expect(_renderedOverlaysForTests.get(slowKey)).toBe('file:///overlay-slow.png');
+    rerender({ frames: FRAMES_SLOW });
+    await waitFor(() => expect(result.current.overlayUri).toBe('file:///overlay-slow.png'));
+  });
+});

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -246,6 +246,10 @@ export const _renderedOverlaysForTests = renderedOverlays;
  * "renderer unavailable", so async-render paths would be untestable.
  */
 export function _setNativeModuleForTests(module: typeof renderModule): void {
+  // No-op in release bundles — this seam mutates module state and must not be
+  // reachable from production code paths. (Mobile vitest runs with __DEV__ set,
+  // so tests pass through.)
+  if (!__DEV__) return;
   renderModule = module;
   moduleLoadAttempted = true;
   moduleLoadFailureCount = 0;

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -239,6 +239,18 @@ export function getOrStartInflightRender(cacheKey: string, startRender: () => Pr
 export const _inflightRendersForTests = inflightRenders;
 export const _renderedOverlaysForTests = renderedOverlays;
 
+/**
+ * Test-only: inject a fake native module. The real one loads via a literal
+ * CJS require() that vitest's mock registry can't intercept — in tests the
+ * try/catch silently exhausts the retry budget and the hook behaves as
+ * "renderer unavailable", so async-render paths would be untestable.
+ */
+export function _setNativeModuleForTests(module: typeof renderModule): void {
+  renderModule = module;
+  moduleLoadAttempted = true;
+  moduleLoadFailureCount = 0;
+}
+
 /** Memoize board render configs to avoid re-computing hold positions */
 const boardConfigCache = new Map<
   string,
@@ -560,6 +572,15 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   });
 
   const mountedRef = useRef(true);
+  // Tracks the cache key of the most recent overlay-effect run so a slow
+  // render's resolution can be discarded once props have moved to a different
+  // climb. Without this, a late .then sets nativeRender to the OLD key: the
+  // key-match guard on overlayUri then returns null for the current climb and
+  // nothing re-fires the effect — the board sits with unlit holds until the
+  // next swipe. Hit in the play-drawer carousel when swiping onto a climb
+  // whose overlay is already cached (sync branch, no new promise) while the
+  // previous climb's render is still in flight.
+  const latestCacheKeyRef = useRef(currentCacheKey);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -645,6 +666,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   // Overlay-render effect: kick off the native render if we don't already
   // have one for this cache key in the sync map.
   useEffect(() => {
+    latestCacheKeyRef.current = currentCacheKey;
     if (!frames || unsupportedRenderSignatures.has(holdRenderSignature)) return;
 
     if (renderedOverlays.has(currentCacheKey)) {
@@ -687,7 +709,12 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     renderPromise
       .then((fileUri) => {
         renderedOverlays.set(currentCacheKey, fileUri);
-        if (mountedRef.current) setNativeRender({ key: currentCacheKey, uri: fileUri });
+        // Discard a stale resolution (props moved on while this render was in
+        // flight) — see latestCacheKeyRef. The sync map above still keeps the
+        // file, so swiping back to this climb is an instant cache hit.
+        if (mountedRef.current && latestCacheKeyRef.current === currentCacheKey) {
+          setNativeRender({ key: currentCacheKey, uri: fileUri });
+        }
       })
       .catch((error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Follow-up to #3509 (the race fix missed the merge by minutes). Fixes the report that the play drawer occasionally (~1 in 10 climbs) shows the board without the lit holds on Android.

Root cause: when a holds-overlay render is still in flight and the user swipes to a climb whose overlay is already cached, the cached overlay shows instantly — then the slow render resolves and clobbers `nativeRender` state back to the *previous* climb's cache key. The key-match guard on `overlayUri` then returns `null` for the current climb, and since the effect deps haven't changed, nothing re-fires: the board sits unlit until the next swipe. The race predates #3509, but #3509's faster drawer open and freed-up JS thread widened the window enough to notice.

Fix: track the latest cache key in a ref (same staleness pattern the background-paths effect already uses) and discard resolutions that no longer match. The late result still lands in the sync cache, so swiping back to that climb is an instant hit.

The regression test drives the exact race with a controllable fake renderer, injected through a new test-only seam (`_setNativeModuleForTests`) because the hook loads the native module via a literal CJS `require` that vitest's mock registry can't intercept. Verified the test fails against the unguarded code and passes with the fix.

## Release Notes

- Fixed the play drawer sometimes showing the board without the lit holds on Android

## Test plan

- New `use-native-climb-render-race.test.tsx` reproduces the clobber (fails without the fix, passes with it)
- `vp run typecheck:mobile`, `vp run test:mobile` (3588 tests), `vp run check:mobile-bundle` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rRcNZWqQX2seq9uuaHcHF