### PR TITLE
fix(kilter-sync): store Grips quality verbatim (already 1-5) + sanitize rating=0 — unblock the daemon

### DIFF
--- a/packages/kilter-sync/src/sync/catalog-stats.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-stats.test.ts
@@ -183,7 +183,7 @@ describe('foldCatalogStat — kilter catalog stat accumulation', () => {
     expect(accum.kilterCount).toBe(17);
   });
 
-  it('#3: quality 0 or negative is stored as NULL (never a literal 0 rating); unknown-era kept as-is', () => {
+  it('#3: quality 0 or negative is stored as NULL (never a literal 0 rating)', () => {
     expect(
       fold({ stat: stat({ climbUuid: CANON, angle: 40, ascentCount: 1, qualityAverage: 0 }), canonical: CANON })
         .qualityAverage,
@@ -192,22 +192,21 @@ describe('foldCatalogStat — kilter catalog stat accumulation', () => {
       fold({ stat: stat({ climbUuid: CANON, angle: 40, ascentCount: 1, qualityAverage: null }), canonical: CANON })
         .qualityAverage,
     ).toBeNull();
-    // No faAt → unknown era → passthrough (assumed native 1-5).
     expect(
       fold({ stat: stat({ climbUuid: CANON, angle: 40, ascentCount: 1, qualityAverage: 5 }), canonical: CANON })
         .qualityAverage,
     ).toBe(5);
   });
 
-  it('#star-scale: an Aurora-era (pre-cutover fa_at) blend is corrected 1-3 → 1-5', () => {
-    // A 3-of-3 classic first ascended before the Grips cutover → 5-of-5.
+  it('#star-scale: Grips quality is stored verbatim (already 1-5) — NOT rescaled, regardless of era', () => {
+    // A Grips 3.0 is a real 3-of-5; the fa_at era is irrelevant — it must stay
+    // 3.0. (An earlier version wrongly pushed pre-cutover climbs 3.0 → 5.0.)
     expect(
       fold({
         stat: stat({ climbUuid: CANON, angle: 40, ascentCount: 8, qualityAverage: 3.0, faAt: '2021-06-01 10:00:00' }),
         canonical: CANON,
       }).qualityAverage,
-    ).toBe(5.0);
-    // A Grips-era (post-cutover) climb stays on its native 1-5 value.
+    ).toBe(3.0);
     expect(
       fold({
         stat: stat({ climbUuid: CANON, angle: 40, ascentCount: 8, qualityAverage: 3.0, faAt: '2026-02-01 10:00:00' }),
@@ -217,7 +216,6 @@ describe('foldCatalogStat — kilter catalog stat accumulation', () => {
   });
 
   it('#star-scale: quality above 5 is rejected → null (ingest guard)', () => {
-    // Post-cutover passthrough can't exceed the domain; a bogus > 5 is dropped.
     expect(
       fold({
         stat: stat({ climbUuid: CANON, angle: 40, ascentCount: 1, qualityAverage: 6.1, faAt: '2026-02-01 10:00:00' }),
@@ -270,49 +268,6 @@ describe('foldCatalogStat — kilter catalog stat accumulation', () => {
     foldCatalogStat(map, stat({ climbUuid: CANON, angle: 40, ascentCount: 2 }), CANON);
     foldCatalogStat(map, stat({ climbUuid: CANON, angle: 30, ascentCount: 3 }), CANON);
     expect(map.size).toBe(2);
-  });
-});
-
-describe('foldCatalogStat — created_at era fallback', () => {
-  const CANON = 'canon-uuid';
-  it('uses the climb creation time when the stat row has no fa_at', () => {
-    const accumByKey = new Map<string, StatAccum>();
-    foldCatalogStat(
-      accumByKey,
-      {
-        climbUuid: CANON,
-        angle: 40,
-        ascentCount: 10,
-        currentDifficultyId: 15,
-        difficultyAverage: 15.2,
-        qualityAverage: 3.0,
-        faUsername: null,
-        faAt: null,
-      },
-      CANON,
-      '2020-05-01 12:00:00', // pre-cutover creation → legacy 1-3 → rescaled
-    );
-    expect(accumByKey.get(`${CANON}|40`)?.qualityAverage).toBe(5.0);
-  });
-
-  it('stays passthrough when both fa_at and created_at are unknown', () => {
-    const accumByKey = new Map<string, StatAccum>();
-    foldCatalogStat(
-      accumByKey,
-      {
-        climbUuid: CANON,
-        angle: 40,
-        ascentCount: 10,
-        currentDifficultyId: 15,
-        difficultyAverage: 15.2,
-        qualityAverage: 3.0,
-        faUsername: null,
-        faAt: null,
-      },
-      CANON,
-      null,
-    );
-    expect(accumByKey.get(`${CANON}|40`)?.qualityAverage).toBe(3.0);
   });
 });
 

--- a/packages/kilter-sync/src/sync/catalog-sync.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.ts
@@ -186,10 +186,6 @@ export function foldCatalogStat(
   accumByKey: Map<string, StatAccum>,
   stat: KilterCatalogStat,
   canonicalUuid: string,
-  // Era fallback for the quality-scale correction when the stat row has no
-  // fa_at (~2.6k rated kilter rows, ~64% pre-cutover): the climb's creation
-  // timestamp. Null when the caller doesn't know it → unknown-era passthrough.
-  climbCreatedAt: string | null = null,
 ): void {
   const key = `${canonicalUuid}|${stat.angle}`;
   let accum = accumByKey.get(key);
@@ -208,12 +204,12 @@ export function foldCatalogStat(
     accumByKey.set(key, accum);
   }
   accum.kilterCount += stat.ascentCount;
-  // Kilter Grips reports a MIXED-scale quality average (Aurora-era 1-3 blended
-  // with Grips-era 1-5). correctGripsQualityAverage puts it on the canonical 1-5
-  // scale using the climb's era (fa_at, falling back to the climb's creation
-  // time when the stat row has no FA) and is self-contained on range: unrated
-  // (≤0) and garbage (>5) both come back null, so no further guard is needed.
-  const incomingQuality = correctGripsQualityAverage(stat.qualityAverage, stat.faAt ?? climbCreatedAt);
+  // Kilter Grips' qualityAverage is ALREADY on the 1-5 scale (Kilter migrated
+  // its legacy 1-3 ratings to 1-5 itself), so we store it verbatim —
+  // correctGripsQualityAverage only guards against non-ratings (≤0 / >5 → null).
+  // Do NOT rescale it: an earlier 2q−1 "correction" double-converted every
+  // climb rated ≥3 up to 5 stars (see quality-scale.ts).
+  const incomingQuality = correctGripsQualityAverage(stat.qualityAverage);
   // Difficulty ingest guard: id 1 doesn't exist and 0 is a "no data" sentinel
   // (valid grade ids are ~10-33), so treat anything ≤ 1 as "no grade" → null.
   const incomingDisplayDifficulty = guardDifficulty(stat.currentDifficultyId ?? stat.difficultyAverage);
@@ -253,14 +249,13 @@ export function foldCatalogStatOnce(
   seenSourceStats: Set<string>,
   stat: KilterCatalogStat,
   canonicalUuid: string,
-  climbCreatedAt: string | null = null,
 ): boolean {
   const sourceKey = catalogStatSourceKey(stat);
   if (seenSourceStats.has(sourceKey)) {
     return false;
   }
   seenSourceStats.add(sourceKey);
-  foldCatalogStat(accumByKey, stat, canonicalUuid, climbCreatedAt);
+  foldCatalogStat(accumByKey, stat, canonicalUuid);
   return true;
 }
 
@@ -347,10 +342,6 @@ async function syncBoardLayoutGroup(
 
   // lower(sourceUuid) → canonicalUuid, for routing stats. Spans the whole group.
   const climbUuidToCanonical = new Map<string, string>();
-  // Source-uuid → climb creation timestamp, the era fallback for stats rows
-  // that carry no fa_at (see foldCatalogStat).
-  const createdAtBySourceUuid = new Map<string, string>();
-
   for (const gripsLayoutUuid of gripsLayoutUuids) {
     const climbs = await withToken(state, (token) => fetchLayoutClimbs(token, gripsLayoutUuid));
 
@@ -368,7 +359,6 @@ async function syncBoardLayoutGroup(
       if (!climb.isListed || climb.isDraft || climb.isDeleted) continue;
       result.climbsSeen += 1;
       const lowerUuid = climb.climbUuid.toLowerCase();
-      if (climb.createdAt) createdAtBySourceUuid.set(lowerUuid, climb.createdAt);
 
       // 1. UUID identity — the Grips catalog inherited Aurora's climb UUIDs, so
       //    most incoming climbs already exist as their own canonical. Match on
@@ -579,13 +569,7 @@ async function syncBoardLayoutGroup(
     for (const stat of stats) {
       const canonicalUuid = climbUuidToCanonical.get(stat.climbUuid.toLowerCase());
       if (!canonicalUuid) continue; // stat for a filtered/unknown climb
-      foldCatalogStatOnce(
-        statsByCanonicalAngle,
-        seenSourceStats,
-        stat,
-        canonicalUuid,
-        createdAtBySourceUuid.get(stat.climbUuid.toLowerCase()) ?? null,
-      );
+      foldCatalogStatOnce(statsByCanonicalAngle, seenSourceStats, stat, canonicalUuid);
     }
   }
 
@@ -600,8 +584,8 @@ async function syncBoardLayoutGroup(
     // upstream term). On a fresh INSERT quality_average == this value because no
     // Boardsesh votes exist yet; on conflict quality_average is re-blended below.
     upstreamQualityAverage: accum.qualityAverage,
-    // qualityAverage was put on the canonical 1-5 scale by correctGripsQualityAverage
-    // in the fold above (Aurora-era 1-3 → 1-5, Grips-era passthrough).
+    // qualityAverage is Grips' own 1-5 value, stored verbatim in the fold above
+    // (correctGripsQualityAverage only drops non-ratings).
     qualityNormalized: true,
     faUsername: accum.faUsername,
     faAt: accum.faAt,
@@ -643,8 +627,7 @@ async function syncBoardLayoutGroup(
             difficultyAverage: sql`COALESCE(excluded.difficulty_average, ${boardClimbStats.difficultyAverage})`,
             upstreamQualityAverage: sql`COALESCE(excluded.upstream_quality_average, ${boardClimbStats.upstreamQualityAverage})`,
             qualityAverage: blendedQuality,
-            // quality is corrected to the canonical 1-5 scale on the way in
-            // (correctGripsQualityAverage), so a written row is always normalized.
+            // Grips quality is natively 1-5, so a written row is always normalized.
             qualityNormalized: sql`true`,
             faUsername: sql`COALESCE(excluded.fa_username, ${boardClimbStats.faUsername})`,
             faAt: sql`COALESCE(excluded.fa_at, ${boardClimbStats.faAt})`,

--- a/packages/kilter-sync/src/sync/quality-scale.test.ts
+++ b/packages/kilter-sync/src/sync/quality-scale.test.ts
@@ -2,45 +2,31 @@ import { describe, it, expect } from 'vitest';
 
 import { correctGripsQualityAverage } from './quality-scale';
 
-const PRE = '2024-03-15 12:00:00'; // before the 2025-09-01 Grips cutover
-const POST = '2026-01-10 09:30:00'; // after the cutover
-
 describe('correctGripsQualityAverage', () => {
-  it('maps a pre-cutover Aurora-era average onto 1-5 with 2q−1', () => {
-    expect(correctGripsQualityAverage(3.0, PRE)).toBe(5.0); // classic 3-of-3 → 5-of-5
-    expect(correctGripsQualityAverage(2.0, PRE)).toBe(3.0);
-    expect(correctGripsQualityAverage(1.0, PRE)).toBe(1.0);
-    expect(correctGripsQualityAverage(2.5, PRE)).toBe(4.0); // continuous average
+  it('stores the Grips value verbatim — it is already on the 1-5 scale', () => {
+    // A Grips 3.0 is a real 3-of-5 (Kilter compresses its legacy ratings toward
+    // 3 via its own 1-3→1-5 migration); it MUST stay 3.0, not be rescaled up.
+    expect(correctGripsQualityAverage(3.0)).toBe(3.0);
+    expect(correctGripsQualityAverage(2.0)).toBe(2.0);
+    expect(correctGripsQualityAverage(1.0)).toBe(1.0);
+    expect(correctGripsQualityAverage(2.5)).toBe(2.5);
+    expect(correctGripsQualityAverage(4.33)).toBe(4.33);
+    expect(correctGripsQualityAverage(5.0)).toBe(5.0);
   });
 
-  it('clamps a pre-cutover average to the 1-5 range', () => {
-    // A blended pre-cutover value above 3 over-converts, then clamps to 5.
-    expect(correctGripsQualityAverage(3.5, PRE)).toBe(5.0);
+  it('does NOT rescale (regression guard: the old 2q−1 pushed 3.0 → 5.0)', () => {
+    expect(correctGripsQualityAverage(3.0)).not.toBe(5.0);
+    expect(correctGripsQualityAverage(4.0)).not.toBe(5.0);
+    expect(correctGripsQualityAverage(4.0)).toBe(4.0);
   });
 
-  it('passes a post-cutover average through unchanged (already native 1-5)', () => {
-    expect(correctGripsQualityAverage(3.25, POST)).toBe(3.25);
-    expect(correctGripsQualityAverage(5.0, POST)).toBe(5.0);
-    expect(correctGripsQualityAverage(1.0, POST)).toBe(1.0);
-  });
-
-  it('passes through when the era is unknown (null / unparseable timestamp)', () => {
-    expect(correctGripsQualityAverage(4.2, null)).toBe(4.2);
-    expect(correctGripsQualityAverage(4.2, 'not-a-date')).toBe(4.2);
-  });
-
-  it('rejects a bogus above-5 upstream value in every era (self-contained guard)', () => {
-    expect(correctGripsQualityAverage(10, POST)).toBeNull();
-    expect(correctGripsQualityAverage(10, null)).toBeNull();
-    expect(correctGripsQualityAverage(10, PRE)).toBeNull();
-  });
-
-  it('treats unrated (null / undefined / ≤ 0 / non-finite) as null', () => {
-    expect(correctGripsQualityAverage(null, PRE)).toBeNull();
-    expect(correctGripsQualityAverage(undefined, PRE)).toBeNull();
-    expect(correctGripsQualityAverage(0, PRE)).toBeNull();
-    expect(correctGripsQualityAverage(0, POST)).toBeNull();
-    expect(correctGripsQualityAverage(-1, PRE)).toBeNull();
-    expect(correctGripsQualityAverage(Number.NaN, POST)).toBeNull();
+  it('treats non-ratings as null (≤ 0 unrated, > 5 garbage, non-finite)', () => {
+    expect(correctGripsQualityAverage(null)).toBeNull();
+    expect(correctGripsQualityAverage(undefined)).toBeNull();
+    expect(correctGripsQualityAverage(0)).toBeNull();
+    expect(correctGripsQualityAverage(-1)).toBeNull();
+    expect(correctGripsQualityAverage(5.0001)).toBeNull();
+    expect(correctGripsQualityAverage(10)).toBeNull();
+    expect(correctGripsQualityAverage(Number.NaN)).toBeNull();
   });
 });

--- a/packages/kilter-sync/src/sync/quality-scale.ts
+++ b/packages/kilter-sync/src/sync/quality-scale.ts
@@ -1,64 +1,35 @@
 /**
- * Kilter Grips quality-average scale correction.
+ * Kilter Grips quality-average pass-through (range guard only).
  *
- * The Kilter Grips catalog reports a single `qualityAverage` per (climb, angle)
- * that is a MIXED-SCALE blend upstream: legacy Aurora-era ratings live on the
- * raw 1-3 scale (Grips inherited Aurora's logbook), while Grips-era ratings are
- * native 1-5. Storing the value verbatim (as the sync originally did) left every
- * Aurora-era classic pinned near 3, so a 3-of-3 "classic" rendered as ~3-of-5.
+ * The Kilter Grips catalog reports one `qualityAverage` per (climb, angle) that
+ * is ALREADY on the 1-5 scale: Kilter migrated its legacy 1-3 per-user ratings
+ * to 1-5 itself (round(q × 5/3): 1→2, 2→3, 3→5 — which is why the synced
+ * per-user ratings in board_climb_ratings are 1-5 with no 1s or 4s). The
+ * aggregate is computed from those 1-5 ratings, so it needs NO scale conversion.
  *
- * We can't tell an individual rating's scale from the aggregate, so we use the
- * climb's era as the discriminator: a climb whose first ascent (or, absent that,
- * creation) predates the Grips cutover is treated as Aurora-era 1-3 and mapped
- * onto 1-5 with the canonical affine `2q − 1`; a climb at/after the cutover (or
- * of unknown era) is assumed already native 1-5 and passed through unchanged.
+ * HISTORY: an earlier version applied an affine `2q − 1` to "pre-cutover"
+ * climbs on the false premise that the aggregate was a mixed 1-3/1-5 blend. That
+ * double-converted every climb rated ≥3 up to 5 (clamped), so ~88% of
+ * well-ascended Kilter climbs rendered at ≥4.5 stars and the median hit exactly
+ * 5.0 — a regression on top of the original (correct) data. The clustering at
+ * ~3.0 the conversion tried to "fix" is Kilter's own legacy-migration artifact
+ * and matches what the Kilter app shows; it was never ours to rescale.
  *
- * This is a deliberately coarse era heuristic: a pre-cutover climb that has since
- * accumulated Grips-era 1-5 ratings has a blended average that this converts (and
- * clamps) too aggressively. That trade-off is accepted — the dominant, visible
- * defect is the wall of Aurora-era classics stuck at 3.
+ * (Aurora-synced boards like Tension ARE genuinely 1-3 and are still rescaled to
+ * 1-5 via normalizeQualityTo5 in aurora-sync — a separate, correct code path.)
  */
 
 /**
- * Grips cutover: first ascents strictly before this are treated as Aurora-era
- * (raw 1-3); at/after it, native 1-5. Parsed once at module load.
- */
-const GRIPS_CUTOVER_MS = Date.parse('2025-09-01T00:00:00Z');
-
-/**
- * Correct a Kilter Grips `qualityAverage` onto the canonical 1-5 scale.
+ * Store a Kilter Grips `qualityAverage` verbatim (it is already 1-5), guarding
+ * only against non-ratings.
  *
  * - `null`/`undefined`/non-finite/`≤ 0`/`> 5` → `null` (unrated is never a 0
- *   rating; above 5 is garbage on either scale).
- * - pre-cutover era (`climbCreatedAtOrFaAt` parses to before 2025-09-01) →
- *   `clamp(2·raw − 1, 1, 5)` (Aurora-era 1-3 → 1-5).
- * - at/after the cutover, or an unknown era (`null`/unparseable) → `raw` as-is
- *   (assumed native Grips 1-5).
- *
- * @param raw the Grips-reported quality average
- * @param climbCreatedAtOrFaAt the stat row's `faAt` (preferred) or the climb's
- *   creation timestamp; `null` when neither is known (→ passthrough)
+ *   rating; above 5 is garbage).
+ * - otherwise → `raw`, unchanged.
  */
-export function correctGripsQualityAverage(
-  raw: number | null | undefined,
-  climbCreatedAtOrFaAt: string | null | undefined,
-): number | null {
+export function correctGripsQualityAverage(raw: number | null | undefined): number | null {
   if (raw == null) return null;
   const quality = Number(raw);
-  // ≤ 0 is the "unrated" sentinel; > 5 is garbage on either scale (legacy tops
-  // out at 3, native at 5) — reject both here so the function is self-contained
-  // and no caller-side range guard is needed for out-of-range input to stay out
-  // of the database.
   if (!Number.isFinite(quality) || quality <= 0 || quality > 5) return null;
-
-  // fa_at arrives as 'YYYY-MM-DD HH:MM:SS' (DB rows) or ISO (API). Space→'T'
-  // makes the former spec-compliant ISO so parsing is engine-independent
-  // (space-separated Date.parse is V8-only behavior). Timezone slop is
-  // irrelevant against a month-scale era cutover.
-  const eraMs = climbCreatedAtOrFaAt != null ? Date.parse(climbCreatedAtOrFaAt.replace(' ', 'T')) : Number.NaN;
-  // Unknown era (null / unparseable) or post-cutover → already native 1-5.
-  if (Number.isNaN(eraMs) || eraMs >= GRIPS_CUTOVER_MS) return quality;
-
-  // Aurora-era: raw 1-3 → 1-5 via the affine map, clamped defensively.
-  return Math.min(5, Math.max(1, 2 * quality - 1));
+  return quality;
 }

--- a/packages/kilter-sync/src/sync/stats-repair.ts
+++ b/packages/kilter-sync/src/sync/stats-repair.ts
@@ -145,22 +145,15 @@ async function loadTopStats(db: DrizzleDb): Promise<KilterStatsRepairTopRow[]> {
 // run after a catalog sync has persisted this run's fingerprint aliases — the repair
 // reads only persisted aliases, it does not re-derive fingerprints. A source UUID
 // with no mapping here is counted in summary.statsUnresolved (observable, not silent).
-async function loadCanonicalMap(
-  db: DrizzleDb,
-  layoutId: number,
-): Promise<{ canonicalBySource: Map<string, string>; createdAtByCanonical: Map<string, string> }> {
+async function loadCanonicalMap(db: DrizzleDb, layoutId: number): Promise<Map<string, string>> {
   const map = new Map<string, string>();
-  // Canonical uuid → climb creation timestamp: the era fallback for the
-  // quality-scale correction on stat rows without fa_at (see foldCatalogStat).
-  const createdAtByCanonical = new Map<string, string>();
   const climbRows = await db
-    .select({ uuid: boardClimbs.uuid, createdAt: boardClimbs.createdAt })
+    .select({ uuid: boardClimbs.uuid })
     .from(boardClimbs)
     .where(and(eq(boardClimbs.boardType, KILTER), eq(boardClimbs.layoutId, layoutId)));
 
   for (const row of climbRows) {
     map.set(row.uuid.toLowerCase(), row.uuid);
-    if (row.createdAt) createdAtByCanonical.set(row.uuid, row.createdAt);
   }
 
   const aliasRows = await db
@@ -182,7 +175,7 @@ async function loadCanonicalMap(
     map.set(row.aliasUuid.toLowerCase(), row.canonicalUuid);
   }
 
-  return { canonicalBySource: map, createdAtByCanonical };
+  return map;
 }
 
 function statValueFromAccum(accum: StatAccum): RepairStatValue {
@@ -192,9 +185,9 @@ function statValueFromAccum(accum: StatAccum): RepairStatValue {
     angle: accum.angle,
     displayDifficulty: accum.displayDifficulty,
     difficultyAverage: accum.difficultyAverage,
-    // qualityAverage / difficulty were already put on the canonical 1-5 scale and
-    // guarded by foldCatalogStat (correctGripsQualityAverage) when this repair
-    // accumulated the stat rows — the repair reads them straight from the accum.
+    // qualityAverage (Grips' native 1-5, stored verbatim) and difficulty were
+    // range-guarded by foldCatalogStat when this repair accumulated the stat
+    // rows — the repair reads them straight from the accum.
     qualityAverage: accum.qualityAverage,
     // Corrected manufacturer average also seeds the blend's upstream term.
     upstreamQualityAverage: accum.qualityAverage,
@@ -352,10 +345,7 @@ export async function repairKilterCatalogStats(args: KilterStatsRepairArgs): Pro
   let gripsLayoutsProcessed = 0;
 
   for (const [boardLayoutId, gripsLayoutUuids] of byBoardLayout) {
-    const { canonicalBySource: canonicalBySourceUuid, createdAtByCanonical } = await loadCanonicalMap(
-      args.db,
-      boardLayoutId,
-    );
+    const canonicalBySourceUuid = await loadCanonicalMap(args.db, boardLayoutId);
     gripsLayoutsProcessed += gripsLayoutUuids.length;
     for (const gripsLayoutUuid of gripsLayoutUuids) {
       const stats = await withToken(state, (token) => fetchLayoutClimbStats(token, gripsLayoutUuid));
@@ -373,7 +363,7 @@ export async function repairKilterCatalogStats(args: KilterStatsRepairArgs): Pro
           statsUnresolved += 1;
           continue;
         }
-        foldCatalogStat(statsByCanonicalAngle, stat, canonicalUuid, createdAtByCanonical.get(canonicalUuid) ?? null);
+        foldCatalogStat(statsByCanonicalAngle, stat, canonicalUuid);
       }
     }
   }


### PR DESCRIPTION
## Summary

**Regression fix.** PR #3547 introduced `correctGripsQualityAverage`, which rescaled Kilter Grips quality with an affine `2q−1` for "pre-cutover" climbs — on the false premise that the Grips catalog `qualityAverage` is a mixed 1‑3 / 1‑5 blend. It isn't. **Kilter migrated its own legacy 1‑3 ratings to 1‑5** (`round(q × 5/3)`: 1→2, 2→3, 3→5 — which is exactly why the synced per‑user `board_climb_ratings` are 1‑5 with no 1s or 4s), so the aggregate is uniformly 1‑5 and needs **no** conversion. Applying `2q−1` on top double‑converted every climb rated ≥3 up to 5 (clamped), so **~88% of well‑ascended Kilter climbs rendered at ≥4.5 stars and the median hit exactly 5.00** — a regression on top of correct data.

The original "too many 3‑star Kilter climbs" observation was **Kilter's genuine data** — its own migration compresses ratings toward 3.0, matching the Kilter app. It was never ours to rescale.

### The fix
`correctGripsQualityAverage` is now a pass‑through with a range guard only (`≤0` unrated / `>5` garbage → `null`; otherwise store `raw` verbatim). Removed the now‑dead era plumbing (the `createdAt` fallback threaded through `foldCatalogStat`, `foldCatalogStatOnce`, and `loadCanonicalMap`). Net −115 lines.

## Second fix in this PR — `rating = 0` crashes the ratings sync

Separately (and pre‑existing), the daemon was hitting a **permanent sync failure** per user: Kilter's PowerSync sends `rating = 0` ("cleared / no opinion — the user didn't give a rating") for some users, and `applyClimbRatings` inserted it verbatim, violating the `board_climb_ratings_rating_range` CHECK (`NULL` or `1‑5`). Postgres aborts the whole bulk insert, so that user's sync never completes. This was masked by the old silent‑sync outage; PR #3557's error‑surfacing now makes it fail loudly.

Fix: `sanitizeKilterRating` maps `0` (and any out‑of‑range / non‑finite value) to `NULL` — which is exactly what `0` means in Kilter ("unrated"), and what our column uses for "no rating." Valid 1‑5 ratings pass through. This is a pure ingest sanitizer; no stored data to repair (the CHECK meant no bad rows were ever written).

### Why only Kilter is affected (verified on prod, read‑only)
- **Kilter's per‑user `board_climb_ratings`** top out at **5** → the Grips catalog aggregate is 1‑5 → pass‑through is correct.
- **Aurora‑synced boards (Tension)** are untouched by this PR and stay correct: their catalog aggregate genuinely **is** 1‑3 — confirmed two ways: the pre‑fix values sat exactly on the `×5/3` grid, and Aurora per‑tick quality is exactly `{1, 3, 5}` (the fingerprint of a 1‑3 source through `convertQuality`). So `normalizeQualityTo5`'s `2q−1` for Tension is the right transform and stays.

## Release Notes

- Kilter star ratings are honest again — climbs that suddenly all looked like 5‑star classics go back to their real ratings

## Test plan

- `correctGripsQualityAverage` unit tests rewritten to assert verbatim storage (3.0→3.0, 2.5→2.5, 5.0→5.0) with an explicit regression guard that 3.0 does **not** become 5.0; non‑ratings (≤0, >5, non‑finite) → null.
- `foldCatalogStat` catalog‑stats tests updated: Grips quality stored verbatim regardless of `fa_at` era; the removed `created_at`‑fallback tests deleted.
- `vp run typecheck` (full) clean; `vp check` clean; 153/153 kilter‑sync tests pass.
- Root cause and scale evidence verified against prod read‑only (Kilter ratings max 5; Aurora ticks `{1,3,5}`; current Kilter median = 5.00, ~88% ≥4.5).

---

## ⚠️ RESTORE RUNBOOK (do this after merge)

The bad values are **already written** to `board_climb_stats` on prod (by migration `0150` and by the daemon runs before it was disabled). This PR stops *new* inflation; the stored values are healed by re‑syncing from the authoritative Grips feed.

**Step 1 — merge this PR** and deploy the new `kilter-sync` build.

**Step 2 — re‑enable the kilter‑sync daemon** (you disabled the docker container). On its next full catalog sync it reads `/climb-stat/all/` for every layout, runs the fixed pass‑through, and upserts. For every currently‑rated Kilter climb the upsert overwrites `upstream_quality_average` with the raw Grips value (`COALESCE(raw, old)` = `raw`) and recomputes `quality_average` from it — so the inflation heals. One full catalog cycle heals every rated, listed Kilter climb.

**Step 3 — (optional, guaranteed‑clean) null first, then re‑enable.** The upsert's `COALESCE` preserves the old value only when the incoming Grips rating is `null` (a climb that *lost* all its ratings) — a tiny residue. To guarantee zero stale values, run this **once, before re‑enabling the daemon**, then re‑enable so it repopulates from raw:

```sql
-- Clears the inflated Kilter aggregate so the daemon can only repopulate from
-- raw Grips values. Non-owned climbs only (owned climbs' quality comes from
-- ticks via recompute, on the correct grid already). Chunk if it locks too long.
UPDATE board_climb_stats s
   SET upstream_quality_average = NULL,
       quality_average = NULL
 WHERE s.board_type = 'kilter'
   AND NOT EXISTS (
     SELECT 1 FROM board_climbs c
      WHERE c.board_type = 'kilter' AND c.uuid = s.climb_uuid AND c.user_id IS NOT NULL
   );
```
Climbs show no rating only during the re‑sync window, then come back correct.

**Step 4 — verify (read‑only).** After a full sync cycle, the distribution should return to a spread (median ≈ 3, not 5), and the ≥4.5 share should fall from ~88%:

```sql
SELECT
  count(*) FILTER (WHERE quality_average >= 4.5) AS ge_4_5,
  count(*) FILTER (WHERE quality_average IS NOT NULL) AS rated,
  round(100.0*count(*) FILTER (WHERE quality_average >= 4.5)
        / nullif(count(*) FILTER (WHERE quality_average IS NOT NULL),0), 1) AS pct_ge_4_5,
  round(percentile_cont(0.5) WITHIN GROUP (ORDER BY quality_average)::numeric, 2) AS median
FROM board_climb_stats
WHERE board_type = 'kilter' AND ascensionist_count >= 20;
-- Broken now:  ge_4_5=32703  pct=87.5  median=5.00
-- Healed:      median back near 3, pct_ge_4_5 much lower (a real spread)
```
Cross‑check a few climbs against the Kilter app — the stars should match.

### Notes / not in scope
- Migrations `0150` (kilter blend backfill) and `0154` (history rescale) are historical and **not** reverted — the daemon re‑sync supersedes `0150` for live stats. **Kilter `board_climb_stats_history` quality is also inflated** (chart‑only; low priority) — a follow‑up can re‑snapshot from the healed live values, or leave it since it only affects the "quality over time" chart.
- **Tension / Aurora quality is correct and unchanged.** No action needed there.
- Everything else in the six‑PR program (ascent counts, dedup, catalog visibility, sync reliability) is unaffected by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vqeM9YNFL3a1GDEjhKuNY
