### PR TITLE
fix(mobile): revert 2.2.1 bump and remove OTA-breaking auto version bump

### DIFF
--- a/.github/workflows/mobile-auto-version-bump.yml
+++ b/.github/workflows/mobile-auto-version-bump.yml
@@ -1,53 +1,50 @@
-name: Mobile Release Anchor & Version Bump
+name: Mobile Release Anchor
 
-# Runs on a schedule (and on demand) to react to App Store approvals. Two jobs of
-# work, both keyed on "which versions has Apple accepted?" (PENDING_DEVELOPER_RELEASE,
-# PENDING_APPLE_RELEASE, PROCESSING_FOR_APP_STORE, READY_FOR_SALE):
+# Runs on a schedule (and on demand) to react to App Store approvals. For each
+# version Apple has accepted (PENDING_DEVELOPER_RELEASE, PENDING_APPLE_RELEASE,
+# PROCESSING_FOR_APP_STORE, READY_FOR_SALE) it anchors the approved release: it cuts a
+# release/<platform>-v<version>-<shortfp> tag at the commit the approved binary was
+# built from (located via the build-<platform>-v<version>-<buildNumber>-<shortfp> tags
+# the native builds push). Because an approved store binary is frozen forever, this tag
+# permanently records the fingerprint an OTA must resolve to reach that release — the
+# backport anchor. See docs/mobile-ota-updates.md and scripts/mobile-cut-release-tags.ts.
 #
-#   1. Anchor the approved release. For each accepted version it cuts a
-#      release/<platform>-v<version>-<shortfp> tag at the commit the approved binary
-#      was built from (located via the build-<platform>-v<version>-<buildNumber>-<shortfp>
-#      tags the native builds push). Because an approved store binary is frozen
-#      forever, this tag permanently records the fingerprint an OTA must resolve to
-#      reach that release — the backport anchor. See docs/mobile-ota-updates.md and
-#      scripts/mobile-cut-release-tags.ts.
-#   2. Bump the marketing version. When the CURRENT app.config version is accepted,
-#      bump the patch and push to main via the OTA push-back app token (bypassing the
-#      PR rule). The commit carries [skip ci].
-#
-# The version bump DOES change the fingerprint, and that's fine by design: we anchor
-# only APPROVED (immutable) fingerprints, so intermediate fingerprint churn between
-# approvals never needs to stay OTA-compatible. This is why the schedule — disabled
-# under the old model precisely because a bump busts the fingerprint — is safe to run
-# now. Minor version bumps stay a manual decision.
+# NO automatic marketing-version bump. We tried auto-bumping the patch on main the
+# moment App Store Connect reported a version accepted, on the theory that anchoring
+# only APPROVED (immutable) fingerprints made the resulting fingerprint churn safe.
+# That was wrong: bumping the version on main busts the fingerprint of the binary
+# ALREADY in the field, and "accepted" is not "adopted" — the vast majority of installs
+# are still on the previous store binary until they update. So the bump stranded every
+# current install's OTA (production publishes resolved a fingerprint no shipped binary
+# embeds). Version bumps are a manual decision, made alongside the native build that
+# ships them. This workflow only anchors; it never writes to app.config or pushes to main.
 
 on:
   schedule:
-    # Every 6h so an approval is anchored + bumped without waiting for a manual run.
+    # Every 6h so an approval is anchored without waiting for a manual run.
     - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Log what would change without writing, tagging, or pushing'
+        description: 'Log which release anchor tags would be cut, without tagging or pushing'
         type: boolean
         default: true
 
 concurrency:
-  group: mobile-auto-version-bump
+  group: mobile-release-anchor
   cancel-in-progress: false
 
 jobs:
-  check-and-bump:
+  anchor-release:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: Production
     permissions:
-      contents: write # needed for push-back; the app token is what actually bypasses branch protection
+      contents: write # needed to push the release/* anchor tags
     steps:
-      # Mint a token for the GitHub App that is in main's PR-bypass list.
+      # Mint a token for the GitHub App that is in main's tag-push allowlist.
       # The checkout action persists this in git's credential store so the
-      # later push authenticates as the app, not github-actions[bot] (which
-      # would be rejected by the branch protection rule).
+      # anchor step's tag push authenticates as the app.
       - name: Mint push token
         id: push_token
         if: vars.OTA_PUSH_APP_ID != ''
@@ -69,31 +66,30 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       # No bun install needed — both scripts use only built-in node modules + git.
-      - name: Check ASC for accepted versions and bump if current is accepted
-        id: bump
+      - name: Check ASC for accepted versions
+        id: accepted
         env:
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bun scripts/mobile-auto-version-bump.ts
 
       # Cut release/<platform>-v<version>-<shortfp> anchors for every accepted
       # version (independent of whether the CURRENT version is accepted — an older
       # accepted version may still be unanchored). Idempotent, so the sibling
       # platform's approval and any re-run are safe. Uses the checkout's persisted
-      # token to push the tags. dry_run mirrors the bump step.
+      # token to push the tags. dry_run gates the tag push.
       #
       # continue-on-error: a transient tag-push failure for an old release must not
-      # block the (independent) version bump below — accepted versions are re-anchored
-      # on the next scheduled run. Skipped when there are no accepted versions
-      # (accepted_builds is '[]' or unset), so it doesn't run for nothing.
+      # fail the run — accepted versions are re-anchored on the next scheduled run.
+      # Skipped when there are no accepted versions (accepted_builds is '[]' or unset),
+      # so it doesn't run for nothing.
       - name: Cut release anchor tags for accepted versions
         id: anchor
-        if: steps.bump.outputs.accepted_builds != '' && steps.bump.outputs.accepted_builds != '[]'
+        if: steps.accepted.outputs.accepted_builds != '' && steps.accepted.outputs.accepted_builds != '[]'
         continue-on-error: true
         env:
-          ACCEPTED_BUILDS: ${{ steps.bump.outputs.accepted_builds }}
+          ACCEPTED_BUILDS: ${{ steps.accepted.outputs.accepted_builds }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
           git config user.name "boardsesh-repo-bot[bot]"
@@ -101,46 +97,9 @@ jobs:
           bun scripts/mobile-cut-release-tags.ts
 
       # Surface an anchor-cut failure loudly. continue-on-error keeps it from
-      # blocking the bump, but a persistent failure (e.g. a tag-push permission
+      # blocking the run, but a persistent failure (e.g. a tag-push permission
       # error) would otherwise be easy to miss — accepted versions are re-anchored
       # next run, so this is a signal to investigate, not a hard failure.
       - name: Warn if anchoring failed
         if: steps.anchor.outcome == 'failure'
-        run: echo "::warning::Cutting release anchor tags failed (see the step above). The version bump still proceeds and accepted versions are re-anchored on the next scheduled run; investigate if this persists."
-
-      - name: Commit and push version bump to main
-        if: steps.bump.outputs.bumped == 'true' && vars.OTA_PUSH_APP_ID != ''
-        run: |
-          set -euo pipefail
-          git config user.name "boardsesh-repo-bot[bot]"
-          git config user.email "boardsesh-repo-bot[bot]@users.noreply.github.com"
-          git add packages/mobile/app.config.ts
-          git commit -m "chore(mobile): auto-bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
-
-          # Rebase-and-retry in case another commit landed on main since checkout.
-          # Hard-reset to main then re-apply our file, same pattern as the OTA
-          # changelog push-back — avoids merge conflicts on unrelated changes.
-          saved_version="${{ steps.bump.outputs.new_version }}"
-          for attempt in 1 2 3; do
-            git fetch origin main
-
-            # Idempotent: skip if main already has our version (shouldn't happen, but safe).
-            main_version="$(git show origin/main:packages/mobile/app.config.ts | grep -oP "version: '\\K[^']+")"
-            if [ "$main_version" = "$saved_version" ]; then
-              echo "main already has version $saved_version — nothing to push."
-              exit 0
-            fi
-
-            git reset --hard origin/main
-            sed -i "s/version: '[0-9]*\.[0-9]*\.[0-9]*'/version: '$saved_version'/" packages/mobile/app.config.ts
-            git add packages/mobile/app.config.ts
-            git commit -m "chore(mobile): auto-bump version to $saved_version [skip ci]"
-
-            if git push origin HEAD:main; then
-              echo "Pushed version bump to main."
-              exit 0
-            fi
-            echo "Push rejected (main advanced); retry ${attempt}/3…"
-          done
-          echo "::error::Could not push version bump to main after 3 attempts."
-          exit 1
+        run: echo "::warning::Cutting release anchor tags failed (see the step above). Accepted versions are re-anchored on the next scheduled run; investigate if this persists."

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -240,11 +240,19 @@ Two tag families do this:
   the approved binary was built from; its `<shortfp>` records the fingerprint an OTA must resolve to
   reach that release. This is the frozen **backport anchor**.
 
-`mobile-auto-version-bump.yml` runs on a schedule (every 6h) and, per accepted version: looks up the
+`mobile-auto-version-bump.yml` runs on a schedule (every 6h) and, per accepted version, looks up the
 approved build's `build-*` tag (iOS by the approved build number, Android by the latest build of the
-same marketing version), cuts the `release/*` anchor at that commit, and — once per version — bumps
-the patch on `main` (`[skip ci]`). All idempotent, so the second platform's approval and any re-run
-are safe.
+same marketing version) and cuts the `release/*` anchor at that commit. It is idempotent, so the
+second platform's approval and any re-run are safe.
+
+**It does not bump the marketing version.** An earlier revision auto-bumped the patch on `main` the
+moment App Store Connect reported a version accepted, on the theory that anchoring only approved
+fingerprints made the churn safe. That was wrong and broke production OTAs: bumping the version on
+`main` busts the fingerprint of the binary **already in the field**, and "accepted" is not "adopted" —
+almost every install is still on the previous store binary until it updates, so those installs stop
+receiving OTAs (the publish resolves a fingerprint no shipped binary embeds). Marketing-version bumps
+are a manual decision, made alongside the native build that ships them. The workflow name (`Mobile
+Release Anchor`) and file name are kept; only the bump was removed.
 
 **iOS anchoring is strict:** it uses App Store Connect's exact approved build number, and if no
 `build-ios-v<version>-<buildNumber>-*` tag matches it, it skips (rather than anchoring a different

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -197,7 +197,7 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
     name: appName,
     slug: 'boardsesh',
     owner: 'boardsesh',
-    version: '2.2.1',
+    version: '2.2.0',
     scheme: 'com.boardsesh.app',
     orientation: 'portrait',
     icon: iconPath,

--- a/scripts/mobile-auto-version-bump.ts
+++ b/scripts/mobile-auto-version-bump.ts
@@ -187,12 +187,11 @@ async function main(): Promise<number> {
     const appConfigPath = join(scriptDir, '..', 'packages', 'mobile', 'app.config.ts');
     const content = readFileSync(appConfigPath, 'utf-8');
 
-    const versionMatch = content.match(/version:\s*'(\d+)\.(\d+)\.(\d+)'/);
+    const versionMatch = content.match(/version:\s*'(\d+\.\d+\.\d+)'/);
     if (!versionMatch) {
       throw new Error(`Could not find version field in ${appConfigPath}`);
     }
-    const [, major, minor, patch] = versionMatch;
-    const currentVersion = `${major}.${minor}.${patch}`;
+    const currentVersion = versionMatch[1];
     console.log(`Current marketing version: ${currentVersion}`);
 
     const appId = await resolveAppId(token);

--- a/scripts/mobile-auto-version-bump.ts
+++ b/scripts/mobile-auto-version-bump.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { appendFileSync, readFileSync } from 'node:fs';
 import { createSign } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -8,9 +8,10 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const APP_STORE_CONNECT_API_BASE = 'https://api.appstoreconnect.apple.com';
 const BUNDLE_ID = 'com.boardsesh.app';
 
-// App Store states that indicate Apple has accepted the submission.
-// Once the current version in app.config.ts appears in any of these states,
-// we bump the patch so the next build gets a fresh marketing version.
+// App Store states that indicate Apple has accepted the submission. A version in
+// any of these states is anchored (release/* tag) so a JS fix can be backported to
+// it. We do NOT bump the marketing version on acceptance — that busts the fingerprint
+// of the binary already in the field and strands its OTAs (see main() below).
 const ACCEPTED_APP_STORE_STATES = [
   'PENDING_DEVELOPER_RELEASE',
   'PENDING_APPLE_RELEASE',
@@ -176,8 +177,6 @@ function emitOutput(name: string, value: string): void {
 
 async function main(): Promise<number> {
   try {
-    const dryRun = process.env['DRY_RUN'] === 'true';
-
     const token = createAppStoreConnectJwt({
       keyId: getRequiredEnv('APP_STORE_CONNECT_API_KEY_ID'),
       issuerId: getRequiredEnv('APP_STORE_CONNECT_ISSUER_ID'),
@@ -212,28 +211,13 @@ async function main(): Promise<number> {
     // still need anchoring). One-line JSON so it fits a single GITHUB_OUTPUT value.
     emitOutput('accepted_builds', JSON.stringify(accepted));
 
-    const acceptedStrings = accepted.map((version) => version.versionString);
-    if (!acceptedStrings.includes(currentVersion)) {
-      console.log(`${currentVersion} is not yet in an accepted state — nothing to bump.`);
-      emitOutput('bumped', 'false');
-      return 0;
-    }
-
-    const newVersion = `${major}.${minor}.${parseInt(patch, 10) + 1}`;
-    console.log(`${currentVersion} is accepted → ${dryRun ? 'would bump' : 'bumping'} to ${newVersion}`);
-
-    if (dryRun) {
-      emitOutput('bumped', 'false');
-      emitOutput('new_version', newVersion);
-      return 0;
-    }
-
-    const updated = content.replace(/version:\s*'(\d+\.\d+\.\d+)'/, `version: '${newVersion}'`);
-    writeFileSync(appConfigPath, updated, 'utf-8');
-    console.log(`Wrote ${newVersion} to ${appConfigPath}`);
-
-    emitOutput('bumped', 'true');
-    emitOutput('new_version', newVersion);
+    // NO marketing-version bump. We used to bump the patch here the moment the current
+    // version was accepted, but bumping the version on main busts the fingerprint of
+    // the binary already in the field — and "accepted" is not "adopted", so every
+    // install still on the previous store binary stopped receiving OTAs (production
+    // publishes resolved a fingerprint no shipped binary embeds). Version bumps are a
+    // manual decision made alongside the native build that ships them. This script only
+    // reports accepted versions for anchoring; it never writes app.config.ts.
     return 0;
   } catch (err) {
     console.error(`[mobile-auto-version-bump] ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Summary

The scheduled release-anchor workflow (`mobile-auto-version-bump.yml`) auto-bumped the mobile marketing version `2.2.0 → 2.2.1` on `main` the moment App Store Connect reported the version accepted (commit `68755d1`). That broke production OTAs.

**Why it breaks OTA:** `runtimeVersion` uses the `fingerprint` policy, and the marketing `version` is part of the fingerprint. Bumping the version on `main` moves the fingerprint away from the one the store binary **already in the field** embeds. "Accepted" by Apple is not "adopted" by users — the vast majority of installs are still on the previous store binary until they update, so every production OTA published after the bump resolved a fingerprint no shipped binary embeds and silently never landed.

The auto-bump was disabled under the old model precisely because a bump busts the fingerprint, then wrongly re-enabled on the theory that anchoring only approved (immutable) fingerprints made the churn safe. It isn't safe for the currently-deployed binary.

### Changes

- `packages/mobile/app.config.ts`: revert `version` `2.2.1 → 2.2.0` to restore OTA delivery to the 2.2.0 binaries in the field.
- `.github/workflows/mobile-auto-version-bump.yml`: remove the "commit and push version bump to main" step and its push-token wiring rationale; the workflow now only cuts `release/*` anchor tags for approved versions. Renamed to *Mobile Release Anchor* (file name kept).
- `scripts/mobile-auto-version-bump.ts`: stop writing `app.config.ts` / bumping. It still reports accepted `(version, buildNumber)` pairs so the anchor step can cut `release/*` tags. Removed now-unused `writeFileSync` import and `DRY_RUN` read.
- `docs/mobile-ota-updates.md`: document that marketing-version bumps are a manual decision made alongside the native build that ships them, and why auto-bump was removed.

Release-anchoring (the independent, correct half of the workflow) is untouched.

## Release Notes

- Fixed over-the-air updates not reaching phones still on the current App Store build

## Test plan

- `vp check` on all changed files — format, lint, and types pass
- `vp test run scripts/__tests__/mobile-auto-version-bump.test.ts` — 6/6 pass (`mapAcceptedVersions`, the anchoring input, is untouched)
- `vp test run scripts/mobile-ci-env-parity.test.ts` — 23/23 pass (fingerprint-parity guard unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01526BFaB7H74Tec9rK1GxGS)_