### PR TITLE
fix(mobile): restore Android scroll in InSessionView

### DIFF
--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { type NativeScrollEvent, type NativeSyntheticEvent, StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector, ScrollView as GestureScrollView } from 'react-native-gesture-handler';
 import { useSharedValue, withSpring, type SharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FlashList } from '@shopify/flash-list';
@@ -574,6 +574,11 @@ export function InSessionView({
       keyExtractor={historyKeyExtractor}
       ListHeaderComponent={listHeader}
       ListFooterComponent={listFooter}
+      // Use a gesture-handler scroll host so the RNGH orchestrator on Android
+      // can properly arbitrate this scroll against the RecordTopChrome Material
+      // container (which became an opaque RNGH touch target in abf7122).
+      renderScrollComponent={GestureScrollView}
+      nestedScrollEnabled
       // The floating chrome owns the top inset (tab mode), so pad manually by the
       // measured chrome height and never auto-inset under the (absent) header.
       contentInsetAdjustmentBehavior="never"

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -575,8 +575,8 @@ export function InSessionView({
       ListHeaderComponent={listHeader}
       ListFooterComponent={listFooter}
       // Tab mode only: use a gesture-handler scroll host so the RNGH orchestrator
-      // on Android can properly arbitrate this scroll against the RecordTopChrome
-      // Material container (pointerEvents="auto" makes it opaque to RNGH).
+      // can properly arbitrate this scroll against the RecordTopChrome Material
+      // container (pointerEvents="auto" makes it opaque to RNGH; safe no-op on iOS).
       // In overlay mode the parent pull-to-dismiss GestureDetector must own the
       // swipe — keeping the native scroll host lets the pan win when at the top.
       renderScrollComponent={showChrome ? GestureScrollView : undefined}

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -576,7 +576,7 @@ export function InSessionView({
       ListFooterComponent={listFooter}
       // Tab mode only: use a gesture-handler scroll host so the RNGH orchestrator
       // on Android can properly arbitrate this scroll against the RecordTopChrome
-      // Material container (which became an opaque RNGH touch target in abf7122).
+      // Material container (pointerEvents="auto" makes it opaque to RNGH).
       // In overlay mode the parent pull-to-dismiss GestureDetector must own the
       // swipe — keeping the native scroll host lets the pan win when at the top.
       renderScrollComponent={showChrome ? GestureScrollView : undefined}

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -574,11 +574,13 @@ export function InSessionView({
       keyExtractor={historyKeyExtractor}
       ListHeaderComponent={listHeader}
       ListFooterComponent={listFooter}
-      // Use a gesture-handler scroll host so the RNGH orchestrator on Android
-      // can properly arbitrate this scroll against the RecordTopChrome Material
-      // container (which became an opaque RNGH touch target in abf7122).
-      renderScrollComponent={GestureScrollView}
-      nestedScrollEnabled
+      // Tab mode only: use a gesture-handler scroll host so the RNGH orchestrator
+      // on Android can properly arbitrate this scroll against the RecordTopChrome
+      // Material container (which became an opaque RNGH touch target in abf7122).
+      // In overlay mode the parent pull-to-dismiss GestureDetector must own the
+      // swipe — keeping the native scroll host lets the pan win when at the top.
+      renderScrollComponent={showChrome ? GestureScrollView : undefined}
+      nestedScrollEnabled={showChrome}
       // The floating chrome owns the top inset (tab mode), so pad manually by the
       // measured chrome height and never auto-inset under the (absent) header.
       contentInsetAdjustmentBehavior="never"

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -574,11 +574,7 @@ export function InSessionView({
       keyExtractor={historyKeyExtractor}
       ListHeaderComponent={listHeader}
       ListFooterComponent={listFooter}
-      // Tab mode only: use a gesture-handler scroll host so the RNGH orchestrator
-      // can properly arbitrate this scroll against the RecordTopChrome Material
-      // container (pointerEvents="auto" makes it opaque to RNGH; safe no-op on iOS).
-      // In overlay mode the parent pull-to-dismiss GestureDetector must own the
-      // swipe — keeping the native scroll host lets the pan win when at the top.
+      // Tab mode only: RNGH must see this scroll to arbitrate against RecordTopChrome's opaque Material container; native host kept in overlay so the dismiss pan wins.
       renderScrollComponent={showChrome ? GestureScrollView : undefined}
       nestedScrollEnabled={showChrome}
       // The floating chrome owns the top inset (tab mode), so pad manually by the

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
@@ -7,6 +7,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // in-session list clears the bottom chrome without an End action bar.
 const list = vi.hoisted(() => ({
   contentContainerStyle: null as Record<string, unknown> | null,
+  hasGestureScrollComponent: false,
+  nestedScrollEnabled: false,
 }));
 
 // Captures the device-local export handoff fired after a confirmed session end.
@@ -55,6 +57,7 @@ vi.mock('react-native-gesture-handler', () => ({
     }),
   },
   GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));
 
 vi.mock('react-native-reanimated', () => ({
@@ -71,12 +74,18 @@ vi.mock('@shopify/flash-list', () => ({
     ListHeaderComponent,
     ListFooterComponent,
     contentContainerStyle,
+    renderScrollComponent,
+    nestedScrollEnabled,
   }: {
     ListHeaderComponent?: ReactNode;
     ListFooterComponent?: ReactNode;
     contentContainerStyle?: Record<string, unknown>;
+    renderScrollComponent?: unknown;
+    nestedScrollEnabled?: boolean;
   }) => {
     list.contentContainerStyle = contentContainerStyle ?? null;
+    list.hasGestureScrollComponent = renderScrollComponent != null;
+    list.nestedScrollEnabled = nestedScrollEnabled ?? false;
     return createElement('div', null, ListHeaderComponent, ListFooterComponent);
   },
 }));
@@ -170,6 +179,8 @@ import { InSessionView } from '../InSessionView';
 describe('InSessionView footer', () => {
   beforeEach(() => {
     list.contentContainerStyle = null;
+    list.hasGestureScrollComponent = false;
+    list.nestedScrollEnabled = false;
     bottomChrome.metrics = { fixedFooterBottom: 88, jsQueueReserve: 0, tabBarBottom: 50, inSessionListBottom: 130 };
     theme.variant = 'liquidGlass';
     queue.endSession.mockReset();
@@ -211,6 +222,12 @@ describe('InSessionView footer', () => {
   it('renders no in-session bottom action bar', () => {
     const { queryByTestId } = render(createElement(InSessionView));
     expect(queryByTestId('in-session-footer')).toBeNull();
+  });
+
+  it('uses a RNGH scroll host so Android can arbitrate the scroll against the RecordTopChrome Material container', () => {
+    render(createElement(InSessionView));
+    expect(list.hasGestureScrollComponent).toBe(true);
+    expect(list.nestedScrollEnabled).toBe(true);
   });
 
   it('clears the ending spinner even when endSession rejects', async () => {

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
@@ -233,7 +233,7 @@ describe('InSessionView footer', () => {
 
   it('keeps the native scroll host in overlay mode so pull-to-dismiss is not blocked', () => {
     const translateY = { value: 0 };
-    render(createElement(InSessionView, { translateY: translateY as never, screenHeight: 844 }));
+    render(createElement(InSessionView, { showChrome: false, translateY: translateY as never, screenHeight: 844 }));
     expect(list.hasGestureScrollComponent).toBe(false);
     expect(list.nestedScrollEnabled).toBe(false);
   });

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
@@ -128,7 +128,8 @@ vi.mock('../../../../providers/theme-provider', () => ({
       secondaryLabel: '#999',
       separator: '#222',
     },
-    brandColors: { success: '#0f0', warning: '#ff0' },
+    brandColors: { success: '#0f0', warning: '#ff0', primary: '#00f', error: '#f00' },
+    features: { inBodyLargeTitle: false },
   }),
 }));
 vi.mock('../../../../providers/queue-provider', () => ({
@@ -225,9 +226,16 @@ describe('InSessionView footer', () => {
   });
 
   it('uses a RNGH scroll host so Android can arbitrate the scroll against the RecordTopChrome Material container', () => {
-    render(createElement(InSessionView));
+    render(createElement(InSessionView, { showChrome: true }));
     expect(list.hasGestureScrollComponent).toBe(true);
     expect(list.nestedScrollEnabled).toBe(true);
+  });
+
+  it('keeps the native scroll host in overlay mode so pull-to-dismiss is not blocked', () => {
+    const translateY = { value: 0 };
+    render(createElement(InSessionView, { translateY: translateY as never, screenHeight: 844 }));
+    expect(list.hasGestureScrollComponent).toBe(false);
+    expect(list.nestedScrollEnabled).toBe(false);
   });
 
   it('clears the ending spinner even when endSession rejects', async () => {

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
@@ -168,9 +168,9 @@ vi.mock('../../../../hooks/use-native-glass', () => ({ useNativeGlass: () => fal
 vi.mock('../../../../theme/colors', () => ({ withAlpha: (color: string) => color }));
 vi.mock('../../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#999' } }));
 vi.mock('../../../../theme/animations', () => ({ springs: { gentle: {} } }));
-vi.mock('../../../../theme/tokens', () => ({ borderRadius: { lg: 16 }, spacing: { 2: 8, 3: 12, 4: 16 } }));
+vi.mock('../../../../theme/tokens', () => ({ borderRadius: { lg: 16 }, spacing: { 2: 8, 3: 12, 4: 16, 5: 20 } }));
 vi.mock('../../../you/profile-chart-colors', () => ({ gradeBadgeColor: () => '#fff' }));
-vi.mock('../../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+vi.mock('../../../../lib/haptics', () => ({ hapticSelection: vi.fn(), hapticMedium: vi.fn() }));
 vi.mock('../SessionAnalytics', () => ({ SessionAnalytics: () => null }));
 vi.mock('../SessionLeaderboard', () => ({ SessionLeaderboard: () => null }));
 vi.mock('../SessionPresenceRow', () => ({ SessionPresenceRow: () => null }));


### PR DESCRIPTION
## Summary

Restores vertical scrolling in the session tab climb list on Android. Closes #3507.

After #3508 (`abf7122`) made the `RecordTopChrome` Material container `pointerEvents="auto"`, RNGH's `GestureHandlerOrchestrator` on Android began including the native `MaterialToolbar` inside the chrome in gesture arbitration. `InSessionView`'s `FlashList` used RN's native `ScrollView` internally and was not registered with RNGH, so the orchestrator blocked the scroll — leaving the list completely stuck.

The fix applies the same pattern already used in `PreSessionView`: swap the `FlashList`'s internal scroll host to RNGH's `ScrollView` via `renderScrollComponent={GestureScrollView}` and add `nestedScrollEnabled`. This registers the scroll with RNGH so it can coexist with the opaque Material chrome overlay above it.

## Release Notes

- Scrolling the climb history list during a session is fixed on Android.

## Test plan

- New unit test in `in-session-view-footer.test.tsx` asserts `hasGestureScrollComponent: true` and `nestedScrollEnabled: true` on the FlashList — mirroring the equivalent assertion in `pre-session-view-preview.test.tsx`.
- CI runs `vp run typecheck:mobile`, `vp run test:mobile`, and `vp run check:mobile-bundle`.
- Manual verification: open the Record tab on Android with an active session; the climb history list should scroll freely again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai3xKY2Rut2zyziDpmo6p6)_