### PR TITLE
fix(mobile): revert forced write-with-response to without-response if it also stalls (#3235)

### DIFF
--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -673,6 +673,65 @@ final class BoardBleWriteFlowTests: XCTestCase {
     }
 
     // 5g
+    // Issue #3235 reversible fallback. A `.write`-only-reading box that ALSO never
+    // acks a with-response write (a marginal box, or a stale GATT cache that
+    // dropped `.writeWithoutResponse` from a box that really wants without-response)
+    // must not get link-cycled/disconnected. After the switch to with-response
+    // stalls too, revert THIS connection to the without-response gate bypass and
+    // re-fire the same chunk — identical to the pre-fix behaviour.
+    func testForcedWithResponseAlsoStallsRevertsToWithoutResponseBypass() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .write)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        var completionError: Error?
+        var completionTelemetry: BoardBleWriteTelemetry?
+        var completionCount = 0
+
+        hooks.sync {
+            hooks.setConfiguration(kilterConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { error, telemetry in
+                completionError = error
+                completionTelemetry = telemetry
+                completionCount += 1
+            }
+        }
+
+        // Without-response stalls -> switch to with-response (chunk out with-response).
+        fireLatestOneShot(label: "writeResumeWatchdog")
+        XCTAssertTrue(hooks.sync { hooks.forceWriteWithResponse })
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(peripheral.writtenChunks[0].type, .withResponse)
+
+        // With-response ALSO never acks -> revert to without-response bypass and
+        // re-fire the SAME chunk without-response. No link cycle, board learned-set
+        // cleared, gate now bypassed.
+        fireLatestOneShot(label: "writeAckWatchdog")
+        XCTAssertFalse(hooks.sync { hooks.forceWriteWithResponse })
+        XCTAssertTrue(hooks.sync { hooks.bypassCanSendWriteWithoutResponse })
+        XCTAssertTrue(hooks.sync { hooks.writeWithResponsePeripheralIds.isEmpty })
+        XCTAssertFalse(hooks.sync {
+            hooks.hasLearnedWriteWithResponseEntry(identity: "peripheral:\(peripheral.identifier.uuidString)")
+        })
+        XCTAssertEqual(peripheral.writtenChunks.count, 2)
+        XCTAssertEqual(peripheral.writtenChunks[1].type, .withoutResponse)
+        // Crucially NOT cycled/disconnected — that is the whole point vs today.
+        XCTAssertTrue(cancelledPeripheralIds.isEmpty)
+        XCTAssertEqual(hooks.sync { hooks.writeStallRecoveries }, 0)
+        XCTAssertEqual(completionCount, 0)
+
+        // The trailing chunkDelay completes the (now without-response) write.
+        fireLatestOneShot(label: "chunkDelay")
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertNil(completionError)
+        XCTAssertEqual(completionTelemetry?.lastResumeSource, "withResponseRevert")
+        XCTAssertEqual(completionTelemetry?.writeType, "withoutResponse")
+        XCTAssertEqual(completionTelemetry?.writeTypeSource, BoardBleWriteTypeSource.defaultWithoutResponse.rawValue)
+    }
+
+    // 5h
     func testPersistedSerialIdentitySeedsWriteWithResponseOnReconnect() {
         let hooks = manager.testHooks
         let peripheral = FakeWritablePeripheral(
@@ -702,7 +761,28 @@ final class BoardBleWriteFlowTests: XCTestCase {
         XCTAssertFalse(hooks.sync { hooks.hasPendingWriteResume })
     }
 
-    // 5i — A bare-name Aurora box (no `#serial@apiLevel` suffix) is a mid-2025+
+    // 5i
+    func testExpiredPersistedWriteWithResponseIdentityIsIgnored() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(
+            name: "Kilter Board#751737@2",
+            canSendDefault: false,
+            maxWriteValueLength: 20
+        )
+        let characteristic = makeCharacteristic(properties: .write)
+        let expiredLearnedAt = Date().addingTimeInterval(-(91 * 24 * 60 * 60)).timeIntervalSince1970
+
+        hooks.sync {
+            hooks.setConfiguration(kilterConfiguration())
+            hooks.setLearnedWriteWithResponseEntry(identity: "aurora:751737", learnedAt: expiredLearnedAt)
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+        }
+
+        XCTAssertFalse(hooks.sync { hooks.forceWriteWithResponse })
+        XCTAssertFalse(hooks.sync { hooks.hasLearnedWriteWithResponseEntry(identity: "aurora:751737") })
+    }
+
+    // 5j — A bare-name Aurora box (no `#serial@apiLevel` suffix) is a mid-2025+
     // Kilter-built, write-with-response-only box. Start it on write-with-response
     // from the FIRST connect (no stall first), driven by the advertised name. A
     // healthy serial'd box never matches, so this can't regress the fleet (#3228).
@@ -733,7 +813,7 @@ final class BoardBleWriteFlowTests: XCTestCase {
         XCTAssertEqual(peripheral.writtenChunks.last?.type, .withResponse)
     }
 
-    // 5j — A healthy box that carries a serial in its name keeps the faster
+    // 5k — A healthy box that carries a serial in its name keeps the faster
     // without-response path: the bare-name hint must NOT fire for it.
     func testSerialNamedBoxDoesNotGetBareNameHint() {
         let hooks = manager.testHooks
@@ -753,7 +833,7 @@ final class BoardBleWriteFlowTests: XCTestCase {
         XCTAssertNil(hooks.sync { hooks.forceWriteWithResponseSource })
     }
 
-    // 5k — A Kilter-built (bare-name) box paces each with-response chunk 100 ms
+    // 5l — A Kilter-built (bare-name) box paces each with-response chunk 100 ms
     // apart ON TOP of the ack, matching its own app. The ack alone does not
     // advance; the next chunk waits on a `kilterChunkDelay` one-shot.
     func testBareNameKilterBoxPacesWithResponseChunksWith100msDelay() {
@@ -786,7 +866,7 @@ final class BoardBleWriteFlowTests: XCTestCase {
         XCTAssertTrue(peripheral.writtenChunks.allSatisfy { $0.type == .withResponse })
     }
 
-    // 5l — A serial'd Aurora box that reached with-response via the learned
+    // 5m — A serial'd Aurora box that reached with-response via the learned
     // fallback is NOT a bare-name Kilter box: it stays ack-only (the fast path),
     // so the ack advances the next chunk immediately with no `kilterChunkDelay`.
     func testAuroraWithResponseFallbackDoesNotAdd100msDelay() {
@@ -813,27 +893,6 @@ final class BoardBleWriteFlowTests: XCTestCase {
         hooks.fireWriteAck(error: nil)
         XCTAssertEqual(peripheral.writtenChunks.count, 2)
         XCTAssertTrue(peripheral.writtenChunks.allSatisfy { $0.type == .withResponse })
-    }
-
-    // 5h
-    func testExpiredPersistedWriteWithResponseIdentityIsIgnored() {
-        let hooks = manager.testHooks
-        let peripheral = FakeWritablePeripheral(
-            name: "Kilter Board#751737@2",
-            canSendDefault: false,
-            maxWriteValueLength: 20
-        )
-        let characteristic = makeCharacteristic(properties: .write)
-        let expiredLearnedAt = Date().addingTimeInterval(-(91 * 24 * 60 * 60)).timeIntervalSince1970
-
-        hooks.sync {
-            hooks.setConfiguration(kilterConfiguration())
-            hooks.setLearnedWriteWithResponseEntry(identity: "aurora:751737", learnedAt: expiredLearnedAt)
-            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
-        }
-
-        XCTAssertFalse(hooks.sync { hooks.forceWriteWithResponse })
-        XCTAssertFalse(hooks.sync { hooks.hasLearnedWriteWithResponseEntry(identity: "aurora:751737") })
     }
 
     // 6

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -173,11 +173,17 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     private struct WriteRequest {
         let chunks: [Data]
-        // Write type and chunk size are snapshotted at enqueue so one request is
-        // internally consistent: a configureBoard landing mid-request must not
-        // flip the write type (or pacing) between chunks of a single frame.
+        // Static preferred write type and chunk size are snapshotted at enqueue
+        // so a configureBoard landing mid-request cannot re-chunk a frame. The
+        // connection-level forceWriteWithResponse latch may still override the
+        // actual per-chunk send type, which is what makes the fallback reversible.
         let writeType: CBCharacteristicWriteType
         let writeTypeSource: BoardBleWriteTypeSource
+        // What the connection resolved to when the request was enqueued. This is
+        // used for telemetry and chunk sizing only; the live latch still decides
+        // each actual send in writeChunk.
+        let initialWriteType: CBCharacteristicWriteType
+        let initialWriteTypeSource: BoardBleWriteTypeSource
         let chunkSize: Int
         let negotiatedMaxWriteWithoutResponse: Int
         let origin: BoardBleWriteOrigin
@@ -813,10 +819,22 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
-        let writeResolution = resolvedWriteType(for: characteristic)
+        // Keep the request's reversible write type on the STATIC preferred path
+        // (Aurora → without-response, MoonBoard → property-driven). The live
+        // `forceWriteWithResponse` latch is applied per-chunk in `writeChunk`, so
+        // clearing the latch mid-write is honoured immediately instead of being
+        // frozen into `request.writeType`. Chunk sizing follows the initially
+        // resolved transport, so boxes that start forced with-response still get
+        // the proven classic 20-byte chunks.
+        let writeType = BoardBleEncoding.preferredWriteType(
+            for: characteristic.properties,
+            boardName: configuration?.boardName
+        )
+        let writeTypeSource: BoardBleWriteTypeSource = writeType == .withResponse ? .moonboardCharacteristic : .defaultWithoutResponse
+        let initialWriteResolution = resolvedWriteType(for: characteristic)
         let chunkSize = BoardBleEncoding.effectiveChunkSize(
-            negotiatedMaxWriteLength: peripheral.maximumWriteValueLength(for: writeResolution.writeType),
-            writeType: writeResolution.writeType,
+            negotiatedMaxWriteLength: peripheral.maximumWriteValueLength(for: initialWriteResolution.writeType),
+            writeType: initialWriteResolution.writeType,
             boardName: configuration?.boardName
         )
         let chunks = stride(from: 0, to: data.count, by: chunkSize).map { offset in
@@ -826,8 +844,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         writeQueue.append(
             WriteRequest(
                 chunks: chunks,
-                writeType: writeResolution.writeType,
-                writeTypeSource: writeResolution.source,
+                writeType: writeType,
+                writeTypeSource: writeTypeSource,
+                initialWriteType: initialWriteResolution.writeType,
+                initialWriteTypeSource: initialWriteResolution.source,
                 chunkSize: chunkSize,
                 negotiatedMaxWriteWithoutResponse: peripheral.maximumWriteValueLength(for: .withoutResponse),
                 origin: origin,
@@ -1555,13 +1575,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         drainWaiters.signalAll()
     }
 
-    /// The write type for THIS connection. Defaults to
+    /// The write type this connection will ACTUALLY use for a send — reported in
+    /// connection diagnostics so `bleChosenWriteType` is honest. Defaults to
     /// `BoardBleEncoding.preferredWriteType` (Aurora → without-response, MoonBoard
     /// → property-driven), but once `forceWriteWithResponse` is latched — because a
     /// without-response write demonstrably stalled on a `.write`-only characteristic
     /// (or a prior connection to this board already learned that) — Aurora also
     /// takes write-with-response. Guarded on `.write` so a characteristic that
     /// advertises neither write flavour can't be pushed onto a path it can't take.
+    /// The per-chunk send decision in `writeChunk` mirrors this expression directly
+    /// (it does not read this method) so a mid-write latch change is honoured.
     private func resolvedWriteType(for characteristic: CBCharacteristic) -> BoardBleWriteTypeResolution {
         if forceWriteWithResponse, characteristic.properties.contains(.write) {
             return BoardBleWriteTypeResolution(
@@ -1630,9 +1653,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // settle point finalizes it (#3230).
         currentWriteTelemetry = BoardBleWriteTelemetry(
             origin: request.origin.rawValue,
-            initialWriteType: request.writeType == .withoutResponse ? "withoutResponse" : "withResponse",
-            finalWriteType: request.writeType == .withoutResponse ? "withoutResponse" : "withResponse",
-            writeTypeSource: request.writeTypeSource.rawValue,
+            initialWriteType: request.initialWriteType == .withoutResponse ? "withoutResponse" : "withResponse",
+            finalWriteType: request.initialWriteType == .withoutResponse ? "withoutResponse" : "withResponse",
+            writeTypeSource: request.initialWriteTypeSource.rawValue,
             chunkSize: request.chunkSize,
             chunkCount: request.chunks.count,
             negotiatedMaxWriteWithoutResponse: request.negotiatedMaxWriteWithoutResponse,
@@ -1664,7 +1687,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         return telemetry
     }
 
-    private func switchQueuedWriteToWithResponseFallback(
+    private func rechunkQueuedWriteForForcedWithResponseFallback(
         requestIndex: Int,
         connectionGeneration: UInt64,
         writeGeneration: UInt64
@@ -1684,8 +1707,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
         writeQueue[requestIndex] = WriteRequest(
             chunks: fallbackChunks,
-            writeType: .withResponse,
-            writeTypeSource: .watchdogFallback,
+            writeType: request.writeType,
+            writeTypeSource: request.writeTypeSource,
+            initialWriteType: request.initialWriteType,
+            initialWriteTypeSource: request.initialWriteTypeSource,
             chunkSize: BoardBleEncoding.classicChunkSize,
             negotiatedMaxWriteWithoutResponse: request.negotiatedMaxWriteWithoutResponse,
             origin: request.origin,
@@ -1697,14 +1722,6 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         currentWriteTelemetry?.writeTypeSource = BoardBleWriteTypeSource.watchdogFallback.rawValue
         currentWriteTelemetry?.chunkSize = BoardBleEncoding.classicChunkSize
         currentWriteTelemetry?.chunkCount = fallbackChunks.count
-        pendingWriteResume = { [weak self] in
-            self?.writeChunk(
-                requestIndex: requestIndex,
-                chunkIndex: 0,
-                connectionGeneration: connectionGeneration,
-                writeGeneration: writeGeneration
-            )
-        }
         return true
     }
 
@@ -1764,6 +1781,19 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // the stall watchdog below switches mid-flight without re-queuing.
         let sendWithResponse = request.writeType == .withResponse
             || (forceWriteWithResponse && characteristic.properties.contains(.write))
+        if sendWithResponse {
+            let actualWriteTypeSource: BoardBleWriteTypeSource
+            if request.writeType == .withResponse {
+                actualWriteTypeSource = request.writeTypeSource
+            } else {
+                actualWriteTypeSource = forceWriteWithResponseSource ?? .watchdogFallback
+            }
+            currentWriteTelemetry?.finalWriteType = "withResponse"
+            currentWriteTelemetry?.writeTypeSource = actualWriteTypeSource.rawValue
+        } else {
+            currentWriteTelemetry?.finalWriteType = "withoutResponse"
+            currentWriteTelemetry?.writeTypeSource = request.writeTypeSource.rawValue
+        }
         if !sendWithResponse {
             // `bypassCanSendWriteWithoutResponse` short-circuits the gate on a
             // connection we've already proven reports the property stuck false
@@ -1834,7 +1864,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                             }
                             self.forceWriteWithResponse = true
                             self.forceWriteWithResponseSource = .watchdogFallback
-                            guard self.switchQueuedWriteToWithResponseFallback(
+                            guard self.rechunkQueuedWriteForForcedWithResponseFallback(
                                 requestIndex: requestIndex,
                                 connectionGeneration: connectionGeneration,
                                 writeGeneration: writeGeneration
@@ -1915,6 +1945,48 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         pendingWriteAckWatchdog = timerScheduler.scheduleOneShot(after: writeResumeTimeout, label: "writeAckWatchdog") { [weak self] in
             guard let self, self.pendingWriteAck != nil else { return }
             self.currentWriteTelemetry?.watchdogTripped = true
+            // Reversible-fallback guard for issue #3235. If this connection was
+            // FORCED onto write-with-response (a without-response write had stalled
+            // on a `.write`-only characteristic) and the with-response write ALSO
+            // never acks, the box can complete neither flavour. That is exactly the
+            // #3235 marginal-box / stale-GATT-cache case: a box that really wants
+            // without-response reads as `.write`-only (a stale cache dropped the
+            // `.writeWithoutResponse` bit) and can't deliver the per-write ATT ack.
+            // Cycling the link would just disconnect the user, and re-forcing
+            // with-response on reconnect would loop. Instead revert THIS connection
+            // to the without-response gate bypass (the pre-fix #3563 behaviour) and
+            // re-fire the SAME chunk: such a box is then no worse off than before
+            // the with-response fix (#3181 still owns any genuine drop), while a
+            // real `.write`-only box that DOES ack keeps working. Forget the learned
+            // decision so reconnects don't immediately force it again.
+            if self.forceWriteWithResponse {
+                if let peripheral = self.connectedPeripheral {
+                    self.writeWithResponsePeripheralIds.remove(peripheral.identifier)
+                    if let characteristic = self.writeCharacteristic,
+                       let identity = self.auroraWriteWithResponseIdentity(
+                           peripheral: peripheral,
+                           characteristic: characteristic
+                       ),
+                       self.learnedWriteWithResponseEntries.removeValue(forKey: identity) != nil {
+                        self.saveLearnedWriteWithResponseEntries()
+                    }
+                }
+                self.forceWriteWithResponse = false
+                self.forceWriteWithResponseSource = nil
+                self.bypassCanSendWriteWithoutResponse = true
+                self.pendingWriteWithResponsePersistenceIdentity = nil
+                self.currentWriteTelemetry?.lastResumeSource = "withResponseRevert"
+                self.pendingWriteAck = nil
+                self.pendingWriteAckWatchdog = nil
+                self.logger.error("BLE write stalled: forced write-with-response never acked; reverting this connection to the without-response gate bypass (#3235)")
+                self.writeChunk(
+                    requestIndex: requestIndex,
+                    chunkIndex: chunkIndex,
+                    connectionGeneration: connectionGeneration,
+                    writeGeneration: writeGeneration
+                )
+                return
+            }
             self.logger.error("BLE write stalled: peripheral never acked write-with-response; attempting recovery")
             self.handleWriteStall()
         }


### PR DESCRIPTION
Follow-up to #3577, hardening it against **issue #3235** (Pete & Nic's marginal box), now rebased on the latest `origin/main` BLE write flow with bare-name Kilter detection and 100 ms with-response pacing.

## The gap #3235 exposes

#3577 switches an Aurora connection to write-**with**-response when a without-response write stalls on a `.write`-only characteristic. But #3235 documents a box class where that is not enough:

- **Nicola's** box failed on the correct without-response path: a marginal box/link that stops accepting writes.
- **Pete's** box failed because a stale iOS GATT cache dropped the `.writeWithoutResponse` bit from a box that really wants without-response. It got routed to with-response, then the marginal box could not deliver the per-write ATT ack.

Without this PR, such a box can read as `.write`-only, get switched or seeded onto with-response, then hit the with-response ack watchdog and fall through to `handleWriteStall`, which link-cycles/disconnects.

## The fix: make forced with-response reversible

If a **forced** write-with-response also stalls (the ack watchdog trips while `forceWriteWithResponse` is set), the connection reverts to the without-response gate bypass and re-fires the same chunk instead of cycling the link.

Net effect:

- **Real `.write`-only box that acks**: lights, still uses with-response.
- **Box that acks neither** (marginal / stale-cache, #3235): no forced link cycle; it falls back to the without-response bypass path.
- **Healthy serial'd box**: stays on without-response and never touches this path.
- **Bare-name Kilter-built box**: keeps the current `main` behavior: starts forced with-response, uses 20-byte chunks, and keeps the Kilter-only 100 ms pacing.

## Why the queued request changed

The queued request now separates:

- the static, reversible preferred write type (`Aurora -> withoutResponse`, `MoonBoard -> property-driven`), and
- the initially resolved transport used for telemetry and chunk sizing.

That keeps forced with-response sends on the proven 20-byte chunks from current `main`, while still letting the ack watchdog clear `forceWriteWithResponse` and have the in-flight request continue without-response immediately. The fallback also clears the pending/persisted learned with-response decision so reconnects do not immediately repeat a bad forced path.

## Testing

- Added Swift write-flow test `5g`: forced with-response also stalls -> revert to without-response bypass, clear learned state, re-fire the chunk, no link cycle.
- Existing Swift write-flow coverage still exercises `.write`-only fallback, non-persistence on explicit ATT ack errors, learned/persisted fallback, bare-name Kilter detection, and Kilter-only 100 ms pacing.
- `vp run typecheck:mobile` passed.
- `vp run check:mobile-bundle` passed.
- Local `vp run test:mobile` failed one JS test outside this Swift change (`src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx`), but GitHub Actions `test-default` passed on the rebased PR.
- `vp check` formatting passed locally, then repo-wide lint/type checks failed on existing TS/JS issues and Vite+ panicked while printing diagnostics; GitHub Actions `lint` and `typecheck` passed on the rebased PR.
- GitHub Actions native `build-and-test` jobs passed, including the generated iOS Swift XCTest target.

## Release Notes

- [x] No release note needed (internal / technical change)

_(User-facing benefit ships via #3577's note in the same 2.2.2 build; this is a robustness hardening of that fix.)_
