### PR TITLE
perf(shared): batch multi-row SQLite upserts in offline-sync

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -468,7 +468,8 @@ async function syncTable(
     // bind-variable limit (see upsertDocuments in pull-client.ts).
     await db.withExclusiveTransactionAsync(async (tx) => {
       for (const rows of chunk(documents, multiRowChunkSize(columns.length))) {
-        await tx.runAsync(buildMultiRowInsertSql(tableName, columns, rows.length), flattenRowValues(rows, columns));
+        const values = rows.flatMap((row) => columns.map((column) => toSqliteValue(row[column])));
+        await tx.runAsync(buildMultiRowInsertSql(tableName, columns, rows.length), values);
       }
     });
 

--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -462,14 +462,15 @@ async function syncTable(
 
     if (documents.length === 0) break;
 
-    // Use smaller transaction batches to minimize write lock duration
-    for (const batch of chunk(documents, 50)) {
-      await db.withExclusiveTransactionAsync(async (tx) => {
-        for (const doc of batch) {
-          await tx.runAsync(`INSERT OR REPLACE INTO ${tableName} (...) VALUES (...)`, mapDocToColumns(tableName, doc));
-        }
-      });
-    }
+    // One exclusive transaction per page; rows go in as multi-row
+    // INSERT OR REPLACE ... VALUES (...),(...) statements chunked to
+    // floor(999 / columnCount) rows so a statement never exceeds SQLite's
+    // bind-variable limit (see upsertDocuments in pull-client.ts).
+    await db.withExclusiveTransactionAsync(async (tx) => {
+      for (const rows of chunk(documents, multiRowChunkSize(columns.length))) {
+        await tx.runAsync(buildMultiRowInsertSql(tableName, columns, rows.length), flattenRowValues(rows, columns));
+      }
+    });
 
     await setCheckpoint(db, checkpointKey, newCursor);
     cursor = newCursor;

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -44,7 +44,7 @@ export type { GraphQLFetch } from './mutation-queue/handlers';
 export { isRetryable, isNetworkError, getErrorStatus } from './mutation-queue/error-classification';
 
 // --- Pull sync -----------------------------------------------------------------
-export { pullSync } from './sync/pull-client';
+export { pullSync, toSqliteValue, multiRowChunkSize } from './sync/pull-client';
 export type { SyncProgress, SyncOptions, SchemaDriftReporter } from './sync/pull-client';
 export { startSyncScheduler, triggerSync } from './sync/sync-scheduler';
 export type { SyncProgressSink, SchedulerTriggers, SchedulerOptions, DrainQueue } from './sync/sync-scheduler';

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
@@ -72,6 +72,10 @@ describe('toSqliteValue', () => {
     expect(toSqliteValue([1, 2, 3])).toBe(JSON.stringify([1, 2, 3]));
     expect(toSqliteValue(['a', 'b'])).toBe(JSON.stringify(['a', 'b']));
   });
+
+  it('stores Date values as ISO strings without JSON quotes', () => {
+    expect(toSqliteValue(new Date('2026-07-08T12:34:56.789Z'))).toBe('2026-07-08T12:34:56.789Z');
+  });
 });
 
 // --- Batched upsert mechanics (driven through pullSync, mirroring the
@@ -166,7 +170,7 @@ describe('upsertDocuments batching (via pullSync)', () => {
     expect(insertCalls[0].params).toEqual(['tick-1', 1, 5, 'tick-2', 2, null]);
   });
 
-  it('preserves per-row column ordering across a multi-row chunk (values land in the right row/column)', async () => {
+  it('preserves per-row column ordering within a multi-row chunk (values land in the right row/column)', async () => {
     const documents = [
       { uuid: 'tick-a', attempt_count: 10, comment: 'first' },
       { uuid: 'tick-b', attempt_count: 20, comment: 'second' },

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
@@ -1,0 +1,204 @@
+// Focused coverage for the multi-row batching added to upsertDocuments
+// (pull-client.ts): the pure chunk-sizing/value-coercion helpers, and the
+// row/column mechanics of the batched INSERT OR REPLACE (parameter ordering,
+// NULL fill for a page-wide column a given document lacks, and that unknown-
+// column drift reporting is unaffected by batching). The sibling
+// pull-client.test.ts covers pullSync's overall control flow; this file
+// isolates the batching behaviour itself.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { OfflineDatabase, QueryInvalidator } from '../../database';
+
+vi.mock('../checkpoints', () => ({
+  getCheckpoint: vi.fn().mockResolvedValue(null),
+  setCheckpoint: vi.fn().mockResolvedValue(undefined),
+  getCheckpointKey: vi.fn((tableName: string, boardType?: string) =>
+    boardType ? `checkpoint:${tableName}:${boardType}` : `checkpoint:${tableName}`,
+  ),
+  markScopeDownloadComplete: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { pullSync, toSqliteValue, multiRowChunkSize } from '../pull-client';
+import { TABLE_CONFIGS } from '../table-config';
+
+// --- Pure helpers ------------------------------------------------------------
+
+describe('multiRowChunkSize', () => {
+  it('27 columns (board_climbs allowlist width) → 37 rows per statement', () => {
+    expect(multiRowChunkSize(27)).toBe(37);
+  });
+
+  it('1 column → 999 rows per statement (the full bind-variable budget)', () => {
+    expect(multiRowChunkSize(1)).toBe(999);
+  });
+
+  it('exactly 999 columns → 1 row per statement', () => {
+    expect(multiRowChunkSize(999)).toBe(1);
+  });
+
+  it('more columns than the bind-variable ceiling → clamps to 1, never 0', () => {
+    expect(multiRowChunkSize(1000)).toBe(1);
+    expect(multiRowChunkSize(5000)).toBe(1);
+  });
+
+  it('12 columns (boardsesh_ticks-shaped) → 83 rows per statement', () => {
+    expect(multiRowChunkSize(12)).toBe(83);
+  });
+});
+
+describe('toSqliteValue', () => {
+  it('maps true → 1 and false → 0', () => {
+    expect(toSqliteValue(true)).toBe(1);
+    expect(toSqliteValue(false)).toBe(0);
+  });
+
+  it('passes numbers and strings through unchanged', () => {
+    expect(toSqliteValue(42)).toBe(42);
+    expect(toSqliteValue(3.14)).toBe(3.14);
+    expect(toSqliteValue('hello')).toBe('hello');
+    expect(toSqliteValue('')).toBe('');
+  });
+
+  it('maps null and undefined to null', () => {
+    expect(toSqliteValue(null)).toBeNull();
+    expect(toSqliteValue(undefined)).toBeNull();
+  });
+
+  it('JSON-stringifies plain objects', () => {
+    expect(toSqliteValue({ frames: [{ position: 1 }] })).toBe(JSON.stringify({ frames: [{ position: 1 }] }));
+  });
+
+  it('JSON-stringifies arrays', () => {
+    expect(toSqliteValue([1, 2, 3])).toBe(JSON.stringify([1, 2, 3]));
+    expect(toSqliteValue(['a', 'b'])).toBe(JSON.stringify(['a', 'b']));
+  });
+});
+
+// --- Batched upsert mechanics (driven through pullSync, mirroring the
+// sibling suite's mock-db style) ----------------------------------------------
+
+type SqlCall = { sql: string; params: unknown[] };
+
+function createMockDb() {
+  const sqlCalls: SqlCall[] = [];
+  const mockTxn = {
+    runAsync: vi.fn(async (sql: string, params: unknown[]) => {
+      sqlCalls.push({ sql, params });
+    }),
+  };
+  const db = {
+    runAsync: vi.fn(async (sql: string, params: unknown[]) => {
+      sqlCalls.push({ sql, params });
+    }),
+    getAllAsync: vi.fn().mockResolvedValue([]),
+    getFirstAsync: vi.fn().mockResolvedValue(null),
+    withExclusiveTransactionAsync: vi.fn(async (callback: (txn: typeof mockTxn) => Promise<void>) => {
+      await callback(mockTxn);
+    }),
+  } as unknown as OfflineDatabase;
+  return { db, sqlCalls, mockTxn };
+}
+
+function createMockQueryClient(): QueryInvalidator {
+  return { invalidateQueries: vi.fn().mockResolvedValue(undefined) } as unknown as QueryInvalidator;
+}
+
+function makeSyncResult(
+  queryName: string,
+  documents: Record<string, unknown>[],
+  hasMore: boolean,
+  cursor = { updatedAt: '2024-06-01T00:00:00Z', syncSeq: '1' },
+) {
+  return { [queryName]: { documents, cursor, hasMore } };
+}
+
+function makeDeletionsResult(hasMore = false) {
+  return { syncDeletions: { deletions: [], cursor: { updatedAt: '2024-06-01T00:00:00Z', syncSeq: '1' }, hasMore } };
+}
+
+type GraphqlFetchMock = ReturnType<typeof vi.fn> &
+  (<T>(query: string, variables?: Record<string, unknown>) => Promise<T>);
+
+describe('upsertDocuments batching (via pullSync)', () => {
+  let db: OfflineDatabase;
+  let sqlCalls: SqlCall[];
+  let queryClient: QueryInvalidator;
+  let graphqlFetch: GraphqlFetchMock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const mock = createMockDb();
+    db = mock.db;
+    sqlCalls = mock.sqlCalls;
+    queryClient = createMockQueryClient();
+    graphqlFetch = vi.fn() as unknown as GraphqlFetchMock;
+  });
+
+  function fetchServingOnly(queryName: string, documents: Record<string, unknown>[]): void {
+    graphqlFetch.mockImplementation(async (query: string) => {
+      if (query.includes('syncDeletions')) return makeDeletionsResult();
+      if (query.includes(queryName)) return makeSyncResult(queryName, documents, false);
+      for (const config of Object.values(TABLE_CONFIGS)) {
+        if (query.includes(config.queryName)) return makeSyncResult(config.queryName, [], false);
+      }
+      throw new Error(`Unexpected query: ${query}`);
+    });
+  }
+
+  it('binds NULL for a document missing a page-wide column another document has', async () => {
+    // doc1 carries `quality`; doc2 omits it entirely. The page-wide column
+    // union still includes `quality` (present in >=1 document), so doc2's row
+    // must bind NULL for it rather than shrinking the column list.
+    fetchServingOnly('syncTicks', [
+      { uuid: 'tick-1', attempt_count: 1, quality: 5 },
+      { uuid: 'tick-2', attempt_count: 2 },
+    ]);
+
+    await pullSync(db, queryClient, graphqlFetch);
+
+    const insertCalls = sqlCalls.filter((call) => call.sql.includes('INSERT OR REPLACE INTO boardsesh_ticks'));
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].sql).toBe(
+      'INSERT OR REPLACE INTO boardsesh_ticks (uuid, attempt_count, quality) VALUES (?, ?, ?), (?, ?, ?)',
+    );
+    // Row-major parameter order: doc1's full row, then doc2's full row with
+    // NULL in the quality slot — not doc2's two present values compacted.
+    expect(insertCalls[0].params).toEqual(['tick-1', 1, 5, 'tick-2', 2, null]);
+  });
+
+  it('preserves per-row column ordering across a multi-row chunk (values land in the right row/column)', async () => {
+    const documents = [
+      { uuid: 'tick-a', attempt_count: 10, comment: 'first' },
+      { uuid: 'tick-b', attempt_count: 20, comment: 'second' },
+      { uuid: 'tick-c', attempt_count: 30, comment: 'third' },
+    ];
+    fetchServingOnly('syncTicks', documents);
+
+    await pullSync(db, queryClient, graphqlFetch);
+
+    const insertCalls = sqlCalls.filter((call) => call.sql.includes('INSERT OR REPLACE INTO boardsesh_ticks'));
+    expect(insertCalls).toHaveLength(1);
+    // columns = [uuid, attempt_count, comment] (table-config declaration order,
+    // filtered to columns present anywhere on the page).
+    expect(insertCalls[0].params).toEqual(['tick-a', 10, 'first', 'tick-b', 20, 'second', 'tick-c', 30, 'third']);
+  });
+
+  it('skips an unknown column and reports schema drift exactly once, unaffected by batching', async () => {
+    const onSchemaDrift = vi.fn();
+    fetchServingOnly('syncTicks', [
+      { uuid: 'tick-drift-1', attempt_count: 1, made_up_column_xyz: 'a' },
+      { uuid: 'tick-drift-2', attempt_count: 2, made_up_column_xyz: 'b' },
+    ]);
+
+    await pullSync(db, queryClient, graphqlFetch, { onSchemaDrift });
+
+    const driftCalls = onSchemaDrift.mock.calls.filter(([drift]) => drift.column === 'made_up_column_xyz');
+    expect(driftCalls).toHaveLength(1);
+    expect(driftCalls[0][0]).toEqual({ tableName: 'boardsesh_ticks', column: 'made_up_column_xyz' });
+
+    // The unknown column never reaches the SQL — only allowlisted columns do.
+    const insertCalls = sqlCalls.filter((call) => call.sql.includes('INSERT OR REPLACE INTO boardsesh_ticks'));
+    expect(insertCalls[0].sql).not.toContain('made_up_column_xyz');
+    expect(insertCalls[0].params).not.toContain('a');
+  });
+});

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
@@ -32,6 +32,7 @@ import { processMutation, type GraphQLFetch } from '../../mutation-queue/handler
 import { runMigrations } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+import { TABLE_CONFIGS } from '../table-config';
 
 // The non-null fields of the backend's `input SaveTickInput`
 // (packages/shared-schema/src/schema/ticks.ts) — i.e. every `Field!` minus the
@@ -344,6 +345,67 @@ describe('sync layer — real-DDL integration', () => {
         sync_seq: 4242,
       });
       expect(await readCheckpoint(db, 'checkpoint:board_climb_grades:kilter:1:5')).toEqual(cursor);
+    });
+
+    it('board_climbs: a page larger than one bind-variable chunk (100 rows × 27 columns) round-trips every row', async () => {
+      // board_climbs' allowlist is 27 columns, so the batched upsert's chunk
+      // size is floor(999/27) = 37 rows/statement — a 100-row page must split
+      // into 3 multi-row INSERT OR REPLACE statements (37 + 37 + 26) inside
+      // ONE exclusive transaction. This proves that split round-trips cleanly
+      // against the real DDL: every row lands, with the right values, and
+      // none are dropped or duplicated at a chunk boundary.
+      const climbsColumns = TABLE_CONFIGS.board_climbs.localColumns;
+      const documents = Array.from({ length: 100 }, (_, index) =>
+        Object.fromEntries(
+          climbsColumns.map((column) => {
+            if (column === 'uuid') return [column, `climb-batch-${index}`];
+            if (column === 'board_type') return [column, 'kilter'];
+            if (column === 'layout_id') return [column, 1];
+            if (column === 'angle') return [column, 40];
+            if (column === 'is_draft' || column === 'is_listed') return [column, index % 2 === 0];
+            if (column === 'frames') return [column, { p: index }];
+            return [column, `${column}-${index}`];
+          }),
+        ),
+      );
+      const cursor = { updatedAt: '2024-06-05T00:00:00Z', syncSeq: '5000' };
+
+      await pullSync(db, queryClient, makeSingleTableFetch({ queryName: 'syncClimbs', documents, cursor }), {
+        enabledBoards: ['kilter:1:5'],
+      });
+
+      const rows = await db.getAllAsync<Record<string, unknown>>(
+        'SELECT * FROM board_climbs WHERE board_type = ? ORDER BY uuid',
+        ['kilter'],
+      );
+      // Every row landed exactly once — no chunk-boundary drops or dupes.
+      expect(rows).toHaveLength(100);
+      const uuidSet = new Set(rows.map((row) => row.uuid));
+      const expectedUuidSet = new Set(Array.from({ length: 100 }, (_, index) => `climb-batch-${index}`));
+      expect(uuidSet).toEqual(expectedUuidSet);
+
+      // Spot-check the first row of chunk 2 (index 37, given chunk size 37)
+      // and the last row, to prove params never drift between rows/columns
+      // across a chunk split; the uuidSet equality above covers the rest.
+      const boundaryRow = rows.find((row) => row.uuid === 'climb-batch-37');
+      expect(boundaryRow).toMatchObject({
+        uuid: 'climb-batch-37',
+        board_type: 'kilter',
+        layout_id: 1,
+        angle: 40,
+        is_draft: 0, // index 37 is odd → index % 2 === 0 is false → 0
+        frames: JSON.stringify({ p: 37 }),
+        name: 'name-37',
+      });
+      const lastRow = rows.find((row) => row.uuid === 'climb-batch-99');
+      expect(lastRow).toMatchObject({
+        uuid: 'climb-batch-99',
+        frames: JSON.stringify({ p: 99 }),
+        is_draft: 0, // index 99 is odd → index % 2 === 0 is false → 0
+        name: 'name-99',
+      });
+
+      expect(await readCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toEqual(cursor);
     });
 
     it('skips an unknown server column (forward compat), lands the row, and reports the drift once', async () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -169,7 +169,7 @@ describe('pullSync', () => {
     );
   });
 
-  it('upserts a whole page inside one exclusive transaction', async () => {
+  it('upserts a whole page inside one exclusive transaction, batched into multi-row statements', async () => {
     const documents = Array.from({ length: 120 }, (_, index) => ({
       uuid: `tick-${index}`,
       attempt_count: index,
@@ -192,14 +192,64 @@ describe('pullSync', () => {
 
     await pullSync(db, queryClient, graphqlFetch);
 
+    // Only 2 columns are present across the page (uuid, attempt_count), so the
+    // chunk size (floor(999/2) = 499) comfortably covers all 120 rows in one
+    // multi-row INSERT OR REPLACE statement — one runAsync call, not 120.
     const ticksInsertCalls = sqlCalls.filter((call) => call.sql.includes('INSERT OR REPLACE INTO boardsesh_ticks'));
-    expect(ticksInsertCalls).toHaveLength(120);
+    expect(ticksInsertCalls).toHaveLength(1);
+    expect(ticksInsertCalls[0].params).toHaveLength(120 * 2);
 
     // One transaction for the 120-row page — per-batch transactions multiplied
     // commit overhead ~10× across a big board download.
     const transactionCalls = (db.withExclusiveTransactionAsync as ReturnType<typeof vi.fn>).mock.calls;
     expect(transactionCalls.length).toBe(1);
-    expect(mockTxn.runAsync).toHaveBeenCalledTimes(120);
+    expect(mockTxn.runAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('splits a page into multiple multi-row statements when it exceeds the bind-variable chunk size', async () => {
+    // board_climbs' real allowlist is 27 columns → chunkSize = floor(999/27) =
+    // 37 rows/statement. Supplying all 27 keys on every document makes the
+    // page-wide column union the full 27, so 100 rows must split into
+    // 37 + 37 + 26 = 3 statements inside the one transaction.
+    const climbsConfig = TABLE_CONFIGS.board_climbs;
+    const documents = Array.from({ length: 100 }, (_, index) =>
+      Object.fromEntries(
+        climbsConfig.localColumns.map((column) => [column, column === 'uuid' ? `climb-${index}` : `${column}-value`]),
+      ),
+    );
+
+    graphqlFetch.mockImplementation(async (query: string) => {
+      if (query.includes('syncDeletions')) {
+        return makeDeletionsResult([], false);
+      }
+      if (query.includes('syncClimbs')) {
+        return makeSyncResult('syncClimbs', documents, false);
+      }
+      for (const config of Object.values(TABLE_CONFIGS)) {
+        if (query.includes(config.queryName)) {
+          return makeSyncResult(config.queryName, [], false);
+        }
+      }
+      throw new Error(`Unexpected query: ${query}`);
+    });
+
+    await pullSync(db, queryClient, graphqlFetch, { enabledBoards: ['kilter:1:5'] });
+
+    const insertCalls = sqlCalls.filter((call) => call.sql.includes('INSERT OR REPLACE INTO board_climbs'));
+    expect(insertCalls).toHaveLength(3);
+    expect(insertCalls[0].params).toHaveLength(37 * climbsConfig.localColumns.length);
+    expect(insertCalls[1].params).toHaveLength(37 * climbsConfig.localColumns.length);
+    expect(insertCalls[2].params).toHaveLength(26 * climbsConfig.localColumns.length);
+
+    // Total row count across the chunked statements still matches the page.
+    const totalRowsInserted = insertCalls.reduce(
+      (sum, call) => sum + call.params.length / climbsConfig.localColumns.length,
+      0,
+    );
+    expect(totalRowsInserted).toBe(100);
+
+    // Still one exclusive transaction for the whole page, batching or not.
+    expect((db.withExclusiveTransactionAsync as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
   });
 
   it('updates checkpoint after each page', async () => {

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -90,16 +90,17 @@ const SQLITE_MAX_BIND_VARIABLES = 999;
 
 /**
  * Coerces a synced document value to what the SQLite bridge accepts:
- * booleans as 0/1 (SQLite has no BOOLEAN type), objects/arrays as their JSON
- * string (frames, characteristics, etc. are stored as TEXT), null/undefined
- * as NULL (undefined means "document omitted this column" — same bind as an
- * explicit null), everything else passed through unchanged. Exported so a
- * future Node export script can reuse the exact same coercion off the same
- * synced documents without re-deriving it.
+ * booleans as 0/1 (SQLite has no BOOLEAN type), Date values as ISO strings,
+ * objects/arrays as their JSON string (frames, characteristics, etc. are stored
+ * as TEXT), null/undefined as NULL (undefined means "document omitted this
+ * column" — same bind as an explicit null), everything else passed through
+ * unchanged. Exported so the snapshot export job can reuse the exact same
+ * coercion off the same synced documents without re-deriving it.
  */
 export function toSqliteValue(value: unknown): SqlValue {
   if (value === null || value === undefined) return null;
   if (typeof value === 'boolean') return value ? 1 : 0;
+  if (value instanceof Date) return value.toISOString();
   if (typeof value === 'object') return JSON.stringify(value);
   return value as SqlValue;
 }

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -82,6 +82,45 @@ const SYNC_DELETIONS_QUERY = `
   }
 `;
 
+// SQLite's default compile-time limit on bound parameters per statement
+// (SQLITE_MAX_VARIABLE_NUMBER's pre-3.32 default, still the safe floor across
+// the SQLite builds we run on — bundled iOS/Android sqlite3, node:sqlite).
+// Batching must never bind more than this per INSERT.
+const SQLITE_MAX_BIND_VARIABLES = 999;
+
+/**
+ * Coerces a synced document value to what the SQLite bridge accepts:
+ * booleans as 0/1 (SQLite has no BOOLEAN type), objects/arrays as their JSON
+ * string (frames, characteristics, etc. are stored as TEXT), null/undefined
+ * as NULL (undefined means "document omitted this column" — same bind as an
+ * explicit null), everything else passed through unchanged. Exported so a
+ * future Node export script can reuse the exact same coercion off the same
+ * synced documents without re-deriving it.
+ */
+export function toSqliteValue(value: unknown): SqlValue {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'boolean') return value ? 1 : 0;
+  if (typeof value === 'object') return JSON.stringify(value);
+  return value as SqlValue;
+}
+
+/**
+ * How many rows fit in one multi-row `INSERT OR REPLACE ... VALUES (...),(...)`
+ * statement without exceeding SQLite's bound-parameter ceiling. Always at
+ * least 1 (a table wider than the ceiling still gets one row per statement —
+ * it just can't batch).
+ */
+export function multiRowChunkSize(columnCount: number): number {
+  return Math.max(1, Math.floor(SQLITE_MAX_BIND_VARIABLES / columnCount));
+}
+
+function buildMultiRowInsertSql(tableName: string, columns: readonly string[], rowCount: number): string {
+  const columnList = columns.join(', ');
+  const rowPlaceholder = `(${columns.map(() => '?').join(', ')})`;
+  const valuesClause = Array.from({ length: rowCount }, () => rowPlaceholder).join(', ');
+  return `INSERT OR REPLACE INTO ${tableName} (${columnList}) VALUES ${valuesClause}`;
+}
+
 async function upsertDocuments(
   db: OfflineDatabase,
   tableName: string,
@@ -108,6 +147,13 @@ async function upsertDocuments(
     }
   }
 
+  // Columns are the union of allowed columns present anywhere in the page (not
+  // per-document) — this was already true before batching, since this filter
+  // ran once over the whole `documents` array. Batching depends on it: every
+  // row in a multi-row VALUES clause must bind the same column list. A
+  // document missing a page-wide column binds NULL for it below, same as the
+  // single-row INSERT OR REPLACE did (INSERT OR REPLACE still does a whole-row
+  // replace, so this matches today's semantics, not just today's SQL shape).
   const columns = allowedColumns.filter((column) =>
     documents.some((document) => Object.prototype.hasOwnProperty.call(document, column)),
   );
@@ -115,24 +161,34 @@ async function upsertDocuments(
     throw new Error(`Sync document for ${tableName} did not contain any allowed columns`);
   }
 
-  const placeholders = columns.map(() => '?').join(', ');
-  const columnList = columns.join(', ');
-  const sql = `INSERT OR REPLACE INTO ${tableName} (${columnList}) VALUES (${placeholders})`;
+  const chunkSize = multiRowChunkSize(columns.length);
+  // At most two distinct row counts occur in a page (full chunks + a smaller
+  // final chunk), so caching the built SQL by row count avoids rebuilding the
+  // same multi-row VALUES string for every full chunk.
+  const sqlByRowCount = new Map<number, string>();
+  const sqlForRowCount = (rowCount: number): string => {
+    let sql = sqlByRowCount.get(rowCount);
+    if (!sql) {
+      sql = buildMultiRowInsertSql(tableName, columns, rowCount);
+      sqlByRowCount.set(rowCount, sql);
+    }
+    return sql;
+  };
 
   // One exclusive transaction per page (≤ PAGE_LIMIT rows): a big board pull is
   // thousands of pages, and a per-50-row transaction multiplied every page's
   // commit overhead by 10 while giving the drainer no meaningful extra window —
   // it can interleave between pages either way.
   await db.withExclusiveTransactionAsync(async (transaction) => {
-    for (const document of documents) {
-      const values = columns.map((col) => {
-        const value = document[col];
-        if (value === null || value === undefined) return null;
-        if (typeof value === 'boolean') return value ? 1 : 0;
-        if (typeof value === 'object') return JSON.stringify(value);
-        return value;
-      });
-      await transaction.runAsync(sql, values as SqlValue[]);
+    for (let chunkStart = 0; chunkStart < documents.length; chunkStart += chunkSize) {
+      const chunk = documents.slice(chunkStart, chunkStart + chunkSize);
+      const values: SqlValue[] = [];
+      for (const document of chunk) {
+        for (const column of columns) {
+          values.push(toSqliteValue(document[column]));
+        }
+      }
+      await transaction.runAsync(sqlForRowCount(chunk.length), values);
     }
   });
 }


### PR DESCRIPTION
## Summary

First phase of the offline-sync first-download optimisation (snapshot-bootstrap plan). `upsertDocuments` in `@boardsesh/offline-sync` previously issued one `INSERT OR REPLACE` `runAsync` call per synced document — up to 500 sequential JS→SQLite bridge calls per page, hundreds of thousands across a first board download. Rows are now chunked into multi-row `VALUES` statements sized `floor(999 / columnCount)` (SQLite's default bind-variable limit), so a 27-column `board_climbs` page goes from 500 statements to 14 (~37 rows per statement).

Semantics are unchanged and covered by tests: page-wide column allowlist, NULL fill for documents missing a page-wide key, whole-row REPLACE, unknown-column drift reporting (deduped), and the one-exclusive-transaction-per-page boundary. The JS→SQLite value coercion is extracted as a pure exported `toSqliteValue()` for reuse by the upcoming snapshot export job.

Follow-ups in this series: nightly per-layout SQLite snapshot artifacts on Tigris + client bootstrap that replaces the ~400-page first crawl with a single CDN-cached download.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --reporter=agent --project offline-sync` — 153 tests / 12 files pass, including new coverage: chunk-size math (27→37, 1→999, >999→1), exact parameter ordering across chunk boundaries, NULL fill, unknown-column skip + drift-once, `toSqliteValue` coercion table, and a real `node:sqlite` round-trip of 100 rows × 27 columns with boundary-row spot checks.
- `vp check packages/shared/offline-sync/src` — 0 errors.
- `vp run typecheck` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dhXrKcRTfpLV8pkH2RMV6