### PR TITLE
fix(db): harden stage 2 grade refresh

### DIFF
--- a/.github/workflows/refresh-climb-grades.yml
+++ b/.github/workflows/refresh-climb-grades.yml
@@ -1,9 +1,10 @@
 name: Refresh Climb Grades
 
-# Nightly: recompute the Boardsesh grade (empirical-Bayes blend of upstream
-# crowd means, angle surface, cross-board offset) into board_climb_grades.
-# Validation gates run first and abort the run — no grades are written on a
-# gate failure. Coefficients refit weekly, frozen in between. Idempotent.
+# Nightly: recompute the Boardsesh v2 grade (empirical-Bayes crowd mean plus
+# capped Stage 2 de-herding, rater, behavior, angle, and cross-board evidence)
+# into board_climb_grades. Validation gates run first and abort the run — no
+# coefficients, gate results, or grades are written on a gate failure.
+# Coefficients refit weekly, frozen in between. Idempotent.
 # Model spec: docs/boardsesh-grade.md.
 on:
   schedule:
@@ -15,7 +16,7 @@ on:
         type: boolean
         default: false
       dry_run:
-        description: 'Gates only, write no grades'
+        description: 'Gates only, write no coefficients, gate results, or grades'
         type: boolean
         default: false
 

--- a/docs/boardsesh-grade.md
+++ b/docs/boardsesh-grade.md
@@ -430,11 +430,24 @@ Unit tests:
 vp run test:db
 ```
 
-The pipeline locally, against the dev DB (or a read-only prod `DB_URL`):
+Read-only validation against the dev DB or a read-only prod `DB_URL`:
 
 ```
 vp run db:refresh-climb-grades -- --validate-only
+vp run db:refresh-climb-grades -- --validate-only --allow-empty-backtest
+```
+
+Publish-path validation is also read-only, but requires the grade tables because
+it exercises hysteresis against existing rows:
+
+```
 vp run db:refresh-climb-grades -- --dry-run
+```
+
+Writable publish paths require a writable `DB_URL`:
+
+```
+vp run db:refresh-climb-grades --
 vp run db:refresh-climb-grades -- --refit-coefficients
 ```
 
@@ -446,6 +459,8 @@ vp run db:refresh-climb-grades -- --refit-coefficients
   coefficients, gate results, or grade rows.
 - `--refit-coefficients` forces a weekly refit instead of reusing the frozen set.
 - A bare run reuses frozen coefficients if they're under a week old, else refits.
+- `--allow-empty-backtest` is only for dev-style databases without stats history;
+  production validation should not use it.
 
 ### Where things are stored
 

--- a/packages/db/scripts/refresh-climb-grades.ts
+++ b/packages/db/scripts/refresh-climb-grades.ts
@@ -78,6 +78,7 @@ import {
   type BacktestSampleRow,
   type BehaviorSampleRow,
   type BoardOffsetSampleRow,
+  type ConfidenceTier,
   type ClimbAngleObservation,
   type EchoRateRow,
   type DisplayDeltaHygieneStats,
@@ -98,14 +99,85 @@ const COEFF_MAX_AGE_DAYS = 7;
 const BACKTEST_SAMPLE_LIMIT = 20000;
 const READ_PAGE_ROWS = 20000;
 const UPSERT_BATCH = 500;
+const REFRESH_KEY_BATCH = 5000;
 
 type Db = ReturnType<typeof createScriptDb>['db'];
+type DbTransaction = Parameters<Parameters<Db['transaction']>[0]>[0];
+type DbWriter = Pick<Db, 'execute' | 'insert'> | Pick<DbTransaction, 'execute' | 'insert'>;
 
 interface CoefficientRow {
   coeff_version: string;
   kind: string;
   key: string;
   payload: unknown;
+}
+
+interface PendingCoefficientRow {
+  kind: string;
+  key: string;
+  payload: unknown;
+}
+
+function buildCoefficientRows(coefficients: GradeCoefficients): PendingCoefficientRow[] {
+  return [
+    ...Object.entries(coefficients.echoFraction).map(([board, lambda]) => ({
+      kind: 'echo_fraction',
+      key: board,
+      payload: { lambda },
+    })),
+    ...Object.entries(coefficients.sigmaWithin).map(([board, payload]) => ({
+      kind: 'sigma_within',
+      key: board,
+      payload,
+    })),
+    ...Object.entries(coefficients.tauSquared).map(([board, payload]) => ({
+      kind: 'tau_squared',
+      key: board,
+      payload,
+    })),
+    ...Object.entries(coefficients.angleOffset).map(([board, payload]) => ({
+      kind: 'angle_offset',
+      key: board,
+      payload,
+    })),
+    ...Object.entries(coefficients.boardOffset).map(([board, payload]) => ({
+      kind: 'board_offset',
+      key: board,
+      payload,
+    })),
+    ...Object.entries(coefficients.raterModel).map(([board, payload]) => ({
+      kind: 'rater_model',
+      key: board,
+      payload,
+    })),
+    ...Object.entries(coefficients.behaviorModel).map(([board, payload]) => ({
+      kind: 'behavior_model',
+      key: board,
+      payload,
+    })),
+    ...Object.entries(coefficients.bridgeReadiness).map(([board, payload]) => ({
+      kind: 'bridge_readiness',
+      key: board,
+      payload,
+    })),
+  ];
+}
+
+async function persistCoefficients(db: DbWriter, coefficients: GradeCoefficients): Promise<void> {
+  for (const row of buildCoefficientRows(coefficients)) {
+    await db
+      .insert(boardGradeCoefficients)
+      .values({
+        coeffVersion: coefficients.coeffVersion,
+        kind: row.kind,
+        key: row.key,
+        payload: row.payload,
+      })
+      .onConflictDoUpdate({
+        target: [boardGradeCoefficients.coeffVersion, boardGradeCoefficients.kind, boardGradeCoefficients.key],
+        set: { payload: row.payload },
+      });
+  }
 }
 
 async function loadFrozenCoefficients(db: Db): Promise<GradeCoefficients | null> {
@@ -221,42 +293,12 @@ async function refitCoefficients(
     console.warn('[grades] too few shared Kilter/Tension users — universal grades for Kilter withheld.');
   }
 
-  const rows = [
-    ...Object.entries(echoFraction).map(([board, lambda]) => ({
-      kind: 'echo_fraction',
-      key: board,
-      payload: { lambda },
-    })),
-    ...Object.entries(sigmaWithin).map(([board, payload]) => ({ kind: 'sigma_within', key: board, payload })),
-    ...Object.entries(tauSquared).map(([board, payload]) => ({ kind: 'tau_squared', key: board, payload })),
-    ...Object.entries(angleOffset).map(([board, payload]) => ({ kind: 'angle_offset', key: board, payload })),
-    ...Object.entries(coefficients.boardOffset).map(([board, payload]) => ({
-      kind: 'board_offset',
-      key: board,
-      payload,
-    })),
-    ...Object.entries(raterModel).map(([board, payload]) => ({ kind: 'rater_model', key: board, payload })),
-    ...Object.entries(behaviorModel).map(([board, payload]) => ({ kind: 'behavior_model', key: board, payload })),
-    ...Object.entries(coefficients.bridgeReadiness).map(([board, payload]) => ({
-      kind: 'bridge_readiness',
-      key: board,
-      payload,
-    })),
-  ];
   if (!options.persist) {
     console.log(`[grades] coefficients ${coeffVersion} (in-memory only): λ=${JSON.stringify(echoFraction)}`);
     return coefficients;
   }
   await db.transaction(async (tx) => {
-    for (const row of rows) {
-      await tx
-        .insert(boardGradeCoefficients)
-        .values({ coeffVersion, kind: row.kind, key: row.key, payload: row.payload })
-        .onConflictDoUpdate({
-          target: [boardGradeCoefficients.coeffVersion, boardGradeCoefficients.kind, boardGradeCoefficients.key],
-          set: { payload: row.payload },
-        });
-    }
+    await persistCoefficients(tx, coefficients);
   });
   console.log(
     `[grades] coefficients ${coeffVersion}: λ=${JSON.stringify(echoFraction)}, boards with angle surface: ${Object.keys(angleOffset).join(', ') || 'none'}`,
@@ -283,7 +325,7 @@ interface ComputedRow {
   universalGrade: number | null;
   gradeLow: number | null;
   gradeHigh: number | null;
-  confidence: string;
+  confidence: ConfidenceTier;
   ascensionistCount: number;
   postSd: number | null;
   rawAverage: number | null;
@@ -736,7 +778,7 @@ function evaluateBehaviorEligibility(coefficients: GradeCoefficients): GateResul
 }
 
 async function upsertGrades(
-  db: Db,
+  db: DbWriter,
   boardType: string,
   computed: ComputedRow[],
   coefficients: GradeCoefficients,
@@ -801,7 +843,7 @@ async function upsertGrades(
       universalGrade: row.universalGrade,
       gradeLow: row.gradeLow,
       gradeHigh: row.gradeHigh,
-      confidence: row.confidence as never,
+      confidence: row.confidence,
       postSd: row.postSd,
     };
     if (shouldPublish(previous.get(`${row.climbUuid}:${row.angle}`), posteriorLike)) {
@@ -835,7 +877,86 @@ async function upsertGrades(
   return { written, held };
 }
 
-async function recordGateResults(db: Db, coefficients: GradeCoefficients, gates: GateResult[]): Promise<void> {
+async function createRefreshKeyTable(db: DbWriter): Promise<void> {
+  await db.execute(sql`
+    CREATE TEMP TABLE IF NOT EXISTS boardsesh_grade_refresh_keys (
+      board_type text NOT NULL,
+      climb_uuid text NOT NULL,
+      angle integer NOT NULL,
+      PRIMARY KEY (board_type, climb_uuid, angle)
+    ) ON COMMIT DROP
+  `);
+  await db.execute(sql`TRUNCATE TABLE pg_temp.boardsesh_grade_refresh_keys`);
+}
+
+async function insertRefreshKeys(db: DbWriter, boardType: string, computed: ComputedRow[]): Promise<void> {
+  for (let start = 0; start < computed.length; start += REFRESH_KEY_BATCH) {
+    const batch = computed.slice(start, start + REFRESH_KEY_BATCH);
+    const valueRows = batch.map((row) => sql`(${boardType}, ${row.climbUuid}, ${row.angle})`);
+    await db.execute(sql`
+      INSERT INTO pg_temp.boardsesh_grade_refresh_keys (board_type, climb_uuid, angle)
+      VALUES ${sql.join(valueRows, sql`, `)}
+      ON CONFLICT DO NOTHING
+    `);
+  }
+}
+
+async function deleteStaleGrades(db: DbWriter, boardType: string): Promise<number> {
+  const rows = rowsOf<{ deleted: number }>(
+    await db.execute(sql`
+      WITH deleted AS (
+        DELETE FROM board_climb_grades g
+        WHERE g.board_type = ${boardType}
+          AND NOT EXISTS (
+            SELECT 1
+            FROM pg_temp.boardsesh_grade_refresh_keys k
+            WHERE k.board_type = g.board_type
+              AND k.climb_uuid = g.climb_uuid
+              AND k.angle = g.angle
+          )
+        RETURNING 1
+      )
+      SELECT COUNT(*)::int AS deleted FROM deleted
+    `),
+  );
+  return rows[0]?.deleted ?? 0;
+}
+
+interface PublishedBoardResult {
+  boardType: string;
+  written: number;
+  held: number;
+  deleted: number;
+}
+
+async function publishPassedRun(
+  db: Db,
+  coefficients: GradeCoefficients,
+  gates: GateResult[],
+  computedByBoard: Map<string, ComputedRow[]>,
+  persistCoefficientSet: boolean,
+): Promise<PublishedBoardResult[]> {
+  return db.transaction(async (tx) => {
+    if (persistCoefficientSet) {
+      await persistCoefficients(tx, coefficients);
+    }
+    await recordGateResults(tx, coefficients, gates);
+    await createRefreshKeyTable(tx);
+    for (const [boardType, computed] of computedByBoard) {
+      await insertRefreshKeys(tx, boardType, computed);
+    }
+
+    const published: PublishedBoardResult[] = [];
+    for (const [boardType, computed] of computedByBoard) {
+      const { written, held } = await upsertGrades(tx, boardType, computed, coefficients);
+      const deleted = await deleteStaleGrades(tx, boardType);
+      published.push({ boardType, written, held, deleted });
+    }
+    return published;
+  });
+}
+
+async function recordGateResults(db: DbWriter, coefficients: GradeCoefficients, gates: GateResult[]): Promise<void> {
   const runKey = new Date().toISOString();
   await db.insert(boardGradeCoefficients).values({
     coeffVersion: coefficients.coeffVersion,
@@ -855,17 +976,37 @@ function blockingGates(gates: GateResult[]): GateResult[] {
  * run the input-side gates, compute every board, evaluate the in-memory gates,
  * and print the report. Writes nothing.
  */
-async function validateOnly(db: Db): Promise<void> {
+async function validateOnly(db: Db, allowEmptyBacktest: boolean): Promise<void> {
   const coefficients = await refitCoefficients(db, { persist: false });
   const baselineCoefficients = withoutStage2Coefficients(coefficients);
   const stage2Evidence = await loadStage2Evidence(db, coefficients);
   const gates: GateResult[] = [];
   console.log('[grades] validate-only: running gates against live data…');
   const backtestRows = rowsOf<BacktestSampleRow>(await db.execute(buildBacktestSampleSql(BACKTEST_SAMPLE_LIMIT)));
-  const backtest = evaluateBacktest(backtestRows, coefficients);
-  gates.push(backtest.tailGate, backtest.headGate);
-  console.log(`[grades]   tail_backtest: ${backtest.tailGate.passed ? 'PASS' : 'FAIL'} — ${backtest.tailGate.detail}`);
-  console.log(`[grades]   head_holdout: ${backtest.headGate.passed ? 'PASS' : 'FAIL'} — ${backtest.headGate.detail}`);
+  if (backtestRows.length === 0 && allowEmptyBacktest) {
+    console.warn('[grades]   backtest SKIPPED — no stats-history sample (--allow-empty-backtest).');
+    gates.push(
+      {
+        gate: 'tail_backtest',
+        passed: true,
+        detail: 'skipped: empty history sample (--allow-empty-backtest)',
+        metrics: { multiN: 0 },
+      },
+      {
+        gate: 'head_holdout',
+        passed: true,
+        detail: 'skipped: empty history sample (--allow-empty-backtest)',
+        metrics: { singleN: 0 },
+      },
+    );
+  } else {
+    const backtest = evaluateBacktest(backtestRows, coefficients);
+    gates.push(backtest.tailGate, backtest.headGate);
+    console.log(
+      `[grades]   tail_backtest: ${backtest.tailGate.passed ? 'PASS' : 'FAIL'} — ${backtest.tailGate.detail}`,
+    );
+    console.log(`[grades]   head_holdout: ${backtest.headGate.passed ? 'PASS' : 'FAIL'} — ${backtest.headGate.detail}`);
+  }
   const behaviorGate = evaluateBehaviorEligibility(coefficients);
   gates.push(behaviorGate);
   console.log(`[grades]   behavior_eligibility: ${behaviorGate.passed ? 'PASS' : 'FAIL'} — ${behaviorGate.detail}`);
@@ -933,14 +1074,19 @@ async function main(): Promise<void> {
   const { db, close } = createScriptDb();
   try {
     if (process.argv.includes('--validate-only')) {
-      await validateOnly(db);
+      await validateOnly(db, allowEmptyBacktest);
       return;
     }
-    let coefficients =
-      (!forceRefit && (await loadFrozenCoefficients(db))) || (await refitCoefficients(db, { persist: !dryRun }));
+    let coefficients = forceRefit ? null : await loadFrozenCoefficients(db);
+    let persistCoefficientSet = false;
+    if (!coefficients) {
+      coefficients = await refitCoefficients(db, { persist: false });
+      persistCoefficientSet = true;
+    }
     if (!forceRefit && Object.keys(coefficients.raterModel).length === 0) {
       console.log('[grades] latest frozen coefficients do not include Stage 2 models; refitting.');
-      coefficients = await refitCoefficients(db, { persist: !dryRun });
+      coefficients = await refitCoefficients(db, { persist: false });
+      persistCoefficientSet = true;
     }
     const baselineCoefficients = withoutStage2Coefficients(coefficients);
     const stage2Evidence = await loadStage2Evidence(db, coefficients);
@@ -966,12 +1112,20 @@ async function main(): Promise<void> {
       // Prod keeps the strict behavior: an empty sample there means a broken
       // query and must block.
       console.warn('[grades]   backtest SKIPPED — no stats-history sample (--allow-empty-backtest).');
-      gates.push({
-        gate: 'tail_backtest',
-        passed: true,
-        detail: 'skipped: empty history sample (--allow-empty-backtest)',
-        metrics: { multiN: 0 },
-      });
+      gates.push(
+        {
+          gate: 'tail_backtest',
+          passed: true,
+          detail: 'skipped: empty history sample (--allow-empty-backtest)',
+          metrics: { multiN: 0 },
+        },
+        {
+          gate: 'head_holdout',
+          passed: true,
+          detail: 'skipped: empty history sample (--allow-empty-backtest)',
+          metrics: { singleN: 0 },
+        },
+      );
     } else {
       const backtest = evaluateBacktest(backtestRows, coefficients);
       gates.push(backtest.tailGate, backtest.headGate);
@@ -1049,18 +1203,19 @@ async function main(): Promise<void> {
       return;
     }
 
-    await recordGateResults(db, coefficients, gates);
     if (blocking.length > 0) {
       console.error(
-        `[grades] blocking gate(s) failed: ${blocking.map((gate) => gate.gate).join(', ')} — no grades written.`,
+        `[grades] blocking gate(s) failed: ${blocking.map((gate) => gate.gate).join(', ')} — no coefficients, gates, or grade rows written.`,
       );
       process.exitCode = 1;
       return;
     }
 
-    for (const [boardType, computed] of computedByBoard) {
-      const { written, held } = await upsertGrades(db, boardType, computed, coefficients);
-      console.log(`[grades]   ${boardType}: ${written} published, ${held} held by hysteresis`);
+    const publishedBoards = await publishPassedRun(db, coefficients, gates, computedByBoard, persistCoefficientSet);
+    for (const { boardType, written, held, deleted } of publishedBoards) {
+      console.log(
+        `[grades]   ${boardType}: ${written} published, ${held} held by hysteresis, ${deleted} stale deleted`,
+      );
     }
 
     // Honesty report (never blocks): boards whose grade is just the label.

--- a/packages/db/src/queries/grade-model/__tests__/stage2-helpers.test.ts
+++ b/packages/db/src/queries/grade-model/__tests__/stage2-helpers.test.ts
@@ -27,6 +27,7 @@ import {
   estimateRaterBiases,
   estimateRaterModels,
   raterOpinionWeight,
+  stage2LeaveoutKey,
   type RaterBiasEstimate,
   type RaterOpinion,
   type RaterSampleRow,
@@ -42,6 +43,33 @@ void describe('Stage 2 rater helpers', () => {
     assert.ok(trainingQuery.includes('md5(s.climb_uuid'));
     assert.ok(trainingQuery.includes('NOT'));
     assert.ok(!predictionQuery.includes('md5(s.climb_uuid'));
+  });
+
+  void test('uses physical fingerprint keys for Stage 2 leave-out where available', () => {
+    const firstKey = stage2LeaveoutKey({
+      board_type: 'kilter',
+      climb_uuid: 'uuid-a',
+      layout_id: 1,
+      hold_fingerprint: 'same-problem',
+      angle: 40,
+    });
+    const siblingKey = stage2LeaveoutKey({
+      board_type: 'kilter',
+      climb_uuid: 'uuid-b',
+      layout_id: 1,
+      hold_fingerprint: 'same-problem',
+      angle: 40,
+    });
+    const otherAngleKey = stage2LeaveoutKey({
+      board_type: 'kilter',
+      climb_uuid: 'uuid-b',
+      layout_id: 1,
+      hold_fingerprint: 'same-problem',
+      angle: 50,
+    });
+
+    assert.equal(firstKey, siblingKey);
+    assert.notEqual(firstKey, otherAngleKey);
   });
 
   void test('does not subtract held-out benchmark rows from fitted rater bias', () => {
@@ -177,7 +205,7 @@ void describe('Stage 2 behavior helpers', () => {
     assert.equal(model.eligible, false);
   });
 
-  void test('leaves target rows out of behavior bucket offsets', () => {
+  void test('uses frozen behavior offsets and leaves target rows out of behavior user ability', () => {
     const trainingRows: BehaviorSampleRow[] = [];
     for (let userIndex = 0; userIndex < 11; userIndex++) {
       for (let outcomeIndex = 0; outcomeIndex < 3; outcomeIndex++) {
@@ -210,7 +238,7 @@ void describe('Stage 2 behavior helpers', () => {
         kilter: {
           boardType: 'kilter',
           boardMean: 20,
-          outcomeOffset: { send_2_3: 999 },
+          outcomeOffset: { send_2_3: 7 },
           eligible: true,
           summary: {
             users: 11,
@@ -229,7 +257,7 @@ void describe('Stage 2 behavior helpers', () => {
     const targetEvidence = evidence.get('kilter\u0000target\u000040');
     assert.ok(targetEvidence);
     assert.ok(targetEvidence.behaviorMean !== null);
-    assert.ok(Math.abs(targetEvidence.behaviorMean - 20) < 1e-9, `behavior mean was ${targetEvidence.behaviorMean}`);
+    assert.ok(Math.abs(targetEvidence.behaviorMean - 27) < 1e-9, `behavior mean was ${targetEvidence.behaviorMean}`);
   });
 
   void test('orders outcome probabilities from flash to repeated-send to attempt', () => {
@@ -376,6 +404,19 @@ void describe('Stage 2 de-herded helpers', () => {
     assert.equal(thin.eligible, false);
     assert.equal(thin.reason, 'thin_evidence');
     assert.equal(thin.grade, 21);
+  });
+
+  void test('keeps the observed-mean cap authoritative when display and observed caps do not overlap', () => {
+    const capped = deherdCrowdMean({
+      observedMean: 25,
+      displayGrade: 20,
+      echoFraction: 0.5,
+      independentWeight: 10,
+    });
+
+    assert.equal(capped.capped, true);
+    assert.equal(capped.grade, 25.75);
+    assert.ok(capped.grade !== null && Math.abs(capped.grade - 25) <= 0.75);
   });
 
   void test('combines grade signals by precision or explicit weight', () => {

--- a/packages/db/src/queries/grade-model/behavior.ts
+++ b/packages/db/src/queries/grade-model/behavior.ts
@@ -7,7 +7,7 @@ import {
   BEHAVIOR_MIN_USERS,
 } from './constants';
 import type { BehaviorModelCoefficient, BehaviorOutcomeBucket, Stage2Evidence } from './types';
-import { type Stage2EvidenceMap, stage2EvidenceKey } from './raters';
+import { type Stage2EvidenceMap, stage2EvidenceKey, stage2LeaveoutKey } from './raters';
 import { buildTensionBenchmarkHoldoutPredicate } from './deherded';
 
 const BEHAVIOR_SUCCESS_WEIGHT = 0.25;
@@ -20,6 +20,8 @@ export interface BehaviorSampleRow {
   board_type: string;
   user_id: string;
   climb_uuid: string;
+  layout_id?: number | null;
+  hold_fingerprint?: string | null;
   angle: number;
   status: 'flash' | 'send' | 'attempt';
   attempt_count: number;
@@ -45,6 +47,8 @@ export function buildBehaviorSampleSql(
            t.board_type,
            t.user_id,
            COALESCE(a.canonical_uuid, t.climb_uuid) AS climb_uuid,
+           bc.layout_id,
+           bc.hold_fingerprint,
            t.angle,
            t.status,
            t.attempt_count,
@@ -164,16 +168,8 @@ interface BehaviorOffsetAccumulator {
   userOutcomes: Map<string, number>;
 }
 
-interface BehaviorUserBucketAccumulator {
-  residualSum: number;
-  outcomes: number;
-}
-
 interface BehaviorOffsetAccumulators {
   bucketAccumulator: Map<string, BehaviorOffsetAccumulator>;
-  userAbilityAccumulatorByKey: Map<string, UserAbilityAccumulator>;
-  userAbilityByKey: Map<string, UserAbility>;
-  userBucketAccumulator: Map<string, BehaviorUserBucketAccumulator>;
   usedUserOutcomesByBoard: Map<string, Map<string, number>>;
 }
 
@@ -190,14 +186,8 @@ function buildBehaviorOffsetAccumulators(
   samples: BehaviorSampleRow[],
   boardMeanByBoard: Map<string, number>,
 ): BehaviorOffsetAccumulators {
-  const userAbilityAccumulatorByKey = buildUserAbilityAccumulators(samples);
-  const userAbilityByKey = new Map<string, UserAbility>();
-  for (const [accumulatorKey, accumulator] of userAbilityAccumulatorByKey) {
-    const ability = userAbilityFromAccumulator(accumulator, boardMeanByBoard);
-    if (ability) userAbilityByKey.set(accumulatorKey, ability);
-  }
+  const userAbilityByKey = buildUserAbilities(samples, boardMeanByBoard);
   const bucketAccumulator = new Map<string, BehaviorOffsetAccumulator>();
-  const userBucketAccumulator = new Map<string, BehaviorUserBucketAccumulator>();
   const usedUserOutcomesByBoard = new Map<string, Map<string, number>>();
 
   for (const sample of samples) {
@@ -216,24 +206,12 @@ function buildBehaviorOffsetAccumulators(
     addUserOutcome(accumulator.userOutcomes, sample.user_id, 1);
     bucketAccumulator.set(accumulatorKey, accumulator);
 
-    const userBucketKey = `${sample.board_type}\u0000${sample.user_id}\u0000${bucket}`;
-    const userBucket = userBucketAccumulator.get(userBucketKey) ?? { residualSum: 0, outcomes: 0 };
-    userBucket.residualSum += numeric(sample.difficulty_average) - ability.ability;
-    userBucket.outcomes += 1;
-    userBucketAccumulator.set(userBucketKey, userBucket);
-
     const usedBoardOutcomes = usedUserOutcomesByBoard.get(sample.board_type) ?? new Map<string, number>();
     addUserOutcome(usedBoardOutcomes, sample.user_id, 1);
     usedUserOutcomesByBoard.set(sample.board_type, usedBoardOutcomes);
   }
 
-  return {
-    bucketAccumulator,
-    userAbilityAccumulatorByKey,
-    userAbilityByKey,
-    userBucketAccumulator,
-    usedUserOutcomesByBoard,
-  };
+  return { bucketAccumulator, usedUserOutcomesByBoard };
 }
 
 function behaviorOffsetFromAccumulator(
@@ -257,74 +235,6 @@ function behaviorOffsetFromAccumulator(
     return null;
   }
   const residualSum = accumulator.residualSum - (heldOut?.residualSum ?? 0);
-  return residualSum / outcomes;
-}
-
-function behaviorOffsetForEvidence(
-  boardType: string,
-  bucket: BehaviorOutcomeBucket,
-  evidenceKey: string,
-  offsetAccumulatorByBucket: Map<string, BehaviorOffsetAccumulator>,
-  heldOutOffsetByEvidenceBucket: Map<string, BehaviorOffsetAccumulator>,
-  userAbilityAccumulatorByKey: Map<string, UserAbilityAccumulator>,
-  userAbilityByKey: Map<string, UserAbility>,
-  userBucketAccumulator: Map<string, BehaviorUserBucketAccumulator>,
-  heldOutUserBucketByEvidence: Map<string, BehaviorUserBucketAccumulator>,
-  heldOutSuccessByEvidenceBoard: Map<string, Map<string, { difficultySum: number; successes: number }>>,
-  boardMeanByBoard: Map<string, number>,
-): number | null {
-  const fullBucket = offsetAccumulatorByBucket.get(`${boardType}\u0000${bucket}`);
-  if (!fullBucket) return null;
-  const heldOutBucket = heldOutOffsetByEvidenceBucket.get(`${evidenceKey}\u0000${boardType}\u0000${bucket}`);
-  let outcomes = fullBucket.outcomes - (heldOutBucket?.outcomes ?? 0);
-  let residualSum = fullBucket.residualSum - (heldOutBucket?.residualSum ?? 0);
-  const userOutcomes = new Map(fullBucket.userOutcomes);
-  if (heldOutBucket) {
-    for (const [userId, heldOutcomes] of heldOutBucket.userOutcomes) {
-      addUserOutcome(userOutcomes, userId, -heldOutcomes);
-    }
-  }
-
-  const heldOutSuccesses = heldOutSuccessByEvidenceBoard.get(`${evidenceKey}\u0000${boardType}`);
-  if (heldOutSuccesses) {
-    for (const [userId, heldOutAbility] of heldOutSuccesses) {
-      const fullAbility = userAbilityByKey.get(`${boardType}\u0000${userId}`);
-      const fullAbilityAccumulator = userAbilityAccumulatorByKey.get(`${boardType}\u0000${userId}`);
-      const fullUserBucket = userBucketAccumulator.get(`${boardType}\u0000${userId}\u0000${bucket}`);
-      if (!fullAbility || !fullAbilityAccumulator || !fullUserBucket) continue;
-
-      const heldOutUserBucket = heldOutUserBucketByEvidence.get(
-        `${evidenceKey}\u0000${boardType}\u0000${userId}\u0000${bucket}`,
-      );
-      const nonTargetOutcomes = fullUserBucket.outcomes - (heldOutUserBucket?.outcomes ?? 0);
-      if (nonTargetOutcomes <= 0) continue;
-      const nonTargetResidualSum = fullUserBucket.residualSum - (heldOutUserBucket?.residualSum ?? 0);
-      const leaveTargetOutAbility = userAbilityFromAccumulator(
-        {
-          ...fullAbilityAccumulator,
-          difficultySum: fullAbilityAccumulator.difficultySum - heldOutAbility.difficultySum,
-          successes: fullAbilityAccumulator.successes - heldOutAbility.successes,
-        },
-        boardMeanByBoard,
-      );
-      if (!leaveTargetOutAbility) {
-        outcomes -= nonTargetOutcomes;
-        residualSum -= nonTargetResidualSum;
-        addUserOutcome(userOutcomes, userId, -nonTargetOutcomes);
-      } else {
-        residualSum += nonTargetOutcomes * (fullAbility.ability - leaveTargetOutAbility.ability);
-      }
-    }
-  }
-
-  if (outcomes < MIN_OUTCOME_BUCKET_SUPPORT) return null;
-  const bucketCoverage = summarizeUserOutcomes(userOutcomes);
-  if (
-    bucketCoverage.users < BEHAVIOR_MIN_BUCKET_USERS ||
-    bucketCoverage.topUserShare > BEHAVIOR_MAX_BUCKET_TOP_USER_SHARE
-  ) {
-    return null;
-  }
   return residualSum / outcomes;
 }
 
@@ -388,32 +298,16 @@ export function buildBehaviorEvidence(
   samples: BehaviorSampleRow[],
   models: Record<string, BehaviorModelCoefficient>,
   existingEvidence: Stage2EvidenceMap,
-  offsetTrainingSamples: BehaviorSampleRow[] = samples,
+  abilityTrainingSamples: BehaviorSampleRow[] = samples,
 ): Stage2EvidenceMap {
   const boardMeanByBoard = new Map<string, number>();
   for (const model of Object.values(models)) boardMeanByBoard.set(model.boardType, model.boardMean);
-  const {
-    bucketAccumulator: offsetAccumulatorByBucket,
-    userAbilityAccumulatorByKey,
-    userAbilityByKey,
-    userBucketAccumulator,
-  } = buildBehaviorOffsetAccumulators(offsetTrainingSamples, boardMeanByBoard);
-  const heldOutOffsetByEvidenceBucket = new Map<string, BehaviorOffsetAccumulator>();
-  const heldOutUserBucketByEvidence = new Map<string, BehaviorUserBucketAccumulator>();
-  const heldOutSuccessByEvidenceBoard = new Map<string, Map<string, { difficultySum: number; successes: number }>>();
+  const userAbilityAccumulatorByKey = buildUserAbilityAccumulators(abilityTrainingSamples);
   const heldOutSuccessByEvidenceUser = new Map<string, { difficultySum: number; successes: number }>();
-  for (const sample of offsetTrainingSamples) {
-    const evidenceKey = stage2EvidenceKey(sample.board_type, sample.climb_uuid, numeric(sample.angle));
+  for (const sample of abilityTrainingSamples) {
+    const leaveoutKey = stage2LeaveoutKey(sample);
     if (sample.status === 'flash' || sample.status === 'send') {
-      const boardSuccessKey = `${evidenceKey}\u0000${sample.board_type}`;
-      const boardSuccesses = heldOutSuccessByEvidenceBoard.get(boardSuccessKey) ?? new Map();
-      const userSuccesses = boardSuccesses.get(sample.user_id) ?? { difficultySum: 0, successes: 0 };
-      userSuccesses.difficultySum += numeric(sample.difficulty_average);
-      userSuccesses.successes += 1;
-      boardSuccesses.set(sample.user_id, userSuccesses);
-      heldOutSuccessByEvidenceBoard.set(boardSuccessKey, boardSuccesses);
-
-      const userSuccessKey = `${evidenceKey}\u0000${sample.board_type}\u0000${sample.user_id}`;
+      const userSuccessKey = `${leaveoutKey}\u0000${sample.board_type}\u0000${sample.user_id}`;
       const evidenceUserSuccesses = heldOutSuccessByEvidenceUser.get(userSuccessKey) ?? {
         difficultySum: 0,
         successes: 0,
@@ -422,28 +316,6 @@ export function buildBehaviorEvidence(
       evidenceUserSuccesses.successes += 1;
       heldOutSuccessByEvidenceUser.set(userSuccessKey, evidenceUserSuccesses);
     }
-
-    if (numeric(sample.ascensionist_count) < 20) continue;
-    const ability = userAbilityByKey.get(`${sample.board_type}\u0000${sample.user_id}`);
-    if (!ability) continue;
-    const bucket = behaviorOutcomeBucket(sample);
-    const residual = numeric(sample.difficulty_average) - ability.ability;
-    const accumulatorKey = `${evidenceKey}\u0000${sample.board_type}\u0000${bucket}`;
-    const accumulator = heldOutOffsetByEvidenceBucket.get(accumulatorKey) ?? {
-      residualSum: 0,
-      outcomes: 0,
-      userOutcomes: new Map<string, number>(),
-    };
-    accumulator.residualSum += residual;
-    accumulator.outcomes += 1;
-    addUserOutcome(accumulator.userOutcomes, sample.user_id, 1);
-    heldOutOffsetByEvidenceBucket.set(accumulatorKey, accumulator);
-
-    const userBucketKey = `${evidenceKey}\u0000${sample.board_type}\u0000${sample.user_id}\u0000${bucket}`;
-    const userBucket = heldOutUserBucketByEvidence.get(userBucketKey) ?? { residualSum: 0, outcomes: 0 };
-    userBucket.residualSum += residual;
-    userBucket.outcomes += 1;
-    heldOutUserBucketByEvidence.set(userBucketKey, userBucket);
   }
   const evidenceAccumulator = new Map<string, { weightedDifficulty: number; effectiveN: number }>();
 
@@ -452,24 +324,12 @@ export function buildBehaviorEvidence(
     if (!model?.eligible) continue;
     const bucket = behaviorOutcomeBucket(sample);
     const evidenceKey = stage2EvidenceKey(sample.board_type, sample.climb_uuid, numeric(sample.angle));
-    const offset = behaviorOffsetForEvidence(
-      sample.board_type,
-      bucket,
-      evidenceKey,
-      offsetAccumulatorByBucket,
-      heldOutOffsetByEvidenceBucket,
-      userAbilityAccumulatorByKey,
-      userAbilityByKey,
-      userBucketAccumulator,
-      heldOutUserBucketByEvidence,
-      heldOutSuccessByEvidenceBoard,
-      boardMeanByBoard,
-    );
-    if (offset === null) continue;
+    const offset = model.outcomeOffset[bucket];
+    if (offset === undefined) continue;
     const fullAbilityAccumulator = userAbilityAccumulatorByKey.get(`${sample.board_type}\u0000${sample.user_id}`);
     if (!fullAbilityAccumulator) continue;
     const heldOutAbility = heldOutSuccessByEvidenceUser.get(
-      `${evidenceKey}\u0000${sample.board_type}\u0000${sample.user_id}`,
+      `${stage2LeaveoutKey(sample)}\u0000${sample.board_type}\u0000${sample.user_id}`,
     );
     const ability = userAbilityFromAccumulator(
       {

--- a/packages/db/src/queries/grade-model/deherded.ts
+++ b/packages/db/src/queries/grade-model/deherded.ts
@@ -338,16 +338,15 @@ export function deherdCrowdMean(input: DeherdCrowdInput, options?: Partial<Deher
   }
 
   const rawDeherdedGrade = input.displayGrade + (input.observedMean - input.displayGrade) / (1 - echoFraction);
-  const cappedByObserved = clampNumber(
-    rawDeherdedGrade,
-    input.observedMean - resolvedOptions.maxMoveFromObserved,
-    input.observedMean + resolvedOptions.maxMoveFromObserved,
-  );
-  const cappedGrade = clampNumber(
-    cappedByObserved,
-    input.displayGrade - resolvedOptions.maxMoveFromDisplay,
-    input.displayGrade + resolvedOptions.maxMoveFromDisplay,
-  );
+  const observedMin = input.observedMean - resolvedOptions.maxMoveFromObserved;
+  const observedMax = input.observedMean + resolvedOptions.maxMoveFromObserved;
+  const displayMin = input.displayGrade - resolvedOptions.maxMoveFromDisplay;
+  const displayMax = input.displayGrade + resolvedOptions.maxMoveFromDisplay;
+  const cappedByObserved = clampNumber(rawDeherdedGrade, observedMin, observedMax);
+  const intersectedMin = Math.max(observedMin, displayMin);
+  const intersectedMax = Math.min(observedMax, displayMax);
+  const cappedGrade =
+    intersectedMin <= intersectedMax ? clampNumber(rawDeherdedGrade, intersectedMin, intersectedMax) : cappedByObserved;
 
   return {
     grade: cappedGrade,

--- a/packages/db/src/queries/grade-model/raters.ts
+++ b/packages/db/src/queries/grade-model/raters.ts
@@ -12,6 +12,8 @@ export interface RaterSampleRow {
   board_type: string;
   user_id: string;
   climb_uuid: string;
+  layout_id?: number | null;
+  hold_fingerprint?: string | null;
   angle: number;
   origin: string;
   difficulty: number;
@@ -25,6 +27,15 @@ export type Stage2EvidenceMap = Map<string, Stage2Evidence>;
 
 export function stage2EvidenceKey(boardType: string, climbUuid: string, angle: number): string {
   return `${boardType}\u0000${climbUuid}\u0000${angle}`;
+}
+
+export function stage2LeaveoutKey(
+  sample: Pick<RaterSampleRow, 'board_type' | 'climb_uuid' | 'layout_id' | 'hold_fingerprint' | 'angle'>,
+): string {
+  if (sample.layout_id !== null && sample.layout_id !== undefined && sample.hold_fingerprint) {
+    return `${sample.board_type}\u0000${sample.layout_id}\u0000${sample.hold_fingerprint}\u0000${numeric(sample.angle)}`;
+  }
+  return stage2EvidenceKey(sample.board_type, sample.climb_uuid, numeric(sample.angle));
 }
 
 interface Stage2SampleSqlOptions {
@@ -43,6 +54,8 @@ export function buildRaterSampleSql(options: Stage2SampleSqlOptions = { excludeT
            t.board_type,
            t.user_id,
            COALESCE(a.canonical_uuid, t.climb_uuid) AS climb_uuid,
+           bc.layout_id,
+           bc.hold_fingerprint,
            t.angle,
            t.origin,
            t.difficulty,
@@ -182,9 +195,9 @@ export function buildRaterEvidence(
   for (const sample of biasTrainingSamples) {
     const weight = raterWeight(sample);
     if (weight <= 0) continue;
-    const evidenceKey = stage2EvidenceKey(sample.board_type, sample.climb_uuid, numeric(sample.angle));
+    const leaveoutKey = stage2LeaveoutKey(sample);
     const locationKey = raterLocationKey(sample);
-    const heldOutKey = `${evidenceKey}\u0000${locationKey}`;
+    const heldOutKey = `${leaveoutKey}\u0000${locationKey}`;
     const accumulator = heldOutByEvidenceLocation.get(heldOutKey) ?? { weightedResidual: 0, effectiveN: 0 };
     accumulator.weightedResidual += (numeric(sample.difficulty) - numeric(sample.difficulty_average)) * weight;
     accumulator.effectiveN += weight;
@@ -200,9 +213,10 @@ export function buildRaterEvidence(
     if (!model) continue;
     const locationKey = raterLocationKey(sample);
     const evidenceKey = stage2EvidenceKey(sample.board_type, sample.climb_uuid, numeric(sample.angle));
+    const leaveoutKey = stage2LeaveoutKey(sample);
     const bias = biasExcludingTarget(
       model.biases[locationKey],
-      heldOutByEvidenceLocation.get(`${evidenceKey}\u0000${locationKey}`),
+      heldOutByEvidenceLocation.get(`${leaveoutKey}\u0000${locationKey}`),
     );
     const adjustedDifficulty = numeric(sample.difficulty) - bias;
     const accumulator = evidenceAccumulator.get(evidenceKey) ?? { weightedDifficulty: 0, effectiveN: 0, rawVotes: 0 };


### PR DESCRIPTION
## Summary

Follow-up to #3582 after adversarial review of the Stage 2 grade refresh.

This hardens the refresh path by:

- keeping newly refit coefficient sets in memory until all blocking gates pass
- committing coefficient persistence, gate results, grade upserts, and stale-row deletion in one transaction
- deleting stale grade rows for refreshed boards while retaining hysteresis-held rows
- making the de-herding observed-mean cap authoritative when display and observed cap ranges do not overlap
- using persisted behavior outcome offsets for prediction instead of recomputing live offset coefficients under an old `coeffVersion`
- using layout/fingerprint physical keys for Stage 2 leave-target-out where duplicate climbs share the same problem
- clarifying read-only vs writable refresh commands and workflow dry-run copy

## Validation

- `vp check --fix packages/db/scripts/refresh-climb-grades.ts packages/db/src/queries/grade-model/behavior.ts packages/db/src/queries/grade-model/raters.ts packages/db/src/queries/grade-model/deherded.ts packages/db/src/queries/grade-model/__tests__/stage2-helpers.test.ts docs/boardsesh-grade.md .github/workflows/refresh-climb-grades.yml`
- `vp run typecheck:db`
- `vp run test:db -- src/queries/grade-model/__tests__/stage2-helpers.test.ts`
  - Stage 2 suites passed
  - command still exits nonzero because of the existing unrelated `user_boards serial uniqueness` integration failure
- `vp run db:refresh-climb-grades -- --validate-only`
  - all blocking gates passed
  - completed with `validate-only done (nothing written)`
- `vp staged`
