### PR TITLE
feat(db): Climb2Vec training matrix + offline eval harness (Phase 1a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,12 @@ fastlane/test_output/
 # Local-only board-data exports (e.g. the MoonBoard 2024 problems JSON). Large
 # raw data files are imported via the db CLIs, never committed to the repo.
 packages/db/data/
+
+# Climb2Vec offline training artifacts (never commit extracts/venv/models)
+ml/climb2vec/data/
+ml/climb2vec/.venv/
+ml/climb2vec/artifacts/
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/docs/climb2vec.md
+++ b/docs/climb2vec.md
@@ -60,17 +60,37 @@ pgvector needed at ~10⁵ climbs/board (it stays a drop-in later swap, same
 
 ## Phased rollout (Kilter-first; each phase stacks on the last)
 
-| #     | Phase                                             | Ships                                                                                                                                    |
-| ----- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| **0** | **Hold-feature substrate** ✅ (this PR)           | `board_hold_features` + nightly `refresh-hold-features.ts`; shadow-fills `user_hold_classifications`.                                    |
-| 1     | Climb2Vec training + validation (offline PyTorch) | Trained encoder + grade/embedding export; grade accuracy vs the MoonBoardRNN benchmark + a GBM baseline; kNN duplicate-retrieval sanity. |
-| 2     | `content_prior` into the blend                    | Geometry-informed grades on sparse/new Kilter climbs.                                                                                    |
-| 3     | Embedding similarity                              | `board_climb_embeddings` + top-K neighbors; upgrades `similarClimbs` (Jaccard fallback).                                                 |
-| 4     | "Also sent" item-item CF                          | Co-send neighbors from `boardsesh_ticks` + a climb-detail rail.                                                                          |
-| 5     | Style / anti-style recs                           | Per-user style centroids → "recommended in your style" / "train your anti-style".                                                        |
-| 6     | Generalize to Tension + MoonBoard                 | First-ever MoonBoard grades (`content_only`); multi-board similarity.                                                                    |
+| #      | Phase                                           | Ships                                                                                                                                  |
+| ------ | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **0**  | **Hold-feature substrate** ✅ (#3584)           | `board_hold_features` + nightly `refresh-hold-features.ts`; shadow-fills `user_hold_classifications`.                                  |
+| **1a** | **Training matrix + offline eval** ✅ (this PR) | `extract-training-matrix.ts` + `ml/climb2vec/` (Deep Sets encoder, GBM/ridge baselines, leakage-free eval). Feasibility numbers below. |
+| 1b     | Climb2Vec grade/embedding export                | Ordinal head + contrastive objective + tuning on the full catalog; export `content_prior` + embeddings.                                |
+| 2      | `content_prior` into the blend                  | Geometry-informed grades on sparse/new Kilter climbs.                                                                                  |
+| 3      | Embedding similarity                            | `board_climb_embeddings` + top-K neighbors; upgrades `similarClimbs` (Jaccard fallback).                                               |
+| 4      | "Also sent" item-item CF                        | Co-send neighbors from `boardsesh_ticks` + a climb-detail rail.                                                                        |
+| 5      | Style / anti-style recs                         | Per-user style centroids → "recommended in your style" / "train your anti-style".                                                      |
+| 6      | Generalize to Tension + MoonBoard               | First-ever MoonBoard grades (`content_only`); multi-board similarity.                                                                  |
 
-## Phase 0 — the hold-feature substrate (shipped here)
+## Phase 1a — offline feasibility (Kilter, 29,748 held-out-by-climb observations)
+
+Grade accuracy on held-out climbs, leakage-free (hold effects fit on train only;
+label = crowd `difficulty_average`, in Aurora units ≈ 2 per V-grade → MAE 1.4 ≈
+~0.7 V-grade). Full method + how to reproduce: `ml/climb2vec/README.md`.
+
+| model                    | exact | within ±1 | MAE      |
+| ------------------------ | ----- | --------- | -------- |
+| ridge (linear content)   | 17.4% | 48.2%     | 1.93     |
+| GBM (aggregate features) | 23.8% | 59.8%     | **1.42** |
+| Deep Sets (Climb2Vec)    | 19.9% | 56.8%     | 1.55     |
+
+Similarity — nearest-neighbour grade agreement (mean |Δgrade|, lower better): the
+Deep Sets embedding scores **2.60** vs **3.74** random, while a raw geometry vector
+is no better than random (3.74). So geometry predicts grade well enough for a
+`content_prior`, and the learned embedding is a real similarity space (the value
+the GBM can't provide). The Deep Sets grade head still trails the GBM by ~0.13 MAE
+— Phase 1b (ordinal head, contrastive objective, tuning, full catalog) closes it.
+
+## Phase 0 — the hold-feature substrate (#3584)
 
 `board_hold_features` (`packages/db/src/schema/app/hold-features.ts`) holds one
 row per placement, regenerated nightly by

--- a/ml/climb2vec/README.md
+++ b/ml/climb2vec/README.md
@@ -1,0 +1,78 @@
+# Climb2Vec — offline training & evaluation
+
+Offline PyTorch/sklearn pipeline for the hold-geometry grade model (see
+`../../docs/climb2vec.md`). **Offline only** — nothing here ships to prod; serving
+is pure TypeScript. The pipeline reads the training matrix exported by
+`packages/db/scripts/extract-training-matrix.ts` and produces grade-accuracy and
+similarity numbers, plus (eventually) the `content_prior` + embedding artifacts
+that a nightly job `COPY`s into Postgres.
+
+## Layout
+
+- `dataset.py` — load the JSONL extract, split by climb (no angle leakage), build
+  label-free geometry features + hold-identity, duplicate-holdset keys.
+- `model.py` — the Deep Sets encoder: per-hold node MLP → masked mean/max/**sum**
+  pool → angle → penultimate **embedding** → linear grade head.
+- `evaluate.py` — the leakage-free eval: ridge + GBM + Deep Sets grade accuracy on
+  held-out climbs, and similarity (duplicate retrieval + nearest-neighbour grade
+  agreement). Writes `artifacts/results.json`.
+
+## Leakage discipline
+
+The per-hold `hd`/`fd` fields in the extract were fit on **all** grades, so using
+them as model inputs would leak the label. Instead every hold effect is learned on
+the **train split only** — a train-fit ridge coefficient (fed as a node feature)
+and a learned per-placement embedding — then applied to held-out climbs. Only
+label-free geometry + hold identity reach the models.
+
+## Run
+
+```bash
+python3 -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt
+pip install torch --index-url https://download.pytorch.org/whl/cpu   # for Deep Sets
+
+# 1. Export the training matrix (needs board_hold_features populated):
+node --import tsx ../../packages/db/scripts/extract-training-matrix.ts \
+  --board=kilter --out=ml/climb2vec/data/kilter-train.jsonl   # run from repo root
+
+# 2. Evaluate:
+python evaluate.py --data data/kilter-train.jsonl --epochs 30
+```
+
+## Phase-1 feasibility result (Kilter, dev-DB extract: 29,748 obs, 80/20 by climb)
+
+Grade accuracy on **held-out** climbs (label = crowd `difficulty_average`, in
+Aurora difficulty units ≈ 2 per V-grade, so MAE 1.4 ≈ ~0.7 V-grade):
+
+| model                    | exact | within ±1 unit | MAE      |
+| ------------------------ | ----- | -------------- | -------- |
+| ridge (linear content)   | 17.4% | 48.2%          | 1.93     |
+| GBM (aggregate features) | 23.8% | 59.8%          | **1.42** |
+| Deep Sets (Climb2Vec)    | 19.9% | 56.8%          | 1.55     |
+
+Similarity — nearest-neighbour **grade agreement** (mean \|Δgrade\| to the nearest
+non-identical climb; lower is better):
+
+| representation          | neighbour \|Δgrade\| | random |
+| ----------------------- | -------------------- | ------ |
+| raw geometry vector     | 3.74                 | 3.74   |
+| **Deep Sets embedding** | **2.60**             | 3.74   |
+
+**Read:** geometry predicts Kilter grade well enough for a `content_prior` (GBM ≈
+0.7 V-grade MAE), and the learned embedding is a real similarity space (30% better
+than random on grade agreement) where raw geometry is no better than random. The
+Deep Sets **grade head** still trails the GBM by ~0.13 MAE — the GBM's strongest
+feature is the _sum_ of train-fit per-hold coefficients, which is nearly the whole
+signal since grade is roughly additive. The value of Deep Sets is the shared
+embedding (grade **and** similarity **and** style from one vector), which the GBM
+can't give. (Duplicate-holdset retrieval is trivially perfect but uninformative on
+the dev extract — only 3 duplicate groups; prod has ~16k fingerprint duplicates.)
+
+## Phase-1b (next)
+
+Close the grade gap and strengthen the embedding: an ordinal (CORAL) head, an
+explicit contrastive objective (hold_fingerprint duplicates as positives),
+hyperparameter tuning, and training on the full prod catalog + all boards (board
+embedding). Then export `content_prior` + embeddings for the Phase-2 blend and the
+Phase-3 similarity table.

--- a/ml/climb2vec/dataset.py
+++ b/ml/climb2vec/dataset.py
@@ -1,0 +1,116 @@
+"""Load + featurize the Climb2Vec training matrix (JSONL from
+packages/db/scripts/extract-training-matrix.ts).
+
+Leakage rule: the per-hold `hd`/`fd` fields in the extract were fit on ALL grades,
+so they are NOT used as model inputs here — that would leak the label. Models learn
+hold effects from the TRAIN split only (a learned pid embedding / a train-fit ridge
+coefficient). Only label-free geometry + hold identity feed the models.
+"""
+
+import json
+import math
+import random
+
+import numpy as np
+
+# Per-hold geometry node features (all label-free): nx, ny, edge, nbr, sin(pull),
+# cos(pull), kickboard, foot-set, is-hand, is-foot.
+GEOM_DIM = 10
+
+
+def load_rows(path):
+    rows = []
+    with open(path) as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def group_split(rows, val_frac=0.2, seed=13):
+    """Split by climb so a climb's angles never straddle train/val."""
+    climbs = sorted({row["climbUuid"] for row in rows})
+    rng = random.Random(seed)
+    rng.shuffle(climbs)
+    n_val = max(1, int(len(climbs) * val_frac))
+    val_climbs = set(climbs[:n_val])
+    train = [row for row in rows if row["climbUuid"] not in val_climbs]
+    val = [row for row in rows if row["climbUuid"] in val_climbs]
+    return train, val
+
+
+def _num(value):
+    return float(value) if value is not None else 0.0
+
+
+def hold_geom(hold):
+    pull = hold.get("pull")
+    sin_p = math.sin(math.radians(pull)) if pull is not None else 0.0
+    cos_p = math.cos(math.radians(pull)) if pull is not None else 0.0
+    return [
+        _num(hold.get("nx")),
+        _num(hold.get("ny")),
+        _num(hold.get("edge")),
+        _num(hold.get("nbr")),
+        sin_p,
+        cos_p,
+        1.0 if hold.get("kb") else 0.0,
+        1.0 if hold.get("footSet") else 0.0,
+        1.0 if hold["role"] == "hand" else 0.0,
+        1.0 if hold["role"] == "foot" else 0.0,
+    ]
+
+
+def holdset_key(row):
+    """Angle-independent identity of a climb's holds — duplicates share it."""
+    return (row.get("layoutId"), frozenset((hold["pid"], hold["role"]) for hold in row["holds"]))
+
+
+def weight(row):
+    return math.sqrt(max(1.0, float(row.get("ascents", 1))))
+
+
+def build_pid_vocab(train_rows):
+    """pid -> dense index (1..N); 0 is the UNK/padding slot for holds unseen in train."""
+    pids = set()
+    for row in train_rows:
+        for hold in row["holds"]:
+            pids.add(hold["pid"])
+    return {pid: index + 1 for index, pid in enumerate(sorted(pids))}
+
+
+def climb_geom_vector(row):
+    """Label-free per-climb aggregate, for the geometry-similarity baseline + GBM."""
+    holds = row["holds"]
+    hands = [h for h in holds if h["role"] == "hand"]
+    foots = [h for h in holds if h["role"] == "foot"]
+
+    def col(subset, key):
+        vals = [float(h[key]) for h in subset if h.get(key) is not None]
+        return np.array(vals, dtype=np.float64) if vals else np.array([0.0])
+
+    feats = [len(holds), len(hands), len(foots)]
+    for subset in (hands, foots):
+        for key in ("nx", "ny", "edge", "nbr"):
+            arr = col(subset, key)
+            feats += [float(arr.mean()), float(arr.std())]
+    nx = col(holds, "nx")
+    ny = col(holds, "ny")
+    feats += [float(nx.max() - nx.min()), float(ny.max() - ny.min())]
+    feats += [
+        float(sum(1 for h in holds if h.get("kb"))),
+        float(sum(1 for h in holds if h.get("footSet"))),
+    ]
+    pull_sin = np.mean([math.sin(math.radians(h["pull"])) for h in holds if h.get("pull") is not None] or [0.0])
+    pull_cos = np.mean([math.cos(math.radians(h["pull"])) for h in holds if h.get("pull") is not None] or [0.0])
+    feats += [float(pull_sin), float(pull_cos)]
+    return np.array(feats, dtype=np.float32)
+
+
+def unique_climbs(rows):
+    """One representative row per climbUuid (holds are identical across its angles)."""
+    seen = {}
+    for row in rows:
+        seen.setdefault(row["climbUuid"], row)
+    return list(seen.values())

--- a/ml/climb2vec/evaluate.py
+++ b/ml/climb2vec/evaluate.py
@@ -1,0 +1,306 @@
+"""Climb2Vec Phase-1 offline evaluation.
+
+Answers the two Phase-1 questions on real Kilter data, leakage-free (hold effects
+are learned on the TRAIN split only, evaluated on held-out climbs):
+
+  1. Does hold geometry/identity predict grade? — ridge, GBM, and the Deep Sets
+     encoder, scored by exact / within-±1 / MAE against the crowd grade.
+  2. Does the learned embedding capture difficulty structure? — duplicate-holdset
+     retrieval (sanity) + nearest-neighbour grade agreement vs a geometry baseline.
+
+Run: python evaluate.py --data data/kilter-train.jsonl [--epochs 25] [--out artifacts/results.json]
+"""
+
+import argparse
+import json
+import os
+import random
+
+import numpy as np
+from scipy.sparse import csr_matrix
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.linear_model import Ridge
+
+import dataset as ds
+
+SEED = 13
+
+
+def metrics(pred, y):
+    pred = np.asarray(pred, dtype=np.float64)
+    y = np.asarray(y, dtype=np.float64)
+    return {
+        "n": int(len(y)),
+        "mae": round(float(np.mean(np.abs(pred - y))), 4),
+        "exact": round(float(np.mean(np.round(pred) == np.round(y))), 4),
+        "within1": round(float(np.mean(np.abs(np.round(pred) - np.round(y)) <= 1)), 4),
+    }
+
+
+def index_map(pids):
+    return {pid: i for i, pid in enumerate(sorted(pids))}
+
+
+def build_incidence(rows, hand_index, foot_index):
+    n_hand, n_foot = len(hand_index), len(foot_index)
+    ncol = n_hand + n_foot + 1  # + angle column
+    data, indices, indptr = [], [], [0]
+    labels, weights = [], []
+    for row in rows:
+        cols = {}
+        for hold in row["holds"]:
+            if hold["role"] == "hand":
+                j = hand_index.get(hold["pid"])
+                if j is not None:
+                    cols[j] = 1.0
+            else:
+                j = foot_index.get(hold["pid"])
+                if j is not None:
+                    cols[n_hand + j] = 1.0
+        cols[ncol - 1] = (row["angle"] - 40) / 10.0
+        for col, val in cols.items():
+            indices.append(col)
+            data.append(val)
+        indptr.append(len(indices))
+        labels.append(row["label"])
+        weights.append(ds.weight(row))
+    matrix = csr_matrix((data, indices, indptr), shape=(len(rows), ncol))
+    return matrix, np.array(labels), np.array(weights)
+
+
+def agg_features(rows, hand_coef, foot_coef):
+    out = []
+    for row in rows:
+        hand_vals = [hand_coef[h["pid"]] for h in row["holds"] if h["role"] == "hand" and h["pid"] in hand_coef]
+        foot_vals = [foot_coef[h["pid"]] for h in row["holds"] if h["role"] == "foot" and h["pid"] in foot_coef]
+
+        def agg(vals):
+            arr = np.array(vals) if vals else np.array([0.0])
+            return [float(arr.sum()), float(arr.mean()), float(arr.max()), float(arr.min())]
+
+        geom = ds.climb_geom_vector(row)
+        row_feats = list(geom) + [(row["angle"] - 40) / 10.0] + agg(hand_vals) + agg(foot_vals)
+        out.append(row_feats)
+    return np.array(out, dtype=np.float64)
+
+
+# Node feature width = geometry (GEOM_DIM) + the train-fit per-hold ridge coefficient
+# (leak-free: learned on TRAIN only, applied by role; 0 for holds unseen in train).
+NODE_DIM = ds.GEOM_DIM + 1
+
+
+def build_tensors(rows, pid_vocab, max_holds, hand_coef, foot_coef):
+    n = len(rows)
+    node = np.zeros((n, max_holds, NODE_DIM), dtype=np.float32)
+    pids = np.zeros((n, max_holds), dtype=np.int64)
+    mask = np.zeros((n, max_holds), dtype=np.float32)
+    angle = np.zeros((n, 1), dtype=np.float32)
+    labels = np.zeros(n, dtype=np.float32)
+    weights = np.zeros(n, dtype=np.float32)
+    for i, row in enumerate(rows):
+        for k, hold in enumerate(row["holds"][:max_holds]):
+            node[i, k, : ds.GEOM_DIM] = ds.hold_geom(hold)
+            coef = hand_coef if hold["role"] == "hand" else foot_coef
+            node[i, k, ds.GEOM_DIM] = coef.get(hold["pid"], 0.0)
+            pids[i, k] = pid_vocab.get(hold["pid"], 0)
+            mask[i, k] = 1.0
+        angle[i, 0] = (row["angle"] - 40) / 20.0
+        labels[i] = row["label"]
+        weights[i] = ds.weight(row)
+    return node, pids, mask, angle, labels, weights
+
+
+def run_deepsets(train, val, pid_vocab, epochs, hand_coef, foot_coef):
+    import torch
+    from model import DeepSetsGrader
+
+    torch.manual_seed(0)
+    max_holds = min(40, max(len(r["holds"]) for r in train + val))
+    ntr = build_tensors(train, pid_vocab, max_holds, hand_coef, foot_coef)
+    nva = build_tensors(val, pid_vocab, max_holds, hand_coef, foot_coef)
+    y_mean = float(ntr[4].mean())
+
+    def tensors(pack):
+        node, pids, mask, angle, labels, weights = pack
+        return (
+            torch.from_numpy(node),
+            torch.from_numpy(pids),
+            torch.from_numpy(mask),
+            torch.from_numpy(angle),
+            torch.from_numpy(labels - y_mean),
+            torch.from_numpy(weights / weights.mean()),
+        )
+
+    tr = tensors(ntr)
+    va = tensors(nva)
+    model = DeepSetsGrader(n_pids=len(pid_vocab), geom_dim=NODE_DIM)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3, weight_decay=1e-5)
+
+    n = tr[0].shape[0]
+    batch = 512
+    for _ in range(epochs):
+        model.train()
+        order = torch.randperm(n)
+        for start in range(0, n, batch):
+            idx = order[start : start + batch]
+            pred, _ = model(tr[0][idx], tr[1][idx], tr[2][idx], tr[3][idx])
+            loss = (((pred - tr[4][idx]) ** 2) * tr[5][idx]).mean()
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+
+    model.eval()
+    with torch.no_grad():
+        pred_val, _ = model(va[0], va[1], va[2], va[3])
+        pred_val = pred_val.numpy() + y_mean
+    return model, metrics(pred_val, nva[4]), max_holds, y_mean
+
+
+def embed_unique(model, rows, pid_vocab, max_holds, hand_coef, foot_coef):
+    """Embed each unique climb at a canonical angle (40°) → [N, emb_dim]."""
+    import torch
+
+    node, pids, mask, angle, _, _ = build_tensors(
+        [{**r, "angle": 40} for r in rows], pid_vocab, max_holds, hand_coef, foot_coef
+    )
+    with torch.no_grad():
+        vecs = model.embed(
+            torch.from_numpy(node), torch.from_numpy(pids), torch.from_numpy(mask), torch.from_numpy(angle)
+        ).numpy()
+    return vecs
+
+
+def cosine_normalize(vectors):
+    return vectors / (np.linalg.norm(vectors, axis=1, keepdims=True) + 1e-9)
+
+
+def duplicate_retrieval(unique_rows, vectors):
+    groups = {}
+    for i, row in enumerate(unique_rows):
+        groups.setdefault(ds.holdset_key(row), []).append(i)
+    dup_groups = {k: v for k, v in groups.items() if len(v) >= 2}
+    dup_idx = [i for members in dup_groups.values() for i in members]
+    if not dup_idx:
+        return {"duplicate_climbs": 0}
+    member_of = {i: k for k, members in dup_groups.items() for i in members}
+    unit = cosine_normalize(vectors)
+    hit1 = hit5 = 0
+    for q in dup_idx:
+        sims = unit @ unit[q]
+        sims[q] = -1e9
+        order = np.argsort(-sims)
+        if member_of.get(int(order[0])) == member_of[q]:
+            hit1 += 1
+        if any(member_of.get(int(i)) == member_of[q] for i in order[:5]):
+            hit5 += 1
+    return {
+        "duplicate_climbs": len(dup_idx),
+        "duplicate_groups": len(dup_groups),
+        "recall@1": round(hit1 / len(dup_idx), 4),
+        "recall@5": round(hit5 / len(dup_idx), 4),
+    }
+
+
+def neighbor_grade_agreement(unique_rows, vectors, climb_grade):
+    """Mean |Δgrade| between a climb and its nearest NON-identical neighbour."""
+    unit = cosine_normalize(vectors)
+    keys = [ds.holdset_key(r) for r in unique_rows]
+    grades = np.array([climb_grade[r["climbUuid"]] for r in unique_rows])
+    deltas = []
+    rng = random.Random(SEED)
+    sample = list(range(len(unique_rows)))
+    if len(sample) > 3000:
+        sample = rng.sample(sample, 3000)
+    for q in sample:
+        sims = unit @ unit[q]
+        order = np.argsort(-sims)
+        neighbor = next((int(i) for i in order if i != q and keys[int(i)] != keys[q]), None)
+        if neighbor is not None:
+            deltas.append(abs(grades[q] - grades[neighbor]))
+    random_delta = float(np.mean(np.abs(grades[rng.sample(range(len(grades)), min(3000, len(grades)))] - np.mean(grades))))
+    return {
+        "neighbor_grade_mae": round(float(np.mean(deltas)), 4) if deltas else None,
+        "random_grade_mae": round(random_delta, 4),
+        "sampled": len(deltas),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data", default="data/kilter-train.jsonl")
+    parser.add_argument("--epochs", type=int, default=25)
+    parser.add_argument("--out", default="artifacts/results.json")
+    args = parser.parse_args()
+
+    random.seed(SEED)
+    np.random.seed(SEED)
+
+    rows = ds.load_rows(args.data)
+    train, val = ds.group_split(rows, seed=SEED)
+    print(f"[eval] {len(rows)} obs · train {len(train)} / val {len(val)} (grouped by climb)")
+
+    # --- Ridge over hold-incidence (the de-confounded linear content model) ---
+    hand_index = index_map({h["pid"] for r in train for h in r["holds"] if h["role"] == "hand"})
+    foot_index = index_map({h["pid"] for r in train for h in r["holds"] if h["role"] == "foot"})
+    x_tr, y_tr, w_tr = build_incidence(train, hand_index, foot_index)
+    x_va, y_va, _ = build_incidence(val, hand_index, foot_index)
+    ridge = Ridge(alpha=5.0)
+    ridge.fit(x_tr, y_tr, sample_weight=w_tr)
+    ridge_metrics = metrics(ridge.predict(x_va), y_va)
+    print(f"[eval] ridge   {ridge_metrics}")
+
+    # --- GBM over compact aggregate features (train-fit hold coefs + geometry) ---
+    n_hand = len(hand_index)
+    hand_coef = {pid: float(ridge.coef_[j]) for pid, j in hand_index.items()}
+    foot_coef = {pid: float(ridge.coef_[n_hand + j]) for pid, j in foot_index.items()}
+    gbm = HistGradientBoostingRegressor(max_iter=300, learning_rate=0.05, max_depth=6, random_state=SEED)
+    gbm.fit(agg_features(train, hand_coef, foot_coef), y_tr, sample_weight=w_tr)
+    gbm_metrics = metrics(gbm.predict(agg_features(val, hand_coef, foot_coef)), y_va)
+    print(f"[eval] gbm     {gbm_metrics}")
+
+    # --- Deep Sets encoder (Climb2Vec) ---
+    pid_vocab = ds.build_pid_vocab(train)
+    model, deep_metrics, max_holds, _ = run_deepsets(train, val, pid_vocab, args.epochs, hand_coef, foot_coef)
+    print(f"[eval] deepsets{deep_metrics}")
+
+    # --- Similarity: duplicate retrieval + neighbour grade agreement (val climbs) ---
+    val_unique = ds.unique_climbs(val)
+    climb_grade = {}
+    grade_bucket = {}
+    for row in val:
+        grade_bucket.setdefault(row["climbUuid"], []).append(row["label"])
+    for uuid, labels in grade_bucket.items():
+        climb_grade[uuid] = float(np.mean(labels))
+
+    geom_vectors = np.array([ds.climb_geom_vector(r) for r in val_unique], dtype=np.float32)
+    deep_vectors = embed_unique(model, val_unique, pid_vocab, max_holds, hand_coef, foot_coef)
+
+    similarity = {
+        "geometry_vector": {
+            "duplicates": duplicate_retrieval(val_unique, geom_vectors),
+            "grade_agreement": neighbor_grade_agreement(val_unique, geom_vectors, climb_grade),
+        },
+        "deepsets_embedding": {
+            "duplicates": duplicate_retrieval(val_unique, deep_vectors),
+            "grade_agreement": neighbor_grade_agreement(val_unique, deep_vectors, climb_grade),
+        },
+    }
+    print(f"[eval] similarity {json.dumps(similarity)}")
+
+    results = {
+        "data": args.data,
+        "n_obs": len(rows),
+        "n_train": len(train),
+        "n_val": len(val),
+        "grade": {"ridge": ridge_metrics, "gbm": gbm_metrics, "deepsets": deep_metrics},
+        "similarity": similarity,
+        "reference": {"moonboardrnn_exact": 0.467, "moonboardrnn_within1": 0.847},
+    }
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w") as handle:
+        json.dump(results, handle, indent=2)
+    print(f"[eval] wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/climb2vec/model.py
+++ b/ml/climb2vec/model.py
@@ -1,0 +1,54 @@
+"""The Climb2Vec Deep Sets encoder (PyTorch).
+
+A climb is a SET of holds. Each hold node = [label-free geometry features] concat
+[a learned per-placement embedding]. Nodes go through a shared MLP (phi), are
+masked-mean/max pooled into a permutation-invariant climb vector, concatenated with
+the (scaled) wall angle, and mapped by psi to the penultimate EMBEDDING that feeds a
+linear grade head. The learned pid embedding is the nonlinear, low-dimensional analog
+of the ridge's per-hold coefficient — and the penultimate embedding is what powers
+climb similarity + style downstream.
+"""
+
+import torch
+import torch.nn as nn
+
+
+class DeepSetsGrader(nn.Module):
+    def __init__(self, n_pids, geom_dim=10, pid_dim=16, hidden=64, emb_dim=64):
+        super().__init__()
+        # padding_idx=0 → UNK/padded holds contribute a zero embedding.
+        self.pid_emb = nn.Embedding(n_pids + 1, pid_dim, padding_idx=0)
+        self.phi = nn.Sequential(
+            nn.Linear(geom_dim + pid_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, hidden),
+            nn.ReLU(),
+        )
+        # Pool = [mean, max, sum]. Sum matters because grade is roughly ADDITIVE in
+        # per-hold difficulty (more hard holds → harder climb); mean/max alone can't
+        # recover the count, so a sum term lets the encoder match the linear/GBM models.
+        self.psi = nn.Sequential(
+            nn.Linear(hidden * 3 + 1, emb_dim),
+            nn.ReLU(),
+        )
+        self.head = nn.Linear(emb_dim, 1)
+
+    def embed(self, node_feats, pids, mask, angle):
+        # node_feats [B,H,geom]; pids [B,H]; mask [B,H] in {0,1}; angle [B,1]
+        pid_vec = self.pid_emb(pids)
+        nodes = torch.cat([node_feats, pid_vec], dim=-1)
+        hidden = self.phi(nodes)
+        mask3 = mask.unsqueeze(-1)
+        hidden = hidden * mask3
+        summed = hidden.sum(dim=1)
+        count = mask3.sum(dim=1).clamp(min=1.0)
+        mean_pool = summed / count
+        masked = hidden.masked_fill(mask3 == 0, float("-inf"))
+        max_pool = torch.nan_to_num(masked.max(dim=1).values, neginf=0.0)
+        pooled = torch.cat([mean_pool, max_pool, summed, angle], dim=-1)
+        return self.psi(pooled)
+
+    def forward(self, node_feats, pids, mask, angle):
+        embedding = self.embed(node_feats, pids, mask, angle)
+        grade = self.head(embedding).squeeze(-1)
+        return grade, embedding

--- a/ml/climb2vec/requirements.txt
+++ b/ml/climb2vec/requirements.txt
@@ -1,0 +1,6 @@
+# Offline Climb2Vec training/eval deps. Kept minimal and CPU-only so the pipeline
+# runs anywhere; it never ships to prod (serving is pure TS, per docs/climb2vec.md).
+numpy>=1.26
+scikit-learn>=1.4
+# torch is optional — only needed for the Deep Sets encoder (evaluate.py --model deepsets).
+# Install separately: pip install torch --index-url https://download.pytorch.org/whl/cpu

--- a/packages/db/scripts/extract-training-matrix.ts
+++ b/packages/db/scripts/extract-training-matrix.ts
@@ -1,0 +1,159 @@
+/**
+ * Export the Climb2Vec training matrix — one JSONL row per graded (climb, angle)
+ * — for offline model training + validation (ml/climb2vec/). Each row carries the
+ * climb's holds, each hold's generated board_hold_features, the angle, the crowd
+ * grade label, the ascent weight, and the hold_fingerprint.
+ *
+ * Requires board_hold_features to be populated first
+ * (`refresh-hold-features.ts`). Reads only; writes a JSONL file, no DB writes.
+ *
+ * Run: `node --import tsx packages/db/scripts/extract-training-matrix.ts \
+ *        --board=kilter --out=ml/climb2vec/data/kilter-train.jsonl`
+ * Flags: --board=<name> (default kilter) · --out=<path> · --min-ascents=<n> (20)
+ *        · --angle=<deg> (optional single-angle slice, e.g. 40) · --limit=<n>.
+ */
+import { mkdirSync, createWriteStream } from 'node:fs';
+import { dirname } from 'node:path';
+import { sql } from 'drizzle-orm';
+import { createScriptDb } from './db-connection.js';
+import {
+  buildTrainingRow,
+  type HoldFeatureLite,
+  type ClimbStatLite,
+  type HoldLite,
+} from '../src/queries/hold-features/index.js';
+
+const DEFAULT_OUT = 'ml/climb2vec/data/kilter-train.jsonl';
+const DEFAULT_MIN_ASCENTS = 20;
+
+type Db = ReturnType<typeof createScriptDb>['db'];
+
+interface Options {
+  board: string;
+  out: string;
+  minAscents: number;
+  angle: number | null;
+  limit: number | null;
+}
+
+function toNumber(value: unknown): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+async function loadFeatures(db: Db, board: string): Promise<Map<number, HoldFeatureLite>> {
+  const rows = (await db.execute(sql`
+    SELECT placement_id, norm_x, norm_y, edge_dist, neighbor_dist,
+           hand_difficulty, foot_difficulty, pull_direction, is_kickboard, coarse_type
+    FROM board_hold_features WHERE board_type = ${board}
+  `)) as unknown as HoldFeatureLite[];
+  const map = new Map<number, HoldFeatureLite>();
+  for (const row of rows) map.set(toNumber(row.placement_id), row);
+  return map;
+}
+
+async function loadStats(db: Db, options: Options): Promise<ClimbStatLite[]> {
+  const angleFilter = options.angle === null ? sql`` : sql`AND st.angle = ${options.angle}`;
+  const limitClause = options.limit === null ? sql`` : sql`LIMIT ${options.limit}`;
+  return (await db.execute(sql`
+    SELECT st.climb_uuid AS climb_uuid, st.angle AS angle, st.difficulty_average AS label,
+           st.ascensionist_count AS n, c.layout_id AS layout_id, c.hold_fingerprint AS fingerprint
+    FROM board_climb_stats st
+    JOIN board_climbs c ON c.uuid = st.climb_uuid
+    WHERE st.board_type = ${options.board}
+      AND c.is_listed = true
+      AND COALESCE(c.is_draft, false) = false
+      AND st.ascensionist_count >= ${options.minAscents}
+      AND st.difficulty_average IS NOT NULL
+      ${angleFilter}
+    ORDER BY st.climb_uuid, st.angle
+    ${limitClause}
+  `)) as unknown as ClimbStatLite[];
+}
+
+async function loadHoldsByClimb(db: Db, options: Options): Promise<Map<string, HoldLite[]>> {
+  const rows = (await db.execute(sql`
+    SELECT ch.climb_uuid AS climb_uuid, ch.hold_id AS placement_id, ch.hold_state AS hold_state
+    FROM board_climb_holds ch
+    WHERE ch.board_type = ${options.board}
+      AND ch.climb_uuid IN (
+        SELECT st.climb_uuid FROM board_climb_stats st
+        JOIN board_climbs c ON c.uuid = st.climb_uuid
+        WHERE st.board_type = ${options.board}
+          AND c.is_listed = true
+          AND COALESCE(c.is_draft, false) = false
+          AND st.ascensionist_count >= ${options.minAscents}
+          AND st.difficulty_average IS NOT NULL
+      )
+  `)) as unknown as Array<{ climb_uuid: string; placement_id: number; hold_state: string }>;
+  const byClimb = new Map<string, HoldLite[]>();
+  for (const row of rows) {
+    let list = byClimb.get(row.climb_uuid);
+    if (!list) {
+      list = [];
+      byClimb.set(row.climb_uuid, list);
+    }
+    list.push({ placement_id: toNumber(row.placement_id), hold_state: row.hold_state });
+  }
+  return byClimb;
+}
+
+function parseArgs(argv: string[]): Options {
+  const get = (flag: string): string | undefined =>
+    argv.find((arg) => arg.startsWith(`${flag}=`))?.slice(flag.length + 1);
+  const angleArg = get('--angle');
+  const limitArg = get('--limit');
+  return {
+    board: get('--board') ?? 'kilter',
+    out: get('--out') ?? DEFAULT_OUT,
+    minAscents: get('--min-ascents') ? Number(get('--min-ascents')) : DEFAULT_MIN_ASCENTS,
+    angle: angleArg ? Number(angleArg) : null,
+    limit: limitArg ? Number(limitArg) : null,
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const { db, close } = createScriptDb();
+  console.log(
+    `[extract] board=${options.board} minAscents=${options.minAscents} angle=${options.angle ?? 'all'} → ${options.out}`,
+  );
+  try {
+    const [features, stats, holdsByClimb] = await Promise.all([
+      loadFeatures(db, options.board),
+      loadStats(db, options),
+      loadHoldsByClimb(db, options),
+    ]);
+    if (features.size === 0) {
+      throw new Error(`board_hold_features is empty for ${options.board} — run refresh-hold-features.ts first.`);
+    }
+
+    mkdirSync(dirname(options.out), { recursive: true });
+    const stream = createWriteStream(options.out, { encoding: 'utf8' });
+    let written = 0;
+    let holdTotal = 0;
+    for (const stat of stats) {
+      const holds = holdsByClimb.get(stat.climb_uuid);
+      if (!holds || holds.length === 0) continue;
+      const row = buildTrainingRow(stat, holds, features);
+      if (row.holds.length === 0) continue;
+      stream.write(`${JSON.stringify(row)}\n`);
+      written++;
+      holdTotal += row.holds.length;
+    }
+    await new Promise<void>((resolve, reject) =>
+      stream.end((error?: Error | null) => (error ? reject(error) : resolve())),
+    );
+    console.log(
+      `[extract] wrote ${written} rows (${features.size} placement features, avg ${
+        written ? (holdTotal / written).toFixed(1) : 0
+      } holds/row) → ${options.out}`,
+    );
+  } finally {
+    await close();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error('[extract] failed:', error);
+  process.exit(1);
+});

--- a/packages/db/src/queries/hold-features/__tests__/extract-training-matrix.test.ts
+++ b/packages/db/src/queries/hold-features/__tests__/extract-training-matrix.test.ts
@@ -1,0 +1,62 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildTrainingRow } from '../training-matrix';
+
+// Minimal FeatureRow shape the assembler reads from.
+const feature = (placementId: number, overrides: Record<string, unknown> = {}) => ({
+  placement_id: placementId,
+  norm_x: 0.5,
+  norm_y: 0.5,
+  edge_dist: 0.5,
+  neighbor_dist: 0.1,
+  hand_difficulty: 2,
+  foot_difficulty: -1,
+  pull_direction: 90,
+  is_kickboard: false,
+  coarse_type: null,
+  ...overrides,
+});
+
+void describe('buildTrainingRow', () => {
+  const stat = { climb_uuid: 'abc', angle: 40, label: 18.5, n: 120, layout_id: 1, fingerprint: 'fp1' };
+
+  test('joins holds to their features and maps roles', () => {
+    const features = new Map([
+      [10, feature(10, { hand_difficulty: 3 })],
+      [20, feature(20, { coarse_type: 'foot' })],
+    ]);
+    const row = buildTrainingRow(
+      stat,
+      [
+        { placement_id: 10, hold_state: 'HAND' },
+        { placement_id: 20, hold_state: 'FOOT' },
+        { placement_id: 30, hold_state: 'STARTING' }, // no feature row → nulls, still a hand hold
+      ],
+      features,
+    );
+    assert.equal(row.climbUuid, 'abc');
+    assert.equal(row.angle, 40);
+    assert.equal(row.label, 18.5);
+    assert.equal(row.holds.length, 3);
+    assert.equal(row.holds[0].role, 'hand');
+    assert.equal(row.holds[0].hd, 3);
+    assert.equal(row.holds[1].role, 'foot');
+    assert.equal(row.holds[1].footSet, true);
+    // Hold with no feature row keeps its role but carries null features.
+    assert.equal(row.holds[2].role, 'hand');
+    assert.equal(row.holds[2].hd, null);
+    assert.equal(row.holds[2].nx, null);
+  });
+
+  test('skips malformed hold states', () => {
+    const row = buildTrainingRow(
+      stat,
+      [
+        { placement_id: 10, hold_state: 'HAND' },
+        { placement_id: 11, hold_state: 'NaN=undefined' }, // known bad-parse rows
+      ],
+      new Map([[10, feature(10)]]),
+    );
+    assert.equal(row.holds.length, 1);
+  });
+});

--- a/packages/db/src/queries/hold-features/index.ts
+++ b/packages/db/src/queries/hold-features/index.ts
@@ -2,3 +2,4 @@ export * from './types.js';
 export * from './geometry.js';
 export * from './behavioral.js';
 export * from './set-type.js';
+export * from './training-matrix.js';

--- a/packages/db/src/queries/hold-features/training-matrix.ts
+++ b/packages/db/src/queries/hold-features/training-matrix.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure assembly of the Climb2Vec training matrix — join a graded (climb, angle)
+ * stat row to its holds and each hold's generated board_hold_features. The I/O
+ * (SQL + JSONL) lives in `packages/db/scripts/extract-training-matrix.ts`; this
+ * module is the testable core.
+ */
+
+/** A placement's generated features, as read from board_hold_features. */
+export interface HoldFeatureLite {
+  placement_id: number;
+  norm_x: number | null;
+  norm_y: number | null;
+  edge_dist: number | null;
+  neighbor_dist: number | null;
+  hand_difficulty: number | null;
+  foot_difficulty: number | null;
+  pull_direction: number | null;
+  is_kickboard: boolean;
+  coarse_type: string | null;
+}
+
+/** A graded (climb, angle) row: crowd label + weight + identity. */
+export interface ClimbStatLite {
+  climb_uuid: string;
+  angle: number;
+  label: number;
+  n: number;
+  layout_id: number | null;
+  fingerprint: string | null;
+}
+
+/** A hold on a climb: placement id + the role state from board_climb_holds. */
+export interface HoldLite {
+  placement_id: number;
+  hold_state: string;
+}
+
+/** A hold as emitted in the training matrix: role + its generated features. */
+export interface TrainingHold {
+  pid: number;
+  role: 'hand' | 'foot';
+  nx: number | null;
+  ny: number | null;
+  edge: number | null;
+  nbr: number | null;
+  hd: number | null;
+  fd: number | null;
+  pull: number | null;
+  kb: boolean;
+  footSet: boolean;
+}
+
+/** One training example: a climb at an angle, its holds, and the label. */
+export interface TrainingRow {
+  climbUuid: string;
+  angle: number;
+  label: number;
+  ascents: number;
+  layoutId: number | null;
+  fingerprint: string | null;
+  holds: TrainingHold[];
+}
+
+const HAND_STATES = new Set(['STARTING', 'HAND', 'FINISH']);
+
+function toNumber(value: unknown): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+/** Join a stat row to its holds and their features into one training example. */
+export function buildTrainingRow(
+  stat: ClimbStatLite,
+  holds: readonly HoldLite[],
+  featureByPlacement: ReadonlyMap<number, HoldFeatureLite>,
+): TrainingRow {
+  const trainingHolds: TrainingHold[] = [];
+  for (const hold of holds) {
+    const isFoot = hold.hold_state === 'FOOT';
+    const isHand = HAND_STATES.has(hold.hold_state);
+    if (!isFoot && !isHand) continue; // skip malformed states
+    const feature = featureByPlacement.get(toNumber(hold.placement_id));
+    trainingHolds.push({
+      pid: toNumber(hold.placement_id),
+      role: isFoot ? 'foot' : 'hand',
+      nx: feature?.norm_x ?? null,
+      ny: feature?.norm_y ?? null,
+      edge: feature?.edge_dist ?? null,
+      nbr: feature?.neighbor_dist ?? null,
+      hd: feature?.hand_difficulty ?? null,
+      fd: feature?.foot_difficulty ?? null,
+      pull: feature?.pull_direction ?? null,
+      kb: feature?.is_kickboard ?? false,
+      footSet: feature?.coarse_type === 'foot',
+    });
+  }
+  return {
+    climbUuid: stat.climb_uuid,
+    angle: toNumber(stat.angle),
+    label: toNumber(stat.label),
+    ascents: toNumber(stat.n),
+    layoutId: stat.layout_id === null ? null : toNumber(stat.layout_id),
+    fingerprint: stat.fingerprint,
+    holds: trainingHolds,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 1a of the Climb2Vec grade pivot (`docs/climb2vec.md`), **stacked on #3584** (Phase 0 — the hold-feature substrate). Turns the generated features into an offline learning pipeline and answers the two Phase-1 feasibility questions on real Kilter data.

- **`extract-training-matrix.ts`** — exports one JSONL row per graded (climb, angle): the climb's holds joined to their `board_hold_features`, the angle, the crowd grade label, the ascent weight, and the fingerprint. The pure assembler (`training-matrix.ts`) is unit-tested.
- **`ml/climb2vec/`** — offline PyTorch/sklearn pipeline (never ships to prod; serving stays pure TS):
  - `model.py` — the **Deep Sets encoder**: per-hold node MLP → masked mean/max/sum pool → angle → penultimate **embedding** → grade head.
  - `evaluate.py` — **leakage-free** evaluation: ridge + GBM baselines + Deep Sets, scored on held-out climbs; plus similarity (duplicate retrieval + nearest-neighbour grade agreement).

### Feasibility results (Kilter, 29,748 obs, 80/20 split by climb)

Grade accuracy, held-out (label in Aurora difficulty units ≈ 2 per V-grade → MAE 1.4 ≈ ~0.7 V-grade):

| model                 | exact | within ±1 | MAE      |
| --------------------- | ----- | --------- | -------- |
| ridge                 | 17.4% | 48.2%     | 1.93     |
| GBM                   | 23.8% | 59.8%     | **1.42** |
| Deep Sets (Climb2Vec) | 19.9% | 56.8%     | 1.55     |

Similarity — nearest-neighbour grade \|Δ\| (lower better): **Deep Sets 2.60** vs **3.74** random; a raw geometry vector is no better than random (3.74).

**Read:** geometry predicts Kilter grade well enough for a `content_prior`, and the learned embedding is a real similarity space (the value the GBM can't give). The Deep Sets grade head trails the GBM by ~0.13 MAE — Phase 1b (ordinal head, contrastive objective, tuning, full catalog) closes it.

**Leakage discipline:** the pre-computed per-hold difficulties in the extract were fit on all grades, so they are **not** used as model inputs — every hold effect is (re)learned on the train split only and applied to held-out climbs.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `node --import tsx --test packages/db/src/queries/hold-features/__tests__/*.test.ts` — **14 pass** (incl. the extractor assembler).
- `vp run typecheck:db` and `vp check` — clean.
- Extractor against the dev DB → **29,748** Kilter training rows (avg 12.5 holds/row).
- `python evaluate.py` on that extract → the numbers above (written to `ml/climb2vec/artifacts/results.json`, gitignored). torch 2.13.0+cpu, sklearn 1.9, Python 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHTC497LJUWygVAye2wchm
