### PR TITLE
feat(mobile): capture BLE advertisement manufacturer/service data for serial recon

### DIFF
--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -11,6 +11,16 @@ struct BoardBleScanResult {
     /// unfiltered — a native service-UUID filter would hide MoonBoard
     /// controllers, which don't reliably advertise the UART service UUID.
     let serviceUuids: [String]
+    /// Advertisement manufacturer-specific data, lowercase hex. Captured for
+    /// PostHog reconnaissance: newer Kilter-built boxes advertise a bare name
+    /// with no `#serial@apiLevel` suffix, so the serial / LED generation may
+    /// ride here (or in `serviceData`) instead. `nil` when the packet carries
+    /// none. We parse nothing from it yet — this is recon only.
+    let manufacturerData: String?
+    /// Advertisement service-data, `{ uuid: hexBytes }`. The undocumented custom
+    /// GATT UUIDs (d9b1fad4…/191b6169…/73a2a497…) would surface here if the box
+    /// advertises them. `nil`/empty when the packet carries none.
+    let serviceData: [String: String]?
 }
 
 /// Connect-time BLE write diagnostics, surfaced to JS (Sentry tags + analytics)
@@ -1018,13 +1028,33 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         let advertisedServiceUuids = ((advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID] ?? [])
             + (advertisementData[CBAdvertisementDataOverflowServiceUUIDsKey] as? [CBUUID] ?? []))
             .map { $0.uuidString }
+        // Undocumented advertisement payload (recon only — parsed nowhere yet):
+        // manufacturer-specific data and per-UUID service data, hex-encoded.
+        let manufacturerData = (advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data)
+            .map { $0.hexEncodedString() }
+        let serviceData = (advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID: Data])
+            .flatMap { rawServiceData -> [String: String]? in
+                guard !rawServiceData.isEmpty else { return nil }
+                var mapped: [String: String] = [:]
+                for (uuid, bytes) in rawServiceData {
+                    mapped[uuid.uuidString] = bytes.hexEncodedString()
+                }
+                return mapped
+            }
         // Only cross the bridge when something material changed for this
-        // device (first sighting, name arriving in a later scan response, or
-        // a different advertised UUID set).
-        let emissionKey = "\(name ?? "")|\(advertisedServiceUuids.joined(separator: ","))"
+        // device (first sighting, name arriving in a later scan response, a
+        // different advertised UUID set, or manufacturer data appearing/changing).
+        let emissionKey = "\(name ?? "")|\(advertisedServiceUuids.joined(separator: ","))|\(manufacturerData ?? "")"
         if emittedScanResults[deviceId] != emissionKey {
             emittedScanResults[deviceId] = emissionKey
-            onScanResult?(BoardBleScanResult(deviceId: deviceId, name: name, rssi: RSSI.intValue, serviceUuids: advertisedServiceUuids))
+            onScanResult?(BoardBleScanResult(
+                deviceId: deviceId,
+                name: name,
+                rssi: RSSI.intValue,
+                serviceUuids: advertisedServiceUuids,
+                manufacturerData: manufacturerData,
+                serviceData: serviceData
+            ))
         }
 
         // Reconnect-by-last-known-board scan fallback: the stored board just
@@ -1931,6 +1961,13 @@ private extension Data {
         }
 
         self = Data(bytes)
+    }
+
+    /// Lowercase hex, matching the JS `uint8ArrayToHex` / ble-plx base64→hex
+    /// normalization so the `bleManufacturerData` PostHog field is comparable
+    /// across platforms.
+    func hexEncodedString() -> String {
+        map { String(format: "%02x", $0) }.joined()
     }
 }
 

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -1030,6 +1030,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             .map { $0.uuidString }
         // Undocumented advertisement payload (recon only — parsed nowhere yet):
         // manufacturer-specific data and per-UUID service data, hex-encoded.
+        // Service-data keys are normalized to lowercase full-128-bit UUIDs so
+        // they match the ble-plx (Android) form and group cleanly in PostHog.
         let manufacturerData = (advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data)
             .map { $0.hexEncodedString() }
         let serviceData = (advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID: Data])
@@ -1037,14 +1039,20 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 guard !rawServiceData.isEmpty else { return nil }
                 var mapped: [String: String] = [:]
                 for (uuid, bytes) in rawServiceData {
-                    mapped[uuid.uuidString] = bytes.hexEncodedString()
+                    mapped[Self.normalizedUuidString(uuid)] = bytes.hexEncodedString()
                 }
                 return mapped
             }
-        // Only cross the bridge when something material changed for this
-        // device (first sighting, name arriving in a later scan response, a
-        // different advertised UUID set, or manufacturer data appearing/changing).
-        let emissionKey = "\(name ?? "")|\(advertisedServiceUuids.joined(separator: ","))|\(manufacturerData ?? "")"
+        // Only cross the bridge when something material changed for this device
+        // (first sighting, name arriving in a later scan response, a different
+        // advertised UUID set, or manufacturer data first *appearing*). Use a
+        // presence flag, not the payload itself: Apple Continuity devices rotate
+        // their manufacturer data every advertisement, and folding the bytes into
+        // the key would re-cross the bridge on every rotation for every nearby
+        // iPhone/AirPod. A board's payload is static, so the JS side merges
+        // whatever arrives (see upsertDiscoveredDevice).
+        let manufacturerDataPresence = manufacturerData != nil ? "m" : ""
+        let emissionKey = "\(name ?? "")|\(advertisedServiceUuids.joined(separator: ","))|\(manufacturerDataPresence)"
         if emittedScanResults[deviceId] != emissionKey {
             emittedScanResults[deviceId] = emissionKey
             onScanResult?(BoardBleScanResult(
@@ -1167,6 +1175,18 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// and writeCharacteristicUuid(for:) keys on the discovered service.
     private func writeServiceUuids() -> [CBUUID] {
         [uartServiceUuid, redBearLabServiceUuid]
+    }
+
+    /// Canonical lowercase full-128-bit UUID string. `CBUUID.uuidString` returns
+    /// the short 4-char form (uppercase) for 16-bit UUIDs and uppercase for
+    /// 128-bit — ble-plx reports lowercase full-128-bit. Normalize so a board's
+    /// service-data key is identical across platforms and groups in PostHog.
+    static func normalizedUuidString(_ uuid: CBUUID) -> String {
+        let raw = uuid.uuidString.lowercased()
+        if raw.count == 4 {
+            return "0000\(raw)-0000-1000-8000-00805f9b34fb"
+        }
+        return raw
     }
 
     /// Outcome of a `didDiscoverServices` callback.

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -43,7 +43,7 @@ public class BoardBleModule: Module {
         OnCreate {
             BoardBleManager.shared.setEventHandlers(
                 onScanResult: { [weak self] result in
-                    self?.emitOrBuffer(name: "scanResult", body: [
+                    var body: [String: Any] = [
                         "device": [
                             "deviceId": result.deviceId,
                             "name": result.name ?? ""
@@ -51,7 +51,16 @@ public class BoardBleModule: Module {
                         "localName": result.name ?? "",
                         "rssi": result.rssi,
                         "serviceUuids": result.serviceUuids
-                    ])
+                    ]
+                    // Recon-only advertisement payload; omitted when absent so
+                    // older JS/sanitize sees no empty fields.
+                    if let manufacturerData = result.manufacturerData {
+                        body["manufacturerData"] = manufacturerData
+                    }
+                    if let serviceData = result.serviceData {
+                        body["serviceData"] = serviceData
+                    }
+                    self?.emitOrBuffer(name: "scanResult", body: body)
                 },
                 onDisconnect: { [weak self] deviceId, reason in
                     var body: [String: Any] = ["deviceId": deviceId]

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -13,6 +13,18 @@ export type NativeBleScanEvent = {
    * omit the field.
    */
   serviceUuids?: string[];
+  /**
+   * Advertisement manufacturer-specific data, lowercase hex. Recon-only
+   * (parsed nowhere yet): newer bare-name boxes may carry their serial / LED
+   * generation here. Optional — omitted when the packet has none, and absent
+   * on binaries older than this field.
+   */
+  manufacturerData?: string;
+  /**
+   * Advertisement service-data, `{ uuid: hexBytes }`. Where the undocumented
+   * custom GATT UUIDs would surface if advertised. Optional/omitted as above.
+   */
+  serviceData?: Record<string, string>;
 };
 
 export type NativeBleDisconnectEvent = {

--- a/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
+++ b/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
@@ -8,10 +8,12 @@ import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { PressableSurface } from '../PressableSurface';
 import { SessionRecordingSwitchRow } from '../settings/SessionRecordingSwitchRow';
+import { SwitchRow } from '../SwitchRow';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useSubmitMobileAppFeedback } from '../../lib/feedback/use-submit-app-feedback';
+import { runBleAdvertisementRecon } from '../../lib/ble/advertisement-recon';
 import { openDiscordInvite } from '../../lib/discord';
 
 export type FeedbackSheetMode = 'rating' | 'bug';
@@ -38,6 +40,7 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
   const { mutateAsync, isPending, reset } = useSubmitMobileAppFeedback();
   const [selectedRating, setSelectedRating] = useState<number | null>(null);
   const [comment, setComment] = useState('');
+  const [captureBleDiag, setCaptureBleDiag] = useState(false);
 
   const isBugReport = mode === 'bug';
   const trimmedComment = comment.trim();
@@ -50,6 +53,7 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
   useEffect(() => {
     setSelectedRating(null);
     setComment('');
+    setCaptureBleDiag(false);
     reset();
   }, [mode, reset]);
 
@@ -63,6 +67,15 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
     if (!canSubmit || isPending) return;
 
     try {
+      // Fire the opt-in Bluetooth scan-recon alongside the report. It scans
+      // (no connect) and ships each in-range board's raw advertisement payload
+      // to PostHog under a shared correlation id, so we can find where bare-name
+      // boxes stash their serial. Runs independently of the sheet lifecycle;
+      // never blocks the submit or surfaces its own errors.
+      if (isBugReport && captureBleDiag) {
+        const reconCorrelationId = `bug-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+        void runBleAdvertisementRecon(reconCorrelationId).catch(() => {});
+      }
       await mutateAsync({
         source: isBugReport ? 'drawer-bug' : 'drawer-feedback',
         rating: isBugReport ? null : selectedRating,
@@ -146,6 +159,12 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
           <SessionRecordingSwitchRow
             label={t('feedbackForm.sessionRecordingLabel')}
             description={t('feedbackForm.sessionRecordingDescription')}
+          />
+          <SwitchRow
+            label={t('feedbackForm.bluetoothBugLabel')}
+            description={t('feedbackForm.bluetoothBugDescription')}
+            value={captureBleDiag}
+            onValueChange={setCaptureBleDiag}
           />
         </View>
       ) : null}

--- a/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
+++ b/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
@@ -69,9 +69,11 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
     try {
       // Fire the opt-in Bluetooth scan-recon alongside the report. It scans
       // (no connect) and ships each in-range board's raw advertisement payload
-      // to PostHog under a shared correlation id, so we can find where bare-name
-      // boxes stash their serial. Runs independently of the sheet lifecycle;
-      // never blocks the submit or surfaces its own errors.
+      // to PostHog so we can find where bare-name boxes stash their serial. The
+      // correlation id groups this one scan's events; joining to the specific bug
+      // report is by person + timestamp (the report goes to the backend, not
+      // PostHog). Runs independently of the sheet lifecycle; never blocks the
+      // submit or surfaces its own errors.
       if (isBugReport && captureBleDiag) {
         const reconCorrelationId = `bug-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
         void runBleAdvertisementRecon(reconCorrelationId).catch(() => {});

--- a/packages/mobile/src/lib/ble/__tests__/advertisement-recon.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/advertisement-recon.test.ts
@@ -92,18 +92,25 @@ describe('runBleAdvertisementRecon', () => {
     expect(mockBleManager.startDeviceScan.mock.calls[0][0]).toBeNull();
 
     const emit = scanCallback();
+    // Name arrives first (SCAN_RSP), manufacturer/service data in a later packet
+    // (ADV_IND) — the recon must accumulate across both, not first-packet-win.
+    emit(null, { id: 'k1', name: 'Kilter Board', serviceUUIDs: ['aurora-uuid'], rssi: -55 });
     emit(null, {
       id: 'k1',
-      name: 'Kilter Board',
-      serviceUUIDs: ['aurora-uuid'],
-      manufacturerData: 'TAACFQ==', // 4c000215
       serviceData: { 'd9b1fad4-0d22-4d20-8521-04166b28cd24': 'AQI=' }, // 0102
-      rssi: -55,
+      manufacturerData: 'TAACFQ==', // 4c000215
     });
-    emit(null, { id: 'k1', name: 'Kilter Board', serviceUUIDs: ['aurora-uuid'] }); // duplicate id
     emit(null, { id: 'buds', name: 'AirPods', manufacturerData: 'TAAP' }); // not a board
     emit(null, { id: 'm1', name: 'MoonBoard A', rssi: -70 });
 
+    // Nothing emitted until the scan window closes.
+    expect(trackMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(8_000);
+    const count = await promise;
+
+    expect(count).toBe(2);
+    expect(mockBleManager.stopDeviceScan).toHaveBeenCalled();
     expect(trackMock).toHaveBeenCalledTimes(2);
     expect(trackMock).toHaveBeenCalledWith(
       'BLE Advertisement Recon',
@@ -113,6 +120,7 @@ describe('runBleAdvertisementRecon', () => {
         deviceName: 'Kilter Board',
         deviceNamePresent: true,
         parsedSerial: undefined,
+        // Merged from the second packet even though the name came in the first.
         bleManufacturerData: '4c000215',
         bleManufacturerCompanyId: 0x004c,
         bleServiceData: JSON.stringify({ 'd9b1fad4-0d22-4d20-8521-04166b28cd24': '0102' }),
@@ -122,10 +130,5 @@ describe('runBleAdvertisementRecon', () => {
       'BLE Advertisement Recon',
       expect.objectContaining({ family: 'moonboard', deviceName: 'MoonBoard A' }),
     );
-
-    vi.advanceTimersByTime(8_000);
-    const count = await promise;
-    expect(count).toBe(2);
-    expect(mockBleManager.stopDeviceScan).toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/advertisement-recon.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/advertisement-recon.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockBleManager = vi.hoisted(() => ({
+  startDeviceScan: vi.fn(),
+  stopDeviceScan: vi.fn(),
+}));
+const trackMock = vi.hoisted(() => vi.fn());
+const permissionMock = vi.hoisted(() => vi.fn());
+const poweredOnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../ble-manager', () => ({ bleManager: mockBleManager }));
+vi.mock('../../analytics', () => ({ track: trackMock }));
+vi.mock('../availability', () => ({ waitForBlePoweredOn: poweredOnMock }));
+vi.mock('../use-ble-permissions', () => ({ requestBleRuntimePermissions: permissionMock }));
+vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: { BleAdvertisementRecon: 'BLE Advertisement Recon' } }));
+vi.mock('@boardsesh/ble-protocol', () => ({
+  parseSerialNumber: (name?: string) => (name?.includes('#') ? name.split('#')[1]?.split('@')[0] : undefined),
+  parseApiLevel: (name?: string) => (name?.includes('@') ? Number(name.split('@')[1]) : 2),
+}));
+vi.mock('../board-device-filter', () => ({
+  isLikelyBoardDevice: ({
+    name,
+    serviceUuids,
+    scanFamily,
+  }: {
+    name?: string;
+    serviceUuids?: string[];
+    scanFamily: string;
+  }) => {
+    if (scanFamily === 'aurora') return serviceUuids?.includes('aurora-uuid') || /kilter|tension/i.test(name ?? '');
+    if (scanFamily === 'moonboard') return /moonboard/i.test(name ?? '');
+    return false;
+  },
+}));
+
+import { runBleAdvertisementRecon } from '../advertisement-recon';
+
+type ScanDevice = {
+  id: string;
+  localName?: string;
+  name?: string;
+  serviceUUIDs?: string[];
+  overflowServiceUUIDs?: string[];
+  manufacturerData?: string | null;
+  serviceData?: Record<string, string> | null;
+  rssi?: number;
+};
+
+function scanCallback() {
+  const call = mockBleManager.startDeviceScan.mock.calls.at(-1);
+  return call?.[2] as (error: unknown, device: ScanDevice | null) => void;
+}
+
+// The recon awaits permissions + powered-on (already-resolved mocks) before it
+// registers the scan callback; flush microtasks so those settle.
+async function flushMicrotasks() {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+describe('runBleAdvertisementRecon', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    permissionMock.mockResolvedValue(true);
+    poweredOnMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not scan when BLE permission is denied', async () => {
+    permissionMock.mockResolvedValue(false);
+    const count = await runBleAdvertisementRecon('corr-denied');
+    expect(count).toBe(0);
+    expect(mockBleManager.startDeviceScan).not.toHaveBeenCalled();
+  });
+
+  it('does not scan when Bluetooth is powered off', async () => {
+    poweredOnMock.mockResolvedValue(false);
+    const count = await runBleAdvertisementRecon('corr-off');
+    expect(count).toBe(0);
+    expect(mockBleManager.startDeviceScan).not.toHaveBeenCalled();
+  });
+
+  it('scans unfiltered and emits one hex-payload event per distinct board', async () => {
+    const promise = runBleAdvertisementRecon('corr-1');
+    await flushMicrotasks();
+
+    expect(mockBleManager.startDeviceScan).toHaveBeenCalledTimes(1);
+    // Unfiltered (null services) so bare-name + MoonBoard boxes surface.
+    expect(mockBleManager.startDeviceScan.mock.calls[0][0]).toBeNull();
+
+    const emit = scanCallback();
+    emit(null, {
+      id: 'k1',
+      name: 'Kilter Board',
+      serviceUUIDs: ['aurora-uuid'],
+      manufacturerData: 'TAACFQ==', // 4c000215
+      serviceData: { 'd9b1fad4-0d22-4d20-8521-04166b28cd24': 'AQI=' }, // 0102
+      rssi: -55,
+    });
+    emit(null, { id: 'k1', name: 'Kilter Board', serviceUUIDs: ['aurora-uuid'] }); // duplicate id
+    emit(null, { id: 'buds', name: 'AirPods', manufacturerData: 'TAAP' }); // not a board
+    emit(null, { id: 'm1', name: 'MoonBoard A', rssi: -70 });
+
+    expect(trackMock).toHaveBeenCalledTimes(2);
+    expect(trackMock).toHaveBeenCalledWith(
+      'BLE Advertisement Recon',
+      expect.objectContaining({
+        reconCorrelationId: 'corr-1',
+        family: 'aurora',
+        deviceName: 'Kilter Board',
+        deviceNamePresent: true,
+        parsedSerial: undefined,
+        bleManufacturerData: '4c000215',
+        bleManufacturerCompanyId: 0x004c,
+        bleServiceData: JSON.stringify({ 'd9b1fad4-0d22-4d20-8521-04166b28cd24': '0102' }),
+      }),
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      'BLE Advertisement Recon',
+      expect.objectContaining({ family: 'moonboard', deviceName: 'MoonBoard A' }),
+    );
+
+    vi.advanceTimersByTime(8_000);
+    const count = await promise;
+    expect(count).toBe(2);
+    expect(mockBleManager.stopDeviceScan).toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/ble/__tests__/advertisement.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/advertisement.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { base64ToHex, serviceDataToHex } from '../base64';
+import { manufacturerCompanyId, parseSerialFromAdvertisement } from '../advertisement';
+
+describe('base64ToHex', () => {
+  it('decodes base64 advertisement bytes to lowercase hex', () => {
+    // bytes [0x4c, 0x00, 0x02, 0x15] → "4c000215"
+    expect(base64ToHex('TAACFQ==')).toBe('4c000215');
+  });
+
+  it('returns undefined for null/undefined/empty/undecodable input', () => {
+    expect(base64ToHex(undefined)).toBeUndefined();
+    expect(base64ToHex(null)).toBeUndefined();
+    expect(base64ToHex('')).toBeUndefined();
+  });
+});
+
+describe('serviceDataToHex', () => {
+  it('maps each uuid value from base64 to hex', () => {
+    expect(serviceDataToHex({ 'd9b1fad4-0d22-4d20-8521-04166b28cd24': 'AQI=' })).toEqual({
+      'd9b1fad4-0d22-4d20-8521-04166b28cd24': '0102',
+    });
+  });
+
+  it('drops empty/undecodable entries and returns undefined when nothing remains', () => {
+    expect(serviceDataToHex(null)).toBeUndefined();
+    expect(serviceDataToHex(undefined)).toBeUndefined();
+    expect(serviceDataToHex({ 'some-uuid': '' })).toBeUndefined();
+  });
+});
+
+describe('manufacturerCompanyId', () => {
+  it('reads the 16-bit little-endian company id from the hex payload', () => {
+    // 0x004c (Apple) → low 0x4c, high 0x00
+    expect(manufacturerCompanyId('4c000215')).toBe(0x004c);
+    // 0x0157 → low 0x57, high 0x01
+    expect(manufacturerCompanyId('5701abcd')).toBe(0x0157);
+  });
+
+  it('returns undefined when there are not two bytes to read', () => {
+    expect(manufacturerCompanyId(undefined)).toBeUndefined();
+    expect(manufacturerCompanyId('')).toBeUndefined();
+    expect(manufacturerCompanyId('4c')).toBeUndefined();
+  });
+});
+
+describe('parseSerialFromAdvertisement', () => {
+  it('is an unimplemented seam that returns undefined for now', () => {
+    expect(parseSerialFromAdvertisement({ manufacturerData: '4c000215' }, 'aurora')).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/lib/ble/__tests__/scan-device-cache.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/scan-device-cache.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { upsertDiscoveredDevice } from '../scan-device-cache';
+import type { DiscoveredDevice } from '../types';
+
+describe('upsertDiscoveredDevice', () => {
+  it('returns true and stores a first-seen device', () => {
+    const devices = new Map<string, DiscoveredDevice>();
+    expect(upsertDiscoveredDevice(devices, { deviceId: 'a', name: 'Kilter Board', rssi: -50 })).toBe(true);
+    expect(devices.get('Kilter Board')?.deviceId).toBe('a');
+  });
+
+  it('enriches the stored record with recon data that arrives in a later packet', () => {
+    // BLE splits the advertisement across packets: the name lands first, the
+    // manufacturer/service data in a later callback with the same identity.
+    const devices = new Map<string, DiscoveredDevice>();
+    upsertDiscoveredDevice(devices, { deviceId: 'a', name: 'Kilter Board', rssi: -50 });
+
+    const pushedAgain = upsertDiscoveredDevice(devices, {
+      deviceId: 'a',
+      name: 'Kilter Board',
+      rssi: -50,
+      manufacturerData: '4c000215',
+      serviceData: { 'uuid-1': '0102' },
+    });
+
+    // No picker re-push (identity unchanged) but the payload must be retained.
+    expect(pushedAgain).toBe(false);
+    expect(devices.get('Kilter Board')?.manufacturerData).toBe('4c000215');
+    expect(devices.get('Kilter Board')?.serviceData).toEqual({ 'uuid-1': '0102' });
+  });
+
+  it('merges service-data entries across packets and does not clobber existing manufacturer data', () => {
+    const devices = new Map<string, DiscoveredDevice>();
+    upsertDiscoveredDevice(devices, {
+      deviceId: 'a',
+      name: 'Board',
+      rssi: -50,
+      manufacturerData: 'aabb',
+      serviceData: { 'uuid-1': '01' },
+    });
+    upsertDiscoveredDevice(devices, {
+      deviceId: 'a',
+      name: 'Board',
+      rssi: -50,
+      serviceData: { 'uuid-2': '02' },
+    });
+
+    const stored = devices.get('Board');
+    expect(stored?.manufacturerData).toBe('aabb');
+    expect(stored?.serviceData).toEqual({ 'uuid-1': '01', 'uuid-2': '02' });
+  });
+});

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -12,7 +12,7 @@ import {
   parseSerialNumber,
 } from '@boardsesh/ble-protocol';
 import { bleManager } from './ble-manager';
-import { uint8ArrayToBase64 } from './base64';
+import { uint8ArrayToBase64, base64ToHex, serviceDataToHex } from './base64';
 import { waitForBlePoweredOn } from './availability';
 import { isLikelyBoardDevice } from './board-device-filter';
 import { upsertDiscoveredDevice } from './scan-device-cache';
@@ -156,6 +156,10 @@ export class RNBleAdapter implements BluetoothAdapter {
           deviceId: scannedDevice.id,
           name: deviceName,
           rssi: scannedDevice.rssi ?? -100,
+          // ble-plx surfaces these as base64; normalize to hex so the recon
+          // payload matches the native iOS path (omitted when absent/empty).
+          manufacturerData: base64ToHex(scannedDevice.manufacturerData),
+          serviceData: serviceDataToHex(scannedDevice.serviceData),
         };
         if (upsertDiscoveredDevice(devices, device)) {
           pushDevices();
@@ -205,9 +209,13 @@ export class RNBleAdapter implements BluetoothAdapter {
     }
 
     let selectedDeviceName: string | undefined;
+    let selectedManufacturerData: string | undefined;
+    let selectedServiceData: Record<string, string> | undefined;
     for (const device of devices.values()) {
       if (device.deviceId === selectedDeviceId) {
         selectedDeviceName = device.name;
+        selectedManufacturerData = device.manufacturerData;
+        selectedServiceData = device.serviceData;
         break;
       }
     }
@@ -283,6 +291,8 @@ export class RNBleAdapter implements BluetoothAdapter {
     return {
       deviceId: selectedDeviceId,
       deviceName: selectedDeviceName,
+      manufacturerData: selectedManufacturerData,
+      serviceData: selectedServiceData,
     };
   }
 

--- a/packages/mobile/src/lib/ble/advertisement-recon.ts
+++ b/packages/mobile/src/lib/ble/advertisement-recon.ts
@@ -1,0 +1,91 @@
+// Consent-driven BLE advertisement reconnaissance. Runs only when a user submits
+// a bug report with the "Bluetooth trouble" toggle on. Scans (without connecting)
+// for in-range boards and ships each one's raw advertisement payload to PostHog,
+// so we can find where newer bare-name Kilter boxes stash their serial / LED
+// generation (in manufacturer data or service data) now that they've dropped the
+// `#serial@apiLevel` name suffix. Parses nothing itself — capture only.
+//
+// Uses the ble-plx `bleManager` directly (scanning needs no native module and
+// works on both platforms), scans UNFILTERED so bare-name and MoonBoard boxes
+// surface, and only emits for peripherals that look like a board (by advertised
+// service UUID or name) so unrelated BLE devices never reach analytics.
+
+import { parseApiLevel, parseSerialNumber } from '@boardsesh/ble-protocol';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../analytics';
+import { bleManager } from './ble-manager';
+import { waitForBlePoweredOn } from './availability';
+import { requestBleRuntimePermissions } from './use-ble-permissions';
+import { isLikelyBoardDevice } from './board-device-filter';
+import { base64ToHex, serviceDataToHex } from './base64';
+import { manufacturerCompanyId } from './advertisement';
+import type { BoardScanFamily } from './types';
+
+const RECON_SCAN_MS = 8_000;
+const MAX_RECON_DEVICES = 30;
+
+function classifyFamily(name: string | undefined, serviceUuids: string[]): BoardScanFamily | undefined {
+  if (isLikelyBoardDevice({ name, serviceUuids, scanFamily: 'aurora' })) return 'aurora';
+  if (isLikelyBoardDevice({ name, serviceUuids, scanFamily: 'moonboard' })) return 'moonboard';
+  return undefined;
+}
+
+/**
+ * Scan for in-range boards and emit one `BLE Advertisement Recon` event per
+ * distinct board discovered, tagged with `reconCorrelationId` so the batch joins
+ * to the bug report. Resolves with the number of boards captured. Never throws:
+ * denied permission / powered-off Bluetooth resolves 0.
+ */
+export async function runBleAdvertisementRecon(reconCorrelationId: string): Promise<number> {
+  const permissionsGranted = await requestBleRuntimePermissions();
+  if (!permissionsGranted) return 0;
+  const poweredOn = await waitForBlePoweredOn();
+  if (!poweredOn) return 0;
+
+  const seen = new Set<string>();
+  return new Promise<number>((resolve) => {
+    let settled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      bleManager.stopDeviceScan();
+      resolve(seen.size);
+    };
+
+    bleManager.startDeviceScan(null, null, (error, device) => {
+      if (error || settled) {
+        finish();
+        return;
+      }
+      if (!device || seen.has(device.id)) return;
+
+      const name = device.localName ?? device.name ?? undefined;
+      const serviceUuids = [...(device.serviceUUIDs ?? []), ...(device.overflowServiceUUIDs ?? [])];
+      const family = classifyFamily(name, serviceUuids);
+      if (!family) return;
+
+      seen.add(device.id);
+      const serviceData = serviceDataToHex(device.serviceData);
+      const manufacturerData = base64ToHex(device.manufacturerData);
+      track(SHARED_EVENTS.BleAdvertisementRecon, {
+        reconCorrelationId,
+        family,
+        deviceName: name ?? undefined,
+        deviceNamePresent: !!name,
+        parsedSerial: parseSerialNumber(name) ?? undefined,
+        apiLevelFromName: parseApiLevel(name),
+        rssi: device.rssi ?? undefined,
+        serviceUuids: serviceUuids.length > 0 ? JSON.stringify(serviceUuids) : undefined,
+        bleManufacturerData: manufacturerData,
+        bleManufacturerCompanyId: manufacturerCompanyId(manufacturerData),
+        bleServiceData: serviceData ? JSON.stringify(serviceData) : undefined,
+      });
+
+      if (seen.size >= MAX_RECON_DEVICES) finish();
+    });
+
+    timeoutId = setTimeout(finish, RECON_SCAN_MS);
+  });
+}

--- a/packages/mobile/src/lib/ble/advertisement-recon.ts
+++ b/packages/mobile/src/lib/ble/advertisement-recon.ts
@@ -42,7 +42,19 @@ export async function runBleAdvertisementRecon(reconCorrelationId: string): Prom
   const poweredOn = await waitForBlePoweredOn();
   if (!poweredOn) return 0;
 
-  const seen = new Set<string>();
+  // Accumulate per device across the whole window and emit once at the end. BLE
+  // splits the advertisement across packets (ADV_IND vs SCAN_RSP), so the name,
+  // manufacturer data, and service data can land in separate callbacks — emitting
+  // on the first board-matching packet would miss whatever arrives later.
+  type ReconEntry = {
+    name?: string;
+    serviceUuids: Set<string>;
+    manufacturerData?: string;
+    serviceData?: Record<string, string>;
+    rssi?: number;
+  };
+  const entries = new Map<string, ReconEntry>();
+
   return new Promise<number>((resolve) => {
     let settled = false;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -50,40 +62,50 @@ export async function runBleAdvertisementRecon(reconCorrelationId: string): Prom
       if (settled) return;
       settled = true;
       if (timeoutId) clearTimeout(timeoutId);
-      bleManager.stopDeviceScan();
-      resolve(seen.size);
+      void bleManager.stopDeviceScan();
+      for (const entry of entries.values()) {
+        track(SHARED_EVENTS.BleAdvertisementRecon, {
+          reconCorrelationId,
+          family: classifyFamily(entry.name, [...entry.serviceUuids]),
+          deviceName: entry.name ?? undefined,
+          deviceNamePresent: !!entry.name,
+          parsedSerial: parseSerialNumber(entry.name) ?? undefined,
+          apiLevelFromName: parseApiLevel(entry.name),
+          rssi: entry.rssi ?? undefined,
+          serviceUuids: entry.serviceUuids.size > 0 ? JSON.stringify([...entry.serviceUuids]) : undefined,
+          bleManufacturerData: entry.manufacturerData,
+          bleManufacturerCompanyId: manufacturerCompanyId(entry.manufacturerData),
+          bleServiceData: entry.serviceData ? JSON.stringify(entry.serviceData) : undefined,
+        });
+      }
+      resolve(entries.size);
     };
 
-    bleManager.startDeviceScan(null, null, (error, device) => {
+    void bleManager.startDeviceScan(null, null, (error, device) => {
       if (error || settled) {
         finish();
         return;
       }
-      if (!device || seen.has(device.id)) return;
+      if (!device) return;
 
       const name = device.localName ?? device.name ?? undefined;
       const serviceUuids = [...(device.serviceUUIDs ?? []), ...(device.overflowServiceUUIDs ?? [])];
-      const family = classifyFamily(name, serviceUuids);
-      if (!family) return;
+      // Only keep board-like peripherals so unrelated BLE devices never reach
+      // analytics. Classify on this packet's fields plus anything already merged.
+      const existing = entries.get(device.id);
+      if (!existing && entries.size >= MAX_RECON_DEVICES) return;
+      const mergedName = name ?? existing?.name;
+      const mergedServiceUuids = new Set([...(existing?.serviceUuids ?? []), ...serviceUuids]);
+      if (!classifyFamily(mergedName, [...mergedServiceUuids])) return;
 
-      seen.add(device.id);
+      const entry: ReconEntry = existing ?? { serviceUuids: new Set() };
+      entry.name = mergedName;
+      entry.serviceUuids = mergedServiceUuids;
+      entry.manufacturerData = base64ToHex(device.manufacturerData) ?? entry.manufacturerData;
       const serviceData = serviceDataToHex(device.serviceData);
-      const manufacturerData = base64ToHex(device.manufacturerData);
-      track(SHARED_EVENTS.BleAdvertisementRecon, {
-        reconCorrelationId,
-        family,
-        deviceName: name ?? undefined,
-        deviceNamePresent: !!name,
-        parsedSerial: parseSerialNumber(name) ?? undefined,
-        apiLevelFromName: parseApiLevel(name),
-        rssi: device.rssi ?? undefined,
-        serviceUuids: serviceUuids.length > 0 ? JSON.stringify(serviceUuids) : undefined,
-        bleManufacturerData: manufacturerData,
-        bleManufacturerCompanyId: manufacturerCompanyId(manufacturerData),
-        bleServiceData: serviceData ? JSON.stringify(serviceData) : undefined,
-      });
-
-      if (seen.size >= MAX_RECON_DEVICES) finish();
+      if (serviceData) entry.serviceData = { ...entry.serviceData, ...serviceData };
+      if (device.rssi != null) entry.rssi = device.rssi;
+      entries.set(device.id, entry);
     });
 
     timeoutId = setTimeout(finish, RECON_SCAN_MS);

--- a/packages/mobile/src/lib/ble/advertisement.ts
+++ b/packages/mobile/src/lib/ble/advertisement.ts
@@ -1,0 +1,27 @@
+// Pure helpers for the undocumented BLE advertisement payload we capture for
+// reconnaissance (see `advertisement-recon.ts` and the `AdvertisementRecon`
+// type). Kept side-effect-free so they're trivially unit-testable and reusable
+// across the connect telemetry and the scan-recon paths.
+
+import type { AdvertisementRecon, BoardScanFamily } from './types';
+
+// BLE manufacturer data leads with a 16-bit little-endian company identifier
+// (Bluetooth SIG assigned number). Decode it from the hex payload as a
+// convenience dimension so PostHog can group boxes by vendor without parsing the
+// raw hex. Returns undefined when there aren't 2 bytes to read.
+export function manufacturerCompanyId(manufacturerDataHex?: string): number | undefined {
+  if (!manufacturerDataHex || manufacturerDataHex.length < 4) return undefined;
+  const low = parseInt(manufacturerDataHex.slice(0, 2), 16);
+  const high = parseInt(manufacturerDataHex.slice(2, 4), 16);
+  if (Number.isNaN(low) || Number.isNaN(high)) return undefined;
+  return low + (high << 8);
+}
+
+// Future seam (intentionally unimplemented): recover a controller serial from the
+// advertisement payload for boxes that dropped the `#serial@apiLevel` name suffix
+// (newer Kilter-built boxes). We don't know the byte layout yet — the point of
+// the `BLE Advertisement Recon` PostHog capture is to reveal it. Once it's known,
+// implement here and wire as a fallback after `parseSerialNumber(name)`.
+export function parseSerialFromAdvertisement(_recon: AdvertisementRecon, _family: BoardScanFamily): string | undefined {
+  return undefined;
+}

--- a/packages/mobile/src/lib/ble/base64.ts
+++ b/packages/mobile/src/lib/ble/base64.ts
@@ -8,3 +8,36 @@ export function uint8ArrayToBase64(bytes: Uint8Array): string {
   }
   return btoa(binary);
 }
+
+// ble-plx surfaces advertisement manufacturer/service data as base64. Normalize
+// to lowercase hex so the recon payload matches the native iOS path (which
+// hex-encodes on the Swift side). Returns undefined for null/empty/undecodable
+// input so callers can drop the field rather than emit an empty string.
+export function base64ToHex(base64?: string | null): string | undefined {
+  if (!base64) return undefined;
+  let binary: string;
+  try {
+    binary = atob(base64);
+  } catch {
+    return undefined;
+  }
+  if (binary.length === 0) return undefined;
+  let hex = '';
+  for (let charIndex = 0; charIndex < binary.length; charIndex++) {
+    hex += (binary.charCodeAt(charIndex) & 0xff).toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+// ble-plx `Device.serviceData` is `{ uuid: base64 } | null`. Normalize each
+// value to hex, matching the native iOS recon payload. Returns undefined when
+// there's nothing usable so callers omit the field.
+export function serviceDataToHex(serviceData?: Record<string, string> | null): Record<string, string> | undefined {
+  if (!serviceData) return undefined;
+  const mapped: Record<string, string> = {};
+  for (const [uuid, base64] of Object.entries(serviceData)) {
+    const hex = base64ToHex(base64);
+    if (hex !== undefined) mapped[uuid] = hex;
+  }
+  return Object.keys(mapped).length > 0 ? mapped : undefined;
+}

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -153,6 +153,9 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
         deviceId: payload.device.deviceId,
         name: deviceName,
         rssi: payload.rssi,
+        // Native already hex-encodes; pass through as-is (omitted when absent).
+        manufacturerData: payload.manufacturerData,
+        serviceData: payload.serviceData,
       };
       if (upsertDiscoveredDevice(devices, device)) {
         pushDevices();
@@ -225,9 +228,13 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
     }
 
     let selectedDeviceName: string | undefined;
+    let selectedManufacturerData: string | undefined;
+    let selectedServiceData: Record<string, string> | undefined;
     for (const device of devices.values()) {
       if (device.deviceId === selectedDeviceId) {
         selectedDeviceName = device.name;
+        selectedManufacturerData = device.manufacturerData;
+        selectedServiceData = device.serviceData;
         break;
       }
     }
@@ -253,6 +260,8 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
     return {
       deviceId: selectedDeviceId,
       deviceName: selectedDeviceName,
+      manufacturerData: selectedManufacturerData,
+      serviceData: selectedServiceData,
     };
   }
 

--- a/packages/mobile/src/lib/ble/scan-device-cache.ts
+++ b/packages/mobile/src/lib/ble/scan-device-cache.ts
@@ -9,6 +9,15 @@ export function upsertDiscoveredDevice(devices: Map<string, DiscoveredDevice>, d
   const deviceKey = getDiscoveredDeviceKey(device);
   const existingDevice = devices.get(deviceKey);
   if (existingDevice?.deviceId === device.deviceId && existingDevice.name === device.name) {
+    // Same board, unchanged identity — no picker re-push. But BLE splits the
+    // advertisement across packets (ADV_IND vs SCAN_RSP), so manufacturer/service
+    // data can arrive in a later callback than the name. Enrich the stored record
+    // in place (the connect-time telemetry reads it back later) rather than
+    // letting the first packet win and dropping a payload that showed up second.
+    if (device.manufacturerData !== undefined) existingDevice.manufacturerData = device.manufacturerData;
+    if (device.serviceData !== undefined) {
+      existingDevice.serviceData = { ...existingDevice.serviceData, ...device.serviceData };
+    }
     return false;
   }
 

--- a/packages/mobile/src/lib/ble/types.ts
+++ b/packages/mobile/src/lib/ble/types.ts
@@ -1,12 +1,27 @@
 export type BleConnection = {
   deviceId: string;
   deviceName?: string;
+  // Advertisement recon payload of the connected device, threaded through so the
+  // `Bluetooth Connection Success` event can carry it. See `AdvertisementRecon`.
+  manufacturerData?: string;
+  serviceData?: Record<string, string>;
 };
 
 export type DiscoveredDevice = {
   deviceId: string;
   name?: string;
   rssi: number;
+} & AdvertisementRecon;
+
+// Undocumented advertisement payload captured for PostHog reconnaissance. Newer
+// Kilter-built boxes advertise a bare name with no `#serial@apiLevel` suffix, so
+// the serial / LED generation may ride in manufacturer data or per-UUID service
+// data instead. Canonical encoding is lowercase hex (both native iOS and the
+// ble-plx base64→hex path normalize to it) so the field is comparable across
+// platforms. Parsed nowhere yet — capture + telemetry only.
+export type AdvertisementRecon = {
+  manufacturerData?: string;
+  serviceData?: Record<string, string>;
 };
 
 export type BoardScanFamily = 'aurora' | 'moonboard';

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -30,6 +30,7 @@ import {
   subscribeNativeBleConnected,
 } from './adapter-factory';
 import { requestBleRuntimePermissions } from './use-ble-permissions';
+import { manufacturerCompanyId } from './advertisement';
 import type {
   BleDisconnectInfo,
   BleWriteDiagnostics,
@@ -884,6 +885,13 @@ export function useBoardBluetooth({
           // write-type one) is visible in PostHog (see #3230).
           bleMaxWriteWithResponse: connectionDiagnostics?.maxWriteWithResponse,
           bleMaxWriteWithoutResponse: connectionDiagnostics?.maxWriteWithoutResponse,
+          // Advertisement recon (parsed nowhere yet): newer bare-name boxes may
+          // carry their serial / LED generation here instead of in the name.
+          // Captured so we can find the layout across the fleet, then teach
+          // parseSerialNumber/parseApiLevel to read it. Absent → fields dropped.
+          bleManufacturerData: connection.manufacturerData ?? undefined,
+          bleManufacturerCompanyId: manufacturerCompanyId(connection.manufacturerData),
+          bleServiceData: connection.serviceData ? JSON.stringify(connection.serviceData) : undefined,
         });
         return true;
       } catch (error) {

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -112,6 +112,12 @@ export const SHARED_EVENTS = {
   // config, current-board fallback, or no preview at all. Measures how often
   // the serial→board resolution actually pays off in the picker UI.
   BlePickerDevicesResolved: 'BLE Picker Devices Resolved',
+  // Consent-driven scan recon: fired once per discovered board when a user
+  // submits a bug report with the "Bluetooth trouble" toggle on. Carries the raw
+  // advertisement payload (manufacturerData/serviceData hex, service UUIDs, name)
+  // so we can find where newer bare-name boxes stash their serial / LED
+  // generation. Batched by reconCorrelationId. Not fired on normal connects.
+  BleAdvertisementRecon: 'BLE Advertisement Recon',
   ClimbSentToBoardSuccess: 'Climb Sent to Board Success',
   ClimbSentToBoardFailure: 'Climb Sent to Board Failure',
   // Fired on a successful USER-INITIATED clear-all write (sendSource 'clear';

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -396,6 +396,8 @@
     "remainingChars": "{{count}} more characters to go",
     "sessionRecordingLabel": "Turn on session recording",
     "sessionRecordingDescription": "Help us fix your bug faster by turning on session recording and reproducing the bug. You can turn it off after.",
+    "bluetoothBugLabel": "I'm having Bluetooth trouble",
+    "bluetoothBugDescription": "Scans for nearby boards and sends us what they broadcast, so we can figure out why yours won't connect. No board is controlled — we just listen.",
     "starRating_one": "{{count}} star",
     "starRating_other": "{{count}} stars",
     "nextAria": "Next"

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -398,6 +398,8 @@
     "starRating_other": "{{count}} estrellas",
     "sessionRecordingLabel": "Activar grabación de sesión",
     "sessionRecordingDescription": "Ayúdanos a corregir tu error más rápido activando la grabación de sesión y reproduciendo el problema. Puedes desactivarla después.",
+    "bluetoothBugLabel": "Tengo problemas con el Bluetooth",
+    "bluetoothBugDescription": "Busca plafones cercanos y nos envía lo que emiten, para entender por qué el tuyo no se conecta. No se controla ningún plafón: solo escuchamos.",
     "nextAria": "Siguiente"
   },
   "feedbackBanner": {

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -398,6 +398,8 @@
     "starRating_other": "{{count}} étoiles",
     "sessionRecordingLabel": "Activer l'enregistrement de session",
     "sessionRecordingDescription": "Aidez-nous à corriger votre bug plus vite en activant l'enregistrement de session et en reproduisant le problème. Vous pourrez le désactiver ensuite.",
+    "bluetoothBugLabel": "J'ai des problèmes de Bluetooth",
+    "bluetoothBugDescription": "Recherche les boards à proximité et nous envoie ce qu'elles diffusent, pour comprendre pourquoi la tienne ne se connecte pas. Aucune board n'est commandée : on se contente d'écouter.",
     "nextAria": "Suivant"
   },
   "feedbackBanner": {


### PR DESCRIPTION
## Summary

Newer Kilter-built controller boxes advertise a **bare BLE name** (`Kilter Board`, no `#serial@apiLevel` suffix), so Boardsesh can't recover their serial or LED generation from the name — the box drops out of serial-gated flows and `parseApiLevel` silently defaults to v2. The official Kilter app doesn't hit this: it reads serial / LED-kit generation from data the box carries elsewhere. The two undocumented channels are the advertisement **manufacturer data** and custom **service-data** UUIDs.

This PR **captures that raw advertisement payload and ships it to PostHog** so we can find the layout across the real fleet — for **both Aurora and MoonBoard** — then teach the parsers to read it in a follow-up. It parses nothing yet (`parseSerialFromAdvertisement` is a stub); this is reconnaissance.

### How it works
- **Capture** at scan time on both stacks: iOS native CoreBluetooth reads `CBAdvertisementDataManufacturerDataKey` / `ServiceDataKey`; the ble-plx path reads `Device.manufacturerData` / `serviceData`. Normalized to one canonical **lowercase hex** string so the field is comparable across platforms.
- **Passive emission**: the connected device's payload rides the existing `Bluetooth Connection Success` event (once per connect), with a decoded `bleManufacturerCompanyId`.
- **Consent-driven recon**: a new **"I'm having Bluetooth trouble"** toggle in the bug-report sheet runs a bounded, scan-only sweep and emits `BLE Advertisement Recon` per in-range board — capturing boxes the user can't even connect to (the actual failure cases). Opt-in only; no board is controlled.

### Scope
- Both board families (the scan path is shared; capture is not gated by family).
- **Out:** parsing serial / API level from the payload (follow-up once PostHog shows the layout); Web Bluetooth (`requestDevice` exposes no advertisement data).
- Sentry parity for the new field was left out (manufacturerData lives on the connection, not the connect-diagnostics struct the Sentry tags mirror) — noted for a follow-up if wanted.

### Key files
- Native iOS: `BoardBleManager.swift` (capture + `hexEncodedString`), `BoardBleModule.swift` (event body).
- Plumbing: `modules/live-activity/src/index.ts`, `ble/types.ts`, `native-ios-adapter.ts`, `adapter.ts`, `base64.ts` (`base64ToHex`/`serviceDataToHex`).
- Telemetry: `use-board-bluetooth.ts`, `advertisement.ts` (`manufacturerCompanyId` + parse seam), `events.ts`.
- Recon: `advertisement-recon.ts`, `FeedbackSheet.tsx`, i18n (`settings.json` × en/es/fr).

## Release Notes

- Hitting a Bluetooth wall? Bug reports now have an "I'm having Bluetooth trouble" toggle — flip it and we'll spot the boards around you so we can work out why yours won't connect.

## Test plan

- Unit tests: `advertisement.test.ts` (hex encoding, company-id decode, parse seam), `advertisement-recon.test.ts` (permission/power gating, unfiltered scan, one hex-payload event per distinct board, dedupe, non-board skip).
- `vp run typecheck:mobile` ✅ · `vp test run --project mobile packages/mobile/src/lib/ble` ✅ (207) · i18n `catalog-completeness` ✅ (28) · `vp check` ✅ · `vp run check:mobile-bundle` ✅.
- **No BLE on simulator/CI** — plumbing is unit-verified; real bytes need a device. Native Swift change needs a new build to reach devices (JS rides OTA).
- **PostHog readback** after a build ships: `Bluetooth Connection Success` (`bleManufacturerData`) + `BLE Advertisement Recon`, segmented by family and by whether the name carried a serial — focus on the bare-name Kilter cohort and MoonBoard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYxwRfm4qnN22mG17Jdk78