### PR TITLE
fix(db): grade honesty report — serial execution, never fails the run

### DIFF
--- a/packages/db/scripts/refresh-climb-grades.ts
+++ b/packages/db/scripts/refresh-climb-grades.ts
@@ -634,16 +634,27 @@ async function main(): Promise<void> {
     }
 
     // Honesty report (never blocks): boards whose grade is just the label.
-    const honesty = rowsOf<{
-      board_type: string;
-      correlation: number | null;
-      mean_abs_delta: number | null;
-      rows: number;
-    }>(await db.execute(buildHonestyCheckSql()));
-    for (const row of honesty) {
-      console.log(
-        `[grades]   honesty ${row.board_type}: corr(display)=${row.correlation === null ? 'n/a' : Number(row.correlation).toFixed(3)}, mean|Δ|=${row.mean_abs_delta === null ? 'n/a' : Number(row.mean_abs_delta).toFixed(3)} over ${row.rows} rows`,
-      );
+    // Run it inside a transaction with parallel workers off — the 589k×900k
+    // hash join's parallel workers exhausted prod's /dev/shm (SQLSTATE 53100)
+    // on the first prod run; serial execution spills to disk instead. And a
+    // report-only failure must never fail the run after grades published.
+    try {
+      const honesty = await db.transaction(async (tx) => {
+        await tx.execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
+        return rowsOf<{
+          board_type: string;
+          correlation: number | null;
+          mean_abs_delta: number | null;
+          rows: number;
+        }>(await tx.execute(buildHonestyCheckSql()));
+      });
+      for (const row of honesty) {
+        console.log(
+          `[grades]   honesty ${row.board_type}: corr(display)=${row.correlation === null ? 'n/a' : Number(row.correlation).toFixed(3)}, mean|Δ|=${row.mean_abs_delta === null ? 'n/a' : Number(row.mean_abs_delta).toFixed(3)} over ${row.rows} rows`,
+        );
+      }
+    } catch (honestyError) {
+      console.warn('[grades] honesty report failed (grades already published, run continues):', honestyError);
     }
     console.log('[grades] done.');
   } finally {


### PR DESCRIPTION
## Summary

Follow-up to #3517. The first prod `refresh-climb-grades` run published all 588,801 grade rows and passed every gate, then failed at the very last step: the report-only honesty query's parallel hash join (589k grades × 900k stats) exhausted prod's /dev/shm (SQLSTATE 53100).

Two changes to the honesty report step:
- Runs in a transaction with `SET LOCAL max_parallel_workers_per_gather = 0` — serial execution spills to disk instead of shared memory. Verified against prod: the query now completes (Kilter corr 0.932, mean |Δ| 0.449 over 383k rows).
- Wrapped in try/catch — a report-only failure after grades have published logs a warning instead of failing the nightly workflow.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- [x] `tsc --noEmit` in packages/db
- [x] Exact serial query verified against prod (read-only) — completes, returns per-board honesty stats
- [x] Grades from the first prod run confirmed intact (588,801 rows, universal grades on Kilter/Tension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HywTspsAcUWNSHonxQbA3p