### PR TITLE
Show board-native Boardsesh grades first

### DIFF
--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -345,6 +345,7 @@
     "universalLabel": "Boardsesh grade",
     "localLabel": "On this board",
     "localScopeNote": "On this board's scale — not comparable across boards yet",
+    "universalComparison": "Tension scale: {{grade}}",
     "confirmedSubline_one": "Confirmed by {{count}} send",
     "confirmedSubline_other": "Confirmed by {{count}} sends",
     "provisionalSubline_one": "Still settling — {{count}} send in",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -345,6 +345,7 @@
     "universalLabel": "Grado Boardsesh",
     "localLabel": "En este plafón",
     "localScopeNote": "En la escala de este plafón — todavía no comparable entre plafones",
+    "universalComparison": "Escala Tension: {{grade}}",
     "confirmedSubline_one": "Confirmado con {{count}} encadene",
     "confirmedSubline_other": "Confirmado con {{count}} encadenes",
     "provisionalSubline_one": "Aún asentándose — {{count}} encadene registrado",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -345,6 +345,7 @@
     "universalLabel": "Grade Boardsesh",
     "localLabel": "Sur cette board",
     "localScopeNote": "Sur l'échelle de cette board — pas encore comparable d'une board à l'autre",
+    "universalComparison": "Échelle Tension : {{grade}}",
     "confirmedSubline_one": "Confirmé par {{count}} croix",
     "confirmedSubline_other": "Confirmé par {{count}} croix",
     "provisionalSubline_one": "Encore en train de se caler — {{count}} croix enregistrée",

--- a/packages/web/app/components/climb-detail/__tests__/boardsesh-grade-section.test.tsx
+++ b/packages/web/app/components/climb-detail/__tests__/boardsesh-grade-section.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { BoardseshGrade } from '@boardsesh/graphql/operations/boardsesh-grade';
+import BoardseshGradeSection from '../boardsesh-grade-section';
+
+const requestMock = vi.fn();
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: requestMock }),
+}));
+
+vi.mock('@/app/hooks/use-is-dark-mode', () => ({
+  useIsDarkMode: () => false,
+}));
+
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    loaded: true,
+    formatGrade: (gradeName: string | null) => gradeName?.split('/')[1] ?? null,
+    getGradeColor: () => null,
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number; grade?: string }) => {
+      if (key === 'boardseshGrade.universalComparison') return `Tension scale: ${options?.grade}`;
+      if (key === 'boardseshGrade.confirmedSubline') return `Confirmed by ${options?.count} sends`;
+      if (key === 'boardseshGrade.provisionalSubline') return `Still settling - ${options?.count} sends in`;
+      if (key === 'boardseshGrade.localLabel') return 'On this board';
+      if (key === 'boardseshGrade.universalLabel') return 'Boardsesh grade';
+      if (key === 'boardseshGrade.localScopeNote') return "On this board's scale";
+      if (key === 'boardseshGrade.setterOnly') return "Setter's call";
+      if (key === 'boardseshGrade.moonboardTitle') return 'Not standardized yet';
+      if (key === 'boardseshGrade.moonboardBody') return 'No MoonBoard grades yet';
+      if (key === 'boardseshGrade.loadError') return "Couldn't load the grade right now.";
+      return key;
+    },
+  }),
+}));
+
+function grade(overrides: Partial<BoardseshGrade>): BoardseshGrade {
+  return {
+    localGrade: 22.03,
+    universalGrade: 21.03,
+    gradeLow: null,
+    gradeHigh: null,
+    confidence: 'confirmed',
+    ascensionistCount: 127,
+    modelVersion: 'v1.1',
+    computedAt: '2026-07-08T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderSection(boardName = 'kilter') {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BoardseshGradeSection boardName={boardName} climbUuid="pinchwork" angle={30} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('BoardseshGradeSection', () => {
+  beforeEach(() => {
+    requestMock.mockReset();
+  });
+
+  it('renders the local grade as primary and universal as secondary comparison', async () => {
+    requestMock.mockResolvedValue({ boardseshGrade: grade({}) });
+
+    renderSection();
+
+    await waitFor(() => expect(screen.getByText('V6')).toBeTruthy());
+    expect(screen.getByText('Tension scale: V5')).toBeTruthy();
+    expect(screen.getByText('On this board')).toBeTruthy();
+    expect(screen.getByText('Confirmed by 127 sends')).toBeTruthy();
+    expect(screen.queryByText("On this board's scale")).toBeNull();
+  });
+
+  it('omits the comparison when local and universal round to the same grade', async () => {
+    requestMock.mockResolvedValue({
+      boardseshGrade: grade({ localGrade: 20.4, universalGrade: 20.2, ascensionistCount: 55 }),
+    });
+
+    renderSection();
+
+    await waitFor(() => expect(screen.getByText('V5')).toBeTruthy());
+    expect(screen.queryByText(/Tension scale:/)).toBeNull();
+    expect(screen.queryByText("On this board's scale")).toBeNull();
+  });
+
+  it('keeps the local-only note when no universal grade exists', async () => {
+    requestMock.mockResolvedValue({
+      boardseshGrade: grade({ localGrade: 17.6, universalGrade: null, ascensionistCount: 42 }),
+    });
+
+    renderSection('grasshopper');
+
+    await waitFor(() => expect(screen.getByText('V4')).toBeTruthy());
+    expect(screen.getByText("On this board's scale")).toBeTruthy();
+  });
+
+  it('does not fetch grades for MoonBoard', () => {
+    renderSection('moonboard');
+
+    expect(screen.getByText('Not standardized yet')).toBeTruthy();
+    expect(screen.getByText('No MoonBoard grades yet')).toBeTruthy();
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/climb-detail/__tests__/boardsesh-grade-view.test.ts
+++ b/packages/web/app/components/climb-detail/__tests__/boardsesh-grade-view.test.ts
@@ -43,12 +43,49 @@ describe('deriveBoardseshGradeView', () => {
     });
   });
 
-  it('rounds the universal grade for a confirmed tier', () => {
+  it('uses the local grade as primary and keeps universal as comparison', () => {
     const view = deriveBoardseshGradeView({
       boardName: 'kilter',
-      grade: grade({ universalGrade: 20.4, localGrade: 19, confidence: 'confirmed', ascensionistCount: 88 }),
+      grade: grade({ localGrade: 22.03, universalGrade: 21.03, confidence: 'confirmed', ascensionistCount: 127 }),
     });
-    expect(view).toEqual({ kind: 'confirmed', scope: 'universal', difficultyId: 20, ascensionistCount: 88 });
+    expect(view).toEqual({
+      kind: 'confirmed',
+      scope: 'local',
+      difficultyId: 22,
+      comparisonDifficultyId: 21,
+      hasUniversalGrade: true,
+      ascensionistCount: 127,
+    });
+  });
+
+  it('uses the local grade as primary for Tension too', () => {
+    const view = deriveBoardseshGradeView({
+      boardName: 'tension',
+      grade: grade({ localGrade: 20.6, universalGrade: 19.6, confidence: 'confirmed', ascensionistCount: 88 }),
+    });
+    expect(view).toEqual({
+      kind: 'confirmed',
+      scope: 'local',
+      difficultyId: 21,
+      comparisonDifficultyId: 20,
+      hasUniversalGrade: true,
+      ascensionistCount: 88,
+    });
+  });
+
+  it('omits the comparison when local and universal round to the same grade', () => {
+    const view = deriveBoardseshGradeView({
+      boardName: 'kilter',
+      grade: grade({ localGrade: 20.4, universalGrade: 20.2, confidence: 'confirmed' }),
+    });
+    expect(view).toEqual({
+      kind: 'confirmed',
+      scope: 'local',
+      difficultyId: 20,
+      comparisonDifficultyId: null,
+      hasUniversalGrade: true,
+      ascensionistCount: 42,
+    });
   });
 
   it('falls back to the local grade when universal is null (local scope)', () => {
@@ -56,13 +93,21 @@ describe('deriveBoardseshGradeView', () => {
       boardName: 'grasshopper',
       grade: grade({ universalGrade: null, localGrade: 17.6, confidence: 'confirmed' }),
     });
-    expect(view).toEqual({ kind: 'confirmed', scope: 'local', difficultyId: 18, ascensionistCount: 42 });
+    expect(view).toEqual({
+      kind: 'confirmed',
+      scope: 'local',
+      difficultyId: 18,
+      comparisonDifficultyId: null,
+      hasUniversalGrade: false,
+      ascensionistCount: 42,
+    });
   });
 
-  it('flags a provisional range when the rounded bounds differ', () => {
+  it('flags a provisional range on the local scale when the rounded bounds differ', () => {
     const view = deriveBoardseshGradeView({
       boardName: 'tension',
       grade: grade({
+        localGrade: 21.5,
         universalGrade: 20.5,
         gradeLow: 20,
         gradeHigh: 22,
@@ -72,10 +117,12 @@ describe('deriveBoardseshGradeView', () => {
     });
     expect(view).toEqual({
       kind: 'provisional',
-      scope: 'universal',
-      difficultyId: 21,
-      lowDifficultyId: 20,
-      highDifficultyId: 22,
+      scope: 'local',
+      difficultyId: 22,
+      lowDifficultyId: 21,
+      highDifficultyId: 23,
+      comparisonDifficultyId: 21,
+      hasUniversalGrade: true,
       isRange: true,
       ascensionistCount: 6,
     });
@@ -85,14 +132,37 @@ describe('deriveBoardseshGradeView', () => {
     const view = deriveBoardseshGradeView({
       boardName: 'tension',
       grade: grade({
-        universalGrade: 20,
-        gradeLow: 19.8,
-        gradeHigh: 20.2,
+        localGrade: 20,
+        universalGrade: 19,
+        gradeLow: 18.8,
+        gradeHigh: 19.2,
         confidence: 'provisional',
         ascensionistCount: 3,
       }),
     });
-    expect(view).toMatchObject({ kind: 'provisional', isRange: false, lowDifficultyId: 20, highDifficultyId: 20 });
+    expect(view).toMatchObject({
+      kind: 'provisional',
+      isRange: false,
+      lowDifficultyId: 20,
+      highDifficultyId: 20,
+      comparisonDifficultyId: 19,
+      hasUniversalGrade: true,
+    });
+  });
+
+  it('falls back to universal when local is missing on a future malformed row', () => {
+    const view = deriveBoardseshGradeView({
+      boardName: 'kilter',
+      grade: grade({ universalGrade: 20.4, localGrade: null, confidence: 'confirmed' }),
+    });
+    expect(view).toEqual({
+      kind: 'confirmed',
+      scope: 'universal',
+      difficultyId: 20,
+      comparisonDifficultyId: null,
+      hasUniversalGrade: true,
+      ascensionistCount: 42,
+    });
   });
 
   it('treats a missing primary grade as setterOnly', () => {

--- a/packages/web/app/components/climb-detail/boardsesh-grade-section.tsx
+++ b/packages/web/app/components/climb-detail/boardsesh-grade-section.tsx
@@ -102,6 +102,8 @@ export default function BoardseshGradeSection({ boardName, climbUuid, angle }: B
   }
 
   const scopeLabel = view.scope === 'universal' ? t('boardseshGrade.universalLabel') : t('boardseshGrade.localLabel');
+  const comparisonName = view.comparisonDifficultyId == null ? null : difficultyNameFor(view.comparisonDifficultyId);
+  const comparisonLabel = comparisonName == null ? null : formatGrade(comparisonName);
 
   const subline =
     view.kind === 'confirmed'
@@ -135,7 +137,12 @@ export default function BoardseshGradeSection({ boardName, climbUuid, angle }: B
         <Typography component="span" variant="body2" color="text.secondary">
           {subline}
         </Typography>
-        {view.scope === 'local' && (
+        {comparisonLabel && (
+          <Typography component="span" variant="caption" color="text.secondary" sx={{ fontStyle: 'italic', mt: '2px' }}>
+            {t('boardseshGrade.universalComparison', { grade: comparisonLabel })}
+          </Typography>
+        )}
+        {view.scope === 'local' && !view.hasUniversalGrade && (
           <Typography component="span" variant="caption" color="text.secondary" sx={{ fontStyle: 'italic', mt: '2px' }}>
             {t('boardseshGrade.localScopeNote')}
           </Typography>

--- a/packages/web/app/components/climb-detail/boardsesh-grade-view.ts
+++ b/packages/web/app/components/climb-detail/boardsesh-grade-view.ts
@@ -12,9 +12,15 @@ export const BOARDSESH_GRADE_CONFIDENCE = {
 
 /**
  * A resolved grade view.
- * - `scope: 'universal'` — comparable across boards (universalGrade present).
- * - `scope: 'local'` — this-board-only scale (universalGrade null, localGrade
- *   present; happens on the small boards like grasshopper/decoy/soill/touchstone).
+ * - `scope: 'local'` — board-native community estimate. This is the primary
+ *   climb-detail grade because users are looking at a climb on its own board.
+ * - `scope: 'universal'` — fallback for malformed/future rows where a universal
+ *   grade exists without a local grade.
+ * - `comparisonDifficultyId` — optional Tension-anchored comparison grade. It is
+ *   secondary context, not the primary grade.
+ * - `hasUniversalGrade` — true when the row is standardized across boards even
+ *   if the rounded universal value matches the primary grade and needs no extra
+ *   comparison line.
  * `difficultyId` is the primary grade rounded to the nearest Aurora difficulty id.
  */
 export type BoardseshGradeView =
@@ -24,6 +30,8 @@ export type BoardseshGradeView =
       kind: 'confirmed';
       scope: 'universal' | 'local';
       difficultyId: number;
+      comparisonDifficultyId: number | null;
+      hasUniversalGrade: boolean;
       ascensionistCount: number;
     }
   | {
@@ -32,6 +40,8 @@ export type BoardseshGradeView =
       difficultyId: number;
       lowDifficultyId: number;
       highDifficultyId: number;
+      comparisonDifficultyId: number | null;
+      hasUniversalGrade: boolean;
       /** True when the rounded low/high bounds differ — render as a range. */
       isRange: boolean;
       ascensionistCount: number;
@@ -51,6 +61,29 @@ function roundToDifficultyId(value: number): number {
   return Math.round(value);
 }
 
+function rangeForPrimaryGrade(
+  grade: BoardseshGrade,
+  primary: number,
+  scope: 'local' | 'universal',
+): { low: number | null; high: number | null } {
+  if (grade.gradeLow == null || grade.gradeHigh == null) {
+    return { low: null, high: null };
+  }
+  if (scope === 'local' && grade.universalGrade != null) {
+    const universalOffset = grade.universalGrade - primary;
+    return { low: grade.gradeLow - universalOffset, high: grade.gradeHigh - universalOffset };
+  }
+  return { low: grade.gradeLow, high: grade.gradeHigh };
+}
+
+function comparisonDifficultyIdFor(grade: BoardseshGrade, primaryDifficultyId: number): number | null {
+  if (grade.universalGrade == null || grade.localGrade == null) {
+    return null;
+  }
+  const universalDifficultyId = roundToDifficultyId(grade.universalGrade);
+  return universalDifficultyId === primaryDifficultyId ? null : universalDifficultyId;
+}
+
 /**
  * Decide which Boardsesh-grade tier to render and pre-round every float to a
  * difficulty id. Returns `null` only when there is genuinely nothing to show —
@@ -66,23 +99,27 @@ export function deriveBoardseshGradeView({ boardName, grade }: DeriveBoardseshGr
     return { kind: 'setterOnly' };
   }
 
-  // Primary grade: universal when comparable across boards, else this-board local.
-  const primary = grade.universalGrade ?? grade.localGrade;
+  const primary = grade.localGrade ?? grade.universalGrade;
   if (primary == null) {
     return { kind: 'setterOnly' };
   }
-  const scope: 'universal' | 'local' = grade.universalGrade != null ? 'universal' : 'local';
+  const scope: 'universal' | 'local' = grade.localGrade != null ? 'local' : 'universal';
   const difficultyId = roundToDifficultyId(primary);
+  const comparisonDifficultyId = scope === 'local' ? comparisonDifficultyIdFor(grade, difficultyId) : null;
+  const hasUniversalGrade = grade.universalGrade != null;
 
   if (grade.confidence === BOARDSESH_GRADE_CONFIDENCE.provisional) {
-    const lowDifficultyId = grade.gradeLow != null ? roundToDifficultyId(grade.gradeLow) : difficultyId;
-    const highDifficultyId = grade.gradeHigh != null ? roundToDifficultyId(grade.gradeHigh) : difficultyId;
+    const range = rangeForPrimaryGrade(grade, primary, scope);
+    const lowDifficultyId = range.low != null ? roundToDifficultyId(range.low) : difficultyId;
+    const highDifficultyId = range.high != null ? roundToDifficultyId(range.high) : difficultyId;
     return {
       kind: 'provisional',
       scope,
       difficultyId,
       lowDifficultyId,
       highDifficultyId,
+      comparisonDifficultyId,
+      hasUniversalGrade,
       isRange: lowDifficultyId !== highDifficultyId,
       ascensionistCount: grade.ascensionistCount,
     };
@@ -93,6 +130,8 @@ export function deriveBoardseshGradeView({ boardName, grade }: DeriveBoardseshGr
     kind: 'confirmed',
     scope,
     difficultyId,
+    comparisonDifficultyId,
+    hasUniversalGrade,
     ascensionistCount: grade.ascensionistCount,
   };
 }


### PR DESCRIPTION
## Summary

- Make the climb-detail Boardsesh grade use the board-native `localGrade` as the primary displayed grade.
- Show the Tension/universal grade only as secondary context when it rounds to a different grade.
- Keep provisional ranges on the same local scale as the primary grade and add renderer/view-model coverage.

## Why

The universal grade is cross-board/Tension-anchored context, not the grade climbers expect as the primary grade on that board. Rendering it first made Kilter climbs look universally downgraded by the Kilter offset, including cases like Pinchwork 30 degrees where the local Boardsesh grade should remain V6 while the Tension-scale comparison is V5.

This is a display-layer precursor to the larger grading-model work in #3543, #3544, and #3545. It does not close those model/pipeline issues.

## Validation

- `vp test run packages/web/app/components/climb-detail/__tests__/boardsesh-grade-view.test.ts packages/web/app/components/climb-detail/__tests__/boardsesh-grade-section.test.tsx --reporter=agent`
- `vp run check:i18n`
- `vp run check:i18n:orphans`
- `vp staged`
- `vp run typecheck:web`

## Manual QA

Dev server: `https://marcos-macbook-pro-2-1.tailedd9d5.ts.net:3100`

QA notes are loaded from `.boardsesh/qa-notes.md`.
