### PR TITLE
fix(mobile): light iOS 26.5 boards when canSendWriteWithoutResponse is stuck false (v2.2.1)

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -197,7 +197,7 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
     name: appName,
     slug: 'boardsesh',
     owner: 'boardsesh',
-    version: '2.2.0',
+    version: '2.2.1',
     scheme: 'com.boardsesh.app',
     orientation: 'portrait',
     icon: iconPath,

--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -380,7 +380,12 @@ final class BoardBleWriteFlowTests: XCTestCase {
     }
 
     // 5
-    func testWatchdogTripRecordsCanSendAtTripFalseAndFailsWritesWithTimeout() {
+    // iOS 26.x "stuck false" signature: the watchdog trips with
+    // canSendWriteWithoutResponse still false and peripheralIsReady never fired.
+    // Rather than cycle the link (which never clears the stuck property and leaves
+    // the wall dark), latch past the gate for this connection and push the parked
+    // write through — the false reading is a lie, the radio takes the write.
+    func testWatchdogTripWithStuckFalseBypassesGateAndCompletesWrite() {
         let hooks = manager.testHooks
         let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
         let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
@@ -388,26 +393,99 @@ final class BoardBleWriteFlowTests: XCTestCase {
 
         var completionError: Error?
         var completionTelemetry: BoardBleWriteTelemetry?
+        var completionCount = 0
 
         hooks.sync {
             hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
             manager.write(data: payload) { error, telemetry in
                 completionError = error
                 completionTelemetry = telemetry
+                completionCount += 1
             }
         }
+        // Parked, not written, gate still armed.
         XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+        XCTAssertFalse(hooks.sync { hooks.bypassCanSendWriteWithoutResponse })
 
+        // Watchdog trips with canSend STILL false -> latch bypass, resume the
+        // parked write, write the chunk despite the false gate.
         fireLatestOneShot(label: "writeResumeWatchdog")
 
-        XCTAssertEqual(completionError as? BoardBleError, .writeTimedOut)
+        XCTAssertTrue(hooks.sync { hooks.bypassCanSendWriteWithoutResponse })
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(completionCount, 0)
+        // No link cycle: the board is not disconnected and the recovery budget is
+        // untouched.
+        XCTAssertTrue(cancelledPeripheralIds.isEmpty)
+        XCTAssertEqual(hooks.sync { hooks.writeStallRecoveries }, 0)
+        XCTAssertNil(scheduler.lastOneShot(label: "writeStallRecoveryWatchdog"))
+        // Poller + watchdog retired by the resume.
+        XCTAssertTrue(scheduler.repeatingTimers[0].cancelled)
+        XCTAssertTrue(scheduler.lastOneShot(label: "writeResumeWatchdog")?.cancelled ?? false)
+
+        // The trailing chunkDelay completes the write successfully.
+        fireLatestOneShot(label: "chunkDelay")
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertNil(completionError)
         XCTAssertEqual(completionTelemetry?.watchdogTripped, true)
         XCTAssertEqual(completionTelemetry?.canSendAtTrip, false)
-        XCTAssertTrue(scheduler.repeatingTimers[0].cancelled)
-        XCTAssertEqual(hooks.sync { hooks.writeStallRecoveries }, 1)
-        XCTAssertEqual(hooks.sync { hooks.writeStallRecoveringPeripheralId }, peripheral.identifier)
-        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
-        XCTAssertNotNil(scheduler.lastOneShot(label: "writeStallRecoveryWatchdog"))
+        XCTAssertEqual(completionTelemetry?.lastResumeSource, "bypass")
+    }
+
+    // 5b
+    // Once bypass is latched, later writes on the SAME connection skip the gate
+    // entirely — no park, no watchdog — even with canSend still false.
+    func testBypassLatchMakesSubsequentWritesSkipTheGate() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: Data((0 ..< 10).map { UInt8($0) })) { _, _ in }
+        }
+        fireLatestOneShot(label: "writeResumeWatchdog") // latch bypass, write first send
+        fireLatestOneShot(label: "chunkDelay") // complete first send
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertTrue(hooks.sync { hooks.bypassCanSendWriteWithoutResponse })
+
+        // Second send: writes immediately, no park (hasPendingWriteResume stays
+        // false), canSend never consulted as a gate.
+        let repeatingTimersBefore = scheduler.repeatingTimers.count
+        hooks.sync {
+            manager.write(data: Data((100 ..< 105).map { UInt8($0) })) { _, _ in }
+        }
+        XCTAssertEqual(peripheral.writtenChunks.count, 2)
+        XCTAssertEqual(peripheral.writtenChunks[1].data, Data((100 ..< 105).map { UInt8($0) }))
+        XCTAssertFalse(hooks.sync { hooks.hasPendingWriteResume })
+        // No new poller was armed for the second write.
+        XCTAssertEqual(scheduler.repeatingTimers.count, repeatingTimersBefore)
+    }
+
+    // 5c
+    // A fresh connection re-arms the gate: the bypass latch must not persist
+    // across reconnects, so a healthy new link earns normal backpressure again.
+    func testReconnectClearsBypassLatch() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+
+        hooks.sync {
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: Data((0 ..< 10).map { UInt8($0) })) { _, _ in }
+        }
+        fireLatestOneShot(label: "writeResumeWatchdog") // latch bypass
+        XCTAssertTrue(hooks.sync { hooks.bypassCanSendWriteWithoutResponse })
+
+        // Reconnect (new characteristic) clears the latch.
+        hooks.sync { hooks.setConnection(peripheral: peripheral, characteristic: characteristic) }
+        XCTAssertFalse(hooks.sync { hooks.bypassCanSendWriteWithoutResponse })
+
+        // The next write on the re-armed link parks again on the false gate.
+        hooks.sync {
+            manager.write(data: Data((0 ..< 10).map { UInt8($0) })) { _, _ in }
+        }
+        XCTAssertTrue(hooks.sync { hooks.hasPendingWriteResume })
     }
 
     // 6
@@ -466,9 +544,20 @@ final class BoardBleWriteFlowTests: XCTestCase {
     }
 
     // 8
+    // The recovery-budget boundary is now reached via the poller-missed-flip
+    // route (canSendAtTrip == true): stuck-false (canSendAtTrip == false) latches
+    // the gate bypass instead, so it never cycles the link. This exercises the
+    // remaining handleWriteStall path — beyond budget -> writeRecoveryFailed +
+    // disconnect — with the property reading true at trip.
     func testWatchdogTripBeyondRecoveryBudgetFailsWithRecoveryFailedAndEmitsDisconnect() {
         let hooks = manager.testHooks
-        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        // Park read = false; the watchdog's canSendAtTrip read = true (the poller
+        // never observed the flip).
+        let peripheral = FakeWritablePeripheral(
+            canSendDefault: true,
+            canSendScript: [false],
+            maxWriteValueLength: 20
+        )
         let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
         let payload = Data((0 ..< 10).map { UInt8($0) })
 
@@ -492,8 +581,14 @@ final class BoardBleWriteFlowTests: XCTestCase {
                 completionError = error
             }
         }
+        // Parked on the scripted false read; the bypass latch is NOT set.
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+        XCTAssertFalse(hooks.sync { hooks.bypassCanSendWriteWithoutResponse })
 
         fireLatestOneShot(label: "writeResumeWatchdog")
+
+        // canSendAtTrip read true -> no bypass -> handleWriteStall -> over budget.
+        XCTAssertFalse(hooks.sync { hooks.bypassCanSendWriteWithoutResponse })
 
         XCTAssertEqual(completionError as? BoardBleError, .writeRecoveryFailed)
         XCTAssertEqual(disconnectDeviceId, peripheral.identifier.uuidString)

--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -474,8 +474,10 @@ final class BoardBleWriteFlowTests: XCTestCase {
             hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
             manager.write(data: Data((0 ..< 10).map { UInt8($0) })) { _, _ in }
         }
-        fireLatestOneShot(label: "writeResumeWatchdog") // latch bypass
+        fireLatestOneShot(label: "writeResumeWatchdog") // latch bypass, resume + write chunk
+        fireLatestOneShot(label: "chunkDelay") // drain the first write (clears isWriting/queue)
         XCTAssertTrue(hooks.sync { hooks.bypassCanSendWriteWithoutResponse })
+        XCTAssertFalse(hooks.sync { hooks.isWriting })
 
         // Reconnect (new characteristic) clears the latch.
         hooks.sync { hooks.setConnection(peripheral: peripheral, characteristic: characteristic) }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -232,6 +232,18 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // iOS 26.5 can flip the property without ever delivering the
     // `peripheralIsReady` delegate. Cancelled wherever the watchdog is.
     private var writeResumePoller: BleRepeatingTimer?
+    // Latched when a write watchdog trips while `canSendWriteWithoutResponse` is
+    // STILL false and `peripheralIsReady` never fired — the iOS 26.x "stuck
+    // false" signature (#3230 covered "flips true, delegate silent"; this is the
+    // stricter case where the property itself never recovers). On these boards
+    // the false reading is a lie: the radio can accept the write, but the poller
+    // and delegate never let us past the gate, so every send times out and the
+    // wall stays dark. Once latched, the without-response path stops gating on
+    // the property for THIS connection and writes chunks directly (still paced by
+    // `chunkDelay`). Reset on every fresh connection so a healthy link re-earns
+    // normal backpressure. Fixes iOS 26.5 Kilter home walls that connected but
+    // never lit a climb (write_timeout with canSendAtTrip=false on every send).
+    private var bypassCanSendWriteWithoutResponse = false
     // Telemetry for the request currently being written (#3230). Requests are
     // strictly serial (`isWriting`), so one slot suffices: seeded when a request
     // starts, finalized at whichever settle point delivers its completion.
@@ -1231,6 +1243,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // Any successful (re)connect closes a write-stall recovery window (#3181)
         // — writes flow normally again from here.
         writeStallRecoveringPeripheralId = nil
+        // A fresh link re-earns normal backpressure: drop any stuck-false gate
+        // bypass so a healthy connection isn't permanently ungated.
+        bypassCanSendWriteWithoutResponse = false
         // Remember the board so the Live Activity lightbulb can reconnect to it
         // by identifier later, no device pick required.
         persistLastConnectedPeripheral(peripheral)
@@ -1556,7 +1571,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
 
         if request.writeType == .withoutResponse {
-            guard peripheral.canSendWriteWithoutResponse else {
+            // `bypassCanSendWriteWithoutResponse` short-circuits the gate on a
+            // connection we've already proven reports the property stuck false
+            // (see the watchdog handler below): keep writing, paced by chunkDelay.
+            guard bypassCanSendWriteWithoutResponse || peripheral.canSendWriteWithoutResponse else {
                 currentWriteTelemetry?.parkCount += 1
                 parkStartedAt = .now()
                 pendingWriteResume = { [weak self] in
@@ -1586,6 +1604,24 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                     let canSendAtTrip = self.connectedPeripheral?.canSendWriteWithoutResponse
                     self.currentWriteTelemetry?.watchdogTripped = true
                     self.currentWriteTelemetry?.canSendAtTrip = canSendAtTrip
+                    // canSendAtTrip == false on a live peripheral is the iOS 26.x
+                    // "stuck false" signature: the property never recovered across
+                    // the whole watchdog window (the poller re-read it every
+                    // writeResumePollInterval and never saw it flip, and
+                    // peripheralIsReady never fired). Cycling the link doesn't
+                    // clear it — it comes back stuck on the fresh connection too —
+                    // so instead latch past the gate for this connection and push
+                    // the parked write through. The false reading is a lie on
+                    // these OS versions; the radio takes the write. First send eats
+                    // one writeResumeTimeout; every later send on this connection
+                    // skips the gate. A vanished peripheral (nil) or a genuine
+                    // missed-flip (true) still falls through to stall recovery.
+                    if canSendAtTrip == false, !self.bypassCanSendWriteWithoutResponse {
+                        self.bypassCanSendWriteWithoutResponse = true
+                        self.logger.error("BLE write stalled: canSendWriteWithoutResponse stuck false across the watchdog window; bypassing the gate for this connection and resuming the write")
+                        self.resumeParkedWrite(source: "bypass")
+                        return
+                    }
                     self.logger.error("BLE write stalled: peripheral never became ready for write-without-response (canSendAtTrip=\(String(describing: canSendAtTrip), privacy: .public)); attempting recovery")
                     self.handleWriteStall()
                 }
@@ -1844,6 +1880,9 @@ extension BoardBleManager {
         func setConnection(peripheral: WritableBlePeripheral?, characteristic: CBCharacteristic?) {
             manager.connectedPeripheral = peripheral
             manager.writeCharacteristic = characteristic
+            // Mirror the production reset in didDiscoverCharacteristicsFor so a
+            // reconnect in a test starts with the gate re-armed.
+            manager.bypassCanSendWriteWithoutResponse = false
         }
 
         /// Set the in-memory board configuration WITHOUT the app-group persistence
@@ -1898,6 +1937,7 @@ extension BoardBleManager {
         var currentTelemetry: BoardBleWriteTelemetry? { manager.currentWriteTelemetry }
         var writeStallRecoveries: Int { manager.writeStallRecoveries }
         var writeStallRecoveringPeripheralId: UUID? { manager.writeStallRecoveringPeripheralId }
+        var bypassCanSendWriteWithoutResponse: Bool { manager.bypassCanSendWriteWithoutResponse }
     }
 
     var testHooks: TestHooks { TestHooks(manager: self) }


### PR DESCRIPTION
## Release Notes

Fixed some iPhones on iOS 26.5 that connected to a board but never lit up climbs.

## Problem

An iOS **26.5.1** user's Kilter home wall (feedback #10177) connected fine but **lit 0 climbs** — every LED send failed. PostHog confirms it's a real, 100%-reproducible native bug, not a flaky session:

- **22** `Bluetooth Connection Success`, **0** `Climb Sent to Board Success`, **37** `Climb Sent to Board Failure` — all `failureReason=write_timeout`.
- Per-failure telemetry: `bleParkCount=1`, `bleWatchdogTripped=true`, `blePeripheralIsReadyFired=false`, `bleCanSendAtTrip=false`, `bleMaxParkMs≈5019`.

`write_timeout` is new since 2.0.1 and has hit **~34 distinct iOS users** in 21 days. For an affected user the board never lights — total loss of the app's core function.

## Root cause

On iOS 26.x, CoreBluetooth's `canSendWriteWithoutResponse` can get **stuck `false` for the entire 5s watchdog window** while `peripheralIsReady(toSendWriteWithoutResponse:)` never fires. The existing mitigations don't cover this exact shape:

- The #3230 **poller** handles "flag flips true but the delegate stays silent" — but here the flag never flips, so polling it never resumes.
- The #3181 **link-cycle recovery** doesn't clear it — a fresh connection comes back stuck too.

So every send parks, hits the watchdog, and records `write_timeout`. The false reading is a lie: the radio *can* accept the write.

## Fix

When the write watchdog trips with `canSendAtTrip == false` (the stuck-false signature), latch a **per-connection bypass** and push the parked write through instead of cycling the link. Once latched, the without-response path stops gating on the property for that connection and paces on `chunkDelay` as before. The latch **resets on every fresh connection** (`didDiscoverCharacteristicsFor`, the single point where `writeCharacteristic` becomes non-nil), so a healthy link re-earns normal backpressure.

- `canSendAtTrip == true` (poller missed a genuine flip) and `== nil` (peripheral gone) still fall through to the existing stall recovery — unchanged.
- MoonBoard/RedBearLab **with-response** path is untouched.

**Trade-off (documented):** for a genuinely dead-but-connected radio that also reports stuck-false, without-response writes have no ack, so a send reports success while the wall is dark until iOS surfaces the disconnect (`didDisconnectPeripheral`, which resets the latch). Acceptable — telemetry shows link-cycling didn't help the real bug and affected boards were 100% dark before.

## Version

Bumps marketing version **2.2.0 → 2.2.1** (`app.config.ts`, the single source of truth read by `fastlane/Fastfile` and the build workflows). This is a **native** change — not OTA-able — so it must ship in a new build.

## Tests

`packages/mobile/ios-tests/BoardBleWriteFlowTests.swift`:
- **#5** rewritten: watchdog stuck-false → bypass latches, write completes (no link cycle, recovery budget untouched, `lastResumeSource="bypass"`).
- **#5b**: subsequent sends on a latched connection skip the gate (no re-park).
- **#5c**: reconnect clears the latch (re-arms backpressure).
- **#8** retargeted at the surviving `canSendAtTrip==true` route so the recovery-budget branch stays covered.

## Reviewed

Adversarially reviewed by an Opus agent: **"Correct and safe to ship, pending on-device verification. No Critical or High findings."** One MEDIUM (the documented dead-radio trade-off above) and three LOW (rare false-latch, one-time ~5s first-send latency per connection, and test #5c exercising the test-hook reset rather than the production reset — unavoidable without CoreBluetooth in CI).

## Verification — must be done on device (no BLE/CoreBluetooth in CI or simulator)

1. On an **iOS 26.5.x** device whose Kilter wall was lighting 0 climbs, sends now light the wall; PostHog shows successful sends with `watchdogTripped=true`, `canSendAtTrip=false`, `lastResumeSource="bypass"`.
2. First climb after each connect takes ~5s (park→latch); subsequent climbs are immediate — confirm acceptable.
3. After a disconnect/reconnect the first send parks again (latch cleared) — bypass doesn't leak across connections.
4. Healthy boards / older iOS: no `lastResumeSource="bypass"` in telemetry; backpressure still works.
5. MoonBoard/RedBearLab (with-response) still light normally.
6. Kill a board mid-session after bypass latched — app eventually surfaces a disconnect rather than silent success forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
