### PR TITLE
docs(ble): Aurora write type is per-characteristic, not always without-response

### DIFF
--- a/docs/AURORA_BLUETOOTH_PROTOCOL_SPEC.md
+++ b/docs/AURORA_BLUETOOTH_PROTOCOL_SPEC.md
@@ -54,7 +54,7 @@ The protocol is built on top of the **Nordic UART Service (NUS)**, a widely-used
 | ------------------------ | -------------------------------------- | ------------------------------------------------------------------- |
 | **Aurora Board Service** | `4488B571-7806-4DF6-BCFF-A2897E4953FF` | Primary advertisement service UUID; used to filter BLE scan results |
 | **Nordic UART Service**  | `6E400001-B5A3-F393-E0A9-E50E24DCCA9E` | Data transport service (NUS)                                        |
-| **RX Characteristic**    | `6E400002-B5A3-F393-E0A9-E50E24DCCA9E` | App writes LED commands here (Write Without Response)               |
+| **RX Characteristic**    | `6E400002-B5A3-F393-E0A9-E50E24DCCA9E` | App writes LED commands here (write type per characteristic — see §9) |
 | **TX Characteristic**    | `6E400003-B5A3-F393-E0A9-E50E24DCCA9E` | Board sends data to app (Notify)                                    |
 | **CCCD**                 | `00002902-0000-1000-8000-00805f9b34fb` | Client Characteristic Configuration Descriptor                      |
 
@@ -461,7 +461,10 @@ Each 20-byte chunk is written to the RX characteristic as a separate GATT write 
 
 ### Write Properties
 
-- **Write type**: Write Without Response (implied by Nordic UART RX characteristic)
+- **Write type depends on the controller-box generation** — it is a property of the box's advertised characteristic, not a protocol invariant. Two generations exist in the field:
+  - The common box (field telemetry `bleCharProperties=12`, API level 3) advertises **both** `.write` (bit 8) and `.writeWithoutResponse` (bit 4), and is driven with **Write Without Response**.
+  - A mid-2025 Kilter-built box (field telemetry `bleCharProperties=8`, API level 2) advertises **only** `.write` — the `.writeWithoutResponse` bit is absent. On iOS, CoreBluetooth **silently drops** a write-without-response to a characteristic that lacks the no-response property, so this box stays dark on a client that hardcodes without-response. An interoperable iOS client must fall back to **write-with-response** (pacing on the GATT write ack) whenever the RX characteristic doesn't advertise `.writeWithoutResponse`. Android's GATT stack issues no-response writes regardless of the advertised property, so the same write call works on both generations there — which is why this defect is iOS-only.
+  - The `bleCharProperties` / API-level correlation is clean and stable per-connect (8↔v2, 12↔v3), distinguishing a genuine hardware generation from a stale iOS GATT cache (which flickers between the two). This is the same characteristic-capability gating the MoonBoard spec already documents for the RedBearLab box (`MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md` §5.4).
 - Each chunk is enqueued as a separate `writeCharacteristic()` command
 - The command queue ensures serial execution with GATT write completion callbacks
 

--- a/docs/LED_BOX_BLE_CONNECTION_PROTOCOL.md
+++ b/docs/LED_BOX_BLE_CONNECTION_PROTOCOL.md
@@ -36,7 +36,7 @@ Each claim is tagged so you can tell evidence from inheritance:
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------- |
 | Same protocol as Aurora app?                  | **Yes.** Identical service/characteristic UUIDs and advertised-service scan filter.              | ✅      |
 | BLE library                                   | `flutter_blue_plus`                                                                              | ✅      |
-| Writes LED data to                            | RX char `6E400002-…` (Nordic UART RX), **Write Without Response**                                | ✅      |
+| Writes LED data to                            | RX char `6E400002-…` (Nordic UART RX); write type derived from the characteristic (see §6.5)     | 🔁      |
 | Subscribes to board notifications?            | **No.** TX char `6E400003-…` does **not** appear anywhere in the binary — the app is write-only. | ✅      |
 | Negotiates MTU?                               | **Yes** (`requestMtu` / `BmMtuChangeRequest`) — new vs. the Aurora-app spec.                     | ✅      |
 | Picks which board?                            | Ranks scan results, reads RSSI per device (`BmReadRssiResult`) to surface the nearest.           | ✅ / ❓ |
@@ -244,7 +244,8 @@ Colour comes from the placement role's 6-hex LED colour (`_colorFromHex`); unkno
 ### 6.5 Multi-part + transport chunking
 
 - LED records are packed into frames; when a frame would exceed 255 payload bytes a new frame is started. One frame → `Single`; many → `First` / `Middle…` / `Last`.
-- All frames are concatenated, then the byte stream is split into BLE writes. The classic transport size is **20 bytes/write**; with this app's negotiated MTU each `writeWithoutResponse` can be larger. ✅ Write type is **Write Without Response** (`, writeWithoutResponse: …`).
+- All frames are concatenated, then the byte stream is split into BLE writes. The classic transport size is **20 bytes/write**; with this app's negotiated MTU each write can be larger.
+- 🔁 **Write type is derived from the characteristic, not hardcoded.** The `, writeWithoutResponse: …` string in the binary is `flutter_blue_plus`'s `CharacteristicProperties.toString()` field — it reports the RX characteristic's advertised *capability*, not the write mode the app actually issues. `flutter_blue_plus`'s `write()` **defaults to write-with-response**; a caller opts into without-response explicitly. So this single cross-platform stack follows whatever the box advertises: without-response on the common `bleCharProperties=12` box, and with-response on the write-only `bleCharProperties=8` box (whose `.writeWithoutResponse` bit is absent). That is why the official app lights **both** box generations on iOS. See the two-generation split and the iOS silent-drop consequence in `AURORA_BLUETOOTH_PROTOCOL_SPEC.md` §9 (Write Properties).
 
 > **Boardsesh implementation note (#3230):** Boardsesh follows this app's MTU-negotiated chunking, but clamps the without-response chunk to **[20, 244]** (ATT 247) — iOS-26.5 field telemetry showed write failures clustering at the full ATT 512. Android requests ATT 247 explicitly (`requestMTU(247)`); iOS clamps whatever CoreBluetooth auto-negotiated. See `effectiveChunkSizeForMtu` in `packages/shared/ble-protocol/src/transport.ts` and its Swift twin `BoardBleEncoding.effectiveChunkSize`.
 


### PR DESCRIPTION
## Summary

Corrects the Aurora BLE protocol docs, which asserted **write-without-response** as a protocol invariant ("implied by the Nordic UART RX characteristic"). That assumption is exactly what left a user's box dark on iOS — and it doesn't match either the hardware or the official Kilter app.

Findings behind this change:
- I pulled the official **Kilter Board** app (`com.kiltergrips.kilter_board_app` v2.7.0) from APKPure and analysed it. It's **Flutter** (`libapp.so`, AOT Dart), driving BLE through **`flutter_blue_plus`** — one cross-platform stack, not a per-brand native path.
- `flutter_blue_plus`'s `write()` **defaults to write-with-response** and follows the characteristic's advertised capability. The `writeWithoutResponse:` string in the binary is `CharacteristicProperties.toString()` (advertised *capability*), not proof the app issues without-response writes.
- Field telemetry shows **two Aurora controller-box generations**, cleanly split: `bleCharProperties=12` / API 3 (advertises `.writeWithoutResponse`) vs. a mid-2025 Kilter-built box `bleCharProperties=8` / API 2 (advertises `.write` only). On the write-only box, iOS CoreBluetooth **silently drops** without-response writes → wall stays dark. The correlation is stable per-connect, distinguishing a real hardware generation from a stale iOS GATT cache.

This is the same characteristic-capability gating the MoonBoard spec (§5.4) already documents for the RedBearLab box; the Aurora docs just never captured it.

### Changes
- `docs/AURORA_BLUETOOTH_PROTOCOL_SPEC.md` — §9 "Write Properties" now documents both box generations and the iOS silent-drop consequence; RX characteristic table row no longer states write-without-response as absolute.
- `docs/LED_BOX_BLE_CONNECTION_PROTOCOL.md` — corrects the over-read of the `writeWithoutResponse:` binary string; write type is derived from the characteristic (defaults to with-response), which is why the official app lights both box generations.

Docs-only. The code fix (make our three BLE write paths derive Aurora write type from the characteristic, with a stale-cache guard) is tracked separately.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

Docs-only change — no runtime surface.
- Verified section cross-references (§9, §6.5, §5.4) resolve.
- Cross-checked claims against `packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift`, `packages/web/app/components/board-bluetooth-control/bluetooth-shared.ts`, `packages/mobile/src/lib/ble/adapter.ts`, and the decompiled `libapp.so` Dart symbol table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYxwRfm4qnN22mG17Jdk78