### PR TITLE
feat(mobile): wire snapshot bootstrap — download source, flag gating, telemetry

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -129,6 +129,11 @@ CREATE TABLE snapshot_meta (
 
 One row per data table (`board_climbs`, `board_climb_stats`).
 
+These rows are artifact-level metadata for the whole `(boardType, layoutId)` artifact. A client importing
+one narrower size scope uses them to validate the file, then computes its checkpoint watermarks from the
+exact scoped rows it imports. This avoids stamping a size-scoped cursor past rows that were present in the
+layout artifact but intentionally outside the enabled size.
+
 - **`format_version`** — the shape of the manifest/artifact contract itself (currently `1`,
   `SNAPSHOT_MANIFEST_FORMAT_VERSION` in `snapshot-manifest.ts`). Bump this only on a breaking shape change
   (new required manifest field, changed meaning of an existing one) — see the runbook procedure below. It
@@ -157,18 +162,19 @@ across every size of the same `(boardType, layoutId)` within a cycle.
 Failure/attempt matrix, copied from the `runBootstrapPhase` doc comment (the source of truth — keep this in
 sync if the code comment changes):
 
-| Condition                                                         | Attempt burned? | Result this cycle                                                                   |
-| ----------------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------- |
-| checkpoint exists on either board table                           | —               | not eligible → normal paged pull                                                    |
-| attempts ≥ `MAX_BOOTSTRAP_ATTEMPTS`                               | —               | gave up → normal paged pull                                                         |
-| manifest `absent` (missing/unparseable)                           | **no**          | permanent miss → normal paged pull                                                  |
-| manifest `error` (network/transport failure)                      | **yes**         | skip paged pull this cycle (retry next cycle)                                       |
-| manifest `ok` but no entry for `(boardType, layoutId)`            | **no**          | permanent miss (not exported yet) → normal paged pull                               |
-| download fails or returns `null`                                  | **yes**         | skip paged pull this cycle                                                          |
-| import throws — corrupt/short artifact, row-count/format mismatch | **yes**         | skip paged pull this cycle                                                          |
-| import throws `SnapshotSchemaStaleError`                          | **no**          | permanent miss this run → normal paged pull                                         |
-| a sign-out wipe is detected mid-phase                             | **no**          | whole phase bails, mirrors `syncTable`'s wipe guard                                 |
-| success                                                           | —               | marked done; deletions rewound; paged pull runs as a small delta from the watermark |
+| Condition                                                         | Attempt burned? | Result this cycle                                                                       |
+| ----------------------------------------------------------------- | --------------- | --------------------------------------------------------------------------------------- |
+| checkpoint exists on either board table                           | —               | not eligible → normal paged pull                                                        |
+| attempts ≥ `MAX_BOOTSTRAP_ATTEMPTS`                               | —               | gave up → normal paged pull                                                             |
+| manifest `absent` (404/missing or invalid JSON/shape)             | **no**          | permanent miss → normal paged pull                                                      |
+| manifest `error` (HTTP non-2xx except 404, network/transport)     | **yes**         | skip paged pull this cycle (retry next cycle)                                           |
+| manifest `ok` but no entry for `(boardType, layoutId)`            | **no**          | permanent miss (not exported yet) → normal paged pull                                   |
+| download fails or returns `null`                                  | **yes**         | skip paged pull this cycle                                                              |
+| download throws `SnapshotPermanentMissError`                      | **no**          | permanent miss → normal paged pull                                                      |
+| import throws — corrupt/short artifact, row-count/format mismatch | **yes**         | skip paged pull this cycle                                                              |
+| import throws `SnapshotSchemaStaleError`                          | **no**          | permanent miss this run → normal paged pull                                             |
+| a sign-out wipe is detected mid-phase                             | **no**          | whole phase bails, mirrors `syncTable`'s wipe guard                                     |
+| success                                                           | —               | marked done; deletions rewound; paged pull runs as a small delta from scoped watermarks |
 
 "Skip paged pull this cycle" matters because a scope whose bootstrap failed but still has attempts left
 must **not** run its ordinary paged pull this cycle either — a first-page checkpoint from that pull would
@@ -178,19 +184,24 @@ all), so the next cycle retries the snapshot path instead of falling through to 
 **Import mechanics** (`bootstrapScopeFromSnapshot`): `ATTACH`es the downloaded file as `bs_snapshot`, runs
 `PRAGMA quick_check` (rejects a truncated/corrupt file before touching any row), verifies `snapshot_meta`
 (format version, schema version, and that `row_count` matches the artifact's actual row count — catches a
-truncated download the integrity check alone might miss), then in **one exclusive transaction**:
+truncated download the integrity check alone might miss), computes watermarks from the exact scoped rows
+inside the artifact, then in **one exclusive transaction**:
 
+- Deletes stale local `board_climbs`/`board_climb_stats` rows for this scope whose cursors are at or
+  before the scoped watermarks but absent from the artifact. This keeps a later bootstrap from overlaying a
+  newer artifact on top of rows that vanished from the exported scope.
 - Imports `board_climbs` filtered by the scope — `board_type = ? AND layout_id = ?`, plus (for
   size-scoped boards; MoonBoard is the one exception, `isSizeScopedBoard`) a `json_each` membership check
   against `compatible_size_ids`, mirroring the resolver's `boardClimbsScope` exactly.
 - Imports `board_climb_stats` via a correlated `EXISTS` against the just-scoped `board_climbs`, mirroring
   the resolver's semi-join.
-- Stamps both table checkpoints at the artifact's watermarks.
-- **Rewinds the deletions checkpoint** to the older of the two table watermarks, in the _same_ transaction
-  as the import. Once a scope has board checkpoints it's never bootstrap-eligible again, so a crash between
-  the import commit and a separate rewind step would permanently strand any board-row deletions that fell
-  in `(watermark, deletions-head]` — they'd never replay against the freshly-imported rows. Doing it in the
-  same transaction closes that gap.
+- Stamps both table checkpoints at the scoped imported-row watermarks.
+- **Rewinds the deletions checkpoint** to the older scoped table watermark timestamp with deletion cursor
+  `syncSeq = '0'`, in the _same_ transaction as the import. Deletion cursors page over deletion-row ids, not
+  board table `sync_seq` values. Once a scope has board checkpoints it's never bootstrap-eligible again, so
+  a crash between the import commit and a separate rewind step would permanently strand any board-row
+  deletions that fell in `(watermark, deletions-head]` — they'd never replay against the freshly-imported
+  rows. Doing it in the same transaction closes that gap.
 
 **Wipe-epoch guard**: a sign-out wipe can start (or fully complete) across any of the `await`s above. The
 bootstrap captures the monotonic wipe epoch before its first `await` and re-checks it (and the
@@ -228,8 +239,9 @@ pre-import empty result set.
   native HTTP stack (`NSURLSession` / OkHttp via `expo-file-system`'s `File.downloadFileAsync`)
   transparently decompresses the object while downloading. `looksGzipCompressed` reads just the first two
   bytes of the downloaded file and checks for the gzip magic number (`0x1f 0x8b`). If they're still present
-  — the stack did **not** auto-decode — the file is deleted, the download is treated as failed (returns
-  `null`, counts as a bootstrap attempt), and a handled error is reported to Sentry with
+  — the stack did **not** auto-decode — the file is deleted, the download throws
+  `SnapshotPermanentMissError` (no attempt burned, same-cycle paged fallback), and a handled error is
+  reported to Sentry with
   `tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' }`. This client does not attempt to gunzip
   the file itself; keep the export job identity-encoded until gzip has been verified on both mobile
   platforms.
@@ -283,12 +295,14 @@ so the two stay in lockstep).
 - **Fastest, no deploy**: flip the `offline-snapshot-bootstrap` PostHog flag off. Every client falls back
   to the paged crawl for newly-enabled boards; nothing already bootstrapped is affected (it's already past
   the eligibility check).
-- **Nuclear, affects every client regardless of flag state**: delete the `board-snapshots/v1/manifest.json`
-  object from the bucket. Every client's `fetchManifest` returns a 404 → `absent` → permanent miss, no
-  attempt burned, straight to the paged crawl. The nightly export writes a fresh manifest the following
-  night (or on the next manual `workflow_dispatch`) — deleting the manifest does **not** delete the
-  artifacts underneath it, so the next run's merge just needs artifacts newer than the deleted manifest, or
-  a rebuild.
+- **Nuclear, affects every client regardless of flag state after cache expiry**: delete the
+  `board-snapshots/v1/manifest.json` object from the bucket. The manifest is cached for up to 5 minutes
+  (`Cache-Control: public, max-age=300`), so clients that already fetched it may keep bootstrapping until
+  that cache entry expires. After that, `fetchManifest` returns a 404 → `absent` → permanent miss, no
+  attempt burned, straight to the paged crawl. Restoring after a manifest delete must use an unfiltered
+  export/workflow run first: a filtered export merges against the now-empty manifest and publishes only the
+  filtered entries, temporarily hiding every untouched layout until an unfiltered run restores the full
+  index.
 
 ### Format-version bump procedure
 

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -1,0 +1,361 @@
+# Board Snapshots
+
+Canonical reference and ops runbook for the pre-built board-catalog snapshots that speed up first-time
+offline sync on mobile. Code: `packages/backend/src/scripts/export-board-snapshots.ts` (export job),
+`packages/shared/offline-sync/src/sync/{snapshot-manifest,snapshot-bootstrap,pull-client,checkpoints}.ts`
+(shared client engine), `packages/mobile/src/offline/snapshot-source.ts` (mobile platform I/O).
+
+## Why
+
+Enabling a board offline means downloading its whole reference catalog: `board_climbs` +
+`board_climb_stats` for every set at that layout, 200k+ rows on the bigger boards. Without a snapshot,
+that catalog comes down as serial, authenticated GraphQL pages of 500 rows each (`PAGE_LIMIT` in
+`pull-client.ts`) — 400+ round trips per user, every time someone enables a board for the first time.
+
+The snapshot turns that into one CDN-cached `GET` of a pre-built SQLite file per `(boardType, layoutId)`,
+followed by a normal incremental pull that only has to cover the gap between the snapshot's build time and
+now — typically under a day.
+
+## Architecture
+
+### Nightly export
+
+`.github/workflows/export-board-snapshots.yml` runs `export-board-snapshots.ts` at **07:15 UTC** daily
+(`workflow_dispatch` also available), with `environment: Production` so it gets the Production secrets.
+`concurrency.group: export-board-snapshots` with `cancel-in-progress: false` means overlapping runs queue
+instead of stepping on each other.
+
+For every `(board_type, layout_id)` pair with at least one climb (`discoverLayoutPairs`), the job:
+
+1. Opens a `node:sqlite` file and applies DDL derived from the shared client `MIGRATIONS` — every
+   migration statement that touches `board_climbs` or `board_climb_stats`, in version order, plus a
+   `snapshot_meta` table (`boardSnapshotDdlStatements`). No hand-maintained DDL: a column added to the
+   client schema shows up in the next artifact automatically.
+2. Inside one Postgres `REPEATABLE READ` transaction, streams both tables through the **same row shaping**
+   the live sync resolvers use (`row-normalize.ts` + `toSqliteValue`), so an artifact row is byte-identical
+   to what an incremental `syncClimbs`/`syncClimbStats` pull would have written. `snapshot-export-golden.test.ts`
+   pins that equivalence by running both paths against the same seeded rows and diffing them.
+3. Excludes rows younger than `SYNC_STABILITY_WINDOW_SECONDS` (default 30s, same env var the resolvers
+   read) — a row still inside its write-transaction's commit window is left for the incremental pull rather
+   than risking a watermark that covers it before it's actually visible.
+4. Computes each table's watermark — the max `(updated_at, sync_seq)` over the exported rows — from the
+   **same transaction snapshot** as the row stream, and writes it into `snapshot_meta` alongside
+   `row_count`, `schema_version` (`LATEST_SCHEMA_VERSION`), and `format_version`.
+5. Uploads the SQLite file to `board-snapshots/v1/<boardType>/<layoutId>/<builtAt-colon-free>.db`.
+   Artifacts are identity-encoded by default; `--gzip` is available once both mobile platforms have been
+   verified to receive a decompressed file from `expo-file-system`.
+6. After every artifact for the run has landed, writes `board-snapshots/v1/manifest.json` **last**, so a
+   reader only ever sees a fully-consistent old-or-new manifest, never a manifest pointing at an artifact
+   that hasn't finished uploading.
+
+#### Why the primary, never a replica
+
+The sync cursor `(updated_at, sync_seq)` is **write-time** ordered, but an async replica's snapshot is
+**commit-order** consistent. A row that commits late (or replicates late) can carry a lower cursor than
+rows already visible on the replica — so a replica read can produce a watermark that covers a row the
+artifact never actually contains. Every client that bootstraps from that artifact resumes strictly past
+the watermark and **loses that row forever** (the strict `>` delta pull never revisits it). The stability
+window only absorbs primary write→commit delay; replica lag stacks on top of it. The export always reads
+the primary pool (`createPool()` from `@boardsesh/db/client`) for this reason — see the long comment at
+`runExport`'s pool call site in `export-board-snapshots.ts`.
+
+#### Merge semantics
+
+The job fetches the currently-published manifest **before** touching S3 (`fetchPreviousManifest`), so a
+bad read aborts the whole run with zero uploads. `mergeManifestEntries` then merges this run's fresh
+entries over the previous manifest's, keyed by `(boardType, layoutId)`:
+
+- A **filtered run** (`--board`/`--layout`) only rebuilds a subset, so every entry it didn't touch is kept
+  verbatim — otherwise a filtered run would silently drop every other board from the manifest.
+- Only an **unfiltered** run has the full picture, so only it may drop an entry whose layout no longer has
+  climbs (passes `livePairs`; filtered runs pass `null` and keep everything).
+- A layout whose export **failed** this run keeps its previous (still-valid, immutable) artifact entry —
+  failures don't block the other layouts' refresh, and the whole run only fails at the very end, after
+  every layout has been attempted.
+
+Previous-manifest failure matrix (`fetchPreviousManifest`), because the merge above needs those entries to
+avoid dropping data on a broken read:
+
+| Previous manifest state        | Filtered run                                            | Unfiltered run                                                                                                                     |
+| ------------------------------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Missing (404/NoSuchKey)        | proceed, merge against empty (legitimately a first run) | same                                                                                                                               |
+| S3 read error (anything else)  | **THROW**, no upload happens                            | **THROW**, no upload happens                                                                                                       |
+| Present but invalid JSON/shape | **THROW** (can't reconstruct entries it would drop)     | warn + merge against empty (rebuilds every live layout anyway; only vanished layouts' entries are lost, and those drop regardless) |
+
+### Storage layout and cache headers
+
+- Artifacts: `board-snapshots/v1/<boardType>/<layoutId>/<builtAt>.db`,
+  `Content-Type: application/x-sqlite3`, with manifest `contentEncoding: 'identity'` by default. `--gzip`
+  uploads with `Content-Encoding: gzip` and records `contentEncoding: 'gzip'` in the manifest, but should
+  stay off for mobile rollout until iOS and Android both prove the downloaded file is decompressed on disk.
+  No explicit `cacheControl` is passed to `uploadToS3`, so artifacts get the storage layer's default:
+  `public, max-age=31536000, immutable`. Content-addressed by build timestamp — safe to cache forever, a
+  new build gets a new key.
+- Manifest: `board-snapshots/v1/manifest.json`, `Content-Type: application/json`,
+  `Cache-Control: public, max-age=300`. Mutable and cheap to refetch, written last so it's the only object
+  in the whole scheme that changes in place.
+
+### Pruning
+
+Artifacts superseded by a newer build for the same `(boardType, layoutId)` are deleted by
+`pruneStaleArtifacts`, but only when **all** of the following hold:
+
+- the run was **unfiltered** (a filtered run doesn't have the full manifest picture to prune safely), and
+- the run had **zero layout failures** (a failed night just defers pruning to the next green run).
+
+An object is eligible for deletion when it's under `board-snapshots/v1/` and NOT referenced by the manifest
+just written, **and** its `lastModified` is older than a **14-day grace window**
+(`PRUNE_GRACE_MS`). The grace window exists because the manifest is CDN-cached for up to 5 minutes and a
+client may hold a fetched manifest (with a now-superseded artifact URL) far longer than that before it
+actually starts the download. Pruning is defensive by design: any failure (per-object or the whole scan) is
+logged and swallowed, never fails the run.
+
+## Artifact format
+
+Each `.db` file carries exactly two data tables — `board_climbs` and `board_climb_stats` — plus
+`snapshot_meta`:
+
+```sql
+CREATE TABLE snapshot_meta (
+  table_name TEXT PRIMARY KEY,
+  watermark_updated_at TEXT,
+  watermark_sync_seq TEXT,   -- decimal string; a Postgres bigint must never round-trip through a JS number
+  row_count INTEGER,
+  built_at TEXT,
+  schema_version INTEGER,
+  format_version INTEGER
+);
+```
+
+One row per data table (`board_climbs`, `board_climb_stats`).
+
+- **`format_version`** — the shape of the manifest/artifact contract itself (currently `1`,
+  `SNAPSHOT_MANIFEST_FORMAT_VERSION` in `snapshot-manifest.ts`). Bump this only on a breaking shape change
+  (new required manifest field, changed meaning of an existing one) — see the runbook procedure below. It
+  is a separate axis from the S3 key prefix's `v1` — see "Format-version bump" below for how the two relate
+  in practice.
+- **`schema_version`** — the on-device client schema version the artifact's DDL was built against
+  (`LATEST_SCHEMA_VERSION` from `@boardsesh/offline-sync`'s migrations). An artifact whose schema is newer
+  than the client is tolerated: bootstrap only imports columns present in both tables (`sharedColumns` in
+  `snapshot-bootstrap.ts`), dropping artifact-only columns. An artifact **staler** than the client
+  (`schema_version < LATEST_SCHEMA_VERSION`) is rejected client-side (`SnapshotSchemaStaleError`) rather
+  than imported, because importing it would NULL-fill the client's newer columns and then stamp the resume
+  cursor _past_ those rows — the strict `>` delta pull would never backfill them. A staler artifact is a
+  **permanent miss for that run, no bootstrap attempt burned** — the scope falls back to the always-correct
+  paged crawl, and the next nightly export rebuilds the artifact at the new schema.
+
+## Client bootstrap flow
+
+Implemented in `snapshot-bootstrap.ts` (the ATTACH/import/verify mechanics) and orchestrated from
+`pull-client.ts`'s `runBootstrapPhase`, which runs **before** the deletions phase of every sync cycle.
+
+**Eligibility**: a board scope (`boardType:layoutId:sizeId`) is only considered when it has **no
+checkpoint on either `board_climbs` or `board_climb_stats`** (i.e. genuinely fresh — nothing pulled yet)
+and its bootstrap attempt count is under `MAX_BOOTSTRAP_ATTEMPTS` (2). One artifact download is shared
+across every size of the same `(boardType, layoutId)` within a cycle.
+
+Failure/attempt matrix, copied from the `runBootstrapPhase` doc comment (the source of truth — keep this in
+sync if the code comment changes):
+
+| Condition                                                         | Attempt burned? | Result this cycle                                                                   |
+| ----------------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------- |
+| checkpoint exists on either board table                           | —               | not eligible → normal paged pull                                                    |
+| attempts ≥ `MAX_BOOTSTRAP_ATTEMPTS`                               | —               | gave up → normal paged pull                                                         |
+| manifest `absent` (missing/unparseable)                           | **no**          | permanent miss → normal paged pull                                                  |
+| manifest `error` (network/transport failure)                      | **yes**         | skip paged pull this cycle (retry next cycle)                                       |
+| manifest `ok` but no entry for `(boardType, layoutId)`            | **no**          | permanent miss (not exported yet) → normal paged pull                               |
+| download fails or returns `null`                                  | **yes**         | skip paged pull this cycle                                                          |
+| import throws — corrupt/short artifact, row-count/format mismatch | **yes**         | skip paged pull this cycle                                                          |
+| import throws `SnapshotSchemaStaleError`                          | **no**          | permanent miss this run → normal paged pull                                         |
+| a sign-out wipe is detected mid-phase                             | **no**          | whole phase bails, mirrors `syncTable`'s wipe guard                                 |
+| success                                                           | —               | marked done; deletions rewound; paged pull runs as a small delta from the watermark |
+
+"Skip paged pull this cycle" matters because a scope whose bootstrap failed but still has attempts left
+must **not** run its ordinary paged pull this cycle either — a first-page checkpoint from that pull would
+permanently disqualify the scope from ever bootstrapping (the eligibility check requires no checkpoint at
+all), so the next cycle retries the snapshot path instead of falling through to a slow crawl by accident.
+
+**Import mechanics** (`bootstrapScopeFromSnapshot`): `ATTACH`es the downloaded file as `bs_snapshot`, runs
+`PRAGMA quick_check` (rejects a truncated/corrupt file before touching any row), verifies `snapshot_meta`
+(format version, schema version, and that `row_count` matches the artifact's actual row count — catches a
+truncated download the integrity check alone might miss), then in **one exclusive transaction**:
+
+- Imports `board_climbs` filtered by the scope — `board_type = ? AND layout_id = ?`, plus (for
+  size-scoped boards; MoonBoard is the one exception, `isSizeScopedBoard`) a `json_each` membership check
+  against `compatible_size_ids`, mirroring the resolver's `boardClimbsScope` exactly.
+- Imports `board_climb_stats` via a correlated `EXISTS` against the just-scoped `board_climbs`, mirroring
+  the resolver's semi-join.
+- Stamps both table checkpoints at the artifact's watermarks.
+- **Rewinds the deletions checkpoint** to the older of the two table watermarks, in the _same_ transaction
+  as the import. Once a scope has board checkpoints it's never bootstrap-eligible again, so a crash between
+  the import commit and a separate rewind step would permanently strand any board-row deletions that fell
+  in `(watermark, deletions-head]` — they'd never replay against the freshly-imported rows. Doing it in the
+  same transaction closes that gap.
+
+**Wipe-epoch guard**: a sign-out wipe can start (or fully complete) across any of the `await`s above. The
+bootstrap captures the monotonic wipe epoch before its first `await` and re-checks it (and the
+signing-out flag) before the transaction, and again after the import completes but before commit. Any
+mismatch throws `SnapshotWipedError`, rolling the transaction back — no rows, no checkpoints — and the
+pull-client treats it as a bail-out, not a counted failure.
+
+**Query-cache invalidation**: because the delta pull that follows a successful bootstrap may legitimately
+return zero documents (the snapshot already satisfied the scope), and `syncTable`'s cache invalidation only
+fires on non-empty pages, `runBootstrapPhase` explicitly invalidates the `board_climbs`/`board_climb_stats`
+query keys right after a successful import — otherwise an active search/detail query would keep serving the
+pre-import empty result set.
+
+## Mobile wiring
+
+- **`EXPO_PUBLIC_SNAPSHOT_BASE_URL`** (`packages/mobile/src/lib/env.ts`) — base URL for
+  `<base>/manifest.json`; each manifest entry carries its own absolute artifact URL, so this constant is
+  only used for the manifest fetch. There is deliberately **no production fallback**: if the env var is
+  unset or empty, `OfflineSyncBridge` does not pass `mobileSnapshotSource` to the scheduler, even when the
+  PostHog flag is on, and fresh boards use the paged crawl. Set this as a real EAS build-time env var
+  before ramping the flag. `EXPO_PUBLIC_*` vars are inlined at build time, not read at runtime, so this
+  needs a new build to take effect, not just a config change.
+- **PostHog flags** (`packages/mobile/src/providers/feature-flags-provider.tsx`):
+  - `offline-board-downloads` — the whole offline engine (downloads, local-first reads, queued
+    offline writes, background sync). Missing/undefined reads as **off**.
+  - `offline-snapshot-bootstrap` — nested under the flag above: whether a freshly-enabled scope warms
+    from the snapshot at all. With `offline-board-downloads` on and `offline-snapshot-bootstrap` off, a
+    fresh board still downloads — just via the paged crawl. `OfflineSyncBridge`
+    (`packages/mobile/src/components/offline-sync-bridge.tsx`) only passes `mobileSnapshotSource` to the
+    sync scheduler when `useSnapshotBootstrapEnabled()` is true **and** `EXPO_PUBLIC_SNAPSHOT_BASE_URL` is
+    configured; otherwise it passes `undefined`, which makes `pullSync` skip the bootstrap phase entirely
+    — behaviourally identical to before this feature existed.
+- **Gzip magic-byte sniff** (`packages/mobile/src/offline/snapshot-source.ts`): identity artifacts skip
+  gzip verification. For manifest entries with `contentEncoding: 'gzip'`, the expectation is that the
+  native HTTP stack (`NSURLSession` / OkHttp via `expo-file-system`'s `File.downloadFileAsync`)
+  transparently decompresses the object while downloading. `looksGzipCompressed` reads just the first two
+  bytes of the downloaded file and checks for the gzip magic number (`0x1f 0x8b`). If they're still present
+  — the stack did **not** auto-decode — the file is deleted, the download is treated as failed (returns
+  `null`, counts as a bootstrap attempt), and a handled error is reported to Sentry with
+  `tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' }`. This client does not attempt to gunzip
+  the file itself; keep the export job identity-encoded until gzip has been verified on both mobile
+  platforms.
+- **Telemetry**:
+  - `Offline Board Download Completed` (PostHog, `SHARED_EVENTS.OfflineBoardDownloadCompleted`) fires once
+    per scope's first-download completion (both board tables reached the tail), with method `snapshot` or
+    `paged` and `durationMs` measured from the start of the sync cycle's work on that scope (so a
+    `'snapshot'` scope's duration includes its manifest/download/import time, not just the trailing delta
+    pull — an apples-to-apples comparison against a full paged crawl).
+  - Sentry handled errors, `tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' }`, for every
+    counted bootstrap failure (manifest/download/import stage, with `scopeKey`/`stage`/`attempt`/`cause` in
+    `extra`) and for the gzip-sniff failure above.
+
+## Ops runbook
+
+### Manual export
+
+From CI: trigger `.github/workflows/export-board-snapshots.yml` via `workflow_dispatch` (GitHub UI or
+`gh workflow run export-board-snapshots.yml`).
+
+From a local shell, from `packages/backend/`:
+
+```sh
+DATABASE_URL=<primary connection string> \
+AWS_S3_BUCKET_NAME=... AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_ENDPOINT_URL=... AWS_DEFAULT_REGION=... \
+node --import tsx src/scripts/export-board-snapshots.ts [--dry-run] [--gzip] [--board <boardType>] [--layout <layoutId>]
+```
+
+- `--dry-run` builds artifacts locally (in a temp dir, cleaned up after) and logs sizes/row counts, but
+  never uploads anything and never touches the manifest. Works with **no AWS credentials at all**.
+- `--gzip` compresses artifact objects and publishes manifest entries with `contentEncoding: 'gzip'`.
+  Leave it off for mobile rollout until a device check proves iOS and Android both download decompressed
+  SQLite files from the object store path.
+- `--board`/`--layout` filter to a subset. A filter matching **zero** `(boardType, layoutId)` pairs is
+  treated as an operator error and throws loudly (e.g. `--board=kilterr` typo) rather than silently leaving
+  that board's artifacts stale.
+- `DATABASE_URL` must point at the **primary**, never a read replica (see the rationale above) — this is
+  read-only-sufficient (the export only `SELECT`s) but the write-time/commit-order mismatch on a replica is
+  a correctness bug, not a permissions one.
+
+### Required Production secrets
+
+Set on the `Production` GitHub environment (referenced by the workflow): `DATABASE_URL`,
+`AWS_S3_BUCKET_NAME`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL`,
+`AWS_DEFAULT_REGION`. `SYNC_STABILITY_WINDOW_SECONDS` is an optional `vars.*` passthrough (only needed if
+the backend's stability window is ever configured off its 30s default — the export reads the same env var
+so the two stay in lockstep).
+
+### Kill switches
+
+- **Fastest, no deploy**: flip the `offline-snapshot-bootstrap` PostHog flag off. Every client falls back
+  to the paged crawl for newly-enabled boards; nothing already bootstrapped is affected (it's already past
+  the eligibility check).
+- **Nuclear, affects every client regardless of flag state**: delete the `board-snapshots/v1/manifest.json`
+  object from the bucket. Every client's `fetchManifest` returns a 404 → `absent` → permanent miss, no
+  attempt burned, straight to the paged crawl. The nightly export writes a fresh manifest the following
+  night (or on the next manual `workflow_dispatch`) — deleting the manifest does **not** delete the
+  artifacts underneath it, so the next run's merge just needs artifacts newer than the deleted manifest, or
+  a rebuild.
+
+### Format-version bump procedure
+
+Bump `SNAPSHOT_MANIFEST_FORMAT_VERSION` in `snapshot-manifest.ts` (and its `formatVersion: 1` literal type)
+only for a breaking shape change to the manifest or `snapshot_meta` contract. Because clients reject a
+`format_version` mismatch outright (`verifySnapshotMeta` throws if it doesn't match exactly), a bump is a
+coordinated change, not just a constant flip:
+
+1. Bump the constant/type in `packages/shared/offline-sync/src/sync/snapshot-manifest.ts`.
+2. Change the export job's `SNAPSHOT_KEY_PREFIX` (`export-board-snapshots.ts`) from `board-snapshots/v1` to
+   `board-snapshots/v2` — the prefix is a **separate, hand-maintained constant**, not derived from the
+   format-version number, so both must move together deliberately.
+3. Ship the client change (new `SNAPSHOT_MANIFEST_FORMAT_VERSION`) in a mobile release before or alongside
+   the backend cutover — an old client binary keeps checking for `format_version === 1` and will simply
+   treat a `v2`-only export as "no entry for this layout" (permanent miss, falls back to paged pull), so
+   there's no crash risk, but it also gets zero benefit from the new artifacts until it updates.
+4. Point `EXPO_PUBLIC_SNAPSHOT_BASE_URL` at the `v2` path in the next build once `v2` artifacts exist.
+5. The old `v1` manifest/artifacts are not automatically cleaned up by this procedure (pruning only ever
+   acts within the prefix a given run is writing to) — delete them manually once old clients have aged out.
+
+### When bootstrap failure rate spikes
+
+1. Check Sentry for handled errors tagged `source: offline-sync`, `kind: snapshot-bootstrap` — `extra`
+   carries `scopeKey`/`stage` (`manifest`/`download`/`import`)/`attempt`/`cause`. A spike concentrated in
+   one `stage` narrows it fast (e.g. `download` failures across many scopes usually means the manifest or
+   an artifact URL is broken; `import` failures usually mean a bad/truncated artifact or a genuine
+   schema/format mismatch).
+2. Check the PostHog `Offline Board Download Completed` event, split by `method` (`snapshot` vs `paged`)
+   and look at `durationMs` percentiles per method — a rising `paged` share among fresh scopes is the
+   downstream signal that bootstrap is failing out even if Sentry volume looks modest (2 failed attempts
+   per scope is a small, capped signal).
+3. Confirm the manifest is actually fetchable and valid: `curl <SNAPSHOT_BASE_URL>/manifest.json` and check
+   `formatVersion`/`entries`.
+4. If it's isolated to one board/layout, re-run the export filtered to it (`--board`/`--layout`) rather
+   than a full unfiltered run.
+
+### Schema-bump staleness window
+
+A schema-version bump on the client (a new migration touching `board_climbs`/`board_climb_stats`) makes
+every existing artifact `schema_version`-stale until the next nightly export rebuilds them — that's a
+window of **at most one nightly run** (worst case: the client release ships right after 07:15 UTC). During
+that window, freshly-enabled scopes on the new client fall back to the paged crawl (a permanent miss, no
+attempt burned, always correct) rather than importing a stale artifact — see the `schema_version` semantics
+above. No manual action needed; it self-heals at the next nightly run. A manual `workflow_dispatch` closes
+the window immediately if a release needs it sooner.
+
+### Deferred: correlated-EXISTS cost on the fallback path
+
+[boardsesh/boardsesh#3561](https://github.com/boardsesh/boardsesh/issues/3561) — `syncClimbStats`'s scope
+filter uses a correlated `EXISTS` against `board_climbs` per page (`queries.ts`, mirrored in the export's
+`STATS_WHERE` and the client's stats-import semi-join). The snapshot path pays this cost once per layout
+per night; the paged fallback pays it once per page, for every user paging that scope. As long as the
+snapshot path stays healthy this is rarely hot, but any sustained drop in the `method: 'snapshot'` share
+(see the failure-rate check above) puts more traffic through the correlated `EXISTS` on every fallback
+page — that's the trigger to prioritize the fix.
+
+## Rollout plan
+
+1. **Internal testers**: flip `offline-snapshot-bootstrap` on for the `tester` PostHog cohort only.
+2. **Two pre-ramp manual verifications** (do both before any percentage ramp):
+   - Confirm `EXPO_PUBLIC_SNAPSHOT_BASE_URL` is set to the real Tigris bucket URL in the build that will
+     ship to testers. With the env var missing, the flag is inert and the app intentionally uses the paged
+     crawl (see Mobile wiring above).
+   - One real on-device bootstrap, confirmed end to end: the `ATTACH` uses a bare filesystem path (no
+     `file://` scheme — SQLite's ATTACH resolution isn't guaranteed URI-mode-safe on either platform's
+     bundled sqlite3), and identity artifacts attach/import without a gzip-magic-byte failure. If `--gzip`
+     is tested separately, verify no gzip-magic-byte handled error is reported to Sentry for that download.
+3. **Percentage ramp**: increase the PostHog rollout gradually, watching `Offline Board Download Completed`
+   duration percentiles split by `method`, and the Sentry `snapshot-bootstrap` failure rate, at each step.
+   Hold or roll back on a `snapshot` p95 that doesn't clearly beat `paged`, or a failure-rate step change.

--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -1,6 +1,8 @@
 # Offline Sync Plan
 
-Offline data layer for the React Native mobile app. Uses `expo-sqlite` for the local database with a custom GraphQL mutation queue for offline writes. Ships a pre-warmed SQLite database as an app asset for instant offline access to all ~10 boards.
+Offline data layer for the React Native mobile app. Uses `expo-sqlite` for the local database with a custom GraphQL mutation queue for offline writes.
+
+> **Shipped design supersedes the "pre-warmed, ships with the app" plan below.** This document is the original architecture evaluation (four approaches compared, one recommended) plus a first-cut design for warming boards on-device. What actually shipped downloads reference data **per board scope, on demand**, warmed by a nightly-built, CDN-hosted SQLite snapshot per `(boardType, layoutId)` rather than a single all-boards database bundled into the app binary. See **[`board-snapshots.md`](board-snapshots.md)** for the shipped export job, artifact format, client bootstrap flow, and ops runbook. The rest of this document (alternatives evaluation, mutation queue, sync pull protocol, table manifest) still describes the shipped system accurately; only the "Pre-warmed SQLite database" section below and any "first sync" / "pre-warmed timestamp" references describe the superseded design.
 
 > **Where the code lives.** The engine (mutation queue + drainer, pull client, checkpoints, table config, SQLite DDL/migrations) is the platform-free package **`@boardsesh/offline-sync`** (`packages/shared/offline-sync`). The mobile app binds its platform seams — expo-sqlite handle, NetInfo/AppState triggers, `onlineManager` connectivity, Sentry telemetry — in `packages/mobile/src/offline/offline-sync-adapter.ts`; mobile code calls `drainMutationQueue`/`startSyncScheduler`/`triggerSync`/`pullSync` via that adapter only, never from the package directly. Expo-specific pieces (DB lifecycle/`connection.ts`, seed ATTACH, local read queries, the sync-status store, hooks, the bridge component) stay in `packages/mobile`.
 
@@ -77,6 +79,15 @@ PostgreSQL (Railway, unchanged)
 No additional services. No MongoDB. No replication slots. Sync happens directly between the mobile app and the existing GraphQL API.
 
 ## Pre-warmed SQLite database
+
+> **Superseded — kept for history.** This section describes an early design: ship one SQLite file with
+> _every_ board's reference data bundled into the app binary (~150-200MB), so first launch has everything
+> offline with no download at all. That design was not what shipped. The shipped design downloads a
+> per-`(boardType, layoutId)` snapshot **only for boards the user actually enables**, fetched from a
+> CDN-hosted artifact built by a nightly GitHub Action rather than committed to the app repo — see
+> [`board-snapshots.md`](board-snapshots.md) for the real build pipeline, artifact format, client bootstrap
+> flow, and rollout status. The rest of this section (app-size table, staleness discussion, build-pipeline
+> pseudocode) reflects the superseded all-boards-in-binary approach, not the shipped one.
 
 The app ships with a CI-built SQLite database containing all board reference data (~150-200MB compressed). All boards are browsable offline from first launch.
 
@@ -799,7 +810,8 @@ On logout or account switch:
 
 ### Phase 5 — client-side offline (Platform features, within the 3-week phase)
 
-- Pre-warmed SQLite database build pipeline (GitHub Action).
+- ~~Pre-warmed SQLite database build pipeline (GitHub Action).~~ Shipped as the per-board nightly snapshot
+  export instead — see [`board-snapshots.md`](board-snapshots.md).
 - On-device schema migration system.
 - Mutation queue (~800-1200 lines) with queue drainer, error classification, dead letter handling.
 - Sync pull client with composite cursor and per-board checkpoints.

--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -2,7 +2,7 @@
 
 Offline data layer for the React Native mobile app. Uses `expo-sqlite` for the local database with a custom GraphQL mutation queue for offline writes.
 
-> **Shipped design supersedes the "pre-warmed, ships with the app" plan below.** This document is the original architecture evaluation (four approaches compared, one recommended) plus a first-cut design for warming boards on-device. What actually shipped downloads reference data **per board scope, on demand**, warmed by a nightly-built, CDN-hosted SQLite snapshot per `(boardType, layoutId)` rather than a single all-boards database bundled into the app binary. See **[`board-snapshots.md`](board-snapshots.md)** for the shipped export job, artifact format, client bootstrap flow, and ops runbook. The rest of this document (alternatives evaluation, mutation queue, sync pull protocol, table manifest) still describes the shipped system accurately; only the "Pre-warmed SQLite database" section below and any "first sync" / "pre-warmed timestamp" references describe the superseded design.
+> **Shipped design supersedes the "pre-warmed, ships with the app" plan below.** This document is the original architecture evaluation (four approaches compared, one recommended) plus a first-cut design for warming boards on-device. What actually shipped downloads reference data **per board scope, on demand**, warmed by a nightly-built, CDN-hosted SQLite snapshot per `(boardType, layoutId)` rather than a single all-boards database bundled into the app binary. See **[`board-snapshots.md`](board-snapshots.md)** for the shipped export job, artifact format, client bootstrap flow, and ops runbook. The alternatives evaluation, mutation queue, sync pull protocol, and table manifest still describe the shipped system accurately; the "Pre-warmed SQLite database" section, app-size/QA notes, and any "first sync" / "pre-warmed timestamp" references describe the superseded all-boards-in-binary design.
 
 > **Where the code lives.** The engine (mutation queue + drainer, pull client, checkpoints, table config, SQLite DDL/migrations) is the platform-free package **`@boardsesh/offline-sync`** (`packages/shared/offline-sync`). The mobile app binds its platform seams — expo-sqlite handle, NetInfo/AppState triggers, `onlineManager` connectivity, Sentry telemetry — in `packages/mobile/src/offline/offline-sync-adapter.ts`; mobile code calls `drainMutationQueue`/`startSyncScheduler`/`triggerSync`/`pullSync` via that adapter only, never from the package directly. Expo-specific pieces (DB lifecycle/`connection.ts`, seed ATTACH, local read queries, the sync-status store, hooks, the bridge component) stay in `packages/mobile`.
 
@@ -47,7 +47,7 @@ The original plan from [mobile-app-plan.md](mobile-app-plan.md) Phase 5. After e
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Climb search        | Full SQL with JOINs, proper column indexes, < 100ms                                                                                                 |
 | Infrastructure cost | $0 — client-only, uses existing GraphQL API                                                                                                         |
-| Pre-warmed database | Just a SQLite file. No internal metadata, no LSN alignment, no RxDB format. Copy to disk and open.                                                  |
+| Snapshot bootstrap  | Plain SQLite artifacts. No internal metadata, no LSN alignment, no RxDB format. Download, ATTACH, import scoped rows.                               |
 | Backend changes     | Sync pull queries (10 resolvers) + `sync_deletions` table + idempotent mutations                                                                    |
 | Delete handling     | `sync_deletions` table + triggers. Existing queries untouched.                                                                                      |
 | Maintenance risk    | `expo-sqlite` is a first-party Expo module. Guaranteed New Architecture support.                                                                    |
@@ -57,11 +57,11 @@ The original plan from [mobile-app-plan.md](mobile-app-plan.md) Phase 5. After e
 
 ```
 React Native App
-  ├── Pre-warmed SQLite (ships with app, all boards, ~150-200MB)
+  ├── On-demand board snapshots (CDN SQLite artifacts, per enabled board scope)
   ├── expo-sqlite manages the database
   ├── TanStack Query for reactive data + cache (staleTime: Infinity for local queries)
   ├── Mutation queue for offline writes
-  └── Sync pull client for incremental updates
+  └── Sync pull client for snapshot bootstrap + incremental updates
         │
         │ GraphQL mutations (push) + sync queries (pull)
         ▼

--- a/docs/sync-table-manifest.md
+++ b/docs/sync-table-manifest.md
@@ -1,12 +1,23 @@
 # Sync Table Manifest — the cross-package contract
 
-This is the **single source of truth** binding three implementations together:
+This is the **single source of truth** binding four implementations together:
 
 1. **Backend** sync-pull resolvers (`packages/backend`) — emit JSON documents whose keys
    are listed here, and deletion triggers that emit `record_id` strings encoded as listed here.
 2. **Client SQLite DDL** (`packages/shared/offline-sync/src/db/schema.ts`) — column names + types + PKs match exactly.
 3. **Client `table-config.ts`** (`packages/shared/offline-sync/src/sync/table-config.ts`) `primaryKeyColumns` — match the
    **Local PK** column order here.
+4. **Board-snapshot export artifacts** (`packages/backend/src/scripts/export-board-snapshots.ts`) — the
+   `board_climbs`/`board_climb_stats` columns baked into the nightly SQLite artifacts (see
+   [`board-snapshots.md`](board-snapshots.md)). This one needs no manual upkeep: the export's DDL is derived
+   from the shared client `MIGRATIONS`, and its SELECT column lists come from each table's `localColumns` in
+   `table-config.ts` — the same source this manifest's **Local PK**/**Columns** entries below describe. A
+   `localColumns` change here flows into the next artifact automatically. The one thing that does NOT
+   auto-verify is row _shaping_ — that the export's Postgres → SQLite coercion actually matches the live
+   resolver → client-upsert coercion byte-for-byte. That's enforced by
+   `packages/backend/src/__tests__/snapshot-export-golden.test.ts`, which runs both paths against the same
+   seeded rows and diffs the result; treat it as this manifest's enforcement for the snapshot artifact the
+   same way this doc is the source of truth for the other three.
 
 It exists because `pull-client.ts:upsertDocuments` does `INSERT OR REPLACE INTO <table> (<Object.keys(doc)>)`:
 the resolver's JSON keys **are** the local column names. And `processDeletions` splits `record_id` on `:`

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -12,11 +12,12 @@ import { useAuth } from '../../src/providers/auth-provider';
 import { useToast } from '../../src/providers/toast-provider';
 import { useConfirm } from '../../src/providers/dialog-provider';
 import { useTheme } from '../../src/providers/theme-provider';
-import { useOfflineDownloadsEnabled } from '../../src/providers/feature-flags-provider';
+import { useOfflineDownloadsEnabled, useSnapshotBootstrapEnabled } from '../../src/providers/feature-flags-provider';
 import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
 import { useSyncStatus, setSyncProgress } from '../../src/sync';
 import { getDownloadedScopeKeys, type GraphQLFetch } from '@boardsesh/offline-sync';
 import { triggerSync, drainMutationQueue } from '../../src/offline/offline-sync-adapter';
+import { mobileSnapshotSource } from '../../src/offline/snapshot-source';
 import {
   getSetting,
   useSetting,
@@ -25,6 +26,7 @@ import {
   offlineBoardScopeForBoard,
 } from '../../src/settings';
 import { getHttpClient } from '../../src/lib/graphql/client';
+import { isSnapshotBaseUrlConfigured } from '../../src/lib/env';
 import { Text } from '../../src/components/Text';
 import { Icon } from '../../src/components/Icon';
 import { Button } from '../../src/components/Button';
@@ -84,6 +86,8 @@ export default function ManageBoards() {
   // flush (see OfflineSyncBridge). This screen stays the only writer of
   // syncEnabledBoards.
   const offlineDownloadsEnabled = useOfflineDownloadsEnabled();
+  const snapshotBootstrapEnabled = useSnapshotBootstrapEnabled();
+  const snapshotSource = snapshotBootstrapEnabled && isSnapshotBaseUrlConfigured() ? mobileSnapshotSource : undefined;
   const db = useSQLiteContext();
   const queryClient = useQueryClient();
   const syncStatus = useSyncStatus();
@@ -136,9 +140,17 @@ export default function ManageBoards() {
       // the next foreground/reconnect trigger. triggerSync → runSync is single-flight
       // (one in-flight run + at most one queued follow-up), so enabling several boards
       // in quick succession collapses into one cycle that reads the latest setting.
-      triggerSync(db, queryClient, graphqlFetch, () => getSetting('syncEnabledBoards'), drainQueue, setSyncProgress);
+      triggerSync(
+        db,
+        queryClient,
+        graphqlFetch,
+        () => getSetting('syncEnabledBoards'),
+        drainQueue,
+        setSyncProgress,
+        snapshotSource,
+      );
     },
-    [confirm, t, db, queryClient, graphqlFetch, drainQueue],
+    [confirm, t, db, queryClient, graphqlFetch, drainQueue, snapshotSource],
   );
 
   // See boards/index.tsx: a hard 401 clears tokens without flipping

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -12,12 +12,12 @@ import { useAuth } from '../../src/providers/auth-provider';
 import { useToast } from '../../src/providers/toast-provider';
 import { useConfirm } from '../../src/providers/dialog-provider';
 import { useTheme } from '../../src/providers/theme-provider';
-import { useOfflineDownloadsEnabled, useSnapshotBootstrapEnabled } from '../../src/providers/feature-flags-provider';
+import { useOfflineDownloadsEnabled } from '../../src/providers/feature-flags-provider';
 import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
 import { useSyncStatus, setSyncProgress } from '../../src/sync';
 import { getDownloadedScopeKeys, type GraphQLFetch } from '@boardsesh/offline-sync';
 import { triggerSync, drainMutationQueue } from '../../src/offline/offline-sync-adapter';
-import { mobileSnapshotSource } from '../../src/offline/snapshot-source';
+import { useSnapshotSource } from '../../src/offline/use-snapshot-source';
 import {
   getSetting,
   useSetting,
@@ -26,7 +26,6 @@ import {
   offlineBoardScopeForBoard,
 } from '../../src/settings';
 import { getHttpClient } from '../../src/lib/graphql/client';
-import { isSnapshotBaseUrlConfigured } from '../../src/lib/env';
 import { Text } from '../../src/components/Text';
 import { Icon } from '../../src/components/Icon';
 import { Button } from '../../src/components/Button';
@@ -86,8 +85,7 @@ export default function ManageBoards() {
   // flush (see OfflineSyncBridge). This screen stays the only writer of
   // syncEnabledBoards.
   const offlineDownloadsEnabled = useOfflineDownloadsEnabled();
-  const snapshotBootstrapEnabled = useSnapshotBootstrapEnabled();
-  const snapshotSource = snapshotBootstrapEnabled && isSnapshotBaseUrlConfigured() ? mobileSnapshotSource : undefined;
+  const snapshotSource = useSnapshotSource();
   const db = useSQLiteContext();
   const queryClient = useQueryClient();
   const syncStatus = useSyncStatus();
@@ -140,15 +138,10 @@ export default function ManageBoards() {
       // the next foreground/reconnect trigger. triggerSync → runSync is single-flight
       // (one in-flight run + at most one queued follow-up), so enabling several boards
       // in quick succession collapses into one cycle that reads the latest setting.
-      triggerSync(
-        db,
-        queryClient,
-        graphqlFetch,
-        () => getSetting('syncEnabledBoards'),
-        drainQueue,
-        setSyncProgress,
+      triggerSync(db, queryClient, graphqlFetch, () => getSetting('syncEnabledBoards'), drainQueue, {
+        onProgress: setSyncProgress,
         snapshotSource,
-      );
+      });
     },
     [confirm, t, db, queryClient, graphqlFetch, drainQueue, snapshotSource],
   );

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -30,7 +30,7 @@ import { Icon } from '../../src/components/Icon';
 import { Button } from '../../src/components/Button';
 import { ActivityIndicator } from '../../src/components/ActivityIndicator';
 import { BoardManageRow } from '../../src/components/board-discovery/BoardManageRow';
-import { boardDownloadState } from '../../src/components/board-discovery/board-offline-state';
+import { boardDownloadState, boardIsBootstrapping } from '../../src/components/board-discovery/board-offline-state';
 import { buildManageItems, type ManageItem } from '../../src/components/board-discovery/manage-items';
 import { iosSystemColors } from '../../src/theme/ios-colors';
 import { spacing } from '../../src/theme/tokens';
@@ -92,6 +92,7 @@ export default function ManageBoards() {
   const isSyncing = syncStatus.isSyncing;
   const currentTable = syncStatus.progress?.currentTable ?? null;
   const currentTableProcessed = syncStatus.progress?.currentTableProcessed;
+  const currentPhase = syncStatus.progress?.phase ?? null;
 
   // Per-scope "downloaded" signal: which scopes actually have a board_climbs
   // checkpoint. Refetched whenever a cycle finishes (isSyncing → false), so a
@@ -216,18 +217,20 @@ export default function ManageBoards() {
         (unfollowBoard.isPending && unfollowBoard.variables === item.board.uuid);
       const scopeKey = offlineBoardKeyForBoard(item.board);
       // undefined (flag off) hides the row's toggle + caption entirely.
-      const downloadState = offlineDownloadsEnabled
-        ? boardDownloadState({
-            scopeKey,
-            enabled: enabledSet.has(scopeKey),
-            isSyncing,
-            downloaded: downloadedSet.has(scopeKey),
-            currentTable,
-          })
-        : undefined;
-      // Only the board actually downloading gets the live count; every other row
-      // gets undefined (a stable prop), so its memo skips the per-frame churn.
+      const downloadStateInput = {
+        scopeKey,
+        enabled: enabledSet.has(scopeKey),
+        isSyncing,
+        downloaded: downloadedSet.has(scopeKey),
+        currentTable,
+        phase: currentPhase,
+      };
+      const downloadState = offlineDownloadsEnabled ? boardDownloadState(downloadStateInput) : undefined;
+      // Only the board actually downloading gets the live count / bootstrap
+      // flag; every other row gets undefined/false (stable props), so its
+      // memo skips the per-frame churn.
       const downloadCount = downloadState === 'downloading' ? currentTableProcessed : undefined;
+      const isBootstrapping = downloadState === 'downloading' && boardIsBootstrapping(downloadStateInput);
       return (
         <BoardManageRow
           board={item.board}
@@ -236,6 +239,7 @@ export default function ManageBoards() {
           isMutating={isMutating}
           downloadState={downloadState}
           downloadCount={downloadCount}
+          isBootstrapping={isBootstrapping}
           onEdit={handleEdit}
           onDelete={handleDelete}
           onUnfollow={handleUnfollow}
@@ -254,6 +258,7 @@ export default function ManageBoards() {
       downloadedSet,
       currentTable,
       currentTableProcessed,
+      currentPhase,
       handleEdit,
       handleDelete,
       handleUnfollow,

--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -21,6 +21,15 @@ vi.mock('../../offline/offline-sync-adapter', () => ({
   drainMutationQueue: (...args: unknown[]) => drainMutationQueueMock(...args),
 }));
 
+// A stable sentinel so tests can assert the bridge passes THIS reference
+// through to startSyncScheduler (rather than exercising the real
+// expo-file-system-backed implementation). vi.hoisted because vi.mock
+// factories are hoisted above regular top-level const declarations.
+const mobileSnapshotSourceStub = vi.hoisted(() => ({ tag: 'snapshot-source' }));
+vi.mock('../../offline/snapshot-source', () => ({
+  mobileSnapshotSource: mobileSnapshotSourceStub,
+}));
+
 const getPendingCountMock = vi.fn(async (..._args: unknown[]) => 0);
 vi.mock('@boardsesh/offline-sync', () => ({
   getPendingCount: (...args: unknown[]) => getPendingCountMock(...args),
@@ -97,6 +106,7 @@ function makeQueryClient() {
 
 const FLAG_ON: FeatureFlags = { 'offline-board-downloads': true };
 const FLAG_OFF: FeatureFlags = { 'offline-board-downloads': false };
+const FLAG_ON_WITH_SNAPSHOT: FeatureFlags = { 'offline-board-downloads': true, 'offline-snapshot-bootstrap': true };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -127,6 +137,21 @@ describe('OfflineSyncBridge — flag ON', () => {
     await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalled());
     unmount();
     expect(startSyncSchedulerStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes no snapshotSource when offline-snapshot-bootstrap is off', async () => {
+    render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
+    await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalledTimes(1));
+    // 7th positional arg (index 6) is the optional snapshotSource.
+    const call = startSyncSchedulerMock.mock.calls[0] as unknown as unknown[];
+    expect(call[6]).toBeUndefined();
+  });
+
+  it('passes the mobile snapshot source when offline-snapshot-bootstrap is also on', async () => {
+    render(<Harness flags={FLAG_ON_WITH_SNAPSHOT} queryClient={makeQueryClient()} />);
+    await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalledTimes(1));
+    const call = startSyncSchedulerMock.mock.calls[0] as unknown as unknown[];
+    expect(call[6]).toBe(mobileSnapshotSourceStub);
   });
 });
 

--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -112,12 +112,13 @@ function makeQueryClient() {
 const FLAG_ON: FeatureFlags = { 'offline-board-downloads': true };
 const FLAG_OFF: FeatureFlags = { 'offline-board-downloads': false };
 const FLAG_ON_WITH_SNAPSHOT: FeatureFlags = { 'offline-board-downloads': true, 'offline-snapshot-bootstrap': true };
-const SNAPSHOT_SOURCE_ARG_INDEX = 6;
-
 function getStartSyncSchedulerSnapshotSource(): unknown {
   const call = startSyncSchedulerMock.mock.calls[0] as unknown[] | undefined;
   expect(call).toBeDefined();
-  return call?.[SNAPSHOT_SOURCE_ARG_INDEX];
+  // The trailing argument is the named options bag — no positional offsets to
+  // silently drift if the scheduler signature grows.
+  const options = call?.at(-1) as { snapshotSource?: unknown } | undefined;
+  return options?.snapshotSource;
 }
 
 beforeEach(() => {

--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -50,6 +50,11 @@ vi.mock('../../lib/graphql/client', () => ({
   getHttpClient: () => ({ request: vi.fn() }),
 }));
 
+const snapshotBaseUrlConfigured = vi.hoisted(() => ({ value: true }));
+vi.mock('../../lib/env', () => ({
+  isSnapshotBaseUrlConfigured: () => snapshotBaseUrlConfigured.value,
+}));
+
 const fakeDb = { tag: 'db' };
 vi.mock('expo-sqlite', () => ({
   useSQLiteContext: () => fakeDb,
@@ -107,12 +112,20 @@ function makeQueryClient() {
 const FLAG_ON: FeatureFlags = { 'offline-board-downloads': true };
 const FLAG_OFF: FeatureFlags = { 'offline-board-downloads': false };
 const FLAG_ON_WITH_SNAPSHOT: FeatureFlags = { 'offline-board-downloads': true, 'offline-snapshot-bootstrap': true };
+const SNAPSHOT_SOURCE_ARG_INDEX = 6;
+
+function getStartSyncSchedulerSnapshotSource(): unknown {
+  const call = startSyncSchedulerMock.mock.calls[0] as unknown[] | undefined;
+  expect(call).toBeDefined();
+  return call?.[SNAPSHOT_SOURCE_ARG_INDEX];
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
   startSyncSchedulerMock.mockReturnValue(startSyncSchedulerStop);
   getPendingCountMock.mockResolvedValue(0);
   isAuthenticated = true;
+  snapshotBaseUrlConfigured.value = true;
 });
 
 afterEach(() => {
@@ -142,16 +155,21 @@ describe('OfflineSyncBridge — flag ON', () => {
   it('passes no snapshotSource when offline-snapshot-bootstrap is off', async () => {
     render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
     await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalledTimes(1));
-    // 7th positional arg (index 6) is the optional snapshotSource.
-    const call = startSyncSchedulerMock.mock.calls[0] as unknown as unknown[];
-    expect(call[6]).toBeUndefined();
+    expect(getStartSyncSchedulerSnapshotSource()).toBeUndefined();
   });
 
   it('passes the mobile snapshot source when offline-snapshot-bootstrap is also on', async () => {
     render(<Harness flags={FLAG_ON_WITH_SNAPSHOT} queryClient={makeQueryClient()} />);
     await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalledTimes(1));
-    const call = startSyncSchedulerMock.mock.calls[0] as unknown as unknown[];
-    expect(call[6]).toBe(mobileSnapshotSourceStub);
+    expect(getStartSyncSchedulerSnapshotSource()).toBe(mobileSnapshotSourceStub);
+  });
+
+  it('passes no snapshotSource when the snapshot manifest URL is not configured', async () => {
+    snapshotBaseUrlConfigured.value = false;
+
+    render(<Harness flags={FLAG_ON_WITH_SNAPSHOT} queryClient={makeQueryClient()} />);
+    await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalledTimes(1));
+    expect(getStartSyncSchedulerSnapshotSource()).toBeUndefined();
   });
 });
 

--- a/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
@@ -31,8 +31,15 @@ type BoardManageRowProps = {
    * the toggle and status caption are not rendered at all.
    */
   downloadState: BoardDownloadState | undefined;
-  /** Climbs pulled so far while this board is the one downloading. */
+  /** Climbs pulled so far while this board is the one downloading (paged crawl only). */
   downloadCount?: number;
+  /**
+   * True while `downloadState === 'downloading'` is the snapshot-bootstrap
+   * warm-up rather than the paged crawl — shows a distinct "Downloading
+   * board…" caption instead of a live climb count (the bootstrap phase has
+   * no per-row count to show).
+   */
+  isBootstrapping?: boolean;
   onEdit: (board: UserBoard) => void;
   onDelete: (board: UserBoard) => void;
   onUnfollow: (board: UserBoard) => void;
@@ -53,6 +60,7 @@ function BoardManageRowComponent({
   isMutating,
   downloadState,
   downloadCount,
+  isBootstrapping,
   onEdit,
   onDelete,
   onUnfollow,
@@ -90,7 +98,9 @@ function BoardManageRowComponent({
   // downloaded rows stay two lines and the extra line appears transiently.
   const offlineStatus =
     downloadState === 'downloading'
-      ? t('mobile.offline.downloadingCount', { count: downloadCount ?? 0 })
+      ? isBootstrapping
+        ? t('mobile.offline.bootstrapping')
+        : t('mobile.offline.downloadingCount', { count: downloadCount ?? 0 })
       : downloadState === 'downloaded'
         ? t('mobile.offline.available')
         : downloadState === 'pending'

--- a/packages/mobile/src/components/board-discovery/__tests__/board-manage-row.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-manage-row.test.tsx
@@ -108,4 +108,18 @@ describe('BoardManageRow offline toggle gating', () => {
     expect(queryByText('mobile.offline.available')).not.toBeNull();
     expect(offlineToggleProps.last?.state).toBe('downloaded');
   });
+
+  it('shows the bootstrapping caption (not the climb count) during the snapshot warm-up', () => {
+    const { queryByText } = render(
+      <BoardManageRow {...rowProps} downloadState="downloading" isBootstrapping downloadCount={0} />,
+    );
+    expect(queryByText('mobile.offline.bootstrapping')).not.toBeNull();
+    expect(queryByText('mobile.offline.downloadingCount')).toBeNull();
+  });
+
+  it('shows the live climb count caption during the paged crawl (not bootstrapping)', () => {
+    const { queryByText } = render(<BoardManageRow {...rowProps} downloadState="downloading" downloadCount={42} />);
+    expect(queryByText('mobile.offline.downloadingCount')).not.toBeNull();
+    expect(queryByText('mobile.offline.bootstrapping')).toBeNull();
+  });
 });

--- a/packages/mobile/src/components/board-discovery/__tests__/board-offline-state.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-offline-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { boardDownloadState } from '../board-offline-state';
+import { boardDownloadState, boardIsBootstrapping } from '../board-offline-state';
 
 const base = {
   scopeKey: 'kilter:1:5',
@@ -68,5 +68,69 @@ describe('boardDownloadState', () => {
         currentTable: 'board_climbs:tension:8:10',
       }),
     ).toBe('downloaded');
+  });
+
+  it('is downloading while the snapshot-bootstrap phase is warming this exact scope', () => {
+    expect(boardDownloadState({ ...base, isSyncing: true, currentTable: 'kilter:1:5', phase: 'bootstrap' })).toBe(
+      'downloading',
+    );
+  });
+
+  it('does not cross-trigger bootstrap on a sibling scope with a shared prefix', () => {
+    expect(
+      boardDownloadState({
+        scopeKey: 'kilter:1:50',
+        enabled: true,
+        isSyncing: true,
+        downloaded: false,
+        currentTable: 'kilter:1:5',
+        phase: 'bootstrap',
+      }),
+    ).toBe('pending');
+  });
+
+  it('does not read as downloading when currentTable matches but the phase is not bootstrap', () => {
+    // A bare scope key matching currentTable only means "bootstrapping" when
+    // phase is actually 'bootstrap' — this guards against a stale/undefined
+    // phase accidentally matching.
+    expect(boardDownloadState({ ...base, isSyncing: true, currentTable: 'kilter:1:5', phase: null })).toBe('pending');
+  });
+});
+
+describe('boardIsBootstrapping', () => {
+  it('is true only during the bootstrap phase for this exact scope while syncing', () => {
+    expect(boardIsBootstrapping({ ...base, isSyncing: true, currentTable: 'kilter:1:5', phase: 'bootstrap' })).toBe(
+      true,
+    );
+  });
+
+  it('is false during the paged board_data phase, even for this scope', () => {
+    expect(
+      boardIsBootstrapping({
+        ...base,
+        isSyncing: true,
+        currentTable: 'board_climbs:kilter:1:5',
+        phase: 'board_data',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false when not syncing at all', () => {
+    expect(boardIsBootstrapping({ ...base, isSyncing: false, currentTable: 'kilter:1:5', phase: 'bootstrap' })).toBe(
+      false,
+    );
+  });
+
+  it('is false for a sibling scope sharing the bootstrap phase', () => {
+    expect(
+      boardIsBootstrapping({
+        scopeKey: 'kilter:1:50',
+        enabled: true,
+        isSyncing: true,
+        downloaded: false,
+        currentTable: 'kilter:1:5',
+        phase: 'bootstrap',
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/mobile/src/components/board-discovery/board-offline-state.ts
+++ b/packages/mobile/src/components/board-discovery/board-offline-state.ts
@@ -2,6 +2,8 @@
 // sync status. Kept renderer-free so the My Boards screen can compute one state
 // per row without each row subscribing to the sync store, and so it can be tested.
 
+import type { SyncProgress } from '@boardsesh/offline-sync';
+
 export type BoardDownloadState =
   | 'off' // not made available offline
   | 'pending' // enabled but not yet pulled (e.g. enabled while offline)
@@ -23,23 +25,55 @@ export type BoardDownloadStateInput = {
   downloaded: boolean;
   /** From useSyncStatus().progress: the table:scope label being pulled, or null. */
   currentTable: string | null;
+  /**
+   * From useSyncStatus().progress?.phase: which pull phase is running. Only
+   * matters for distinguishing the snapshot-bootstrap warm-up (currentTable is
+   * the bare scope key, not a `table:scope` label) from the paged crawl.
+   * Undefined/null is treated as "not bootstrapping" — the paged-crawl match
+   * below still applies.
+   */
+  phase?: SyncProgress['phase'] | null;
 };
 
 /**
- * A board is "downloading" only while the pull is on one of its two per-board
- * tables — matched exactly so a sibling scope (e.g. kilter:1:50 vs kilter:1:5)
- * can't cross-trigger. "downloaded" is driven by this scope's own checkpoint, so a
- * board enabled after another already synced shows "pending" (not a false
- * "downloaded") until its own data lands.
+ * True when the live progress frame is the snapshot-bootstrap warm-up for
+ * THIS scope. The bootstrap phase reports `currentTable` as the bare scope key
+ * (pull-client.ts's `runBootstrapPhase`), unlike the paged board_data phase's
+ * `table:scope` label — so this is a distinct match, not a prefix variant.
+ */
+function isBootstrappingThisScope(
+  input: Pick<BoardDownloadStateInput, 'scopeKey' | 'phase' | 'currentTable'>,
+): boolean {
+  return input.phase === 'bootstrap' && input.currentTable === input.scopeKey;
+}
+
+/**
+ * A board is "downloading" while the pull is on one of its two per-board
+ * tables (matched exactly so a sibling scope, e.g. kilter:1:50 vs kilter:1:5,
+ * can't cross-trigger) OR while it's being warmed from a snapshot artifact.
+ * "downloaded" is driven by this scope's own checkpoint, so a board enabled
+ * after another already synced shows "pending" (not a false "downloaded")
+ * until its own data lands.
  */
 export function boardDownloadState(input: BoardDownloadStateInput): BoardDownloadState {
   if (!input.enabled) return 'off';
 
   const isCurrentBoard =
+    isBootstrappingThisScope(input) ||
     input.currentTable === `board_climbs:${input.scopeKey}` ||
     input.currentTable === `board_climb_stats:${input.scopeKey}`;
   if (input.isSyncing && isCurrentBoard) return 'downloading';
 
   if (input.downloaded) return 'downloaded';
   return 'pending';
+}
+
+/**
+ * Whether THIS row's `'downloading'` state is the snapshot-bootstrap warm-up
+ * rather than the paged crawl. The bootstrap phase carries no per-row climb
+ * count (unlike the paged crawl's `currentTableProcessed`), so the UI needs a
+ * distinct caption ("Downloading board…") instead of "Downloading N climbs".
+ */
+export function boardIsBootstrapping(input: BoardDownloadStateInput): boolean {
+  return input.isSyncing && isBootstrappingThisScope(input);
 }

--- a/packages/mobile/src/components/offline-sync-bridge.tsx
+++ b/packages/mobile/src/components/offline-sync-bridge.tsx
@@ -10,7 +10,8 @@ import { setupNotificationHandlers } from '../notifications';
 import { getHttpClient } from '../lib/graphql/client';
 import { setOfflineEngineEnabled } from '../lib/offline-engine';
 import { useAuth } from '../providers/auth-provider';
-import { useOfflineDownloadsEnabled } from '../providers/feature-flags-provider';
+import { useOfflineDownloadsEnabled, useSnapshotBootstrapEnabled } from '../providers/feature-flags-provider';
+import { mobileSnapshotSource } from '../offline/snapshot-source';
 
 /**
  * Publishes the offline-engine flag decision to the module-level store that
@@ -50,6 +51,7 @@ export function OfflineSyncBridge() {
   const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
   const offlineEnabled = useOfflineDownloadsEnabled();
+  const snapshotBootstrapEnabled = useSnapshotBootstrapEnabled();
 
   // getHttpClient() already carries auth + endpoint; binding .request keeps the
   // GraphQLFetch shape the scheduler and drainer expect.
@@ -86,6 +88,10 @@ export function OfflineSyncBridge() {
           // Publish pull progress to the module-level store so the Settings screen
           // can render "last synced" + live progress without prop-drilling.
           setSyncProgress,
+          // Snapshot bootstrap is its own flag, nested under offline-board-downloads
+          // — a freshly-enabled board still downloads with the flag off, just via
+          // the (today's default) paged crawl.
+          snapshotBootstrapEnabled ? mobileSnapshotSource : undefined,
         );
         return stop;
       } catch (error) {
@@ -116,7 +122,7 @@ export function OfflineSyncBridge() {
     return () => {
       cancelled = true;
     };
-  }, [db, queryClient, graphqlFetch, offlineEnabled, isAuthenticated]);
+  }, [db, queryClient, graphqlFetch, offlineEnabled, snapshotBootstrapEnabled, isAuthenticated]);
 
   // Deep-link routing for tapped push notifications. Deliberately independent
   // of the offline flag — notifications ship inert for everyone today.

--- a/packages/mobile/src/components/offline-sync-bridge.tsx
+++ b/packages/mobile/src/components/offline-sync-bridge.tsx
@@ -9,10 +9,9 @@ import { getSetting } from '../settings';
 import { setupNotificationHandlers } from '../notifications';
 import { getHttpClient } from '../lib/graphql/client';
 import { setOfflineEngineEnabled } from '../lib/offline-engine';
-import { isSnapshotBaseUrlConfigured } from '../lib/env';
 import { useAuth } from '../providers/auth-provider';
-import { useOfflineDownloadsEnabled, useSnapshotBootstrapEnabled } from '../providers/feature-flags-provider';
-import { mobileSnapshotSource } from '../offline/snapshot-source';
+import { useOfflineDownloadsEnabled } from '../providers/feature-flags-provider';
+import { useSnapshotSource } from '../offline/use-snapshot-source';
 
 /**
  * Publishes the offline-engine flag decision to the module-level store that
@@ -52,8 +51,7 @@ export function OfflineSyncBridge() {
   const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
   const offlineEnabled = useOfflineDownloadsEnabled();
-  const snapshotBootstrapEnabled = useSnapshotBootstrapEnabled();
-  const snapshotSource = snapshotBootstrapEnabled && isSnapshotBaseUrlConfigured() ? mobileSnapshotSource : undefined;
+  const snapshotSource = useSnapshotSource();
 
   // getHttpClient() already carries auth + endpoint; binding .request keeps the
   // GraphQLFetch shape the scheduler and drainer expect.
@@ -87,13 +85,13 @@ export function OfflineSyncBridge() {
           graphqlFetch,
           () => getSetting('syncEnabledBoards'),
           () => drainMutationQueue(db, queryClient, graphqlFetch),
-          // Publish pull progress to the module-level store so the Settings screen
-          // can render "last synced" + live progress without prop-drilling.
-          setSyncProgress,
-          // Snapshot bootstrap is its own flag, nested under offline-board-downloads
-          // and a real build-time manifest URL — otherwise a freshly-enabled
-          // board still downloads through the paged crawl.
-          snapshotSource,
+          {
+            // Publish pull progress to the module-level store so the Settings
+            // screen can render "last synced" + live progress without
+            // prop-drilling. snapshotSource is gated by useSnapshotSource.
+            onProgress: setSyncProgress,
+            snapshotSource,
+          },
         );
         return stop;
       } catch (error) {

--- a/packages/mobile/src/components/offline-sync-bridge.tsx
+++ b/packages/mobile/src/components/offline-sync-bridge.tsx
@@ -9,6 +9,7 @@ import { getSetting } from '../settings';
 import { setupNotificationHandlers } from '../notifications';
 import { getHttpClient } from '../lib/graphql/client';
 import { setOfflineEngineEnabled } from '../lib/offline-engine';
+import { isSnapshotBaseUrlConfigured } from '../lib/env';
 import { useAuth } from '../providers/auth-provider';
 import { useOfflineDownloadsEnabled, useSnapshotBootstrapEnabled } from '../providers/feature-flags-provider';
 import { mobileSnapshotSource } from '../offline/snapshot-source';
@@ -52,6 +53,7 @@ export function OfflineSyncBridge() {
   const { isAuthenticated } = useAuth();
   const offlineEnabled = useOfflineDownloadsEnabled();
   const snapshotBootstrapEnabled = useSnapshotBootstrapEnabled();
+  const snapshotSource = snapshotBootstrapEnabled && isSnapshotBaseUrlConfigured() ? mobileSnapshotSource : undefined;
 
   // getHttpClient() already carries auth + endpoint; binding .request keeps the
   // GraphQLFetch shape the scheduler and drainer expect.
@@ -89,9 +91,9 @@ export function OfflineSyncBridge() {
           // can render "last synced" + live progress without prop-drilling.
           setSyncProgress,
           // Snapshot bootstrap is its own flag, nested under offline-board-downloads
-          // — a freshly-enabled board still downloads with the flag off, just via
-          // the (today's default) paged crawl.
-          snapshotBootstrapEnabled ? mobileSnapshotSource : undefined,
+          // and a real build-time manifest URL — otherwise a freshly-enabled
+          // board still downloads through the paged crawl.
+          snapshotSource,
         );
         return stop;
       } catch (error) {
@@ -122,7 +124,7 @@ export function OfflineSyncBridge() {
     return () => {
       cancelled = true;
     };
-  }, [db, queryClient, graphqlFetch, offlineEnabled, snapshotBootstrapEnabled, isAuthenticated]);
+  }, [db, queryClient, graphqlFetch, offlineEnabled, snapshotSource, isAuthenticated]);
 
   // Deep-link routing for tapped push notifications. Deliberately independent
   // of the offline flag — notifications ship inert for everyone today.

--- a/packages/mobile/src/lib/env.ts
+++ b/packages/mobile/src/lib/env.ts
@@ -6,13 +6,12 @@ export const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'https://www.boar
 // is an absolute artifact URL, so this constant is only used for the manifest
 // fetch. Mirrors packages/backend/src/scripts/export-board-snapshots.ts's
 // `board-snapshots/v1` key prefix, served from the same Tigris/S3 bucket
-// packages/backend/src/storage/s3.ts uploads to.
+// packages/backend/src/storage/s3.ts uploads to. This must be supplied by the
+// EAS build environment; there is deliberately no guessed production fallback.
 //
-// UNCONFIRMED DEFAULT: the actual bucket host/name is only known via the
-// backend's AWS_S3_BUCKET_NAME/AWS_ENDPOINT_URL secrets (not visible from this
-// worktree). This fallback is a placeholder guess at the Tigris virtual-hosted
-// bucket domain — confirm the real value and set it as an EAS build-time env
-// var before this ships (EXPO_PUBLIC_* vars are inlined at build time, not read
-// at runtime).
-export const SNAPSHOT_BASE_URL =
-  process.env.EXPO_PUBLIC_SNAPSHOT_BASE_URL ?? 'https://boardsesh-data.fly.storage.tigris.dev/board-snapshots/v1';
+// EXPO_PUBLIC_* vars are inlined at build time, not read at runtime.
+export const SNAPSHOT_BASE_URL = (process.env.EXPO_PUBLIC_SNAPSHOT_BASE_URL?.trim() ?? '').replace(/\/+$/, '');
+
+export function isSnapshotBaseUrlConfigured(): boolean {
+  return SNAPSHOT_BASE_URL.length > 0;
+}

--- a/packages/mobile/src/lib/env.ts
+++ b/packages/mobile/src/lib/env.ts
@@ -1,2 +1,18 @@
 export const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL ?? 'https://ws.boardsesh.com';
 export const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'https://www.boardsesh.com';
+
+// Base URL for the board-snapshot manifest directory (offline-sync Phase 2/4):
+// `${SNAPSHOT_BASE_URL}/manifest.json` is the manifest; each entry's own `url`
+// is an absolute artifact URL, so this constant is only used for the manifest
+// fetch. Mirrors packages/backend/src/scripts/export-board-snapshots.ts's
+// `board-snapshots/v1` key prefix, served from the same Tigris/S3 bucket
+// packages/backend/src/storage/s3.ts uploads to.
+//
+// UNCONFIRMED DEFAULT: the actual bucket host/name is only known via the
+// backend's AWS_S3_BUCKET_NAME/AWS_ENDPOINT_URL secrets (not visible from this
+// worktree). This fallback is a placeholder guess at the Tigris virtual-hosted
+// bucket domain — confirm the real value and set it as an EAS build-time env
+// var before this ships (EXPO_PUBLIC_* vars are inlined at build time, not read
+// at runtime).
+export const SNAPSHOT_BASE_URL =
+  process.env.EXPO_PUBLIC_SNAPSHOT_BASE_URL ?? 'https://boardsesh-data.fly.storage.tigris.dev/board-snapshots/v1';

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -50,12 +50,17 @@ vi.mock('../../lib/error-reporting', () => ({
   reportHandledError: (...args: unknown[]) => reportHandledError(...args),
 }));
 
+const trackMock = vi.fn();
+vi.mock('../../lib/analytics', () => ({ track: (...args: unknown[]) => trackMock(...args) }));
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { drainMutationQueue, startSyncScheduler, triggerSync, pullSync } from '../offline-sync-adapter';
 import type {
   OfflineDatabase,
   DrainOptions,
   SchedulerTriggers,
   SchedulerOptions,
+  SnapshotSource,
   SyncOptions,
 } from '@boardsesh/offline-sync';
 
@@ -145,6 +150,119 @@ describe('scheduler trigger bindings', () => {
         extra: { tableName: 'boardsesh_ticks', column: 'shiny_new_column' },
       }),
     );
+  });
+});
+
+describe('snapshot-bootstrap bindings', () => {
+  const fakeSnapshotSource = {} as SnapshotSource;
+
+  it('startSyncScheduler passes snapshotSource through only when the caller supplies one', () => {
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+      undefined,
+      fakeSnapshotSource,
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+    expect(options.snapshotSource).toBe(fakeSnapshotSource);
+
+    vi.clearAllMocks();
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const optionsWithoutSource = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+    expect(optionsWithoutSource.snapshotSource).toBeUndefined();
+  });
+
+  it('startSyncScheduler always wires the snapshot-bootstrap telemetry handlers', () => {
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+    expect(options.onSnapshotBootstrapError).toBeTypeOf('function');
+    expect(options.onScopeDownloadComplete).toBeTypeOf('function');
+  });
+
+  it('triggerSync passes snapshotSource through and wires the telemetry handlers', () => {
+    triggerSync(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+      undefined,
+      fakeSnapshotSource,
+    );
+    const options = triggerSyncCore.mock.calls[0][5] as SchedulerOptions;
+    expect(options.snapshotSource).toBe(fakeSnapshotSource);
+    expect(options.onSnapshotBootstrapError).toBeTypeOf('function');
+    expect(options.onScopeDownloadComplete).toBeTypeOf('function');
+  });
+
+  it('reports a bootstrap failure to Sentry with the snapshot-bootstrap tags', () => {
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+    options.onSnapshotBootstrapError?.({ scopeKey: 'kilter:1:5', stage: 'download', attempt: 1, cause: null });
+
+    expect(reportHandledError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('kilter:1:5') }),
+      expect.objectContaining({
+        tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },
+        extra: expect.objectContaining({ scopeKey: 'kilter:1:5', stage: 'download', attempt: 1 }),
+      }),
+    );
+  });
+
+  it('captures a PostHog event on scope-download completion with the method + duration', () => {
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+    options.onScopeDownloadComplete?.({ scopeKey: 'kilter:1:5', method: 'snapshot', durationMs: 1234 });
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
+      scopeKey: 'kilter:1:5',
+      method: 'snapshot',
+      durationMs: 1234,
+    });
+  });
+
+  it('pullSync binds the snapshot-bootstrap telemetry defaults but lets caller options win', async () => {
+    const customBootstrapError = vi.fn();
+    await pullSync(db, queryClient, graphqlFetch, { onSnapshotBootstrapError: customBootstrapError });
+
+    const options = pullSyncCore.mock.calls[0][3] as SyncOptions;
+    options.onSnapshotBootstrapError?.({ scopeKey: 'kilter:1:5', stage: 'manifest', attempt: 1, cause: null });
+    expect(customBootstrapError).toHaveBeenCalled();
+    expect(reportHandledError).not.toHaveBeenCalled();
+
+    options.onScopeDownloadComplete?.({ scopeKey: 'kilter:1:5', method: 'paged', durationMs: 500 });
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
+      scopeKey: 'kilter:1:5',
+      method: 'paged',
+      durationMs: 500,
+    });
   });
 });
 

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -163,8 +163,7 @@ describe('snapshot-bootstrap bindings', () => {
       graphqlFetch,
       () => [],
       async () => {},
-      undefined,
-      fakeSnapshotSource,
+      { snapshotSource: fakeSnapshotSource },
     );
     const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
     expect(options.snapshotSource).toBe(fakeSnapshotSource);
@@ -201,8 +200,7 @@ describe('snapshot-bootstrap bindings', () => {
       graphqlFetch,
       () => [],
       async () => {},
-      undefined,
-      fakeSnapshotSource,
+      { snapshotSource: fakeSnapshotSource },
     );
     const options = triggerSyncCore.mock.calls[0][5] as SchedulerOptions;
     expect(options.snapshotSource).toBe(fakeSnapshotSource);
@@ -275,7 +273,7 @@ describe('triggerSync / pullSync bindings', () => {
       graphqlFetch,
       () => ['kilter:1:5'],
       async () => {},
-      onProgress,
+      { onProgress },
     );
 
     const options = triggerSyncCore.mock.calls[0][5] as SchedulerOptions;

--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -1,0 +1,235 @@
+// expo-file-system is native and globally stubbed for every mobile suite
+// (packages/mobile/vite.config.ts's `expo-file-system` alias); this suite
+// needs a richer, controllable fake to actually exercise downloadArtifact's
+// disk-space check, download, gzip-magic detection, and cleanup — so it
+// registers its own vi.mock, which takes precedence over that alias.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  availableDiskSpace: 10_000_000_000, // 10 GB — plenty of headroom by default
+  createdDirectories: [] as string[],
+  downloadCalls: [] as Array<{ url: string; idempotent?: boolean }>,
+  downloadError: null as Error | null,
+  downloadBytes: new Uint8Array([9, 9, 9, 9]), // non-gzip payload by default
+  deletedUris: [] as string[],
+}));
+
+vi.mock('expo-file-system', () => {
+  class FakeDirectory {
+    path: string;
+    constructor(...parts: unknown[]) {
+      this.path = parts.map((part) => (part instanceof FakeDirectory ? part.path : String(part))).join('/');
+    }
+    create() {
+      state.createdDirectories.push(this.path);
+    }
+  }
+
+  class FakeFile {
+    uri: string;
+    exists = true;
+    bytes: Uint8Array = new Uint8Array();
+
+    constructor(...parts: unknown[]) {
+      const joined = parts
+        .map((part) => {
+          if (part instanceof FakeDirectory) return part.path;
+          if (part instanceof FakeFile) return part.uri.replace('file://', '');
+          return String(part);
+        })
+        .join('/');
+      this.uri = joined.startsWith('file://') ? joined : `file://${joined}`;
+    }
+
+    static downloadFileAsync = vi.fn(async (url: string, destination: FakeFile, options?: { idempotent?: boolean }) => {
+      state.downloadCalls.push({ url, idempotent: options?.idempotent });
+      if (state.downloadError) throw state.downloadError;
+      destination.bytes = state.downloadBytes;
+      return destination;
+    });
+
+    delete() {
+      state.deletedUris.push(this.uri);
+    }
+
+    readableStream() {
+      const bytes = this.bytes;
+      let consumed = false;
+      return {
+        getReader: () => ({
+          read: async () => {
+            if (consumed) return { done: true, value: undefined };
+            consumed = true;
+            return { done: false, value: bytes };
+          },
+          cancel: async () => {},
+        }),
+      };
+    }
+  }
+
+  return {
+    Directory: FakeDirectory,
+    File: FakeFile,
+    Paths: {
+      get cache() {
+        return new FakeDirectory('cache-root');
+      },
+      get availableDiskSpace() {
+        return state.availableDiskSpace;
+      },
+    },
+  };
+});
+
+vi.mock('../../lib/env', () => ({
+  SNAPSHOT_BASE_URL: 'https://example.test/board-snapshots/v1',
+}));
+
+const reportHandledError = vi.fn();
+vi.mock('../../lib/error-reporting', () => ({
+  reportHandledError: (...args: unknown[]) => reportHandledError(...args),
+}));
+
+import { mobileSnapshotSource } from '../snapshot-source';
+import type { SnapshotManifestEntry } from '@boardsesh/offline-sync';
+
+const ENTRY: SnapshotManifestEntry = {
+  boardType: 'kilter',
+  layoutId: 8,
+  key: 'board-snapshots/v1/kilter/8/2026-06-01.db',
+  url: 'https://example.test/artifacts/kilter-8.db',
+  bytes: 1_000_000,
+  contentEncoding: 'gzip',
+  builtAt: '2026-06-01T00:00:00.000Z',
+  schemaVersion: 1,
+  tables: {
+    board_climbs: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '10', rowCount: 100 },
+    board_climb_stats: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '10', rowCount: 100 },
+  },
+};
+
+const GZIP_BYTES = new Uint8Array([0x1f, 0x8b, 0x08, 0x00]);
+const PLAIN_SQLITE_BYTES = new Uint8Array([0x53, 0x51, 0x4c, 0x69]); // "SQLi" — not gzip magic
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.availableDiskSpace = 10_000_000_000;
+  state.createdDirectories = [];
+  state.downloadCalls = [];
+  state.downloadError = null;
+  state.downloadBytes = PLAIN_SQLITE_BYTES;
+  state.deletedUris = [];
+});
+
+describe('fetchManifest', () => {
+  it('fetches the manifest URL with cache: no-store and returns the parsed JSON on 200', async () => {
+    const manifestBody = { formatVersion: 1, generatedAt: '2026-06-01T00:00:00.000Z', entries: [] };
+    const fetchMock = vi.fn(async () => jsonResponse(manifestBody));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await mobileSnapshotSource.fetchManifest();
+
+    expect(fetchMock).toHaveBeenCalledWith('https://example.test/board-snapshots/v1/manifest.json', {
+      cache: 'no-store',
+    });
+    expect(result).toEqual(manifestBody);
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null on a non-200 response (treated as "not published yet")', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({}, 404)),
+    );
+
+    await expect(mobileSnapshotSource.fetchManifest()).resolves.toBeNull();
+    vi.unstubAllGlobals();
+  });
+
+  it('lets a network/transport error throw (the engine counts it as a bootstrap attempt)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network request failed');
+      }),
+    );
+
+    await expect(mobileSnapshotSource.fetchManifest()).rejects.toThrow('network request failed');
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('downloadArtifact', () => {
+  it('returns null without downloading when free disk space is below the safety multiple of entry.bytes', async () => {
+    state.availableDiskSpace = ENTRY.bytes * 2; // well under the 6x safety multiplier
+
+    const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(result).toBeNull();
+    expect(state.downloadCalls).toHaveLength(0);
+  });
+
+  it('downloads to the cache directory idempotently and returns a plain filesystem path (no file:// scheme)', async () => {
+    const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.downloadCalls).toEqual([{ url: ENTRY.url, idempotent: true }]);
+    expect(result).not.toBeNull();
+    expect(result?.filePath.startsWith('file://')).toBe(false);
+    expect(result?.filePath).toContain('kilter-8-2026-06-01T00-00-00-000Z.db');
+  });
+
+  it('returns null when the download itself fails', async () => {
+    state.downloadError = new Error('boom');
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).resolves.toBeNull();
+  });
+
+  it('accepts a gzip-encoded entry whose downloaded bytes are already decompressed', async () => {
+    state.downloadBytes = PLAIN_SQLITE_BYTES;
+
+    const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(result).not.toBeNull();
+    expect(state.deletedUris).toHaveLength(0);
+    expect(reportHandledError).not.toHaveBeenCalled();
+  });
+
+  it('deletes the file, returns null, and reports a handled error when the body is STILL gzip-compressed', async () => {
+    state.downloadBytes = GZIP_BYTES;
+
+    const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(result).toBeNull();
+    expect(state.deletedUris).toHaveLength(1);
+    expect(reportHandledError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('still gzip-compressed') }),
+      expect.objectContaining({
+        tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },
+        extra: expect.objectContaining({ boardType: 'kilter', layoutId: 8 }),
+      }),
+    );
+  });
+
+  it('skips the gzip-magic check entirely for an identity-encoded entry', async () => {
+    state.downloadBytes = GZIP_BYTES; // would fail the check if it ran
+    const identityEntry: SnapshotManifestEntry = { ...ENTRY, contentEncoding: 'identity' };
+
+    const result = await mobileSnapshotSource.downloadArtifact(identityEntry);
+
+    expect(result).not.toBeNull();
+    expect(state.deletedUris).toHaveLength(0);
+  });
+});
+
+describe('deleteArtifact', () => {
+  it('deletes the file at the given plain path, best-effort', async () => {
+    await mobileSnapshotSource.deleteArtifact('/cache/board-snapshots/kilter-8.db');
+    expect(state.deletedUris).toEqual(['file:///cache/board-snapshots/kilter-8.db']);
+  });
+});

--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -8,7 +8,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const state = vi.hoisted(() => ({
   availableDiskSpace: 10_000_000_000, // 10 GB — plenty of headroom by default
-  createdDirectories: [] as string[],
+  createdDirectories: [] as Array<{
+    path: string;
+    options?: { intermediates?: boolean; idempotent?: boolean; overwrite?: boolean };
+  }>,
   downloadCalls: [] as Array<{ url: string; idempotent?: boolean }>,
   downloadError: null as Error | null,
   downloadBytes: new Uint8Array([9, 9, 9, 9]), // non-gzip payload by default
@@ -21,8 +24,8 @@ vi.mock('expo-file-system', () => {
     constructor(...parts: unknown[]) {
       this.path = parts.map((part) => (part instanceof FakeDirectory ? part.path : String(part))).join('/');
     }
-    create() {
-      state.createdDirectories.push(this.path);
+    create(options?: { intermediates?: boolean; idempotent?: boolean; overwrite?: boolean }) {
+      state.createdDirectories.push({ path: this.path, options });
     }
   }
 
@@ -166,7 +169,7 @@ describe('fetchManifest', () => {
 });
 
 describe('downloadArtifact', () => {
-  it('returns null without downloading when free disk space is below the safety multiple of entry.bytes', async () => {
+  it('returns null without downloading when free disk space is below the gzip safety multiple of entry.bytes', async () => {
     state.availableDiskSpace = ENTRY.bytes * 2; // well under the 6x safety multiplier
 
     const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
@@ -175,9 +178,22 @@ describe('downloadArtifact', () => {
     expect(state.downloadCalls).toHaveLength(0);
   });
 
+  it('allows identity artifacts with the lower identity safety multiple', async () => {
+    state.availableDiskSpace = ENTRY.bytes * 3;
+    const identityEntry: SnapshotManifestEntry = { ...ENTRY, contentEncoding: 'identity' };
+
+    const result = await mobileSnapshotSource.downloadArtifact(identityEntry);
+
+    expect(result).not.toBeNull();
+    expect(state.downloadCalls).toHaveLength(1);
+  });
+
   it('downloads to the cache directory idempotently and returns a plain filesystem path (no file:// scheme)', async () => {
     const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
 
+    expect(state.createdDirectories).toEqual([
+      { path: 'cache-root/board-snapshots', options: { intermediates: true, idempotent: true } },
+    ]);
     expect(state.downloadCalls).toEqual([{ url: ENTRY.url, idempotent: true }]);
     expect(result).not.toBeNull();
     expect(result?.filePath.startsWith('file://')).toBe(false);

--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -96,7 +96,7 @@ vi.mock('../../lib/error-reporting', () => ({
 }));
 
 import { mobileSnapshotSource } from '../snapshot-source';
-import type { SnapshotManifestEntry } from '@boardsesh/offline-sync';
+import { SnapshotPermanentMissError, type SnapshotManifestEntry } from '@boardsesh/offline-sync';
 
 const ENTRY: SnapshotManifestEntry = {
   boardType: 'kilter',
@@ -118,6 +118,16 @@ const PLAIN_SQLITE_BYTES = new Uint8Array([0x53, 0x51, 0x4c, 0x69]); // "SQLi" â
 
 function jsonResponse(body: unknown, status = 200): Response {
   return { ok: status >= 200 && status < 300, status, json: async () => body } as unknown as Response;
+}
+
+function brokenJsonResponse(status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => {
+      throw new Error('bad json');
+    },
+  } as unknown as Response;
 }
 
 beforeEach(() => {
@@ -145,10 +155,30 @@ describe('fetchManifest', () => {
     vi.unstubAllGlobals();
   });
 
-  it('returns null on a non-200 response (treated as "not published yet")', async () => {
+  it('returns null on a 404 response (treated as "not published yet")', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => jsonResponse({}, 404)),
+    );
+
+    await expect(mobileSnapshotSource.fetchManifest()).resolves.toBeNull();
+    vi.unstubAllGlobals();
+  });
+
+  it('throws on non-404 HTTP failures so the engine retries the manifest path', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({}, 500)),
+    );
+
+    await expect(mobileSnapshotSource.fetchManifest()).rejects.toThrow('HTTP 500');
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null for unparseable JSON so the engine falls back to paged sync', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => brokenJsonResponse()),
     );
 
     await expect(mobileSnapshotSource.fetchManifest()).resolves.toBeNull();
@@ -216,12 +246,11 @@ describe('downloadArtifact', () => {
     expect(reportHandledError).not.toHaveBeenCalled();
   });
 
-  it('deletes the file, returns null, and reports a handled error when the body is STILL gzip-compressed', async () => {
+  it('deletes the file, reports, and permanently misses when the body is STILL gzip-compressed', async () => {
     state.downloadBytes = GZIP_BYTES;
 
-    const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(SnapshotPermanentMissError);
 
-    expect(result).toBeNull();
     expect(state.deletedUris).toHaveLength(1);
     expect(reportHandledError).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining('still gzip-compressed') }),

--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -15,6 +15,10 @@ const state = vi.hoisted(() => ({
   downloadCalls: [] as Array<{ url: string; idempotent?: boolean }>,
   downloadError: null as Error | null,
   downloadBytes: new Uint8Array([9, 9, 9, 9]), // non-gzip payload by default
+  // When set, readableStream() yields these chunks one read() at a time
+  // instead of the whole file in one chunk — for the empty-first-chunk and
+  // split-header edge cases the ReadableStream spec allows.
+  streamChunks: null as Uint8Array[] | null,
   deletedUris: [] as string[],
 }));
 
@@ -57,14 +61,13 @@ vi.mock('expo-file-system', () => {
     }
 
     readableStream() {
-      const bytes = this.bytes;
-      let consumed = false;
+      const chunks = state.streamChunks ?? [this.bytes];
+      let index = 0;
       return {
         getReader: () => ({
           read: async () => {
-            if (consumed) return { done: true, value: undefined };
-            consumed = true;
-            return { done: false, value: bytes };
+            if (index >= chunks.length) return { done: true, value: undefined };
+            return { done: false, value: chunks[index++] };
           },
           cancel: async () => {},
         }),
@@ -137,6 +140,7 @@ beforeEach(() => {
   state.downloadCalls = [];
   state.downloadError = null;
   state.downloadBytes = PLAIN_SQLITE_BYTES;
+  state.streamChunks = null;
   state.deletedUris = [];
 });
 
@@ -259,6 +263,26 @@ describe('downloadArtifact', () => {
         extra: expect.objectContaining({ boardType: 'kilter', layoutId: 8 }),
       }),
     );
+  });
+
+  it('still detects gzip when the stream yields an empty chunk, then a split header', async () => {
+    // A ReadableStream may legally deliver empty or tiny chunks before real
+    // data. An empty first read followed by the magic bytes split across two
+    // chunks must still be recognised as an undecoded gzip body.
+    state.streamChunks = [new Uint8Array([]), new Uint8Array([0x1f]), new Uint8Array([0x8b, 0x08])];
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(SnapshotPermanentMissError);
+    expect(state.deletedUris).toHaveLength(1);
+  });
+
+  it('treats a sub-2-byte stream as not gzip (EOF before the header completes)', async () => {
+    state.streamChunks = [new Uint8Array([]), new Uint8Array([0x1f])];
+
+    const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(result).not.toBeNull();
+    expect(state.deletedUris).toHaveLength(0);
+    expect(reportHandledError).not.toHaveBeenCalled();
   });
 
   it('skips the gzip-magic check entirely for an identity-encoded entry', async () => {

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -26,12 +26,17 @@ import {
   type DrainQueue,
   type GraphQLFetch,
   type OfflineDatabase,
+  type ScopeDownloadCompleteReporter,
   type SchedulerTriggers,
   type SchemaDriftReporter,
+  type SnapshotBootstrapErrorReporter,
+  type SnapshotSource,
   type SyncOptions,
   type SyncProgressSink,
 } from '@boardsesh/offline-sync';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { reportHandledError } from '../lib/error-reporting';
+import { track } from '../lib/analytics';
 
 const isOnline = () => onlineManager.isOnline();
 
@@ -40,6 +45,24 @@ const reportSchemaDrift: SchemaDriftReporter = ({ tableName, column }) => {
     tags: { source: 'offline-sync', kind: 'schema-drift' },
     extra: { tableName, column },
   });
+};
+
+// Snapshot-bootstrap telemetry. Both handlers are wired unconditionally (like
+// reportSchemaDrift above) — they're inert when no `snapshotSource` is passed
+// in, since the engine only ever calls them from the bootstrap phase, which it
+// skips entirely without one.
+const reportSnapshotBootstrapError: SnapshotBootstrapErrorReporter = ({ scopeKey, stage, attempt, cause }) => {
+  reportHandledError(new Error(`Snapshot bootstrap failed for ${scopeKey} at stage "${stage}" (attempt ${attempt})`), {
+    tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },
+    extra: { scopeKey, stage, attempt, cause: cause instanceof Error ? cause.message : cause },
+  });
+};
+
+// Fired once per board scope's initial download so the snapshot-bootstrap
+// warm-up can be compared against the plain paged crawl in the field (which
+// path actually got used, and how long it took).
+const reportScopeDownloadComplete: ScopeDownloadCompleteReporter = ({ scopeKey, method, durationMs }) => {
+  track(SHARED_EVENTS.OfflineBoardDownloadCompleted, { scopeKey, method, durationMs });
 };
 
 // A failed cycle is routine for offline users (the reconnect trigger retries),
@@ -84,11 +107,18 @@ export function startSyncScheduler(
   getEnabledBoards: () => string[],
   drainQueue: DrainQueue,
   onProgress?: SyncProgressSink,
+  // Injected only when the offline-snapshot-bootstrap flag is on (see
+  // OfflineSyncBridge) — undefined here reproduces the pure paged-crawl
+  // behaviour exactly, byte-identical to before this seam existed.
+  snapshotSource?: SnapshotSource,
 ): () => void {
   return startSyncSchedulerCore(db, queryClient, graphqlFetch, getEnabledBoards, drainQueue, schedulerTriggers, {
     onProgress,
     onCycleError: warnCycleError,
     onSchemaDrift: reportSchemaDrift,
+    snapshotSource,
+    onSnapshotBootstrapError: reportSnapshotBootstrapError,
+    onScopeDownloadComplete: reportScopeDownloadComplete,
   });
 }
 
@@ -99,11 +129,15 @@ export function triggerSync(
   getEnabledBoards: () => string[],
   drainQueue: DrainQueue,
   onProgress?: SyncProgressSink,
+  snapshotSource?: SnapshotSource,
 ): void {
   triggerSyncCore(db, queryClient, graphqlFetch, getEnabledBoards, drainQueue, {
     onProgress,
     onCycleError: warnCycleError,
     onSchemaDrift: reportSchemaDrift,
+    snapshotSource,
+    onSnapshotBootstrapError: reportSnapshotBootstrapError,
+    onScopeDownloadComplete: reportScopeDownloadComplete,
   });
 }
 
@@ -113,5 +147,10 @@ export function pullSync(
   graphqlFetch: GraphQLFetch,
   options?: SyncOptions,
 ): Promise<void> {
-  return pullSyncCore(db, queryClient, graphqlFetch, { onSchemaDrift: reportSchemaDrift, ...options });
+  return pullSyncCore(db, queryClient, graphqlFetch, {
+    onSchemaDrift: reportSchemaDrift,
+    onSnapshotBootstrapError: reportSnapshotBootstrapError,
+    onScopeDownloadComplete: reportScopeDownloadComplete,
+    ...options,
+  });
 }

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -47,10 +47,12 @@ const reportSchemaDrift: SchemaDriftReporter = ({ tableName, column }) => {
   });
 };
 
-// Snapshot-bootstrap telemetry. Both handlers are wired unconditionally (like
-// reportSchemaDrift above) — they're inert when no `snapshotSource` is passed
-// in, since the engine only ever calls them from the bootstrap phase, which it
-// skips entirely without one.
+// Offline-download telemetry. Both handlers are wired unconditionally (like
+// reportSchemaDrift above). reportSnapshotBootstrapError is inert without a
+// `snapshotSource` (the engine only calls it from the bootstrap phase, which
+// it skips entirely without one); reportScopeDownloadComplete fires for EVERY
+// scope's first full download — paged crawls included — because the
+// snapshot-vs-paged rollout comparison needs both methods to emit the event.
 const reportSnapshotBootstrapError: SnapshotBootstrapErrorReporter = ({ scopeKey, stage, attempt, cause }) => {
   reportHandledError(new Error(`Snapshot bootstrap failed for ${scopeKey} at stage "${stage}" (attempt ${attempt})`), {
     tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -100,23 +100,29 @@ export function drainMutationQueue(
   });
 }
 
+// A named bag rather than trailing positionals so callers (and their tests)
+// never depend on argument order for the optional seams.
+export type SyncRunOptions = {
+  onProgress?: SyncProgressSink;
+  // Injected only when the offline-snapshot-bootstrap flag is on (see
+  // useSnapshotSource) — undefined here reproduces the pure paged-crawl
+  // behaviour exactly, byte-identical to before this seam existed.
+  snapshotSource?: SnapshotSource;
+};
+
 export function startSyncScheduler(
   db: OfflineDatabase,
   queryClient: QueryClient,
   graphqlFetch: GraphQLFetch,
   getEnabledBoards: () => string[],
   drainQueue: DrainQueue,
-  onProgress?: SyncProgressSink,
-  // Injected only when the offline-snapshot-bootstrap flag is on (see
-  // OfflineSyncBridge) — undefined here reproduces the pure paged-crawl
-  // behaviour exactly, byte-identical to before this seam existed.
-  snapshotSource?: SnapshotSource,
+  options?: SyncRunOptions,
 ): () => void {
   return startSyncSchedulerCore(db, queryClient, graphqlFetch, getEnabledBoards, drainQueue, schedulerTriggers, {
-    onProgress,
+    onProgress: options?.onProgress,
     onCycleError: warnCycleError,
     onSchemaDrift: reportSchemaDrift,
-    snapshotSource,
+    snapshotSource: options?.snapshotSource,
     onSnapshotBootstrapError: reportSnapshotBootstrapError,
     onScopeDownloadComplete: reportScopeDownloadComplete,
   });
@@ -128,14 +134,13 @@ export function triggerSync(
   graphqlFetch: GraphQLFetch,
   getEnabledBoards: () => string[],
   drainQueue: DrainQueue,
-  onProgress?: SyncProgressSink,
-  snapshotSource?: SnapshotSource,
+  options?: SyncRunOptions,
 ): void {
   triggerSyncCore(db, queryClient, graphqlFetch, getEnabledBoards, drainQueue, {
-    onProgress,
+    onProgress: options?.onProgress,
     onCycleError: warnCycleError,
     onSchemaDrift: reportSchemaDrift,
-    snapshotSource,
+    snapshotSource: options?.snapshotSource,
     onSnapshotBootstrapError: reportSnapshotBootstrapError,
     onScopeDownloadComplete: reportScopeDownloadComplete,
   });

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -17,7 +17,7 @@
 // caps it at two tries before giving up on the snapshot path for that scope).
 
 import { Directory, File, Paths } from 'expo-file-system';
-import type { SnapshotManifestEntry, SnapshotSource } from '@boardsesh/offline-sync';
+import { SnapshotPermanentMissError, type SnapshotManifestEntry, type SnapshotSource } from '@boardsesh/offline-sync';
 import { SNAPSHOT_BASE_URL } from '../lib/env';
 import { reportHandledError } from '../lib/error-reporting';
 
@@ -89,15 +89,19 @@ function safeDeleteFile(file: File): void {
 }
 
 /**
- * Fetch the manifest JSON. Returns `null` on a non-200 response (the engine
- * treats that as "not published yet this cycle" — a permanent miss that burns
- * no bootstrap attempt). Network/transport errors are left to throw, which the
- * engine DOES count as an attempt (see `resolveManifestOnce` in pull-client.ts).
+ * Fetch the manifest JSON. Returns `null` only when the manifest is genuinely
+ * absent or unparseable (permanent miss this cycle, no attempt). HTTP outages
+ * throw so the engine treats them as retryable manifest errors.
  */
 async function fetchManifest(): Promise<unknown> {
   const response = await fetch(MANIFEST_URL, { cache: 'no-store' });
-  if (!response.ok) return null;
-  return response.json();
+  if (response.status === 404) return null;
+  if (!response.ok) throw new Error(`snapshot manifest fetch failed with HTTP ${response.status}`);
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
 }
 
 async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePath: string } | null> {
@@ -149,7 +153,7 @@ async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePat
           extra: { boardType: entry.boardType, layoutId: entry.layoutId, url: entry.url },
         },
       );
-      return null;
+      throw new SnapshotPermanentMissError('snapshot artifact arrived still gzip-compressed');
     }
   }
 

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -1,0 +1,169 @@
+// Mobile SnapshotSource: the platform I/O the offline-sync engine's snapshot
+// bootstrap phase (@boardsesh/offline-sync's snapshot-bootstrap.ts, "Phase 3")
+// injects to warm a freshly-enabled board scope from a pre-built artifact
+// instead of paging the whole catalog over GraphQL. See
+// packages/backend/src/scripts/export-board-snapshots.ts for what this
+// downloads: a per-(boardType, layoutId) SQLite file gzipped and uploaded to
+// Tigris/S3 under `board-snapshots/v1/`, served with `Content-Encoding: gzip`
+// (so a compliant HTTP stack decompresses it transparently while downloading)
+// plus `manifest.json` listing every artifact's URL, size, and resume
+// watermarks.
+//
+// The engine only consumes what this returns — it never fetches, downloads, or
+// gunzips anything itself (see snapshot-bootstrap.ts's `SnapshotSource`
+// contract). Every failure path here (disk space, download error, a stubborn
+// gzip body) returns `null`/throws, which the engine counts as one bootstrap
+// attempt and falls back to the ordinary paged crawl (MAX_BOOTSTRAP_ATTEMPTS
+// caps it at two tries before giving up on the snapshot path for that scope).
+
+import { Directory, File, Paths } from 'expo-file-system';
+import type { SnapshotManifestEntry, SnapshotSource } from '@boardsesh/offline-sync';
+import { SNAPSHOT_BASE_URL } from '../lib/env';
+import { reportHandledError } from '../lib/error-reporting';
+
+const MANIFEST_URL = `${SNAPSHOT_BASE_URL}/manifest.json`;
+
+// Cache-dir subfolder for downloaded artifacts. The engine ATTACHes the file,
+// imports the scope's rows, then calls `deleteArtifact` once it's done with
+// it (in a `finally`) — nothing here is meant to persist across app launches,
+// so the OS is also free to reclaim it under storage pressure (Paths.cache,
+// not Paths.document).
+const SNAPSHOT_DIR_NAME = 'board-snapshots';
+
+// The space a download could occupy is bounded by whichever is larger: the
+// gzip-on-the-wire size (if the platform does NOT auto-decompress and we end
+// up deleting it) or the decompressed SQLite file (if it does — board_climbs +
+// board_climb_stats are text-heavy, so gzip commonly gets 4-8x on this data).
+// This multiplier is a deliberately conservative ceiling on top of
+// `entry.bytes` (the gzip size) so a marginal device never gets walked into
+// running out of disk mid-download — a `null` here just falls back to the
+// paged crawl, so there is no cost to erring generous.
+const FREE_SPACE_SAFETY_MULTIPLIER = 6;
+
+const GZIP_MAGIC_BYTE_0 = 0x1f;
+const GZIP_MAGIC_BYTE_1 = 0x8b;
+
+function snapshotDirectory(): Directory {
+  return new Directory(Paths.cache, SNAPSHOT_DIR_NAME);
+}
+
+/**
+ * A plain filesystem path (no `file://` scheme) for the SQLite ATTACH
+ * statement in snapshot-bootstrap.ts. SQLite's ATTACH filename resolution only
+ * reliably accepts a bare path unless the connection was explicitly opened in
+ * URI mode — expo-sqlite does not guarantee that, so stripping the scheme here
+ * (rather than trusting `file://` to work) is the portable choice across both
+ * platforms' bundled sqlite3.
+ */
+function toSqlitePath(fileUri: string): string {
+  return fileUri.startsWith('file://') ? fileUri.slice('file://'.length) : fileUri;
+}
+
+/** Inverse of `toSqlitePath`, for reconstructing a `File` from the plain path the engine hands back to `deleteArtifact`. */
+function toFileUri(sqlitePath: string): string {
+  return sqlitePath.startsWith('file://') ? sqlitePath : `file://${sqlitePath}`;
+}
+
+/**
+ * True when `file`'s first two bytes are the gzip magic number — i.e. the
+ * native HTTP stack did NOT transparently decompress a `Content-Encoding:
+ * gzip` response body, and the file on disk is still the raw gzip stream.
+ * Reads only the stream's first chunk (never the whole file), so this stays
+ * cheap even for a large artifact.
+ */
+async function looksGzipCompressed(file: File): Promise<boolean> {
+  const reader = file.readableStream().getReader();
+  try {
+    const { value } = await reader.read();
+    if (!value || value.byteLength < 2) return false;
+    return value[0] === GZIP_MAGIC_BYTE_0 && value[1] === GZIP_MAGIC_BYTE_1;
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+}
+
+/** Best-effort delete — a leftover partial/bad file just wastes cache space until the OS reclaims it. */
+function safeDeleteFile(file: File): void {
+  try {
+    if (file.exists) file.delete();
+  } catch {
+    // Ignore — see above.
+  }
+}
+
+/**
+ * Fetch the manifest JSON. Returns `null` on a non-200 response (the engine
+ * treats that as "not published yet this cycle" — a permanent miss that burns
+ * no bootstrap attempt). Network/transport errors are left to throw, which the
+ * engine DOES count as an attempt (see `resolveManifestOnce` in pull-client.ts).
+ */
+async function fetchManifest(): Promise<unknown> {
+  const response = await fetch(MANIFEST_URL, { cache: 'no-store' });
+  if (!response.ok) return null;
+  return response.json();
+}
+
+async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePath: string } | null> {
+  const requiredBytes = entry.bytes * FREE_SPACE_SAFETY_MULTIPLIER;
+  if (Paths.availableDiskSpace < requiredBytes) return null;
+
+  const directory = snapshotDirectory();
+  try {
+    directory.create({ intermediates: true, idempotent: true });
+  } catch {
+    return null;
+  }
+
+  // Content-addressed filename (boardType/layoutId/builtAt) so a retried
+  // download for the same artifact overwrites cleanly (idempotent: true below)
+  // instead of accumulating orphaned files across bootstrap attempts.
+  const safeBuiltAt = entry.builtAt.replace(/[^a-zA-Z0-9]/g, '-');
+  const destination = new File(directory, `${entry.boardType}-${entry.layoutId}-${safeBuiltAt}.db`);
+
+  let downloaded: File;
+  try {
+    downloaded = await File.downloadFileAsync(entry.url, destination, { idempotent: true });
+  } catch {
+    return null;
+  }
+
+  if (entry.contentEncoding === 'gzip') {
+    let stillCompressed: boolean;
+    try {
+      stillCompressed = await looksGzipCompressed(downloaded);
+    } catch {
+      // Can't verify the body — treat it as untrustworthy, same as a failed download.
+      safeDeleteFile(downloaded);
+      return null;
+    }
+    if (stillCompressed) {
+      safeDeleteFile(downloaded);
+      // Expected behaviour is that the native HTTP stack (NSURLSession /
+      // OkHttp) auto-decodes a gzip Content-Encoding while downloading — this
+      // path should be rare-to-never. Report it as a handled error (not just a
+      // dev warning) so a real pattern shows up in Sentry; if it turns out to
+      // be common on some platform/OS combo, the fix is to flip the export job
+      // to `contentEncoding: 'identity'` rather than trying to gunzip client-side.
+      reportHandledError(
+        new Error('snapshot artifact arrived still gzip-compressed (Content-Encoding was not auto-decoded)'),
+        {
+          tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },
+          extra: { boardType: entry.boardType, layoutId: entry.layoutId, url: entry.url },
+        },
+      );
+      return null;
+    }
+  }
+
+  return { filePath: toSqlitePath(downloaded.uri) };
+}
+
+async function deleteArtifact(filePath: string): Promise<void> {
+  safeDeleteFile(new File(toFileUri(filePath)));
+}
+
+export const mobileSnapshotSource: SnapshotSource = {
+  fetchManifest,
+  downloadArtifact,
+  deleteArtifact,
+};

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -3,11 +3,11 @@
 // injects to warm a freshly-enabled board scope from a pre-built artifact
 // instead of paging the whole catalog over GraphQL. See
 // packages/backend/src/scripts/export-board-snapshots.ts for what this
-// downloads: a per-(boardType, layoutId) SQLite file gzipped and uploaded to
-// Tigris/S3 under `board-snapshots/v1/`, served with `Content-Encoding: gzip`
-// (so a compliant HTTP stack decompresses it transparently while downloading)
-// plus `manifest.json` listing every artifact's URL, size, and resume
-// watermarks.
+// downloads: a per-(boardType, layoutId) SQLite file uploaded to Tigris/S3
+// under `board-snapshots/v1/`, plus `manifest.json` listing every artifact's
+// URL, stored size, content encoding, and resume watermarks. Artifacts default
+// to identity encoding; gzip is opt-in and verified by this adapter before the
+// file is handed to SQLite.
 //
 // The engine only consumes what this returns — it never fetches, downloads, or
 // gunzips anything itself (see snapshot-bootstrap.ts's `SnapshotSource`
@@ -30,15 +30,12 @@ const MANIFEST_URL = `${SNAPSHOT_BASE_URL}/manifest.json`;
 // not Paths.document).
 const SNAPSHOT_DIR_NAME = 'board-snapshots';
 
-// The space a download could occupy is bounded by whichever is larger: the
-// gzip-on-the-wire size (if the platform does NOT auto-decompress and we end
-// up deleting it) or the decompressed SQLite file (if it does — board_climbs +
-// board_climb_stats are text-heavy, so gzip commonly gets 4-8x on this data).
-// This multiplier is a deliberately conservative ceiling on top of
-// `entry.bytes` (the gzip size) so a marginal device never gets walked into
-// running out of disk mid-download — a `null` here just falls back to the
-// paged crawl, so there is no cost to erring generous.
-const FREE_SPACE_SAFETY_MULTIPLIER = 6;
+// Identity artifacts are already stored as SQLite files, so they only need room
+// for the download plus write overhead. Gzip artifacts may temporarily require
+// the compressed object and the decompressed SQLite file; board_climbs +
+// board_climb_stats are text-heavy, so keep that path deliberately conservative.
+const IDENTITY_FREE_SPACE_SAFETY_MULTIPLIER = 2;
+const GZIP_FREE_SPACE_SAFETY_MULTIPLIER = 6;
 
 const GZIP_MAGIC_BYTE_0 = 0x1f;
 const GZIP_MAGIC_BYTE_1 = 0x8b;
@@ -104,7 +101,9 @@ async function fetchManifest(): Promise<unknown> {
 }
 
 async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePath: string } | null> {
-  const requiredBytes = entry.bytes * FREE_SPACE_SAFETY_MULTIPLIER;
+  const freeSpaceSafetyMultiplier =
+    entry.contentEncoding === 'gzip' ? GZIP_FREE_SPACE_SAFETY_MULTIPLIER : IDENTITY_FREE_SPACE_SAFETY_MULTIPLIER;
+  const requiredBytes = entry.bytes * freeSpaceSafetyMultiplier;
   if (Paths.availableDiskSpace < requiredBytes) return null;
 
   const directory = snapshotDirectory();
@@ -141,9 +140,8 @@ async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePat
       // Expected behaviour is that the native HTTP stack (NSURLSession /
       // OkHttp) auto-decodes a gzip Content-Encoding while downloading — this
       // path should be rare-to-never. Report it as a handled error (not just a
-      // dev warning) so a real pattern shows up in Sentry; if it turns out to
-      // be common on some platform/OS combo, the fix is to flip the export job
-      // to `contentEncoding: 'identity'` rather than trying to gunzip client-side.
+      // dev warning) so a real pattern shows up in Sentry before gzip is enabled
+      // for mobile artifacts.
       reportHandledError(
         new Error('snapshot artifact arrived still gzip-compressed (Content-Encoding was not auto-decoded)'),
         {

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -65,15 +65,23 @@ function toFileUri(sqlitePath: string): string {
  * True when `file`'s first two bytes are the gzip magic number — i.e. the
  * native HTTP stack did NOT transparently decompress a `Content-Encoding:
  * gzip` response body, and the file on disk is still the raw gzip stream.
- * Reads only the stream's first chunk (never the whole file), so this stays
- * cheap even for a large artifact.
+ * A ReadableStream may legally yield empty (or 1-byte) chunks before real
+ * data, so this keeps reading until it has the two header bytes or EOF — but
+ * never more than that, so it stays cheap even for a large artifact.
  */
 async function looksGzipCompressed(file: File): Promise<boolean> {
   const reader = file.readableStream().getReader();
   try {
-    const { value } = await reader.read();
-    if (!value || value.byteLength < 2) return false;
-    return value[0] === GZIP_MAGIC_BYTE_0 && value[1] === GZIP_MAGIC_BYTE_1;
+    const header: number[] = [];
+    while (header.length < 2) {
+      const { value, done } = await reader.read();
+      if (done) return false; // < 2 bytes total — not a gzip stream
+      for (const byte of value ?? []) {
+        header.push(byte);
+        if (header.length === 2) break;
+      }
+    }
+    return header[0] === GZIP_MAGIC_BYTE_0 && header[1] === GZIP_MAGIC_BYTE_1;
   } finally {
     await reader.cancel().catch(() => {});
   }
@@ -82,6 +90,8 @@ async function looksGzipCompressed(file: File): Promise<boolean> {
 /** Best-effort delete — a leftover partial/bad file just wastes cache space until the OS reclaims it. */
 function safeDeleteFile(file: File): void {
   try {
+    // `exists` is a synchronous property on SDK 57's File API (older expo-file-system
+    // versions exposed an async `exists()` — revisit if the SDK pin moves).
     if (file.exists) file.delete();
   } catch {
     // Ignore — see above.

--- a/packages/mobile/src/offline/use-snapshot-source.ts
+++ b/packages/mobile/src/offline/use-snapshot-source.ts
@@ -1,0 +1,18 @@
+import type { SnapshotSource } from '@boardsesh/offline-sync';
+import { isSnapshotBaseUrlConfigured } from '../lib/env';
+import { useSnapshotBootstrapEnabled } from '../providers/feature-flags-provider';
+import { mobileSnapshotSource } from './snapshot-source';
+
+/**
+ * The one gate for handing the engine snapshot I/O: the
+ * `offline-snapshot-bootstrap` flag (nested under `offline-board-downloads`)
+ * AND a real build-time manifest URL. `undefined` otherwise, which makes
+ * `pullSync` skip the bootstrap phase entirely — a freshly-enabled board still
+ * downloads, just through the paged crawl. Every caller that starts or
+ * triggers a sync must source its `snapshotSource` from here so the gate can
+ * never diverge between surfaces.
+ */
+export function useSnapshotSource(): SnapshotSource | undefined {
+  const snapshotBootstrapEnabled = useSnapshotBootstrapEnabled();
+  return snapshotBootstrapEnabled && isSnapshotBaseUrlConfigured() ? mobileSnapshotSource : undefined;
+}

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -59,6 +59,12 @@ export const FEATURE_FLAG_DEFINITIONS = [
       'The whole offline engine: board downloads, local-first climb reads, queued offline ticks/favorites, background sync. Off fully disables it (previously-queued writes still flush).',
   },
   {
+    key: 'offline-snapshot-bootstrap',
+    label: 'Offline snapshot bootstrap',
+    description:
+      'Warm a freshly-enabled board from the nightly pre-built SQLite snapshot instead of paging the whole catalog over GraphQL. Requires offline-board-downloads to also be on; off falls back to the plain paged crawl.',
+  },
+  {
     key: 'boardsesh-grade',
     label: 'Boardsesh grade',
     description:
@@ -131,6 +137,18 @@ export function useFeatureFlag<K extends keyof FeatureFlags>(key: K): FeatureFla
  */
 export function useOfflineDownloadsEnabled(): boolean {
   return useFeatureFlag('offline-board-downloads') === true;
+}
+
+/**
+ * Gate for the snapshot-bootstrap warm-up (offline-sync Phase 3/4): whether a
+ * freshly-enabled board scope should warm from the nightly pre-built SQLite
+ * artifact instead of paging the whole catalog. Missing/undefined reads as
+ * OFF — the paged crawl (today's only behaviour) is the safe default while
+ * this rolls out. Independent of `useOfflineDownloadsEnabled`; the bridge only
+ * consults this when the offline engine itself is already on.
+ */
+export function useSnapshotBootstrapEnabled(): boolean {
+  return useFeatureFlag('offline-snapshot-bootstrap') === true;
 }
 
 /**

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -211,6 +211,13 @@ export const SHARED_EVENTS = {
   IntegrationDisconnected: 'Integration Disconnected',
   IntegrationAutoSyncToggled: 'Integration Auto Sync Toggled',
   SessionExportedToIntegration: 'Session Exported to Integration',
+  // Offline sync — fired once per board scope when its INITIAL download
+  // completes (offline-sync's onScopeDownloadComplete, both tables reached the
+  // tail), so the snapshot-bootstrap warm-up (Phase 3/4) can be compared
+  // against the plain paged crawl in the field. Props: { scopeKey,
+  // method: 'snapshot' | 'paged', durationMs }. Mobile-only today (the engine
+  // is shared, so a future web offline consumer would fire this too).
+  OfflineBoardDownloadCompleted: 'Offline Board Download Completed',
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -241,6 +241,7 @@
     "offline": {
       "available": "Available offline",
       "pending": "Waiting to download",
+      "bootstrapping": "Downloading board…",
       "downloadingCount_one": "Downloading {{count}} climb",
       "downloadingCount_other": "Downloading {{count}} climbs",
       "makeAvailableAria": "Make {{name}} available offline",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -241,6 +241,7 @@
     "offline": {
       "available": "Disponible sin conexión",
       "pending": "Esperando para descargar",
+      "bootstrapping": "Descargando el plafón…",
       "downloadingCount_one": "Descargando {{count}} vía",
       "downloadingCount_other": "Descargando {{count}} vías",
       "makeAvailableAria": "Hacer que {{name}} esté disponible sin conexión",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -241,6 +241,7 @@
     "offline": {
       "available": "Disponible hors ligne",
       "pending": "En attente de téléchargement",
+      "bootstrapping": "Téléchargement de la board…",
       "downloadingCount_one": "Téléchargement de {{count}} voie",
       "downloadingCount_other": "Téléchargement de {{count}} voies",
       "makeAvailableAria": "Rendre {{name}} disponible hors ligne",

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -45,7 +45,13 @@ export { isRetryable, isNetworkError, getErrorStatus } from './mutation-queue/er
 
 // --- Pull sync -----------------------------------------------------------------
 export { pullSync, toSqliteValue, multiRowChunkSize } from './sync/pull-client';
-export type { SyncProgress, SyncOptions, SchemaDriftReporter } from './sync/pull-client';
+export type {
+  SyncProgress,
+  SyncOptions,
+  SchemaDriftReporter,
+  ScopeDownloadCompleteInfo,
+  ScopeDownloadCompleteReporter,
+} from './sync/pull-client';
 export {
   bootstrapScopeFromSnapshot,
   getBootstrapAttempts,

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -8,6 +8,7 @@ vi.mock('../checkpoints', () => ({
     boardType ? `checkpoint:${tableName}:${boardType}` : `checkpoint:${tableName}`,
   ),
   markScopeDownloadComplete: vi.fn().mockResolvedValue(undefined),
+  isScopeDownloadComplete: vi.fn().mockResolvedValue(false),
   rewindDeletionsCheckpoint: vi.fn().mockResolvedValue(undefined),
   compareCheckpoints: vi.fn().mockReturnValue(0),
   DELETIONS_CHECKPOINT_KEY: 'checkpoint:deletions',

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -1031,6 +1031,26 @@ describe('pullSync onScopeDownloadComplete', () => {
     expect(info.method).toBe('paged');
   });
 
+  it('reports scope-download completion only once for an already complete scope', async () => {
+    const firstRun = makeGraphqlFetch();
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), firstRun.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      onScopeDownloadComplete,
+    });
+    expect(onScopeDownloadComplete).toHaveBeenCalledTimes(1);
+
+    onScopeDownloadComplete.mockClear();
+    const secondRun = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), secondRun.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      onScopeDownloadComplete,
+    });
+
+    expect(onScopeDownloadComplete).not.toHaveBeenCalled();
+  });
+
   it('reports method "paged" when a snapshotSource is configured but the scope is not bootstrap-eligible (mid-crawl)', async () => {
     // Pre-existing checkpoint makes the scope ineligible for bootstrap, so its
     // completion this cycle is a resumed paged crawl even though a snapshotSource

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -982,6 +982,138 @@ describe('pullSync snapshot bootstrap', () => {
 });
 
 // ---------------------------------------------------------------------------
+// onScopeDownloadComplete — snapshot vs paged telemetry
+// ---------------------------------------------------------------------------
+
+describe('pullSync onScopeDownloadComplete', () => {
+  it('reports method "snapshot" when the scope bootstrapped successfully this run', async () => {
+    const filePath = join(workDir, 'complete-snapshot.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+    });
+
+    expect(onScopeDownloadComplete).toHaveBeenCalledTimes(1);
+    const info = onScopeDownloadComplete.mock.calls[0][0] as {
+      scopeKey: string;
+      method: string;
+      durationMs: number;
+    };
+    expect(info.scopeKey).toBe('kilter:1:5');
+    expect(info.method).toBe('snapshot');
+    expect(info.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('reports method "paged" when no snapshotSource is configured (pure paged crawl)', async () => {
+    const { fetch } = makeGraphqlFetch();
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      onScopeDownloadComplete,
+    });
+
+    expect(onScopeDownloadComplete).toHaveBeenCalledTimes(1);
+    const info = onScopeDownloadComplete.mock.calls[0][0] as { scopeKey: string; method: string };
+    expect(info.scopeKey).toBe('kilter:1:5');
+    expect(info.method).toBe('paged');
+  });
+
+  it('reports method "paged" when a snapshotSource is configured but the scope is not bootstrap-eligible (mid-crawl)', async () => {
+    // Pre-existing checkpoint makes the scope ineligible for bootstrap, so its
+    // completion this cycle is a resumed paged crawl even though a snapshotSource
+    // is present.
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', {
+      updatedAt: '2026-01-01T00:00:00Z',
+      syncSeq: '1',
+    });
+    await setCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5', {
+      updatedAt: '2026-01-01T00:00:00Z',
+      syncSeq: '1',
+    });
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => join(workDir, 'never.db'),
+    });
+    const { fetch } = makeGraphqlFetch();
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+    });
+
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    expect(onScopeDownloadComplete).toHaveBeenCalledTimes(1);
+    const info = onScopeDownloadComplete.mock.calls[0][0] as { scopeKey: string; method: string };
+    expect(info.method).toBe('paged');
+  });
+
+  it('reports method "paged" for a scope whose artifact was rejected as schema-stale (same-cycle paged fallback)', async () => {
+    // A stale-schema artifact is a permanent miss: the bootstrap never marks
+    // the scope, the paged crawl runs the SAME cycle, and completion must
+    // therefore report 'paged' — not 'snapshot'.
+    const filePath = join(workDir, 'stale-method.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+      schemaVersion: LATEST_SCHEMA_VERSION - 1,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+    });
+
+    expect(onScopeDownloadComplete).toHaveBeenCalledTimes(1);
+    const info = onScopeDownloadComplete.mock.calls[0][0] as { scopeKey: string; method: string };
+    expect(info.scopeKey).toBe('kilter:1:5');
+    expect(info.method).toBe('paged');
+  });
+
+  it('does not fire when a table bails early (sign-out mid-cycle) and the scope never reaches its tail', async () => {
+    const { fetch } = makeGraphqlFetch();
+    const onScopeDownloadComplete = vi.fn();
+
+    // syncTable's very first guard (`isSigningOut() || ...`) returns
+    // `{ reachedTail: false }` before any page fetch, so every table in this
+    // cycle bails immediately and allTablesReachedTail stays false —
+    // markScopeDownloadComplete (and thus onScopeDownloadComplete) must not fire.
+    setSigningOut(true);
+    try {
+      await pullSync(db, noopQueryClient(), fetch, {
+        enabledBoards: ['kilter:1:5'],
+        onScopeDownloadComplete,
+      });
+    } finally {
+      setSigningOut(false);
+    }
+
+    expect(onScopeDownloadComplete).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // deletions rewind
 // ---------------------------------------------------------------------------
 

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -1016,6 +1016,55 @@ describe('pullSync onScopeDownloadComplete', () => {
     expect(info.durationMs).toBeGreaterThanOrEqual(0);
   });
 
+  it('reports method "snapshot" when the import and the completing delta pull land in different cycles', async () => {
+    // Cycle 1 bootstraps the scope but dies mid-delta (connectivity drop on the
+    // stats pull) — markBootstrapDone has been persisted, but the scope never
+    // reaches the tail, so no completion event fires. Cycle 2 is a fresh
+    // pullSync whose in-memory bootstrap state is empty; the one-and-only
+    // completion event it emits must still read the persisted marker and
+    // attribute the download to the snapshot, not the trailing delta.
+    const filePath = join(workDir, 'cross-cycle-snapshot.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const onScopeDownloadComplete = vi.fn();
+
+    const run1 = makeGraphqlFetch();
+    const failingStatsFetch = (async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+      if (query.includes('syncClimbStats')) throw new Error('network dropped mid-delta');
+      return run1.fetch<T>(query, variables);
+    }) as GraphqlFetchMock;
+    await expect(
+      pullSync(db, noopQueryClient(), failingStatsFetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        onScopeDownloadComplete,
+      }),
+    ).rejects.toThrow('network dropped mid-delta');
+    expect(onScopeDownloadComplete).not.toHaveBeenCalled();
+    // The bootstrap itself committed before the delta died.
+    expect(await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-done:kilter:1:5'])).toEqual({
+      value: '1',
+    });
+
+    const run2 = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), run2.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+    });
+
+    expect(onScopeDownloadComplete).toHaveBeenCalledTimes(1);
+    const info = onScopeDownloadComplete.mock.calls[0][0] as { scopeKey: string; method: string };
+    expect(info.scopeKey).toBe('kilter:1:5');
+    expect(info.method).toBe('snapshot');
+  });
+
   it('reports method "paged" when no snapshotSource is configured (pure paged crawl)', async () => {
     const { fetch } = makeGraphqlFetch();
     const onScopeDownloadComplete = vi.fn();

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -6,6 +6,7 @@ import {
   setCheckpoint,
   getCheckpointKey,
   markScopeDownloadComplete,
+  isScopeDownloadComplete,
   DELETIONS_CHECKPOINT_KEY,
 } from './checkpoints';
 import {
@@ -747,7 +748,9 @@ export async function pullSync(
     // searches — a first-page checkpoint would otherwise serve a sliver of the
     // catalog as if it were everything.
     if (allTablesReachedTail) {
+      const wasScopeComplete = await isScopeDownloadComplete(db, scopeKey);
       await markScopeDownloadComplete(db, scopeKey);
+      if (wasScopeComplete) continue;
       const startedAt = scopeStartedAt.get(scopeKey);
       // Should be unreachable because scopeStartedAt is seeded from the same
       // parsed boardScopes list this loop iterates. If that invariant breaks,

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -60,11 +60,13 @@ export type SyncProgress = {
  * completing delta pull may land in different cycles when connectivity drops
  * between them), `'paged'` otherwise (fresh paged crawl, a resumed mid-crawl
  * scope, or bootstrap unavailable/exhausted).
- * `durationMs` is measured from when this pullSync cycle started working on the
- * scope (before the bootstrap eligibility check), so a `'snapshot'` scope's
- * duration includes its manifest/download/import time, not just the trailing
- * delta pull — an apples-to-apples comparison against a `'paged'` scope's full
- * crawl time.
+ * `durationMs` is measured from when this pullSync cycle FIRST touched the
+ * scope — a snapshot-eligible scope is stamped at its bootstrap eligibility
+ * check (so the duration includes its manifest/download/import time, not just
+ * the trailing delta pull), a paged-only scope at its turn in the board-data
+ * loop. Per-scope stamping keeps a multi-board cycle honest: scope B's
+ * duration never includes scope A's download time, so `'snapshot'` vs
+ * `'paged'` percentiles stay apples-to-apples.
  */
 export type ScopeDownloadCompleteInfo = {
   scopeKey: string;
@@ -497,6 +499,7 @@ async function runBootstrapPhase(
   queryClient: QueryInvalidator,
   source: SnapshotSource,
   scopes: BoardScope[],
+  stampScopeStart: (scopeKey: string) => void,
   onProgress: ((progress: SyncProgress) => void) | undefined,
   onSchemaDrift: SchemaDriftReporter | undefined,
   onSnapshotBootstrapError: SnapshotBootstrapErrorReporter | undefined,
@@ -514,6 +517,10 @@ async function runBootstrapPhase(
   try {
     for (const scope of scopes) {
       if (isSigningOut() || getWipeEpoch() !== startEpoch) break;
+
+      // Duration telemetry starts here — before the eligibility check — so a
+      // snapshot scope's durationMs covers its manifest/download/import work.
+      stampScopeStart(scope.scopeKey);
 
       // Eligibility: FRESH on BOTH board tables and under the attempt cap.
       const climbsCheckpoint = await getCheckpoint(db, getCheckpointKey('board_climbs', scope.scopeKey));
@@ -651,13 +658,15 @@ export async function pullSync(
     if (scope) boardScopes.push({ ...scope, scopeKey });
   }
 
-  // Start-of-cycle timestamp per scope, captured before the bootstrap eligibility
-  // check runs — so a 'snapshot' scope's ScopeDownloadCompleteInfo.durationMs
-  // includes its manifest/download/import time, not just the trailing delta pull.
+  // Per-scope start timestamp for ScopeDownloadCompleteInfo.durationMs, stamped
+  // when the cycle FIRST touches that scope (bootstrap eligibility check, or
+  // its turn in the board-data loop) — NOT once at cycle start, which would
+  // fold scope A's entire download time into scope B's duration whenever a
+  // cycle processes several boards.
   const scopeStartedAt = new Map<string, number>();
-  for (const boardScope of boardScopes) {
-    scopeStartedAt.set(boardScope.scopeKey, Date.now());
-  }
+  const stampScopeStart = (scopeKey: string): void => {
+    if (!scopeStartedAt.has(scopeKey)) scopeStartedAt.set(scopeKey, Date.now());
+  };
 
   // Phase 0: snapshot bootstrap (BEFORE deletions). Only when an adapter injected
   // snapshot I/O; otherwise this is a pure paged pull, byte-identical to before.
@@ -669,6 +678,7 @@ export async function pullSync(
       queryClient,
       options.snapshotSource,
       boardScopes,
+      stampScopeStart,
       onProgress,
       options.onSchemaDrift,
       options.onSnapshotBootstrapError,
@@ -709,6 +719,9 @@ export async function pullSync(
   // can match itself.
   for (const boardScope of boardScopes) {
     const scopeKey = boardScope.scopeKey;
+    // No-op when the bootstrap phase already stamped this scope; the paged-only
+    // path (no snapshotSource) starts its duration clock here.
+    stampScopeStart(scopeKey);
     // A scope whose bootstrap failed this cycle (with attempts still left) skips
     // its paged pull: a first-page checkpoint would permanently disqualify the
     // snapshot path, so the next cycle retries the snapshot instead.
@@ -751,9 +764,9 @@ export async function pullSync(
       await markScopeDownloadComplete(db, scopeKey);
       if (wasScopeComplete) continue;
       const startedAt = scopeStartedAt.get(scopeKey);
-      // Should be unreachable because scopeStartedAt is seeded from the same
-      // parsed boardScopes list this loop iterates. If that invariant breaks,
-      // skip telemetry rather than emit a misleading 0ms duration.
+      // Should be unreachable because stampScopeStart runs at the top of this
+      // loop for every scope. If that invariant breaks, skip telemetry rather
+      // than emit a misleading 0ms duration.
       if (startedAt === undefined) continue;
       // Attribution reads the persisted marker, not this run's bootstrap set:
       // the import and the completing delta pull can land in different cycles

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -749,10 +749,14 @@ export async function pullSync(
     if (allTablesReachedTail) {
       await markScopeDownloadComplete(db, scopeKey);
       const startedAt = scopeStartedAt.get(scopeKey);
+      // Should be unreachable because scopeStartedAt is seeded from the same
+      // parsed boardScopes list this loop iterates. If that invariant breaks,
+      // skip telemetry rather than emit a misleading 0ms duration.
+      if (startedAt === undefined) continue;
       options?.onScopeDownloadComplete?.({
         scopeKey,
         method: bootstrappedScopeKeys.has(scopeKey) ? 'snapshot' : 'paged',
-        durationMs: startedAt !== undefined ? Date.now() - startedAt : 0,
+        durationMs: Date.now() - startedAt,
       });
     }
   }

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -14,6 +14,7 @@ import {
   getBootstrapAttempts,
   recordBootstrapAttempt,
   markBootstrapDone,
+  isBootstrapDone,
   MAX_BOOTSTRAP_ATTEMPTS,
   SnapshotWipedError,
   SnapshotSchemaStaleError,
@@ -54,9 +55,11 @@ export type SyncProgress = {
  * Fired once a board scope's initial download completes this cycle (both
  * board_climbs and board_climb_stats reached their tail — the same gate as
  * `markScopeDownloadComplete`). Lets the app compare the two download paths in
- * the field: `method` is `'snapshot'` when a bootstrap warm-up succeeded for
- * this scope THIS run (see `runBootstrapPhase`), `'paged'` otherwise (fresh
- * paged crawl, a resumed mid-crawl scope, or bootstrap unavailable/exhausted).
+ * the field: `method` is `'snapshot'` when a bootstrap warm-up ever succeeded
+ * for this scope (the persisted `isBootstrapDone` marker — the import and the
+ * completing delta pull may land in different cycles when connectivity drops
+ * between them), `'paged'` otherwise (fresh paged crawl, a resumed mid-crawl
+ * scope, or bootstrap unavailable/exhausted).
  * `durationMs` is measured from when this pullSync cycle started working on the
  * scope (before the bootstrap eligibility check), so a `'snapshot'` scope's
  * duration includes its manifest/download/import time, not just the trailing
@@ -484,9 +487,10 @@ async function resolveManifestOnce(
  * syncTable). One artifact is downloaded per (boardType, layoutId) and reused
  * across that layout's sizes; all downloads are deleted in a finally.
  *
- * Returns both the skip-set (above) and `bootstrappedScopeKeys` — the scopes
- * whose bootstrap actually succeeded THIS run (markBootstrapDone was called) —
- * so pullSync can report ScopeDownloadCompleteInfo.method accurately.
+ * Returns the skip-set (above). Snapshot attribution for
+ * ScopeDownloadCompleteInfo.method is NOT threaded through here — it reads the
+ * persisted `isBootstrapDone` marker instead, because the completing delta
+ * pull can land cycles after the import (see ScopeDownloadCompleteInfo).
  */
 async function runBootstrapPhase(
   db: OfflineDatabase,
@@ -496,9 +500,8 @@ async function runBootstrapPhase(
   onProgress: ((progress: SyncProgress) => void) | undefined,
   onSchemaDrift: SchemaDriftReporter | undefined,
   onSnapshotBootstrapError: SnapshotBootstrapErrorReporter | undefined,
-): Promise<{ skipPagedPull: Set<string>; bootstrappedScopeKeys: Set<string> }> {
+): Promise<Set<string>> {
   const skipPagedPull = new Set<string>();
-  const bootstrappedScopeKeys = new Set<string>();
   const manifestCache: { value?: ManifestResolution } = {};
   // Absent = not yet attempted; `file: null` = download failed (with its cause).
   const downloadByLayout = new Map<
@@ -591,7 +594,6 @@ async function runBootstrapPhase(
           onSchemaDrift,
         });
         await markBootstrapDone(db, scope.scopeKey);
-        bootstrappedScopeKeys.add(scope.scopeKey);
         // Bust the board-table query caches now: if the snapshot fully satisfies
         // the scope, the delta pull returns zero documents and syncTable's
         // arrivals-only invalidation never fires — an active search/detail query
@@ -627,7 +629,7 @@ async function runBootstrapPhase(
     }
   }
 
-  return { skipPagedPull, bootstrappedScopeKeys };
+  return skipPagedPull;
 }
 
 export async function pullSync(
@@ -660,10 +662,9 @@ export async function pullSync(
   // Phase 0: snapshot bootstrap (BEFORE deletions). Only when an adapter injected
   // snapshot I/O; otherwise this is a pure paged pull, byte-identical to before.
   let skipBootstrapPagedPull: Set<string> = new Set();
-  let bootstrappedScopeKeys: Set<string> = new Set();
   if (options?.snapshotSource && boardScopes.length > 0) {
     onProgress?.({ phase: 'bootstrap', currentTable: null, documentsProcessed: 0 });
-    const bootstrapResult = await runBootstrapPhase(
+    skipBootstrapPagedPull = await runBootstrapPhase(
       db,
       queryClient,
       options.snapshotSource,
@@ -672,8 +673,6 @@ export async function pullSync(
       options.onSchemaDrift,
       options.onSnapshotBootstrapError,
     );
-    skipBootstrapPagedPull = bootstrapResult.skipPagedPull;
-    bootstrappedScopeKeys = bootstrapResult.bootstrappedScopeKeys;
   }
 
   // Deletions FIRST, table pulls second. This ordering is what makes a
@@ -756,9 +755,14 @@ export async function pullSync(
       // parsed boardScopes list this loop iterates. If that invariant breaks,
       // skip telemetry rather than emit a misleading 0ms duration.
       if (startedAt === undefined) continue;
+      // Attribution reads the persisted marker, not this run's bootstrap set:
+      // the import and the completing delta pull can land in different cycles
+      // (connectivity drop between them), and this event fires exactly once per
+      // scope — misreporting that one event as 'paged' would permanently
+      // undercount snapshot wins in the rollout comparison.
       options?.onScopeDownloadComplete?.({
         scopeKey,
-        method: bootstrappedScopeKeys.has(scopeKey) ? 'snapshot' : 'paged',
+        method: (await isBootstrapDone(db, scopeKey)) ? 'snapshot' : 'paged',
         durationMs: Date.now() - startedAt,
       });
     }

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -49,6 +49,26 @@ export type SyncProgress = {
   failed?: boolean;
 };
 
+/**
+ * Fired once a board scope's initial download completes this cycle (both
+ * board_climbs and board_climb_stats reached their tail — the same gate as
+ * `markScopeDownloadComplete`). Lets the app compare the two download paths in
+ * the field: `method` is `'snapshot'` when a bootstrap warm-up succeeded for
+ * this scope THIS run (see `runBootstrapPhase`), `'paged'` otherwise (fresh
+ * paged crawl, a resumed mid-crawl scope, or bootstrap unavailable/exhausted).
+ * `durationMs` is measured from when this pullSync cycle started working on the
+ * scope (before the bootstrap eligibility check), so a `'snapshot'` scope's
+ * duration includes its manifest/download/import time, not just the trailing
+ * delta pull — an apples-to-apples comparison against a `'paged'` scope's full
+ * crawl time.
+ */
+export type ScopeDownloadCompleteInfo = {
+  scopeKey: string;
+  method: 'snapshot' | 'paged';
+  durationMs: number;
+};
+export type ScopeDownloadCompleteReporter = (info: ScopeDownloadCompleteInfo) => void;
+
 export type SyncOptions = {
   /** Encoded board scope keys ("boardType:layoutId:sizeId") to download offline. */
   enabledBoards?: string[];
@@ -62,6 +82,8 @@ export type SyncOptions = {
   snapshotSource?: SnapshotSource;
   /** Telemetry for a counted bootstrap failure (manifest/download/import). */
   onSnapshotBootstrapError?: SnapshotBootstrapErrorReporter;
+  /** Telemetry for comparing the snapshot vs paged download paths. See ScopeDownloadCompleteInfo. */
+  onScopeDownloadComplete?: ScopeDownloadCompleteReporter;
 };
 
 /** A per-board download target: the parsed scope plus its encoded key. */
@@ -460,6 +482,10 @@ async function resolveManifestOnce(
  * A wipe detected mid-phase bails the whole phase with no attempt (mirrors
  * syncTable). One artifact is downloaded per (boardType, layoutId) and reused
  * across that layout's sizes; all downloads are deleted in a finally.
+ *
+ * Returns both the skip-set (above) and `bootstrappedScopeKeys` — the scopes
+ * whose bootstrap actually succeeded THIS run (markBootstrapDone was called) —
+ * so pullSync can report ScopeDownloadCompleteInfo.method accurately.
  */
 async function runBootstrapPhase(
   db: OfflineDatabase,
@@ -469,8 +495,9 @@ async function runBootstrapPhase(
   onProgress: ((progress: SyncProgress) => void) | undefined,
   onSchemaDrift: SchemaDriftReporter | undefined,
   onSnapshotBootstrapError: SnapshotBootstrapErrorReporter | undefined,
-): Promise<Set<string>> {
+): Promise<{ skipPagedPull: Set<string>; bootstrappedScopeKeys: Set<string> }> {
   const skipPagedPull = new Set<string>();
+  const bootstrappedScopeKeys = new Set<string>();
   const manifestCache: { value?: ManifestResolution } = {};
   // Absent = not yet attempted; `file: null` = download failed (with its cause).
   const downloadByLayout = new Map<
@@ -563,6 +590,7 @@ async function runBootstrapPhase(
           onSchemaDrift,
         });
         await markBootstrapDone(db, scope.scopeKey);
+        bootstrappedScopeKeys.add(scope.scopeKey);
         // Bust the board-table query caches now: if the snapshot fully satisfies
         // the scope, the delta pull returns zero documents and syncTable's
         // arrivals-only invalidation never fires — an active search/detail query
@@ -598,7 +626,7 @@ async function runBootstrapPhase(
     }
   }
 
-  return skipPagedPull;
+  return { skipPagedPull, bootstrappedScopeKeys };
 }
 
 export async function pullSync(
@@ -620,12 +648,21 @@ export async function pullSync(
     if (scope) boardScopes.push({ ...scope, scopeKey });
   }
 
+  // Start-of-cycle timestamp per scope, captured before the bootstrap eligibility
+  // check runs — so a 'snapshot' scope's ScopeDownloadCompleteInfo.durationMs
+  // includes its manifest/download/import time, not just the trailing delta pull.
+  const scopeStartedAt = new Map<string, number>();
+  for (const boardScope of boardScopes) {
+    scopeStartedAt.set(boardScope.scopeKey, Date.now());
+  }
+
   // Phase 0: snapshot bootstrap (BEFORE deletions). Only when an adapter injected
   // snapshot I/O; otherwise this is a pure paged pull, byte-identical to before.
   let skipBootstrapPagedPull: Set<string> = new Set();
+  let bootstrappedScopeKeys: Set<string> = new Set();
   if (options?.snapshotSource && boardScopes.length > 0) {
     onProgress?.({ phase: 'bootstrap', currentTable: null, documentsProcessed: 0 });
-    skipBootstrapPagedPull = await runBootstrapPhase(
+    const bootstrapResult = await runBootstrapPhase(
       db,
       queryClient,
       options.snapshotSource,
@@ -634,6 +671,8 @@ export async function pullSync(
       options.onSchemaDrift,
       options.onSnapshotBootstrapError,
     );
+    skipBootstrapPagedPull = bootstrapResult.skipPagedPull;
+    bootstrappedScopeKeys = bootstrapResult.bootstrappedScopeKeys;
   }
 
   // Deletions FIRST, table pulls second. This ordering is what makes a
@@ -709,6 +748,12 @@ export async function pullSync(
     // catalog as if it were everything.
     if (allTablesReachedTail) {
       await markScopeDownloadComplete(db, scopeKey);
+      const startedAt = scopeStartedAt.get(scopeKey);
+      options?.onScopeDownloadComplete?.({
+        scopeKey,
+        method: bootstrappedScopeKeys.has(scopeKey) ? 'snapshot' : 'paged',
+        durationMs: startedAt !== undefined ? Date.now() - startedAt : 0,
+      });
     }
   }
 

--- a/packages/shared/offline-sync/src/sync/sync-scheduler.ts
+++ b/packages/shared/offline-sync/src/sync/sync-scheduler.ts
@@ -1,5 +1,11 @@
 import type { OfflineDatabase, QueryInvalidator } from '../database';
-import { pullSync, type SyncProgress, type SchemaDriftReporter } from './pull-client';
+import {
+  pullSync,
+  type SyncProgress,
+  type SchemaDriftReporter,
+  type ScopeDownloadCompleteReporter,
+} from './pull-client';
+import type { SnapshotSource, SnapshotBootstrapErrorReporter } from './snapshot-bootstrap';
 
 /**
  * Optional progress sink for the pull phase. The bridge passes the sync-status
@@ -46,6 +52,12 @@ export type SchedulerOptions = {
   onCycleError?: (error: unknown) => void;
   /** Threaded through to pullSync — see SchemaDriftReporter. */
   onSchemaDrift?: SchemaDriftReporter;
+  /** Threaded through to pullSync's SyncOptions — see snapshot-bootstrap.ts. */
+  snapshotSource?: SnapshotSource;
+  /** Threaded through to pullSync's SyncOptions. */
+  onSnapshotBootstrapError?: SnapshotBootstrapErrorReporter;
+  /** Threaded through to pullSync's SyncOptions — see ScopeDownloadCompleteInfo. */
+  onScopeDownloadComplete?: ScopeDownloadCompleteReporter;
 };
 
 let isSyncing = false;
@@ -81,6 +93,9 @@ async function runSync(
       enabledBoards: getEnabledBoards(),
       onProgress: options?.onProgress,
       onSchemaDrift: options?.onSchemaDrift,
+      snapshotSource: options?.snapshotSource,
+      onSnapshotBootstrapError: options?.onSnapshotBootstrapError,
+      onScopeDownloadComplete: options?.onScopeDownloadComplete,
     });
   } catch (error) {
     options?.onCycleError?.(error);


### PR DESCRIPTION
## Summary

Phase 4 of the snapshot-bootstrap series (stacked on #3560) — the mobile wiring that turns the engine on:

- `packages/mobile/src/offline/snapshot-source.ts`: the injected `SnapshotSource` — manifest fetch (`cache: 'no-store'`), artifact download via the SDK 57 expo-file-system `File`/`Paths` API into the cache directory, a free-disk gate (6× the compressed size), and a gzip-magic-bytes sniff on the first stream chunk (if the native HTTP stack didn't transparently decompress the `Content-Encoding: gzip` object, the file is deleted and the engine records an attempt — surfaced via Sentry so we see which platforms need the export flipped to identity encoding).
- Scheduler threading: `sync-scheduler.ts` now forwards `snapshotSource`/`onSnapshotBootstrapError`/`onScopeDownloadComplete` into `pullSync` (it previously couldn't drive bootstrap at all).
- Flag gating: new PostHog flag `offline-snapshot-bootstrap`, nested under `offline-board-downloads` — the source is only injected when both are on; flag off = byte-identical current behaviour.
- Telemetry: new engine hook `onScopeDownloadComplete` fires when a scope's initial download reaches its tail, with `method: 'snapshot' | 'paged'` and duration → PostHog `Offline Board Download Completed`. This is the before/after metric for the rollout. Bootstrap failures go to Sentry (`kind: 'snapshot-bootstrap'`).
- UI: the manage-boards rows show a distinct "Downloading board…" state during the bootstrap phase (i18n keys added for en-US/es/fr per the glossaries).

## Open items before flag ramp
- `SNAPSHOT_BASE_URL` default in `src/lib/env.ts` is a **placeholder** (`https://boardsesh-data.fly.storage.tigris.dev/board-snapshots/v1`) — the real Tigris bucket host lives in the backend CI secrets; set `EXPO_PUBLIC_SNAPSHOT_BASE_URL` at build time or correct the default.
- ATTACH-by-bare-path (vs `file://` URI) and transparent gzip decode need one manual on-device bootstrap run to confirm native behaviour (vitest can't answer either).

## Release Notes

- [x] No release note needed (internal / technical change — dark behind a feature flag; the user-facing note ships when the flag ramps)

## Test plan

- `vp run test:mobile` — 457 files / 3646 tests.
- `vp test run --project offline-sync` — 186 tests (5 new telemetry cases incl. method='paged' for schema-stale scopes).
- `vp run typecheck` (full monorepo), `vp check`, `vp run check:mobile-bundle` (13.8 MB, OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dhXrKcRTfpLV8pkH2RMV6