### PR TITLE
fix(db): per-climb isotonic angle constraint — same climb can't be easier at a steeper angle (grade model v1.1)

### DIFF
--- a/docs/boardsesh-grade.md
+++ b/docs/boardsesh-grade.md
@@ -178,6 +178,22 @@ fake a tighter CI. This is why the middle regime below leaves the mean alone.
 3. **No crowd mean** → the cross-angle prior if one exists (SD √V0), else the
    display grade passed through **with no CI**, always tiered `setter_only`.
 
+### Per-climb isotonic angle constraint (v1.1)
+
+Each angle's crowd herds independently, so raw per-angle grades can invert —
+The Enchiridion (Kilter Homewall) was crowd-graded a full point *harder* at 30°
+(n=55) than at 35° (n=33), display grades included. The blend can't fix that:
+with real evidence at both angles, own-angle data rightly dominates the
+cross-angle prior. But the same holds at a steeper wall cannot be easier, so
+after blending, each climb's grades are projected onto "non-decreasing with
+angle" via weighted isotonic regression (pool-adjacent-violators, weights =
+posterior precision 1/post_sd²) — violating neighbours merge to their
+precision-weighted mean, monotone climbs are untouched. Established rows keep
+the no-shock promise (never moved more than 1 grade from their own crowd mean;
+a binding cap can leave a residual inversion, which the run counts and logs).
+Display-only pass-through rows carry no evidence and don't participate.
+Implementation: `isotonic.ts`.
+
 ### Duplicate climbs share one identity
 
 Climbs with the same `hold_fingerprint` are the same physical problem listed

--- a/packages/db/scripts/refresh-climb-grades.ts
+++ b/packages/db/scripts/refresh-climb-grades.ts
@@ -29,6 +29,8 @@ import {
   CROWD_MEAN_BOARDS,
   GRADE_MODEL_VERSION,
   OFFSET_LOO_MAX_DELTA,
+  applyIsotonicAngleConstraint,
+  type AngleGradeRow,
   buildAngleSurfaceSql,
   buildBacktestSampleSql,
   buildBoardOffsetSampleSql,
@@ -284,9 +286,14 @@ async function loadPooledFingerprintEvidence(db: Db, boardType: string): Promise
 }
 
 /** Stream one board's listed, non-draft climb+angle stats, grouped by climb. */
-async function computeBoard(db: Db, boardType: string, coefficients: GradeCoefficients): Promise<ComputedRow[]> {
+async function computeBoard(
+  db: Db,
+  boardType: string,
+  coefficients: GradeCoefficients,
+): Promise<{ computed: ComputedRow[]; isotonicStats: { movedRows: number; residualInversions: number } }> {
   const pooledEvidence = await loadPooledFingerprintEvidence(db, boardType);
   const computed: ComputedRow[] = [];
+  const isotonicStats = { movedRows: 0, residualInversions: 0 };
   let lastClimbUuid = '';
   for (;;) {
     const rows = rowsOf<StatsRow>(
@@ -336,23 +343,36 @@ async function computeBoard(db: Db, boardType: string, coefficients: GradeCoeffi
             displayDifficulty: row.display_difficulty === null ? null : Number(row.display_difficulty),
             ascensionistCount: Number(row.ascensionist_count),
           }));
-      // Emit one output row per angle THIS climb actually has (the pooled
-      // angle set may be wider than this member's own angles).
+      // Posteriors for the full angle set first (pooled set may be wider than
+      // this member's own angles), then the per-climb isotonic projection —
+      // grades may not decrease as the wall gets steeper (see isotonic.ts;
+      // The Enchiridion @30° > @35° was the motivating inversion).
+      const angleRows: AngleGradeRow[] = observations.map((target) => ({
+        angle: target.angle,
+        posterior: computePosteriorGrade(target, observations, coefficients),
+        observedMean: target.difficultyAverage,
+        ascensionistCount: target.ascensionistCount,
+      }));
+      const { adjusted, residualInversions, movedRows } = applyIsotonicAngleConstraint(angleRows);
+      isotonicStats.movedRows += movedRows;
+      isotonicStats.residualInversions += residualInversions;
+
+      // Emit one output row per angle THIS climb actually has.
       const ownAngles = new Set(group.map((row) => row.angle));
-      for (const target of observations) {
-        if (!ownAngles.has(target.angle)) continue;
-        const posterior = computePosteriorGrade(target, observations, coefficients);
+      for (let i = 0; i < angleRows.length; i++) {
+        if (!ownAngles.has(angleRows[i].angle)) continue;
+        const posterior = adjusted[i];
         computed.push({
           climbUuid: group[0].climb_uuid,
-          angle: target.angle,
+          angle: angleRows[i].angle,
           localGrade: posterior.localGrade,
           universalGrade: posterior.universalGrade,
           gradeLow: posterior.gradeLow,
           gradeHigh: posterior.gradeHigh,
           confidence: posterior.confidence,
-          ascensionistCount: target.ascensionistCount,
+          ascensionistCount: angleRows[i].ascensionistCount,
           postSd: posterior.postSd,
-          rawAverage: target.difficultyAverage,
+          rawAverage: angleRows[i].observedMean,
           holdFingerprint: group[0].hold_fingerprint,
         });
       }
@@ -367,7 +387,7 @@ async function computeBoard(db: Db, boardType: string, coefficients: GradeCoeffi
     lastClimbUuid = effective[effective.length - 1].climb_uuid;
     if (isFinalPage) break;
   }
-  return computed;
+  return { computed, isotonicStats };
 }
 
 /** No-shock gate evaluated in memory on the freshly computed rows. */
@@ -378,7 +398,9 @@ function evaluateNoShock(computed: ComputedRow[]): GateResult {
     if (row.ascensionistCount < GATE_NO_SHOCK_MIN_ASCENTS || row.rawAverage === null || row.localGrade === null)
       continue;
     checked += 1;
-    if (Math.abs(row.localGrade - row.rawAverage) > GATE_NO_SHOCK_MAX_MOVE) violations += 1;
+    // 1e-6 tolerance: the blend/isotonic clamps place grades exactly ON the
+    // bound, and (x + 1.0) - x can exceed 1.0 by float noise.
+    if (Math.abs(row.localGrade - row.rawAverage) > GATE_NO_SHOCK_MAX_MOVE + 1e-6) violations += 1;
   }
   return {
     gate: 'no_shock',
@@ -463,7 +485,14 @@ async function upsertGrades(
     batch = [];
   };
 
+  // Hysteresis is CLIMB-scoped, not row-scoped: the isotonic projection keeps a
+  // climb's angles mutually consistent, and holding back one angle's small
+  // correction while publishing its neighbour's would put the inversion right
+  // back in the published table. If ANY angle of a climb crosses the publish
+  // threshold, all of that climb's angles publish together.
+  const publishClimb = new Map<string, boolean>();
   for (const row of computed) {
+    if (publishClimb.get(row.climbUuid)) continue;
     const posteriorLike = {
       localGrade: row.localGrade,
       universalGrade: row.universalGrade,
@@ -472,7 +501,15 @@ async function upsertGrades(
       confidence: row.confidence as never,
       postSd: row.postSd,
     };
-    if (!shouldPublish(previous.get(`${row.climbUuid}:${row.angle}`), posteriorLike)) {
+    if (shouldPublish(previous.get(`${row.climbUuid}:${row.angle}`), posteriorLike)) {
+      publishClimb.set(row.climbUuid, true);
+    } else if (!publishClimb.has(row.climbUuid)) {
+      publishClimb.set(row.climbUuid, false);
+    }
+  }
+
+  for (const row of computed) {
+    if (!publishClimb.get(row.climbUuid)) {
       held += 1;
       continue;
     }
@@ -528,7 +565,7 @@ async function validateOnly(db: Db): Promise<void> {
     );
   }
   for (const boardType of CROWD_MEAN_BOARDS) {
-    const computed = await computeBoard(db, boardType, coefficients);
+    const { computed, isotonicStats } = await computeBoard(db, boardType, coefficients);
     const noShock = evaluateNoShock(computed);
     const fingerprint = evaluateFingerprintConsistency(computed);
     const tiers = computed.reduce<Record<string, number>>((acc, row) => {
@@ -536,7 +573,7 @@ async function validateOnly(db: Db): Promise<void> {
       return acc;
     }, {});
     console.log(
-      `[grades]   ${boardType}: ${computed.length} rows, tiers=${JSON.stringify(tiers)}; no_shock ${noShock.passed ? 'PASS' : 'FAIL'} (${noShock.detail}); fingerprint ${fingerprint.passed ? 'PASS' : 'FAIL'} (${fingerprint.detail})`,
+      `[grades]   ${boardType}: ${computed.length} rows, tiers=${JSON.stringify(tiers)}; isotonic moved ${isotonicStats.movedRows} rows (${isotonicStats.residualInversions} residual inversions); no_shock ${noShock.passed ? 'PASS' : 'FAIL'} (${noShock.detail}); fingerprint ${fingerprint.passed ? 'PASS' : 'FAIL'} (${fingerprint.detail})`,
     );
   }
   console.log('[grades] validate-only done (nothing written).');
@@ -600,9 +637,11 @@ async function main(): Promise<void> {
     const computedByBoard = new Map<string, ComputedRow[]>();
     for (const boardType of CROWD_MEAN_BOARDS) {
       console.log(`[grades] computing ${boardType}…`);
-      const computed = await computeBoard(db, boardType, coefficients);
+      const { computed, isotonicStats } = await computeBoard(db, boardType, coefficients);
       computedByBoard.set(boardType, computed);
-      console.log(`[grades]   ${computed.length} climb+angle rows`);
+      console.log(
+        `[grades]   ${computed.length} climb+angle rows (isotonic moved ${isotonicStats.movedRows}, ${isotonicStats.residualInversions} residual inversions)`,
+      );
     }
     const allComputed = [...computedByBoard.values()].flat();
     const noShockGate = evaluateNoShock(allComputed);

--- a/packages/db/src/queries/grade-model/__tests__/isotonic.test.ts
+++ b/packages/db/src/queries/grade-model/__tests__/isotonic.test.ts
@@ -1,0 +1,116 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyIsotonicAngleConstraint, isotonicNonDecreasing, type AngleGradeRow } from '../isotonic';
+import { CONFIDENCE } from '../constants';
+import type { PosteriorGrade } from '../types';
+
+function posterior(
+  localGrade: number | null,
+  postSd: number | null,
+  universalGrade: number | null = null,
+): PosteriorGrade {
+  return {
+    localGrade,
+    universalGrade,
+    gradeLow: localGrade === null || postSd === null ? null : localGrade - 1.96 * postSd,
+    gradeHigh: localGrade === null || postSd === null ? null : localGrade + 1.96 * postSd,
+    confidence: CONFIDENCE.provisional,
+    postSd,
+  };
+}
+
+function row(
+  angle: number,
+  grade: number | null,
+  sd: number | null,
+  observed: number | null = grade,
+  count = 30,
+): AngleGradeRow {
+  return { angle, posterior: posterior(grade, sd), observedMean: observed, ascensionistCount: count };
+}
+
+void describe('isotonicNonDecreasing', () => {
+  void test('leaves monotone sequences untouched', () => {
+    assert.deepEqual(isotonicNonDecreasing([1, 2, 3], [1, 1, 1]), [1, 2, 3]);
+  });
+  void test('merges a violating pair to its weighted mean', () => {
+    const fitted = isotonicNonDecreasing([24, 22], [3, 1]);
+    // (24·3 + 22·1)/4 = 23.5 for both
+    assert.deepEqual(fitted, [23.5, 23.5]);
+  });
+  void test('cascading merge across three values', () => {
+    const fitted = isotonicNonDecreasing([5, 3, 1], [1, 1, 1]);
+    assert.deepEqual(fitted, [3, 3, 3]);
+  });
+  void test('heavier evidence wins the merge', () => {
+    const fitted = isotonicNonDecreasing([20, 24, 22], [1, 1, 100]);
+    assert.ok(fitted[1] < 22.1, `high-weight 22 should dominate, got ${fitted[1]}`);
+    assert.ok(fitted[1] === fitted[2]);
+  });
+});
+
+void describe('applyIsotonicAngleConstraint', () => {
+  void test('fixes the Enchiridion inversion (30° above 35°)', () => {
+    // Real-world shape: 30° graded ~1 above 35°, both with real evidence.
+    const rows = [
+      row(20, 20.12, 0.35),
+      row(25, 19.95, 0.42),
+      row(30, 23.81, 0.24, 23.83, 55),
+      row(35, 22.86, 0.31, 22.83, 33),
+      row(40, 24.94, 0.19, 24.96, 95),
+    ];
+    const { adjusted, residualInversions, movedRows } = applyIsotonicAngleConstraint(rows);
+    const byAngle = new Map(rows.map((r, i) => [r.angle, adjusted[i]]));
+    const at30 = byAngle.get(30)!.localGrade as number;
+    const at35 = byAngle.get(35)!.localGrade as number;
+    assert.ok(at30 <= at35 + 1e-9, `30° (${at30}) must not exceed 35° (${at35})`);
+    // Merged toward the precision-weighted middle, and 20/25 fixed too.
+    const at20 = byAngle.get(20)!.localGrade as number;
+    const at25 = byAngle.get(25)!.localGrade as number;
+    assert.ok(at20 <= at25 + 1e-9);
+    assert.equal(residualInversions, 0);
+    assert.ok(movedRows >= 4);
+    // 40° was already above everything — untouched.
+    assert.equal(byAngle.get(40)!.localGrade, 24.94);
+  });
+
+  void test('shifts universal grade and CI with the mean', () => {
+    const rows = [
+      { ...row(30, 24, 0.3), posterior: posterior(24, 0.3, 23) },
+      { ...row(35, 22, 0.3), posterior: posterior(22, 0.3, 21) },
+    ];
+    const { adjusted } = applyIsotonicAngleConstraint(rows);
+    // Equal weights → both merge to 23; universal keeps the −1 offset.
+    assert.ok(Math.abs((adjusted[0].localGrade as number) - 23) < 1e-9);
+    assert.ok(Math.abs((adjusted[0].universalGrade as number) - 22) < 1e-9);
+    const width = (adjusted[0].gradeHigh as number) - (adjusted[0].gradeLow as number);
+    assert.ok(Math.abs(width - 2 * 1.96 * 0.3) < 1e-9, 'CI width preserved');
+  });
+
+  void test('established rows never move more than the no-shock bound', () => {
+    // Massive-precision low grade at 35° would drag 30° far below its crowd.
+    const rows = [row(30, 24, 0.5, 24, 100), row(35, 18, 0.01, 18, 5000)];
+    const { adjusted, residualInversions } = applyIsotonicAngleConstraint(rows);
+    const at30 = adjusted[0].localGrade as number;
+    assert.ok(at30 >= 23 - 1e-9, `30° clamped to crowd−1, got ${at30}`);
+    // The cap leaves a residual inversion — counted, not hidden.
+    assert.equal(residualInversions, 1);
+  });
+
+  void test('display-only rows (no postSd) do not participate and are unchanged', () => {
+    const rows = [
+      { angle: 30, posterior: posterior(24, null), observedMean: null, ascensionistCount: 0 },
+      row(35, 22, 0.3),
+    ];
+    const { adjusted } = applyIsotonicAngleConstraint(rows);
+    assert.equal(adjusted[0].localGrade, 24);
+    assert.equal(adjusted[1].localGrade, 22);
+  });
+
+  void test('single-angle climbs pass through', () => {
+    const rows = [row(40, 20, 0.4)];
+    const { adjusted, movedRows } = applyIsotonicAngleConstraint(rows);
+    assert.equal(adjusted[0].localGrade, 20);
+    assert.equal(movedRows, 0);
+  });
+});

--- a/packages/db/src/queries/grade-model/constants.ts
+++ b/packages/db/src/queries/grade-model/constants.ts
@@ -8,7 +8,7 @@
  */
 
 /** Blend/tier/hysteresis logic version, stored on every published row. */
-export const GRADE_MODEL_VERSION = 'v1.0';
+export const GRADE_MODEL_VERSION = 'v1.1'; // v1.1: per-climb isotonic angle constraint
 
 /**
  * Boards whose upstream `difficulty_average` is a live crowd mean (fractional,

--- a/packages/db/src/queries/grade-model/gates.ts
+++ b/packages/db/src/queries/grade-model/gates.ts
@@ -19,7 +19,9 @@ export function buildNoShockCheckSql(): SQL {
   return sql`
     SELECT COUNT(*) FILTER (
              WHERE g.local_grade IS NOT NULL
-               AND ABS(g.local_grade - s.difficulty_average) > ${GATE_NO_SHOCK_MAX_MOVE}
+               -- 1e-6 tolerance: clamps place grades exactly ON the bound and
+               -- float noise can push the difference a hair past it.
+               AND ABS(g.local_grade - s.difficulty_average) > ${GATE_NO_SHOCK_MAX_MOVE} + 1e-6
            )::int AS violations,
            COUNT(*)::int AS checked
     FROM board_climb_grades g

--- a/packages/db/src/queries/grade-model/index.ts
+++ b/packages/db/src/queries/grade-model/index.ts
@@ -3,3 +3,4 @@ export * from './types';
 export * from './blend';
 export * from './coefficients';
 export * from './gates';
+export * from './isotonic';

--- a/packages/db/src/queries/grade-model/isotonic.ts
+++ b/packages/db/src/queries/grade-model/isotonic.ts
@@ -1,0 +1,126 @@
+import { GATE_NO_SHOCK_MAX_MOVE, GATE_NO_SHOCK_MIN_ASCENTS } from './constants';
+import type { PosteriorGrade } from './types';
+
+/**
+ * Per-climb cross-angle coherence: the same holds at a steeper angle cannot be
+ * easier, but each angle's crowd herds independently, so raw per-angle
+ * posteriors can invert (The Enchiridion @30° graded a full point above @35°,
+ * n=55 vs n=33 — the display grades invert too). The blend alone can't fix
+ * this: with real evidence on both sides, own-angle data rightly dominates the
+ * cross-angle prior.
+ *
+ * Fix: project each climb's grades onto "non-decreasing with angle" via
+ * weighted isotonic regression (pool-adjacent-violators), weights = posterior
+ * precision (1/post_sd²). Violating neighbours merge to their
+ * precision-weighted mean; already-monotone climbs are untouched.
+ */
+
+/**
+ * Weighted PAVA, non-decreasing. Returns the fitted values (same order as
+ * input). Inputs must be sorted by the independent variable (angle).
+ */
+export function isotonicNonDecreasing(values: number[], weights: number[]): number[] {
+  const blocks: { sum: number; weight: number; size: number }[] = [];
+  for (let i = 0; i < values.length; i++) {
+    const weight = weights[i] > 0 && Number.isFinite(weights[i]) ? weights[i] : 1e-6;
+    blocks.push({ sum: values[i] * weight, weight, size: 1 });
+    // Merge backwards while the stack violates monotonicity.
+    while (blocks.length >= 2) {
+      const last = blocks[blocks.length - 1];
+      const prev = blocks[blocks.length - 2];
+      if (prev.sum / prev.weight <= last.sum / last.weight) break;
+      prev.sum += last.sum;
+      prev.weight += last.weight;
+      prev.size += last.size;
+      blocks.pop();
+    }
+  }
+  const fitted: number[] = [];
+  for (const block of blocks) {
+    const mean = block.sum / block.weight;
+    for (let i = 0; i < block.size; i++) fitted.push(mean);
+  }
+  return fitted;
+}
+
+export interface AngleGradeRow {
+  angle: number;
+  posterior: PosteriorGrade;
+  /** Crowd mean + count for the no-shock cap (null when no crowd evidence). */
+  observedMean: number | null;
+  ascensionistCount: number;
+}
+
+/**
+ * Apply the isotonic constraint to one climb's per-angle posteriors, in place
+ * on copies. Rules:
+ *  - Only rows with a numeric localGrade AND postSd participate (display-only
+ *    pass-throughs carry no evidence and are left untouched).
+ *  - Established rows (n ≥ GATE_NO_SHOCK_MIN_ASCENTS) never move further than
+ *    GATE_NO_SHOCK_MAX_MOVE from their own crowd mean — the same promise the
+ *    blend makes. A binding cap can leave a residual inversion; callers may
+ *    count those via `residualInversions`.
+ *  - CI bounds and universal grade shift with the mean (width unchanged).
+ */
+export function applyIsotonicAngleConstraint(rows: AngleGradeRow[]): {
+  adjusted: PosteriorGrade[];
+  /** Adjacent pairs still inverted after capping (should be rare). */
+  residualInversions: number;
+  /** Rows whose grade the projection moved (beyond fp noise). */
+  movedRows: number;
+} {
+  const sorted = [...rows].sort((a, b) => a.angle - b.angle);
+  const participating = sorted.filter(
+    (row) => row.posterior.localGrade !== null && row.posterior.postSd !== null && row.posterior.postSd > 0,
+  );
+  if (participating.length < 2) {
+    return { adjusted: rows.map((row) => row.posterior), residualInversions: 0, movedRows: 0 };
+  }
+
+  const values = participating.map((row) => row.posterior.localGrade as number);
+  const weights = participating.map((row) => 1 / (row.posterior.postSd as number) ** 2);
+  const fitted = isotonicNonDecreasing(values, weights);
+
+  const adjustedByAngle = new Map<number, PosteriorGrade>();
+  let movedRows = 0;
+  for (let i = 0; i < participating.length; i++) {
+    const row = participating[i];
+    const original = row.posterior.localGrade as number;
+    let target = fitted[i];
+    // No-shock cap: an established crowd is never overruled by more than the
+    // model-wide bound, even in the name of monotonicity.
+    if (row.observedMean !== null && row.ascensionistCount >= GATE_NO_SHOCK_MIN_ASCENTS) {
+      target = Math.min(
+        row.observedMean + GATE_NO_SHOCK_MAX_MOVE,
+        Math.max(row.observedMean - GATE_NO_SHOCK_MAX_MOVE, target),
+      );
+    }
+    const delta = target - original;
+    if (Math.abs(delta) < 1e-9) {
+      adjustedByAngle.set(row.angle, row.posterior);
+      continue;
+    }
+    movedRows += 1;
+    adjustedByAngle.set(row.angle, {
+      ...row.posterior,
+      localGrade: target,
+      universalGrade: row.posterior.universalGrade === null ? null : row.posterior.universalGrade + delta,
+      gradeLow: row.posterior.gradeLow === null ? null : row.posterior.gradeLow + delta,
+      gradeHigh: row.posterior.gradeHigh === null ? null : row.posterior.gradeHigh + delta,
+    });
+  }
+
+  let residualInversions = 0;
+  let previous: number | null = null;
+  for (const row of participating) {
+    const grade = (adjustedByAngle.get(row.angle) ?? row.posterior).localGrade as number;
+    if (previous !== null && grade < previous - 1e-9) residualInversions += 1;
+    previous = grade;
+  }
+
+  return {
+    adjusted: rows.map((row) => adjustedByAngle.get(row.angle) ?? row.posterior),
+    residualInversions,
+    movedRows,
+  };
+}


### PR DESCRIPTION
## Summary

Marco found The Enchiridion (Kilter Homewall) with a *harder* Boardsesh grade at 30° than 35° — each angle's crowd herds independently (30°: n=55 → 23.8; 35°: n=33 → 22.9; Aurora's own display grades invert too), and the blend rightly lets real own-angle evidence dominate the cross-angle prior, so nothing enforced cross-angle coherence.

v1.1 adds the physical constraint: after blending, each climb's per-angle grades are projected onto **non-decreasing with angle** via precision-weighted isotonic regression (PAVA, weights = 1/post_sd²). Violating neighbours merge to their precision-weighted mean; monotone climbs are untouched. For Enchiridion the merge lands both 30° and 35° on V7 — matching first-hand beta that the 35° V7 is accurate — and pulls the over-graded 30° down from V8.

Guards kept honest:
- Established rows (≥50 ascents) keep the no-shock promise — the projection never moves them >1 grade from their own crowd mean. A binding cap can leave a residual inversion, which is **counted and logged**, not hidden (418 of 384k Kilter rows).
- **Hysteresis is now climb-scoped**: previously a sub-threshold correction on one angle could be held back while its neighbour published, re-creating the inversion in the published table. Now if any angle of a climb crosses the publish threshold, all its angles publish together.
- No-shock gate gains a 1e-6 float tolerance (clamps place grades exactly on the bound; float noise tripped 7 false violations on prod).

## Prod validation (read-only `--validate-only`)

All gates pass. Isotonic corrections: Kilter 66,669 rows (418 residual), Tension 21,350 (96), Grasshopper 5,707 (10), Decoy 1,615, So iLL 415, Touchstone 10. Backtest: 2.6% better than raw (no regression). Model version bumped to v1.1; docs updated (`docs/boardsesh-grade.md` → "Per-climb isotonic angle constraint").

## Release Notes

- The Boardsesh grade now stays consistent across angles — the same climb can't be graded easier at a steeper angle (fixes inversions like The Enchiridion reading harder at 30° than 35°)

## Test plan

- [x] 9 new isotonic unit tests (PAVA correctness, the real Enchiridion fixture, no-shock cap, CI/universal shift, non-participating rows) — 38/38 grade-model tests pass
- [x] `tsc --noEmit` in packages/db
- [x] Read-only prod validation — all gates pass, numbers above
- [x] Spot-check harness on Enchiridion's real inputs: 21/21/21 → 23/23 → 25/25, zero inversions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HywTspsAcUWNSHonxQbA3p