### PR TITLE
Add MoonBoard CSV logbook importer

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -20,22 +20,22 @@ session_type` already accommodates inferred solo sessions for later.
 
 ## Code map
 
-| Piece                              | Location                                                                                                      |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Provider abstraction + Strava impl | `packages/backend/src/integrations/{types,strava,registry}.ts`                                                |
-| Credential store + token refresh   | `packages/backend/src/integrations/credentials.ts`                                                            |
-| Export/claim/dedupe service        | `packages/backend/src/integrations/export-service.ts`                                                         |
-| Signed handoff/state tokens        | `packages/backend/src/integrations/state.ts`                                                                  |
-| Browser OAuth HTTP handlers        | `packages/backend/src/handlers/integrations-oauth.ts`                                                         |
-| GraphQL resolvers                  | `packages/backend/src/graphql/resolvers/integrations/`                                                        |
-| DB tables                          | `packages/db/src/schema/auth/integration-credentials.ts`, `packages/db/src/schema/app/integration-exports.ts` |
-| Mobile registry + orchestration    | `packages/mobile/src/lib/integrations/`                                                                       |
-| HealthKit native module            | `packages/mobile/modules/health-workouts/` (+ `plugins/with-healthkit.js`)                                    |
-| Mobile UI                          | `packages/mobile/src/components/integrations/`, `app/(tabs)/profile/integrations.tsx`                         |
-| Board account REST handlers        | `packages/backend/src/handlers/aurora-{credentials,import}.ts`, `kilter-credentials-oauth.ts`                 |
-| Board account services             | `packages/backend/src/services/aurora-credentials.ts`, `board-credential-state.ts`                            |
-| Shared Aurora JSON importer        | `packages/aurora-sync/src/sync/json-import.ts`, `packages/shared-schema/src/aurora-import.ts`                 |
-| Mobile board account UI/client     | `packages/mobile/src/components/integrations/BoardAccountsSection.tsx`, `src/lib/aurora-credentials.ts`       |
+| Piece                              | Location                                                                                                             |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Provider abstraction + Strava impl | `packages/backend/src/integrations/{types,strava,registry}.ts`                                                       |
+| Credential store + token refresh   | `packages/backend/src/integrations/credentials.ts`                                                                   |
+| Export/claim/dedupe service        | `packages/backend/src/integrations/export-service.ts`                                                                |
+| Signed handoff/state tokens        | `packages/backend/src/integrations/state.ts`                                                                         |
+| Browser OAuth HTTP handlers        | `packages/backend/src/handlers/integrations-oauth.ts`                                                                |
+| GraphQL resolvers                  | `packages/backend/src/graphql/resolvers/integrations/`                                                               |
+| DB tables                          | `packages/db/src/schema/auth/integration-credentials.ts`, `packages/db/src/schema/app/integration-exports.ts`        |
+| Mobile registry + orchestration    | `packages/mobile/src/lib/integrations/`                                                                              |
+| HealthKit native module            | `packages/mobile/modules/health-workouts/` (+ `plugins/with-healthkit.js`)                                           |
+| Mobile UI                          | `packages/mobile/src/components/integrations/`, `app/(tabs)/profile/integrations.tsx`                                |
+| Board account REST handlers        | `packages/backend/src/handlers/aurora-{credentials,import}.ts`, `moonboard-import.ts`, `kilter-credentials-oauth.ts` |
+| Board account services             | `packages/backend/src/services/aurora-credentials.ts`, `moonboard-import.ts`, `board-credential-state.ts`            |
+| Shared import parsers              | `packages/aurora-sync/src/sync/json-import.ts`, `packages/shared-schema/src/{aurora,moonboard}-import.ts`            |
+| Mobile board account UI/client     | `packages/mobile/src/components/integrations/BoardAccountsSection.tsx`, `src/lib/aurora-credentials.ts`              |
 
 ## Mobile availability and flags
 
@@ -178,9 +178,14 @@ allowlist.
 
 - `POST /api/aurora-import` streams newline-delimited progress events while
   importing Aurora JSON export chunks through the shared importer.
+- `POST /api/moonboard-import` streams newline-delimited progress events while
+  importing a stripped MoonBoard CSV export. MoonBoard logs are saved at 40°;
+  Project/Fail rows become attempts, and Session Flash rows become sends with
+  one attempt. The importer resolves Moon problem ids against the deterministic
+  MoonBoard catalog UUIDs and canonical aliases before writing ticks.
 
-The JSON import parser is shared with web so mobile previews and server-side
-validation agree on board mismatches, missing users, and item counts.
+The JSON and CSV import parsers are shared with web/mobile so previews and
+server-side validation agree on missing users, board mismatches, and item counts.
 
 ## Adding a provider
 

--- a/docs/ui/18-settings.md
+++ b/docs/ui/18-settings.md
@@ -163,13 +163,14 @@ credential to `pending` so the daemon picks it up again).
 
 - Route: `packages/mobile/app/(tabs)/profile/integrations.tsx`.
 - Board account cards render above platform/device integration cards.
-- A **MoonBoard** card renders first, above the Aurora-board cards (mobile only).
+- A **MoonBoard** card renders first, above the Aurora-board cards on web and mobile.
   MoonBoard isn't in `AURORA_BOARDS`, so the card is self-contained — no
   credential, status chip, or sync flow. It offers two actions: "Request your
   data" opens a pre-filled mailto to `moonboardsupport@moonclimbing.com` (body
-  reads "MoonBoard app user"), and "Import data" opens an explanatory dialog
-  asking the user to send their MoonBoard export to Marco on Discord, since the
-  importer isn't built yet.
+  is copied to the clipboard on mobile), and "Import data" opens a CSV picker.
+  The CSV import previews MoonBoard logbook row counts, stores all entries at
+  40°, turns Project/Fail rows into attempts, and streams progress from
+  `/api/moonboard-import`.
 - Uses backend REST endpoints instead of Next internal routes.
 - Kilter links via the username/password (ROPC) "Sign in to Kilter" card when the
   `kilter-oauth-linking` PostHog flag is on; otherwise only the "Kilter (Aurora)"

--- a/packages/backend/src/__tests__/moonboard-import-service.test.ts
+++ b/packages/backend/src/__tests__/moonboard-import-service.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import { v5 as uuidv5 } from 'uuid';
+import type { MoonBoardExportLogRow, StrippedMoonBoardExportData } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { importMoonBoardExportData } from '../services/moonboard-import';
+
+const TEST_USER_ID = 'moonboard-import-test-user';
+const UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+const SIX_A_PLUS_DIFFICULTY_ID = 17;
+const SIX_B_DIFFICULTY_ID = 18;
+
+const describeWithDatabase = process.env.SKIP_TEST_INFRA === '1' ? describe.skip : describe;
+
+type ImportedTickRow = {
+  climb_uuid: string;
+  status: string;
+  attempt_count: number | string;
+  climbed_on: string;
+};
+
+function moonBoardCandidateUuid(problemId: number): string {
+  return uuidv5(`moonboard:${problemId}`, UUID_NAMESPACE);
+}
+
+function moonBoardLogRow(input: {
+  lineNumber: number;
+  problemId: number;
+  grade?: string;
+  tries: string;
+  attempts?: number;
+  rating?: number | null;
+  date?: string;
+}): MoonBoardExportLogRow {
+  return {
+    lineNumber: input.lineNumber,
+    problemId: input.problemId,
+    grade: input.grade ?? '6A+',
+    tries: input.tries,
+    attempts: input.attempts ?? 0,
+    rating: 'rating' in input ? (input.rating ?? null) : 4,
+    date: input.date ?? '13/02/26',
+  };
+}
+
+function moonBoardImportData(logs: MoonBoardExportLogRow[]): StrippedMoonBoardExportData {
+  return {
+    user: { username: 'moonboard-import-test' },
+    logs,
+  };
+}
+
+async function insertMoonBoardClimb(input: {
+  problemId: number;
+  difficultyId?: number;
+  canonicalUuid?: string;
+}): Promise<string> {
+  const climbUuid = input.canonicalUuid ?? moonBoardCandidateUuid(input.problemId);
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, name, angle)
+    VALUES (${climbUuid}, 'moonboard', 2, ${'MoonBoard import fixture ' + input.problemId}, 40)
+  `);
+  await db.execute(sql`
+    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty)
+    VALUES ('moonboard', ${climbUuid}, 40, ${input.difficultyId ?? SIX_A_PLUS_DIFFICULTY_ID})
+  `);
+  return climbUuid;
+}
+
+async function insertMoonBoardAlias(problemId: number, canonicalUuid: string): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO board_climb_aliases (board_type, alias_uuid, canonical_uuid, source)
+    VALUES ('moonboard', ${moonBoardCandidateUuid(problemId)}, ${canonicalUuid}, 'moonboard-import-test')
+  `);
+}
+
+async function importedTicks(): Promise<ImportedTickRow[]> {
+  return (await db.execute(sql`
+    SELECT
+      climb_uuid,
+      status,
+      attempt_count,
+      to_char(climbed_at::date, 'YYYY-MM-DD') AS climbed_on
+    FROM boardsesh_ticks
+    WHERE user_id = ${TEST_USER_ID}
+    ORDER BY climbed_at, status, attempt_count
+  `)) as unknown as ImportedTickRow[];
+}
+
+describeWithDatabase('importMoonBoardExportData', () => {
+  beforeEach(async () => {
+    await db.execute(sql`
+      TRUNCATE TABLE boardsesh_ticks, board_climb_aliases, board_climb_stats, board_climbs, users
+      RESTART IDENTITY CASCADE
+    `);
+    await db.execute(sql`
+      INSERT INTO users (id, email, name, created_at, updated_at)
+      VALUES (${TEST_USER_ID}, 'moonboard-import@test.boardsesh.com', 'MoonBoard Import Test', now(), now())
+    `);
+  });
+
+  it('skips existing MoonBoard ticks on the same calendar day even when the time differs', async () => {
+    const climbUuid = await insertMoonBoardClimb({ problemId: 101 });
+    await db.execute(sql`
+      INSERT INTO boardsesh_ticks (
+        uuid,
+        user_id,
+        board_type,
+        climb_uuid,
+        angle,
+        origin,
+        status,
+        attempt_count,
+        quality,
+        difficulty,
+        climbed_at
+      )
+      VALUES (
+        'moonboard-import-existing-same-day',
+        ${TEST_USER_ID},
+        'moonboard',
+        ${climbUuid},
+        40,
+        'native',
+        'send',
+        2,
+        4,
+        ${SIX_A_PLUS_DIFFICULTY_ID},
+        '2026-02-13 09:06:00'
+      )
+    `);
+
+    const result = await importMoonBoardExportData(
+      db,
+      TEST_USER_ID,
+      moonBoardImportData([moonBoardLogRow({ lineNumber: 1, problemId: 101, tries: 'Flashed' })]),
+      () => {},
+    );
+
+    expect(result.ticks).toEqual({ imported: 0, skipped: 1, failed: 0 });
+    expect(await importedTicks()).toHaveLength(1);
+  });
+
+  it('imports distinct project and send rows for the same climb on the same CSV date', async () => {
+    const climbUuid = await insertMoonBoardClimb({ problemId: 102 });
+
+    const result = await importMoonBoardExportData(
+      db,
+      TEST_USER_ID,
+      moonBoardImportData([
+        moonBoardLogRow({ lineNumber: 1, problemId: 102, tries: 'Project', attempts: 3, rating: null }),
+        moonBoardLogRow({ lineNumber: 2, problemId: 102, tries: 'Flashed' }),
+      ]),
+      () => {},
+    );
+
+    expect(result.ticks).toEqual({ imported: 2, skipped: 0, failed: 0 });
+    expect(result.ascents).toEqual({ imported: 1, skipped: 0, failed: 0 });
+    expect(result.attempts).toEqual({ imported: 1, skipped: 0, failed: 0 });
+    expect(await importedTicks()).toEqual([
+      { climb_uuid: climbUuid, status: 'flash', attempt_count: 1, climbed_on: '2026-02-13' },
+      { climb_uuid: climbUuid, status: 'attempt', attempt_count: 3, climbed_on: '2026-02-13' },
+    ]);
+  });
+
+  it('resolves aliases to canonical climbs and rejects grade mismatches', async () => {
+    const canonicalUuid = 'moonboard-import-canonical-103';
+    await insertMoonBoardClimb({
+      problemId: 103,
+      canonicalUuid,
+      difficultyId: SIX_A_PLUS_DIFFICULTY_ID,
+    });
+    await insertMoonBoardAlias(103, canonicalUuid);
+    await insertMoonBoardClimb({ problemId: 104, difficultyId: SIX_B_DIFFICULTY_ID });
+
+    const result = await importMoonBoardExportData(
+      db,
+      TEST_USER_ID,
+      moonBoardImportData([
+        moonBoardLogRow({ lineNumber: 1, problemId: 103, tries: 'Flashed' }),
+        moonBoardLogRow({ lineNumber: 2, problemId: 104, tries: 'Flashed' }),
+      ]),
+      () => {},
+    );
+
+    expect(result.ticks).toEqual({ imported: 1, skipped: 0, failed: 1 });
+    expect(result.ascents).toEqual({ imported: 1, skipped: 0, failed: 1 });
+    expect(result.unresolvedClimbs).toEqual(['104']);
+    expect(await importedTicks()).toEqual([
+      { climb_uuid: canonicalUuid, status: 'flash', attempt_count: 1, climbed_on: '2026-02-13' },
+    ]);
+  });
+});

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -296,7 +296,7 @@ export const schemaSQL = `
   END $$;
 
   DO $$ BEGIN
-    CREATE TYPE tick_origin AS ENUM ('native', 'aurora_pull', 'kilter_pull', 'json_import');
+    CREATE TYPE tick_origin AS ENUM ('native', 'aurora_pull', 'kilter_pull', 'json_import', 'moonboard_import');
   EXCEPTION WHEN duplicate_object THEN NULL;
   END $$;
 

--- a/packages/backend/src/handlers/moonboard-import.ts
+++ b/packages/backend/src/handlers/moonboard-import.ts
@@ -1,0 +1,142 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import { z } from 'zod';
+import type { MoonBoardImportProgressEvent } from '@boardsesh/shared-schema';
+import { applyCorsHeaders } from './cors';
+import { validateToken } from '../middleware/auth';
+import { db } from '../db/client';
+import { importMoonBoardExportData } from '../services/moonboard-import';
+import { logger } from '../utils/logger';
+
+const MAX_IMPORT_BODY_BYTES = 25 * 1024 * 1024;
+
+const moonBoardExportLogRowSchema = z.object({
+  lineNumber: z.number().int().positive(),
+  problemId: z.number().int().positive(),
+  grade: z.string().min(1),
+  tries: z.string().min(1),
+  attempts: z.number().int().min(0),
+  rating: z.number().int().min(1).max(5).nullable(),
+  date: z.string().min(1),
+});
+
+const requestSchema = z.object({
+  data: z.object({
+    user: z
+      .object({
+        firstName: z.string().optional(),
+        lastName: z.string().optional(),
+        setterName: z.string().optional(),
+        username: z.string().optional(),
+        city: z.string().optional(),
+        country: z.string().optional(),
+      })
+      .default({}),
+    logs: z.array(moonBoardExportLogRowSchema).default([]),
+  }),
+});
+
+function extractAuthTokenFromHeader(req: IncomingMessage): string | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return null;
+
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
+async function authenticate(req: IncomingMessage, res: ServerResponse): Promise<string | null> {
+  const token = extractAuthTokenFromHeader(req);
+  if (!token) {
+    sendJson(res, 401, { error: 'Authentication required' });
+    return null;
+  }
+
+  const authResult = await validateToken(token);
+  if (!authResult) {
+    sendJson(res, 401, { error: 'Invalid or expired token' });
+    return null;
+  }
+
+  return authResult.userId;
+}
+
+function sendJson(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+  });
+  res.end(JSON.stringify(body));
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let bytesRead = 0;
+
+  for await (const chunk of req) {
+    const chunkBuffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+    bytesRead += chunkBuffer.byteLength;
+    if (bytesRead > MAX_IMPORT_BODY_BYTES) {
+      throw new Error('Request body too large');
+    }
+    chunks.push(chunkBuffer);
+  }
+
+  const body = Buffer.concat(chunks).toString('utf8');
+  if (!body.trim()) return {};
+
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    throw new Error('Invalid JSON body');
+  }
+}
+
+function writeImportEvent(res: ServerResponse, event: MoonBoardImportProgressEvent): void {
+  res.write(`${JSON.stringify(event)}\n`);
+}
+
+export async function handleMoonBoardImport(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+
+  if (req.method !== 'POST') {
+    sendJson(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+
+  const userId = await authenticate(req, res);
+  if (!userId) return;
+
+  let body: unknown;
+  try {
+    body = await readJsonBody(req);
+  } catch (error) {
+    sendJson(res, error instanceof Error && error.message === 'Request body too large' ? 413 : 400, {
+      error: error instanceof Error ? error.message : 'Invalid request body',
+    });
+    return;
+  }
+
+  const validationResult = requestSchema.safeParse(body);
+  if (!validationResult.success) {
+    sendJson(res, 400, { error: 'Invalid request body', details: validationResult.error.flatten() });
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': 'text/plain; charset=utf-8',
+    'Cache-Control': 'no-cache, no-transform',
+    'X-Content-Type-Options': 'nosniff',
+  });
+
+  try {
+    const results = await importMoonBoardExportData(db, userId, validationResult.data.data, (event) =>
+      writeImportEvent(res, event),
+    );
+    writeImportEvent(res, { type: 'complete', results });
+  } catch (error) {
+    logger.error('[MoonBoardImport] Import failed:', error);
+    writeImportEvent(res, { type: 'error', error: error instanceof Error ? error.message : 'Import failed' });
+  } finally {
+    res.end();
+  }
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -18,6 +18,7 @@ import { handleUserDataExport, handleUserDataExportDownload } from './handlers/u
 import { pruneSyncDeletions } from './services/sync-deletions-prune';
 import { handleAuroraCredentials, handleAuroraCredentialsUnsynced } from './handlers/aurora-credentials';
 import { handleAuroraImport } from './handlers/aurora-import';
+import { handleMoonBoardImport } from './handlers/moonboard-import';
 import {
   handleKilterCredentialsCallback,
   handleKilterCredentialsFinalize,
@@ -365,6 +366,11 @@ export async function startServer(): Promise<ServerResources> {
         return;
       }
 
+      if (pathname === '/api/moonboard-import' && (req.method === 'POST' || req.method === 'OPTIONS')) {
+        await handleMoonBoardImport(req, res);
+        return;
+      }
+
       if (pathname === '/api/board-credentials/kilter/handoff' && (req.method === 'POST' || req.method === 'OPTIONS')) {
         await handleKilterCredentialsHandoff(req, res);
         return;
@@ -588,6 +594,7 @@ export async function startServer(): Promise<ServerResources> {
     logger.info(`  User data export: ${httpScheme}://0.0.0.0:${PORT}/api/user-data-export`);
     logger.info(`  Aurora credentials: ${httpScheme}://0.0.0.0:${PORT}/api/aurora-credentials`);
     logger.info(`  Aurora import: ${httpScheme}://0.0.0.0:${PORT}/api/aurora-import`);
+    logger.info(`  MoonBoard import: ${httpScheme}://0.0.0.0:${PORT}/api/moonboard-import`);
     logger.info(`  Kilter credential OAuth: ${httpScheme}://0.0.0.0:${PORT}/board-credentials/kilter/start`);
     logger.info(`  Kilter credential password: ${httpScheme}://0.0.0.0:${PORT}/api/board-credentials/kilter/password`);
     logger.info(`  Widget navigate: ${httpScheme}://0.0.0.0:${PORT}/api/widget/navigate`);

--- a/packages/backend/src/services/moonboard-import.ts
+++ b/packages/backend/src/services/moonboard-import.ts
@@ -33,7 +33,7 @@ type MoonBoardResolutionRow = {
 
 type ExistingTickRow = {
   climbUuid: string;
-  climbedAt: string;
+  climbedOn: string;
 };
 
 type PendingInsertRow = {
@@ -120,8 +120,18 @@ function pushUnique(items: string[], item: string): void {
   if (!items.includes(item)) items.push(item);
 }
 
-function existingTickKey(row: Pick<ResolvedMoonBoardLogRow, 'climbUuid' | 'climbedAt'>): string {
-  return `${row.climbUuid}:${row.climbedAt}`;
+function climbedOn(row: Pick<ResolvedMoonBoardLogRow, 'climbedAt'>): string {
+  return row.climbedAt.slice(0, 10);
+}
+
+function existingTickDateKey(row: Pick<ResolvedMoonBoardLogRow, 'climbUuid' | 'climbedAt'>): string {
+  return `${row.climbUuid}:${climbedOn(row)}`;
+}
+
+function importTickKey(
+  row: Pick<ResolvedMoonBoardLogRow, 'climbUuid' | 'climbedAt' | 'status' | 'attemptCount'>,
+): string {
+  return `${row.climbUuid}:${row.climbedAt}:${row.status}:${row.attemptCount}`;
 }
 
 async function resolveClimbUuid(
@@ -176,19 +186,19 @@ async function findExistingTickKeys(
   if (rows.length === 0) return new Set();
 
   const climbUuids = [...new Set(rows.map((row) => row.climbUuid))];
-  const climbedAtValues = [...new Set(rows.map((row) => row.climbedAt))];
+  const climbedOnValues = [...new Set(rows.map((row) => climbedOn(row)))];
   const climbUuidArraySql = sql.join(
     climbUuids.map((climbUuid) => sql`${climbUuid}`),
     sql`, `,
   );
-  const climbedAtArraySql = sql.join(
-    climbedAtValues.map((climbedAt) => sql`${climbedAt}`),
+  const climbedOnArraySql = sql.join(
+    climbedOnValues.map((climbedOnValue) => sql`${climbedOnValue}`),
     sql`, `,
   );
   const existingResult = await db.execute<ExistingTickRow>(sql`
     SELECT
       COALESCE(board_climb_aliases.canonical_uuid, boardsesh_ticks.climb_uuid) AS "climbUuid",
-      to_char(boardsesh_ticks.climbed_at, 'YYYY-MM-DD HH24:MI:SS') AS "climbedAt"
+      to_char(boardsesh_ticks.climbed_at::date, 'YYYY-MM-DD') AS "climbedOn"
     FROM boardsesh_ticks
     LEFT JOIN board_climb_aliases
       ON board_climb_aliases.board_type = boardsesh_ticks.board_type
@@ -197,17 +207,10 @@ async function findExistingTickKeys(
       AND boardsesh_ticks.board_type = 'moonboard'
       AND boardsesh_ticks.angle = ${MOONBOARD_ANGLE}
       AND COALESCE(board_climb_aliases.canonical_uuid, boardsesh_ticks.climb_uuid) = ANY(ARRAY[${climbUuidArraySql}]::text[])
-      AND boardsesh_ticks.climbed_at = ANY(ARRAY[${climbedAtArraySql}]::timestamp[])
+      AND boardsesh_ticks.climbed_at::date = ANY(ARRAY[${climbedOnArraySql}]::date[])
   `);
 
-  return new Set(
-    rowsOf<ExistingTickRow>(existingResult).map((row) =>
-      existingTickKey({
-        climbUuid: row.climbUuid,
-        climbedAt: row.climbedAt,
-      }),
-    ),
-  );
+  return new Set(rowsOf<ExistingTickRow>(existingResult).map((row) => `${row.climbUuid}:${row.climbedOn}`));
 }
 
 function countSkippedResult(result: MoonBoardImportResult, row: ResolvedMoonBoardLogRow): void {
@@ -289,7 +292,8 @@ export async function importMoonBoardExportData(
     });
   }
 
-  const claimedTickKeys = await findExistingTickKeys(db, userId, resolvedRows);
+  const existingTickDateKeys = await findExistingTickKeys(db, userId, resolvedRows);
+  const claimedImportTickKeys = new Set<string>();
   const recomputeKeys = new Map<string, ClimbStatsKey>();
 
   for (let start = 0; start < resolvedRows.length; start += INSERT_BATCH_SIZE) {
@@ -303,12 +307,17 @@ export async function importMoonBoardExportData(
 
     const rowsToInsert: PendingInsertRow[] = [];
     for (const row of batch) {
-      const rowNaturalKey = existingTickKey(row);
-      if (claimedTickKeys.has(rowNaturalKey)) {
+      if (existingTickDateKeys.has(existingTickDateKey(row))) {
         countSkippedResult(result, row);
         continue;
       }
-      claimedTickKeys.add(rowNaturalKey);
+
+      const rowImportKey = importTickKey(row);
+      if (claimedImportTickKeys.has(rowImportKey)) {
+        countSkippedResult(result, row);
+        continue;
+      }
+      claimedImportTickKeys.add(rowImportKey);
 
       rowsToInsert.push({
         source: row,

--- a/packages/backend/src/services/moonboard-import.ts
+++ b/packages/backend/src/services/moonboard-import.ts
@@ -1,0 +1,377 @@
+import { sql } from 'drizzle-orm';
+import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
+import { v5 as uuidv5 } from 'uuid';
+import { MOONBOARD_GRADES } from '@boardsesh/board-config';
+import { boardseshTicks } from '@boardsesh/db/schema';
+import { recomputeClimbStatsBulk, rowsOf, type ClimbStatsKey } from '@boardsesh/db/queries';
+import {
+  classifyMoonBoardLogRow,
+  type MoonBoardExportLogRow,
+  type MoonBoardImportProgressEvent,
+  type MoonBoardImportResult,
+  type StrippedMoonBoardExportData,
+} from '@boardsesh/shared-schema';
+
+type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
+
+type ResolvedMoonBoardLogRow = {
+  row: MoonBoardExportLogRow;
+  climbUuid: string;
+  climbedAt: string;
+  status: 'flash' | 'send' | 'attempt';
+  attemptCount: number;
+  difficulty: number;
+  quality: number | null;
+};
+
+type MoonBoardResolutionRow = {
+  candidateUuid: string;
+  canonicalUuid: string | null;
+  climbAngle: number | string | null;
+  displayDifficulty: number | string | null;
+};
+
+type ExistingTickRow = {
+  climbUuid: string;
+  climbedAt: string;
+};
+
+type PendingInsertRow = {
+  source: ResolvedMoonBoardLogRow;
+  insert: {
+    uuid: string;
+    userId: string;
+    boardType: 'moonboard';
+    climbUuid: string;
+    angle: 40;
+    isMirror: false;
+    origin: 'moonboard_import';
+    status: 'flash' | 'send' | 'attempt';
+    attemptCount: number;
+    quality: number | null;
+    difficulty: number;
+    isBenchmark: false;
+    comment: string;
+    climbedAt: string;
+  };
+};
+
+const MOONBOARD_CLIMB_UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+const MOONBOARD_ANGLE = 40;
+const INSERT_BATCH_SIZE = 100;
+const GRADE_TO_DIFFICULTY_ID = new Map<string, number>(
+  MOONBOARD_GRADES.flatMap((grade) => [
+    [grade.value.toUpperCase(), grade.difficultyId],
+    [grade.label.split('/')[0].toUpperCase(), grade.difficultyId],
+  ]),
+);
+
+GRADE_TO_DIFFICULTY_ID.set('5A', 13);
+
+function moonBoardGradeToDifficultyId(grade: string): number | undefined {
+  return GRADE_TO_DIFFICULTY_ID.get(grade.trim().toUpperCase());
+}
+
+function deterministicUuid(name: string): string {
+  return uuidv5(name, MOONBOARD_CLIMB_UUID_NAMESPACE);
+}
+
+function candidateClimbUuids(problemId: number): string[] {
+  return [deterministicUuid(`moonboard:${problemId}`), deterministicUuid(`moonboard:${problemId}:${MOONBOARD_ANGLE}`)];
+}
+
+function parseMoonBoardDate(date: string): string | null {
+  const match = date.trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})$/);
+  if (!match) return null;
+
+  const day = Number(match[1]);
+  const month = Number(match[2]);
+  const rawYear = Number(match[3]);
+  const year = rawYear < 100 ? 2000 + rawYear : rawYear;
+  const utcDate = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+
+  if (utcDate.getUTCFullYear() !== year || utcDate.getUTCMonth() !== month - 1 || utcDate.getUTCDate() !== day) {
+    return null;
+  }
+
+  return `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')} 12:00:00`;
+}
+
+function importTickUuid(userId: string, row: ResolvedMoonBoardLogRow): string {
+  return deterministicUuid(
+    ['moonboard-import', userId, row.row.problemId, row.row.grade, row.climbedAt, row.status, row.attemptCount].join(
+      ':',
+    ),
+  );
+}
+
+function resultCounts(): MoonBoardImportResult {
+  return {
+    ticks: { imported: 0, skipped: 0, failed: 0 },
+    ascents: { imported: 0, skipped: 0, failed: 0 },
+    attempts: { imported: 0, skipped: 0, failed: 0 },
+    unresolvedClimbs: [],
+    unresolvedAscentClimbs: [],
+    unresolvedAttemptClimbs: [],
+  };
+}
+
+function pushUnique(items: string[], item: string): void {
+  if (!items.includes(item)) items.push(item);
+}
+
+function existingTickKey(row: Pick<ResolvedMoonBoardLogRow, 'climbUuid' | 'climbedAt'>): string {
+  return `${row.climbUuid}:${row.climbedAt}`;
+}
+
+async function resolveClimbUuid(
+  db: DrizzleDb,
+  row: MoonBoardExportLogRow,
+  difficultyId: number,
+): Promise<string | null> {
+  const candidates = candidateClimbUuids(row.problemId);
+  const candidateSql = sql.join(
+    candidates.map((candidateUuid, index) => sql`(${candidateUuid}, ${index + 1})`),
+    sql`, `,
+  );
+  const resolutionResult = await db.execute<MoonBoardResolutionRow>(sql`
+    WITH candidate_input(candidate_uuid, ordinal) AS (
+      VALUES ${candidateSql}
+    )
+    SELECT
+      candidate_input.candidate_uuid AS "candidateUuid",
+      COALESCE(board_climb_aliases.canonical_uuid, board_climbs.uuid) AS "canonicalUuid",
+      board_climbs.angle AS "climbAngle",
+      board_climb_stats.display_difficulty AS "displayDifficulty"
+    FROM candidate_input
+    LEFT JOIN board_climb_aliases
+      ON board_climb_aliases.board_type = 'moonboard'
+     AND board_climb_aliases.alias_uuid = candidate_input.candidate_uuid
+    LEFT JOIN board_climbs
+      ON board_climbs.board_type = 'moonboard'
+     AND board_climbs.uuid = COALESCE(board_climb_aliases.canonical_uuid, candidate_input.candidate_uuid)
+    LEFT JOIN board_climb_stats
+      ON board_climb_stats.board_type = 'moonboard'
+     AND board_climb_stats.climb_uuid = board_climbs.uuid
+     AND board_climb_stats.angle = ${MOONBOARD_ANGLE}
+    ORDER BY candidate_input.ordinal
+  `);
+
+  for (const candidate of rowsOf<MoonBoardResolutionRow>(resolutionResult)) {
+    if (!candidate.canonicalUuid) continue;
+    const climbAngle = candidate.climbAngle == null ? null : Number(candidate.climbAngle);
+    if (climbAngle != null && climbAngle !== MOONBOARD_ANGLE) continue;
+    if (Number(candidate.displayDifficulty) !== difficultyId) continue;
+    return candidate.canonicalUuid;
+  }
+
+  return null;
+}
+
+async function findExistingTickKeys(
+  db: DrizzleDb,
+  userId: string,
+  rows: ResolvedMoonBoardLogRow[],
+): Promise<Set<string>> {
+  if (rows.length === 0) return new Set();
+
+  const climbUuids = [...new Set(rows.map((row) => row.climbUuid))];
+  const climbedAtValues = [...new Set(rows.map((row) => row.climbedAt))];
+  const climbUuidArraySql = sql.join(
+    climbUuids.map((climbUuid) => sql`${climbUuid}`),
+    sql`, `,
+  );
+  const climbedAtArraySql = sql.join(
+    climbedAtValues.map((climbedAt) => sql`${climbedAt}`),
+    sql`, `,
+  );
+  const existingResult = await db.execute<ExistingTickRow>(sql`
+    SELECT
+      COALESCE(board_climb_aliases.canonical_uuid, boardsesh_ticks.climb_uuid) AS "climbUuid",
+      to_char(boardsesh_ticks.climbed_at, 'YYYY-MM-DD HH24:MI:SS') AS "climbedAt"
+    FROM boardsesh_ticks
+    LEFT JOIN board_climb_aliases
+      ON board_climb_aliases.board_type = boardsesh_ticks.board_type
+     AND board_climb_aliases.alias_uuid = boardsesh_ticks.climb_uuid
+    WHERE boardsesh_ticks.user_id = ${userId}
+      AND boardsesh_ticks.board_type = 'moonboard'
+      AND boardsesh_ticks.angle = ${MOONBOARD_ANGLE}
+      AND COALESCE(board_climb_aliases.canonical_uuid, boardsesh_ticks.climb_uuid) = ANY(ARRAY[${climbUuidArraySql}]::text[])
+      AND boardsesh_ticks.climbed_at = ANY(ARRAY[${climbedAtArraySql}]::timestamp[])
+  `);
+
+  return new Set(
+    rowsOf<ExistingTickRow>(existingResult).map((row) =>
+      existingTickKey({
+        climbUuid: row.climbUuid,
+        climbedAt: row.climbedAt,
+      }),
+    ),
+  );
+}
+
+function countSkippedResult(result: MoonBoardImportResult, row: ResolvedMoonBoardLogRow): void {
+  result.ticks.skipped += 1;
+  if (row.status === 'attempt') {
+    result.attempts.skipped += 1;
+  } else {
+    result.ascents.skipped += 1;
+  }
+}
+
+function countImportedResult(result: MoonBoardImportResult, row: ResolvedMoonBoardLogRow): void {
+  result.ticks.imported += 1;
+  if (row.status === 'attempt') {
+    result.attempts.imported += 1;
+  } else {
+    result.ascents.imported += 1;
+  }
+}
+
+function countFailedResult(
+  result: MoonBoardImportResult,
+  row: MoonBoardExportLogRow,
+  classification?: { status: 'flash' | 'send' | 'attempt' },
+): void {
+  result.ticks.failed += 1;
+  if (classification?.status === 'attempt') {
+    result.attempts.failed += 1;
+    pushUnique(result.unresolvedAttemptClimbs, String(row.problemId));
+  } else if (classification) {
+    result.ascents.failed += 1;
+    pushUnique(result.unresolvedAscentClimbs, String(row.problemId));
+  }
+  pushUnique(result.unresolvedClimbs, String(row.problemId));
+}
+
+export async function importMoonBoardExportData(
+  db: DrizzleDb,
+  userId: string,
+  data: StrippedMoonBoardExportData,
+  onEvent: (event: MoonBoardImportProgressEvent) => void,
+): Promise<MoonBoardImportResult> {
+  const result = resultCounts();
+  const resolvedRows: ResolvedMoonBoardLogRow[] = [];
+
+  for (let rowIndex = 0; rowIndex < data.logs.length; rowIndex += 1) {
+    const row = data.logs[rowIndex];
+    onEvent({ type: 'progress', step: 'resolving', current: rowIndex + 1, total: data.logs.length });
+
+    let classification: { status: 'flash' | 'send' | 'attempt'; attemptCount: number };
+    try {
+      classification = classifyMoonBoardLogRow(row);
+    } catch {
+      countFailedResult(result, row);
+      continue;
+    }
+
+    const difficultyId = moonBoardGradeToDifficultyId(row.grade);
+    const climbedAt = parseMoonBoardDate(row.date);
+    if (difficultyId == null || climbedAt == null) {
+      countFailedResult(result, row, classification);
+      continue;
+    }
+
+    const climbUuid = await resolveClimbUuid(db, row, difficultyId);
+    if (!climbUuid) {
+      countFailedResult(result, row, classification);
+      continue;
+    }
+
+    resolvedRows.push({
+      row,
+      climbUuid,
+      climbedAt,
+      status: classification.status,
+      attemptCount: classification.attemptCount,
+      difficulty: difficultyId,
+      quality: classification.status === 'attempt' ? null : row.rating,
+    });
+  }
+
+  const claimedTickKeys = await findExistingTickKeys(db, userId, resolvedRows);
+  const recomputeKeys = new Map<string, ClimbStatsKey>();
+
+  for (let start = 0; start < resolvedRows.length; start += INSERT_BATCH_SIZE) {
+    const batch = resolvedRows.slice(start, start + INSERT_BATCH_SIZE);
+    onEvent({
+      type: 'progress',
+      step: 'importing',
+      current: Math.min(start + batch.length, resolvedRows.length),
+      total: resolvedRows.length,
+    });
+
+    const rowsToInsert: PendingInsertRow[] = [];
+    for (const row of batch) {
+      const rowNaturalKey = existingTickKey(row);
+      if (claimedTickKeys.has(rowNaturalKey)) {
+        countSkippedResult(result, row);
+        continue;
+      }
+      claimedTickKeys.add(rowNaturalKey);
+
+      rowsToInsert.push({
+        source: row,
+        insert: {
+          uuid: importTickUuid(userId, row),
+          userId,
+          boardType: 'moonboard',
+          climbUuid: row.climbUuid,
+          angle: MOONBOARD_ANGLE,
+          isMirror: false,
+          origin: 'moonboard_import',
+          status: row.status,
+          attemptCount: row.attemptCount,
+          quality: row.quality,
+          difficulty: row.difficulty,
+          isBenchmark: false,
+          comment: '',
+          climbedAt: row.climbedAt,
+        },
+      });
+    }
+
+    if (rowsToInsert.length === 0) continue;
+
+    const insertedRows = await db
+      .insert(boardseshTicks)
+      .values(rowsToInsert.map((pendingRow) => pendingRow.insert))
+      .onConflictDoNothing()
+      .returning({
+        uuid: boardseshTicks.uuid,
+        climbUuid: boardseshTicks.climbUuid,
+        angle: boardseshTicks.angle,
+        status: boardseshTicks.status,
+      });
+
+    const uncountedInsertedIds = new Set(insertedRows.map((insertedRow) => insertedRow.uuid));
+
+    for (const pendingRow of rowsToInsert) {
+      if (!uncountedInsertedIds.has(pendingRow.insert.uuid)) {
+        countSkippedResult(result, pendingRow.source);
+        continue;
+      }
+
+      uncountedInsertedIds.delete(pendingRow.insert.uuid);
+      countImportedResult(result, pendingRow.source);
+      if (pendingRow.source.status !== 'attempt') {
+        recomputeKeys.set(`${pendingRow.source.climbUuid}:${MOONBOARD_ANGLE}`, {
+          boardType: 'moonboard',
+          climbUuid: pendingRow.source.climbUuid,
+          angle: MOONBOARD_ANGLE,
+        });
+      }
+    }
+  }
+
+  const recomputeKeyList = [...recomputeKeys.values()];
+  if (recomputeKeyList.length > 0) {
+    onEvent({ type: 'progress', step: 'recomputing', message: String(recomputeKeyList.length) });
+    await recomputeClimbStatsBulk(db, recomputeKeyList);
+  }
+
+  result.unresolvedClimbs.sort((first, second) => Number(first) - Number(second));
+  result.unresolvedAscentClimbs.sort((first, second) => Number(first) - Number(second));
+  result.unresolvedAttemptClimbs.sort((first, second) => Number(first) - Number(second));
+  return result;
+}

--- a/packages/db/drizzle/0172_cuddly_psynapse.sql
+++ b/packages/db/drizzle/0172_cuddly_psynapse.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."tick_origin" ADD VALUE 'moonboard_import';

--- a/packages/db/drizzle/meta/0172_snapshot.json
+++ b/packages/db/drizzle/meta/0172_snapshot.json
@@ -1,0 +1,11094 @@
+{
+  "id": "8b8f4fae-0e16-4755-8656-1d4fb3896b02",
+  "prevId": "3c2838c2-1d38-428d-bc07-0ed2cd33afa3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.board_attempts": {
+      "name": "board_attempts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_attempts_board_type_id_pk": {
+          "name": "board_attempts_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_beta_links": {
+      "name": "board_beta_links",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tick_uuid": {
+          "name": "tick_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shortcode": {
+          "name": "shortcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_identity": {
+          "name": "video_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_beta_links_shortcode_idx": {
+          "name": "board_beta_links_shortcode_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shortcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"shortcode\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_created_by_idx": {
+          "name": "board_beta_links_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"created_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_video_identity_unique": {
+          "name": "board_beta_links_video_identity_unique",
+          "columns": [
+            {
+              "expression": "video_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_beta_links\".\"video_identity\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_tick_uuid_unique": {
+          "name": "board_beta_links_tick_uuid_unique",
+          "columns": [
+            {
+              "expression": "tick_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_beta_links\".\"tick_uuid\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_board_id_idx": {
+          "name": "board_beta_links_board_id_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"board_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_beta_links_board_type_climb_uuid_link_pk": {
+          "name": "board_beta_links_board_type_climb_uuid_link_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "link"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits": {
+      "name": "board_circuits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_user_fk": {
+          "name": "board_circuits_user_fk",
+          "tableFrom": "board_circuits",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_board_type_uuid_pk": {
+          "name": "board_circuits_board_type_uuid_pk",
+          "columns": [
+            "board_type",
+            "uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits_climbs": {
+      "name": "board_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_climbs_circuit_fk": {
+          "name": "board_circuits_climbs_circuit_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_circuits",
+          "columnsFrom": [
+            "board_type",
+            "circuit_uuid"
+          ],
+          "columnsTo": [
+            "board_type",
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_circuits_climbs_climb_fk": {
+          "name": "board_circuits_climbs_climb_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
+          "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
+          "columns": [
+            "board_type",
+            "circuit_uuid",
+            "climb_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_aliases": {
+      "name": "board_climb_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_uuid": {
+          "name": "alias_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_uuid": {
+          "name": "canonical_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_aliases_canonical_idx": {
+          "name": "board_climb_aliases_canonical_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_aliases_canonical_fk": {
+          "name": "board_climb_aliases_canonical_fk",
+          "tableFrom": "board_climb_aliases",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "canonical_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_aliases_board_type_alias_uuid_pk": {
+          "name": "board_climb_aliases_board_type_alias_uuid_pk",
+          "columns": [
+            "board_type",
+            "alias_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_aliases_uuids_non_empty": {
+          "name": "board_climb_aliases_uuids_non_empty",
+          "value": "\"board_climb_aliases\".\"alias_uuid\" <> '' AND \"board_climb_aliases\".\"canonical_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_holds": {
+      "name": "board_climb_holds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_holds_search_idx": {
+          "name": "board_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_holds_climb_fk": {
+          "name": "board_climb_holds_climb_fk",
+          "tableFrom": "board_climb_holds",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
+          "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "hold_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_ratings": {
+      "name": "board_climb_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_grade_id": {
+          "name": "difficulty_grade_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_ratings_user_climb_angle_idx": {
+          "name": "board_climb_ratings_user_climb_angle_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_kilter_id_unique": {
+          "name": "board_climb_ratings_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_aurora_id_unique": {
+          "name": "board_climb_ratings_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_climb_ratings\".\"aurora_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_user_kilter_idx": {
+          "name": "board_climb_ratings_user_kilter_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_ratings_user_id_users_id_fk": {
+          "name": "board_climb_ratings_user_id_users_id_fk",
+          "tableFrom": "board_climb_ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_ratings_rating_range": {
+          "name": "board_climb_ratings_rating_range",
+          "value": "\"board_climb_ratings\".\"rating\" IS NULL OR (\"board_climb_ratings\".\"rating\" >= 1 AND \"board_climb_ratings\".\"rating\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats": {
+      "name": "board_climb_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_ascensionist_count": {
+          "name": "upstream_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_ascensionist_count": {
+          "name": "boardsesh_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_quality_average": {
+          "name": "upstream_quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_quality_sum": {
+          "name": "boardsesh_quality_sum",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_quality_count": {
+          "name": "boardsesh_quality_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_normalized": {
+          "name": "quality_normalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_synced_at": {
+          "name": "upstream_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_seq": {
+          "name": "sync_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "board_climb_stats_sync_cursor_idx": {
+          "name": "board_climb_stats_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_stats_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats_history": {
+      "name": "board_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_stats_history_lookup_idx": {
+          "name": "board_climb_stats_history_lookup_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climbs": {
+      "name": "board_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_set_ids": {
+          "name": "required_set_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compatible_size_ids": {
+          "name": "compatible_size_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hold_fingerprint": {
+          "name": "hold_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "characteristics": {
+          "name": "characteristics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_seq": {
+          "name": "sync_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "board_climbs_board_type_idx": {
+          "name": "board_climbs_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_sync_cursor_idx": {
+          "name": "board_climbs_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_hold_fingerprint_idx": {
+          "name": "board_climbs_hold_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_search_filter_idx": {
+          "name": "board_climbs_search_filter_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_setter_username_idx": {
+          "name": "board_climbs_setter_username_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_user_id_idx": {
+          "name": "board_climbs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_climbs\".\"user_id\" IS NOT NULL AND \"board_climbs\".\"is_draft\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_name_idx": {
+          "name": "board_climbs_name_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climbs_user_id_users_id_fk": {
+          "name": "board_climbs_user_id_users_id_fk",
+          "tableFrom": "board_climbs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_difficulty_grades": {
+      "name": "board_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_difficulty_grades_board_type_difficulty_pk": {
+          "name": "board_difficulty_grades_board_type_difficulty_pk",
+          "columns": [
+            "board_type",
+            "difficulty"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_holes": {
+      "name": "board_holes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_holes_product_fk": {
+          "name": "board_holes_product_fk",
+          "tableFrom": "board_holes",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_holes_board_type_id_pk": {
+          "name": "board_holes_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_kits": {
+      "name": "board_kits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_autoconnect": {
+          "name": "is_autoconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_kits_board_type_serial_number_pk": {
+          "name": "board_kits_board_type_serial_number_pk",
+          "columns": [
+            "board_type",
+            "serial_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_layout_aliases": {
+      "name": "board_layout_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_uuid": {
+          "name": "layout_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_layout_aliases_layout_idx": {
+          "name": "board_layout_aliases_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_layout_aliases_layout_fk": {
+          "name": "board_layout_aliases_layout_fk",
+          "tableFrom": "board_layout_aliases",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layout_aliases_board_type_layout_uuid_pk": {
+          "name": "board_layout_aliases_board_type_layout_uuid_pk",
+          "columns": [
+            "board_type",
+            "layout_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_layout_aliases_uuid_non_empty": {
+          "name": "board_layout_aliases_uuid_non_empty",
+          "value": "\"board_layout_aliases\".\"layout_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_layouts": {
+      "name": "board_layouts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_layouts_product_fk": {
+          "name": "board_layouts_product_fk",
+          "tableFrom": "board_layouts",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layouts_board_type_id_pk": {
+          "name": "board_layouts_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_leds": {
+      "name": "board_leds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_leds_product_size_fk": {
+          "name": "board_leds_product_size_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_leds_hole_fk": {
+          "name": "board_leds_hole_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_holes",
+          "columnsFrom": [
+            "board_type",
+            "hole_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_leds_board_type_id_pk": {
+          "name": "board_leds_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placement_roles": {
+      "name": "board_placement_roles",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_placement_roles_product_fk": {
+          "name": "board_placement_roles_product_fk",
+          "tableFrom": "board_placement_roles",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placement_roles_board_type_id_pk": {
+          "name": "board_placement_roles_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placements": {
+      "name": "board_placements",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_placements_board_type_layout_id_set_hole_idx": {
+          "name": "board_placements_board_type_layout_id_set_hole_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hole_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_placements_layout_fk": {
+          "name": "board_placements_layout_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_hole_fk": {
+          "name": "board_placements_hole_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_holes",
+          "columnsFrom": [
+            "board_type",
+            "hole_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_set_fk": {
+          "name": "board_placements_set_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_sets",
+          "columnsFrom": [
+            "board_type",
+            "set_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_role_fk": {
+          "name": "board_placements_role_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_placement_roles",
+          "columnsFrom": [
+            "board_type",
+            "default_placement_role_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placements_board_type_id_pk": {
+          "name": "board_placements_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes": {
+      "name": "board_product_sizes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_product_sizes_product_fk": {
+          "name": "board_product_sizes_product_fk",
+          "tableFrom": "board_product_sizes",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_board_type_id_pk": {
+          "name": "board_product_sizes_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes_layouts_sets": {
+      "name": "board_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_psls_product_size_fk": {
+          "name": "board_psls_product_size_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_layout_fk": {
+          "name": "board_psls_layout_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_set_fk": {
+          "name": "board_psls_set_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_sets",
+          "columnsFrom": [
+            "board_type",
+            "set_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_layouts_sets_board_type_id_pk": {
+          "name": "board_product_sizes_layouts_sets_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_products": {
+      "name": "board_products",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_products_board_type_id_pk": {
+          "name": "board_products_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sets": {
+      "name": "board_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_sets_board_type_id_pk": {
+          "name": "board_sets_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_shared_syncs": {
+      "name": "board_shared_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_shared_syncs_board_type_table_name_pk": {
+          "name": "board_shared_syncs_board_type_table_name_pk",
+          "columns": [
+            "board_type",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_tags": {
+      "name": "board_tags",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_tags_board_type_entity_uuid_user_id_name_pk": {
+          "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
+          "columns": [
+            "board_type",
+            "entity_uuid",
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_user_syncs": {
+      "name": "board_user_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_user_syncs_user_fk": {
+          "name": "board_user_syncs_user_fk",
+          "tableFrom": "board_user_syncs",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_user_syncs_board_type_user_id_table_name_pk": {
+          "name": "board_user_syncs_board_type_user_id_table_name_pk",
+          "columns": [
+            "board_type",
+            "user_id",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_users": {
+      "name": "board_users",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_users_board_type_id_pk": {
+          "name": "board_users_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_walls": {
+      "name": "board_walls",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_walls_user_fk": {
+          "name": "board_walls_user_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_fk": {
+          "name": "board_walls_product_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_layout_fk": {
+          "name": "board_walls_layout_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_size_fk": {
+          "name": "board_walls_product_size_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_walls_board_type_uuid_pk": {
+          "name": "board_walls_board_type_uuid_pk",
+          "columns": [
+            "board_type",
+            "uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationTokens": {
+      "name": "verificationTokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationTokens_identifier_token_pk": {
+          "name": "verificationTokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credentials": {
+      "name": "user_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aurora_credentials": {
+      "name": "aurora_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_username": {
+          "name": "encrypted_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_user_id": {
+          "name": "aurora_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_token": {
+          "name": "aurora_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_attempt_at": {
+          "name": "last_sync_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_failure_count": {
+          "name": "credential_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_credential_failure_at": {
+          "name": "last_credential_failure_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_credential": {
+          "name": "unique_user_board_credential",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_user_idx": {
+          "name": "aurora_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_sync_priority_idx": {
+          "name": "aurora_credentials_sync_priority_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_sync_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"aurora_credentials\".\"sync_status\" IN ('pending', 'active', 'error')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_sync_attempt_priority_idx": {
+          "name": "aurora_credentials_sync_attempt_priority_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_sync_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"aurora_credentials\".\"sync_status\" IN ('pending', 'active', 'error')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "aurora_credentials_user_id_users_id_fk": {
+          "name": "aurora_credentials_user_id_users_id_fk",
+          "tableFrom": "aurora_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_mappings": {
+      "name": "user_board_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_user_id": {
+          "name": "board_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_user_id_text": {
+          "name": "board_user_id_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_username": {
+          "name": "board_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_mapping": {
+          "name": "unique_user_board_mapping",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_idx": {
+          "name": "board_user_mapping_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_text_idx": {
+          "name": "board_user_mapping_text_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_mappings_user_id_users_id_fk": {
+          "name": "user_board_mappings_user_id_users_id_fk",
+          "tableFrom": "user_board_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mobile_refresh_tokens": {
+      "name": "mobile_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mobile_refresh_tokens_token_hash_idx": {
+          "name": "mobile_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_user_id_idx": {
+          "name": "mobile_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_expires_at_idx": {
+          "name": "mobile_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_revoked_at_partial_idx": {
+          "name": "mobile_refresh_tokens_revoked_at_partial_idx",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"revoked_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mobile_refresh_tokens_user_id_users_id_fk": {
+          "name": "mobile_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "mobile_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credentials": {
+      "name": "integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_name": {
+          "name": "external_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_integration": {
+          "name": "unique_user_integration",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credentials_user_id_users_id_fk": {
+          "name": "integration_credentials_user_id_users_id_fk",
+          "tableFrom": "integration_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_claims": {
+      "name": "gym_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimant_user_id": {
+          "name": "claimant_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "gym_claim_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "gym_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_claims_gym_idx": {
+          "name": "gym_claims_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_claimant_idx": {
+          "name": "gym_claims_claimant_idx",
+          "columns": [
+            {
+              "expression": "claimant_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_status_idx": {
+          "name": "gym_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_token_hash_idx": {
+          "name": "gym_claims_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gym_claims\".\"token_hash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_unique_pending": {
+          "name": "gym_claims_unique_pending",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimant_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gym_claims\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_claims_gym_id_gyms_id_fk": {
+          "name": "gym_claims_gym_id_gyms_id_fk",
+          "tableFrom": "gym_claims",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_claims_claimant_user_id_users_id_fk": {
+          "name": "gym_claims_claimant_user_id_users_id_fk",
+          "tableFrom": "gym_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimant_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_claims_reviewed_by_users_id_fk": {
+          "name": "gym_claims_reviewed_by_users_id_fk",
+          "tableFrom": "gym_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_follows": {
+      "name": "gym_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_follows_unique_gym_user": {
+          "name": "gym_follows_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_follows_gym_id_gyms_id_fk": {
+          "name": "gym_follows_gym_id_gyms_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_follows_user_id_users_id_fk": {
+          "name": "gym_follows_user_id_users_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_members": {
+      "name": "gym_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "gym_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_members_unique_gym_user": {
+          "name": "gym_members_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_members_gym_id_gyms_id_fk": {
+          "name": "gym_members_gym_id_gyms_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_members_user_id_users_id_fk": {
+          "name": "gym_members_user_id_users_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gyms": {
+      "name": "gyms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gyms_unique_slug": {
+          "name": "gyms_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_uuid_idx": {
+          "name": "gyms_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_owner_idx": {
+          "name": "gyms_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_public_idx": {
+          "name": "gyms_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gyms_owner_id_users_id_fk": {
+          "name": "gyms_owner_id_users_id_fk",
+          "tableFrom": "gyms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gyms_uuid_unique": {
+          "name": "gyms_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_follows": {
+      "name": "board_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_follows_unique_user_board": {
+          "name": "board_follows_unique_user_board",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_user_idx": {
+          "name": "board_follows_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_board_uuid_idx": {
+          "name": "board_follows_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_follows_user_id_users_id_fk": {
+          "name": "board_follows_user_id_users_id_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_follows_board_uuid_user_boards_uuid_fk": {
+          "name": "board_follows_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_boards": {
+      "name": "user_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_unlisted": {
+          "name": "is_unlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_location": {
+          "name": "hide_location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_owned": {
+          "name": "is_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "is_angle_adjustable": {
+          "name": "is_angle_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timer_name": {
+          "name": "timer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_boards_gym_idx": {
+          "name": "user_boards_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_owner_config": {
+          "name": "user_boards_unique_owner_config",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL AND \"user_boards\".\"owner_id\" != '00000000-0000-0000-0000-000000000000'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_owner_owned_idx": {
+          "name": "user_boards_owner_owned_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_owned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_public_idx": {
+          "name": "user_boards_public_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_slug": {
+          "name": "user_boards_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_uuid_idx": {
+          "name": "user_boards_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_owner_serial": {
+          "name": "user_boards_unique_owner_serial",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"serial_number\" IS NOT NULL AND \"user_boards\".\"serial_number\" <> '' AND \"user_boards\".\"deleted_at\" IS NULL AND \"user_boards\".\"owner_id\" != '00000000-0000-0000-0000-000000000000'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_serial_idx": {
+          "name": "user_boards_serial_idx",
+          "columns": [
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"serial_number\" IS NOT NULL AND \"user_boards\".\"serial_number\" <> '' AND \"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_boards_owner_id_users_id_fk": {
+          "name": "user_boards_owner_id_users_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_boards_gym_id_gyms_id_fk": {
+          "name": "user_boards_gym_id_gyms_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_boards_uuid_unique": {
+          "name": "user_boards_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_serials": {
+      "name": "user_board_serials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_level": {
+          "name": "api_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_board_serials_unique_user_serial": {
+          "name": "user_board_serials_unique_user_serial",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_serial_idx": {
+          "name": "user_board_serials_serial_idx",
+          "columns": [
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_board_uuid_idx": {
+          "name": "user_board_serials_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_serials_user_id_users_id_fk": {
+          "name": "user_board_serials_user_id_users_id_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_board_serials_board_uuid_user_boards_uuid_fk": {
+          "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_queues": {
+      "name": "board_session_queues",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_climb_queue_item": {
+          "name": "current_climb_queue_item",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_queues_session_id_board_sessions_id_fk": {
+          "name": "board_session_queues_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_queues",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sessions": {
+      "name": "board_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_path": {
+          "name": "board_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_permanent": {
+          "name": "is_permanent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_sessions_location_idx": {
+          "name": "board_sessions_location_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discoverable_idx": {
+          "name": "board_sessions_discoverable_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_user_idx": {
+          "name": "board_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_status_idx": {
+          "name": "board_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_last_activity_idx": {
+          "name": "board_sessions_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discovery_idx": {
+          "name": "board_sessions_discovery_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_sessions_created_by_user_id_users_id_fk": {
+          "name": "board_sessions_created_by_user_id_users_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_sessions_board_id_user_boards_id_fk": {
+          "name": "board_sessions_board_id_user_boards_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_boards": {
+      "name": "session_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_boards_session_board_idx": {
+          "name": "session_boards_session_board_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_session_idx": {
+          "name": "session_boards_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_board_idx": {
+          "name": "session_boards_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_boards_session_id_board_sessions_id_fk": {
+          "name": "session_boards_session_id_board_sessions_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_boards_board_id_user_boards_id_fk": {
+          "name": "session_boards_board_id_user_boards_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_health_kit_workouts": {
+      "name": "session_health_kit_workouts",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_health_kit_workouts_session_idx": {
+          "name": "session_health_kit_workouts_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_health_kit_workouts_user_idx": {
+          "name": "session_health_kit_workouts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_health_kit_workouts_session_id_board_sessions_id_fk": {
+          "name": "session_health_kit_workouts_session_id_board_sessions_id_fk",
+          "tableFrom": "session_health_kit_workouts",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_health_kit_workouts_user_id_users_id_fk": {
+          "name": "session_health_kit_workouts_user_id_users_id_fk",
+          "tableFrom": "session_health_kit_workouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_health_kit_workouts_session_id_user_id_pk": {
+          "name": "session_health_kit_workouts_session_id_user_id_pk",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_favorite": {
+          "name": "unique_user_favorite",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_idx": {
+          "name": "user_favorites_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_climb_idx": {
+          "name": "user_favorites_climb_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_sync_cursor_idx": {
+          "name": "user_favorites_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boardsesh_ticks": {
+      "name": "boardsesh_ticks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "tick_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "status": {
+          "name": "status",
+          "type": "tick_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "aurora_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_sync_error": {
+          "name": "aurora_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "kilter_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_sync_error": {
+          "name": "kilter_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_detached_at": {
+          "name": "kilter_detached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boardsesh_ticks_user_board_idx": {
+          "name": "boardsesh_ticks_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climb_idx": {
+          "name": "boardsesh_ticks_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_aurora_id_unique": {
+          "name": "boardsesh_ticks_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_pending_idx": {
+          "name": "boardsesh_ticks_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_id_unique": {
+          "name": "boardsesh_ticks_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_sync_pending_idx": {
+          "name": "boardsesh_ticks_kilter_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_session_idx": {
+          "name": "boardsesh_ticks_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climbed_at_idx": {
+          "name": "boardsesh_ticks_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climbed_at_idx": {
+          "name": "boardsesh_ticks_user_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_climbed_at_idx": {
+          "name": "boardsesh_ticks_board_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_user_idx": {
+          "name": "boardsesh_ticks_board_user_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climb_lookup_idx": {
+          "name": "boardsesh_ticks_user_climb_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_cursor_idx": {
+          "name": "boardsesh_ticks_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_flash_send_updated_at_idx": {
+          "name": "boardsesh_ticks_flash_send_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"boardsesh_ticks\".\"status\" IN ('flash','send')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boardsesh_ticks_user_id_users_id_fk": {
+          "name": "boardsesh_ticks_user_id_users_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_session_id_board_sessions_id_fk": {
+          "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_board_id_user_boards_id_fk": {
+          "name": "boardsesh_ticks_board_id_user_boards_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boardsesh_ticks_uuid_unique": {
+          "name": "boardsesh_ticks_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "boardsesh_ticks_quality_range": {
+          "name": "boardsesh_ticks_quality_range",
+          "value": "\"boardsesh_ticks\".\"quality\" IS NULL OR (\"boardsesh_ticks\".\"quality\" >= 1 AND \"boardsesh_ticks\".\"quality\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_events": {
+      "name": "board_climb_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter": {
+          "name": "setter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_events_board_confirmed_at_idx": {
+          "name": "board_climb_events_board_confirmed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confirmed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_events_board_seq_unique": {
+          "name": "board_climb_events_board_seq_unique",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_events_session_idx": {
+          "name": "board_climb_events_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_events_board_climb_idx": {
+          "name": "board_climb_events_board_climb_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_events_board_id_user_boards_id_fk": {
+          "name": "board_climb_events_board_id_user_boards_id_fk",
+          "tableFrom": "board_climb_events",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_climb_events_user_id_users_id_fk": {
+          "name": "board_climb_events_user_id_users_id_fk",
+          "tableFrom": "board_climb_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_climb_events_session_id_board_sessions_id_fk": {
+          "name": "board_climb_events_session_id_board_sessions_id_fk",
+          "tableFrom": "board_climb_events",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_climbs": {
+      "name": "playlist_climbs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_climb": {
+          "name": "unique_playlist_climb",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_climb_idx": {
+          "name": "playlist_climbs_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_position_idx": {
+          "name": "playlist_climbs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_sync_cursor_idx": {
+          "name": "playlist_climbs_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_climbs_playlist_id_playlists_id_fk": {
+          "name": "playlist_climbs_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_climbs",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_ownership": {
+      "name": "playlist_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_ownership": {
+          "name": "unique_playlist_ownership",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_ownership_user_idx": {
+          "name": "playlist_ownership_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_ownership_playlist_id_playlists_id_fk": {
+          "name": "playlist_ownership_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_ownership_user_id_users_id_fk": {
+          "name": "playlist_ownership_user_id_users_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_recommendation": {
+          "name": "generated_recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "playlists_board_layout_idx": {
+          "name": "playlists_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_generated_recommendation_idx": {
+          "name": "playlists_generated_recommendation_idx",
+          "columns": [
+            {
+              "expression": "generated_recommendation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_uuid_idx": {
+          "name": "playlists_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_updated_at_idx": {
+          "name": "playlists_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_sync_cursor_idx": {
+          "name": "playlists_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_last_accessed_at_idx": {
+          "name": "playlists_last_accessed_at_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_aurora_id_idx": {
+          "name": "playlists_aurora_id_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_kilter_id_idx": {
+          "name": "playlists_kilter_id_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlists_uuid_unique": {
+          "name": "playlists_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlist_pins": {
+      "name": "user_playlist_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_playlist_pin": {
+          "name": "unique_user_playlist_pin",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_user_idx": {
+          "name": "user_playlist_pins_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_playlist_idx": {
+          "name": "user_playlist_pins_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_playlist_pins_user_id_users_id_fk": {
+          "name": "user_playlist_pins_user_id_users_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_playlist_pins_playlist_id_playlists_id_fk": {
+          "name": "user_playlist_pins_playlist_id_playlists_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hold_classifications": {
+      "name": "user_hold_classifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_type": {
+          "name": "hold_type",
+          "type": "hold_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_rating": {
+          "name": "hand_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foot_rating": {
+          "name": "foot_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_direction": {
+          "name": "pull_direction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hold_classifications_user_board_idx": {
+          "name": "user_hold_classifications_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_unique_idx": {
+          "name": "user_hold_classifications_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_hold_idx": {
+          "name": "user_hold_classifications_hold_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hold_classifications_user_id_users_id_fk": {
+          "name": "user_hold_classifications_user_id_users_id_fk",
+          "tableFrom": "user_hold_classifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esp32_controllers": {
+      "name": "esp32_controllers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "esp32_controllers_user_idx": {
+          "name": "esp32_controllers_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_api_key_idx": {
+          "name": "esp32_controllers_api_key_idx",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_session_idx": {
+          "name": "esp32_controllers_session_idx",
+          "columns": [
+            {
+              "expression": "authorized_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esp32_controllers_user_id_users_id_fk": {
+          "name": "esp32_controllers_user_id_users_id_fk",
+          "tableFrom": "esp32_controllers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "esp32_controllers_api_key_unique": {
+          "name": "esp32_controllers_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_follows": {
+      "name": "playlist_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_uuid": {
+          "name": "playlist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_follow": {
+          "name": "unique_playlist_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_follower_idx": {
+          "name": "playlist_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_playlist_idx": {
+          "name": "playlist_follows_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_sync_cursor_idx": {
+          "name": "playlist_follows_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_follows_follower_id_users_id_fk": {
+          "name": "playlist_follows_follower_id_users_id_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_follows_playlist_uuid_playlists_uuid_fk": {
+          "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setter_follows": {
+      "name": "setter_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_setter_follow": {
+          "name": "unique_setter_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_follower_idx": {
+          "name": "setter_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_setter_idx": {
+          "name": "setter_follows_setter_idx",
+          "columns": [
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_sync_cursor_idx": {
+          "name": "setter_follows_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setter_follows_follower_id_users_id_fk": {
+          "name": "setter_follows_follower_id_users_id_fk",
+          "tableFrom": "setter_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_follow": {
+          "name": "unique_user_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_following_idx": {
+          "name": "user_follows_following_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_sync_cursor_idx": {
+          "name": "user_follows_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_follow": {
+          "name": "no_self_follow",
+          "value": "\"user_follows\".\"follower_id\" != \"user_follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_entity_created_at_idx": {
+          "name": "comments_entity_created_at_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_user_created_at_idx": {
+          "name": "comments_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_parent_comment_idx": {
+          "name": "comments_parent_comment_idx",
+          "columns": [
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comments_uuid_unique": {
+          "name": "comments_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_unique_user_entity": {
+          "name": "votes_unique_user_entity",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_entity_idx": {
+          "name": "votes_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_idx": {
+          "name": "votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vote_value_check": {
+          "name": "vote_value_check",
+          "value": "\"votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_created_at_idx": {
+          "name": "notifications_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_dedup_idx": {
+          "name": "notifications_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_comments_id_fk": {
+          "name": "notifications_comment_id_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_uuid_unique": {
+          "name": "notifications_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "feed_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_recipient_created_at_idx": {
+          "name": "feed_items_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_recipient_board_created_at_idx": {
+          "name": "feed_items_recipient_board_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_actor_created_at_idx": {
+          "name": "feed_items_actor_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_created_at_idx": {
+          "name": "feed_items_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_entity_type_entity_id_idx": {
+          "name": "feed_items_entity_type_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_recipient_id_users_id_fk": {
+          "name": "feed_items_recipient_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feed_items_actor_id_users_id_fk": {
+          "name": "feed_items_actor_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_classic_status": {
+      "name": "climb_classic_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_classic": {
+          "name": "is_classic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_classic_status_unique_idx": {
+          "name": "climb_classic_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_classic_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_classic_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "last_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_community_status": {
+      "name": "climb_community_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_grade": {
+          "name": "community_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_community_status_unique_idx": {
+          "name": "climb_community_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_community_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_community_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "last_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_proposals": {
+      "name": "climb_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "climb_proposals_climb_angle_type_idx": {
+          "name": "climb_proposals_climb_angle_type_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_status_idx": {
+          "name": "climb_proposals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_proposer_idx": {
+          "name": "climb_proposals_proposer_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_board_type_idx": {
+          "name": "climb_proposals_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_created_at_idx": {
+          "name": "climb_proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_proposals_proposer_id_users_id_fk": {
+          "name": "climb_proposals_proposer_id_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "climb_proposals_resolved_by_users_id_fk": {
+          "name": "climb_proposals_resolved_by_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "climb_proposals_uuid_unique": {
+          "name": "climb_proposals_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_roles": {
+      "name": "community_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_roles_board_type_idx": {
+          "name": "community_roles_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_roles_user_id_users_id_fk": {
+          "name": "community_roles_user_id_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_roles_granted_by_users_id_fk": {
+          "name": "community_roles_granted_by_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_roles_user_role_board_idx": {
+          "name": "community_roles_user_role_board_idx",
+          "nullsNotDistinct": true,
+          "columns": [
+            "user_id",
+            "role",
+            "board_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_by": {
+          "name": "set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_settings_scope_key_idx": {
+          "name": "community_settings_scope_key_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_settings_set_by_users_id_fk": {
+          "name": "community_settings_set_by_users_id_fk",
+          "tableFrom": "community_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "set_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_votes_unique_user_proposal": {
+          "name": "proposal_votes_unique_user_proposal",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_proposal_idx": {
+          "name": "proposal_votes_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_climb_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_user_id_users_id_fk": {
+          "name": "proposal_votes_user_id_users_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_vote_value_check": {
+          "name": "proposal_vote_value_check",
+          "value": "\"proposal_votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.new_climb_subscriptions": {
+      "name": "new_climb_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "new_climb_subscriptions_unique_user_board_layout": {
+          "name": "new_climb_subscriptions_unique_user_board_layout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_user_idx": {
+          "name": "new_climb_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_board_layout_idx": {
+          "name": "new_climb_subscriptions_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_climb_subscriptions_user_id_users_id_fk": {
+          "name": "new_climb_subscriptions_user_id_users_id_fk",
+          "tableFrom": "new_climb_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_counts": {
+      "name": "vote_counts",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vote_counts_score_idx": {
+          "name": "vote_counts_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_counts_hot_score_idx": {
+          "name": "vote_counts_hot_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hot_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_counts_entity_type_entity_id_pk": {
+          "name": "vote_counts_entity_type_entity_id_pk",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_participants": {
+      "name": "board_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_session_participants_session_idx": {
+          "name": "board_session_participants_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_session_participants_user_idx": {
+          "name": "board_session_participants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_session_participants_session_id_board_sessions_id_fk": {
+          "name": "board_session_participants_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_session_participants_user_id_users_id_fk": {
+          "name": "board_session_participants_user_id_users_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_session_participants_session_id_user_id_pk": {
+          "name": "board_session_participants_session_id_user_id_pk",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_feedback": {
+      "name": "app_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_feedback_created_at_idx": {
+          "name": "app_feedback_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_user_idx": {
+          "name": "app_feedback_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_board_idx": {
+          "name": "app_feedback_board_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_feedback_user_id_users_id_fk": {
+          "name": "app_feedback_user_id_users_id_fk",
+          "tableFrom": "app_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_climb_percentiles": {
+      "name": "user_climb_percentiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_distinct_climbs": {
+          "name": "total_distinct_climbs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_climb_percentiles_user_id_users_id_fk": {
+          "name": "user_climb_percentiles_user_id_users_id_fk",
+          "tableFrom": "user_climb_percentiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_push_tokens": {
+      "name": "activity_push_tokens",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_push_tokens_session_idx": {
+          "name": "activity_push_tokens_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_push_tokens_user_idx": {
+          "name": "activity_push_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_push_tokens_updated_at_idx": {
+          "name": "activity_push_tokens_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_push_tokens_session_id_board_sessions_id_fk": {
+          "name": "activity_push_tokens_session_id_board_sessions_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_push_tokens_user_id_users_id_fk": {
+          "name": "activity_push_tokens_user_id_users_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_send_stats": {
+      "name": "board_climb_send_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "send_count_30d": {
+          "name": "send_count_30d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sender_count_30d": {
+          "name": "sender_count_30d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "send_count_90d": {
+          "name": "send_count_90d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_send_stats_trending_idx": {
+          "name": "board_climb_send_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "send_count_30d",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_send_stats_board_type_climb_uuid_pk": {
+          "name": "board_climb_send_stats_board_type_climb_uuid_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_setter_stats": {
+      "name": "board_setter_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_count": {
+          "name": "climb_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_ascents": {
+          "name": "total_ascents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_ascents_per_climb": {
+          "name": "avg_ascents_per_climb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_quality": {
+          "name": "avg_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_score": {
+          "name": "setter_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_setter_stats_score_idx": {
+          "name": "board_setter_stats_score_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_setter_stats_board_type_setter_username_pk": {
+          "name": "board_setter_stats_board_type_setter_username_pk",
+          "columns": [
+            "board_type",
+            "setter_username"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_grades": {
+      "name": "board_climb_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_grade": {
+          "name": "local_grade",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "universal_grade": {
+          "name": "universal_grade",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_low": {
+          "name": "grade_low",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_high": {
+          "name": "grade_high",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "content_prior": {
+          "name": "content_prior",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coeff_version": {
+          "name": "coeff_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_seq": {
+          "name": "sync_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "board_climb_grades_confidence_idx": {
+          "name": "board_climb_grades_confidence_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_grades_sync_cursor_idx": {
+          "name": "board_climb_grades_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_grades_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_grades_board_type_climb_uuid_angle_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_grade_coefficients": {
+      "name": "board_grade_coefficients",
+      "schema": "",
+      "columns": {
+        "coeff_version": {
+          "name": "coeff_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_grade_coefficients_coeff_version_kind_key_pk": {
+          "name": "board_grade_coefficients_coeff_version_kind_key_pk",
+          "columns": [
+            "coeff_version",
+            "kind",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_exports": {
+      "name": "integration_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_activity_id": {
+          "name": "external_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_integration_export": {
+          "name": "unique_integration_export",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_exports_user_provider_idx": {
+          "name": "integration_exports_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_exports_session_idx": {
+          "name": "integration_exports_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_exports_user_id_users_id_fk": {
+          "name": "integration_exports_user_id_users_id_fk",
+          "tableFrom": "integration_exports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_sync_gym_sources": {
+      "name": "location_sync_gym_sources",
+      "schema": "",
+      "columns": {
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "location_sync_gym_sources_gym_idx": {
+          "name": "location_sync_gym_sources_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_sync_gym_sources_gym_id_gyms_id_fk": {
+          "name": "location_sync_gym_sources_gym_id_gyms_id_fk",
+          "tableFrom": "location_sync_gym_sources",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_deletions": {
+      "name": "sync_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_deletions_user_since_idx": {
+          "name": "sync_deletions_user_since_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_deletions_null_scope_idx": {
+          "name": "sync_deletions_null_scope_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sync_deletions\".\"user_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_deletions_deleted_at_idx": {
+          "name": "sync_deletions_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.gym_claim_method": {
+      "name": "gym_claim_method",
+      "schema": "public",
+      "values": [
+        "domain",
+        "admin"
+      ]
+    },
+    "public.gym_claim_status": {
+      "name": "gym_claim_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied",
+        "expired"
+      ]
+    },
+    "public.gym_member_role": {
+      "name": "gym_member_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "editor",
+        "member"
+      ]
+    },
+    "public.aurora_table_type": {
+      "name": "aurora_table_type",
+      "schema": "public",
+      "values": [
+        "ascents",
+        "bids"
+      ]
+    },
+    "public.kilter_table_type": {
+      "name": "kilter_table_type",
+      "schema": "public",
+      "values": [
+        "logs",
+        "attempts"
+      ]
+    },
+    "public.tick_origin": {
+      "name": "tick_origin",
+      "schema": "public",
+      "values": [
+        "native",
+        "aurora_pull",
+        "kilter_pull",
+        "json_import",
+        "moonboard_import"
+      ]
+    },
+    "public.tick_status": {
+      "name": "tick_status",
+      "schema": "public",
+      "values": [
+        "flash",
+        "send",
+        "attempt"
+      ]
+    },
+    "public.hold_type": {
+      "name": "hold_type",
+      "schema": "public",
+      "values": [
+        "jug",
+        "sloper",
+        "pinch",
+        "crimp",
+        "pocket"
+      ]
+    },
+    "public.social_entity_type": {
+      "name": "social_entity_type",
+      "schema": "public",
+      "values": [
+        "playlist_climb",
+        "climb",
+        "tick",
+        "comment",
+        "proposal",
+        "board",
+        "gym",
+        "session"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "new_follower",
+        "comment_reply",
+        "comment_on_tick",
+        "comment_on_climb",
+        "vote_on_tick",
+        "vote_on_comment",
+        "new_climb",
+        "new_climb_global",
+        "proposal_approved",
+        "proposal_rejected",
+        "proposal_vote",
+        "proposal_created",
+        "new_climbs_synced"
+      ]
+    },
+    "public.feed_item_type": {
+      "name": "feed_item_type",
+      "schema": "public",
+      "values": [
+        "ascent",
+        "new_climb",
+        "comment",
+        "proposal_approved",
+        "session_summary"
+      ]
+    },
+    "public.community_role_type": {
+      "name": "community_role_type",
+      "schema": "public",
+      "values": [
+        "admin",
+        "community_leader",
+        "tester"
+      ]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "approved",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.proposal_type": {
+      "name": "proposal_type",
+      "schema": "public",
+      "values": [
+        "grade",
+        "classic",
+        "benchmark"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1205,6 +1205,13 @@
       "when": 1783507403048,
       "tag": "0171_backfill_dead_kilter_link_errors",
       "breakpoints": true
+    },
+    {
+      "idx": 172,
+      "version": "7",
+      "when": 1783553077349,
+      "tag": "0172_cuddly_psynapse",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app/ascents.ts
+++ b/packages/db/src/schema/app/ascents.ts
@@ -35,13 +35,21 @@ export const tickStatusEnum = pgEnum('tick_status', ['flash', 'send', 'attempt']
  *   Already inside upstream_ascensionist_count.
  * - json_import: imported from an Aurora account export JSON. Already inside
  *   upstream_ascensionist_count.
+ * - moonboard_import: imported from a MoonBoard account export CSV. Already
+ *   inside upstream_ascensionist_count.
  *
  * The tick recompute counts a user toward boardsesh_ascensionist_count only
  * when ALL their ticks at a (board, climb, angle) key are 'native' — a user
  * with any imported tick is already represented in the upstream count, so
  * counting them again would double-count the ascent.
  */
-export const tickOriginEnum = pgEnum('tick_origin', ['native', 'aurora_pull', 'kilter_pull', 'json_import']);
+export const tickOriginEnum = pgEnum('tick_origin', [
+  'native',
+  'aurora_pull',
+  'kilter_pull',
+  'json_import',
+  'moonboard_import',
+]);
 
 /**
  * Aurora table type for sync
@@ -185,6 +193,6 @@ export const boardseshTicks = pgTable(
 export type BoardseshTick = typeof boardseshTicks.$inferSelect;
 export type NewBoardseshTick = typeof boardseshTicks.$inferInsert;
 export type TickStatus = 'flash' | 'send' | 'attempt';
-export type TickOrigin = 'native' | 'aurora_pull' | 'kilter_pull' | 'json_import';
+export type TickOrigin = 'native' | 'aurora_pull' | 'kilter_pull' | 'json_import' | 'moonboard_import';
 export type AuroraTableType = 'ascents' | 'bids';
 export type KilterTableType = 'logs' | 'attempts';

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -42,12 +42,26 @@ import {
   saveAuroraCredential,
   saveKilterCredentialViaPassword,
   streamAuroraImport,
+  streamMoonBoardImport,
   type AuroraCredentialStatus,
+  type MoonBoardImportProgressEvent,
+  type MoonBoardImportResult,
+  type StrippedMoonBoardExportData,
   type UnsyncedCounts,
 } from '../../lib/aurora-credentials';
 
 type ImportPhase = 'preview' | 'importing' | 'complete' | 'error';
 type ImportStep = 'climbs' | 'resolving' | 'dedup' | 'ascents' | 'attempts' | 'circuits';
+type MoonBoardExportPreview = {
+  username?: string;
+  rows: number;
+  sends: number;
+  flashes: number;
+  attempts: number;
+  projects: number;
+  fails: number;
+  angle: number;
+};
 
 // Kilter renders two cards: `kilterAurora` for the legacy Aurora-built app (JSON
 // import + data request) and `kilterNew` for the new Kilter Grips account, which
@@ -60,6 +74,22 @@ type ImportProgress = {
   total?: number;
 };
 
+type MoonBoardProgress = {
+  step: string;
+  message?: string;
+  current?: number;
+  total?: number;
+};
+
+type ParsedMoonBoardExport = {
+  data: StrippedMoonBoardExportData;
+  preview: MoonBoardExportPreview;
+};
+
+type MoonBoardSharedSchemaModule = {
+  parseMoonBoardExportCsv?: (csv: string) => unknown | Promise<unknown>;
+};
+
 const MAX_IMPORT_SIZE_BYTES = 200 * 1024 * 1024;
 const IMPORT_RESULT_LIMIT = 8;
 const AURORA_CREDENTIALS_QUERY_KEY = ['auroraCredentials'] as const;
@@ -67,7 +97,6 @@ const AURORA_UNSYNCED_QUERY_KEY = ['auroraCredentials', 'unsynced'] as const;
 
 // MoonBoard isn't an Aurora board, so it has no credential/sync flow.
 const MOONBOARD_SUPPORT_EMAIL = 'moonboardsupport@moonclimbing.com';
-const MOONBOARD_DISCORD_URL = 'https://discord.gg/YXA8GsXfQK';
 
 function boardDisplayName(boardType: AuroraBoardName): string {
   return boardType.charAt(0).toUpperCase() + boardType.slice(1);
@@ -83,6 +112,51 @@ function getUnsyncedCount(counts: UnsyncedCounts | undefined, boardType: AuroraB
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readNumber(record: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+function readString(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim().length > 0) return value;
+  }
+  return undefined;
+}
+
+function normalizeMoonBoardParsedExport(parsed: unknown): ParsedMoonBoardExport {
+  if (!isRecord(parsed) || !('data' in parsed) || !isRecord(parsed.preview)) {
+    throw new Error('moonboard_parser_invalid_result');
+  }
+
+  const preview = parsed.preview;
+  return {
+    data: parsed.data,
+    preview: {
+      username: readString(preview, ['username', 'userName']),
+      rows: readNumber(preview, ['rows', 'rowCount', 'entries', 'totalRows']) ?? 0,
+      sends: readNumber(preview, ['sends', 'ascents', 'sendCount']) ?? 0,
+      flashes: readNumber(preview, ['flashes', 'flashCount']) ?? 0,
+      attempts: readNumber(preview, ['attempts', 'attemptCount']) ?? 0,
+      projects: readNumber(preview, ['projects', 'projectCount']) ?? 0,
+      fails: readNumber(preview, ['fails', 'failures', 'failCount']) ?? 0,
+      angle: readNumber(preview, ['angle', 'boardAngle']) ?? 40,
+    },
+  };
+}
+
+async function parseMoonBoardCsvForImport(csv: string): Promise<ParsedMoonBoardExport> {
+  const sharedSchema = (await import('@boardsesh/shared-schema')) as unknown as MoonBoardSharedSchemaModule;
+  if (typeof sharedSchema.parseMoonBoardExportCsv !== 'function') {
+    throw new Error('moonboard_parser_unavailable');
+  }
+  return normalizeMoonBoardParsedExport(await sharedSchema.parseMoonBoardExportCsv(csv));
 }
 
 // The i18n keys must stay literal in each builder (the linter hard-fails on
@@ -112,6 +186,40 @@ function buildMoonBoardDataRequestMailto(t: TFunction<'settings'>): string {
 
 function totalImported(result: ImportResult): number {
   return result.climbs.imported + result.ascents.imported + result.attempts.imported + result.circuits.imported;
+}
+
+function totalMoonBoardImported(result: MoonBoardImportResult): number {
+  return result.ascents.imported + result.attempts.imported;
+}
+
+function moonBoardUnresolvedClimbs(result: MoonBoardImportResult): string[] {
+  return [
+    ...new Set([
+      ...result.unresolvedClimbs,
+      ...(result.unresolvedAscentClimbs ?? []),
+      ...(result.unresolvedAttemptClimbs ?? []),
+    ]),
+  ].sort();
+}
+
+function getMoonBoardProgressLabel(t: TFunction<'settings'>, progress: MoonBoardProgress | null): string {
+  if (!progress) return t('aurora.moonboard.csvImport.steps.resolving');
+  switch (progress.step) {
+    case 'ascents':
+      return t('aurora.moonboard.csvImport.steps.ascents');
+    case 'attempts':
+      return t('aurora.moonboard.csvImport.steps.attempts');
+    case 'dedup':
+      return t('aurora.moonboard.csvImport.steps.dedup');
+    case 'resolving':
+      return t('aurora.moonboard.csvImport.steps.resolving');
+    case 'importing':
+      return t('aurora.moonboard.csvImport.steps.importing');
+    case 'recomputing':
+      return t('aurora.moonboard.csvImport.steps.recomputing');
+    default:
+      return t('aurora.moonboard.csvImport.steps.importing');
+  }
 }
 
 // Kilter links via the password grant (`/api/board-credentials/kilter/password`);
@@ -519,14 +627,25 @@ export function BoardAccountsSection() {
 // heavy BoardAccountsSection parent re-renders.
 const MoonBoardAccountCard = memo(function MoonBoardAccountCard() {
   const { t } = useTranslation('settings');
-  const { t: tCommon } = useTranslation('common');
   const { systemColors } = useTheme();
   const { showToast } = useToast();
   const confirm = useConfirm();
-  const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [importPreview, setImportPreview] = useState<MoonBoardExportPreview | null>(null);
+  const [importData, setImportData] = useState<StrippedMoonBoardExportData | null>(null);
+  const [importPhase, setImportPhase] = useState<ImportPhase | null>(null);
+  const [importProgress, setImportProgress] = useState<MoonBoardProgress | null>(null);
+  const [importResult, setImportResult] = useState<MoonBoardImportResult | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
 
-  const openImportDialog = useCallback(() => setImportDialogOpen(true), []);
-  const closeImportDialog = useCallback(() => setImportDialogOpen(false), []);
+  const resetImport = useCallback(() => {
+    if (importPhase === 'importing') return;
+    setImportPreview(null);
+    setImportData(null);
+    setImportPhase(null);
+    setImportProgress(null);
+    setImportResult(null);
+    setImportError(null);
+  }, [importPhase]);
 
   const handleRequestData = useCallback(() => {
     // The GDPR letter is too long to encode into the mailto: body reliably, so
@@ -558,11 +677,91 @@ const MoonBoardAccountCard = memo(function MoonBoardAccountCard() {
     void openRequest();
   }, [confirm, showToast, t]);
 
-  const handleOpenDiscord = useCallback(() => {
-    void Linking.openURL(MOONBOARD_DISCORD_URL).catch(() => {
-      showToast(t('aurora.moonboard.importDialog.openFailed'), 'error');
-    });
+  const handleImportPress = useCallback(() => {
+    void (async () => {
+      try {
+        const DocumentPicker = await import('expo-document-picker');
+        const document = await DocumentPicker.getDocumentAsync({
+          type: ['text/csv', 'text/plain', 'application/vnd.ms-excel'],
+          copyToCacheDirectory: true,
+        });
+        if (document.canceled) return;
+
+        const asset = document.assets[0];
+        if (!asset) return;
+        if (asset.size != null && asset.size > MAX_IMPORT_SIZE_BYTES) {
+          showToast(t('aurora.import.tooLarge'), 'error');
+          return;
+        }
+
+        const csv = await new File(asset.uri).text();
+        const parsed = await parseMoonBoardCsvForImport(csv);
+        setImportData(parsed.data);
+        setImportPreview(parsed.preview);
+        setImportPhase('preview');
+        setImportProgress(null);
+        setImportResult(null);
+        setImportError(null);
+      } catch (error) {
+        const message =
+          error instanceof Error && error.message === 'moonboard_parser_unavailable'
+            ? t('aurora.moonboard.csvImport.parserUnavailable')
+            : t('aurora.moonboard.csvImport.parseError');
+        showToast(message, 'error');
+        setImportPreview(null);
+        setImportData(null);
+        setImportPhase(null);
+      }
+    })();
   }, [showToast, t]);
+
+  const handleImportConfirm = useCallback(() => {
+    if (!importData) return;
+
+    setImportPhase('importing');
+    setImportProgress(null);
+    setImportPreview(null);
+    setImportResult(null);
+    setImportError(null);
+
+    void (async () => {
+      try {
+        await streamMoonBoardImport(importData, (event: MoonBoardImportProgressEvent) => {
+          if (event.type === 'progress') {
+            setImportProgress({
+              step: event.step,
+              message: 'message' in event ? event.message : undefined,
+              current: 'current' in event ? event.current : undefined,
+              total: 'total' in event ? event.total : undefined,
+            });
+            return;
+          }
+
+          if (event.type === 'complete') {
+            setImportResult(event.results);
+            setImportPhase('complete');
+            showToast(
+              event.results.partialError
+                ? t('aurora.moonboard.csvImport.partialWarning')
+                : t('aurora.moonboard.csvImport.successCount', { count: totalMoonBoardImported(event.results) }),
+              event.results.partialError ? 'warning' : 'success',
+            );
+            return;
+          }
+
+          setImportError(event.error);
+          setImportPhase('error');
+          showToast(event.error, 'error');
+        });
+      } catch {
+        setImportError(t('aurora.moonboard.csvImport.interrupted'));
+        setImportPhase('error');
+        showToast(t('aurora.moonboard.csvImport.failed'), 'error');
+      } finally {
+        setImportData(null);
+      }
+    })();
+  }, [importData, showToast, t]);
 
   return (
     <View
@@ -587,7 +786,9 @@ const MoonBoardAccountCard = memo(function MoonBoardAccountCard() {
           icon="upload"
           variant="outlined"
           size="small"
-          onPress={openImportDialog}
+          loading={importPhase === 'importing'}
+          disabled={importPhase === 'importing'}
+          onPress={handleImportPress}
         />
         <Button
           title={t('aurora.moonboard.requestData')}
@@ -598,29 +799,161 @@ const MoonBoardAccountCard = memo(function MoonBoardAccountCard() {
         />
       </View>
 
-      <Modal visible={importDialogOpen} transparent animationType="fade" onRequestClose={closeImportDialog}>
-        <View style={styles.modalBackdrop}>
-          <View style={[styles.modalCard, { backgroundColor: systemColors.secondaryBackground }]}>
-            <Text variant="headline" style={styles.modalTitle}>
-              {t('aurora.moonboard.importDialog.title')}
-            </Text>
-            <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.modalCopy}>
-              {t('aurora.moonboard.importDialog.body')}
-            </Text>
-            <View style={styles.modalActions}>
-              <Button title={tCommon('actions.close')} variant="text" role="cancel" onPress={closeImportDialog} />
-              <Button
-                title={t('aurora.moonboard.importDialog.discordCta')}
-                icon="open.external"
-                onPress={handleOpenDiscord}
-              />
-            </View>
-          </View>
-        </View>
-      </Modal>
+      <MoonBoardImportDialog
+        visible={importPhase !== null}
+        phase={importPhase}
+        preview={importPreview}
+        progress={importProgress}
+        result={importResult}
+        error={importError}
+        systemColors={systemColors}
+        onCancel={resetImport}
+        onConfirm={handleImportConfirm}
+      />
     </View>
   );
 });
+
+type MoonBoardImportDialogProps = {
+  visible: boolean;
+  phase: ImportPhase | null;
+  preview: MoonBoardExportPreview | null;
+  progress: MoonBoardProgress | null;
+  result: MoonBoardImportResult | null;
+  error: string | null;
+  systemColors: ReturnType<typeof useTheme>['systemColors'];
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+function MoonBoardImportDialog({
+  visible,
+  phase,
+  preview,
+  progress,
+  result,
+  error,
+  systemColors,
+  onCancel,
+  onConfirm,
+}: MoonBoardImportDialogProps) {
+  const { t } = useTranslation('settings');
+  const { t: tCommon } = useTranslation('common');
+  let title = t('aurora.moonboard.importDialog.errorTitle');
+  if (phase === 'preview') {
+    title = t('aurora.moonboard.importDialog.previewTitle');
+  } else if (phase === 'importing') {
+    title = t('aurora.moonboard.importDialog.importingTitle');
+  } else if (phase === 'complete') {
+    title = t('aurora.moonboard.importDialog.completeTitle');
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={phase === 'importing' ? undefined : onCancel}
+    >
+      <View style={styles.modalBackdrop}>
+        <View style={[styles.modalCard, styles.importModalCard, { backgroundColor: systemColors.secondaryBackground }]}>
+          <Text variant="headline" style={styles.modalTitle}>
+            {title}
+          </Text>
+
+          {phase === 'preview' && preview ? (
+            <>
+              <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.modalCopy}>
+                {preview.username
+                  ? t('aurora.moonboard.importDialog.previewIntroWithUser', { username: preview.username })
+                  : t('aurora.moonboard.importDialog.previewIntro')}
+              </Text>
+              <View style={[styles.summaryBox, { backgroundColor: systemColors.tertiaryBackground }]}>
+                <SummaryLine label={t('aurora.moonboard.importDialog.rows', { count: preview.rows })} />
+                <SummaryLine label={t('aurora.moonboard.importDialog.sends', { count: preview.sends })} />
+                <SummaryLine label={t('aurora.moonboard.importDialog.attempts', { count: preview.attempts })} />
+                {preview.projects > 0 ? (
+                  <SummaryLine label={t('aurora.moonboard.importDialog.projects', { count: preview.projects })} />
+                ) : null}
+                {preview.fails > 0 ? (
+                  <SummaryLine label={t('aurora.moonboard.importDialog.fails', { count: preview.fails })} />
+                ) : null}
+                <SummaryLine label={t('aurora.moonboard.importDialog.angleNote', { angle: preview.angle })} />
+              </View>
+              <Text variant="footnote" color={systemColors.secondaryLabel}>
+                {t('aurora.moonboard.importDialog.previewNote')}
+              </Text>
+              <View style={styles.modalActions}>
+                <Button title={tCommon('actions.cancel')} variant="text" role="cancel" onPress={onCancel} />
+                <Button title={t('aurora.import.dialog.confirm')} icon="upload" onPress={onConfirm} />
+              </View>
+            </>
+          ) : null}
+
+          {phase === 'importing' ? (
+            <View style={styles.importProgressBlock}>
+              <ActivityIndicator />
+              <Text variant="subheadline" color={systemColors.secondaryLabel}>
+                {getMoonBoardProgressLabel(t, progress)}
+                {progress?.current != null && progress.total != null ? ` (${progress.current}/${progress.total})` : ''}
+              </Text>
+            </View>
+          ) : null}
+
+          {phase === 'complete' && result ? (
+            <>
+              <ScrollView style={styles.resultScroll}>
+                <MoonBoardImportResultSummary result={result} />
+              </ScrollView>
+              <View style={styles.modalActions}>
+                <Button title={tCommon('actions.done')} onPress={onCancel} />
+              </View>
+            </>
+          ) : null}
+
+          {phase === 'error' ? (
+            <>
+              <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.modalCopy}>
+                {error ?? t('aurora.moonboard.csvImport.interrupted')}
+              </Text>
+              <View style={styles.modalActions}>
+                <Button title={tCommon('actions.close')} onPress={onCancel} />
+              </View>
+            </>
+          ) : null}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function MoonBoardImportResultSummary({ result }: { result: MoonBoardImportResult }) {
+  const { t } = useTranslation('settings');
+  const { systemColors } = useTheme();
+  const unresolvedNames = moonBoardUnresolvedClimbs(result);
+
+  return (
+    <View style={styles.resultList}>
+      <ResultLine
+        title={t('aurora.moonboard.importResults.ascents')}
+        summary={t('aurora.moonboard.importResults.ascentsSummary', result.ascents)}
+      />
+      <ResultLine
+        title={t('aurora.moonboard.importResults.attempts')}
+        summary={t('aurora.moonboard.importResults.attemptsSummary', result.attempts)}
+      />
+      {result.partialError ? (
+        <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.resultWarning}>
+          {t('aurora.moonboard.importResults.partialBody')}
+        </Text>
+      ) : null}
+      <UnresolvedList
+        title={t('aurora.moonboard.importResults.unresolvedTitle', { count: unresolvedNames.length })}
+        names={unresolvedNames}
+      />
+    </View>
+  );
+}
 
 type BoardAccountSkeletonCardProps = {
   isLast: boolean;

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -222,6 +222,14 @@ function getMoonBoardProgressLabel(t: TFunction<'settings'>, progress: MoonBoard
   }
 }
 
+function getMoonBoardImportErrorMessage(t: TFunction<'settings'>, error: unknown): string {
+  const errorCode = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  if (errorCode === 'moonboard_import_interrupted') {
+    return t('aurora.moonboard.csvImport.interrupted');
+  }
+  return t('aurora.moonboard.csvImport.failed');
+}
+
 // Kilter links via the password grant (`/api/board-credentials/kilter/password`);
 // every other board posts username/password to the Aurora endpoint.
 async function saveBoardCredential(input: { boardType: AuroraBoardName; username: string; password: string }) {
@@ -749,14 +757,16 @@ const MoonBoardAccountCard = memo(function MoonBoardAccountCard() {
             return;
           }
 
-          setImportError(event.error);
+          const importErrorMessage = getMoonBoardImportErrorMessage(t, event.error);
+          setImportError(importErrorMessage);
           setImportPhase('error');
-          showToast(event.error, 'error');
+          showToast(importErrorMessage, 'error');
         });
-      } catch {
-        setImportError(t('aurora.moonboard.csvImport.interrupted'));
+      } catch (error) {
+        const importErrorMessage = getMoonBoardImportErrorMessage(t, error);
+        setImportError(importErrorMessage);
         setImportPhase('error');
-        showToast(t('aurora.moonboard.csvImport.failed'), 'error');
+        showToast(importErrorMessage, 'error');
       } finally {
         setImportData(null);
       }
@@ -871,6 +881,7 @@ function MoonBoardImportDialog({
               <View style={[styles.summaryBox, { backgroundColor: systemColors.tertiaryBackground }]}>
                 <SummaryLine label={t('aurora.moonboard.importDialog.rows', { count: preview.rows })} />
                 <SummaryLine label={t('aurora.moonboard.importDialog.sends', { count: preview.sends })} />
+                <SummaryLine label={t('aurora.moonboard.importDialog.flashes', { count: preview.flashes })} />
                 <SummaryLine label={t('aurora.moonboard.importDialog.attempts', { count: preview.attempts })} />
                 {preview.projects > 0 ? (
                   <SummaryLine label={t('aurora.moonboard.importDialog.projects', { count: preview.projects })} />

--- a/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
@@ -245,7 +245,7 @@ describe('BoardAccountsSection — MoonBoard card', () => {
     mocks.streamMoonBoardImport.mockReset().mockResolvedValue(undefined);
     mocks.parseMoonBoardCsv.mockReset().mockReturnValue({
       data: { rows: [{ problemId: 123 }] },
-      preview: { username: 'moonuser', rows: 3, sends: 1, attempts: 2, projects: 1, fails: 0, angle: 40 },
+      preview: { username: 'moonuser', rows: 3, sends: 1, flashes: 1, attempts: 2, projects: 1, fails: 0, angle: 40 },
     });
     mocks.pickDocument.mockReset().mockResolvedValue({
       canceled: false,
@@ -296,6 +296,7 @@ describe('BoardAccountsSection — MoonBoard card', () => {
         'ProblemId,Grade,Tries,Attempts,Rating,Date\n123,6B+,Send,1,3,2026-01-01',
       );
       expect(button(container, 'aurora.import.dialog.confirm')).not.toBeNull();
+      expect(container.textContent).toContain('aurora.moonboard.importDialog.flashes');
     });
   });
 
@@ -355,6 +356,23 @@ describe('BoardAccountsSection — MoonBoard card', () => {
       expect(mocks.streamMoonBoardImport).toHaveBeenCalledWith({ rows: [{ problemId: 123 }] }, expect.any(Function));
       expect(mocks.showToast).toHaveBeenCalledWith('aurora.moonboard.csvImport.successCount', 'success');
     });
+  });
+
+  it('shows the localized failed copy when the MoonBoard import stream rejects', async () => {
+    mocks.streamMoonBoardImport.mockRejectedValueOnce(new Error('moonboard_import_failed'));
+    const { container } = render(<BoardAccountsSection />);
+    fireEvent.click(button(container, 'aurora.moonboard.import')!);
+    await waitFor(() => {
+      expect(button(container, 'aurora.import.dialog.confirm')).not.toBeNull();
+    });
+
+    fireEvent.click(button(container, 'aurora.import.dialog.confirm')!);
+
+    await waitFor(() => {
+      expect(mocks.showToast).toHaveBeenCalledWith('aurora.moonboard.csvImport.failed', 'error');
+      expect(container.textContent).toContain('aurora.moonboard.csvImport.failed');
+    });
+    expect(container.textContent).not.toContain('aurora.moonboard.csvImport.interrupted');
   });
 
   it('closes the MoonBoard preview dialog via the Cancel button', async () => {

--- a/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
@@ -10,6 +10,10 @@ const mocks = vi.hoisted(() => ({
   saveKilterViaPassword: vi.fn(() => Promise.resolve()),
   deleteAurora: vi.fn(),
   streamImport: vi.fn(),
+  streamMoonBoardImport: vi.fn(),
+  parseMoonBoardCsv: vi.fn(),
+  pickDocument: vi.fn(),
+  fileText: vi.fn(),
   showToast: vi.fn(),
   openURL: vi.fn((_url: string) => Promise.resolve()),
   setClipboard: vi.fn((_text: string) => Promise.resolve()),
@@ -28,6 +32,16 @@ vi.mock('../../../lib/aurora-credentials', () => ({
   saveKilterCredentialViaPassword: mocks.saveKilterViaPassword,
   deleteAuroraCredential: mocks.deleteAurora,
   streamAuroraImport: mocks.streamImport,
+  streamMoonBoardImport: mocks.streamMoonBoardImport,
+}));
+
+vi.mock('@boardsesh/shared-schema', () => ({
+  AURORA_BOARDS: ['kilter', 'tension'],
+  parseAuroraExportJson: vi.fn(() => ({
+    data: { user: { username: 'aurora' }, ascents: [], attempts: [], circuits: [], climbs: [] },
+    preview: { username: 'aurora', ascents: 0, attempts: 0, circuits: 0, climbs: 0 },
+  })),
+  parseMoonBoardExportCsv: mocks.parseMoonBoardCsv,
 }));
 
 type MutationOptions = {
@@ -86,7 +100,20 @@ vi.mock('react-native', () => ({
   Linking: { openURL: mocks.openURL },
 }));
 
-vi.mock('expo-file-system', () => ({ File: class File {} }));
+vi.mock('expo-document-picker', () => ({ getDocumentAsync: mocks.pickDocument }));
+vi.mock('expo-file-system', () => ({
+  File: class File {
+    private readonly uri: string;
+
+    constructor(uri: string) {
+      this.uri = uri;
+    }
+
+    text() {
+      return mocks.fileText(this.uri);
+    }
+  },
+}));
 vi.mock('expo-clipboard', () => ({ setStringAsync: mocks.setClipboard }));
 
 vi.mock('react-i18next', () => ({
@@ -215,6 +242,18 @@ describe('BoardAccountsSection — MoonBoard card', () => {
     mocks.showToast.mockReset();
     mocks.openURL.mockReset().mockResolvedValue(undefined);
     mocks.setClipboard.mockReset().mockResolvedValue(undefined);
+    mocks.streamMoonBoardImport.mockReset().mockResolvedValue(undefined);
+    mocks.parseMoonBoardCsv.mockReset().mockReturnValue({
+      data: { rows: [{ problemId: 123 }] },
+      preview: { username: 'moonuser', rows: 3, sends: 1, attempts: 2, projects: 1, fails: 0, angle: 40 },
+    });
+    mocks.pickDocument.mockReset().mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file://moonboard.csv', size: 128 }],
+    });
+    mocks.fileText
+      .mockReset()
+      .mockResolvedValue('ProblemId,Grade,Tries,Attempts,Rating,Date\n123,6B+,Send,1,3,2026-01-01');
     mocks.confirm.mockReset().mockResolvedValue(true);
     mocks.flags = {};
     mocks.credentials = [];
@@ -242,17 +281,22 @@ describe('BoardAccountsSection — MoonBoard card', () => {
     expect(mailto).not.toContain('body=');
   });
 
-  it('opens the Discord hand-off dialog from "Import data" and links to Discord', () => {
+  it('opens a CSV picker and shows the MoonBoard preview from the selected file', async () => {
     const { container } = render(<BoardAccountsSection />);
-    // Dialog starts closed, so the Discord CTA is not rendered yet.
-    expect(button(container, 'aurora.moonboard.importDialog.discordCta')).toBeNull();
 
     fireEvent.click(button(container, 'aurora.moonboard.import')!);
-    const discordButton = button(container, 'aurora.moonboard.importDialog.discordCta');
-    expect(discordButton).not.toBeNull();
 
-    fireEvent.click(discordButton!);
-    expect(mocks.openURL).toHaveBeenCalledWith('https://discord.gg/YXA8GsXfQK');
+    await waitFor(() => {
+      expect(mocks.pickDocument).toHaveBeenCalledWith({
+        type: ['text/csv', 'text/plain', 'application/vnd.ms-excel'],
+        copyToCacheDirectory: true,
+      });
+      expect(mocks.fileText).toHaveBeenCalledWith('file://moonboard.csv');
+      expect(mocks.parseMoonBoardCsv).toHaveBeenCalledWith(
+        'ProblemId,Grade,Tries,Attempts,Rating,Date\n123,6B+,Send,1,3,2026-01-01',
+      );
+      expect(button(container, 'aurora.import.dialog.confirm')).not.toBeNull();
+    });
   });
 
   it('copies the letter but leaves email unopened when the dialog is dismissed', async () => {
@@ -286,22 +330,41 @@ describe('BoardAccountsSection — MoonBoard card', () => {
     expect(mocks.openURL).not.toHaveBeenCalled();
   });
 
-  it('shows a Discord-specific error toast when the Discord link fails to open', async () => {
-    mocks.openURL.mockReset().mockRejectedValueOnce(new Error('no discord handler'));
+  it('streams the MoonBoard import after preview confirmation', async () => {
+    mocks.streamMoonBoardImport.mockImplementation(
+      async (_data: unknown, onEvent: (event: { type: 'complete'; results: unknown }) => void) => {
+        onEvent({
+          type: 'complete',
+          results: {
+            ascents: { imported: 1, skipped: 0, failed: 0 },
+            attempts: { imported: 2, skipped: 0, failed: 0 },
+            unresolvedClimbs: [],
+          },
+        });
+      },
+    );
     const { container } = render(<BoardAccountsSection />);
     fireEvent.click(button(container, 'aurora.moonboard.import')!);
-    fireEvent.click(button(container, 'aurora.moonboard.importDialog.discordCta')!);
     await waitFor(() => {
-      expect(mocks.showToast).toHaveBeenCalledWith('aurora.moonboard.importDialog.openFailed', 'error');
+      expect(button(container, 'aurora.import.dialog.confirm')).not.toBeNull();
+    });
+
+    fireEvent.click(button(container, 'aurora.import.dialog.confirm')!);
+
+    await waitFor(() => {
+      expect(mocks.streamMoonBoardImport).toHaveBeenCalledWith({ rows: [{ problemId: 123 }] }, expect.any(Function));
+      expect(mocks.showToast).toHaveBeenCalledWith('aurora.moonboard.csvImport.successCount', 'success');
     });
   });
 
-  it('closes the import dialog via the Close button', () => {
+  it('closes the MoonBoard preview dialog via the Cancel button', async () => {
     const { container } = render(<BoardAccountsSection />);
     fireEvent.click(button(container, 'aurora.moonboard.import')!);
-    expect(button(container, 'aurora.moonboard.importDialog.discordCta')).not.toBeNull();
+    await waitFor(() => {
+      expect(button(container, 'actions.cancel')).not.toBeNull();
+    });
 
-    fireEvent.click(button(container, 'actions.close')!);
-    expect(button(container, 'aurora.moonboard.importDialog.discordCta')).toBeNull();
+    fireEvent.click(button(container, 'actions.cancel')!);
+    expect(button(container, 'aurora.import.dialog.confirm')).toBeNull();
   });
 });

--- a/packages/mobile/src/lib/aurora-credentials.ts
+++ b/packages/mobile/src/lib/aurora-credentials.ts
@@ -458,6 +458,22 @@ function parseMoonBoardImportEvent(line: string): MoonBoardImportProgressEvent |
   }
 }
 
+function normalizeMoonBoardImportErrorCode(message: string): string {
+  switch (message) {
+    case 'moonboard_import_failed':
+    case 'moonboard_import_interrupted':
+      return message;
+    case 'Authentication required':
+    case 'Invalid or expired token':
+    case 'Invalid JSON body':
+    case 'Invalid request body':
+    case 'Request body too large':
+      return 'moonboard_import_failed';
+    default:
+      return 'moonboard_import_failed';
+  }
+}
+
 async function handleMoonBoardImportEvent(
   event: MoonBoardImportProgressEvent,
   onEvent: (event: MoonBoardImportProgressEvent) => void,
@@ -501,7 +517,7 @@ async function readStreamingMoonBoardImportResponse(
       if (!event) continue;
       const eventResult = await handleMoonBoardImportEvent(event, onEvent);
       if (eventResult.type === 'complete') result = eventResult.result;
-      if (eventResult.type === 'error') throw new Error(eventResult.error);
+      if (eventResult.type === 'error') throw new Error(normalizeMoonBoardImportErrorCode(eventResult.error));
     }
   }
 
@@ -510,7 +526,7 @@ async function readStreamingMoonBoardImportResponse(
     if (event) {
       const eventResult = await handleMoonBoardImportEvent(event, onEvent);
       if (eventResult.type === 'complete') result = eventResult.result;
-      if (eventResult.type === 'error') throw new Error(eventResult.error);
+      if (eventResult.type === 'error') throw new Error(normalizeMoonBoardImportErrorCode(eventResult.error));
     }
   }
 
@@ -531,11 +547,22 @@ async function readTextMoonBoardImportResponse(
     if (!event) continue;
     const eventResult = await handleMoonBoardImportEvent(event, onEvent);
     if (eventResult.type === 'complete') result = eventResult.result;
-    if (eventResult.type === 'error') throw new Error(eventResult.error);
+    if (eventResult.type === 'error') throw new Error(normalizeMoonBoardImportErrorCode(eventResult.error));
   }
 
   if (!result) throw new Error('moonboard_import_interrupted');
   return result;
+}
+
+async function readMoonBoardErrorCode(response: Response): Promise<string> {
+  try {
+    const errorBody = (await response.json()) as { error?: unknown };
+    return normalizeMoonBoardImportErrorCode(
+      typeof errorBody.error === 'string' ? errorBody.error : 'moonboard_import_failed',
+    );
+  } catch {
+    return 'moonboard_import_failed';
+  }
 }
 
 export async function streamMoonBoardImport(
@@ -549,7 +576,7 @@ export async function streamMoonBoardImport(
   });
 
   if (!response.ok) {
-    throw new Error('moonboard_import_failed');
+    throw new Error(await readMoonBoardErrorCode(response));
   }
 
   const result = await readStreamingMoonBoardImportResponse(response, onEvent);

--- a/packages/mobile/src/lib/aurora-credentials.ts
+++ b/packages/mobile/src/lib/aurora-credentials.ts
@@ -60,6 +60,29 @@ type ChunkPayload = {
   skipFinalization: boolean;
 };
 
+export type MoonBoardImportCounts = {
+  imported: number;
+  skipped: number;
+  failed: number;
+};
+
+export type MoonBoardImportResult = {
+  ticks?: MoonBoardImportCounts;
+  ascents: MoonBoardImportCounts;
+  attempts: MoonBoardImportCounts;
+  unresolvedClimbs: string[];
+  unresolvedAscentClimbs?: string[];
+  unresolvedAttemptClimbs?: string[];
+  partialError?: string;
+};
+
+export type StrippedMoonBoardExportData = unknown;
+
+export type MoonBoardImportProgressEvent =
+  | { type: 'progress'; step: string; message?: string; current?: number; total?: number }
+  | { type: 'complete'; results: MoonBoardImportResult }
+  | { type: 'error'; error: string };
+
 function endpoint(path: string): string {
   return `${BACKEND_URL.replace(/\/+$/, '')}${path}`;
 }
@@ -425,4 +448,110 @@ export async function streamAuroraImport(
   }
 
   onEvent({ type: 'complete', results: merged });
+}
+
+function parseMoonBoardImportEvent(line: string): MoonBoardImportProgressEvent | null {
+  try {
+    return JSON.parse(line) as MoonBoardImportProgressEvent;
+  } catch {
+    return null;
+  }
+}
+
+async function handleMoonBoardImportEvent(
+  event: MoonBoardImportProgressEvent,
+  onEvent: (event: MoonBoardImportProgressEvent) => void,
+): Promise<
+  { type: 'complete'; result: MoonBoardImportResult } | { type: 'error'; error: string } | { type: 'progress' }
+> {
+  if (event.type === 'complete') {
+    return { type: 'complete', result: event.results };
+  }
+  if (event.type === 'error') {
+    return { type: 'error', error: event.error };
+  }
+  onEvent(event);
+  return { type: 'progress' };
+}
+
+async function readStreamingMoonBoardImportResponse(
+  response: Response,
+  onEvent: (event: MoonBoardImportProgressEvent) => void,
+): Promise<MoonBoardImportResult> {
+  if (!hasReadableBody(response.body)) {
+    return readTextMoonBoardImportResponse(response, onEvent);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let result: MoonBoardImportResult | null = null;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const event = parseMoonBoardImportEvent(line);
+      if (!event) continue;
+      const eventResult = await handleMoonBoardImportEvent(event, onEvent);
+      if (eventResult.type === 'complete') result = eventResult.result;
+      if (eventResult.type === 'error') throw new Error(eventResult.error);
+    }
+  }
+
+  if (buffer.trim()) {
+    const event = parseMoonBoardImportEvent(buffer);
+    if (event) {
+      const eventResult = await handleMoonBoardImportEvent(event, onEvent);
+      if (eventResult.type === 'complete') result = eventResult.result;
+      if (eventResult.type === 'error') throw new Error(eventResult.error);
+    }
+  }
+
+  if (!result) throw new Error('moonboard_import_interrupted');
+  return result;
+}
+
+async function readTextMoonBoardImportResponse(
+  response: Response,
+  onEvent: (event: MoonBoardImportProgressEvent) => void,
+): Promise<MoonBoardImportResult> {
+  const text = await response.text();
+  let result: MoonBoardImportResult | null = null;
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    const event = parseMoonBoardImportEvent(line);
+    if (!event) continue;
+    const eventResult = await handleMoonBoardImportEvent(event, onEvent);
+    if (eventResult.type === 'complete') result = eventResult.result;
+    if (eventResult.type === 'error') throw new Error(eventResult.error);
+  }
+
+  if (!result) throw new Error('moonboard_import_interrupted');
+  return result;
+}
+
+export async function streamMoonBoardImport(
+  data: StrippedMoonBoardExportData,
+  onEvent: (event: MoonBoardImportProgressEvent) => void,
+): Promise<void> {
+  const response = await authenticatedFetch(endpoint('/api/moonboard-import'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data }),
+  });
+
+  if (!response.ok) {
+    throw new Error('moonboard_import_failed');
+  }
+
+  const result = await readStreamingMoonBoardImportResponse(response, onEvent);
+  onEvent({ type: 'complete', results: result });
 }

--- a/packages/shared-schema/package.json
+++ b/packages/shared-schema/package.json
@@ -26,6 +26,11 @@
       "import": "./src/schema.ts",
       "default": "./src/schema.ts"
     },
+    "./moonboard-import": {
+      "types": "./src/moonboard-import.ts",
+      "import": "./src/moonboard-import.ts",
+      "default": "./src/moonboard-import.ts"
+    },
     "./generated": {
       "types": "./src/generated/types.ts",
       "import": "./src/generated/types.ts",

--- a/packages/shared-schema/src/__tests__/moonboard-import.test.ts
+++ b/packages/shared-schema/src/__tests__/moonboard-import.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { classifyMoonBoardLogRow, parseMoonBoardExportCsv } from '../moonboard-import';
+
+const SAMPLE_CSV = `FirstName,Cathal,,,,
+LastName,Tone,,,,
+SetterName,cathaltone,,,,
+UserName,cathaltone,,,,
+City,Galway,,,,
+Country,Ireland,,,,
+,,,,,
+ProblemId,Grade,Tries,Attempts,Rating,Date
+309386,6A+,Flashed,0,4,25/07/20
+309231,6A+,2nd try,0,4,25/07/20
+580006,7A,Session Flash,0,5,13/02/26
+580007,7A,Project,6,0,13/02/26
+580008,7A,Fail,1,,13/02/26
+`;
+
+describe('parseMoonBoardExportCsv', () => {
+  it('parses metadata, log rows, and preview counts from a MoonBoard export', () => {
+    const result = parseMoonBoardExportCsv(SAMPLE_CSV);
+
+    expect(result.data.user).toEqual({
+      firstName: 'Cathal',
+      lastName: 'Tone',
+      setterName: 'cathaltone',
+      username: 'cathaltone',
+      city: 'Galway',
+      country: 'Ireland',
+    });
+    expect(result.data.logs).toHaveLength(5);
+    expect(result.data.logs[0]).toMatchObject({
+      lineNumber: 9,
+      problemId: 309386,
+      grade: '6A+',
+      tries: 'Flashed',
+      attempts: 0,
+      rating: 4,
+      date: '25/07/20',
+    });
+    expect(result.preview).toEqual({
+      username: 'cathaltone',
+      rows: 5,
+      sends: 3,
+      flashes: 1,
+      attempts: 2,
+      projects: 1,
+      fails: 1,
+      angle: 40,
+    });
+  });
+
+  it('classifies Session Flash as a send and projects as failed attempts', () => {
+    const { logs } = parseMoonBoardExportCsv(SAMPLE_CSV).data;
+
+    expect(classifyMoonBoardLogRow(logs[0])).toEqual({ status: 'flash', attemptCount: 1 });
+    expect(classifyMoonBoardLogRow(logs[1])).toEqual({ status: 'send', attemptCount: 2 });
+    expect(classifyMoonBoardLogRow(logs[2])).toEqual({ status: 'send', attemptCount: 1 });
+    expect(classifyMoonBoardLogRow(logs[3])).toEqual({ status: 'attempt', attemptCount: 6 });
+    expect(classifyMoonBoardLogRow(logs[4])).toEqual({ status: 'attempt', attemptCount: 1 });
+  });
+
+  it('rejects files without the MoonBoard log header', () => {
+    expect(() => parseMoonBoardExportCsv('Problem,Grade\n1,6A')).toThrow('missing_moonboard_log_header');
+  });
+});

--- a/packages/shared-schema/src/index.ts
+++ b/packages/shared-schema/src/index.ts
@@ -9,4 +9,5 @@ export * from './beta-video-url';
 export * from './caption-climb-match';
 export * from './image-sizes';
 export * from './aurora-import';
+export * from './moonboard-import';
 export * from './instagram-caption-parse';

--- a/packages/shared-schema/src/moonboard-import.ts
+++ b/packages/shared-schema/src/moonboard-import.ts
@@ -1,0 +1,265 @@
+export type MoonBoardExportUser = {
+  firstName?: string;
+  lastName?: string;
+  setterName?: string;
+  username?: string;
+  city?: string;
+  country?: string;
+};
+
+export type MoonBoardExportLogRow = {
+  lineNumber: number;
+  problemId: number;
+  grade: string;
+  tries: string;
+  attempts: number;
+  rating: number | null;
+  date: string;
+};
+
+export type StrippedMoonBoardExportData = {
+  user: MoonBoardExportUser;
+  logs: MoonBoardExportLogRow[];
+};
+
+export type MoonBoardExportPreview = {
+  username: string;
+  rows: number;
+  sends: number;
+  flashes: number;
+  attempts: number;
+  projects: number;
+  fails: number;
+  angle: 40;
+};
+
+export type ParsedMoonBoardExportResult = {
+  data: StrippedMoonBoardExportData;
+  preview: MoonBoardExportPreview;
+};
+
+export type MoonBoardLogRowClassification =
+  | { status: 'flash'; attemptCount: 1 }
+  | { status: 'send'; attemptCount: number }
+  | { status: 'attempt'; attemptCount: number };
+
+export type MoonBoardImportCounts = {
+  imported: number;
+  skipped: number;
+  failed: number;
+};
+
+export type MoonBoardImportResult = {
+  ticks: MoonBoardImportCounts;
+  ascents: MoonBoardImportCounts;
+  attempts: MoonBoardImportCounts;
+  unresolvedClimbs: string[];
+  unresolvedAscentClimbs: string[];
+  unresolvedAttemptClimbs: string[];
+  partialError?: string;
+};
+
+export type MoonBoardImportProgressEvent =
+  | { type: 'progress'; step: 'resolving'; current: number; total: number }
+  | { type: 'progress'; step: 'importing'; current: number; total: number }
+  | { type: 'progress'; step: 'recomputing'; message: string }
+  | { type: 'complete'; results: MoonBoardImportResult }
+  | { type: 'error'; error: string };
+
+const HEADER_NAMES = ['problemid', 'grade', 'tries', 'attempts', 'rating', 'date'] as const;
+
+const USER_METADATA_KEYS: Record<string, keyof MoonBoardExportUser> = {
+  firstname: 'firstName',
+  lastname: 'lastName',
+  settername: 'setterName',
+  username: 'username',
+  city: 'city',
+  country: 'country',
+};
+
+function normalizeHeaderCell(cell: string): string {
+  return cell.trim().replace(/\s+/g, '').toLowerCase();
+}
+
+function normalizeMetadataKey(cell: string): string {
+  return cell.trim().replace(/\s+/g, '').toLowerCase();
+}
+
+function parseCsvRows(csv: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = '';
+  let inQuotes = false;
+
+  for (let index = 0; index < csv.length; index += 1) {
+    const char = csv[index];
+    const nextChar = csv[index + 1];
+
+    if (char === '"') {
+      if (inQuotes && nextChar === '"') {
+        cell += '"';
+        index += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      row.push(cell);
+      cell = '';
+      continue;
+    }
+
+    if ((char === '\n' || char === '\r') && !inQuotes) {
+      if (char === '\r' && nextChar === '\n') index += 1;
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = '';
+      continue;
+    }
+
+    cell += char;
+  }
+
+  row.push(cell);
+  if (row.some((value) => value.trim() !== '') || rows.length === 0) rows.push(row);
+  return rows;
+}
+
+function isMoonBoardHeader(row: string[]): boolean {
+  return HEADER_NAMES.every((name, index) => normalizeHeaderCell(row[index] ?? '') === name);
+}
+
+function parseRequiredInteger(value: string, field: string, lineNumber: number): number {
+  const trimmedValue = value.trim();
+  if (!/^\d+$/.test(trimmedValue)) {
+    throw new Error(`invalid_${field}_line_${lineNumber}`);
+  }
+  return Number(trimmedValue);
+}
+
+function parseOptionalRating(value: string, lineNumber: number): number | null {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) return null;
+  const rating = parseRequiredInteger(trimmedValue, 'rating', lineNumber);
+  if (rating === 0) return null;
+  if (rating < 1 || rating > 5) {
+    throw new Error(`invalid_rating_line_${lineNumber}`);
+  }
+  return rating;
+}
+
+function normalizeTriesLabel(tries: string): string {
+  return tries.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function classifyMoonBoardLogRow(row: MoonBoardExportLogRow): MoonBoardLogRowClassification {
+  const label = normalizeTriesLabel(row.tries);
+  if (label === 'flashed') {
+    return { status: 'flash', attemptCount: 1 };
+  }
+  if (label === 'session flash') {
+    return { status: 'send', attemptCount: 1 };
+  }
+
+  const tryMatch = label.match(/^(\d+)(?:st|nd|rd|th)? try$/);
+  if (tryMatch) {
+    const attemptCount = Number(tryMatch[1]);
+    return attemptCount <= 1 ? { status: 'flash', attemptCount: 1 } : { status: 'send', attemptCount };
+  }
+
+  if (label === 'more than 3 tries') {
+    return { status: 'send', attemptCount: Math.max(row.attempts, 4) };
+  }
+
+  if (label === 'project' || label === 'fail') {
+    return { status: 'attempt', attemptCount: Math.max(row.attempts, 1) };
+  }
+
+  throw new Error(`unsupported_tries_line_${row.lineNumber}`);
+}
+
+function buildPreview(data: StrippedMoonBoardExportData): MoonBoardExportPreview {
+  let sends = 0;
+  let flashes = 0;
+  let attempts = 0;
+  let projects = 0;
+  let fails = 0;
+
+  for (const row of data.logs) {
+    const classification = classifyMoonBoardLogRow(row);
+    const triesLabel = normalizeTriesLabel(row.tries);
+    if (classification.status === 'attempt') {
+      attempts += 1;
+      if (triesLabel === 'project') projects += 1;
+      if (triesLabel === 'fail') fails += 1;
+    } else {
+      sends += 1;
+      if (classification.status === 'flash') flashes += 1;
+    }
+  }
+
+  return {
+    username: data.user.username ?? data.user.setterName ?? '',
+    rows: data.logs.length,
+    sends,
+    flashes,
+    attempts,
+    projects,
+    fails,
+    angle: 40,
+  };
+}
+
+export function parseMoonBoardExportCsv(csv: string): ParsedMoonBoardExportResult {
+  const rows = parseCsvRows(csv.replace(/^\uFEFF/, ''));
+  const headerIndex = rows.findIndex(isMoonBoardHeader);
+  if (headerIndex === -1) {
+    throw new Error('missing_moonboard_log_header');
+  }
+
+  const user: MoonBoardExportUser = {};
+  for (const row of rows.slice(0, headerIndex)) {
+    const mappedKey = USER_METADATA_KEYS[normalizeMetadataKey(row[0] ?? '')];
+    const value = (row[1] ?? '').trim();
+    if (mappedKey && value && value.toLowerCase() !== 'null' && value !== '-') {
+      user[mappedKey] = value;
+    }
+  }
+
+  const logs: MoonBoardExportLogRow[] = [];
+  for (let rowIndex = headerIndex + 1; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex];
+    if (row.every((value) => value.trim() === '')) continue;
+
+    const lineNumber = rowIndex + 1;
+    const problemId = parseRequiredInteger(row[0] ?? '', 'problem_id', lineNumber);
+    const grade = (row[1] ?? '').trim().toUpperCase();
+    const tries = (row[2] ?? '').trim();
+    const attempts = parseRequiredInteger(row[3] ?? '', 'attempts', lineNumber);
+    const rating = parseOptionalRating(row[4] ?? '', lineNumber);
+    const date = (row[5] ?? '').trim();
+
+    if (!grade) throw new Error(`missing_grade_line_${lineNumber}`);
+    if (!tries) throw new Error(`missing_tries_line_${lineNumber}`);
+    if (!date) throw new Error(`missing_date_line_${lineNumber}`);
+
+    logs.push({
+      lineNumber,
+      problemId,
+      grade,
+      tries,
+      attempts,
+      rating,
+      date,
+    });
+  }
+
+  const data: StrippedMoonBoardExportData = { user, logs };
+  return {
+    data,
+    preview: buildPreview(data),
+  };
+}

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -325,6 +325,7 @@
         "previewIntroWithUser": "Import MoonBoard data for {{username}} into Boardsesh:",
         "rows": "{{count}} CSV rows",
         "sends": "{{count}} sends",
+        "flashes": "{{count}} flashes",
         "attempts": "{{count}} attempts",
         "projects": "{{count}} projects",
         "fails": "{{count}} fails",

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -285,7 +285,7 @@
     },
     "moonboard": {
       "title": "MoonBoard",
-      "copy": "Logged climbs in the MoonBoard app? Email MoonBoard to request your data, then send it over so we can pull it into Boardsesh.",
+      "copy": "Got a MoonBoard CSV export? Import it here. Need the file first? Email MoonBoard to request your data.",
       "import": "Import data",
       "requestData": "Request your data",
       "requestDataDialog": {
@@ -298,11 +298,47 @@
         "subject": "Subject access request – MoonBoard account data",
         "body": "Name: [full name]\nMoonBoard username: [username]\nAccount email: [email address]\n\nMy MoonBoard logbook is personal data because it records my climbing activity and sporting achievements and is linked to my identifiable account. Please treat this as a UK GDPR subject access request and, where applicable, a data portability request. ICO guidance on personal data, subject access requests, data portability, and response time limits is linked below for reference:\nhttps://ico.org.uk/for-the-public/time-limits-for-responding-to-data-protection-rights-requests/\n\nPlease include all personal data linked to my MoonBoard account, including where available:\n\naccount/profile details;\nusername and account identifiers;\nproblems I have created or logged;\nsends, ascents, benchmarks, grades, repeats, attempts, dates, and session/history data;\nfavourites, saved problems, custom problems, and user-generated content linked to my account;\nboard/setup preferences and app/service usage data linked to my account;\nany related metadata or identifiers associated with my MoonBoard profile.\n\nUK GDPR requires personal data to be processed securely, including protection against accidental loss, destruction, or damage, using appropriate technical and organisational measures. ICO guidance also states that organisations should keep personal data accessible and usable, and should be able to recover it if it is accidentally lost, altered, or destroyed. If any of my logbook data is missing, unavailable, corrupted, or has been deleted other than under a lawful retention policy, please confirm what happened, what recovery steps Moon is taking, and whether Moon has assessed this as a personal data breach under UK GDPR.\n\nThe ICO’s guidance says organisations should respond to subject access requests without undue delay and within one month. If you require identity verification, clarification, or a secure delivery method, please let me know promptly.\n\nWhere technically feasible, I would prefer the export in CSV or JSON format. Alternatively, please provide the data in another structured, commonly used, machine-readable format.\n\nPlease confirm receipt of this request and the date by which you expect to respond.\n\nKind regards,\n[name]"
       },
+      "csvImport": {
+        "fileLabel": "MoonBoard CSV export",
+        "parseError": "Couldn't read that MoonBoard CSV. Check that it starts with ProblemId,Grade,Tries,Attempts,Rating,Date.",
+        "parserUnavailable": "MoonBoard CSV import isn't available in this build yet.",
+        "failed": "MoonBoard import failed. Try again.",
+        "successCount": "{{count}} MoonBoard logbook items imported",
+        "partialWarning": "MoonBoard import partially finished. Re-importing the file is safe.",
+        "interrupted": "MoonBoard import stopped before it finished. Re-importing the file is safe.",
+        "interruptedShort": "MoonBoard import stopped before it finished.",
+        "steps": {
+          "resolving": "Matching MoonBoard problems",
+          "dedup": "Checking for duplicates",
+          "ascents": "Importing sends",
+          "attempts": "Importing attempts",
+          "recomputing": "Updating MoonBoard stats",
+          "importing": "Importing MoonBoard data"
+        }
+      },
       "importDialog": {
-        "title": "MoonBoard import is on the way",
-        "body": "We're still building the MoonBoard importer. Export your data from the MoonBoard app and send it to Marco on Discord — he'll use it to build the import.",
-        "discordCta": "Open Discord",
-        "openFailed": "Couldn't open Discord. Try again."
+        "previewTitle": "Import MoonBoard CSV",
+        "importingTitle": "Importing MoonBoard data...",
+        "completeTitle": "MoonBoard import complete",
+        "errorTitle": "MoonBoard import failed",
+        "previewIntro": "Import this MoonBoard export into Boardsesh:",
+        "previewIntroWithUser": "Import MoonBoard data for {{username}} into Boardsesh:",
+        "rows": "{{count}} CSV rows",
+        "sends": "{{count}} sends",
+        "attempts": "{{count}} attempts",
+        "projects": "{{count}} projects",
+        "fails": "{{count}} fails",
+        "angleNote": "Imports are saved at {{angle}}°.",
+        "previewNote": "Project and fail rows become attempts. Session Flash rows become sends with one attempt."
+      },
+      "importResults": {
+        "ascents": "Sends",
+        "ascentsSummary": "{{imported}} imported, {{skipped}} skipped (already exist), {{failed}} unmatched",
+        "attempts": "Attempts",
+        "attemptsSummary": "{{imported}} imported, {{skipped}} skipped (already exist), {{failed}} unmatched",
+        "unresolvedTitle": "{{count}} MoonBoard problems couldn't be matched",
+        "partialTitle": "Import was interrupted",
+        "partialBody": "Some MoonBoard data may not have been imported. Re-importing the same file is safe and will fill in the gaps."
       }
     },
     "mobile": {

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -309,7 +309,7 @@
     },
     "moonboard": {
       "title": "MoonBoard",
-      "copy": "¿Registraste bloques en la app de MoonBoard? Escribe a MoonBoard para pedir tus datos y luego envíanoslos para incorporarlos a Boardsesh.",
+      "copy": "¿Tienes una exportación CSV de MoonBoard? Impórtala aquí. ¿Necesitas el archivo primero? Escribe a MoonBoard para pedir tus datos.",
       "import": "Importar datos",
       "requestData": "Pedir tus datos",
       "requestDataDialog": {
@@ -322,11 +322,47 @@
         "subject": "Subject access request – MoonBoard account data",
         "body": "Name: [full name]\nMoonBoard username: [username]\nAccount email: [email address]\n\nMy MoonBoard logbook is personal data because it records my climbing activity and sporting achievements and is linked to my identifiable account. Please treat this as a UK GDPR subject access request and, where applicable, a data portability request. ICO guidance on personal data, subject access requests, data portability, and response time limits is linked below for reference:\nhttps://ico.org.uk/for-the-public/time-limits-for-responding-to-data-protection-rights-requests/\n\nPlease include all personal data linked to my MoonBoard account, including where available:\n\naccount/profile details;\nusername and account identifiers;\nproblems I have created or logged;\nsends, ascents, benchmarks, grades, repeats, attempts, dates, and session/history data;\nfavourites, saved problems, custom problems, and user-generated content linked to my account;\nboard/setup preferences and app/service usage data linked to my account;\nany related metadata or identifiers associated with my MoonBoard profile.\n\nUK GDPR requires personal data to be processed securely, including protection against accidental loss, destruction, or damage, using appropriate technical and organisational measures. ICO guidance also states that organisations should keep personal data accessible and usable, and should be able to recover it if it is accidentally lost, altered, or destroyed. If any of my logbook data is missing, unavailable, corrupted, or has been deleted other than under a lawful retention policy, please confirm what happened, what recovery steps Moon is taking, and whether Moon has assessed this as a personal data breach under UK GDPR.\n\nThe ICO’s guidance says organisations should respond to subject access requests without undue delay and within one month. If you require identity verification, clarification, or a secure delivery method, please let me know promptly.\n\nWhere technically feasible, I would prefer the export in CSV or JSON format. Alternatively, please provide the data in another structured, commonly used, machine-readable format.\n\nPlease confirm receipt of this request and the date by which you expect to respond.\n\nKind regards,\n[name]"
       },
+      "csvImport": {
+        "fileLabel": "Exportación CSV de MoonBoard",
+        "parseError": "No se pudo leer ese CSV de MoonBoard. Comprueba que empiece con ProblemId,Grade,Tries,Attempts,Rating,Date.",
+        "parserUnavailable": "La importación CSV de MoonBoard aún no está disponible en esta versión.",
+        "failed": "La importación de MoonBoard falló. Inténtalo de nuevo.",
+        "successCount": "{{count}} elementos del logbook de MoonBoard importados",
+        "partialWarning": "La importación de MoonBoard terminó parcialmente. Puedes volver a importar el archivo.",
+        "interrupted": "La importación de MoonBoard se detuvo antes de terminar. Puedes volver a importar el archivo.",
+        "interruptedShort": "La importación de MoonBoard se detuvo antes de terminar.",
+        "steps": {
+          "resolving": "Emparejando problemas de MoonBoard",
+          "dedup": "Comprobando duplicados",
+          "ascents": "Importando encadenes",
+          "attempts": "Importando intentos",
+          "recomputing": "Actualizando estadísticas de MoonBoard",
+          "importing": "Importando datos de MoonBoard"
+        }
+      },
       "importDialog": {
-        "title": "La importación de MoonBoard está en camino",
-        "body": "Todavía estamos creando el importador de MoonBoard. Exporta tus datos desde la app de MoonBoard y envíaselos a Marco por Discord — los usará para crear la importación.",
-        "discordCta": "Abrir Discord",
-        "openFailed": "No se pudo abrir Discord. Inténtalo de nuevo."
+        "previewTitle": "Importar CSV de MoonBoard",
+        "importingTitle": "Importando datos de MoonBoard...",
+        "completeTitle": "Importación de MoonBoard completada",
+        "errorTitle": "La importación de MoonBoard falló",
+        "previewIntro": "Importar esta exportación de MoonBoard en Boardsesh:",
+        "previewIntroWithUser": "Importar datos de MoonBoard de {{username}} en Boardsesh:",
+        "rows": "{{count}} filas CSV",
+        "sends": "{{count}} encadenes",
+        "attempts": "{{count}} intentos",
+        "projects": "{{count}} proyectos",
+        "fails": "{{count}} fallos",
+        "angleNote": "Las importaciones se guardan a {{angle}}°.",
+        "previewNote": "Las filas Project y Fail se guardan como intentos. Las filas Session Flash se guardan como encadenes con un intento."
+      },
+      "importResults": {
+        "ascents": "Encadenes",
+        "ascentsSummary": "{{imported}} importados, {{skipped}} omitidos (ya existían), {{failed}} sin emparejar",
+        "attempts": "Intentos",
+        "attemptsSummary": "{{imported}} importados, {{skipped}} omitidos (ya existían), {{failed}} sin emparejar",
+        "unresolvedTitle": "{{count}} problemas de MoonBoard no se pudieron emparejar",
+        "partialTitle": "La importación se interrumpió",
+        "partialBody": "Es posible que algunos datos de MoonBoard no se hayan importado. Volver a importar el mismo archivo es seguro y completará lo que falte."
       }
     }
   },

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -349,6 +349,7 @@
         "previewIntroWithUser": "Importar datos de MoonBoard de {{username}} en Boardsesh:",
         "rows": "{{count}} filas CSV",
         "sends": "{{count}} encadenes",
+        "flashes": "{{count}} flashes",
         "attempts": "{{count}} intentos",
         "projects": "{{count}} proyectos",
         "fails": "{{count}} fallos",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -349,6 +349,7 @@
         "previewIntroWithUser": "Importer les données MoonBoard de {{username}} dans Boardsesh :",
         "rows": "{{count}} lignes CSV",
         "sends": "{{count}} croix",
+        "flashes": "{{count}} flashes",
         "attempts": "{{count}} essais",
         "projects": "{{count}} projets",
         "fails": "{{count}} échecs",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -309,7 +309,7 @@
     },
     "moonboard": {
       "title": "MoonBoard",
-      "copy": "Vous avez enregistré des blocs dans l'app MoonBoard ? Écrivez à MoonBoard pour demander vos données, puis envoyez-les-nous pour les intégrer à Boardsesh.",
+      "copy": "Vous avez une exportation CSV MoonBoard ? Importez-la ici. Besoin du fichier d'abord ? Écrivez à MoonBoard pour demander vos données.",
       "import": "Importer les données",
       "requestData": "Demander vos données",
       "requestDataDialog": {
@@ -322,11 +322,47 @@
         "subject": "Subject access request – MoonBoard account data",
         "body": "Name: [full name]\nMoonBoard username: [username]\nAccount email: [email address]\n\nMy MoonBoard logbook is personal data because it records my climbing activity and sporting achievements and is linked to my identifiable account. Please treat this as a UK GDPR subject access request and, where applicable, a data portability request. ICO guidance on personal data, subject access requests, data portability, and response time limits is linked below for reference:\nhttps://ico.org.uk/for-the-public/time-limits-for-responding-to-data-protection-rights-requests/\n\nPlease include all personal data linked to my MoonBoard account, including where available:\n\naccount/profile details;\nusername and account identifiers;\nproblems I have created or logged;\nsends, ascents, benchmarks, grades, repeats, attempts, dates, and session/history data;\nfavourites, saved problems, custom problems, and user-generated content linked to my account;\nboard/setup preferences and app/service usage data linked to my account;\nany related metadata or identifiers associated with my MoonBoard profile.\n\nUK GDPR requires personal data to be processed securely, including protection against accidental loss, destruction, or damage, using appropriate technical and organisational measures. ICO guidance also states that organisations should keep personal data accessible and usable, and should be able to recover it if it is accidentally lost, altered, or destroyed. If any of my logbook data is missing, unavailable, corrupted, or has been deleted other than under a lawful retention policy, please confirm what happened, what recovery steps Moon is taking, and whether Moon has assessed this as a personal data breach under UK GDPR.\n\nThe ICO’s guidance says organisations should respond to subject access requests without undue delay and within one month. If you require identity verification, clarification, or a secure delivery method, please let me know promptly.\n\nWhere technically feasible, I would prefer the export in CSV or JSON format. Alternatively, please provide the data in another structured, commonly used, machine-readable format.\n\nPlease confirm receipt of this request and the date by which you expect to respond.\n\nKind regards,\n[name]"
       },
+      "csvImport": {
+        "fileLabel": "Export CSV MoonBoard",
+        "parseError": "Impossible de lire ce CSV MoonBoard. Vérifiez qu'il commence par ProblemId,Grade,Tries,Attempts,Rating,Date.",
+        "parserUnavailable": "L'import CSV MoonBoard n'est pas encore disponible dans cette version.",
+        "failed": "L'import MoonBoard a échoué. Réessayez.",
+        "successCount": "{{count}} éléments du carnet MoonBoard importés",
+        "partialWarning": "L'import MoonBoard s'est terminé partiellement. Réimporter le fichier est sûr.",
+        "interrupted": "L'import MoonBoard s'est arrêté avant la fin. Réimporter le fichier est sûr.",
+        "interruptedShort": "L'import MoonBoard s'est arrêté avant la fin.",
+        "steps": {
+          "resolving": "Association des problèmes MoonBoard",
+          "dedup": "Recherche de doublons",
+          "ascents": "Import des croix",
+          "attempts": "Import des essais",
+          "recomputing": "Mise à jour des stats MoonBoard",
+          "importing": "Import des données MoonBoard"
+        }
+      },
       "importDialog": {
-        "title": "L'import MoonBoard arrive bientôt",
-        "body": "Nous construisons encore l'importateur MoonBoard. Exportez vos données depuis l'app MoonBoard et envoyez-les à Marco sur Discord — il s'en servira pour créer l'import.",
-        "discordCta": "Ouvrir Discord",
-        "openFailed": "Impossible d'ouvrir Discord. Réessayez."
+        "previewTitle": "Importer un CSV MoonBoard",
+        "importingTitle": "Import des données MoonBoard...",
+        "completeTitle": "Import MoonBoard terminé",
+        "errorTitle": "Échec de l'import MoonBoard",
+        "previewIntro": "Importer cette exportation MoonBoard dans Boardsesh :",
+        "previewIntroWithUser": "Importer les données MoonBoard de {{username}} dans Boardsesh :",
+        "rows": "{{count}} lignes CSV",
+        "sends": "{{count}} croix",
+        "attempts": "{{count}} essais",
+        "projects": "{{count}} projets",
+        "fails": "{{count}} échecs",
+        "angleNote": "Les imports sont enregistrés à {{angle}}°.",
+        "previewNote": "Les lignes Project et Fail deviennent des essais. Les lignes Session Flash deviennent des croix avec un essai."
+      },
+      "importResults": {
+        "ascents": "Croix",
+        "ascentsSummary": "{{imported}} importées, {{skipped}} ignorées (déjà existantes), {{failed}} non associées",
+        "attempts": "Essais",
+        "attemptsSummary": "{{imported}} importés, {{skipped}} ignorés (déjà existants), {{failed}} non associés",
+        "unresolvedTitle": "{{count}} problèmes MoonBoard n'ont pas pu être associés",
+        "partialTitle": "Importation interrompue",
+        "partialBody": "Certaines données MoonBoard n'ont peut-être pas été importées. Réimporter le même fichier est sûr et complétera ce qui manque."
       }
     }
   },

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -58,6 +58,14 @@ import {
   type AuroraExportPreview,
   type StrippedExportData,
 } from '@/app/lib/data-sync/aurora/parse-aurora-export';
+import {
+  parseMoonBoardExportCsvForImport,
+  streamMoonBoardImport,
+  type MoonBoardExportPreview,
+  type MoonBoardImportProgress as MoonBoardProgress,
+  type MoonBoardImportResult,
+  type StrippedMoonBoardExportData,
+} from '@/app/lib/data-sync/moonboard/csv-import-stream';
 import { AURORA_BOARDS, type AuroraBoardName } from '@boardsesh/shared-schema';
 import styles from './aurora-credentials-section.module.css';
 
@@ -110,6 +118,47 @@ function buildKilterDataRequestMailto(
   const body = t('aurora.kilterEmail.body', { name, email });
 
   return `mailto:peter@auroraclimbing.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}
+
+const MOONBOARD_SUPPORT_EMAIL = 'moonboardsupport@moonclimbing.com';
+
+function buildMoonBoardDataRequestMailto(t: TFunction<'settings'>): string {
+  const subject = t('aurora.moonboard.email.subject');
+  return `mailto:${MOONBOARD_SUPPORT_EMAIL}?subject=${encodeURIComponent(subject)}`;
+}
+
+function totalMoonBoardImported(result: MoonBoardImportResult): number {
+  return result.ascents.imported + result.attempts.imported;
+}
+
+function moonBoardUnresolvedClimbs(result: MoonBoardImportResult): string[] {
+  return [
+    ...new Set([
+      ...result.unresolvedClimbs,
+      ...(result.unresolvedAscentClimbs ?? []),
+      ...(result.unresolvedAttemptClimbs ?? []),
+    ]),
+  ].sort();
+}
+
+function getMoonBoardProgressLabel(t: TFunction<'settings'>, progress: MoonBoardProgress | null): string {
+  if (!progress) return t('aurora.moonboard.csvImport.steps.resolving');
+  switch (progress.step) {
+    case 'ascents':
+      return t('aurora.moonboard.csvImport.steps.ascents');
+    case 'attempts':
+      return t('aurora.moonboard.csvImport.steps.attempts');
+    case 'dedup':
+      return t('aurora.moonboard.csvImport.steps.dedup');
+    case 'resolving':
+      return t('aurora.moonboard.csvImport.steps.resolving');
+    case 'importing':
+      return t('aurora.moonboard.csvImport.steps.importing');
+    case 'recomputing':
+      return t('aurora.moonboard.csvImport.steps.recomputing');
+    default:
+      return t('aurora.moonboard.csvImport.steps.importing');
+  }
 }
 
 // Localise a link failure. The duplicate-account rejection carries a stable
@@ -346,6 +395,50 @@ export function BoardCredentialCard({
   );
 }
 
+type MoonBoardCredentialCardProps = {
+  onImportCsv: () => void;
+  onRequestData: () => void;
+  requestDataHref: string;
+  isImporting: boolean;
+};
+
+function MoonBoardCredentialCard({
+  onImportCsv,
+  onRequestData,
+  requestDataHref,
+  isImporting,
+}: MoonBoardCredentialCardProps) {
+  const { t } = useTranslation('settings');
+
+  return (
+    <Card className={styles.credentialCard}>
+      <CardContent>
+        <div className={styles.cardHeader}>
+          <Typography variant="h5" sx={{ margin: 0 }}>
+            {t('aurora.moonboard.title')}
+          </Typography>
+        </div>
+        <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
+          {t('aurora.moonboard.copy')}
+        </Typography>
+        <div className={styles.buttonRowStacked}>
+          <Button
+            variant="contained"
+            startIcon={isImporting ? <CircularProgress size={16} /> : <FileUploadOutlined />}
+            onClick={onImportCsv}
+            disabled={isImporting}
+          >
+            {t('aurora.moonboard.import')}
+          </Button>
+          <Button variant="outlined" startIcon={<EmailOutlined />} href={requestDataHref} onClick={onRequestData}>
+            {t('aurora.moonboard.requestData')}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 export function ImportProgressSteps({ progress }: { progress: ImportProgress | null }) {
   const { t } = useTranslation('settings');
   const stepLabels = getStepLabels(t);
@@ -416,6 +509,14 @@ export default function AuroraCredentialsSection() {
   const [importError, setImportError] = useState<string | null>(null);
   const receivedCompleteRef = useRef(false);
   const handledKilterCompletionRef = useRef<string | null>(null);
+  const moonBoardFileInputRef = useRef<HTMLInputElement>(null);
+  const [moonBoardImportPreview, setMoonBoardImportPreview] = useState<MoonBoardExportPreview | null>(null);
+  const [moonBoardImportData, setMoonBoardImportData] = useState<StrippedMoonBoardExportData | null>(null);
+  const [moonBoardImportPhase, setMoonBoardImportPhase] = useState<ImportPhase | null>(null);
+  const [moonBoardImportProgress, setMoonBoardImportProgress] = useState<MoonBoardProgress | null>(null);
+  const [moonBoardImportResult, setMoonBoardImportResult] = useState<MoonBoardImportResult | null>(null);
+  const [moonBoardImportError, setMoonBoardImportError] = useState<string | null>(null);
+  const receivedMoonBoardCompleteRef = useRef(false);
 
   const fetchCredentials = async () => {
     setCredentialsLoadError(false);
@@ -731,6 +832,138 @@ export default function AuroraCredentialsSection() {
     resetImportState();
   };
 
+  const resetMoonBoardImportState = () => {
+    setMoonBoardImportPhase(null);
+    setMoonBoardImportProgress(null);
+    setMoonBoardImportPreview(null);
+    setMoonBoardImportData(null);
+    setMoonBoardImportResult(null);
+    setMoonBoardImportError(null);
+  };
+
+  const handleMoonBoardImportClick = () => {
+    moonBoardFileInputRef.current?.click();
+  };
+
+  const handleMoonBoardRequestDataClick = () => {
+    if (!navigator.clipboard) return;
+
+    void navigator.clipboard.writeText(t('aurora.moonboard.email.body')).then(
+      () => showMessage(t('aurora.moonboard.requestDataDialog.title'), 'success'),
+      () => showMessage(t('aurora.mobile.requestDataCopyFailed'), 'error'),
+    );
+  };
+
+  const handleMoonBoardFileSelected = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const maxSizeBytes = 200 * 1024 * 1024;
+    if (file.size > maxSizeBytes) {
+      showMessage(t('aurora.import.tooLarge'), 'error');
+      event.target.value = '';
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      void (async () => {
+        try {
+          const csv = typeof reader.result === 'string' ? reader.result : '';
+          const parsed = await parseMoonBoardExportCsvForImport(csv);
+          setMoonBoardImportData(parsed.data);
+          setMoonBoardImportPreview(parsed.preview);
+          setMoonBoardImportPhase('preview');
+        } catch (error) {
+          const message =
+            error instanceof Error && error.message === 'moonboard_parser_unavailable'
+              ? t('aurora.moonboard.csvImport.parserUnavailable')
+              : t('aurora.moonboard.csvImport.parseError');
+          showMessage(message, 'error');
+          resetMoonBoardImportState();
+        }
+      })();
+    };
+    reader.onerror = () => {
+      showMessage(t('aurora.import.readError'), 'error');
+      resetMoonBoardImportState();
+    };
+    reader.readAsText(file);
+
+    event.target.value = '';
+  };
+
+  const handleMoonBoardImportConfirm = async () => {
+    if (!moonBoardImportData) return;
+
+    setMoonBoardImportPhase('importing');
+    setMoonBoardImportProgress(null);
+    setMoonBoardImportPreview(null);
+    setMoonBoardImportResult(null);
+    setMoonBoardImportError(null);
+    receivedMoonBoardCompleteRef.current = false;
+
+    try {
+      const transport = resolveAuroraBackendTransport(authToken);
+      if (!transport) throw new Error(t('aurora.moonboard.csvImport.failed'));
+
+      await streamMoonBoardImport(
+        moonBoardImportData,
+        (event) => {
+          switch (event.type) {
+            case 'progress':
+              setMoonBoardImportProgress({
+                step: event.step,
+                message: 'message' in event ? event.message : undefined,
+                current: 'current' in event ? event.current : undefined,
+                total: 'total' in event ? event.total : undefined,
+              });
+              break;
+            case 'complete':
+              receivedMoonBoardCompleteRef.current = true;
+              setMoonBoardImportResult(event.results);
+              setMoonBoardImportPhase('complete');
+              showMessage(
+                event.results.partialError
+                  ? t('aurora.moonboard.csvImport.partialWarning')
+                  : t('aurora.moonboard.csvImport.successCount', { count: totalMoonBoardImported(event.results) }),
+                event.results.partialError ? 'warning' : 'success',
+              );
+              break;
+            case 'error':
+              receivedMoonBoardCompleteRef.current = true;
+              setMoonBoardImportError(event.error);
+              setMoonBoardImportPhase('error');
+              showMessage(event.error, 'error');
+              break;
+          }
+        },
+        {
+          backendUrl: transport.backendUrl,
+          authToken: transport.authToken,
+        },
+      );
+
+      if (!receivedMoonBoardCompleteRef.current) {
+        setMoonBoardImportError(t('aurora.moonboard.csvImport.interrupted'));
+        setMoonBoardImportPhase('error');
+        showMessage(t('aurora.moonboard.csvImport.interruptedShort'), 'error');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : t('aurora.moonboard.csvImport.failed');
+      setMoonBoardImportError(message);
+      setMoonBoardImportPhase('error');
+      showMessage(message, 'error');
+    } finally {
+      setMoonBoardImportData(null);
+    }
+  };
+
+  const handleMoonBoardImportDialogClose = () => {
+    if (moonBoardImportPhase === 'importing') return;
+    resetMoonBoardImportState();
+  };
+
   const getCredentialForBoard = (boardType: AuroraBoardName) => {
     return credentials.find((credential) => credential.boardType === boardType) || null;
   };
@@ -754,6 +987,12 @@ export default function AuroraCredentialsSection() {
   const isImporting = importPhase === 'importing';
   const isImportDialogOpen =
     importPhase === 'preview' || importPhase === 'importing' || importPhase === 'complete' || importPhase === 'error';
+  const isMoonBoardImporting = moonBoardImportPhase === 'importing';
+  const isMoonBoardImportDialogOpen =
+    moonBoardImportPhase === 'preview' ||
+    moonBoardImportPhase === 'importing' ||
+    moonBoardImportPhase === 'complete' ||
+    moonBoardImportPhase === 'error';
 
   const getImportDialogTitle = () => {
     switch (importPhase) {
@@ -770,7 +1009,24 @@ export default function AuroraCredentialsSection() {
     }
   };
 
+  const getMoonBoardImportDialogTitle = () => {
+    switch (moonBoardImportPhase) {
+      case 'preview':
+        return t('aurora.moonboard.importDialog.previewTitle');
+      case 'importing':
+        return t('aurora.moonboard.importDialog.importingTitle');
+      case 'complete':
+        return t('aurora.moonboard.importDialog.completeTitle');
+      case 'error':
+        return t('aurora.moonboard.importDialog.errorTitle');
+      default:
+        return '';
+    }
+  };
+
   const importingBoardName = importingBoard ? importingBoard.charAt(0).toUpperCase() + importingBoard.slice(1) : '';
+  const moonBoardProgressLabel = getMoonBoardProgressLabel(t, moonBoardImportProgress);
+  const moonBoardUnresolvedNames = moonBoardImportResult ? moonBoardUnresolvedClimbs(moonBoardImportResult) : [];
 
   if (loading) {
     return (
@@ -821,6 +1077,12 @@ export default function AuroraCredentialsSection() {
           </Typography>
 
           <Stack spacing={2} className={styles.cardsContainer}>
+            <MoonBoardCredentialCard
+              onImportCsv={handleMoonBoardImportClick}
+              onRequestData={handleMoonBoardRequestDataClick}
+              requestDataHref={buildMoonBoardDataRequestMailto(t)}
+              isImporting={isMoonBoardImporting}
+            />
             {cardConfigs.map(({ key, boardType, variant }) => {
               // The legacy "Kilter (Aurora)" card never owns the linked-account state —
               // that belongs to the new card.
@@ -853,6 +1115,16 @@ export default function AuroraCredentialsSection() {
         accept=".json"
         onChange={handleFileSelected}
         aria-label={t('aurora.import.fileLabel')}
+        hidden
+      />
+
+      {/* Hidden file input for MoonBoard CSV import */}
+      <input
+        ref={moonBoardFileInputRef}
+        type="file"
+        accept=".csv,text/csv"
+        onChange={handleMoonBoardFileSelected}
+        aria-label={t('aurora.moonboard.csvImport.fileLabel')}
         hidden
       />
 
@@ -1059,6 +1331,161 @@ export default function AuroraCredentialsSection() {
         {(importPhase === 'complete' || importPhase === 'error') && (
           <DialogActions>
             <Button variant="contained" onClick={handleImportDialogClose}>
+              {t('aurora.import.dialog.close')}
+            </Button>
+          </DialogActions>
+        )}
+      </Dialog>
+
+      {/* MoonBoard CSV Import Dialog */}
+      <Dialog
+        open={isMoonBoardImportDialogOpen}
+        onClose={handleMoonBoardImportDialogClose}
+        maxWidth="sm"
+        fullWidth
+        disableEscapeKeyDown={isMoonBoardImporting}
+      >
+        <DialogTitle>{getMoonBoardImportDialogTitle()}</DialogTitle>
+        <DialogContent>
+          {moonBoardImportPhase === 'preview' && moonBoardImportPreview && (
+            <>
+              <Typography variant="body2" color="text.secondary" className={styles.modalDescription}>
+                {moonBoardImportPreview.username
+                  ? t('aurora.moonboard.importDialog.previewIntroWithUser', {
+                      username: moonBoardImportPreview.username,
+                    })
+                  : t('aurora.moonboard.importDialog.previewIntro')}
+              </Typography>
+              <List dense>
+                <ListItem>
+                  <ListItemText
+                    primary={t('aurora.moonboard.importDialog.rows', { count: moonBoardImportPreview.rows })}
+                  />
+                </ListItem>
+                <ListItem>
+                  <ListItemText
+                    primary={t('aurora.moonboard.importDialog.sends', { count: moonBoardImportPreview.sends })}
+                  />
+                </ListItem>
+                <ListItem>
+                  <ListItemText
+                    primary={t('aurora.moonboard.importDialog.attempts', {
+                      count: moonBoardImportPreview.attempts,
+                    })}
+                  />
+                </ListItem>
+                {moonBoardImportPreview.projects > 0 && (
+                  <ListItem>
+                    <ListItemText
+                      primary={t('aurora.moonboard.importDialog.projects', {
+                        count: moonBoardImportPreview.projects,
+                      })}
+                    />
+                  </ListItem>
+                )}
+                {moonBoardImportPreview.fails > 0 && (
+                  <ListItem>
+                    <ListItemText
+                      primary={t('aurora.moonboard.importDialog.fails', { count: moonBoardImportPreview.fails })}
+                    />
+                  </ListItem>
+                )}
+              </List>
+              <MuiAlert severity="info" className={styles.unsyncedAlert}>
+                {t('aurora.moonboard.importDialog.angleNote', { angle: moonBoardImportPreview.angle })}
+              </MuiAlert>
+              <Typography variant="body2" color="text.secondary">
+                {t('aurora.moonboard.importDialog.previewNote')}
+              </Typography>
+            </>
+          )}
+
+          {moonBoardImportPhase === 'importing' && (
+            <Stack spacing={2} alignItems="center" sx={{ py: 2 }}>
+              <CircularProgress />
+              <Typography variant="body2" color="text.secondary">
+                {moonBoardProgressLabel}
+                {moonBoardImportProgress?.current != null && moonBoardImportProgress.total != null
+                  ? ` (${moonBoardImportProgress.current} / ${moonBoardImportProgress.total})`
+                  : ''}
+              </Typography>
+              {moonBoardImportProgress?.current != null && moonBoardImportProgress.total != null ? (
+                <LinearProgress
+                  variant="determinate"
+                  value={(moonBoardImportProgress.current / moonBoardImportProgress.total) * 100}
+                  sx={{ width: '100%' }}
+                />
+              ) : (
+                <LinearProgress variant="indeterminate" sx={{ width: '100%' }} />
+              )}
+            </Stack>
+          )}
+
+          {moonBoardImportPhase === 'complete' && moonBoardImportResult && (
+            <>
+              {moonBoardImportResult.partialError && (
+                <MuiAlert severity="warning" className={styles.unsyncedAlert}>
+                  <AlertTitle>{t('aurora.moonboard.importResults.partialTitle')}</AlertTitle>
+                  {t('aurora.moonboard.importResults.partialBody')}
+                </MuiAlert>
+              )}
+              <List dense>
+                <ListItem>
+                  <ListItemText
+                    primary={t('aurora.moonboard.importResults.ascents')}
+                    secondary={t('aurora.moonboard.importResults.ascentsSummary', moonBoardImportResult.ascents)}
+                  />
+                </ListItem>
+                <ListItem>
+                  <ListItemText
+                    primary={t('aurora.moonboard.importResults.attempts')}
+                    secondary={t('aurora.moonboard.importResults.attemptsSummary', moonBoardImportResult.attempts)}
+                  />
+                </ListItem>
+              </List>
+              {moonBoardUnresolvedNames.length > 0 && (
+                <MuiAlert severity="warning" className={styles.unsyncedAlert}>
+                  <AlertTitle>
+                    {t('aurora.moonboard.importResults.unresolvedTitle', { count: moonBoardUnresolvedNames.length })}
+                  </AlertTitle>
+                  <div className={styles.unresolvedList}>
+                    {moonBoardUnresolvedNames.slice(0, 20).map((name) => (
+                      <Typography key={name} variant="body2">
+                        {name}
+                      </Typography>
+                    ))}
+                    {moonBoardUnresolvedNames.length > 20 && (
+                      <Typography variant="body2" color="text.secondary">
+                        {t('aurora.import.results.unresolvedMore', {
+                          count: moonBoardUnresolvedNames.length - 20,
+                        })}
+                      </Typography>
+                    )}
+                  </div>
+                </MuiAlert>
+              )}
+            </>
+          )}
+
+          {moonBoardImportPhase === 'error' && moonBoardImportError && (
+            <MuiAlert severity="error">
+              <AlertTitle>{t('aurora.moonboard.importDialog.errorTitle')}</AlertTitle>
+              {moonBoardImportError}
+            </MuiAlert>
+          )}
+        </DialogContent>
+
+        {moonBoardImportPhase === 'preview' && (
+          <DialogActions>
+            <Button onClick={handleMoonBoardImportDialogClose}>{t('aurora.import.dialog.cancel')}</Button>
+            <Button variant="contained" onClick={handleMoonBoardImportConfirm}>
+              {t('aurora.import.dialog.confirm')}
+            </Button>
+          </DialogActions>
+        )}
+        {(moonBoardImportPhase === 'complete' || moonBoardImportPhase === 'error') && (
+          <DialogActions>
+            <Button variant="contained" onClick={handleMoonBoardImportDialogClose}>
               {t('aurora.import.dialog.close')}
             </Button>
           </DialogActions>

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -161,6 +161,14 @@ function getMoonBoardProgressLabel(t: TFunction<'settings'>, progress: MoonBoard
   }
 }
 
+function getMoonBoardImportErrorMessage(t: TFunction<'settings'>, error: unknown): string {
+  const errorCode = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  if (errorCode === 'moonboard_import_interrupted') {
+    return t('aurora.moonboard.csvImport.interrupted');
+  }
+  return t('aurora.moonboard.csvImport.failed');
+}
+
 // Localise a link failure. The duplicate-account rejection carries a stable
 // `account_already_linked` code we map to a dedicated string; everything else
 // keeps the existing behaviour (backend message, or the generic fallback).
@@ -905,7 +913,7 @@ export default function AuroraCredentialsSection() {
 
     try {
       const transport = resolveAuroraBackendTransport(authToken);
-      if (!transport) throw new Error(t('aurora.moonboard.csvImport.failed'));
+      if (!transport) throw new Error('moonboard_import_endpoint_unavailable');
 
       await streamMoonBoardImport(
         moonBoardImportData,
@@ -930,12 +938,14 @@ export default function AuroraCredentialsSection() {
                 event.results.partialError ? 'warning' : 'success',
               );
               break;
-            case 'error':
+            case 'error': {
               receivedMoonBoardCompleteRef.current = true;
-              setMoonBoardImportError(event.error);
+              const importErrorMessage = getMoonBoardImportErrorMessage(t, event.error);
+              setMoonBoardImportError(importErrorMessage);
               setMoonBoardImportPhase('error');
-              showMessage(event.error, 'error');
+              showMessage(importErrorMessage, 'error');
               break;
+            }
           }
         },
         {
@@ -950,7 +960,7 @@ export default function AuroraCredentialsSection() {
         showMessage(t('aurora.moonboard.csvImport.interruptedShort'), 'error');
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : t('aurora.moonboard.csvImport.failed');
+      const message = getMoonBoardImportErrorMessage(t, error);
       setMoonBoardImportError(message);
       setMoonBoardImportPhase('error');
       showMessage(message, 'error');
@@ -1365,6 +1375,11 @@ export default function AuroraCredentialsSection() {
                 <ListItem>
                   <ListItemText
                     primary={t('aurora.moonboard.importDialog.sends', { count: moonBoardImportPreview.sends })}
+                  />
+                </ListItem>
+                <ListItem>
+                  <ListItemText
+                    primary={t('aurora.moonboard.importDialog.flashes', { count: moonBoardImportPreview.flashes })}
                   />
                 </ListItem>
                 <ListItem>

--- a/packages/web/app/lib/data-sync/moonboard/csv-import-stream.ts
+++ b/packages/web/app/lib/data-sync/moonboard/csv-import-stream.ts
@@ -110,6 +110,23 @@ function parseMoonBoardImportEvent(line: string): MoonBoardImportProgressEvent |
   }
 }
 
+function normalizeMoonBoardImportErrorCode(message: string): string {
+  switch (message) {
+    case 'moonboard_import_endpoint_unavailable':
+    case 'moonboard_import_failed':
+    case 'moonboard_import_interrupted':
+      return message;
+    case 'Authentication required':
+    case 'Invalid or expired token':
+    case 'Invalid JSON body':
+    case 'Invalid request body':
+    case 'Request body too large':
+      return 'moonboard_import_failed';
+    default:
+      return 'moonboard_import_failed';
+  }
+}
+
 async function handleMoonBoardImportEvent(
   event: MoonBoardImportProgressEvent,
   onEvent: (event: MoonBoardImportProgressEvent) => void,
@@ -153,7 +170,7 @@ async function readStreamingMoonBoardImportResponse(
       if (!event) continue;
       const eventResult = await handleMoonBoardImportEvent(event, onEvent);
       if (eventResult.type === 'complete') result = eventResult.result;
-      if (eventResult.type === 'error') throw new Error(eventResult.error);
+      if (eventResult.type === 'error') throw new Error(normalizeMoonBoardImportErrorCode(eventResult.error));
     }
   }
 
@@ -162,7 +179,7 @@ async function readStreamingMoonBoardImportResponse(
     if (event) {
       const eventResult = await handleMoonBoardImportEvent(event, onEvent);
       if (eventResult.type === 'complete') result = eventResult.result;
-      if (eventResult.type === 'error') throw new Error(eventResult.error);
+      if (eventResult.type === 'error') throw new Error(normalizeMoonBoardImportErrorCode(eventResult.error));
     }
   }
 
@@ -183,17 +200,19 @@ async function readTextMoonBoardImportResponse(
     if (!event) continue;
     const eventResult = await handleMoonBoardImportEvent(event, onEvent);
     if (eventResult.type === 'complete') result = eventResult.result;
-    if (eventResult.type === 'error') throw new Error(eventResult.error);
+    if (eventResult.type === 'error') throw new Error(normalizeMoonBoardImportErrorCode(eventResult.error));
   }
 
   if (!result) throw new Error('moonboard_import_interrupted');
   return result;
 }
 
-async function readMoonBoardErrorMessage(response: Response): Promise<string> {
+async function readMoonBoardErrorCode(response: Response): Promise<string> {
   try {
     const errorBody = (await response.json()) as { error?: unknown };
-    return typeof errorBody.error === 'string' ? errorBody.error : 'moonboard_import_failed';
+    return normalizeMoonBoardImportErrorCode(
+      typeof errorBody.error === 'string' ? errorBody.error : 'moonboard_import_failed',
+    );
   } catch {
     return 'moonboard_import_failed';
   }
@@ -220,7 +239,7 @@ export async function streamMoonBoardImport(
   });
 
   if (!response.ok) {
-    throw new Error(await readMoonBoardErrorMessage(response));
+    throw new Error(await readMoonBoardErrorCode(response));
   }
 
   const result = await readStreamingMoonBoardImportResponse(response, onEvent);

--- a/packages/web/app/lib/data-sync/moonboard/csv-import-stream.ts
+++ b/packages/web/app/lib/data-sync/moonboard/csv-import-stream.ts
@@ -1,0 +1,228 @@
+export type MoonBoardImportCounts = {
+  imported: number;
+  skipped: number;
+  failed: number;
+};
+
+export type MoonBoardImportResult = {
+  ticks?: MoonBoardImportCounts;
+  ascents: MoonBoardImportCounts;
+  attempts: MoonBoardImportCounts;
+  unresolvedClimbs: string[];
+  unresolvedAscentClimbs?: string[];
+  unresolvedAttemptClimbs?: string[];
+  partialError?: string;
+};
+
+export type MoonBoardImportProgress = {
+  step: string;
+  message?: string;
+  current?: number;
+  total?: number;
+};
+
+export type MoonBoardImportProgressEvent =
+  | ({ type: 'progress' } & MoonBoardImportProgress)
+  | { type: 'complete'; results: MoonBoardImportResult }
+  | { type: 'error'; error: string };
+
+export type MoonBoardExportPreview = {
+  username?: string;
+  rows: number;
+  sends: number;
+  flashes: number;
+  attempts: number;
+  projects: number;
+  fails: number;
+  angle: number;
+};
+
+export type StrippedMoonBoardExportData = unknown;
+
+export type ParsedMoonBoardExport = {
+  data: StrippedMoonBoardExportData;
+  preview: MoonBoardExportPreview;
+};
+
+type MoonBoardSharedSchemaModule = {
+  parseMoonBoardExportCsv?: (csv: string) => unknown | Promise<unknown>;
+};
+
+type StreamMoonBoardImportOptions = {
+  backendUrl?: string | null;
+  authToken?: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readNumber(record: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+function readString(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim().length > 0) return value;
+  }
+  return undefined;
+}
+
+function normalizeMoonBoardParsedExport(parsed: unknown): ParsedMoonBoardExport {
+  if (!isRecord(parsed) || !('data' in parsed) || !isRecord(parsed.preview)) {
+    throw new Error('moonboard_parser_invalid_result');
+  }
+
+  const preview = parsed.preview;
+  return {
+    data: parsed.data,
+    preview: {
+      username: readString(preview, ['username', 'userName']),
+      rows: readNumber(preview, ['rows', 'rowCount', 'entries', 'totalRows']) ?? 0,
+      sends: readNumber(preview, ['sends', 'ascents', 'sendCount']) ?? 0,
+      flashes: readNumber(preview, ['flashes', 'flashCount']) ?? 0,
+      attempts: readNumber(preview, ['attempts', 'attemptCount']) ?? 0,
+      projects: readNumber(preview, ['projects', 'projectCount']) ?? 0,
+      fails: readNumber(preview, ['fails', 'failures', 'failCount']) ?? 0,
+      angle: readNumber(preview, ['angle', 'boardAngle']) ?? 40,
+    },
+  };
+}
+
+export async function parseMoonBoardExportCsvForImport(csv: string): Promise<ParsedMoonBoardExport> {
+  const sharedSchema = (await import('@boardsesh/shared-schema')) as unknown as MoonBoardSharedSchemaModule;
+  if (typeof sharedSchema.parseMoonBoardExportCsv !== 'function') {
+    throw new Error('moonboard_parser_unavailable');
+  }
+  return normalizeMoonBoardParsedExport(await sharedSchema.parseMoonBoardExportCsv(csv));
+}
+
+function parseMoonBoardImportEvent(line: string): MoonBoardImportProgressEvent | null {
+  try {
+    return JSON.parse(line) as MoonBoardImportProgressEvent;
+  } catch {
+    return null;
+  }
+}
+
+async function handleMoonBoardImportEvent(
+  event: MoonBoardImportProgressEvent,
+  onEvent: (event: MoonBoardImportProgressEvent) => void,
+): Promise<
+  { type: 'complete'; result: MoonBoardImportResult } | { type: 'error'; error: string } | { type: 'progress' }
+> {
+  if (event.type === 'complete') {
+    return { type: 'complete', result: event.results };
+  }
+  if (event.type === 'error') {
+    return { type: 'error', error: event.error };
+  }
+  onEvent(event);
+  return { type: 'progress' };
+}
+
+async function readStreamingMoonBoardImportResponse(
+  response: Response,
+  onEvent: (event: MoonBoardImportProgressEvent) => void,
+): Promise<MoonBoardImportResult> {
+  if (!response.body) {
+    return readTextMoonBoardImportResponse(response, onEvent);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let result: MoonBoardImportResult | null = null;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const event = parseMoonBoardImportEvent(line);
+      if (!event) continue;
+      const eventResult = await handleMoonBoardImportEvent(event, onEvent);
+      if (eventResult.type === 'complete') result = eventResult.result;
+      if (eventResult.type === 'error') throw new Error(eventResult.error);
+    }
+  }
+
+  if (buffer.trim()) {
+    const event = parseMoonBoardImportEvent(buffer);
+    if (event) {
+      const eventResult = await handleMoonBoardImportEvent(event, onEvent);
+      if (eventResult.type === 'complete') result = eventResult.result;
+      if (eventResult.type === 'error') throw new Error(eventResult.error);
+    }
+  }
+
+  if (!result) throw new Error('moonboard_import_interrupted');
+  return result;
+}
+
+async function readTextMoonBoardImportResponse(
+  response: Response,
+  onEvent: (event: MoonBoardImportProgressEvent) => void,
+): Promise<MoonBoardImportResult> {
+  const text = await response.text();
+  let result: MoonBoardImportResult | null = null;
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    const event = parseMoonBoardImportEvent(line);
+    if (!event) continue;
+    const eventResult = await handleMoonBoardImportEvent(event, onEvent);
+    if (eventResult.type === 'complete') result = eventResult.result;
+    if (eventResult.type === 'error') throw new Error(eventResult.error);
+  }
+
+  if (!result) throw new Error('moonboard_import_interrupted');
+  return result;
+}
+
+async function readMoonBoardErrorMessage(response: Response): Promise<string> {
+  try {
+    const errorBody = (await response.json()) as { error?: unknown };
+    return typeof errorBody.error === 'string' ? errorBody.error : 'moonboard_import_failed';
+  } catch {
+    return 'moonboard_import_failed';
+  }
+}
+
+export async function streamMoonBoardImport(
+  data: StrippedMoonBoardExportData,
+  onEvent: (event: MoonBoardImportProgressEvent) => void,
+  options: StreamMoonBoardImportOptions = {},
+): Promise<void> {
+  if (!options.backendUrl) {
+    throw new Error('moonboard_import_endpoint_unavailable');
+  }
+
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  if (options.authToken) {
+    headers.set('Authorization', `Bearer ${options.authToken}`);
+  }
+
+  const response = await fetch(`${options.backendUrl.replace(/\/+$/, '')}/api/moonboard-import`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ data }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await readMoonBoardErrorMessage(response));
+  }
+
+  const result = await readStreamingMoonBoardImportResponse(response, onEvent);
+  onEvent({ type: 'complete', results: result });
+}


### PR DESCRIPTION
## Summary
- add shared MoonBoard CSV parsing/preview support and parser tests
- add authenticated /api/moonboard-import streaming endpoint that resolves Moon problem ids, imports 40 degree ticks, and stamps origin=moonboard_import
- show MoonBoard CSV import/request-data cards on web and mobile connected apps screens
- add tick_origin migration for moonboard_import and update docs/i18n
- fix review findings around same-day dedupe, flash preview counts, and localized import errors

## Release Notes
Import your MoonBoard CSV logbook into Boardsesh from connected apps, with sends, flashes, attempts, projects, and fails matched at 40 degrees.

## Validation
- vp test run packages/shared-schema/src/__tests__/moonboard-import.test.ts
- vp test run packages/backend/src/__tests__/moonboard-import-service.test.ts
- vp test run packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
- vp run typecheck:backend
- vp run typecheck:web
- vp run typecheck:mobile
- vp run typecheck:db
- vp run check:i18n:orphans && vp run check:i18n
- git diff --check

## Notes
- vp check currently fails before lint on pre-existing formatting drift in docs/offline-sync-plan.md and packages/shared/offline-sync/tsconfig.json; those files are unrelated and left untouched.