### PR TITLE
feat(db): implement stage 2 grade model

### DIFF
--- a/docs/boardsesh-grade.md
+++ b/docs/boardsesh-grade.md
@@ -39,9 +39,10 @@ data problem rather than a matter of opinion. The reference point is theCrag's
 GRAID, which applies Whole-History Rating to per-user ascent outcomes — we use a
 different backbone (see §6) because our per-user data is far sparser than theirs.
 
-The v1 model is deliberately small: `GROUP BY` aggregates, two coefficient
-tables, and one closed-form empirical-Bayes blend, all in TypeScript. No MCMC,
-no IRT, no neural net. It ships behind the `boardsesh-grade` feature flag.
+The model is deliberately small: `GROUP BY` aggregates, frozen coefficient
+rows, capped per-user evidence, and one closed-form empirical-Bayes blend, all
+in TypeScript. No MCMC, no IRT, no neural net. It ships behind the
+`boardsesh-grade` feature flag.
 
 ## 2. Data sources and their verified quirks
 
@@ -57,7 +58,7 @@ MoonBoard**: fractional, and it moves as ascents accumulate.
 
 - **MoonBoard is the exception.** Moon's feed carries only integer labels —
   `difficulty_average == display_difficulty == benchmark` byte-for-byte. There
-  is no crowd mean to model, so Moon gets no computed grade in v1 (§5).
+  is no crowd mean to model, so Moon gets no computed grade yet (§5).
 - **Zero shrinkage upstream.** A one-ascent "grade" is one person's opinion
   surfaced raw. On Kilter, 34% of climb+angle rows have exactly one ascent and
   70% have four or fewer. The ≥20-ascent head is already stable (p90 lifetime
@@ -94,8 +95,9 @@ label is right" vote. A synced exact-echo is treated as "no opinion expressed"
 - **Kilter's `benchmark_difficulty` column is not curation** — 164k rows, it is
   not a hand-picked reference set and must not be treated as one.
 - **Moon benchmarks are circular** in our feed (they equal the label).
-- **No Moon standardization is possible in v1**: zero users have ≥3 graded sends
-  on both Moon and another board, so there is no bridge to anchor Moon against.
+- **No Moon standardization is publishable yet**: the feed has no crowd mean,
+  and live paired-user coverage is still below the bridge threshold, so Moon
+  remains report-only until the data grows.
 
 ### Structure and hygiene
 
@@ -126,9 +128,8 @@ label is right" vote. A synced exact-echo is treated as "no opinion expressed"
   Tension's top user is 33% of expressed opinions and tick-weighting would cut
   `σ_within` from 1.74 to 1.38 — one person's tight personal dispersion faking
   ~26% more confidence in every Tension crowd mean. On Kilter (top user 5.7%)
-  the choice barely matters (1.55 vs 1.52). Reproduce all three checks with
-  `node --import tsx packages/db/scripts/analyze-grader-concentration.ts`
-  (read-only).
+  the choice barely matters (1.55 vs 1.52). The read-only reproduction script is
+  `packages/db/scripts/analyze-grader-concentration.ts`.
 - Drafts and unlisted climbs are excluded from the pipeline.
 
 ## 3. The model
@@ -240,14 +241,53 @@ lowered so the UI stops presenting an outlier as settled. The nightly run logs
 and persists how many rows were downgraded. Implementation:
 `applyDisplayDeltaHygiene` in `hygiene.ts`.
 
+### Capped rater and behavior evidence (v2.0)
+
+Stage 2 adds two per-user signals before the EB blend, but keeps them bounded
+so they cannot overpower the upstream crowd aggregate they often feed.
+
+**Rater model.** For every user × gym/board location, we estimate a shrunk bias
+against the current crowd mean. Native Boardsesh grade ticks count as explicit
+opinions, including exact display matches. Synced exact-display echoes count as
+zero opinion because they are likely quick-log auto-fills; synced non-echo
+grades count at `0.25`. Biases need at least 3 effective opinions, shrink toward
+zero with a 12-opinion prior, and clamp to ±1 grade. The climb-level rater
+signal is capped to ±0.5 grade from the raw crowd mean and at 5 effective
+opinions.
+
+**Behavior model.** Native flash/send/attempt outcomes are converted into a
+weak grade signal after fitting shrunk user ability from successful ticks.
+Behavior only publishes for boards whose **used** native rows are broad enough
+after the high-traffic and ability filters (≥100 users, ≥500 outcomes, top user
+≤3% of outcomes). Outcome buckets need support and cannot be dominated by one
+user before they are used. The climb-level behavior signal is capped to ±0.35
+grade from the raw crowd mean and at 2 effective opinions.
+
+**De-echoed crowd mean.** The crowd mean point estimate is gently moved away
+from display by dividing the observed display delta by `(1 − λ)`, but only when
+there is enough independent evidence and only up to ±0.75 grade from the
+observed mean. If the de-echo step is not eligible, the raw crowd mean stands.
+
+Rater and behavior coefficients are fit on training rows. Prediction evidence
+is then built separately, with Tension benchmark holdout rows allowed in
+prediction but excluded from fitting. For normal published rows, per-user rater
+bias and behavior ability are applied leave-target-out so the target climb does
+not help calibrate the user signal used to grade that same target.
+
+All three signals are blended into the observation's `difficultyAverage` before
+the existing cross-angle prior, isotonic projection, no-shock gate, and
+hysteresis. The visible ascent count and confidence-tier thresholds still use
+the upstream raw ascent count, so Stage 2 cannot make a thin climb look like a
+head climb.
+
 ### Duplicate climbs share one identity
 
-Climbs with the same `hold_fingerprint` are the same physical problem listed
-under different UUIDs. The pipeline treats a duplicate group as ONE climb: per
-angle an n-weighted pooled mean/count (and averaged display), and every member
-uses the group's full angle set as its cross-angle evidence — so members get
-identical posteriors by construction. Before pooling, 44% of Kilter duplicate
-groups disagreed by more than a grade.
+Climbs with the same `(layout_id, hold_fingerprint)` are the same physical
+problem listed under different UUIDs. The pipeline treats a duplicate group as
+ONE climb: per angle an n-weighted pooled mean/count (and averaged display),
+pooled Stage 2 evidence, and every member uses the group's full angle set as
+its cross-angle evidence — so members get identical posteriors by construction.
+Before pooling, 44% of Kilter duplicate groups disagreed by more than a grade.
 
 ### Grade × angle surface
 
@@ -282,11 +322,11 @@ Estimator: `estimateBoardOffsets`.
 
 ### Confidence tiers
 
-| Tier          | Condition                                                                                           | UI                                 |
-| ------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `confirmed`   | n ≥ 20 and `post_sd` ≤ 0.35, unless Kilter display-delta hygiene downgrades the row                  | grade, "confirmed by N sends"      |
-| `provisional` | 3 ≤ n < 20, or a confirmed Kilter row tripped the v1.2 display-delta hygiene rule                    | grade with a visible ± band        |
-| `setter_only` | n < 3                                                                                               | no Boardsesh number, setter's call |
+| Tier          | Condition                                                                           | UI                                 |
+| ------------- | ----------------------------------------------------------------------------------- | ---------------------------------- |
+| `confirmed`   | n ≥ 20 and `post_sd` ≤ 0.35, unless Kilter display-delta hygiene downgrades the row | grade, "confirmed by N sends"      |
+| `provisional` | 3 ≤ n < 20, or a confirmed Kilter row tripped the v1.2 display-delta hygiene rule   | grade with a visible ± band        |
+| `setter_only` | n < 3                                                                               | no Boardsesh number, setter's call |
 
 ### Publish hysteresis
 
@@ -301,15 +341,20 @@ Coefficients are refit weekly and frozen between refits. Every nightly run
 evaluates the gates first and **writes zero grade rows if any blocking gate
 fails**. Results persist to `board_grade_coefficients` (kind `gate_results`).
 
-| Gate                      | Threshold                                                                                                                         | Blocks?             | What a failure means                                                                                                          |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `tail_backtest`           | multi-angle shrunk MAE must not exceed raw MAE (+0.01 tolerance), n ≥ 100; improvement % reported against an aspirational 20% bar | yes                 | the blend makes sparse grades worse than doing nothing                                                                        |
-| `head_holdout`            | single-angle shrunk MAE must not exceed raw MAE (+0.01), n ≥ 100                                                                  | yes                 | the model regressed the rows where it is supposed to be a no-op                                                               |
-| `no_shock`                | no ≥50-ascent climb's local grade moves >1.0 from its raw mean                                                                    | yes                 | the prior is overpowering established grades (also enforced by a clamp inside the blend itself; the gate catches regressions) |
-| `fingerprint_consistency` | ≤1% of duplicate-fingerprint groups disagree by >1 grade at the same angle                                                        | yes                 | evidence for one physical problem is being split badly                                                                        |
-| `residual_paired_gap`     | shared-user mean gap vs fitted offset ≤ 0.3 after the Kilter offset                                                               | withholds universal | the "constant offset" story is wrong; local grades still publish, universal grades don't                                      |
-| `display_delta_hygiene`   | reports Kilter rows downgraded from `confirmed` to `provisional` for rounded universal-display delta outside [-3, +1]             | no (repaired)       | source labels likely contain mixed-scale/corrupt display values; the grade publishes, but not as confirmed                    |
-| honesty report            | reports `corr(grade, display)` and mean \|Δ\| per board                                                                           | no (report only)    | a board whose numbers never leave the label is dressing the label as a data product; UI copy must say so                      |
+| Gate                             | Threshold                                                                                                                         | Blocks?             | What a failure means                                                                                                          |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `tail_backtest`                  | multi-angle shrunk MAE must not exceed raw MAE (+0.01 tolerance), n ≥ 100; improvement % reported against an aspirational 20% bar | yes                 | the blend makes sparse grades worse than doing nothing                                                                        |
+| `head_holdout`                   | single-angle shrunk MAE must not exceed raw MAE (+0.01), n ≥ 100                                                                  | yes                 | the model regressed the rows where it is supposed to be a no-op                                                               |
+| `behavior_eligibility`           | reports how many board behavior models pass the Stage 2 coverage guard                                                            | no (report only)    | behavior data is too concentrated or sparse on some boards, so their outcome signal is ignored                                |
+| `moon_bridge_readiness`          | reports Moon paired-user coverage and candidate offset stability                                                                  | no (report only)    | Moon still lacks a publishable bridge; this deliberately does not block Kilter/Tension grades                                 |
+| `deherded_tension_benchmark`     | held-out Tension benchmark Stage 2 MAE must not exceed Stage 1 MAE by >0.01, n ≥ 100; display MAE is reported only                | yes                 | rater/behavior/de-echo evidence made the benchmark set worse than the existing model                                          |
+| `deherded_tension_calibration`   | held-out Tension benchmark 95% interval coverage must land in [85%, 98%], n ≥ 100                                                 | yes                 | Stage 2 uncertainty is materially under- or over-confident                                                                    |
+| `deherded_segment_no_regression` | no grade-band, angle, or traffic segment with ≥50 rows may regress by >0.05 MAE vs Stage 1                                        | yes                 | the aggregate benchmark score hid a segment-level regression                                                                  |
+| `no_shock`                       | no ≥50-ascent climb's local grade moves >1.0 from its raw mean                                                                    | yes                 | the prior is overpowering established grades (also enforced by a clamp inside the blend itself; the gate catches regressions) |
+| `fingerprint_consistency`        | ≤1% of duplicate-fingerprint groups disagree by >1 grade at the same angle                                                        | yes                 | evidence for one physical problem is being split badly                                                                        |
+| `residual_paired_gap`            | shared-user mean gap vs fitted offset ≤ 0.3 after the Kilter offset                                                               | withholds universal | the "constant offset" story is wrong; local grades still publish, universal grades don't                                      |
+| `display_delta_hygiene`          | reports Kilter rows downgraded from `confirmed` to `provisional` for rounded universal-display delta outside [-3, +1]             | no (repaired)       | source labels likely contain mixed-scale/corrupt display values; the grade publishes, but not as confirmed                    |
+| honesty report                   | reports `corr(grade, display)` and mean \|Δ\| per board                                                                           | no (report only)    | a board whose numbers never leave the label is dressing the label as a data product; UI copy must say so                      |
 
 The backtest replays `board_climb_stats_history` (5.4M snapshots): for series
 that later reached ≥50 ascents (their final mean ≈ truth), it takes the
@@ -325,74 +370,80 @@ win big; what it must never do is lose. On the 2026-07-07 prod run the blend
 beat raw by 2.5% on the multi-angle subset (MAE 0.592 vs 0.607) and exactly
 matched it on single-angle rows. The 20% figure remains in the gate output as
 an aspirational bar so refits that help or hurt stay visible run over run; a
-de-herded evaluation (predicting held-out Tension benchmarks) is the Stage-2
+de-herded evaluation (predicting held-out Tension benchmarks) is the Stage 2
 way to raise it honestly.
+
+The Stage 2 benchmark split withholds 20% of Tension benchmarks from rater and
+behavior fitting using a stable climb+angle hash. The withheld rows are still
+allowed to produce prediction evidence; only coefficient fitting is withheld.
+The withheld rows are scored against a true Stage 1 compute path with all Stage
+2 transforms disabled, and against the Stage 2 model. Display grade remains a
+report-only yardstick because benchmarks are curated labels, and requiring the
+model to beat the display label itself would reject any useful non-label signal.
 
 ## 5. Known limitations
 
 These are real and we'd rather state them than paper over them.
 
-- **Moon is not standardized.** No crowd mean (label-only feed), no bridge users
-  to any other board, circular benchmarks. Moon shows its native grade plus "not
-  standardized yet." The unlock is Moon logbook growth — more logged Moon sends
-  create both a crowd mean and shared users.
+- **Moon is not standardized.** No crowd mean (label-only feed), circular
+  benchmarks, and paired-user coverage below the bridge threshold. Moon shows
+  its native grade plus "not standardized yet." The unlock is Moon logbook
+  growth — more logged Moon sends create shared users for the bridge report.
 - **Small boards aren't universalized.** Decoy, Grasshopper, So iLL, and
   Touchstone have no anchor, so they get a within-board grade with no
   cross-board claim.
 - **Mirrors inherit the base grade.** The aggregates carry no mirror dimension,
   so a mirrored climb reads at its base orientation's grade. Documented, not
   fixed.
-- **Anchoring / herding attenuates deviations.** Because loggers anchor to the
-  displayed grade, the crowd mean drifts less than true disagreement would
-  warrant. v1 applies the (1 − λ) de-attenuation to the _standard error_ but
-  does **not** de-attenuate the point estimate itself — inflating the deviation
-  is easy to get wrong and could manufacture movement on thin evidence, so we
-  chose the conservative option and left it for Stage 2's rater model.
+- **Anchoring / herding is only partially corrected.** Stage 2 de-echoes the
+  crowd point estimate and adds rater/behavior evidence, but every step is
+  capped. That is intentional: the data is still sparse and self-selected, so a
+  bounded correction is preferable to manufacturing movement from thin ticks.
 - **Single-angle sparse climbs gain little.** With one angle and few ascents the
   posterior is essentially the raw mean. The model's tail value is cross-angle
   pooling; a lone sparse angle has nothing to pool with.
 
 ## 6. Rejected alternatives
 
-| Alternative               | Why not (for v1)                                                                                                                                                                                                                                                                        |
+| Alternative               | Why not                                                                                                                                                                                                                                                                                 |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Full Bayesian / MCMC      | Upstream gives us aggregate means, not per-ascent variances. Without the underlying distributions there's nothing for a sampler to condition on that the closed-form EB blend doesn't already capture — the cost buys no extra signal.                                                  |
 | WHR / IRT as the backbone | Per-user outcomes cover only ~14% of the Kilter catalog. theCrag's GRAID works because it has dense per-user ascent data; ours is too sparse to carry a rating system as the primary estimator. Ticks are a coefficient factory (variance, cross-board offset), not a grading backbone. |
-| CNN content model         | Deferred, not rejected. A gradient-boosted model on hold features is the cheaper, more credible Stage-3 version (`content_prior` column is already reserved, NULL in v1).                                                                                                               |
+| CNN content model         | Deferred, not rejected. A gradient-boosted model on hold features is the cheaper, more credible Stage 3 version (`content_prior` column is already reserved, NULL in v2).                                                                                                               |
 
 ## 7. Contributing
 
 ### The roadmap
 
-- **Stage 2 — ordinal rater model.** Model per-rater bias on an ordinal scale
-  with echo ticks down-weighted, so the point estimate can be de-attenuated
-  safely. Add a behavioral flash/attempt Rasch signal from tick outcomes, which
-  is anchoring-immune (whether someone flashed a climb doesn't depend on the
-  displayed number).
+- **Stage 2 — rater and behavior evidence.** Implemented in v2.0 with capped
+  per-user rater bias, weak native behavior outcomes, de-echoed crowd means,
+  held-out Tension benchmark gates, and report-only Moon bridge readiness.
 - **Stage 3 — hold-feature content prior.** A gradient-boosted model over hold
   features to give the cold tail a prior before any ascents exist. The
   `content_prior` column on `board_climb_grades` is reserved for this.
 
 ### Running it
 
-Unit tests (Node's native runner via tsx):
+Unit tests:
 
 ```
-node --import tsx --test packages/db/src/queries/grade-model/__tests__/grade-model.test.ts
+vp run test:db
 ```
 
 The pipeline locally, against the dev DB (or a read-only prod `DB_URL`):
 
 ```
-node --import tsx packages/db/scripts/refresh-climb-grades.ts --validate-only
-node --import tsx packages/db/scripts/refresh-climb-grades.ts --dry-run
-node --import tsx packages/db/scripts/refresh-climb-grades.ts --refit-coefficients
+vp run db:refresh-climb-grades -- --validate-only
+vp run db:refresh-climb-grades -- --dry-run
+vp run db:refresh-climb-grades -- --refit-coefficients
 ```
 
 - `--validate-only` refits coefficients in memory, runs every gate against live
-  data, prints per-board tier counts and the honesty report, and writes nothing.
-  It works even before the grade tables exist (e.g. prod pre-migration).
-- `--dry-run` evaluates and records gates but writes no grade rows.
+  data, prints per-board tier counts, writes nothing, and exits nonzero if a
+  blocking gate fails. It works even before the grade tables exist (e.g. prod
+  pre-migration).
+- `--dry-run` evaluates gates through the normal publish path but writes no
+  coefficients, gate results, or grade rows.
 - `--refit-coefficients` forces a weekly refit instead of reusing the frozen set.
 - A bare run reuses frozen coefficients if they're under a week old, else refits.
 
@@ -400,12 +451,13 @@ node --import tsx packages/db/scripts/refresh-climb-grades.ts --refit-coefficien
 
 - `board_climb_grades` — one row per climb+angle: `local_grade`,
   `universal_grade` (NULL when unanchorable), `grade_low`/`grade_high`,
-  `confidence`, `ascensionist_count` snapshot, `content_prior` (NULL in v1),
+  `confidence`, `ascensionist_count` snapshot, `content_prior` (NULL in v2),
   `model_version`, `coeff_version`.
 - `board_grade_coefficients` — versioned coefficient rows keyed by
   `(coeff_version, kind, key)`. Kinds: `echo_fraction`, `sigma_within`,
-  `tau_squared`, `angle_offset`, `board_offset`, and `gate_results` (per-run
-  pass/fail + metrics). Plain table, `pg_dump`-portable.
+  `tau_squared`, `angle_offset`, `board_offset`, `rater_model`,
+  `behavior_model`, `bridge_readiness`, and `gate_results` (per-run pass/fail +
+  metrics). Plain table, `pg_dump`-portable.
 - Climb and tick/session GraphQL payloads (`climb`, `searchClimbs`, `ticks`,
   `sessionGroupedFeed`, `sessionDetail`, and friends) each embed
   `boardseshDifficulty` (`COALESCE(universal_grade, local_grade)`) and

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -76,6 +76,7 @@
     "db:backfill-moonboard-set-ids": "tsx scripts/backfill-moonboard-set-ids.ts",
     "db:dedupe-gyms": "tsx scripts/dedupe-gym-locations.ts",
     "db:dedupe-beta-links": "tsx scripts/dedupe-beta-links.ts",
+    "db:refresh-climb-grades": "tsx scripts/refresh-climb-grades.ts",
     "db:seed-social": "tsx scripts/seed-social.ts",
     "db:create-test-user": "tsx scripts/create-test-user.ts",
     "db:seed-beta-links": "tsx scripts/seed-dev-beta-links.ts"

--- a/packages/db/scripts/refresh-climb-grades.ts
+++ b/packages/db/scripts/refresh-climb-grades.ts
@@ -15,7 +15,7 @@
  *
  * Model spec and the reasoning behind every threshold: docs/boardsesh-grade.md.
  *
- * Run locally: `node --import tsx packages/db/scripts/refresh-climb-grades.ts`
+ * Run locally: `vp run db:refresh-climb-grades --`
  * Flags: --refit-coefficients (force a refit), --dry-run (gates + stats only),
  * --validate-only (read-only gates report, works without the grade tables),
  * --allow-empty-backtest (dev DBs without stats history: skip the backtest
@@ -34,36 +34,62 @@ import {
   applyDisplayDeltaHygiene,
   buildAngleSurfaceSql,
   buildBacktestSampleSql,
+  buildBehaviorEvidence,
+  buildBehaviorSampleSql,
   buildBoardOffsetSampleSql,
   buildEchoRatesSql,
   buildHonestyCheckSql,
+  buildMoonBridgeSampleSql,
+  buildRaterEvidence,
+  buildRaterSampleSql,
   buildSigmaWithinSql,
   buildTauSampleSql,
+  buildTensionBenchmarkHoldoutSql,
   computePosteriorGrade,
   createDisplayDeltaHygieneStats,
+  deherdCrowdMean,
   estimateAngleSurface,
+  estimateBehaviorModels,
   estimateBoardOffsets,
   estimateEchoFractions,
+  estimateRaterModels,
+  evaluateMoonBridgeReadiness,
   estimateSigmaWithin,
   estimateTauSquared,
   evaluateBacktest,
   evaluateDisplayDeltaHygiene,
   evaluateFingerprintGate,
+  evaluateTensionBenchmarkHoldout,
+  echoFractionFor,
+  effectiveN,
   evaluateResidualGapGate,
   mergeDisplayDeltaHygieneStats,
+  moonBridgeReadinessGate,
   recordDisplayDeltaHygiene,
   shouldPublish,
   GATE_NO_SHOCK_MAX_MOVE,
   GATE_NO_SHOCK_MIN_ASCENTS,
+  STAGE2_BEHAVIOR_MAX_EFFECTIVE_N,
+  STAGE2_BEHAVIOR_MAX_MOVE,
+  STAGE2_DEECHO_MAX_MOVE,
+  STAGE2_RATER_MAX_EFFECTIVE_N,
+  STAGE2_RATER_MAX_MOVE,
   type AngleSurfaceRow,
   type BacktestSampleRow,
+  type BehaviorSampleRow,
   type BoardOffsetSampleRow,
   type ClimbAngleObservation,
   type EchoRateRow,
   type DisplayDeltaHygieneStats,
   type GateResult,
   type GradeCoefficients,
+  type MoonBridgeSampleRow,
+  type RaterSampleRow,
   type SigmaWithinRow,
+  type Stage2Evidence,
+  type Stage2EvidenceMap,
+  type TensionBenchmarkHoldoutRow,
+  type TensionBenchmarkPrediction,
   type TauSampleRow,
 } from '../src/queries/grade-model/index.js';
 import { rowsOf } from '../src/queries/util/rows.js';
@@ -109,6 +135,9 @@ async function loadFrozenCoefficients(db: Db): Promise<GradeCoefficients | null>
     tauSquared: {},
     angleOffset: {},
     boardOffset: {},
+    raterModel: {},
+    behaviorModel: {},
+    bridgeReadiness: {},
   };
   // Payload shapes are documented per `kind` on the boardGradeCoefficients
   // schema; the writer below is the only producer, so shape-by-kind casts are
@@ -124,6 +153,12 @@ async function loadFrozenCoefficients(db: Db): Promise<GradeCoefficients | null>
       coefficients.angleOffset[row.key] = row.payload as GradeCoefficients['angleOffset'][string];
     } else if (row.kind === 'board_offset') {
       coefficients.boardOffset[row.key] = row.payload as GradeCoefficients['boardOffset'][string];
+    } else if (row.kind === 'rater_model') {
+      coefficients.raterModel[row.key] = row.payload as GradeCoefficients['raterModel'][string];
+    } else if (row.kind === 'behavior_model') {
+      coefficients.behaviorModel[row.key] = row.payload as GradeCoefficients['behaviorModel'][string];
+    } else if (row.kind === 'bridge_readiness') {
+      coefficients.bridgeReadiness[row.key] = row.payload as GradeCoefficients['bridgeReadiness'][string];
     }
   }
   return coefficients;
@@ -134,7 +169,8 @@ async function refitCoefficients(
   options: { persist: boolean } = { persist: true },
 ): Promise<GradeCoefficients> {
   console.log('[grades] refitting coefficients…');
-  const coeffVersion = new Date().toISOString().slice(0, 10);
+  const coeffVersion = new Date().toISOString();
+  await db.execute(sql`SET max_parallel_workers_per_gather = 0`);
 
   const echoRows = rowsOf<EchoRateRow>(await db.execute(buildEchoRatesSql()));
   const echoFraction = estimateEchoFractions(echoRows);
@@ -151,6 +187,19 @@ async function refitCoefficients(
   const offsetRows = rowsOf<BoardOffsetSampleRow>(await db.execute(buildBoardOffsetSampleSql()));
   const { kilter } = estimateBoardOffsets(offsetRows);
 
+  const raterRows = rowsOf<RaterSampleRow>(
+    await db.execute(buildRaterSampleSql({ excludeTensionBenchmarkHoldout: true })),
+  );
+  const raterModel = estimateRaterModels(raterRows);
+
+  const behaviorRows = rowsOf<BehaviorSampleRow>(
+    await db.execute(buildBehaviorSampleSql({ excludeTensionBenchmarkHoldout: true })),
+  );
+  const behaviorModel = estimateBehaviorModels(behaviorRows);
+
+  const moonBridgeRows = rowsOf<MoonBridgeSampleRow>(await db.execute(buildMoonBridgeSampleSql()));
+  const moonBridgeReadiness = evaluateMoonBridgeReadiness(moonBridgeRows);
+
   const coefficients: GradeCoefficients = {
     coeffVersion,
     echoFraction,
@@ -158,6 +207,9 @@ async function refitCoefficients(
     tauSquared,
     angleOffset,
     boardOffset: { [ANCHOR_BOARD]: { offset: 0, sd: 0, users: 0, looMaxDelta: 0 } },
+    raterModel,
+    behaviorModel,
+    bridgeReadiness: { moonboard: moonBridgeReadiness },
   };
   if (kilter && kilter.looMaxDelta <= OFFSET_LOO_MAX_DELTA) {
     coefficients.boardOffset.kilter = kilter;
@@ -183,20 +235,29 @@ async function refitCoefficients(
       key: board,
       payload,
     })),
+    ...Object.entries(raterModel).map(([board, payload]) => ({ kind: 'rater_model', key: board, payload })),
+    ...Object.entries(behaviorModel).map(([board, payload]) => ({ kind: 'behavior_model', key: board, payload })),
+    ...Object.entries(coefficients.bridgeReadiness).map(([board, payload]) => ({
+      kind: 'bridge_readiness',
+      key: board,
+      payload,
+    })),
   ];
   if (!options.persist) {
     console.log(`[grades] coefficients ${coeffVersion} (in-memory only): λ=${JSON.stringify(echoFraction)}`);
     return coefficients;
   }
-  for (const row of rows) {
-    await db
-      .insert(boardGradeCoefficients)
-      .values({ coeffVersion, kind: row.kind, key: row.key, payload: row.payload })
-      .onConflictDoUpdate({
-        target: [boardGradeCoefficients.coeffVersion, boardGradeCoefficients.kind, boardGradeCoefficients.key],
-        set: { payload: row.payload },
-      });
-  }
+  await db.transaction(async (tx) => {
+    for (const row of rows) {
+      await tx
+        .insert(boardGradeCoefficients)
+        .values({ coeffVersion, kind: row.kind, key: row.key, payload: row.payload })
+        .onConflictDoUpdate({
+          target: [boardGradeCoefficients.coeffVersion, boardGradeCoefficients.kind, boardGradeCoefficients.key],
+          set: { payload: row.payload },
+        });
+    }
+  });
   console.log(
     `[grades] coefficients ${coeffVersion}: λ=${JSON.stringify(echoFraction)}, boards with angle surface: ${Object.keys(angleOffset).join(', ') || 'none'}`,
   );
@@ -205,6 +266,7 @@ async function refitCoefficients(
 
 interface StatsRow {
   climb_uuid: string;
+  layout_id: number;
   angle: number;
   difficulty_average: number | null;
   display_difficulty: number | null;
@@ -213,7 +275,9 @@ interface StatsRow {
 }
 
 interface ComputedRow {
+  boardType: string;
   climbUuid: string;
+  layoutId: number;
   angle: number;
   localGrade: number | null;
   universalGrade: number | null;
@@ -233,60 +297,206 @@ interface PooledAngleEvidence {
   pooledDisplay: number | null;
 }
 
+interface PooledFingerprintEvidence {
+  layoutId: number;
+  holdFingerprint: string;
+  climbUuids: string[];
+  angles: PooledAngleEvidence[];
+}
+
+async function loadStage2Evidence(db: Db, coefficients: GradeCoefficients): Promise<Stage2EvidenceMap> {
+  await db.execute(sql`SET max_parallel_workers_per_gather = 0`);
+  const raterTrainingRows = rowsOf<RaterSampleRow>(
+    await db.execute(buildRaterSampleSql({ excludeTensionBenchmarkHoldout: true })),
+  );
+  const raterPredictionRows = rowsOf<RaterSampleRow>(
+    await db.execute(buildRaterSampleSql({ excludeTensionBenchmarkHoldout: false })),
+  );
+  const raterEvidence = buildRaterEvidence(raterPredictionRows, coefficients.raterModel, raterTrainingRows);
+  const behaviorTrainingRows = rowsOf<BehaviorSampleRow>(
+    await db.execute(buildBehaviorSampleSql({ excludeTensionBenchmarkHoldout: true })),
+  );
+  const behaviorPredictionRows = rowsOf<BehaviorSampleRow>(
+    await db.execute(buildBehaviorSampleSql({ excludeTensionBenchmarkHoldout: false })),
+  );
+  return buildBehaviorEvidence(behaviorPredictionRows, coefficients.behaviorModel, raterEvidence, behaviorTrainingRows);
+}
+
+function clampDelta(delta: number, maxAbsDelta: number): number {
+  return Math.min(maxAbsDelta, Math.max(-maxAbsDelta, delta));
+}
+
+function finiteNumber(value: number | null): value is number {
+  return value !== null && Number.isFinite(value);
+}
+
+function applyCappedStage2Evidence(
+  observation: ClimbAngleObservation,
+  coefficients: GradeCoefficients,
+  evidence: Stage2Evidence | undefined,
+): ClimbAngleObservation {
+  if (!finiteNumber(observation.difficultyAverage)) return observation;
+
+  const echoFraction = echoFractionFor(coefficients, observation.boardType);
+  const rawEffectiveN = effectiveN(observation.ascensionistCount, echoFraction);
+  const deherded = deherdCrowdMean(
+    {
+      observedMean: observation.difficultyAverage,
+      displayGrade: observation.displayDifficulty,
+      echoFraction,
+      independentWeight: rawEffectiveN,
+    },
+    { maxMoveFromObserved: STAGE2_DEECHO_MAX_MOVE },
+  );
+
+  const signals: Array<{ grade: number; weight: number }> = [
+    {
+      grade: finiteNumber(deherded.grade) ? deherded.grade : observation.difficultyAverage,
+      weight: Math.max(1, rawEffectiveN),
+    },
+  ];
+
+  if (evidence?.raterMean !== null && evidence?.raterMean !== undefined && evidence.raterEffectiveN > 0) {
+    signals.push({
+      grade:
+        observation.difficultyAverage +
+        clampDelta(evidence.raterMean - observation.difficultyAverage, STAGE2_RATER_MAX_MOVE),
+      weight: Math.min(STAGE2_RATER_MAX_EFFECTIVE_N, evidence.raterEffectiveN),
+    });
+  }
+
+  if (evidence?.behaviorMean !== null && evidence?.behaviorMean !== undefined && evidence.behaviorEffectiveN > 0) {
+    signals.push({
+      grade:
+        observation.difficultyAverage +
+        clampDelta(evidence.behaviorMean - observation.difficultyAverage, STAGE2_BEHAVIOR_MAX_MOVE),
+      weight: Math.min(STAGE2_BEHAVIOR_MAX_EFFECTIVE_N, evidence.behaviorEffectiveN),
+    });
+  }
+
+  const weightTotal = signals.reduce((total, signal) => total + signal.weight, 0);
+  const modeledAverage =
+    weightTotal > 0
+      ? signals.reduce((total, signal) => total + signal.grade * signal.weight, 0) / weightTotal
+      : observation.difficultyAverage;
+
+  return { ...observation, difficultyAverage: modeledAverage };
+}
+
+function withoutStage2Coefficients(coefficients: GradeCoefficients): GradeCoefficients {
+  return {
+    ...coefficients,
+    raterModel: {},
+    behaviorModel: {},
+    bridgeReadiness: {},
+  };
+}
+
+function fingerprintGroupKey(layoutId: number, holdFingerprint: string): string {
+  return `${layoutId}\u0000${holdFingerprint}`;
+}
+
+function pooledStage2Evidence(
+  boardType: string,
+  pooled: PooledFingerprintEvidence | undefined,
+  angle: number,
+  stage2Evidence: Stage2EvidenceMap,
+): Stage2Evidence | undefined {
+  if (!pooled) return undefined;
+  let raterWeighted = 0;
+  let raterEffectiveN = 0;
+  let behaviorWeighted = 0;
+  let behaviorEffectiveN = 0;
+  for (const climbUuid of pooled.climbUuids) {
+    const evidence = stage2Evidence.get(`${boardType}\u0000${climbUuid}\u0000${angle}`);
+    if (evidence?.raterMean !== null && evidence?.raterMean !== undefined && evidence.raterEffectiveN > 0) {
+      raterWeighted += evidence.raterMean * evidence.raterEffectiveN;
+      raterEffectiveN += evidence.raterEffectiveN;
+    }
+    if (evidence?.behaviorMean !== null && evidence?.behaviorMean !== undefined && evidence.behaviorEffectiveN > 0) {
+      behaviorWeighted += evidence.behaviorMean * evidence.behaviorEffectiveN;
+      behaviorEffectiveN += evidence.behaviorEffectiveN;
+    }
+  }
+  if (raterEffectiveN === 0 && behaviorEffectiveN === 0) return undefined;
+  return {
+    raterMean: raterEffectiveN > 0 ? raterWeighted / raterEffectiveN : null,
+    raterEffectiveN,
+    behaviorMean: behaviorEffectiveN > 0 ? behaviorWeighted / behaviorEffectiveN : null,
+    behaviorEffectiveN,
+  };
+}
+
 /**
- * Duplicate climbs (same hold_fingerprint = same physical problem under
- * different UUIDs) must not split their crowd evidence — measured on prod,
- * 44% of Kilter duplicate groups disagreed by >1 grade before pooling. A
+ * Duplicate climbs (same layout_id + hold_fingerprint = same physical problem
+ * under different UUIDs) must not split their crowd evidence — measured on
+ * prod, 44% of Kilter duplicate groups disagreed by >1 grade before pooling. A
  * fingerprint group is treated as ONE climb: per angle an n-weighted pooled
- * mean/count and averaged display, and every member uses the group's full
- * angle set as its cross-angle evidence — so members produce identical
- * posteriors by construction.
+ * mean/count and averaged display, and every member uses the group's full angle
+ * set as its cross-angle evidence — so members produce identical posteriors by
+ * construction.
  */
-async function loadPooledFingerprintEvidence(db: Db, boardType: string): Promise<Map<string, PooledAngleEvidence[]>> {
+async function loadPooledFingerprintEvidence(
+  db: Db,
+  boardType: string,
+): Promise<Map<string, PooledFingerprintEvidence>> {
   // Two-step shape on purpose: finding duplicate fingerprints over the small
   // board_climbs table first keeps the stats join tiny — the single-pass
   // GROUP BY ... HAVING COUNT(DISTINCT) variant exhausted shared memory on prod.
   const rows = rowsOf<{
+    layout_id: number;
     hold_fingerprint: string;
     angle: number;
     pooled_average: number | null;
     pooled_count: number;
     pooled_display: number | null;
+    climb_uuids: string[];
   }>(
     await db.execute(sql`
       WITH duplicate_fingerprints AS (
-        SELECT hold_fingerprint
+        SELECT layout_id, hold_fingerprint
         FROM board_climbs
         WHERE board_type = ${boardType}
           AND hold_fingerprint IS NOT NULL
           AND is_listed = true
           AND COALESCE(is_draft, false) = false
-        GROUP BY hold_fingerprint
+        GROUP BY layout_id, hold_fingerprint
         HAVING COUNT(*) >= 2
       )
-      SELECT bc.hold_fingerprint, s.angle,
+      SELECT bc.layout_id, bc.hold_fingerprint, s.angle,
              SUM(s.difficulty_average * s.ascensionist_count) FILTER (WHERE s.difficulty_average IS NOT NULL AND s.ascensionist_count > 0)
                / NULLIF(SUM(s.ascensionist_count) FILTER (WHERE s.difficulty_average IS NOT NULL AND s.ascensionist_count > 0), 0)
                AS pooled_average,
              COALESCE(SUM(s.ascensionist_count), 0)::int AS pooled_count,
-             AVG(s.display_difficulty) AS pooled_display
+             AVG(s.display_difficulty) AS pooled_display,
+             ARRAY_AGG(DISTINCT bc.uuid) AS climb_uuids
       FROM duplicate_fingerprints df
-      JOIN board_climbs bc ON bc.hold_fingerprint = df.hold_fingerprint AND bc.board_type = ${boardType}
+      JOIN board_climbs bc
+        ON bc.layout_id = df.layout_id
+       AND bc.hold_fingerprint = df.hold_fingerprint
+       AND bc.board_type = ${boardType}
       JOIN board_climb_stats s ON s.board_type = bc.board_type AND s.climb_uuid = bc.uuid
       WHERE bc.is_listed = true AND COALESCE(bc.is_draft, false) = false
-      GROUP BY bc.hold_fingerprint, s.angle
+      GROUP BY bc.layout_id, bc.hold_fingerprint, s.angle
     `),
   );
-  const pooled = new Map<string, PooledAngleEvidence[]>();
+  const pooled = new Map<string, PooledFingerprintEvidence>();
   for (const row of rows) {
-    const list = pooled.get(row.hold_fingerprint) ?? [];
-    list.push({
+    const key = fingerprintGroupKey(Number(row.layout_id), row.hold_fingerprint);
+    const group = pooled.get(key) ?? {
+      layoutId: Number(row.layout_id),
+      holdFingerprint: row.hold_fingerprint,
+      climbUuids: [],
+      angles: [],
+    };
+    group.angles.push({
       angle: Number(row.angle),
       pooledAverage: row.pooled_average === null ? null : Number(row.pooled_average),
       pooledCount: Number(row.pooled_count),
       pooledDisplay: row.pooled_display === null ? null : Number(row.pooled_display),
     });
-    pooled.set(row.hold_fingerprint, list);
+    group.climbUuids = Array.from(new Set([...group.climbUuids, ...row.climb_uuids]));
+    pooled.set(key, group);
   }
   return pooled;
 }
@@ -296,6 +506,8 @@ async function computeBoard(
   db: Db,
   boardType: string,
   coefficients: GradeCoefficients,
+  stage2Evidence: Stage2EvidenceMap = new Map(),
+  options: { applyStage2?: boolean } = { applyStage2: true },
 ): Promise<{
   computed: ComputedRow[];
   isotonicStats: { movedRows: number; residualInversions: number };
@@ -309,7 +521,7 @@ async function computeBoard(
   for (;;) {
     const rows = rowsOf<StatsRow>(
       await db.execute(sql`
-        SELECT s.climb_uuid, s.angle, s.difficulty_average, s.display_difficulty,
+        SELECT s.climb_uuid, bc.layout_id, s.angle, s.difficulty_average, s.display_difficulty,
                COALESCE(s.ascensionist_count, 0)::int AS ascensionist_count,
                bc.hold_fingerprint
         FROM board_climb_stats s
@@ -336,9 +548,11 @@ async function computeBoard(
       if (group.length === 0) return;
       // Duplicated fingerprint → the whole group's pooled angle set stands in
       // for this climb's own rows (same physical problem, shared evidence).
-      const fingerprintEvidence = group[0].hold_fingerprint ? pooledEvidence.get(group[0].hold_fingerprint) : undefined;
-      const observations: ClimbAngleObservation[] = fingerprintEvidence
-        ? fingerprintEvidence.map((pooled) => ({
+      const fingerprintEvidence = group[0].hold_fingerprint
+        ? pooledEvidence.get(fingerprintGroupKey(Number(group[0].layout_id), group[0].hold_fingerprint))
+        : undefined;
+      const rawObservations: ClimbAngleObservation[] = fingerprintEvidence
+        ? fingerprintEvidence.angles.map((pooled) => ({
             boardType,
             climbUuid: group[0].climb_uuid,
             angle: pooled.angle,
@@ -354,15 +568,29 @@ async function computeBoard(
             displayDifficulty: row.display_difficulty === null ? null : Number(row.display_difficulty),
             ascensionistCount: Number(row.ascensionist_count),
           }));
+      const observations = rawObservations.map((observation) =>
+        options.applyStage2 === false
+          ? observation
+          : applyCappedStage2Evidence(
+              observation,
+              coefficients,
+              fingerprintEvidence
+                ? pooledStage2Evidence(observation.boardType, fingerprintEvidence, observation.angle, stage2Evidence)
+                : stage2Evidence.get(
+                    `${observation.boardType}\u0000${observation.climbUuid}\u0000${observation.angle}`,
+                  ),
+            ),
+      );
       // Posteriors for the full angle set first (pooled set may be wider than
       // this member's own angles), then the per-climb isotonic projection —
       // grades may not decrease as the wall gets steeper (see isotonic.ts;
       // The Enchiridion @30° > @35° was the motivating inversion).
+      const rawObservationByAngle = new Map(rawObservations.map((observation) => [observation.angle, observation]));
       const angleRows: AngleGradeRow[] = observations.map((target) => ({
         angle: target.angle,
         posterior: computePosteriorGrade(target, observations, coefficients),
-        observedMean: target.difficultyAverage,
-        ascensionistCount: target.ascensionistCount,
+        observedMean: rawObservationByAngle.get(target.angle)?.difficultyAverage ?? null,
+        ascensionistCount: rawObservationByAngle.get(target.angle)?.ascensionistCount ?? target.ascensionistCount,
       }));
       const { adjusted, residualInversions, movedRows } = applyIsotonicAngleConstraint(angleRows);
       isotonicStats.movedRows += movedRows;
@@ -385,7 +613,9 @@ async function computeBoard(
         recordDisplayDeltaHygiene(displayDeltaHygieneStats, hygiene);
         const posterior = hygiene.posterior;
         computed.push({
+          boardType,
           climbUuid: group[0].climb_uuid,
+          layoutId: Number(group[0].layout_id),
           angle: angleRows[i].angle,
           localGrade: posterior.localGrade,
           universalGrade: posterior.universalGrade,
@@ -437,7 +667,7 @@ function evaluateFingerprintConsistency(computed: ComputedRow[]): GateResult {
   const groups = new Map<string, { min: number; max: number; uuids: Set<string> }>();
   for (const row of computed) {
     if (!row.holdFingerprint || row.localGrade === null) continue;
-    const key = `${row.holdFingerprint}:${row.angle}`;
+    const key = `${row.boardType}:${row.layoutId}:${row.holdFingerprint}:${row.angle}`;
     const group = groups.get(key) ?? { min: row.localGrade, max: row.localGrade, uuids: new Set<string>() };
     group.min = Math.min(group.min, row.localGrade);
     group.max = Math.max(group.max, row.localGrade);
@@ -452,6 +682,57 @@ function evaluateFingerprintConsistency(computed: ComputedRow[]): GateResult {
     if (group.max - group.min > 1.0) violations += 1;
   }
   return evaluateFingerprintGate({ violations, groups: multiGroups });
+}
+
+function computedRowKey(climbUuid: string, angle: number): string {
+  return `${climbUuid}\u0000${angle}`;
+}
+
+function indexComputedRows(rows: ComputedRow[]): Map<string, ComputedRow> {
+  const indexed = new Map<string, ComputedRow>();
+  for (const row of rows) indexed.set(computedRowKey(row.climbUuid, row.angle), row);
+  return indexed;
+}
+
+function buildBenchmarkPredictions(
+  holdoutRows: TensionBenchmarkHoldoutRow[],
+  stage1Computed: ComputedRow[],
+  stage2Computed: ComputedRow[],
+): TensionBenchmarkPrediction[] {
+  const stage1ByKey = indexComputedRows(stage1Computed);
+  const stage2ByKey = indexComputedRows(stage2Computed);
+  return holdoutRows.map((row) => {
+    const stage1 = stage1ByKey.get(computedRowKey(row.climb_uuid, Number(row.angle)));
+    const stage2 = stage2ByKey.get(computedRowKey(row.climb_uuid, Number(row.angle)));
+    return {
+      climbUuid: row.climb_uuid,
+      angle: Number(row.angle),
+      displayDifficulty: Number(row.display_difficulty),
+      benchmarkDifficulty: Number(row.benchmark_difficulty),
+      ascensionistCount: Number(row.ascensionist_count),
+      stage1Grade: stage1?.universalGrade ?? stage1?.localGrade ?? null,
+      stage1Low: stage1?.gradeLow ?? null,
+      stage1High: stage1?.gradeHigh ?? null,
+      stage2Grade: stage2?.universalGrade ?? stage2?.localGrade ?? null,
+      stage2Low: stage2?.gradeLow ?? null,
+      stage2High: stage2?.gradeHigh ?? null,
+    };
+  });
+}
+
+function evaluateBehaviorEligibility(coefficients: GradeCoefficients): GateResult {
+  let eligibleBoards = 0;
+  let modeledBoards = 0;
+  for (const model of Object.values(coefficients.behaviorModel)) {
+    modeledBoards += 1;
+    if (model.eligible) eligibleBoards += 1;
+  }
+  return {
+    gate: 'behavior_eligibility',
+    passed: true,
+    detail: `${eligibleBoards} of ${modeledBoards} behavior models eligible for Stage 2 evidence`,
+    metrics: { eligibleBoards, modeledBoards },
+  };
 }
 
 async function upsertGrades(
@@ -564,6 +845,10 @@ async function recordGateResults(db: Db, coefficients: GradeCoefficients, gates:
   });
 }
 
+function blockingGates(gates: GateResult[]): GateResult[] {
+  return gates.filter((gate) => !gate.passed && gate.gate !== 'residual_paired_gap');
+}
+
 /**
  * Read-only validation against a database that may not have the grade tables
  * yet (e.g. prod before the migration lands): refit coefficients in memory,
@@ -572,25 +857,47 @@ async function recordGateResults(db: Db, coefficients: GradeCoefficients, gates:
  */
 async function validateOnly(db: Db): Promise<void> {
   const coefficients = await refitCoefficients(db, { persist: false });
+  const baselineCoefficients = withoutStage2Coefficients(coefficients);
+  const stage2Evidence = await loadStage2Evidence(db, coefficients);
+  const gates: GateResult[] = [];
   console.log('[grades] validate-only: running gates against live data…');
   const backtestRows = rowsOf<BacktestSampleRow>(await db.execute(buildBacktestSampleSql(BACKTEST_SAMPLE_LIMIT)));
   const backtest = evaluateBacktest(backtestRows, coefficients);
+  gates.push(backtest.tailGate, backtest.headGate);
   console.log(`[grades]   tail_backtest: ${backtest.tailGate.passed ? 'PASS' : 'FAIL'} — ${backtest.tailGate.detail}`);
   console.log(`[grades]   head_holdout: ${backtest.headGate.passed ? 'PASS' : 'FAIL'} — ${backtest.headGate.detail}`);
+  const behaviorGate = evaluateBehaviorEligibility(coefficients);
+  gates.push(behaviorGate);
+  console.log(`[grades]   behavior_eligibility: ${behaviorGate.passed ? 'PASS' : 'FAIL'} — ${behaviorGate.detail}`);
+  const moonReadiness = coefficients.bridgeReadiness.moonboard;
+  if (moonReadiness) {
+    const moonGate = moonBridgeReadinessGate(moonReadiness);
+    gates.push(moonGate);
+    console.log(`[grades]   moon_bridge_readiness: ${moonGate.passed ? 'PASS' : 'FAIL'} — ${moonGate.detail}`);
+  }
   const kilterOffset = coefficients.boardOffset.kilter;
   if (kilterOffset) {
     const offsetRows = rowsOf<BoardOffsetSampleRow>(await db.execute(buildBoardOffsetSampleSql()));
     const residualGate = evaluateResidualGapGate(offsetRows, kilterOffset.offset);
+    gates.push(residualGate);
     console.log(`[grades]   residual_paired_gap: ${residualGate.passed ? 'PASS' : 'FAIL'} — ${residualGate.detail}`);
     console.log(
       `[grades]   kilter offset ${kilterOffset.offset.toFixed(2)} ± ${kilterOffset.sd.toFixed(2)} (${kilterOffset.users} users, LOO max Δ ${kilterOffset.looMaxDelta.toFixed(3)})`,
     );
   }
+  const computedByBoard = new Map<string, ComputedRow[]>();
   for (const boardType of CROWD_MEAN_BOARDS) {
-    const { computed, isotonicStats, displayDeltaHygieneStats } = await computeBoard(db, boardType, coefficients);
+    const { computed, isotonicStats, displayDeltaHygieneStats } = await computeBoard(
+      db,
+      boardType,
+      coefficients,
+      stage2Evidence,
+    );
+    computedByBoard.set(boardType, computed);
     const noShock = evaluateNoShock(computed);
     const fingerprint = evaluateFingerprintConsistency(computed);
     const displayDeltaHygiene = evaluateDisplayDeltaHygiene(displayDeltaHygieneStats);
+    gates.push(noShock, fingerprint, displayDeltaHygiene);
     const tiers = computed.reduce<Record<string, number>>((acc, row) => {
       acc[row.confidence] = (acc[row.confidence] ?? 0) + 1;
       return acc;
@@ -598,6 +905,23 @@ async function validateOnly(db: Db): Promise<void> {
     console.log(
       `[grades]   ${boardType}: ${computed.length} rows, tiers=${JSON.stringify(tiers)}; isotonic moved ${isotonicStats.movedRows} rows (${isotonicStats.residualInversions} residual inversions); no_shock ${noShock.passed ? 'PASS' : 'FAIL'} (${noShock.detail}); fingerprint ${fingerprint.passed ? 'PASS' : 'FAIL'} (${fingerprint.detail}); display_delta_hygiene ${displayDeltaHygiene.passed ? 'PASS' : 'FAIL'} (${displayDeltaHygiene.detail})`,
     );
+  }
+  const baselineTension = await computeBoard(db, 'tension', baselineCoefficients, new Map(), { applyStage2: false });
+  const holdoutRows = rowsOf<TensionBenchmarkHoldoutRow>(await db.execute(buildTensionBenchmarkHoldoutSql()));
+  const benchmarkPredictions = buildBenchmarkPredictions(
+    holdoutRows,
+    baselineTension.computed,
+    computedByBoard.get('tension') ?? [],
+  );
+  const benchmarkGates = evaluateTensionBenchmarkHoldout(benchmarkPredictions);
+  gates.push(...benchmarkGates);
+  for (const gate of benchmarkGates) {
+    console.log(`[grades]   ${gate.gate}: ${gate.passed ? 'PASS' : 'FAIL'} — ${gate.detail}`);
+  }
+  const blocking = blockingGates(gates);
+  if (blocking.length > 0) {
+    console.error(`[grades] validate-only blocking gate(s) failed: ${blocking.map((gate) => gate.gate).join(', ')}`);
+    process.exitCode = 1;
   }
   console.log('[grades] validate-only done (nothing written).');
 }
@@ -612,10 +936,26 @@ async function main(): Promise<void> {
       await validateOnly(db);
       return;
     }
-    const coefficients = (!forceRefit && (await loadFrozenCoefficients(db))) || (await refitCoefficients(db));
+    let coefficients =
+      (!forceRefit && (await loadFrozenCoefficients(db))) || (await refitCoefficients(db, { persist: !dryRun }));
+    if (!forceRefit && Object.keys(coefficients.raterModel).length === 0) {
+      console.log('[grades] latest frozen coefficients do not include Stage 2 models; refitting.');
+      coefficients = await refitCoefficients(db, { persist: !dryRun });
+    }
+    const baselineCoefficients = withoutStage2Coefficients(coefficients);
+    const stage2Evidence = await loadStage2Evidence(db, coefficients);
     console.log(`[grades] using coefficients ${coefficients.coeffVersion} (model ${GRADE_MODEL_VERSION})`);
 
     const gates: GateResult[] = [];
+    const behaviorGate = evaluateBehaviorEligibility(coefficients);
+    gates.push(behaviorGate);
+    console.log(`[grades]   behavior_eligibility: ${behaviorGate.passed ? 'PASS' : 'FAIL'} — ${behaviorGate.detail}`);
+    const moonReadiness = coefficients.bridgeReadiness.moonboard;
+    if (moonReadiness) {
+      const moonGate = moonBridgeReadinessGate(moonReadiness);
+      gates.push(moonGate);
+      console.log(`[grades]   moon_bridge_readiness: ${moonGate.passed ? 'PASS' : 'FAIL'} — ${moonGate.detail}`);
+    }
 
     // Pre-write gates: history backtest + cross-board residual.
     console.log('[grades] running backtest gate…');
@@ -665,7 +1005,7 @@ async function main(): Promise<void> {
         computed,
         isotonicStats,
         displayDeltaHygieneStats: boardDisplayDeltaHygieneStats,
-      } = await computeBoard(db, boardType, coefficients);
+      } = await computeBoard(db, boardType, coefficients, stage2Evidence);
       mergeDisplayDeltaHygieneStats(displayDeltaHygieneStats, boardDisplayDeltaHygieneStats);
       computedByBoard.set(boardType, computed);
       console.log(
@@ -677,6 +1017,15 @@ async function main(): Promise<void> {
     const fingerprintGate = evaluateFingerprintConsistency(allComputed);
     const displayDeltaHygieneGate = evaluateDisplayDeltaHygiene(displayDeltaHygieneStats);
     gates.push(noShockGate, fingerprintGate, displayDeltaHygieneGate);
+    const baselineTension = await computeBoard(db, 'tension', baselineCoefficients, new Map(), { applyStage2: false });
+    const holdoutRows = rowsOf<TensionBenchmarkHoldoutRow>(await db.execute(buildTensionBenchmarkHoldoutSql()));
+    const benchmarkPredictions = buildBenchmarkPredictions(
+      holdoutRows,
+      baselineTension.computed,
+      computedByBoard.get('tension') ?? [],
+    );
+    const benchmarkGates = evaluateTensionBenchmarkHoldout(benchmarkPredictions);
+    gates.push(...benchmarkGates);
     console.log(`[grades]   no_shock: ${noShockGate.passed ? 'PASS' : 'FAIL'} — ${noShockGate.detail}`);
     console.log(
       `[grades]   fingerprint_consistency: ${fingerprintGate.passed ? 'PASS' : 'FAIL'} — ${fingerprintGate.detail}`,
@@ -684,19 +1033,28 @@ async function main(): Promise<void> {
     console.log(
       `[grades]   display_delta_hygiene: ${displayDeltaHygieneGate.passed ? 'PASS' : 'FAIL'} — ${displayDeltaHygieneGate.detail}`,
     );
+    for (const gate of benchmarkGates) {
+      console.log(`[grades]   ${gate.gate}: ${gate.passed ? 'PASS' : 'FAIL'} — ${gate.detail}`);
+    }
+
+    const blocking = blockingGates(gates);
+    if (dryRun) {
+      if (blocking.length > 0) {
+        console.error(
+          `[grades] dry-run blocking gate(s) failed: ${blocking.map((gate) => gate.gate).join(', ')} — nothing written.`,
+        );
+        process.exitCode = 1;
+      }
+      console.log('[grades] dry run — no coefficients, gates, or grade rows written.');
+      return;
+    }
 
     await recordGateResults(db, coefficients, gates);
-
-    const blocking = gates.filter((gate) => !gate.passed && gate.gate !== 'residual_paired_gap');
     if (blocking.length > 0) {
       console.error(
         `[grades] blocking gate(s) failed: ${blocking.map((gate) => gate.gate).join(', ')} — no grades written.`,
       );
       process.exitCode = 1;
-      return;
-    }
-    if (dryRun) {
-      console.log('[grades] dry run — gates recorded, no grades written.');
       return;
     }
 

--- a/packages/db/src/queries/grade-model/__tests__/grade-model.test.ts
+++ b/packages/db/src/queries/grade-model/__tests__/grade-model.test.ts
@@ -52,6 +52,9 @@ function makeCoefficients(overrides: Partial<GradeCoefficients> = {}): GradeCoef
       kilter: { offset: -1.2, sd: 0.4, users: 50, looMaxDelta: 0.1 },
       tension: { offset: 0, sd: 0, users: 0, looMaxDelta: 0 },
     },
+    raterModel: {},
+    behaviorModel: {},
+    bridgeReadiness: {},
     ...overrides,
   };
 }

--- a/packages/db/src/queries/grade-model/__tests__/stage2-helpers.test.ts
+++ b/packages/db/src/queries/grade-model/__tests__/stage2-helpers.test.ts
@@ -1,0 +1,427 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import {
+  buildBehaviorEvidence,
+  buildBehaviorSampleSql,
+  estimateBehaviorModels,
+  behaviorOutcomeProbability,
+  estimateBehaviorAbilities,
+  estimateBehaviorDifficulty,
+  type BehaviorSampleRow,
+  type BehaviorObservation,
+} from '../behavior';
+import { estimateAnchorBridgeOffsets, estimatePairwiseBridgeEdges, type BoardBridgeSample } from '../bridges';
+import {
+  combineDeherdedSignals,
+  deherdCrowdMean,
+  evaluateDeherdedBenchmark,
+  evaluateTensionBenchmarkHoldout,
+  type TensionBenchmarkPrediction,
+} from '../deherded';
+import {
+  buildRaterEvidence,
+  buildRaterSampleSql,
+  computeBiasAdjustedGrade,
+  estimateRaterBiases,
+  estimateRaterModels,
+  raterOpinionWeight,
+  type RaterBiasEstimate,
+  type RaterOpinion,
+  type RaterSampleRow,
+} from '../raters';
+
+const renderedSql = (query: SQL): string => new PgDialect().sqlToQuery(query).sql;
+
+void describe('Stage 2 rater helpers', () => {
+  void test('splits benchmark holdout rows for rater training versus prediction evidence', () => {
+    const trainingQuery = renderedSql(buildRaterSampleSql({ excludeTensionBenchmarkHoldout: true }));
+    const predictionQuery = renderedSql(buildRaterSampleSql({ excludeTensionBenchmarkHoldout: false }));
+
+    assert.ok(trainingQuery.includes('md5(s.climb_uuid'));
+    assert.ok(trainingQuery.includes('NOT'));
+    assert.ok(!predictionQuery.includes('md5(s.climb_uuid'));
+  });
+
+  void test('does not subtract held-out benchmark rows from fitted rater bias', () => {
+    const trainingRows: RaterSampleRow[] = Array.from({ length: 3 }, (_, rowIndex) => ({
+      board_type: 'tension',
+      user_id: 'hard-rater',
+      climb_uuid: `train-${rowIndex}`,
+      angle: 40,
+      origin: 'native',
+      difficulty: 30,
+      display_difficulty: 20,
+      difficulty_average: 20,
+      gym_id: null,
+      board_id: null,
+    }));
+    const models = estimateRaterModels(trainingRows);
+    const evidence = buildRaterEvidence(
+      [
+        {
+          board_type: 'tension',
+          user_id: 'hard-rater',
+          climb_uuid: 'held-out',
+          angle: 40,
+          origin: 'native',
+          difficulty: 30,
+          display_difficulty: 20,
+          difficulty_average: 20,
+          gym_id: null,
+          board_id: null,
+        },
+      ],
+      models,
+      trainingRows,
+    );
+
+    const heldOutEvidence = evidence.get('tension\u0000held-out\u000040');
+    assert.ok(heldOutEvidence);
+    assert.equal(heldOutEvidence.raterMean, 29);
+  });
+
+  void test('down-weights synced display echoes but keeps native echoes as opt-in agreement', () => {
+    const syncedEcho: RaterOpinion = {
+      raterId: 'u1',
+      difficulty: 20,
+      referenceGrade: 21,
+      displayDifficulty: 20,
+      origin: 'aurora_pull',
+    };
+    const nativeEcho: RaterOpinion = { ...syncedEcho, origin: 'native' };
+
+    assert.equal(raterOpinionWeight(syncedEcho), 0);
+    assert.equal(raterOpinionWeight(nativeEcho), 1);
+  });
+
+  void test('estimates rater bias with zero-centered shrinkage and a conservative cap', () => {
+    const opinions: RaterOpinion[] = Array.from({ length: 5 }, (_, opinionIndex) => ({
+      raterId: 'hard-grader',
+      difficulty: 24 + (opinionIndex % 2),
+      referenceGrade: 20 + (opinionIndex % 2),
+      displayDifficulty: 20,
+      origin: 'native',
+    }));
+
+    const biases = estimateRaterBiases(opinions);
+    const estimate = biases.get('hard-grader');
+    assert.ok(estimate);
+    assert.ok(estimate.bias > 0 && estimate.bias <= 1, `bias was ${estimate.bias}`);
+    assert.equal(estimate.effectiveWeight, 5);
+  });
+
+  void test('computes a bias-adjusted climb grade from explicit opinions', () => {
+    const biases = new Map<string, RaterBiasEstimate>([
+      ['hard-grader', { raterId: 'hard-grader', bias: 2, effectiveWeight: 10, opinionCount: 10 }],
+    ]);
+    const estimate = computeBiasAdjustedGrade(
+      [
+        {
+          raterId: 'hard-grader',
+          difficulty: 22,
+          referenceGrade: 20,
+          displayDifficulty: 20,
+          origin: 'native',
+        },
+        {
+          raterId: 'neutral-grader',
+          difficulty: 20,
+          referenceGrade: 20,
+          displayDifficulty: 20,
+          origin: 'native',
+        },
+      ],
+      biases,
+    );
+
+    assert.ok(estimate);
+    assert.equal(estimate.grade, 20);
+    assert.equal(estimate.meanBiasApplied, 1);
+  });
+});
+
+void describe('Stage 2 behavior helpers', () => {
+  void test('splits benchmark holdout rows for behavior training versus prediction evidence', () => {
+    const trainingQuery = renderedSql(buildBehaviorSampleSql({ excludeTensionBenchmarkHoldout: true }));
+    const predictionQuery = renderedSql(buildBehaviorSampleSql({ excludeTensionBenchmarkHoldout: false }));
+
+    assert.ok(trainingQuery.includes('md5(s.climb_uuid'));
+    assert.ok(trainingQuery.includes('NOT'));
+    assert.ok(!predictionQuery.includes('md5(s.climb_uuid'));
+  });
+
+  void test('measures behavior eligibility on rows usable for offsets, not raw native coverage', () => {
+    const samples: BehaviorSampleRow[] = [];
+    for (let userIndex = 0; userIndex < 120; userIndex++) {
+      for (let outcomeIndex = 0; outcomeIndex < 5; outcomeIndex++) {
+        samples.push({
+          board_type: 'kilter',
+          user_id: `user-${userIndex}`,
+          climb_uuid: `climb-${userIndex}-${outcomeIndex}`,
+          angle: 40,
+          status: 'send',
+          attempt_count: 2,
+          difficulty_average: 20,
+          ascensionist_count: userIndex < 5 ? 20 : 1,
+        });
+      }
+    }
+
+    const model = estimateBehaviorModels(samples).kilter;
+    assert.ok(model);
+    assert.equal(model.summary.users, 120);
+    assert.equal(model.summary.outcomes, 600);
+    assert.equal(model.summary.usedUsers, 5);
+    assert.equal(model.eligible, false);
+  });
+
+  void test('leaves target rows out of behavior bucket offsets', () => {
+    const trainingRows: BehaviorSampleRow[] = [];
+    for (let userIndex = 0; userIndex < 11; userIndex++) {
+      for (let outcomeIndex = 0; outcomeIndex < 3; outcomeIndex++) {
+        trainingRows.push({
+          board_type: 'kilter',
+          user_id: `user-${userIndex}`,
+          climb_uuid: `steady-${userIndex}-${outcomeIndex}`,
+          angle: 40,
+          status: 'send',
+          attempt_count: 2,
+          difficulty_average: 20,
+          ascensionist_count: 20,
+        });
+      }
+    }
+    trainingRows.push({
+      board_type: 'kilter',
+      user_id: 'user-0',
+      climb_uuid: 'target',
+      angle: 40,
+      status: 'send',
+      attempt_count: 2,
+      difficulty_average: 30,
+      ascensionist_count: 20,
+    });
+
+    const evidence = buildBehaviorEvidence(
+      [trainingRows[trainingRows.length - 1]],
+      {
+        kilter: {
+          boardType: 'kilter',
+          boardMean: 20,
+          outcomeOffset: { send_2_3: 999 },
+          eligible: true,
+          summary: {
+            users: 11,
+            outcomes: 34,
+            topUserShare: 4 / 34,
+            usedUsers: 11,
+            usedOutcomes: 34,
+            usedTopUserShare: 4 / 34,
+          },
+        },
+      },
+      new Map(),
+      trainingRows,
+    );
+
+    const targetEvidence = evidence.get('kilter\u0000target\u000040');
+    assert.ok(targetEvidence);
+    assert.ok(targetEvidence.behaviorMean !== null);
+    assert.ok(Math.abs(targetEvidence.behaviorMean - 20) < 1e-9, `behavior mean was ${targetEvidence.behaviorMean}`);
+  });
+
+  void test('orders outcome probabilities from flash to repeated-send to attempt', () => {
+    const flashProbability = behaviorOutcomeProbability('flash', 1);
+    const secondGoSendProbability = behaviorOutcomeProbability('send', 2);
+    const fifthGoSendProbability = behaviorOutcomeProbability('send', 5);
+    const attemptProbability = behaviorOutcomeProbability('attempt', 1);
+
+    assert.ok(flashProbability > secondGoSendProbability);
+    assert.ok(secondGoSendProbability > fifthGoSendProbability);
+    assert.ok(fifthGoSendProbability > attemptProbability);
+  });
+
+  void test('fits higher ability for flashes than repeated failed attempts on the same references', () => {
+    const flashRows: BehaviorObservation[] = Array.from({ length: 3 }, () => ({
+      raterId: 'flash-user',
+      status: 'flash',
+      attemptCount: 1,
+      referenceGrade: 20,
+    }));
+    const attemptRows: BehaviorObservation[] = Array.from({ length: 6 }, () => ({
+      raterId: 'attempt-user',
+      status: 'attempt',
+      attemptCount: 1,
+      referenceGrade: 20,
+    }));
+
+    const abilities = estimateBehaviorAbilities([...flashRows, ...attemptRows]);
+    const flashAbility = abilities.get('flash-user');
+    const attemptAbility = abilities.get('attempt-user');
+    assert.ok(flashAbility);
+    assert.ok(attemptAbility);
+    assert.ok(flashAbility.ability > attemptAbility.ability);
+  });
+
+  void test('infers a harder climb from failed attempts than from flashes by equal-ability users', () => {
+    const abilities = new Map([
+      ['flash-user', { raterId: 'flash-user', ability: 22, effectiveWeight: 10, observationCount: 10 }],
+      ['attempt-user', { raterId: 'attempt-user', ability: 22, effectiveWeight: 10, observationCount: 10 }],
+    ]);
+
+    const flashed = estimateBehaviorDifficulty(
+      [{ raterId: 'flash-user', status: 'flash', attemptCount: 1, referenceGrade: null }],
+      abilities,
+    );
+    const attempted = estimateBehaviorDifficulty(
+      [{ raterId: 'attempt-user', status: 'attempt', attemptCount: 1, referenceGrade: null }],
+      abilities,
+    );
+
+    assert.ok(flashed);
+    assert.ok(attempted);
+    assert.ok(attempted.grade > flashed.grade);
+  });
+});
+
+void describe('Stage 2 bridge helpers', () => {
+  void test('estimates pairwise board offsets with the expected sign', () => {
+    const samples: BoardBridgeSample[] = Array.from({ length: 5 }, (_, userIndex) => ({
+      userId: `user-${userIndex}`,
+      boardType: 'kilter',
+      grade: 20,
+    })).concat(
+      Array.from({ length: 5 }, (_, userIndex) => ({
+        userId: `user-${userIndex}`,
+        boardType: 'tension',
+        grade: 18.8,
+      })),
+    );
+
+    const edges = estimatePairwiseBridgeEdges(samples, { minSharedUsers: 5 });
+    assert.equal(edges.length, 1);
+    assert.equal(edges[0].fromBoard, 'kilter');
+    assert.equal(edges[0].toBoard, 'tension');
+    assert.ok(Math.abs(edges[0].offset - -1.2) < 1e-9);
+  });
+
+  void test('returns anchor-scale offsets and withholds unstable bridges', () => {
+    const stableSamples: BoardBridgeSample[] = Array.from({ length: 5 }, (_, userIndex) => ({
+      userId: `stable-${userIndex}`,
+      boardType: 'kilter',
+      grade: 20,
+    })).concat(
+      Array.from({ length: 5 }, (_, userIndex) => ({
+        userId: `stable-${userIndex}`,
+        boardType: 'tension',
+        grade: 18.8,
+      })),
+    );
+    const stable = estimateAnchorBridgeOffsets(stableSamples, 'tension', { minSharedUsers: 5 });
+    assert.ok(stable.offsets.kilter);
+    assert.ok(Math.abs(stable.offsets.kilter.offset - -1.2) < 1e-9);
+    assert.deepEqual(stable.withheldBoards, []);
+
+    const unstableSamples: BoardBridgeSample[] = [
+      { userId: 'u1', boardType: 'kilter', grade: 20 },
+      { userId: 'u1', boardType: 'tension', grade: 20 },
+      { userId: 'u2', boardType: 'kilter', grade: 20 },
+      { userId: 'u2', boardType: 'tension', grade: 30 },
+      { userId: 'u3', boardType: 'kilter', grade: 20 },
+      { userId: 'u3', boardType: 'tension', grade: 30 },
+    ];
+    const unstable = estimateAnchorBridgeOffsets(unstableSamples, 'tension', {
+      minSharedUsers: 3,
+      maxLooDelta: 0.5,
+    });
+    assert.equal(unstable.offsets.kilter, undefined);
+    assert.deepEqual(unstable.withheldBoards, ['kilter']);
+  });
+});
+
+void describe('Stage 2 de-herded helpers', () => {
+  void test('de-attenuates an echoed crowd mean and records the moved delta', () => {
+    const result = deherdCrowdMean({
+      observedMean: 20.5,
+      displayGrade: 20,
+      echoFraction: 0.5,
+      independentWeight: 10,
+    });
+
+    assert.equal(result.eligible, true);
+    assert.equal(result.capped, false);
+    assert.ok(result.grade !== null && Math.abs(result.grade - 21) < 1e-9);
+    assert.equal(result.rawDeltaFromDisplay, 0.5);
+    assert.equal(result.deherdedDeltaFromDisplay, 1);
+  });
+
+  void test('caps aggressive de-herding and leaves thin rows unchanged', () => {
+    const capped = deherdCrowdMean({
+      observedMean: 21,
+      displayGrade: 20,
+      echoFraction: 0.9,
+      independentWeight: 10,
+    });
+    assert.equal(capped.capped, true);
+    assert.equal(capped.grade, 21.75);
+
+    const thin = deherdCrowdMean({
+      observedMean: 21,
+      displayGrade: 20,
+      echoFraction: 0.9,
+      independentWeight: 1,
+    });
+    assert.equal(thin.eligible, false);
+    assert.equal(thin.reason, 'thin_evidence');
+    assert.equal(thin.grade, 21);
+  });
+
+  void test('combines grade signals by precision or explicit weight', () => {
+    const blend = combineDeherdedSignals([
+      { name: 'crowd', grade: 20, standardError: 1 },
+      { name: 'behavior', grade: 22, standardError: 0.5 },
+    ]);
+
+    assert.ok(blend);
+    assert.ok(Math.abs(blend.grade - 21.6) < 1e-9);
+    assert.equal(blend.signalCount, 2);
+  });
+
+  void test('scores de-herded benchmark evaluation as no-regression', () => {
+    const summary = evaluateDeherdedBenchmark([
+      { benchmarkGrade: 20, rawGrade: 21, deherdedGrade: 20.5 },
+      { benchmarkGrade: 22, rawGrade: 21, deherdedGrade: 21.5 },
+    ]);
+
+    assert.equal(summary.rows, 2);
+    assert.equal(summary.rawMae, 1);
+    assert.equal(summary.deherdedMae, 0.5);
+    assert.equal(summary.improvement, 0.5);
+    assert.equal(summary.passedNoRegression, true);
+  });
+
+  void test('counts missing benchmark intervals as calibration failures', () => {
+    const predictions: TensionBenchmarkPrediction[] = Array.from({ length: 120 }, (_, rowIndex) => ({
+      climbUuid: `benchmark-${rowIndex}`,
+      angle: 40,
+      displayDifficulty: 20,
+      benchmarkDifficulty: 20,
+      ascensionistCount: 100,
+      stage1Grade: 20,
+      stage1Low: 19,
+      stage1High: 21,
+      stage2Grade: 20,
+      stage2Low: rowIndex === 0 ? null : 19,
+      stage2High: rowIndex === 0 ? null : 21,
+    }));
+
+    const calibrationGate = evaluateTensionBenchmarkHoldout(predictions).find(
+      (gate) => gate.gate === 'deherded_tension_calibration',
+    );
+    assert.ok(calibrationGate);
+    assert.equal(calibrationGate.passed, false);
+    assert.equal(calibrationGate.metrics.missingIntervalRows, 1);
+  });
+});

--- a/packages/db/src/queries/grade-model/behavior.ts
+++ b/packages/db/src/queries/grade-model/behavior.ts
@@ -1,0 +1,698 @@
+import { sql, type SQL } from 'drizzle-orm';
+import {
+  BEHAVIOR_MAX_BUCKET_TOP_USER_SHARE,
+  BEHAVIOR_MAX_TOP_USER_SHARE,
+  BEHAVIOR_MIN_BUCKET_USERS,
+  BEHAVIOR_MIN_OUTCOMES,
+  BEHAVIOR_MIN_USERS,
+} from './constants';
+import type { BehaviorModelCoefficient, BehaviorOutcomeBucket, Stage2Evidence } from './types';
+import { type Stage2EvidenceMap, stage2EvidenceKey } from './raters';
+import { buildTensionBenchmarkHoldoutPredicate } from './deherded';
+
+const BEHAVIOR_SUCCESS_WEIGHT = 0.25;
+const BEHAVIOR_ATTEMPT_WEIGHT = 0.1;
+const USER_ABILITY_PRIOR_WEIGHT = 10;
+const MIN_USER_SUCCESS_OUTCOMES = 3;
+const MIN_OUTCOME_BUCKET_SUPPORT = 30;
+
+export interface BehaviorSampleRow {
+  board_type: string;
+  user_id: string;
+  climb_uuid: string;
+  angle: number;
+  status: 'flash' | 'send' | 'attempt';
+  attempt_count: number;
+  difficulty_average: number;
+  ascensionist_count: number;
+}
+
+interface Stage2SampleSqlOptions {
+  excludeTensionBenchmarkHoldout?: boolean;
+}
+
+/**
+ * Latest native outcome per user/canonical-climb/angle. Behavior uses only
+ * Boardsesh-native events because imported/synced failures and flashes are
+ * already shaped by external logging UX and are not first-exposure-like.
+ */
+export function buildBehaviorSampleSql(
+  options: Stage2SampleSqlOptions = { excludeTensionBenchmarkHoldout: true },
+): SQL {
+  const excludeHoldout = options.excludeTensionBenchmarkHoldout ?? true;
+  return sql`
+    SELECT DISTINCT ON (t.user_id, t.board_type, COALESCE(a.canonical_uuid, t.climb_uuid), t.angle)
+           t.board_type,
+           t.user_id,
+           COALESCE(a.canonical_uuid, t.climb_uuid) AS climb_uuid,
+           t.angle,
+           t.status,
+           t.attempt_count,
+           s.difficulty_average,
+           COALESCE(s.ascensionist_count, 0)::int AS ascensionist_count
+    FROM boardsesh_ticks t
+    LEFT JOIN board_climb_aliases a
+      ON a.board_type = t.board_type AND a.alias_uuid = t.climb_uuid
+    JOIN board_climb_stats s
+      ON s.board_type = t.board_type
+     AND s.climb_uuid = COALESCE(a.canonical_uuid, t.climb_uuid)
+     AND s.angle = t.angle
+    JOIN board_climbs bc
+      ON bc.board_type = s.board_type AND bc.uuid = s.climb_uuid
+    WHERE t.origin = 'native'
+      AND s.difficulty_average IS NOT NULL
+      AND bc.is_listed = true
+      AND COALESCE(bc.is_draft, false) = false
+      AND (${excludeHoldout ? sql`NOT (${buildTensionBenchmarkHoldoutPredicate()})` : sql`true`})
+    ORDER BY t.user_id, t.board_type, COALESCE(a.canonical_uuid, t.climb_uuid), t.angle, t.climbed_at DESC
+  `;
+}
+
+function numeric(value: number | string): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+export function behaviorOutcomeBucket(
+  sample: Pick<BehaviorSampleRow, 'status' | 'attempt_count'>,
+): BehaviorOutcomeBucket {
+  const attempts = Math.max(1, numeric(sample.attempt_count));
+  if (sample.status === 'flash') return 'flash';
+  if (sample.status === 'send') return attempts <= 3 ? 'send_2_3' : 'send_4_plus';
+  return attempts <= 3 ? 'attempt_1_3' : 'attempt_4_plus';
+}
+
+function behaviorWeight(bucket: BehaviorOutcomeBucket): number {
+  return bucket === 'attempt_1_3' || bucket === 'attempt_4_plus' ? BEHAVIOR_ATTEMPT_WEIGHT : BEHAVIOR_SUCCESS_WEIGHT;
+}
+
+interface UserAbility {
+  ability: number;
+  successes: number;
+}
+
+interface UserAbilityAccumulator {
+  boardType: string;
+  difficultySum: number;
+  successes: number;
+}
+
+function buildUserAbilityAccumulators(samples: BehaviorSampleRow[]): Map<string, UserAbilityAccumulator> {
+  const userAccumulator = new Map<string, { boardType: string; difficultySum: number; successes: number }>();
+  for (const sample of samples) {
+    if (sample.status !== 'flash' && sample.status !== 'send') continue;
+    const accumulatorKey = `${sample.board_type}\u0000${sample.user_id}`;
+    const accumulator = userAccumulator.get(accumulatorKey) ?? {
+      boardType: sample.board_type,
+      difficultySum: 0,
+      successes: 0,
+    };
+    accumulator.difficultySum += numeric(sample.difficulty_average);
+    accumulator.successes += 1;
+    userAccumulator.set(accumulatorKey, accumulator);
+  }
+  return userAccumulator;
+}
+
+function userAbilityFromAccumulator(
+  accumulator: UserAbilityAccumulator,
+  boardMeanByBoard: Map<string, number>,
+): UserAbility | null {
+  if (accumulator.successes < MIN_USER_SUCCESS_OUTCOMES) return null;
+  const boardMean = boardMeanByBoard.get(accumulator.boardType) ?? accumulator.difficultySum / accumulator.successes;
+  const rawAbility = accumulator.difficultySum / accumulator.successes;
+  const shrinkage = accumulator.successes / (accumulator.successes + USER_ABILITY_PRIOR_WEIGHT);
+  return {
+    ability: boardMean + (rawAbility - boardMean) * shrinkage,
+    successes: accumulator.successes,
+  };
+}
+
+function buildUserAbilities(
+  samples: BehaviorSampleRow[],
+  boardMeanByBoard: Map<string, number>,
+): Map<string, UserAbility> {
+  const userAccumulator = buildUserAbilityAccumulators(samples);
+  const userAbilities = new Map<string, UserAbility>();
+  for (const [accumulatorKey, accumulator] of userAccumulator) {
+    const ability = userAbilityFromAccumulator(accumulator, boardMeanByBoard);
+    if (ability) userAbilities.set(accumulatorKey, ability);
+  }
+  return userAbilities;
+}
+
+function summarizeUserOutcomes(userOutcomes: Map<string, number>): {
+  users: number;
+  outcomes: number;
+  topUserShare: number;
+} {
+  let topUserOutcomes = 0;
+  let totalOutcomes = 0;
+  for (const outcomes of userOutcomes.values()) {
+    topUserOutcomes = Math.max(topUserOutcomes, outcomes);
+    totalOutcomes += outcomes;
+  }
+  return {
+    users: userOutcomes.size,
+    outcomes: totalOutcomes,
+    topUserShare: totalOutcomes > 0 ? topUserOutcomes / totalOutcomes : 0,
+  };
+}
+
+interface BehaviorOffsetAccumulator {
+  residualSum: number;
+  outcomes: number;
+  userOutcomes: Map<string, number>;
+}
+
+interface BehaviorUserBucketAccumulator {
+  residualSum: number;
+  outcomes: number;
+}
+
+interface BehaviorOffsetAccumulators {
+  bucketAccumulator: Map<string, BehaviorOffsetAccumulator>;
+  userAbilityAccumulatorByKey: Map<string, UserAbilityAccumulator>;
+  userAbilityByKey: Map<string, UserAbility>;
+  userBucketAccumulator: Map<string, BehaviorUserBucketAccumulator>;
+  usedUserOutcomesByBoard: Map<string, Map<string, number>>;
+}
+
+function addUserOutcome(userOutcomes: Map<string, number>, userId: string, delta: number): void {
+  const next = (userOutcomes.get(userId) ?? 0) + delta;
+  if (next <= 0) {
+    userOutcomes.delete(userId);
+  } else {
+    userOutcomes.set(userId, next);
+  }
+}
+
+function buildBehaviorOffsetAccumulators(
+  samples: BehaviorSampleRow[],
+  boardMeanByBoard: Map<string, number>,
+): BehaviorOffsetAccumulators {
+  const userAbilityAccumulatorByKey = buildUserAbilityAccumulators(samples);
+  const userAbilityByKey = new Map<string, UserAbility>();
+  for (const [accumulatorKey, accumulator] of userAbilityAccumulatorByKey) {
+    const ability = userAbilityFromAccumulator(accumulator, boardMeanByBoard);
+    if (ability) userAbilityByKey.set(accumulatorKey, ability);
+  }
+  const bucketAccumulator = new Map<string, BehaviorOffsetAccumulator>();
+  const userBucketAccumulator = new Map<string, BehaviorUserBucketAccumulator>();
+  const usedUserOutcomesByBoard = new Map<string, Map<string, number>>();
+
+  for (const sample of samples) {
+    if (numeric(sample.ascensionist_count) < 20) continue;
+    const ability = userAbilityByKey.get(`${sample.board_type}\u0000${sample.user_id}`);
+    if (!ability) continue;
+    const bucket = behaviorOutcomeBucket(sample);
+    const accumulatorKey = `${sample.board_type}\u0000${bucket}`;
+    const accumulator = bucketAccumulator.get(accumulatorKey) ?? {
+      residualSum: 0,
+      outcomes: 0,
+      userOutcomes: new Map<string, number>(),
+    };
+    accumulator.residualSum += numeric(sample.difficulty_average) - ability.ability;
+    accumulator.outcomes += 1;
+    addUserOutcome(accumulator.userOutcomes, sample.user_id, 1);
+    bucketAccumulator.set(accumulatorKey, accumulator);
+
+    const userBucketKey = `${sample.board_type}\u0000${sample.user_id}\u0000${bucket}`;
+    const userBucket = userBucketAccumulator.get(userBucketKey) ?? { residualSum: 0, outcomes: 0 };
+    userBucket.residualSum += numeric(sample.difficulty_average) - ability.ability;
+    userBucket.outcomes += 1;
+    userBucketAccumulator.set(userBucketKey, userBucket);
+
+    const usedBoardOutcomes = usedUserOutcomesByBoard.get(sample.board_type) ?? new Map<string, number>();
+    addUserOutcome(usedBoardOutcomes, sample.user_id, 1);
+    usedUserOutcomesByBoard.set(sample.board_type, usedBoardOutcomes);
+  }
+
+  return {
+    bucketAccumulator,
+    userAbilityAccumulatorByKey,
+    userAbilityByKey,
+    userBucketAccumulator,
+    usedUserOutcomesByBoard,
+  };
+}
+
+function behaviorOffsetFromAccumulator(
+  accumulator: BehaviorOffsetAccumulator | undefined,
+  heldOut: BehaviorOffsetAccumulator | undefined,
+): number | null {
+  if (!accumulator) return null;
+  const outcomes = accumulator.outcomes - (heldOut?.outcomes ?? 0);
+  if (outcomes < MIN_OUTCOME_BUCKET_SUPPORT) return null;
+  const userOutcomes = new Map(accumulator.userOutcomes);
+  if (heldOut) {
+    for (const [userId, heldOutcomes] of heldOut.userOutcomes) {
+      addUserOutcome(userOutcomes, userId, -heldOutcomes);
+    }
+  }
+  const bucketCoverage = summarizeUserOutcomes(userOutcomes);
+  if (
+    bucketCoverage.users < BEHAVIOR_MIN_BUCKET_USERS ||
+    bucketCoverage.topUserShare > BEHAVIOR_MAX_BUCKET_TOP_USER_SHARE
+  ) {
+    return null;
+  }
+  const residualSum = accumulator.residualSum - (heldOut?.residualSum ?? 0);
+  return residualSum / outcomes;
+}
+
+function behaviorOffsetForEvidence(
+  boardType: string,
+  bucket: BehaviorOutcomeBucket,
+  evidenceKey: string,
+  offsetAccumulatorByBucket: Map<string, BehaviorOffsetAccumulator>,
+  heldOutOffsetByEvidenceBucket: Map<string, BehaviorOffsetAccumulator>,
+  userAbilityAccumulatorByKey: Map<string, UserAbilityAccumulator>,
+  userAbilityByKey: Map<string, UserAbility>,
+  userBucketAccumulator: Map<string, BehaviorUserBucketAccumulator>,
+  heldOutUserBucketByEvidence: Map<string, BehaviorUserBucketAccumulator>,
+  heldOutSuccessByEvidenceBoard: Map<string, Map<string, { difficultySum: number; successes: number }>>,
+  boardMeanByBoard: Map<string, number>,
+): number | null {
+  const fullBucket = offsetAccumulatorByBucket.get(`${boardType}\u0000${bucket}`);
+  if (!fullBucket) return null;
+  const heldOutBucket = heldOutOffsetByEvidenceBucket.get(`${evidenceKey}\u0000${boardType}\u0000${bucket}`);
+  let outcomes = fullBucket.outcomes - (heldOutBucket?.outcomes ?? 0);
+  let residualSum = fullBucket.residualSum - (heldOutBucket?.residualSum ?? 0);
+  const userOutcomes = new Map(fullBucket.userOutcomes);
+  if (heldOutBucket) {
+    for (const [userId, heldOutcomes] of heldOutBucket.userOutcomes) {
+      addUserOutcome(userOutcomes, userId, -heldOutcomes);
+    }
+  }
+
+  const heldOutSuccesses = heldOutSuccessByEvidenceBoard.get(`${evidenceKey}\u0000${boardType}`);
+  if (heldOutSuccesses) {
+    for (const [userId, heldOutAbility] of heldOutSuccesses) {
+      const fullAbility = userAbilityByKey.get(`${boardType}\u0000${userId}`);
+      const fullAbilityAccumulator = userAbilityAccumulatorByKey.get(`${boardType}\u0000${userId}`);
+      const fullUserBucket = userBucketAccumulator.get(`${boardType}\u0000${userId}\u0000${bucket}`);
+      if (!fullAbility || !fullAbilityAccumulator || !fullUserBucket) continue;
+
+      const heldOutUserBucket = heldOutUserBucketByEvidence.get(
+        `${evidenceKey}\u0000${boardType}\u0000${userId}\u0000${bucket}`,
+      );
+      const nonTargetOutcomes = fullUserBucket.outcomes - (heldOutUserBucket?.outcomes ?? 0);
+      if (nonTargetOutcomes <= 0) continue;
+      const nonTargetResidualSum = fullUserBucket.residualSum - (heldOutUserBucket?.residualSum ?? 0);
+      const leaveTargetOutAbility = userAbilityFromAccumulator(
+        {
+          ...fullAbilityAccumulator,
+          difficultySum: fullAbilityAccumulator.difficultySum - heldOutAbility.difficultySum,
+          successes: fullAbilityAccumulator.successes - heldOutAbility.successes,
+        },
+        boardMeanByBoard,
+      );
+      if (!leaveTargetOutAbility) {
+        outcomes -= nonTargetOutcomes;
+        residualSum -= nonTargetResidualSum;
+        addUserOutcome(userOutcomes, userId, -nonTargetOutcomes);
+      } else {
+        residualSum += nonTargetOutcomes * (fullAbility.ability - leaveTargetOutAbility.ability);
+      }
+    }
+  }
+
+  if (outcomes < MIN_OUTCOME_BUCKET_SUPPORT) return null;
+  const bucketCoverage = summarizeUserOutcomes(userOutcomes);
+  if (
+    bucketCoverage.users < BEHAVIOR_MIN_BUCKET_USERS ||
+    bucketCoverage.topUserShare > BEHAVIOR_MAX_BUCKET_TOP_USER_SHARE
+  ) {
+    return null;
+  }
+  return residualSum / outcomes;
+}
+
+export function estimateBehaviorModels(samples: BehaviorSampleRow[]): Record<string, BehaviorModelCoefficient> {
+  const boardMeanAccumulator = new Map<string, { difficultySum: number; outcomes: number }>();
+  const userOutcomesByBoard = new Map<string, Map<string, number>>();
+  for (const sample of samples) {
+    const boardAccumulator = boardMeanAccumulator.get(sample.board_type) ?? { difficultySum: 0, outcomes: 0 };
+    boardAccumulator.difficultySum += numeric(sample.difficulty_average);
+    boardAccumulator.outcomes += 1;
+    boardMeanAccumulator.set(sample.board_type, boardAccumulator);
+
+    const boardUserOutcomes = userOutcomesByBoard.get(sample.board_type) ?? new Map<string, number>();
+    boardUserOutcomes.set(sample.user_id, (boardUserOutcomes.get(sample.user_id) ?? 0) + 1);
+    userOutcomesByBoard.set(sample.board_type, boardUserOutcomes);
+  }
+
+  const boardMeanByBoard = new Map<string, number>();
+  for (const [boardType, accumulator] of boardMeanAccumulator) {
+    if (accumulator.outcomes > 0) boardMeanByBoard.set(boardType, accumulator.difficultySum / accumulator.outcomes);
+  }
+  const { bucketAccumulator, usedUserOutcomesByBoard } = buildBehaviorOffsetAccumulators(samples, boardMeanByBoard);
+
+  const models: Record<string, BehaviorModelCoefficient> = {};
+  for (const [boardType, boardMean] of boardMeanByBoard) {
+    const boardUserOutcomes = userOutcomesByBoard.get(boardType) ?? new Map<string, number>();
+    const rawCoverage = summarizeUserOutcomes(boardUserOutcomes);
+    const usedCoverage = summarizeUserOutcomes(usedUserOutcomesByBoard.get(boardType) ?? new Map<string, number>());
+    const model: BehaviorModelCoefficient = {
+      boardType,
+      boardMean,
+      outcomeOffset: {},
+      eligible:
+        usedCoverage.users >= BEHAVIOR_MIN_USERS &&
+        usedCoverage.outcomes >= BEHAVIOR_MIN_OUTCOMES &&
+        usedCoverage.topUserShare <= BEHAVIOR_MAX_TOP_USER_SHARE,
+      summary: {
+        users: rawCoverage.users,
+        outcomes: rawCoverage.outcomes,
+        topUserShare: rawCoverage.topUserShare,
+        usedUsers: usedCoverage.users,
+        usedOutcomes: 0,
+        usedTopUserShare: usedCoverage.topUserShare,
+      },
+    };
+    for (const bucket of ['flash', 'send_2_3', 'send_4_plus', 'attempt_1_3', 'attempt_4_plus'] as const) {
+      const accumulator = bucketAccumulator.get(`${boardType}\u0000${bucket}`);
+      if (!accumulator) continue;
+      const offset = behaviorOffsetFromAccumulator(accumulator, undefined);
+      if (offset === null) continue;
+      model.outcomeOffset[bucket] = offset;
+      model.summary.usedOutcomes += accumulator.outcomes;
+    }
+    models[boardType] = model;
+  }
+
+  return models;
+}
+
+export function buildBehaviorEvidence(
+  samples: BehaviorSampleRow[],
+  models: Record<string, BehaviorModelCoefficient>,
+  existingEvidence: Stage2EvidenceMap,
+  offsetTrainingSamples: BehaviorSampleRow[] = samples,
+): Stage2EvidenceMap {
+  const boardMeanByBoard = new Map<string, number>();
+  for (const model of Object.values(models)) boardMeanByBoard.set(model.boardType, model.boardMean);
+  const {
+    bucketAccumulator: offsetAccumulatorByBucket,
+    userAbilityAccumulatorByKey,
+    userAbilityByKey,
+    userBucketAccumulator,
+  } = buildBehaviorOffsetAccumulators(offsetTrainingSamples, boardMeanByBoard);
+  const heldOutOffsetByEvidenceBucket = new Map<string, BehaviorOffsetAccumulator>();
+  const heldOutUserBucketByEvidence = new Map<string, BehaviorUserBucketAccumulator>();
+  const heldOutSuccessByEvidenceBoard = new Map<string, Map<string, { difficultySum: number; successes: number }>>();
+  const heldOutSuccessByEvidenceUser = new Map<string, { difficultySum: number; successes: number }>();
+  for (const sample of offsetTrainingSamples) {
+    const evidenceKey = stage2EvidenceKey(sample.board_type, sample.climb_uuid, numeric(sample.angle));
+    if (sample.status === 'flash' || sample.status === 'send') {
+      const boardSuccessKey = `${evidenceKey}\u0000${sample.board_type}`;
+      const boardSuccesses = heldOutSuccessByEvidenceBoard.get(boardSuccessKey) ?? new Map();
+      const userSuccesses = boardSuccesses.get(sample.user_id) ?? { difficultySum: 0, successes: 0 };
+      userSuccesses.difficultySum += numeric(sample.difficulty_average);
+      userSuccesses.successes += 1;
+      boardSuccesses.set(sample.user_id, userSuccesses);
+      heldOutSuccessByEvidenceBoard.set(boardSuccessKey, boardSuccesses);
+
+      const userSuccessKey = `${evidenceKey}\u0000${sample.board_type}\u0000${sample.user_id}`;
+      const evidenceUserSuccesses = heldOutSuccessByEvidenceUser.get(userSuccessKey) ?? {
+        difficultySum: 0,
+        successes: 0,
+      };
+      evidenceUserSuccesses.difficultySum += numeric(sample.difficulty_average);
+      evidenceUserSuccesses.successes += 1;
+      heldOutSuccessByEvidenceUser.set(userSuccessKey, evidenceUserSuccesses);
+    }
+
+    if (numeric(sample.ascensionist_count) < 20) continue;
+    const ability = userAbilityByKey.get(`${sample.board_type}\u0000${sample.user_id}`);
+    if (!ability) continue;
+    const bucket = behaviorOutcomeBucket(sample);
+    const residual = numeric(sample.difficulty_average) - ability.ability;
+    const accumulatorKey = `${evidenceKey}\u0000${sample.board_type}\u0000${bucket}`;
+    const accumulator = heldOutOffsetByEvidenceBucket.get(accumulatorKey) ?? {
+      residualSum: 0,
+      outcomes: 0,
+      userOutcomes: new Map<string, number>(),
+    };
+    accumulator.residualSum += residual;
+    accumulator.outcomes += 1;
+    addUserOutcome(accumulator.userOutcomes, sample.user_id, 1);
+    heldOutOffsetByEvidenceBucket.set(accumulatorKey, accumulator);
+
+    const userBucketKey = `${evidenceKey}\u0000${sample.board_type}\u0000${sample.user_id}\u0000${bucket}`;
+    const userBucket = heldOutUserBucketByEvidence.get(userBucketKey) ?? { residualSum: 0, outcomes: 0 };
+    userBucket.residualSum += residual;
+    userBucket.outcomes += 1;
+    heldOutUserBucketByEvidence.set(userBucketKey, userBucket);
+  }
+  const evidenceAccumulator = new Map<string, { weightedDifficulty: number; effectiveN: number }>();
+
+  for (const sample of samples) {
+    const model = models[sample.board_type];
+    if (!model?.eligible) continue;
+    const bucket = behaviorOutcomeBucket(sample);
+    const evidenceKey = stage2EvidenceKey(sample.board_type, sample.climb_uuid, numeric(sample.angle));
+    const offset = behaviorOffsetForEvidence(
+      sample.board_type,
+      bucket,
+      evidenceKey,
+      offsetAccumulatorByBucket,
+      heldOutOffsetByEvidenceBucket,
+      userAbilityAccumulatorByKey,
+      userAbilityByKey,
+      userBucketAccumulator,
+      heldOutUserBucketByEvidence,
+      heldOutSuccessByEvidenceBoard,
+      boardMeanByBoard,
+    );
+    if (offset === null) continue;
+    const fullAbilityAccumulator = userAbilityAccumulatorByKey.get(`${sample.board_type}\u0000${sample.user_id}`);
+    if (!fullAbilityAccumulator) continue;
+    const heldOutAbility = heldOutSuccessByEvidenceUser.get(
+      `${evidenceKey}\u0000${sample.board_type}\u0000${sample.user_id}`,
+    );
+    const ability = userAbilityFromAccumulator(
+      {
+        ...fullAbilityAccumulator,
+        difficultySum: fullAbilityAccumulator.difficultySum - (heldOutAbility?.difficultySum ?? 0),
+        successes: fullAbilityAccumulator.successes - (heldOutAbility?.successes ?? 0),
+      },
+      boardMeanByBoard,
+    );
+    if (!ability) continue;
+    const weight = behaviorWeight(bucket);
+    const accumulator = evidenceAccumulator.get(evidenceKey) ?? { weightedDifficulty: 0, effectiveN: 0 };
+    accumulator.weightedDifficulty += (ability.ability + offset) * weight;
+    accumulator.effectiveN += weight;
+    evidenceAccumulator.set(evidenceKey, accumulator);
+  }
+
+  const evidence = new Map<string, Stage2Evidence>(existingEvidence);
+  for (const [evidenceKey, accumulator] of evidenceAccumulator) {
+    const current = evidence.get(evidenceKey) ?? {
+      raterMean: null,
+      raterEffectiveN: 0,
+      behaviorMean: null,
+      behaviorEffectiveN: 0,
+    };
+    evidence.set(evidenceKey, {
+      ...current,
+      behaviorMean: accumulator.effectiveN > 0 ? accumulator.weightedDifficulty / accumulator.effectiveN : null,
+      behaviorEffectiveN: accumulator.effectiveN,
+    });
+  }
+  return evidence;
+}
+
+export type BehaviorTickStatus = 'flash' | 'send' | 'attempt';
+
+export interface BehaviorObservation {
+  raterId: string;
+  status: BehaviorTickStatus;
+  /** Attempts used for sends; ignored for flashes, optional for failed attempts. */
+  attemptCount: number | null;
+  /** Reference grade for ability fitting, when the climb has a trusted grade. */
+  referenceGrade: number | null;
+}
+
+export interface BehaviorModelOptions {
+  flashProbability: number;
+  sendProbability: number;
+  sendAttemptPenalty: number;
+  minSendProbability: number;
+  attemptProbability: number;
+  flashWeight: number;
+  sendWeight: number;
+  attemptWeight: number;
+  minEffectiveWeight: number;
+  /** Shrinks ability toward the reference grades the climber sampled. */
+  priorWeight: number;
+  probabilityClamp: readonly [number, number];
+}
+
+export interface BehaviorAbilityEstimate {
+  raterId: string;
+  ability: number;
+  effectiveWeight: number;
+  observationCount: number;
+}
+
+export interface BehaviorDifficultyEstimate {
+  grade: number;
+  effectiveWeight: number;
+  observationCount: number;
+  weightedSd: number | null;
+}
+
+export const DEFAULT_BEHAVIOR_HELPER_OPTIONS: Readonly<BehaviorModelOptions> = {
+  flashProbability: 0.85,
+  sendProbability: 0.65,
+  sendAttemptPenalty: 0.05,
+  minSendProbability: 0.45,
+  attemptProbability: 0.2,
+  flashWeight: 1,
+  sendWeight: 1,
+  attemptWeight: 0.5,
+  minEffectiveWeight: 3,
+  priorWeight: 2,
+  probabilityClamp: [0.02, 0.98],
+};
+
+function resolveBehaviorOptions(options: Partial<BehaviorModelOptions> | undefined): BehaviorModelOptions {
+  return { ...DEFAULT_BEHAVIOR_HELPER_OPTIONS, ...options };
+}
+
+function isFiniteGrade(gradeNumber: number | null): gradeNumber is number {
+  return gradeNumber !== null && Number.isFinite(gradeNumber);
+}
+
+function clampProbability(probability: number, [low, high]: readonly [number, number]): number {
+  return Math.min(high, Math.max(low, probability));
+}
+
+export function logitProbability(probability: number, options?: Partial<BehaviorModelOptions>): number {
+  const resolvedOptions = resolveBehaviorOptions(options);
+  const clampedProbability = clampProbability(probability, resolvedOptions.probabilityClamp);
+  return Math.log(clampedProbability / (1 - clampedProbability));
+}
+
+export function behaviorOutcomeProbability(
+  status: BehaviorTickStatus,
+  attemptCount: number | null,
+  options?: Partial<BehaviorModelOptions>,
+): number {
+  const resolvedOptions = resolveBehaviorOptions(options);
+  if (status === 'flash') return clampProbability(resolvedOptions.flashProbability, resolvedOptions.probabilityClamp);
+  if (status === 'attempt')
+    return clampProbability(resolvedOptions.attemptProbability, resolvedOptions.probabilityClamp);
+  const countedAttempts = attemptCount !== null && Number.isFinite(attemptCount) ? Math.max(2, attemptCount) : 2;
+  const sendProbability =
+    resolvedOptions.sendProbability - Math.max(0, countedAttempts - 2) * resolvedOptions.sendAttemptPenalty;
+  return clampProbability(
+    Math.max(resolvedOptions.minSendProbability, sendProbability),
+    resolvedOptions.probabilityClamp,
+  );
+}
+
+export function behaviorObservationWeight(status: BehaviorTickStatus, options?: Partial<BehaviorModelOptions>): number {
+  const resolvedOptions = resolveBehaviorOptions(options);
+  if (status === 'flash') return Math.max(0, resolvedOptions.flashWeight);
+  if (status === 'send') return Math.max(0, resolvedOptions.sendWeight);
+  return Math.max(0, resolvedOptions.attemptWeight);
+}
+
+export function estimateBehaviorAbilities(
+  observations: readonly BehaviorObservation[],
+  options?: Partial<BehaviorModelOptions>,
+): Map<string, BehaviorAbilityEstimate> {
+  const resolvedOptions = resolveBehaviorOptions(options);
+  const accumulators = new Map<
+    string,
+    { impliedAbilitySum: number; referenceGradeSum: number; effectiveWeight: number; observationCount: number }
+  >();
+
+  for (const observation of observations) {
+    if (!isFiniteGrade(observation.referenceGrade)) continue;
+    const weight = behaviorObservationWeight(observation.status, resolvedOptions);
+    if (weight <= 0) continue;
+    const outcomeLogit = logitProbability(
+      behaviorOutcomeProbability(observation.status, observation.attemptCount, resolvedOptions),
+      resolvedOptions,
+    );
+    const accumulator = accumulators.get(observation.raterId) ?? {
+      impliedAbilitySum: 0,
+      referenceGradeSum: 0,
+      effectiveWeight: 0,
+      observationCount: 0,
+    };
+    accumulator.impliedAbilitySum += (observation.referenceGrade + outcomeLogit) * weight;
+    accumulator.referenceGradeSum += observation.referenceGrade * weight;
+    accumulator.effectiveWeight += weight;
+    accumulator.observationCount += 1;
+    accumulators.set(observation.raterId, accumulator);
+  }
+
+  const estimates = new Map<string, BehaviorAbilityEstimate>();
+  for (const [raterId, accumulator] of accumulators) {
+    if (accumulator.effectiveWeight < resolvedOptions.minEffectiveWeight) continue;
+    const priorMean = accumulator.referenceGradeSum / accumulator.effectiveWeight;
+    estimates.set(raterId, {
+      raterId,
+      ability:
+        (accumulator.impliedAbilitySum + priorMean * resolvedOptions.priorWeight) /
+        (accumulator.effectiveWeight + resolvedOptions.priorWeight),
+      effectiveWeight: accumulator.effectiveWeight,
+      observationCount: accumulator.observationCount,
+    });
+  }
+  return estimates;
+}
+
+export function estimateBehaviorDifficulty(
+  observations: readonly BehaviorObservation[],
+  abilities: ReadonlyMap<string, BehaviorAbilityEstimate>,
+  options?: Partial<BehaviorModelOptions>,
+): BehaviorDifficultyEstimate | null {
+  const resolvedOptions = resolveBehaviorOptions(options);
+  const impliedDifficulties: Array<{ grade: number; weight: number }> = [];
+
+  for (const observation of observations) {
+    const ability = abilities.get(observation.raterId);
+    if (!ability) continue;
+    const weight = behaviorObservationWeight(observation.status, resolvedOptions);
+    if (weight <= 0) continue;
+    const outcomeLogit = logitProbability(
+      behaviorOutcomeProbability(observation.status, observation.attemptCount, resolvedOptions),
+      resolvedOptions,
+    );
+    impliedDifficulties.push({ grade: ability.ability - outcomeLogit, weight });
+  }
+
+  const effectiveWeight = impliedDifficulties.reduce(
+    (weightTotal, impliedDifficulty) => weightTotal + impliedDifficulty.weight,
+    0,
+  );
+  if (effectiveWeight <= 0) return null;
+
+  const grade =
+    impliedDifficulties.reduce(
+      (weightedGradeSum, impliedDifficulty) => weightedGradeSum + impliedDifficulty.grade * impliedDifficulty.weight,
+      0,
+    ) / effectiveWeight;
+  const weightedVariance =
+    impliedDifficulties.length < 2
+      ? null
+      : impliedDifficulties.reduce(
+          (varianceSum, impliedDifficulty) =>
+            varianceSum +
+            impliedDifficulty.weight * (impliedDifficulty.grade - grade) * (impliedDifficulty.grade - grade),
+          0,
+        ) / effectiveWeight;
+
+  return {
+    grade,
+    effectiveWeight,
+    observationCount: impliedDifficulties.length,
+    weightedSd: weightedVariance === null ? null : Math.sqrt(weightedVariance),
+  };
+}

--- a/packages/db/src/queries/grade-model/bridges.ts
+++ b/packages/db/src/queries/grade-model/bridges.ts
@@ -1,0 +1,224 @@
+import { sql, type SQL } from 'drizzle-orm';
+import { MOON_BRIDGE_MAX_LOO_DELTA, MOON_BRIDGE_MIN_SENDS_PER_BOARD, MOON_BRIDGE_MIN_USERS } from './constants';
+import type { GateResult, MoonBridgeReadiness } from './types';
+
+export interface MoonBridgeSampleRow {
+  user_id: string;
+  moon_median: number;
+  anchor_median: number;
+  moon_graded: number;
+  anchor_graded: number;
+}
+
+export function buildMoonBridgeSampleSql(): SQL {
+  return sql`
+    WITH per_board AS (
+      SELECT user_id,
+             board_type,
+             percentile_cont(0.5) WITHIN GROUP (ORDER BY difficulty) AS median_grade,
+             COUNT(*)::int AS graded_sends
+      FROM boardsesh_ticks
+      WHERE difficulty IS NOT NULL
+        AND status IN ('flash', 'send')
+        AND board_type IN ('moonboard', 'kilter', 'tension')
+      GROUP BY user_id, board_type
+    ),
+    anchor AS (
+      SELECT user_id,
+             percentile_cont(0.5) WITHIN GROUP (ORDER BY median_grade) AS anchor_median,
+             MAX(graded_sends)::int AS anchor_graded
+      FROM per_board
+      WHERE board_type IN ('kilter', 'tension')
+      GROUP BY user_id
+    )
+    SELECT moon.user_id,
+           moon.median_grade AS moon_median,
+           anchor.anchor_median,
+           moon.graded_sends AS moon_graded,
+           anchor.anchor_graded
+    FROM per_board moon
+    JOIN anchor ON anchor.user_id = moon.user_id
+    WHERE moon.board_type = 'moonboard'
+      AND moon.graded_sends >= ${MOON_BRIDGE_MIN_SENDS_PER_BOARD}
+      AND anchor.anchor_graded >= ${MOON_BRIDGE_MIN_SENDS_PER_BOARD}
+  `;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const midpoint = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[midpoint - 1] + sorted[midpoint]) / 2 : sorted[midpoint];
+}
+
+export function evaluateMoonBridgeReadiness(samples: MoonBridgeSampleRow[]): MoonBridgeReadiness {
+  const gaps = samples.map((sample) => Number(sample.anchor_median) - Number(sample.moon_median));
+  const candidateOffset = median(gaps);
+  let looMaxDelta: number | null = null;
+  if (candidateOffset !== null && gaps.length > 1) {
+    looMaxDelta = 0;
+    for (let gapIndex = 0; gapIndex < gaps.length; gapIndex++) {
+      const leaveOneOut = median(gaps.slice(0, gapIndex).concat(gaps.slice(gapIndex + 1)));
+      if (leaveOneOut !== null) looMaxDelta = Math.max(looMaxDelta, Math.abs(leaveOneOut - candidateOffset));
+    }
+  }
+  return {
+    boardType: 'moonboard',
+    bridgeUsers: samples.length,
+    requiredUsers: MOON_BRIDGE_MIN_USERS,
+    minSendsPerBoard: MOON_BRIDGE_MIN_SENDS_PER_BOARD,
+    candidateOffset,
+    looMaxDelta,
+    publishable:
+      samples.length >= MOON_BRIDGE_MIN_USERS &&
+      candidateOffset !== null &&
+      looMaxDelta !== null &&
+      looMaxDelta <= MOON_BRIDGE_MAX_LOO_DELTA,
+  };
+}
+
+export function moonBridgeReadinessGate(readiness: MoonBridgeReadiness): GateResult {
+  const reason = readiness.publishable
+    ? 'Moon bridge has enough paired users for a future publish path'
+    : `Moon bridge report-only: ${readiness.bridgeUsers}/${readiness.requiredUsers} users with >=${readiness.minSendsPerBoard} graded sends per side`;
+  return {
+    gate: 'moon_bridge_readiness',
+    passed: true,
+    detail: reason,
+    metrics: {
+      users: readiness.bridgeUsers,
+      requiredUsers: readiness.requiredUsers,
+      minSendsPerBoard: readiness.minSendsPerBoard,
+      candidateOffset: readiness.candidateOffset ?? 0,
+      looMaxDelta: readiness.looMaxDelta ?? 0,
+      publishable: readiness.publishable ? 1 : 0,
+      maxLooDelta: MOON_BRIDGE_MAX_LOO_DELTA,
+    },
+  };
+}
+
+export interface BoardBridgeSample {
+  userId: string;
+  boardType: string;
+  grade: number;
+}
+
+export interface PairwiseBridgeEdge {
+  fromBoard: string;
+  toBoard: string;
+  offset: number;
+  sharedUsers: number;
+  looMaxDelta: number;
+}
+
+export interface AnchorBridgeOffsets {
+  offsets: Record<string, { offset: number; users: number; looMaxDelta: number }>;
+  withheldBoards: string[];
+}
+
+export interface PairwiseBridgeOptions {
+  minSharedUsers: number;
+  maxLooDelta: number;
+}
+
+const DEFAULT_PAIRWISE_BRIDGE_OPTIONS: PairwiseBridgeOptions = {
+  minSharedUsers: MOON_BRIDGE_MIN_USERS,
+  maxLooDelta: MOON_BRIDGE_MAX_LOO_DELTA,
+};
+
+function resolvePairwiseBridgeOptions(options: Partial<PairwiseBridgeOptions> | undefined): PairwiseBridgeOptions {
+  return { ...DEFAULT_PAIRWISE_BRIDGE_OPTIONS, ...options };
+}
+
+function looMaxDelta(values: number[], estimate: number): number {
+  if (values.length <= 1) return 0;
+  let maxDelta = 0;
+  for (let valueIndex = 0; valueIndex < values.length; valueIndex++) {
+    const leaveOneOut = median(values.slice(0, valueIndex).concat(values.slice(valueIndex + 1)));
+    if (leaveOneOut !== null) maxDelta = Math.max(maxDelta, Math.abs(leaveOneOut - estimate));
+  }
+  return maxDelta;
+}
+
+export function estimatePairwiseBridgeEdges(
+  samples: readonly BoardBridgeSample[],
+  options?: Partial<PairwiseBridgeOptions>,
+): PairwiseBridgeEdge[] {
+  const resolvedOptions = resolvePairwiseBridgeOptions(options);
+  const perUserBoardGrades = new Map<string, Map<string, number[]>>();
+  for (const sample of samples) {
+    const userGrades = perUserBoardGrades.get(sample.userId) ?? new Map<string, number[]>();
+    const boardGrades = userGrades.get(sample.boardType) ?? [];
+    boardGrades.push(sample.grade);
+    userGrades.set(sample.boardType, boardGrades);
+    perUserBoardGrades.set(sample.userId, userGrades);
+  }
+
+  const perUserBoardMedian = new Map<string, Map<string, number>>();
+  const boards = new Set<string>();
+  for (const [userId, userGrades] of perUserBoardGrades) {
+    const userMedians = new Map<string, number>();
+    for (const [boardType, grades] of userGrades) {
+      const boardMedian = median(grades);
+      if (boardMedian === null) continue;
+      userMedians.set(boardType, boardMedian);
+      boards.add(boardType);
+    }
+    perUserBoardMedian.set(userId, userMedians);
+  }
+
+  const sortedBoards = [...boards].sort();
+  const edges: PairwiseBridgeEdge[] = [];
+  for (let fromIndex = 0; fromIndex < sortedBoards.length; fromIndex++) {
+    for (let toIndex = fromIndex + 1; toIndex < sortedBoards.length; toIndex++) {
+      const fromBoard = sortedBoards[fromIndex];
+      const toBoard = sortedBoards[toIndex];
+      const gaps: number[] = [];
+      for (const userMedians of perUserBoardMedian.values()) {
+        const fromGrade = userMedians.get(fromBoard);
+        const toGrade = userMedians.get(toBoard);
+        if (fromGrade === undefined || toGrade === undefined) continue;
+        gaps.push(toGrade - fromGrade);
+      }
+      const offset = median(gaps);
+      if (offset === null || gaps.length < resolvedOptions.minSharedUsers) continue;
+      edges.push({
+        fromBoard,
+        toBoard,
+        offset,
+        sharedUsers: gaps.length,
+        looMaxDelta: looMaxDelta(gaps, offset),
+      });
+    }
+  }
+  return edges;
+}
+
+export function estimateAnchorBridgeOffsets(
+  samples: readonly BoardBridgeSample[],
+  anchorBoard: string,
+  options?: Partial<PairwiseBridgeOptions>,
+): AnchorBridgeOffsets {
+  const resolvedOptions = resolvePairwiseBridgeOptions(options);
+  const edges = estimatePairwiseBridgeEdges(samples, resolvedOptions);
+  const offsets: AnchorBridgeOffsets['offsets'] = {};
+  const withheldBoards: string[] = [];
+  for (const edge of edges) {
+    let boardType: string | null = null;
+    let offset: number | null = null;
+    if (edge.toBoard === anchorBoard) {
+      boardType = edge.fromBoard;
+      offset = edge.offset;
+    } else if (edge.fromBoard === anchorBoard) {
+      boardType = edge.toBoard;
+      offset = -edge.offset;
+    }
+    if (boardType === null || offset === null) continue;
+    if (edge.looMaxDelta > resolvedOptions.maxLooDelta) {
+      withheldBoards.push(boardType);
+      continue;
+    }
+    offsets[boardType] = { offset, users: edge.sharedUsers, looMaxDelta: edge.looMaxDelta };
+  }
+  return { offsets, withheldBoards };
+}

--- a/packages/db/src/queries/grade-model/constants.ts
+++ b/packages/db/src/queries/grade-model/constants.ts
@@ -8,7 +8,7 @@
  */
 
 /** Blend/tier/hysteresis logic version, stored on every published row. */
-export const GRADE_MODEL_VERSION = 'v1.2'; // v1.2: Kilter display-delta hygiene
+export const GRADE_MODEL_VERSION = 'v2.0'; // v2.0: capped Stage 2 rater/behavior evidence + benchmark gates
 
 /**
  * Boards whose upstream `difficulty_average` is a live crowd mean (fractional,
@@ -122,3 +122,36 @@ export const GATE_BACKTEST_REGRESSION_TOLERANCE = 0.01; // shrunk MAE may not ex
 export const GATE_NO_SHOCK_MAX_MOVE = 1.0; // no ≥50-ascent climb moves further than this from its raw mean
 export const GATE_NO_SHOCK_MIN_ASCENTS = 50;
 export const GATE_RESIDUAL_PAIRED_GAP = 0.3; // shared-user Kilter/Tension gap after offset
+
+/** Stage 2 evidence caps. These keep per-user ticks from overpowering the upstream aggregate they often feed. */
+export const STAGE2_DEECHO_MAX_MOVE = 0.75;
+export const STAGE2_RATER_MAX_MOVE = 0.5;
+export const STAGE2_RATER_MAX_EFFECTIVE_N = 5;
+export const STAGE2_BEHAVIOR_MAX_MOVE = 0.35;
+export const STAGE2_BEHAVIOR_MAX_EFFECTIVE_N = 2;
+export const STAGE2_USER_BIAS_PRIOR_WEIGHT = 12;
+export const STAGE2_USER_BIAS_MIN_EFFECTIVE_N = 3;
+export const STAGE2_USER_BIAS_MAX_ABS = 1;
+export const STAGE2_SYNCED_NON_ECHO_WEIGHT = 0.25;
+
+/** De-herded Tension benchmark validation. */
+export const TENSION_BENCHMARK_HOLDOUT_MODULUS = 5;
+export const TENSION_BENCHMARK_HOLDOUT_REMAINDER = 0;
+export const GATE_BENCHMARK_MIN_ROWS = 100;
+export const GATE_BENCHMARK_REGRESSION_TOLERANCE = 0.01;
+export const GATE_BENCHMARK_SEGMENT_TOLERANCE = 0.05;
+export const GATE_BENCHMARK_SEGMENT_MIN_ROWS = 50;
+export const GATE_BENCHMARK_MIN_COVERAGE = 0.85;
+export const GATE_BENCHMARK_MAX_COVERAGE = 0.98;
+
+/** Behavior publishing is only allowed where native outcome coverage is broad enough. */
+export const BEHAVIOR_MIN_USERS = 100;
+export const BEHAVIOR_MIN_OUTCOMES = 500;
+export const BEHAVIOR_MAX_TOP_USER_SHARE = 0.03;
+export const BEHAVIOR_MIN_BUCKET_USERS = 10;
+export const BEHAVIOR_MAX_BUCKET_TOP_USER_SHARE = 0.2;
+
+/** Moon bridge remains report-only until there is real paired-user coverage. */
+export const MOON_BRIDGE_MIN_USERS = 50;
+export const MOON_BRIDGE_MIN_SENDS_PER_BOARD = 10;
+export const MOON_BRIDGE_MAX_LOO_DELTA = 0.25;

--- a/packages/db/src/queries/grade-model/deherded.ts
+++ b/packages/db/src/queries/grade-model/deherded.ts
@@ -1,0 +1,413 @@
+import { sql, type SQL } from 'drizzle-orm';
+import {
+  GATE_BENCHMARK_MAX_COVERAGE,
+  GATE_BENCHMARK_MIN_COVERAGE,
+  GATE_BENCHMARK_MIN_ROWS,
+  GATE_BENCHMARK_REGRESSION_TOLERANCE,
+  GATE_BENCHMARK_SEGMENT_MIN_ROWS,
+  GATE_BENCHMARK_SEGMENT_TOLERANCE,
+  STAGE2_DEECHO_MAX_MOVE,
+  TENSION_BENCHMARK_HOLDOUT_MODULUS,
+  TENSION_BENCHMARK_HOLDOUT_REMAINDER,
+} from './constants';
+import { gradeBandForDifficulty } from './blend';
+import type { GateResult } from './types';
+
+export interface TensionBenchmarkHoldoutRow {
+  climb_uuid: string;
+  angle: number;
+  display_difficulty: number;
+  benchmark_difficulty: number;
+  ascensionist_count: number;
+}
+
+export interface TensionBenchmarkPrediction {
+  climbUuid: string;
+  angle: number;
+  displayDifficulty: number;
+  benchmarkDifficulty: number;
+  ascensionistCount: number;
+  stage1Grade: number | null;
+  stage1Low: number | null;
+  stage1High: number | null;
+  stage2Grade: number | null;
+  stage2Low: number | null;
+  stage2High: number | null;
+}
+
+export function buildTensionBenchmarkHoldoutPredicate(): SQL {
+  return sql`
+    s.board_type = 'tension'
+    AND s.benchmark_difficulty IS NOT NULL
+    AND ABS(('x' || SUBSTR(md5(s.climb_uuid || ':' || s.angle::text), 1, 8))::bit(32)::int)
+      % ${TENSION_BENCHMARK_HOLDOUT_MODULUS} = ${TENSION_BENCHMARK_HOLDOUT_REMAINDER}
+  `;
+}
+
+export function buildTensionBenchmarkHoldoutSql(): SQL {
+  return sql`
+    SELECT s.climb_uuid,
+           s.angle,
+           s.display_difficulty,
+           s.benchmark_difficulty,
+           COALESCE(s.ascensionist_count, 0)::int AS ascensionist_count
+    FROM board_climb_stats s
+    JOIN board_climbs bc ON bc.board_type = s.board_type AND bc.uuid = s.climb_uuid
+    WHERE s.board_type = 'tension'
+      AND s.benchmark_difficulty IS NOT NULL
+      AND s.display_difficulty IS NOT NULL
+      AND bc.is_listed = true
+      AND COALESCE(bc.is_draft, false) = false
+      AND ${buildTensionBenchmarkHoldoutPredicate()}
+  `;
+}
+
+function finiteNumber(value: number | null): value is number {
+  return value !== null && Number.isFinite(value);
+}
+
+function meanAbsoluteError(values: number[]): number {
+  return values.length === 0 ? 0 : values.reduce((total, value) => total + Math.abs(value), 0) / values.length;
+}
+
+function bootstrapImprovementLowerBound(improvements: number[]): number {
+  if (improvements.length === 0) return 0;
+  let seed = 3543;
+  const samples: number[] = [];
+  for (let sampleIndex = 0; sampleIndex < 200; sampleIndex++) {
+    let sum = 0;
+    for (let drawIndex = 0; drawIndex < improvements.length; drawIndex++) {
+      seed = (1664525 * seed + 1013904223) >>> 0;
+      const pickedIndex = seed % improvements.length;
+      sum += improvements[pickedIndex];
+    }
+    samples.push(sum / improvements.length);
+  }
+  samples.sort((left, right) => left - right);
+  return samples[Math.floor(samples.length * 0.025)] ?? 0;
+}
+
+export function evaluateTensionBenchmarkHoldout(predictions: TensionBenchmarkPrediction[]): GateResult[] {
+  const scored = predictions.filter(
+    (prediction) => finiteNumber(prediction.stage1Grade) && finiteNumber(prediction.stage2Grade),
+  );
+  const displayErrors = scored.map((prediction) => prediction.displayDifficulty - prediction.benchmarkDifficulty);
+  const stage1Errors = scored.map((prediction) => (prediction.stage1Grade as number) - prediction.benchmarkDifficulty);
+  const stage2Errors = scored.map((prediction) => (prediction.stage2Grade as number) - prediction.benchmarkDifficulty);
+  const pairedImprovements = scored.map(
+    (prediction) =>
+      Math.abs((prediction.stage1Grade as number) - prediction.benchmarkDifficulty) -
+      Math.abs((prediction.stage2Grade as number) - prediction.benchmarkDifficulty),
+  );
+
+  const displayMae = meanAbsoluteError(displayErrors);
+  const stage1Mae = meanAbsoluteError(stage1Errors);
+  const stage2Mae = meanAbsoluteError(stage2Errors);
+  const improvement = stage1Mae > 0 ? 1 - stage2Mae / stage1Mae : 0;
+  const improvementLower95 = bootstrapImprovementLowerBound(pairedImprovements);
+  const benchmarkGate: GateResult = {
+    gate: 'deherded_tension_benchmark',
+    passed: scored.length >= GATE_BENCHMARK_MIN_ROWS && stage2Mae <= stage1Mae + GATE_BENCHMARK_REGRESSION_TOLERANCE,
+    detail:
+      `holdout n=${scored.length}: Stage 2 MAE ${stage2Mae.toFixed(3)} vs Stage 1 ${stage1Mae.toFixed(3)} ` +
+      `(${(improvement * 100).toFixed(1)}% vs Stage 1); display report-only MAE ${displayMae.toFixed(3)}`,
+    metrics: {
+      n: scored.length,
+      displayMae,
+      stage1Mae,
+      stage2Mae,
+      improvement,
+      improvementLower95,
+      tolerance: GATE_BENCHMARK_REGRESSION_TOLERANCE,
+    },
+  };
+
+  const missingIntervalRows = scored.filter(
+    (prediction) => !finiteNumber(prediction.stage2Low) || !finiteNumber(prediction.stage2High),
+  ).length;
+  const coveredRows = scored.filter(
+    (prediction) =>
+      finiteNumber(prediction.stage2Low) &&
+      finiteNumber(prediction.stage2High) &&
+      prediction.stage2Low <= prediction.benchmarkDifficulty &&
+      prediction.benchmarkDifficulty <= prediction.stage2High,
+  ).length;
+  const coverage = scored.length > 0 ? coveredRows / scored.length : 0;
+  const calibrationGate: GateResult = {
+    gate: 'deherded_tension_calibration',
+    passed:
+      scored.length >= GATE_BENCHMARK_MIN_ROWS &&
+      missingIntervalRows === 0 &&
+      coverage >= GATE_BENCHMARK_MIN_COVERAGE &&
+      coverage <= GATE_BENCHMARK_MAX_COVERAGE,
+    detail:
+      `holdout 95% interval coverage ${(coverage * 100).toFixed(1)}% over ${scored.length} rows` +
+      (missingIntervalRows > 0 ? ` (${missingIntervalRows} missing intervals counted uncovered)` : ''),
+    metrics: {
+      n: scored.length,
+      coveredRows,
+      missingIntervalRows,
+      coverage,
+      minCoverage: GATE_BENCHMARK_MIN_COVERAGE,
+      maxCoverage: GATE_BENCHMARK_MAX_COVERAGE,
+    },
+  };
+
+  const segmentGate = evaluateBenchmarkSegments(scored);
+  return [benchmarkGate, calibrationGate, segmentGate];
+}
+
+function trafficBucket(ascensionistCount: number): string {
+  if (ascensionistCount >= 100) return 'traffic_100_plus';
+  if (ascensionistCount >= 20) return 'traffic_20_99';
+  return 'traffic_under_20';
+}
+
+function angleBucket(angle: number): string {
+  return `angle_${Math.floor(angle / 10) * 10}_${Math.floor(angle / 10) * 10 + 9}`;
+}
+
+function addSegment(
+  segments: Map<string, TensionBenchmarkPrediction[]>,
+  key: string,
+  prediction: TensionBenchmarkPrediction,
+): void {
+  const values = segments.get(key) ?? [];
+  values.push(prediction);
+  segments.set(key, values);
+}
+
+function evaluateBenchmarkSegments(scored: TensionBenchmarkPrediction[]): GateResult {
+  const segments = new Map<string, TensionBenchmarkPrediction[]>();
+  for (const prediction of scored) {
+    addSegment(segments, `band_${gradeBandForDifficulty(prediction.displayDifficulty)}`, prediction);
+    addSegment(segments, angleBucket(prediction.angle), prediction);
+    addSegment(segments, trafficBucket(prediction.ascensionistCount), prediction);
+  }
+
+  let checkedSegments = 0;
+  let violations = 0;
+  let worstRegression = 0;
+  let worstSegment = '';
+  for (const [segmentKey, segmentRows] of segments) {
+    if (segmentRows.length < GATE_BENCHMARK_SEGMENT_MIN_ROWS) continue;
+    checkedSegments += 1;
+    const stage1Mae = meanAbsoluteError(
+      segmentRows.map((prediction) => (prediction.stage1Grade as number) - prediction.benchmarkDifficulty),
+    );
+    const stage2Mae = meanAbsoluteError(
+      segmentRows.map((prediction) => (prediction.stage2Grade as number) - prediction.benchmarkDifficulty),
+    );
+    const regression = stage2Mae - stage1Mae;
+    if (regression > worstRegression) {
+      worstRegression = regression;
+      worstSegment = segmentKey;
+    }
+    if (regression > GATE_BENCHMARK_SEGMENT_TOLERANCE) violations += 1;
+  }
+
+  return {
+    gate: 'deherded_segment_no_regression',
+    passed: violations === 0 && checkedSegments > 0,
+    detail:
+      `${violations} of ${checkedSegments} benchmark segments regressed by > ${GATE_BENCHMARK_SEGMENT_TOLERANCE} MAE` +
+      (worstSegment ? `; worst=${worstSegment} Δ=${worstRegression.toFixed(3)}` : ''),
+    metrics: {
+      checkedSegments,
+      violations,
+      worstRegression,
+      tolerance: GATE_BENCHMARK_SEGMENT_TOLERANCE,
+      minRows: GATE_BENCHMARK_SEGMENT_MIN_ROWS,
+    },
+  };
+}
+
+export interface DeherdCrowdInput {
+  observedMean: number | null;
+  displayGrade: number | null;
+  echoFraction: number;
+  independentWeight: number;
+}
+
+export interface DeherdCrowdOptions {
+  minIndependentWeight: number;
+  maxMoveFromObserved: number;
+  maxMoveFromDisplay: number;
+  echoFractionClamp: readonly [number, number];
+}
+
+export interface DeherdCrowdResult {
+  grade: number | null;
+  eligible: boolean;
+  capped: boolean;
+  reason: 'missing_observed_mean' | 'missing_display_grade' | 'thin_evidence' | 'no_echo' | null;
+  rawDeltaFromDisplay: number | null;
+  deherdedDeltaFromDisplay: number | null;
+}
+
+export interface DeherdedGradeSignal {
+  name: string;
+  grade: number | null;
+  standardError: number | null;
+  weight?: number | null;
+}
+
+export interface DeherdedSignalBlend {
+  grade: number;
+  totalWeight: number;
+  signalCount: number;
+}
+
+export interface DeherdedBenchmarkRow {
+  benchmarkGrade: number | null;
+  rawGrade: number | null;
+  deherdedGrade: number | null;
+  weight?: number | null;
+}
+
+export interface DeherdedBenchmarkSummary {
+  rows: number;
+  rawMae: number;
+  deherdedMae: number;
+  improvement: number;
+  passedNoRegression: boolean;
+}
+
+export const DEFAULT_DEHERD_CROWD_OPTIONS: Readonly<DeherdCrowdOptions> = {
+  minIndependentWeight: 3,
+  maxMoveFromObserved: STAGE2_DEECHO_MAX_MOVE,
+  maxMoveFromDisplay: 4,
+  echoFractionClamp: [0, 0.95],
+};
+
+function resolveDeherdOptions(options: Partial<DeherdCrowdOptions> | undefined): DeherdCrowdOptions {
+  return { ...DEFAULT_DEHERD_CROWD_OPTIONS, ...options };
+}
+
+function clampNumber(gradeNumber: number, low: number, high: number): number {
+  return Math.min(high, Math.max(low, gradeNumber));
+}
+
+export function deherdCrowdMean(input: DeherdCrowdInput, options?: Partial<DeherdCrowdOptions>): DeherdCrowdResult {
+  const resolvedOptions = resolveDeherdOptions(options);
+  if (!finiteNumber(input.observedMean)) {
+    return {
+      grade: null,
+      eligible: false,
+      capped: false,
+      reason: 'missing_observed_mean',
+      rawDeltaFromDisplay: null,
+      deherdedDeltaFromDisplay: null,
+    };
+  }
+  if (!finiteNumber(input.displayGrade)) {
+    return {
+      grade: input.observedMean,
+      eligible: false,
+      capped: false,
+      reason: 'missing_display_grade',
+      rawDeltaFromDisplay: null,
+      deherdedDeltaFromDisplay: null,
+    };
+  }
+  if (input.independentWeight < resolvedOptions.minIndependentWeight) {
+    return {
+      grade: input.observedMean,
+      eligible: false,
+      capped: false,
+      reason: 'thin_evidence',
+      rawDeltaFromDisplay: input.observedMean - input.displayGrade,
+      deherdedDeltaFromDisplay: input.observedMean - input.displayGrade,
+    };
+  }
+
+  const echoFraction = clampNumber(
+    input.echoFraction,
+    resolvedOptions.echoFractionClamp[0],
+    resolvedOptions.echoFractionClamp[1],
+  );
+  if (echoFraction <= 0) {
+    return {
+      grade: input.observedMean,
+      eligible: false,
+      capped: false,
+      reason: 'no_echo',
+      rawDeltaFromDisplay: input.observedMean - input.displayGrade,
+      deherdedDeltaFromDisplay: input.observedMean - input.displayGrade,
+    };
+  }
+
+  const rawDeherdedGrade = input.displayGrade + (input.observedMean - input.displayGrade) / (1 - echoFraction);
+  const cappedByObserved = clampNumber(
+    rawDeherdedGrade,
+    input.observedMean - resolvedOptions.maxMoveFromObserved,
+    input.observedMean + resolvedOptions.maxMoveFromObserved,
+  );
+  const cappedGrade = clampNumber(
+    cappedByObserved,
+    input.displayGrade - resolvedOptions.maxMoveFromDisplay,
+    input.displayGrade + resolvedOptions.maxMoveFromDisplay,
+  );
+
+  return {
+    grade: cappedGrade,
+    eligible: true,
+    capped: Math.abs(cappedGrade - rawDeherdedGrade) > 1e-12,
+    reason: null,
+    rawDeltaFromDisplay: input.observedMean - input.displayGrade,
+    deherdedDeltaFromDisplay: cappedGrade - input.displayGrade,
+  };
+}
+
+export function combineDeherdedSignals(signals: readonly DeherdedGradeSignal[]): DeherdedSignalBlend | null {
+  let weightedGradeSum = 0;
+  let totalWeight = 0;
+  let signalCount = 0;
+
+  for (const signal of signals) {
+    if (!finiteNumber(signal.grade)) continue;
+    let signalWeight: number;
+    if (signal.weight !== undefined && signal.weight !== null && Number.isFinite(signal.weight) && signal.weight > 0) {
+      signalWeight = signal.weight;
+    } else if (signal.standardError !== null && Number.isFinite(signal.standardError) && signal.standardError > 0) {
+      signalWeight = 1 / (signal.standardError * signal.standardError);
+    } else {
+      signalWeight = 1;
+    }
+    weightedGradeSum += signal.grade * signalWeight;
+    totalWeight += signalWeight;
+    signalCount += 1;
+  }
+
+  if (totalWeight <= 0) return null;
+  return { grade: weightedGradeSum / totalWeight, totalWeight, signalCount };
+}
+
+export function evaluateDeherdedBenchmark(rows: readonly DeherdedBenchmarkRow[]): DeherdedBenchmarkSummary {
+  let rawAbsError = 0;
+  let deherdedAbsError = 0;
+  let totalWeight = 0;
+  let rowCount = 0;
+
+  for (const row of rows) {
+    if (!finiteNumber(row.benchmarkGrade) || !finiteNumber(row.rawGrade) || !finiteNumber(row.deherdedGrade)) {
+      continue;
+    }
+    const rowWeight = row.weight === undefined || row.weight === null ? 1 : row.weight;
+    if (!Number.isFinite(rowWeight) || rowWeight <= 0) continue;
+    rawAbsError += Math.abs(row.rawGrade - row.benchmarkGrade) * rowWeight;
+    deherdedAbsError += Math.abs(row.deherdedGrade - row.benchmarkGrade) * rowWeight;
+    totalWeight += rowWeight;
+    rowCount += 1;
+  }
+
+  const rawMae = totalWeight > 0 ? rawAbsError / totalWeight : 0;
+  const deherdedMae = totalWeight > 0 ? deherdedAbsError / totalWeight : 0;
+  return {
+    rows: rowCount,
+    rawMae,
+    deherdedMae,
+    improvement: rawMae > 0 ? 1 - deherdedMae / rawMae : 0,
+    passedNoRegression: deherdedMae <= rawMae + 1e-12,
+  };
+}

--- a/packages/db/src/queries/grade-model/index.ts
+++ b/packages/db/src/queries/grade-model/index.ts
@@ -5,3 +5,7 @@ export * from './coefficients';
 export * from './gates';
 export * from './hygiene';
 export * from './isotonic';
+export * from './raters';
+export * from './behavior';
+export * from './bridges';
+export * from './deherded';

--- a/packages/db/src/queries/grade-model/raters.ts
+++ b/packages/db/src/queries/grade-model/raters.ts
@@ -1,0 +1,395 @@
+import { sql, type SQL } from 'drizzle-orm';
+import {
+  STAGE2_SYNCED_NON_ECHO_WEIGHT,
+  STAGE2_USER_BIAS_MAX_ABS,
+  STAGE2_USER_BIAS_MIN_EFFECTIVE_N,
+  STAGE2_USER_BIAS_PRIOR_WEIGHT,
+} from './constants';
+import type { RaterModelCoefficient, Stage2Evidence } from './types';
+import { buildTensionBenchmarkHoldoutPredicate } from './deherded';
+
+export interface RaterSampleRow {
+  board_type: string;
+  user_id: string;
+  climb_uuid: string;
+  angle: number;
+  origin: string;
+  difficulty: number;
+  display_difficulty: number;
+  difficulty_average: number;
+  gym_id: number | null;
+  board_id: number | null;
+}
+
+export type Stage2EvidenceMap = Map<string, Stage2Evidence>;
+
+export function stage2EvidenceKey(boardType: string, climbUuid: string, angle: number): string {
+  return `${boardType}\u0000${climbUuid}\u0000${angle}`;
+}
+
+interface Stage2SampleSqlOptions {
+  excludeTensionBenchmarkHoldout?: boolean;
+}
+
+/**
+ * Latest graded opinion per user/canonical-climb/angle. Tension benchmark
+ * holdout rows are excluded from fitting; benchmark grades may only be used as
+ * validation targets.
+ */
+export function buildRaterSampleSql(options: Stage2SampleSqlOptions = { excludeTensionBenchmarkHoldout: true }): SQL {
+  const excludeHoldout = options.excludeTensionBenchmarkHoldout ?? true;
+  return sql`
+    SELECT DISTINCT ON (t.user_id, t.board_type, COALESCE(a.canonical_uuid, t.climb_uuid), t.angle)
+           t.board_type,
+           t.user_id,
+           COALESCE(a.canonical_uuid, t.climb_uuid) AS climb_uuid,
+           t.angle,
+           t.origin,
+           t.difficulty,
+           s.display_difficulty,
+           s.difficulty_average,
+           ub.gym_id,
+           t.board_id
+    FROM boardsesh_ticks t
+    LEFT JOIN board_climb_aliases a
+      ON a.board_type = t.board_type AND a.alias_uuid = t.climb_uuid
+    JOIN board_climb_stats s
+      ON s.board_type = t.board_type
+     AND s.climb_uuid = COALESCE(a.canonical_uuid, t.climb_uuid)
+     AND s.angle = t.angle
+    JOIN board_climbs bc
+      ON bc.board_type = s.board_type AND bc.uuid = s.climb_uuid
+    LEFT JOIN user_boards ub ON ub.id = t.board_id
+    WHERE t.difficulty IS NOT NULL
+      AND t.status IN ('flash', 'send')
+      AND s.difficulty_average IS NOT NULL
+      AND s.display_difficulty IS NOT NULL
+      AND bc.is_listed = true
+      AND COALESCE(bc.is_draft, false) = false
+      AND (${excludeHoldout ? sql`NOT (${buildTensionBenchmarkHoldoutPredicate()})` : sql`true`})
+    ORDER BY t.user_id, t.board_type, COALESCE(a.canonical_uuid, t.climb_uuid), t.angle, t.climbed_at DESC
+  `;
+}
+
+function numeric(value: number | string): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+function raterWeight(sample: RaterSampleRow): number {
+  const isNative = sample.origin === 'native';
+  const isExactDisplayEcho = numeric(sample.difficulty) === Math.round(numeric(sample.display_difficulty));
+  if (isNative) return 1;
+  return isExactDisplayEcho ? 0 : STAGE2_SYNCED_NON_ECHO_WEIGHT;
+}
+
+export function raterLocationKey(sample: Pick<RaterSampleRow, 'user_id' | 'gym_id' | 'board_id'>): string {
+  if (sample.gym_id !== null) return `${sample.user_id}:gym:${sample.gym_id}`;
+  if (sample.board_id !== null) return `${sample.user_id}:board:${sample.board_id}`;
+  return `${sample.user_id}:unknown`;
+}
+
+function clampBias(value: number): number {
+  return Math.min(STAGE2_USER_BIAS_MAX_ABS, Math.max(-STAGE2_USER_BIAS_MAX_ABS, value));
+}
+
+export function estimateRaterModels(samples: RaterSampleRow[]): Record<string, RaterModelCoefficient> {
+  const residualsByBoardLocation = new Map<
+    string,
+    { boardType: string; weightedResidual: number; effectiveN: number; rawVotes: number }
+  >();
+  const userWeightsByBoard = new Map<string, Map<string, number>>();
+
+  for (const sample of samples) {
+    const weight = raterWeight(sample);
+    if (weight <= 0) continue;
+    const boardType = sample.board_type;
+    const locationKey = raterLocationKey(sample);
+    const accumulatorKey = `${boardType}\u0000${locationKey}`;
+    const accumulator = residualsByBoardLocation.get(accumulatorKey) ?? {
+      boardType,
+      weightedResidual: 0,
+      effectiveN: 0,
+      rawVotes: 0,
+    };
+    accumulator.weightedResidual += (numeric(sample.difficulty) - numeric(sample.difficulty_average)) * weight;
+    accumulator.effectiveN += weight;
+    accumulator.rawVotes += 1;
+    residualsByBoardLocation.set(accumulatorKey, accumulator);
+
+    const boardUserWeights = userWeightsByBoard.get(boardType) ?? new Map<string, number>();
+    boardUserWeights.set(sample.user_id, (boardUserWeights.get(sample.user_id) ?? 0) + weight);
+    userWeightsByBoard.set(boardType, boardUserWeights);
+  }
+
+  const models: Record<string, RaterModelCoefficient> = {};
+  for (const [accumulatorKey, accumulator] of residualsByBoardLocation) {
+    if (accumulator.effectiveN < STAGE2_USER_BIAS_MIN_EFFECTIVE_N) continue;
+    const [, locationKey] = accumulatorKey.split('\u0000');
+    const shrinkage = accumulator.effectiveN / (accumulator.effectiveN + STAGE2_USER_BIAS_PRIOR_WEIGHT);
+    const bias = clampBias((accumulator.weightedResidual / accumulator.effectiveN) * shrinkage);
+    const model =
+      models[accumulator.boardType] ??
+      ({
+        boardType: accumulator.boardType,
+        biases: {},
+        summary: { expressedVotes: 0, users: 0, locations: 0, topUserShare: 0 },
+      } satisfies RaterModelCoefficient);
+    model.biases[locationKey] = {
+      bias,
+      shrinkage,
+      effectiveN: accumulator.effectiveN,
+      rawVotes: accumulator.rawVotes,
+      weightedResidual: accumulator.weightedResidual,
+    };
+    model.summary.expressedVotes += accumulator.effectiveN;
+    model.summary.locations += 1;
+    models[accumulator.boardType] = model;
+  }
+
+  for (const [boardType, model] of Object.entries(models)) {
+    const boardUserWeights = userWeightsByBoard.get(boardType) ?? new Map<string, number>();
+    let topUserWeight = 0;
+    let totalUserWeight = 0;
+    for (const userWeight of boardUserWeights.values()) {
+      topUserWeight = Math.max(topUserWeight, userWeight);
+      totalUserWeight += userWeight;
+    }
+    model.summary.users = boardUserWeights.size;
+    model.summary.topUserShare = totalUserWeight > 0 ? topUserWeight / totalUserWeight : 0;
+  }
+
+  return models;
+}
+
+function biasExcludingTarget(
+  coefficient: RaterModelCoefficient['biases'][string] | undefined,
+  heldOut: { weightedResidual: number; effectiveN: number } | undefined,
+): number {
+  if (!coefficient) return 0;
+  const effectiveN = coefficient.effectiveN - (heldOut?.effectiveN ?? 0);
+  if (effectiveN < STAGE2_USER_BIAS_MIN_EFFECTIVE_N) return 0;
+  const weightedResidual = coefficient.weightedResidual - (heldOut?.weightedResidual ?? 0);
+  const shrinkage = effectiveN / (effectiveN + STAGE2_USER_BIAS_PRIOR_WEIGHT);
+  return clampBias((weightedResidual / effectiveN) * shrinkage);
+}
+
+export function buildRaterEvidence(
+  samples: RaterSampleRow[],
+  models: Record<string, RaterModelCoefficient>,
+  biasTrainingSamples: RaterSampleRow[] = samples,
+): Stage2EvidenceMap {
+  const heldOutByEvidenceLocation = new Map<string, { weightedResidual: number; effectiveN: number }>();
+  for (const sample of biasTrainingSamples) {
+    const weight = raterWeight(sample);
+    if (weight <= 0) continue;
+    const evidenceKey = stage2EvidenceKey(sample.board_type, sample.climb_uuid, numeric(sample.angle));
+    const locationKey = raterLocationKey(sample);
+    const heldOutKey = `${evidenceKey}\u0000${locationKey}`;
+    const accumulator = heldOutByEvidenceLocation.get(heldOutKey) ?? { weightedResidual: 0, effectiveN: 0 };
+    accumulator.weightedResidual += (numeric(sample.difficulty) - numeric(sample.difficulty_average)) * weight;
+    accumulator.effectiveN += weight;
+    heldOutByEvidenceLocation.set(heldOutKey, accumulator);
+  }
+
+  const evidenceAccumulator = new Map<string, { weightedDifficulty: number; effectiveN: number; rawVotes: number }>();
+
+  for (const sample of samples) {
+    const weight = raterWeight(sample);
+    if (weight <= 0) continue;
+    const model = models[sample.board_type];
+    if (!model) continue;
+    const locationKey = raterLocationKey(sample);
+    const evidenceKey = stage2EvidenceKey(sample.board_type, sample.climb_uuid, numeric(sample.angle));
+    const bias = biasExcludingTarget(
+      model.biases[locationKey],
+      heldOutByEvidenceLocation.get(`${evidenceKey}\u0000${locationKey}`),
+    );
+    const adjustedDifficulty = numeric(sample.difficulty) - bias;
+    const accumulator = evidenceAccumulator.get(evidenceKey) ?? { weightedDifficulty: 0, effectiveN: 0, rawVotes: 0 };
+    accumulator.weightedDifficulty += adjustedDifficulty * weight;
+    accumulator.effectiveN += weight;
+    accumulator.rawVotes += 1;
+    evidenceAccumulator.set(evidenceKey, accumulator);
+  }
+
+  const evidence = new Map<string, Stage2Evidence>();
+  for (const [evidenceKey, accumulator] of evidenceAccumulator) {
+    evidence.set(evidenceKey, {
+      raterMean: accumulator.effectiveN > 0 ? accumulator.weightedDifficulty / accumulator.effectiveN : null,
+      raterEffectiveN: accumulator.effectiveN,
+      behaviorMean: null,
+      behaviorEffectiveN: 0,
+    });
+  }
+  return evidence;
+}
+
+export interface RaterOpinion {
+  raterId: string;
+  /** The grade the user explicitly logged, on the board's ordinal grade scale. */
+  difficulty: number | null;
+  /** Independent reference grade to compare against, usually a held-out/posterior grade. */
+  referenceGrade: number | null;
+  /** Displayed grade at logging time when available; used only to identify echoes. */
+  displayDifficulty: number | null;
+  /** Tick provenance, for example 'native', 'aurora_pull', or 'kilter_pull'. */
+  origin: string | null;
+}
+
+export interface RaterModelOptions {
+  /** Synced exact-display echoes are likely quick-log auto-fills. */
+  syncedEchoWeight: number;
+  /** Native exact-display echoes are opt-in agreement and keep full weight by default. */
+  nativeEchoWeight: number;
+  nonEchoWeight: number;
+  /** Synced non-echo grades are opinions, but still come from an anchored upstream flow. */
+  syncedNonEchoWeight: number;
+  minEffectiveWeight: number;
+  /** Zero-centered ridge prior, in effective-opinion units. */
+  priorWeight: number;
+  maxAbsBias: number;
+}
+
+export interface RaterBiasEstimate {
+  raterId: string;
+  /** Positive means the rater logs grades harder than the reference. */
+  bias: number;
+  effectiveWeight: number;
+  opinionCount: number;
+}
+
+export interface BiasAdjustedGradeEstimate {
+  grade: number;
+  effectiveWeight: number;
+  opinionCount: number;
+  meanBiasApplied: number;
+  weightedSd: number | null;
+}
+
+export const DEFAULT_RATER_MODEL_OPTIONS: Readonly<RaterModelOptions> = {
+  syncedEchoWeight: 0,
+  nativeEchoWeight: 1,
+  nonEchoWeight: 1,
+  syncedNonEchoWeight: STAGE2_SYNCED_NON_ECHO_WEIGHT,
+  minEffectiveWeight: STAGE2_USER_BIAS_MIN_EFFECTIVE_N,
+  priorWeight: STAGE2_USER_BIAS_PRIOR_WEIGHT,
+  maxAbsBias: STAGE2_USER_BIAS_MAX_ABS,
+};
+
+function resolveRaterOptions(options: Partial<RaterModelOptions> | undefined): RaterModelOptions {
+  return { ...DEFAULT_RATER_MODEL_OPTIONS, ...options };
+}
+
+function isFiniteGrade(gradeNumber: number | null): gradeNumber is number {
+  return gradeNumber !== null && Number.isFinite(gradeNumber);
+}
+
+function clampMagnitude(gradeDelta: number, maxAbsMagnitude: number): number {
+  return Math.min(maxAbsMagnitude, Math.max(-maxAbsMagnitude, gradeDelta));
+}
+
+export function isDisplayEcho(opinion: RaterOpinion): boolean {
+  return isFiniteGrade(opinion.difficulty) && isFiniteGrade(opinion.displayDifficulty)
+    ? opinion.difficulty === Math.round(opinion.displayDifficulty)
+    : false;
+}
+
+export function isSyncedDisplayEcho(opinion: RaterOpinion): boolean {
+  return isDisplayEcho(opinion) && opinion.origin !== 'native';
+}
+
+export function raterOpinionWeight(opinion: RaterOpinion, options?: Partial<RaterModelOptions>): number {
+  const resolvedOptions = resolveRaterOptions(options);
+  if (!isFiniteGrade(opinion.difficulty) || !isFiniteGrade(opinion.referenceGrade)) return 0;
+  if (!isDisplayEcho(opinion)) {
+    return Math.max(
+      0,
+      opinion.origin === 'native' ? resolvedOptions.nonEchoWeight : resolvedOptions.syncedNonEchoWeight,
+    );
+  }
+  return Math.max(0, opinion.origin === 'native' ? resolvedOptions.nativeEchoWeight : resolvedOptions.syncedEchoWeight);
+}
+
+export function estimateRaterBiases(
+  opinions: readonly RaterOpinion[],
+  options?: Partial<RaterModelOptions>,
+): Map<string, RaterBiasEstimate> {
+  const resolvedOptions = resolveRaterOptions(options);
+  const accumulators = new Map<
+    string,
+    { weightedResidualSum: number; effectiveWeight: number; opinionCount: number }
+  >();
+
+  for (const opinion of opinions) {
+    const weight = raterOpinionWeight(opinion, resolvedOptions);
+    if (weight <= 0 || !isFiniteGrade(opinion.difficulty) || !isFiniteGrade(opinion.referenceGrade)) continue;
+    const accumulator = accumulators.get(opinion.raterId) ?? {
+      weightedResidualSum: 0,
+      effectiveWeight: 0,
+      opinionCount: 0,
+    };
+    accumulator.weightedResidualSum += (opinion.difficulty - opinion.referenceGrade) * weight;
+    accumulator.effectiveWeight += weight;
+    accumulator.opinionCount += 1;
+    accumulators.set(opinion.raterId, accumulator);
+  }
+
+  const estimates = new Map<string, RaterBiasEstimate>();
+  for (const [raterId, accumulator] of accumulators) {
+    if (accumulator.effectiveWeight < resolvedOptions.minEffectiveWeight) continue;
+    const shrunkBias = accumulator.weightedResidualSum / (accumulator.effectiveWeight + resolvedOptions.priorWeight);
+    estimates.set(raterId, {
+      raterId,
+      bias: clampMagnitude(shrunkBias, resolvedOptions.maxAbsBias),
+      effectiveWeight: accumulator.effectiveWeight,
+      opinionCount: accumulator.opinionCount,
+    });
+  }
+  return estimates;
+}
+
+export function computeBiasAdjustedGrade(
+  opinions: readonly RaterOpinion[],
+  biases: ReadonlyMap<string, RaterBiasEstimate>,
+  options?: Partial<RaterModelOptions>,
+): BiasAdjustedGradeEstimate | null {
+  const resolvedOptions = resolveRaterOptions(options);
+  const adjustedGrades: Array<{ grade: number; weight: number; bias: number }> = [];
+
+  for (const opinion of opinions) {
+    const weight = raterOpinionWeight(opinion, resolvedOptions);
+    if (weight <= 0 || !isFiniteGrade(opinion.difficulty)) continue;
+    const bias = biases.get(opinion.raterId)?.bias ?? 0;
+    adjustedGrades.push({ grade: opinion.difficulty - bias, weight, bias });
+  }
+
+  const effectiveWeight = adjustedGrades.reduce((weightTotal, adjustedGrade) => weightTotal + adjustedGrade.weight, 0);
+  if (effectiveWeight <= 0) return null;
+
+  const grade =
+    adjustedGrades.reduce(
+      (weightedGradeSum, adjustedGrade) => weightedGradeSum + adjustedGrade.grade * adjustedGrade.weight,
+      0,
+    ) / effectiveWeight;
+  const meanBiasApplied =
+    adjustedGrades.reduce(
+      (weightedBiasSum, adjustedGrade) => weightedBiasSum + adjustedGrade.bias * adjustedGrade.weight,
+      0,
+    ) / effectiveWeight;
+  const weightedVariance =
+    adjustedGrades.length < 2
+      ? null
+      : adjustedGrades.reduce(
+          (varianceSum, adjustedGrade) =>
+            varianceSum + adjustedGrade.weight * (adjustedGrade.grade - grade) * (adjustedGrade.grade - grade),
+          0,
+        ) / effectiveWeight;
+
+  return {
+    grade,
+    effectiveWeight,
+    opinionCount: adjustedGrades.length,
+    meanBiasApplied,
+    weightedSd: weightedVariance === null ? null : Math.sqrt(weightedVariance),
+  };
+}

--- a/packages/db/src/queries/grade-model/types.ts
+++ b/packages/db/src/queries/grade-model/types.ts
@@ -1,5 +1,58 @@
 import type { ConfidenceTier, GradeBandKey } from './constants';
 
+export interface RaterBiasCoefficient {
+  bias: number;
+  shrinkage: number;
+  effectiveN: number;
+  rawVotes: number;
+  weightedResidual: number;
+}
+
+export interface RaterModelCoefficient {
+  boardType: string;
+  biases: Record<string, RaterBiasCoefficient>;
+  summary: {
+    expressedVotes: number;
+    users: number;
+    locations: number;
+    topUserShare: number;
+  };
+}
+
+export type BehaviorOutcomeBucket = 'flash' | 'send_2_3' | 'send_4_plus' | 'attempt_1_3' | 'attempt_4_plus';
+
+export interface BehaviorModelCoefficient {
+  boardType: string;
+  boardMean: number;
+  outcomeOffset: Partial<Record<BehaviorOutcomeBucket, number>>;
+  eligible: boolean;
+  summary: {
+    users: number;
+    outcomes: number;
+    topUserShare: number;
+    usedUsers: number;
+    usedOutcomes: number;
+    usedTopUserShare: number;
+  };
+}
+
+export interface Stage2Evidence {
+  raterMean: number | null;
+  raterEffectiveN: number;
+  behaviorMean: number | null;
+  behaviorEffectiveN: number;
+}
+
+export interface MoonBridgeReadiness {
+  boardType: 'moonboard';
+  bridgeUsers: number;
+  requiredUsers: number;
+  minSendsPerBoard: number;
+  candidateOffset: number | null;
+  looMaxDelta: number | null;
+  publishable: boolean;
+}
+
 /** Frozen coefficient set the nightly re-blend runs against. */
 export interface GradeCoefficients {
   coeffVersion: string;
@@ -21,6 +74,12 @@ export interface GradeCoefficients {
    * entry never publish a universal grade.
    */
   boardOffset: Record<string, { offset: number; sd: number; users: number; looMaxDelta: number }>;
+  /** Stage 2 shrunk per-user/location rater bias models, per board. */
+  raterModel: Record<string, RaterModelCoefficient>;
+  /** Stage 2 anchoring-resistant behavior outcome models, per board. */
+  behaviorModel: Record<string, BehaviorModelCoefficient>;
+  /** Report-only bridge readiness for boards that are not yet publishable. */
+  bridgeReadiness: Record<string, MoonBridgeReadiness>;
 }
 
 /** One climb+angle observation from board_climb_stats, ready to blend. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -189,6 +189,12 @@ export default defineConfig({
         // flags with `vp run db:dedupe-beta-links -- --apply`.
         cache: false,
       },
+      'db:refresh-climb-grades': {
+        command: 'bun run --filter=@boardsesh/db db:refresh-climb-grades',
+        // No db:up dependency: this often targets a remote DB_URL and supports
+        // read-only validation/dry-runs before writing published grade rows.
+        cache: false,
+      },
       'test:db': {
         command: 'bun run --filter=@boardsesh/db test',
       },


### PR DESCRIPTION
## Summary

Fixes #3543.

Implements the Stage 2 grade model for Boardsesh grades:

- adds capped de-herding, rater-bias, and native behavior evidence paths
- validates Stage 2 against the held-out Tension benchmark set before publishing
- keeps MoonBoard bridge work report-only until the paired-user data gap is closed
- adds a `db:refresh-climb-grades` task and documents the v2.0 model/gates

## Notes

The Moon data gap is intentionally not fixed in this PR. The bridge readiness gate reports current coverage and withholds Moon standardization until there is enough paired-user evidence.

The behavior and rater models use train/predict splits for the benchmark holdout. Behavior offsets also leave target climb rows out of the bucket and user ability sufficient stats to avoid in-sample leakage.

## Validation

- `vp staged`
- `vp run typecheck:db`
- `vp run db:refresh-climb-grades -- --validate-only`
  - all blocking gates passed
  - completed with `validate-only done (nothing written)`
- `vp run test:db -- src/queries/grade-model/__tests__/stage2-helpers.test.ts`
  - Stage 2 rater, behavior, bridge, and de-herded helper suites passed
  - command still exits nonzero because of the existing unrelated `user_boards serial uniqueness` integration failure
