### PR TITLE
fix(kilter-sync): sanitize Kilter rating=0 to NULL (unblock per-user ratings sync)

### DIFF
--- a/packages/kilter-sync/src/sync/user-sync.test.ts
+++ b/packages/kilter-sync/src/sync/user-sync.test.ts
@@ -1037,7 +1037,21 @@ describe('applyLogs — PR4 offset inference + edit guard', () => {
 // hand-fed select results, assert exact statement counts.
 // ---------------------------------------------------------------------------
 
-import { applyCircuits, applyClimbRatings } from './user-sync';
+import { applyCircuits, applyClimbRatings, sanitizeKilterRating } from './user-sync';
+
+describe('sanitizeKilterRating', () => {
+  it('keeps valid 1-5 ratings', () => {
+    for (const r of [1, 2, 3, 4, 5]) expect(sanitizeKilterRating(r)).toBe(r);
+  });
+  it('maps 0 (Kilter "cleared") and out-of-range / non-finite to NULL so the CHECK accepts the row', () => {
+    expect(sanitizeKilterRating(0)).toBeNull();
+    expect(sanitizeKilterRating(-1)).toBeNull();
+    expect(sanitizeKilterRating(6)).toBeNull();
+    expect(sanitizeKilterRating(null)).toBeNull();
+    expect(sanitizeKilterRating(undefined)).toBeNull();
+    expect(sanitizeKilterRating(Number.NaN)).toBeNull();
+  });
+});
 import { boardClimbRatings, playlists, playlistClimbs, playlistOwnership } from '@boardsesh/db/schema';
 
 type ChainTx = {
@@ -1184,6 +1198,17 @@ describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
     expect(calls.filter((c) => c.kind === 'delete')).toHaveLength(0);
     // boardClimbRatings is the schema target — used by the bulk insert.
     expect(boardClimbRatings).toBeDefined();
+  });
+
+  it('sanitizes a Kilter rating=0 to NULL so the batch does not violate the CHECK', () => {
+    const { tx, insertValues } = createRichTx();
+    const ops = [makeRatingPutOp({ climb_rating_uuid: 'r-0', climb_uuid: 'climb-A', angle: 40, rating: 0 })];
+    return applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', ops, aliasCacheFor(['climb-A'])).then(
+      () => {
+        expect(insertValues[0]).toHaveLength(1);
+        expect(insertValues[0][0]).toMatchObject({ kilterId: 'r-0', rating: null });
+      },
+    );
   });
 
   it('issues exactly one bulk DELETE for N REMOVE ops, no INSERT', async () => {

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -963,6 +963,20 @@ export async function applyLogs(
  * board_climb_ratings.comment) — Kilter sending `comment: null` must
  * not clobber a non-empty Boardsesh-originated comment.
  */
+/**
+ * Kilter's per-user climb rating is a 1-5 star value; it also sends 0 to mean
+ * "cleared / no opinion". board_climb_ratings has a CHECK (rating IS NULL OR
+ * 1..5), so a raw 0 (or any out-of-range value) aborts the whole ratings batch
+ * insert and permanently fails that user's sync. Map anything outside 1-5 to
+ * NULL ("unrated") so the row is accepted. Exported for unit testing.
+ */
+export function sanitizeKilterRating(rating: number | null | undefined): number | null {
+  if (rating == null) return null;
+  const value = Number(rating);
+  if (!Number.isFinite(value) || value < 1 || value > 5) return null;
+  return value;
+}
+
 export async function applyClimbRatings(
   tx: DrizzleDb,
   userId: string,
@@ -1020,7 +1034,10 @@ export async function applyClimbRatings(
       climbUuid: canonical,
       angle: raw.angle,
       userId,
-      rating: raw.rating,
+      // Kilter sends 0 for "cleared"; the DB CHECK only allows NULL or 1-5, so
+      // a raw 0 would abort the whole batch. sanitizeKilterRating maps it (and
+      // any other out-of-range value) to NULL.
+      rating: sanitizeKilterRating(raw.rating),
       difficultyGradeId: raw.difficulty_grade_id,
       comment: raw.comment ?? '',
       // Kilter's per-rating payload doesn't carry a `weight`; the field


### PR DESCRIPTION
## Summary

Follow-up hotfix after #3567. The kilter-sync daemon hit a **permanent sync failure** per affected user: Kilter's PowerSync sends `rating = 0` — its "cleared / no opinion" sentinel, i.e. *the user didn't give a rating* — for some users. `applyClimbRatings` inserted that `0` verbatim, violating the `board_climb_ratings_rating_range` CHECK (`rating IS NULL OR 1..5`). Postgres aborts the entire bulk insert, so that user's whole ratings sync never completes.

It was masked before by the silent-sync outage; #3557's error-surfacing now makes it fail loudly (which is how we caught it).

## The fix

`sanitizeKilterRating` maps `0` (and any out-of-range / non-finite value) to `NULL` — which is exactly what `0` means to Kilter ("unrated") and what our column already uses for "no rating." A real 1–5 rating passes through unchanged. There is no such thing as a stored 0-star rating (the CHECK enforces NULL-or-1..5), so this loses no information: an unrated climb correctly contributes no rating.

Pure ingest sanitizer — **no stored data to repair** (the CHECK meant no bad rows were ever written; the inserts were just being rejected).

## Release Notes

- Kilter logbook sync no longer stalls for climbers who cleared a star rating

## Test plan

- `sanitizeKilterRating` unit tests: 1–5 pass through; 0 / negative / >5 / null / NaN → null.
- `applyClimbRatings` integration case: a `rating: 0` PUT is inserted as `rating: null` (batch not rejected).
- `vp run typecheck:kilter`, `vp check` clean; 156/156 kilter-sync tests pass.

## Deploy

Merge → redeploy kilter-sync → re-enable the daemon. It will now complete the per-user ratings sync instead of permanently failing on a 0-rating. (The quality-scale pass-through from #3567 is already on main/deployed, so quality also heals on this same completed sync.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vqeM9YNFL3a1GDEjhKuNY