### PR TITLE
Clear MoonBoard catalog FA crowns

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -160,11 +160,11 @@ A FIFO queue for offline mutations. Estimated ~800-1200 lines of production-qual
 
 ### Why an outbox, not dirty flags on the data tables
 
-The obvious-seeming alternative — write only to the data tables and sync "unsynced" rows from them directly — was considered and doesn't survive contact with this design. Offline writes DO go to the data tables (optimistically, in the same SQLite transaction as the outbox insert, so the two can't diverge); the `pending_mutations` row is *replay state* that a dirty-flag column cannot represent:
+The obvious-seeming alternative — write only to the data tables and sync "unsynced" rows from them directly — was considered and doesn't survive contact with this design. Offline writes DO go to the data tables (optimistically, in the same SQLite transaction as the outbox insert, so the two can't diverge); the `pending_mutations` row is _replay state_ that a dirty-flag column cannot represent:
 
 1. **Deletes.** An offline delete removes the data row — nothing remains to mark dirty. In-table tracking needs soft-delete/tombstone columns on every user table, which is exactly the WatermelonDB dealbreaker above.
 2. **Pulls destroy in-table flags.** The pull client applies server rows with `INSERT OR REPLACE` (delete + re-insert), which would reset any client-only `dirty` column on every sync — and the manifest contract (resolver JSON keys == local columns) would need per-table carve-outs plus merge logic so pulls don't clobber unsynced edits.
-3. **The server API is domain mutations, not row upserts.** The drainer replays ~18 distinct GraphQL mutations (`saveTick` vs `updateTick` vs `deleteTick`, `addFavorite`/`removeFavorite`, …). A dirty row can't say *which operation* produced it; syncing row state directly means building a generic push protocol server-side — the rejected WatermelonDB/PowerSync shape.
+3. **The server API is domain mutations, not row upserts.** The drainer replays ~18 distinct GraphQL mutations (`saveTick` vs `updateTick` vs `deleteTick`, `addFavorite`/`removeFavorite`, …). A dirty row can't say _which operation_ produced it; syncing row state directly means building a generic push protocol server-side — the rejected WatermelonDB/PowerSync shape.
 4. **Retry/dead-letter bookkeeping** (`retry_count`, `last_error`, `status`, the dead-letter UI) lives on the outbox row instead of polluting every data table.
 5. **Cross-table FIFO + cancellation.** The queue preserves user-action order across tables and lets an offline add→remove pair net out to zero server calls (the queued add is cancelled in-transaction).
 6. **Queue-only entities.** `user_playlist_pins` has mutations but no local mirror table at all.

--- a/packages/backend/src/__tests__/moonboard-fa-cleanup-migration.test.ts
+++ b/packages/backend/src/__tests__/moonboard-fa-cleanup-migration.test.ts
@@ -1,0 +1,143 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { sql } from 'drizzle-orm';
+import { getWorkerDatabaseUrl, setupWorkerDatabase } from './worker-db';
+
+const drizzleDir = fileURLToPath(new URL('../../../db/drizzle/', import.meta.url));
+const MIGRATION_0173 = readFileSync(`${drizzleDir}0173_clear_moonboard_catalog_fa.sql`, 'utf8');
+
+type StatsRow = {
+  board_type: string;
+  climb_uuid: string;
+  fa_username: string | null;
+  fa_at: string | null;
+};
+
+function rowsFromResult<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  if (typeof result === 'object' && result !== null && 'rows' in result) {
+    return (result as { rows: T[] }).rows;
+  }
+  return [];
+}
+
+describe('MoonBoard FA cleanup migration 0173 - real DB replay', () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+
+  beforeAll(async () => {
+    await setupWorkerDatabase();
+    client = postgres(getWorkerDatabaseUrl(), { max: 1, onnotice: () => {} });
+    db = drizzle(client);
+  });
+
+  afterAll(async () => {
+    if (client) await client.end();
+  });
+
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE TABLE board_climb_stats, board_climbs, users RESTART IDENTITY CASCADE`);
+  });
+
+  async function seedUser(id: string): Promise<void> {
+    await db.execute(sql`
+      INSERT INTO users (id, email, name, created_at, updated_at)
+      VALUES (${id}, ${`${id}@example.test`}, ${id}, now(), now())
+    `);
+  }
+
+  async function seedClimb(args: { boardType: string; uuid: string; ownerUserId: string | null }): Promise<void> {
+    await db.execute(sql`
+      INSERT INTO board_climbs
+        (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed, user_id)
+      VALUES
+        (${args.uuid}, ${args.boardType}, 1, 'setter', ${args.uuid}, '', 'p1r1', true, ${args.ownerUserId})
+    `);
+  }
+
+  async function seedStats(args: {
+    boardType: string;
+    uuid: string;
+    faUsername: string | null;
+    faAt: string | null;
+  }): Promise<void> {
+    await db.execute(sql`
+      INSERT INTO board_climb_stats
+        (board_type, climb_uuid, angle, ascensionist_count, upstream_ascensionist_count,
+         boardsesh_ascensionist_count, quality_normalized, fa_username, fa_at)
+      VALUES
+        (${args.boardType}, ${args.uuid}, 40, 1, 1, 0, true, ${args.faUsername}, ${args.faAt})
+    `);
+  }
+
+  async function statsRows(): Promise<StatsRow[]> {
+    const result = await db.execute(sql`
+      SELECT board_type, climb_uuid, fa_username, fa_at::text AS fa_at
+        FROM board_climb_stats
+       ORDER BY board_type, climb_uuid
+    `);
+    return rowsFromResult<StatsRow>(result);
+  }
+
+  async function applyMigration(): Promise<void> {
+    await client.unsafe(MIGRATION_0173);
+  }
+
+  async function seedEveryBranch(): Promise<void> {
+    await seedUser('owner-user');
+    await seedClimb({ boardType: 'moonboard', uuid: 'moonboard-catalog', ownerUserId: null });
+    await seedClimb({ boardType: 'moonboard', uuid: 'moonboard-owned', ownerUserId: 'owner-user' });
+    await seedClimb({ boardType: 'kilter', uuid: 'kilter-upstream', ownerUserId: null });
+
+    await seedStats({
+      boardType: 'moonboard',
+      uuid: 'moonboard-catalog',
+      faUsername: 'Tick Crown',
+      faAt: '2024-01-01 00:00:00',
+    });
+    await seedStats({
+      boardType: 'moonboard',
+      uuid: 'moonboard-owned',
+      faUsername: 'Owned Crown',
+      faAt: '2024-02-01 00:00:00',
+    });
+    await seedStats({
+      boardType: 'kilter',
+      uuid: 'kilter-upstream',
+      faUsername: 'Kilter Upstream',
+      faAt: '1999-05-05 12:00:00',
+    });
+  }
+
+  it('clears only non-owned MoonBoard catalog FA fields and is idempotent', async () => {
+    await seedEveryBranch();
+
+    await applyMigration();
+    await applyMigration();
+
+    const rows = await statsRows();
+    expect(rows).toEqual([
+      {
+        board_type: 'kilter',
+        climb_uuid: 'kilter-upstream',
+        fa_username: 'Kilter Upstream',
+        fa_at: '1999-05-05 12:00:00',
+      },
+      {
+        board_type: 'moonboard',
+        climb_uuid: 'moonboard-catalog',
+        fa_username: null,
+        fa_at: null,
+      },
+      {
+        board_type: 'moonboard',
+        climb_uuid: 'moonboard-owned',
+        fa_username: 'Owned Crown',
+        fa_at: '2024-02-01 00:00:00',
+      },
+    ]);
+  });
+});

--- a/packages/db/drizzle/0173_clear_moonboard_catalog_fa.sql
+++ b/packages/db/drizzle/0173_clear_moonboard_catalog_fa.sql
@@ -1,0 +1,29 @@
+-- Custom SQL migration file, put your code below! --
+--
+-- MoonBoard app-catalog data does not carry authoritative first-ascent fields.
+-- The catalog importer inserts fa_username/fa_at as NULL and leaves existing FA
+-- fields untouched on conflict. A pre-0157 tick recompute derived FA crowns from
+-- Boardsesh ticks on manufacturer climbs; 0157 cleared only exact earliest-tick
+-- matches, leaving rows whose fa_at drifted after earlier imported ticks arrived.
+--
+-- Prod preflight (2026-07-09, read-only): 428 MoonBoard stats rows still carry
+-- FA fields, all catalog/manufacturer rows; 0 Boardsesh-owned MoonBoard rows.
+-- Clear only non-owned rows so user-created MoonBoard climbs keep the generic
+-- owned-climb invariant: their FA can be derived from ticks by recompute.
+--
+-- Offline propagation is handled by trg_board_climb_stats_set_sync_fields
+-- (0144/0146) for rows whose FA fields actually change. Do not stamp
+-- updated_at/sync_seq manually.
+
+UPDATE board_climb_stats s
+   SET fa_username = NULL,
+       fa_at       = NULL
+ WHERE s.board_type = 'moonboard'
+   AND (s.fa_username IS NOT NULL OR s.fa_at IS NOT NULL)
+   AND NOT EXISTS (
+     SELECT 1
+       FROM board_climbs bc
+      WHERE bc.board_type = s.board_type
+        AND bc.uuid       = s.climb_uuid
+        AND bc.user_id IS NOT NULL
+   );

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1212,6 +1212,13 @@
       "when": 1783553077349,
       "tag": "0172_cuddly_psynapse",
       "breakpoints": true
+    },
+    {
+      "idx": 173,
+      "version": "7",
+      "when": 1783556904000,
+      "tag": "0173_clear_moonboard_catalog_fa",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/offline-sync/tsconfig.json
+++ b/packages/shared/offline-sync/tsconfig.json
@@ -12,15 +12,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- Add migration `0173_clear_moonboard_catalog_fa` to clear legacy `fa_username` / `fa_at` on non-owned MoonBoard stats rows.
- Preserve Boardsesh-owned MoonBoard climb FA fields by guarding on `board_climbs.user_id IS NOT NULL`.
- Add a real-DB migration replay test for catalog, owned, non-MoonBoard, and double-apply behavior.
- Include formatter-only cleanup for two files that blocked `vp check` formatting.

## Root Cause

The 0157 ascent-count/FA repair only cleared tick-derived manufacturer FA crowns when the stored `fa_at` exactly matched the current earliest tick. MoonBoard app-catalog data has no authoritative FA fields, so drifted MoonBoard catalog crowns that no longer matched the earliest tick survived.

Fixes #3550.

## Validation

- `vp test run --project backend packages/backend/src/__tests__/moonboard-fa-cleanup-migration.test.ts --reporter=agent`
- `vp run typecheck:backend`
- `vp run typecheck:db`
- `vp check docs/offline-sync-plan.md packages/shared/offline-sync/tsconfig.json packages/db/drizzle/meta/_journal.json packages/db/drizzle/0173_clear_moonboard_catalog_fa.sql packages/backend/src/__tests__/moonboard-fa-cleanup-migration.test.ts`
- `vp staged`
- `vp run dev` started at `http://localhost:3200` with QA notes loaded from `.boardsesh/qa-notes.md`

Note: full `vp check` passes formatting but currently fails on unrelated pre-existing lint/type issues across other packages, and Vite+ also emitted a stdout panic while printing that backlog.