### PR TITLE
fix(mobile): show real name + avatar in sessions instead of user-&lt;uuid&gt;

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -95,6 +95,9 @@ vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: ht
 vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+vi.mock('../party-profile-provider', () => ({
+  usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
+}));
 
 import { QueueProvider, useQueue, useQueueSessionId } from '../queue-provider';
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
@@ -133,6 +133,9 @@ vi.mock('../../lib/error-reporting', () => ({
 }));
 vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: toast.showToast }) }));
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+vi.mock('../party-profile-provider', () => ({
+  usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
+}));
 
 import { QueueProvider, usePlaylistSuggestionSource, useQueue } from '../queue-provider';
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-narrow-contexts.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-narrow-contexts.test.tsx
@@ -132,6 +132,9 @@ vi.mock('../../lib/error-reporting', () => ({
 }));
 vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: toast.showToast }) }));
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+vi.mock('../party-profile-provider', () => ({
+  usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
+}));
 
 import { QueueProvider, useQueue, useQueueData } from '../queue-provider';
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
@@ -93,6 +93,9 @@ vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: ht
 vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+vi.mock('../party-profile-provider', () => ({
+  usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
+}));
 
 import { QueueProvider, usePlaylistSuggestionSource, useQueue } from '../queue-provider';
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -565,12 +565,15 @@ describe('QueueProvider session update subscription', () => {
     renderProvider((snapshot) => snapshots.push(snapshot));
 
     await waitFor(() => {
-      expect(graph.execute).toHaveBeenCalled();
+      expect(ws.client.subscribe).toHaveBeenCalled();
     });
 
     expect(executeVariablesFor('joinSession')).toEqual(
       expect.objectContaining({ username: 'Marco', avatarUrl: 'https://example.com/marco.png' }),
     );
+    // JOIN already carried the identity, so the re-announce effect must not
+    // fire a redundant UPDATE_USERNAME (announcedIdentityRef is seeded at join).
+    expect(executeVariablesFor('updateUsername')).toBeUndefined();
   });
 
   it('re-announces identity with UPDATE_USERNAME when the profile resolves after joining', async () => {

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -356,6 +356,17 @@ function renderProviderWithSelectors(
   );
 }
 
+// Find the variables of the graph.execute call whose GraphQL document contains
+// `marker` (e.g. the mutation's field name). mock.calls elements are `any[]`, so
+// pull the operation out by index rather than tuple-destructuring.
+function executeVariablesFor(marker: string): Record<string, unknown> | undefined {
+  const call = graph.execute.mock.calls.find((args) => {
+    const operation = args[1] as { query?: string } | undefined;
+    return operation?.query?.includes(marker) ?? false;
+  });
+  return call ? (call[1] as { variables?: Record<string, unknown> }).variables : undefined;
+}
+
 describe('QueueProvider session update subscription', () => {
   beforeEach(() => {
     ws.reset();
@@ -547,17 +558,6 @@ describe('QueueProvider session update subscription', () => {
     });
   });
 
-  // Find the variables of the graph.execute call whose GraphQL document contains
-  // `marker` (e.g. the mutation's field name). mock.calls elements are `any[]`,
-  // so pull the operation out by index rather than tuple-destructuring.
-  function executeVariablesFor(marker: string): Record<string, unknown> | undefined {
-    const call = graph.execute.mock.calls.find((args) => {
-      const operation = args[1] as { query?: string } | undefined;
-      return operation?.query?.includes(marker) ?? false;
-    });
-    return call ? (call[1] as { variables?: Record<string, unknown> }).variables : undefined;
-  }
-
   it('sends the signed-in profile identity with JOIN_SESSION', async () => {
     partyProfile.username = 'Marco';
     partyProfile.avatarUrl = 'https://example.com/marco.png';
@@ -604,6 +604,40 @@ describe('QueueProvider session update subscription', () => {
       expect(executeVariablesFor('updateUsername')).toEqual({
         username: 'Marco',
         avatarUrl: 'https://example.com/marco.png',
+      });
+    });
+  });
+
+  it('re-announces identity with UPDATE_USERNAME when the profile is edited mid-session', async () => {
+    // Signed in with a real identity from the start — JOIN carries it, so no
+    // re-announce fires yet.
+    partyProfile.username = 'Marco';
+    partyProfile.avatarUrl = 'https://example.com/marco.png';
+    const snapshots: Snapshot[] = [];
+    const makeTree = () =>
+      createElement(
+        QueueProvider,
+        null,
+        createElement(Probe, { onSnapshot: (snapshot: Snapshot) => snapshots.push(snapshot) }),
+      );
+    const { rerender } = render(makeTree());
+
+    await waitFor(() => {
+      expect(ws.client.subscribe).toHaveBeenCalled();
+    });
+    expect(executeVariablesFor('updateUsername')).toBeUndefined();
+
+    // User edits their display name + avatar while still in the session.
+    act(() => {
+      partyProfile.username = 'Marco Polo';
+      partyProfile.avatarUrl = 'https://example.com/marco-2.png';
+      rerender(makeTree());
+    });
+
+    await waitFor(() => {
+      expect(executeVariablesFor('updateUsername')).toEqual({
+        username: 'Marco Polo',
+        avatarUrl: 'https://example.com/marco-2.png',
       });
     });
   });

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -645,6 +645,52 @@ describe('QueueProvider session update subscription', () => {
     });
   });
 
+  it('re-announces when the profile resolves while JOIN is still in flight', async () => {
+    // Profile unresolved when JOIN is dispatched, then resolves before JOIN
+    // returns. announcedIdentityRef must record what we actually sent (empty),
+    // not the newer ref value, or the re-announce would be skipped and the
+    // roster would stay on the `User-<id>` fallback.
+    partyProfile.username = undefined;
+    partyProfile.avatarUrl = undefined;
+    const joinDeferred = createDeferred<ReturnType<typeof createJoinSessionResponse>>();
+    graph.execute.mockReturnValueOnce(joinDeferred.promise);
+
+    const snapshots: Snapshot[] = [];
+    const makeTree = () =>
+      createElement(
+        QueueProvider,
+        null,
+        createElement(Probe, { onSnapshot: (snapshot: Snapshot) => snapshots.push(snapshot) }),
+      );
+    const { rerender } = render(makeTree());
+
+    await waitFor(() => {
+      expect(graph.execute).toHaveBeenCalled();
+    });
+    expect(executeVariablesFor('joinSession')).toEqual(
+      expect.objectContaining({ username: undefined, avatarUrl: undefined }),
+    );
+
+    // Profile resolves while JOIN is still awaiting.
+    act(() => {
+      partyProfile.username = 'Marco';
+      partyProfile.avatarUrl = 'https://example.com/marco.png';
+      rerender(makeTree());
+    });
+
+    await act(async () => {
+      joinDeferred.resolve(createJoinSessionResponse());
+      await joinDeferred.promise;
+    });
+
+    await waitFor(() => {
+      expect(executeVariablesFor('updateUsername')).toEqual({
+        username: 'Marco',
+        avatarUrl: 'https://example.com/marco.png',
+      });
+    });
+  });
+
   it('keeps the session-id selector value stable across queue mutations', async () => {
     const snapshots: Snapshot[] = [];
     const selectorSnapshots: SelectorSnapshot[] = [];

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -91,6 +91,13 @@ const toast = vi.hoisted(() => ({
   showToast: vi.fn(),
 }));
 
+// Mutable so a test can flip identity from "still loading" (undefined) to a
+// resolved profile and re-render to exercise the re-announce path.
+const partyProfile = vi.hoisted(() => ({
+  username: undefined as string | undefined,
+  avatarUrl: undefined as string | undefined,
+}));
+
 const queueMutations = vi.hoisted(() => ({
   addQueueItem: vi.fn(async () => {}),
   removeQueueItem: vi.fn(async () => {}),
@@ -168,6 +175,10 @@ vi.mock('../toast-provider', () => ({
 
 vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
+}));
+
+vi.mock('../party-profile-provider', () => ({
+  usePartyProfile: () => ({ username: partyProfile.username, avatarUrl: partyProfile.avatarUrl }),
 }));
 
 import {
@@ -377,6 +388,11 @@ describe('QueueProvider session update subscription', () => {
     activeBoard.getStoredActiveBoard.mockResolvedValue(activeBoard.stored);
     activeBoard.setActiveBoard.mockClear();
     toast.showToast.mockClear();
+    // Default to "profile still loading" so existing JOIN/backoff tests keep
+    // their exact graph.execute call counts (undefined identity never triggers
+    // the re-announce effect). Identity-carrying tests opt in explicitly.
+    partyProfile.username = undefined;
+    partyProfile.avatarUrl = undefined;
     for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
       mutation.mockReset();
       mutation.mockResolvedValue(undefined);
@@ -528,6 +544,67 @@ describe('QueueProvider session update subscription', () => {
 
     await waitFor(() => {
       expect(ws.client.subscribe).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // Find the variables of the graph.execute call whose GraphQL document contains
+  // `marker` (e.g. the mutation's field name). mock.calls elements are `any[]`,
+  // so pull the operation out by index rather than tuple-destructuring.
+  function executeVariablesFor(marker: string): Record<string, unknown> | undefined {
+    const call = graph.execute.mock.calls.find((args) => {
+      const operation = args[1] as { query?: string } | undefined;
+      return operation?.query?.includes(marker) ?? false;
+    });
+    return call ? (call[1] as { variables?: Record<string, unknown> }).variables : undefined;
+  }
+
+  it('sends the signed-in profile identity with JOIN_SESSION', async () => {
+    partyProfile.username = 'Marco';
+    partyProfile.avatarUrl = 'https://example.com/marco.png';
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(graph.execute).toHaveBeenCalled();
+    });
+
+    expect(executeVariablesFor('joinSession')).toEqual(
+      expect.objectContaining({ username: 'Marco', avatarUrl: 'https://example.com/marco.png' }),
+    );
+  });
+
+  it('re-announces identity with UPDATE_USERNAME when the profile resolves after joining', async () => {
+    // Profile still loading at join time — JOIN carries an empty identity and the
+    // roster shows the backend's `User-<id>` fallback.
+    const snapshots: Snapshot[] = [];
+    // A fresh element each render — passing the same reference makes React bail
+    // out of re-rendering QueueProvider, so the updated usePartyProfile mock
+    // would never be re-read.
+    const makeTree = () =>
+      createElement(
+        QueueProvider,
+        null,
+        createElement(Probe, { onSnapshot: (snapshot: Snapshot) => snapshots.push(snapshot) }),
+      );
+    const { rerender } = render(makeTree());
+
+    await waitFor(() => {
+      expect(ws.client.subscribe).toHaveBeenCalled();
+    });
+    expect(executeVariablesFor('updateUsername')).toBeUndefined();
+
+    // Profile resolves → provider re-renders → re-announce fires.
+    act(() => {
+      partyProfile.username = 'Marco';
+      partyProfile.avatarUrl = 'https://example.com/marco.png';
+      rerender(makeTree());
+    });
+
+    await waitFor(() => {
+      expect(executeVariablesFor('updateUsername')).toEqual({
+        username: 'Marco',
+        avatarUrl: 'https://example.com/marco.png',
+      });
     });
   });
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -691,6 +691,55 @@ describe('QueueProvider session update subscription', () => {
     });
   });
 
+  it('retries the re-announce on the next identity change after a failed UPDATE_USERNAME', async () => {
+    // Profile unresolved at join; JOIN carries the empty identity.
+    partyProfile.username = undefined;
+    partyProfile.avatarUrl = undefined;
+    const snapshots: Snapshot[] = [];
+    const makeTree = () =>
+      createElement(
+        QueueProvider,
+        null,
+        createElement(Probe, { onSnapshot: (snapshot: Snapshot) => snapshots.push(snapshot) }),
+      );
+    const { rerender } = render(makeTree());
+
+    await waitFor(() => {
+      expect(ws.client.subscribe).toHaveBeenCalled();
+    });
+
+    // Profile resolves — the re-announce fires but the mutation fails, so the
+    // ref must NOT advance (otherwise the next change wouldn't retry).
+    graph.execute.mockRejectedValueOnce(new Error('transient network error'));
+    act(() => {
+      partyProfile.username = 'Marco';
+      partyProfile.avatarUrl = 'https://example.com/marco.png';
+      rerender(makeTree());
+    });
+    await waitFor(() => {
+      const attempted = graph.execute.mock.calls.some((args) => {
+        const operation = args[1] as { query?: string; variables?: Record<string, unknown> } | undefined;
+        return operation?.query?.includes('updateUsername') && operation.variables?.username === 'Marco';
+      });
+      expect(attempted).toBe(true);
+    });
+
+    // Identity changes again — because the failure left the ref untouched, the
+    // re-announce retries with the new identity.
+    act(() => {
+      partyProfile.username = 'Marco Polo';
+      partyProfile.avatarUrl = 'https://example.com/marco-2.png';
+      rerender(makeTree());
+    });
+    await waitFor(() => {
+      const retried = graph.execute.mock.calls.some((args) => {
+        const operation = args[1] as { query?: string; variables?: Record<string, unknown> } | undefined;
+        return operation?.query?.includes('updateUsername') && operation.variables?.username === 'Marco Polo';
+      });
+      expect(retried).toBe(true);
+    });
+  });
+
   it('keeps the session-id selector value stable across queue mutations', async () => {
     const snapshots: Snapshot[] = [];
     const selectorSnapshots: SelectorSnapshot[] = [];

--- a/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
@@ -186,6 +186,10 @@ vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
 }));
 
+vi.mock('../party-profile-provider', () => ({
+  usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
+}));
+
 vi.mock('../../lib/error-reporting', () => ({
   reportError: errorReporter.reportError,
   reportHandledError: errorReporter.reportHandledError,

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -288,19 +288,21 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // race where the authenticated profile resolves after a cold-launch eager join
   // (roster would otherwise stay on the `User-<uuid>` fallback), and profile
   // edits made mid-session. `announcedIdentityRef` is seeded at join time so this
-  // never fires a redundant re-announce right after joining. Best-effort — a
-  // failed presence update isn't worth surfacing to the user.
+  // never fires a redundant re-announce right after joining. Best-effort, but the
+  // ref only advances on success — so a transient failure is retried the next
+  // time identity changes instead of being silently swallowed.
   useEffect(() => {
     if (!participantId || !partyUsername) return;
     const announced = announcedIdentityRef.current;
     if (announced && announced.username === partyUsername && announced.avatarUrl === partyAvatarUrl) return;
-    announcedIdentityRef.current = { username: partyUsername, avatarUrl: partyAvatarUrl };
-    void execute(getWsClient(), {
-      query: UPDATE_USERNAME,
-      variables: { username: partyUsername, avatarUrl: partyAvatarUrl },
-    }).catch((error) => {
-      if (__DEV__) console.warn('[queue] failed to re-announce identity', error);
-    });
+    const pending = { username: partyUsername, avatarUrl: partyAvatarUrl };
+    void execute(getWsClient(), { query: UPDATE_USERNAME, variables: pending })
+      .then(() => {
+        announcedIdentityRef.current = pending;
+      })
+      .catch((error) => {
+        if (__DEV__) console.warn('[queue] failed to re-announce identity', error);
+      });
   }, [participantId, partyUsername, partyAvatarUrl]);
 
   // Build the sync coordinator once per provider mount. The clientId is

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -20,7 +20,7 @@ import type { SubscriptionQueueEvent, SessionUser } from '@boardsesh/shared-sche
 import { execute, GraphQLOperationError, isRateLimitedExtension } from '@boardsesh/graphql-client';
 import { buildBoardPath } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { JOIN_SESSION } from '@boardsesh/graphql/operations/queue-session';
+import { JOIN_SESSION, UPDATE_USERNAME } from '@boardsesh/graphql/operations/queue-session';
 import { getWsClient } from '../lib/graphql/ws-client';
 import { getHttpClient } from '../lib/graphql/client';
 import {
@@ -37,6 +37,7 @@ import { track } from '../lib/analytics';
 import { reportHandledError } from '../lib/error-reporting';
 import { useToast } from './toast-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
+import { usePartyProfile } from './party-profile-provider';
 import {
   QueueContext,
   QueueSessionControlContext,
@@ -186,6 +187,23 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const { showQueueAddedSnackbar } = useQueueSnackbar();
   const { t } = useTranslation('session');
 
+  // The signed-in user's display name + avatar (undefined while signed out or
+  // still loading). Sent with JOIN_SESSION so the backend roster shows real
+  // identity instead of a `User-<uuid>` fallback + empty avatar. Mirrored into a
+  // ref because the joinTracker is memoized once (empty deps) and its execute
+  // closure must read the latest value — mirrors web's usernameRef/avatarUrlRef
+  // in persistent-session/hooks/session-connection-ports.ts.
+  const { username: partyUsername, avatarUrl: partyAvatarUrl } = usePartyProfile();
+  const identityRef = useRef<{ username: string | undefined; avatarUrl: string | undefined }>({
+    username: partyUsername,
+    avatarUrl: partyAvatarUrl,
+  });
+  identityRef.current = { username: partyUsername, avatarUrl: partyAvatarUrl };
+  // The identity last announced to the session, seeded at JOIN time so the
+  // re-announce effect (below) only fires when it changes afterwards — e.g. the
+  // profile resolved after a cold-launch eager join, or the user edited it.
+  const announcedIdentityRef = useRef<{ username: string | undefined; avatarUrl: string | undefined } | null>(null);
+
   // The active board is read synchronously from the React Query cache
   // (staleTime: Infinity, hydrated from AsyncStorage) so analytics call sites
   // can tag events with the current board layout without re-creating the
@@ -223,8 +241,16 @@ export function QueueProvider({ children }: { children: ReactNode }) {
             };
           }>(getWsClient(), {
             query: JOIN_SESSION,
-            variables: { sessionId: sid, boardPath },
+            variables: {
+              sessionId: sid,
+              boardPath,
+              username: identityRef.current.username,
+              avatarUrl: identityRef.current.avatarUrl,
+            },
           });
+          // Remember what we announced so the re-announce effect only fires if
+          // the identity changes after this join (profile loaded late / edited).
+          announcedIdentityRef.current = { ...identityRef.current };
           const joined = result?.joinSession;
           // Remember our participant id so we can ignore the echo of our own
           // board-path broadcasts. Only overwrite on a concrete value.
@@ -251,6 +277,26 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     (sessionIdToJoin: string) => joinTracker.ensureJoined(sessionIdToJoin),
     [joinTracker],
   );
+
+  // Re-announce identity to the session when it changes after we've joined.
+  // JOIN_SESSION already carries the profile in the common case; this covers the
+  // race where the authenticated profile resolves after a cold-launch eager join
+  // (roster would otherwise stay on the `User-<uuid>` fallback), and profile
+  // edits made mid-session. `announcedIdentityRef` is seeded at join time so this
+  // never fires a redundant re-announce right after joining. Best-effort — a
+  // failed presence update isn't worth surfacing to the user.
+  useEffect(() => {
+    if (!participantId || !partyUsername) return;
+    const announced = announcedIdentityRef.current;
+    if (announced && announced.username === partyUsername && announced.avatarUrl === partyAvatarUrl) return;
+    announcedIdentityRef.current = { username: partyUsername, avatarUrl: partyAvatarUrl };
+    void execute(getWsClient(), {
+      query: UPDATE_USERNAME,
+      variables: { username: partyUsername, avatarUrl: partyAvatarUrl },
+    }).catch((error) => {
+      if (__DEV__) console.warn('[queue] failed to re-announce identity', error);
+    });
+  }, [participantId, partyUsername, partyAvatarUrl]);
 
   // Build the sync coordinator once per provider mount. The clientId is
   // generated fresh per app launch (no persistence needed today — only

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -230,6 +230,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
           );
         },
         execute: async ({ sessionId: sid, boardPath }) => {
+          // Snapshot identity at the moment we build the payload. If the profile
+          // resolves while JOIN is in flight, we must record the values we
+          // actually sent — not identityRef.current's newer ones — so the
+          // re-announce effect still fires UPDATE_USERNAME for the new identity.
+          const sentIdentity = { username: identityRef.current.username, avatarUrl: identityRef.current.avatarUrl };
           const result = await execute<{
             joinSession?: {
               participantId?: string | null;
@@ -244,13 +249,13 @@ export function QueueProvider({ children }: { children: ReactNode }) {
             variables: {
               sessionId: sid,
               boardPath,
-              username: identityRef.current.username,
-              avatarUrl: identityRef.current.avatarUrl,
+              username: sentIdentity.username,
+              avatarUrl: sentIdentity.avatarUrl,
             },
           });
           // Remember what we announced so the re-announce effect only fires if
           // the identity changes after this join (profile loaded late / edited).
-          announcedIdentityRef.current = { ...identityRef.current };
+          announcedIdentityRef.current = sentIdentity;
           const joined = result?.joinSession;
           // Remember our participant id so we can ignore the echo of our own
           // board-path broadcasts. Only overwrite on a concrete value.

--- a/packages/shared/graphql/src/operations/queue-session.ts
+++ b/packages/shared/graphql/src/operations/queue-session.ts
@@ -88,6 +88,16 @@ export const LEAVE_SESSION = `
   }
 `;
 
+// Re-announce the current connection's display name + avatar to everyone in the
+// session. Used when the authenticated profile resolves after we've already
+// joined (cold launch into a restored session) or when the user edits their
+// profile mid-session — JOIN_SESSION carries identity for the common case.
+export const UPDATE_USERNAME = `
+  mutation UpdateUsername($username: String!, $avatarUrl: String) {
+    updateUsername(username: $username, avatarUrl: $avatarUrl)
+  }
+`;
+
 export const END_SESSION = `
   mutation EndSession($sessionId: ID!, $timezone: String) {
     endSession(sessionId: $sessionId, timezone: $timezone) {


### PR DESCRIPTION
## Summary

The mobile app joined collaborative sessions without sending the signed-in user's `username`/`avatarUrl`, so the backend fell back to a `User-<uuid>` name + empty (generated) avatar for the roster entry. That wrong identity then showed up in two places that read the roster:

- the in-session presence row (Closes #3503 — "Session title doesn't show correct user avatar")
- the join-session confirmation card (Closes #3501 — host name + participant avatars)

Web already sends identity on join (`session-connection-ports.ts`); mobile just omitted it.

Changes:
- `queue-provider.tsx` — read `usePartyProfile()` and pass the real display name + avatar in the `JOIN_SESSION` variables (mirrored into a ref because the join tracker is memoized once, like web's `usernameRef`/`avatarUrlRef`). This covers both the session creator (leader) and joiners, since both get their roster identity from the WS join.
- A `UPDATE_USERNAME` re-announce effect handles the race where the profile resolves *after* a cold-launch eager join (roster would otherwise stay on the `User-<uuid>` fallback), and profile edits made mid-session. Added the `UPDATE_USERNAME` operation to `@boardsesh/graphql` (the backend mutation already existed and re-broadcasts name + avatar).
- Tests: mock `party-profile-provider` in the six QueueProvider harnesses (else the provider guard throws), assert `JOIN_SESSION` now carries identity, and cover the re-announce path.

No user-facing strings added (name/avatar come from data), so no i18n changes.

Closes #3503
Closes #3501

## Release Notes

- Your real name and avatar now show up when you start or join a session with your crew — no more `user-3f8a12`.

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run typecheck:shared` — pass
- `vp run test:mobile` — 3596 pass (incl. new JOIN-identity + re-announce assertions across the 6 QueueProvider harnesses)
- `vp run check:mobile-bundle` — Android bundle OK
- `vp check` — format/lint clean on changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wtgr7dsApiELD7sL2SA4tu)_