### PR TITLE
fix(mobile): light iOS Kilter boxes whose RX char is write-with-response only

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -197,7 +197,7 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
     name: appName,
     slug: 'boardsesh',
     owner: 'boardsesh',
-    version: '2.2.1',
+    version: '2.2.2',
     scheme: 'com.boardsesh.app',
     orientation: 'portrait',
     icon: iconPath,

--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -189,6 +189,18 @@ final class BoardBleWriteFlowTests: XCTestCase {
         )
     }
 
+    private func kilterConfiguration() -> BoardBleConfiguration {
+        BoardBleConfiguration(
+            boardName: "kilter",
+            layoutId: 1,
+            sizeId: 1,
+            apiLevel: nil,
+            deviceName: nil,
+            colorOverrides: [:],
+            numRows: nil
+        )
+    }
+
     /// Fire the most recently scheduled one-shot with `label`, on the BLE queue.
     private func fireLatestOneShot(label: String) {
         manager.testHooks.sync {
@@ -488,6 +500,100 @@ final class BoardBleWriteFlowTests: XCTestCase {
             manager.write(data: Data((0 ..< 10).map { UInt8($0) })) { _, _ in }
         }
         XCTAssertTrue(hooks.sync { hooks.hasPendingWriteResume })
+    }
+
+    // 5d
+    // A Kilter box whose RX characteristic advertises ONLY `.write` (no
+    // `.writeWithoutResponse` bit — the original MoonBoard box's signature, and
+    // some Kilter-built controllers). The app starts it on without-response
+    // (Aurora default), the write parks and the watchdog trips with canSend stuck
+    // false. Because the characteristic can't take a no-response write at all,
+    // switch THIS connection to write-with-response instead of bypassing the gate,
+    // and remember the board so a reconnect skips the stall.
+    func testWatchdogTripOnWriteOnlyCharacteristicSwitchesToWriteWithResponse() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .write)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        var completionError: Error?
+        var completionTelemetry: BoardBleWriteTelemetry?
+        var completionCount = 0
+
+        hooks.sync {
+            hooks.setConfiguration(kilterConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { error, telemetry in
+                completionError = error
+                completionTelemetry = telemetry
+                completionCount += 1
+            }
+        }
+        // Started on the Aurora without-response path: parked on the false gate,
+        // neither latch set yet.
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+        XCTAssertFalse(hooks.sync { hooks.forceWriteWithResponse })
+        XCTAssertFalse(hooks.sync { hooks.bypassCanSendWriteWithoutResponse })
+
+        // Watchdog trips with canSend STILL false -> `.write`-only characteristic
+        // -> switch to write-with-response and fire the chunk on that path.
+        fireLatestOneShot(label: "writeResumeWatchdog")
+
+        XCTAssertTrue(hooks.sync { hooks.forceWriteWithResponse })
+        // Did NOT take the stuck-false bypass (that keeps without-response).
+        XCTAssertFalse(hooks.sync { hooks.bypassCanSendWriteWithoutResponse })
+        // The board is remembered for next time.
+        XCTAssertTrue(hooks.sync { hooks.writeWithResponsePeripheralIds.contains(peripheral.identifier) })
+        // The chunk went out WITH response, paced on the ack watchdog (no chunkDelay).
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(peripheral.writtenChunks[0].type, .withResponse)
+        XCTAssertNotNil(scheduler.lastOneShot(label: "writeAckWatchdog"))
+        XCTAssertEqual(completionCount, 0)
+        // No link cycle: not disconnected, recovery budget untouched.
+        XCTAssertTrue(cancelledPeripheralIds.isEmpty)
+        XCTAssertEqual(hooks.sync { hooks.writeStallRecoveries }, 0)
+
+        // The board's ack completes the write.
+        hooks.fireWriteAck(error: nil)
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertNil(completionError)
+        XCTAssertEqual(completionTelemetry?.watchdogTripped, true)
+        XCTAssertEqual(completionTelemetry?.canSendAtTrip, false)
+        XCTAssertEqual(completionTelemetry?.lastResumeSource, "withResponse")
+    }
+
+    // 5e
+    // Once a board is learned to need write-with-response, a reconnect starts it
+    // on that path immediately — no repeat of the one-time without-response stall.
+    func testLearnedWriteWithResponsePersistsAcrossReconnect() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .write)
+
+        // First connection: learn via the stall -> switch -> ack.
+        hooks.sync {
+            hooks.setConfiguration(kilterConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: Data((0 ..< 10).map { UInt8($0) })) { _, _ in }
+        }
+        fireLatestOneShot(label: "writeResumeWatchdog")
+        hooks.fireWriteAck(error: nil)
+        XCTAssertTrue(hooks.sync { hooks.forceWriteWithResponse })
+
+        // Reconnect to the same board: the latch is re-seeded from the learned set
+        // straight away.
+        hooks.sync { hooks.setConnection(peripheral: peripheral, characteristic: characteristic) }
+        XCTAssertTrue(hooks.sync { hooks.forceWriteWithResponse })
+
+        // A fresh write goes out with-response with NO park — even though canSend
+        // is still false, the without-response gate is never consulted.
+        let writtenBefore = peripheral.writtenChunks.count
+        hooks.sync {
+            manager.write(data: Data((100 ..< 110).map { UInt8($0) })) { _, _ in }
+        }
+        XCTAssertEqual(peripheral.writtenChunks.count, writtenBefore + 1)
+        XCTAssertEqual(peripheral.writtenChunks.last?.type, .withResponse)
+        XCTAssertFalse(hooks.sync { hooks.hasPendingWriteResume })
     }
 
     // 6

--- a/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
@@ -32,13 +32,22 @@ enum BoardBleEncoding {
     /// to write-with-response made boards whose ATT ack never arrives stall on
     /// every write — the status LED lights but the climb never displays.
     ///
-    /// Only the original MoonBoard LED box needs write-with-response: its UART RX
-    /// characteristic advertises only `.write`, and CoreBluetooth SILENTLY DROPS a
-    /// `.withoutResponse` write to a characteristic that lacks the property (which
-    /// left the MoonBoard wall dark on iOS while Android — whose GATT stack sends
-    /// no-response writes regardless — worked). So for MoonBoard, and only
+    /// Only the original MoonBoard LED box needs write-with-response UP FRONT: its
+    /// UART RX characteristic advertises only `.write`, and CoreBluetooth SILENTLY
+    /// DROPS a `.withoutResponse` write to a characteristic that lacks the property
+    /// (which left the MoonBoard wall dark on iOS while Android — whose GATT stack
+    /// sends no-response writes regardless — worked). So for MoonBoard, and only
     /// MoonBoard, fall back to `.withResponse` whenever `.writeWithoutResponse` is
     /// absent.
+    ///
+    /// Aurora boxes that ALSO advertise only `.write` (some Kilter-built
+    /// controllers) are handled the other way round — behaviourally, not here:
+    /// `BoardBleManager` still starts them on without-response, and only switches
+    /// this connection to with-response once a write demonstrably stalls on that
+    /// `.write`-only characteristic (see `forceWriteWithResponse`). Deciding it
+    /// up-front from the property bit is exactly what regressed the fleet in #3228
+    /// (a stale GATT cache can drop the bit on a healthy board), so this function
+    /// deliberately keeps Aurora on without-response regardless of the bit.
     static func preferredWriteType(
         for properties: CBCharacteristicProperties,
         boardName: String?

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -244,6 +244,27 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // normal backpressure. Fixes iOS 26.5 Kilter home walls that connected but
     // never lit a climb (write_timeout with canSendAtTrip=false on every send).
     private var bypassCanSendWriteWithoutResponse = false
+    // Latched when a without-response write stalls (watchdog trips, canSendAtTrip
+    // false, peripheralIsReady never fired) AND the RX characteristic advertises
+    // only `.write` — no `.writeWithoutResponse` bit. That is the original
+    // MoonBoard box's signature, and some Kilter-built controller boxes advertise
+    // the same way: CoreBluetooth SILENTLY DROPS every `.withoutResponse` write to
+    // such a characteristic, so the wall connects but never lights (a fast, fake
+    // "success" on iOS 26.x once the stuck-false gate is bypassed). Once latched,
+    // this connection sends on the ack-paced write-WITH-response path instead.
+    // Reset on every fresh connection, then re-seeded from
+    // `writeWithResponsePeripheralIds` so a board already proven to need it skips
+    // the stall on reconnect. Crucially BEHAVIOUR-driven, not property-driven: the
+    // without-response path is always tried first on a board we haven't learned,
+    // so a healthy board (or one whose `.writeWithoutResponse` bit is missing only
+    // because of a stale GATT cache) is never wrongly forced onto with-response —
+    // it just never trips the stall. This is what makes re-enabling with-response
+    // for Aurora safe after the #3228 property-driven attempt regressed the fleet.
+    private var forceWriteWithResponse = false
+    // Boards (by peripheral identifier) proven this session to need
+    // write-with-response. In-memory only: a re-learn on the next launch is cheap
+    // and avoids a stale decision sticking after a firmware update or box swap.
+    private var writeWithResponsePeripheralIds: Set<UUID> = []
     // Telemetry for the request currently being written (#3230). Requests are
     // strictly serial (`isWriting`), so one slot suffices: seeded when a request
     // starts, finalized at whichever settle point delivers its completion.
@@ -740,10 +761,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
-        let writeType = BoardBleEncoding.preferredWriteType(
-            for: characteristic.properties,
-            boardName: configuration?.boardName
-        )
+        let writeType = resolvedWriteType(for: characteristic)
         let chunkSize = BoardBleEncoding.effectiveChunkSize(
             negotiatedMaxWriteLength: peripheral.maximumWriteValueLength(for: writeType),
             writeType: writeType,
@@ -1246,6 +1264,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // A fresh link re-earns normal backpressure: drop any stuck-false gate
         // bypass so a healthy connection isn't permanently ungated.
         bypassCanSendWriteWithoutResponse = false
+        // Re-seed the with-response latch from what we've learned this session: a
+        // board previously proven to accept only write-with-response starts on that
+        // path immediately (no repeat of the one-time without-response stall);
+        // every other board starts on without-response and only switches if it
+        // actually stalls, so this never wrongly forces a healthy board.
+        forceWriteWithResponse = writeWithResponsePeripheralIds.contains(peripheral.identifier)
         // Remember the board so the Live Activity lightbulb can reconnect to it
         // by identifier later, no device pick required.
         persistLastConnectedPeripheral(peripheral)
@@ -1436,12 +1460,29 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         drainWaiters.signalAll()
     }
 
+    /// The write type for THIS connection. Defaults to
+    /// `BoardBleEncoding.preferredWriteType` (Aurora → without-response, MoonBoard
+    /// → property-driven), but once `forceWriteWithResponse` is latched — because a
+    /// without-response write demonstrably stalled on a `.write`-only characteristic
+    /// (or a prior connection to this board already learned that) — Aurora also
+    /// takes write-with-response. Guarded on `.write` so a characteristic that
+    /// advertises neither write flavour can't be pushed onto a path it can't take.
+    private func resolvedWriteType(for characteristic: CBCharacteristic) -> CBCharacteristicWriteType {
+        if forceWriteWithResponse, characteristic.properties.contains(.write) {
+            return .withResponse
+        }
+        return BoardBleEncoding.preferredWriteType(
+            for: characteristic.properties,
+            boardName: configuration?.boardName
+        )
+    }
+
     private func connectionDiagnosticsOnBleQueue(
         peripheral: WritableBlePeripheral,
         characteristic: CBCharacteristic
     ) -> BoardBleConnectionDiagnostics {
         let properties = characteristic.properties
-        let writeType = BoardBleEncoding.preferredWriteType(for: properties, boardName: configuration?.boardName)
+        let writeType = resolvedWriteType(for: characteristic)
         return BoardBleConnectionDiagnostics(
             characteristicProperties: Int(properties.rawValue),
             supportsWriteWithoutResponse: properties.contains(.writeWithoutResponse),
@@ -1570,7 +1611,13 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
-        if request.writeType == .withoutResponse {
+        // Effective write type: honour the request's own type, but also route to
+        // write-with-response when this connection has been latched onto it
+        // (`forceWriteWithResponse`) — a parked without-response write that trips
+        // the stall watchdog below switches mid-flight without re-queuing.
+        let sendWithResponse = request.writeType == .withResponse
+            || (forceWriteWithResponse && characteristic.properties.contains(.write))
+        if !sendWithResponse {
             // `bypassCanSendWriteWithoutResponse` short-circuits the gate on a
             // connection we've already proven reports the property stuck false
             // (see the watchdog handler below): keep writing, paced by chunkDelay.
@@ -1616,7 +1663,34 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                     // one writeResumeTimeout; every later send on this connection
                     // skips the gate. A vanished peripheral (nil) or a genuine
                     // missed-flip (true) still falls through to stall recovery.
-                    if canSendAtTrip == false, !self.bypassCanSendWriteWithoutResponse {
+                    if canSendAtTrip == false, !self.bypassCanSendWriteWithoutResponse, !self.forceWriteWithResponse {
+                        // Split the two iOS failure modes by the characteristic's OWN
+                        // advertised properties. A characteristic that advertises only
+                        // `.write` (no `.writeWithoutResponse` bit) genuinely cannot take a
+                        // no-response write — CoreBluetooth silently drops it — so bypassing
+                        // the gate would just fire more writes into the void. That is the
+                        // original MoonBoard box's signature, and some Kilter-built controller
+                        // boxes advertise the same way. Switch THIS connection to the
+                        // ack-paced write-with-response path (and remember the board so a
+                        // reconnect skips this stall). Reaching here proves without-response
+                        // already failed, so this can never degrade a board it would have
+                        // worked on.
+                        if let characteristic = self.writeCharacteristic,
+                           characteristic.properties.contains(.write),
+                           !characteristic.properties.contains(.writeWithoutResponse) {
+                            if let peripheral = self.connectedPeripheral {
+                                self.writeWithResponsePeripheralIds.insert(peripheral.identifier)
+                            }
+                            self.forceWriteWithResponse = true
+                            self.logger.error("BLE write stalled: RX characteristic advertises only .write; switching this connection to write-with-response")
+                            self.resumeParkedWrite(source: "withResponse")
+                            return
+                        }
+                        // The characteristic DOES advertise `.writeWithoutResponse` but the
+                        // property is stuck false — the iOS 26.x flow-control bug on an
+                        // otherwise-normal board. Latch past the gate and keep
+                        // write-without-response; the radio takes the write even though the
+                        // flag lies.
                         self.bypassCanSendWriteWithoutResponse = true
                         self.logger.error("BLE write stalled: canSendWriteWithoutResponse stuck false across the watchdog window; bypassing the gate for this connection and resuming the write")
                         self.resumeParkedWrite(source: "bypass")
@@ -1641,9 +1715,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
-        // Write-WITH-response path (e.g. the original MoonBoard LED box, whose
-        // UART RX characteristic advertises only `.write`). CoreBluetooth would
-        // silently drop a `.withoutResponse` write to it — so pace on the
+        // Write-WITH-response path: the original MoonBoard LED box (whose UART RX
+        // characteristic advertises only `.write`), and any Aurora box latched onto
+        // it via `forceWriteWithResponse` after without-response stalled on the same
+        // `.write`-only signature. CoreBluetooth would silently drop a
+        // `.withoutResponse` write to such a characteristic — so pace on the
         // `didWriteValueFor` ack instead of `canSendWriteWithoutResponse` /
         // `peripheralIsReady`. The ack is itself the backpressure signal, so the
         // fixed `chunkDelay` isn't needed here.
@@ -1881,8 +1957,14 @@ extension BoardBleManager {
             manager.connectedPeripheral = peripheral
             manager.writeCharacteristic = characteristic
             // Mirror the production reset in didDiscoverCharacteristicsFor so a
-            // reconnect in a test starts with the gate re-armed.
+            // reconnect in a test starts with the gate re-armed and the
+            // with-response latch re-seeded from what the session has learned.
             manager.bypassCanSendWriteWithoutResponse = false
+            if let identifier = peripheral?.identifier {
+                manager.forceWriteWithResponse = manager.writeWithResponsePeripheralIds.contains(identifier)
+            } else {
+                manager.forceWriteWithResponse = false
+            }
         }
 
         /// Set the in-memory board configuration WITHOUT the app-group persistence
@@ -1938,6 +2020,8 @@ extension BoardBleManager {
         var writeStallRecoveries: Int { manager.writeStallRecoveries }
         var writeStallRecoveringPeripheralId: UUID? { manager.writeStallRecoveringPeripheralId }
         var bypassCanSendWriteWithoutResponse: Bool { manager.bypassCanSendWriteWithoutResponse }
+        var forceWriteWithResponse: Bool { manager.forceWriteWithResponse }
+        var writeWithResponsePeripheralIds: Set<UUID> { manager.writeWithResponsePeripheralIds }
     }
 
     var testHooks: TestHooks { TestHooks(manager: self) }


### PR DESCRIPTION
## What & why

Some **mid-2025 Kilter-built** LED boxes advertise a UART RX characteristic with **only the `.write` property** (no `.writeWithoutResponse`) — the same signature as the original MoonBoard box. Boardsesh forced write-**without**-response for all Aurora boards, and iOS CoreBluetooth **silently drops** a no-response write to such a characteristic. The result on iOS: the box connects, you can swipe climbs, the send even reports a fast "success" (a fake ack once the iOS-26.x stuck-false gate is bypassed), **but the holds never light** and the link drops within seconds.

Diagnosed from PostHog for Discord user *skunk* (iOS 26.5.2, Kilter-built box):
- `bleCharProperties = 8` (`.write` only), `bleSupportsWithoutResponse = false`
- `bleChosenWriteType = withoutResponse`, `blePeripheralIsReadyFired = false` on every write
- 2.2.0 → 5 s `write_timeout` failures; 2.2.1 → instant fake "success", board still dark
- Session recording: connected, swiping climbs, wall dark

**Scope:** ~24 iOS users share this box class (21 Kilter + 3 Tension over 60 days). A normal box reports `bleCharProperties = 12` (both write flavours) and works fine.

## The fix (and why it can't regress the fleet)

Deciding write-type from the characteristic's property bit **up front** is exactly what regressed the fleet in #3225 → reverted by #3228 (a stale GATT cache can drop the `.writeWithoutResponse` bit on a healthy board, wrongly forcing it onto a with-response path that then stalls).

So this fix is **behaviour-driven, not property-driven**:
- Aurora boards still **start** on write-without-response — unchanged for every working box.
- Only when a write **demonstrably stalls** (watchdog trips, `canSend` stuck false, `peripheralIsReady` never fired) **and** the characteristic advertises **only `.write`** does the connection switch to the existing ack-paced write-**with**-response path.
- The board is remembered (in-memory, per session) so reconnects skip the one-time stall.

A healthy board never trips that stall, so it's **never** forced onto with-response — even if its `.writeWithoutResponse` bit is momentarily missing from a stale cache. Reaching the switch proves without-response already failed, so it can only ever help.

Native-iOS only (`BoardBleManager.swift` / `BoardBleEncoding.swift`); MoonBoard and the JS/Android path are untouched. Ships in a **native build (2.2.2)** — not OTA-able.

## Testing
- Swift write-flow tests `5d` (watchdog trip on a `.write`-only char → switch to with-response + remember board) and `5e` (learned decision persists across reconnect). XCTests run on macOS CI only.
- TS `vp run typecheck:mobile` green.
- **On-device (needs a `.write`-only Kilter box or skunk's box):** cannot be reproduced on a simulator or a normal Kilter box. QA plan in `.boardsesh/qa-notes.md`. Plan: skunk validates on the 2.2.2 TestFlight build; confirm a normal Kilter box still writes `withoutResponse` (regression guard).

## Release Notes
Using an early-2025 Kilter LED box on iPhone? It would connect but the holds stayed dark no matter which climb you picked. Now it lights up like it should — pick a climb and the wall comes on.
