### PR TITLE
fix(db): add Kilter grade display-delta hygiene

### DIFF
--- a/docs/boardsesh-grade.md
+++ b/docs/boardsesh-grade.md
@@ -221,6 +221,25 @@ a binding cap can leave a residual inversion, which the run counts and logs).
 Display-only pass-through rows carry no evidence and don't participate.
 Implementation: `isotonic.ts`.
 
+### Kilter display-delta hygiene (v1.2)
+
+Kilter has a small data-quality tail where the upstream displayed grade appears
+mixed-scale or corrupted: the crowd mean is normal, but the label sits near the
+scale floor or several grades away from the standardized result. The model does
+not repair those source rows and does not clamp the computed grade back toward
+the suspect label. Instead, after blending and isotonic projection, any Kilter
+row that would be `confirmed` is downgraded to `provisional` when:
+
+```
+round(universal_grade) - round(display_difficulty) < -3
+round(universal_grade) - round(display_difficulty) >  1
+```
+
+The local/universal grade and confidence band stay unchanged; only the tier is
+lowered so the UI stops presenting an outlier as settled. The nightly run logs
+and persists how many rows were downgraded. Implementation:
+`applyDisplayDeltaHygiene` in `hygiene.ts`.
+
 ### Duplicate climbs share one identity
 
 Climbs with the same `hold_fingerprint` are the same physical problem listed
@@ -263,11 +282,11 @@ Estimator: `estimateBoardOffsets`.
 
 ### Confidence tiers
 
-| Tier          | Condition                   | UI                                 |
-| ------------- | --------------------------- | ---------------------------------- |
-| `confirmed`   | n ≥ 20 and `post_sd` ≤ 0.35 | grade, "confirmed by N sends"      |
-| `provisional` | 3 ≤ n < 20                  | grade with a visible ± band        |
-| `setter_only` | n < 3                       | no Boardsesh number, setter's call |
+| Tier          | Condition                                                                                           | UI                                 |
+| ------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `confirmed`   | n ≥ 20 and `post_sd` ≤ 0.35, unless Kilter display-delta hygiene downgrades the row                  | grade, "confirmed by N sends"      |
+| `provisional` | 3 ≤ n < 20, or a confirmed Kilter row tripped the v1.2 display-delta hygiene rule                    | grade with a visible ± band        |
+| `setter_only` | n < 3                                                                                               | no Boardsesh number, setter's call |
 
 ### Publish hysteresis
 
@@ -289,6 +308,7 @@ fails**. Results persist to `board_grade_coefficients` (kind `gate_results`).
 | `no_shock`                | no ≥50-ascent climb's local grade moves >1.0 from its raw mean                                                                    | yes                 | the prior is overpowering established grades (also enforced by a clamp inside the blend itself; the gate catches regressions) |
 | `fingerprint_consistency` | ≤1% of duplicate-fingerprint groups disagree by >1 grade at the same angle                                                        | yes                 | evidence for one physical problem is being split badly                                                                        |
 | `residual_paired_gap`     | shared-user mean gap vs fitted offset ≤ 0.3 after the Kilter offset                                                               | withholds universal | the "constant offset" story is wrong; local grades still publish, universal grades don't                                      |
+| `display_delta_hygiene`   | reports Kilter rows downgraded from `confirmed` to `provisional` for rounded universal-display delta outside [-3, +1]             | no (repaired)       | source labels likely contain mixed-scale/corrupt display values; the grade publishes, but not as confirmed                    |
 | honesty report            | reports `corr(grade, display)` and mean \|Δ\| per board                                                                           | no (report only)    | a board whose numbers never leave the label is dressing the label as a data product; UI copy must say so                      |
 
 The backtest replays `board_climb_stats_history` (5.4M snapshots): for series

--- a/packages/db/scripts/refresh-climb-grades.ts
+++ b/packages/db/scripts/refresh-climb-grades.ts
@@ -31,6 +31,7 @@ import {
   OFFSET_LOO_MAX_DELTA,
   applyIsotonicAngleConstraint,
   type AngleGradeRow,
+  applyDisplayDeltaHygiene,
   buildAngleSurfaceSql,
   buildBacktestSampleSql,
   buildBoardOffsetSampleSql,
@@ -39,14 +40,18 @@ import {
   buildSigmaWithinSql,
   buildTauSampleSql,
   computePosteriorGrade,
+  createDisplayDeltaHygieneStats,
   estimateAngleSurface,
   estimateBoardOffsets,
   estimateEchoFractions,
   estimateSigmaWithin,
   estimateTauSquared,
   evaluateBacktest,
+  evaluateDisplayDeltaHygiene,
   evaluateFingerprintGate,
   evaluateResidualGapGate,
+  mergeDisplayDeltaHygieneStats,
+  recordDisplayDeltaHygiene,
   shouldPublish,
   GATE_NO_SHOCK_MAX_MOVE,
   GATE_NO_SHOCK_MIN_ASCENTS,
@@ -55,6 +60,7 @@ import {
   type BoardOffsetSampleRow,
   type ClimbAngleObservation,
   type EchoRateRow,
+  type DisplayDeltaHygieneStats,
   type GateResult,
   type GradeCoefficients,
   type SigmaWithinRow,
@@ -290,10 +296,15 @@ async function computeBoard(
   db: Db,
   boardType: string,
   coefficients: GradeCoefficients,
-): Promise<{ computed: ComputedRow[]; isotonicStats: { movedRows: number; residualInversions: number } }> {
+): Promise<{
+  computed: ComputedRow[];
+  isotonicStats: { movedRows: number; residualInversions: number };
+  displayDeltaHygieneStats: DisplayDeltaHygieneStats;
+}> {
   const pooledEvidence = await loadPooledFingerprintEvidence(db, boardType);
   const computed: ComputedRow[] = [];
   const isotonicStats = { movedRows: 0, residualInversions: 0 };
+  const displayDeltaHygieneStats = createDisplayDeltaHygieneStats();
   let lastClimbUuid = '';
   for (;;) {
     const rows = rowsOf<StatsRow>(
@@ -359,9 +370,20 @@ async function computeBoard(
 
       // Emit one output row per angle THIS climb actually has.
       const ownAngles = new Set(group.map((row) => row.angle));
+      // Grade evidence may be pooled across duplicate fingerprints, but hygiene
+      // compares against this emitted row's own upstream display label.
+      const ownDisplayDifficultyByAngle = new Map(
+        group.map((row) => [row.angle, row.display_difficulty === null ? null : Number(row.display_difficulty)]),
+      );
       for (let i = 0; i < angleRows.length; i++) {
         if (!ownAngles.has(angleRows[i].angle)) continue;
-        const posterior = adjusted[i];
+        const hygiene = applyDisplayDeltaHygiene({
+          boardType,
+          displayDifficulty: ownDisplayDifficultyByAngle.get(angleRows[i].angle) ?? null,
+          posterior: adjusted[i],
+        });
+        recordDisplayDeltaHygiene(displayDeltaHygieneStats, hygiene);
+        const posterior = hygiene.posterior;
         computed.push({
           climbUuid: group[0].climb_uuid,
           angle: angleRows[i].angle,
@@ -387,7 +409,7 @@ async function computeBoard(
     lastClimbUuid = effective[effective.length - 1].climb_uuid;
     if (isFinalPage) break;
   }
-  return { computed, isotonicStats };
+  return { computed, isotonicStats, displayDeltaHygieneStats };
 }
 
 /** No-shock gate evaluated in memory on the freshly computed rows. */
@@ -565,15 +587,16 @@ async function validateOnly(db: Db): Promise<void> {
     );
   }
   for (const boardType of CROWD_MEAN_BOARDS) {
-    const { computed, isotonicStats } = await computeBoard(db, boardType, coefficients);
+    const { computed, isotonicStats, displayDeltaHygieneStats } = await computeBoard(db, boardType, coefficients);
     const noShock = evaluateNoShock(computed);
     const fingerprint = evaluateFingerprintConsistency(computed);
+    const displayDeltaHygiene = evaluateDisplayDeltaHygiene(displayDeltaHygieneStats);
     const tiers = computed.reduce<Record<string, number>>((acc, row) => {
       acc[row.confidence] = (acc[row.confidence] ?? 0) + 1;
       return acc;
     }, {});
     console.log(
-      `[grades]   ${boardType}: ${computed.length} rows, tiers=${JSON.stringify(tiers)}; isotonic moved ${isotonicStats.movedRows} rows (${isotonicStats.residualInversions} residual inversions); no_shock ${noShock.passed ? 'PASS' : 'FAIL'} (${noShock.detail}); fingerprint ${fingerprint.passed ? 'PASS' : 'FAIL'} (${fingerprint.detail})`,
+      `[grades]   ${boardType}: ${computed.length} rows, tiers=${JSON.stringify(tiers)}; isotonic moved ${isotonicStats.movedRows} rows (${isotonicStats.residualInversions} residual inversions); no_shock ${noShock.passed ? 'PASS' : 'FAIL'} (${noShock.detail}); fingerprint ${fingerprint.passed ? 'PASS' : 'FAIL'} (${fingerprint.detail}); display_delta_hygiene ${displayDeltaHygiene.passed ? 'PASS' : 'FAIL'} (${displayDeltaHygiene.detail})`,
     );
   }
   console.log('[grades] validate-only done (nothing written).');
@@ -635,21 +658,31 @@ async function main(): Promise<void> {
 
     // Compute all boards up front so the in-memory gates see the whole run.
     const computedByBoard = new Map<string, ComputedRow[]>();
+    const displayDeltaHygieneStats = createDisplayDeltaHygieneStats();
     for (const boardType of CROWD_MEAN_BOARDS) {
       console.log(`[grades] computing ${boardType}…`);
-      const { computed, isotonicStats } = await computeBoard(db, boardType, coefficients);
+      const {
+        computed,
+        isotonicStats,
+        displayDeltaHygieneStats: boardDisplayDeltaHygieneStats,
+      } = await computeBoard(db, boardType, coefficients);
+      mergeDisplayDeltaHygieneStats(displayDeltaHygieneStats, boardDisplayDeltaHygieneStats);
       computedByBoard.set(boardType, computed);
       console.log(
-        `[grades]   ${computed.length} climb+angle rows (isotonic moved ${isotonicStats.movedRows}, ${isotonicStats.residualInversions} residual inversions)`,
+        `[grades]   ${computed.length} climb+angle rows (isotonic moved ${isotonicStats.movedRows}, ${isotonicStats.residualInversions} residual inversions; display-delta hygiene downgraded ${boardDisplayDeltaHygieneStats.downgradedRows})`,
       );
     }
     const allComputed = [...computedByBoard.values()].flat();
     const noShockGate = evaluateNoShock(allComputed);
     const fingerprintGate = evaluateFingerprintConsistency(allComputed);
-    gates.push(noShockGate, fingerprintGate);
+    const displayDeltaHygieneGate = evaluateDisplayDeltaHygiene(displayDeltaHygieneStats);
+    gates.push(noShockGate, fingerprintGate, displayDeltaHygieneGate);
     console.log(`[grades]   no_shock: ${noShockGate.passed ? 'PASS' : 'FAIL'} — ${noShockGate.detail}`);
     console.log(
       `[grades]   fingerprint_consistency: ${fingerprintGate.passed ? 'PASS' : 'FAIL'} — ${fingerprintGate.detail}`,
+    );
+    console.log(
+      `[grades]   display_delta_hygiene: ${displayDeltaHygieneGate.passed ? 'PASS' : 'FAIL'} — ${displayDeltaHygieneGate.detail}`,
     );
 
     await recordGateResults(db, coefficients, gates);

--- a/packages/db/src/queries/grade-model/__tests__/grade-model.test.ts
+++ b/packages/db/src/queries/grade-model/__tests__/grade-model.test.ts
@@ -23,8 +23,15 @@ import {
   type TauSampleRow,
 } from '../coefficients';
 import { evaluateBacktest, evaluateFingerprintGate, evaluateResidualGapGate, type BacktestSampleRow } from '../gates';
+import {
+  applyDisplayDeltaHygiene,
+  createDisplayDeltaHygieneStats,
+  evaluateDisplayDeltaHygiene,
+  mergeDisplayDeltaHygieneStats,
+  recordDisplayDeltaHygiene,
+} from '../hygiene';
 import { CONFIDENCE, DEFAULT_ECHO_FRACTION } from '../constants';
-import type { ClimbAngleObservation, GradeCoefficients } from '../types';
+import type { ClimbAngleObservation, GradeCoefficients, PosteriorGrade } from '../types';
 
 function makeCoefficients(overrides: Partial<GradeCoefficients> = {}): GradeCoefficients {
   return {
@@ -57,6 +64,18 @@ function observation(partial: Partial<ClimbAngleObservation>): ClimbAngleObserva
     difficultyAverage: null,
     displayDifficulty: null,
     ascensionistCount: 0,
+    ...partial,
+  };
+}
+
+function posterior(partial: Partial<PosteriorGrade>): PosteriorGrade {
+  return {
+    localGrade: 20,
+    universalGrade: 19,
+    gradeLow: 18.5,
+    gradeHigh: 19.5,
+    confidence: CONFIDENCE.confirmed,
+    postSd: 0.25,
     ...partial,
   };
 }
@@ -242,6 +261,129 @@ void describe('shouldPublish', () => {
       true,
     );
     assert.equal(shouldPublish({ localGrade: 21, universalGrade: 19.5, confidence: CONFIDENCE.confirmed }, next), true);
+  });
+});
+
+void describe('applyDisplayDeltaHygiene', () => {
+  void test('downgrades confirmed Kilter rows outside the rounded universal-display band', () => {
+    const high = applyDisplayDeltaHygiene({
+      boardType: 'kilter',
+      displayDifficulty: 10,
+      posterior: posterior({ universalGrade: 14 }),
+    });
+    assert.equal(high.downgraded, true);
+    assert.equal(high.checked, true);
+    assert.equal(high.skippedMissingUniversal, false);
+    assert.equal(high.roundedDelta, 4);
+    assert.equal(high.posterior.confidence, CONFIDENCE.provisional);
+    assert.equal(high.posterior.universalGrade, 14);
+
+    const low = applyDisplayDeltaHygiene({
+      boardType: 'kilter',
+      displayDifficulty: 20,
+      posterior: posterior({ universalGrade: 16 }),
+    });
+    assert.equal(low.downgraded, true);
+    assert.equal(low.checked, true);
+    assert.equal(low.roundedDelta, -4);
+    assert.equal(low.posterior.confidence, CONFIDENCE.provisional);
+  });
+
+  void test('keeps boundary deltas confirmed', () => {
+    const lowerBoundary = applyDisplayDeltaHygiene({
+      boardType: 'kilter',
+      displayDifficulty: 20,
+      posterior: posterior({ universalGrade: 17 }),
+    });
+    const upperBoundary = applyDisplayDeltaHygiene({
+      boardType: 'kilter',
+      displayDifficulty: 20,
+      posterior: posterior({ universalGrade: 21 }),
+    });
+    assert.equal(lowerBoundary.downgraded, false);
+    assert.equal(lowerBoundary.checked, true);
+    assert.equal(lowerBoundary.roundedDelta, -3);
+    assert.equal(lowerBoundary.posterior.confidence, CONFIDENCE.confirmed);
+    assert.equal(upperBoundary.downgraded, false);
+    assert.equal(upperBoundary.checked, true);
+    assert.equal(upperBoundary.roundedDelta, 1);
+    assert.equal(upperBoundary.posterior.confidence, CONFIDENCE.confirmed);
+  });
+
+  void test('leaves non-Kilter, non-confirmed, and incomplete rows unchanged', () => {
+    const nonKilter = applyDisplayDeltaHygiene({
+      boardType: 'tension',
+      displayDifficulty: 10,
+      posterior: posterior({ universalGrade: 14 }),
+    });
+    const provisional = applyDisplayDeltaHygiene({
+      boardType: 'kilter',
+      displayDifficulty: 10,
+      posterior: posterior({ confidence: CONFIDENCE.provisional, universalGrade: 14 }),
+    });
+    const noUniversal = applyDisplayDeltaHygiene({
+      boardType: 'kilter',
+      displayDifficulty: 10,
+      posterior: posterior({ universalGrade: null }),
+    });
+    const noDisplay = applyDisplayDeltaHygiene({
+      boardType: 'kilter',
+      displayDifficulty: null,
+      posterior: posterior({ universalGrade: 14 }),
+    });
+    assert.equal(nonKilter.downgraded, false);
+    assert.equal(provisional.downgraded, false);
+    assert.equal(noUniversal.downgraded, false);
+    assert.equal(noUniversal.checked, false);
+    assert.equal(noUniversal.skippedMissingUniversal, true);
+    assert.equal(noDisplay.downgraded, false);
+    assert.equal(noDisplay.skippedMissingUniversal, false);
+  });
+
+  void test('records report-only hygiene gate metrics', () => {
+    const left = createDisplayDeltaHygieneStats();
+    const right = createDisplayDeltaHygieneStats();
+    recordDisplayDeltaHygiene(
+      left,
+      applyDisplayDeltaHygiene({
+        boardType: 'kilter',
+        displayDifficulty: 10,
+        posterior: posterior({ universalGrade: 14 }),
+      }),
+    );
+    recordDisplayDeltaHygiene(
+      right,
+      applyDisplayDeltaHygiene({
+        boardType: 'kilter',
+        displayDifficulty: 20,
+        posterior: posterior({ universalGrade: 16 }),
+      }),
+    );
+    mergeDisplayDeltaHygieneStats(left, right);
+    const gate = evaluateDisplayDeltaHygiene(left);
+    assert.equal(gate.passed, true);
+    assert.equal(gate.metrics.checkedRows, 2);
+    assert.equal(gate.metrics.skippedMissingUniversalRows, 0);
+    assert.equal(gate.metrics.downgradedRows, 2);
+    assert.equal(gate.metrics.minDelta, -4);
+    assert.equal(gate.metrics.maxDelta, 4);
+  });
+
+  void test('reports skipped hygiene when Kilter universal grades are unavailable', () => {
+    const stats = createDisplayDeltaHygieneStats();
+    recordDisplayDeltaHygiene(
+      stats,
+      applyDisplayDeltaHygiene({
+        boardType: 'kilter',
+        displayDifficulty: 10,
+        posterior: posterior({ universalGrade: null }),
+      }),
+    );
+    const gate = evaluateDisplayDeltaHygiene(stats);
+    assert.equal(gate.passed, true);
+    assert.equal(gate.metrics.checkedRows, 0);
+    assert.equal(gate.metrics.skippedMissingUniversalRows, 1);
+    assert.match(gate.detail, /not checked/);
   });
 });
 

--- a/packages/db/src/queries/grade-model/constants.ts
+++ b/packages/db/src/queries/grade-model/constants.ts
@@ -8,7 +8,7 @@
  */
 
 /** Blend/tier/hysteresis logic version, stored on every published row. */
-export const GRADE_MODEL_VERSION = 'v1.1'; // v1.1: per-climb isotonic angle constraint
+export const GRADE_MODEL_VERSION = 'v1.2'; // v1.2: Kilter display-delta hygiene
 
 /**
  * Boards whose upstream `difficulty_average` is a live crowd mean (fractional,
@@ -67,6 +67,15 @@ export const CONFIRMED_MAX_POST_SD = 0.35;
  * kills nightly jitter without hiding real movement.
  */
 export const PUBLISH_HYSTERESIS_GRADE = 0.5;
+
+/**
+ * Kilter upstream has a small tail of confirmed rows whose display grade is
+ * clearly mixed-scale or corrupted. Keep the computed grade but never call that
+ * row confirmed when its rounded universal grade is outside this display delta.
+ */
+export const KILTER_DISPLAY_DELTA_HYGIENE_BOARD = 'kilter';
+export const KILTER_DISPLAY_DELTA_MIN = -3;
+export const KILTER_DISPLAY_DELTA_MAX = 1;
 
 /**
  * Fallback echo fraction: the share of logged grades that are quick-log

--- a/packages/db/src/queries/grade-model/hygiene.ts
+++ b/packages/db/src/queries/grade-model/hygiene.ts
@@ -1,0 +1,133 @@
+import {
+  CONFIDENCE,
+  KILTER_DISPLAY_DELTA_HYGIENE_BOARD,
+  KILTER_DISPLAY_DELTA_MAX,
+  KILTER_DISPLAY_DELTA_MIN,
+} from './constants';
+import type { GateResult, PosteriorGrade } from './types';
+
+export interface DisplayDeltaHygieneInput {
+  boardType: string;
+  displayDifficulty: number | null;
+  posterior: PosteriorGrade;
+}
+
+export interface DisplayDeltaHygieneResult {
+  posterior: PosteriorGrade;
+  downgraded: boolean;
+  checked: boolean;
+  skippedMissingUniversal: boolean;
+  roundedDelta: number | null;
+}
+
+export interface DisplayDeltaHygieneStats {
+  checkedRows: number;
+  skippedMissingUniversalRows: number;
+  downgradedRows: number;
+  minDelta: number | null;
+  maxDelta: number | null;
+}
+
+export function createDisplayDeltaHygieneStats(): DisplayDeltaHygieneStats {
+  return { checkedRows: 0, skippedMissingUniversalRows: 0, downgradedRows: 0, minDelta: null, maxDelta: null };
+}
+
+function isOutsideKilterDisplayDelta(delta: number): boolean {
+  return delta < KILTER_DISPLAY_DELTA_MIN || delta > KILTER_DISPLAY_DELTA_MAX;
+}
+
+export function applyDisplayDeltaHygiene(input: DisplayDeltaHygieneInput): DisplayDeltaHygieneResult {
+  if (
+    input.boardType !== KILTER_DISPLAY_DELTA_HYGIENE_BOARD ||
+    input.posterior.confidence !== CONFIDENCE.confirmed ||
+    input.displayDifficulty === null ||
+    !Number.isFinite(input.displayDifficulty)
+  ) {
+    return {
+      posterior: input.posterior,
+      downgraded: false,
+      checked: false,
+      skippedMissingUniversal: false,
+      roundedDelta: null,
+    };
+  }
+
+  if (input.posterior.universalGrade === null || !Number.isFinite(input.posterior.universalGrade)) {
+    return {
+      posterior: input.posterior,
+      downgraded: false,
+      checked: false,
+      skippedMissingUniversal: true,
+      roundedDelta: null,
+    };
+  }
+
+  const roundedDelta = Math.round(input.posterior.universalGrade) - Math.round(input.displayDifficulty);
+  if (!isOutsideKilterDisplayDelta(roundedDelta)) {
+    return {
+      posterior: input.posterior,
+      downgraded: false,
+      checked: true,
+      skippedMissingUniversal: false,
+      roundedDelta,
+    };
+  }
+
+  return {
+    posterior: { ...input.posterior, confidence: CONFIDENCE.provisional },
+    downgraded: true,
+    checked: true,
+    skippedMissingUniversal: false,
+    roundedDelta,
+  };
+}
+
+export function recordDisplayDeltaHygiene(stats: DisplayDeltaHygieneStats, result: DisplayDeltaHygieneResult): void {
+  if (result.checked) stats.checkedRows += 1;
+  if (result.skippedMissingUniversal) stats.skippedMissingUniversalRows += 1;
+  if (!result.downgraded || result.roundedDelta === null) return;
+  stats.downgradedRows += 1;
+  stats.minDelta = stats.minDelta === null ? result.roundedDelta : Math.min(stats.minDelta, result.roundedDelta);
+  stats.maxDelta = stats.maxDelta === null ? result.roundedDelta : Math.max(stats.maxDelta, result.roundedDelta);
+}
+
+export function mergeDisplayDeltaHygieneStats(
+  target: DisplayDeltaHygieneStats,
+  source: DisplayDeltaHygieneStats,
+): void {
+  target.checkedRows += source.checkedRows;
+  target.skippedMissingUniversalRows += source.skippedMissingUniversalRows;
+  target.downgradedRows += source.downgradedRows;
+  if (source.minDelta !== null)
+    target.minDelta = target.minDelta === null ? source.minDelta : Math.min(target.minDelta, source.minDelta);
+  if (source.maxDelta !== null)
+    target.maxDelta = target.maxDelta === null ? source.maxDelta : Math.max(target.maxDelta, source.maxDelta);
+}
+
+export function evaluateDisplayDeltaHygiene(stats: DisplayDeltaHygieneStats): GateResult {
+  const minDelta = stats.minDelta ?? 0;
+  const maxDelta = stats.maxDelta ?? 0;
+  let detail: string;
+  if (stats.checkedRows === 0 && stats.skippedMissingUniversalRows > 0) {
+    detail = `${stats.skippedMissingUniversalRows} Kilter confirmed rows not checked for rounded universal-display delta because universal grades were unavailable`;
+  } else if (stats.downgradedRows === 0) {
+    detail = `0 Kilter confirmed rows downgraded for rounded universal-display delta outside [${KILTER_DISPLAY_DELTA_MIN}, ${KILTER_DISPLAY_DELTA_MAX}] across ${stats.checkedRows} checked rows`;
+  } else {
+    detail = `${stats.downgradedRows} Kilter confirmed rows downgraded for rounded universal-display delta outside [${KILTER_DISPLAY_DELTA_MIN}, ${KILTER_DISPLAY_DELTA_MAX}] across ${stats.checkedRows} checked rows (min ${minDelta}, max ${maxDelta})`;
+  }
+
+  return {
+    gate: 'display_delta_hygiene',
+    passed: true,
+    detail,
+    metrics: {
+      checkedRows: stats.checkedRows,
+      skippedMissingUniversalRows: stats.skippedMissingUniversalRows,
+      downgradedRows: stats.downgradedRows,
+      minDelta,
+      maxDelta,
+      minAllowed: KILTER_DISPLAY_DELTA_MIN,
+      maxAllowed: KILTER_DISPLAY_DELTA_MAX,
+    },
+  };
+}

--- a/packages/db/src/queries/grade-model/index.ts
+++ b/packages/db/src/queries/grade-model/index.ts
@@ -3,4 +3,5 @@ export * from './types';
 export * from './blend';
 export * from './coefficients';
 export * from './gates';
+export * from './hygiene';
 export * from './isotonic';


### PR DESCRIPTION
## Summary

- Add Kilter-only display-delta hygiene for Boardsesh grades.
- Downgrade otherwise-confirmed Kilter rows to `provisional` when `round(universal_grade) - round(display_difficulty)` falls outside `[-3, +1]`.
- Keep the computed grade, bands, and source data unchanged; this is output confidence hygiene, not universal grade lowering or source repair.
- Report/persist a `display_delta_hygiene` gate metric and include the report in `--validate-only`.

## Notes

- Built as the follow-up to #3573, which has now merged to `main`.
- Duplicate-fingerprint pooling still computes shared grade posteriors, but the hygiene comparison uses the emitted climb+angle row's own display label.
- Fixes #3545.

## Validation

- `vp staged`
- `vp run typecheck:db`
- `vp run test:db` ran the full db suite. The new `applyDisplayDeltaHygiene` tests passed in the output, but the suite failed on an unrelated local DB-state-sensitive `user_boards serial uniqueness` integration test.
