### PR TITLE
feat(backend): nightly board-snapshot export to S3 + shared manifest contract

### DIFF
--- a/.github/workflows/export-board-snapshots.yml
+++ b/.github/workflows/export-board-snapshots.yml
@@ -1,0 +1,49 @@
+name: Export Board Snapshots
+
+# Nightly: build a per-(board, layout) SQLite snapshot of board_climbs +
+# board_climb_stats, gzip it, and upload to Tigris/S3 under board-snapshots/v1/.
+# A freshly downloaded board on mobile warms from these artifacts instead of
+# paging the whole catalog over GraphQL, then resumes an incremental pull from
+# the watermarks the manifest records. Idempotent — each run mints new
+# content-addressed artifacts and rewrites the manifest last.
+on:
+  schedule:
+    - cron: '15 7 * * *' # 07:15 UTC daily (off-peak; distinct from the 06:00/06:30 refresh crons)
+  workflow_dispatch:
+
+concurrency:
+  group: export-board-snapshots
+  cancel-in-progress: false
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # DATABASE_URL is read-only-sufficient (snapshots only SELECT); READ_REPLICA_URL
+    # is optional and offloads the scan to a replica when present.
+    environment: Production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Export board snapshots
+        working-directory: packages/backend
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          READ_REPLICA_URL: ${{ secrets.READ_REPLICA_URL }}
+          AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: node --import tsx src/scripts/export-board-snapshots.ts

--- a/.github/workflows/export-board-snapshots.yml
+++ b/.github/workflows/export-board-snapshots.yml
@@ -1,7 +1,7 @@
 name: Export Board Snapshots
 
 # Nightly: build a per-(board, layout) SQLite snapshot of board_climbs +
-# board_climb_stats, gzip it, and upload to Tigris/S3 under board-snapshots/v1/.
+# board_climb_stats and upload it to Tigris/S3 under board-snapshots/v1/.
 # A freshly downloaded board on mobile warms from these artifacts instead of
 # paging the whole catalog over GraphQL, then resumes an incremental pull from
 # the watermarks the manifest records. Idempotent — each run mints new

--- a/.github/workflows/export-board-snapshots.yml
+++ b/.github/workflows/export-board-snapshots.yml
@@ -46,4 +46,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          # Keep the export's stability window in lockstep with the backend if
+          # it's ever configured off-default (empty → the shared 30s default).
+          SYNC_STABILITY_WINDOW_SECONDS: ${{ vars.SYNC_STABILITY_WINDOW_SECONDS }}
         run: node --import tsx src/scripts/export-board-snapshots.ts

--- a/.github/workflows/export-board-snapshots.yml
+++ b/.github/workflows/export-board-snapshots.yml
@@ -19,8 +19,12 @@ jobs:
   export:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # DATABASE_URL is read-only-sufficient (snapshots only SELECT); READ_REPLICA_URL
-    # is optional and offloads the scan to a replica when present.
+    # DATABASE_URL is read-only-sufficient (snapshots only SELECT) but MUST
+    # point at the PRIMARY, never a read replica: the sync cursor
+    # (updated_at, sync_seq) is write-time ordered while a replica snapshot is
+    # commit-order consistent, so a lagging replica can yield watermarks that
+    # cover rows absent from the artifact — bootstrapped clients would skip
+    # those rows forever.
     environment: Production
     steps:
       - name: Checkout repository
@@ -40,7 +44,6 @@ jobs:
         working-directory: packages/backend
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          READ_REPLICA_URL: ${{ secrets.READ_REPLICA_URL }}
           AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,7 @@
         "@boardsesh/graphql": "*",
         "@boardsesh/gym-claim": "*",
         "@boardsesh/kilter-sync": "*",
+        "@boardsesh/offline-sync": "*",
         "@boardsesh/queue": "*",
         "@boardsesh/shared-schema": "*",
         "@escape.tech/graphql-armor-cost-limit": "^2.4.3",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,6 +33,7 @@
     "@boardsesh/graphql": "*",
     "@boardsesh/gym-claim": "*",
     "@boardsesh/kilter-sync": "*",
+    "@boardsesh/offline-sync": "*",
     "@boardsesh/queue": "*",
     "@boardsesh/shared-schema": "*",
     "@escape.tech/graphql-armor-cost-limit": "^2.4.3",

--- a/packages/backend/src/__tests__/snapshot-export-golden.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-golden.test.ts
@@ -1,0 +1,369 @@
+// Golden parity test — the contract keeper for the nightly board-snapshot export.
+//
+// It proves that a row written into a snapshot artifact by the export job
+// (scripts/export-board-snapshots.ts) is byte-identical to the row a live
+// `syncClimbs` / `syncClimbStats` pull would write into the on-device SQLite. If
+// the two paths ever diverge (a column dropped, a timestamp shaped differently,
+// an array serialized another way), a warmed-from-snapshot board would disagree
+// with an incrementally-pulled one and this test fails.
+//
+//   Path A — the export core (`exportLayoutSnapshot`) streams Postgres → a SQLite
+//            artifact file (node:sqlite).
+//   Path B — the REAL resolvers feed the REAL client `pullSync` upsert path into a
+//            second node:sqlite DB built from the shared client DDL.
+//
+// Both DBs are then read back and compared column-for-column. It also pins the
+// snapshot_meta watermarks and the 30s stability-window exclusion.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import { DatabaseSync } from 'node:sqlite';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ConnectionContext, SyncCursorInput } from '@boardsesh/shared-schema';
+import type { QueryInvalidator } from '@boardsesh/offline-sync';
+import { pullSync, runMigrations, TABLE_CONFIGS } from '@boardsesh/offline-sync';
+import { createTestDatabase } from '@boardsesh/offline-sync/testing';
+import { createReadPool } from '@boardsesh/db/client';
+import { db } from '../db/client';
+import { syncQueries } from '../graphql/resolvers/sync/queries';
+import { toIso } from '../graphql/resolvers/sync/row-normalize';
+import { exportLayoutSnapshot } from '../scripts/export-board-snapshots';
+
+const USER_ID = 'snapshot-export-user';
+const BOARD_TYPE = 'kilter';
+const LAYOUT_ID = 1;
+const SIZE_ID = 5;
+const SCOPE_KEY = `${BOARD_TYPE}:${LAYOUT_ID}:${SIZE_ID}`;
+const BUILT_AT = '2026-06-01T00:00:00.000Z';
+
+const CLIMB_COLUMNS = TABLE_CONFIGS.board_climbs.localColumns;
+const STATS_COLUMNS = TABLE_CONFIGS.board_climb_stats.localColumns;
+
+function ctx(): ConnectionContext {
+  return {
+    connectionId: 'snapshot-export-conn',
+    isAuthenticated: true,
+    userId: USER_ID,
+    sessionId: null,
+    controllerId: null,
+    controllerApiKey: null,
+  } as unknown as ConnectionContext;
+}
+
+type EmptyPage = { documents: never[]; cursor: SyncCursorInput; hasMore: false };
+type ResolverResponse = Record<string, unknown>;
+
+// A graphqlFetch that routes the two board queries to the REAL resolvers (against
+// the seeded Postgres) and serves an empty page for every other sync query and
+// deletions — exactly the shape pullSync expects, so the full client upsert path
+// runs unchanged.
+async function graphqlFetch<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+  const emptyCursor: SyncCursorInput = { updatedAt: '1970-01-01T00:00:00.000Z', syncSeq: '0' };
+  const resolverArgs = variables as Parameters<typeof syncQueries.syncClimbs>[1];
+
+  if (query.includes('syncDeletions')) {
+    return { syncDeletions: { deletions: [], cursor: emptyCursor, hasMore: false } } as T;
+  }
+  // Check stats before climbs: 'syncClimbStats' does not contain the substring
+  // 'syncClimbs' (capital S after 'syncClimb'), so ordering is unambiguous.
+  if (query.includes('syncClimbStats')) {
+    return { syncClimbStats: await syncQueries.syncClimbStats(undefined, resolverArgs, ctx()) } as T;
+  }
+  if (query.includes('syncClimbs')) {
+    return { syncClimbs: await syncQueries.syncClimbs(undefined, resolverArgs, ctx()) } as T;
+  }
+  const fieldMatch = query.match(/\{\s*\n?\s*(sync[A-Za-z]+)\(/);
+  const fieldName = fieldMatch ? fieldMatch[1] : 'unknown';
+  const emptyPage: EmptyPage = { documents: [], cursor: emptyCursor, hasMore: false };
+  return { [fieldName]: emptyPage } as ResolverResponse as T;
+}
+
+function noopQueryClient(): QueryInvalidator {
+  return { invalidateQueries: () => {} } as unknown as QueryInvalidator;
+}
+
+async function insertClimb(values: {
+  uuid: string;
+  name?: string;
+  description?: string | null;
+  isDraft?: boolean;
+  isListed?: boolean | null;
+  compatibleSizeIds: number[];
+  requiredSetIds?: number[] | null;
+  characteristics?: string[] | null;
+  frames?: string | null;
+  setterId?: number | null;
+  updatedAt: string;
+}): Promise<void> {
+  const compatible = `{${values.compatibleSizeIds.join(',')}}`;
+  const requiredSetIds = values.requiredSetIds == null ? null : `{${values.requiredSetIds.join(',')}}`;
+  const characteristics = values.characteristics == null ? null : `{${values.characteristics.join(',')}}`;
+  await db.execute(sql`
+    INSERT INTO board_climbs
+      (uuid, board_type, layout_id, setter_id, name, description, is_draft, is_listed,
+       compatible_size_ids, required_set_ids, characteristics, frames, updated_at)
+    VALUES
+      (${values.uuid}, ${BOARD_TYPE}, ${LAYOUT_ID}, ${values.setterId ?? null},
+       ${values.name ?? null}, ${values.description ?? null}, ${values.isDraft ?? false},
+       ${values.isListed ?? true}, ${compatible}::int[], ${requiredSetIds}::int[],
+       ${characteristics}::text[], ${values.frames ?? null}, ${values.updatedAt}::timestamp)
+  `);
+}
+
+async function insertStat(values: {
+  climbUuid: string;
+  angle: number;
+  displayDifficulty?: number | null;
+  ascensionistCount?: number | null;
+  qualityAverage?: number | null;
+  faUsername?: string | null;
+  faAt?: string | null;
+  updatedAt: string;
+}): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO board_climb_stats
+      (board_type, climb_uuid, angle, display_difficulty, ascensionist_count,
+       quality_average, fa_username, fa_at, updated_at)
+    VALUES
+      (${BOARD_TYPE}, ${values.climbUuid}, ${values.angle}, ${values.displayDifficulty ?? null},
+       ${values.ascensionistCount ?? null}, ${values.qualityAverage ?? null},
+       ${values.faUsername ?? null}, ${values.faAt ?? null}, ${values.updatedAt}::timestamp)
+  `);
+}
+
+function readArtifactRows(filePath: string, table: string, columns: readonly string[]): Record<string, unknown>[] {
+  const artifactDb = new DatabaseSync(filePath);
+  try {
+    const orderBy = table === 'board_climbs' ? 'uuid' : 'climb_uuid, angle';
+    return artifactDb.prepare(`SELECT ${columns.join(', ')} FROM ${table} ORDER BY ${orderBy}`).all() as Record<
+      string,
+      unknown
+    >[];
+  } finally {
+    artifactDb.close();
+  }
+}
+
+function readArtifactMeta(filePath: string, table: string): Record<string, unknown> | undefined {
+  const artifactDb = new DatabaseSync(filePath);
+  try {
+    return artifactDb.prepare('SELECT * FROM snapshot_meta WHERE table_name = ?').get(table) as
+      | Record<string, unknown>
+      | undefined;
+  } finally {
+    artifactDb.close();
+  }
+}
+
+let workDir: string;
+
+beforeEach(async () => {
+  workDir = mkdtempSync(join(tmpdir(), 'snapshot-golden-'));
+  await db.execute(sql`TRUNCATE TABLE board_climbs, board_climb_stats RESTART IDENTITY CASCADE`);
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('board-snapshot export ↔ live pull parity', () => {
+  it('produces byte-identical board_climbs / board_climb_stats rows via the export core and the real resolver pull', async () => {
+    // Tricky shapes: booleans, int[] and text[] arrays, NULLs in arrays/text,
+    // fractional-second timestamps, multi-angle stats, and a climb with no stats.
+    await insertClimb({
+      uuid: 'c1',
+      name: 'Crimp Master',
+      description: 'a real description',
+      isDraft: false,
+      isListed: true,
+      setterId: 42,
+      compatibleSizeIds: [5, 6],
+      requiredSetIds: [10, 20],
+      characteristics: ['crimpy', 'powerful'],
+      frames: 'p1145r12p1146r13',
+      updatedAt: '2026-05-01T00:00:00Z',
+    });
+    await insertClimb({
+      uuid: 'c2',
+      name: 'Draft Problem',
+      description: null,
+      isDraft: true,
+      isListed: false,
+      compatibleSizeIds: [5],
+      requiredSetIds: null,
+      characteristics: null,
+      frames: null,
+      updatedAt: '2026-05-01T00:00:01.5Z', // fractional seconds
+    });
+    await insertClimb({
+      uuid: 'c3',
+      name: 'Über Sloper ✦',
+      compatibleSizeIds: [5, 7],
+      requiredSetIds: [10],
+      characteristics: ['slopey'],
+      frames: 'p900r15',
+      updatedAt: '2026-05-02T09:30:00Z',
+    });
+
+    await insertStat({
+      climbUuid: 'c1',
+      angle: 40,
+      displayDifficulty: 21.5,
+      ascensionistCount: 1234,
+      qualityAverage: 4.6,
+      faUsername: 'setterfa',
+      faAt: '2023-01-01T00:00:00Z',
+      updatedAt: '2026-05-01T00:00:00Z',
+    });
+    await insertStat({
+      climbUuid: 'c1',
+      angle: 50,
+      displayDifficulty: 24.0,
+      ascensionistCount: 88,
+      qualityAverage: null,
+      faUsername: null,
+      faAt: null,
+      updatedAt: '2026-05-01T00:00:30Z',
+    });
+    await insertStat({
+      climbUuid: 'c2',
+      angle: 40,
+      displayDifficulty: null,
+      ascensionistCount: null,
+      updatedAt: '2026-05-01T00:00:02Z',
+    });
+    // c3 deliberately has no stats — the stats table must still round-trip cleanly.
+
+    // --- Path A: export core → SQLite artifact ---
+    const filePath = join(workDir, 'artifact.db');
+    await exportLayoutSnapshot({
+      sqlClient: createReadPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath,
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 0, // match the resolvers' test window so row sets align
+    });
+    const artifactClimbs = readArtifactRows(filePath, 'board_climbs', CLIMB_COLUMNS);
+    const artifactStats = readArtifactRows(filePath, 'board_climb_stats', STATS_COLUMNS);
+
+    // --- Path B: real resolvers → real client upsert ---
+    const clientDb = createTestDatabase();
+    await runMigrations(clientDb);
+    await pullSync(clientDb, noopQueryClient(), graphqlFetch, { enabledBoards: [SCOPE_KEY] });
+    const pulledClimbs = await clientDb.getAllAsync<Record<string, unknown>>(
+      `SELECT ${CLIMB_COLUMNS.join(', ')} FROM board_climbs ORDER BY uuid`,
+    );
+    const pulledStats = await clientDb.getAllAsync<Record<string, unknown>>(
+      `SELECT ${STATS_COLUMNS.join(', ')} FROM board_climb_stats ORDER BY climb_uuid, angle`,
+    );
+
+    // The export and the live pull must agree exactly.
+    expect(artifactClimbs).toEqual(pulledClimbs);
+    expect(artifactStats).toEqual(pulledStats);
+
+    // Sanity: they actually carry the seeded data (not both empty).
+    expect(artifactClimbs.map((row) => row.uuid)).toEqual(['c1', 'c2', 'c3']);
+    expect(artifactStats).toHaveLength(3);
+    // Spot-check the tricky coercions landed as the manifest dictates.
+    const c1 = artifactClimbs.find((row) => row.uuid === 'c1')!;
+    expect(c1.is_draft).toBe(0);
+    expect(c1.is_listed).toBe(1);
+    expect(c1.compatible_size_ids).toBe(JSON.stringify([5, 6]));
+    expect(c1.characteristics).toBe(JSON.stringify(['crimpy', 'powerful']));
+    expect(c1.updated_at).toBe('2026-05-01T00:00:00Z');
+    const c2 = artifactClimbs.find((row) => row.uuid === 'c2')!;
+    expect(c2.characteristics).toBeNull();
+    expect(c2.updated_at).toBe('2026-05-01T00:00:01.5Z');
+  });
+
+  it('records snapshot_meta watermarks equal to the max keyset cursor of the exported rows', async () => {
+    await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+    await insertClimb({ uuid: 'c2', compatibleSizeIds: [5], updatedAt: '2026-05-02T09:30:00Z' });
+    await insertStat({ climbUuid: 'c1', angle: 40, updatedAt: '2026-05-01T00:00:00Z' });
+    await insertStat({ climbUuid: 'c2', angle: 40, updatedAt: '2026-05-03T00:00:00Z' });
+
+    const filePath = join(workDir, 'artifact.db');
+    await exportLayoutSnapshot({
+      sqlClient: createReadPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath,
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 0,
+    });
+
+    // Expected watermark = the greatest (updated_at, sync_seq) among the scoped rows.
+    const climbWatermarkRow = (
+      await db.execute(sql`
+        SELECT updated_at, sync_seq FROM board_climbs
+        WHERE board_type = ${BOARD_TYPE} AND layout_id = ${LAYOUT_ID}
+        ORDER BY updated_at DESC, sync_seq DESC LIMIT 1
+      `)
+    )[0] as { updated_at: unknown; sync_seq: unknown };
+    const statsWatermarkRow = (
+      await db.execute(sql`
+        SELECT s.updated_at, s.sync_seq FROM board_climb_stats s
+        WHERE s.board_type = ${BOARD_TYPE}
+          AND EXISTS (SELECT 1 FROM board_climbs bc WHERE bc.uuid = s.climb_uuid AND bc.layout_id = ${LAYOUT_ID})
+        ORDER BY s.updated_at DESC, s.sync_seq DESC LIMIT 1
+      `)
+    )[0] as { updated_at: unknown; sync_seq: unknown };
+
+    const climbMeta = readArtifactMeta(filePath, 'board_climbs')!;
+    expect(climbMeta.row_count).toBe(2);
+    expect(climbMeta.watermark_updated_at).toBe(toIso(climbWatermarkRow.updated_at));
+    expect(climbMeta.watermark_sync_seq).toBe(Number(climbWatermarkRow.sync_seq));
+    expect(climbMeta.schema_version).toBeGreaterThanOrEqual(1);
+    expect(climbMeta.format_version).toBe(1);
+
+    const statsMeta = readArtifactMeta(filePath, 'board_climb_stats')!;
+    expect(statsMeta.row_count).toBe(2);
+    expect(statsMeta.watermark_updated_at).toBe(toIso(statsWatermarkRow.updated_at));
+    expect(statsMeta.watermark_sync_seq).toBe(Number(statsWatermarkRow.sync_seq));
+  });
+
+  it('excludes a row inside the stability window from both the artifact and its watermark', async () => {
+    // Old rows are well outside any window; the recent row is inside a 30s window.
+    await insertClimb({ uuid: 'old-1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+    await insertClimb({ uuid: 'old-2', compatibleSizeIds: [5], updatedAt: '2026-05-02T00:00:00Z' });
+    // updated_at = now() → inside a 30s stability window.
+    await db.execute(sql`
+      INSERT INTO board_climbs (uuid, board_type, layout_id, compatible_size_ids, updated_at)
+      VALUES ('recent', ${BOARD_TYPE}, ${LAYOUT_ID}, '{5}'::int[], now())
+    `);
+
+    const filePath = join(workDir, 'artifact.db');
+    await exportLayoutSnapshot({
+      sqlClient: createReadPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath,
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 30,
+    });
+
+    const artifactClimbs = readArtifactRows(filePath, 'board_climbs', ['uuid']);
+    const uuids = artifactClimbs.map((row) => row.uuid);
+    expect(uuids).toEqual(['old-1', 'old-2']); // 'recent' excluded
+    expect(uuids).not.toContain('recent');
+
+    // The watermark stops at the newest STABLE row, never covering the excluded one.
+    const stableWatermarkRow = (
+      await db.execute(sql`
+        SELECT sync_seq FROM board_climbs
+        WHERE board_type = ${BOARD_TYPE} AND layout_id = ${LAYOUT_ID} AND uuid = 'old-2'
+      `)
+    )[0] as { sync_seq: unknown };
+    const recentRow = (await db.execute(sql`SELECT sync_seq FROM board_climbs WHERE uuid = 'recent'`))[0] as {
+      sync_seq: unknown;
+    };
+
+    const climbMeta = readArtifactMeta(filePath, 'board_climbs')!;
+    expect(climbMeta.row_count).toBe(2);
+    expect(climbMeta.watermark_sync_seq).toBe(Number(stableWatermarkRow.sync_seq));
+    expect(Number(climbMeta.watermark_sync_seq)).toBeLessThan(Number(recentRow.sync_seq));
+  });
+});

--- a/packages/backend/src/__tests__/snapshot-export-golden.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-golden.test.ts
@@ -315,14 +315,14 @@ describe('board-snapshot export ↔ live pull parity', () => {
     const climbMeta = readArtifactMeta(filePath, 'board_climbs')!;
     expect(climbMeta.row_count).toBe(2);
     expect(climbMeta.watermark_updated_at).toBe(toIso(climbWatermarkRow.updated_at));
-    expect(climbMeta.watermark_sync_seq).toBe(Number(climbWatermarkRow.sync_seq));
+    expect(climbMeta.watermark_sync_seq).toBe(String(climbWatermarkRow.sync_seq));
     expect(climbMeta.schema_version).toBeGreaterThanOrEqual(1);
     expect(climbMeta.format_version).toBe(1);
 
     const statsMeta = readArtifactMeta(filePath, 'board_climb_stats')!;
     expect(statsMeta.row_count).toBe(2);
     expect(statsMeta.watermark_updated_at).toBe(toIso(statsWatermarkRow.updated_at));
-    expect(statsMeta.watermark_sync_seq).toBe(Number(statsWatermarkRow.sync_seq));
+    expect(statsMeta.watermark_sync_seq).toBe(String(statsWatermarkRow.sync_seq));
   });
 
   it('excludes a row inside the stability window from both the artifact and its watermark', async () => {
@@ -363,7 +363,7 @@ describe('board-snapshot export ↔ live pull parity', () => {
 
     const climbMeta = readArtifactMeta(filePath, 'board_climbs')!;
     expect(climbMeta.row_count).toBe(2);
-    expect(climbMeta.watermark_sync_seq).toBe(Number(stableWatermarkRow.sync_seq));
+    expect(climbMeta.watermark_sync_seq).toBe(String(stableWatermarkRow.sync_seq));
     expect(Number(climbMeta.watermark_sync_seq)).toBeLessThan(Number(recentRow.sync_seq));
   });
 });

--- a/packages/backend/src/__tests__/snapshot-export-golden.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-golden.test.ts
@@ -25,11 +25,12 @@ import type { ConnectionContext, SyncCursorInput } from '@boardsesh/shared-schem
 import type { QueryInvalidator } from '@boardsesh/offline-sync';
 import { pullSync, runMigrations, TABLE_CONFIGS } from '@boardsesh/offline-sync';
 import { createTestDatabase } from '@boardsesh/offline-sync/testing';
-// createReadPool GUARANTEES the drizzle wrapper is constructed before the raw
-// pool is returned (both branches in packages/db/src/client/postgres.ts), so
-// the pool used here carries drizzle's transparent timestamp parsers exactly
-// like production — calling createReadDb() first is not required.
-import { createReadPool } from '@boardsesh/db/client';
+// createPool is the SAME accessor runExport uses (primary-only: replica
+// commit-order snapshots can omit lower-cursor rows, so the export never reads
+// a replica). It GUARANTEES the drizzle wrapper is constructed before the raw
+// pool is returned (packages/db/src/client/postgres.ts), so the pool used here
+// carries drizzle's transparent timestamp parsers exactly like production.
+import { createPool } from '@boardsesh/db/client';
 import { db } from '../db/client';
 import { syncQueries } from '../graphql/resolvers/sync/queries';
 import { toIso } from '../graphql/resolvers/sync/row-normalize';
@@ -243,7 +244,7 @@ describe('board-snapshot export ↔ live pull parity', () => {
     // --- Path A: export core → SQLite artifact ---
     const filePath = join(workDir, 'artifact.db');
     await exportLayoutSnapshot({
-      sqlClient: createReadPool(),
+      sqlClient: createPool(),
       boardType: BOARD_TYPE,
       layoutId: LAYOUT_ID,
       filePath,
@@ -291,7 +292,7 @@ describe('board-snapshot export ↔ live pull parity', () => {
 
     const filePath = join(workDir, 'artifact.db');
     await exportLayoutSnapshot({
-      sqlClient: createReadPool(),
+      sqlClient: createPool(),
       boardType: BOARD_TYPE,
       layoutId: LAYOUT_ID,
       filePath,
@@ -341,7 +342,7 @@ describe('board-snapshot export ↔ live pull parity', () => {
 
     const filePath = join(workDir, 'artifact.db');
     await exportLayoutSnapshot({
-      sqlClient: createReadPool(),
+      sqlClient: createPool(),
       boardType: BOARD_TYPE,
       layoutId: LAYOUT_ID,
       filePath,

--- a/packages/backend/src/__tests__/snapshot-export-golden.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-golden.test.ts
@@ -25,6 +25,10 @@ import type { ConnectionContext, SyncCursorInput } from '@boardsesh/shared-schem
 import type { QueryInvalidator } from '@boardsesh/offline-sync';
 import { pullSync, runMigrations, TABLE_CONFIGS } from '@boardsesh/offline-sync';
 import { createTestDatabase } from '@boardsesh/offline-sync/testing';
+// createReadPool GUARANTEES the drizzle wrapper is constructed before the raw
+// pool is returned (both branches in packages/db/src/client/postgres.ts), so
+// the pool used here carries drizzle's transparent timestamp parsers exactly
+// like production — calling createReadDb() first is not required.
 import { createReadPool } from '@boardsesh/db/client';
 import { db } from '../db/client';
 import { syncQueries } from '../graphql/resolvers/sync/queries';

--- a/packages/backend/src/__tests__/snapshot-export-run.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-run.test.ts
@@ -1,0 +1,237 @@
+// runExport-level behaviour of the nightly board-snapshot export: manifest
+// MERGE semantics (a filtered run must not clobber other boards' entries),
+// per-layout failure resilience (one bad layout still publishes everyone
+// else's entries, then fails the run), and stale-artifact pruning (unfiltered
+// successful runs only, 14-day grace, never fatal).
+//
+// S3 is mocked at the storage/s3 function boundary (the beta-link-thumbnails
+// precedent); Postgres is the real worker test DB.
+
+import { describe, it, expect, beforeEach, vi } from 'vite-plus/test';
+
+vi.mock('../storage/s3', () => ({
+  isS3Configured: vi.fn(() => true),
+  getPublicUrl: vi.fn((key: string) => `https://cdn.example/${key}`),
+  uploadToS3: vi.fn(async (_buffer: Buffer, key: string) => ({ url: `https://cdn.example/${key}`, key })),
+  getFromS3: vi.fn(async () => null),
+  deleteFromS3: vi.fn(async () => {}),
+  listS3Objects: vi.fn(async () => []),
+}));
+
+import { Readable } from 'node:stream';
+import { sql } from 'drizzle-orm';
+import type { SnapshotManifest, SnapshotManifestEntry } from '@boardsesh/offline-sync';
+import { db } from '../db/client';
+import { uploadToS3, getFromS3, deleteFromS3, listS3Objects } from '../storage/s3';
+import { runExport, mergeManifestEntries } from '../scripts/export-board-snapshots';
+
+const MANIFEST_KEY = 'board-snapshots/v1/manifest.json';
+
+function manifestEntryFixture(boardType: string, layoutId: number, key: string): SnapshotManifestEntry {
+  return {
+    boardType,
+    layoutId,
+    key,
+    url: `https://cdn.example/${key}`,
+    bytes: 1234,
+    contentEncoding: 'gzip',
+    builtAt: '2026-06-01T00:00:00.000Z',
+    schemaVersion: 3,
+    tables: {
+      board_climbs: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '10', rowCount: 5 },
+      board_climb_stats: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '7', rowCount: 3 },
+    },
+  };
+}
+
+function manifestFixture(entries: SnapshotManifestEntry[]): SnapshotManifest {
+  return { formatVersion: 1, generatedAt: '2026-06-01T00:00:00.000Z', entries };
+}
+
+/** Serves `manifest` as the previous manifest through the getFromS3 mock. */
+function serveExistingManifest(manifest: SnapshotManifest): void {
+  vi.mocked(getFromS3).mockResolvedValue({
+    stream: Readable.from([Buffer.from(JSON.stringify(manifest))]),
+    contentType: 'application/json',
+    contentLength: undefined,
+  });
+}
+
+/** Parses the manifest JSON out of the uploadToS3 mock's manifest-key call. */
+function uploadedManifest(): SnapshotManifest {
+  const manifestCalls = vi.mocked(uploadToS3).mock.calls.filter(([, key]) => key === MANIFEST_KEY);
+  expect(manifestCalls.length).toBeGreaterThan(0);
+  const [buffer] = manifestCalls[manifestCalls.length - 1];
+  return JSON.parse(buffer.toString('utf8')) as SnapshotManifest;
+}
+
+async function seedClimb(boardType: string, layoutId: number, uuid: string): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, name, is_listed, is_draft, compatible_size_ids, updated_at)
+    VALUES (${uuid}, ${boardType}, ${layoutId}, ${'Climb ' + uuid}, true, false, '{5}'::int[], '2026-05-01T00:00:00Z')
+  `);
+}
+
+beforeEach(async () => {
+  // clearAllMocks resets call records but NOT implementations, so re-pin every
+  // implementation a test may have overridden (the throwing uploadToS3, the
+  // rejecting listS3Objects) back to the happy path.
+  vi.clearAllMocks();
+  vi.mocked(uploadToS3).mockImplementation(async (_buffer: Buffer, key: string) => ({
+    url: `https://cdn.example/${key}`,
+    key,
+  }));
+  vi.mocked(getFromS3).mockResolvedValue(null);
+  vi.mocked(listS3Objects).mockResolvedValue([]);
+  vi.mocked(deleteFromS3).mockResolvedValue(undefined);
+  await db.execute(sql`TRUNCATE TABLE board_climbs, board_climb_stats RESTART IDENTITY CASCADE`);
+});
+
+describe('mergeManifestEntries', () => {
+  const kilterOld = manifestEntryFixture('kilter', 1, 'board-snapshots/v1/kilter/1/old.db');
+  const kilterNew = manifestEntryFixture('kilter', 1, 'board-snapshots/v1/kilter/1/new.db');
+  const tensionOld = manifestEntryFixture('tension', 9, 'board-snapshots/v1/tension/9/old.db');
+
+  it('filtered semantics (livePairs null): upserts new entries, preserves every other previous entry', () => {
+    const merged = mergeManifestEntries({
+      previousEntries: [kilterOld, tensionOld],
+      newEntries: [kilterNew],
+      livePairs: null,
+    });
+    expect(merged).toEqual([kilterNew, tensionOld]);
+  });
+
+  it('unfiltered semantics: drops previous entries whose pair is no longer live', () => {
+    const merged = mergeManifestEntries({
+      previousEntries: [kilterOld, tensionOld],
+      newEntries: [kilterNew],
+      livePairs: [{ boardType: 'kilter', layoutId: 1 }],
+    });
+    expect(merged).toEqual([kilterNew]);
+  });
+
+  it('unfiltered semantics: a live pair with no new entry (failed layout) keeps its previous entry', () => {
+    const merged = mergeManifestEntries({
+      previousEntries: [kilterOld, tensionOld],
+      newEntries: [],
+      livePairs: [
+        { boardType: 'kilter', layoutId: 1 },
+        { boardType: 'tension', layoutId: 9 },
+      ],
+    });
+    expect(merged).toEqual([kilterOld, tensionOld]);
+  });
+});
+
+describe('runExport — manifest merge on filtered runs', () => {
+  it('a --board run preserves other boards’ manifest entries instead of clobbering them', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    const foreignEntry = manifestEntryFixture('tension', 9, 'board-snapshots/v1/tension/9/old.db');
+    const staleKilterEntry = manifestEntryFixture('kilter', 1, 'board-snapshots/v1/kilter/1/old.db');
+    serveExistingManifest(manifestFixture([foreignEntry, staleKilterEntry]));
+
+    await runExport(['--board', 'kilter']);
+
+    const manifest = uploadedManifest();
+    const entryKeys = manifest.entries.map((entry) => `${entry.boardType}:${entry.layoutId}`);
+    expect(entryKeys).toEqual(['kilter:1', 'tension:9']);
+    // The foreign entry rides through verbatim; the kilter entry is the fresh one.
+    expect(manifest.entries.find((entry) => entry.boardType === 'tension')).toEqual(foreignEntry);
+    const refreshedKilter = manifest.entries.find((entry) => entry.boardType === 'kilter')!;
+    expect(refreshedKilter.key).not.toBe(staleKilterEntry.key);
+    expect(refreshedKilter.tables.board_climbs.rowCount).toBe(1);
+  });
+
+  it('an unfiltered run drops entries for layouts that no longer exist in the DB', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    const vanishedEntry = manifestEntryFixture('tension', 9, 'board-snapshots/v1/tension/9/old.db');
+    serveExistingManifest(manifestFixture([vanishedEntry]));
+
+    await runExport([]);
+
+    const manifest = uploadedManifest();
+    expect(manifest.entries.map((entry) => `${entry.boardType}:${entry.layoutId}`)).toEqual(['kilter:1']);
+  });
+});
+
+describe('runExport — per-layout failure resilience', () => {
+  it('one failing layout still publishes the successful entries, preserves the failed layout’s previous entry, and exits non-zero', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    await seedClimb('kilter', 2, 'k2-a');
+    const previousLayout2Entry = manifestEntryFixture('kilter', 2, 'board-snapshots/v1/kilter/2/old.db');
+    serveExistingManifest(manifestFixture([previousLayout2Entry]));
+
+    // Fail exactly layout 2's artifact upload; every other upload succeeds.
+    vi.mocked(uploadToS3).mockImplementation(async (_buffer: Buffer, key: string) => {
+      if (key.includes('/kilter/2/')) throw new Error('simulated S3 outage for layout 2');
+      return { url: `https://cdn.example/${key}`, key };
+    });
+
+    await expect(runExport([])).rejects.toThrow(/Export failed for 1 layout\(s\): kilter:2/);
+
+    // The manifest still went out, carrying the fresh layout-1 entry and the
+    // PREVIOUS layout-2 entry (old artifacts are immutable, so it stays valid).
+    const manifest = uploadedManifest();
+    const byPair = new Map(manifest.entries.map((entry) => [`${entry.boardType}:${entry.layoutId}`, entry]));
+    expect([...byPair.keys()].sort()).toEqual(['kilter:1', 'kilter:2']);
+    expect(byPair.get('kilter:2')).toEqual(previousLayout2Entry);
+    expect(byPair.get('kilter:1')!.key).toContain('board-snapshots/v1/kilter/1/');
+
+    // Pruning is skipped on a failure night.
+    expect(listS3Objects).not.toHaveBeenCalled();
+    expect(deleteFromS3).not.toHaveBeenCalled();
+  });
+});
+
+describe('runExport — stale-artifact pruning', () => {
+  it('an unfiltered successful run prunes unreferenced artifacts older than the grace window only', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    vi.mocked(listS3Objects).mockResolvedValue([
+      // Unreferenced + old → pruned.
+      { key: 'board-snapshots/v1/kilter/1/ancient.db', size: 10, lastModified: thirtyDaysAgo },
+      // Unreferenced but inside the grace window → kept.
+      { key: 'board-snapshots/v1/kilter/1/yesterday.db', size: 10, lastModified: oneDayAgo },
+      // The manifest itself is always kept, whatever its age.
+      { key: MANIFEST_KEY, size: 10, lastModified: thirtyDaysAgo },
+    ]);
+
+    await runExport([]);
+
+    expect(listS3Objects).toHaveBeenCalledWith('board-snapshots/v1/');
+    expect(deleteFromS3).toHaveBeenCalledTimes(1);
+    expect(deleteFromS3).toHaveBeenCalledWith('board-snapshots/v1/kilter/1/ancient.db');
+  });
+
+  it('never prunes an artifact referenced by the manifest just written', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    vi.mocked(listS3Objects).mockImplementation(async () => {
+      // Derive the just-uploaded artifact key from the recorded upload calls, so
+      // the listing contains a REFERENCED old-looking object.
+      const artifactCall = vi.mocked(uploadToS3).mock.calls.find(([, key]) => key !== MANIFEST_KEY)!;
+      return [{ key: artifactCall[1], size: 10, lastModified: thirtyDaysAgo }];
+    });
+
+    await runExport([]);
+
+    expect(deleteFromS3).not.toHaveBeenCalled();
+  });
+
+  it('a filtered run never prunes', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+
+    await runExport(['--board', 'kilter']);
+
+    expect(listS3Objects).not.toHaveBeenCalled();
+    expect(deleteFromS3).not.toHaveBeenCalled();
+  });
+
+  it('a prune failure is swallowed — the run still succeeds', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    vi.mocked(listS3Objects).mockRejectedValue(new Error('ListObjectsV2 exploded'));
+
+    await expect(runExport([])).resolves.toBeUndefined();
+  });
+});

--- a/packages/backend/src/__tests__/snapshot-export-run.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-run.test.ts
@@ -131,6 +131,12 @@ describe('mergeManifestEntries', () => {
 });
 
 describe('runExport — manifest merge on filtered runs', () => {
+  it('fails fast when --board is missing its value', async () => {
+    await expect(runExport(['--board'])).rejects.toThrow('--board expects a board type');
+    await expect(runExport(['--board', '--layout', '1'])).rejects.toThrow('--board expects a board type');
+    expect(uploadToS3).not.toHaveBeenCalled();
+  });
+
   it('a --board run preserves other boards’ manifest entries instead of clobbering them', async () => {
     await seedClimb('kilter', 1, 'k1-a');
     const foreignEntry = manifestEntryFixture('tension', 9, 'board-snapshots/v1/tension/9/old.db');

--- a/packages/backend/src/__tests__/snapshot-export-run.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-run.test.ts
@@ -13,7 +13,9 @@ vi.mock('../storage/s3', () => ({
   isS3Configured: vi.fn(() => true),
   getPublicUrl: vi.fn((key: string) => `https://cdn.example/${key}`),
   uploadToS3: vi.fn(async (_buffer: Buffer, key: string) => ({ url: `https://cdn.example/${key}`, key })),
-  getFromS3: vi.fn(async () => null),
+  // The script reads the previous manifest through the STRICT variant (null =
+  // genuinely missing; read errors throw).
+  getFromS3Strict: vi.fn(async () => null),
   deleteFromS3: vi.fn(async () => {}),
   listS3Objects: vi.fn(async () => []),
 }));
@@ -22,7 +24,7 @@ import { Readable } from 'node:stream';
 import { sql } from 'drizzle-orm';
 import type { SnapshotManifest, SnapshotManifestEntry } from '@boardsesh/offline-sync';
 import { db } from '../db/client';
-import { uploadToS3, getFromS3, deleteFromS3, listS3Objects } from '../storage/s3';
+import { uploadToS3, getFromS3Strict, deleteFromS3, listS3Objects } from '../storage/s3';
 import { runExport, mergeManifestEntries } from '../scripts/export-board-snapshots';
 
 const MANIFEST_KEY = 'board-snapshots/v1/manifest.json';
@@ -48,10 +50,15 @@ function manifestFixture(entries: SnapshotManifestEntry[]): SnapshotManifest {
   return { formatVersion: 1, generatedAt: '2026-06-01T00:00:00.000Z', entries };
 }
 
-/** Serves `manifest` as the previous manifest through the getFromS3 mock. */
+/** Serves `manifest` as the previous manifest through the getFromS3Strict mock. */
 function serveExistingManifest(manifest: SnapshotManifest): void {
-  vi.mocked(getFromS3).mockResolvedValue({
-    stream: Readable.from([Buffer.from(JSON.stringify(manifest))]),
+  serveManifestBody(JSON.stringify(manifest));
+}
+
+/** Serves an arbitrary (possibly invalid) previous-manifest body. */
+function serveManifestBody(body: string): void {
+  vi.mocked(getFromS3Strict).mockResolvedValue({
+    stream: Readable.from([Buffer.from(body)]),
     contentType: 'application/json',
     contentLength: undefined,
   });
@@ -81,7 +88,7 @@ beforeEach(async () => {
     url: `https://cdn.example/${key}`,
     key,
   }));
-  vi.mocked(getFromS3).mockResolvedValue(null);
+  vi.mocked(getFromS3Strict).mockResolvedValue(null);
   vi.mocked(listS3Objects).mockResolvedValue([]);
   vi.mocked(deleteFromS3).mockResolvedValue(undefined);
   await db.execute(sql`TRUNCATE TABLE board_climbs, board_climb_stats RESTART IDENTITY CASCADE`);
@@ -148,6 +155,62 @@ describe('runExport — manifest merge on filtered runs', () => {
     serveExistingManifest(manifestFixture([vanishedEntry]));
 
     await runExport([]);
+
+    const manifest = uploadedManifest();
+    expect(manifest.entries.map((entry) => `${entry.boardType}:${entry.layoutId}`)).toEqual(['kilter:1']);
+  });
+});
+
+describe('runExport — previous-manifest failure matrix', () => {
+  it('S3 read error on a filtered run aborts BEFORE anything is uploaded', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    vi.mocked(getFromS3Strict).mockRejectedValue(new Error('S3 connection reset'));
+
+    await expect(runExport(['--board', 'kilter'])).rejects.toThrow(/S3 connection reset/);
+
+    // Nothing was uploaded: no artifacts, no manifest.
+    expect(uploadToS3).not.toHaveBeenCalled();
+  });
+
+  it('S3 read error on an unfiltered run also aborts before anything is uploaded (failed layouts need previous entries too)', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    vi.mocked(getFromS3Strict).mockRejectedValue(new Error('S3 connection reset'));
+
+    await expect(runExport([])).rejects.toThrow(/S3 connection reset/);
+    expect(uploadToS3).not.toHaveBeenCalled();
+  });
+
+  it('manifest genuinely missing (strict null) on a filtered run proceeds against an empty previous manifest', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    // beforeEach default: getFromS3Strict resolves null (NoSuchKey — first run).
+
+    await runExport(['--board', 'kilter']);
+
+    const manifest = uploadedManifest();
+    expect(manifest.entries.map((entry) => `${entry.boardType}:${entry.layoutId}`)).toEqual(['kilter:1']);
+  });
+
+  it('unparseable previous manifest is FATAL on a filtered run (it cannot reconstruct what it would drop)', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    serveManifestBody('{{{ not json');
+
+    await expect(runExport(['--board', 'kilter'])).rejects.toThrow(/filtered run cannot merge safely/);
+    expect(uploadToS3).not.toHaveBeenCalled();
+  });
+
+  it('schema-invalid previous manifest is FATAL on a filtered run too', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    serveManifestBody(JSON.stringify({ formatVersion: 999, generatedAt: 'x', entries: [] }));
+
+    await expect(runExport(['--board', 'kilter'])).rejects.toThrow(/filtered run cannot merge safely/);
+    expect(uploadToS3).not.toHaveBeenCalled();
+  });
+
+  it('unparseable previous manifest on an UNFILTERED run warns and continues (it rebuilds everything anyway)', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    serveManifestBody('{{{ not json');
+
+    await expect(runExport([])).resolves.toBeUndefined();
 
     const manifest = uploadedManifest();
     expect(manifest.entries.map((entry) => `${entry.boardType}:${entry.layoutId}`)).toEqual(['kilter:1']);

--- a/packages/backend/src/graphql/resolvers/sync/queries.ts
+++ b/packages/backend/src/graphql/resolvers/sync/queries.ts
@@ -4,6 +4,7 @@ import { isSizeScopedBoard } from '@boardsesh/board-config';
 import { db } from '../../../db/client';
 import { rowsFromResult } from '@boardsesh/db/client';
 import { requireAuthenticated } from '../shared/helpers';
+import { normalizeRow, toIso, type RawRow } from './row-normalize';
 import {
   validateInput,
   SyncCursorInputSchema,
@@ -46,49 +47,6 @@ const EPOCH_SEQ = '0';
 // every sync query with a NaN interval.
 const parsedStabilityWindow = Number(process.env.SYNC_STABILITY_WINDOW_SECONDS ?? 30);
 const STABILITY_WINDOW_SECONDS = Number.isFinite(parsedStabilityWindow) ? parsedStabilityWindow : 30;
-
-const PG_TIMESTAMP_TEXT = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)$/;
-
-type RawRow = Record<string, unknown>;
-
-/**
- * Convert a raw postgres-js row into a sync document. The manifest pins every
- * timestamp to ISO-8601 TEXT on the client, but drizzle's postgres-js driver
- * returns `timestamp` columns as 'YYYY-MM-DD HH:MM:SS[.ffffff]' STRINGS (it
- * registers passthrough parsers for OIDs 1114/1184), so both shapes are
- * normalized here — a Date via toISOString, a pg-text timestamp via toIso.
- * Without the string branch, pulled rows and offline-written local rows would
- * mix formats in the same SQLite TEXT column, breaking ordering and the
- * tombstone resurrection guard. int[] columns stay as JS arrays (the mobile
- * upsert JSON-stringifies them); bigint columns stay as-is.
- */
-function normalizeRow(row: RawRow): RawRow {
-  const out: RawRow = {};
-  for (const [key, value] of Object.entries(row)) {
-    if (value instanceof Date) {
-      out[key] = value.toISOString();
-    } else if (typeof value === 'string' && PG_TIMESTAMP_TEXT.test(value)) {
-      out[key] = toIso(value);
-    } else {
-      out[key] = value;
-    }
-  }
-  return out;
-}
-
-function toIso(value: unknown): string {
-  if (value instanceof Date) return value.toISOString();
-  // postgres.js returns `timestamp` (without time zone) columns as
-  // 'YYYY-MM-DD HH:MM:SS[.ffffff]' strings. Normalize textually to ISO-8601
-  // UTC ('T' separator, trailing 'Z') — these columns are written by now() in
-  // UTC — instead of round-tripping through Date, which would apply the
-  // process timezone and clamp microsecond precision. The `::timestamp` cast
-  // on cursor replay ignores the 'Z', so the value round-trips losslessly.
-  const stringValue = String(value);
-  const timestampMatch = PG_TIMESTAMP_TEXT.exec(stringValue);
-  if (timestampMatch) return `${timestampMatch[1]}T${timestampMatch[2]}Z`;
-  return stringValue;
-}
 
 /**
  * Resolve the incoming cursor into the two bound comparison values. Null/absent

--- a/packages/backend/src/graphql/resolvers/sync/row-normalize.ts
+++ b/packages/backend/src/graphql/resolvers/sync/row-normalize.ts
@@ -1,0 +1,52 @@
+// Row shaping shared by the offline-sync pull resolvers (sync/queries.ts) and
+// the nightly snapshot export job (scripts/export-board-snapshots.ts). Kept in
+// its own module so both paths coerce a raw postgres-js row into a sync document
+// identically — the export artifact and a live pull must produce byte-identical
+// SQLite rows. See docs/sync-table-manifest.md.
+
+export type RawRow = Record<string, unknown>;
+
+// postgres.js returns `timestamp` (without time zone) columns as
+// 'YYYY-MM-DD HH:MM:SS[.ffffff]' strings — drizzle's postgres-js driver installs
+// passthrough parsers for the timestamp/date OIDs, so both the resolvers and any
+// consumer of the same drizzle-constructed client see this shape.
+export const PG_TIMESTAMP_TEXT = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)$/;
+
+/**
+ * Convert a raw postgres-js row into a sync document. The manifest pins every
+ * timestamp to ISO-8601 TEXT on the client, but drizzle's postgres-js driver
+ * returns `timestamp` columns as 'YYYY-MM-DD HH:MM:SS[.ffffff]' STRINGS (it
+ * registers passthrough parsers for OIDs 1114/1184), so both shapes are
+ * normalized here — a Date via toISOString, a pg-text timestamp via toIso.
+ * Without the string branch, pulled rows and offline-written local rows would
+ * mix formats in the same SQLite TEXT column, breaking ordering and the
+ * tombstone resurrection guard. int[] columns stay as JS arrays (the mobile
+ * upsert JSON-stringifies them); bigint columns stay as-is.
+ */
+export function normalizeRow(row: RawRow): RawRow {
+  const out: RawRow = {};
+  for (const [key, value] of Object.entries(row)) {
+    if (value instanceof Date) {
+      out[key] = value.toISOString();
+    } else if (typeof value === 'string' && PG_TIMESTAMP_TEXT.test(value)) {
+      out[key] = toIso(value);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+export function toIso(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  // postgres.js returns `timestamp` (without time zone) columns as
+  // 'YYYY-MM-DD HH:MM:SS[.ffffff]' strings. Normalize textually to ISO-8601
+  // UTC ('T' separator, trailing 'Z') — these columns are written by now() in
+  // UTC — instead of round-tripping through Date, which would apply the
+  // process timezone and clamp microsecond precision. The `::timestamp` cast
+  // on cursor replay ignores the 'Z', so the value round-trips losslessly.
+  const stringValue = String(value);
+  const timestampMatch = PG_TIMESTAMP_TEXT.exec(stringValue);
+  if (timestampMatch) return `${timestampMatch[1]}T${timestampMatch[2]}Z`;
+  return stringValue;
+}

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -34,14 +34,15 @@ import {
   TABLE_CONFIGS,
   toSqliteValue,
   multiRowChunkSize,
+  parseSnapshotManifest,
   SNAPSHOT_MANIFEST_FORMAT_VERSION,
   type SnapshotManifest,
   type SnapshotManifestEntry,
   type SnapshotTableName,
 } from '@boardsesh/offline-sync';
-import { createReadDb, createReadPool, closeReadPool } from '@boardsesh/db/client';
+import { createReadPool, closeReadPool } from '@boardsesh/db/client';
 import { normalizeRow, toIso, type RawRow } from '../graphql/resolvers/sync/row-normalize';
-import { uploadToS3, isS3Configured, getPublicUrl } from '../storage/s3';
+import { uploadToS3, isS3Configured, getPublicUrl, getFromS3, deleteFromS3, listS3Objects } from '../storage/s3';
 import { logger } from '../utils/logger';
 
 // --- Constants ----------------------------------------------------------------
@@ -50,6 +51,12 @@ const SNAPSHOT_KEY_PREFIX = 'board-snapshots/v1';
 const MANIFEST_KEY = `${SNAPSHOT_KEY_PREFIX}/manifest.json`;
 const MANIFEST_CACHE_CONTROL = 'public, max-age=300';
 const ARTIFACT_CONTENT_TYPE = 'application/x-sqlite3';
+
+// How long a superseded (manifest-unreferenced) artifact survives before the
+// unfiltered nightly run prunes it. The manifest is CDN-cached for max-age=300,
+// but a client may hold a fetched manifest much longer before starting the
+// download — 14 days is a generous grace window.
+const PRUNE_GRACE_MS = 14 * 24 * 60 * 60 * 1000;
 
 // Matches the resolvers' stability window: rows younger than this are left for a
 // live incremental pull so the watermark never covers a still-in-flight write.
@@ -133,15 +140,15 @@ export function boardSnapshotDdlStatements(): string[] {
 
 /** Every (board_type, layout_id) pair that has at least one climb. */
 export async function discoverLayoutPairs(sqlClient: Sql, filter?: Partial<LayoutPair>): Promise<LayoutPair[]> {
+  const boardCondition = filter?.boardType ? sqlClient`board_type = ${filter.boardType}` : sqlClient`TRUE`;
+  const layoutCondition = filter?.layoutId != null ? sqlClient`layout_id = ${filter.layoutId}` : sqlClient`TRUE`;
   const rows = await sqlClient<{ board_type: string; layout_id: number }[]>`
     SELECT DISTINCT board_type, layout_id
     FROM board_climbs
+    WHERE ${boardCondition} AND ${layoutCondition}
     ORDER BY board_type, layout_id
   `;
-  return rows
-    .map((row) => ({ boardType: String(row.board_type), layoutId: Number(row.layout_id) }))
-    .filter((pair) => (filter?.boardType ? pair.boardType === filter.boardType : true))
-    .filter((pair) => (filter?.layoutId != null ? pair.layoutId === filter.layoutId : true));
+  return rows.map((row) => ({ boardType: String(row.board_type), layoutId: Number(row.layout_id) }));
 }
 
 function assertSafeColumns(columns: readonly string[]): void {
@@ -155,18 +162,14 @@ function assertSafeColumns(columns: readonly string[]): void {
 // Scope predicates matching the resolvers exactly. `now()` is transaction-start
 // time and constant across the whole export transaction, so the streamed rows and
 // the watermark query below apply the identical stability boundary.
-function climbsWhere(): string {
-  return `board_type = $1 AND layout_id = $2 AND updated_at < now() - make_interval(secs => $3)`;
-}
+const CLIMBS_WHERE = `board_type = $1 AND layout_id = $2 AND updated_at < now() - make_interval(secs => $3)`;
 
-function statsWhere(): string {
-  return `board_type = $1
+const STATS_WHERE = `board_type = $1
     AND EXISTS (
       SELECT 1 FROM board_climbs bc
       WHERE bc.uuid = board_climb_stats.climb_uuid AND bc.board_type = $1 AND bc.layout_id = $2
     )
     AND updated_at < now() - make_interval(secs => $3)`;
-}
 
 /**
  * Stream one table's scoped rows from Postgres through the shared row shaping into
@@ -291,22 +294,22 @@ export async function exportLayoutSnapshot(params: {
         sqliteDb,
         'board_climbs',
         climbColumns,
-        climbsWhere(),
+        CLIMBS_WHERE,
         scopeParams,
         streamBatchSize,
       );
-      const climbWatermark = await tableWatermark(tx, 'board_climbs', climbsWhere(), scopeParams);
+      const climbWatermark = await tableWatermark(tx, 'board_climbs', CLIMBS_WHERE, scopeParams);
 
       const statsRowCount = await streamTableIntoSqlite(
         tx,
         sqliteDb,
         'board_climb_stats',
         statsColumns,
-        statsWhere(),
+        STATS_WHERE,
         scopeParams,
         streamBatchSize,
       );
-      const statsWatermark = await tableWatermark(tx, 'board_climb_stats', statsWhere(), scopeParams);
+      const statsWatermark = await tableWatermark(tx, 'board_climb_stats', STATS_WHERE, scopeParams);
 
       return {
         board_climbs: { rowCount: climbRowCount, ...climbWatermark },
@@ -410,9 +413,116 @@ function buildManifestEntry(
   };
 }
 
+/**
+ * Merge this run's freshly-built entries over the previous manifest's, keyed by
+ * (boardType, layoutId). A filtered run (`--board`/`--layout`) rebuilds only a
+ * subset, so every previous entry it did not rebuild is preserved verbatim —
+ * without this, a filtered run would silently drop every other board from the
+ * manifest. Only an unfiltered run has the full picture, so only it may drop
+ * entries whose layout no longer has climbs in the database: it passes the
+ * discovered pairs as `livePairs`; filtered runs pass null and keep everything.
+ */
+export function mergeManifestEntries(params: {
+  previousEntries: SnapshotManifestEntry[];
+  newEntries: SnapshotManifestEntry[];
+  livePairs: LayoutPair[] | null;
+}): SnapshotManifestEntry[] {
+  const pairKey = (boardType: string, layoutId: number): string => `${boardType}:${layoutId}`;
+  const liveKeys = params.livePairs
+    ? new Set(params.livePairs.map((pair) => pairKey(pair.boardType, pair.layoutId)))
+    : null;
+
+  const merged = new Map<string, SnapshotManifestEntry>();
+  for (const previousEntry of params.previousEntries) {
+    const entryKey = pairKey(previousEntry.boardType, previousEntry.layoutId);
+    // Layout vanished from the DB — drop its entry (unfiltered runs only). A
+    // failed layout is still discovered, so its previous entry survives here.
+    if (liveKeys && !liveKeys.has(entryKey)) continue;
+    merged.set(entryKey, previousEntry);
+  }
+  for (const newEntry of params.newEntries) {
+    merged.set(pairKey(newEntry.boardType, newEntry.layoutId), newEntry);
+  }
+  return [...merged.values()].sort(
+    (left, right) => left.boardType.localeCompare(right.boardType) || left.layoutId - right.layoutId,
+  );
+}
+
+/**
+ * Fetch + validate the currently-published manifest. Returns null when there is
+ * none (first run) or it is unreadable/unparseable — the caller merges against
+ * empty. Missing-vs-error is not distinguishable through getFromS3, so both are
+ * logged loudly; a filtered run that hits this writes a manifest containing only
+ * its own entries, which the next unfiltered nightly run heals.
+ */
+async function fetchPreviousManifest(): Promise<SnapshotManifest | null> {
+  const manifestObject = await getFromS3(MANIFEST_KEY);
+  if (!manifestObject) {
+    logger.warn('[export-snapshots] no previous manifest readable (first run?) — merging against empty');
+    return null;
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of manifestObject.stream as AsyncIterable<Buffer | string>) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  try {
+    const parsed = parseSnapshotManifest(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+    if (!parsed) {
+      logger.warn('[export-snapshots] previous manifest failed validation — merging against empty');
+    }
+    return parsed;
+  } catch (error) {
+    logger.warn('[export-snapshots] previous manifest is not valid JSON — merging against empty', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * Delete superseded artifacts under the snapshot prefix: objects that are (a)
+ * not referenced by the manifest just written and (b) older than the grace
+ * window (a CDN-cached manifest, max-age=300, or a client holding a fetched
+ * manifest may still point at a previous run's artifacts for a while). Only a
+ * fully-successful UNFILTERED run calls this — it is the only run whose merged
+ * manifest provably references every artifact that must survive. Defensive by
+ * design: any prune failure is logged and swallowed, never failing the run.
+ */
+async function pruneStaleArtifacts(manifest: SnapshotManifest, nowMs: number): Promise<void> {
+  try {
+    const referencedKeys = new Set<string>(manifest.entries.map((entry) => entry.key));
+    referencedKeys.add(MANIFEST_KEY);
+    const cutoffMs = nowMs - PRUNE_GRACE_MS;
+
+    const objects = await listS3Objects(`${SNAPSHOT_KEY_PREFIX}/`);
+    let prunedCount = 0;
+    for (const object of objects) {
+      if (referencedKeys.has(object.key)) continue;
+      if (!object.lastModified || object.lastModified.getTime() >= cutoffMs) continue;
+      try {
+        await deleteFromS3(object.key);
+        prunedCount += 1;
+      } catch (error) {
+        logger.warn('[export-snapshots] failed to prune stale artifact — continuing', {
+          key: object.key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    logger.info('[export-snapshots] prune complete', { scanned: objects.length, pruned: prunedCount });
+  } catch (error) {
+    logger.warn('[export-snapshots] artifact prune failed — continuing (prune is never fatal)', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+type LayoutFailure = LayoutPair & { error: string };
+
 export async function runExport(argv: string[]): Promise<void> {
   const options = parseArgs(argv);
   const builtAt = new Date().toISOString();
+  const isFilteredRun = options.boardFilter !== undefined || options.layoutFilter !== undefined;
 
   if (!options.dryRun && !isS3Configured()) {
     throw new Error(
@@ -420,12 +530,14 @@ export async function runExport(argv: string[]): Promise<void> {
     );
   }
 
-  // createReadPool installs drizzle's transparent timestamp parsers on the
-  // postgres.js client, so streamed timestamps match the resolver shaping.
-  createReadDb();
+  // createReadPool GUARANTEES the drizzle wrapper is constructed before the raw
+  // pool is returned (see packages/db/src/client/postgres.ts), so the pool
+  // already carries drizzle's transparent timestamp parsers and streamed rows
+  // match the resolver shaping.
   const sqlClient = createReadPool();
   const workDir = mkdtempSync(join(tmpdir(), 'board-snapshots-'));
-  const entries: SnapshotManifestEntry[] = [];
+  const newEntries: SnapshotManifestEntry[] = [];
+  const failures: LayoutFailure[] = [];
 
   try {
     const pairs = await discoverLayoutPairs(sqlClient, {
@@ -434,6 +546,7 @@ export async function runExport(argv: string[]): Promise<void> {
     });
     logger.info('[export-snapshots] starting run', {
       dryRun: options.dryRun,
+      filtered: isFilteredRun,
       pairs: pairs.length,
       builtAt,
       stabilityWindowSeconds: DEFAULT_STABILITY_WINDOW_SECONDS,
@@ -442,86 +555,120 @@ export async function runExport(argv: string[]): Promise<void> {
     for (const pair of pairs) {
       const startedAt = Date.now();
       const filePath = join(workDir, `${pair.boardType}-${pair.layoutId}.db`);
-      const result = await exportLayoutSnapshot({
-        sqlClient,
-        boardType: pair.boardType,
-        layoutId: pair.layoutId,
-        filePath,
-        builtAt,
-      });
-
-      const rawBuffer = readFileSync(filePath);
-      const gzipped = gzipSync(rawBuffer);
-      // Colon-free key stamp: ISO colons are legal in S3 keys but historically
-      // trip CDNs/URL parsers, and getPublicUrl does no percent-encoding.
-      const keyStamp = builtAt.replace(/[:.]/g, '-');
-      const key = `${SNAPSHOT_KEY_PREFIX}/${pair.boardType}/${pair.layoutId}/${keyStamp}.db`;
-
-      if (options.dryRun) {
-        logger.info('[export-snapshots] built (dry-run, not uploaded)', {
+      try {
+        const result = await exportLayoutSnapshot({
+          sqlClient,
           boardType: pair.boardType,
           layoutId: pair.layoutId,
-          climbs: result.tables.board_climbs.rowCount,
-          stats: result.tables.board_climb_stats.rowCount,
-          rawBytes: rawBuffer.length,
-          gzipBytes: gzipped.length,
-          durationMs: Date.now() - startedAt,
+          filePath,
+          builtAt,
         });
-        entries.push(
-          buildManifestEntry(result, {
-            // getPublicUrl instantiates the S3 client, so only call it when S3 is
-            // configured — a dry-run must work with no AWS credentials at all.
-            url: isS3Configured() ? getPublicUrl(key) : `dry-run:${key}`,
-            key,
-            bytes: gzipped.length,
-            contentEncoding: 'gzip',
-          }),
-        );
-      } else {
-        const uploaded = await uploadToS3(gzipped, key, ARTIFACT_CONTENT_TYPE, { contentEncoding: 'gzip' });
-        logger.info('[export-snapshots] uploaded', {
-          boardType: pair.boardType,
-          layoutId: pair.layoutId,
-          climbs: result.tables.board_climbs.rowCount,
-          stats: result.tables.board_climb_stats.rowCount,
-          gzipBytes: gzipped.length,
-          key: uploaded.key,
-          durationMs: Date.now() - startedAt,
-        });
-        entries.push(
-          buildManifestEntry(result, {
-            url: uploaded.url,
+
+        const rawBuffer = readFileSync(filePath);
+        const gzipped = gzipSync(rawBuffer);
+        // Colon-free key stamp: ISO colons are legal in S3 keys but historically
+        // trip CDNs/URL parsers, and getPublicUrl does no percent-encoding.
+        const keyStamp = builtAt.replace(/[:.]/g, '-');
+        const key = `${SNAPSHOT_KEY_PREFIX}/${pair.boardType}/${pair.layoutId}/${keyStamp}.db`;
+
+        if (options.dryRun) {
+          logger.info('[export-snapshots] built (dry-run, not uploaded)', {
+            boardType: pair.boardType,
+            layoutId: pair.layoutId,
+            climbs: result.tables.board_climbs.rowCount,
+            stats: result.tables.board_climb_stats.rowCount,
+            rawBytes: rawBuffer.length,
+            gzipBytes: gzipped.length,
+            durationMs: Date.now() - startedAt,
+          });
+          newEntries.push(
+            buildManifestEntry(result, {
+              // getPublicUrl instantiates the S3 client, so only call it when S3 is
+              // configured — a dry-run must work with no AWS credentials at all.
+              url: isS3Configured() ? getPublicUrl(key) : `dry-run:${key}`,
+              key,
+              bytes: gzipped.length,
+              contentEncoding: 'gzip',
+            }),
+          );
+        } else {
+          const uploaded = await uploadToS3(gzipped, key, ARTIFACT_CONTENT_TYPE, { contentEncoding: 'gzip' });
+          logger.info('[export-snapshots] uploaded', {
+            boardType: pair.boardType,
+            layoutId: pair.layoutId,
+            climbs: result.tables.board_climbs.rowCount,
+            stats: result.tables.board_climb_stats.rowCount,
+            gzipBytes: gzipped.length,
             key: uploaded.key,
-            bytes: gzipped.length,
-            contentEncoding: 'gzip',
-          }),
-        );
+            durationMs: Date.now() - startedAt,
+          });
+          newEntries.push(
+            buildManifestEntry(result, {
+              url: uploaded.url,
+              key: uploaded.key,
+              bytes: gzipped.length,
+              contentEncoding: 'gzip',
+            }),
+          );
+        }
+      } catch (error) {
+        // One bad layout must not block every other board's nightly refresh:
+        // record the failure, keep exporting, and fail the run at the very end.
+        // The merge below preserves the failed layout's previous manifest entry
+        // (its old artifact is immutable, so it stays valid).
+        const message = error instanceof Error ? error.message : String(error);
+        failures.push({ boardType: pair.boardType, layoutId: pair.layoutId, error: message });
+        logger.error('[export-snapshots] layout export failed — continuing with remaining layouts', {
+          boardType: pair.boardType,
+          layoutId: pair.layoutId,
+          error: message,
+        });
+      } finally {
+        rmSync(filePath, { force: true });
       }
-
-      rmSync(filePath, { force: true });
     }
-
-    const manifest: SnapshotManifest = {
-      formatVersion: SNAPSHOT_MANIFEST_FORMAT_VERSION,
-      generatedAt: new Date().toISOString(),
-      entries,
-    };
 
     if (options.dryRun) {
       logger.info('[export-snapshots] dry-run complete — manifest NOT uploaded', {
-        entries: entries.length,
-        totalGzipBytes: entries.reduce((sum, entry) => sum + entry.bytes, 0),
+        entries: newEntries.length,
+        failedLayouts: failures.length,
+        totalGzipBytes: newEntries.reduce((sum, entry) => sum + entry.bytes, 0),
       });
     } else {
-      // Manifest LAST: readers see an atomic old-or-new manifest, never a
-      // manifest pointing at artifacts that failed to upload.
+      // MERGE the previous manifest, never overwrite: a filtered run rebuilds
+      // only its own pairs and must not drop everyone else's entries. Written
+      // LAST so readers see an atomic old-or-new manifest.
+      const previousManifest = await fetchPreviousManifest();
+      const mergedEntries = mergeManifestEntries({
+        previousEntries: previousManifest?.entries ?? [],
+        newEntries,
+        livePairs: isFilteredRun ? null : pairs,
+      });
+      const manifest: SnapshotManifest = {
+        formatVersion: SNAPSHOT_MANIFEST_FORMAT_VERSION,
+        generatedAt: new Date().toISOString(),
+        entries: mergedEntries,
+      };
       await uploadToS3(Buffer.from(JSON.stringify(manifest)), MANIFEST_KEY, 'application/json', {
         cacheControl: MANIFEST_CACHE_CONTROL,
       });
-      logger.info('[export-snapshots] manifest uploaded — run complete', {
-        entries: entries.length,
+      logger.info('[export-snapshots] manifest uploaded', {
+        entries: mergedEntries.length,
+        refreshed: newEntries.length,
         key: MANIFEST_KEY,
       });
+
+      // Prune superseded artifacts only after a fully-successful unfiltered
+      // run: filtered runs lack the full picture, and skipping on failure
+      // nights just defers pruning to the next green nightly.
+      if (!isFilteredRun && failures.length === 0) {
+        await pruneStaleArtifacts(manifest, Date.now());
+      }
+    }
+
+    if (failures.length > 0) {
+      const failedPairs = failures.map((failure) => `${failure.boardType}:${failure.layoutId}`).join(', ');
+      throw new Error(`Export failed for ${failures.length} layout(s): ${failedPairs}`);
     }
   } finally {
     rmSync(workDir, { recursive: true, force: true });

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -625,8 +625,7 @@ export async function runExport(argv: string[]): Promise<void> {
         // downloaders (expo-file-system) may write the raw gzip stream, and the
         // client treats a gzip-on-disk artifact as a failed download (it has no
         // JS gunzip). The manifest's contentEncoding field keeps the client
-        // agnostic, so flipping to --gzip later needs no app update. See
-        // docs/board-snapshots.md.
+        // agnostic, so flipping to --gzip later needs no app update.
         const uploadBody = options.gzip ? gzipSync(rawBuffer) : rawBuffer;
         const contentEncoding = options.gzip ? ('gzip' as const) : ('identity' as const);
         // Colon-free key stamp: ISO colons are legal in S3 keys but historically

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -544,6 +544,15 @@ export async function runExport(argv: string[]): Promise<void> {
       boardType: options.boardFilter,
       layoutId: options.layoutFilter,
     });
+    if (pairs.length === 0 && isFilteredRun) {
+      // A filter that matches nothing is an operator error (e.g. --board=kilterr).
+      // Exiting zero here would silently leave the filtered board's artifacts
+      // stale, so fail loudly instead.
+      throw new Error(
+        `--board/--layout filter matched no (board_type, layout_id) pairs with climbs ` +
+          `(board=${options.boardFilter ?? '*'}, layout=${options.layoutFilter ?? '*'})`,
+      );
+    }
     logger.info('[export-snapshots] starting run', {
       dryRun: options.dryRun,
       filtered: isFilteredRun,

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -365,17 +365,23 @@ export async function exportLayoutSnapshot(params: {
 
 type ExportOptions = {
   dryRun: boolean;
+  // Off by default: upload artifacts uncompressed until transparent
+  // Content-Encoding: gzip decode is verified on-device (see the encoding
+  // comment in the pair loop).
+  gzip: boolean;
   boardFilter?: string;
   layoutFilter?: number;
 };
 
 function parseArgs(argv: string[]): ExportOptions {
-  const options: ExportOptions = { dryRun: false };
+  const options: ExportOptions = { dryRun: false, gzip: false };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--') continue; // vp forwards a literal `--` into argv
     if (arg === '--dry-run') {
       options.dryRun = true;
+    } else if (arg === '--gzip') {
+      options.gzip = true;
     } else if (arg === '--board') {
       options.boardFilter = argv[(index += 1)];
     } else if (arg.startsWith('--board=')) {
@@ -614,7 +620,15 @@ export async function runExport(argv: string[]): Promise<void> {
         });
 
         const rawBuffer = readFileSync(filePath);
-        const gzipped = gzipSync(rawBuffer);
+        // Encoding default is IDENTITY until transparent Content-Encoding: gzip
+        // decode is verified on-device for both platforms: straight-to-disk
+        // downloaders (expo-file-system) may write the raw gzip stream, and the
+        // client treats a gzip-on-disk artifact as a failed download (it has no
+        // JS gunzip). The manifest's contentEncoding field keeps the client
+        // agnostic, so flipping to --gzip later needs no app update. See
+        // docs/board-snapshots.md.
+        const uploadBody = options.gzip ? gzipSync(rawBuffer) : rawBuffer;
+        const contentEncoding = options.gzip ? ('gzip' as const) : ('identity' as const);
         // Colon-free key stamp: ISO colons are legal in S3 keys but historically
         // trip CDNs/URL parsers, and getPublicUrl does no percent-encoding.
         const keyStamp = builtAt.replace(/[:.]/g, '-');
@@ -627,7 +641,8 @@ export async function runExport(argv: string[]): Promise<void> {
             climbs: result.tables.board_climbs.rowCount,
             stats: result.tables.board_climb_stats.rowCount,
             rawBytes: rawBuffer.length,
-            gzipBytes: gzipped.length,
+            uploadBytes: uploadBody.length,
+            contentEncoding,
             durationMs: Date.now() - startedAt,
           });
           newEntries.push(
@@ -636,18 +651,24 @@ export async function runExport(argv: string[]): Promise<void> {
               // configured — a dry-run must work with no AWS credentials at all.
               url: isS3Configured() ? getPublicUrl(key) : `dry-run:${key}`,
               key,
-              bytes: gzipped.length,
-              contentEncoding: 'gzip',
+              bytes: uploadBody.length,
+              contentEncoding,
             }),
           );
         } else {
-          const uploaded = await uploadToS3(gzipped, key, ARTIFACT_CONTENT_TYPE, { contentEncoding: 'gzip' });
+          const uploaded = await uploadToS3(
+            uploadBody,
+            key,
+            ARTIFACT_CONTENT_TYPE,
+            options.gzip ? { contentEncoding: 'gzip' } : undefined,
+          );
           logger.info('[export-snapshots] uploaded', {
             boardType: pair.boardType,
             layoutId: pair.layoutId,
             climbs: result.tables.board_climbs.rowCount,
             stats: result.tables.board_climb_stats.rowCount,
-            gzipBytes: gzipped.length,
+            uploadBytes: uploadBody.length,
+            contentEncoding,
             key: uploaded.key,
             durationMs: Date.now() - startedAt,
           });
@@ -655,8 +676,8 @@ export async function runExport(argv: string[]): Promise<void> {
             buildManifestEntry(result, {
               url: uploaded.url,
               key: uploaded.key,
-              bytes: gzipped.length,
-              contentEncoding: 'gzip',
+              bytes: uploadBody.length,
+              contentEncoding,
             }),
           );
         }

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -1,0 +1,525 @@
+// Nightly board-snapshot export (offline-sync Phase 2).
+//
+// For every (board_type, layout_id) that has climbs, builds a small SQLite file
+// carrying ONLY `board_climbs` + `board_climb_stats` (plus a `snapshot_meta`
+// watermark table), gzips it, and uploads it to Tigris/S3 under
+// `board-snapshots/v1/<boardType>/<layoutId>/<builtAt>.db`. After every artifact
+// lands, writes `board-snapshots/v1/manifest.json` LAST so a reader always sees
+// a consistent old-or-new manifest. Phase 3 (pull-client) reads that manifest to
+// warm a freshly-downloaded board from the artifact instead of paging the whole
+// catalog over GraphQL, then resumes an incremental pull from the per-table
+// watermarks recorded here.
+//
+// The row shaping is the SAME code the live sync resolvers use (row-normalize.ts
+// + toSqliteValue), read through the SAME drizzle-constructed postgres.js client
+// (transparent timestamp parsers), so an artifact row is byte-identical to what a
+// live `syncClimbs`/`syncClimbStats` pull would have written. The
+// snapshot-export-golden test pins that equivalence.
+//
+// Structure: a testable core (`exportLayoutSnapshot`, `boardSnapshotDdlStatements`,
+// `discoverLayoutPairs`) under a thin CLI (`runExport`). The CLI is only invoked
+// when this module is the process entry, so importing it in a test has no side
+// effects.
+
+import { pathToFileURL } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+import { gzipSync } from 'node:zlib';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Sql, TransactionSql } from 'postgres';
+import {
+  MIGRATIONS,
+  LATEST_SCHEMA_VERSION,
+  TABLE_CONFIGS,
+  toSqliteValue,
+  multiRowChunkSize,
+  SNAPSHOT_MANIFEST_FORMAT_VERSION,
+  type SnapshotManifest,
+  type SnapshotManifestEntry,
+  type SnapshotTableName,
+} from '@boardsesh/offline-sync';
+import { createReadDb, createReadPool, closeReadPool } from '@boardsesh/db/client';
+import { normalizeRow, toIso, type RawRow } from '../graphql/resolvers/sync/row-normalize';
+import { uploadToS3, isS3Configured, getPublicUrl } from '../storage/s3';
+import { logger } from '../utils/logger';
+
+// --- Constants ----------------------------------------------------------------
+
+const SNAPSHOT_KEY_PREFIX = 'board-snapshots/v1';
+const MANIFEST_KEY = `${SNAPSHOT_KEY_PREFIX}/manifest.json`;
+const MANIFEST_CACHE_CONTROL = 'public, max-age=300';
+const ARTIFACT_CONTENT_TYPE = 'application/x-sqlite3';
+
+// Matches the resolvers' stability window: rows younger than this are left for a
+// live incremental pull so the watermark never covers a still-in-flight write.
+// Reads the SAME env var the sync resolvers read so both stay in lockstep.
+const parsedStabilityWindow = Number(process.env.SYNC_STABILITY_WINDOW_SECONDS ?? 30);
+const DEFAULT_STABILITY_WINDOW_SECONDS = Number.isFinite(parsedStabilityWindow) ? parsedStabilityWindow : 30;
+
+// The keyset epoch a client resumes from when a table's snapshot is empty — the
+// same sentinel the resolvers echo on a first (cursorless) pull.
+const EPOCH_WATERMARK_UPDATED_AT = '1970-01-01T00:00:00.000Z';
+const EPOCH_WATERMARK_SYNC_SEQ = 0;
+
+const SNAPSHOT_TABLES: readonly SnapshotTableName[] = ['board_climbs', 'board_climb_stats'];
+
+const SNAPSHOT_META_DDL = `
+CREATE TABLE IF NOT EXISTS snapshot_meta (
+  table_name TEXT PRIMARY KEY,
+  watermark_updated_at TEXT,
+  watermark_sync_seq INTEGER,
+  row_count INTEGER,
+  built_at TEXT,
+  schema_version INTEGER,
+  format_version INTEGER
+);
+`.trim();
+
+// Only snake_case identifiers may be spliced into the SELECT column list. The
+// column names come from TABLE_CONFIGS (a trusted allowlist), but validating
+// keeps the string-built SQL provably injection-free.
+const SAFE_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+
+// --- Types --------------------------------------------------------------------
+
+export type SnapshotTableExportResult = {
+  rowCount: number;
+  watermarkUpdatedAt: string;
+  watermarkSyncSeq: number;
+};
+
+export type LayoutSnapshotResult = {
+  boardType: string;
+  layoutId: number;
+  filePath: string;
+  builtAt: string;
+  schemaVersion: number;
+  tables: Record<SnapshotTableName, SnapshotTableExportResult>;
+};
+
+export type LayoutPair = { boardType: string; layoutId: number };
+
+// --- DDL ----------------------------------------------------------------------
+
+/**
+ * The DDL for a snapshot file: every statement in the client migrations that
+ * targets `board_climbs` or `board_climb_stats` (in migration/version order, so a
+ * CREATE precedes its ALTERs and indexes), plus `snapshot_meta`. Derived from the
+ * shared MIGRATIONS — the single source of truth — so a future column added on the
+ * client (e.g. the v2 `characteristics` ALTER) flows into the snapshot with no
+ * duplicated DDL here.
+ */
+export function boardSnapshotDdlStatements(): string[] {
+  const referencesSnapshotTable = (statement: string): boolean =>
+    SNAPSHOT_TABLES.some((table) => new RegExp(`\\b${table}\\b`).test(statement));
+
+  const statements: string[] = [];
+  for (const migration of [...MIGRATIONS].sort((left, right) => left.version - right.version)) {
+    for (const statement of migration.statements) {
+      if (referencesSnapshotTable(statement)) statements.push(statement.trim());
+    }
+  }
+  statements.push(SNAPSHOT_META_DDL);
+  return statements;
+}
+
+// --- Postgres discovery + streaming ------------------------------------------
+
+/** Every (board_type, layout_id) pair that has at least one climb. */
+export async function discoverLayoutPairs(sqlClient: Sql, filter?: Partial<LayoutPair>): Promise<LayoutPair[]> {
+  const rows = await sqlClient<{ board_type: string; layout_id: number }[]>`
+    SELECT DISTINCT board_type, layout_id
+    FROM board_climbs
+    ORDER BY board_type, layout_id
+  `;
+  return rows
+    .map((row) => ({ boardType: String(row.board_type), layoutId: Number(row.layout_id) }))
+    .filter((pair) => (filter?.boardType ? pair.boardType === filter.boardType : true))
+    .filter((pair) => (filter?.layoutId != null ? pair.layoutId === filter.layoutId : true));
+}
+
+function assertSafeColumns(columns: readonly string[]): void {
+  for (const column of columns) {
+    if (!SAFE_IDENTIFIER.test(column)) {
+      throw new Error(`Refusing to build snapshot SELECT with unsafe column identifier: ${column}`);
+    }
+  }
+}
+
+// Scope predicates matching the resolvers exactly. `now()` is transaction-start
+// time and constant across the whole export transaction, so the streamed rows and
+// the watermark query below apply the identical stability boundary.
+function climbsWhere(): string {
+  return `board_type = $1 AND layout_id = $2 AND updated_at < now() - make_interval(secs => $3)`;
+}
+
+function statsWhere(): string {
+  return `board_type = $1
+    AND EXISTS (
+      SELECT 1 FROM board_climbs bc
+      WHERE bc.uuid = board_climb_stats.climb_uuid AND bc.board_type = $1 AND bc.layout_id = $2
+    )
+    AND updated_at < now() - make_interval(secs => $3)`;
+}
+
+/**
+ * Stream one table's scoped rows from Postgres through the shared row shaping into
+ * the SQLite artifact, batched into multi-row INSERTs. Returns the number of rows
+ * written; the watermark is computed separately (see `tableWatermark`) from the
+ * same repeatable-read snapshot.
+ */
+async function streamTableIntoSqlite(
+  tx: TransactionSql,
+  sqliteDb: DatabaseSync,
+  tableName: SnapshotTableName,
+  columns: readonly string[],
+  whereClause: string,
+  params: (string | number)[],
+  streamBatchSize: number,
+): Promise<number> {
+  assertSafeColumns(columns);
+  const selectSql = `SELECT ${columns.join(', ')} FROM ${tableName} WHERE ${whereClause}`;
+  const chunkSize = multiRowChunkSize(columns.length);
+  const insertSqlByRowCount = new Map<number, string>();
+  const insertSqlFor = (rowCount: number): string => {
+    let cached = insertSqlByRowCount.get(rowCount);
+    if (!cached) {
+      const rowPlaceholder = `(${columns.map(() => '?').join(', ')})`;
+      const valuesClause = Array.from({ length: rowCount }, () => rowPlaceholder).join(', ');
+      cached = `INSERT OR REPLACE INTO ${tableName} (${columns.join(', ')}) VALUES ${valuesClause}`;
+      insertSqlByRowCount.set(rowCount, cached);
+    }
+    return cached;
+  };
+
+  let rowCount = 0;
+  const pending: RawRow[] = [];
+  const flush = (): void => {
+    if (pending.length === 0) return;
+    for (let chunkStart = 0; chunkStart < pending.length; chunkStart += chunkSize) {
+      const chunk = pending.slice(chunkStart, chunkStart + chunkSize);
+      const values = chunk.flatMap((row) => columns.map((column) => toSqliteValue(row[column])));
+      sqliteDb.prepare(insertSqlFor(chunk.length)).run(...values);
+    }
+    pending.length = 0;
+  };
+
+  for await (const batch of tx.unsafe(selectSql, params).cursor(streamBatchSize)) {
+    for (const rawRow of batch) {
+      pending.push(normalizeRow(rawRow as RawRow));
+      rowCount += 1;
+    }
+    flush();
+  }
+  flush();
+  return rowCount;
+}
+
+/**
+ * Compute a table's watermark (the greatest `(updated_at, sync_seq)` keyset over
+ * the scoped rows) inside the same transaction/snapshot as the row stream, so it
+ * never covers a row the artifact omitted. Postgres orders the timestamps as real
+ * timestamps — never string-compared in JS, which would misorder mixed sub-second
+ * precision. Empty scope → the epoch sentinel, so a client resumes from the start.
+ */
+async function tableWatermark(
+  tx: TransactionSql,
+  tableName: SnapshotTableName,
+  whereClause: string,
+  params: (string | number)[],
+): Promise<{ watermarkUpdatedAt: string; watermarkSyncSeq: number }> {
+  const rows = await tx.unsafe(
+    `SELECT updated_at, sync_seq
+     FROM ${tableName}
+     WHERE ${whereClause}
+     ORDER BY updated_at DESC, sync_seq DESC
+     LIMIT 1`,
+    params,
+  );
+  const watermarkRow = rows[0] as unknown as { updated_at: unknown; sync_seq: unknown } | undefined;
+  if (!watermarkRow) {
+    return { watermarkUpdatedAt: EPOCH_WATERMARK_UPDATED_AT, watermarkSyncSeq: EPOCH_WATERMARK_SYNC_SEQ };
+  }
+  return {
+    watermarkUpdatedAt: toIso(watermarkRow.updated_at),
+    watermarkSyncSeq: Number(watermarkRow.sync_seq),
+  };
+}
+
+// --- Layout snapshot build ----------------------------------------------------
+
+/**
+ * Build ONE (boardType, layoutId) SQLite snapshot at `filePath`. Both tables and
+ * every watermark are read inside a single REPEATABLE READ transaction so climbs,
+ * stats, and their watermarks come from one consistent database snapshot.
+ */
+export async function exportLayoutSnapshot(params: {
+  sqlClient: Sql;
+  boardType: string;
+  layoutId: number;
+  filePath: string;
+  builtAt: string;
+  stabilityWindowSeconds?: number;
+  streamBatchSize?: number;
+}): Promise<LayoutSnapshotResult> {
+  const { sqlClient, boardType, layoutId, filePath, builtAt } = params;
+  const stabilityWindowSeconds = params.stabilityWindowSeconds ?? DEFAULT_STABILITY_WINDOW_SECONDS;
+  const streamBatchSize = params.streamBatchSize ?? 5000;
+  const scopeParams: (string | number)[] = [boardType, layoutId, stabilityWindowSeconds];
+
+  const sqliteDb = new DatabaseSync(filePath);
+  try {
+    for (const statement of boardSnapshotDdlStatements()) {
+      sqliteDb.exec(statement);
+    }
+
+    sqliteDb.exec('BEGIN');
+    const tables = await sqlClient.begin(async (tx) => {
+      await tx.unsafe('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+
+      const climbColumns = TABLE_CONFIGS.board_climbs.localColumns;
+      const statsColumns = TABLE_CONFIGS.board_climb_stats.localColumns;
+
+      const climbRowCount = await streamTableIntoSqlite(
+        tx,
+        sqliteDb,
+        'board_climbs',
+        climbColumns,
+        climbsWhere(),
+        scopeParams,
+        streamBatchSize,
+      );
+      const climbWatermark = await tableWatermark(tx, 'board_climbs', climbsWhere(), scopeParams);
+
+      const statsRowCount = await streamTableIntoSqlite(
+        tx,
+        sqliteDb,
+        'board_climb_stats',
+        statsColumns,
+        statsWhere(),
+        scopeParams,
+        streamBatchSize,
+      );
+      const statsWatermark = await tableWatermark(tx, 'board_climb_stats', statsWhere(), scopeParams);
+
+      return {
+        board_climbs: { rowCount: climbRowCount, ...climbWatermark },
+        board_climb_stats: { rowCount: statsRowCount, ...statsWatermark },
+      } satisfies Record<SnapshotTableName, SnapshotTableExportResult>;
+    });
+
+    const insertMeta = sqliteDb.prepare(
+      `INSERT OR REPLACE INTO snapshot_meta
+        (table_name, watermark_updated_at, watermark_sync_seq, row_count, built_at, schema_version, format_version)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const tableName of SNAPSHOT_TABLES) {
+      const tableResult = tables[tableName];
+      insertMeta.run(
+        tableName,
+        tableResult.watermarkUpdatedAt,
+        tableResult.watermarkSyncSeq,
+        tableResult.rowCount,
+        builtAt,
+        LATEST_SCHEMA_VERSION,
+        SNAPSHOT_MANIFEST_FORMAT_VERSION,
+      );
+    }
+    sqliteDb.exec('COMMIT');
+
+    return {
+      boardType,
+      layoutId,
+      filePath,
+      builtAt,
+      schemaVersion: LATEST_SCHEMA_VERSION,
+      tables,
+    };
+  } catch (error) {
+    try {
+      sqliteDb.exec('ROLLBACK');
+    } catch {
+      // No open transaction to roll back — ignore.
+    }
+    throw error;
+  } finally {
+    sqliteDb.close();
+  }
+}
+
+// --- CLI ----------------------------------------------------------------------
+
+type ExportOptions = {
+  dryRun: boolean;
+  boardFilter?: string;
+  layoutFilter?: number;
+};
+
+function parseArgs(argv: string[]): ExportOptions {
+  const options: ExportOptions = { dryRun: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') continue; // vp forwards a literal `--` into argv
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--board') {
+      options.boardFilter = argv[(index += 1)];
+    } else if (arg.startsWith('--board=')) {
+      options.boardFilter = arg.slice('--board='.length);
+    } else if (arg === '--layout') {
+      options.layoutFilter = Number(argv[(index += 1)]);
+    } else if (arg.startsWith('--layout=')) {
+      options.layoutFilter = Number(arg.slice('--layout='.length));
+    }
+  }
+  return options;
+}
+
+function buildManifestEntry(
+  result: LayoutSnapshotResult,
+  upload: { url: string; key: string; bytes: number; contentEncoding: 'gzip' | 'identity' },
+): SnapshotManifestEntry {
+  return {
+    boardType: result.boardType,
+    layoutId: result.layoutId,
+    key: upload.key,
+    url: upload.url,
+    bytes: upload.bytes,
+    contentEncoding: upload.contentEncoding,
+    builtAt: result.builtAt,
+    schemaVersion: result.schemaVersion,
+    tables: {
+      board_climbs: result.tables.board_climbs,
+      board_climb_stats: result.tables.board_climb_stats,
+    },
+  };
+}
+
+export async function runExport(argv: string[]): Promise<void> {
+  const options = parseArgs(argv);
+  const builtAt = new Date().toISOString();
+
+  if (!options.dryRun && !isS3Configured()) {
+    throw new Error(
+      'S3 is not configured (AWS_S3_BUCKET_NAME / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY). Use --dry-run to build locally.',
+    );
+  }
+
+  // createReadPool installs drizzle's transparent timestamp parsers on the
+  // postgres.js client, so streamed timestamps match the resolver shaping.
+  createReadDb();
+  const sqlClient = createReadPool();
+  const workDir = mkdtempSync(join(tmpdir(), 'board-snapshots-'));
+  const entries: SnapshotManifestEntry[] = [];
+
+  try {
+    const pairs = await discoverLayoutPairs(sqlClient, {
+      boardType: options.boardFilter,
+      layoutId: options.layoutFilter,
+    });
+    logger.info('[export-snapshots] starting run', {
+      dryRun: options.dryRun,
+      pairs: pairs.length,
+      builtAt,
+      stabilityWindowSeconds: DEFAULT_STABILITY_WINDOW_SECONDS,
+    });
+
+    for (const pair of pairs) {
+      const startedAt = Date.now();
+      const filePath = join(workDir, `${pair.boardType}-${pair.layoutId}.db`);
+      const result = await exportLayoutSnapshot({
+        sqlClient,
+        boardType: pair.boardType,
+        layoutId: pair.layoutId,
+        filePath,
+        builtAt,
+      });
+
+      const rawBuffer = readFileSync(filePath);
+      const gzipped = gzipSync(rawBuffer);
+      const key = `${SNAPSHOT_KEY_PREFIX}/${pair.boardType}/${pair.layoutId}/${builtAt}.db`;
+
+      if (options.dryRun) {
+        logger.info('[export-snapshots] built (dry-run, not uploaded)', {
+          boardType: pair.boardType,
+          layoutId: pair.layoutId,
+          climbs: result.tables.board_climbs.rowCount,
+          stats: result.tables.board_climb_stats.rowCount,
+          rawBytes: rawBuffer.length,
+          gzipBytes: gzipped.length,
+          durationMs: Date.now() - startedAt,
+        });
+        entries.push(
+          buildManifestEntry(result, {
+            // getPublicUrl instantiates the S3 client, so only call it when S3 is
+            // configured — a dry-run must work with no AWS credentials at all.
+            url: isS3Configured() ? getPublicUrl(key) : `dry-run:${key}`,
+            key,
+            bytes: gzipped.length,
+            contentEncoding: 'gzip',
+          }),
+        );
+      } else {
+        const uploaded = await uploadToS3(gzipped, key, ARTIFACT_CONTENT_TYPE, { contentEncoding: 'gzip' });
+        logger.info('[export-snapshots] uploaded', {
+          boardType: pair.boardType,
+          layoutId: pair.layoutId,
+          climbs: result.tables.board_climbs.rowCount,
+          stats: result.tables.board_climb_stats.rowCount,
+          gzipBytes: gzipped.length,
+          key: uploaded.key,
+          durationMs: Date.now() - startedAt,
+        });
+        entries.push(
+          buildManifestEntry(result, {
+            url: uploaded.url,
+            key: uploaded.key,
+            bytes: gzipped.length,
+            contentEncoding: 'gzip',
+          }),
+        );
+      }
+
+      rmSync(filePath, { force: true });
+    }
+
+    const manifest: SnapshotManifest = {
+      formatVersion: SNAPSHOT_MANIFEST_FORMAT_VERSION,
+      generatedAt: new Date().toISOString(),
+      entries,
+    };
+
+    if (options.dryRun) {
+      logger.info('[export-snapshots] dry-run complete — manifest NOT uploaded', {
+        entries: entries.length,
+        totalGzipBytes: entries.reduce((sum, entry) => sum + entry.bytes, 0),
+      });
+    } else {
+      // Manifest LAST: readers see an atomic old-or-new manifest, never a
+      // manifest pointing at artifacts that failed to upload.
+      await uploadToS3(Buffer.from(JSON.stringify(manifest)), MANIFEST_KEY, 'application/json', {
+        cacheControl: MANIFEST_CACHE_CONTROL,
+      });
+      logger.info('[export-snapshots] manifest uploaded — run complete', {
+        entries: entries.length,
+        key: MANIFEST_KEY,
+      });
+    }
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+    await closeReadPool();
+  }
+}
+
+// Only run when executed directly (`node --import tsx .../export-board-snapshots.ts`),
+// never when imported by a test.
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : '';
+if (invokedPath === import.meta.url) {
+  runExport(process.argv.slice(2)).catch((error) => {
+    logger.error('[export-snapshots] run failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exitCode = 1;
+  });
+}

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -16,6 +16,11 @@
 // live `syncClimbs`/`syncClimbStats` pull would have written. The
 // snapshot-export-golden test pins that equivalence.
 //
+// Reads the PRIMARY database, never a replica: the sync cursor (updated_at,
+// sync_seq) is write-time ordered, but a replica snapshot is commit-order
+// consistent, so a lagging replica can omit a lower-cursor row while containing
+// higher-cursor ones — see the pool call-site comment in runExport.
+//
 // Structure: a testable core (`exportLayoutSnapshot`, `boardSnapshotDdlStatements`,
 // `discoverLayoutPairs`) under a thin CLI (`runExport`). The CLI is only invoked
 // when this module is the process entry, so importing it in a test has no side
@@ -40,9 +45,9 @@ import {
   type SnapshotManifestEntry,
   type SnapshotTableName,
 } from '@boardsesh/offline-sync';
-import { createReadPool, closeReadPool } from '@boardsesh/db/client';
+import { createPool, closePool } from '@boardsesh/db/client';
 import { normalizeRow, toIso, type RawRow } from '../graphql/resolvers/sync/row-normalize';
-import { uploadToS3, isS3Configured, getPublicUrl, getFromS3, deleteFromS3, listS3Objects } from '../storage/s3';
+import { uploadToS3, isS3Configured, getPublicUrl, getFromS3Strict, deleteFromS3, listS3Objects } from '../storage/s3';
 import { logger } from '../utils/logger';
 
 // --- Constants ----------------------------------------------------------------
@@ -449,34 +454,55 @@ export function mergeManifestEntries(params: {
 }
 
 /**
- * Fetch + validate the currently-published manifest. Returns null when there is
- * none (first run) or it is unreadable/unparseable — the caller merges against
- * empty. Missing-vs-error is not distinguishable through getFromS3, so both are
- * logged loudly; a filtered run that hits this writes a manifest containing only
- * its own entries, which the next unfiltered nightly run heals.
+ * Fetch + validate the currently-published manifest. Called BEFORE any artifact
+ * upload, so a fatal outcome aborts the run with S3 completely untouched.
+ *
+ * Failure matrix (the merge needs the previous entries — a filtered run to
+ * preserve every other board, an unfiltered run to preserve failed layouts —
+ * so guessing "empty" on a broken read could drop them from the manifest):
+ *
+ *   object missing (NoSuchKey/404)   → null, proceed (legitimately a first run)
+ *   S3 read error (anything else)    → THROW — fatal on filtered AND unfiltered
+ *   present but invalid JSON/shape   → filtered: THROW (the run cannot
+ *                                      reconstruct the entries it would drop);
+ *                                      unfiltered: warn + merge against empty
+ *                                      (it rebuilds every live layout anyway —
+ *                                      only vanished layouts' entries are lost,
+ *                                      and those drop regardless)
  */
-async function fetchPreviousManifest(): Promise<SnapshotManifest | null> {
-  const manifestObject = await getFromS3(MANIFEST_KEY);
+async function fetchPreviousManifest(options: { isFilteredRun: boolean }): Promise<SnapshotManifest | null> {
+  const manifestObject = await getFromS3Strict(MANIFEST_KEY);
   if (!manifestObject) {
-    logger.warn('[export-snapshots] no previous manifest readable (first run?) — merging against empty');
+    logger.warn('[export-snapshots] no previous manifest on S3 (first run?) — merging against empty');
     return null;
   }
   const chunks: Buffer[] = [];
   for await (const chunk of manifestObject.stream as AsyncIterable<Buffer | string>) {
     chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
   }
+
+  let parsed: SnapshotManifest | null = null;
+  let invalidReason: string | null = null;
   try {
-    const parsed = parseSnapshotManifest(JSON.parse(Buffer.concat(chunks).toString('utf8')));
-    if (!parsed) {
-      logger.warn('[export-snapshots] previous manifest failed validation — merging against empty');
-    }
-    return parsed;
+    parsed = parseSnapshotManifest(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+    if (!parsed) invalidReason = 'failed schema validation';
   } catch (error) {
-    logger.warn('[export-snapshots] previous manifest is not valid JSON — merging against empty', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
+    invalidReason = error instanceof Error ? error.message : String(error);
   }
+  if (invalidReason) {
+    if (options.isFilteredRun) {
+      throw new Error(
+        `previous manifest at ${MANIFEST_KEY} is invalid (${invalidReason}); a filtered run cannot merge safely — aborting before any upload`,
+      );
+    }
+    logger.warn(
+      '[export-snapshots] previous manifest invalid — unfiltered run rebuilds everything, merging against empty',
+      {
+        reason: invalidReason,
+      },
+    );
+  }
+  return parsed;
 }
 
 /**
@@ -530,11 +556,21 @@ export async function runExport(argv: string[]): Promise<void> {
     );
   }
 
-  // createReadPool GUARANTEES the drizzle wrapper is constructed before the raw
-  // pool is returned (see packages/db/src/client/postgres.ts), so the pool
-  // already carries drizzle's transparent timestamp parsers and streamed rows
-  // match the resolver shaping.
-  const sqlClient = createReadPool();
+  // PRIMARY pool, deliberately NOT the read-replica seam: the sync cursor
+  // (updated_at, sync_seq) is assigned at WRITE time, but an async replica's
+  // snapshot is consistent by COMMIT order — a lower-cursor row that commits
+  // late (or replays late through replication lag) can be absent from the
+  // replica while higher-cursor rows are present. The 30s stability window only
+  // absorbs write→commit delay measured on the primary; replica lag stacks on
+  // top, and once (commit delay + lag) exceeds the window the exported
+  // watermark covers a row the artifact doesn't contain — every bootstrapped
+  // client resumes strictly past it and loses it FOREVER. The sync resolvers
+  // serve from the primary for the same reason. createPool GUARANTEES the
+  // drizzle wrapper is constructed before the raw pool is returned (see
+  // packages/db/src/client/postgres.ts), so the pool carries drizzle's
+  // transparent timestamp parsers and streamed rows match the resolver shaping.
+  // Closed by the CLI entry below, not here — tests share the cached pool.
+  const sqlClient = createPool();
   const workDir = mkdtempSync(join(tmpdir(), 'board-snapshots-'));
   const newEntries: SnapshotManifestEntry[] = [];
   const failures: LayoutFailure[] = [];
@@ -560,6 +596,10 @@ export async function runExport(argv: string[]): Promise<void> {
       builtAt,
       stabilityWindowSeconds: DEFAULT_STABILITY_WINDOW_SECONDS,
     });
+
+    // Fetch the previous manifest BEFORE any upload: if it is unreadable the
+    // run aborts with S3 completely untouched (matrix in fetchPreviousManifest).
+    const previousManifest = options.dryRun ? null : await fetchPreviousManifest({ isFilteredRun });
 
     for (const pair of pairs) {
       const startedAt = Date.now();
@@ -644,10 +684,10 @@ export async function runExport(argv: string[]): Promise<void> {
         totalGzipBytes: newEntries.reduce((sum, entry) => sum + entry.bytes, 0),
       });
     } else {
-      // MERGE the previous manifest, never overwrite: a filtered run rebuilds
-      // only its own pairs and must not drop everyone else's entries. Written
-      // LAST so readers see an atomic old-or-new manifest.
-      const previousManifest = await fetchPreviousManifest();
+      // MERGE the previous manifest (fetched up front), never overwrite: a
+      // filtered run rebuilds only its own pairs and must not drop everyone
+      // else's entries. Written LAST so readers see an atomic old-or-new
+      // manifest.
       const mergedEntries = mergeManifestEntries({
         previousEntries: previousManifest?.entries ?? [],
         newEntries,
@@ -681,18 +721,24 @@ export async function runExport(argv: string[]): Promise<void> {
     }
   } finally {
     rmSync(workDir, { recursive: true, force: true });
-    await closeReadPool();
   }
 }
 
 // Only run when executed directly (`node --import tsx .../export-board-snapshots.ts`),
-// never when imported by a test.
+// never when imported by a test. The pool is closed HERE, not inside runExport:
+// tests invoke runExport against the process-wide cached primary pool, and
+// closing it there would kill the connection every other test in the worker
+// shares.
 const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : '';
 if (invokedPath === import.meta.url) {
-  runExport(process.argv.slice(2)).catch((error) => {
-    logger.error('[export-snapshots] run failed', {
-      error: error instanceof Error ? error.message : String(error),
+  runExport(process.argv.slice(2))
+    .catch((error) => {
+      logger.error('[export-snapshots] run failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await closePool();
     });
-    process.exitCode = 1;
-  });
 }

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -53,14 +53,17 @@ const ARTIFACT_CONTENT_TYPE = 'application/x-sqlite3';
 
 // Matches the resolvers' stability window: rows younger than this are left for a
 // live incremental pull so the watermark never covers a still-in-flight write.
-// Reads the SAME env var the sync resolvers read so both stay in lockstep.
-const parsedStabilityWindow = Number(process.env.SYNC_STABILITY_WINDOW_SECONDS ?? 30);
+// Reads the SAME env var the sync resolvers read so both stay in lockstep. A
+// blank value (e.g. an unset GitHub Actions `vars.*` passthrough) means unset —
+// Number('') would otherwise silently zero the window.
+const rawStabilityWindow = process.env.SYNC_STABILITY_WINDOW_SECONDS?.trim();
+const parsedStabilityWindow = rawStabilityWindow ? Number(rawStabilityWindow) : 30;
 const DEFAULT_STABILITY_WINDOW_SECONDS = Number.isFinite(parsedStabilityWindow) ? parsedStabilityWindow : 30;
 
 // The keyset epoch a client resumes from when a table's snapshot is empty — the
 // same sentinel the resolvers echo on a first (cursorless) pull.
 const EPOCH_WATERMARK_UPDATED_AT = '1970-01-01T00:00:00.000Z';
-const EPOCH_WATERMARK_SYNC_SEQ = 0;
+const EPOCH_WATERMARK_SYNC_SEQ = '0';
 
 const SNAPSHOT_TABLES: readonly SnapshotTableName[] = ['board_climbs', 'board_climb_stats'];
 
@@ -68,7 +71,9 @@ const SNAPSHOT_META_DDL = `
 CREATE TABLE IF NOT EXISTS snapshot_meta (
   table_name TEXT PRIMARY KEY,
   watermark_updated_at TEXT,
-  watermark_sync_seq INTEGER,
+  -- Decimal string, like every seq in the sync protocol: a Postgres bigint must
+  -- never round-trip through a JS number.
+  watermark_sync_seq TEXT,
   row_count INTEGER,
   built_at TEXT,
   schema_version INTEGER,
@@ -86,7 +91,7 @@ const SAFE_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
 export type SnapshotTableExportResult = {
   rowCount: number;
   watermarkUpdatedAt: string;
-  watermarkSyncSeq: number;
+  watermarkSyncSeq: string;
 };
 
 export type LayoutSnapshotResult = {
@@ -228,7 +233,7 @@ async function tableWatermark(
   tableName: SnapshotTableName,
   whereClause: string,
   params: (string | number)[],
-): Promise<{ watermarkUpdatedAt: string; watermarkSyncSeq: number }> {
+): Promise<{ watermarkUpdatedAt: string; watermarkSyncSeq: string }> {
   const rows = await tx.unsafe(
     `SELECT updated_at, sync_seq
      FROM ${tableName}
@@ -243,7 +248,7 @@ async function tableWatermark(
   }
   return {
     watermarkUpdatedAt: toIso(watermarkRow.updated_at),
-    watermarkSyncSeq: Number(watermarkRow.sync_seq),
+    watermarkSyncSeq: String(watermarkRow.sync_seq),
   };
 }
 
@@ -368,12 +373,21 @@ function parseArgs(argv: string[]): ExportOptions {
     } else if (arg.startsWith('--board=')) {
       options.boardFilter = arg.slice('--board='.length);
     } else if (arg === '--layout') {
-      options.layoutFilter = Number(argv[(index += 1)]);
+      options.layoutFilter = parseLayoutFilter(argv[(index += 1)]);
     } else if (arg.startsWith('--layout=')) {
-      options.layoutFilter = Number(arg.slice('--layout='.length));
+      options.layoutFilter = parseLayoutFilter(arg.slice('--layout='.length));
     }
   }
   return options;
+}
+
+function parseLayoutFilter(raw: string | undefined): number {
+  const layoutId = Number(raw);
+  if (!Number.isInteger(layoutId)) {
+    // A NaN filter would silently match nothing and export zero layouts.
+    throw new Error(`--layout expects an integer layout id, got ${JSON.stringify(raw)}`);
+  }
+  return layoutId;
 }
 
 function buildManifestEntry(
@@ -438,7 +452,10 @@ export async function runExport(argv: string[]): Promise<void> {
 
       const rawBuffer = readFileSync(filePath);
       const gzipped = gzipSync(rawBuffer);
-      const key = `${SNAPSHOT_KEY_PREFIX}/${pair.boardType}/${pair.layoutId}/${builtAt}.db`;
+      // Colon-free key stamp: ISO colons are legal in S3 keys but historically
+      // trip CDNs/URL parsers, and getPublicUrl does no percent-encoding.
+      const keyStamp = builtAt.replace(/[:.]/g, '-');
+      const key = `${SNAPSHOT_KEY_PREFIX}/${pair.boardType}/${pair.layoutId}/${keyStamp}.db`;
 
       if (options.dryRun) {
         logger.info('[export-snapshots] built (dry-run, not uploaded)', {

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -2,7 +2,7 @@
 //
 // For every (board_type, layout_id) that has climbs, builds a small SQLite file
 // carrying ONLY `board_climbs` + `board_climb_stats` (plus a `snapshot_meta`
-// watermark table), gzips it, and uploads it to Tigris/S3 under
+// watermark table), optionally gzips it, and uploads it to Tigris/S3 under
 // `board-snapshots/v1/<boardType>/<layoutId>/<builtAt>.db`. After every artifact
 // lands, writes `board-snapshots/v1/manifest.json` LAST so a reader always sees
 // a consistent old-or-new manifest. Phase 3 (pull-client) reads that manifest to
@@ -383,9 +383,9 @@ function parseArgs(argv: string[]): ExportOptions {
     } else if (arg === '--gzip') {
       options.gzip = true;
     } else if (arg === '--board') {
-      options.boardFilter = argv[(index += 1)];
+      options.boardFilter = parseBoardFilter(argv[(index += 1)]);
     } else if (arg.startsWith('--board=')) {
-      options.boardFilter = arg.slice('--board='.length);
+      options.boardFilter = parseBoardFilter(arg.slice('--board='.length));
     } else if (arg === '--layout') {
       options.layoutFilter = parseLayoutFilter(argv[(index += 1)]);
     } else if (arg.startsWith('--layout=')) {
@@ -393,6 +393,13 @@ function parseArgs(argv: string[]): ExportOptions {
     }
   }
   return options;
+}
+
+function parseBoardFilter(raw: string | undefined): string {
+  if (!raw || raw.startsWith('--')) {
+    throw new Error(`--board expects a board type, got ${JSON.stringify(raw)}`);
+  }
+  return raw;
 }
 
 function parseLayoutFilter(raw: string | undefined): number {

--- a/packages/backend/src/storage/s3.test.ts
+++ b/packages/backend/src/storage/s3.test.ts
@@ -29,6 +29,7 @@ vi.mock('@aws-sdk/client-s3', () => {
     DeleteObjectCommand: class DeleteObjectCommand extends MockCommand {},
     GetObjectCommand: class GetObjectCommand extends MockCommand {},
     HeadObjectCommand: class HeadObjectCommand extends MockCommand {},
+    ListObjectsV2Command: class ListObjectsV2Command extends MockCommand {},
   };
 });
 
@@ -161,5 +162,36 @@ describe('s3 storage', () => {
     const { getFromS3 } = await import('./s3');
     awsMocks.send.mockRejectedValueOnce(new Error('connection reset'));
     await expect(getFromS3('broken.json')).resolves.toBeNull();
+  });
+
+  it('listS3Objects follows continuation tokens across pages and skips keyless entries', async () => {
+    const { listS3Objects } = await import('./s3');
+
+    const firstModified = new Date('2026-06-01T00:00:00Z');
+    const secondModified = new Date('2026-06-02T00:00:00Z');
+    awsMocks.send
+      .mockResolvedValueOnce({
+        Contents: [
+          { Key: 'board-snapshots/v1/kilter/1/a.db', Size: 10, LastModified: firstModified },
+          { Size: 5 }, // keyless entry must be skipped, not crash
+        ],
+        IsTruncated: true,
+        NextContinuationToken: 'token-2',
+      })
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'board-snapshots/v1/kilter/1/b.db', Size: 20, LastModified: secondModified }],
+        IsTruncated: false,
+      });
+
+    const objects = await listS3Objects('board-snapshots/v1/');
+
+    expect(objects).toEqual([
+      { key: 'board-snapshots/v1/kilter/1/a.db', size: 10, lastModified: firstModified },
+      { key: 'board-snapshots/v1/kilter/1/b.db', size: 20, lastModified: secondModified },
+    ]);
+    expect(awsMocks.send).toHaveBeenCalledTimes(2);
+    const secondCall = awsMocks.send.mock.calls[1][0] as { input: Record<string, unknown> };
+    expect(secondCall.input.ContinuationToken).toBe('token-2');
+    expect(secondCall.input.Prefix).toBe('board-snapshots/v1/');
   });
 });

--- a/packages/backend/src/storage/s3.test.ts
+++ b/packages/backend/src/storage/s3.test.ts
@@ -139,4 +139,27 @@ describe('s3 storage', () => {
     awsMocks.send.mockRejectedValueOnce(new Error('not found'));
     await expect(getFromS3('missing.json')).resolves.toBeNull();
   });
+
+  it('getFromS3Strict distinguishes a missing object (null) from a read failure (throws)', async () => {
+    const { getFromS3Strict } = await import('./s3');
+
+    // NoSuchKey / 404 shapes → null (the object genuinely does not exist).
+    const noSuchKey = Object.assign(new Error('no such key'), { name: 'NoSuchKey' });
+    awsMocks.send.mockRejectedValueOnce(noSuchKey);
+    await expect(getFromS3Strict('missing.json')).resolves.toBeNull();
+
+    const http404 = Object.assign(new Error('not found'), { $metadata: { httpStatusCode: 404 } });
+    awsMocks.send.mockRejectedValueOnce(http404);
+    await expect(getFromS3Strict('missing.json')).resolves.toBeNull();
+
+    // Anything else (network/auth/throttle) must PROPAGATE — callers like the
+    // snapshot manifest merge treat "missing" and "unreadable" very differently.
+    awsMocks.send.mockRejectedValueOnce(new Error('connection reset'));
+    await expect(getFromS3Strict('broken.json')).rejects.toThrow('connection reset');
+
+    // The lenient getFromS3 still maps that same failure to null (caller contract).
+    const { getFromS3 } = await import('./s3');
+    awsMocks.send.mockRejectedValueOnce(new Error('connection reset'));
+    await expect(getFromS3('broken.json')).resolves.toBeNull();
+  });
 });

--- a/packages/backend/src/storage/s3.ts
+++ b/packages/backend/src/storage/s3.ts
@@ -4,6 +4,7 @@ import {
   DeleteObjectCommand,
   GetObjectCommand,
   HeadObjectCommand,
+  ListObjectsV2Command,
   type ObjectCannedACL,
   type PutObjectCommandInput,
 } from '@aws-sdk/client-s3';
@@ -197,6 +198,41 @@ export async function getS3ObjectMetadata(key: string): Promise<{
   } catch {
     return null;
   }
+}
+
+export type S3ObjectSummary = {
+  key: string;
+  size: number | undefined;
+  lastModified: Date | undefined;
+};
+
+/**
+ * List every object under a key prefix (paginates ListObjectsV2 until done).
+ * Errors propagate — callers decide whether a listing failure is fatal.
+ */
+export async function listS3Objects(prefix: string): Promise<S3ObjectSummary[]> {
+  const client = getS3Client();
+  const bucket = getBucketName();
+
+  const objects: S3ObjectSummary[] = [];
+  let continuationToken: string | undefined;
+  do {
+    const response = await client.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      }),
+    );
+    for (const object of response.Contents ?? []) {
+      if (object.Key) {
+        objects.push({ key: object.Key, size: object.Size, lastModified: object.LastModified });
+      }
+    }
+    continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+  } while (continuationToken);
+
+  return objects;
 }
 
 /**

--- a/packages/backend/src/storage/s3.ts
+++ b/packages/backend/src/storage/s3.ts
@@ -91,6 +91,9 @@ export async function uploadToS3(
   options: {
     cacheControl?: string;
     acl?: ObjectCannedACL | null;
+    // Sets the object's Content-Encoding (e.g. 'gzip' for a pre-compressed body
+    // so a browser/CDN decompresses transparently). Omit for uncompressed bodies.
+    contentEncoding?: string;
   } = {},
 ): Promise<{ url: string; key: string }> {
   const client = getS3Client();
@@ -103,6 +106,10 @@ export async function uploadToS3(
     ContentType: contentType,
     CacheControl: options.cacheControl ?? 'public, max-age=31536000, immutable',
   };
+
+  if (options.contentEncoding) {
+    input.ContentEncoding = options.contentEncoding;
+  }
 
   if (options.acl !== null) {
     input.ACL = options.acl ?? 'public-read';

--- a/packages/backend/src/storage/s3.ts
+++ b/packages/backend/src/storage/s3.ts
@@ -137,10 +137,27 @@ export async function deleteFromS3(key: string): Promise<void> {
   );
 }
 
+/** True for the S3 shapes of "the object does not exist" (vs a read failure). */
+function isS3NotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const candidate = error as { name?: string; Code?: string; $metadata?: { httpStatusCode?: number } };
+  return (
+    candidate.name === 'NoSuchKey' ||
+    candidate.name === 'NotFound' ||
+    candidate.Code === 'NoSuchKey' ||
+    candidate.$metadata?.httpStatusCode === 404
+  );
+}
+
 /**
- * Get a file from S3 and return the stream along with metadata
+ * Get a file from S3, distinguishing MISSING from BROKEN: returns null only
+ * when the object genuinely does not exist (NoSuchKey / NotFound / 404); any
+ * other failure (network, auth, throttling) throws. Use this when acting on
+ * "no object" is destructive — e.g. the board-snapshot manifest merge, where
+ * treating a transient read error as "no previous manifest" would drop every
+ * other board's entries from the published manifest.
  */
-export async function getFromS3(key: string): Promise<{
+export async function getFromS3Strict(key: string): Promise<{
   stream: Readable;
   contentType: string | undefined;
   contentLength: number | undefined;
@@ -165,8 +182,28 @@ export async function getFromS3(key: string): Promise<{
       contentType: response.ContentType,
       contentLength: response.ContentLength,
     };
+  } catch (error) {
+    if (isS3NotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Get a file from S3 and return the stream along with metadata. Lenient
+ * variant of getFromS3Strict: returns null for not-found AND for any read
+ * error — the existing caller contract (static asset serving, user-data
+ * export) treats both as a cache/object miss and falls back.
+ */
+export async function getFromS3(key: string): Promise<{
+  stream: Readable;
+  contentType: string | undefined;
+  contentLength: number | undefined;
+} | null> {
+  try {
+    return await getFromS3Strict(key);
   } catch {
-    // Return null for not found or other errors
     return null;
   }
 }

--- a/packages/db/src/client/postgres.ts
+++ b/packages/db/src/client/postgres.ts
@@ -86,6 +86,15 @@ export function createDb() {
   return cache.db;
 }
 
+/**
+ * Raw postgres.js pool for the primary. GUARANTEE: the drizzle wrapper is always
+ * constructed before the pool is handed out (createDb runs first), so drizzle's
+ * transparent timestamp/date parsers (OIDs 1114/1184/…) are installed on
+ * `client.options.parsers` and raw queries return pg-text timestamps, not JS
+ * Dates. Consumers that stream raw rows and expect resolver-shaped values (e.g.
+ * the board-snapshot export) rely on this — never return a pool from here
+ * without constructing drizzle over it first.
+ */
 export function createPool() {
   if (!cache.client) {
     createDb();
@@ -125,6 +134,13 @@ export function createReadDb() {
   return ensureReadConnection(readReplicaUrl).readDb;
 }
 
+/**
+ * Raw postgres.js pool for reads. Same parser GUARANTEE as createPool: both
+ * branches construct the drizzle wrapper before returning the raw pool (no
+ * replica → createPool → createDb; replica → ensureReadConnection creates
+ * readClient and readDb together), so callers get drizzle's transparent
+ * timestamp parsers without having to call createReadDb() themselves.
+ */
 export function createReadPool() {
   const { readReplicaUrl } = getConnectionConfig();
   if (!readReplicaUrl) {

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -63,6 +63,15 @@ export type { SyncCheckpoint } from './sync/checkpoints';
 export { TABLE_CONFIGS, USER_DATA_TABLES, BOARD_DATA_TABLES } from './sync/table-config';
 export type { TableSyncConfig } from './sync/table-config';
 
+// --- Board-snapshot manifest (Phase 2 export ↔ Phase 3 bootstrap) ----------------
+export { parseSnapshotManifest, SNAPSHOT_MANIFEST_FORMAT_VERSION } from './sync/snapshot-manifest';
+export type {
+  SnapshotManifest,
+  SnapshotManifestEntry,
+  SnapshotTableStats,
+  SnapshotTableName,
+} from './sync/snapshot-manifest';
+
 // --- On-device schema ------------------------------------------------------------
 export { SCHEMA_STATEMENTS } from './db/schema';
 export { runMigrations, MIGRATIONS, LATEST_SCHEMA_VERSION } from './db/migrations';

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-manifest.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-manifest.test.ts
@@ -43,7 +43,28 @@ describe('parseSnapshotManifest', () => {
   });
 
   it('accepts an empty entries array', () => {
-    expect(parseSnapshotManifest({ formatVersion: 1, generatedAt: 'now-ish', entries: [] })).not.toBeNull();
+    expect(
+      parseSnapshotManifest({ formatVersion: 1, generatedAt: '2026-06-01T00:05:00.000Z', entries: [] }),
+    ).not.toBeNull();
+  });
+
+  it('rejects non-ISO timestamps in generatedAt, builtAt, and watermarkUpdatedAt', () => {
+    // A corrupted timestamp would otherwise be stored as the resume watermark
+    // and pulled from later — reject the whole manifest instead.
+    expect(parseSnapshotManifest({ formatVersion: 1, generatedAt: 'now-ish', entries: [] })).toBeNull();
+    expect(parseSnapshotManifest(withEntry({ builtAt: 'yesterday' }))).toBeNull();
+    expect(parseSnapshotManifest(withEntry({ builtAt: '2026-06-01T00:00:00' }))).toBeNull(); // no Z
+    const validTables = validEntry().tables;
+    expect(
+      parseSnapshotManifest(
+        withEntry({
+          tables: {
+            ...validTables,
+            board_climbs: { ...validTables.board_climbs, watermarkUpdatedAt: '01/06/2026' },
+          },
+        }),
+      ),
+    ).toBeNull();
   });
 
   it('rejects non-objects and wrong format versions', () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-manifest.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-manifest.test.ts
@@ -1,0 +1,101 @@
+// Structural validation of the board-snapshot manifest (the Phase 2 export ↔
+// Phase 3 bootstrap contract). Focuses on the corruption modes a client must
+// reject: wrong format version, fractional values where integers are required,
+// numeric sync seqs (the protocol carries them as decimal strings), and
+// missing per-table stats.
+
+import { describe, it, expect } from 'vitest';
+import { parseSnapshotManifest, type SnapshotManifest, type SnapshotManifestEntry } from '../snapshot-manifest';
+
+function validEntry(): SnapshotManifestEntry {
+  return {
+    boardType: 'kilter',
+    layoutId: 8,
+    key: 'board-snapshots/v1/kilter/8/2026-06-01T00-00-00-000Z.db',
+    url: 'https://cdn.example/board-snapshots/v1/kilter/8/2026-06-01T00-00-00-000Z.db',
+    bytes: 123456,
+    contentEncoding: 'gzip',
+    builtAt: '2026-06-01T00:00:00.000Z',
+    schemaVersion: 3,
+    tables: {
+      board_climbs: {
+        watermarkUpdatedAt: '2026-05-30T10:00:00Z',
+        watermarkSyncSeq: '9007199254740993',
+        rowCount: 40000,
+      },
+      board_climb_stats: { watermarkUpdatedAt: '2026-05-30T09:00:00Z', watermarkSyncSeq: '12345', rowCount: 90000 },
+    },
+  };
+}
+
+function validManifest(): SnapshotManifest {
+  return { formatVersion: 1, generatedAt: '2026-06-01T00:05:00.000Z', entries: [validEntry()] };
+}
+
+function withEntry(patch: Partial<SnapshotManifestEntry>): unknown {
+  return { ...validManifest(), entries: [{ ...validEntry(), ...patch }] };
+}
+
+describe('parseSnapshotManifest', () => {
+  it('accepts a valid manifest (round-trips through JSON)', () => {
+    const manifest = JSON.parse(JSON.stringify(validManifest())) as unknown;
+    expect(parseSnapshotManifest(manifest)).toEqual(validManifest());
+  });
+
+  it('accepts an empty entries array', () => {
+    expect(parseSnapshotManifest({ formatVersion: 1, generatedAt: 'now-ish', entries: [] })).not.toBeNull();
+  });
+
+  it('rejects non-objects and wrong format versions', () => {
+    expect(parseSnapshotManifest(null)).toBeNull();
+    expect(parseSnapshotManifest('manifest')).toBeNull();
+    expect(parseSnapshotManifest([])).toBeNull();
+    expect(parseSnapshotManifest({ ...validManifest(), formatVersion: 2 })).toBeNull();
+  });
+
+  it('rejects fractional layoutId / bytes / schemaVersion / rowCount (integer-strict)', () => {
+    expect(parseSnapshotManifest(withEntry({ layoutId: 1.5 }))).toBeNull();
+    expect(parseSnapshotManifest(withEntry({ bytes: 1.5 }))).toBeNull();
+    expect(parseSnapshotManifest(withEntry({ schemaVersion: 1.5 }))).toBeNull();
+    const fractionalRowCount = withEntry({
+      tables: {
+        board_climbs: { watermarkUpdatedAt: 't', watermarkSyncSeq: '1', rowCount: 1.5 },
+        board_climb_stats: { watermarkUpdatedAt: 't', watermarkSyncSeq: '1', rowCount: 1 },
+      },
+    });
+    expect(parseSnapshotManifest(fractionalRowCount)).toBeNull();
+  });
+
+  it('rejects a numeric watermarkSyncSeq — the protocol carries seqs as decimal strings', () => {
+    const numericSeq = withEntry({
+      tables: {
+        board_climbs: {
+          watermarkUpdatedAt: 't',
+          watermarkSyncSeq: 12 as unknown as string,
+          rowCount: 1,
+        },
+        board_climb_stats: { watermarkUpdatedAt: 't', watermarkSyncSeq: '1', rowCount: 1 },
+      },
+    });
+    expect(parseSnapshotManifest(numericSeq)).toBeNull();
+    const nonDecimalSeq = withEntry({
+      tables: {
+        board_climbs: { watermarkUpdatedAt: 't', watermarkSyncSeq: '12abc', rowCount: 1 },
+        board_climb_stats: { watermarkUpdatedAt: 't', watermarkSyncSeq: '1', rowCount: 1 },
+      },
+    });
+    expect(parseSnapshotManifest(nonDecimalSeq)).toBeNull();
+  });
+
+  it('rejects an entry missing one of the two per-table stats', () => {
+    const missingStats = {
+      ...validManifest(),
+      entries: [{ ...validEntry(), tables: { board_climbs: validEntry().tables.board_climbs } }],
+    };
+    expect(parseSnapshotManifest(missingStats)).toBeNull();
+  });
+
+  it('rejects an unknown contentEncoding', () => {
+    expect(parseSnapshotManifest(withEntry({ contentEncoding: 'br' as unknown as 'gzip' }))).toBeNull();
+  });
+});

--- a/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
@@ -77,10 +77,20 @@ function isDecimalString(value: unknown): value is string {
   return typeof value === 'string' && /^\d+$/.test(value);
 }
 
+// generatedAt / builtAt / watermarkUpdatedAt become resume watermarks and cache
+// keys, so a corrupted manifest carrying a non-ISO string must be rejected here
+// rather than stored and pulled-from later. Zulu-suffixed ISO-8601 with optional
+// fractional seconds — the only shape toIso() ever emits.
+const ISO_UTC_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z$/;
+
+function isIsoUtcTimestamp(value: unknown): value is string {
+  return typeof value === 'string' && ISO_UTC_TIMESTAMP.test(value) && Number.isFinite(Date.parse(value));
+}
+
 function isTableStats(value: unknown): value is SnapshotTableStats {
   if (!isRecord(value)) return false;
   return (
-    typeof value.watermarkUpdatedAt === 'string' && isDecimalString(value.watermarkSyncSeq) && isInteger(value.rowCount)
+    isIsoUtcTimestamp(value.watermarkUpdatedAt) && isDecimalString(value.watermarkSyncSeq) && isInteger(value.rowCount)
   );
 }
 
@@ -93,7 +103,7 @@ function isManifestEntry(value: unknown): value is SnapshotManifestEntry {
     typeof value.url !== 'string' ||
     !isInteger(value.bytes) ||
     (value.contentEncoding !== 'gzip' && value.contentEncoding !== 'identity') ||
-    typeof value.builtAt !== 'string' ||
+    !isIsoUtcTimestamp(value.builtAt) ||
     !isInteger(value.schemaVersion)
   ) {
     return false;
@@ -111,7 +121,7 @@ function isManifestEntry(value: unknown): value is SnapshotManifestEntry {
 export function parseSnapshotManifest(value: unknown): SnapshotManifest | null {
   if (!isRecord(value)) return null;
   if (value.formatVersion !== SNAPSHOT_MANIFEST_FORMAT_VERSION) return null;
-  if (typeof value.generatedAt !== 'string') return null;
+  if (!isIsoUtcTimestamp(value.generatedAt)) return null;
   if (!Array.isArray(value.entries)) return null;
   if (!value.entries.every(isManifestEntry)) return null;
   return value as SnapshotManifest;

--- a/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
@@ -18,8 +18,10 @@ export type SnapshotTableStats = {
   // ISO-8601 UTC. The max `updated_at` across the rows actually exported.
   watermarkUpdatedAt: string;
   // The `sync_seq` paired with `watermarkUpdatedAt` (the composite keyset cursor
-  // the sync resolvers page on: `(updated_at, sync_seq)`).
-  watermarkSyncSeq: number;
+  // the sync resolvers page on: `(updated_at, sync_seq)`). Carried as a decimal
+  // string, like every seq in the sync protocol, so a Postgres bigint can never
+  // lose precision in a JS number.
+  watermarkSyncSeq: string;
   rowCount: number;
 };
 
@@ -33,7 +35,8 @@ export type SnapshotManifestEntry = {
   // Stored (gzip-compressed) object size in bytes.
   bytes: number;
   contentEncoding: 'gzip' | 'identity';
-  // ISO-8601 UTC build timestamp; also the artifact key's basename.
+  // ISO-8601 UTC build timestamp (the key's basename is this stamp with
+  // colons/dots replaced by dashes).
   builtAt: string;
   // The offline-sync client schema version the artifact's SQLite DDL was built
   // at (LATEST_SCHEMA_VERSION). A client older than this must migrate the file
@@ -61,11 +64,15 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
+function isDecimalString(value: unknown): value is string {
+  return typeof value === 'string' && /^\d+$/.test(value);
+}
+
 function isTableStats(value: unknown): value is SnapshotTableStats {
   if (!isRecord(value)) return false;
   return (
     typeof value.watermarkUpdatedAt === 'string' &&
-    isFiniteNumber(value.watermarkSyncSeq) &&
+    isDecimalString(value.watermarkSyncSeq) &&
     isFiniteNumber(value.rowCount)
   );
 }

--- a/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
@@ -2,7 +2,7 @@
 // writes it (packages/backend/scripts/export-board-snapshots.ts) and the client
 // bootstrap that reads it (Phase 3, pull-client). One JSON object published at
 // `board-snapshots/v1/manifest.json`; each entry points a downloaded board at a
-// pre-built, gzipped SQLite artifact plus the watermarks a client resumes its
+// pre-built SQLite artifact plus the watermarks a client resumes its
 // incremental pull from.
 //
 // Pure types + a hand-rolled validator (this package intentionally ships zero
@@ -32,9 +32,9 @@ export type SnapshotManifestEntry = {
   key: string;
   // Public URL of the artifact.
   url: string;
-  // Stored (gzip-compressed) object size in bytes.
+  // Stored object size in bytes.
   bytes: number;
-  // The S3 OBJECT's Content-Encoding — how the bytes are stored at rest, NOT
+  // The S3 object's Content-Encoding — how the bytes are stored at rest, NOT
   // necessarily what a client receives: an HTTP stack that honours
   // Content-Encoding (browser/RN fetch) hands back decompressed bytes, while a
   // straight-to-disk downloader (e.g. expo-file-system) typically writes the

--- a/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
@@ -34,6 +34,12 @@ export type SnapshotManifestEntry = {
   url: string;
   // Stored (gzip-compressed) object size in bytes.
   bytes: number;
+  // The S3 OBJECT's Content-Encoding — how the bytes are stored at rest, NOT
+  // necessarily what a client receives: an HTTP stack that honours
+  // Content-Encoding (browser/RN fetch) hands back decompressed bytes, while a
+  // straight-to-disk downloader (e.g. expo-file-system) typically writes the
+  // raw gzip stream. Downloaders must sniff the result (gzip magic 0x1f 0x8b)
+  // rather than trust this field for the local file's shape.
   contentEncoding: 'gzip' | 'identity';
   // ISO-8601 UTC build timestamp (the key's basename is this stamp with
   // colons/dots replaced by dashes).

--- a/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
@@ -1,0 +1,104 @@
+// The board-snapshot manifest contract, shared by the backend export job that
+// writes it (packages/backend/scripts/export-board-snapshots.ts) and the client
+// bootstrap that reads it (Phase 3, pull-client). One JSON object published at
+// `board-snapshots/v1/manifest.json`; each entry points a downloaded board at a
+// pre-built, gzipped SQLite artifact plus the watermarks a client resumes its
+// incremental pull from.
+//
+// Pure types + a hand-rolled validator (this package intentionally ships zero
+// runtime dependencies, so no zod). Bump `formatVersion` on any breaking shape
+// change so an old client rejects a manifest it can't parse rather than acting
+// on partial data.
+
+/** The two reference-data tables a snapshot carries. */
+export type SnapshotTableName = 'board_climbs' | 'board_climb_stats';
+
+/** Per-table watermark + row count, the resume point for an incremental pull. */
+export type SnapshotTableStats = {
+  // ISO-8601 UTC. The max `updated_at` across the rows actually exported.
+  watermarkUpdatedAt: string;
+  // The `sync_seq` paired with `watermarkUpdatedAt` (the composite keyset cursor
+  // the sync resolvers page on: `(updated_at, sync_seq)`).
+  watermarkSyncSeq: number;
+  rowCount: number;
+};
+
+export type SnapshotManifestEntry = {
+  boardType: string;
+  layoutId: number;
+  // S3 object key of the artifact, e.g. `board-snapshots/v1/kilter/8/<iso>.db`.
+  key: string;
+  // Public URL of the artifact.
+  url: string;
+  // Stored (gzip-compressed) object size in bytes.
+  bytes: number;
+  contentEncoding: 'gzip' | 'identity';
+  // ISO-8601 UTC build timestamp; also the artifact key's basename.
+  builtAt: string;
+  // The offline-sync client schema version the artifact's SQLite DDL was built
+  // at (LATEST_SCHEMA_VERSION). A client older than this must migrate the file
+  // up (or refuse it) before serving reads from it.
+  schemaVersion: number;
+  tables: Record<SnapshotTableName, SnapshotTableStats>;
+};
+
+export type SnapshotManifest = {
+  formatVersion: 1;
+  // ISO-8601 UTC — when the run that produced this manifest finished.
+  generatedAt: string;
+  entries: SnapshotManifestEntry[];
+};
+
+export const SNAPSHOT_MANIFEST_FORMAT_VERSION = 1 as const;
+
+const SNAPSHOT_TABLE_NAMES: readonly SnapshotTableName[] = ['board_climbs', 'board_climb_stats'];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isTableStats(value: unknown): value is SnapshotTableStats {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.watermarkUpdatedAt === 'string' &&
+    isFiniteNumber(value.watermarkSyncSeq) &&
+    isFiniteNumber(value.rowCount)
+  );
+}
+
+function isManifestEntry(value: unknown): value is SnapshotManifestEntry {
+  if (!isRecord(value)) return false;
+  if (
+    typeof value.boardType !== 'string' ||
+    !isFiniteNumber(value.layoutId) ||
+    typeof value.key !== 'string' ||
+    typeof value.url !== 'string' ||
+    !isFiniteNumber(value.bytes) ||
+    (value.contentEncoding !== 'gzip' && value.contentEncoding !== 'identity') ||
+    typeof value.builtAt !== 'string' ||
+    !isFiniteNumber(value.schemaVersion)
+  ) {
+    return false;
+  }
+  const tables = value.tables;
+  if (!isRecord(tables)) return false;
+  return SNAPSHOT_TABLE_NAMES.every((tableName) => isTableStats(tables[tableName]));
+}
+
+/**
+ * Structurally validate a parsed-JSON value as a SnapshotManifest. Returns the
+ * narrowed value or null — callers treat null as "no usable manifest" and fall
+ * back to a from-scratch incremental pull rather than throwing.
+ */
+export function parseSnapshotManifest(value: unknown): SnapshotManifest | null {
+  if (!isRecord(value)) return null;
+  if (value.formatVersion !== SNAPSHOT_MANIFEST_FORMAT_VERSION) return null;
+  if (typeof value.generatedAt !== 'string') return null;
+  if (!Array.isArray(value.entries)) return null;
+  if (!value.entries.every(isManifestEntry)) return null;
+  return value as SnapshotManifest;
+}

--- a/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
@@ -2,8 +2,9 @@
 // writes it (packages/backend/scripts/export-board-snapshots.ts) and the client
 // bootstrap that reads it (Phase 3, pull-client). One JSON object published at
 // `board-snapshots/v1/manifest.json`; each entry points a downloaded board at a
-// pre-built SQLite artifact plus the watermarks a client resumes its
-// incremental pull from.
+// pre-built SQLite artifact plus artifact-level table stats. Clients importing a
+// narrower size scope compute their own scoped resume watermarks from the
+// artifact rows they actually import.
 //
 // Pure types + a hand-rolled validator (this package intentionally ships zero
 // runtime dependencies, so no zod). Bump `formatVersion` on any breaking shape
@@ -13,7 +14,7 @@
 /** The two reference-data tables a snapshot carries. */
 export type SnapshotTableName = 'board_climbs' | 'board_climb_stats';
 
-/** Per-table watermark + row count, the resume point for an incremental pull. */
+/** Artifact-level per-table watermark + row count. */
 export type SnapshotTableStats = {
   // ISO-8601 UTC. The max `updated_at` across the rows actually exported.
   watermarkUpdatedAt: string;

--- a/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
@@ -60,8 +60,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function isFiniteNumber(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value);
+// layoutId / bytes / schemaVersion / rowCount are all integral by construction
+// (a DB id, an object size, a migration version, a count) — a fractional value
+// can only mean a corrupted or hand-edited manifest, so reject it outright.
+function isInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value);
 }
 
 function isDecimalString(value: unknown): value is string {
@@ -71,9 +74,7 @@ function isDecimalString(value: unknown): value is string {
 function isTableStats(value: unknown): value is SnapshotTableStats {
   if (!isRecord(value)) return false;
   return (
-    typeof value.watermarkUpdatedAt === 'string' &&
-    isDecimalString(value.watermarkSyncSeq) &&
-    isFiniteNumber(value.rowCount)
+    typeof value.watermarkUpdatedAt === 'string' && isDecimalString(value.watermarkSyncSeq) && isInteger(value.rowCount)
   );
 }
 
@@ -81,13 +82,13 @@ function isManifestEntry(value: unknown): value is SnapshotManifestEntry {
   if (!isRecord(value)) return false;
   if (
     typeof value.boardType !== 'string' ||
-    !isFiniteNumber(value.layoutId) ||
+    !isInteger(value.layoutId) ||
     typeof value.key !== 'string' ||
     typeof value.url !== 'string' ||
-    !isFiniteNumber(value.bytes) ||
+    !isInteger(value.bytes) ||
     (value.contentEncoding !== 'gzip' && value.contentEncoding !== 'identity') ||
     typeof value.builtAt !== 'string' ||
-    !isFiniteNumber(value.schemaVersion)
+    !isInteger(value.schemaVersion)
   ) {
     return false;
   }


### PR DESCRIPTION
## Summary

Phase 2 of the snapshot-bootstrap plan (stacked on #3558). Adds the server half: a nightly job that exports each `(board_type, layout_id)` catalog into a prebuilt SQLite artifact using the client's own DDL, gzips it, and uploads it to the S3-compatible bucket (Tigris) under `board-snapshots/v1/`, writing a small mutable `manifest.json` last so readers only ever see a manifest whose artifacts are fully uploaded.

- `packages/backend/src/scripts/export-board-snapshots.ts` — streams both tables inside one REPEATABLE READ transaction per layout via the read-replica seam, shapes rows with the exact `normalizeRow`/`toIso` the sync resolvers use, applies the same 30s stability window, and records per-table watermarks (max `(updated_at, sync_seq)` of the exported rows, as a bigint-safe decimal string) in `snapshot_meta`. `--dry-run` / `--board` / `--layout` for manual runs.
- Row shaping extracted to `row-normalize.ts` (pure refactor) so script and resolvers cannot drift.
- `@boardsesh/offline-sync` gains the `SnapshotManifest` types + `parseSnapshotManifest` the Phase 3 client bootstrap will consume.
- `uploadToS3` gains a `contentEncoding` passthrough (artifacts upload with `ContentEncoding: gzip`, immutable 1y cache headers; manifest `max-age=300`).
- `.github/workflows/export-board-snapshots.yml` — daily 07:15 UTC + `workflow_dispatch`, `environment: Production`.

**Golden parity test** (`snapshot-export-golden.test.ts`): proves the artifact path and the real resolvers→`pullSync` path produce identical SQLite rows (booleans, int[]/text[] arrays, NULL arrays, fractional timestamps, multi-angle stats, climb-without-stats), and that watermarks/stability-window exclusions match. This is the standing contract keeping the two paths convergent.

New Production secrets needed before the cron does anything useful: `AWS_S3_BUCKET_NAME` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_ENDPOINT_URL` (reuses the existing backend s3.ts names).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Golden parity test 3/3 against the dockerised test Postgres (`vp test run --reporter=agent --project backend`, full backend suite 2126 pass).
- `vp test run --reporter=agent --project offline-sync` — 153 pass.
- `vp run typecheck` + `vp check` on touched files — green.
- Live `--dry-run --board kilter` against a dev DB: 2 layouts discovered and built, gzip ~1.3KB for the seed layout, clean exit with no AWS credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dhXrKcRTfpLV8pkH2RMV6