### PR TITLE
feat(mobile): Show Boardsesh grades toggle + richer grade section, by-angle chart

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -34,8 +34,13 @@ import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useSessionRecordingPreference } from '../../../src/lib/session-recording-preference';
 import { setSessionRecordingEnabled } from '../../../src/lib/analytics';
 import { useShowPlaylistTagsPreference } from '../../../src/lib/show-playlist-tags-preference';
+import { useBoardseshGradesPreference } from '../../../src/lib/boardsesh-grades-preference';
 import { useToast } from '../../../src/providers/toast-provider';
-import { useFeatureFlag, useOfflineDownloadsEnabled } from '../../../src/providers/feature-flags-provider';
+import {
+  useFeatureFlag,
+  useOfflineDownloadsEnabled,
+  useBoardseshGradeEnabled,
+} from '../../../src/providers/feature-flags-provider';
 import { replayOnboarding } from '../../../src/lib/onboarding/onboarding-storage';
 import { reportError } from '../../../src/lib/error-reporting';
 
@@ -62,6 +67,8 @@ export default function MoreScreen() {
   const { enabled: sessionRecordingEnabled, setEnabled: setSessionRecordingPreference } =
     useSessionRecordingPreference();
   const { enabled: showPlaylistTags, setEnabled: setShowPlaylistTags } = useShowPlaylistTagsPreference();
+  const { enabled: showBoardseshGrades, setEnabled: setShowBoardseshGrades } = useBoardseshGradesPreference();
+  const boardseshGradeFlagEnabled = useBoardseshGradeEnabled();
   const { showToast } = useToast();
   const stravaEnabled = useFeatureFlag('strava-integration') === true;
   // Off until the Connect IQ watch app ships — nothing to pair to before then.
@@ -350,7 +357,9 @@ export default function MoreScreen() {
     ],
   });
 
-  // Display options — show playlist tags toggle.
+  // Display options — show playlist tags toggle, plus the Boardsesh grades
+  // toggle when the `boardsesh-grade` flag is on (the row itself is the
+  // opt-in; the flag gates whether it's offered at all).
   sections.push({
     key: 'displayOptions',
     title: t('mobile.more.displayOptions.title'),
@@ -366,6 +375,21 @@ export default function MoreScreen() {
           setShowPlaylistTags(next);
         },
       },
+      ...(boardseshGradeFlagEnabled
+        ? [
+            {
+              kind: 'toggle' as const,
+              key: 'boardseshGrades',
+              label: t('mobile.more.displayOptions.boardseshGrades'),
+              subtitle: t('mobile.more.displayOptions.boardseshGradesDescription'),
+              value: showBoardseshGrades,
+              onValueChange: (next: boolean) => {
+                hapticSelection();
+                setShowBoardseshGrades(next);
+              },
+            },
+          ]
+        : []),
     ],
   });
 

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -48,6 +48,15 @@ export type ClimbListItemClimb = {
   // from PR #3554. Optional + permissive so both the web-schema `Climb` and the
   // `@boardsesh/queue` `Climb` satisfy this shape; `resolveGrade` renders the
   // Boardsesh grade in their place when the "Show Boardsesh grades" toggle is on.
+  //
+  // INVARIANT (enforced at the callers, not here): set these two fields ONLY when
+  // `difficulty` above is a COMMUNITY/CONSENSUS grade — NEVER a user's own logged
+  // ascent grade. `resolveGrade` swaps in the Boardsesh grade unconditionally when
+  // the toggle is on, so it cannot tell the two apart; a caller that renders a
+  // climber's own logged grade would silently violate the hard rule (a user grade
+  // always wins) if it populated these. Such callers MUST omit them — see
+  // `sessionTickToClimb`, which carries the Boardsesh fields only for an ungraded
+  // tick and drops them the moment a logged grade is present.
   boardseshDifficulty?: number | null;
   boardseshConfidence?: string | null;
 };

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -2,11 +2,10 @@ import React, { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { BoardName } from '@boardsesh/shared-schema';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { Text } from './Text';
 import { ClimbListThumbnail, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT } from './ClimbListThumbnail';
 import { formatSends, formatQuality } from '../lib/format-climb-stats';
-import { useGradeFormat } from '../hooks/use-grade-format';
+import { useDisplayGrade } from '../hooks/use-display-grade';
 import { useAscentStatus } from '../hooks/use-ascent-status';
 import { useTheme } from '../providers/theme-provider';
 import { Icon } from './Icon';
@@ -45,6 +44,12 @@ export type ClimbListItemClimb = {
   is_no_match?: boolean | null;
   benchmark_difficulty?: string | null;
   characteristics?: string[] | null;
+  // Boardsesh grade (data-science difficulty + confidence), carried on every climb
+  // from PR #3554. Optional + permissive so both the web-schema `Climb` and the
+  // `@boardsesh/queue` `Climb` satisfy this shape; `resolveGrade` renders the
+  // Boardsesh grade in their place when the "Show Boardsesh grades" toggle is on.
+  boardseshDifficulty?: number | null;
+  boardseshConfidence?: string | null;
 };
 
 type ClimbListItemContentProps = {
@@ -150,11 +155,14 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   showPlaylistChips = false,
 }: ClimbListItemContentProps) {
   const { t } = useTranslation('climbs');
-  const { formatGrade } = useGradeFormat();
+  const { resolveGrade } = useDisplayGrade();
   const { systemColors } = useTheme();
 
-  const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
-  const formattedGrade = formatGrade(climb.difficulty);
+  // One O(1) resolve per row: the Boardsesh grade (label + colour) when the "Show
+  // Boardsesh grades" toggle is on and a trusted one exists, else the legacy
+  // Aurora grade. `resolveGrade` is the stable callback from `useDisplayGrade`
+  // (called once above), so it never re-derives per render beyond this call.
+  const { label: formattedGrade, color: gradeColor } = resolveGrade(climb);
 
   // Subtitle parts: sends · quality★ · setter (each dropped when absent). A
   // caller-supplied override wins outright — a string replaces the line, null
@@ -236,7 +244,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
           <View style={styles.iconGradeRow}>
             {gradeIsConsensus ? <Icon name="people" size={13} color={systemColors.secondaryLabel} /> : null}
             <Text variant="title3" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
-              {formattedGrade ?? climb.difficulty}
+              {formattedGrade}
             </Text>
           </View>
           {consensusGrade ? (

--- a/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// The one dependency under test: the row renders exactly the label + colour that
+// `resolveGrade` returns (the app-wide "Show Boardsesh grades" swap), instead of
+// computing the legacy grade colour itself. A controllable stub lets us assert the
+// wiring without the flag/preference plumbing (covered by use-display-grade's tests).
+const resolveGrade = vi.fn();
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', {}, children),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../hooks/use-display-grade', () => ({
+  useDisplayGrade: () => ({ boardseshActive: true, resolveGrade }),
+}));
+
+vi.mock('../../hooks/use-ascent-status', () => ({
+  useAscentStatus: () => null,
+}));
+
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryLabel: '#8E8E93' } }),
+}));
+
+vi.mock('../../lib/format-climb-stats', () => ({
+  formatSends: () => 'sends',
+  formatQuality: () => '4.5',
+}));
+
+// Text → a span carrying its variant + flattened style colour, so we can find the
+// grade (the only variant="title3") and read the colour applied to it.
+vi.mock('../Text', () => ({
+  Text: ({ children, style, variant }: { children?: ReactNode; style?: unknown; variant?: string }) => {
+    const flattened = Array.isArray(style) ? Object.assign({}, ...style.filter(Boolean)) : (style ?? {});
+    return createElement(
+      'span',
+      { 'data-variant': variant, 'data-color': (flattened as { color?: string }).color },
+      children,
+    );
+  },
+}));
+
+vi.mock('../ClimbListThumbnail', () => ({
+  ClimbListThumbnail: () => null,
+  THUMBNAIL_WIDTH: 60,
+  THUMBNAIL_HEIGHT: 80,
+}));
+
+vi.mock('../Icon', () => ({ Icon: () => null }));
+vi.mock('../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => null }));
+vi.mock('../ClimbPlaylistChips', () => ({ ClimbPlaylistChips: () => null }));
+
+import { ClimbListItemContent } from '../ClimbListItemContent';
+
+const baseClimb = {
+  uuid: 'c1',
+  name: 'Test Climb',
+  frames: 'p1r1',
+  difficulty: '6b/V4',
+  quality_average: '4.5',
+  ascensionist_count: 10,
+  boardseshDifficulty: 20,
+  boardseshConfidence: 'confirmed',
+};
+
+const gradeNode = (container: HTMLElement) => container.querySelector('[data-variant="title3"]');
+
+describe('ClimbListItemContent grade', () => {
+  beforeEach(() => resolveGrade.mockReset());
+
+  it('renders the label + colour resolveGrade returns (Boardsesh grade when active)', () => {
+    resolveGrade.mockReturnValue({ label: 'V5', color: '#abcdef', isBoardsesh: true });
+    const { container } = render(
+      <ClimbListItemContent climb={baseClimb} boardName="kilter" layoutId={1} sizeId={1} setIds="1" angle={40} />,
+    );
+    const node = gradeNode(container);
+    expect(node?.textContent).toBe('V5');
+    expect(node?.getAttribute('data-color')).toBe('#abcdef');
+  });
+
+  it('falls back to the legacy label + colour resolveGrade returns', () => {
+    resolveGrade.mockReturnValue({ label: 'V4', color: '#111111', isBoardsesh: false });
+    const { container } = render(
+      <ClimbListItemContent climb={baseClimb} boardName="kilter" layoutId={1} sizeId={1} setIds="1" angle={40} />,
+    );
+    const node = gradeNode(container);
+    expect(node?.textContent).toBe('V4');
+    expect(node?.getAttribute('data-color')).toBe('#111111');
+  });
+
+  it('passes the climb (with its Boardsesh grade fields) to resolveGrade', () => {
+    resolveGrade.mockReturnValue({ label: 'V4', color: '#111111', isBoardsesh: false });
+    render(<ClimbListItemContent climb={baseClimb} boardName="kilter" layoutId={1} sizeId={1} setIds="1" angle={40} />);
+    expect(resolveGrade).toHaveBeenCalledWith(
+      expect.objectContaining({ difficulty: '6b/V4', boardseshDifficulty: 20, boardseshConfidence: 'confirmed' }),
+    );
+  });
+});

--- a/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
+++ b/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
@@ -26,7 +26,6 @@ import { FlatList, Pressable, RefreshControl, StyleSheet, View, type ColorValue 
 import { BottomSheetFlatList } from '@expo/ui/community/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import {
   boardHistoryEntryKey,
   useBoardHistoryPagination,
@@ -49,6 +48,7 @@ import { useBoardPresenceControls } from '../../providers/board-presence-provide
 import { track } from '../../lib/analytics';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useDisplayGrade } from '../../hooks/use-display-grade';
 import { offlineAwareRequest } from '../../lib/graphql/offline-request';
 import { GET_CLIMB, type GetClimbQueryResponse } from '../../lib/graphql/operations';
 import { boardPresenceClimbToClimb } from '../../lib/board-presence/presence-climb';
@@ -187,7 +187,13 @@ function NowOnTheWallPanelComponent(
   const insets = useSafeAreaInsets();
   const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
+  // `formatGrade` still renders the board-wide aggregate grade tiles (hardest / top
+  // grade), which aren't a single climb's grade; `resolveGrade` swaps the per-climb
+  // grades (hero, history rows, hardest send) to the Boardsesh grade when the toggle
+  // is on. BoardPresenceClimb / BoardPresenceHardestSend carry no Boardsesh grade
+  // today, so those fall back to the legacy grade until the backend stamps them.
   const { formatGrade } = useGradeFormat();
+  const { resolveGrade } = useDisplayGrade();
   const boardConfigRef = useRef(boardConfig);
   boardConfigRef.current = boardConfig;
   const boardConfigSignature = useMemo(() => boardConfigActionSignature(boardConfig), [boardConfig]);
@@ -471,8 +477,9 @@ function NowOnTheWallPanelComponent(
 
   const renderHistoryItem = useCallback(
     ({ item }: { item: BoardPresenceClimb }) => {
-      const formattedGrade = item.grade ? formatGrade(item.grade) : null;
-      const gradeColor = getGradeColor(item.grade ?? '') ?? DEFAULT_GRADE_COLOR;
+      const resolvedGrade = resolveGrade({ difficulty: item.grade ?? '' });
+      const formattedGrade = item.grade ? resolvedGrade.label : null;
+      const gradeColor = resolvedGrade.color;
 
       if (canUseInteractiveRows && rowBoard) {
         return (
@@ -510,7 +517,7 @@ function NowOnTheWallPanelComponent(
       rowBoard,
       systemColors.label,
       systemColors.secondaryLabel,
-      formatGrade,
+      resolveGrade,
       handleInteractiveClimbPress,
       handleInteractiveAddToQueue,
       handleInteractiveOpenPlaylist,
@@ -532,8 +539,13 @@ function NowOnTheWallPanelComponent(
         )
       : false;
 
-  const listHeader = useMemo(
-    () => (
+  const listHeader = useMemo(() => {
+    // Per-climb grades under the "Show Boardsesh grades" toggle. resolveGrade with
+    // an empty difficulty yields the default colour + empty label, so these are
+    // safe to compute even when there's no current climb / hardest send.
+    const heroGrade = resolveGrade({ difficulty: currentClimb?.grade ?? '' });
+    const hardestSendGrade = resolveGrade({ difficulty: stats?.hardestSend?.grade ?? '' });
+    return (
       <View>
         {canUseInteractiveRows && rowBoard && currentClimb ? (
           <InteractiveHeroRow
@@ -544,8 +556,8 @@ function NowOnTheWallPanelComponent(
             secondaryColor={systemColors.secondaryLabel}
             accentColor={brandColors.warning}
             surfaceColor={systemColors.secondaryBackground}
-            formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
-            gradeColor={getGradeColor(currentClimb.grade ?? '') ?? DEFAULT_GRADE_COLOR}
+            formattedGrade={currentClimb.grade ? heroGrade.label : null}
+            gradeColor={heroGrade.color}
             isActionLoading={heroActionLoading}
             onPress={onClimbPress ? handleInteractiveClimbPress : undefined}
             onAddToQueue={handleInteractiveAddToQueue}
@@ -560,8 +572,8 @@ function NowOnTheWallPanelComponent(
             secondaryColor={systemColors.secondaryLabel}
             accentColor={brandColors.warning}
             surfaceColor={systemColors.secondaryBackground}
-            formattedGrade={currentClimb?.grade ? formatGrade(currentClimb.grade) : null}
-            gradeColor={getGradeColor(currentClimb?.grade ?? '') ?? DEFAULT_GRADE_COLOR}
+            formattedGrade={currentClimb?.grade ? heroGrade.label : null}
+            gradeColor={heroGrade.color}
           />
         )}
         {stats ? (
@@ -606,8 +618,8 @@ function NowOnTheWallPanelComponent(
                 secondaryColor={systemColors.secondaryLabel}
                 surfaceColor={systemColors.secondaryBackground}
                 crownColor={brandColors.warning}
-                formattedGrade={formatGrade(stats.hardestSend.grade) ?? stats.hardestSend.grade}
-                gradeColor={getGradeColor(stats.hardestSend.grade) ?? DEFAULT_GRADE_COLOR}
+                formattedGrade={hardestSendGrade.label}
+                gradeColor={hardestSendGrade.color}
               />
             ) : null}
           </View>
@@ -618,26 +630,26 @@ function NowOnTheWallPanelComponent(
           </Text>
         ) : null}
       </View>
-    ),
-    [
-      currentClimb,
-      boardConfig,
-      stats,
-      visibleHistory.length,
-      systemColors,
-      brandColors.warning,
-      formatGrade,
-      t,
-      canUseInteractiveRows,
-      rowBoard,
-      handleInteractiveClimbPress,
-      handleInteractiveAddToQueue,
-      handleInteractiveOpenPlaylist,
-      handleInteractiveOpenActions,
-      heroActionLoading,
-      onClimbPress,
-    ],
-  );
+    );
+  }, [
+    currentClimb,
+    boardConfig,
+    stats,
+    visibleHistory.length,
+    systemColors,
+    brandColors.warning,
+    formatGrade,
+    resolveGrade,
+    t,
+    canUseInteractiveRows,
+    rowBoard,
+    handleInteractiveClimbPress,
+    handleInteractiveAddToQueue,
+    handleInteractiveOpenPlaylist,
+    handleInteractiveOpenActions,
+    heroActionLoading,
+    onClimbPress,
+  ]);
 
   const listEmpty = useMemo(
     () => (

--- a/packages/mobile/src/components/board-presence/WallStrip.tsx
+++ b/packages/mobile/src/components/board-presence/WallStrip.tsx
@@ -8,7 +8,7 @@ import { AccessoryClimbThumbnail } from '../queue-control/AccessoryClimbThumbnai
 import { useWallClimbIfDistinct } from '../queue-control/use-wall-or-queue-climb';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useTheme } from '../../providers/theme-provider';
-import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useDisplayGrade } from '../../hooks/use-display-grade';
 import { hapticSelection } from '../../lib/haptics';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { WALL_LIVE_DOT_SIZE } from '../../theme/layout';
@@ -28,7 +28,7 @@ function WallStripComponent() {
   const { t } = useTranslation('session');
   const insets = useSafeAreaInsets();
   const { systemColors, brandColors } = useTheme();
-  const { formatGrade } = useGradeFormat();
+  const { resolveGrade } = useDisplayGrade();
   // Pass `null`: the strip always mirrors whatever's lit on the wall, so it never
   // hides the climb as a duplicate of the local queue head.
   const litClimb = useWallClimbIfDistinct(null);
@@ -40,7 +40,11 @@ function WallStripComponent() {
     openBoardSheet();
   }, [openBoardSheet]);
 
-  const grade = litClimb ? formatGrade(litClimb.grade ?? '') : null;
+  // The lit-climb payload (BoardPresenceClimb) carries no Boardsesh grade today, so
+  // `resolveGrade` falls back to the legacy label — the strip lights up the
+  // Boardsesh grade once the backend stamps presence climbs. The colour stays the
+  // warm live accent, so only the label matters here.
+  const grade = litClimb ? resolveGrade({ difficulty: litClimb.grade ?? '' }).label : null;
 
   return (
     <Pressable

--- a/packages/mobile/src/components/board-presence/wall-kiosk/WallChromeRegion.tsx
+++ b/packages/mobile/src/components/board-presence/wall-kiosk/WallChromeRegion.tsx
@@ -1,14 +1,13 @@
 import { memo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 import { WallStateStrip, type WallStateMode } from './WallStateStrip';
 import { WallIdentityBlock } from './WallIdentityBlock';
 import { WallScrubber } from './WallScrubber';
 import { Text } from '../../Text';
 import { useTheme } from '../../../providers/theme-provider';
-import { useGradeFormat } from '../../../hooks/use-grade-format';
+import { useDisplayGrade } from '../../../hooks/use-display-grade';
 import { formatRelativeTime } from '../../../lib/format-relative-time';
 import { borderRadius, spacing } from '../../../theme/tokens';
 import type { WallKioskRegion } from './wall-kiosk-layout';
@@ -30,11 +29,14 @@ function WallIdleRecovery({
 }) {
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
-  const { formatGrade } = useGradeFormat();
+  const { resolveGrade } = useDisplayGrade();
 
   const name = lastLitClimb?.name?.trim() || '';
-  const grade = lastLitClimb?.grade ? formatGrade(lastLitClimb.grade) : null;
-  const gradeColor = getGradeColor(lastLitClimb?.grade ?? '') ?? DEFAULT_GRADE_COLOR;
+  // BoardPresenceClimb carries no Boardsesh grade today, so `resolveGrade` falls
+  // back to the legacy label + colour — lights up once the backend stamps them.
+  const resolvedGrade = resolveGrade({ difficulty: lastLitClimb?.grade ?? '' });
+  const grade = lastLitClimb?.grade ? resolvedGrade.label : null;
+  const gradeColor = resolvedGrade.color;
   const lastLine = { fontSize: typeScale.metaFontSize, lineHeight: typeScale.metaLineHeight };
   const hintLine = { fontSize: Math.round(typeScale.metaFontSize * 0.85) };
 

--- a/packages/mobile/src/components/board-presence/wall-kiosk/WallIdentityBlock.tsx
+++ b/packages/mobile/src/components/board-presence/wall-kiosk/WallIdentityBlock.tsx
@@ -1,13 +1,12 @@
 import { memo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 import { Text } from '../../Text';
 import { BoardDriverAvatar } from '../BoardDriverAvatar';
 import { readableTextColor } from '../../grade/grade-chip-colors';
 import { useTheme } from '../../../providers/theme-provider';
-import { useGradeFormat } from '../../../hooks/use-grade-format';
+import { useDisplayGrade } from '../../../hooks/use-display-grade';
 import { borderRadius, spacing } from '../../../theme/tokens';
 import type { WallKioskTypeScale } from './wall-kiosk-type';
 
@@ -38,13 +37,17 @@ function WallIdentityBlockComponent({
 }: WallIdentityBlockProps) {
   const { t } = useTranslation('session');
   const { systemColors, brandColors } = useTheme();
-  const { formatGrade } = useGradeFormat();
+  const { resolveGrade } = useDisplayGrade();
 
   if (!climb) return null;
 
   const name = climb.name?.trim() || '';
-  const grade = climb.grade ? formatGrade(climb.grade) : null;
-  const gradeColor = getGradeColor(climb.grade ?? '') ?? DEFAULT_GRADE_COLOR;
+  // BoardPresenceClimb carries no Boardsesh grade today, so `resolveGrade` falls
+  // back to the legacy label + colour — the kiosk lights up the Boardsesh grade
+  // once the backend stamps presence climbs.
+  const resolvedGrade = resolveGrade({ difficulty: climb.grade ?? '' });
+  const grade = climb.grade ? resolvedGrade.label : null;
+  const gradeColor = resolvedGrade.color;
   const gradeTextColor = readableTextColor(gradeColor);
   const setter = climb.setter?.trim();
   const litBy = climb.sentByDisplayName?.trim() || null;

--- a/packages/mobile/src/components/board-presence/wall-kiosk/WallStateStrip.tsx
+++ b/packages/mobile/src/components/board-presence/wall-kiosk/WallStateStrip.tsx
@@ -1,12 +1,11 @@
 import { memo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 import { Text } from '../../Text';
 import { readableTextColor } from '../../grade/grade-chip-colors';
 import { useTheme } from '../../../providers/theme-provider';
-import { useGradeFormat } from '../../../hooks/use-grade-format';
+import { useDisplayGrade } from '../../../hooks/use-display-grade';
 import { formatRelativeTime } from '../../../lib/format-relative-time';
 import { borderRadius, spacing } from '../../../theme/tokens';
 import type { WallKioskTypeScale } from './wall-kiosk-type';
@@ -32,7 +31,7 @@ type WallStateStripProps = {
 function WallStateStripComponent({ mode, stepsBack, previewTimestamp, liveClimb, typeScale }: WallStateStripProps) {
   const { t } = useTranslation('session');
   const { brandColors, systemColors } = useTheme();
-  const { formatGrade } = useGradeFormat();
+  const { resolveGrade } = useDisplayGrade();
 
   const barColor =
     mode === 'live' ? brandColors.live : mode === 'history' ? brandColors.historyFill : systemColors.fill;
@@ -62,8 +61,11 @@ function WallStateStripComponent({ mode, stepsBack, previewTimestamp, liveClimb,
     lineHeight: Math.round(typeScale.stateLineHeight * 0.7),
   };
   const liveName = liveClimb?.name?.trim() || null;
-  const liveGrade = liveClimb?.grade ? formatGrade(liveClimb.grade) : null;
-  const liveGradeColor = getGradeColor(liveClimb?.grade ?? '') ?? DEFAULT_GRADE_COLOR;
+  // BoardPresenceClimb carries no Boardsesh grade today, so `resolveGrade` falls
+  // back to the legacy label + colour — lights up once the backend stamps them.
+  const liveResolvedGrade = resolveGrade({ difficulty: liveClimb?.grade ?? '' });
+  const liveGrade = liveClimb?.grade ? liveResolvedGrade.label : null;
+  const liveGradeColor = liveResolvedGrade.color;
 
   return (
     <View style={styles.root}>

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -140,6 +140,8 @@ export const iconMap = {
   // Data
   'chart.bar': { ios: 'chart.bar', android: 'chart-bar' },
   repeat: { ios: 'repeat', android: 'repeat' },
+  'arrow.right': { ios: 'arrow.right', android: 'arrow-right' },
+  'checkmark.seal.fill': { ios: 'checkmark.seal.fill', android: 'check-decagram' },
 
   // Misc
   star: { ios: 'star', android: 'star-outline' },

--- a/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
+++ b/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
@@ -17,6 +17,15 @@ type BoardseshGradeSectionProps = {
   angle: number;
 };
 
+// Reserved copy for the upcoming by-angle detail view (the collapsed-grade →
+// expanded-chart follow-up to this section): the per-angle breakdown title,
+// the "last computed" timestamp line, and the board-local grade line shown
+// alongside the universal grade. Not wired up yet — this file is where they
+// land once that view exists.
+// i18n-keep climbs.boardseshGrade.byAngle
+// i18n-keep climbs.boardseshGrade.updated
+// i18n-keep climbs.boardseshGrade.localGradeLine
+
 // Locale-neutral math symbol shown after a provisional single grade to signal it
 // may still shift by a grade. Not user-facing prose, so it stays out of i18n.
 const APPROX_SYMBOL = '±';

--- a/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
+++ b/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
@@ -261,11 +261,6 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
       {/* DUMBBELL — crowd rings vs Boardsesh diamonds, one per angle. */}
       {dumbbellRows.length >= 1 && (
         <View style={styles.histogram}>
-          {dumbbellRows.length >= 2 && (
-            <Text variant="footnote" color={iosSystemColors.systemGray}>
-              {t('boardseshGrade.byAngle')}
-            </Text>
-          )}
           <DumbbellByAngleChart
             rows={dumbbellRows}
             headlineGrade={view.gradeValue}

--- a/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
+++ b/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
@@ -4,31 +4,26 @@ import { useTranslation } from 'react-i18next';
 import * as Haptics from 'expo-haptics';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import { useBoardseshGrade } from '../../lib/graphql/hooks';
+import { DifficultyByAngleChart } from './DifficultyByAngleChart';
+import { useBoardseshGrade, useBoardseshGradesForAngles } from '../../lib/graphql/hooks';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useTheme } from '../../providers/theme-provider';
+import { formatRelativeTime } from '../../lib/format-relative-time';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
-import { buildBoardseshGradeView, isMoonBoard, type GradeScope } from './boardsesh-grade-utils';
+import {
+  buildBoardseshGradeView,
+  buildBoardseshAngleGradeBars,
+  isMoonBoard,
+  APPROX_SYMBOL,
+  type GradeScope,
+} from './boardsesh-grade-utils';
 
 type BoardseshGradeSectionProps = {
   climbUuid: string;
   boardName: string;
   angle: number;
 };
-
-// Reserved copy for the upcoming by-angle detail view (the collapsed-grade →
-// expanded-chart follow-up to this section): the per-angle breakdown title,
-// the "last computed" timestamp line, and the board-local grade line shown
-// alongside the universal grade. Not wired up yet — this file is where they
-// land once that view exists.
-// i18n-keep climbs.boardseshGrade.byAngle
-// i18n-keep climbs.boardseshGrade.updated
-// i18n-keep climbs.boardseshGrade.localGradeLine
-
-// Locale-neutral math symbol shown after a provisional single grade to signal it
-// may still shift by a grade. Not user-facing prose, so it stays out of i18n.
-const APPROX_SYMBOL = '±';
 
 export const BoardseshGradeSection = memo(function BoardseshGradeSection({
   climbUuid,
@@ -54,6 +49,13 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
     () => buildBoardseshGradeView(boardName, grade ?? null, gradeFormat),
     [boardName, grade, gradeFormat],
   );
+
+  // Independent of the singular query above: an angle that's still setter-only
+  // can still show a fuller Boardsesh picture at the climb's other angles.
+  // Progressive enhancement — loading/error here render nothing; the section's
+  // own loading/error state stays owned by the singular query above.
+  const { data: angleRows } = useBoardseshGradesForAngles(boardName, climbUuid, { enabled: !moonboard });
+  const angleBars = useMemo(() => buildBoardseshAngleGradeBars(angleRows ?? [], gradeFormat), [angleRows, gradeFormat]);
 
   const scopeLabel = useCallback(
     (scope: GradeScope) =>
@@ -86,81 +88,121 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
     );
   }
 
-  if (view.kind === 'moonboard') {
-    return (
-      <View style={styles.row}>
-        <Icon name="info" size={20} color={iosSystemColors.systemGray} />
-        <Text variant="subheadline" color={iosSystemColors.systemGray} style={styles.flexText}>
-          {t('boardseshGrade.moonboardBody')}
-        </Text>
-      </View>
-    );
-  }
+  // Confirmed/provisional share the same local-grade-line + freshness +
+  // explainer footer, appended below the headline that's specific to each tier.
+  // Narrowed inline (not via a boolean intermediate) so TS keeps `view` as the
+  // confirmed/provisional member of the union on each access.
+  const computedAt = view.kind === 'confirmed' || view.kind === 'provisional' ? view.computedAt : null;
+  const localSecondary = view.kind === 'confirmed' || view.kind === 'provisional' ? view.localSecondary : null;
+  const showGradeFooter = view.kind === 'confirmed' || view.kind === 'provisional';
 
-  if (view.kind === 'setterOnly') {
-    return (
-      <View style={styles.row}>
-        <Icon name="flag" size={20} color={iosSystemColors.systemGray} />
-        <Text variant="subheadline" color={iosSystemColors.systemGray} style={styles.flexText}>
-          {t('boardseshGrade.setterOnly')}
-        </Text>
-      </View>
-    );
-  }
-
-  if (view.kind === 'confirmed') {
-    return (
-      <View style={styles.gradeRow}>
-        <Text variant="largeTitle" style={[styles.gradeValue, { color: view.grade.color }]}>
-          {view.grade.label}
-        </Text>
-        <View style={styles.gradeMeta}>
-          <View style={styles.scopeRow}>
-            <Icon name="checkmark.circle.fill" size={16} color={iosSystemColors.systemGreen} />
-            <Text variant="subheadline">{scopeLabel(view.scope)}</Text>
-          </View>
-          <Text variant="footnote" color={iosSystemColors.systemGray}>
-            {t('boardseshGrade.confirmedSubline', { count: view.count })}
-          </Text>
-          {view.scope === 'local' && (
-            <Text variant="caption1" color={iosSystemColors.systemGray}>
-              {t('boardseshGrade.localScopeNote')}
-            </Text>
-          )}
-        </View>
-      </View>
-    );
-  }
-
-  // Provisional: a range spanning two grades, else the single grade with a subtle ±.
   return (
-    <View style={styles.gradeRow}>
-      <View style={styles.provisionalValue}>
-        <Text variant="largeTitle" style={[styles.gradeValue, { color: view.grade.color }]}>
-          {view.rangeLabel ?? view.grade.label}
-        </Text>
-        {!view.rangeLabel && (
-          <Text variant="callout" color={iosSystemColors.systemGray} style={styles.approx}>
-            {APPROX_SYMBOL}
+    <View style={styles.container}>
+      {view.kind === 'moonboard' && (
+        <View style={styles.row}>
+          <Icon name="info" size={20} color={iosSystemColors.systemGray} />
+          <Text variant="subheadline" color={iosSystemColors.systemGray} style={styles.flexText}>
+            {t('boardseshGrade.moonboardBody')}
           </Text>
-        )}
-      </View>
-      <View style={styles.gradeMeta}>
-        <Text variant="subheadline">{scopeLabel(view.scope)}</Text>
-        <Text variant="footnote" color={iosSystemColors.systemGray}>
-          {t('boardseshGrade.provisionalSubline', { count: view.count })}
-        </Text>
-        {view.scope === 'local' && (
-          <Text variant="caption1" color={iosSystemColors.systemGray}>
-            {t('boardseshGrade.localScopeNote')}
+        </View>
+      )}
+
+      {view.kind === 'setterOnly' && (
+        <View style={styles.row}>
+          <Icon name="flag" size={20} color={iosSystemColors.systemGray} />
+          <Text variant="subheadline" color={iosSystemColors.systemGray} style={styles.flexText}>
+            {t('boardseshGrade.setterOnly')}
           </Text>
-        )}
-      </View>
+        </View>
+      )}
+
+      {view.kind === 'confirmed' && (
+        <View style={styles.gradeRow}>
+          <Text variant="largeTitle" style={[styles.gradeValue, { color: view.grade.color }]}>
+            {view.grade.label}
+          </Text>
+          <View style={styles.gradeMeta}>
+            <View style={styles.scopeRow}>
+              <Icon name="checkmark.circle.fill" size={16} color={iosSystemColors.systemGreen} />
+              <Text variant="subheadline">{scopeLabel(view.scope)}</Text>
+            </View>
+            <Text variant="footnote" color={iosSystemColors.systemGray}>
+              {t('boardseshGrade.confirmedSubline', { count: view.count })}
+            </Text>
+            {view.scope === 'local' && (
+              <Text variant="caption1" color={iosSystemColors.systemGray}>
+                {t('boardseshGrade.localScopeNote')}
+              </Text>
+            )}
+          </View>
+        </View>
+      )}
+
+      {/* Provisional: a range spanning two grades, else the single grade with a subtle ±. */}
+      {view.kind === 'provisional' && (
+        <View style={styles.gradeRow}>
+          <View style={styles.provisionalValue}>
+            <Text variant="largeTitle" style={[styles.gradeValue, { color: view.grade.color }]}>
+              {view.rangeLabel ?? view.grade.label}
+            </Text>
+            {!view.rangeLabel && (
+              <Text variant="callout" color={iosSystemColors.systemGray} style={styles.approx}>
+                {APPROX_SYMBOL}
+              </Text>
+            )}
+          </View>
+          <View style={styles.gradeMeta}>
+            <Text variant="subheadline">{scopeLabel(view.scope)}</Text>
+            <Text variant="footnote" color={iosSystemColors.systemGray}>
+              {t('boardseshGrade.provisionalSubline', { count: view.count })}
+            </Text>
+            {view.scope === 'local' && (
+              <Text variant="caption1" color={iosSystemColors.systemGray}>
+                {t('boardseshGrade.localScopeNote')}
+              </Text>
+            )}
+          </View>
+        </View>
+      )}
+
+      {localSecondary && (
+        <Text variant="caption1" color={localSecondary.color}>
+          {t('boardseshGrade.localGradeLine', { grade: localSecondary.label })}
+        </Text>
+      )}
+
+      {showGradeFooter && (
+        <Text variant="caption1" color={iosSystemColors.systemGray}>
+          {t('boardseshGrade.summary')}
+        </Text>
+      )}
+
+      {computedAt && (
+        <Text variant="caption2" color={iosSystemColors.systemGray}>
+          {t('boardseshGrade.updated', { when: formatRelativeTime(computedAt) })}
+        </Text>
+      )}
+
+      {angleBars.length >= 2 && (
+        <View style={styles.histogram}>
+          <Text variant="footnote" color={iosSystemColors.systemGray}>
+            {t('boardseshGrade.byAngle')}
+          </Text>
+          <DifficultyByAngleChart
+            data={angleBars}
+            accessibilityLabel={t('boardseshGrade.byAngle')}
+            logScaleLabel={t('boardseshGrade.logScale')}
+          />
+        </View>
+      )}
     </View>
   );
 });
 
 const styles = StyleSheet.create({
+  container: {
+    gap: spacing[3],
+  },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -194,6 +236,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[1],
+  },
+  histogram: {
+    gap: spacing[2],
   },
   skeleton: {
     borderRadius: borderRadius.md,

--- a/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
+++ b/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
@@ -2,7 +2,6 @@ import { memo, useCallback, useMemo } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import * as Haptics from 'expo-haptics';
-import type { GradeDisplayFormat } from '@boardsesh/play-view';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { DumbbellByAngleChart } from './DumbbellByAngleChart';
@@ -11,27 +10,15 @@ import { buildAngleGradeBars } from './community-utils';
 import { useBoardseshGrade, useBoardseshGradesForAngles, useClimbStatsHistory } from '../../lib/graphql/hooks';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useTheme } from '../../providers/theme-provider';
-import { formatRelativeTime } from '../../lib/format-relative-time';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
-import {
-  buildBoardseshGradeView,
-  buildCorrection,
-  isMoonBoard,
-  renderDifficulty,
-  type RenderedGrade,
-} from './boardsesh-grade-utils';
+import { buildBoardseshGradeView, buildCorrection, buildTrustBand, isMoonBoard } from './boardsesh-grade-utils';
 
 type BoardseshGradeSectionProps = {
   climbUuid: string;
   boardName: string;
   angle: number;
 };
-
-/** Capitalise the board slug for prose ("kilter" → "Kilter"). Brand name — not translated. */
-function displayBoardName(boardName: string): string {
-  return boardName.charAt(0).toUpperCase() + boardName.slice(1);
-}
 
 export const BoardseshGradeSection = memo(function BoardseshGradeSection({
   climbUuid,
@@ -149,11 +136,12 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
   const showConfirmedSeal = view.kind === 'confirmed' && view.universal;
   const rangeLabel = view.kind === 'provisional' ? view.rangeLabel : null;
   const count = view.count;
-  const computedAt = view.computedAt;
-  const band = buildBand(view.gradeLow, view.gradeHigh, heroGrade, gradeFormat);
-  // The everywhere grade shows the two-grade span for a provisional read.
+  // Low/high labels for the trust line. When both bounds round to the same grade
+  // there is no real range ("V4–V4"), so we show a single-grade line instead.
+  const band = buildTrustBand(view.gradeLow, view.gradeHigh, heroGrade.label, gradeFormat);
+  // The all-boards grade shows the two-grade span for a provisional read.
   const everywhereLabel = rangeLabel ?? heroGrade.label;
-  // "about ½" for a provisional pill/payoff; "½" when confirmed.
+  // "About ½" for a provisional payoff; "½" when confirmed.
   const amount = correction?.label
     ? provisional
       ? t('boardseshGrade.hero.approx', { amount: correction.label })
@@ -207,7 +195,8 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
           </View>
         </View>
       ) : (
-        // Full correction: [THIS BOARD crowd] → [delta pill] → [EVERYWHERE Boardsesh ✓].
+        // Full correction: [THIS BOARD crowd] → [arrow] → [ALL BOARDS Boardsesh ✓].
+        // The grey→coloured grades + the single payoff sentence carry the delta.
         <View style={styles.correctionRow}>
           <View style={styles.correctionSide}>
             <Text variant="caption1" color={iosSystemColors.systemGray}>
@@ -219,15 +208,6 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
           </View>
 
           <View style={styles.correctionArrow}>
-            {amount && (
-              <View style={styles.pill}>
-                <Text variant="caption1" color={iosSystemColors.systemGray} allowFontScaling={false}>
-                  {t(correction.direction === 'easier' ? 'boardseshGrade.hero.softer' : 'boardseshGrade.hero.stiffer', {
-                    amount,
-                  })}
-                </Text>
-              </View>
-            )}
             <Icon name="arrow.right" size={18} color={iosSystemColors.systemGray} />
           </View>
 
@@ -254,27 +234,26 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
           <Text variant="subheadline" style={styles.flexText}>
             {t(correction.direction === 'easier' ? 'boardseshGrade.payoff.softer' : 'boardseshGrade.payoff.stiffer', {
               amount,
-              board: displayBoardName(boardName),
             })}
           </Text>
         </View>
       )}
 
-      {/* TRUST — owns the sample + band + freshness on one line. */}
+      {/* TRUST — the sample + (only a real) band on one line. A range collapses to
+          a single-grade line when both bounds round to the same grade. */}
       {provisional ? (
         <Text variant="footnote" color={iosSystemColors.systemOrange}>
-          {t('boardseshGrade.trust.provisional', { low: band.low, high: band.high, count })}
+          {band.sameLabel
+            ? t('boardseshGrade.trust.provisionalSingle', { count })
+            : t('boardseshGrade.trust.provisionalRange', { low: band.low, high: band.high, count })}
         </Text>
       ) : (
         <View style={styles.trustRow}>
           <Icon name="check.small" size={14} color={iosSystemColors.systemGreen} />
           <Text variant="footnote" color={iosSystemColors.systemGray} style={styles.flexText}>
-            {t('boardseshGrade.trust.confirmed', {
-              low: band.low,
-              high: band.high,
-              count,
-              when: formatRelativeTime(computedAt),
-            })}
+            {band.sameLabel
+              ? t('boardseshGrade.trust.confirmedSingle', { count })
+              : t('boardseshGrade.trust.confirmedRange', { low: band.low, high: band.high, count })}
           </Text>
         </View>
       )}
@@ -298,19 +277,6 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
     </View>
   );
 });
-
-/** The 95%/likely band labels, falling back to the headline grade when a bound is missing. */
-function buildBand(
-  low: number | null,
-  high: number | null,
-  headline: RenderedGrade,
-  gradeFormat: GradeDisplayFormat,
-): { low: string; high: string } {
-  return {
-    low: (low != null ? renderDifficulty(low, gradeFormat)?.label : null) ?? headline.label,
-    high: (high != null ? renderDifficulty(high, gradeFormat)?.label : null) ?? headline.label,
-  };
-}
 
 const styles = StyleSheet.create({
   container: {
@@ -348,12 +314,6 @@ const styles = StyleSheet.create({
   correctionArrow: {
     alignItems: 'center',
     gap: spacing[1],
-  },
-  pill: {
-    paddingHorizontal: spacing[2],
-    paddingVertical: 2,
-    borderRadius: borderRadius.full,
-    backgroundColor: `${iosSystemColors.systemGray}22`,
   },
   everywhereValue: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
+++ b/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
@@ -2,10 +2,13 @@ import { memo, useCallback, useMemo } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import * as Haptics from 'expo-haptics';
+import type { GradeDisplayFormat } from '@boardsesh/play-view';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import { DifficultyByAngleChart } from './DifficultyByAngleChart';
-import { useBoardseshGrade, useBoardseshGradesForAngles } from '../../lib/graphql/hooks';
+import { DumbbellByAngleChart } from './DumbbellByAngleChart';
+import { buildDumbbellByAngleModel } from './by-angle-comparison';
+import { buildAngleGradeBars } from './community-utils';
+import { useBoardseshGrade, useBoardseshGradesForAngles, useClimbStatsHistory } from '../../lib/graphql/hooks';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useTheme } from '../../providers/theme-provider';
 import { formatRelativeTime } from '../../lib/format-relative-time';
@@ -13,10 +16,10 @@ import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import {
   buildBoardseshGradeView,
-  buildBoardseshAngleGradeBars,
+  buildCorrection,
   isMoonBoard,
-  APPROX_SYMBOL,
-  type GradeScope,
+  renderDifficulty,
+  type RenderedGrade,
 } from './boardsesh-grade-utils';
 
 type BoardseshGradeSectionProps = {
@@ -24,6 +27,11 @@ type BoardseshGradeSectionProps = {
   boardName: string;
   angle: number;
 };
+
+/** Capitalise the board slug for prose ("kilter" → "Kilter"). Brand name — not translated. */
+function displayBoardName(boardName: string): string {
+  return boardName.charAt(0).toUpperCase() + boardName.slice(1);
+}
 
 export const BoardseshGradeSection = memo(function BoardseshGradeSection({
   climbUuid,
@@ -50,18 +58,30 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
     [boardName, grade, gradeFormat],
   );
 
-  // Independent of the singular query above: an angle that's still setter-only
-  // can still show a fuller Boardsesh picture at the climb's other angles.
-  // Progressive enhancement — loading/error here render nothing; the section's
-  // own loading/error state stays owned by the singular query above.
-  const { data: angleRows } = useBoardseshGradesForAngles(boardName, climbUuid, { enabled: !moonboard });
-  const angleBars = useMemo(() => buildBoardseshAngleGradeBars(angleRows ?? [], gradeFormat), [angleRows, gradeFormat]);
-
-  const scopeLabel = useCallback(
-    (scope: GradeScope) =>
-      scope === 'universal' ? t('boardseshGrade.universalLabel') : t('boardseshGrade.localLabel'),
-    [t],
+  // Progressive enhancement — the crowd (community) series feeds the hero's
+  // "this board" number and the dumbbell's rings. Loading/error render nothing;
+  // the section's own loading/error stays owned by the singular grade above.
+  const { data: history } = useClimbStatsHistory(boardName, moonboard ? null : climbUuid);
+  const crowdBars = useMemo(() => buildAngleGradeBars(history, gradeFormat), [history, gradeFormat]);
+  const crowdDifficulty = useMemo(
+    () => crowdBars.find((bar) => bar.angle === angle)?.difficulty ?? null,
+    [crowdBars, angle],
   );
+
+  // The cross-board Boardsesh series per angle → the dumbbell's diamonds.
+  const { data: angleRows } = useBoardseshGradesForAngles(boardName, climbUuid, { enabled: !moonboard });
+  const dumbbellRows = useMemo(
+    () => buildDumbbellByAngleModel(angleRows ?? [], crowdBars, gradeFormat),
+    [angleRows, crowdBars, gradeFormat],
+  );
+
+  // The correction only exists for a real cross-board grade with a crowd number
+  // at this angle. Setter-only / moonboard / local-only never carry one.
+  const correction = useMemo(() => {
+    if (view.kind !== 'confirmed' && view.kind !== 'provisional') return null;
+    if (!view.universal) return null;
+    return buildCorrection(crowdDifficulty, view.gradeValue, gradeFormat);
+  }, [view, crowdDifficulty, gradeFormat]);
 
   const handleRetry = useCallback(() => {
     void Haptics.selectionAsync();
@@ -88,116 +108,209 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
     );
   }
 
-  // Confirmed/provisional share the same local-grade-line + freshness +
-  // explainer footer, appended below the headline that's specific to each tier.
-  // Narrowed inline (not via a boolean intermediate) so TS keeps `view` as the
-  // confirmed/provisional member of the union on each access.
-  const computedAt = view.kind === 'confirmed' || view.kind === 'provisional' ? view.computedAt : null;
-  const localSecondary = view.kind === 'confirmed' || view.kind === 'provisional' ? view.localSecondary : null;
-  const showGradeFooter = view.kind === 'confirmed' || view.kind === 'provisional';
+  if (view.kind === 'moonboard') {
+    return (
+      <View style={styles.row}>
+        <Icon name="info" size={20} color={iosSystemColors.systemGray} />
+        <Text variant="subheadline" color={iosSystemColors.systemGray} style={styles.flexText}>
+          {t('boardseshGrade.moonboardBody')}
+        </Text>
+      </View>
+    );
+  }
+
+  if (view.kind === 'setterOnly') {
+    return (
+      <View style={styles.container}>
+        <View style={styles.setterHero}>
+          <Text variant="caption1" color={iosSystemColors.systemGray}>
+            {t('boardseshGrade.setterCall')}
+          </Text>
+          {view.grade && (
+            <Text variant="title1" style={[styles.gradeValue, styles.setterGrade]}>
+              {view.grade.label}
+            </Text>
+          )}
+        </View>
+        <Text variant="footnote" color={iosSystemColors.systemGray}>
+          {t('boardseshGrade.trust.setter')}
+        </Text>
+      </View>
+    );
+  }
+
+  // Confirmed / provisional from here down. Everything the hero + trust rows
+  // need is projected off the narrowed `view` here in the main body — the JSX
+  // below reads only these primitives, so TS's narrowing survives (it drops
+  // inside nested closures) and the render stays a flat, memo-clean tree.
+  const provisional = view.kind === 'provisional';
+  const universal = view.universal;
+  const heroGrade = view.grade;
+  const showConfirmedSeal = view.kind === 'confirmed' && view.universal;
+  const rangeLabel = view.kind === 'provisional' ? view.rangeLabel : null;
+  const count = view.count;
+  const computedAt = view.computedAt;
+  const band = buildBand(view.gradeLow, view.gradeHigh, heroGrade, gradeFormat);
+  // The everywhere grade shows the two-grade span for a provisional read.
+  const everywhereLabel = rangeLabel ?? heroGrade.label;
+  // "about ½" for a provisional pill/payoff; "½" when confirmed.
+  const amount = correction?.label
+    ? provisional
+      ? t('boardseshGrade.hero.approx', { amount: correction.label })
+      : correction.label
+    : null;
+
+  const seal = showConfirmedSeal ? (
+    <Icon name="checkmark.seal.fill" size={22} color={iosSystemColors.systemGreen} />
+  ) : null;
 
   return (
     <View style={styles.container}>
-      {view.kind === 'moonboard' && (
-        <View style={styles.row}>
-          <Icon name="info" size={20} color={iosSystemColors.systemGray} />
-          <Text variant="subheadline" color={iosSystemColors.systemGray} style={styles.flexText}>
-            {t('boardseshGrade.moonboardBody')}
+      {/* HERO — leads left→right with the cross-board correction. */}
+      {!universal ? (
+        // Local-only: no cross-board number yet — one centred grade, no comparison.
+        <View style={styles.singleHero}>
+          <Text variant="caption1" color={iosSystemColors.systemGray}>
+            {t('boardseshGrade.hero.thisBoardOnly')}
+          </Text>
+          <Text variant="largeTitle" style={[styles.gradeValue, { color: heroGrade.color }]}>
+            {everywhereLabel}
+          </Text>
+          <Text variant="footnote" color={iosSystemColors.systemGray} style={styles.centered}>
+            {t('boardseshGrade.localOnlyNote')}
           </Text>
         </View>
-      )}
-
-      {view.kind === 'setterOnly' && (
-        <View style={styles.row}>
-          <Icon name="flag" size={20} color={iosSystemColors.systemGray} />
-          <Text variant="subheadline" color={iosSystemColors.systemGray} style={styles.flexText}>
-            {t('boardseshGrade.setterOnly')}
+      ) : correction && correction.direction === 'equal' ? (
+        // Crowd rounds equal to the cross-board grade: drop the comparison, say so.
+        <View style={styles.singleHero}>
+          <View style={styles.everywhereValue}>
+            <Text variant="largeTitle" style={[styles.gradeValue, { color: heroGrade.color }]}>
+              {everywhereLabel}
+            </Text>
+            {seal}
+          </View>
+          <Text variant="footnote" color={iosSystemColors.systemGray} style={styles.centered}>
+            {t('boardseshGrade.matchesBoard')}
           </Text>
         </View>
-      )}
-
-      {view.kind === 'confirmed' && (
-        <View style={styles.gradeRow}>
-          <Text variant="largeTitle" style={[styles.gradeValue, { color: view.grade.color }]}>
-            {view.grade.label}
+      ) : !correction ? (
+        // No crowd grade at this angle: show the cross-board grade alone.
+        <View style={styles.singleHero}>
+          <Text variant="caption1" color={iosSystemColors.systemGray}>
+            {t('boardseshGrade.hero.everywhere')}
           </Text>
-          <View style={styles.gradeMeta}>
-            <View style={styles.scopeRow}>
-              <Icon name="checkmark.circle.fill" size={16} color={iosSystemColors.systemGreen} />
-              <Text variant="subheadline">{scopeLabel(view.scope)}</Text>
+          <View style={styles.everywhereValue}>
+            <Text variant="largeTitle" style={[styles.gradeValue, { color: heroGrade.color }]}>
+              {everywhereLabel}
+            </Text>
+            {seal}
+          </View>
+        </View>
+      ) : (
+        // Full correction: [THIS BOARD crowd] → [delta pill] → [EVERYWHERE Boardsesh ✓].
+        <View style={styles.correctionRow}>
+          <View style={styles.correctionSide}>
+            <Text variant="caption1" color={iosSystemColors.systemGray}>
+              {t('boardseshGrade.hero.thisBoard')}
+            </Text>
+            <Text variant="title1" style={[styles.gradeValue, styles.crowdGrade]}>
+              {correction.crowd.label}
+            </Text>
+          </View>
+
+          <View style={styles.correctionArrow}>
+            {amount && (
+              <View style={styles.pill}>
+                <Text variant="caption1" color={iosSystemColors.systemGray} allowFontScaling={false}>
+                  {t(correction.direction === 'easier' ? 'boardseshGrade.hero.easier' : 'boardseshGrade.hero.stiffer', {
+                    amount,
+                  })}
+                </Text>
+              </View>
+            )}
+            <Icon name="arrow.right" size={18} color={iosSystemColors.systemGray} />
+          </View>
+
+          <View style={styles.correctionSide}>
+            <Text variant="caption1" color={iosSystemColors.systemGray}>
+              {t('boardseshGrade.hero.everywhere')}
+            </Text>
+            <View style={styles.everywhereValue}>
+              <Text variant="largeTitle" style={[styles.gradeValue, { color: heroGrade.color }]}>
+                {everywhereLabel}
+              </Text>
+              {seal}
             </View>
-            <Text variant="footnote" color={iosSystemColors.systemGray}>
-              {t('boardseshGrade.confirmedSubline', { count: view.count })}
-            </Text>
-            {view.scope === 'local' && (
-              <Text variant="caption1" color={iosSystemColors.systemGray}>
-                {t('boardseshGrade.localScopeNote')}
-              </Text>
-            )}
           </View>
         </View>
       )}
 
-      {/* Provisional: a range spanning two grades, else the single grade with a subtle ±. */}
-      {view.kind === 'provisional' && (
-        <View style={styles.gradeRow}>
-          <View style={styles.provisionalValue}>
-            <Text variant="largeTitle" style={[styles.gradeValue, { color: view.grade.color }]}>
-              {view.rangeLabel ?? view.grade.label}
-            </Text>
-            {!view.rangeLabel && (
-              <Text variant="callout" color={iosSystemColors.systemGray} style={styles.approx}>
-                {APPROX_SYMBOL}
-              </Text>
-            )}
-          </View>
-          <View style={styles.gradeMeta}>
-            <Text variant="subheadline">{scopeLabel(view.scope)}</Text>
-            <Text variant="footnote" color={iosSystemColors.systemGray}>
-              {t('boardseshGrade.provisionalSubline', { count: view.count })}
-            </Text>
-            {view.scope === 'local' && (
-              <Text variant="caption1" color={iosSystemColors.systemGray}>
-                {t('boardseshGrade.localScopeNote')}
-              </Text>
-            )}
-          </View>
-        </View>
-      )}
-
-      {localSecondary && (
-        <Text variant="caption1" color={localSecondary.color}>
-          {t('boardseshGrade.localGradeLine', { grade: localSecondary.label })}
-        </Text>
-      )}
-
-      {showGradeFooter && (
-        <Text variant="caption1" color={iosSystemColors.systemGray}>
-          {t('boardseshGrade.summary')}
-        </Text>
-      )}
-
-      {computedAt && (
-        <Text variant="caption2" color={iosSystemColors.systemGray}>
-          {t('boardseshGrade.updated', { when: formatRelativeTime(computedAt) })}
-        </Text>
-      )}
-
-      {angleBars.length >= 2 && (
-        <View style={styles.histogram}>
-          <Text variant="footnote" color={iosSystemColors.systemGray}>
-            {t('boardseshGrade.byAngle')}
+      {/* PAYOFF — softer/stiffer/same voice, in one line under the hero. */}
+      {correction && (
+        <View style={styles.payoffRow}>
+          <View style={[styles.accentBar, { backgroundColor: brandColors.primary }]} />
+          <Text variant="subheadline" style={styles.flexText}>
+            {correction.direction === 'equal'
+              ? t('boardseshGrade.payoff.same')
+              : t(
+                  correction.direction === 'easier' ? 'boardseshGrade.payoff.softer' : 'boardseshGrade.payoff.stiffer',
+                  { amount, board: displayBoardName(boardName) },
+                )}
           </Text>
-          <DifficultyByAngleChart
-            data={angleBars}
+        </View>
+      )}
+
+      {/* TRUST — owns the sample + band + freshness on one line. */}
+      {provisional ? (
+        <Text variant="footnote" color={iosSystemColors.systemOrange}>
+          {t('boardseshGrade.trust.provisional', { low: band.low, high: band.high, count })}
+        </Text>
+      ) : (
+        <View style={styles.trustRow}>
+          <Icon name="check.small" size={14} color={iosSystemColors.systemGreen} />
+          <Text variant="footnote" color={iosSystemColors.systemGray} style={styles.flexText}>
+            {t('boardseshGrade.trust.confirmed', {
+              low: band.low,
+              high: band.high,
+              count,
+              when: formatRelativeTime(computedAt),
+            })}
+          </Text>
+        </View>
+      )}
+
+      {/* DUMBBELL — crowd rings vs Boardsesh diamonds, one per angle. */}
+      {dumbbellRows.length >= 1 && (
+        <View style={styles.histogram}>
+          {dumbbellRows.length >= 2 && (
+            <Text variant="footnote" color={iosSystemColors.systemGray}>
+              {t('boardseshGrade.byAngle')}
+            </Text>
+          )}
+          <DumbbellByAngleChart
+            rows={dumbbellRows}
+            headlineGrade={view.gradeValue}
+            gradeFormat={gradeFormat}
             accessibilityLabel={t('boardseshGrade.byAngle')}
-            logScaleLabel={t('boardseshGrade.logScale')}
           />
         </View>
       )}
     </View>
   );
 });
+
+/** The 95%/likely band labels, falling back to the headline grade when a bound is missing. */
+function buildBand(
+  low: number | null,
+  high: number | null,
+  headline: RenderedGrade,
+  gradeFormat: GradeDisplayFormat,
+): { low: string; high: string } {
+  return {
+    low: (low != null ? renderDifficulty(low, gradeFormat)?.label : null) ?? headline.label,
+    high: (high != null ? renderDifficulty(high, gradeFormat)?.label : null) ?? headline.label,
+  };
+}
 
 const styles = StyleSheet.create({
   container: {
@@ -211,28 +324,67 @@ const styles = StyleSheet.create({
   flexText: {
     flex: 1,
   },
-  gradeRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[3],
+  centered: {
+    textAlign: 'center',
   },
   gradeValue: {
     fontVariant: ['tabular-nums'],
     fontWeight: '700',
   },
-  provisionalValue: {
+  // HERO — correction row
+  correctionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing[2],
+  },
+  correctionSide: {
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  crowdGrade: {
+    color: iosSystemColors.systemGray,
+  },
+  correctionArrow: {
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  pill: {
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: borderRadius.full,
+    backgroundColor: `${iosSystemColors.systemGray}22`,
+  },
+  everywhereValue: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  // HERO — single-grade layouts (local-only / matches / no-crowd)
+  singleHero: {
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  // HERO — setter-only
+  setterHero: {
+    gap: spacing[1],
+  },
+  setterGrade: {
+    color: iosSystemColors.systemGray,
+  },
+  // PAYOFF
+  payoffRow: {
     flexDirection: 'row',
     alignItems: 'flex-start',
-    gap: 2,
+    gap: spacing[2],
   },
-  approx: {
-    marginTop: spacing[1],
+  accentBar: {
+    width: 2,
+    alignSelf: 'stretch',
+    borderRadius: 1,
   },
-  gradeMeta: {
-    flex: 1,
-    gap: 2,
-  },
-  scopeRow: {
+  // TRUST
+  trustRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[1],

--- a/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
+++ b/packages/mobile/src/components/play-drawer/BoardseshGradeSection.tsx
@@ -222,7 +222,7 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
             {amount && (
               <View style={styles.pill}>
                 <Text variant="caption1" color={iosSystemColors.systemGray} allowFontScaling={false}>
-                  {t(correction.direction === 'easier' ? 'boardseshGrade.hero.easier' : 'boardseshGrade.hero.stiffer', {
+                  {t(correction.direction === 'easier' ? 'boardseshGrade.hero.softer' : 'boardseshGrade.hero.stiffer', {
                     amount,
                   })}
                 </Text>
@@ -245,17 +245,17 @@ export const BoardseshGradeSection = memo(function BoardseshGradeSection({
         </View>
       )}
 
-      {/* PAYOFF — softer/stiffer/same voice, in one line under the hero. */}
-      {correction && (
+      {/* PAYOFF — softer/stiffer voice, in one line under the hero. Suppressed on
+          the equal tier: the hero's "matches this board" note already says it, so
+          a payoff row here would just repeat it. */}
+      {correction && correction.direction !== 'equal' && (
         <View style={styles.payoffRow}>
           <View style={[styles.accentBar, { backgroundColor: brandColors.primary }]} />
           <Text variant="subheadline" style={styles.flexText}>
-            {correction.direction === 'equal'
-              ? t('boardseshGrade.payoff.same')
-              : t(
-                  correction.direction === 'easier' ? 'boardseshGrade.payoff.softer' : 'boardseshGrade.payoff.stiffer',
-                  { amount, board: displayBoardName(boardName) },
-                )}
+            {t(correction.direction === 'easier' ? 'boardseshGrade.payoff.softer' : 'boardseshGrade.payoff.stiffer', {
+              amount,
+              board: displayBoardName(boardName),
+            })}
           </Text>
         </View>
       )}

--- a/packages/mobile/src/components/play-drawer/DeferredSections.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredSections.tsx
@@ -10,11 +10,12 @@ import { SimilarClimbsSection } from './SimilarClimbsSection';
 import { CommunitySection } from './CommunitySection';
 import { BoardseshGradeSection } from './BoardseshGradeSection';
 import { buildBoardseshGradeView, buildBoardseshGradeSummary, isMoonBoard } from './boardsesh-grade-utils';
+import { buildAngleGradeBars } from './community-utils';
 import { BetaVideosSection } from './BetaVideosSection';
 import { useAuth } from '../../providers/auth-provider';
 import { useBoardseshGradeEnabled } from '../../providers/feature-flags-provider';
 import { useTheme } from '../../providers/theme-provider';
-import { useBoardseshGrade } from '../../lib/graphql/hooks';
+import { useBoardseshGrade, useClimbStatsHistory } from '../../lib/graphql/hooks';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useDeferredAfterInteractions } from '../../hooks/use-deferred-after-interactions';
@@ -91,13 +92,19 @@ export const DeferredSections = memo(function DeferredSections({
   // unmounts while collapsed — React Query dedupes this fetch with the
   // section's identical-key one once it expands, so this costs no extra request.
   const moonboard = isMoonBoard(boardName);
+  const boardseshReady = boardseshGradeEnabled && !moonboard && readyToRender;
   const { data: boardseshGrade } = useBoardseshGrade(boardName, climb.uuid, angle, {
-    enabled: boardseshGradeEnabled && !moonboard && readyToRender,
+    enabled: boardseshReady,
   });
-  const boardseshSummary = useMemo(
-    () => buildBoardseshGradeSummary(buildBoardseshGradeView(boardName, boardseshGrade ?? null, gradeFormat)),
-    [boardName, boardseshGrade, gradeFormat],
-  );
+  // The crowd grade at this angle turns the teaser into the correction "V4 ▸ V3+ ✓".
+  // React Query dedupes this with CommunitySection's identical fetch, so it costs
+  // no extra request; it stays null until loaded and the teaser drops the "V4 ▸".
+  const { data: history } = useClimbStatsHistory(boardName, boardseshReady ? climb.uuid : null);
+  const boardseshSummary = useMemo(() => {
+    const view = buildBoardseshGradeView(boardName, boardseshGrade ?? null, gradeFormat);
+    const crowdLabel = buildAngleGradeBars(history, gradeFormat).find((bar) => bar.angle === angle)?.gradeName ?? null;
+    return buildBoardseshGradeSummary(view, { crowdLabel, localWord: tClimbs('boardseshGrade.summaryLocal') });
+  }, [boardName, boardseshGrade, gradeFormat, history, angle, tClimbs]);
 
   if (!enabled) {
     return null;

--- a/packages/mobile/src/components/play-drawer/DeferredSections.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredSections.tsx
@@ -9,10 +9,13 @@ import { LogbookSection } from './LogbookSection';
 import { SimilarClimbsSection } from './SimilarClimbsSection';
 import { CommunitySection } from './CommunitySection';
 import { BoardseshGradeSection } from './BoardseshGradeSection';
+import { buildBoardseshGradeView, buildBoardseshGradeSummary, isMoonBoard } from './boardsesh-grade-utils';
 import { BetaVideosSection } from './BetaVideosSection';
 import { useAuth } from '../../providers/auth-provider';
 import { useBoardseshGradeEnabled } from '../../providers/feature-flags-provider';
 import { useTheme } from '../../providers/theme-provider';
+import { useBoardseshGrade } from '../../lib/graphql/hooks';
+import { useGradeFormat } from '../../hooks/use-grade-format';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useDeferredAfterInteractions } from '../../hooks/use-deferred-after-interactions';
 
@@ -56,6 +59,7 @@ export const DeferredSections = memo(function DeferredSections({
   const { t: tClimbs } = useTranslation('climbs');
   const { isAuthenticated } = useAuth();
   const { brandColors } = useTheme();
+  const { gradeFormat } = useGradeFormat();
   const boardseshGradeEnabled = useBoardseshGradeEnabled();
 
   const handleAddBetaVideoPress = useCallback(() => {
@@ -81,6 +85,19 @@ export const DeferredSections = memo(function DeferredSections({
     if (attempts > 0) return t('mobile.logbook.attemptsOnly', { attempts });
     return null;
   }, [climb.userAscents, climb.userAttempts, t]);
+
+  // Grade shown next to the collapsed Boardsesh grade header. Lifted up here
+  // (rather than read from BoardseshGradeSection) because that section
+  // unmounts while collapsed — React Query dedupes this fetch with the
+  // section's identical-key one once it expands, so this costs no extra request.
+  const moonboard = isMoonBoard(boardName);
+  const { data: boardseshGrade } = useBoardseshGrade(boardName, climb.uuid, angle, {
+    enabled: boardseshGradeEnabled && !moonboard && readyToRender,
+  });
+  const boardseshSummary = useMemo(
+    () => buildBoardseshGradeSummary(buildBoardseshGradeView(boardName, boardseshGrade ?? null, gradeFormat)),
+    [boardName, boardseshGrade, gradeFormat],
+  );
 
   if (!enabled) {
     return null;
@@ -123,6 +140,17 @@ export const DeferredSections = memo(function DeferredSections({
             />
           </CollapsibleSection>
 
+          {boardseshGradeEnabled && (
+            <CollapsibleSection
+              title={tClimbs('boardseshGrade.title')}
+              summary={boardseshSummary}
+              defaultExpanded
+              persistKey="boardseshGrade"
+            >
+              <BoardseshGradeSection climbUuid={climb.uuid} boardName={boardName} angle={angle} />
+            </CollapsibleSection>
+          )}
+
           <CollapsibleSection title={t('mobile.community.title')} defaultExpanded persistKey="community">
             <CommunitySection
               climbUuid={climb.uuid}
@@ -131,12 +159,6 @@ export const DeferredSections = memo(function DeferredSections({
               ascensionistCount={climb.ascensionist_count}
             />
           </CollapsibleSection>
-
-          {boardseshGradeEnabled && (
-            <CollapsibleSection title={tClimbs('boardseshGrade.title')} defaultExpanded persistKey="boardseshGrade">
-              <BoardseshGradeSection climbUuid={climb.uuid} boardName={boardName} angle={angle} />
-            </CollapsibleSection>
-          )}
 
           <CollapsibleSection title={t('mobile.similarClimbs.title')} persistKey="similarClimbs">
             <SimilarClimbsSection

--- a/packages/mobile/src/components/play-drawer/DumbbellByAngleChart.tsx
+++ b/packages/mobile/src/components/play-drawer/DumbbellByAngleChart.tsx
@@ -1,0 +1,385 @@
+import { memo, useCallback, useMemo, useState, type ReactNode } from 'react';
+import { StyleSheet, View, Pressable, type LayoutChangeEvent } from 'react-native';
+import { LineChart } from 'react-native-gifted-charts';
+import type { GradeDisplayFormat } from '@boardsesh/play-view';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
+import { useTranslation } from 'react-i18next';
+import {
+  buildDumbbellAxis,
+  hasAnyBoardseshDiamond,
+  type DumbbellAngleRow,
+  type DumbbellSizeBin,
+} from './by-angle-comparison';
+
+type DumbbellByAngleChartProps = {
+  /** Per-angle join model from `buildDumbbellByAngleModel` (sorted by angle). */
+  rows: DumbbellAngleRow[];
+  /** Overall Boardsesh grade (float) for the dashed reference line; null hides it. */
+  headlineGrade: number | null;
+  /** The viewer's grade-format preference, for the tap caption's dash fallback. */
+  gradeFormat: GradeDisplayFormat;
+  /** Screen-reader summary of the chart (built by the parent section). */
+  accessibilityLabel: string;
+};
+
+const CHART_HEIGHT = 168;
+const AXIS_LABEL_SIZE = 11;
+const Y_AXIS_LABEL_WIDTH = 30;
+const INITIAL_SPACING = 26;
+const END_SPACING = 16;
+// Cap the per-angle tap column so a two-angle climb doesn't give each marker
+// half the screen; the floor keeps a comfortable touch target when there's room.
+const MAX_SLOT_WIDTH = 76;
+const MIN_SLOT_WIDTH = 44;
+
+// Ring (crowd) outer diameter and diamond (Boardsesh) square side, by ascent bin.
+const RING_DIAMETER: Record<DumbbellSizeBin, number> = { small: 12, medium: 16, large: 22 };
+const DIAMOND_SIDE: Record<DumbbellSizeBin, number> = { small: 9, medium: 12, large: 16 };
+const NESTED_DIAMOND_SIDE: Record<DumbbellSizeBin, number> = { small: 6, medium: 8, large: 10 };
+const RING_BORDER = 2;
+const STEM_WIDTH = 2;
+const WHISKER_WIDTH = 2;
+const WHISKER_CAP = 6;
+
+const BIN_ORDER: DumbbellSizeBin[] = ['small', 'medium', 'large'];
+
+/** Bump a size bin up one step when its angle is focused (tap-to-enlarge). */
+function bumpBin(bin: DumbbellSizeBin, focused: boolean): DumbbellSizeBin {
+  if (!focused) return bin;
+  return BIN_ORDER[Math.min(BIN_ORDER.length - 1, BIN_ORDER.indexOf(bin) + 1)];
+}
+
+// A per-angle dumbbell comparing the crowd's community grade (hollow ring) with
+// the cross-board Boardsesh grade (filled diamond, tinted by its own grade) on
+// ONE standardized-grade Y axis. The vertical gap between the two markers is the
+// correction. Series are told apart by SHAPE + FILL + POSITION, never hue alone,
+// so it survives colour-blindness. Ascent count drives marker size; a tap
+// enlarges an angle and prints its numbers above the chart.
+export const DumbbellByAngleChart = memo(function DumbbellByAngleChart({
+  rows,
+  headlineGrade,
+  gradeFormat,
+  accessibilityLabel,
+}: DumbbellByAngleChartProps) {
+  const { chartColors } = useTheme();
+  const { t } = useTranslation('climbs');
+  const [width, setWidth] = useState(0);
+  const [focusedAngle, setFocusedAngle] = useState<number | null>(null);
+
+  const axis = useMemo(() => buildDumbbellAxis(rows, gradeFormat), [rows, gradeFormat]);
+  const anyDiamond = useMemo(() => hasAnyBoardseshDiamond(rows), [rows]);
+
+  // A grade float → its y offset from the container top (0 = axis top). This
+  // exactly mirrors gifted's own getY (slope = height / maxValue), so markers
+  // register on the gridlines. Every anchor sits at the axis midpoint so each
+  // customDataPoint container spans the full plot area (markers never clip).
+  const localY = useCallback(
+    (grade: number) => (CHART_HEIGHT * (axis.maxId - grade)) / axis.maxValue,
+    [axis.maxId, axis.maxValue],
+  );
+
+  const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);
+
+  const plotWidth = Math.max(0, width - Y_AXIS_LABEL_WIDTH);
+  const count = rows.length;
+  const rawSpacing = count > 1 ? (plotWidth - INITIAL_SPACING - END_SPACING) / (count - 1) : 0;
+  const slotWidth = Math.max(MIN_SLOT_WIDTH, Math.min(rawSpacing, MAX_SLOT_WIDTH));
+
+  const neutralStroke = chartColors.secondaryLabel;
+  const diamondEdge = chartColors.label;
+
+  const renderMarker = useCallback(
+    (row: DumbbellAngleRow): ReactNode => {
+      const focused = row.angle === focusedAngle;
+      const bin = bumpBin(row.sizeBin, focused);
+      const centerX = slotWidth / 2;
+
+      const crowdY = row.crowdGrade != null ? localY(row.crowdGrade) : null;
+      const diamondY = row.boardseshGrade != null ? localY(row.boardseshGrade) : null;
+
+      const ringSize = RING_DIAMETER[bin];
+      const diaSize = DIAMOND_SIDE[bin];
+      const isProvisional = row.tier === 'provisional';
+
+      return (
+        <Pressable
+          style={[styles.column, { width: slotWidth, height: CHART_HEIGHT }]}
+          onPress={() => setFocusedAngle((current) => (current === row.angle ? null : row.angle))}
+          accessibilityRole="button"
+          accessibilityLabel={`${row.angle}°`}
+        >
+          {/* Provisional whisker: gradeLow–gradeHigh span behind the diamond. */}
+          {isProvisional && row.gradeLow != null && row.gradeHigh != null && diamondY != null ? (
+            <View
+              pointerEvents="none"
+              style={[
+                styles.whisker,
+                {
+                  left: centerX - WHISKER_WIDTH / 2,
+                  top: localY(row.gradeHigh),
+                  height: Math.max(WHISKER_CAP, localY(row.gradeLow) - localY(row.gradeHigh)),
+                  backgroundColor: chartColors.tertiaryLabel,
+                },
+              ]}
+            />
+          ) : null}
+
+          {/* Connector stem — only when the two markers disagree and both exist. */}
+          {!row.agree && crowdY != null && diamondY != null ? (
+            <View
+              pointerEvents="none"
+              style={[
+                styles.stem,
+                {
+                  left: centerX - STEM_WIDTH / 2,
+                  top: Math.min(crowdY, diamondY),
+                  height: Math.abs(crowdY - diamondY),
+                  backgroundColor: chartColors.separator,
+                },
+              ]}
+            />
+          ) : null}
+
+          {/* Crowd ring (hollow, neutral). */}
+          {crowdY != null ? (
+            <View
+              pointerEvents="none"
+              style={[
+                styles.ring,
+                {
+                  width: ringSize,
+                  height: ringSize,
+                  borderRadius: ringSize / 2,
+                  borderColor: neutralStroke,
+                  left: centerX - ringSize / 2,
+                  top: crowdY - ringSize / 2,
+                },
+              ]}
+            />
+          ) : null}
+
+          {/* Agree → a small diamond nested in the ring (no stem). */}
+          {row.agree && crowdY != null && row.boardseshColor ? (
+            <View
+              pointerEvents="none"
+              style={[
+                styles.diamond,
+                {
+                  width: NESTED_DIAMOND_SIDE[bin],
+                  height: NESTED_DIAMOND_SIDE[bin],
+                  backgroundColor: row.boardseshColor,
+                  borderColor: diamondEdge,
+                  left: centerX - NESTED_DIAMOND_SIDE[bin] / 2,
+                  top: crowdY - NESTED_DIAMOND_SIDE[bin] / 2,
+                },
+              ]}
+            />
+          ) : null}
+
+          {/* Boardsesh diamond (filled, grade-tinted) — disagree case. */}
+          {!row.agree && diamondY != null && row.boardseshColor ? (
+            <View
+              pointerEvents="none"
+              style={[
+                styles.diamond,
+                {
+                  width: diaSize,
+                  height: diaSize,
+                  backgroundColor: row.boardseshColor,
+                  borderColor: diamondEdge,
+                  left: centerX - diaSize / 2,
+                  top: diamondY - diaSize / 2,
+                },
+              ]}
+            />
+          ) : null}
+        </Pressable>
+      );
+    },
+    [focusedAngle, slotWidth, localY, neutralStroke, diamondEdge, chartColors.tertiaryLabel, chartColors.separator],
+  );
+
+  // All points anchor at the axis midpoint so every marker container spans the
+  // full plot; the array identity also changes on focus so gifted re-runs
+  // customDataPoint (enlarging the tapped angle).
+  const chartData = useMemo(
+    () => rows.map(() => ({ value: axis.maxValue / 2 })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- focusedAngle forces a re-render of the custom points
+    [rows, axis.maxValue, focusedAngle],
+  );
+
+  const caption = useMemo(() => {
+    if (focusedAngle == null) return null;
+    const row = rows.find((candidate) => candidate.angle === focusedAngle);
+    if (!row) return null;
+    if (row.agree && row.boardseshLabel) {
+      return t('boardseshGrade.dumbbell.tapCaptionAgree', {
+        angle: row.angle,
+        grade: row.boardseshLabel,
+        count: row.sends,
+      });
+    }
+    return t('boardseshGrade.dumbbell.tapCaption', {
+      angle: row.angle,
+      crowd: row.crowdLabel ?? '—',
+      boardsesh: row.boardseshLabel ?? '—',
+      count: row.sends,
+    });
+  }, [focusedAngle, rows, t]);
+
+  if (count === 0) return null;
+
+  // Single angle: a chart of one point reads as a bug — say it in a sentence.
+  if (count === 1) {
+    const [row] = rows;
+    return (
+      <Text variant="footnote" color={chartColors.secondaryLabel} accessibilityLabel={accessibilityLabel}>
+        {t('boardseshGrade.dumbbell.singleAngle', {
+          angle: row.angle,
+          crowd: row.crowdLabel ?? '—',
+          boardsesh: row.boardseshLabel ?? '—',
+          count: row.sends,
+        })}
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.container} accessible accessibilityRole="image" accessibilityLabel={accessibilityLabel}>
+      <Text
+        variant="caption1"
+        color={chartColors.label}
+        style={styles.caption}
+        numberOfLines={2}
+        allowFontScaling={false}
+      >
+        {caption ?? ''}
+      </Text>
+
+      <View onLayout={onLayout}>
+        {width > 0 ? (
+          <LineChart
+            data={chartData}
+            width={plotWidth}
+            height={CHART_HEIGHT}
+            thickness={0}
+            color="transparent"
+            spacing={rawSpacing}
+            initialSpacing={INITIAL_SPACING}
+            endSpacing={END_SPACING}
+            maxValue={axis.maxValue}
+            noOfSections={axis.noOfSections}
+            yAxisLabelTexts={axis.yAxisLabelTexts}
+            yAxisLabelWidth={Y_AXIS_LABEL_WIDTH}
+            dataPointsWidth={slotWidth}
+            dataPointsHeight={CHART_HEIGHT}
+            customDataPoint={(_item: unknown, index: number) => renderMarker(rows[index])}
+            showReferenceLine1={headlineGrade != null}
+            referenceLine1Position={headlineGrade != null ? headlineGrade - axis.minId : undefined}
+            referenceLine1Config={{
+              thickness: 1,
+              color: chartColors.tertiaryLabel,
+              dashWidth: 4,
+              dashGap: 4,
+            }}
+            rulesColor={chartColors.separator}
+            rulesType="solid"
+            yAxisThickness={0}
+            xAxisThickness={StyleSheet.hairlineWidth}
+            xAxisColor={chartColors.separator}
+            yAxisTextStyle={{ color: chartColors.secondaryLabel, fontSize: AXIS_LABEL_SIZE }}
+            xAxisLabelTexts={rows.map((row) => `${row.angle}°`)}
+            xAxisLabelTextStyle={{ color: chartColors.secondaryLabel, fontSize: AXIS_LABEL_SIZE }}
+            // gifted's entry animation collapses points to 0 inside the drawer's
+            // FadeIn on Android — render statically like every other chart here.
+            isAnimated={false}
+            disableScroll
+          />
+        ) : null}
+      </View>
+
+      {!anyDiamond ? (
+        <Text variant="caption2" color={chartColors.secondaryLabel} style={styles.note}>
+          {t('boardseshGrade.dumbbell.crowdOnlyNote')}
+        </Text>
+      ) : null}
+
+      <View style={styles.legend}>
+        <View style={styles.legendItem}>
+          <View style={[styles.legendDiamond, { backgroundColor: chartColors.label }]} />
+          <Text variant="caption2" color={chartColors.secondaryLabel} allowFontScaling={false}>
+            {t('boardseshGrade.dumbbell.legendBoardsesh')}
+          </Text>
+        </View>
+        <View style={styles.legendItem}>
+          <View style={[styles.legendRing, { borderColor: chartColors.secondaryLabel }]} />
+          <Text variant="caption2" color={chartColors.secondaryLabel} allowFontScaling={false}>
+            {t('boardseshGrade.dumbbell.legendCrowd')}
+          </Text>
+        </View>
+      </View>
+      <Text variant="caption2" color={chartColors.tertiaryLabel} allowFontScaling={false}>
+        {t('boardseshGrade.dumbbell.legendSize')}
+      </Text>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing[2],
+  },
+  caption: {
+    minHeight: 34,
+  },
+  column: {
+    position: 'relative',
+  },
+  ring: {
+    position: 'absolute',
+    borderWidth: RING_BORDER,
+    backgroundColor: 'transparent',
+  },
+  diamond: {
+    position: 'absolute',
+    borderWidth: 1,
+    borderRadius: 2,
+    transform: [{ rotate: '45deg' }],
+  },
+  stem: {
+    position: 'absolute',
+    width: STEM_WIDTH,
+  },
+  whisker: {
+    position: 'absolute',
+    width: WHISKER_WIDTH,
+  },
+  note: {
+    fontStyle: 'italic',
+  },
+  legend: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[4],
+  },
+  legendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  legendDiamond: {
+    width: 10,
+    height: 10,
+    borderRadius: 2,
+    transform: [{ rotate: '45deg' }],
+  },
+  legendRing: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    borderWidth: RING_BORDER,
+    backgroundColor: 'transparent',
+  },
+});

--- a/packages/mobile/src/components/play-drawer/DumbbellByAngleChart.tsx
+++ b/packages/mobile/src/components/play-drawer/DumbbellByAngleChart.tsx
@@ -30,9 +30,13 @@ const Y_AXIS_LABEL_WIDTH = 30;
 const INITIAL_SPACING = 26;
 const END_SPACING = 16;
 // Cap the per-angle tap column so a two-angle climb doesn't give each marker
-// half the screen; the floor keeps a comfortable touch target when there's room.
+// half the screen. There is deliberately NO lower floor: a column wider than the
+// marker spacing overlaps its neighbour, and RN hands the overlap to the later
+// sibling, so a marker's edge pixels would trigger the wrong angle. Tiling the
+// column to the spacing (below the cap) keeps every marker owning its own tap
+// target; the column runs the full plot height, so even a crowded ~30px-wide
+// slot stays a usable target.
 const MAX_SLOT_WIDTH = 76;
-const MIN_SLOT_WIDTH = 44;
 
 // Ring (crowd) outer diameter and diamond (Boardsesh) square side, by ascent bin.
 const RING_DIAMETER: Record<DumbbellSizeBin, number> = { small: 12, medium: 16, large: 22 };
@@ -85,7 +89,7 @@ export const DumbbellByAngleChart = memo(function DumbbellByAngleChart({
   const plotWidth = Math.max(0, width - Y_AXIS_LABEL_WIDTH);
   const count = rows.length;
   const rawSpacing = count > 1 ? (plotWidth - INITIAL_SPACING - END_SPACING) / (count - 1) : 0;
-  const slotWidth = Math.max(MIN_SLOT_WIDTH, Math.min(rawSpacing, MAX_SLOT_WIDTH));
+  const slotWidth = Math.min(rawSpacing, MAX_SLOT_WIDTH);
 
   const neutralStroke = chartColors.secondaryLabel;
   const diamondEdge = chartColors.label;

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -61,7 +61,8 @@ import type { OpenClimbActionsOptions } from '../../providers/drawer-host-provid
 import { useAuth } from '../../providers/auth-provider';
 import { useToast } from '../../providers/toast-provider';
 import { useToggleFavorite, useFavoriteStatus } from '../../lib/graphql/hooks';
-import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useDisplayGrade } from '../../hooks/use-display-grade';
+import { resolveTickDefaultGradeName } from '../../lib/boardsesh-grade-display';
 import { useShareClimb } from '../../hooks/use-share-climb';
 import { useMountedOnFirstOpen } from '../../hooks/use-mounted-on-first-open';
 import { getBoardRenderData } from '../../lib/board-details';
@@ -322,7 +323,11 @@ export function PlayDrawer({
   const playlistSuggestionSource = usePlaylistSuggestionSource();
   const bluetooth = useOptionalBluetoothContext();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
-  const { formatGrade } = useGradeFormat();
+  // App-wide grade resolver: swaps the header grade (label + colour) to the
+  // Boardsesh grade when the "Show Boardsesh grades" toggle is on and a trusted
+  // one exists, else the legacy Aurora grade. `boardseshActive` also seeds the
+  // tick picker's default grade below.
+  const { resolveGrade, boardseshActive } = useDisplayGrade();
   const { isAuthenticated } = useAuth();
 
   const { boardName, layoutId, sizeId, setIds, angle } = boardConfig;
@@ -394,6 +399,12 @@ export function PlayDrawer({
   // During the commit hand-off use the frozen climb (captured at fling start) so
   // the peek doesn't jump to the new climb's neighbour mid-swap.
   const headerPeekClimb = isSwipeCommitting ? frozenPeekClimb : peekClimb;
+
+  // The grade the header renders for the current + peek climbs under the "Show
+  // Boardsesh grades" toggle. `resolveGrade` is O(1) and auto-falls-back to the
+  // legacy Aurora grade, so this is safe to call each render (not a list).
+  const displayedGrade = displayedClimb ? resolveGrade(displayedClimb) : null;
+  const peekGrade = headerPeekClimb ? resolveGrade(headerPeekClimb) : null;
 
   // Host-owned post-fling reset: once the swiped-to climb has actually rendered
   // (the displayed queue item changes), snap the shared swipe offset back to 0 and
@@ -807,8 +818,9 @@ export function PlayDrawer({
                     current={
                       <PlayDrawerHeader
                         name={displayedClimb.name}
-                        difficulty={formatGrade(displayedClimb.difficulty) ?? displayedClimb.difficulty}
+                        difficulty={displayedGrade?.label ?? displayedClimb.difficulty}
                         rawDifficulty={displayedClimb.difficulty}
+                        gradeColor={displayedGrade?.color}
                         qualityAverage={displayedClimb.quality_average}
                         ascensionistCount={displayedClimb.ascensionist_count}
                         setterUsername={displayedClimb.setter_username}
@@ -825,8 +837,9 @@ export function PlayDrawer({
                       headerPeekClimb ? (
                         <PlayDrawerHeader
                           name={headerPeekClimb.name}
-                          difficulty={formatGrade(headerPeekClimb.difficulty) ?? headerPeekClimb.difficulty}
+                          difficulty={peekGrade?.label ?? headerPeekClimb.difficulty}
                           rawDifficulty={headerPeekClimb.difficulty}
+                          gradeColor={peekGrade?.color}
                           qualityAverage={headerPeekClimb.quality_average}
                           ascensionistCount={headerPeekClimb.ascensionist_count}
                           setterUsername={headerPeekClimb.setter_username}
@@ -1036,7 +1049,11 @@ export function PlayDrawer({
           sizeId={sizeId}
           setIds={setIds}
           sessionId={sessionId}
-          consensusGradeName={displayedClimb.difficulty}
+          // The tick picker opens on the Boardsesh grade (when the toggle is on and
+          // a trusted one exists) instead of the Aurora consensus, so a logged grade
+          // defaults to what the app now shows. Only the DEFAULT changes — the saved
+          // tick value stays on the Aurora scale and null until the climber picks.
+          consensusGradeName={resolveTickDefaultGradeName(displayedClimb, boardseshActive) ?? displayedClimb.difficulty}
         />
       )}
 

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -16,6 +16,11 @@ type PlayDrawerHeaderProps = {
   /** Raw difficulty (e.g. "6a/V3") used for grade-color lookup. Optional —
    *  falls back to `difficulty` if not provided. */
   rawDifficulty?: string;
+  /** Explicit grade colour, overriding the internal `getGradeColor` lookup. The
+   *  play drawer passes this so the colour matches the shown grade when the "Show
+   *  Boardsesh grades" toggle swaps the label to the Boardsesh grade. Falls back
+   *  to `getGradeColor(rawDifficulty ?? difficulty)` when omitted. */
+  gradeColor?: string;
   qualityAverage: string;
   ascensionistCount: number;
   setterUsername: string;
@@ -35,6 +40,7 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   name,
   difficulty,
   rawDifficulty,
+  gradeColor,
   qualityAverage,
   ascensionistCount,
   setterUsername,
@@ -44,9 +50,9 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   onLongPressName,
 }: PlayDrawerHeaderProps) {
   const { t } = useTranslation('climbs');
-  const gradeColor = useMemo(
-    () => getGradeColor(rawDifficulty ?? difficulty) ?? DEFAULT_GRADE_COLOR,
-    [rawDifficulty, difficulty],
+  const resolvedGradeColor = useMemo(
+    () => gradeColor ?? getGradeColor(rawDifficulty ?? difficulty) ?? DEFAULT_GRADE_COLOR,
+    [gradeColor, rawDifficulty, difficulty],
   );
 
   const subtitleParts: string[] = [];
@@ -85,7 +91,7 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
         </>
       }
       trailing={
-        <Text variant="headline" style={[styles.gradeText, { color: gradeColor }]} numberOfLines={1}>
+        <Text variant="headline" style={[styles.gradeText, { color: resolvedGradeColor }]} numberOfLines={1}>
           {difficulty}
         </Text>
       }

--- a/packages/mobile/src/components/play-drawer/SimilarClimbsSection.tsx
+++ b/packages/mobile/src/components/play-drawer/SimilarClimbsSection.tsx
@@ -2,14 +2,13 @@ import { memo, useCallback, useMemo } from 'react';
 import { ScrollView, View, Pressable, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { Climb, BoardName, SimilarClimb } from '@boardsesh/shared-schema';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import * as Haptics from 'expo-haptics';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { ClimbListThumbnail } from '../ClimbListThumbnail';
 import { buildClimbStub, formatByline, rankBySizeCompatibility } from './similar-climbs-utils';
 import { useSimilarClimbs } from '../../lib/graphql/hooks';
-import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useDisplayGrade } from '../../hooks/use-display-grade';
 import { useTheme } from '../../providers/theme-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
@@ -39,7 +38,7 @@ export const SimilarClimbsSection = memo(function SimilarClimbsSection({
   const { t } = useTranslation('session');
   const { t: tClimbs } = useTranslation('climbs');
   const { brandColors } = useTheme();
-  const { formatGrade } = useGradeFormat();
+  const { resolveGrade } = useDisplayGrade();
   const { data: climbs, isLoading, isError, refetch } = useSimilarClimbs(boardName, climbUuid, layoutId, angle);
 
   // Wall-compatible climbs rank first; incompatible ones are dimmed and last.
@@ -98,8 +97,9 @@ export const SimilarClimbsSection = memo(function SimilarClimbsSection({
   return (
     <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.scroller}>
       {ranked.map(({ climb: similar, compatible }) => {
-        const gradeColor = getGradeColor(similar.difficultyName) ?? DEFAULT_GRADE_COLOR;
-        const formattedGrade = formatGrade(similar.difficultyName) ?? similar.difficultyName ?? '';
+        // SimilarClimb carries no Boardsesh grade today, so `resolveGrade` falls
+        // back to the legacy label + colour — lights up once the backend stamps them.
+        const { label: formattedGrade, color: gradeColor } = resolveGrade({ difficulty: similar.difficultyName });
         const byline = formatByline(similar, tClimbs);
         return (
           <Pressable

--- a/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-section.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-section.test.tsx
@@ -110,7 +110,7 @@ describe('BoardseshGradeSection', () => {
 
     expect(text).toContain('boardseshGrade.hero.thisBoard');
     expect(text).toContain('boardseshGrade.hero.everywhere');
-    expect(text).toContain('boardseshGrade.hero.easier'); // delta pill
+    expect(text).toContain('boardseshGrade.hero.softer'); // delta pill
     expect(text).toContain('boardseshGrade.payoff.softer');
     expect(text).toContain('boardseshGrade.trust.confirmed');
     expect(container.querySelector('[data-icon="checkmark.seal.fill"]')).not.toBeNull();
@@ -156,7 +156,7 @@ describe('BoardseshGradeSection', () => {
     expect(text).toContain('boardseshGrade.hero.thisBoardOnly');
     expect(text).toContain('boardseshGrade.localOnlyNote');
     // No correction: no delta pill, no payoff sentence.
-    expect(text).not.toContain('boardseshGrade.hero.easier');
+    expect(text).not.toContain('boardseshGrade.hero.softer');
     expect(text).not.toContain('boardseshGrade.payoff');
   });
 
@@ -169,8 +169,9 @@ describe('BoardseshGradeSection', () => {
     const text = container.textContent ?? '';
 
     expect(text).toContain('boardseshGrade.matchesBoard');
-    expect(text).toContain('boardseshGrade.payoff.same');
-    expect(text).not.toContain('boardseshGrade.hero.easier');
+    // The "matches this board" note is the single "same" line — no duplicate payoff row.
+    expect(text).not.toContain('boardseshGrade.payoff');
+    expect(text).not.toContain('boardseshGrade.hero.softer');
     expect(text).not.toContain('boardseshGrade.hero.stiffer');
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-section.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-section.test.tsx
@@ -99,8 +99,8 @@ describe('BoardseshGradeSection', () => {
     hookState.history = undefined;
   });
 
-  it('leads with the correction: this-board crowd → delta pill → everywhere grade + seal + trust + chart', () => {
-    // Crowd calls it V6 (22) at 40°; cross-board grade is V5 (20) — everywhere it's a grade easier.
+  it('leads with the correction: this-board crowd → arrow → all-boards grade + seal + trust + chart', () => {
+    // Crowd calls it V6 (22) at 40°; cross-board grade is V5 (20) — across all boards it's a grade easier.
     hookState.grade = grade({ universalGrade: 20 });
     hookState.history = [historyEntry(40, 22, 205), historyEntry(20, 21, 50)];
     hookState.angleRows = [angleRow(40, 20), angleRow(20, 19)];
@@ -110,11 +110,26 @@ describe('BoardseshGradeSection', () => {
 
     expect(text).toContain('boardseshGrade.hero.thisBoard');
     expect(text).toContain('boardseshGrade.hero.everywhere');
-    expect(text).toContain('boardseshGrade.hero.softer'); // delta pill
+    // The delta now reads only from the arrow + the single payoff sentence — no pill.
+    expect(container.querySelector('[data-icon="arrow.right"]')).not.toBeNull();
     expect(text).toContain('boardseshGrade.payoff.softer');
-    expect(text).toContain('boardseshGrade.trust.confirmed');
+    // gradeLow 19 (V4) / gradeHigh 21 (V5) round apart → the ranged trust line.
+    expect(text).toContain('boardseshGrade.trust.confirmedRange');
     expect(container.querySelector('[data-icon="checkmark.seal.fill"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="dumbbell"]')).not.toBeNull();
+  });
+
+  it('collapses the confirmed trust line to a single grade when both bounds round together', () => {
+    // gradeLow 20 and gradeHigh 20 both render V5 — no real range, so no "V5–V5".
+    hookState.grade = grade({ universalGrade: 20, gradeLow: 20, gradeHigh: 20 });
+    hookState.history = [historyEntry(40, 22, 205)];
+    hookState.angleRows = [angleRow(40, 20)];
+
+    const { container } = renderSection();
+    const text = container.textContent ?? '';
+
+    expect(text).toContain('boardseshGrade.trust.confirmedSingle');
+    expect(text).not.toContain('boardseshGrade.trust.confirmedRange');
   });
 
   it('renders provisional in the amber, no-seal path with the likely range', () => {
@@ -125,10 +140,10 @@ describe('BoardseshGradeSection', () => {
     const { container } = renderSection();
     const text = container.textContent ?? '';
 
-    expect(text).toContain('boardseshGrade.trust.provisional');
-    expect(text).toContain('V5–V6'); // the two-grade range shown as the everywhere grade
+    expect(text).toContain('boardseshGrade.trust.provisionalRange');
+    expect(text).toContain('V5–V6'); // the two-grade range shown as the all-boards grade
     expect(container.querySelector('[data-icon="checkmark.seal.fill"]')).toBeNull();
-    expect(text).not.toContain('boardseshGrade.trust.confirmed');
+    expect(text).not.toContain('boardseshGrade.trust.confirmedRange');
   });
 
   it('shows a muted setter call with no comparison or chart for setter_only', () => {
@@ -155,8 +170,8 @@ describe('BoardseshGradeSection', () => {
 
     expect(text).toContain('boardseshGrade.hero.thisBoardOnly');
     expect(text).toContain('boardseshGrade.localOnlyNote');
-    // No correction: no delta pill, no payoff sentence.
-    expect(text).not.toContain('boardseshGrade.hero.softer');
+    // No correction: no arrow, no payoff sentence.
+    expect(container.querySelector('[data-icon="arrow.right"]')).toBeNull();
     expect(text).not.toContain('boardseshGrade.payoff');
   });
 
@@ -169,9 +184,8 @@ describe('BoardseshGradeSection', () => {
     const text = container.textContent ?? '';
 
     expect(text).toContain('boardseshGrade.matchesBoard');
-    // The "matches this board" note is the single "same" line — no duplicate payoff row.
+    // The "matches this board" note is the single "same" line — no arrow, no payoff row.
+    expect(container.querySelector('[data-icon="arrow.right"]')).toBeNull();
     expect(text).not.toContain('boardseshGrade.payoff');
-    expect(text).not.toContain('boardseshGrade.hero.softer');
-    expect(text).not.toContain('boardseshGrade.hero.stiffer');
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-section.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-section.test.tsx
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BoardseshGrade, BoardseshGradeAtAngle, ClimbStatsHistoryEntry } from '@boardsesh/graphql/operations';
+
+const hookState = vi.hoisted(() => ({
+  grade: undefined as BoardseshGrade | undefined,
+  angleRows: undefined as BoardseshGradeAtAngle[] | undefined,
+  history: undefined as ClimbStatsHistoryEntry[] | undefined,
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('expo-haptics', () => ({ selectionAsync: vi.fn() }));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
+}));
+vi.mock('../DumbbellByAngleChart', () => ({
+  DumbbellByAngleChart: () => createElement('div', { 'data-testid': 'dumbbell' }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ brandColors: { primary: '#6D28D9' } }),
+}));
+vi.mock('../../../hooks/use-grade-format', () => ({ useGradeFormat: () => ({ gradeFormat: 'v-grade' }) }));
+
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useBoardseshGrade: () => ({ data: hookState.grade, isLoading: false, isError: false, refetch: vi.fn() }),
+  useBoardseshGradesForAngles: () => ({ data: hookState.angleRows }),
+  useClimbStatsHistory: () => ({ data: hookState.history }),
+}));
+
+import { BoardseshGradeSection } from '../BoardseshGradeSection';
+
+function grade(overrides: Partial<BoardseshGrade> = {}): BoardseshGrade {
+  return {
+    localGrade: 20,
+    universalGrade: 20,
+    gradeLow: 19,
+    gradeHigh: 21,
+    confidence: 'confirmed',
+    ascensionistCount: 205,
+    modelVersion: 'v1',
+    computedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function historyEntry(angle: number, displayDifficulty: number, sends: number): ClimbStatsHistoryEntry {
+  return {
+    angle,
+    displayDifficulty,
+    difficultyAverage: displayDifficulty,
+    ascensionistCount: sends,
+    qualityAverage: 3,
+    createdAt: '2026-01-01T00:00:00Z',
+  } as ClimbStatsHistoryEntry;
+}
+
+function angleRow(
+  angle: number,
+  universalGrade: number | null,
+  overrides: Partial<BoardseshGradeAtAngle> = {},
+): BoardseshGradeAtAngle {
+  return {
+    angle,
+    localGrade: 20,
+    universalGrade,
+    gradeLow: 19,
+    gradeHigh: 21,
+    confidence: 'confirmed',
+    ascensionistCount: 100,
+    modelVersion: 'v1',
+    computedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderSection() {
+  return render(<BoardseshGradeSection climbUuid="climb-1" boardName="kilter" angle={40} />);
+}
+
+describe('BoardseshGradeSection', () => {
+  beforeEach(() => {
+    hookState.grade = undefined;
+    hookState.angleRows = undefined;
+    hookState.history = undefined;
+  });
+
+  it('leads with the correction: this-board crowd → delta pill → everywhere grade + seal + trust + chart', () => {
+    // Crowd calls it V6 (22) at 40°; cross-board grade is V5 (20) — everywhere it's a grade easier.
+    hookState.grade = grade({ universalGrade: 20 });
+    hookState.history = [historyEntry(40, 22, 205), historyEntry(20, 21, 50)];
+    hookState.angleRows = [angleRow(40, 20), angleRow(20, 19)];
+
+    const { container } = renderSection();
+    const text = container.textContent ?? '';
+
+    expect(text).toContain('boardseshGrade.hero.thisBoard');
+    expect(text).toContain('boardseshGrade.hero.everywhere');
+    expect(text).toContain('boardseshGrade.hero.easier'); // delta pill
+    expect(text).toContain('boardseshGrade.payoff.softer');
+    expect(text).toContain('boardseshGrade.trust.confirmed');
+    expect(container.querySelector('[data-icon="checkmark.seal.fill"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="dumbbell"]')).not.toBeNull();
+  });
+
+  it('renders provisional in the amber, no-seal path with the likely range', () => {
+    hookState.grade = grade({ confidence: 'provisional', universalGrade: 20, gradeLow: 20, gradeHigh: 22 });
+    hookState.history = [historyEntry(40, 22, 8)];
+    hookState.angleRows = [angleRow(40, 20, { confidence: 'provisional' })];
+
+    const { container } = renderSection();
+    const text = container.textContent ?? '';
+
+    expect(text).toContain('boardseshGrade.trust.provisional');
+    expect(text).toContain('V5–V6'); // the two-grade range shown as the everywhere grade
+    expect(container.querySelector('[data-icon="checkmark.seal.fill"]')).toBeNull();
+    expect(text).not.toContain('boardseshGrade.trust.confirmed');
+  });
+
+  it('shows a muted setter call with no comparison or chart for setter_only', () => {
+    hookState.grade = grade({ confidence: 'setter_only', ascensionistCount: 2 });
+    hookState.history = [historyEntry(40, 22, 2)];
+    hookState.angleRows = [angleRow(40, 20), angleRow(20, 19)];
+
+    const { container } = renderSection();
+    const text = container.textContent ?? '';
+
+    expect(text).toContain('boardseshGrade.setterCall');
+    expect(text).toContain('boardseshGrade.trust.setter');
+    expect(text).not.toContain('boardseshGrade.hero.thisBoard');
+    expect(container.querySelector('[data-testid="dumbbell"]')).toBeNull();
+  });
+
+  it('shows a single centred grade + note for a local-only (no cross-board) grade', () => {
+    hookState.grade = grade({ universalGrade: null, localGrade: 20 });
+    hookState.history = [historyEntry(40, 22, 205)];
+    hookState.angleRows = [angleRow(40, null), angleRow(20, null)];
+
+    const { container } = renderSection();
+    const text = container.textContent ?? '';
+
+    expect(text).toContain('boardseshGrade.hero.thisBoardOnly');
+    expect(text).toContain('boardseshGrade.localOnlyNote');
+    // No correction: no delta pill, no payoff sentence.
+    expect(text).not.toContain('boardseshGrade.hero.easier');
+    expect(text).not.toContain('boardseshGrade.payoff');
+  });
+
+  it('drops the comparison and says it matches when the crowd rounds to the same grade', () => {
+    hookState.grade = grade({ universalGrade: 20 });
+    hookState.history = [historyEntry(40, 20, 205)]; // crowd V5 == cross-board V5
+    hookState.angleRows = [angleRow(40, 20)];
+
+    const { container } = renderSection();
+    const text = container.textContent ?? '';
+
+    expect(text).toContain('boardseshGrade.matchesBoard');
+    expect(text).toContain('boardseshGrade.payoff.same');
+    expect(text).not.toContain('boardseshGrade.hero.easier');
+    expect(text).not.toContain('boardseshGrade.hero.stiffer');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-utils.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-utils.test.ts
@@ -1,9 +1,30 @@
 import { describe, it, expect } from 'vitest';
-import type { BoardseshGrade } from '@boardsesh/graphql/operations';
-import { buildBoardseshGradeView, renderDifficulty, isMoonBoard } from '../boardsesh-grade-utils';
+import type { BoardseshGrade, BoardseshGradeAtAngle } from '@boardsesh/graphql/operations';
+import {
+  buildBoardseshGradeView,
+  buildBoardseshGradeSummary,
+  buildBoardseshAngleGradeBars,
+  renderDifficulty,
+  isMoonBoard,
+} from '../boardsesh-grade-utils';
 
 function makeGrade(overrides: Partial<BoardseshGrade> = {}): BoardseshGrade {
   return {
+    localGrade: 20,
+    universalGrade: 20,
+    gradeLow: 20,
+    gradeHigh: 20,
+    confidence: 'confirmed',
+    ascensionistCount: 42,
+    modelVersion: 'v1',
+    computedAt: '2026-01-01',
+    ...overrides,
+  };
+}
+
+function makeAngleRow(overrides: Partial<BoardseshGradeAtAngle> = {}): BoardseshGradeAtAngle {
+  return {
+    angle: 40,
     localGrade: 20,
     universalGrade: 20,
     gradeLow: 20,
@@ -102,5 +123,127 @@ describe('buildBoardseshGradeView', () => {
       'v-grade',
     );
     expect(view.kind).toBe('provisional');
+  });
+
+  it('passes computedAt through unchanged for confirmed and provisional tiers', () => {
+    const confirmed = buildBoardseshGradeView('kilter', makeGrade({ computedAt: '2026-03-15T00:00:00Z' }), 'v-grade');
+    expect(confirmed).toMatchObject({ kind: 'confirmed', computedAt: '2026-03-15T00:00:00Z' });
+
+    const provisional = buildBoardseshGradeView(
+      'kilter',
+      makeGrade({ confidence: 'provisional', computedAt: '2026-03-16T00:00:00Z' }),
+      'v-grade',
+    );
+    expect(provisional).toMatchObject({ kind: 'provisional', computedAt: '2026-03-16T00:00:00Z' });
+  });
+
+  describe('localSecondary', () => {
+    it('shows the board-local grade when it rounds to a different label than the universal headline', () => {
+      // universalGrade 22 = V6; localGrade 20 = V5 — the board scales harder/easier locally.
+      const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 22, localGrade: 20 }), 'v-grade');
+      expect(view).toMatchObject({ kind: 'confirmed', scope: 'universal' });
+      if (view.kind === 'confirmed') {
+        expect(view.localSecondary?.label).toBe('V5');
+      }
+    });
+
+    it('omits localSecondary when the local grade rounds to the same label as the universal headline', () => {
+      const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 20, localGrade: 20.3 }), 'v-grade');
+      expect(view).toMatchObject({ kind: 'confirmed', localSecondary: null });
+    });
+
+    it('omits localSecondary when the grade is already scoped to this board', () => {
+      const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: null, localGrade: 20 }), 'v-grade');
+      expect(view).toMatchObject({ kind: 'confirmed', scope: 'local', localSecondary: null });
+    });
+
+    it('omits localSecondary when there is no local grade value', () => {
+      const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 22, localGrade: null }), 'v-grade');
+      expect(view).toMatchObject({ kind: 'confirmed', localSecondary: null });
+    });
+  });
+});
+
+describe('buildBoardseshGradeSummary', () => {
+  it('returns the grade label for a confirmed grade', () => {
+    const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 20 }), 'v-grade');
+    expect(buildBoardseshGradeSummary(view)).toBe('V5');
+  });
+
+  it('returns the range label for a provisional grade spanning two grades', () => {
+    const view = buildBoardseshGradeView(
+      'kilter',
+      makeGrade({ confidence: 'provisional', universalGrade: 20, gradeLow: 20, gradeHigh: 22 }),
+      'v-grade',
+    );
+    expect(buildBoardseshGradeSummary(view)).toBe('V5–V6');
+  });
+
+  it('returns the grade label with a trailing ± for a provisional single grade', () => {
+    const view = buildBoardseshGradeView(
+      'kilter',
+      makeGrade({ confidence: 'provisional', universalGrade: 20, gradeLow: 20, gradeHigh: 20.4 }),
+      'v-grade',
+    );
+    expect(buildBoardseshGradeSummary(view)).toBe('V5 ±');
+  });
+
+  it('returns null for moonboard and setter-only tiers', () => {
+    expect(buildBoardseshGradeSummary({ kind: 'moonboard' })).toBeNull();
+    expect(buildBoardseshGradeSummary({ kind: 'setterOnly' })).toBeNull();
+  });
+});
+
+describe('buildBoardseshAngleGradeBars', () => {
+  it('skips rows with setter_only confidence', () => {
+    const bars = buildBoardseshAngleGradeBars(
+      [makeAngleRow({ angle: 40, confidence: 'setter_only' }), makeAngleRow({ angle: 25, confidence: 'confirmed' })],
+      'v-grade',
+    );
+    expect(bars).toHaveLength(1);
+    expect(bars[0].angle).toBe(25);
+  });
+
+  it('skips rows with no usable grade value', () => {
+    const bars = buildBoardseshAngleGradeBars(
+      [makeAngleRow({ angle: 40, universalGrade: null, localGrade: null })],
+      'v-grade',
+    );
+    expect(bars).toHaveLength(0);
+  });
+
+  it('prefers the universal grade over the local grade', () => {
+    const bars = buildBoardseshAngleGradeBars(
+      [makeAngleRow({ angle: 40, universalGrade: 22, localGrade: 20 })],
+      'v-grade',
+    );
+    expect(bars[0].difficulty).toBe(22);
+    expect(bars[0].gradeName).toBe('V6');
+  });
+
+  it('falls back to the local grade when there is no universal grade', () => {
+    const bars = buildBoardseshAngleGradeBars(
+      [makeAngleRow({ angle: 40, universalGrade: null, localGrade: 20 })],
+      'v-grade',
+    );
+    expect(bars[0].difficulty).toBe(20);
+    expect(bars[0].gradeName).toBe('V5');
+  });
+
+  it('maps ascensionistCount to sends', () => {
+    const bars = buildBoardseshAngleGradeBars([makeAngleRow({ angle: 40, ascensionistCount: 17 })], 'v-grade');
+    expect(bars[0].sends).toBe(17);
+  });
+
+  it('sorts bars by angle ascending', () => {
+    const bars = buildBoardseshAngleGradeBars(
+      [makeAngleRow({ angle: 55 }), makeAngleRow({ angle: 10 }), makeAngleRow({ angle: 40 })],
+      'v-grade',
+    );
+    expect(bars.map((bar) => bar.angle)).toEqual([10, 40, 55]);
+  });
+
+  it('returns an empty array for no rows', () => {
+    expect(buildBoardseshAngleGradeBars([], 'v-grade')).toEqual([]);
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-utils.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-utils.test.ts
@@ -4,6 +4,7 @@ import {
   buildBoardseshGradeView,
   buildBoardseshGradeSummary,
   buildCorrection,
+  buildTrustBand,
   formatHalfGrades,
   renderDifficulty,
   isMoonBoard,
@@ -203,6 +204,33 @@ describe('buildCorrection', () => {
     expect(buildCorrection(14, 13, 'v-grade')?.direction).toBe('equal');
     const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 13 }), 'v-grade');
     expect(buildBoardseshGradeSummary(view, { crowdLabel: 'V1' })).toBe('V1 ✓');
+  });
+});
+
+describe('buildTrustBand', () => {
+  it('reports a real range when the bounds render different labels', () => {
+    // 18 = 6b/V4, 22 = 7a/V6.
+    expect(buildTrustBand(18, 22, 'V5', 'v-grade')).toEqual({ low: 'V4', high: 'V6', sameLabel: false });
+  });
+
+  it('collapses to a single grade when two different ids render the SAME label', () => {
+    // 10 (4a) and 12 (4c) are different ids that both render "V0" — a "V0–V0"
+    // range reads as a bug (this is the "V4+–V4+" the review flagged), so
+    // sameLabel is true and the caller shows one grade.
+    expect(buildTrustBand(10, 12, 'V0', 'v-grade')).toEqual({ low: 'V0', high: 'V0', sameLabel: true });
+  });
+
+  it('collapses to a single grade when both bounds are the same id', () => {
+    expect(buildTrustBand(20, 20, 'V5', 'v-grade')).toEqual({ low: 'V5', high: 'V5', sameLabel: true });
+  });
+
+  it('keeps a half-grade range when the labels differ by a "+" step', () => {
+    // 20 = 6c/V5 renders "V5"; 21 = 6c+/V5 renders "V5+" — a real range.
+    expect(buildTrustBand(20, 21, 'V5', 'v-grade')).toEqual({ low: 'V5', high: 'V5+', sameLabel: false });
+  });
+
+  it('falls back to the headline label when a bound is missing', () => {
+    expect(buildTrustBand(null, null, 'V7', 'v-grade')).toEqual({ low: 'V7', high: 'V7', sameLabel: true });
   });
 });
 

--- a/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-utils.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-utils.test.ts
@@ -160,14 +160,49 @@ describe('buildCorrection', () => {
     expect(correction).toMatchObject({ direction: 'stiffer', steps: 1, label: '1' });
   });
 
-  it('rounds a one-id gap to half a grade', () => {
-    const correction = buildCorrection(21, 20, 'v-grade');
+  it('rounds a one-id gap that crosses a grade boundary to half a grade', () => {
+    // Crowd 22 (V6) vs cross-board 21 (V5): one Font step apart, and — crucially —
+    // the rendered labels differ, so it surfaces as a ½-grade correction.
+    const correction = buildCorrection(22, 21, 'v-grade');
     expect(correction).toMatchObject({ direction: 'easier', steps: 0.5, label: '½' });
+    expect(correction?.crowd.label).toBe('V6');
+  });
+
+  it('reads a genuine one-V difference as a full-grade correction', () => {
+    // Crowd 18 (V4) vs cross-board 16 (V3): two id steps, labels differ.
+    const correction = buildCorrection(18, 16, 'v-grade');
+    expect(correction).toMatchObject({ direction: 'easier', steps: 1, label: '1' });
+    expect(correction?.crowd.label).toBe('V4');
   });
 
   it('reports equal when both round to the same grade bucket', () => {
     const correction = buildCorrection(20.3, 20, 'v-grade');
     expect(correction).toMatchObject({ direction: 'equal', steps: 0, label: null });
+  });
+
+  it('agrees (no pill, no payoff) when two different ids render the same V-grade label', () => {
+    // V1 covers ids 13 (5a) and 14 (5b) — neither Font grade takes a "+", so both
+    // render exactly "V1". The crowd rounds V1 from id 14, the Boardsesh grade V1
+    // from id 13; the hero shows "V1" on both sides, so the one-id gap must NOT
+    // surface as a correction — the displayed label, not the id delta, decides.
+    const correction = buildCorrection(14, 13, 'v-grade');
+    expect(correction).toMatchObject({ direction: 'equal', steps: 0, label: null });
+    expect(correction?.crowd.label).toBe('V1');
+  });
+
+  it('surfaces the same ids as a correction under font format, where the labels differ', () => {
+    // Same ids, but font format renders 5B vs 5A — different labels — so at font
+    // resolution it IS a ½-grade correction. Agreement follows what the viewer sees.
+    const correction = buildCorrection(14, 13, 'font');
+    expect(correction).toMatchObject({ direction: 'easier', steps: 0.5, label: '½' });
+  });
+
+  it('gates agreement the same way the collapsed teaser does', () => {
+    // crowd id 14 and Boardsesh id 13 both render V1: the correction reads equal
+    // AND the teaser drops its "▸" arrow, so hero and teaser stay in lockstep.
+    expect(buildCorrection(14, 13, 'v-grade')?.direction).toBe('equal');
+    const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 13 }), 'v-grade');
+    expect(buildBoardseshGradeSummary(view, { crowdLabel: 'V1' })).toBe('V1 ✓');
   });
 });
 

--- a/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-utils.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/boardsesh-grade-utils.test.ts
@@ -1,30 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import type { BoardseshGrade, BoardseshGradeAtAngle } from '@boardsesh/graphql/operations';
+import type { BoardseshGrade } from '@boardsesh/graphql/operations';
 import {
   buildBoardseshGradeView,
   buildBoardseshGradeSummary,
-  buildBoardseshAngleGradeBars,
+  buildCorrection,
+  formatHalfGrades,
   renderDifficulty,
   isMoonBoard,
 } from '../boardsesh-grade-utils';
 
 function makeGrade(overrides: Partial<BoardseshGrade> = {}): BoardseshGrade {
   return {
-    localGrade: 20,
-    universalGrade: 20,
-    gradeLow: 20,
-    gradeHigh: 20,
-    confidence: 'confirmed',
-    ascensionistCount: 42,
-    modelVersion: 'v1',
-    computedAt: '2026-01-01',
-    ...overrides,
-  };
-}
-
-function makeAngleRow(overrides: Partial<BoardseshGradeAtAngle> = {}): BoardseshGradeAtAngle {
-  return {
-    angle: 40,
     localGrade: 20,
     universalGrade: 20,
     gradeLow: 20,
@@ -68,33 +54,41 @@ describe('buildBoardseshGradeView', () => {
     expect(buildBoardseshGradeView('moonboard', makeGrade(), 'v-grade')).toEqual({ kind: 'moonboard' });
   });
 
-  it('falls back to setter-only when there is no grade row', () => {
-    expect(buildBoardseshGradeView('kilter', null, 'v-grade')).toEqual({ kind: 'setterOnly' });
+  it('falls back to setter-only (no grade) when there is no grade row', () => {
+    expect(buildBoardseshGradeView('kilter', null, 'v-grade')).toEqual({ kind: 'setterOnly', grade: null, count: 0 });
   });
 
-  it('returns setter-only for setter_only confidence', () => {
-    const view = buildBoardseshGradeView('kilter', makeGrade({ confidence: 'setter_only' }), 'v-grade');
+  it('carries the setter grade + count for setter_only confidence', () => {
+    const view = buildBoardseshGradeView(
+      'kilter',
+      makeGrade({ confidence: 'setter_only', ascensionistCount: 2 }),
+      'v-grade',
+    );
     expect(view.kind).toBe('setterOnly');
+    if (view.kind === 'setterOnly') {
+      expect(view.grade?.label).toBe('V5');
+      expect(view.count).toBe(2);
+    }
   });
 
-  it('returns setter-only when both grade values are null', () => {
+  it('returns setter-only with a null grade when both grade values are null', () => {
     const view = buildBoardseshGradeView(
       'kilter',
       makeGrade({ confidence: 'confirmed', universalGrade: null, localGrade: null }),
       'v-grade',
     );
-    expect(view.kind).toBe('setterOnly');
+    expect(view).toMatchObject({ kind: 'setterOnly', grade: null });
   });
 
-  it('shows a confirmed universal (cross-board) grade with the send count', () => {
+  it('shows a confirmed cross-board grade with the send count and raw value', () => {
     const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 22, ascensionistCount: 7 }), 'v-grade');
-    expect(view).toMatchObject({ kind: 'confirmed', scope: 'universal', count: 7 });
+    expect(view).toMatchObject({ kind: 'confirmed', universal: true, count: 7, gradeValue: 22 });
     if (view.kind === 'confirmed') expect(view.grade.label).toBe('V6'); // 22 = 7a/V6
   });
 
-  it('scopes to this board only when there is no universal grade', () => {
+  it('marks the grade local-only when there is no universal grade', () => {
     const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: null, localGrade: 20 }), 'v-grade');
-    expect(view).toMatchObject({ kind: 'confirmed', scope: 'local' });
+    expect(view).toMatchObject({ kind: 'confirmed', universal: false, gradeValue: 20 });
   });
 
   it('shows a provisional range when the bounds round to different grades', () => {
@@ -103,7 +97,7 @@ describe('buildBoardseshGradeView', () => {
       makeGrade({ confidence: 'provisional', universalGrade: 20, gradeLow: 20, gradeHigh: 22 }),
       'v-grade',
     );
-    expect(view).toMatchObject({ kind: 'provisional', scope: 'universal', rangeLabel: 'V5–V6' });
+    expect(view).toMatchObject({ kind: 'provisional', universal: true, rangeLabel: 'V5–V6' });
   });
 
   it('shows a provisional single grade (no range) when the bounds round together', () => {
@@ -136,114 +130,93 @@ describe('buildBoardseshGradeView', () => {
     );
     expect(provisional).toMatchObject({ kind: 'provisional', computedAt: '2026-03-16T00:00:00Z' });
   });
+});
 
-  describe('localSecondary', () => {
-    it('shows the board-local grade when it rounds to a different label than the universal headline', () => {
-      // universalGrade 22 = V6; localGrade 20 = V5 — the board scales harder/easier locally.
-      const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 22, localGrade: 20 }), 'v-grade');
-      expect(view).toMatchObject({ kind: 'confirmed', scope: 'universal' });
-      if (view.kind === 'confirmed') {
-        expect(view.localSecondary?.label).toBe('V5');
-      }
-    });
+describe('formatHalfGrades', () => {
+  it('renders ½-step magnitudes compactly', () => {
+    expect(formatHalfGrades(0)).toBeNull();
+    expect(formatHalfGrades(0.5)).toBe('½');
+    expect(formatHalfGrades(1)).toBe('1');
+    expect(formatHalfGrades(1.5)).toBe('1½');
+    expect(formatHalfGrades(2)).toBe('2');
+  });
+});
 
-    it('omits localSecondary when the local grade rounds to the same label as the universal headline', () => {
-      const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 20, localGrade: 20.3 }), 'v-grade');
-      expect(view).toMatchObject({ kind: 'confirmed', localSecondary: null });
-    });
+describe('buildCorrection', () => {
+  it('returns null when there is no crowd grade at this angle', () => {
+    expect(buildCorrection(null, 20, 'v-grade')).toBeNull();
+  });
 
-    it('omits localSecondary when the grade is already scoped to this board', () => {
-      const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: null, localGrade: 20 }), 'v-grade');
-      expect(view).toMatchObject({ kind: 'confirmed', scope: 'local', localSecondary: null });
-    });
+  it('reads a stiffer crowd as "everywhere is easier"', () => {
+    // Crowd 22 (V6) vs cross-board 20 (V5): the crowd over-grades by one V-grade
+    // (two id steps), so everywhere it climbs a full grade easier.
+    const correction = buildCorrection(22, 20, 'v-grade');
+    expect(correction).toMatchObject({ direction: 'easier', steps: 1, label: '1' });
+    expect(correction?.crowd.label).toBe('V6');
+  });
 
-    it('omits localSecondary when there is no local grade value', () => {
-      const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 22, localGrade: null }), 'v-grade');
-      expect(view).toMatchObject({ kind: 'confirmed', localSecondary: null });
-    });
+  it('reads a softer crowd as "everywhere is stiffer"', () => {
+    const correction = buildCorrection(20, 22, 'v-grade');
+    expect(correction).toMatchObject({ direction: 'stiffer', steps: 1, label: '1' });
+  });
+
+  it('rounds a one-id gap to half a grade', () => {
+    const correction = buildCorrection(21, 20, 'v-grade');
+    expect(correction).toMatchObject({ direction: 'easier', steps: 0.5, label: '½' });
+  });
+
+  it('reports equal when both round to the same grade bucket', () => {
+    const correction = buildCorrection(20.3, 20, 'v-grade');
+    expect(correction).toMatchObject({ direction: 'equal', steps: 0, label: null });
   });
 });
 
 describe('buildBoardseshGradeSummary', () => {
-  it('returns the grade label for a confirmed grade', () => {
+  it('leads with the correction when a differing crowd label is supplied', () => {
     const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 20 }), 'v-grade');
+    expect(buildBoardseshGradeSummary(view, { crowdLabel: 'V6' })).toBe('V6 ▸ V5 ✓');
+  });
+
+  it('shows just the confirmed grade with a check when there is no crowd label', () => {
+    const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 20 }), 'v-grade');
+    expect(buildBoardseshGradeSummary(view)).toBe('V5 ✓');
+  });
+
+  it('drops the arrow when the crowd label matches the cross-board grade', () => {
+    const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: 20 }), 'v-grade');
+    expect(buildBoardseshGradeSummary(view, { crowdLabel: 'V5' })).toBe('V5 ✓');
+  });
+
+  it('marks a local-only grade with the local word', () => {
+    const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: null, localGrade: 20 }), 'v-grade');
+    expect(buildBoardseshGradeSummary(view, { localWord: 'local' })).toBe('V5 · local');
+  });
+
+  it('shows the bare local grade when no local word is supplied', () => {
+    const view = buildBoardseshGradeView('kilter', makeGrade({ universalGrade: null, localGrade: 20 }), 'v-grade');
     expect(buildBoardseshGradeSummary(view)).toBe('V5');
   });
 
-  it('returns the range label for a provisional grade spanning two grades', () => {
-    const view = buildBoardseshGradeView(
-      'kilter',
-      makeGrade({ confidence: 'provisional', universalGrade: 20, gradeLow: 20, gradeHigh: 22 }),
-      'v-grade',
-    );
-    expect(buildBoardseshGradeSummary(view)).toBe('V5–V6');
-  });
-
-  it('returns the grade label with a trailing ± for a provisional single grade', () => {
+  it('marks a provisional grade with a tilde', () => {
     const view = buildBoardseshGradeView(
       'kilter',
       makeGrade({ confidence: 'provisional', universalGrade: 20, gradeLow: 20, gradeHigh: 20.4 }),
       'v-grade',
     );
-    expect(buildBoardseshGradeSummary(view)).toBe('V5 ±');
+    expect(buildBoardseshGradeSummary(view)).toBe('V5 ~');
+  });
+
+  it('uses the range for a provisional grade spanning two grades', () => {
+    const view = buildBoardseshGradeView(
+      'kilter',
+      makeGrade({ confidence: 'provisional', universalGrade: 20, gradeLow: 20, gradeHigh: 22 }),
+      'v-grade',
+    );
+    expect(buildBoardseshGradeSummary(view)).toBe('V5–V6 ~');
   });
 
   it('returns null for moonboard and setter-only tiers', () => {
     expect(buildBoardseshGradeSummary({ kind: 'moonboard' })).toBeNull();
-    expect(buildBoardseshGradeSummary({ kind: 'setterOnly' })).toBeNull();
-  });
-});
-
-describe('buildBoardseshAngleGradeBars', () => {
-  it('skips rows with setter_only confidence', () => {
-    const bars = buildBoardseshAngleGradeBars(
-      [makeAngleRow({ angle: 40, confidence: 'setter_only' }), makeAngleRow({ angle: 25, confidence: 'confirmed' })],
-      'v-grade',
-    );
-    expect(bars).toHaveLength(1);
-    expect(bars[0].angle).toBe(25);
-  });
-
-  it('skips rows with no usable grade value', () => {
-    const bars = buildBoardseshAngleGradeBars(
-      [makeAngleRow({ angle: 40, universalGrade: null, localGrade: null })],
-      'v-grade',
-    );
-    expect(bars).toHaveLength(0);
-  });
-
-  it('prefers the universal grade over the local grade', () => {
-    const bars = buildBoardseshAngleGradeBars(
-      [makeAngleRow({ angle: 40, universalGrade: 22, localGrade: 20 })],
-      'v-grade',
-    );
-    expect(bars[0].difficulty).toBe(22);
-    expect(bars[0].gradeName).toBe('V6');
-  });
-
-  it('falls back to the local grade when there is no universal grade', () => {
-    const bars = buildBoardseshAngleGradeBars(
-      [makeAngleRow({ angle: 40, universalGrade: null, localGrade: 20 })],
-      'v-grade',
-    );
-    expect(bars[0].difficulty).toBe(20);
-    expect(bars[0].gradeName).toBe('V5');
-  });
-
-  it('maps ascensionistCount to sends', () => {
-    const bars = buildBoardseshAngleGradeBars([makeAngleRow({ angle: 40, ascensionistCount: 17 })], 'v-grade');
-    expect(bars[0].sends).toBe(17);
-  });
-
-  it('sorts bars by angle ascending', () => {
-    const bars = buildBoardseshAngleGradeBars(
-      [makeAngleRow({ angle: 55 }), makeAngleRow({ angle: 10 }), makeAngleRow({ angle: 40 })],
-      'v-grade',
-    );
-    expect(bars.map((bar) => bar.angle)).toEqual([10, 40, 55]);
-  });
-
-  it('returns an empty array for no rows', () => {
-    expect(buildBoardseshAngleGradeBars([], 'v-grade')).toEqual([]);
+    expect(buildBoardseshGradeSummary({ kind: 'setterOnly', grade: null, count: 0 })).toBeNull();
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/by-angle-comparison.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/by-angle-comparison.test.ts
@@ -7,6 +7,7 @@ import {
   sizeBinForSends,
   hasAnyBoardseshDiamond,
 } from '../by-angle-comparison';
+import { MAX_DIFFICULTY_ID } from '../../../lib/boardsesh-grade-display';
 
 // 20 = 6c/V5, 22 = 7a/V6 on the shared difficulty scale.
 function bsRow(overrides: Partial<BoardseshGradeAtAngle> = {}): BoardseshGradeAtAngle {
@@ -206,5 +207,25 @@ describe('buildDumbbellAxis', () => {
     const axis = buildDumbbellAxis([], 'v-grade');
     expect(axis.noOfSections).toBeGreaterThanOrEqual(1);
     expect(axis.yAxisLabelTexts).toHaveLength(axis.noOfSections + 1);
+  });
+
+  it('keeps the top tick truthful when the step extension would overflow the scale', () => {
+    // Boardsesh grades V6 (id 22) and V16 (id 33, the top of the scale). Padding
+    // gives the window [20, 33], span 13 → step 2, ceil(13/2)=7 sections,
+    // maxValue 14. Growing the top upward would land on id 34, whose label clamps
+    // to a false "V16"; instead the window grows downward so the top tick is a
+    // real V16 and the marker-geometry invariant (maxId − minId === maxValue) holds.
+    const rows = buildDumbbellByAngleModel(
+      [
+        bsRow({ angle: 20, universalGrade: 22, gradeLow: 22, gradeHigh: 22 }),
+        bsRow({ angle: 45, universalGrade: 33, gradeLow: 33, gradeHigh: 33 }),
+      ],
+      [],
+      'v-grade',
+    );
+    const axis = buildDumbbellAxis(rows, 'v-grade');
+    expect(axis.maxId).toBeLessThanOrEqual(MAX_DIFFICULTY_ID); // never past the hardest real grade
+    expect(axis.maxId).toBe(axis.minId + axis.maxValue); // marker geometry stays consistent
+    expect(axis.yAxisLabelTexts[axis.yAxisLabelTexts.length - 1]).toBe('V16'); // truthful top tick
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/by-angle-comparison.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/by-angle-comparison.test.ts
@@ -175,7 +175,10 @@ describe('buildDumbbellAxis', () => {
     expect(axis.minId).toBeLessThanOrEqual(18);
     expect(axis.maxId).toBeGreaterThanOrEqual(24);
     expect(axis.yAxisLabelTexts).toHaveLength(axis.noOfSections + 1);
-    expect(axis.yAxisLabelTexts.every((label) => label.length > 0)).toBe(true);
+    // A V-grade spanning several ids is labelled once; the shown labels never repeat.
+    const shown = axis.yAxisLabelTexts.filter((label) => label.length > 0);
+    expect(shown.length).toBeGreaterThan(0);
+    expect(new Set(shown).size).toBe(shown.length);
     expect(axis.maxValue).toBe(axis.maxId - axis.minId);
   });
 
@@ -191,16 +194,47 @@ describe('buildDumbbellAxis', () => {
     expect(axis.maxId).toBeGreaterThanOrEqual(24);
   });
 
-  it('steps by two ids and labels fewer gridlines on a wide span', () => {
+  it('labels every whole V-grade once across the range — no duplicates, no skipped grades', () => {
+    // Crowd + Boardsesh at V0 (12) and V6 (22); after ±2 padding the window
+    // covers V0…V8. The old id-stepped axis rendered "V0, V0, V1, V3, V4, V5,
+    // V6, V8" — V0 duplicated, V2 and V7 skipped. The fixed axis shows each
+    // whole grade exactly once, in order.
     const rows = buildDumbbellByAngleModel(
-      [bsRow({ angle: 20, universalGrade: 12 }), bsRow({ angle: 45, universalGrade: 26 })],
+      [
+        bsRow({ angle: 20, universalGrade: 12, gradeLow: 12, gradeHigh: 12 }),
+        bsRow({ angle: 45, universalGrade: 22, gradeLow: 22, gradeHigh: 22 }),
+      ],
+      [
+        crowdBar({ angle: 20, difficulty: 12, gradeName: 'V0' }),
+        crowdBar({ angle: 45, difficulty: 22, gradeName: 'V6' }),
+      ],
+      'v-grade',
+    );
+    const axis = buildDumbbellAxis(rows, 'v-grade');
+    const shown = axis.yAxisLabelTexts.filter((label) => label.length > 0);
+    expect(new Set(shown).size).toBe(shown.length); // no repeats
+    expect(shown).toEqual(['V0', 'V1', 'V2', 'V3', 'V4', 'V5', 'V6', 'V7', 'V8']); // even, no gaps
+    // Marker geometry invariant: a grade float plots at `grade - minId` in the span.
+    expect(axis.maxValue).toBe(axis.maxId - axis.minId);
+    expect(axis.yAxisLabelTexts).toHaveLength(axis.noOfSections + 1);
+  });
+
+  it('thins labels to every other grade on a very wide span but never repeats one', () => {
+    // A window spanning ~V0…V16 has too many grades to label each; the axis
+    // keeps every other, plus the top grade, and still shows no duplicates.
+    const rows = buildDumbbellByAngleModel(
+      [
+        bsRow({ angle: 20, universalGrade: 12, gradeLow: 12, gradeHigh: 12 }),
+        bsRow({ angle: 45, universalGrade: 33, gradeLow: 33, gradeHigh: 33 }),
+      ],
       [],
       'v-grade',
     );
     const axis = buildDumbbellAxis(rows, 'v-grade');
-    expect(axis.step).toBe(2);
-    expect(axis.maxValue).toBe(axis.step * axis.noOfSections);
-    expect(axis.maxId).toBe(axis.minId + axis.maxValue);
+    const shown = axis.yAxisLabelTexts.filter((label) => label.length > 0);
+    expect(new Set(shown).size).toBe(shown.length);
+    expect(shown.length).toBeLessThan(axis.noOfSections); // thinned, not one per gridline
+    expect(shown[shown.length - 1]).toBe('V16'); // top grade kept
   });
 
   it('returns a safe default window for an empty model', () => {

--- a/packages/mobile/src/components/play-drawer/__tests__/by-angle-comparison.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/by-angle-comparison.test.ts
@@ -194,11 +194,11 @@ describe('buildDumbbellAxis', () => {
     expect(axis.maxId).toBeGreaterThanOrEqual(24);
   });
 
-  it('labels every whole V-grade once across the range — no duplicates, no skipped grades', () => {
+  it('labels every gridline with a distinct, increasing grade — no blanks, no "0" ticks', () => {
     // Crowd + Boardsesh at V0 (12) and V6 (22); after ±2 padding the window
-    // covers V0…V8. The old id-stepped axis rendered "V0, V0, V1, V3, V4, V5,
-    // V6, V8" — V0 duplicated, V2 and V7 skipped. The fixed axis shows each
-    // whole grade exactly once, in order.
+    // covers ~V0…V7. gifted renders a blank y tick as "0", so EVERY tick must
+    // carry a real grade label — the old "blank the in-between ids" scheme
+    // leaked stray 0s. Ticks read as distinct, increasing grades bottom→top.
     const rows = buildDumbbellByAngleModel(
       [
         bsRow({ angle: 20, universalGrade: 12, gradeLow: 12, gradeHigh: 12 }),
@@ -211,17 +211,21 @@ describe('buildDumbbellAxis', () => {
       'v-grade',
     );
     const axis = buildDumbbellAxis(rows, 'v-grade');
-    const shown = axis.yAxisLabelTexts.filter((label) => label.length > 0);
-    expect(new Set(shown).size).toBe(shown.length); // no repeats
-    expect(shown).toEqual(['V0', 'V1', 'V2', 'V3', 'V4', 'V5', 'V6', 'V7', 'V8']); // even, no gaps
+    const labels = axis.yAxisLabelTexts;
+    expect(labels).toHaveLength(axis.noOfSections + 1);
+    // No blank ticks anywhere (a blank would render as "0"), and no repeats.
+    expect(labels.every((label) => label.length > 0)).toBe(true);
+    expect(new Set(labels).size).toBe(labels.length);
+    // Strictly increasing V-numbers bottom→top.
+    const vNumbers = labels.map((label) => Number.parseInt(label.replace(/[^0-9]/g, ''), 10));
+    for (let i = 1; i < vNumbers.length; i++) expect(vNumbers[i]).toBeGreaterThan(vNumbers[i - 1]);
     // Marker geometry invariant: a grade float plots at `grade - minId` in the span.
     expect(axis.maxValue).toBe(axis.maxId - axis.minId);
-    expect(axis.yAxisLabelTexts).toHaveLength(axis.noOfSections + 1);
   });
 
-  it('thins labels to every other grade on a very wide span but never repeats one', () => {
+  it('caps the tick count on a very wide span — still every tick labelled, no repeats', () => {
     // A window spanning ~V0…V16 has too many grades to label each; the axis
-    // keeps every other, plus the top grade, and still shows no duplicates.
+    // caps the gridlines, labels every one, keeps the true top grade, no dupes.
     const rows = buildDumbbellByAngleModel(
       [
         bsRow({ angle: 20, universalGrade: 12, gradeLow: 12, gradeHigh: 12 }),
@@ -231,10 +235,12 @@ describe('buildDumbbellAxis', () => {
       'v-grade',
     );
     const axis = buildDumbbellAxis(rows, 'v-grade');
-    const shown = axis.yAxisLabelTexts.filter((label) => label.length > 0);
-    expect(new Set(shown).size).toBe(shown.length);
-    expect(shown.length).toBeLessThan(axis.noOfSections); // thinned, not one per gridline
-    expect(shown[shown.length - 1]).toBe('V16'); // top grade kept
+    const labels = axis.yAxisLabelTexts;
+    expect(axis.noOfSections).toBeLessThanOrEqual(6); // capped
+    expect(labels).toHaveLength(axis.noOfSections + 1);
+    expect(labels.every((label) => label.length > 0)).toBe(true); // no blanks
+    expect(new Set(labels).size).toBe(labels.length); // no repeats
+    expect(labels[labels.length - 1]).toBe('V16'); // truthful top grade
   });
 
   it('returns a safe default window for an empty model', () => {
@@ -243,12 +249,11 @@ describe('buildDumbbellAxis', () => {
     expect(axis.yAxisLabelTexts).toHaveLength(axis.noOfSections + 1);
   });
 
-  it('keeps the top tick truthful when the step extension would overflow the scale', () => {
+  it('keeps the top tick truthful at the top of the scale', () => {
     // Boardsesh grades V6 (id 22) and V16 (id 33, the top of the scale). Padding
-    // gives the window [20, 33], span 13 → step 2, ceil(13/2)=7 sections,
-    // maxValue 14. Growing the top upward would land on id 34, whose label clamps
-    // to a false "V16"; instead the window grows downward so the top tick is a
-    // real V16 and the marker-geometry invariant (maxId − minId === maxValue) holds.
+    // clamps the window to [20, 33]; the top id can't grow past 33, so the top
+    // tick is a real V16 (never a clamped-from-34 false label) and the
+    // marker-geometry invariant (maxId − minId === maxValue) holds.
     const rows = buildDumbbellByAngleModel(
       [
         bsRow({ angle: 20, universalGrade: 22, gradeLow: 22, gradeHigh: 22 }),

--- a/packages/mobile/src/components/play-drawer/__tests__/by-angle-comparison.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/by-angle-comparison.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import type { BoardseshGradeAtAngle } from '@boardsesh/graphql/operations';
+import type { AngleGradeBar } from '../community-utils';
+import {
+  buildDumbbellByAngleModel,
+  buildDumbbellAxis,
+  sizeBinForSends,
+  hasAnyBoardseshDiamond,
+} from '../by-angle-comparison';
+
+// 20 = 6c/V5, 22 = 7a/V6 on the shared difficulty scale.
+function bsRow(overrides: Partial<BoardseshGradeAtAngle> = {}): BoardseshGradeAtAngle {
+  return {
+    angle: 40,
+    localGrade: 20,
+    universalGrade: 20,
+    gradeLow: 20,
+    gradeHigh: 20,
+    confidence: 'confirmed',
+    ascensionistCount: 30,
+    modelVersion: 'v1',
+    computedAt: '2026-01-01',
+    ...overrides,
+  };
+}
+
+function crowdBar(overrides: Partial<AngleGradeBar> = {}): AngleGradeBar {
+  return { angle: 40, difficulty: 20, gradeName: 'V5', sends: 30, ...overrides };
+}
+
+describe('sizeBinForSends', () => {
+  it('bins by ascent count: <5 small, 5–20 medium, >20 large', () => {
+    expect(sizeBinForSends(0)).toBe('small');
+    expect(sizeBinForSends(4)).toBe('small');
+    expect(sizeBinForSends(5)).toBe('medium');
+    expect(sizeBinForSends(20)).toBe('medium');
+    expect(sizeBinForSends(21)).toBe('large');
+    expect(sizeBinForSends(2000)).toBe('large');
+  });
+});
+
+describe('buildDumbbellByAngleModel', () => {
+  it('returns an empty model for no data', () => {
+    expect(buildDumbbellByAngleModel([], [], 'v-grade')).toEqual([]);
+  });
+
+  it('joins crowd and Boardsesh at the same angle and sorts by angle', () => {
+    const rows = buildDumbbellByAngleModel(
+      [bsRow({ angle: 45, universalGrade: 22 }), bsRow({ angle: 20, universalGrade: 20 })],
+      [crowdBar({ angle: 45, difficulty: 22, gradeName: 'V6' }), crowdBar({ angle: 20, difficulty: 20 })],
+      'v-grade',
+    );
+    expect(rows.map((row) => row.angle)).toEqual([20, 45]);
+    expect(rows[0]).toMatchObject({
+      angle: 20,
+      crowdLabel: 'V5',
+      boardseshLabel: 'V5',
+      hasCrowd: true,
+      hasBoardsesh: true,
+    });
+    expect(rows[1]).toMatchObject({ angle: 45, crowdLabel: 'V6', boardseshLabel: 'V6' });
+  });
+
+  it('detects agreement when crowd and Boardsesh round to the same grade', () => {
+    const [row] = buildDumbbellByAngleModel(
+      [bsRow({ universalGrade: 20.3 })],
+      [crowdBar({ difficulty: 19.8 })],
+      'v-grade',
+    );
+    // Both round to V5.
+    expect(row.agree).toBe(true);
+  });
+
+  it('does not mark agreement when the grades round apart', () => {
+    const [row] = buildDumbbellByAngleModel(
+      [bsRow({ universalGrade: 20 })],
+      [crowdBar({ difficulty: 22, gradeName: 'V6' })],
+      'v-grade',
+    );
+    expect(row.agree).toBe(false);
+    expect(row.crowdLabel).toBe('V6');
+    expect(row.boardseshLabel).toBe('V5');
+  });
+
+  it('prefers the universal grade over the local grade for the diamond', () => {
+    const [row] = buildDumbbellByAngleModel([bsRow({ universalGrade: 22, localGrade: 20 })], [], 'v-grade');
+    expect(row.boardseshGrade).toBe(22);
+    expect(row.boardseshLabel).toBe('V6');
+  });
+
+  it('falls back to the local grade when there is no universal grade', () => {
+    const [row] = buildDumbbellByAngleModel([bsRow({ universalGrade: null, localGrade: 20 })], [], 'v-grade');
+    expect(row.boardseshGrade).toBe(20);
+    expect(row.boardseshLabel).toBe('V5');
+  });
+
+  it('draws no diamond for a setter_only Boardsesh row but keeps the crowd ring', () => {
+    const [row] = buildDumbbellByAngleModel(
+      [bsRow({ confidence: 'setter_only' })],
+      [crowdBar({ difficulty: 20 })],
+      'v-grade',
+    );
+    expect(row).toMatchObject({ hasCrowd: true, hasBoardsesh: false, tier: 'setter_only' });
+    expect(row.boardseshGrade).toBeNull();
+    expect(row.crowdLabel).toBe('V5');
+  });
+
+  it('drops an angle that has neither a crowd grade nor a Boardsesh diamond', () => {
+    const rows = buildDumbbellByAngleModel([bsRow({ angle: 40, confidence: 'setter_only' })], [], 'v-grade');
+    expect(rows).toEqual([]);
+  });
+
+  it('keeps a lone crowd ring when Boardsesh has no row at that angle', () => {
+    const [row] = buildDumbbellByAngleModel([], [crowdBar({ angle: 30, difficulty: 20, sends: 12 })], 'v-grade');
+    expect(row).toMatchObject({ angle: 30, hasCrowd: true, hasBoardsesh: false, tier: null, agree: false });
+    expect(row.sizeBin).toBe('medium');
+  });
+
+  it('keeps a lone Boardsesh diamond when the crowd has no bar at that angle', () => {
+    const [row] = buildDumbbellByAngleModel([bsRow({ angle: 35, universalGrade: 22 })], [], 'v-grade');
+    expect(row).toMatchObject({ angle: 35, hasCrowd: false, hasBoardsesh: true, crowdGrade: null });
+  });
+
+  it('sizes a joined angle by the larger of crowd and Boardsesh counts', () => {
+    const [row] = buildDumbbellByAngleModel([bsRow({ ascensionistCount: 40 })], [crowdBar({ sends: 3 })], 'v-grade');
+    expect(row.sends).toBe(40);
+    expect(row.sizeBin).toBe('large');
+  });
+
+  it('carries the provisional whisker bounds only when a diamond is drawn', () => {
+    const [withDiamond] = buildDumbbellByAngleModel(
+      [bsRow({ confidence: 'provisional', universalGrade: 20, gradeLow: 18, gradeHigh: 22 })],
+      [],
+      'v-grade',
+    );
+    expect(withDiamond).toMatchObject({ tier: 'provisional', gradeLow: 18, gradeHigh: 22 });
+
+    const [setterOnly] = buildDumbbellByAngleModel(
+      [bsRow({ confidence: 'setter_only', gradeLow: 18, gradeHigh: 22 })],
+      [crowdBar()],
+      'v-grade',
+    );
+    expect(setterOnly.gradeLow).toBeNull();
+    expect(setterOnly.gradeHigh).toBeNull();
+  });
+
+  it('tints the diamond by its own grade colour', () => {
+    const [row] = buildDumbbellByAngleModel([bsRow({ universalGrade: 20 })], [], 'v-grade');
+    expect(row.boardseshColor).toMatch(/^#/);
+  });
+});
+
+describe('hasAnyBoardseshDiamond', () => {
+  it('is false when every row is crowd-only', () => {
+    const rows = buildDumbbellByAngleModel([], [crowdBar({ angle: 30 }), crowdBar({ angle: 40 })], 'v-grade');
+    expect(hasAnyBoardseshDiamond(rows)).toBe(false);
+  });
+
+  it('is true when any row carries a diamond', () => {
+    const rows = buildDumbbellByAngleModel([bsRow({ angle: 40 })], [crowdBar({ angle: 30 })], 'v-grade');
+    expect(hasAnyBoardseshDiamond(rows)).toBe(true);
+  });
+});
+
+describe('buildDumbbellAxis', () => {
+  it('spans the plotted values with grade headroom on each side', () => {
+    const rows = buildDumbbellByAngleModel(
+      [bsRow({ angle: 40, universalGrade: 22 })],
+      [crowdBar({ angle: 40, difficulty: 20 })],
+      'v-grade',
+    );
+    const axis = buildDumbbellAxis(rows, 'v-grade');
+    // Values 20 and 22, padded by two ids each side → window contains 18..24.
+    expect(axis.minId).toBeLessThanOrEqual(18);
+    expect(axis.maxId).toBeGreaterThanOrEqual(24);
+    expect(axis.yAxisLabelTexts).toHaveLength(axis.noOfSections + 1);
+    expect(axis.yAxisLabelTexts.every((label) => label.length > 0)).toBe(true);
+    expect(axis.maxValue).toBe(axis.maxId - axis.minId);
+  });
+
+  it('includes the whisker bounds in the span', () => {
+    const rows = buildDumbbellByAngleModel(
+      [bsRow({ angle: 40, confidence: 'provisional', universalGrade: 20, gradeLow: 16, gradeHigh: 24 })],
+      [],
+      'v-grade',
+    );
+    const axis = buildDumbbellAxis(rows, 'v-grade');
+    // gradeLow 16 and gradeHigh 24 both fall inside the padded window.
+    expect(axis.minId).toBeLessThanOrEqual(16);
+    expect(axis.maxId).toBeGreaterThanOrEqual(24);
+  });
+
+  it('steps by two ids and labels fewer gridlines on a wide span', () => {
+    const rows = buildDumbbellByAngleModel(
+      [bsRow({ angle: 20, universalGrade: 12 }), bsRow({ angle: 45, universalGrade: 26 })],
+      [],
+      'v-grade',
+    );
+    const axis = buildDumbbellAxis(rows, 'v-grade');
+    expect(axis.step).toBe(2);
+    expect(axis.maxValue).toBe(axis.step * axis.noOfSections);
+    expect(axis.maxId).toBe(axis.minId + axis.maxValue);
+  });
+
+  it('returns a safe default window for an empty model', () => {
+    const axis = buildDumbbellAxis([], 'v-grade');
+    expect(axis.noOfSections).toBeGreaterThanOrEqual(1);
+    expect(axis.yAxisLabelTexts).toHaveLength(axis.noOfSections + 1);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/deferred-sections.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/deferred-sections.test.tsx
@@ -11,6 +11,11 @@ const deferred = vi.hoisted(() => ({
 
 const flags = vi.hoisted(() => ({ boardseshGrade: false }));
 
+const boardseshGradeQuery = vi.hoisted(() => ({
+  calls: [] as Array<{ boardName: string; climbUuid: string | null; angle: number; enabled: boolean | undefined }>,
+  data: undefined as unknown,
+}));
+
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
   PlatformColor: (name: string) => name,
@@ -71,6 +76,17 @@ vi.mock('../../../providers/feature-flags-provider', () => ({
   useBoardseshGradeEnabled: () => flags.boardseshGrade,
 }));
 
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useBoardseshGrade: (boardName: string, climbUuid: string | null, angle: number, options?: { enabled?: boolean }) => {
+    boardseshGradeQuery.calls.push({ boardName, climbUuid, angle, enabled: options?.enabled });
+    return { data: boardseshGradeQuery.data };
+  },
+}));
+
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ gradeFormat: 'v_grade' }),
+}));
+
 import { DeferredSections } from '../DeferredSections';
 
 const climb = {
@@ -102,6 +118,8 @@ describe('DeferredSections', () => {
     deferred.ready = false;
     deferred.calls = [];
     flags.boardseshGrade = false;
+    boardseshGradeQuery.calls = [];
+    boardseshGradeQuery.data = undefined;
   });
 
   it('keeps Beta videos eager while heavier sections wait for scroll and interaction readiness', () => {

--- a/packages/mobile/src/components/play-drawer/__tests__/deferred-sections.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/deferred-sections.test.tsx
@@ -81,6 +81,7 @@ vi.mock('../../../lib/graphql/hooks', () => ({
     boardseshGradeQuery.calls.push({ boardName, climbUuid, angle, enabled: options?.enabled });
     return { data: boardseshGradeQuery.data };
   },
+  useClimbStatsHistory: () => ({ data: undefined }),
 }));
 
 vi.mock('../../../hooks/use-grade-format', () => ({

--- a/packages/mobile/src/components/play-drawer/boardsesh-grade-utils.ts
+++ b/packages/mobile/src/components/play-drawer/boardsesh-grade-utils.ts
@@ -1,12 +1,16 @@
-// Pure view-model builder for the play drawer's "Boardsesh grade" section.
-// Turns the nightly data-science grade (floats on the shared difficulty scale,
-// where 10 = 4a/V0 and one unit is one Font letter step) into a display model:
-// which confidence tier to show, the formatted grade label + colour, and whether
-// the grade is cross-board (universal) or scoped to this board only (local).
+// Pure view-model builders for the play drawer's "Boardsesh grade" section.
+//
+// The section leads with the CROSS-BOARD CORRECTION: what this board's crowd
+// calls a climb (its community grade at the current angle) versus what it climbs
+// everywhere (the nightly data-science Boardsesh grade). These helpers turn the
+// grade floats (on the shared difficulty scale, where 10 = 4a/V0 and one unit is
+// one Font letter step) into a display model: which confidence tier to show, the
+// formatted labels + colours, whether the grade is cross-board (universal), and
+// the magnitude + direction of the correction.
 //
 // Kept free of React so it unit-tests without a renderer.
 import type { GradeDisplayFormat } from '@boardsesh/play-view';
-import type { BoardseshGrade, BoardseshGradeAtAngle } from '@boardsesh/graphql/operations';
+import type { BoardseshGrade } from '@boardsesh/graphql/operations';
 import {
   renderDifficulty,
   clampDifficultyId,
@@ -15,7 +19,6 @@ import {
   MAX_DIFFICULTY_ID,
   type RenderedGrade,
 } from '../../lib/boardsesh-grade-display';
-import type { AngleGradeBar } from './community-utils';
 
 // Re-exported for existing/back-compat call sites — the difficulty-scale
 // primitives now live in lib/boardsesh-grade-display.ts (a lib must not
@@ -23,62 +26,53 @@ import type { AngleGradeBar } from './community-utils';
 // helper, imports them like any other consumer).
 export { renderDifficulty, clampDifficultyId, GRADE_BY_ID, MIN_DIFFICULTY_ID, MAX_DIFFICULTY_ID, type RenderedGrade };
 
-// Locale-neutral math symbol shown after a provisional single grade to signal it
-// may still shift by a grade. Not user-facing prose, so it stays out of i18n.
-export const APPROX_SYMBOL = '±';
+// Compact status markers for the collapsed-header teaser. Not user-facing
+// prose (glyphs, not words), so they stay out of i18n.
+const TEASER_ARROW = '▸';
+const TEASER_CONFIRMED = '✓';
+const TEASER_PROVISIONAL = '~';
 
 /** MoonBoard has no standardized community grade in our feed yet. */
 export function isMoonBoard(boardName: string): boolean {
   return boardName.toLowerCase() === 'moonboard';
 }
 
-/** `'universal'` = one grade across every board; `'local'` = this board only. */
-export type GradeScope = 'universal' | 'local';
-
 export type BoardseshGradeView =
   | { kind: 'moonboard' }
-  | { kind: 'setterOnly' }
+  | {
+      kind: 'setterOnly';
+      /** The setter's grade to show muted ("Setter's call: V4"), or null when there's none at all. */
+      grade: RenderedGrade | null;
+      count: number;
+    }
   | {
       kind: 'confirmed';
-      scope: GradeScope;
+      /** True = cross-board (universal) grade; false = scoped to this board only. */
+      universal: boolean;
       grade: RenderedGrade;
+      /** Raw primary grade float (drives the correction delta + chart reference line). */
+      gradeValue: number;
+      gradeLow: number | null;
+      gradeHigh: number | null;
       count: number;
-      /** The board-local grade ("On this board: V4"), shown alongside a universal
-       *  headline only when it rounds to a different label than the primary grade. */
-      localSecondary: RenderedGrade | null;
       computedAt: string;
     }
   | {
       kind: 'provisional';
-      scope: GradeScope;
+      universal: boolean;
       grade: RenderedGrade;
+      gradeValue: number;
       /** Non-null when the low/high bounds round to different grades ("V5–V6"). */
       rangeLabel: string | null;
+      gradeLow: number | null;
+      gradeHigh: number | null;
       count: number;
-      localSecondary: RenderedGrade | null;
       computedAt: string;
     };
 
 /** The label a bound rounds to, used to decide whether a range spans two grades. */
 function boundLabel(value: number, gradeFormat: GradeDisplayFormat): string | null {
   return renderDifficulty(value, gradeFormat)?.label ?? null;
-}
-
-/**
- * The board-local grade line ("On this board: V4"), or null when it wouldn't
- * add information: the headline is already board-local, there's no local
- * grade, or it rounds to the same label as the universal headline.
- */
-function buildLocalSecondary(
-  scope: GradeScope,
-  grade: BoardseshGrade,
-  primaryLabel: string,
-  gradeFormat: GradeDisplayFormat,
-): RenderedGrade | null {
-  if (scope !== 'universal' || grade.localGrade == null) return null;
-  const rendered = renderDifficulty(grade.localGrade, gradeFormat);
-  if (!rendered || rendered.label === primaryLabel) return null;
-  return rendered;
 }
 
 /**
@@ -91,29 +85,27 @@ export function buildBoardseshGradeView(
   gradeFormat: GradeDisplayFormat,
 ): BoardseshGradeView {
   if (isMoonBoard(boardName)) return { kind: 'moonboard' };
-  if (!grade) return { kind: 'setterOnly' };
+  if (!grade) return { kind: 'setterOnly', grade: null, count: 0 };
 
   // Prefer the cross-board universal grade; fall back to the board-local grade
   // (small boards that never earn a universal number).
-  const scope: GradeScope = grade.universalGrade != null ? 'universal' : 'local';
+  const universal = grade.universalGrade != null;
   const primary = grade.universalGrade ?? grade.localGrade;
+  const rendered = primary != null ? renderDifficulty(primary, gradeFormat) : null;
 
-  if (grade.confidence === 'setter_only' || primary == null) {
-    return { kind: 'setterOnly' };
+  if (grade.confidence === 'setter_only' || primary == null || !rendered) {
+    return { kind: 'setterOnly', grade: rendered, count: grade.ascensionistCount };
   }
-
-  const rendered = renderDifficulty(primary, gradeFormat);
-  if (!rendered) return { kind: 'setterOnly' };
-
-  const localSecondary = buildLocalSecondary(scope, grade, rendered.label, gradeFormat);
 
   if (grade.confidence === 'confirmed') {
     return {
       kind: 'confirmed',
-      scope,
+      universal,
       grade: rendered,
+      gradeValue: primary,
+      gradeLow: grade.gradeLow,
+      gradeHigh: grade.gradeHigh,
       count: grade.ascensionistCount,
-      localSecondary,
       computedAt: grade.computedAt,
     };
   }
@@ -131,50 +123,93 @@ export function buildBoardseshGradeView(
 
   return {
     kind: 'provisional',
-    scope,
+    universal,
     grade: rendered,
+    gradeValue: primary,
     rangeLabel,
+    gradeLow: grade.gradeLow,
+    gradeHigh: grade.gradeHigh,
     count: grade.ascensionistCount,
-    localSecondary,
     computedAt: grade.computedAt,
   };
 }
 
+/** Direction of the crowd grade relative to the cross-board Boardsesh grade. */
+export type DeltaDirection = 'easier' | 'stiffer' | 'equal';
+
+export type BoardseshCorrection = {
+  /** The crowd's community grade at this angle ("This board"). */
+  crowd: RenderedGrade;
+  /** Correction magnitude in V-grade steps (a multiple of ½), 0 when they agree. */
+  steps: number;
+  /** Magnitude label for the pill ("½", "1", "1½"), or null when the grades agree. */
+  label: string | null;
+  /** Which way the crowd sits relative to everywhere: `easier` = everywhere is
+   *  easier than the crowd calls it (crowd over-grades); `stiffer` = the reverse. */
+  direction: DeltaDirection;
+};
+
 /**
- * Collapsed-header summary for the Boardsesh grade section: just the label
- * (or range) with no metadata, or null when there's nothing headline-worthy
- * yet (moonboard / setter-only).
+ * Render a ½-step magnitude as a compact label: 0.5 → "½", 1 → "1", 1.5 → "1½".
+ * Returns null for a zero (or negative) magnitude.
  */
-export function buildBoardseshGradeSummary(view: BoardseshGradeView): string | null {
-  switch (view.kind) {
-    case 'confirmed':
-      return view.grade.label;
-    case 'provisional':
-      return view.rangeLabel ?? `${view.grade.label} ${APPROX_SYMBOL}`;
-    default:
-      return null;
-  }
+export function formatHalfGrades(steps: number): string | null {
+  if (steps <= 0) return null;
+  const whole = Math.floor(steps);
+  const hasHalf = steps - whole >= 0.5;
+  const label = `${whole > 0 ? whole : ''}${hasHalf ? '½' : ''}`;
+  return label.length ? label : null;
 }
 
 /**
- * Per-angle bars for the Boardsesh-grade-by-angle chart, built from the
- * plural `useBoardseshGradesForAngles` rows. Prefers each row's universal
- * grade, falling back to its local grade; skips angles with no usable
- * grade and setter-only rows (no Boardsesh-branded setter numbers). Sorted
- * ascending by angle, matching the Community chart's convention.
+ * The correction between the crowd's grade at this angle and the cross-board
+ * Boardsesh grade. Both are rounded to a difficulty id first — one id step is
+ * one Font letter, i.e. half a V-grade — so the magnitude reads in ½-grades and
+ * "they agree" means they round to the same bucket. Null when there's no crowd
+ * grade at this angle (nothing to correct against).
  */
-export function buildBoardseshAngleGradeBars(
-  rows: BoardseshGradeAtAngle[],
+export function buildCorrection(
+  crowdDifficulty: number | null,
+  boardseshValue: number,
   gradeFormat: GradeDisplayFormat,
-): AngleGradeBar[] {
-  const bars: AngleGradeBar[] = [];
-  for (const row of rows) {
-    if (row.confidence === 'setter_only') continue;
-    const primary = row.universalGrade ?? row.localGrade;
-    if (primary == null) continue;
-    const rendered = renderDifficulty(primary, gradeFormat);
-    if (!rendered) continue;
-    bars.push({ angle: row.angle, difficulty: primary, gradeName: rendered.label, sends: row.ascensionistCount });
+): BoardseshCorrection | null {
+  if (crowdDifficulty == null) return null;
+  const crowd = renderDifficulty(crowdDifficulty, gradeFormat);
+  if (!crowd) return null;
+
+  const idDelta = clampDifficultyId(crowdDifficulty) - clampDifficultyId(boardseshValue);
+  const steps = Math.abs(idDelta) / 2;
+  const direction: DeltaDirection = idDelta > 0 ? 'easier' : idDelta < 0 ? 'stiffer' : 'equal';
+  return { crowd, steps, label: formatHalfGrades(steps), direction };
+}
+
+/**
+ * Collapsed-header teaser for the Boardsesh grade section — a compact plain
+ * string leading with the correction. When a crowd label is supplied and it
+ * differs from the confirmed cross-board grade, shows "{crowd} ▸ {bs} ✓"; a
+ * confident cross-board grade alone reads "{bs} ✓"; provisional "{bs} ~";
+ * local-only "{bs} · {localWord}". Null for moonboard / setter-only.
+ */
+export function buildBoardseshGradeSummary(
+  view: BoardseshGradeView,
+  options?: { crowdLabel?: string | null; localWord?: string },
+): string | null {
+  const crowdLabel = options?.crowdLabel ?? null;
+  const localWord = options?.localWord;
+
+  switch (view.kind) {
+    case 'confirmed': {
+      const bs = view.grade.label;
+      if (!view.universal) return localWord ? `${bs} · ${localWord}` : bs;
+      if (crowdLabel && crowdLabel !== bs) return `${crowdLabel} ${TEASER_ARROW} ${bs} ${TEASER_CONFIRMED}`;
+      return `${bs} ${TEASER_CONFIRMED}`;
+    }
+    case 'provisional': {
+      const bs = view.rangeLabel ?? view.grade.label;
+      if (!view.universal && localWord) return `${bs} · ${localWord}`;
+      return `${bs} ${TEASER_PROVISIONAL}`;
+    }
+    default:
+      return null;
   }
-  return bars.sort((a, b) => a.angle - b.angle);
 }

--- a/packages/mobile/src/components/play-drawer/boardsesh-grade-utils.ts
+++ b/packages/mobile/src/components/play-drawer/boardsesh-grade-utils.ts
@@ -5,16 +5,22 @@
 // the grade is cross-board (universal) or scoped to this board only (local).
 //
 // Kept free of React so it unit-tests without a renderer.
-import { formatGrade, type GradeDisplayFormat } from '@boardsesh/play-view';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
-import { BOULDER_GRADES, type BoulderGrade } from '@boardsesh/board-constants/boulder-grade-mapping';
+import type { GradeDisplayFormat } from '@boardsesh/play-view';
 import type { BoardseshGrade } from '@boardsesh/graphql/operations';
+import {
+  renderDifficulty,
+  clampDifficultyId,
+  GRADE_BY_ID,
+  MIN_DIFFICULTY_ID,
+  MAX_DIFFICULTY_ID,
+  type RenderedGrade,
+} from '../../lib/boardsesh-grade-display';
 
-const GRADE_BY_ID = new Map<number, BoulderGrade>(BOULDER_GRADES.map((grade) => [grade.difficulty_id, grade]));
-
-// The difficulty scale the data-science grade shares with Aurora's ids.
-const MIN_DIFFICULTY_ID = BOULDER_GRADES[0].difficulty_id;
-const MAX_DIFFICULTY_ID = BOULDER_GRADES[BOULDER_GRADES.length - 1].difficulty_id;
+// Re-exported for existing/back-compat call sites — the difficulty-scale
+// primitives now live in lib/boardsesh-grade-display.ts (a lib must not
+// import from components, so they moved there; this file, a component-tree
+// helper, imports them like any other consumer).
+export { renderDifficulty, clampDifficultyId, GRADE_BY_ID, MIN_DIFFICULTY_ID, MAX_DIFFICULTY_ID, type RenderedGrade };
 
 /** MoonBoard has no standardized community grade in our feed yet. */
 export function isMoonBoard(boardName: string): boolean {
@@ -23,13 +29,6 @@ export function isMoonBoard(boardName: string): boolean {
 
 /** `'universal'` = one grade across every board; `'local'` = this board only. */
 export type GradeScope = 'universal' | 'local';
-
-export type RenderedGrade = {
-  /** Formatted label per the user's grade preference (e.g. "V5", "6c"). */
-  label: string;
-  /** Hex colour for the grade, consistent with the play drawer header. */
-  color: string;
-};
 
 export type BoardseshGradeView =
   | { kind: 'moonboard' }
@@ -43,20 +42,6 @@ export type BoardseshGradeView =
       rangeLabel: string | null;
       count: number;
     };
-
-function clampDifficultyId(value: number): number {
-  return Math.min(MAX_DIFFICULTY_ID, Math.max(MIN_DIFFICULTY_ID, Math.round(value)));
-}
-
-/** Round a float difficulty to the nearest grade and render its label + colour. */
-export function renderDifficulty(value: number, gradeFormat: GradeDisplayFormat): RenderedGrade | null {
-  const grade = GRADE_BY_ID.get(clampDifficultyId(value));
-  if (!grade) return null;
-  return {
-    label: formatGrade(grade.difficulty_name, gradeFormat) ?? grade.v_grade,
-    color: getGradeColor(grade.difficulty_name) ?? DEFAULT_GRADE_COLOR,
-  };
-}
 
 /** The label a bound rounds to, used to decide whether a range spans two grades. */
 function boundLabel(value: number, gradeFormat: GradeDisplayFormat): string | null {

--- a/packages/mobile/src/components/play-drawer/boardsesh-grade-utils.ts
+++ b/packages/mobile/src/components/play-drawer/boardsesh-grade-utils.ts
@@ -163,10 +163,12 @@ export function formatHalfGrades(steps: number): string | null {
 
 /**
  * The correction between the crowd's grade at this angle and the cross-board
- * Boardsesh grade. Both are rounded to a difficulty id first — one id step is
- * one Font letter, i.e. half a V-grade — so the magnitude reads in ½-grades and
- * "they agree" means they round to the same bucket. Null when there's no crowd
- * grade at this angle (nothing to correct against).
+ * Boardsesh grade. Agreement is decided by the LABEL each side renders under the
+ * viewer's grade format — not the raw id delta — so two ids that fall in the same
+ * displayed V-grade read as "matches this board". When the labels differ, the
+ * magnitude comes from the id delta (one id step is one Font letter, i.e. half a
+ * V-grade), so it reads in ½-grades. Null when there's no crowd grade at this
+ * angle (nothing to correct against).
  */
 export function buildCorrection(
   crowdDifficulty: number | null,
@@ -176,6 +178,18 @@ export function buildCorrection(
   if (crowdDifficulty == null) return null;
   const crowd = renderDifficulty(crowdDifficulty, gradeFormat);
   if (!crowd) return null;
+
+  // Gate agreement on the LABEL the hero actually shows, not the id delta. Some
+  // V-grades cover multiple ids that collapse to one label — V0 (4a/4b/4c) and V1
+  // (5a/5b), whose Font members never take a "+" suffix — so a crowd id and a
+  // Boardsesh id can differ yet render the identical label. When the two displayed
+  // labels match it "matches this board" — no pill, no payoff — even if the ids
+  // differ, which keeps the hero in step with the collapsed teaser (it gates the
+  // same way on the label).
+  const boardsesh = renderDifficulty(boardseshValue, gradeFormat);
+  if (boardsesh && crowd.label === boardsesh.label) {
+    return { crowd, steps: 0, label: null, direction: 'equal' };
+  }
 
   const idDelta = clampDifficultyId(crowdDifficulty) - clampDifficultyId(boardseshValue);
   const steps = Math.abs(idDelta) / 2;

--- a/packages/mobile/src/components/play-drawer/boardsesh-grade-utils.ts
+++ b/packages/mobile/src/components/play-drawer/boardsesh-grade-utils.ts
@@ -76,6 +76,23 @@ function boundLabel(value: number, gradeFormat: GradeDisplayFormat): string | nu
 }
 
 /**
+ * The low/high grade labels for the trust line, falling back to the headline
+ * grade when a bound is missing. `sameLabel` is true when both bounds round to
+ * the SAME displayed grade — the caller then drops the range (a "V4–V4" reads
+ * as a bug) and shows a single-grade trust line instead.
+ */
+export function buildTrustBand(
+  low: number | null,
+  high: number | null,
+  headlineLabel: string,
+  gradeFormat: GradeDisplayFormat,
+): { low: string; high: string; sameLabel: boolean } {
+  const lowLabel = (low != null ? boundLabel(low, gradeFormat) : null) ?? headlineLabel;
+  const highLabel = (high != null ? boundLabel(high, gradeFormat) : null) ?? headlineLabel;
+  return { low: lowLabel, high: highLabel, sameLabel: lowLabel === highLabel };
+}
+
+/**
  * Build the display model for a climb+angle's Boardsesh grade.
  * `grade` is null when the nightly job has no row yet (falls back to setter-only).
  */

--- a/packages/mobile/src/components/play-drawer/boardsesh-grade-utils.ts
+++ b/packages/mobile/src/components/play-drawer/boardsesh-grade-utils.ts
@@ -6,7 +6,7 @@
 //
 // Kept free of React so it unit-tests without a renderer.
 import type { GradeDisplayFormat } from '@boardsesh/play-view';
-import type { BoardseshGrade } from '@boardsesh/graphql/operations';
+import type { BoardseshGrade, BoardseshGradeAtAngle } from '@boardsesh/graphql/operations';
 import {
   renderDifficulty,
   clampDifficultyId,
@@ -15,12 +15,17 @@ import {
   MAX_DIFFICULTY_ID,
   type RenderedGrade,
 } from '../../lib/boardsesh-grade-display';
+import type { AngleGradeBar } from './community-utils';
 
 // Re-exported for existing/back-compat call sites — the difficulty-scale
 // primitives now live in lib/boardsesh-grade-display.ts (a lib must not
 // import from components, so they moved there; this file, a component-tree
 // helper, imports them like any other consumer).
 export { renderDifficulty, clampDifficultyId, GRADE_BY_ID, MIN_DIFFICULTY_ID, MAX_DIFFICULTY_ID, type RenderedGrade };
+
+// Locale-neutral math symbol shown after a provisional single grade to signal it
+// may still shift by a grade. Not user-facing prose, so it stays out of i18n.
+export const APPROX_SYMBOL = '±';
 
 /** MoonBoard has no standardized community grade in our feed yet. */
 export function isMoonBoard(boardName: string): boolean {
@@ -33,7 +38,16 @@ export type GradeScope = 'universal' | 'local';
 export type BoardseshGradeView =
   | { kind: 'moonboard' }
   | { kind: 'setterOnly' }
-  | { kind: 'confirmed'; scope: GradeScope; grade: RenderedGrade; count: number }
+  | {
+      kind: 'confirmed';
+      scope: GradeScope;
+      grade: RenderedGrade;
+      count: number;
+      /** The board-local grade ("On this board: V4"), shown alongside a universal
+       *  headline only when it rounds to a different label than the primary grade. */
+      localSecondary: RenderedGrade | null;
+      computedAt: string;
+    }
   | {
       kind: 'provisional';
       scope: GradeScope;
@@ -41,11 +55,30 @@ export type BoardseshGradeView =
       /** Non-null when the low/high bounds round to different grades ("V5–V6"). */
       rangeLabel: string | null;
       count: number;
+      localSecondary: RenderedGrade | null;
+      computedAt: string;
     };
 
 /** The label a bound rounds to, used to decide whether a range spans two grades. */
 function boundLabel(value: number, gradeFormat: GradeDisplayFormat): string | null {
   return renderDifficulty(value, gradeFormat)?.label ?? null;
+}
+
+/**
+ * The board-local grade line ("On this board: V4"), or null when it wouldn't
+ * add information: the headline is already board-local, there's no local
+ * grade, or it rounds to the same label as the universal headline.
+ */
+function buildLocalSecondary(
+  scope: GradeScope,
+  grade: BoardseshGrade,
+  primaryLabel: string,
+  gradeFormat: GradeDisplayFormat,
+): RenderedGrade | null {
+  if (scope !== 'universal' || grade.localGrade == null) return null;
+  const rendered = renderDifficulty(grade.localGrade, gradeFormat);
+  if (!rendered || rendered.label === primaryLabel) return null;
+  return rendered;
 }
 
 /**
@@ -72,8 +105,17 @@ export function buildBoardseshGradeView(
   const rendered = renderDifficulty(primary, gradeFormat);
   if (!rendered) return { kind: 'setterOnly' };
 
+  const localSecondary = buildLocalSecondary(scope, grade, rendered.label, gradeFormat);
+
   if (grade.confidence === 'confirmed') {
-    return { kind: 'confirmed', scope, grade: rendered, count: grade.ascensionistCount };
+    return {
+      kind: 'confirmed',
+      scope,
+      grade: rendered,
+      count: grade.ascensionistCount,
+      localSecondary,
+      computedAt: grade.computedAt,
+    };
   }
 
   // Everything else ('provisional', or any unexpected value) reads as still
@@ -87,5 +129,52 @@ export function buildBoardseshGradeView(
     }
   }
 
-  return { kind: 'provisional', scope, grade: rendered, rangeLabel, count: grade.ascensionistCount };
+  return {
+    kind: 'provisional',
+    scope,
+    grade: rendered,
+    rangeLabel,
+    count: grade.ascensionistCount,
+    localSecondary,
+    computedAt: grade.computedAt,
+  };
+}
+
+/**
+ * Collapsed-header summary for the Boardsesh grade section: just the label
+ * (or range) with no metadata, or null when there's nothing headline-worthy
+ * yet (moonboard / setter-only).
+ */
+export function buildBoardseshGradeSummary(view: BoardseshGradeView): string | null {
+  switch (view.kind) {
+    case 'confirmed':
+      return view.grade.label;
+    case 'provisional':
+      return view.rangeLabel ?? `${view.grade.label} ${APPROX_SYMBOL}`;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Per-angle bars for the Boardsesh-grade-by-angle chart, built from the
+ * plural `useBoardseshGradesForAngles` rows. Prefers each row's universal
+ * grade, falling back to its local grade; skips angles with no usable
+ * grade and setter-only rows (no Boardsesh-branded setter numbers). Sorted
+ * ascending by angle, matching the Community chart's convention.
+ */
+export function buildBoardseshAngleGradeBars(
+  rows: BoardseshGradeAtAngle[],
+  gradeFormat: GradeDisplayFormat,
+): AngleGradeBar[] {
+  const bars: AngleGradeBar[] = [];
+  for (const row of rows) {
+    if (row.confidence === 'setter_only') continue;
+    const primary = row.universalGrade ?? row.localGrade;
+    if (primary == null) continue;
+    const rendered = renderDifficulty(primary, gradeFormat);
+    if (!rendered) continue;
+    bars.push({ angle: row.angle, difficulty: primary, gradeName: rendered.label, sends: row.ascensionistCount });
+  }
+  return bars.sort((a, b) => a.angle - b.angle);
 }

--- a/packages/mobile/src/components/play-drawer/by-angle-comparison.ts
+++ b/packages/mobile/src/components/play-drawer/by-angle-comparison.ts
@@ -211,9 +211,17 @@ export function buildDumbbellAxis(rows: DumbbellAngleRow[], gradeFormat: GradeDi
   const step = maxId - minId > DENSE_SPAN_THRESHOLD ? 2 : 1;
   const noOfSections = Math.ceil((maxId - minId) / step);
   const maxValue = step * noOfSections;
-  // Extend the top so the window is an exact multiple of the step (keeps the top
-  // tick label truthful and the marker for the hardest grade inside the plot).
+  // Round the window up to an exact multiple of the step so every marker sits
+  // inside the plot. Normally we grow the top upward, but that can push maxId
+  // past MAX_DIFFICULTY_ID and the top tick would render a clamped, over-read
+  // label (e.g. id 34 → "V16"). When it would overflow, pin the top to the
+  // hardest real grade and grow the window downward instead, preserving the
+  // maxId − minId === maxValue invariant the marker geometry relies on.
   maxId = minId + maxValue;
+  if (maxId > MAX_DIFFICULTY_ID) {
+    maxId = MAX_DIFFICULTY_ID;
+    minId = maxId - maxValue;
+  }
 
   const yAxisLabelTexts = Array.from(
     { length: noOfSections + 1 },

--- a/packages/mobile/src/components/play-drawer/by-angle-comparison.ts
+++ b/packages/mobile/src/components/play-drawer/by-angle-comparison.ts
@@ -1,0 +1,224 @@
+// Pure join builder for the "crowd vs Boardsesh grade by angle" dumbbell chart.
+//
+// Fuses two per-angle series into ONE comparison model:
+//  - the CROWD series (community displayDifficulty per angle, from
+//    `buildAngleGradeBars`) — "what this board's crowd calls it".
+//  - the BOARDSESH series (the nightly cross-board grade per angle, from
+//    `useBoardseshGradesForAngles`) — "what it climbs everywhere".
+//
+// The gap between the two markers at an angle IS the correction. Kept free of
+// React so the join + axis math unit-test without a renderer.
+import type { GradeDisplayFormat } from '@boardsesh/play-view';
+import type { BoardseshGradeAtAngle } from '@boardsesh/graphql/operations';
+import {
+  renderDifficulty,
+  clampDifficultyId,
+  MIN_DIFFICULTY_ID,
+  MAX_DIFFICULTY_ID,
+} from '../../lib/boardsesh-grade-display';
+import type { AngleGradeBar } from './community-utils';
+
+/** Boardsesh confidence at an angle. Mirrors the grade resolver's tiers. */
+export type DumbbellTier = 'confirmed' | 'provisional' | 'setter_only';
+
+/** Ascent-count bin → marker size. `<5` small · `5–20` medium · `>20` large. */
+export type DumbbellSizeBin = 'small' | 'medium' | 'large';
+
+/**
+ * One angle of the dumbbell chart. `crowd*` fields describe the community ring;
+ * `boardsesh*` fields describe the Boardsesh diamond. Either side may be null
+ * (an angle present in only one source draws a lone marker). A diamond is only
+ * drawn when `hasBoardsesh` is true — a `setter_only` (or grade-less) Boardsesh
+ * row keeps its crowd ring but carries no diamond.
+ */
+export type DumbbellAngleRow = {
+  angle: number;
+  /** Community display difficulty (float on the shared scale), or null. */
+  crowdGrade: number | null;
+  /** Formatted community grade label (e.g. "V5"), or null. */
+  crowdLabel: string | null;
+  /** Boardsesh grade (float), or null when no diamond is drawn at this angle. */
+  boardseshGrade: number | null;
+  /** Formatted Boardsesh grade label, or null. */
+  boardseshLabel: string | null;
+  /** Grade colour for the diamond (tinted by ITS grade), or null. */
+  boardseshColor: string | null;
+  /** Ascent count driving the marker size at this angle. */
+  sends: number;
+  /** Size bin derived from `sends`. */
+  sizeBin: DumbbellSizeBin;
+  /** Boardsesh confidence at this angle, or null when there's no Boardsesh row. */
+  tier: DumbbellTier | null;
+  /** Provisional whisker bounds (float), or null. */
+  gradeLow: number | null;
+  gradeHigh: number | null;
+  /** True when crowd + Boardsesh round to the same grade (draw a nested glyph, no stem). */
+  agree: boolean;
+  /** True when the crowd has a grade at this angle (draw a ring). */
+  hasCrowd: boolean;
+  /** True when a Boardsesh diamond is drawn at this angle. */
+  hasBoardsesh: boolean;
+};
+
+const KNOWN_TIERS: ReadonlySet<string> = new Set<DumbbellTier>(['confirmed', 'provisional', 'setter_only']);
+
+/** Normalise a confidence string to a known tier, defaulting unknowns to provisional. */
+function toTier(confidence: string | undefined): DumbbellTier | null {
+  if (confidence == null) return null;
+  if (KNOWN_TIERS.has(confidence)) return confidence as DumbbellTier;
+  // An unexpected confidence value reads as still-settling, matching the
+  // singular grade view's "everything else is provisional" rule.
+  return 'provisional';
+}
+
+/** `<5` small · `5–20` medium · `>20` large. */
+export function sizeBinForSends(sends: number): DumbbellSizeBin {
+  if (sends < 5) return 'small';
+  if (sends <= 20) return 'medium';
+  return 'large';
+}
+
+/**
+ * Join the Boardsesh per-angle rows with the community per-angle bars into one
+ * dumbbell model, sorted ascending by angle.
+ *
+ * Rules:
+ *  - Boardsesh series prefers each row's `universalGrade`, falling back to
+ *    `localGrade` (small boards that never earn a universal number).
+ *  - A `setter_only` Boardsesh row (or one with no usable grade) draws NO
+ *    diamond, but its crowd ring is still kept when the crowd has that angle.
+ *  - An angle present in only one source yields a lone marker (no stem).
+ *  - An angle with neither a crowd grade nor a Boardsesh diamond is dropped.
+ *  - `sends` (marker size) uses the larger of the community count and the
+ *    Boardsesh ascensionist count at that angle, so a lone marker still sizes.
+ */
+export function buildDumbbellByAngleModel(
+  boardseshRows: BoardseshGradeAtAngle[],
+  crowdBars: AngleGradeBar[],
+  gradeFormat: GradeDisplayFormat,
+): DumbbellAngleRow[] {
+  const crowdByAngle = new Map<number, AngleGradeBar>();
+  for (const bar of crowdBars) crowdByAngle.set(bar.angle, bar);
+
+  const boardseshByAngle = new Map<number, BoardseshGradeAtAngle>();
+  for (const row of boardseshRows) boardseshByAngle.set(row.angle, row);
+
+  const angles = Array.from(new Set([...crowdByAngle.keys(), ...boardseshByAngle.keys()])).sort((a, b) => a - b);
+
+  const rows: DumbbellAngleRow[] = [];
+  for (const angle of angles) {
+    const crowd = crowdByAngle.get(angle);
+    const boardsesh = boardseshByAngle.get(angle);
+
+    const crowdGrade = crowd?.difficulty ?? null;
+    const crowdLabel = crowd?.gradeName ?? null;
+    const crowdSends = crowd?.sends ?? 0;
+
+    const tier = toTier(boardsesh?.confidence);
+    // No Boardsesh-branded number for setter-only rows — they carry no diamond.
+    const boardseshRaw =
+      boardsesh && tier !== 'setter_only' ? (boardsesh.universalGrade ?? boardsesh.localGrade) : null;
+    const rendered = boardseshRaw != null ? renderDifficulty(boardseshRaw, gradeFormat) : null;
+    const boardseshGrade = rendered ? boardseshRaw : null;
+    const boardseshLabel = rendered?.label ?? null;
+    const boardseshColor = rendered?.color ?? null;
+
+    const hasCrowd = crowdGrade != null;
+    const hasBoardsesh = boardseshGrade != null && boardseshLabel != null;
+    if (!hasCrowd && !hasBoardsesh) continue;
+
+    const sends = Math.max(crowdSends, boardsesh?.ascensionistCount ?? 0);
+    const agree = hasCrowd && hasBoardsesh && clampDifficultyId(crowdGrade) === clampDifficultyId(boardseshGrade);
+
+    rows.push({
+      angle,
+      crowdGrade,
+      crowdLabel,
+      boardseshGrade,
+      boardseshLabel,
+      boardseshColor,
+      sends,
+      sizeBin: sizeBinForSends(sends),
+      tier,
+      gradeLow: hasBoardsesh ? (boardsesh?.gradeLow ?? null) : null,
+      gradeHigh: hasBoardsesh ? (boardsesh?.gradeHigh ?? null) : null,
+      agree,
+      hasCrowd,
+      hasBoardsesh,
+    });
+  }
+
+  return rows;
+}
+
+/** True when at least one row carries a Boardsesh diamond. */
+export function hasAnyBoardseshDiamond(rows: DumbbellAngleRow[]): boolean {
+  return rows.some((row) => row.hasBoardsesh);
+}
+
+/**
+ * The standardized-grade Y axis for the dumbbell: an integer grade window that
+ * covers every plotted value (both markers + whisker bounds) with ~1 grade of
+ * padding on each side, plus the V-grade tick labels. Values are plotted after
+ * shifting by `minId` (so the axis can start above V0 instead of wasting the
+ * lower half of the plot).
+ */
+export type DumbbellAxis = {
+  /** Integer grade id at the axis bottom. */
+  minId: number;
+  /** Integer grade id at the axis top. */
+  maxId: number;
+  /** Grade ids per gridline section (1, or 2 for a wide span). */
+  step: number;
+  /** Number of gridline sections. */
+  noOfSections: number;
+  /** Plotted-unit span (a grade float shifted by `minId` never exceeds this). */
+  maxValue: number;
+  /** Tick labels bottom→top, one per section boundary (`noOfSections + 1`). */
+  yAxisLabelTexts: string[];
+};
+
+// Above this many grades of span, one gridline per grade crowds the axis, so
+// we label every other grade instead.
+const DENSE_SPAN_THRESHOLD = 8;
+
+/**
+ * Build the shared Y axis from the dumbbell rows. Falls back to a small window
+ * around V0 when there are no plottable values (an empty/degenerate model).
+ */
+export function buildDumbbellAxis(rows: DumbbellAngleRow[], gradeFormat: GradeDisplayFormat): DumbbellAxis {
+  const values: number[] = [];
+  for (const row of rows) {
+    if (row.crowdGrade != null) values.push(row.crowdGrade);
+    if (row.boardseshGrade != null) values.push(row.boardseshGrade);
+    if (row.gradeLow != null) values.push(row.gradeLow);
+    if (row.gradeHigh != null) values.push(row.gradeHigh);
+  }
+
+  const lowValue = values.length ? Math.min(...values) : MIN_DIFFICULTY_ID;
+  const highValue = values.length ? Math.max(...values) : MIN_DIFFICULTY_ID + 2;
+
+  // ~One grade of headroom on each side (two Font steps on the id scale),
+  // clamped to the scale, so markers + whiskers never sit on the axis edge.
+  let minId = Math.max(MIN_DIFFICULTY_ID, clampDifficultyId(lowValue) - 2);
+  let maxId = Math.min(MAX_DIFFICULTY_ID, clampDifficultyId(highValue) + 2);
+  // Guarantee at least a two-grade window so markers never sit on the edge.
+  if (maxId - minId < 2) {
+    maxId = Math.min(MAX_DIFFICULTY_ID, minId + 2);
+    minId = Math.max(MIN_DIFFICULTY_ID, maxId - 2);
+  }
+
+  const step = maxId - minId > DENSE_SPAN_THRESHOLD ? 2 : 1;
+  const noOfSections = Math.ceil((maxId - minId) / step);
+  const maxValue = step * noOfSections;
+  // Extend the top so the window is an exact multiple of the step (keeps the top
+  // tick label truthful and the marker for the hardest grade inside the plot).
+  maxId = minId + maxValue;
+
+  const yAxisLabelTexts = Array.from(
+    { length: noOfSections + 1 },
+    (_, index) => renderDifficulty(minId + index * step, gradeFormat)?.label ?? '',
+  );
+
+  return { minId, maxId, step, noOfSections, maxValue, yAxisLabelTexts };
+}

--- a/packages/mobile/src/components/play-drawer/by-angle-comparison.ts
+++ b/packages/mobile/src/components/play-drawer/by-angle-comparison.ts
@@ -13,6 +13,7 @@ import type { BoardseshGradeAtAngle } from '@boardsesh/graphql/operations';
 import {
   renderDifficulty,
   clampDifficultyId,
+  GRADE_BY_ID,
   MIN_DIFFICULTY_ID,
   MAX_DIFFICULTY_ID,
 } from '../../lib/boardsesh-grade-display';
@@ -168,23 +169,33 @@ export type DumbbellAxis = {
   minId: number;
   /** Integer grade id at the axis top. */
   maxId: number;
-  /** Grade ids per gridline section (1, or 2 for a wide span). */
-  step: number;
-  /** Number of gridline sections. */
+  /** Number of gridline sections (one per grade id: `maxId - minId`). */
   noOfSections: number;
   /** Plotted-unit span (a grade float shifted by `minId` never exceeds this). */
   maxValue: number;
-  /** Tick labels bottom→top, one per section boundary (`noOfSections + 1`). */
+  /** Tick labels bottom→top, one per section boundary (`noOfSections + 1`); a
+   *  V-grade spanning several ids is labelled once, the rest blank. */
   yAxisLabelTexts: string[];
 };
 
-// Above this many grades of span, one gridline per grade crowds the axis, so
-// we label every other grade instead.
-const DENSE_SPAN_THRESHOLD = 8;
+// Above this many distinct V-grades in the window, one label per grade crowds
+// the axis text, so we thin the labels to every other grade (the gridlines
+// themselves stay one-per-id).
+const DENSE_LABEL_THRESHOLD = 9;
 
 /**
  * Build the shared Y axis from the dumbbell rows. Falls back to a small window
  * around V0 when there are no plottable values (an empty/degenerate model).
+ *
+ * One gridline per grade id (step 1). V-grades span a VARIABLE number of ids
+ * (V0 = 4a/4b/4c, three ids; V2 = 5c, one id), so an id step wider than 1 would
+ * jump over the single-id grades and land the ticks on a duplicated/uneven set
+ * of V labels ("V0, V0, V1, V3, V5…"). Stepping by one id visits every grade;
+ * we then label only the FIRST id of each whole V-grade (V0, V1, V2…), blanking
+ * the rest, so each whole grade is labelled exactly once with no repeats and no
+ * gaps — even though the shown label follows the viewer's format (a "6c+/V5" id
+ * keyed under V5). `maxValue === maxId - minId` keeps the linear marker geometry
+ * (`localY`) exact — a grade float plots at `grade - minId` in the axis span.
  */
 export function buildDumbbellAxis(rows: DumbbellAngleRow[], gradeFormat: GradeDisplayFormat): DumbbellAxis {
   const values: number[] = [];
@@ -207,26 +218,43 @@ export function buildDumbbellAxis(rows: DumbbellAngleRow[], gradeFormat: GradeDi
     maxId = Math.min(MAX_DIFFICULTY_ID, minId + 2);
     minId = Math.max(MIN_DIFFICULTY_ID, maxId - 2);
   }
+  // maxId is already clamped to the hardest real grade, so the top tick renders
+  // a truthful label — no overflow correction needed at step 1.
 
-  const step = maxId - minId > DENSE_SPAN_THRESHOLD ? 2 : 1;
-  const noOfSections = Math.ceil((maxId - minId) / step);
-  const maxValue = step * noOfSections;
-  // Round the window up to an exact multiple of the step so every marker sits
-  // inside the plot. Normally we grow the top upward, but that can push maxId
-  // past MAX_DIFFICULTY_ID and the top tick would render a clamped, over-read
-  // label (e.g. id 34 → "V16"). When it would overflow, pin the top to the
-  // hardest real grade and grow the window downward instead, preserving the
-  // maxId − minId === maxValue invariant the marker geometry relies on.
-  maxId = minId + maxValue;
-  if (maxId > MAX_DIFFICULTY_ID) {
-    maxId = MAX_DIFFICULTY_ID;
-    minId = maxId - maxValue;
+  const noOfSections = maxId - minId;
+  const maxValue = noOfSections;
+
+  // Label the first id of each whole V-grade, blanking the rest — so a grade
+  // spanning several ids (V0 = 4a/4b/4c) is labelled once, at its lowest id.
+  // Dedup keys on the whole V-grade (`v_grade`), not the formatted label, so the
+  // axis reads V0, V1, V2… rather than the format's finer V5 / V5+ steps.
+  // `distinctIndices` collects the label positions so a wide window can thin them.
+  const yAxisLabelTexts: string[] = [];
+  const distinctIndices: number[] = [];
+  let lastVGrade: string | null = null;
+  for (let index = 0; index <= noOfSections; index++) {
+    const id = minId + index;
+    const vGrade = GRADE_BY_ID.get(id)?.v_grade ?? null;
+    const label = renderDifficulty(id, gradeFormat)?.label ?? '';
+    if (label && vGrade && vGrade !== lastVGrade) {
+      yAxisLabelTexts.push(label);
+      distinctIndices.push(index);
+      lastVGrade = vGrade;
+    } else {
+      yAxisLabelTexts.push('');
+    }
   }
 
-  const yAxisLabelTexts = Array.from(
-    { length: noOfSections + 1 },
-    (_, index) => renderDifficulty(minId + index * step, gradeFormat)?.label ?? '',
-  );
+  // Wide window: thin to every other distinct grade so the axis text stays
+  // legible, always keeping the top grade so the range reads end to end.
+  if (distinctIndices.length > DENSE_LABEL_THRESHOLD) {
+    const keep = new Set<number>();
+    for (let i = 0; i < distinctIndices.length; i += 2) keep.add(distinctIndices[i]);
+    keep.add(distinctIndices[distinctIndices.length - 1]);
+    for (const index of distinctIndices) {
+      if (!keep.has(index)) yAxisLabelTexts[index] = '';
+    }
+  }
 
-  return { minId, maxId, step, noOfSections, maxValue, yAxisLabelTexts };
+  return { minId, maxId, noOfSections, maxValue, yAxisLabelTexts };
 }

--- a/packages/mobile/src/components/play-drawer/by-angle-comparison.ts
+++ b/packages/mobile/src/components/play-drawer/by-angle-comparison.ts
@@ -13,7 +13,6 @@ import type { BoardseshGradeAtAngle } from '@boardsesh/graphql/operations';
 import {
   renderDifficulty,
   clampDifficultyId,
-  GRADE_BY_ID,
   MIN_DIFFICULTY_ID,
   MAX_DIFFICULTY_ID,
 } from '../../lib/boardsesh-grade-display';
@@ -173,29 +172,32 @@ export type DumbbellAxis = {
   noOfSections: number;
   /** Plotted-unit span (a grade float shifted by `minId` never exceeds this). */
   maxValue: number;
-  /** Tick labels bottom→top, one per section boundary (`noOfSections + 1`); a
-   *  V-grade spanning several ids is labelled once, the rest blank. */
+  /** Tick labels bottom→top, one per gridline (`noOfSections + 1`). Every tick
+   *  is labelled with the grade at its height — gifted renders a blank y label
+   *  as "0", so we never emit blanks. */
   yAxisLabelTexts: string[];
 };
 
-// Above this many distinct V-grades in the window, one label per grade crowds
-// the axis text, so we thin the labels to every other grade (the gridlines
-// themselves stay one-per-id).
-const DENSE_LABEL_THRESHOLD = 9;
+// Grade gridlines are coarse and fully labelled (see buildDumbbellAxis): aim for
+// ~one line per this many ids (≈2 grades), capped at MAX_AXIS_SECTIONS so the
+// axis text stays sparse and even rather than crowded.
+const IDS_PER_AXIS_SECTION = 4;
+const MAX_AXIS_SECTIONS = 6;
 
 /**
  * Build the shared Y axis from the dumbbell rows. Falls back to a small window
  * around V0 when there are no plottable values (an empty/degenerate model).
  *
- * One gridline per grade id (step 1). V-grades span a VARIABLE number of ids
- * (V0 = 4a/4b/4c, three ids; V2 = 5c, one id), so an id step wider than 1 would
- * jump over the single-id grades and land the ticks on a duplicated/uneven set
- * of V labels ("V0, V0, V1, V3, V5…"). Stepping by one id visits every grade;
- * we then label only the FIRST id of each whole V-grade (V0, V1, V2…), blanking
- * the rest, so each whole grade is labelled exactly once with no repeats and no
- * gaps — even though the shown label follows the viewer's format (a "6c+/V5" id
- * keyed under V5). `maxValue === maxId - minId` keeps the linear marker geometry
- * (`localY`) exact — a grade float plots at `grade - minId` in the axis span.
+ * Coarse, fully-labelled gridlines. gifted renders a blank y-axis tick as "0"
+ * (there is no per-tick "no label"), so we must label EVERY gridline. V-grades
+ * span a variable number of ids, so we can't drop an evenly-spaced line on every
+ * whole grade; instead we grid evenly in id space (~one line per
+ * IDS_PER_AXIS_SECTION ids) and label each line with the grade at its height.
+ * Markers still land on their own grade line via the shared value scale
+ * (`maxValue === maxId - minId`, so a grade float plots at `grade - minId`);
+ * off-grade markers sit between lines. We pick the finest section count whose
+ * labels don't repeat — a coarse step keeps neighbouring ticks on distinct
+ * grades even though one grade can cover up to three ids.
  */
 export function buildDumbbellAxis(rows: DumbbellAngleRow[], gradeFormat: GradeDisplayFormat): DumbbellAxis {
   const values: number[] = [];
@@ -221,39 +223,33 @@ export function buildDumbbellAxis(rows: DumbbellAngleRow[], gradeFormat: GradeDi
   // maxId is already clamped to the hardest real grade, so the top tick renders
   // a truthful label — no overflow correction needed at step 1.
 
-  const noOfSections = maxId - minId;
-  const maxValue = noOfSections;
+  const span = maxId - minId;
+  // Keep the plotted-unit span equal to the id span so `localY` (which divides
+  // by maxValue) lands a grade float at `grade - minId`.
+  const maxValue = span;
 
-  // Label the first id of each whole V-grade, blanking the rest — so a grade
-  // spanning several ids (V0 = 4a/4b/4c) is labelled once, at its lowest id.
-  // Dedup keys on the whole V-grade (`v_grade`), not the formatted label, so the
-  // axis reads V0, V1, V2… rather than the format's finer V5 / V5+ steps.
-  // `distinctIndices` collects the label positions so a wide window can thin them.
-  const yAxisLabelTexts: string[] = [];
-  const distinctIndices: number[] = [];
-  let lastVGrade: string | null = null;
-  for (let index = 0; index <= noOfSections; index++) {
-    const id = minId + index;
-    const vGrade = GRADE_BY_ID.get(id)?.v_grade ?? null;
-    const label = renderDifficulty(id, gradeFormat)?.label ?? '';
-    if (label && vGrade && vGrade !== lastVGrade) {
-      yAxisLabelTexts.push(label);
-      distinctIndices.push(index);
-      lastVGrade = vGrade;
-    } else {
-      yAxisLabelTexts.push('');
+  // Evenly-spaced ticks in id space, each labelled with the grade at its
+  // height. index 0 = bottom (minId), index N = top (maxId); every entry is a
+  // real grade label so gifted never falls back to a "0" tick.
+  const labelsForSections = (sections: number): string[] => {
+    const labels: string[] = [];
+    for (let index = 0; index <= sections; index++) {
+      const id = Math.round(minId + (span * index) / sections);
+      labels.push(renderDifficulty(id, gradeFormat)?.label ?? '');
     }
-  }
+    return labels;
+  };
+  const hasAdjacentDuplicate = (labels: string[]): boolean =>
+    labels.some((label, index) => index > 0 && label === labels[index - 1]);
 
-  // Wide window: thin to every other distinct grade so the axis text stays
-  // legible, always keeping the top grade so the range reads end to end.
-  if (distinctIndices.length > DENSE_LABEL_THRESHOLD) {
-    const keep = new Set<number>();
-    for (let i = 0; i < distinctIndices.length; i += 2) keep.add(distinctIndices[i]);
-    keep.add(distinctIndices[distinctIndices.length - 1]);
-    for (const index of distinctIndices) {
-      if (!keep.has(index)) yAxisLabelTexts[index] = '';
-    }
+  // Start from the target density, then coarsen until neighbouring ticks stop
+  // repeating (a single V-grade can cover up to three ids). Floors at 1 section
+  // = just the bottom + top grade for a tiny window.
+  let noOfSections = Math.min(MAX_AXIS_SECTIONS, Math.max(1, Math.round(span / IDS_PER_AXIS_SECTION)));
+  let yAxisLabelTexts = labelsForSections(noOfSections);
+  while (noOfSections > 1 && hasAdjacentDuplicate(yAxisLabelTexts)) {
+    noOfSections -= 1;
+    yAxisLabelTexts = labelsForSections(noOfSections);
   }
 
   return { minId, maxId, noOfSections, maxValue, yAxisLabelTexts };

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -7,12 +7,12 @@
 import { useMemo, type ReactNode } from 'react';
 import { View, StyleSheet, type ColorValue } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { Climb } from '@boardsesh/queue';
 import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH, glassSize } from '../../theme/layout';
 import { spacing } from '../../theme/tokens';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
-import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useDisplayGrade } from '../../hooks/use-display-grade';
 import { Text } from '../Text';
 import { MarqueeText } from '../MarqueeText';
 import { useTheme } from '../../providers/theme-provider';
@@ -82,7 +82,7 @@ export function ClimbCapsule({
 }: ClimbCapsuleProps) {
   const { systemColors, brandColors } = useTheme();
   const { boardConfig } = useDrawerHost();
-  const { formatGrade } = useGradeFormat();
+  const { resolveGrade } = useDisplayGrade();
   const { openGesture, currentItem } = useAccessoryClimbTap();
   // Connection state drives the leading control + the "you have control" glow.
   // Read from the single source so the bar can't disagree with the drawer bulb.
@@ -97,15 +97,15 @@ export function ClimbCapsule({
   // Only "you are driving the wall" lights the bar up.
   const connected = boardConnection === 'connectedByMe';
 
+  // Boardsesh grade (label + colour) when the toggle is on and a trusted one
+  // exists, else the legacy Aurora grade — the same treatment as the list rows.
   const grades = useMemo(() => {
-    const currentColor = currentClimb
-      ? (getGradeColor(currentClimb.difficulty) ?? DEFAULT_GRADE_COLOR)
-      : DEFAULT_GRADE_COLOR;
+    const resolved = currentClimb ? resolveGrade(currentClimb) : null;
     return {
-      current: currentClimb ? formatGrade(currentClimb.difficulty) : null,
-      currentColor,
+      current: resolved?.label ?? null,
+      currentColor: resolved?.color ?? DEFAULT_GRADE_COLOR,
     };
-  }, [currentClimb, formatGrade]);
+  }, [currentClimb, resolveGrade]);
 
   if (!currentClimb) return null;
 

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, View, type ColorValue } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import type { Climb } from '@boardsesh/queue';
-import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useDisplayGrade } from '../../hooks/use-display-grade';
 import { useTheme } from '../../providers/theme-provider';
 import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
 import { spacing } from '../../theme/tokens';
@@ -83,12 +83,14 @@ function ClimbLabel({ climb, labelColor, formattedGrade, showThumbnail, boardCon
 export function NativeAccessoryClimbRow({ climb, placement, width }: NativeAccessoryClimbRowProps) {
   const { boardConfig } = useDrawerHost();
   const { systemColors } = useTheme();
-  const { formatGrade } = useGradeFormat();
+  const { resolveGrade } = useDisplayGrade();
   const { openGesture } = useAccessoryClimbTap();
 
   const showThumbnail = placement === 'regular' && boardConfig !== null;
   const rowHeight = placement === 'inline' ? glassSize.inline : glassSize.standard;
-  const currentFormattedGrade = formatGrade(climb.difficulty);
+  // The platter shows a plain (non-colorized) grade; only the label swaps to the
+  // Boardsesh grade when the toggle is on and a trusted one exists.
+  const currentFormattedGrade = resolveGrade(climb).label;
 
   return (
     <View style={[styles.row, { width, height: rowHeight }]}>

--- a/packages/mobile/src/components/queue-control/WallStatusCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/WallStatusCapsule.tsx
@@ -25,9 +25,8 @@ import { AccessibilityInfo, Pressable, StyleSheet, View } from 'react-native';
 import Animated, { FadeIn, useReducedMotion } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { useTheme } from '../../providers/theme-provider';
-import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useDisplayGrade } from '../../hooks/use-display-grade';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { withAlpha } from '../../theme/colors';
 import { selectByVariant } from '../../theme/variants/select-by-variant';
@@ -63,13 +62,17 @@ type WallStatusCapsuleProps = {
 function WallStatusCapsuleImpl({ climb }: WallStatusCapsuleProps) {
   const { t } = useTranslation('session');
   const { variant, colorScheme, systemColors, brandColors, m3, m3SurfaceContainers } = useTheme();
-  const { formatGrade } = useGradeFormat();
+  const { resolveGrade } = useDisplayGrade();
   const reduceMotion = useReducedMotion();
   const openWallPreview = useOpenWallPreview();
 
   const name = climb.name ?? '';
-  const formattedGrade = formatGrade(climb.grade ?? '');
-  const gradeColor = getGradeColor(climb.grade ?? '') ?? DEFAULT_GRADE_COLOR;
+  // BoardPresenceClimb carries no Boardsesh grade today, so `resolveGrade` falls
+  // back to the legacy label + colour — the capsule swaps to the Boardsesh grade
+  // once the backend stamps presence climbs.
+  const resolvedGrade = resolveGrade({ difficulty: climb.grade ?? '' });
+  const formattedGrade = climb.grade ? resolvedGrade.label : null;
+  const gradeColor = resolvedGrade.color;
   const senderName = climb.sentByDisplayName?.trim() || null;
   const hasSenderIdentity = climb.sentByAvatarUrl != null || senderName != null;
 

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -147,11 +147,18 @@ vi.mock('../../../providers/drawer-host-provider', () => ({
 // only renders it when boardConfig is set (null here), so stub it out.
 vi.mock('../AccessoryClimbThumbnail', () => ({ AccessoryClimbThumbnail: () => null }));
 
-// formatGrade prefixes so the displayed grade is distinguishable from the raw
-// difficulty key used for colour lookup.
-vi.mock('../../../hooks/use-grade-format', () => ({
-  useGradeFormat: () => ({
-    formatGrade: (difficulty: string | null | undefined) => (difficulty ? `${difficulty} 6C` : null),
+// The capsule renders whatever `resolveGrade` returns (the app-wide "Show Boardsesh
+// grades" swap). Stub it to the legacy behaviour: label = formatGrade output
+// ("<difficulty> 6C"), colour = the mocked grade hue (#FF0000 for V6, else default),
+// so the colorization assertions below hold under the new resolver.
+vi.mock('../../../hooks/use-display-grade', () => ({
+  useDisplayGrade: () => ({
+    boardseshActive: false,
+    resolveGrade: (climb: { difficulty?: string | null }) => ({
+      label: climb.difficulty ? `${climb.difficulty} 6C` : null,
+      color: climb.difficulty === 'V6' ? '#FF0000' : '#808080',
+      isBoardsesh: false,
+    }),
   }),
 }));
 

--- a/packages/mobile/src/components/queue-control/__tests__/wall-status-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/wall-status-capsule.test.tsx
@@ -85,9 +85,18 @@ vi.mock('../../../providers/theme-provider', () => ({
     m3SurfaceContainers: { high: '#2A2142', highest: '#322748' },
   }),
 }));
-vi.mock('../../../hooks/use-grade-format', () => ({
-  useGradeFormat: () => ({
-    formatGrade: (grade: string | null | undefined) => (grade ? `${grade} 6C` : null),
+// The capsule renders whatever `resolveGrade` returns (the app-wide "Show Boardsesh
+// grades" swap). Stub it to the legacy behaviour: label = "<grade> 6C", colour = the
+// mocked grade hue (#FF0000 for V5, else default). BoardPresenceClimb carries no
+// Boardsesh grade today, so the toggle-on path still falls through to this.
+vi.mock('../../../hooks/use-display-grade', () => ({
+  useDisplayGrade: () => ({
+    boardseshActive: false,
+    resolveGrade: (fields: { difficulty?: string | null }) => ({
+      label: fields.difficulty ? `${fields.difficulty} 6C` : '',
+      color: fields.difficulty === 'V5' ? '#FF0000' : '#808080',
+      isBoardsesh: false,
+    }),
   }),
 }));
 vi.mock('../../Text', () => ({

--- a/packages/mobile/src/components/session/SessionLeaderboard.tsx
+++ b/packages/mobile/src/components/session/SessionLeaderboard.tsx
@@ -14,6 +14,8 @@ import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useBoardseshGradesActive } from '../../hooks/use-display-grade';
+import { resolveCrowdDifficultyId, GRADE_BY_ID, clampDifficultyId } from '../../lib/boardsesh-grade-display';
 
 type SessionLeaderboardProps = {
   participants: SessionFeedParticipant[];
@@ -33,19 +35,27 @@ export function SessionLeaderboard({ participants, ticks }: SessionLeaderboardPr
   const { t } = useTranslation('session');
   const { t: tYou } = useTranslation('you');
   const { brandColors } = useTheme();
+  const boardseshActive = useBoardseshGradesActive();
 
   // Each climber's hardest grade (max difficulty among their sends/flashes).
+  // The logger's OWN grade wins; only an ungraded tick falls back to the crowd
+  // grade (the Boardsesh grade when the app-wide toggle is on and it's trusted),
+  // so an ungraded send still counts toward — and names — their hardest.
   const hardestByUser = useMemo(() => {
     const best = new Map<string, Hardest>();
     for (const tick of ticks) {
       if (tick.status === 'attempt') continue;
-      const difficulty = tick.difficulty ?? -1;
+      const crowdDifficulty = tick.difficulty == null ? resolveCrowdDifficultyId(tick, boardseshActive) : null;
+      const difficulty = tick.difficulty ?? crowdDifficulty ?? -1;
+      const name =
+        crowdDifficulty != null
+          ? (GRADE_BY_ID.get(clampDifficultyId(crowdDifficulty))?.difficulty_name ?? null)
+          : (tick.difficultyName ?? null);
       const prev = best.get(tick.userId);
-      if (!prev || difficulty > prev.difficulty)
-        best.set(tick.userId, { difficulty, name: tick.difficultyName ?? null });
+      if (!prev || difficulty > prev.difficulty) best.set(tick.userId, { difficulty, name });
     }
     return best;
-  }, [ticks]);
+  }, [ticks, boardseshActive]);
 
   const ranked = useMemo(
     () =>

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -12,6 +12,8 @@ import { PressableSurface } from '../PressableSurface';
 import { ClimbListItemContent } from '../ClimbListItemContent';
 import { gradeBadgeColor } from '../you/profile-chart-colors';
 import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useBoardseshGradesActive } from '../../hooks/use-display-grade';
+import { resolveCrowdDifficultyId, GRADE_BY_ID, clampDifficultyId } from '../../lib/boardsesh-grade-display';
 import { useTheme } from '../../providers/theme-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { brandColors, withAlpha } from '../../theme/colors';
@@ -92,6 +94,7 @@ export const SessionTickRow = memo(function SessionTickRow({
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
   const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
+  const boardseshActive = useBoardseshGradesActive();
   const { openClimbActions } = useDrawerHost();
 
   const meta = statusMeta(tick.status);
@@ -178,9 +181,17 @@ export const SessionTickRow = memo(function SessionTickRow({
     );
   }
 
+  // The logger's OWN grade (`tick.difficulty`) wins; only an ungraded tick falls
+  // back to the crowd grade — the Boardsesh grade when the app-wide toggle is on
+  // and it's trusted, otherwise nothing (session ticks carry no consensus grade).
+  const crowdDifficulty = tick.difficulty == null ? resolveCrowdDifficultyId(tick, boardseshActive) : null;
+  const effectiveDifficulty = tick.difficulty ?? crowdDifficulty;
   const gradeLabel =
-    formatGradeByDifficultyId(tick.difficulty) ?? formatGrade(tick.difficultyName) ?? tick.difficultyName;
-  const gradeColor = gradeLabel ? gradeBadgeColor(tick.difficultyName ?? gradeLabel) : undefined;
+    formatGradeByDifficultyId(effectiveDifficulty) ?? formatGrade(tick.difficultyName) ?? tick.difficultyName;
+  const gradeColorName =
+    tick.difficultyName ??
+    (crowdDifficulty != null ? (GRADE_BY_ID.get(clampDifficultyId(crowdDifficulty))?.difficulty_name ?? null) : null);
+  const gradeColor = gradeLabel ? gradeBadgeColor(gradeColorName ?? gradeLabel) : undefined;
 
   return (
     <ListRow

--- a/packages/mobile/src/components/you/LogbookRow.tsx
+++ b/packages/mobile/src/components/you/LogbookRow.tsx
@@ -32,6 +32,8 @@ import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useBoardseshGradesActive } from '../../hooks/use-display-grade';
+import { resolveCrowdDifficultyId, GRADE_BY_ID, clampDifficultyId } from '../../lib/boardsesh-grade-display';
 import { getBoardConfigForPlaylist } from '../../lib/playlists/board-details-for-playlist';
 import { hapticSelection, hapticMedium, hapticLight, hapticSuccess } from '../../lib/haptics';
 
@@ -168,34 +170,42 @@ export const LogbookRow = memo(function LogbookRow({
   const { t, i18n } = useTranslation('you');
   const { systemColors, brandColors: brand } = useTheme();
   const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
+  const boardseshActive = useBoardseshGradesActive();
 
   const statusColor =
     ascent.status === 'flash' ? brand.warning : ascent.status === 'send' ? brand.success : iosSystemColors.systemGray;
 
   // --- Grade column: the big grade is always the climber's effective grade
-  // (their own, or the consensus when they never graded it — marked with the
-  // `people` glyph). The consensus shows as a small secondary only when the
-  // crowd disagrees, with an arrow for the direction of the disagreement.
+  // (their own, or the crowd grade when they never graded it — marked with the
+  // `people` glyph). The crowd grade shows as a small secondary only when it
+  // disagrees, with an arrow for the direction of the disagreement.
+  //
+  // A climber's OWN logged grade (`ascent.difficulty`) always wins; the crowd
+  // side is the only thing the app-wide "Show Boardsesh grades" toggle swaps —
+  // the Boardsesh grade replaces the legacy community consensus as the crowd
+  // grade when it's active, present and trusted (see resolveCrowdDifficultyId).
+  const crowdDifficulty = resolveCrowdDifficultyId(ascent, boardseshActive);
+  const { showConsensusSecondary, gradeIsConsensus } = deriveLogbookGradeDisplay(ascent.difficulty, crowdDifficulty);
   const rawGradeLabel = ascent.difficultyName ?? ascent.consensusDifficultyName;
-  const gradeLabel =
-    formatGradeByDifficultyId(ascent.difficulty ?? ascent.consensusDifficulty) ??
-    formatGrade(rawGradeLabel) ??
-    rawGradeLabel;
-  const gradeColor = rawGradeLabel ? (getGradeColor(rawGradeLabel) ?? DEFAULT_GRADE_COLOR) : DEFAULT_GRADE_COLOR;
-  const { showConsensusSecondary, gradeIsConsensus } = deriveLogbookGradeDisplay(
-    ascent.difficulty,
-    ascent.consensusDifficulty,
-  );
+  const bigGradeDifficulty = ascent.difficulty ?? crowdDifficulty;
+  const gradeLabel = formatGradeByDifficultyId(bigGradeDifficulty) ?? formatGrade(rawGradeLabel) ?? rawGradeLabel;
+  // Colour the big grade to match the value actually shown: when the row is
+  // showing a crowd grade (Boardsesh grade when active), colour it from that
+  // grade's own difficulty bucket rather than the legacy consensus name; the
+  // climber's own logged-grade colour path is untouched.
+  const gradeColorName =
+    gradeIsConsensus && crowdDifficulty != null
+      ? (GRADE_BY_ID.get(clampDifficultyId(crowdDifficulty))?.difficulty_name ?? rawGradeLabel)
+      : rawGradeLabel;
+  const gradeColor = gradeColorName ? (getGradeColor(gradeColorName) ?? DEFAULT_GRADE_COLOR) : DEFAULT_GRADE_COLOR;
   const consensusGradeLabel = showConsensusSecondary
-    ? (formatGradeByDifficultyId(ascent.consensusDifficulty) ??
+    ? (formatGradeByDifficultyId(crowdDifficulty) ??
       formatGrade(ascent.consensusDifficultyName) ??
       ascent.consensusDifficultyName)
     : null;
   // 'up' = you found it harder than the crowd. Informational, not a warning —
   // the sub-line renders in secondaryLabel, never an alert tone.
-  const deltaDirection = showConsensusSecondary
-    ? consensusDeltaDirection(ascent.difficulty, ascent.consensusDifficulty)
-    : null;
+  const deltaDirection = showConsensusSecondary ? consensusDeltaDirection(ascent.difficulty, crowdDifficulty) : null;
 
   // --- Meta line parts (review data — the climber's own record, not the
   // crowd's). Board+angle always renders: with no thumbnail it is the only

--- a/packages/mobile/src/components/you/__tests__/logbook-row.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-row.test.tsx
@@ -11,6 +11,11 @@ import type { AscentFeedItem } from '@boardsesh/graphql/operations';
 // decisions + the row's label formatting are exercised end-to-end.
 const swipeable = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
 const a11y = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+// Controls the app-wide "Show Boardsesh grades" toggle for the row. Default OFF
+// so the existing consensus-fallback tests are unaffected; the Boardsesh-grade
+// block flips it per case. resolveCrowdDifficultyId (@boardsesh/logbook, via the
+// real boardsesh-grade-display lib) is exercised for real off this flag.
+const boardsesh = vi.hoisted(() => ({ active: false }));
 
 vi.mock('react-native', () => ({
   View: (props: { children?: ReactNode } & Record<string, unknown>) => {
@@ -118,6 +123,9 @@ vi.mock('../../../hooks/use-grade-format', () => ({
     formatGradeByDifficultyId: (id: number | null | undefined) => (id != null ? `V${id}` : null),
   }),
 }));
+vi.mock('../../../hooks/use-display-grade', () => ({
+  useBoardseshGradesActive: () => boardsesh.active,
+}));
 vi.mock('../../../lib/playlists/board-details-for-playlist', () => ({
   getBoardConfigForPlaylist: () => ({ boardName: 'kilter', layoutId: 1, sizeId: 1, setIds: [1] }),
 }));
@@ -179,6 +187,7 @@ function iconNames(container: HTMLElement): string[] {
 beforeEach(() => {
   swipeable.props = null;
   a11y.props = null;
+  boardsesh.active = false;
 });
 
 describe('LogbookRow — grade column', () => {
@@ -219,6 +228,76 @@ describe('LogbookRow — grade column', () => {
     expect(icons).not.toContain('people');
     expect(icons).not.toContain('chevron.up');
     expect(icons).not.toContain('chevron.down');
+  });
+});
+
+describe('LogbookRow — Boardsesh grade fallback', () => {
+  it('keeps the climber’s own grade big and shows the Boardsesh grade as the crowd secondary when active', () => {
+    boardsesh.active = true;
+    // User graded V18; Boardsesh grade (trusted) is V22 and no legacy consensus.
+    const { container, getByText } = renderRow(
+      ascent({ difficulty: 18, difficultyName: '18', boardseshDifficulty: 22, boardseshConfidence: 'confirmed' }),
+    );
+
+    // The logger's own grade always wins as the big grade.
+    getByText('V18');
+    // Boardsesh grade fills the crowd side as the small secondary.
+    getByText('V22');
+    const icons = iconNames(container);
+    expect(icons.filter((name) => name === 'people')).toHaveLength(1);
+    // 18 < 22 → you found it softer than the Boardsesh grade → arrow down.
+    expect(icons).toContain('chevron.down');
+    expect(icons).not.toContain('chevron.up');
+  });
+
+  it('shows the Boardsesh grade as the big grade (with the people marker) for an ungraded tick when active', () => {
+    boardsesh.active = true;
+    const { container, getByText, queryByText } = renderRow(
+      ascent({
+        consensusDifficulty: 25,
+        consensusDifficultyName: '25',
+        boardseshDifficulty: 20,
+        boardseshConfidence: 'confirmed',
+      }),
+    );
+
+    // Boardsesh grade replaces the legacy consensus as the crowd grade shown.
+    getByText('V20');
+    expect(queryByText('V25')).toBeNull();
+    const icons = iconNames(container);
+    expect(icons.filter((name) => name === 'people')).toHaveLength(1);
+    expect(icons).not.toContain('chevron.up');
+    expect(icons).not.toContain('chevron.down');
+  });
+
+  it('shows the legacy consensus for an ungraded tick when the toggle is off', () => {
+    boardsesh.active = false;
+    const { getByText, queryByText } = renderRow(
+      ascent({
+        consensusDifficulty: 25,
+        consensusDifficultyName: '25',
+        boardseshDifficulty: 20,
+        boardseshConfidence: 'confirmed',
+      }),
+    );
+
+    getByText('V25');
+    expect(queryByText('V20')).toBeNull();
+  });
+
+  it('never uses a setter_only Boardsesh grade — falls back to the consensus even when active', () => {
+    boardsesh.active = true;
+    const { getByText, queryByText } = renderRow(
+      ascent({
+        consensusDifficulty: 25,
+        consensusDifficultyName: '25',
+        boardseshDifficulty: 20,
+        boardseshConfidence: 'setter_only',
+      }),
+    );
+
+    getByText('V25');
+    expect(queryByText('V20')).toBeNull();
   });
 });
 

--- a/packages/mobile/src/hooks/__tests__/use-display-grade.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-display-grade.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// Controllable stand-ins for the three hooks useDisplayGrade composes, so
+// these tests exercise the composition (hard kill switch, resolveGrade
+// wiring) rather than AsyncStorage/PostHog plumbing already covered by each
+// dependency's own tests.
+const ctrl = vi.hoisted(() => ({
+  flagEnabled: false,
+  preferenceEnabled: false,
+  gradeFormat: 'v-grade' as 'v-grade' | 'font' | 'both',
+}));
+
+vi.mock('../../providers/feature-flags-provider', () => ({
+  useBoardseshGradeEnabled: () => ctrl.flagEnabled,
+}));
+
+vi.mock('../../lib/boardsesh-grades-preference', () => ({
+  useBoardseshGradesPreference: () => ({
+    enabled: ctrl.preferenceEnabled,
+    loaded: true,
+    setEnabled: vi.fn(),
+  }),
+}));
+
+vi.mock('../use-grade-format', () => ({
+  useGradeFormat: () => ({
+    gradeFormat: ctrl.gradeFormat,
+    setGradeFormat: vi.fn(),
+    loaded: true,
+    formatGrade: vi.fn(),
+    formatGradeByDifficultyId: vi.fn(),
+  }),
+}));
+
+import { useBoardseshGradesActive, useDisplayGrade } from '../use-display-grade';
+
+describe('useBoardseshGradesActive', () => {
+  it('is off when the flag is off, even if the preference is on (hard kill switch)', () => {
+    ctrl.flagEnabled = false;
+    ctrl.preferenceEnabled = true;
+    expect(renderHook(() => useBoardseshGradesActive()).result.current).toBe(false);
+  });
+
+  it('is off when the preference is off, even if the flag is on', () => {
+    ctrl.flagEnabled = true;
+    ctrl.preferenceEnabled = false;
+    expect(renderHook(() => useBoardseshGradesActive()).result.current).toBe(false);
+  });
+
+  it('is on only when both the flag and the preference are on', () => {
+    ctrl.flagEnabled = true;
+    ctrl.preferenceEnabled = true;
+    expect(renderHook(() => useBoardseshGradesActive()).result.current).toBe(true);
+  });
+});
+
+describe('useDisplayGrade', () => {
+  const climb = { difficulty: '6b/V4', boardseshDifficulty: 20, boardseshConfidence: 'confirmed' };
+
+  it('resolveGrade renders the legacy grade when inactive', () => {
+    ctrl.flagEnabled = false;
+    ctrl.preferenceEnabled = false;
+    ctrl.gradeFormat = 'v-grade';
+
+    const { result } = renderHook(() => useDisplayGrade());
+    expect(result.current.boardseshActive).toBe(false);
+    expect(result.current.resolveGrade(climb)).toEqual({
+      label: 'V4',
+      color: expect.stringMatching(/^#/),
+      isBoardsesh: false,
+    });
+  });
+
+  it('resolveGrade renders the Boardsesh grade when active', () => {
+    ctrl.flagEnabled = true;
+    ctrl.preferenceEnabled = true;
+    ctrl.gradeFormat = 'v-grade';
+
+    const { result } = renderHook(() => useDisplayGrade());
+    expect(result.current.boardseshActive).toBe(true);
+    // 20 = 6c/V5, differs from the legacy 6b/V4 so the swap is observable.
+    expect(result.current.resolveGrade(climb)).toEqual({
+      label: 'V5',
+      color: expect.stringMatching(/^#/),
+      isBoardsesh: true,
+    });
+  });
+});

--- a/packages/mobile/src/hooks/use-display-grade.ts
+++ b/packages/mobile/src/hooks/use-display-grade.ts
@@ -1,0 +1,42 @@
+import { useCallback, useMemo } from 'react';
+import { useBoardseshGradeEnabled } from '../providers/feature-flags-provider';
+import { useBoardseshGradesPreference } from '../lib/boardsesh-grades-preference';
+import { useGradeFormat } from './use-grade-format';
+import { resolveDisplayGrade, type BoardseshGradeFields, type DisplayGrade } from '../lib/boardsesh-grade-display';
+
+/**
+ * Whether a climb/tick should render its Boardsesh grade instead of the
+ * legacy Aurora grade right now: the `boardsesh-grade` PostHog flag AND the
+ * climber's own "Show Boardsesh grades" preference. The flag is a hard kill
+ * switch — off wins even over a stale persisted `true` preference, so a
+ * rollback instantly reverts everyone to the legacy grade with no local
+ * migration needed.
+ */
+export function useBoardseshGradesActive(): boolean {
+  const flagEnabled = useBoardseshGradeEnabled();
+  const { enabled: preferenceEnabled } = useBoardseshGradesPreference();
+  return flagEnabled && preferenceEnabled;
+}
+
+/**
+ * The app-wide grade resolver for climb rows/headers: whether Boardsesh
+ * grades are active, plus a stable `resolveGrade` callback that renders a
+ * climb's label + colour per the current preference and grade-format
+ * setting. Call this once per list/screen component (it's cheap, but
+ * `resolveGrade` is meant to run per row, not be re-derived per row).
+ */
+export function useDisplayGrade(): {
+  boardseshActive: boolean;
+  resolveGrade: (climb: BoardseshGradeFields & { difficulty?: string | null }) => DisplayGrade;
+} {
+  const boardseshActive = useBoardseshGradesActive();
+  const { gradeFormat } = useGradeFormat();
+
+  const resolveGrade = useCallback(
+    (climb: BoardseshGradeFields & { difficulty?: string | null }): DisplayGrade =>
+      resolveDisplayGrade(climb, { useBoardseshGrades: boardseshActive, gradeFormat }),
+    [boardseshActive, gradeFormat],
+  );
+
+  return useMemo(() => ({ boardseshActive, resolveGrade }), [boardseshActive, resolveGrade]);
+}

--- a/packages/mobile/src/lib/__tests__/boardsesh-grade-display.test.ts
+++ b/packages/mobile/src/lib/__tests__/boardsesh-grade-display.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderDifficulty,
+  clampDifficultyId,
+  resolveBoardseshDifficulty,
+  resolveBoardseshDifficultyId,
+  resolveDisplayGrade,
+  resolveCrowdDifficultyId,
+  resolveTickDefaultGradeName,
+  MIN_DIFFICULTY_ID,
+  MAX_DIFFICULTY_ID,
+} from '../boardsesh-grade-display';
+
+describe('renderDifficulty / clampDifficultyId', () => {
+  it('rounds a float to the nearest grade and colours it', () => {
+    // 20 = 6c/V5 on the shared scale.
+    const rendered = renderDifficulty(20.3, 'v-grade');
+    expect(rendered?.label).toBe('V5');
+    expect(rendered?.color).toMatch(/^#/);
+  });
+
+  it('clamps below and above the scale bounds', () => {
+    expect(clampDifficultyId(-100)).toBe(MIN_DIFFICULTY_ID);
+    expect(clampDifficultyId(9999)).toBe(MAX_DIFFICULTY_ID);
+  });
+});
+
+describe('resolveBoardseshDifficulty', () => {
+  it('returns null when boardseshDifficulty is null or undefined', () => {
+    expect(resolveBoardseshDifficulty({ boardseshDifficulty: null })).toBeNull();
+    expect(resolveBoardseshDifficulty({ boardseshDifficulty: undefined })).toBeNull();
+    expect(resolveBoardseshDifficulty({})).toBeNull();
+  });
+
+  it('returns null for setter_only confidence even with a value present', () => {
+    expect(resolveBoardseshDifficulty({ boardseshDifficulty: 20.3, boardseshConfidence: 'setter_only' })).toBeNull();
+  });
+
+  it('returns the raw value for confirmed/provisional/unknown confidence', () => {
+    expect(resolveBoardseshDifficulty({ boardseshDifficulty: 20.3, boardseshConfidence: 'confirmed' })).toBe(20.3);
+    expect(resolveBoardseshDifficulty({ boardseshDifficulty: 20.3, boardseshConfidence: 'provisional' })).toBe(20.3);
+    expect(resolveBoardseshDifficulty({ boardseshDifficulty: 20.3, boardseshConfidence: undefined })).toBe(20.3);
+  });
+
+  it('treats a zero difficulty as present (not falsy-skipped)', () => {
+    expect(resolveBoardseshDifficulty({ boardseshDifficulty: 0, boardseshConfidence: 'confirmed' })).toBe(0);
+  });
+});
+
+describe('resolveBoardseshDifficultyId', () => {
+  it('rounds and clamps the resolved difficulty', () => {
+    expect(resolveBoardseshDifficultyId({ boardseshDifficulty: 20.6, boardseshConfidence: 'confirmed' })).toBe(21);
+    expect(resolveBoardseshDifficultyId({ boardseshDifficulty: -100, boardseshConfidence: 'confirmed' })).toBe(
+      MIN_DIFFICULTY_ID,
+    );
+    expect(resolveBoardseshDifficultyId({ boardseshDifficulty: 9999, boardseshConfidence: 'confirmed' })).toBe(
+      MAX_DIFFICULTY_ID,
+    );
+  });
+
+  it('returns null when the underlying value resolves to null', () => {
+    expect(resolveBoardseshDifficultyId({ boardseshDifficulty: null })).toBeNull();
+    expect(resolveBoardseshDifficultyId({ boardseshDifficulty: 20, boardseshConfidence: 'setter_only' })).toBeNull();
+  });
+});
+
+describe('resolveDisplayGrade', () => {
+  const legacyClimb = { difficulty: '6b/V4', boardseshDifficulty: 20, boardseshConfidence: 'confirmed' as const };
+
+  it('renders the legacy grade when the toggle is off', () => {
+    const display = resolveDisplayGrade(legacyClimb, { useBoardseshGrades: false, gradeFormat: 'v-grade' });
+    expect(display).toEqual({ label: 'V4', color: expect.stringMatching(/^#/), isBoardsesh: false });
+  });
+
+  it('renders the legacy grade when boardseshDifficulty is null, even with the toggle on', () => {
+    const display = resolveDisplayGrade(
+      { difficulty: '6b/V4', boardseshDifficulty: null, boardseshConfidence: null },
+      { useBoardseshGrades: true, gradeFormat: 'v-grade' },
+    );
+    expect(display).toEqual({ label: 'V4', color: expect.stringMatching(/^#/), isBoardsesh: false });
+  });
+
+  it('renders the legacy grade for setter_only confidence, even with the toggle on', () => {
+    const display = resolveDisplayGrade(
+      { difficulty: '6b/V4', boardseshDifficulty: 27, boardseshConfidence: 'setter_only' },
+      { useBoardseshGrades: true, gradeFormat: 'v-grade' },
+    );
+    expect(display).toEqual({ label: 'V4', color: expect.stringMatching(/^#/), isBoardsesh: false });
+  });
+
+  it('prefers the Boardsesh grade when the toggle is on and it is trusted', () => {
+    // 20 = 6c/V5, differs from the legacy 6b/V4 so the swap is observable.
+    const display = resolveDisplayGrade(legacyClimb, { useBoardseshGrades: true, gradeFormat: 'v-grade' });
+    expect(display).toEqual({ label: 'V5', color: expect.stringMatching(/^#/), isBoardsesh: true });
+  });
+
+  it('formats the Boardsesh grade per the v-grade/font/both preference', () => {
+    // 20 = 6c/V5.
+    expect(resolveDisplayGrade(legacyClimb, { useBoardseshGrades: true, gradeFormat: 'v-grade' }).label).toBe('V5');
+    expect(resolveDisplayGrade(legacyClimb, { useBoardseshGrades: true, gradeFormat: 'font' }).label).toBe('6C');
+    expect(resolveDisplayGrade(legacyClimb, { useBoardseshGrades: true, gradeFormat: 'both' }).label).toBe('V5 / 6C');
+  });
+
+  it('rounds and clamps the Boardsesh difficulty before rendering', () => {
+    const display = resolveDisplayGrade(
+      { difficulty: '6b/V4', boardseshDifficulty: 9999, boardseshConfidence: 'confirmed' },
+      { useBoardseshGrades: true, gradeFormat: 'v-grade' },
+    );
+    expect(display.label).toBe('V16'); // clamps to 8c+/V16
+    expect(display.isBoardsesh).toBe(true);
+  });
+
+  it('falls back to an empty label when the legacy difficulty is missing entirely', () => {
+    const display = resolveDisplayGrade({}, { useBoardseshGrades: false, gradeFormat: 'v-grade' });
+    expect(display).toEqual({ label: '', color: expect.stringMatching(/^#/), isBoardsesh: false });
+  });
+});
+
+describe('resolveCrowdDifficultyId', () => {
+  it('returns the legacy consensus when the toggle is off, ignoring the Boardsesh grade', () => {
+    expect(
+      resolveCrowdDifficultyId(
+        { boardseshDifficulty: 18.4, boardseshConfidence: 'confirmed', consensusDifficulty: 15 },
+        false,
+      ),
+    ).toBe(15);
+  });
+
+  it('returns the rounded Boardsesh grade when the toggle is on and it is trusted', () => {
+    expect(
+      resolveCrowdDifficultyId(
+        { boardseshDifficulty: 18.4, boardseshConfidence: 'confirmed', consensusDifficulty: 15 },
+        true,
+      ),
+    ).toBe(18);
+  });
+
+  it('falls back to the consensus for a setter_only Boardsesh grade even with the toggle on', () => {
+    expect(
+      resolveCrowdDifficultyId(
+        { boardseshDifficulty: 18.4, boardseshConfidence: 'setter_only', consensusDifficulty: 15 },
+        true,
+      ),
+    ).toBe(15);
+  });
+
+  it('returns null when neither a trusted Boardsesh grade nor a consensus is available', () => {
+    expect(resolveCrowdDifficultyId({ boardseshDifficulty: null, consensusDifficulty: null }, true)).toBeNull();
+  });
+
+  // A user's own logged ascent grade is never an input here — it always wins
+  // upstream of this resolver, which only ever sees the crowd-sourced side.
+});
+
+describe('resolveTickDefaultGradeName', () => {
+  it('returns null when the toggle is off', () => {
+    expect(
+      resolveTickDefaultGradeName({ boardseshDifficulty: 20, boardseshConfidence: 'confirmed' }, false),
+    ).toBeNull();
+  });
+
+  it('returns null when there is no trusted Boardsesh grade', () => {
+    expect(resolveTickDefaultGradeName({ boardseshDifficulty: null }, true)).toBeNull();
+    expect(
+      resolveTickDefaultGradeName({ boardseshDifficulty: 20, boardseshConfidence: 'setter_only' }, true),
+    ).toBeNull();
+  });
+
+  it('returns the Aurora difficulty_name for the resolved Boardsesh grade id', () => {
+    // 20 = 6c/V5.
+    expect(resolveTickDefaultGradeName({ boardseshDifficulty: 20.3, boardseshConfidence: 'confirmed' }, true)).toBe(
+      '6c/V5',
+    );
+  });
+
+  it('rounds and clamps before resolving the name', () => {
+    expect(resolveTickDefaultGradeName({ boardseshDifficulty: 9999, boardseshConfidence: 'confirmed' }, true)).toBe(
+      '8c+/V16',
+    );
+  });
+});

--- a/packages/mobile/src/lib/__tests__/boardsesh-grades-preference.test.ts
+++ b/packages/mobile/src/lib/__tests__/boardsesh-grades-preference.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  let storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+      __reset: () => {
+        storage = {};
+      },
+      __setRaw: (key: string, value: string) => {
+        storage[key] = value;
+      },
+    },
+  };
+});
+
+describe('boardsesh-grades-preference', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __reset: () => void;
+    };
+    asyncStorage.__reset();
+  });
+
+  it('defaults OFF when nothing is stored', async () => {
+    const { loadBoardseshGradesPreference } = await import('../boardsesh-grades-preference');
+    await expect(loadBoardseshGradesPreference()).resolves.toBe(false);
+  });
+
+  it('honours an explicit ON choice persisted from a previous session', async () => {
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __setRaw: (key: string, value: string) => void;
+    };
+    asyncStorage.__setRaw('useBoardseshGrades', JSON.stringify(true));
+
+    const { loadBoardseshGradesPreference } = await import('../boardsesh-grades-preference');
+    await expect(loadBoardseshGradesPreference()).resolves.toBe(true);
+  });
+
+  it('honours an explicit OFF choice persisted from a previous session', async () => {
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __setRaw: (key: string, value: string) => void;
+    };
+    asyncStorage.__setRaw('useBoardseshGrades', JSON.stringify(false));
+
+    const { loadBoardseshGradesPreference } = await import('../boardsesh-grades-preference');
+    await expect(loadBoardseshGradesPreference()).resolves.toBe(false);
+  });
+
+  it('persists the user opt-in', async () => {
+    const { loadBoardseshGradesPreference, setBoardseshGradesPreference } =
+      await import('../boardsesh-grades-preference');
+    await setBoardseshGradesPreference(true);
+    await expect(loadBoardseshGradesPreference()).resolves.toBe(true);
+  });
+
+  it('lets a set() that races in during the initial load win over the (now stale) persisted value', async () => {
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __setRaw: (key: string, value: string) => void;
+      getItem: ReturnType<typeof vi.fn>;
+    };
+    // Persisted value is OFF, but gate the read so it resolves only after the
+    // user's explicit choice has already landed.
+    asyncStorage.__setRaw('useBoardseshGrades', JSON.stringify(false));
+    let releaseRead: () => void = () => {};
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    asyncStorage.getItem.mockImplementationOnce(async () => {
+      await readGate;
+      return JSON.stringify(false);
+    });
+
+    const { loadBoardseshGradesPreference, setBoardseshGradesPreference } =
+      await import('../boardsesh-grades-preference');
+
+    const loadPromise = loadBoardseshGradesPreference();
+    // The user's explicit ON choice lands while the (slow) disk read is
+    // still in flight.
+    await setBoardseshGradesPreference(true);
+    releaseRead();
+
+    await expect(loadPromise).resolves.toBe(true);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/session-tick-mapping.test.ts
+++ b/packages/mobile/src/lib/__tests__/session-tick-mapping.test.ts
@@ -7,6 +7,7 @@ vi.mock('../playlists/board-details-for-playlist', () => ({
 
 import { getBoardConfigForPlaylist } from '../playlists/board-details-for-playlist';
 import { sessionTickToClimb, navigateToSessionClimb } from '../session-tick-mapping';
+import { resolveDisplayGrade } from '../boardsesh-grade-display';
 
 const mockedGetBoardConfig = vi.mocked(getBoardConfigForPlaylist);
 
@@ -90,6 +91,115 @@ describe('sessionTickToClimb', () => {
     expect(climb?.name).toBe('');
     expect(climb?.difficulty).toBe('');
     expect(climb?.setter_username).toBe('');
+  });
+
+  // The Boardsesh grade only fills in for an UNGRADED tick (`difficulty == null`,
+  // the same signal SessionTickRow's frameless path uses). A logged/consensus
+  // grade always wins, so the fields must be dropped when one is present — else
+  // ClimbListItemContent's unconditional swap would override the user's grade.
+  it('carries the Boardsesh grade fields for an ungraded tick (difficulty == null)', () => {
+    const climb = sessionTickToClimb(
+      makeTick({ frames: 'p1', difficulty: null, boardseshDifficulty: 20, boardseshConfidence: 'confirmed' }),
+    );
+    expect(climb?.boardseshDifficulty).toBe(20);
+    expect(climb?.boardseshConfidence).toBe('confirmed');
+  });
+
+  it('OMITS the Boardsesh grade fields when the tick has a logged grade (difficulty set)', () => {
+    const climb = sessionTickToClimb(
+      makeTick({ frames: 'p1', difficulty: 12, boardseshDifficulty: 20, boardseshConfidence: 'confirmed' }),
+    );
+    expect(climb).not.toHaveProperty('boardseshDifficulty');
+    expect(climb).not.toHaveProperty('boardseshConfidence');
+    expect(climb?.boardseshDifficulty).toBeUndefined();
+  });
+});
+
+// End-to-end grade resolution for the FRAMED session-tick path: the climb built
+// by `sessionTickToClimb` is rendered through `resolveDisplayGrade` — the exact
+// pure resolver `ClimbListItemContent` calls via `useDisplayGrade`. The
+// `useBoardseshGrades` argument mirrors `useBoardseshGradesActive` (flag AND the
+// climber's "Show Boardsesh grades" preference), so `true` == toggle ON.
+describe('sessionTickToClimb → resolveDisplayGrade (framed path grade)', () => {
+  const gradeFormat = 'v-grade' as const;
+  function resolveFramedGrade(tick: SessionDetailTick, useBoardseshGrades: boolean) {
+    const climb = sessionTickToClimb(tick);
+    if (!climb) throw new Error('expected a framed climb');
+    return resolveDisplayGrade(climb, { useBoardseshGrades, gradeFormat });
+  }
+
+  it('(a) ungraded framed tick + toggle ON → renders the Boardsesh grade', () => {
+    // 20 = 6c/V5; the ungraded legacy label is blank, so the swap is observable.
+    const tick = makeTick({
+      frames: 'p1',
+      difficulty: null,
+      difficultyName: null,
+      boardseshDifficulty: 20,
+      boardseshConfidence: 'confirmed',
+    });
+    expect(resolveFramedGrade(tick, true)).toEqual({
+      label: 'V5',
+      color: expect.stringMatching(/^#/),
+      isBoardsesh: true,
+    });
+  });
+
+  it('(b) ungraded framed tick + toggle OFF → legacy grade, never Boardsesh', () => {
+    const tick = makeTick({
+      frames: 'p1',
+      difficulty: null,
+      difficultyName: '6b/V4',
+      boardseshDifficulty: 20,
+      boardseshConfidence: 'confirmed',
+    });
+    expect(resolveFramedGrade(tick, false)).toEqual({
+      label: 'V4',
+      color: expect.stringMatching(/^#/),
+      isBoardsesh: false,
+    });
+  });
+
+  it('(c) GRADED framed tick + toggle ON → renders the USER grade, NOT the Boardsesh grade', () => {
+    // The critical user-grade-wins case: the logger graded V4; the Boardsesh grade
+    // (V5) is present on the tick but must be dropped so it can never override.
+    const tick = makeTick({
+      frames: 'p1',
+      difficulty: 12,
+      difficultyName: '6b/V4',
+      boardseshDifficulty: 20,
+      boardseshConfidence: 'confirmed',
+    });
+    const display = resolveFramedGrade(tick, true);
+    expect(display).toEqual({ label: 'V4', color: expect.stringMatching(/^#/), isBoardsesh: false });
+    expect(display.label).not.toBe('V5');
+  });
+
+  it('(d) ungraded framed tick with a setter_only or null Boardsesh grade → legacy, never Boardsesh', () => {
+    const setterOnly = makeTick({
+      frames: 'p1',
+      difficulty: null,
+      difficultyName: '6b/V4',
+      boardseshDifficulty: 27,
+      boardseshConfidence: 'setter_only',
+    });
+    expect(resolveFramedGrade(setterOnly, true)).toEqual({
+      label: 'V4',
+      color: expect.stringMatching(/^#/),
+      isBoardsesh: false,
+    });
+
+    const noGrade = makeTick({
+      frames: 'p1',
+      difficulty: null,
+      difficultyName: '6b/V4',
+      boardseshDifficulty: null,
+      boardseshConfidence: null,
+    });
+    expect(resolveFramedGrade(noGrade, true)).toEqual({
+      label: 'V4',
+      color: expect.stringMatching(/^#/),
+      isBoardsesh: false,
+    });
   });
 });
 

--- a/packages/mobile/src/lib/boardsesh-grade-display.ts
+++ b/packages/mobile/src/lib/boardsesh-grade-display.ts
@@ -1,0 +1,126 @@
+// Pure, O(1) resolver for how a climb/tick renders its grade under the
+// app-wide "Show Boardsesh grades" preference (boardsesh-grades-preference.ts
+// + hooks/use-display-grade.ts): the data-science Boardsesh grade versus the
+// legacy Aurora-set difficulty. No React — one Map lookup + format per call,
+// so list rows can call this per item without cost.
+//
+// Owns the difficulty-scale primitives (GRADE_BY_ID, renderDifficulty,
+// clampDifficultyId, MIN/MAX_DIFFICULTY_ID) that used to live in the play
+// drawer's boardsesh-grade-utils.ts. That file now re-exports them from here
+// unchanged so its own callers (buildBoardseshGradeView) and tests are
+// untouched — a lib must not import from components, so the primitives moved
+// here and components import them, never the reverse.
+import { formatGrade, type GradeDisplayFormat } from '@boardsesh/play-view';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { BOULDER_GRADES, type BoulderGrade } from '@boardsesh/board-constants/boulder-grade-mapping';
+import { resolveCrowdDifficulty } from '@boardsesh/logbook';
+
+export const GRADE_BY_ID = new Map<number, BoulderGrade>(BOULDER_GRADES.map((grade) => [grade.difficulty_id, grade]));
+
+// The difficulty scale the data-science grade shares with Aurora's ids.
+export const MIN_DIFFICULTY_ID = BOULDER_GRADES[0].difficulty_id;
+export const MAX_DIFFICULTY_ID = BOULDER_GRADES[BOULDER_GRADES.length - 1].difficulty_id;
+
+export type RenderedGrade = {
+  /** Formatted label per the user's grade preference (e.g. "V5", "6c"). */
+  label: string;
+  /** Hex colour for the grade, consistent with the play drawer header. */
+  color: string;
+};
+
+/** Round to the nearest grade id and clamp to the shared difficulty scale. */
+export function clampDifficultyId(value: number): number {
+  return Math.min(MAX_DIFFICULTY_ID, Math.max(MIN_DIFFICULTY_ID, Math.round(value)));
+}
+
+/** Round a float difficulty to the nearest grade and render its label + colour. */
+export function renderDifficulty(value: number, gradeFormat: GradeDisplayFormat): RenderedGrade | null {
+  const grade = GRADE_BY_ID.get(clampDifficultyId(value));
+  if (!grade) return null;
+  return {
+    label: formatGrade(grade.difficulty_name, gradeFormat) ?? grade.v_grade,
+    color: getGradeColor(grade.difficulty_name) ?? DEFAULT_GRADE_COLOR,
+  };
+}
+
+// --- App-wide "Show Boardsesh grades" resolver ------------------------------
+
+/** The two Boardsesh grade fields carried on every climb and tick/ascent object. */
+export type BoardseshGradeFields = {
+  boardseshDifficulty?: number | null;
+  boardseshConfidence?: string | null;
+};
+
+export type DisplayGrade = {
+  label: string;
+  color: string;
+  /** True when this label/color came from the Boardsesh grade, not the legacy Aurora grade. */
+  isBoardsesh: boolean;
+};
+
+/**
+ * The raw Boardsesh difficulty value a climb/tick should use, or null when
+ * there is none or it isn't trusted enough to show (`setter_only`
+ * confidence). Does not check the app-wide toggle — callers gate on that
+ * separately (see `resolveDisplayGrade`, `useDisplayGrade`).
+ */
+export function resolveBoardseshDifficulty(fields: BoardseshGradeFields): number | null {
+  if (fields.boardseshDifficulty == null) return null;
+  if (fields.boardseshConfidence === 'setter_only') return null;
+  return fields.boardseshDifficulty;
+}
+
+/** `resolveBoardseshDifficulty`, rounded to a real grade bucket and clamped to the scale. */
+export function resolveBoardseshDifficultyId(fields: BoardseshGradeFields): number | null {
+  const difficulty = resolveBoardseshDifficulty(fields);
+  if (difficulty == null) return null;
+  return clampDifficultyId(difficulty);
+}
+
+/**
+ * Resolve how a climb/tick renders its grade under the "Show Boardsesh
+ * grades" preference: the Boardsesh grade when the toggle is on and one is
+ * available and trusted, otherwise the legacy Aurora-set grade. This never
+ * looks at a climber's own logged ascent grade — a user grade always wins,
+ * so callers with one must check it themselves before falling through here.
+ */
+export function resolveDisplayGrade(
+  climb: BoardseshGradeFields & { difficulty?: string | null },
+  opts: { useBoardseshGrades: boolean; gradeFormat: GradeDisplayFormat },
+): DisplayGrade {
+  if (opts.useBoardseshGrades) {
+    const boardseshId = resolveBoardseshDifficultyId(climb);
+    if (boardseshId != null) {
+      const rendered = renderDifficulty(boardseshId, opts.gradeFormat);
+      if (rendered) return { ...rendered, isBoardsesh: true };
+    }
+  }
+  return {
+    label: formatGrade(climb.difficulty, opts.gradeFormat) ?? climb.difficulty ?? '',
+    color: getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR,
+    isBoardsesh: false,
+  };
+}
+
+/**
+ * Which crowd-sourced difficulty id a row should show for an ungraded
+ * ascent: the Boardsesh grade when the toggle is on and one is trusted,
+ * otherwise the legacy community consensus. Re-exported (renamed) from
+ * `@boardsesh/logbook`'s `resolveCrowdDifficulty` — same rules, same tests —
+ * so mobile has one source of truth for the toggle/consensus fallback
+ * instead of a second implementation to keep in sync.
+ */
+export const resolveCrowdDifficultyId = resolveCrowdDifficulty;
+
+/**
+ * The Aurora `difficulty_name` string (e.g. `"6b/V4"`) for the Boardsesh
+ * grade, used to seed the tick picker's default grade when a climber hasn't
+ * graded their own ascent. Logging itself still writes to the normal Aurora
+ * scale — this only chooses which value the picker opens on.
+ */
+export function resolveTickDefaultGradeName(fields: BoardseshGradeFields, useBoardseshGrades: boolean): string | null {
+  if (!useBoardseshGrades) return null;
+  const boardseshId = resolveBoardseshDifficultyId(fields);
+  if (boardseshId == null) return null;
+  return GRADE_BY_ID.get(boardseshId)?.difficulty_name ?? null;
+}

--- a/packages/mobile/src/lib/boardsesh-grades-preference.ts
+++ b/packages/mobile/src/lib/boardsesh-grades-preference.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { getPreference, setPreference } from './preference-store';
+
+// Whether to render the data-science "Boardsesh grade" in place of the legacy
+// Aurora-set grade across the app (play drawer, climb lists, logbook). Opt-in:
+// the default is OFF, so grades look unchanged until a climber turns it on
+// from More → Display. Gated behind the `boardsesh-grade` PostHog flag on top
+// of this preference — see `useBoardseshGradesActive` in
+// hooks/use-display-grade.ts (flag off is a hard kill switch even over a
+// stale persisted preference).
+//
+// Structure mirrors `show-playlist-tags-preference.ts`: a module-level store
+// read via `useSyncExternalStore` with a referentially-stable cached snapshot
+// (rebuilt only inside `notify()`), plus a promise-singleton one-time load so
+// any number of mounted consumers trigger the AsyncStorage read exactly once.
+const STORAGE_KEY = 'useBoardseshGrades';
+const DEFAULT_USE_BOARDSESH_GRADES = false;
+
+type BoardseshGradesSnapshot = { enabled: boolean; loaded: boolean };
+
+let current = DEFAULT_USE_BOARDSESH_GRADES;
+let hasLoaded = false;
+let snapshot: BoardseshGradesSnapshot = { enabled: current, loaded: hasLoaded };
+const listeners = new Set<() => void>();
+
+const SERVER_SNAPSHOT: BoardseshGradesSnapshot = { enabled: DEFAULT_USE_BOARDSESH_GRADES, loaded: false };
+
+function notify(): void {
+  snapshot = { enabled: current, loaded: hasLoaded };
+  for (const listener of listeners) listener();
+}
+
+export async function loadBoardseshGradesPreference(): Promise<boolean> {
+  if (hasLoaded) return current;
+  const stored = await getPreference<boolean>(STORAGE_KEY);
+  // A `setBoardseshGradesPreference` may have raced in while we awaited
+  // storage; honour the user's choice over the (now stale) persisted value.
+  if (hasLoaded) return current;
+  // An explicit stored choice (true/false) wins; an absent value falls back to
+  // OFF so Boardsesh grades are opt-in only.
+  current = typeof stored === 'boolean' ? stored : DEFAULT_USE_BOARDSESH_GRADES;
+  hasLoaded = true;
+  notify();
+  return current;
+}
+
+export async function setBoardseshGradesPreference(enabled: boolean): Promise<void> {
+  current = enabled;
+  hasLoaded = true;
+  notify();
+  await setPreference(STORAGE_KEY, enabled);
+}
+
+let loadPromise: Promise<boolean> | null = null;
+function ensureBoardseshGradesLoaded(): Promise<boolean> {
+  if (!loadPromise) {
+    loadPromise = loadBoardseshGradesPreference().catch((error: unknown) => {
+      // A failed read must not leave a rejected promise cached — clear the
+      // singleton so the next mount retries instead of staying stuck at the
+      // default until the app restarts.
+      loadPromise = null;
+      throw error;
+    });
+  }
+  return loadPromise;
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): BoardseshGradesSnapshot {
+  return snapshot;
+}
+
+function getServerSnapshot(): BoardseshGradesSnapshot {
+  return SERVER_SNAPSHOT;
+}
+
+export function useBoardseshGradesPreference(): {
+  enabled: boolean;
+  loaded: boolean;
+  setEnabled: (enabled: boolean) => void;
+} {
+  const { enabled, loaded } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  useEffect(() => {
+    // Swallow read failures here — the load already clears its cached promise so
+    // a later mount retries; nothing to do at this call site.
+    ensureBoardseshGradesLoaded().catch(() => {});
+  }, []);
+
+  const setEnabled = useCallback((next: boolean) => {
+    void setBoardseshGradesPreference(next);
+  }, []);
+
+  return { enabled, loaded, setEnabled };
+}

--- a/packages/mobile/src/lib/session-tick-mapping.ts
+++ b/packages/mobile/src/lib/session-tick-mapping.ts
@@ -13,9 +13,23 @@ type Router = ReturnType<typeof useRouter>;
  *
  * The logger's personal `quality` is deliberately NOT surfaced as the community
  * star average, so `quality_average` stays '0' (the row hides the star when 0).
+ *
+ * Boardsesh-grade fallback: a climber's OWN logged ascent grade always wins over
+ * the Boardsesh grade (the hard rule). `tick.difficulty` is that effective grade
+ * (their own, or the community consensus the resolver folds in) — null only for a
+ * truly ungraded/attempt tick, the exact signal the frameless path uses
+ * (SessionTickRow ~L187). So we carry the Boardsesh grade fields onto the climb
+ * ONLY when `tick.difficulty == null`: then `ClimbListItemContent.resolveGrade`
+ * fills the blank with the Boardsesh grade (when the toggle is on and it's
+ * trusted), instead of showing nothing. When a grade IS present we OMIT the
+ * fields, so `ClimbListItemContent` renders `difficulty` (the climber's / crowd's
+ * grade) unchanged — honouring the invariant documented on `ClimbListItemClimb`
+ * that the Boardsesh fields are set only alongside a community/consensus grade,
+ * never a user's own logged one.
  */
 export function sessionTickToClimb(tick: SessionDetailTick): ClimbListItemClimb | null {
   if (!tick.frames) return null;
+  const isUngraded = tick.difficulty == null;
   return {
     uuid: tick.climbUuid,
     name: tick.climbName ?? '',
@@ -27,6 +41,9 @@ export function sessionTickToClimb(tick: SessionDetailTick): ClimbListItemClimb 
     benchmark_difficulty: tick.isBenchmark ? (tick.difficultyName ?? null) : null,
     mirrored: tick.isMirror,
     is_no_match: tick.isNoMatch,
+    ...(isUngraded
+      ? { boardseshDifficulty: tick.boardseshDifficulty, boardseshConfidence: tick.boardseshConfidence }
+      : {}),
   };
 }
 

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -356,7 +356,19 @@
     "byAngle": "Boardsesh grade by angle",
     "updated": "Updated {{when}}",
     "localGradeLine": "On this board: {{grade}}",
-    "logScale": "Log scale"
+    "logScale": "Log scale",
+    "dumbbell": {
+      "legendBoardsesh": "Everywhere (Boardsesh)",
+      "legendCrowd": "This board (crowd)",
+      "legendSize": "Bigger dot = more sends",
+      "tapCaption_one": "{{angle}}° · this board {{crowd}} · everywhere {{boardsesh}} · {{count}} send",
+      "tapCaption_other": "{{angle}}° · this board {{crowd}} · everywhere {{boardsesh}} · {{count}} sends",
+      "tapCaptionAgree_one": "{{angle}}° · crowd & Boardsesh agree · {{grade}} · {{count}} send",
+      "tapCaptionAgree_other": "{{angle}}° · crowd & Boardsesh agree · {{grade}} · {{count}} sends",
+      "singleAngle_one": "At {{angle}}° · this board {{crowd}} · everywhere {{boardsesh}} · {{count}} send",
+      "singleAngle_other": "At {{angle}}° · this board {{crowd}} · everywhere {{boardsesh}} · {{count}} sends",
+      "crowdOnlyNote": "Not enough cross-board sends yet to compare by angle."
+    }
   },
   "similarClimbs": {
     "loadError": "Couldn't load similar climbs.",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -355,18 +355,18 @@
     "loadError": "Couldn't load the grade right now.",
     "byAngle": "How it climbs by angle",
     "summaryLocal": "local",
-    "matchesBoard": "Matches this board's grade",
+    "matchesBoard": "Matches the old grade",
     "localOnlyNote": "Not enough cross-board sends yet to standardize.",
     "setterCall": "Setter's call",
     "hero": {
-      "thisBoard": "This board",
-      "everywhere": "All boards",
-      "thisBoardOnly": "This board only",
+      "thisBoard": "Old grade",
+      "everywhere": "Boardsesh grade",
+      "thisBoardOnly": "Boardsesh grade",
       "approx": "About {{amount}}"
     },
     "payoff": {
-      "softer": "{{amount}} softer than this board calls it.",
-      "stiffer": "{{amount}} stiffer than this board calls it."
+      "softer": "{{amount}} softer than the old grade.",
+      "stiffer": "{{amount}} stiffer than the old grade."
     },
     "trust": {
       "confirmedSingle_one": "Confirmed · {{count}} send",
@@ -380,15 +380,15 @@
       "setter": "Fewer than 3 sends to standardize"
     },
     "dumbbell": {
-      "legendBoardsesh": "All boards (Boardsesh)",
-      "legendCrowd": "This board (crowd)",
+      "legendBoardsesh": "Boardsesh grade",
+      "legendCrowd": "Old grade",
       "legendSize": "Bigger dot = more sends",
-      "tapCaption_one": "{{angle}}° · this board {{crowd}} · all boards {{boardsesh}} · {{count}} send",
-      "tapCaption_other": "{{angle}}° · this board {{crowd}} · all boards {{boardsesh}} · {{count}} sends",
-      "tapCaptionAgree_one": "{{angle}}° · crowd & Boardsesh agree · {{grade}} · {{count}} send",
-      "tapCaptionAgree_other": "{{angle}}° · crowd & Boardsesh agree · {{grade}} · {{count}} sends",
-      "singleAngle_one": "At {{angle}}° · this board {{crowd}} · all boards {{boardsesh}} · {{count}} send",
-      "singleAngle_other": "At {{angle}}° · this board {{crowd}} · all boards {{boardsesh}} · {{count}} sends",
+      "tapCaption_one": "{{angle}}° · old grade {{crowd}} · Boardsesh grade {{boardsesh}} · {{count}} send",
+      "tapCaption_other": "{{angle}}° · old grade {{crowd}} · Boardsesh grade {{boardsesh}} · {{count}} sends",
+      "tapCaptionAgree_one": "{{angle}}° · both grades agree · {{grade}} · {{count}} send",
+      "tapCaptionAgree_other": "{{angle}}° · both grades agree · {{grade}} · {{count}} sends",
+      "singleAngle_one": "At {{angle}}° · old grade {{crowd}} · Boardsesh grade {{boardsesh}} · {{count}} send",
+      "singleAngle_other": "At {{angle}}° · old grade {{crowd}} · Boardsesh grade {{boardsesh}} · {{count}} sends",
       "crowdOnlyNote": "Not enough cross-board sends yet to compare by angle."
     }
   },

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -354,9 +354,30 @@
     "moonboardBody": "We don't have community grade data for MoonBoard yet. Log your Moon sends on Boardsesh to help unlock it.",
     "loadError": "Couldn't load the grade right now.",
     "byAngle": "Boardsesh grade by angle",
-    "updated": "Updated {{when}}",
-    "localGradeLine": "On this board: {{grade}}",
-    "logScale": "Log scale",
+    "summaryLocal": "local",
+    "matchesBoard": "Matches this board's grade",
+    "localOnlyNote": "Not enough cross-board sends yet to standardize.",
+    "setterCall": "Setter's call",
+    "hero": {
+      "thisBoard": "This board",
+      "everywhere": "Everywhere",
+      "thisBoardOnly": "This board only",
+      "easier": "{{amount}} easier",
+      "stiffer": "{{amount}} stiffer",
+      "approx": "about {{amount}}"
+    },
+    "payoff": {
+      "softer": "{{amount}} softer than this {{board}} board calls it.",
+      "stiffer": "{{amount}} stiffer than this {{board}} board calls it.",
+      "same": "Climbs the same everywhere as it does here."
+    },
+    "trust": {
+      "confirmed_one": "95% land {{low}}–{{high}} · {{count}} send · updated {{when}}",
+      "confirmed_other": "95% land {{low}}–{{high}} · {{count}} sends · updated {{when}}",
+      "provisional_one": "Likely {{low}}–{{high}} · only {{count}} send",
+      "provisional_other": "Likely {{low}}–{{high}} · only {{count}} sends",
+      "setter": "Fewer than 3 sends to standardize"
+    },
     "dumbbell": {
       "legendBoardsesh": "Everywhere (Boardsesh)",
       "legendCrowd": "This board (crowd)",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -352,7 +352,10 @@
     "setterOnly": "Setter's call — not enough sends yet.",
     "moonboardTitle": "Not standardized yet",
     "moonboardBody": "We don't have community grade data for MoonBoard yet. Log your Moon sends on Boardsesh to help unlock it.",
-    "loadError": "Couldn't load the grade right now."
+    "loadError": "Couldn't load the grade right now.",
+    "byAngle": "Boardsesh grade by angle",
+    "updated": "Updated {{when}}",
+    "localGradeLine": "On this board: {{grade}}"
   },
   "similarClimbs": {
     "loadError": "Couldn't load similar climbs.",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -362,14 +362,13 @@
       "thisBoard": "This board",
       "everywhere": "Everywhere",
       "thisBoardOnly": "This board only",
-      "easier": "{{amount}} easier",
+      "softer": "{{amount}} softer",
       "stiffer": "{{amount}} stiffer",
       "approx": "about {{amount}}"
     },
     "payoff": {
       "softer": "{{amount}} softer than this {{board}} board calls it.",
-      "stiffer": "{{amount}} stiffer than this {{board}} board calls it.",
-      "same": "Climbs the same everywhere as it does here."
+      "stiffer": "{{amount}} stiffer than this {{board}} board calls it."
     },
     "trust": {
       "confirmed_one": "95% land {{low}}–{{high}} · {{count}} send · updated {{when}}",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -355,7 +355,8 @@
     "loadError": "Couldn't load the grade right now.",
     "byAngle": "Boardsesh grade by angle",
     "updated": "Updated {{when}}",
-    "localGradeLine": "On this board: {{grade}}"
+    "localGradeLine": "On this board: {{grade}}",
+    "logScale": "Log scale"
   },
   "similarClimbs": {
     "loadError": "Couldn't load similar climbs.",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -353,40 +353,42 @@
     "moonboardTitle": "Not standardized yet",
     "moonboardBody": "We don't have community grade data for MoonBoard yet. Log your Moon sends on Boardsesh to help unlock it.",
     "loadError": "Couldn't load the grade right now.",
-    "byAngle": "Boardsesh grade by angle",
+    "byAngle": "How it climbs by angle",
     "summaryLocal": "local",
     "matchesBoard": "Matches this board's grade",
     "localOnlyNote": "Not enough cross-board sends yet to standardize.",
     "setterCall": "Setter's call",
     "hero": {
       "thisBoard": "This board",
-      "everywhere": "Everywhere",
+      "everywhere": "All boards",
       "thisBoardOnly": "This board only",
-      "softer": "{{amount}} softer",
-      "stiffer": "{{amount}} stiffer",
-      "approx": "about {{amount}}"
+      "approx": "About {{amount}}"
     },
     "payoff": {
-      "softer": "{{amount}} softer than this {{board}} board calls it.",
-      "stiffer": "{{amount}} stiffer than this {{board}} board calls it."
+      "softer": "{{amount}} softer than this board calls it.",
+      "stiffer": "{{amount}} stiffer than this board calls it."
     },
     "trust": {
-      "confirmed_one": "95% land {{low}}–{{high}} · {{count}} send · updated {{when}}",
-      "confirmed_other": "95% land {{low}}–{{high}} · {{count}} sends · updated {{when}}",
-      "provisional_one": "Likely {{low}}–{{high}} · only {{count}} send",
-      "provisional_other": "Likely {{low}}–{{high}} · only {{count}} sends",
+      "confirmedSingle_one": "Confirmed · {{count}} send",
+      "confirmedSingle_other": "Confirmed · {{count}} sends",
+      "confirmedRange_one": "Usually {{low}}–{{high}} · {{count}} send",
+      "confirmedRange_other": "Usually {{low}}–{{high}} · {{count}} sends",
+      "provisionalSingle_one": "Still settling · {{count}} send",
+      "provisionalSingle_other": "Still settling · {{count}} sends",
+      "provisionalRange_one": "Still settling · likely {{low}}–{{high}} · {{count}} send",
+      "provisionalRange_other": "Still settling · likely {{low}}–{{high}} · {{count}} sends",
       "setter": "Fewer than 3 sends to standardize"
     },
     "dumbbell": {
-      "legendBoardsesh": "Everywhere (Boardsesh)",
+      "legendBoardsesh": "All boards (Boardsesh)",
       "legendCrowd": "This board (crowd)",
       "legendSize": "Bigger dot = more sends",
-      "tapCaption_one": "{{angle}}° · this board {{crowd}} · everywhere {{boardsesh}} · {{count}} send",
-      "tapCaption_other": "{{angle}}° · this board {{crowd}} · everywhere {{boardsesh}} · {{count}} sends",
+      "tapCaption_one": "{{angle}}° · this board {{crowd}} · all boards {{boardsesh}} · {{count}} send",
+      "tapCaption_other": "{{angle}}° · this board {{crowd}} · all boards {{boardsesh}} · {{count}} sends",
       "tapCaptionAgree_one": "{{angle}}° · crowd & Boardsesh agree · {{grade}} · {{count}} send",
       "tapCaptionAgree_other": "{{angle}}° · crowd & Boardsesh agree · {{grade}} · {{count}} sends",
-      "singleAngle_one": "At {{angle}}° · this board {{crowd}} · everywhere {{boardsesh}} · {{count}} send",
-      "singleAngle_other": "At {{angle}}° · this board {{crowd}} · everywhere {{boardsesh}} · {{count}} sends",
+      "singleAngle_one": "At {{angle}}° · this board {{crowd}} · all boards {{boardsesh}} · {{count}} send",
+      "singleAngle_other": "At {{angle}}° · this board {{crowd}} · all boards {{boardsesh}} · {{count}} sends",
       "crowdOnlyNote": "Not enough cross-board sends yet to compare by angle."
     }
   },

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -101,7 +101,9 @@
       "displayOptions": {
         "title": "Display",
         "playlistTags": "Show playlist tags",
-        "playlistTagsDescription": "See which playlists each climb is in, right on the list."
+        "playlistTagsDescription": "See which playlists each climb is in, right on the list.",
+        "boardseshGrades": "Show Boardsesh grades",
+        "boardseshGradesDescription": "Grades built from real sends across boards. The setter's grade stays until enough sends come in."
       },
       "language": {
         "title": "Language",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -352,7 +352,10 @@
     "setterOnly": "Criterio del setter — todavía no hay suficientes encadenes.",
     "moonboardTitle": "Todavía sin estandarizar",
     "moonboardBody": "Aún no tenemos datos de grado de la comunidad para MoonBoard. Registra tus encadenes en Moon con Boardsesh para ayudar a desbloquearlo.",
-    "loadError": "No se pudo cargar el grado ahora mismo."
+    "loadError": "No se pudo cargar el grado ahora mismo.",
+    "byAngle": "Grado Boardsesh por ángulo",
+    "updated": "Actualizado {{when}}",
+    "localGradeLine": "En este plafón: {{grade}}"
   },
   "multiboardList": {
     "noClimbsFound": "No se encontraron bloques",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -354,9 +354,30 @@
     "moonboardBody": "Aún no tenemos datos de grado de la comunidad para MoonBoard. Registra tus encadenes en Moon con Boardsesh para ayudar a desbloquearlo.",
     "loadError": "No se pudo cargar el grado ahora mismo.",
     "byAngle": "Grado Boardsesh por ángulo",
-    "updated": "Actualizado {{when}}",
-    "localGradeLine": "En este plafón: {{grade}}",
-    "logScale": "Escala logarítmica",
+    "summaryLocal": "local",
+    "matchesBoard": "Coincide con el grado de este plafón",
+    "localOnlyNote": "Todavía no hay suficientes encadenes entre plafones para estandarizar.",
+    "setterCall": "Criterio del setter",
+    "hero": {
+      "thisBoard": "Este plafón",
+      "everywhere": "En todas partes",
+      "thisBoardOnly": "Solo este plafón",
+      "easier": "{{amount}} más fácil",
+      "stiffer": "{{amount}} más duro",
+      "approx": "unos {{amount}}"
+    },
+    "payoff": {
+      "softer": "{{amount}} más blando de lo que dice este plafón {{board}}.",
+      "stiffer": "{{amount}} más duro de lo que dice este plafón {{board}}.",
+      "same": "Cuesta lo mismo en todas partes que aquí."
+    },
+    "trust": {
+      "confirmed_one": "95% encadenan {{low}}–{{high}} · {{count}} encadene · actualizado {{when}}",
+      "confirmed_other": "95% encadenan {{low}}–{{high}} · {{count}} encadenes · actualizado {{when}}",
+      "provisional_one": "Probablemente {{low}}–{{high}} · solo {{count}} encadene",
+      "provisional_other": "Probablemente {{low}}–{{high}} · solo {{count}} encadenes",
+      "setter": "Menos de 3 encadenes para estandarizar"
+    },
     "dumbbell": {
       "legendBoardsesh": "En todas partes (Boardsesh)",
       "legendCrowd": "Este plafón (comunidad)",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -353,40 +353,42 @@
     "moonboardTitle": "Todavía sin estandarizar",
     "moonboardBody": "Aún no tenemos datos de grado de la comunidad para MoonBoard. Registra tus encadenes en Moon con Boardsesh para ayudar a desbloquearlo.",
     "loadError": "No se pudo cargar el grado ahora mismo.",
-    "byAngle": "Grado Boardsesh por ángulo",
+    "byAngle": "Cómo cuesta según el ángulo",
     "summaryLocal": "local",
     "matchesBoard": "Coincide con el grado de este plafón",
     "localOnlyNote": "Todavía no hay suficientes encadenes entre plafones para estandarizar.",
     "setterCall": "Criterio del setter",
     "hero": {
       "thisBoard": "Este plafón",
-      "everywhere": "En todas partes",
+      "everywhere": "Todos los plafones",
       "thisBoardOnly": "Solo este plafón",
-      "softer": "{{amount}} más blando",
-      "stiffer": "{{amount}} más duro",
-      "approx": "unos {{amount}}"
+      "approx": "Unos {{amount}}"
     },
     "payoff": {
-      "softer": "{{amount}} más blando de lo que dice este plafón {{board}}.",
-      "stiffer": "{{amount}} más duro de lo que dice este plafón {{board}}."
+      "softer": "{{amount}} más blando de lo que dice este plafón.",
+      "stiffer": "{{amount}} más duro de lo que dice este plafón."
     },
     "trust": {
-      "confirmed_one": "95% encadenan {{low}}–{{high}} · {{count}} encadene · actualizado {{when}}",
-      "confirmed_other": "95% encadenan {{low}}–{{high}} · {{count}} encadenes · actualizado {{when}}",
-      "provisional_one": "Probablemente {{low}}–{{high}} · solo {{count}} encadene",
-      "provisional_other": "Probablemente {{low}}–{{high}} · solo {{count}} encadenes",
+      "confirmedSingle_one": "Confirmado · {{count}} encadene",
+      "confirmedSingle_other": "Confirmado · {{count}} encadenes",
+      "confirmedRange_one": "Normalmente {{low}}–{{high}} · {{count}} encadene",
+      "confirmedRange_other": "Normalmente {{low}}–{{high}} · {{count}} encadenes",
+      "provisionalSingle_one": "Aún asentándose · {{count}} encadene",
+      "provisionalSingle_other": "Aún asentándose · {{count}} encadenes",
+      "provisionalRange_one": "Aún asentándose · probablemente {{low}}–{{high}} · {{count}} encadene",
+      "provisionalRange_other": "Aún asentándose · probablemente {{low}}–{{high}} · {{count}} encadenes",
       "setter": "Menos de 3 encadenes para estandarizar"
     },
     "dumbbell": {
-      "legendBoardsesh": "En todas partes (Boardsesh)",
+      "legendBoardsesh": "Todos los plafones (Boardsesh)",
       "legendCrowd": "Este plafón (comunidad)",
       "legendSize": "Punto más grande = más encadenes",
-      "tapCaption_one": "{{angle}}° · este plafón {{crowd}} · en todas partes {{boardsesh}} · {{count}} encadene",
-      "tapCaption_other": "{{angle}}° · este plafón {{crowd}} · en todas partes {{boardsesh}} · {{count}} encadenes",
+      "tapCaption_one": "{{angle}}° · este plafón {{crowd}} · todos los plafones {{boardsesh}} · {{count}} encadene",
+      "tapCaption_other": "{{angle}}° · este plafón {{crowd}} · todos los plafones {{boardsesh}} · {{count}} encadenes",
       "tapCaptionAgree_one": "{{angle}}° · la comunidad y Boardsesh coinciden · {{grade}} · {{count}} encadene",
       "tapCaptionAgree_other": "{{angle}}° · la comunidad y Boardsesh coinciden · {{grade}} · {{count}} encadenes",
-      "singleAngle_one": "A {{angle}}° · este plafón {{crowd}} · en todas partes {{boardsesh}} · {{count}} encadene",
-      "singleAngle_other": "A {{angle}}° · este plafón {{crowd}} · en todas partes {{boardsesh}} · {{count}} encadenes",
+      "singleAngle_one": "A {{angle}}° · este plafón {{crowd}} · todos los plafones {{boardsesh}} · {{count}} encadene",
+      "singleAngle_other": "A {{angle}}° · este plafón {{crowd}} · todos los plafones {{boardsesh}} · {{count}} encadenes",
       "crowdOnlyNote": "Todavía no hay suficientes encadenes entre plafones para comparar por ángulo."
     }
   },

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -355,18 +355,18 @@
     "loadError": "No se pudo cargar el grado ahora mismo.",
     "byAngle": "Cómo cuesta según el ángulo",
     "summaryLocal": "local",
-    "matchesBoard": "Coincide con el grado de este plafón",
+    "matchesBoard": "Coincide con el grado anterior",
     "localOnlyNote": "Todavía no hay suficientes encadenes entre plafones para estandarizar.",
     "setterCall": "Criterio del setter",
     "hero": {
-      "thisBoard": "Este plafón",
-      "everywhere": "Todos los plafones",
-      "thisBoardOnly": "Solo este plafón",
+      "thisBoard": "Grado anterior",
+      "everywhere": "Grado Boardsesh",
+      "thisBoardOnly": "Grado Boardsesh",
       "approx": "Unos {{amount}}"
     },
     "payoff": {
-      "softer": "{{amount}} más blando de lo que dice este plafón.",
-      "stiffer": "{{amount}} más duro de lo que dice este plafón."
+      "softer": "{{amount}} más blando que el grado anterior.",
+      "stiffer": "{{amount}} más duro que el grado anterior."
     },
     "trust": {
       "confirmedSingle_one": "Confirmado · {{count}} encadene",
@@ -380,15 +380,15 @@
       "setter": "Menos de 3 encadenes para estandarizar"
     },
     "dumbbell": {
-      "legendBoardsesh": "Todos los plafones (Boardsesh)",
-      "legendCrowd": "Este plafón (comunidad)",
+      "legendBoardsesh": "Grado Boardsesh",
+      "legendCrowd": "Grado anterior",
       "legendSize": "Punto más grande = más encadenes",
-      "tapCaption_one": "{{angle}}° · este plafón {{crowd}} · todos los plafones {{boardsesh}} · {{count}} encadene",
-      "tapCaption_other": "{{angle}}° · este plafón {{crowd}} · todos los plafones {{boardsesh}} · {{count}} encadenes",
-      "tapCaptionAgree_one": "{{angle}}° · la comunidad y Boardsesh coinciden · {{grade}} · {{count}} encadene",
-      "tapCaptionAgree_other": "{{angle}}° · la comunidad y Boardsesh coinciden · {{grade}} · {{count}} encadenes",
-      "singleAngle_one": "A {{angle}}° · este plafón {{crowd}} · todos los plafones {{boardsesh}} · {{count}} encadene",
-      "singleAngle_other": "A {{angle}}° · este plafón {{crowd}} · todos los plafones {{boardsesh}} · {{count}} encadenes",
+      "tapCaption_one": "{{angle}}° · grado anterior {{crowd}} · grado Boardsesh {{boardsesh}} · {{count}} encadene",
+      "tapCaption_other": "{{angle}}° · grado anterior {{crowd}} · grado Boardsesh {{boardsesh}} · {{count}} encadenes",
+      "tapCaptionAgree_one": "{{angle}}° · ambos grados coinciden · {{grade}} · {{count}} encadene",
+      "tapCaptionAgree_other": "{{angle}}° · ambos grados coinciden · {{grade}} · {{count}} encadenes",
+      "singleAngle_one": "A {{angle}}° · grado anterior {{crowd}} · grado Boardsesh {{boardsesh}} · {{count}} encadene",
+      "singleAngle_other": "A {{angle}}° · grado anterior {{crowd}} · grado Boardsesh {{boardsesh}} · {{count}} encadenes",
       "crowdOnlyNote": "Todavía no hay suficientes encadenes entre plafones para comparar por ángulo."
     }
   },

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -356,7 +356,19 @@
     "byAngle": "Grado Boardsesh por ángulo",
     "updated": "Actualizado {{when}}",
     "localGradeLine": "En este plafón: {{grade}}",
-    "logScale": "Escala logarítmica"
+    "logScale": "Escala logarítmica",
+    "dumbbell": {
+      "legendBoardsesh": "En todas partes (Boardsesh)",
+      "legendCrowd": "Este plafón (comunidad)",
+      "legendSize": "Punto más grande = más encadenes",
+      "tapCaption_one": "{{angle}}° · este plafón {{crowd}} · en todas partes {{boardsesh}} · {{count}} encadene",
+      "tapCaption_other": "{{angle}}° · este plafón {{crowd}} · en todas partes {{boardsesh}} · {{count}} encadenes",
+      "tapCaptionAgree_one": "{{angle}}° · la comunidad y Boardsesh coinciden · {{grade}} · {{count}} encadene",
+      "tapCaptionAgree_other": "{{angle}}° · la comunidad y Boardsesh coinciden · {{grade}} · {{count}} encadenes",
+      "singleAngle_one": "A {{angle}}° · este plafón {{crowd}} · en todas partes {{boardsesh}} · {{count}} encadene",
+      "singleAngle_other": "A {{angle}}° · este plafón {{crowd}} · en todas partes {{boardsesh}} · {{count}} encadenes",
+      "crowdOnlyNote": "Todavía no hay suficientes encadenes entre plafones para comparar por ángulo."
+    }
   },
   "multiboardList": {
     "noClimbsFound": "No se encontraron bloques",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -355,7 +355,8 @@
     "loadError": "No se pudo cargar el grado ahora mismo.",
     "byAngle": "Grado Boardsesh por ángulo",
     "updated": "Actualizado {{when}}",
-    "localGradeLine": "En este plafón: {{grade}}"
+    "localGradeLine": "En este plafón: {{grade}}",
+    "logScale": "Escala logarítmica"
   },
   "multiboardList": {
     "noClimbsFound": "No se encontraron bloques",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -362,14 +362,13 @@
       "thisBoard": "Este plafón",
       "everywhere": "En todas partes",
       "thisBoardOnly": "Solo este plafón",
-      "easier": "{{amount}} más fácil",
+      "softer": "{{amount}} más blando",
       "stiffer": "{{amount}} más duro",
       "approx": "unos {{amount}}"
     },
     "payoff": {
       "softer": "{{amount}} más blando de lo que dice este plafón {{board}}.",
-      "stiffer": "{{amount}} más duro de lo que dice este plafón {{board}}.",
-      "same": "Cuesta lo mismo en todas partes que aquí."
+      "stiffer": "{{amount}} más duro de lo que dice este plafón {{board}}."
     },
     "trust": {
       "confirmed_one": "95% encadenan {{low}}–{{high}} · {{count}} encadene · actualizado {{when}}",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -302,7 +302,9 @@
       "displayOptions": {
         "title": "Visualización",
         "playlistTags": "Mostrar etiquetas de playlist",
-        "playlistTagsDescription": "Mira en qué playlists está cada bloque, directamente en la lista."
+        "playlistTagsDescription": "Mira en qué playlists está cada bloque, directamente en la lista.",
+        "boardseshGrades": "Mostrar grados Boardsesh",
+        "boardseshGradesDescription": "Grados calculados a partir de encadenes reales en varios plafones. El grado del setter se mantiene hasta que haya suficientes encadenes."
       },
       "language": {
         "title": "Idioma",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -353,40 +353,42 @@
     "moonboardTitle": "Pas encore standardisé",
     "moonboardBody": "Nous n'avons pas encore de données de grade communautaires pour le MoonBoard. Enregistre tes croix Moon sur Boardsesh pour aider à le débloquer.",
     "loadError": "Impossible de charger le grade pour le moment.",
-    "byAngle": "Grade Boardsesh par angle",
+    "byAngle": "Sa difficulté selon l'angle",
     "summaryLocal": "local",
     "matchesBoard": "Correspond au grade de cette board",
     "localOnlyNote": "Pas encore assez de croix inter-boards pour standardiser.",
     "setterCall": "Avis de l'ouvreur",
     "hero": {
       "thisBoard": "Cette board",
-      "everywhere": "Partout",
+      "everywhere": "Toutes les boards",
       "thisBoardOnly": "Cette board seulement",
-      "softer": "{{amount}} plus souple",
-      "stiffer": "{{amount}} plus dur",
-      "approx": "environ {{amount}}"
+      "approx": "Environ {{amount}}"
     },
     "payoff": {
-      "softer": "{{amount}} plus souple que ce que dit cette board {{board}}.",
-      "stiffer": "{{amount}} plus dur que ce que dit cette board {{board}}."
+      "softer": "{{amount}} plus souple que ce que dit cette board.",
+      "stiffer": "{{amount}} plus dur que ce que dit cette board."
     },
     "trust": {
-      "confirmed_one": "95% enchaînent {{low}}–{{high}} · {{count}} croix · mis à jour {{when}}",
-      "confirmed_other": "95% enchaînent {{low}}–{{high}} · {{count}} croix · mis à jour {{when}}",
-      "provisional_one": "Sans doute {{low}}–{{high}} · seulement {{count}} croix",
-      "provisional_other": "Sans doute {{low}}–{{high}} · seulement {{count}} croix",
+      "confirmedSingle_one": "Confirmé · {{count}} croix",
+      "confirmedSingle_other": "Confirmé · {{count}} croix",
+      "confirmedRange_one": "En général {{low}}–{{high}} · {{count}} croix",
+      "confirmedRange_other": "En général {{low}}–{{high}} · {{count}} croix",
+      "provisionalSingle_one": "Encore en train de se caler · {{count}} croix",
+      "provisionalSingle_other": "Encore en train de se caler · {{count}} croix",
+      "provisionalRange_one": "Encore en train de se caler · sans doute {{low}}–{{high}} · {{count}} croix",
+      "provisionalRange_other": "Encore en train de se caler · sans doute {{low}}–{{high}} · {{count}} croix",
       "setter": "Moins de 3 croix pour standardiser"
     },
     "dumbbell": {
-      "legendBoardsesh": "Partout (Boardsesh)",
+      "legendBoardsesh": "Toutes les boards (Boardsesh)",
       "legendCrowd": "Cette board (communauté)",
       "legendSize": "Point plus grand = plus de croix",
-      "tapCaption_one": "{{angle}}° · cette board {{crowd}} · partout {{boardsesh}} · {{count}} croix",
-      "tapCaption_other": "{{angle}}° · cette board {{crowd}} · partout {{boardsesh}} · {{count}} croix",
+      "tapCaption_one": "{{angle}}° · cette board {{crowd}} · toutes les boards {{boardsesh}} · {{count}} croix",
+      "tapCaption_other": "{{angle}}° · cette board {{crowd}} · toutes les boards {{boardsesh}} · {{count}} croix",
       "tapCaptionAgree_one": "{{angle}}° · communauté et Boardsesh d'accord · {{grade}} · {{count}} croix",
       "tapCaptionAgree_other": "{{angle}}° · communauté et Boardsesh d'accord · {{grade}} · {{count}} croix",
-      "singleAngle_one": "À {{angle}}° · cette board {{crowd}} · partout {{boardsesh}} · {{count}} croix",
-      "singleAngle_other": "À {{angle}}° · cette board {{crowd}} · partout {{boardsesh}} · {{count}} croix",
+      "singleAngle_one": "À {{angle}}° · cette board {{crowd}} · toutes les boards {{boardsesh}} · {{count}} croix",
+      "singleAngle_other": "À {{angle}}° · cette board {{crowd}} · toutes les boards {{boardsesh}} · {{count}} croix",
       "crowdOnlyNote": "Pas encore assez de croix inter-boards pour comparer par angle."
     }
   },

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -354,9 +354,30 @@
     "moonboardBody": "Nous n'avons pas encore de données de grade communautaires pour le MoonBoard. Enregistre tes croix Moon sur Boardsesh pour aider à le débloquer.",
     "loadError": "Impossible de charger le grade pour le moment.",
     "byAngle": "Grade Boardsesh par angle",
-    "updated": "Mis à jour {{when}}",
-    "localGradeLine": "Sur cette board : {{grade}}",
-    "logScale": "Échelle logarithmique",
+    "summaryLocal": "local",
+    "matchesBoard": "Correspond au grade de cette board",
+    "localOnlyNote": "Pas encore assez de croix inter-boards pour standardiser.",
+    "setterCall": "Avis de l'ouvreur",
+    "hero": {
+      "thisBoard": "Cette board",
+      "everywhere": "Partout",
+      "thisBoardOnly": "Cette board seulement",
+      "easier": "{{amount}} plus facile",
+      "stiffer": "{{amount}} plus dur",
+      "approx": "environ {{amount}}"
+    },
+    "payoff": {
+      "softer": "{{amount}} plus facile que ce que dit cette board {{board}}.",
+      "stiffer": "{{amount}} plus dur que ce que dit cette board {{board}}.",
+      "same": "Se grimpe pareil partout qu'ici."
+    },
+    "trust": {
+      "confirmed_one": "95% enchaînent {{low}}–{{high}} · {{count}} croix · mis à jour {{when}}",
+      "confirmed_other": "95% enchaînent {{low}}–{{high}} · {{count}} croix · mis à jour {{when}}",
+      "provisional_one": "Sans doute {{low}}–{{high}} · seulement {{count}} croix",
+      "provisional_other": "Sans doute {{low}}–{{high}} · seulement {{count}} croix",
+      "setter": "Moins de 3 croix pour standardiser"
+    },
     "dumbbell": {
       "legendBoardsesh": "Partout (Boardsesh)",
       "legendCrowd": "Cette board (communauté)",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -362,14 +362,13 @@
       "thisBoard": "Cette board",
       "everywhere": "Partout",
       "thisBoardOnly": "Cette board seulement",
-      "easier": "{{amount}} plus facile",
+      "softer": "{{amount}} plus souple",
       "stiffer": "{{amount}} plus dur",
       "approx": "environ {{amount}}"
     },
     "payoff": {
-      "softer": "{{amount}} plus facile que ce que dit cette board {{board}}.",
-      "stiffer": "{{amount}} plus dur que ce que dit cette board {{board}}.",
-      "same": "Se grimpe pareil partout qu'ici."
+      "softer": "{{amount}} plus souple que ce que dit cette board {{board}}.",
+      "stiffer": "{{amount}} plus dur que ce que dit cette board {{board}}."
     },
     "trust": {
       "confirmed_one": "95% enchaînent {{low}}–{{high}} · {{count}} croix · mis à jour {{when}}",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -355,7 +355,8 @@
     "loadError": "Impossible de charger le grade pour le moment.",
     "byAngle": "Grade Boardsesh par angle",
     "updated": "Mis à jour {{when}}",
-    "localGradeLine": "Sur cette board : {{grade}}"
+    "localGradeLine": "Sur cette board : {{grade}}",
+    "logScale": "Échelle logarithmique"
   },
   "similarClimbs": {
     "loadError": "Impossible de charger les blocs similaires.",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -356,7 +356,19 @@
     "byAngle": "Grade Boardsesh par angle",
     "updated": "Mis à jour {{when}}",
     "localGradeLine": "Sur cette board : {{grade}}",
-    "logScale": "Échelle logarithmique"
+    "logScale": "Échelle logarithmique",
+    "dumbbell": {
+      "legendBoardsesh": "Partout (Boardsesh)",
+      "legendCrowd": "Cette board (communauté)",
+      "legendSize": "Point plus grand = plus de croix",
+      "tapCaption_one": "{{angle}}° · cette board {{crowd}} · partout {{boardsesh}} · {{count}} croix",
+      "tapCaption_other": "{{angle}}° · cette board {{crowd}} · partout {{boardsesh}} · {{count}} croix",
+      "tapCaptionAgree_one": "{{angle}}° · communauté et Boardsesh d'accord · {{grade}} · {{count}} croix",
+      "tapCaptionAgree_other": "{{angle}}° · communauté et Boardsesh d'accord · {{grade}} · {{count}} croix",
+      "singleAngle_one": "À {{angle}}° · cette board {{crowd}} · partout {{boardsesh}} · {{count}} croix",
+      "singleAngle_other": "À {{angle}}° · cette board {{crowd}} · partout {{boardsesh}} · {{count}} croix",
+      "crowdOnlyNote": "Pas encore assez de croix inter-boards pour comparer par angle."
+    }
   },
   "similarClimbs": {
     "loadError": "Impossible de charger les blocs similaires.",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -352,7 +352,10 @@
     "setterOnly": "Avis de l'ouvreur — pas encore assez de croix.",
     "moonboardTitle": "Pas encore standardisé",
     "moonboardBody": "Nous n'avons pas encore de données de grade communautaires pour le MoonBoard. Enregistre tes croix Moon sur Boardsesh pour aider à le débloquer.",
-    "loadError": "Impossible de charger le grade pour le moment."
+    "loadError": "Impossible de charger le grade pour le moment.",
+    "byAngle": "Grade Boardsesh par angle",
+    "updated": "Mis à jour {{when}}",
+    "localGradeLine": "Sur cette board : {{grade}}"
   },
   "similarClimbs": {
     "loadError": "Impossible de charger les blocs similaires.",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -355,18 +355,18 @@
     "loadError": "Impossible de charger le grade pour le moment.",
     "byAngle": "Sa difficulté selon l'angle",
     "summaryLocal": "local",
-    "matchesBoard": "Correspond au grade de cette board",
+    "matchesBoard": "Correspond à l'ancien grade",
     "localOnlyNote": "Pas encore assez de croix inter-boards pour standardiser.",
     "setterCall": "Avis de l'ouvreur",
     "hero": {
-      "thisBoard": "Cette board",
-      "everywhere": "Toutes les boards",
-      "thisBoardOnly": "Cette board seulement",
+      "thisBoard": "Ancien grade",
+      "everywhere": "Grade Boardsesh",
+      "thisBoardOnly": "Grade Boardsesh",
       "approx": "Environ {{amount}}"
     },
     "payoff": {
-      "softer": "{{amount}} plus souple que ce que dit cette board.",
-      "stiffer": "{{amount}} plus dur que ce que dit cette board."
+      "softer": "{{amount}} plus souple que l'ancien grade.",
+      "stiffer": "{{amount}} plus dur que l'ancien grade."
     },
     "trust": {
       "confirmedSingle_one": "Confirmé · {{count}} croix",
@@ -380,15 +380,15 @@
       "setter": "Moins de 3 croix pour standardiser"
     },
     "dumbbell": {
-      "legendBoardsesh": "Toutes les boards (Boardsesh)",
-      "legendCrowd": "Cette board (communauté)",
+      "legendBoardsesh": "Grade Boardsesh",
+      "legendCrowd": "Ancien grade",
       "legendSize": "Point plus grand = plus de croix",
-      "tapCaption_one": "{{angle}}° · cette board {{crowd}} · toutes les boards {{boardsesh}} · {{count}} croix",
-      "tapCaption_other": "{{angle}}° · cette board {{crowd}} · toutes les boards {{boardsesh}} · {{count}} croix",
-      "tapCaptionAgree_one": "{{angle}}° · communauté et Boardsesh d'accord · {{grade}} · {{count}} croix",
-      "tapCaptionAgree_other": "{{angle}}° · communauté et Boardsesh d'accord · {{grade}} · {{count}} croix",
-      "singleAngle_one": "À {{angle}}° · cette board {{crowd}} · toutes les boards {{boardsesh}} · {{count}} croix",
-      "singleAngle_other": "À {{angle}}° · cette board {{crowd}} · toutes les boards {{boardsesh}} · {{count}} croix",
+      "tapCaption_one": "{{angle}}° · ancien grade {{crowd}} · grade Boardsesh {{boardsesh}} · {{count}} croix",
+      "tapCaption_other": "{{angle}}° · ancien grade {{crowd}} · grade Boardsesh {{boardsesh}} · {{count}} croix",
+      "tapCaptionAgree_one": "{{angle}}° · les deux grades sont d'accord · {{grade}} · {{count}} croix",
+      "tapCaptionAgree_other": "{{angle}}° · les deux grades sont d'accord · {{grade}} · {{count}} croix",
+      "singleAngle_one": "À {{angle}}° · ancien grade {{crowd}} · grade Boardsesh {{boardsesh}} · {{count}} croix",
+      "singleAngle_other": "À {{angle}}° · ancien grade {{crowd}} · grade Boardsesh {{boardsesh}} · {{count}} croix",
       "crowdOnlyNote": "Pas encore assez de croix inter-boards pour comparer par angle."
     }
   },

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -101,7 +101,9 @@
       "displayOptions": {
         "title": "Affichage",
         "playlistTags": "Afficher les étiquettes de playlist",
-        "playlistTagsDescription": "Voyez dans quelles playlists se trouve chaque bloc, directement dans la liste."
+        "playlistTagsDescription": "Voyez dans quelles playlists se trouve chaque bloc, directement dans la liste.",
+        "boardseshGrades": "Afficher les grades Boardsesh",
+        "boardseshGradesDescription": "Des grades calculés à partir de vraies croix sur plusieurs boards. Le grade de l'ouvreur reste affiché tant qu'il n'y a pas assez de croix."
       },
       "language": {
         "title": "Langue",


### PR DESCRIPTION
## Summary

Third and final PR surfacing the Boardsesh grade in the mobile app, following #3554 (grade on payloads) and #3564 (offline). This is the user-facing part.

**The "Show Boardsesh grades" setting.** A new toggle under More → Display (visible only when the `boardsesh-grade` flag is on, default off) makes climbs across the app show the Boardsesh grade — the cross-board grade built from real sends — instead of the legacy per-board grade. It swaps: search and queue lists, the play-drawer header, the queue capsule and iOS accessory row, similar climbs, and the logbook / session ascent rows. One rule holds everywhere: **a climber's own logged grade always wins** — the Boardsesh grade only fills in for ascents you never graded, and only once it's real (never a setter-only placeholder or a missing grade, which both fall back to the legacy grade).

**A richer Boardsesh grade section in the play drawer.** Collapsed, the section header now shows the grade on the right (like the logbook tally). Expanded, it leads with the grade and its confidence — "confirmed by N sends" or a settling ± range — plus a "on this board" line when the cross-board grade differs from the local one, and when it was last computed. It now sits above the Community section.

**Grade-by-angle chart.** The same ascents-by-angle chart the Community section shows, but drawn with Boardsesh grades — so you can see how the standardized grade shifts across wall angles. Setter-only and ungraded angles are left off (no Boardsesh-branded placeholder numbers).

Under the hood: one pure resolver (`resolveDisplayGrade` / `resolveCrowdDifficultyId` / `resolveTickDefaultGradeName`) does the legacy-vs-Boardsesh choice; it's O(1) and lives outside the render path so list rows stay memoized. The tick logger's default grade also seeds from the Boardsesh grade when you haven't picked one (the saved tick still writes the normal grade scale).

### Known limitations (v1)
- **Wall-presence surfaces** (the currently-lit climb strips) stay on the legacy grade — that payload doesn't carry the Boardsesh fields yet. Follow-up: stamp them server-side so the highest-visibility display honors the toggle.
- Server-computed session aggregates (hardest grade, grade distribution) and search grade **filters** stay on the legacy scale (rendering swaps, filtering doesn't), as documented in `docs/boardsesh-grade.md`.

## Release Notes

- Turn on "Show Boardsesh grades" in Settings to see every climb on one cross-board grade, built from real sends across every board.
- The Boardsesh grade section in the play drawer now shows the grade at a glance when collapsed, how confident it is, and how it shifts by wall angle.
- Logged a send without grading it? We'll show the Boardsesh grade — your own grade always stays put when you set one.

## Test plan

- Unit/component: full matrix for the display resolver (toggle off / null / setter_only / format variants / rounding), the preference store (default off, persisted, set-wins-over-stale-load race), `useDisplayGrade` composition (flag-off kill switch), the by-angle bar adapter (skips setter_only/null, universal-preferred, angle sort), the collapsed-summary builder, and the user-grade-wins path in logbook + framed/frameless session ticks.
- Full mobile suite green: `vp run typecheck:mobile`, `vp run test:mobile` (3675+ tests), `vp run check:mobile-bundle`, `vp run check:i18n` + `check:i18n:orphans` (catalog parity across en-US/es/fr).
- On-device: the `pr-<number>` OTA channel carries this against production grade data (dev DB grades are local-only) for real-grade visual QA; Android emulator smoke check of the settings toggle + section render attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeUvCaseizdxs4RAgtQkh3
