### PR TITLE
feat(shared): snapshot bootstrap for first-time board downloads

### DIFF
--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -55,6 +55,7 @@ export {
   MAX_BOOTSTRAP_ATTEMPTS,
   SnapshotWipedError,
   SnapshotSchemaStaleError,
+  SnapshotPermanentMissError,
 } from './sync/snapshot-bootstrap';
 export type {
   SnapshotSource,

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -46,6 +46,20 @@ export { isRetryable, isNetworkError, getErrorStatus } from './mutation-queue/er
 // --- Pull sync -----------------------------------------------------------------
 export { pullSync, toSqliteValue, multiRowChunkSize } from './sync/pull-client';
 export type { SyncProgress, SyncOptions, SchemaDriftReporter } from './sync/pull-client';
+export {
+  bootstrapScopeFromSnapshot,
+  getBootstrapAttempts,
+  recordBootstrapAttempt,
+  markBootstrapDone,
+  isBootstrapDone,
+  MAX_BOOTSTRAP_ATTEMPTS,
+  SnapshotWipedError,
+} from './sync/snapshot-bootstrap';
+export type {
+  SnapshotSource,
+  SnapshotBootstrapResult,
+  SnapshotBootstrapErrorReporter,
+} from './sync/snapshot-bootstrap';
 export { startSyncScheduler, triggerSync } from './sync/sync-scheduler';
 export type { SyncProgressSink, SchedulerTriggers, SchedulerOptions, DrainQueue } from './sync/sync-scheduler';
 export {
@@ -58,6 +72,9 @@ export {
   markScopeDownloadComplete,
   isScopeDownloadComplete,
   getDownloadedScopeKeys,
+  rewindDeletionsCheckpoint,
+  compareCheckpoints,
+  DELETIONS_CHECKPOINT_KEY,
 } from './sync/checkpoints';
 export type { SyncCheckpoint } from './sync/checkpoints';
 export { TABLE_CONFIGS, USER_DATA_TABLES, BOARD_DATA_TABLES } from './sync/table-config';

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -54,6 +54,7 @@ export {
   isBootstrapDone,
   MAX_BOOTSTRAP_ATTEMPTS,
   SnapshotWipedError,
+  SnapshotSchemaStaleError,
 } from './sync/snapshot-bootstrap';
 export type {
   SnapshotSource,

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -73,9 +73,8 @@ export {
   markScopeDownloadComplete,
   isScopeDownloadComplete,
   getDownloadedScopeKeys,
-  rewindDeletionsCheckpoint,
-  compareCheckpoints,
-  DELETIONS_CHECKPOINT_KEY,
+  // rewindDeletionsCheckpoint / compareCheckpoints / DELETIONS_CHECKPOINT_KEY
+  // stay package-internal (only the bootstrap engine consumes them).
 } from './sync/checkpoints';
 export type { SyncCheckpoint } from './sync/checkpoints';
 export { TABLE_CONFIGS, USER_DATA_TABLES, BOARD_DATA_TABLES } from './sync/table-config';

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
@@ -16,6 +16,9 @@ vi.mock('../checkpoints', () => ({
     boardType ? `checkpoint:${tableName}:${boardType}` : `checkpoint:${tableName}`,
   ),
   markScopeDownloadComplete: vi.fn().mockResolvedValue(undefined),
+  rewindDeletionsCheckpoint: vi.fn().mockResolvedValue(undefined),
+  compareCheckpoints: vi.fn().mockReturnValue(0),
+  DELETIONS_CHECKPOINT_KEY: 'checkpoint:deletions',
 }));
 
 import { pullSync, toSqliteValue, multiRowChunkSize } from '../pull-client';

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -8,6 +8,9 @@ vi.mock('../checkpoints', () => ({
     boardType ? `checkpoint:${tableName}:${boardType}` : `checkpoint:${tableName}`,
   ),
   markScopeDownloadComplete: vi.fn().mockResolvedValue(undefined),
+  rewindDeletionsCheckpoint: vi.fn().mockResolvedValue(undefined),
+  compareCheckpoints: vi.fn().mockReturnValue(0),
+  DELETIONS_CHECKPOINT_KEY: 'checkpoint:deletions',
 }));
 
 vi.mock('../table-config', async () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -1,0 +1,747 @@
+// Snapshot-bootstrap coverage (offline-sync Phase 3) against the REAL client DDL.
+//
+// Fixture artifacts are built with node:sqlite (the same engine expo-sqlite and
+// the export job use) so ATTACH, quick_check, json_each size filtering, and the
+// column-intersection copy all run for real — no mocking of the SQLite layer.
+// Two surfaces are exercised: `bootstrapScopeFromSnapshot` directly (import
+// filter, verification, drift, wipe rollback) and `pullSync` end-to-end (the
+// eligibility/failure matrix, artifact reuse, delta continuity, deletions rewind).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { QueryInvalidator } from '../../database';
+import { pullSync } from '../pull-client';
+import { bootstrapScopeFromSnapshot, type SnapshotSource } from '../snapshot-bootstrap';
+import { getCheckpoint, setCheckpoint, DELETIONS_CHECKPOINT_KEY } from '../checkpoints';
+import { runMigrations } from '../../db/migrations';
+import { ensureMutationQueueTable } from '../../mutation-queue/schema';
+import { setSigningOut, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
+import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+import { SCHEMA_STATEMENTS } from '../../db/schema';
+import type { OfflineBoardScope } from '../../offline-board-key';
+import type { SnapshotManifest, SnapshotManifestEntry } from '../snapshot-manifest';
+
+const SNAPSHOT_META_DDL = `
+CREATE TABLE IF NOT EXISTS snapshot_meta (
+  table_name TEXT PRIMARY KEY,
+  watermark_updated_at TEXT,
+  watermark_sync_seq TEXT,
+  row_count INTEGER,
+  built_at TEXT,
+  schema_version INTEGER,
+  format_version INTEGER
+);`;
+
+type Cursor = { updatedAt: string; syncSeq: string };
+
+type ClimbInput = {
+  uuid: string;
+  boardType?: string;
+  layoutId?: number;
+  compatibleSizeIds: number[] | null;
+  name?: string;
+  updatedAt?: string;
+  syncSeq?: number;
+};
+
+type StatInput = {
+  climbUuid: string;
+  boardType?: string;
+  angle?: number;
+  displayDifficulty?: number | null;
+  updatedAt?: string;
+  syncSeq?: number;
+};
+
+type ArtifactSpec = {
+  filePath: string;
+  climbs: ClimbInput[];
+  stats: StatInput[];
+  climbsWatermark: Cursor;
+  statsWatermark: Cursor;
+  formatVersion?: number;
+  climbsRowCountOverride?: number;
+  statsRowCountOverride?: number;
+  climbsDdl?: string;
+  statsDdl?: string;
+};
+
+/** Builds a gzip-free SQLite artifact carrying board_climbs + stats + meta. */
+function buildArtifact(spec: ArtifactSpec): void {
+  const db = new DatabaseSync(spec.filePath);
+  try {
+    if (spec.climbsDdl || spec.statsDdl) {
+      // Custom DDL for the schema-drift fixtures.
+      db.exec(spec.climbsDdl ?? '');
+      db.exec(spec.statsDdl ?? '');
+    } else {
+      for (const statement of SCHEMA_STATEMENTS) db.exec(statement);
+    }
+    db.exec(SNAPSHOT_META_DDL);
+
+    for (const climb of spec.climbs) {
+      db.prepare(
+        `INSERT OR REPLACE INTO board_climbs
+          (uuid, board_type, layout_id, name, is_draft, is_listed, compatible_size_ids, updated_at, sync_seq)
+         VALUES (?, ?, ?, ?, 0, 1, ?, ?, ?)`,
+      ).run(
+        climb.uuid,
+        climb.boardType ?? 'kilter',
+        climb.layoutId ?? 1,
+        climb.name ?? `name-${climb.uuid}`,
+        climb.compatibleSizeIds === null ? null : JSON.stringify(climb.compatibleSizeIds),
+        climb.updatedAt ?? '2026-05-01T00:00:00Z',
+        climb.syncSeq ?? 1,
+      );
+    }
+    for (const stat of spec.stats) {
+      db.prepare(
+        `INSERT OR REPLACE INTO board_climb_stats
+          (board_type, climb_uuid, angle, display_difficulty, updated_at, sync_seq)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(
+        stat.boardType ?? 'kilter',
+        stat.climbUuid,
+        stat.angle ?? 40,
+        stat.displayDifficulty ?? 20.0,
+        stat.updatedAt ?? '2026-05-01T00:00:00Z',
+        stat.syncSeq ?? 1,
+      );
+    }
+
+    const meta = db.prepare(
+      `INSERT OR REPLACE INTO snapshot_meta
+        (table_name, watermark_updated_at, watermark_sync_seq, row_count, built_at, schema_version, format_version)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const formatVersion = spec.formatVersion ?? 1;
+    meta.run(
+      'board_climbs',
+      spec.climbsWatermark.updatedAt,
+      spec.climbsWatermark.syncSeq,
+      spec.climbsRowCountOverride ?? spec.climbs.length,
+      '2026-06-01T00:00:00.000Z',
+      1,
+      formatVersion,
+    );
+    meta.run(
+      'board_climb_stats',
+      spec.statsWatermark.updatedAt,
+      spec.statsWatermark.syncSeq,
+      spec.statsRowCountOverride ?? spec.stats.length,
+      '2026-06-01T00:00:00.000Z',
+      1,
+      formatVersion,
+    );
+  } finally {
+    db.close();
+  }
+}
+
+function makeEntry(overrides: Partial<SnapshotManifestEntry> = {}): SnapshotManifestEntry {
+  return {
+    boardType: 'kilter',
+    layoutId: 1,
+    key: 'board-snapshots/v1/kilter/1/2026-06-01.db',
+    url: 'https://example.test/kilter-1.db',
+    bytes: 1024,
+    contentEncoding: 'gzip',
+    builtAt: '2026-06-01T00:00:00.000Z',
+    schemaVersion: 1,
+    tables: {
+      board_climbs: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '10', rowCount: 1 },
+      board_climb_stats: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '10', rowCount: 1 },
+    },
+    ...overrides,
+  };
+}
+
+function makeManifest(entries: SnapshotManifestEntry[]): SnapshotManifest {
+  return { formatVersion: 1, generatedAt: '2026-06-01T00:00:00.000Z', entries };
+}
+
+/** A recording fake of the injected snapshot I/O. */
+function makeSnapshotSource(config: {
+  manifest?: SnapshotManifest | null;
+  manifestThrows?: boolean;
+  fileForEntry?: (entry: SnapshotManifestEntry) => string | null;
+  downloadThrows?: boolean;
+}): SnapshotSource & {
+  fetchManifest: ReturnType<typeof vi.fn>;
+  downloadArtifact: ReturnType<typeof vi.fn>;
+  deleteArtifact: ReturnType<typeof vi.fn>;
+} {
+  const fetchManifest = vi.fn(async () => {
+    if (config.manifestThrows) throw new Error('network down');
+    return config.manifest ?? null;
+  });
+  const downloadArtifact = vi.fn(async (entry: SnapshotManifestEntry) => {
+    if (config.downloadThrows) throw new Error('download failed');
+    const filePath = config.fileForEntry?.(entry) ?? null;
+    return filePath ? { filePath } : null;
+  });
+  const deleteArtifact = vi.fn(async () => {});
+  return { fetchManifest, downloadArtifact, deleteArtifact } as never;
+}
+
+function noopQueryClient(): QueryInvalidator {
+  return { invalidateQueries: vi.fn() } as unknown as QueryInvalidator;
+}
+
+function compareCursor(a: Cursor, b: Cursor): number {
+  const at = Date.parse(a.updatedAt);
+  const bt = Date.parse(b.updatedAt);
+  if (at !== bt) return at < bt ? -1 : 1;
+  const as = BigInt(a.syncSeq);
+  const bs = BigInt(b.syncSeq);
+  return as < bs ? -1 : as > bs ? 1 : 0;
+}
+
+/**
+ * A graphqlFetch that emulates the strict `>` cursor resolvers: for syncClimbs it
+ * returns any `climbServerRows` strictly after the incoming cursor (else an empty
+ * tail page). Every other query is an empty page. Captures the cursor each board
+ * query received so delta continuity can be asserted.
+ */
+function makeGraphqlFetch(options?: { climbServerRows?: Array<{ doc: Record<string, unknown>; cursor: Cursor }> }) {
+  const capturedClimbCursors: Array<Cursor | undefined> = [];
+  const capturedStatsCursors: Array<Cursor | undefined> = [];
+  const emptyCursor: Cursor = { updatedAt: '1970-01-01T00:00:00.000Z', syncSeq: '0' };
+
+  const fetch = vi.fn(async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+    const cursor = variables?.cursor as Cursor | undefined;
+    if (query.includes('syncDeletions')) {
+      return { syncDeletions: { deletions: [], cursor: emptyCursor, hasMore: false } } as T;
+    }
+    if (query.includes('syncClimbStats')) {
+      capturedStatsCursors.push(cursor);
+      return { syncClimbStats: { documents: [], cursor: cursor ?? emptyCursor, hasMore: false } } as T;
+    }
+    if (query.includes('syncClimbs')) {
+      capturedClimbCursors.push(cursor);
+      const rows = (options?.climbServerRows ?? []).filter((row) => !cursor || compareCursor(row.cursor, cursor) > 0);
+      if (rows.length === 0) {
+        return { syncClimbs: { documents: [], cursor: cursor ?? emptyCursor, hasMore: false } } as T;
+      }
+      const last = rows[rows.length - 1];
+      return {
+        syncClimbs: { documents: rows.map((row) => row.doc), cursor: last.cursor, hasMore: false },
+      } as T;
+    }
+    const match = query.match(/\{\s*\n?\s*(sync[A-Za-z]+)\(/);
+    const field = match ? match[1] : 'unknown';
+    return { [field]: { documents: [], cursor: emptyCursor, hasMore: false } } as T;
+  });
+
+  // Keep the generic call signature pullSync expects AND the mock's `.mock`.
+  const typedFetch = fetch as unknown as GraphqlFetchMock;
+  return { fetch: typedFetch, capturedClimbCursors, capturedStatsCursors };
+}
+
+type GraphqlFetchMock = ReturnType<typeof vi.fn> &
+  (<T>(query: string, variables?: Record<string, unknown>) => Promise<T>);
+
+const SCOPE_KILTER_5: OfflineBoardScope = { boardType: 'kilter', layoutId: 1, sizeId: 5 };
+const CLIMBS_WATERMARK: Cursor = { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' };
+const STATS_WATERMARK: Cursor = { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' };
+
+let workDir: string;
+let db: TestSqliteDb;
+
+beforeEach(async () => {
+  workDir = mkdtempSync(join(tmpdir(), 'snapshot-bootstrap-'));
+  db = createTestDatabase();
+  await runMigrations(db);
+  await ensureMutationQueueTable(db);
+  __resetDrainerStateForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetDrainerStateForTests();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+async function countRows(table: string): Promise<number> {
+  const row = await db.getFirstAsync<{ n: number }>(`SELECT COUNT(*) AS n FROM ${table}`);
+  return row?.n ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// bootstrapScopeFromSnapshot — direct
+// ---------------------------------------------------------------------------
+
+describe('bootstrapScopeFromSnapshot', () => {
+  it('imports the size-matched climbs + their stats and stamps both checkpoints at the watermarks', async () => {
+    const filePath = join(workDir, 'artifact.db');
+    buildArtifact({
+      filePath,
+      climbs: [
+        { uuid: 'in-5', compatibleSizeIds: [5, 6] },
+        { uuid: 'in-5-only', compatibleSizeIds: [5] },
+        { uuid: 'out-7', compatibleSizeIds: [7] },
+        { uuid: 'null-size', compatibleSizeIds: null },
+      ],
+      stats: [
+        { climbUuid: 'in-5', angle: 40 },
+        { climbUuid: 'out-7', angle: 40 },
+        { climbUuid: 'null-size', angle: 40 },
+      ],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+
+    const result = await bootstrapScopeFromSnapshot({
+      db,
+      scope: SCOPE_KILTER_5,
+      scopeKey: 'kilter:1:5',
+      filePath,
+    });
+
+    // Only the size-5-compatible climbs land; the NULL-size row is excluded
+    // exactly as Postgres `NULL @> ARRAY[5]` (queries.ts:173-175) excludes it.
+    const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs ORDER BY uuid');
+    expect(climbs.map((row) => row.uuid)).toEqual(['in-5', 'in-5-only']);
+    // Stats follow their climb through the semi-join: out-7 and null-size excluded.
+    const stats = await db.getAllAsync<{ climb_uuid: string }>(
+      'SELECT climb_uuid FROM board_climb_stats ORDER BY climb_uuid',
+    );
+    expect(stats.map((row) => row.climb_uuid)).toEqual(['in-5']);
+
+    expect(result.climbsWatermark).toEqual(CLIMBS_WATERMARK);
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toEqual(CLIMBS_WATERMARK);
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5')).toEqual(STATS_WATERMARK);
+  });
+
+  it('imports ALL climbs for a non-size-scoped board (moonboard), ignoring compatible_size_ids', async () => {
+    const filePath = join(workDir, 'moon.db');
+    buildArtifact({
+      filePath,
+      climbs: [
+        { uuid: 'm1', boardType: 'moonboard', layoutId: 15, compatibleSizeIds: null },
+        { uuid: 'm2', boardType: 'moonboard', layoutId: 15, compatibleSizeIds: [17] },
+      ],
+      stats: [{ climbUuid: 'm1', boardType: 'moonboard', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+
+    await bootstrapScopeFromSnapshot({
+      db,
+      scope: { boardType: 'moonboard', layoutId: 15, sizeId: 1 },
+      scopeKey: 'moonboard:15:1',
+      filePath,
+    });
+
+    const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs ORDER BY uuid');
+    expect(climbs.map((row) => row.uuid)).toEqual(['m1', 'm2']); // NULL-size row included
+    expect(await countRows('board_climb_stats')).toBe(1);
+  });
+
+  it('tolerates schema drift in both directions and reports it to telemetry', async () => {
+    const filePath = join(workDir, 'drift.db');
+    // Seed has an extra column (extra_seed, ignored) and is missing one the live
+    // table has (setter_username → NULL-filled). Stats table is the standard one.
+    buildArtifact({
+      filePath,
+      climbs: [],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+      climbsDdl: `CREATE TABLE board_climbs (
+        uuid TEXT PRIMARY KEY, board_type TEXT, layout_id INTEGER, name TEXT, is_draft INTEGER,
+        is_listed INTEGER, compatible_size_ids TEXT, updated_at TEXT, sync_seq INTEGER, extra_seed TEXT
+      )`,
+      statsDdl: `CREATE TABLE board_climb_stats (
+        board_type TEXT NOT NULL, climb_uuid TEXT NOT NULL, angle INTEGER NOT NULL,
+        display_difficulty REAL, updated_at TEXT, sync_seq INTEGER,
+        PRIMARY KEY (board_type, climb_uuid, angle)
+      )`,
+    });
+    // Insert a drifted climb directly so the copy exercises the intersection.
+    const seed = new DatabaseSync(filePath);
+    seed
+      .prepare(
+        'INSERT INTO board_climbs (uuid, board_type, layout_id, compatible_size_ids, extra_seed) VALUES (?,?,?,?,?)',
+      )
+      .run('d1', 'kilter', 1, JSON.stringify([5]), 'ignored');
+    // Fix the meta row_count now that a climb exists.
+    seed.prepare('UPDATE snapshot_meta SET row_count = 1 WHERE table_name = ?').run('board_climbs');
+    seed.close();
+
+    const onSchemaDrift = vi.fn();
+    await expect(
+      bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath, onSchemaDrift }),
+    ).resolves.toBeDefined();
+
+    const row = await db.getFirstAsync<{ uuid: string; setter_username: string | null }>(
+      'SELECT uuid, setter_username FROM board_climbs WHERE uuid = ?',
+      ['d1'],
+    );
+    expect(row?.uuid).toBe('d1');
+    expect(row?.setter_username).toBeNull(); // main-only column, NULL-filled
+    const driftColumns = onSchemaDrift.mock.calls.map(([drift]) => (drift as { column: string }).column);
+    expect(driftColumns).toContain('extra_seed'); // seed-only → dropped
+    expect(driftColumns).toContain('setter_username'); // main-only → NULL-filled
+  });
+
+  it('throws (no rows, no checkpoints) on a corrupt/garbage artifact', async () => {
+    const filePath = join(workDir, 'garbage.db');
+    writeFileSync(filePath, 'this is definitely not a sqlite database');
+
+    await expect(
+      bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath }),
+    ).rejects.toThrow();
+
+    expect(await countRows('board_climbs')).toBe(0);
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toBeNull();
+  });
+
+  it('throws when snapshot_meta row_count disagrees with the artifact (truncated download)', async () => {
+    const filePath = join(workDir, 'shortcount.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+      climbsRowCountOverride: 999, // claims 999 rows, artifact holds 1
+    });
+
+    await expect(
+      bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath }),
+    ).rejects.toThrow(/row_count/);
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toBeNull();
+  });
+
+  it('throws on a format_version the client does not understand', async () => {
+    const filePath = join(workDir, 'badformat.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+      formatVersion: 999,
+    });
+
+    await expect(
+      bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath }),
+    ).rejects.toThrow(/format_version/);
+  });
+
+  it('rolls back with no checkpoints when a wipe lands mid-import', async () => {
+    const filePath = join(workDir, 'wipe.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+
+    // Flip the real wipe epoch the moment the stats INSERT runs (after the climbs
+    // INSERT already executed inside the transaction), simulating a full sign-out
+    // wipe cycle in flight. The final in-txn epoch check must then roll everything
+    // back — no imported rows, no checkpoints.
+    const realRunAsync = db.runAsync.bind(db);
+    let wiped = false;
+    vi.spyOn(db, 'runAsync').mockImplementation((async (source: string, ...rest: unknown[]) => {
+      if (!wiped && source.includes('INSERT OR REPLACE INTO main.board_climb_stats')) {
+        wiped = true;
+        setSigningOut(true);
+        setSigningOut(false); // epoch stays bumped; isSigningOut back to false
+      }
+      return realRunAsync(source, ...(rest as never[]));
+    }) as typeof db.runAsync);
+
+    await expect(
+      bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath }),
+    ).rejects.toThrow();
+
+    expect(await countRows('board_climbs')).toBe(0);
+    expect(await countRows('board_climb_stats')).toBe(0);
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toBeNull();
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pullSync — bootstrap phase wiring
+// ---------------------------------------------------------------------------
+
+describe('pullSync snapshot bootstrap', () => {
+  it('warms a fresh scope, then the paged pull resumes from the watermark and marks the scope complete', async () => {
+    const filePath = join(workDir, 'happy.db');
+    buildArtifact({
+      filePath,
+      climbs: [
+        { uuid: 'c-in', compatibleSizeIds: [5] },
+        { uuid: 'c-out', compatibleSizeIds: [9] },
+      ],
+      stats: [{ climbUuid: 'c-in', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => filePath,
+    });
+    const { fetch, capturedClimbCursors, capturedStatsCursors } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    // Rows imported, size-filtered.
+    const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs ORDER BY uuid');
+    expect(climbs.map((row) => row.uuid)).toEqual(['c-in']);
+
+    // The delta paged pull continued from the watermark checkpoints.
+    expect(capturedClimbCursors[0]).toEqual(CLIMBS_WATERMARK);
+    expect(capturedStatsCursors[0]).toEqual(STATS_WATERMARK);
+
+    // Both tables reached their (empty) tail → scope marked available offline.
+    const marker = await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['scope-complete:kilter:1:5']);
+    expect(marker).not.toBeNull();
+    // Permanent done marker written.
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-done:kilter:1:5']),
+    ).not.toBeNull();
+    // Artifact cleaned up.
+    expect(source.deleteArtifact).toHaveBeenCalledWith(filePath);
+  });
+
+  it('catches a delta row exactly after the watermark while the at-watermark row stays the artifact copy', async () => {
+    const filePath = join(workDir, 'continuity.db');
+    buildArtifact({
+      filePath,
+      climbs: [
+        {
+          uuid: 'at-wm',
+          compatibleSizeIds: [5],
+          name: 'from-artifact',
+          updatedAt: '2026-05-02T00:00:00Z',
+          syncSeq: 20,
+        },
+      ],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK, // (2026-05-02T00:00:00Z, 20)
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+
+    // Server holds the row AT the watermark (must NOT re-appear via strict >) and a
+    // row just AFTER it (must be caught by the delta).
+    const { fetch } = makeGraphqlFetch({
+      climbServerRows: [
+        {
+          doc: { uuid: 'at-wm', name: 'server-should-not-send' },
+          cursor: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' },
+        },
+        {
+          doc: { uuid: 'after-wm', name: 'delta', compatible_size_ids: JSON.stringify([5]) },
+          cursor: { updatedAt: '2026-05-03T00:00:00Z', syncSeq: '30' },
+        },
+      ],
+    });
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    const atWm = await db.getFirstAsync<{ name: string }>('SELECT name FROM board_climbs WHERE uuid = ?', ['at-wm']);
+    expect(atWm?.name).toBe('from-artifact'); // never overwritten by the delta
+    const afterWm = await db.getFirstAsync<{ name: string }>('SELECT name FROM board_climbs WHERE uuid = ?', [
+      'after-wm',
+    ]);
+    expect(afterWm?.name).toBe('delta'); // the strictly-after row landed
+  });
+
+  it('downloads one artifact for two sizes of the same layout', async () => {
+    const filePath = join(workDir, 'reuse.db');
+    buildArtifact({
+      filePath,
+      climbs: [
+        { uuid: 'c5', compatibleSizeIds: [5] },
+        { uuid: 'c6', compatibleSizeIds: [6] },
+      ],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5', 'kilter:1:6'],
+      snapshotSource: source,
+    });
+
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(1);
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toEqual(CLIMBS_WATERMARK);
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:6')).toEqual(CLIMBS_WATERMARK);
+    // Each size imported its own compatible climb.
+    expect(await db.getFirstAsync('SELECT uuid FROM board_climbs WHERE uuid = ?', ['c5'])).not.toBeNull();
+    expect(await db.getFirstAsync('SELECT uuid FROM board_climbs WHERE uuid = ?', ['c6'])).not.toBeNull();
+  });
+
+  it('skips bootstrap for a scope that already has a board checkpoint (mid-crawl user)', async () => {
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', { updatedAt: '2026-01-01T00:00:00Z', syncSeq: '5' });
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => join(workDir, 'never.db'),
+    });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    // Manifest never fetched, nothing downloaded — the paged pull just runs.
+    expect(source.fetchManifest).not.toHaveBeenCalled();
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    expect(await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-done:kilter:1:5'])).toBeNull();
+  });
+
+  it('falls straight to the paged crawl (no attempt burned) when the manifest has no entry for the layout', async () => {
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry({ layoutId: 99 })]), // different layout
+      fileForEntry: () => join(workDir, 'never.db'),
+    });
+    const { fetch, capturedClimbCursors } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    // Paged pull ran from scratch (no checkpoint → cursor undefined on first page).
+    expect(capturedClimbCursors[0]).toBeUndefined();
+    // No attempt recorded — the layout may be exported later.
+    expect(
+      await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
+    ).toBeNull();
+  });
+
+  it('falls straight to the paged crawl (no attempt burned) when the manifest is absent', async () => {
+    const source = makeSnapshotSource({ manifest: null });
+    const { fetch, capturedClimbCursors } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    expect(capturedClimbCursors[0]).toBeUndefined();
+    expect(
+      await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
+    ).toBeNull();
+  });
+
+  it('counts an attempt AND skips the paged pull when the manifest fetch fails (network)', async () => {
+    const source = makeSnapshotSource({ manifestThrows: true });
+    const onSnapshotBootstrapError = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    // Paged pull SKIPPED this cycle (a first-page checkpoint would disqualify bootstrap).
+    const climbsCalls = fetch.mock.calls.filter((args) => (args[0] as string).includes('syncClimbs'));
+    expect(climbsCalls).toHaveLength(0);
+    expect(
+      await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
+    ).toEqual({
+      value: '1',
+    });
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(expect.objectContaining({ stage: 'manifest', attempt: 1 }));
+  });
+
+  it('records two attempts on repeated corrupt artifacts, then the third run falls back to the paged crawl', async () => {
+    const filePath = join(workDir, 'corrupt.db');
+    writeFileSync(filePath, 'not a database');
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+
+    // Run 1: import fails → attempt 1, paged pull skipped.
+    const run1 = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), run1.fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+    expect(run1.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs'))).toHaveLength(0);
+    expect(
+      await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
+    ).toEqual({ value: '1' });
+
+    // Run 2: import fails again → attempt 2, still skipped.
+    const run2 = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), run2.fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+    expect(run2.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs'))).toHaveLength(0);
+    expect(
+      await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
+    ).toEqual({ value: '2' });
+
+    // Run 3: attempts >= MAX → bootstrap not eligible → paged crawl runs from scratch.
+    const run3 = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), run3.fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+    const run3ClimbsCalls = run3.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs'));
+    expect(run3ClimbsCalls.length).toBeGreaterThan(0);
+    expect(run3.capturedClimbCursors[0]).toBeUndefined();
+    // downloadArtifact was NOT called on run 3 (bootstrap skipped entirely).
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deletions rewind
+// ---------------------------------------------------------------------------
+
+describe('deletions checkpoint rewind on bootstrap', () => {
+  it('rewinds the deletions checkpoint to min(watermarks) when it sits ahead of the snapshot', async () => {
+    // Deletions already advanced well past the snapshot's watermark.
+    await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, { updatedAt: '2026-09-01T00:00:00Z', syncSeq: '5000' });
+
+    const filePath = join(workDir, 'rewind.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      // climbs watermark is OLDER than stats → min() picks climbs.
+      climbsWatermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+      statsWatermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' },
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    // Rewound to the OLDER (climbs) watermark so no board deletion in the imported
+    // window is skipped.
+    expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual({
+      updatedAt: '2026-05-01T00:00:00Z',
+      syncSeq: '10',
+    });
+  });
+
+  it('leaves the deletions checkpoint untouched when it is already behind the watermark (BigInt seq compare)', async () => {
+    // Same timestamp, seq '9' — behind the watermark's seq '10' (a raw string
+    // compare would wrongly rank '9' > '10' and rewind).
+    await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '9' });
+
+    const filePath = join(workDir, 'behind.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+      statsWatermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    // Untouched — the deletions cursor was already behind, so nothing to rewind.
+    expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual({
+      updatedAt: '2026-05-01T00:00:00Z',
+      syncSeq: '9',
+    });
+  });
+});

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -467,6 +467,41 @@ describe('bootstrapScopeFromSnapshot', () => {
     expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toBeNull();
     expect(await getCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5')).toBeNull();
   });
+
+  it('aborts when a full wipe cycle completes during the pre-transaction integrity checks', async () => {
+    const filePath = join(workDir, 'wipe-preflight.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+
+    // Flip the wipe epoch during the quick_check read — BEFORE the import
+    // transaction opens. The epoch captured before the first await must catch a
+    // wipe cycle that starts AND finishes inside the integrity checks; nothing
+    // may be imported into the freshly wiped DB.
+    const realGetAllAsync = db.getAllAsync.bind(db);
+    let wiped = false;
+    vi.spyOn(db, 'getAllAsync').mockImplementation((async (source: string, ...rest: unknown[]) => {
+      if (!wiped && source.includes('quick_check')) {
+        wiped = true;
+        setSigningOut(true);
+        setSigningOut(false); // epoch stays bumped; isSigningOut back to false
+      }
+      return realGetAllAsync(source, ...(rest as never[]));
+    }) as typeof db.getAllAsync);
+
+    await expect(
+      bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath }),
+    ).rejects.toThrow();
+
+    expect(await countRows('board_climbs')).toBe(0);
+    expect(await countRows('board_climb_stats')).toBe(0);
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toBeNull();
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5')).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -14,7 +14,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { QueryInvalidator } from '../../database';
 import { pullSync } from '../pull-client';
-import { bootstrapScopeFromSnapshot, SnapshotSchemaStaleError, type SnapshotSource } from '../snapshot-bootstrap';
+import {
+  bootstrapScopeFromSnapshot,
+  getBootstrapAttempts,
+  SnapshotPermanentMissError,
+  SnapshotSchemaStaleError,
+  type SnapshotSource,
+} from '../snapshot-bootstrap';
 import { getCheckpoint, setCheckpoint, DELETIONS_CHECKPOINT_KEY } from '../checkpoints';
 import { runMigrations, LATEST_SCHEMA_VERSION } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
@@ -95,8 +101,8 @@ function buildArtifact(spec: ArtifactSpec): void {
         climb.layoutId ?? 1,
         climb.name ?? `name-${climb.uuid}`,
         climb.compatibleSizeIds === null ? null : JSON.stringify(climb.compatibleSizeIds),
-        climb.updatedAt ?? '2026-05-01T00:00:00Z',
-        climb.syncSeq ?? 1,
+        climb.updatedAt ?? spec.climbsWatermark.updatedAt,
+        climb.syncSeq ?? Number(spec.climbsWatermark.syncSeq),
       );
     }
     for (const stat of spec.stats) {
@@ -109,8 +115,8 @@ function buildArtifact(spec: ArtifactSpec): void {
         stat.climbUuid,
         stat.angle ?? 40,
         stat.displayDifficulty ?? 20.0,
-        stat.updatedAt ?? '2026-05-01T00:00:00Z',
-        stat.syncSeq ?? 1,
+        stat.updatedAt ?? spec.statsWatermark.updatedAt,
+        stat.syncSeq ?? Number(spec.statsWatermark.syncSeq),
       );
     }
 
@@ -319,6 +325,81 @@ describe('bootstrapScopeFromSnapshot', () => {
     expect(result.climbsWatermark).toEqual(CLIMBS_WATERMARK);
     expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toEqual(CLIMBS_WATERMARK);
     expect(await getCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5')).toEqual(STATS_WATERMARK);
+  });
+
+  it('stamps checkpoints from the exact scoped rows, not the wider layout artifact meta', async () => {
+    const filePath = join(workDir, 'scoped-watermark.db');
+    const scopedClimbWatermark = { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '5' };
+    const scopedStatsWatermark = { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '6' };
+    buildArtifact({
+      filePath,
+      climbs: [
+        { uuid: 'size-5', compatibleSizeIds: [5], updatedAt: scopedClimbWatermark.updatedAt, syncSeq: 5 },
+        { uuid: 'size-7-later', compatibleSizeIds: [7], updatedAt: '2026-05-03T00:00:00Z', syncSeq: 30 },
+      ],
+      stats: [
+        { climbUuid: 'size-5', updatedAt: scopedStatsWatermark.updatedAt, syncSeq: 6 },
+        { climbUuid: 'size-7-later', updatedAt: '2026-05-03T00:00:00Z', syncSeq: 31 },
+      ],
+      climbsWatermark: { updatedAt: '2026-05-03T00:00:00Z', syncSeq: '30' },
+      statsWatermark: { updatedAt: '2026-05-03T00:00:00Z', syncSeq: '31' },
+    });
+
+    const result = await bootstrapScopeFromSnapshot({
+      db,
+      scope: SCOPE_KILTER_5,
+      scopeKey: 'kilter:1:5',
+      filePath,
+    });
+
+    expect(result.climbsWatermark).toEqual(scopedClimbWatermark);
+    expect(result.statsWatermark).toEqual(scopedStatsWatermark);
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toEqual(scopedClimbWatermark);
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5')).toEqual(scopedStatsWatermark);
+  });
+
+  it('removes stale scoped rows absent from the artifact before importing replacements', async () => {
+    await db.runAsync(
+      `INSERT INTO board_climbs
+        (uuid, board_type, layout_id, name, is_draft, is_listed, compatible_size_ids, updated_at, sync_seq)
+       VALUES (?, 'kilter', 1, ?, 0, 1, ?, ?, ?)`,
+      ['deleted-before-snapshot', 'deleted-before-snapshot', JSON.stringify([5]), '2026-04-01T00:00:00Z', 1],
+    );
+    await db.runAsync(
+      `INSERT INTO board_climb_stats
+        (board_type, climb_uuid, angle, display_difficulty, updated_at, sync_seq)
+       VALUES ('kilter', ?, 40, 15, ?, ?)`,
+      ['deleted-before-snapshot', '2026-04-01T00:00:00Z', 1],
+    );
+    await db.runAsync(
+      `INSERT INTO board_climbs
+        (uuid, board_type, layout_id, name, is_draft, is_listed, compatible_size_ids, updated_at, sync_seq)
+       VALUES (?, 'kilter', 1, ?, 0, 1, ?, ?, ?)`,
+      ['newer-local', 'newer-local', JSON.stringify([5]), '2026-06-01T00:00:00Z', 100],
+    );
+
+    const filePath = join(workDir, 'reconcile.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'artifact-row', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'artifact-row', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+
+    await bootstrapScopeFromSnapshot({
+      db,
+      scope: SCOPE_KILTER_5,
+      scopeKey: 'kilter:1:5',
+      filePath,
+    });
+
+    const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs ORDER BY uuid');
+    expect(climbs.map((row) => row.uuid)).toEqual(['artifact-row', 'newer-local']);
+    const stats = await db.getAllAsync<{ climb_uuid: string }>(
+      'SELECT climb_uuid FROM board_climb_stats ORDER BY climb_uuid',
+    );
+    expect(stats.map((row) => row.climb_uuid)).toEqual(['artifact-row']);
   });
 
   it('imports ALL climbs for a non-size-scoped board (moonboard), ignoring compatible_size_ids', async () => {
@@ -827,6 +908,25 @@ describe('pullSync snapshot bootstrap', () => {
     ).toBeNull();
   });
 
+  it('falls straight to the paged crawl when the source marks a download as a permanent miss', async () => {
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => null });
+    source.downloadArtifact.mockImplementation(async () => {
+      throw new SnapshotPermanentMissError('unsupported content encoding');
+    });
+    const onSnapshotBootstrapError = vi.fn();
+    const { fetch, capturedClimbCursors } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    expect(capturedClimbCursors[0]).toBeUndefined();
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(expect.objectContaining({ stage: 'download', attempt: 0 }));
+  });
+
   it('counts an attempt AND skips the paged pull when the manifest fetch fails (network)', async () => {
     const source = makeSnapshotSource({ manifestThrows: true });
     const onSnapshotBootstrapError = vi.fn();
@@ -904,18 +1004,40 @@ describe('deletions checkpoint rewind on bootstrap', () => {
 
     await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
 
-    // Rewound to the OLDER (climbs) watermark so no board deletion in the imported
-    // window is skipped.
+    // Rewound to the OLDER (climbs) timestamp, with deletion-domain seq 0 so
+    // tombstones at exactly that timestamp are replayed too.
     expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual({
       updatedAt: '2026-05-01T00:00:00Z',
-      syncSeq: '10',
+      syncSeq: '0',
     });
   });
 
-  it('leaves the deletions checkpoint untouched when it is already behind the watermark (BigInt seq compare)', async () => {
-    // Same timestamp, seq '9' — behind the watermark's seq '10' (a raw string
-    // compare would wrongly rank '9' > '10' and rewind).
+  it('rewinds same-timestamp deletion cursors to seq 0 because deletion ids are independent of board sync_seq', async () => {
     await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '9' });
+
+    const filePath = join(workDir, 'same-timestamp.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+      statsWatermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    // Board sync_seq 10 is not a deletion id. Rewinding to deletion seq 0 makes
+    // `(deleted_at, id) > (watermark, 0)` replay every tombstone at the timestamp.
+    expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual({
+      updatedAt: '2026-05-01T00:00:00Z',
+      syncSeq: '0',
+    });
+  });
+
+  it('leaves the deletions checkpoint untouched when it is already behind the watermark timestamp', async () => {
+    await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, { updatedAt: '2026-04-30T23:59:59Z', syncSeq: '5000' });
 
     const filePath = join(workDir, 'behind.db');
     buildArtifact({
@@ -930,10 +1052,9 @@ describe('deletions checkpoint rewind on bootstrap', () => {
 
     await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
 
-    // Untouched — the deletions cursor was already behind, so nothing to rewind.
     expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual({
-      updatedAt: '2026-05-01T00:00:00Z',
-      syncSeq: '9',
+      updatedAt: '2026-04-30T23:59:59Z',
+      syncSeq: '5000',
     });
   });
 });

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -152,7 +152,9 @@ function makeEntry(overrides: Partial<SnapshotManifestEntry> = {}): SnapshotMani
     bytes: 1024,
     contentEncoding: 'gzip',
     builtAt: '2026-06-01T00:00:00.000Z',
-    schemaVersion: 1,
+    // Default to the client's current schema so the manifest-level staleness
+    // pre-check in runBootstrapPhase doesn't skip fixture entries.
+    schemaVersion: LATEST_SCHEMA_VERSION,
     tables: {
       board_climbs: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '10', rowCount: 1 },
       board_climb_stats: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '10', rowCount: 1 },
@@ -638,6 +640,41 @@ describe('pullSync snapshot bootstrap', () => {
       await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
     ).toBeNull();
     expect(errors).toEqual([{ stage: 'import', attempt: 0 }]);
+  });
+
+  it('skips the download entirely when the MANIFEST already reports a stale schemaVersion', async () => {
+    // The artifact itself is current — only the manifest entry is stale. The
+    // pre-check must skip before the (multi-MB) download, not after.
+    const filePath = join(workDir, 'stale-manifest.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c-artifact', compatibleSizeIds: [5] }],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry({ schemaVersion: LATEST_SCHEMA_VERSION - 1 })]),
+      fileForEntry: () => filePath,
+    });
+    const { fetch } = makeGraphqlFetch({
+      climbServerRows: [
+        {
+          doc: { uuid: 'c-paged', name: 'paged', compatible_size_ids: JSON.stringify([5]) },
+          cursor: { updatedAt: '2026-05-03T00:00:00Z', syncSeq: '30' },
+        },
+      ],
+    });
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    // Paged crawl ran this cycle and no attempt was burned.
+    const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs ORDER BY uuid');
+    expect(climbs.map((row) => row.uuid)).toEqual(['c-paged']);
+    expect(
+      await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
+    ).toBeNull();
   });
 
   it('rejects a stale-schema artifact directly with SnapshotSchemaStaleError', async () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS snapshot_meta (
   schema_version INTEGER,
   format_version INTEGER
 );`;
+const SNAPSHOT_ALIAS = 'bs_snapshot';
 
 type Cursor = { updatedAt: string; syncSeq: string };
 
@@ -343,6 +344,37 @@ describe('bootstrapScopeFromSnapshot', () => {
     const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs ORDER BY uuid');
     expect(climbs.map((row) => row.uuid)).toEqual(['m1', 'm2']); // NULL-size row included
     expect(await countRows('board_climb_stats')).toBe(1);
+  });
+
+  it('clears a leftover attached snapshot alias before attaching the next artifact', async () => {
+    const staleFilePath = join(workDir, 'stale-attached.db');
+    buildArtifact({
+      filePath: staleFilePath,
+      climbs: [{ uuid: 'stale-row', compatibleSizeIds: [5] }],
+      stats: [],
+      climbsWatermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '1' },
+      statsWatermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '1' },
+    });
+    const freshFilePath = join(workDir, 'fresh-after-leftover-attach.db');
+    buildArtifact({
+      filePath: freshFilePath,
+      climbs: [{ uuid: 'fresh-row', compatibleSizeIds: [5] }],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+
+    await db.execAsync(`ATTACH DATABASE '${staleFilePath.replace(/'/g, "''")}' AS ${SNAPSHOT_ALIAS}`);
+
+    await bootstrapScopeFromSnapshot({
+      db,
+      scope: SCOPE_KILTER_5,
+      scopeKey: 'kilter:1:5',
+      filePath: freshFilePath,
+    });
+
+    const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs ORDER BY uuid');
+    expect(climbs.map((row) => row.uuid)).toEqual(['fresh-row']);
   });
 
   it('tolerates schema drift in both directions and reports it to telemetry', async () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -14,9 +14,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { QueryInvalidator } from '../../database';
 import { pullSync } from '../pull-client';
-import { bootstrapScopeFromSnapshot, type SnapshotSource } from '../snapshot-bootstrap';
+import { bootstrapScopeFromSnapshot, SnapshotSchemaStaleError, type SnapshotSource } from '../snapshot-bootstrap';
 import { getCheckpoint, setCheckpoint, DELETIONS_CHECKPOINT_KEY } from '../checkpoints';
-import { runMigrations } from '../../db/migrations';
+import { runMigrations, LATEST_SCHEMA_VERSION } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
 import { setSigningOut, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
@@ -63,6 +63,7 @@ type ArtifactSpec = {
   climbsWatermark: Cursor;
   statsWatermark: Cursor;
   formatVersion?: number;
+  schemaVersion?: number;
   climbsRowCountOverride?: number;
   statsRowCountOverride?: number;
   climbsDdl?: string;
@@ -118,13 +119,14 @@ function buildArtifact(spec: ArtifactSpec): void {
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
     );
     const formatVersion = spec.formatVersion ?? 1;
+    const schemaVersion = spec.schemaVersion ?? LATEST_SCHEMA_VERSION;
     meta.run(
       'board_climbs',
       spec.climbsWatermark.updatedAt,
       spec.climbsWatermark.syncSeq,
       spec.climbsRowCountOverride ?? spec.climbs.length,
       '2026-06-01T00:00:00.000Z',
-      1,
+      schemaVersion,
       formatVersion,
     );
     meta.run(
@@ -133,7 +135,7 @@ function buildArtifact(spec: ArtifactSpec): void {
       spec.statsWatermark.syncSeq,
       spec.statsRowCountOverride ?? spec.stats.length,
       '2026-06-01T00:00:00.000Z',
-      1,
+      schemaVersion,
       formatVersion,
     );
   } finally {
@@ -593,6 +595,92 @@ describe('pullSync snapshot bootstrap', () => {
       'after-wm',
     ]);
     expect(afterWm?.name).toBe('delta'); // the strictly-after row landed
+  });
+
+  it('rejects a stale-schema artifact and falls straight through to the paged pull without burning an attempt', async () => {
+    const filePath = join(workDir, 'stale-schema.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c-artifact', compatibleSizeIds: [5] }],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+      schemaVersion: LATEST_SCHEMA_VERSION - 1,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+
+    // The server carries a row the paged crawl must deliver THIS cycle.
+    const { fetch, capturedClimbCursors } = makeGraphqlFetch({
+      climbServerRows: [
+        {
+          doc: { uuid: 'c-paged', name: 'paged', compatible_size_ids: JSON.stringify([5]) },
+          cursor: { updatedAt: '2026-05-03T00:00:00Z', syncSeq: '30' },
+        },
+      ],
+    });
+    const errors: Array<{ stage: string; attempt: number }> = [];
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError: (report) => errors.push({ stage: report.stage, attempt: report.attempt }),
+    });
+
+    // Nothing imported from the artifact; the paged crawl ran from scratch and
+    // delivered the server row in the SAME cycle.
+    const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs ORDER BY uuid');
+    expect(climbs.map((row) => row.uuid)).toEqual(['c-paged']);
+    expect(capturedClimbCursors[0]).toBeUndefined(); // from-scratch, not from a watermark
+
+    // No attempt burned: a stale artifact is tonight's-export's problem, not a
+    // transient failure to retry.
+    expect(
+      await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
+    ).toBeNull();
+    expect(errors).toEqual([{ stage: 'import', attempt: 0 }]);
+  });
+
+  it('rejects a stale-schema artifact directly with SnapshotSchemaStaleError', async () => {
+    const filePath = join(workDir, 'stale-direct.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+      schemaVersion: LATEST_SCHEMA_VERSION - 1,
+    });
+    await expect(
+      bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath }),
+    ).rejects.toThrow(SnapshotSchemaStaleError);
+    expect(await db.getFirstAsync('SELECT 1 AS n FROM board_climbs LIMIT 1')).toBeNull();
+  });
+
+  it('invalidates board-table query caches after a bootstrap even when the delta pull is empty', async () => {
+    const filePath = join(workDir, 'invalidate.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c-in', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c-in', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch(); // delta returns zero documents everywhere
+    const invalidated: unknown[] = [];
+    const queryClient = {
+      invalidateQueries: vi.fn((filter: { queryKey: unknown }) => {
+        invalidated.push(filter.queryKey);
+      }),
+    } as unknown as QueryInvalidator;
+
+    await pullSync(db, queryClient, fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    // syncTable's arrivals-only invalidation never fires (0 delta documents), so
+    // the bootstrap itself must have busted the board-table caches.
+    expect(invalidated.length).toBeGreaterThan(0);
+    const flattened = JSON.stringify(invalidated);
+    expect(flattened).toContain('climb');
   });
 
   it('downloads one artifact for two sizes of the same layout', async () => {

--- a/packages/shared/offline-sync/src/sync/checkpoints.ts
+++ b/packages/shared/offline-sync/src/sync/checkpoints.ts
@@ -52,7 +52,7 @@ function toSeqBigInt(rawSeq: string): bigint {
 }
 
 /**
- * Lower the deletions checkpoint to `watermark` when it currently sits AHEAD of
+ * Lower the deletions checkpoint to `watermark.updatedAt` when it currently sits AHEAD of
  * it, leaving it untouched otherwise. A scope warmed from a snapshot re-introduces
  * board rows as of the snapshot's (older) watermark; if the global deletions
  * cursor had already advanced past that point in an earlier cycle, any board-row
@@ -61,12 +61,17 @@ function toSeqBigInt(rawSeq: string): bigint {
  * stale, already-deleted climb would linger. Rewinding makes the next deletions
  * pull re-scan that window against the imported rows. A missing (fresh) deletions
  * checkpoint is already at the epoch, behind any watermark, so it is left alone.
+ *
+ * Deletions page on `(deleted_at, sync_deletions.id)`, not board-table
+ * `sync_seq`, so the rewind target uses sequence `0` to include every tombstone
+ * at the exact snapshot timestamp.
  */
 export async function rewindDeletionsCheckpoint(db: SqlExecutor, watermark: SyncCheckpoint): Promise<void> {
   const current = await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY);
+  const deletionCursorWatermark = { updatedAt: watermark.updatedAt, syncSeq: '0' };
   if (!current) return;
-  if (compareCheckpoints(current, watermark) > 0) {
-    await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, watermark);
+  if (compareCheckpoints(current, deletionCursorWatermark) > 0) {
+    await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, deletionCursorWatermark);
   }
 }
 

--- a/packages/shared/offline-sync/src/sync/checkpoints.ts
+++ b/packages/shared/offline-sync/src/sync/checkpoints.ts
@@ -15,6 +15,51 @@ export function getCheckpointKey(tableName: string, scope?: string): string {
   return scope ? `checkpoint:${tableName}:${scope}` : `checkpoint:${tableName}`;
 }
 
+// The single deletions checkpoint key. Deletions are global (a user's own plus
+// reference-data deletions), so there is exactly one, not one per table/scope.
+// Exported so the snapshot bootstrap can rewind it against a snapshot watermark.
+export const DELETIONS_CHECKPOINT_KEY = 'checkpoint:deletions';
+
+/**
+ * Order two checkpoints on the composite keyset `(updatedAt, syncSeq)`, the same
+ * ordering the sync resolvers page on. `updatedAt` is compared as an instant
+ * (Date.parse) rather than lexically — ISO strings with mixed sub-second
+ * precision (`…00Z` vs `…00.5Z`) misorder under a raw string compare. `syncSeq`
+ * is a decimal string that can exceed Number's safe range, so it is compared via
+ * BigInt (a raw string compare would rank `'9'` above `'10'`). Returns <0 when
+ * `a` precedes `b`, 0 when equal, >0 when `a` follows `b`. An unparseable
+ * `updatedAt` sorts as equal-timestamp so the seq tiebreak still applies.
+ */
+export function compareCheckpoints(a: SyncCheckpoint, b: SyncCheckpoint): number {
+  const aTime = Date.parse(a.updatedAt);
+  const bTime = Date.parse(b.updatedAt);
+  if (Number.isFinite(aTime) && Number.isFinite(bTime) && aTime !== bTime) {
+    return aTime < bTime ? -1 : 1;
+  }
+  const aSeq = BigInt(a.syncSeq);
+  const bSeq = BigInt(b.syncSeq);
+  return aSeq < bSeq ? -1 : aSeq > bSeq ? 1 : 0;
+}
+
+/**
+ * Lower the deletions checkpoint to `watermark` when it currently sits AHEAD of
+ * it, leaving it untouched otherwise. A scope warmed from a snapshot re-introduces
+ * board rows as of the snapshot's (older) watermark; if the global deletions
+ * cursor had already advanced past that point in an earlier cycle, any board-row
+ * deletions in the window `(watermark, deletions-head]` were consumed while those
+ * rows were absent and would never re-apply to the freshly-imported ones — a
+ * stale, already-deleted climb would linger. Rewinding makes the next deletions
+ * pull re-scan that window against the imported rows. A missing (fresh) deletions
+ * checkpoint is already at the epoch, behind any watermark, so it is left alone.
+ */
+export async function rewindDeletionsCheckpoint(db: SqlExecutor, watermark: SyncCheckpoint): Promise<void> {
+  const current = await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY);
+  if (!current) return;
+  if (compareCheckpoints(current, watermark) > 0) {
+    await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, watermark);
+  }
+}
+
 // Per-scope "initial download finished" marker. A checkpoint proves only that
 // the FIRST page landed — a 40k-climb board pulls for minutes, and serving
 // local-first reads from a fraction of the catalog (with stats still empty)

--- a/packages/shared/offline-sync/src/sync/checkpoints.ts
+++ b/packages/shared/offline-sync/src/sync/checkpoints.ts
@@ -28,7 +28,9 @@ export const DELETIONS_CHECKPOINT_KEY = 'checkpoint:deletions';
  * is a decimal string that can exceed Number's safe range, so it is compared via
  * BigInt (a raw string compare would rank `'9'` above `'10'`). Returns <0 when
  * `a` precedes `b`, 0 when equal, >0 when `a` follows `b`. An unparseable
- * `updatedAt` sorts as equal-timestamp so the seq tiebreak still applies.
+ * `updatedAt` sorts as equal-timestamp so the seq tiebreak still applies; an
+ * unparseable `syncSeq` (a corrupt sync_meta row — every server cursor is
+ * Zod-validated) sorts as seq 0 rather than crashing the sync cycle.
  */
 export function compareCheckpoints(a: SyncCheckpoint, b: SyncCheckpoint): number {
   const aTime = Date.parse(a.updatedAt);
@@ -36,9 +38,17 @@ export function compareCheckpoints(a: SyncCheckpoint, b: SyncCheckpoint): number
   if (Number.isFinite(aTime) && Number.isFinite(bTime) && aTime !== bTime) {
     return aTime < bTime ? -1 : 1;
   }
-  const aSeq = BigInt(a.syncSeq);
-  const bSeq = BigInt(b.syncSeq);
+  const aSeq = toSeqBigInt(a.syncSeq);
+  const bSeq = toSeqBigInt(b.syncSeq);
   return aSeq < bSeq ? -1 : aSeq > bSeq ? 1 : 0;
+}
+
+function toSeqBigInt(rawSeq: string): bigint {
+  try {
+    return BigInt(rawSeq);
+  } catch {
+    return 0n;
+  }
 }
 
 /**

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -469,8 +469,8 @@ async function runBootstrapPhase(
 ): Promise<Set<string>> {
   const skipPagedPull = new Set<string>();
   const manifestCache: { value?: ManifestResolution } = {};
-  // `undefined` = not yet attempted; `null` = download failed; else the file.
-  const downloadByLayout = new Map<string, { filePath: string } | null>();
+  // Absent = not yet attempted; `file: null` = download failed (with its cause).
+  const downloadByLayout = new Map<string, { file: { filePath: string } | null; cause: unknown }>();
   const downloadedPaths = new Set<string>();
   const startEpoch = getWipeEpoch();
 
@@ -501,21 +501,29 @@ async function runBootstrapPhase(
       if (!entry) continue; // layout not exported yet — permanent miss, no attempt
 
       const layoutKey = `${scope.boardType}:${scope.layoutId}`;
-      let download = downloadByLayout.get(layoutKey);
-      let downloadCause: unknown = null;
-      if (!downloadByLayout.has(layoutKey)) {
+      // The failure cause is cached alongside the result so a second size of the
+      // same layout (which reuses this entry instead of re-downloading) still
+      // reports the real error, not null.
+      let cachedDownload = downloadByLayout.get(layoutKey);
+      if (!cachedDownload) {
+        cachedDownload = { file: null, cause: null };
         try {
-          download = (await source.downloadArtifact(entry)) ?? null;
+          cachedDownload.file = (await source.downloadArtifact(entry)) ?? null;
         } catch (error) {
-          download = null;
-          downloadCause = error;
+          cachedDownload.cause = error;
         }
-        downloadByLayout.set(layoutKey, download ?? null);
-        if (download) downloadedPaths.add(download.filePath);
+        downloadByLayout.set(layoutKey, cachedDownload);
+        if (cachedDownload.file) downloadedPaths.add(cachedDownload.file.filePath);
       }
+      const download = cachedDownload.file;
       if (!download) {
         const attempt = await recordBootstrapAttempt(db, scope.scopeKey);
-        onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'download', attempt, cause: downloadCause });
+        onSnapshotBootstrapError?.({
+          scopeKey: scope.scopeKey,
+          stage: 'download',
+          attempt,
+          cause: cachedDownload.cause,
+        });
         skipPagedPull.add(scope.scopeKey);
         continue;
       }

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -15,6 +15,7 @@ import {
   markBootstrapDone,
   MAX_BOOTSTRAP_ATTEMPTS,
   SnapshotWipedError,
+  SnapshotSchemaStaleError,
   type SnapshotSource,
   type SnapshotBootstrapErrorReporter,
 } from './snapshot-bootstrap';
@@ -459,6 +460,7 @@ async function resolveManifestOnce(
  */
 async function runBootstrapPhase(
   db: OfflineDatabase,
+  queryClient: QueryInvalidator,
   source: SnapshotSource,
   scopes: BoardScope[],
   onProgress: ((progress: SyncProgress) => void) | undefined,
@@ -531,12 +533,30 @@ async function runBootstrapPhase(
           onSchemaDrift,
         });
         await markBootstrapDone(db, scope.scopeKey);
+        // Bust the board-table query caches now: if the snapshot fully satisfies
+        // the scope, the delta pull returns zero documents and syncTable's
+        // arrivals-only invalidation never fires — an active search/detail query
+        // would keep serving the pre-import (empty) result set.
+        for (const tableName of ['board_climbs', 'board_climb_stats'] as const) {
+          for (const key of TABLE_CONFIGS[tableName].invalidateKeys) {
+            queryClient.invalidateQueries({ queryKey: key });
+          }
+        }
         // Not skipped: the board-data phase delta-pulls from the watermark
         // checkpoints and fires markScopeDownloadComplete through the tail logic.
       } catch (error) {
         // A wipe mid-import rolls the transaction back and bails the phase — no
         // attempt (the pull is being torn down, not failing).
         if (error instanceof SnapshotWipedError || isSigningOut() || getWipeEpoch() !== startEpoch) break;
+        if (error instanceof SnapshotSchemaStaleError) {
+          // The artifact predates this client's schema — importing it would
+          // NULL-fill newer columns and stamp the cursor past them forever.
+          // Permanent miss for this run: no attempt burned, and the scope's
+          // paged pull runs NOW (always correct); tonight's export rebuilds the
+          // artifact at the new schema for future fresh scopes.
+          onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'import', attempt: 0, cause: error });
+          continue;
+        }
         const attempt = await recordBootstrapAttempt(db, scope.scopeKey);
         onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'import', attempt, cause: error });
         skipPagedPull.add(scope.scopeKey);
@@ -577,6 +597,7 @@ export async function pullSync(
     onProgress?.({ phase: 'bootstrap', currentTable: null, documentsProcessed: 0 });
     skipBootstrapPagedPull = await runBootstrapPhase(
       db,
+      queryClient,
       options.snapshotSource,
       boardScopes,
       onProgress,

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -405,7 +405,10 @@ async function processDeletions(
 // exported must not disqualify bootstrap two cycles from now). `error` = a
 // transport failure reaching the manifest → a counted attempt, retried next
 // cycle. `ok` carries the parsed manifest.
-type ManifestResolution = { status: 'ok'; manifest: SnapshotManifest } | { status: 'absent' } | { status: 'error' };
+type ManifestResolution =
+  | { status: 'ok'; manifest: SnapshotManifest }
+  | { status: 'absent' }
+  | { status: 'error'; cause: unknown };
 
 async function resolveManifestOnce(
   source: SnapshotSource,
@@ -415,8 +418,8 @@ async function resolveManifestOnce(
   let raw: unknown;
   try {
     raw = await source.fetchManifest();
-  } catch {
-    cache.value = { status: 'error' };
+  } catch (error) {
+    cache.value = { status: 'error', cause: error };
     return cache.value;
   }
   if (raw == null) {
@@ -485,7 +488,7 @@ async function runBootstrapPhase(
       if (resolution.status === 'absent') continue; // permanent miss, no attempt
       if (resolution.status === 'error') {
         const attempt = await recordBootstrapAttempt(db, scope.scopeKey);
-        onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'manifest', attempt, cause: null });
+        onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'manifest', attempt, cause: resolution.cause });
         skipPagedPull.add(scope.scopeKey);
         continue;
       }
@@ -497,18 +500,20 @@ async function runBootstrapPhase(
 
       const layoutKey = `${scope.boardType}:${scope.layoutId}`;
       let download = downloadByLayout.get(layoutKey);
+      let downloadCause: unknown = null;
       if (!downloadByLayout.has(layoutKey)) {
         try {
           download = (await source.downloadArtifact(entry)) ?? null;
-        } catch {
+        } catch (error) {
           download = null;
+          downloadCause = error;
         }
         downloadByLayout.set(layoutKey, download ?? null);
         if (download) downloadedPaths.add(download.filePath);
       }
       if (!download) {
         const attempt = await recordBootstrapAttempt(db, scope.scopeKey);
-        onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'download', attempt, cause: null });
+        onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'download', attempt, cause: downloadCause });
         skipPagedPull.add(scope.scopeKey);
         continue;
       }

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -1,7 +1,24 @@
 import type { OfflineDatabase, QueryInvalidator, SqlValue } from '../database';
 import type { SyncCursorInput, SyncResult, SyncDeletionsResult } from '../types';
 import { TABLE_CONFIGS, USER_DATA_TABLES, BOARD_DATA_TABLES } from './table-config';
-import { getCheckpoint, setCheckpoint, getCheckpointKey, markScopeDownloadComplete } from './checkpoints';
+import {
+  getCheckpoint,
+  setCheckpoint,
+  getCheckpointKey,
+  markScopeDownloadComplete,
+  DELETIONS_CHECKPOINT_KEY,
+} from './checkpoints';
+import {
+  bootstrapScopeFromSnapshot,
+  getBootstrapAttempts,
+  recordBootstrapAttempt,
+  markBootstrapDone,
+  MAX_BOOTSTRAP_ATTEMPTS,
+  SnapshotWipedError,
+  type SnapshotSource,
+  type SnapshotBootstrapErrorReporter,
+} from './snapshot-bootstrap';
+import { parseSnapshotManifest, type SnapshotManifest } from './snapshot-manifest';
 import { isSigningOut, getWipeEpoch } from '../mutation-queue/drainer';
 import { parseOfflineBoardKey, type OfflineBoardScope } from '../offline-board-key';
 
@@ -13,7 +30,7 @@ import { parseOfflineBoardKey, type OfflineBoardScope } from '../offline-board-k
 export type SchemaDriftReporter = (drift: { tableName: string; column: string }) => void;
 
 export type SyncProgress = {
-  phase: 'user_data' | 'board_data' | 'deletions' | 'idle';
+  phase: 'bootstrap' | 'user_data' | 'board_data' | 'deletions' | 'idle';
   currentTable: string | null;
   documentsProcessed: number;
   /**
@@ -34,6 +51,14 @@ export type SyncOptions = {
   enabledBoards?: string[];
   onProgress?: (progress: SyncProgress) => void;
   onSchemaDrift?: SchemaDriftReporter;
+  /**
+   * Injected snapshot I/O. When present, an eligible fresh board scope is warmed
+   * from a pre-built artifact before the paged crawl (see the bootstrap phase in
+   * pullSync). Omitted → behaviour is identical to a pure paged pull.
+   */
+  snapshotSource?: SnapshotSource;
+  /** Telemetry for a counted bootstrap failure (manifest/download/import). */
+  onSnapshotBootstrapError?: SnapshotBootstrapErrorReporter;
 };
 
 /** A per-board download target: the parsed scope plus its encoded key. */
@@ -277,7 +302,7 @@ async function processDeletions(
   graphqlFetch: <T>(query: string, variables?: Record<string, unknown>) => Promise<T>,
   onProgress?: (documentsProcessed: number) => void,
 ): Promise<void> {
-  const checkpointKey = 'checkpoint:deletions';
+  const checkpointKey = DELETIONS_CHECKPOINT_KEY;
   const checkpoint = await getCheckpoint(db, checkpointKey);
 
   let cursor: SyncCursorInput | undefined = checkpoint
@@ -374,6 +399,153 @@ async function processDeletions(
   }
 }
 
+// The manifest is fetched at most once per pullSync run and its outcome cached
+// across scopes. `absent` = no usable manifest THIS cycle (missing 404 or
+// unparseable) → a permanent miss that burns NO attempt (a layout not yet
+// exported must not disqualify bootstrap two cycles from now). `error` = a
+// transport failure reaching the manifest → a counted attempt, retried next
+// cycle. `ok` carries the parsed manifest.
+type ManifestResolution = { status: 'ok'; manifest: SnapshotManifest } | { status: 'absent' } | { status: 'error' };
+
+async function resolveManifestOnce(
+  source: SnapshotSource,
+  cache: { value?: ManifestResolution },
+): Promise<ManifestResolution> {
+  if (cache.value) return cache.value;
+  let raw: unknown;
+  try {
+    raw = await source.fetchManifest();
+  } catch {
+    cache.value = { status: 'error' };
+    return cache.value;
+  }
+  if (raw == null) {
+    cache.value = { status: 'absent' };
+    return cache.value;
+  }
+  const manifest = parseSnapshotManifest(raw);
+  cache.value = manifest ? { status: 'ok', manifest } : { status: 'absent' };
+  return cache.value;
+}
+
+/**
+ * Snapshot-bootstrap phase (runs BEFORE deletions). For each enabled scope that
+ * is FRESH (no checkpoint on either board table) and still under the attempt cap,
+ * warm it from a pre-built artifact instead of paging the whole catalog. Returns
+ * the set of scope keys whose paged board-table pull must be SKIPPED this cycle —
+ * a scope whose bootstrap failed (and still has attempts left): letting its paged
+ * pull run would write a first-page checkpoint and permanently disqualify the
+ * snapshot path, so it is skipped so the NEXT cycle retries the snapshot.
+ *
+ * Eligibility + failure matrix (per scope):
+ *   - checkpoint exists on either board table → NOT eligible → normal paged pull.
+ *   - attempts ≥ MAX → gave up → normal paged pull.
+ *   - manifest `absent` (missing/unparseable) → permanent miss, NO attempt →
+ *     normal paged pull.
+ *   - manifest `error` (network) → counted attempt → SKIP paged pull this cycle.
+ *   - manifest `ok` but no entry for (boardType, layoutId) → permanent miss, NO
+ *     attempt → normal paged pull (layout not exported yet).
+ *   - download fails/returns null → counted attempt → SKIP paged pull this cycle.
+ *   - import throws (corrupt/short artifact, row-count/format mismatch) → counted
+ *     attempt → SKIP paged pull this cycle.
+ *   - success → mark done, rewind deletions to min(watermarks); paged pull runs
+ *     normally, now a ~1-day delta from the watermark checkpoints.
+ * A wipe detected mid-phase bails the whole phase with no attempt (mirrors
+ * syncTable). One artifact is downloaded per (boardType, layoutId) and reused
+ * across that layout's sizes; all downloads are deleted in a finally.
+ */
+async function runBootstrapPhase(
+  db: OfflineDatabase,
+  source: SnapshotSource,
+  scopes: BoardScope[],
+  onProgress: ((progress: SyncProgress) => void) | undefined,
+  onSchemaDrift: SchemaDriftReporter | undefined,
+  onSnapshotBootstrapError: SnapshotBootstrapErrorReporter | undefined,
+): Promise<Set<string>> {
+  const skipPagedPull = new Set<string>();
+  const manifestCache: { value?: ManifestResolution } = {};
+  // `undefined` = not yet attempted; `null` = download failed; else the file.
+  const downloadByLayout = new Map<string, { filePath: string } | null>();
+  const downloadedPaths = new Set<string>();
+  const startEpoch = getWipeEpoch();
+
+  try {
+    for (const scope of scopes) {
+      if (isSigningOut() || getWipeEpoch() !== startEpoch) break;
+
+      // Eligibility: FRESH on BOTH board tables and under the attempt cap.
+      const climbsCheckpoint = await getCheckpoint(db, getCheckpointKey('board_climbs', scope.scopeKey));
+      const statsCheckpoint = await getCheckpoint(db, getCheckpointKey('board_climb_stats', scope.scopeKey));
+      if (climbsCheckpoint || statsCheckpoint) continue;
+      if ((await getBootstrapAttempts(db, scope.scopeKey)) >= MAX_BOOTSTRAP_ATTEMPTS) continue;
+
+      onProgress?.({ phase: 'bootstrap', currentTable: scope.scopeKey, documentsProcessed: 0 });
+
+      const resolution = await resolveManifestOnce(source, manifestCache);
+      if (resolution.status === 'absent') continue; // permanent miss, no attempt
+      if (resolution.status === 'error') {
+        const attempt = await recordBootstrapAttempt(db, scope.scopeKey);
+        onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'manifest', attempt, cause: null });
+        skipPagedPull.add(scope.scopeKey);
+        continue;
+      }
+
+      const entry = resolution.manifest.entries.find(
+        (candidate) => candidate.boardType === scope.boardType && candidate.layoutId === scope.layoutId,
+      );
+      if (!entry) continue; // layout not exported yet — permanent miss, no attempt
+
+      const layoutKey = `${scope.boardType}:${scope.layoutId}`;
+      let download = downloadByLayout.get(layoutKey);
+      if (!downloadByLayout.has(layoutKey)) {
+        try {
+          download = (await source.downloadArtifact(entry)) ?? null;
+        } catch {
+          download = null;
+        }
+        downloadByLayout.set(layoutKey, download ?? null);
+        if (download) downloadedPaths.add(download.filePath);
+      }
+      if (!download) {
+        const attempt = await recordBootstrapAttempt(db, scope.scopeKey);
+        onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'download', attempt, cause: null });
+        skipPagedPull.add(scope.scopeKey);
+        continue;
+      }
+
+      try {
+        // Imports the scope's rows, stamps both table checkpoints, and rewinds
+        // the global deletions cursor to the older table watermark — all in one
+        // transaction, so no crash point can separate the imported rows from
+        // the tombstone-replay window that must cover them.
+        await bootstrapScopeFromSnapshot({
+          db,
+          scope,
+          scopeKey: scope.scopeKey,
+          filePath: download.filePath,
+          onSchemaDrift,
+        });
+        await markBootstrapDone(db, scope.scopeKey);
+        // Not skipped: the board-data phase delta-pulls from the watermark
+        // checkpoints and fires markScopeDownloadComplete through the tail logic.
+      } catch (error) {
+        // A wipe mid-import rolls the transaction back and bails the phase — no
+        // attempt (the pull is being torn down, not failing).
+        if (error instanceof SnapshotWipedError || isSigningOut() || getWipeEpoch() !== startEpoch) break;
+        const attempt = await recordBootstrapAttempt(db, scope.scopeKey);
+        onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'import', attempt, cause: error });
+        skipPagedPull.add(scope.scopeKey);
+      }
+    }
+  } finally {
+    for (const filePath of downloadedPaths) {
+      await source.deleteArtifact(filePath).catch(() => {});
+    }
+  }
+
+  return skipPagedPull;
+}
+
 export async function pullSync(
   db: OfflineDatabase,
   queryClient: QueryInvalidator,
@@ -383,6 +555,30 @@ export async function pullSync(
   const enabledBoards = options?.enabledBoards ?? [];
   const onProgress = options?.onProgress;
   let totalDocuments = 0;
+
+  // Parse the enabled scope keys once; malformed keys are dropped (a stray value
+  // can't crash the pull) so both the bootstrap phase and the paged board loop
+  // iterate the same validated set.
+  const boardScopes: BoardScope[] = [];
+  for (const scopeKey of enabledBoards) {
+    const scope = parseOfflineBoardKey(scopeKey);
+    if (scope) boardScopes.push({ ...scope, scopeKey });
+  }
+
+  // Phase 0: snapshot bootstrap (BEFORE deletions). Only when an adapter injected
+  // snapshot I/O; otherwise this is a pure paged pull, byte-identical to before.
+  let skipBootstrapPagedPull: Set<string> = new Set();
+  if (options?.snapshotSource && boardScopes.length > 0) {
+    onProgress?.({ phase: 'bootstrap', currentTable: null, documentsProcessed: 0 });
+    skipBootstrapPagedPull = await runBootstrapPhase(
+      db,
+      options.snapshotSource,
+      boardScopes,
+      onProgress,
+      options.onSchemaDrift,
+      options.onSnapshotBootstrapError,
+    );
+  }
 
   // Deletions FIRST, table pulls second. This ordering is what makes a
   // delete-then-recreate on the server converge: the tombstone removes the old
@@ -413,13 +609,15 @@ export async function pullSync(
     );
   }
 
-  // Each enabled board is a "boardType:layoutId:sizeId" scope key. Malformed keys
-  // are skipped (parseOfflineBoardKey returns null) so a stray value can't crash the
-  // pull. currentTable carries the full scope key so a per-board UI can match itself.
-  for (const scopeKey of enabledBoards) {
-    const scope = parseOfflineBoardKey(scopeKey);
-    if (!scope) continue;
-    const boardScope: BoardScope = { ...scope, scopeKey };
+  // Each enabled board is a "boardType:layoutId:sizeId" scope key (already parsed
+  // into boardScopes). currentTable carries the full scope key so a per-board UI
+  // can match itself.
+  for (const boardScope of boardScopes) {
+    const scopeKey = boardScope.scopeKey;
+    // A scope whose bootstrap failed this cycle (with attempts still left) skips
+    // its paged pull: a first-page checkpoint would permanently disqualify the
+    // snapshot path, so the next cycle retries the snapshot instead.
+    if (skipBootstrapPagedPull.has(scopeKey)) continue;
     let allTablesReachedTail = true;
     for (const tableName of BOARD_DATA_TABLES) {
       const tableLabel = `${tableName}:${scopeKey}`;

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -452,10 +452,11 @@ async function resolveManifestOnce(
  *   - manifest `ok` but no entry for (boardType, layoutId) → permanent miss, NO
  *     attempt → normal paged pull (layout not exported yet).
  *   - download fails/returns null → counted attempt → SKIP paged pull this cycle.
+ *   - download throws SnapshotPermanentMissError → NO attempt → normal paged pull.
  *   - import throws (corrupt/short artifact, row-count/format mismatch) → counted
  *     attempt → SKIP paged pull this cycle.
  *   - success → mark done, rewind deletions to min(watermarks); paged pull runs
- *     normally, now a ~1-day delta from the watermark checkpoints.
+ *     normally, now a ~1-day delta from the scoped watermark checkpoints.
  * A wipe detected mid-phase bails the whole phase with no attempt (mirrors
  * syncTable). One artifact is downloaded per (boardType, layoutId) and reused
  * across that layout's sizes; all downloads are deleted in a finally.
@@ -472,7 +473,10 @@ async function runBootstrapPhase(
   const skipPagedPull = new Set<string>();
   const manifestCache: { value?: ManifestResolution } = {};
   // Absent = not yet attempted; `file: null` = download failed (with its cause).
-  const downloadByLayout = new Map<string, { file: { filePath: string } | null; cause: unknown; permanentMiss: boolean }>();
+  const downloadByLayout = new Map<
+    string,
+    { file: { filePath: string } | null; cause: unknown; permanentMiss: boolean }
+  >();
   const downloadedPaths = new Set<string>();
   const startEpoch = getWipeEpoch();
 

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -20,6 +20,7 @@ import {
   type SnapshotBootstrapErrorReporter,
 } from './snapshot-bootstrap';
 import { parseSnapshotManifest, type SnapshotManifest } from './snapshot-manifest';
+import { LATEST_SCHEMA_VERSION } from '../db/migrations';
 import { isSigningOut, getWipeEpoch } from '../mutation-queue/drainer';
 import { parseOfflineBoardKey, type OfflineBoardScope } from '../offline-board-key';
 
@@ -499,6 +500,12 @@ async function runBootstrapPhase(
         (candidate) => candidate.boardType === scope.boardType && candidate.layoutId === scope.layoutId,
       );
       if (!entry) continue; // layout not exported yet — permanent miss, no attempt
+      // Pre-check the manifest's schemaVersion so a schema-stale artifact is
+      // skipped BEFORE the multi-MB download; verifySnapshotMeta re-checks the
+      // authoritative value inside the file. Same permanent-miss semantics as
+      // SnapshotSchemaStaleError: no attempt, paged crawl runs this cycle, and
+      // tonight's export rebuilds at the new schema.
+      if (entry.schemaVersion < LATEST_SCHEMA_VERSION) continue;
 
       const layoutKey = `${scope.boardType}:${scope.layoutId}`;
       // The failure cause is cached alongside the result so a second size of the

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -16,6 +16,7 @@ import {
   MAX_BOOTSTRAP_ATTEMPTS,
   SnapshotWipedError,
   SnapshotSchemaStaleError,
+  SnapshotPermanentMissError,
   type SnapshotSource,
   type SnapshotBootstrapErrorReporter,
 } from './snapshot-bootstrap';
@@ -471,7 +472,7 @@ async function runBootstrapPhase(
   const skipPagedPull = new Set<string>();
   const manifestCache: { value?: ManifestResolution } = {};
   // Absent = not yet attempted; `file: null` = download failed (with its cause).
-  const downloadByLayout = new Map<string, { file: { filePath: string } | null; cause: unknown }>();
+  const downloadByLayout = new Map<string, { file: { filePath: string } | null; cause: unknown; permanentMiss: boolean }>();
   const downloadedPaths = new Set<string>();
   const startEpoch = getWipeEpoch();
 
@@ -513,17 +514,27 @@ async function runBootstrapPhase(
       // reports the real error, not null.
       let cachedDownload = downloadByLayout.get(layoutKey);
       if (!cachedDownload) {
-        cachedDownload = { file: null, cause: null };
+        cachedDownload = { file: null, cause: null, permanentMiss: false };
         try {
           cachedDownload.file = (await source.downloadArtifact(entry)) ?? null;
         } catch (error) {
           cachedDownload.cause = error;
+          cachedDownload.permanentMiss = error instanceof SnapshotPermanentMissError;
         }
         downloadByLayout.set(layoutKey, cachedDownload);
         if (cachedDownload.file) downloadedPaths.add(cachedDownload.file.filePath);
       }
       const download = cachedDownload.file;
       if (!download) {
+        if (cachedDownload.permanentMiss) {
+          onSnapshotBootstrapError?.({
+            scopeKey: scope.scopeKey,
+            stage: 'download',
+            attempt: 0,
+            cause: cachedDownload.cause,
+          });
+          continue;
+        }
         const attempt = await recordBootstrapAttempt(db, scope.scopeKey);
         onSnapshotBootstrapError?.({
           scopeKey: scope.scopeKey,

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -4,8 +4,8 @@
 // (200k+ climbs) over GraphQL before it is browsable offline. Instead, this
 // warms the scope from a pre-built SQLite artifact (the nightly export job in
 // packages/backend/src/scripts/export-board-snapshots.ts), then lets the normal
-// paged pull resume from the artifact's watermark — a ~1-day delta rather than
-// the full crawl. The two paths are byte-identical by construction (the export
+// paged pull resume from the imported scope's watermarks — a ~1-day delta rather
+// than the full crawl. The two paths are byte-identical by construction (the export
 // reuses the client's `toSqliteValue` shaping); the backend snapshot-export-golden
 // test pins that equivalence.
 //
@@ -79,8 +79,9 @@ export interface SnapshotSource {
   fetchManifest(): Promise<unknown>;
   /**
    * Download (and decompress) one artifact to a local path ready to ATTACH as a
-   * plain SQLite file. Return `null` or throw on failure — both count as a
-   * bootstrap attempt.
+   * plain SQLite file. Return `null` or throw on retryable failure — both count
+   * as a bootstrap attempt. Throw SnapshotPermanentMissError for a known
+   * unusable artifact that should fall through to the paged pull immediately.
    */
   downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePath: string } | null>;
   /** Delete a downloaded artifact once the run is done with it. Best-effort. */
@@ -225,8 +226,7 @@ function climbsScopeFilter(scope: OfflineBoardScope, qualifier = ''): { sql: str
   const params: (string | number)[] = [scope.boardType, scope.layoutId];
   let sql = `${qualifier}board_type = ? AND ${qualifier}layout_id = ?`;
   if (isSizeScopedBoard(scope.boardType)) {
-    sql +=
-      ` AND ${qualifier}compatible_size_ids IS NOT NULL AND EXISTS (SELECT 1 FROM json_each(${qualifier}compatible_size_ids) WHERE value = ?)`;
+    sql += ` AND ${qualifier}compatible_size_ids IS NOT NULL AND EXISTS (SELECT 1 FROM json_each(${qualifier}compatible_size_ids) WHERE value = ?)`;
     params.push(scope.sizeId);
   }
   return { sql, params };
@@ -345,11 +345,7 @@ async function reconcileScope(
          WHERE snapshot_climb.uuid = main_climb.uuid
            AND ${snapshotClimbScope.sql}
        )`,
-    [
-      ...mainClimbScope.params,
-      ...checkpointLeqParams(watermarks.board_climbs),
-      ...snapshotClimbScope.params,
-    ],
+    [...mainClimbScope.params, ...checkpointLeqParams(watermarks.board_climbs), ...snapshotClimbScope.params],
   );
 }
 
@@ -434,7 +430,8 @@ export class SnapshotSchemaStaleError extends Error {
  * `format_version` matching this client, `schema_version` not older than this
  * client's schema, and each recorded `row_count` equal to the artifact's ACTUAL
  * table count (a truncated/partial download is caught here before any row is
- * imported). Returns the per-table watermarks.
+ * imported). Artifact-level watermarks are validation/export metadata; the
+ * imported scope's checkpoints are computed from scoped artifact rows.
  */
 async function verifySnapshotMeta(db: SqlExecutor): Promise<void> {
   for (const tableName of SNAPSHOT_TABLES) {
@@ -469,7 +466,8 @@ async function verifySnapshotMeta(db: SqlExecutor): Promise<void> {
 /**
  * Warm one board scope from a downloaded artifact. ATTACHes the file, integrity-
  * checks it, verifies the meta, then in ONE exclusive transaction imports the
- * scoped climbs + stats and stamps both resume checkpoints at their watermarks.
+ * scoped climbs + stats, reconciles stale scoped rows absent from the artifact,
+ * and stamps both resume checkpoints at the scoped imported-row watermarks.
  * ATTACH/DETACH bracket the transaction (SQLite forbids ATTACH inside one).
  * A wipe that starts (or completes) mid-import rolls the transaction back and
  * throws SnapshotWipedError — no rows, no checkpoints.

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -1,0 +1,381 @@
+// Client-side snapshot bootstrap (offline-sync Phase 3).
+//
+// A freshly-enabled board would otherwise page its whole reference catalog
+// (200k+ climbs) over GraphQL before it is browsable offline. Instead, this
+// warms the scope from a pre-built SQLite artifact (the nightly export job in
+// packages/backend/src/scripts/export-board-snapshots.ts), then lets the normal
+// paged pull resume from the artifact's watermark — a ~1-day delta rather than
+// the full crawl. The two paths are byte-identical by construction (the export
+// reuses the client's `toSqliteValue` shaping); the backend snapshot-export-golden
+// test pins that equivalence.
+//
+// Platform I/O is injected via `SnapshotSource`: the shared engine never fetches,
+// downloads, or gunzips — it ATTACHes a decompressed artifact file the adapter
+// hands it, imports the scope's rows, and stamps the resume checkpoints. The
+// import filter is EXACTLY as wide as the sync resolvers' scope filter
+// (packages/backend/.../sync/queries.ts): a row the resolver's scope would return
+// with a cursor ≤ watermark but this import dropped would be lost forever (the
+// strict `>` delta never revisits it), so when in doubt this imports MORE — extra
+// rows are harmless because reads are scoped.
+
+import type { OfflineDatabase, SqlExecutor } from '../database';
+import type { OfflineBoardScope } from '../offline-board-key';
+import type { SnapshotManifestEntry } from './snapshot-manifest';
+import { SNAPSHOT_MANIFEST_FORMAT_VERSION } from './snapshot-manifest';
+import {
+  compareCheckpoints,
+  getCheckpointKey,
+  rewindDeletionsCheckpoint,
+  setCheckpoint,
+  type SyncCheckpoint,
+} from './checkpoints';
+import { getWipeEpoch, isSigningOut } from '../mutation-queue/drainer';
+import type { SchemaDriftReporter } from './pull-client';
+
+/** The two reference tables a snapshot carries; import order is climbs → stats. */
+const SNAPSHOT_TABLES = ['board_climbs', 'board_climb_stats'] as const;
+
+/** The ATTACH alias for the artifact. Distinct from connection.ts's `seed`. */
+const SNAPSHOT_ALIAS = 'bs_snapshot';
+
+/** Two bootstrap attempts, then a scope falls through to the normal paged crawl. */
+export const MAX_BOOTSTRAP_ATTEMPTS = 2;
+
+const BOOTSTRAP_ATTEMPTS_PREFIX = 'bootstrap-attempts:';
+const BOOTSTRAP_DONE_PREFIX = 'bootstrap-done:';
+
+// Only snake_case identifiers may be spliced into the INSERT/SELECT column list.
+// The names come from PRAGMA table_info over our own DDL (trusted), but validating
+// keeps the string-built SQL provably injection-free — same guard the export uses.
+const SAFE_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+
+/**
+ * Mirror of `@boardsesh/board-config`'s `isSizeScopedBoard`, inlined so this
+ * zero-runtime-dependency package stays free of the board-config → board-constants
+ * → shared-schema chain. MoonBoard has one fixed size, so its climbs are never
+ * size-filtered; every other board scopes by `compatible_size_ids`. This one fact
+ * must track the resolver's `isSizeScopedBoard` guard
+ * (queries.ts:boardClimbsLayoutSizeConditions) exactly.
+ */
+function isSizeScopedBoard(boardType: string): boolean {
+  return boardType !== 'moonboard';
+}
+
+/**
+ * Platform-injected snapshot I/O. The adapter (mobile: Phase 4) owns the network
+ * and gzip; the engine only consumes what these return.
+ */
+export interface SnapshotSource {
+  /**
+   * Fetch the raw manifest JSON (the engine validates it via parseSnapshotManifest).
+   * Return `null` when the manifest resource does not exist yet (e.g. a 404 before
+   * the first export run) — a permanent miss this cycle, not a failure. THROW on a
+   * transport/network error, which the engine counts as a bootstrap attempt so it
+   * retries next cycle. (`unknown` already admits `null`; the return is `unknown`
+   * rather than `unknown | null` only because the linter forbids that redundancy.)
+   */
+  fetchManifest(): Promise<unknown>;
+  /**
+   * Download (and decompress) one artifact to a local path ready to ATTACH as a
+   * plain SQLite file. Return `null` or throw on failure — both count as a
+   * bootstrap attempt.
+   */
+  downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePath: string } | null>;
+  /** Delete a downloaded artifact once the run is done with it. Best-effort. */
+  deleteArtifact(filePath: string): Promise<void>;
+}
+
+/** Where a bootstrap failed, for telemetry. */
+export type SnapshotBootstrapErrorReporter = (report: {
+  scopeKey: string;
+  stage: 'manifest' | 'download' | 'import';
+  attempt: number;
+  cause: unknown;
+}) => void;
+
+export type SnapshotBootstrapResult = {
+  climbsWatermark: SyncCheckpoint;
+  statsWatermark: SyncCheckpoint;
+};
+
+/**
+ * Thrown when a sign-out wipe starts (or fully completes) mid-import. The
+ * enclosing transaction rolls back — no rows, no checkpoints — and the pull
+ * client treats it as a bail-out, NOT a counted failure (mirrors syncTable).
+ */
+export class SnapshotWipedError extends Error {
+  constructor() {
+    super('snapshot bootstrap aborted: local data wipe in progress');
+    this.name = 'SnapshotWipedError';
+  }
+}
+
+// --- Attempt / done markers (sync_meta, NOT under the checkpoint: prefix so the
+// sign-out checkpoint wipe leaves them alone, matching the board rows they
+// describe, which survive as the shared cache) ---------------------------------
+
+export async function getBootstrapAttempts(db: SqlExecutor, scopeKey: string): Promise<number> {
+  const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+    `${BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
+  ]);
+  if (!row) return 0;
+  const parsed = Number(row.value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/** Increments the attempt counter for a scope and returns the new count. */
+export async function recordBootstrapAttempt(db: SqlExecutor, scopeKey: string): Promise<number> {
+  const next = (await getBootstrapAttempts(db, scopeKey)) + 1;
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    `${BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
+    String(next),
+  ]);
+  return next;
+}
+
+/** Permanent "this scope was warmed from a snapshot" marker (cheap, unambiguous). */
+export async function markBootstrapDone(db: SqlExecutor, scopeKey: string): Promise<void> {
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    `${BOOTSTRAP_DONE_PREFIX}${scopeKey}`,
+    '1',
+  ]);
+}
+
+export async function isBootstrapDone(db: SqlExecutor, scopeKey: string): Promise<boolean> {
+  const row = await db.getFirstAsync<{ key: string }>('SELECT key FROM sync_meta WHERE key = ?', [
+    `${BOOTSTRAP_DONE_PREFIX}${scopeKey}`,
+  ]);
+  return row !== null;
+}
+
+// --- Column helpers -----------------------------------------------------------
+
+function assertSafeColumns(columns: readonly string[]): void {
+  for (const column of columns) {
+    if (!SAFE_IDENTIFIER.test(column)) {
+      throw new Error(`snapshot bootstrap: refusing unsafe column identifier "${column}"`);
+    }
+  }
+}
+
+/** Column names of a table for the given schema (`main` or the snapshot alias). */
+async function tableColumns(
+  db: SqlExecutor,
+  tableName: string,
+  schema: 'main' | typeof SNAPSHOT_ALIAS,
+): Promise<string[]> {
+  const rows =
+    schema === 'main'
+      ? await db.getAllAsync<{ name: string }>('SELECT name FROM pragma_table_info(?)', [tableName])
+      : await db.getAllAsync<{ name: string }>('SELECT name FROM pragma_table_info(?, ?)', [tableName, schema]);
+  return rows.map((row) => row.name);
+}
+
+/**
+ * The columns present in BOTH the live table and the artifact's copy of it, in
+ * live (main) order. A snapshot built at a different client schema than the live
+ * DB is tolerated: a column only in the artifact is dropped from the copy (its
+ * data is skipped); a column only in main is left out of the SELECT and thus
+ * NULL-filled. Both directions are reported as drift telemetry.
+ */
+async function sharedColumns(
+  db: SqlExecutor,
+  tableName: string,
+  onSchemaDrift: SchemaDriftReporter | undefined,
+): Promise<string[]> {
+  const mainColumns = await tableColumns(db, tableName, 'main');
+  const snapshotColumns = await tableColumns(db, tableName, SNAPSHOT_ALIAS);
+  const mainSet = new Set(mainColumns);
+  const snapshotSet = new Set(snapshotColumns);
+  for (const column of snapshotColumns) {
+    if (!mainSet.has(column)) onSchemaDrift?.({ tableName, column });
+  }
+  for (const column of mainColumns) {
+    if (!snapshotSet.has(column)) onSchemaDrift?.({ tableName, column });
+  }
+  return mainColumns.filter((column) => snapshotSet.has(column));
+}
+
+// --- Import SQL ---------------------------------------------------------------
+
+/**
+ * The board_climbs import filter for one scope, mirroring `syncClimbs`'
+ * `boardClimbsScope` (queries.ts:183-188): `board_type = ? AND layout_id = ?`,
+ * plus — only for size-scoped boards — a `compatible_size_ids` containment check.
+ * SQLite has no `@>`, so containment is `json_each` membership; a NULL
+ * `compatible_size_ids` is excluded exactly as Postgres `NULL @> ARRAY[x]` is
+ * (queries.ts:173-175). Unqualified column names resolve against the single FROM
+ * table (the artifact's board_climbs). Params returned alongside.
+ */
+function climbsScopeFilter(scope: OfflineBoardScope): { sql: string; params: (string | number)[] } {
+  const params: (string | number)[] = [scope.boardType, scope.layoutId];
+  let sql = 'board_type = ? AND layout_id = ?';
+  if (isSizeScopedBoard(scope.boardType)) {
+    sql +=
+      ' AND compatible_size_ids IS NOT NULL AND EXISTS (SELECT 1 FROM json_each(compatible_size_ids) WHERE value = ?)';
+    params.push(scope.sizeId);
+  }
+  return { sql, params };
+}
+
+/**
+ * Import one scope's rows from the ATTACHed artifact. Called INSIDE the exclusive
+ * transaction. board_climbs is filtered by the resolver's scope; board_climb_stats
+ * is scoped by a correlated EXISTS over the artifact's board_climbs — the same
+ * semi-join `syncClimbStats` uses (queries.ts:426-434) — so stats land iff their
+ * climb is in scope.
+ */
+async function importScope(
+  txn: SqlExecutor,
+  scope: OfflineBoardScope,
+  onSchemaDrift: SchemaDriftReporter | undefined,
+): Promise<void> {
+  const climbColumns = await sharedColumns(txn, 'board_climbs', onSchemaDrift);
+  const statsColumns = await sharedColumns(txn, 'board_climb_stats', onSchemaDrift);
+  assertSafeColumns(climbColumns);
+  assertSafeColumns(statsColumns);
+  if (climbColumns.length === 0) throw new Error('snapshot bootstrap: no shared board_climbs columns');
+  if (statsColumns.length === 0) throw new Error('snapshot bootstrap: no shared board_climb_stats columns');
+
+  const climbScope = climbsScopeFilter(scope);
+  const climbList = climbColumns.join(', ');
+  await txn.runAsync(
+    `INSERT OR REPLACE INTO main.board_climbs (${climbList})
+     SELECT ${climbList} FROM ${SNAPSHOT_ALIAS}.board_climbs WHERE ${climbScope.sql}`,
+    climbScope.params,
+  );
+
+  // Stats semi-join: mirror the resolver's EXISTS over board_climbs, filtered by
+  // the SAME scope conditions (board_type + layout + size). The inner size check
+  // reuses the climbs filter but qualified to the correlated `bc` alias.
+  const statsList = statsColumns.join(', ');
+  const sizeScoped = isSizeScopedBoard(scope.boardType);
+  const innerSize = sizeScoped
+    ? ' AND bc.compatible_size_ids IS NOT NULL AND EXISTS (SELECT 1 FROM json_each(bc.compatible_size_ids) WHERE value = ?)'
+    : '';
+  const statsParams: (string | number)[] = [scope.boardType, scope.boardType, scope.layoutId];
+  if (sizeScoped) statsParams.push(scope.sizeId);
+  await txn.runAsync(
+    `INSERT OR REPLACE INTO main.board_climb_stats (${statsList})
+     SELECT ${statsList} FROM ${SNAPSHOT_ALIAS}.board_climb_stats s
+     WHERE s.board_type = ?
+       AND EXISTS (
+         SELECT 1 FROM ${SNAPSHOT_ALIAS}.board_climbs bc
+         WHERE bc.uuid = s.climb_uuid AND bc.board_type = ? AND bc.layout_id = ?${innerSize}
+       )`,
+    statsParams,
+  );
+}
+
+// --- Verification -------------------------------------------------------------
+
+type SnapshotMetaRow = {
+  table_name: string;
+  watermark_updated_at: string;
+  watermark_sync_seq: string;
+  row_count: number;
+  format_version: number;
+};
+
+/**
+ * Read + validate the artifact's `snapshot_meta`: every snapshot table present,
+ * `format_version` matching this client, and each recorded `row_count` equal to
+ * the artifact's ACTUAL table count (a truncated/partial download is caught here
+ * before any row is imported). Returns the per-table watermarks.
+ */
+async function verifySnapshotMeta(db: SqlExecutor): Promise<Record<(typeof SNAPSHOT_TABLES)[number], SyncCheckpoint>> {
+  const watermarks: Partial<Record<string, SyncCheckpoint>> = {};
+  for (const tableName of SNAPSHOT_TABLES) {
+    const meta = await db.getFirstAsync<SnapshotMetaRow>(
+      `SELECT table_name, watermark_updated_at, watermark_sync_seq, row_count, format_version
+       FROM ${SNAPSHOT_ALIAS}.snapshot_meta WHERE table_name = ?`,
+      [tableName],
+    );
+    if (!meta) throw new Error(`snapshot bootstrap: snapshot_meta missing row for ${tableName}`);
+    if (meta.format_version !== SNAPSHOT_MANIFEST_FORMAT_VERSION) {
+      throw new Error(
+        `snapshot bootstrap: format_version ${meta.format_version} != ${SNAPSHOT_MANIFEST_FORMAT_VERSION} for ${tableName}`,
+      );
+    }
+    const actual = await db.getFirstAsync<{ n: number }>(`SELECT COUNT(*) AS n FROM ${SNAPSHOT_ALIAS}.${tableName}`);
+    const actualCount = actual?.n ?? 0;
+    if (actualCount !== meta.row_count) {
+      throw new Error(
+        `snapshot bootstrap: ${tableName} row_count ${meta.row_count} != actual ${actualCount} (truncated artifact?)`,
+      );
+    }
+    watermarks[tableName] = { updatedAt: meta.watermark_updated_at, syncSeq: meta.watermark_sync_seq };
+  }
+  return watermarks as Record<(typeof SNAPSHOT_TABLES)[number], SyncCheckpoint>;
+}
+
+// --- Bootstrap ----------------------------------------------------------------
+
+/**
+ * Warm one board scope from a downloaded artifact. ATTACHes the file, integrity-
+ * checks it, verifies the meta, then in ONE exclusive transaction imports the
+ * scoped climbs + stats and stamps both resume checkpoints at their watermarks.
+ * ATTACH/DETACH bracket the transaction (SQLite forbids ATTACH inside one).
+ * A wipe that starts (or completes) mid-import rolls the transaction back and
+ * throws SnapshotWipedError — no rows, no checkpoints.
+ */
+export async function bootstrapScopeFromSnapshot(params: {
+  db: OfflineDatabase;
+  scope: OfflineBoardScope;
+  scopeKey: string;
+  filePath: string;
+  onSchemaDrift?: SchemaDriftReporter;
+}): Promise<SnapshotBootstrapResult> {
+  const { db, scope, scopeKey, filePath, onSchemaDrift } = params;
+
+  let attached = false;
+  try {
+    await db.execAsync(`ATTACH DATABASE '${filePath.replace(/'/g, "''")}' AS ${SNAPSHOT_ALIAS}`);
+    attached = true;
+
+    const integrity = await db.getAllAsync<{ quick_check: string }>(`PRAGMA ${SNAPSHOT_ALIAS}.quick_check`);
+    if (integrity.length !== 1 || integrity[0].quick_check !== 'ok') {
+      throw new Error(`snapshot bootstrap: quick_check failed: ${integrity.map((row) => row.quick_check).join('; ')}`);
+    }
+
+    const watermarks = await verifySnapshotMeta(db);
+
+    // The whole import + checkpoint stamping is all-or-nothing. A wipe that runs
+    // (or starts AND finishes) across an await inside would otherwise resurrect
+    // the artifact's rows into a wiped DB and write checkpoints past the next
+    // account's data — the monotonic epoch catches even a complete cycle.
+    const startEpoch = getWipeEpoch();
+    if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
+
+    await db.withExclusiveTransactionAsync(async (txn) => {
+      if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
+
+      await importScope(txn, scope, onSchemaDrift);
+
+      // Re-check after the (awaited) imports: abort before committing any rows or
+      // checkpoints if a wipe landed while they ran.
+      if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
+
+      await setCheckpoint(txn, getCheckpointKey('board_climbs', scopeKey), watermarks.board_climbs);
+      await setCheckpoint(txn, getCheckpointKey('board_climb_stats', scopeKey), watermarks.board_climb_stats);
+
+      // Rewind the global deletions cursor to the OLDER of the two table
+      // watermarks IN THE SAME transaction as the import: once the board
+      // checkpoints exist this scope is never bootstrap-eligible again, so a
+      // crash between the import commit and a separate rewind would leave
+      // board-row deletions in `(watermark, deletions-head]` permanently
+      // unreplayed against the imported rows.
+      const minWatermark =
+        compareCheckpoints(watermarks.board_climbs, watermarks.board_climb_stats) <= 0
+          ? watermarks.board_climbs
+          : watermarks.board_climb_stats;
+      await rewindDeletionsCheckpoint(txn, minWatermark);
+    });
+
+    return { climbsWatermark: watermarks.board_climbs, statsWatermark: watermarks.board_climb_stats };
+  } finally {
+    if (attached) {
+      await db.execAsync(`DETACH DATABASE ${SNAPSHOT_ALIAS}`).catch(() => {});
+    }
+  }
+}

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -362,6 +362,11 @@ export async function bootstrapScopeFromSnapshot(params: {
 
   let attached = false;
   try {
+    // Defensive detach first: a failed DETACH from a previous scope in this run
+    // (swallowed in the finally below) would leave the alias attached and make
+    // this ATTACH fail for every remaining scope. Clearing it here confines a
+    // DETACH failure to its own scope.
+    await db.execAsync(`DETACH DATABASE ${SNAPSHOT_ALIAS}`).catch(() => {});
     await db.execAsync(`ATTACH DATABASE '${filePath.replace(/'/g, "''")}' AS ${SNAPSHOT_ALIAS}`);
     attached = true;
 

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -328,6 +328,14 @@ export async function bootstrapScopeFromSnapshot(params: {
 }): Promise<SnapshotBootstrapResult> {
   const { db, scope, scopeKey, filePath, onSchemaDrift } = params;
 
+  // The whole import + checkpoint stamping is all-or-nothing. A wipe that runs
+  // (or starts AND finishes) across ANY await below — including the ATTACH,
+  // quick_check, and snapshot_meta reads — would otherwise resurrect the
+  // artifact's rows into a wiped DB and write checkpoints past the next
+  // account's data. Capture the monotonic epoch before the FIRST await so even
+  // a wipe cycle that completes during the integrity checks is caught.
+  const startEpoch = getWipeEpoch();
+
   let attached = false;
   try {
     await db.execAsync(`ATTACH DATABASE '${filePath.replace(/'/g, "''")}' AS ${SNAPSHOT_ALIAS}`);
@@ -340,11 +348,6 @@ export async function bootstrapScopeFromSnapshot(params: {
 
     const watermarks = await verifySnapshotMeta(db);
 
-    // The whole import + checkpoint stamping is all-or-nothing. A wipe that runs
-    // (or starts AND finishes) across an await inside would otherwise resurrect
-    // the artifact's rows into a wiped DB and write checkpoints past the next
-    // account's data — the monotonic epoch catches even a complete cycle.
-    const startEpoch = getWipeEpoch();
     if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
 
     await db.withExclusiveTransactionAsync(async (txn) => {

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -20,7 +20,7 @@
 
 import type { OfflineDatabase, SqlExecutor } from '../database';
 import type { OfflineBoardScope } from '../offline-board-key';
-import type { SnapshotManifestEntry } from './snapshot-manifest';
+import type { SnapshotManifestEntry, SnapshotTableName } from './snapshot-manifest';
 import { SNAPSHOT_MANIFEST_FORMAT_VERSION } from './snapshot-manifest';
 import {
   compareCheckpoints,
@@ -44,6 +44,7 @@ export const MAX_BOOTSTRAP_ATTEMPTS = 2;
 
 const BOOTSTRAP_ATTEMPTS_PREFIX = 'bootstrap-attempts:';
 const BOOTSTRAP_DONE_PREFIX = 'bootstrap-done:';
+const EPOCH_WATERMARK: SyncCheckpoint = { updatedAt: '1970-01-01T00:00:00.000Z', syncSeq: '0' };
 
 // Only snake_case identifiers may be spliced into the INSERT/SELECT column list.
 // The names come from PRAGMA table_info over our own DDL (trusted), but validating
@@ -108,6 +109,18 @@ export class SnapshotWipedError extends Error {
   constructor() {
     super('snapshot bootstrap aborted: local data wipe in progress');
     this.name = 'SnapshotWipedError';
+  }
+}
+
+/**
+ * Thrown by a SnapshotSource when an artifact is known unusable for this client
+ * but the normal paged crawl should run in the same cycle. Example: a mobile
+ * downloader persisted a raw gzip stream and the shared engine has no gunzipper.
+ */
+export class SnapshotPermanentMissError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SnapshotPermanentMissError';
   }
 }
 
@@ -208,15 +221,136 @@ async function sharedColumns(
  * (queries.ts:173-175). Unqualified column names resolve against the single FROM
  * table (the artifact's board_climbs). Params returned alongside.
  */
-function climbsScopeFilter(scope: OfflineBoardScope): { sql: string; params: (string | number)[] } {
+function climbsScopeFilter(scope: OfflineBoardScope, qualifier = ''): { sql: string; params: (string | number)[] } {
   const params: (string | number)[] = [scope.boardType, scope.layoutId];
-  let sql = 'board_type = ? AND layout_id = ?';
+  let sql = `${qualifier}board_type = ? AND ${qualifier}layout_id = ?`;
   if (isSizeScopedBoard(scope.boardType)) {
     sql +=
-      ' AND compatible_size_ids IS NOT NULL AND EXISTS (SELECT 1 FROM json_each(compatible_size_ids) WHERE value = ?)';
+      ` AND ${qualifier}compatible_size_ids IS NOT NULL AND EXISTS (SELECT 1 FROM json_each(${qualifier}compatible_size_ids) WHERE value = ?)`;
     params.push(scope.sizeId);
   }
   return { sql, params };
+}
+
+function checkpointLeqSql(columnPrefix: string): string {
+  return `(${columnPrefix}updated_at < ? OR (${columnPrefix}updated_at = ? AND ${columnPrefix}sync_seq <= ?))`;
+}
+
+function checkpointLeqParams(checkpoint: SyncCheckpoint): (string | number)[] {
+  return [checkpoint.updatedAt, checkpoint.updatedAt, checkpoint.syncSeq];
+}
+
+async function tableWatermark(
+  db: SqlExecutor,
+  tableName: SnapshotTableName,
+  whereClause: string,
+  params: (string | number)[],
+): Promise<SyncCheckpoint> {
+  const row = await db.getFirstAsync<{ updated_at: string; sync_seq: number | string }>(
+    `SELECT updated_at, sync_seq
+     FROM ${SNAPSHOT_ALIAS}.${tableName}
+     WHERE ${whereClause}
+     ORDER BY updated_at DESC, sync_seq DESC
+     LIMIT 1`,
+    params,
+  );
+  if (!row) return EPOCH_WATERMARK;
+  return { updatedAt: String(row.updated_at), syncSeq: String(row.sync_seq) };
+}
+
+async function scopedWatermarks(
+  db: SqlExecutor,
+  scope: OfflineBoardScope,
+): Promise<Record<SnapshotTableName, SyncCheckpoint>> {
+  const climbScope = climbsScopeFilter(scope);
+  const climbWatermark = await tableWatermark(db, 'board_climbs', climbScope.sql, climbScope.params);
+
+  const sizeScoped = isSizeScopedBoard(scope.boardType);
+  const innerSize = sizeScoped
+    ? ' AND bc.compatible_size_ids IS NOT NULL AND EXISTS (SELECT 1 FROM json_each(bc.compatible_size_ids) WHERE value = ?)'
+    : '';
+  const statsParams: (string | number)[] = [scope.boardType, scope.boardType, scope.layoutId];
+  if (sizeScoped) statsParams.push(scope.sizeId);
+  const statsWatermark = await tableWatermark(
+    db,
+    'board_climb_stats',
+    `board_type = ?
+       AND EXISTS (
+         SELECT 1 FROM ${SNAPSHOT_ALIAS}.board_climbs bc
+         WHERE bc.uuid = board_climb_stats.climb_uuid AND bc.board_type = ? AND bc.layout_id = ?${innerSize}
+       )`,
+    statsParams,
+  );
+
+  return { board_climbs: climbWatermark, board_climb_stats: statsWatermark };
+}
+
+async function reconcileScope(
+  txn: SqlExecutor,
+  scope: OfflineBoardScope,
+  watermarks: Record<SnapshotTableName, SyncCheckpoint>,
+): Promise<void> {
+  const mainClimbScope = climbsScopeFilter(scope, 'main_climb.');
+  const snapshotClimbScope = climbsScopeFilter(scope, 'snapshot_climb.');
+
+  const sizeScoped = isSizeScopedBoard(scope.boardType);
+  const localStatsSize = sizeScoped
+    ? ' AND main_climb.compatible_size_ids IS NOT NULL AND EXISTS (SELECT 1 FROM json_each(main_climb.compatible_size_ids) WHERE value = ?)'
+    : '';
+  const snapshotStatsSize = sizeScoped
+    ? ' AND snapshot_climb.compatible_size_ids IS NOT NULL AND EXISTS (SELECT 1 FROM json_each(snapshot_climb.compatible_size_ids) WHERE value = ?)'
+    : '';
+
+  const statsParams: (string | number)[] = [
+    scope.boardType,
+    ...checkpointLeqParams(watermarks.board_climb_stats),
+    scope.boardType,
+    scope.layoutId,
+  ];
+  if (sizeScoped) statsParams.push(scope.sizeId);
+  statsParams.push(scope.boardType, scope.layoutId);
+  if (sizeScoped) statsParams.push(scope.sizeId);
+
+  await txn.runAsync(
+    `DELETE FROM main.board_climb_stats AS main_stats
+     WHERE main_stats.board_type = ?
+       AND ${checkpointLeqSql('main_stats.')}
+       AND EXISTS (
+         SELECT 1 FROM main.board_climbs main_climb
+         WHERE main_climb.uuid = main_stats.climb_uuid
+           AND main_climb.board_type = ?
+           AND main_climb.layout_id = ?${localStatsSize}
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM ${SNAPSHOT_ALIAS}.board_climb_stats snapshot_stats
+         WHERE snapshot_stats.board_type = main_stats.board_type
+           AND snapshot_stats.climb_uuid = main_stats.climb_uuid
+           AND snapshot_stats.angle = main_stats.angle
+           AND EXISTS (
+             SELECT 1 FROM ${SNAPSHOT_ALIAS}.board_climbs snapshot_climb
+             WHERE snapshot_climb.uuid = snapshot_stats.climb_uuid
+               AND snapshot_climb.board_type = ?
+               AND snapshot_climb.layout_id = ?${snapshotStatsSize}
+           )
+       )`,
+    statsParams,
+  );
+
+  await txn.runAsync(
+    `DELETE FROM main.board_climbs AS main_climb
+     WHERE ${mainClimbScope.sql}
+       AND ${checkpointLeqSql('main_climb.')}
+       AND NOT EXISTS (
+         SELECT 1 FROM ${SNAPSHOT_ALIAS}.board_climbs snapshot_climb
+         WHERE snapshot_climb.uuid = main_climb.uuid
+           AND ${snapshotClimbScope.sql}
+       )`,
+    [
+      ...mainClimbScope.params,
+      ...checkpointLeqParams(watermarks.board_climbs),
+      ...snapshotClimbScope.params,
+    ],
+  );
 }
 
 /**
@@ -302,8 +436,7 @@ export class SnapshotSchemaStaleError extends Error {
  * table count (a truncated/partial download is caught here before any row is
  * imported). Returns the per-table watermarks.
  */
-async function verifySnapshotMeta(db: SqlExecutor): Promise<Record<(typeof SNAPSHOT_TABLES)[number], SyncCheckpoint>> {
-  const watermarks: Partial<Record<string, SyncCheckpoint>> = {};
+async function verifySnapshotMeta(db: SqlExecutor): Promise<void> {
   for (const tableName of SNAPSHOT_TABLES) {
     const meta = await db.getFirstAsync<SnapshotMetaRow>(
       `SELECT table_name, watermark_updated_at, watermark_sync_seq, row_count, schema_version, format_version
@@ -328,9 +461,7 @@ async function verifySnapshotMeta(db: SqlExecutor): Promise<Record<(typeof SNAPS
         `snapshot bootstrap: ${tableName} row_count ${meta.row_count} != actual ${actualCount} (truncated artifact?)`,
       );
     }
-    watermarks[tableName] = { updatedAt: meta.watermark_updated_at, syncSeq: meta.watermark_sync_seq };
   }
-  return watermarks as Record<(typeof SNAPSHOT_TABLES)[number], SyncCheckpoint>;
 }
 
 // --- Bootstrap ----------------------------------------------------------------
@@ -375,13 +506,15 @@ export async function bootstrapScopeFromSnapshot(params: {
       throw new Error(`snapshot bootstrap: quick_check failed: ${integrity.map((row) => row.quick_check).join('; ')}`);
     }
 
-    const watermarks = await verifySnapshotMeta(db);
+    await verifySnapshotMeta(db);
+    const watermarks = await scopedWatermarks(db, scope);
 
     if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
 
     await db.withExclusiveTransactionAsync(async (txn) => {
       if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
 
+      await reconcileScope(txn, scope, watermarks);
       await importScope(txn, scope, onSchemaDrift);
 
       // Re-check after the (awaited) imports: abort before committing any rows or

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -30,6 +30,7 @@ import {
   type SyncCheckpoint,
 } from './checkpoints';
 import { getWipeEpoch, isSigningOut } from '../mutation-queue/drainer';
+import { LATEST_SCHEMA_VERSION } from '../db/migrations';
 import type { SchemaDriftReporter } from './pull-client';
 
 /** The two reference tables a snapshot carries; import order is climbs → stats. */
@@ -274,20 +275,38 @@ type SnapshotMetaRow = {
   watermark_updated_at: string;
   watermark_sync_seq: string;
   row_count: number;
+  schema_version: number;
   format_version: number;
 };
 
 /**
+ * Thrown when the artifact was built at an older client schema version than this
+ * app runs. Importing it would NULL-fill columns the newer schema added and then
+ * stamp the cursor PAST those rows — the strict-`>` delta pull would never
+ * backfill them, silently degrading data a paged crawl would have delivered.
+ * The caller treats this as a permanent miss for this run (no attempt burned):
+ * the nightly export rebuilds artifacts at the new schema within a day, but a
+ * fresh scope enabled TODAY falls back to the always-correct paged crawl.
+ */
+export class SnapshotSchemaStaleError extends Error {
+  constructor(artifactVersion: number) {
+    super(`snapshot bootstrap: artifact schema_version ${artifactVersion} < client ${LATEST_SCHEMA_VERSION}`);
+    this.name = 'SnapshotSchemaStaleError';
+  }
+}
+
+/**
  * Read + validate the artifact's `snapshot_meta`: every snapshot table present,
- * `format_version` matching this client, and each recorded `row_count` equal to
- * the artifact's ACTUAL table count (a truncated/partial download is caught here
- * before any row is imported). Returns the per-table watermarks.
+ * `format_version` matching this client, `schema_version` not older than this
+ * client's schema, and each recorded `row_count` equal to the artifact's ACTUAL
+ * table count (a truncated/partial download is caught here before any row is
+ * imported). Returns the per-table watermarks.
  */
 async function verifySnapshotMeta(db: SqlExecutor): Promise<Record<(typeof SNAPSHOT_TABLES)[number], SyncCheckpoint>> {
   const watermarks: Partial<Record<string, SyncCheckpoint>> = {};
   for (const tableName of SNAPSHOT_TABLES) {
     const meta = await db.getFirstAsync<SnapshotMetaRow>(
-      `SELECT table_name, watermark_updated_at, watermark_sync_seq, row_count, format_version
+      `SELECT table_name, watermark_updated_at, watermark_sync_seq, row_count, schema_version, format_version
        FROM ${SNAPSHOT_ALIAS}.snapshot_meta WHERE table_name = ?`,
       [tableName],
     );
@@ -296,6 +315,11 @@ async function verifySnapshotMeta(db: SqlExecutor): Promise<Record<(typeof SNAPS
       throw new Error(
         `snapshot bootstrap: format_version ${meta.format_version} != ${SNAPSHOT_MANIFEST_FORMAT_VERSION} for ${tableName}`,
       );
+    }
+    // A NEWER artifact schema is fine (extra columns are dropped by the shared-
+    // column intersection); an OLDER one is not — see SnapshotSchemaStaleError.
+    if (meta.schema_version < LATEST_SCHEMA_VERSION) {
+      throw new SnapshotSchemaStaleError(meta.schema_version);
     }
     const actual = await db.getFirstAsync<{ n: number }>(`SELECT COUNT(*) AS n FROM ${SNAPSHOT_ALIAS}.${tableName}`);
     const actualCount = actual?.n ?? 0;


### PR DESCRIPTION
## Summary

Phase 3 of the snapshot-bootstrap plan (stacked on #3559). When a newly enabled board scope has no sync checkpoints yet, `pullSync` now runs a **bootstrap** phase before deletions: fetch the `board-snapshots` manifest, download the layout's prebuilt SQLite artifact (one CDN-cached GET), ATTACH it, `quick_check` + row-count verify, then in **one exclusive transaction** copy the scope's rows and stamp both table checkpoints to the artifact watermarks — plus rewind the global deletions cursor to the older watermark so tombstones from the snapshot-age window replay against the imported rows. The existing paged pull then only fetches the post-snapshot delta instead of crawling ~200k rows 500 at a time.

Correctness properties (all test-pinned):
- **Delta continuity**: watermark checkpoints are the exact `{updatedAt, syncSeq-string}` shape the resolvers' Zod cursor schema accepts; a row at cursor == watermark is in the artifact and strict-`>` delta pulls start past it with no gap or overlap.
- **Size-filter parity**: the import WHERE mirrors `boardClimbsScope` exactly (json_each containment == Postgres `@>`, NULL `compatible_size_ids` excluded on both paths, MoonBoard un-scoped); stats semi-join mirrors the resolver's EXISTS.
- **Safety rails**: bootstrap only when BOTH scope checkpoints are absent (mid-crawl/completed users untouched); failures record an attempt and skip the scope's paged pull for up to 2 cycles (a paged first page would permanently disqualify bootstrap); manifest-has-no-entry falls straight to the paged path without burning attempts; wipe-epoch changes roll the whole import back; deletions rewind is atomic with the import.

Platform I/O stays injected (`SnapshotSource`); nothing is wired on mobile yet, so this is dormant until the next PR — with `snapshotSource` undefined the control flow is byte-identical to today.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- 177 offline-sync tests pass (24 new: happy path, size filtering incl. MoonBoard + NULL arrays, artifact reuse across sizes, schema drift both directions, corrupt artifact → 2-attempt fallback, checkpoint-exists skip, manifest-miss matrix, deletions rewind + BigInt seq compare, wipe mid-import rollback, watermark→delta cursor continuity asserted against the mock server).
- Opus review pass: all 12 hunt-list invariants confirmed (cursor Zod shape verified against `SyncCursorInputSchema`, resolver SQL parity line-by-line).
- `vp run typecheck` full monorepo + `vp check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dhXrKcRTfpLV8pkH2RMV6