### PR TITLE
fix(mobile): open beta sheet in-tree from the play-drawer ellipsis

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -52,6 +52,19 @@ it renders inline in `ClimbReactionMenu`'s `FullWindowOverlay` (plain `TextInput
 `AddToPlaylistSheet`'s `ModalSheet` (`BottomSheetTextInput`), so add-to-playlist never stacks a
 second sheet. Feedback is inline, not a toast (a toast renders behind the overlay/sheet).
 
+**In-tree opener override — a root menu opening a sheet over a route.** `ClimbReactionMenu` is a
+`FullWindowOverlay` rendered at the **app root** (via `DrawerHostProvider`), but it floats over the
+player route too. If one of its actions opens a sheet through a **root-level** opener
+(`useDrawerHost().openAddBetaVideo` / `openLogAscent` → the sheets in `DrawerHostProvider`), that
+sheet presents off the root and lands **under** the `/play` fullScreenModal — so from the player it
+flashes open and vanishes (rule 1; #3505 was this, #3294 the playlist variant). The fix: when the
+menu is opened **from the player**, thread the player's **own in-tree opener** through
+`openClimbActions` → `ClimbReactionMenu` → `useClimbActions` (the `onAddBetaVideo` override, mirroring
+`onEditEntry` / `onSelectPlaylist`), so the action drives `PlayDrawer`'s local `AddBetaVideoSheet`
+(which presents inside the modal, above it) instead of the root one. Off the player (climb list,
+logbook, board sheet) the override is omitted and the root sheet is correct — nothing covers it.
+**Any new ellipsis action that opens a native sheet needs this override**, or it re-hits the bug.
+
 **Every native sheet must go through the presentation coordinator.** `@expo/ui`
 sheets all present off the **same** root-window view controller, and the library
 does no serialization — overlapping a present with another sheet's dismiss

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -42,8 +42,9 @@ type ClimbReactionMenuProps = {
   onEditEntry?: () => void;
   /** When provided, the "Add beta video" action runs this instead of opening the
    *  root beta sheet — the play drawer passes its own in-tree opener so the sheet
-   *  stacks above the `/play` modal (#3505). */
-  onAddBetaVideo?: () => void;
+   *  stacks above the `/play` modal (#3505). Receives the climb/board snapshot the
+   *  menu was opened for. */
+  onAddBetaVideo?: (climb: Climb, boardConfig: BoardConfig) => void;
   /** Read once at the app root (resolved) and passed in, so the mount-time enter
    *  animation uses the real value rather than useReduceMotion's conservative default. */
   reduceMotion: boolean;

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -40,6 +40,10 @@ type ClimbReactionMenuProps = {
   currentUserId?: string | null;
   isAuthenticated: boolean;
   onEditEntry?: () => void;
+  /** When provided, the "Add beta video" action runs this instead of opening the
+   *  root beta sheet — the play drawer passes its own in-tree opener so the sheet
+   *  stacks above the `/play` modal (#3505). */
+  onAddBetaVideo?: () => void;
   /** Read once at the app root (resolved) and passed in, so the mount-time enter
    *  animation uses the real value rather than useReduceMotion's conservative default. */
   reduceMotion: boolean;
@@ -81,6 +85,7 @@ export function ClimbReactionMenu({
   currentUserId,
   isAuthenticated,
   onEditEntry,
+  onAddBetaVideo,
   reduceMotion,
   onClose,
 }: ClimbReactionMenuProps) {
@@ -133,6 +138,7 @@ export function ClimbReactionMenu({
     onEditEntry,
     onAfterAction: dismiss,
     onSelectPlaylist: openPlaylist,
+    onAddBetaVideo,
   });
 
   const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -102,7 +102,7 @@ import { ClimbReactionMenu } from '../ClimbReactionMenu';
 const climb = { uuid: 'climb-1', name: 'Big Move', frames: '', difficulty: 'V4', quality_average: '0' } as Climb;
 const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
 
-function renderMenu(onClose = vi.fn()) {
+function renderMenu(onClose = vi.fn(), extraProps: Record<string, unknown> = {}) {
   return {
     onClose,
     ...render(
@@ -112,6 +112,7 @@ function renderMenu(onClose = vi.fn()) {
         isAuthenticated
         reduceMotion
         onClose={onClose}
+        {...extraProps}
       />,
     ),
   };
@@ -140,16 +141,7 @@ describe('ClimbReactionMenu view switching', () => {
 
   it('forwards the onAddBetaVideo override into useClimbActions', () => {
     const onAddBetaVideo = vi.fn();
-    render(
-      <ClimbReactionMenu
-        climb={climb}
-        boardConfig={boardConfig as never}
-        isAuthenticated
-        onAddBetaVideo={onAddBetaVideo}
-        reduceMotion
-        onClose={vi.fn()}
-      />,
-    );
+    renderMenu(vi.fn(), { onAddBetaVideo });
     expect(captured.actionArgs?.onAddBetaVideo).toBe(onAddBetaVideo);
   });
 

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -138,6 +138,21 @@ describe('ClimbReactionMenu view switching', () => {
     expect(queryByLabelText('Add to Playlist')).toBeNull();
   });
 
+  it('forwards the onAddBetaVideo override into useClimbActions', () => {
+    const onAddBetaVideo = vi.fn();
+    render(
+      <ClimbReactionMenu
+        climb={climb}
+        boardConfig={boardConfig as never}
+        isAuthenticated
+        onAddBetaVideo={onAddBetaVideo}
+        reduceMotion
+        onClose={vi.fn()}
+      />,
+    );
+    expect(captured.actionArgs?.onAddBetaVideo).toBe(onAddBetaVideo);
+  });
+
   it('returns to the action list when the picker calls onBack', () => {
     const { getByLabelText, container } = renderMenu();
     act(() => fireEvent.click(getByLabelText('Add to Playlist')));

--- a/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
@@ -156,6 +156,30 @@ describe('useClimbActions colours and dispatch', () => {
     expect(onAfterAction).not.toHaveBeenCalled();
   });
 
+  it('betaVideo.run opens the root beta sheet and fires onAfterAction by default', () => {
+    const onAfterAction = vi.fn();
+    const { result } = renderHook(() =>
+      useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: true, onAfterAction }),
+    );
+    result.current.find((action) => action.id === 'betaVideo')?.run();
+    expect(openers.openAddBetaVideo).toHaveBeenCalledWith(climb, kilterBoard);
+    expect(onAfterAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('betaVideo.run calls onAddBetaVideo (in-tree) instead of the root sheet when provided', () => {
+    const onAddBetaVideo = vi.fn();
+    const onAfterAction = vi.fn();
+    const { result } = renderHook(() =>
+      useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: true, onAddBetaVideo, onAfterAction }),
+    );
+    result.current.find((action) => action.id === 'betaVideo')?.run();
+    expect(onAddBetaVideo).toHaveBeenCalledTimes(1);
+    // The play drawer's own sheet takes over — the root opener is skipped, but the
+    // reaction menu still dismisses (unlike the inline playlist path).
+    expect(openers.openAddBetaVideo).not.toHaveBeenCalled();
+    expect(onAfterAction).toHaveBeenCalledTimes(1);
+  });
+
   it('share.run opens the native share sheet', () => {
     const { result } = renderHook(() => useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false }));
     result.current.find((action) => action.id === 'share')?.run();

--- a/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
@@ -173,7 +173,8 @@ describe('useClimbActions colours and dispatch', () => {
       useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: true, onAddBetaVideo, onAfterAction }),
     );
     result.current.find((action) => action.id === 'betaVideo')?.run();
-    expect(onAddBetaVideo).toHaveBeenCalledTimes(1);
+    // Same climb/board snapshot the root path uses, so a live queue change can't retarget it.
+    expect(onAddBetaVideo).toHaveBeenCalledWith(climb, kilterBoard);
     // The play drawer's own sheet takes over — the root opener is skipped, but the
     // reaction menu still dismisses (unlike the inline playlist path).
     expect(openers.openAddBetaVideo).not.toHaveBeenCalled();

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -76,9 +76,11 @@ type UseClimbActionsArgs = {
    * When provided, the "Add beta video" action runs this INSTEAD of opening the
    * root `AddBetaVideoSheet`. The play drawer passes its own in-tree sheet opener
    * so the beta sheet stacks above the `/play` fullScreenModal (a root-tree sheet
-   * can't present over it — see #3505). Omit it and beta opens the root sheet.
+   * can't present over it — see #3505). Receives the same `climb`/`boardConfig`
+   * snapshot the fallback path uses, so a party-session queue/angle change while
+   * the menu is open can't retarget it. Omit it and beta opens the root sheet.
    */
-  onAddBetaVideo?: () => void;
+  onAddBetaVideo?: (climb: Climb, boardConfig: BoardConfig) => void;
 };
 
 // Mirrors web's constructClimbInfoUrl: Kilter no longer has a public app URL.
@@ -265,8 +267,9 @@ export function useClimbActions({
         run: () => {
           // Play drawer passes its own in-tree opener so the beta sheet stacks
           // above the `/play` modal; every other surface falls back to the root
-          // sheet (correct there — no covering modal). See #3505.
-          if (onAddBetaVideo) onAddBetaVideo();
+          // sheet (correct there — no covering modal). Both take the same
+          // climb/board snapshot so a live queue change can't retarget it. See #3505.
+          if (onAddBetaVideo) onAddBetaVideo(climb, boardConfig);
           else openAddBetaVideo(climb, boardConfig);
           after();
         },

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -72,6 +72,13 @@ type UseClimbActionsArgs = {
    * sheet dismisses the first (#3294). Omit it and playlist opens the sheet.
    */
   onSelectPlaylist?: () => void;
+  /**
+   * When provided, the "Add beta video" action runs this INSTEAD of opening the
+   * root `AddBetaVideoSheet`. The play drawer passes its own in-tree sheet opener
+   * so the beta sheet stacks above the `/play` fullScreenModal (a root-tree sheet
+   * can't present over it — see #3505). Omit it and beta opens the root sheet.
+   */
+  onAddBetaVideo?: () => void;
 };
 
 // Mirrors web's constructClimbInfoUrl: Kilter no longer has a public app URL.
@@ -89,6 +96,7 @@ export function useClimbActions({
   onEditEntry,
   onAfterAction,
   onSelectPlaylist,
+  onAddBetaVideo,
 }: UseClimbActionsArgs): ClimbActionItem[] {
   const { t } = useTranslation('climbs');
   const router = useRouter();
@@ -255,7 +263,11 @@ export function useClimbActions({
         icon: 'video',
         color: accentColor,
         run: () => {
-          openAddBetaVideo(climb, boardConfig);
+          // Play drawer passes its own in-tree opener so the beta sheet stacks
+          // above the `/play` modal; every other surface falls back to the root
+          // sheet (correct there — no covering modal). See #3505.
+          if (onAddBetaVideo) onAddBetaVideo();
+          else openAddBetaVideo(climb, boardConfig);
           after();
         },
       });
@@ -346,6 +358,7 @@ export function useClimbActions({
     isAuthenticated,
     onEditEntry,
     onSelectPlaylist,
+    onAddBetaVideo,
     after,
     t,
     actionColors,

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -265,10 +265,9 @@ export function useClimbActions({
         icon: 'video',
         color: accentColor,
         run: () => {
-          // Play drawer passes its own in-tree opener so the beta sheet stacks
-          // above the `/play` modal; every other surface falls back to the root
-          // sheet (correct there — no covering modal). Both take the same
-          // climb/board snapshot so a live queue change can't retarget it. See #3505.
+          // In-tree override (play drawer) stacks the sheet above the `/play` modal;
+          // the root sheet can't. Both take the climb/board snapshot so a live queue
+          // change can't retarget it. See #3505.
           if (onAddBetaVideo) onAddBetaVideo(climb, boardConfig);
           else openAddBetaVideo(climb, boardConfig);
           after();

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -228,9 +228,8 @@ export function PlayDrawer({
   const [isTickBarActive, setIsTickBarActive] = useState(false);
   const [activeSubDrawer, setActiveSubDrawer] = useState<ActiveSubDrawer>('none');
   const [addBetaVideoOpen, setAddBetaVideoOpen] = useState(false);
-  // Non-null when the reaction menu opened the beta sheet for a specific climb
-  // snapshot (so a live queue/angle change can't retarget it); null when the Beta
-  // Videos "+" button opened it for the live displayedClimb. See #3505.
+  // Pinned climb/board the reaction menu opened the beta sheet for; null falls back
+  // to the live displayedClimb (the "+" button path). See #3505.
   const [betaVideoTarget, setBetaVideoTarget] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const [belowFoldContentRequested, setBelowFoldContentRequested] = useState(false);
   const resetZoomRef = useRef<(() => void) | null>(null);
@@ -635,22 +634,22 @@ export function PlayDrawer({
     setBleControlVisible(true);
   }, [bluetooth]);
 
-  // The "+" button in the Beta Videos section adds beta for the climb currently
-  // shown — clear any snapshot so the sheet reads the live displayedClimb.
+  // Beta Videos "+" button: null target → the sheet tracks the live displayedClimb.
   const handleOpenAddBetaVideo = useCallback(() => {
     setBetaVideoTarget(null);
     setAddBetaVideoOpen(true);
   }, []);
 
-  // The reaction menu's beta action passes the climb/board it was opened for.
-  // Snapshot it so a party-session queue/angle change while the menu is open can't
-  // retarget the sheet onto a different climb (the root-sheet fallback snapshots
-  // the same way — see #3505 review).
+  // Reaction-menu beta: pin the climb/board the menu was opened for so a party-session
+  // queue/angle change mid-menu can't retarget the sheet (#3505).
   const handleOpenAddBetaVideoForClimb = useCallback((targetClimb: Climb, targetBoardConfig: BoardConfig) => {
     setBetaVideoTarget({ climb: targetClimb, boardConfig: targetBoardConfig });
     setAddBetaVideoOpen(true);
   }, []);
 
+  // Don't clear betaVideoTarget here: the sheet is still animating out and reads
+  // from it, so nulling it mid-dismiss would swap the shown climb for a frame. The
+  // next open overwrites it (the "+" path to null, the reaction path to its snapshot).
   const handleCloseAddBetaVideo = useCallback(() => {
     setAddBetaVideoOpen(false);
   }, []);
@@ -997,8 +996,6 @@ export function PlayDrawer({
       {mountAddBetaVideo && (
         <AddBetaVideoSheet
           visible={addBetaVideoOpen}
-          // Snapshot when the reaction menu opened it for a specific climb;
-          // otherwise the live displayedClimb (the "+" button path). See #3505.
           climb={betaVideoTarget?.climb ?? displayedClimb ?? null}
           boardName={(betaVideoTarget?.boardConfig.boardName ?? boardName) as BoardName}
           layoutId={betaVideoTarget?.boardConfig.layoutId ?? layoutId}

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -57,6 +57,7 @@ import {
   useQueueSessionId,
 } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
+import type { OpenClimbActionsOptions } from '../../providers/drawer-host-provider';
 import { useAuth } from '../../providers/auth-provider';
 import { useToast } from '../../providers/toast-provider';
 import { useToggleFavorite, useFavoriteStatus } from '../../lib/graphql/hooks';
@@ -146,8 +147,10 @@ type PlayDrawerProps = {
   /** Switch to the climb's board (one-tap if owned, else the board picker). */
   onSwitchBoard?: () => void;
   /** Opens the climb reaction menu (DrawerHostProvider's openClimbActions). On iOS
-   *  the ellipsis uses this instead of the in-drawer bottom sheet. */
-  onOpenClimbActions?: (climb: Climb) => void;
+   *  the ellipsis uses this instead of the in-drawer bottom sheet. The drawer passes
+   *  its own in-tree beta opener via `options.onAddBetaVideo` so the beta sheet
+   *  stacks above the `/play` modal (#3505). */
+  onOpenClimbActions?: (climb: Climb, boardConfigOverride?: BoardConfig, options?: OpenClimbActionsOptions) => void;
   /** The climb to show; applied on mount and whenever `nonce` changes. */
   openTarget: PlayDrawerOpenTarget | null;
   /** Rendering context. `'route'` (default) is the full-screen `/play` modal — a
@@ -628,16 +631,6 @@ export function PlayDrawer({
     setBleControlVisible(true);
   }, [bluetooth]);
 
-  const handleOpenActions = useCallback(() => {
-    // iOS: open the floating reaction menu (over the drawer) instead of the in-drawer
-    // bottom sheet. Android keeps the bottom sheet.
-    if (Platform.OS === 'ios' && onOpenClimbActions && displayedClimb) {
-      onOpenClimbActions(displayedClimb);
-      return;
-    }
-    setActiveSubDrawer('actions');
-  }, [onOpenClimbActions, displayedClimb]);
-
   const handleOpenAddBetaVideo = useCallback(() => {
     setAddBetaVideoOpen(true);
   }, []);
@@ -645,6 +638,19 @@ export function PlayDrawer({
   const handleCloseAddBetaVideo = useCallback(() => {
     setAddBetaVideoOpen(false);
   }, []);
+
+  const handleOpenActions = useCallback(() => {
+    // iOS: open the floating reaction menu (over the drawer) instead of the in-drawer
+    // bottom sheet. Android keeps the bottom sheet.
+    if (Platform.OS === 'ios' && onOpenClimbActions && displayedClimb) {
+      // Hand the reaction menu the drawer's OWN beta opener so the share-your-beta
+      // sheet presents inside the `/play` modal (above it) rather than the root
+      // sheet, which can't stack over the fullScreenModal (#3505).
+      onOpenClimbActions(displayedClimb, undefined, { onAddBetaVideo: handleOpenAddBetaVideo });
+      return;
+    }
+    setActiveSubDrawer('actions');
+  }, [onOpenClimbActions, displayedClimb, handleOpenAddBetaVideo]);
 
   const handleScrollTowardBelowFold = useCallback(() => {
     setBelowFoldContentRequested(true);

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -228,6 +228,10 @@ export function PlayDrawer({
   const [isTickBarActive, setIsTickBarActive] = useState(false);
   const [activeSubDrawer, setActiveSubDrawer] = useState<ActiveSubDrawer>('none');
   const [addBetaVideoOpen, setAddBetaVideoOpen] = useState(false);
+  // Non-null when the reaction menu opened the beta sheet for a specific climb
+  // snapshot (so a live queue/angle change can't retarget it); null when the Beta
+  // Videos "+" button opened it for the live displayedClimb. See #3505.
+  const [betaVideoTarget, setBetaVideoTarget] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const [belowFoldContentRequested, setBelowFoldContentRequested] = useState(false);
   const resetZoomRef = useRef<(() => void) | null>(null);
 
@@ -631,7 +635,19 @@ export function PlayDrawer({
     setBleControlVisible(true);
   }, [bluetooth]);
 
+  // The "+" button in the Beta Videos section adds beta for the climb currently
+  // shown — clear any snapshot so the sheet reads the live displayedClimb.
   const handleOpenAddBetaVideo = useCallback(() => {
+    setBetaVideoTarget(null);
+    setAddBetaVideoOpen(true);
+  }, []);
+
+  // The reaction menu's beta action passes the climb/board it was opened for.
+  // Snapshot it so a party-session queue/angle change while the menu is open can't
+  // retarget the sheet onto a different climb (the root-sheet fallback snapshots
+  // the same way — see #3505 review).
+  const handleOpenAddBetaVideoForClimb = useCallback((targetClimb: Climb, targetBoardConfig: BoardConfig) => {
+    setBetaVideoTarget({ climb: targetClimb, boardConfig: targetBoardConfig });
     setAddBetaVideoOpen(true);
   }, []);
 
@@ -646,11 +662,11 @@ export function PlayDrawer({
       // Hand the reaction menu the drawer's OWN beta opener so the share-your-beta
       // sheet presents inside the `/play` modal (above it) rather than the root
       // sheet, which can't stack over the fullScreenModal (#3505).
-      onOpenClimbActions(displayedClimb, undefined, { onAddBetaVideo: handleOpenAddBetaVideo });
+      onOpenClimbActions(displayedClimb, undefined, { onAddBetaVideo: handleOpenAddBetaVideoForClimb });
       return;
     }
     setActiveSubDrawer('actions');
-  }, [onOpenClimbActions, displayedClimb, handleOpenAddBetaVideo]);
+  }, [onOpenClimbActions, displayedClimb, handleOpenAddBetaVideoForClimb]);
 
   const handleScrollTowardBelowFold = useCallback(() => {
     setBelowFoldContentRequested(true);
@@ -981,10 +997,12 @@ export function PlayDrawer({
       {mountAddBetaVideo && (
         <AddBetaVideoSheet
           visible={addBetaVideoOpen}
-          climb={displayedClimb ?? null}
-          boardName={boardName as BoardName}
-          layoutId={layoutId}
-          angle={angle}
+          // Snapshot when the reaction menu opened it for a specific climb;
+          // otherwise the live displayedClimb (the "+" button path). See #3505.
+          climb={betaVideoTarget?.climb ?? displayedClimb ?? null}
+          boardName={(betaVideoTarget?.boardConfig.boardName ?? boardName) as BoardName}
+          layoutId={betaVideoTarget?.boardConfig.layoutId ?? layoutId}
+          angle={betaVideoTarget?.boardConfig.angle ?? angle}
           onClose={handleCloseAddBetaVideo}
         />
       )}

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -59,8 +59,9 @@ export type OpenClimbActionsOptions = {
   onEditEntry?: () => void;
   /** When set, the "Add beta video" action runs this instead of opening the root
    *  beta sheet. The play drawer passes its own in-tree opener so the sheet stacks
-   *  above the `/play` fullScreenModal (a root-tree sheet can't — see #3505). */
-  onAddBetaVideo?: () => void;
+   *  above the `/play` fullScreenModal (a root-tree sheet can't — see #3505). It
+   *  receives the climb/board snapshot the menu was opened for. */
+  onAddBetaVideo?: (climb: Climb, boardConfig: BoardConfig) => void;
 };
 
 export type LogAscentInput = {
@@ -325,7 +326,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     climb: Climb;
     boardConfig: BoardConfig;
     onEditEntry?: () => void;
-    onAddBetaVideo?: () => void;
+    onAddBetaVideo?: (climb: Climb, boardConfig: BoardConfig) => void;
   } | null>(null);
   const { addToQueue, setSessionBoardPath, setCurrentClimb } = useQueueActions();
   const { sessionId } = useQueueSessionControls();

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -57,6 +57,10 @@ export type OpenClimbActionsOptions = {
   /** When set, the climb actions sheet shows an "Edit entry" row wired to this
    *  callback (logbook rows pass it to open the tick editor). */
   onEditEntry?: () => void;
+  /** When set, the "Add beta video" action runs this instead of opening the root
+   *  beta sheet. The play drawer passes its own in-tree opener so the sheet stacks
+   *  above the `/play` fullScreenModal (a root-tree sheet can't — see #3505). */
+  onAddBetaVideo?: () => void;
 };
 
 export type LogAscentInput = {
@@ -115,7 +119,7 @@ export type PlayDrawerPaneProps = {
   boardMismatch: boolean;
   mismatchBoardLabel: string | undefined;
   onSwitchBoard: () => void;
-  onOpenClimbActions: (climb: Climb) => void;
+  onOpenClimbActions: (climb: Climb, boardConfigOverride?: BoardConfig, options?: OpenClimbActionsOptions) => void;
   /** The climb to show in the pane, with a bumped nonce per selection so the pane
    *  re-applies even when the same climb is re-tapped. Set by `openPlayDrawer` on
    *  iPad regular width (where it drives the pane instead of the `/play` route). */
@@ -321,6 +325,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     climb: Climb;
     boardConfig: BoardConfig;
     onEditEntry?: () => void;
+    onAddBetaVideo?: () => void;
   } | null>(null);
   const { addToQueue, setSessionBoardPath, setCurrentClimb } = useQueueActions();
   const { sessionId } = useQueueSessionControls();
@@ -504,7 +509,12 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     (climb: Climb, boardConfigOverride?: BoardConfig, options?: OpenClimbActionsOptions) => {
       const boardConfig = boardConfigOverride ?? storedActiveBoardConfigRef.current;
       if (!boardConfig) return;
-      setClimbActions({ climb, boardConfig, onEditEntry: options?.onEditEntry });
+      setClimbActions({
+        climb,
+        boardConfig,
+        onEditEntry: options?.onEditEntry,
+        onAddBetaVideo: options?.onAddBetaVideo,
+      });
     },
     [],
   );
@@ -893,6 +903,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
             currentUserId={profile?.id ?? null}
             isAuthenticated={isAuthenticated}
             onEditEntry={climbActions.onEditEntry}
+            onAddBetaVideo={climbActions.onAddBetaVideo}
             reduceMotion={reduceMotion}
             onClose={closeClimbActions}
           />


### PR DESCRIPTION
## Summary

Fixes the broken **Add beta video** action from the play-drawer ellipsis on iOS. Opening a climb in the full-screen player (`/play`) and tapping ellipsis → **Add beta video** made the player close, the beta sheet flash open, then immediately close — so you couldn't add a beta video from the player.

**Root cause:** `/play` is a real native modal view controller (`presentation: 'fullScreenModal'`). Sheets only stack above it when they're presented from *inside* its React tree — which is exactly why `PlayDrawer` renders its own local `AddBetaVideoSheet` (the Beta Videos "+" button uses it and works). But the ellipsis on iOS routes to `ClimbReactionMenu`, rendered at the app root, whose "Add beta video" action opened the **root-level** `AddBetaVideoSheet` in `DrawerHostProvider`. A root-tree sheet can't present over the fullScreenModal, so it fails immediately. This is the same class of bug already fixed for the playlist action in #3294.

**Fix:** Thread a new optional `onAddBetaVideo` override through `openClimbActions` → `ClimbReactionMenu` → `useClimbActions`, mirroring the existing `onEditEntry` path. When the reaction menu is opened from the play drawer, it passes the drawer's own in-tree opener (`handleOpenAddBetaVideo`) so the beta sheet presents inside `/play`, above it. Every other surface (climb list, board sheet, logbook) omits the override and keeps the root sheet, which is correct there since no modal covers it.

Closes #3505

## Release Notes

- Adding a beta video from the player's "..." menu works again — the share sheet opens over the player instead of vanishing.

## Test plan

- `vp run typecheck:mobile` — passes
- `vp run test:mobile` — 3597 passed (added cases: `betaVideo.run` uses the in-tree opener when provided and skips the root sheet; falls back to the root sheet otherwise; `ClimbReactionMenu` forwards `onAddBetaVideo` into `useClimbActions`)
- `vp run check:mobile-bundle` — Android bundle OK
- `vp lint` / `vp fmt --check` on the changed files — clean
- Manual QA (iOS, pending device): player → ellipsis → **Add beta video** opens the Share-your-beta sheet over the player and it stays open; the player does not close. Beta Videos "+" button and "Add beta video" from the climb list / logbook still open the root sheet normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tfVzNBK9KNm3itDS8fDfx

---
_Generated by [Claude Code](https://claude.ai/code/session_018tfVzNBK9KNm3itDS8fDfx)_