### PR TITLE
Reduce noisy PostHog events

### DIFF
--- a/POSTHOG_INVENTORY.md
+++ b/POSTHOG_INVENTORY.md
@@ -72,25 +72,23 @@ Boardsesh has comprehensive PostHog instrumentation across both web (Next.js) an
 | Login Succeeded (Party)  | party-profile-context.tsx:104                      | `auth_method`, `flow` (OAuth provider)     | OAuth flow completed (server-side redirect) |
 | Logout                   | user-drawer.tsx:221, delete-account-section.tsx:99 | `method`                                   | User clicked logout                         |
 
-### 2.2 Climb Management (15 events)
+### 2.2 Climb Management (13 events)
 
-| Event Name                        | File:Line                                                          | Properties                                                                                                            | Context                                                                                                                                     |
-| --------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Climb Created                     | create-climb-form.tsx:900                                          | `boardLayout`, `isDraft`, `holdCount`                                                                                 | User saved new climb                                                                                                                        |
-| Climb Updated                     | create-climb-form.tsx:863                                          | `boardLayout`, `isDraft`, `holdCount`                                                                                 | User edited existing climb                                                                                                                  |
-| Climb Create Failed               | create-climb-form.tsx:932                                          | `error_message`, `boardLayout`                                                                                        | Save attempt failed                                                                                                                         |
-| Climb Forked                      | use-climb-actions.ts:100                                           | `fromClimbUuid`, `boardLayout`                                                                                        | User created copy of climb                                                                                                                  |
-| Draft Edited                      | fork-action.tsx:58                                                 | (same as Fork)                                                                                                        | User edited draft version                                                                                                                   |
-| Climb Info Viewed                 | use-climb-actions.ts:88                                            | `climbUuid`, `boardLayout`                                                                                            | User opened climb details. WEB-ONLY now — mobile retired this; mobile climb-view opens fire `Play Drawer Opened` with `source: climb_view`. |
-| Climb Shared                      | use-climb-actions.ts:196,204                                       | `climbUuid`, `boardLayout`, `method` (native/clipboard)                                                               | User shared via web share or copy                                                                                                           |
-| Mirror Climb                      | use-climb-actions.ts:174                                           | `climbUuid`, `boardLayout`                                                                                            | User flipped climb horizontally                                                                                                             |
-| Set Active Climb                  | QueueContext.tsx:598,740,862; queue-bridge-context.tsx:270,389,536 | `climbUuid`, `boardType`, `layoutId`, `source` (setCurrentClimb / setCurrentClimbQueueItem / takeControl / bridge.\*) | User activated a climb (any UI path — button, queue nav, list tap, swipe, playlist, browse). Fired centrally from queue context mutators.   |
-| Climb List Row Clicked            | climbs-list.tsx:419                                                | `climbUuid`                                                                                                           | User tapped climb in list view                                                                                                              |
-| Open in Aurora App                | use-climb-actions.ts:160                                           | `climbUuid`, `boardLayout`                                                                                            | User clicked "open in app"                                                                                                                  |
-| Create Climb Set Active           | create-climb-form.tsx:747                                          | `boardLayout`                                                                                                         | User toggled active during create                                                                                                           |
-| Create Climb Heatmap Shown/Hidden | create-climb-form.tsx:1346                                         | `boardLayout`                                                                                                         | User toggled heatmap overlay                                                                                                                |
-| Beta Video Added                  | attach-beta-link-form.tsx:137                                      | `boardType`, `climbUuid`, `platform` (youtube/vimeo)                                                                  | User attached beta video link                                                                                                               |
-| Beta Video Link Clicked           | boardsesh-beta-card.tsx:56                                         | `boardType`, `climbUuid`, `platform`                                                                                  | User clicked embedded video                                                                                                                 |
+| Event Name              | File:Line                                                          | Properties                                                                                                            | Context                                                                                                                                     |
+| ----------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Climb Created           | create-climb-form.tsx:900                                          | `boardLayout`, `isDraft`, `holdCount`                                                                                 | User saved new climb                                                                                                                        |
+| Climb Updated           | create-climb-form.tsx:863                                          | `boardLayout`, `isDraft`, `holdCount`                                                                                 | User edited existing climb                                                                                                                  |
+| Climb Create Failed     | create-climb-form.tsx:932                                          | `error_message`, `boardLayout`                                                                                        | Save attempt failed                                                                                                                         |
+| Climb Forked            | use-climb-actions.ts:100                                           | `fromClimbUuid`, `boardLayout`                                                                                        | User created copy of climb                                                                                                                  |
+| Draft Edited            | fork-action.tsx:58                                                 | (same as Fork)                                                                                                        | User edited draft version                                                                                                                   |
+| Climb Info Viewed       | use-climb-actions.ts:88                                            | `climbUuid`, `boardLayout`                                                                                            | User opened climb details. WEB-ONLY now — mobile retired this; mobile climb-view opens fire `Play Drawer Opened` with `source: climb_view`. |
+| Climb Shared            | use-climb-actions.ts:196,204                                       | `climbUuid`, `boardLayout`, `method` (native/clipboard)                                                               | User shared via web share or copy                                                                                                           |
+| Mirror Climb            | use-climb-actions.ts:174                                           | `climbUuid`, `boardLayout`                                                                                            | User flipped climb horizontally                                                                                                             |
+| Set Active Climb        | QueueContext.tsx:598,740,862; queue-bridge-context.tsx:270,389,536 | `climbUuid`, `boardType`, `layoutId`, `source` (setCurrentClimb / setCurrentClimbQueueItem / takeControl / bridge.\*) | User activated a climb (any UI path — button, queue nav, list tap, swipe, playlist, browse). Fired centrally from queue context mutators.   |
+| Open in Aurora App      | use-climb-actions.ts:160                                           | `climbUuid`, `boardLayout`                                                                                            | User clicked "open in app"                                                                                                                  |
+| Create Climb Set Active | create-climb-form.tsx:747                                          | `boardLayout`                                                                                                         | User toggled active during create                                                                                                           |
+| Beta Video Added        | attach-beta-link-form.tsx:137                                      | `boardType`, `climbUuid`, `platform` (youtube/vimeo)                                                                  | User attached beta video link                                                                                                               |
+| Beta Video Link Clicked | boardsesh-beta-card.tsx:56                                         | `boardType`, `climbUuid`, `platform`                                                                                  | User clicked embedded video                                                                                                                 |
 
 ### 2.3 Logbook / Ticks / Ascents (6 events)
 
@@ -119,7 +117,7 @@ Boardsesh has comprehensive PostHog instrumentation across both web (Next.js) an
 | Play Drawer Opened      | queue-control-bar.tsx:802                     | `climbUuid`, `boardName`, `layoutId`, `source` (`climb_view` / `current_queue_item` / `mobile`) | User opened the play drawer (`climb_view` = real climb-view; `current_queue_item` = queue-nav/accessory tap; `mobile` = default) |
 | Session Queue Generated | start-sesh-drawer.tsx:613                     | `count` (queue items generated)                                                                 | Workout generator produced queue                                                                                                 |
 
-### 2.5 Board Search / Filtering (9 events)
+### 2.5 Board Search / Filtering (7 events)
 
 | Event Name                 | File:Line                       | Properties                             | Context                         |
 | -------------------------- | ------------------------------- | -------------------------------------- | ------------------------------- |
@@ -130,65 +128,52 @@ Boardsesh has comprehensive PostHog instrumentation across both web (Next.js) an
 | Search Zone Cleared        | climb-search-form.tsx:291       | `boardLayout`                          | User cleared zone selection     |
 | Search Zone Mode Changed   | climb-search-form.tsx:304       | `boardLayout`, `mode`                  | User toggled between zone types |
 | Search Zone Updated        | climb-search-form.tsx:355       | `boardLayout`, `zoneName`              | User edited zone bounds         |
-| Heatmap Shown/Hidden       | climb-search-form.tsx:484       | `boardLayout`                          | User toggled heatmap in search  |
-| View Mode Changed          | climbs-list.tsx:385             | `mode` (grid/list)                     | User switched list view type    |
 
-### 2.6 Playlist / Workout Generator (8 events)
+### 2.6 Playlist / Workout Generator (4 events)
 
-| Event Name                         | File:Line                         | Properties                                 | Context                           |
-| ---------------------------------- | --------------------------------- | ------------------------------------------ | --------------------------------- |
-| Workout Generator Opened           | playlist-generator-drawer.tsx:88  | `boardLayout`                              | User clicked AI generator button  |
-| Workout Type Selected              | playlist-generator-drawer.tsx:106 | `workoutType` (endurance/strength/etc)     | User chose workout profile        |
-| Workout Generator Back Clicked     | playlist-generator-drawer.tsx:117 | `fromStep`                                 | User clicked back in generator    |
-| Workout Generator Cancelled        | playlist-generator-drawer.tsx:133 | (no properties)                            | User closed generator             |
-| Workout Generator Generate Clicked | playlist-generator-drawer.tsx:225 | `boardLayout`, `workoutType`               | User clicked generate button      |
-| Workout Generated                  | playlist-generator-drawer.tsx:287 | `boardLayout`, `workoutType`, `climbCount` | AI playlist generated             |
-| Create Playlist (via drawer)       | create-playlist-drawer.tsx:122    | `playlistName`, `boardLayout`              | User created playlist from drawer |
-| Liked Climbs Add All To Queue      | liked-climbs-view-content.tsx:102 | `count`                                    | User bulk-added liked climbs      |
+| Event Name                    | File:Line                         | Properties                                 | Context                           |
+| ----------------------------- | --------------------------------- | ------------------------------------------ | --------------------------------- |
+| Workout Generator Opened      | playlist-generator-drawer.tsx:88  | `boardLayout`                              | User clicked AI generator button  |
+| Workout Generated             | playlist-generator-drawer.tsx:287 | `boardLayout`, `workoutType`, `climbCount` | AI playlist generated             |
+| Create Playlist (via drawer)  | create-playlist-drawer.tsx:122    | `playlistName`, `boardLayout`              | User created playlist from drawer |
+| Liked Climbs Add All To Queue | liked-climbs-view-content.tsx:102 | `count`                                    | User bulk-added liked climbs      |
 
-### 2.7 Navigation / UI (15 events)
+### 2.7 Navigation / UI (10 events)
 
-| Event Name                             | File:Line                                         | Properties                                                                     | Context                            |
-| -------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------ | ---------------------------------- |
-| Bottom Tab Bar                         | bottom-tab-bar.tsx:182+                           | `tab` (home/climbs/library/feed/create/you), `action` (open_selector optional) | User tapped tab                    |
-| View Mode Changed (Liked)              | liked-climbs-list.tsx:190                         | `mode`                                                                         | User switched liked climbs view    |
-| Infinite Scroll Load More              | climbs-list.tsx:392                               | `boardLayout`, `offset`                                                        | User scrolled down to load more    |
-| Liked Climbs Infinite Scroll Load More | liked-climbs-list.tsx:239                         | `boardLayout`, `offset`                                                        | Liked climbs pagination            |
-| Liked Climb Card Clicked               | liked-climbs-list.tsx:268                         | `climbUuid`                                                                    | User tapped liked climb            |
-| Logbook Thumbnail Clicked              | logbook-feed-item.tsx:473                         | `climbUuid`                                                                    | User tapped logbook photo          |
-| Angle Changed                          | angle-selector.tsx:80                             | `angle` (degrees), `boardLayout`                                               | User rotated board view            |
-| App Install Click                      | home-page-content.tsx:208,230                     | `platform` (ios/android), `source` (app-store/google-play)                     | User clicked app store link        |
-| Favorite Toggle                        | use-climb-actions.ts:122, favorite-action.tsx:45+ | `climbUuid`, `boardLayout`, `isFavorited` (true/false)                         | User liked/unliked climb           |
-| Onboarding Tour Started                | onboarding-tour-provider.tsx:188                  | `durationSeconds`                                                              | User started first-time experience |
-| Onboarding Tour Step Viewed            | onboarding-tour-provider.tsx:167                  | `stepName`, `stepIndex`                                                        | User saw step in tour              |
-| Onboarding Tour Step Advanced          | onboarding-tour-provider.tsx:153                  | `stepName`, `stepIndex`                                                        | User progressed to next step       |
-| Onboarding Tour Completed              | onboarding-tour-provider.tsx:233                  | `durationSeconds`, `totalSteps`                                                | User finished tour                 |
-| Onboarding Tour Skipped                | onboarding-tour-provider.tsx:260                  | `skippedAtStep`, `durationSeconds`                                             | User closed tour early             |
-| Favorite Toggle (via button)           | favorite-button.tsx:59,83                         | `climbUuid`, `isFavorited`                                                     | Quick favorite button              |
+| Event Name                    | File:Line                                         | Properties                                                 | Context                            |
+| ----------------------------- | ------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------- |
+| Logbook Thumbnail Clicked     | logbook-feed-item.tsx:473                         | `climbUuid`                                                | User tapped logbook photo          |
+| Angle Changed                 | angle-selector.tsx:80                             | `angle` (degrees), `boardLayout`                           | User rotated board view            |
+| App Install Click             | home-page-content.tsx:208,230                     | `platform` (ios/android), `source` (app-store/google-play) | User clicked app store link        |
+| Favorite Toggle               | use-climb-actions.ts:122, favorite-action.tsx:45+ | `climbUuid`, `boardLayout`, `isFavorited` (true/false)     | User liked/unliked climb           |
+| Onboarding Tour Started       | onboarding-tour-provider.tsx:188                  | `durationSeconds`                                          | User started first-time experience |
+| Onboarding Tour Step Viewed   | onboarding-tour-provider.tsx:167                  | `stepName`, `stepIndex`                                    | User saw step in tour              |
+| Onboarding Tour Step Advanced | onboarding-tour-provider.tsx:153                  | `stepName`, `stepIndex`                                    | User progressed to next step       |
+| Onboarding Tour Completed     | onboarding-tour-provider.tsx:233                  | `durationSeconds`, `totalSteps`                            | User finished tour                 |
+| Onboarding Tour Skipped       | onboarding-tour-provider.tsx:260                  | `skippedAtStep`, `durationSeconds`                         | User closed tour early             |
+| Favorite Toggle (via button)  | favorite-button.tsx:59,83                         | `climbUuid`, `isFavorited`                                 | Quick favorite button              |
 
 ### 2.8 Bluetooth / Hardware (10 events)
 
-| Event Name                              | File:Line                              | Properties                                                        | Context                                             |
-| --------------------------------------- | -------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
-| Bluetooth Connection Success            | use-board-bluetooth.ts:390             | `boardLayout`                                                     | Device paired and connected                         |
-| Bluetooth Connection Failed             | use-board-bluetooth.ts:415             | `boardLayout`                                                     | BLE connection attempt failed                       |
-| Bluetooth Disconnected                  | use-board-bluetooth.ts:181,371,455,480 | `boardLayout`, `reason`                                           | Device lost connection                              |
-| Climb Sent to Board Success             | bluetooth-context.tsx:106              | `climbUuid`, `boardLayout`                                        | LED frames transmitted                              |
-| Climb Sent to Board Failure             | bluetooth-context.tsx:111,119          | `climbUuid`, `boardLayout`, `error_reason`                        | Frame transmission failed                           |
-| Mirror Climb Toggled                    | queue-control-bar.tsx:1340             | `isMirrored` (true/false)                                         | User toggled board mirroring                        |
-| Play Mode Entered                       | queue-control-bar.tsx:1367             | `boardLayout`                                                     | User entered play/send mode                         |
-| Board Render Error                      | rendering-metrics.ts:11                | `context` (thumbnail/card/full-board/feed), `renderer` (svg/wasm) | SVG/WebAssembly render failed (max 5 per session)   |
-| Board Worker Rendering Disabled         | rendering-metrics.ts:22                | `reason` (load-failed/construct-failed)                           | Web Worker initialization failed (once per session) |
-| Beta Caption Copy Clicked/Copied/Failed | attach-beta-link-form.tsx:157+         | `boardType`, `climbUuid`, `surface` (card/drawer)                 | User copied beta share caption                      |
+| Event Name                      | File:Line                              | Properties                                                        | Context                                             |
+| ------------------------------- | -------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
+| Bluetooth Connection Success    | use-board-bluetooth.ts:390             | `boardLayout`                                                     | Device paired and connected                         |
+| Bluetooth Connection Failed     | use-board-bluetooth.ts:415             | `boardLayout`                                                     | BLE connection attempt failed                       |
+| Bluetooth Disconnected          | use-board-bluetooth.ts:181,371,455,480 | `boardLayout`, `reason`                                           | Device lost connection                              |
+| Climb Sent to Board Success     | bluetooth-context.tsx:106              | `climbUuid`, `boardLayout`                                        | LED frames transmitted                              |
+| Climb Sent to Board Failure     | bluetooth-context.tsx:111,119          | `climbUuid`, `boardLayout`, `error_reason`                        | Frame transmission failed                           |
+| Play Mode Entered               | queue-control-bar.tsx:1367             | `boardLayout`                                                     | User entered play/send mode                         |
+| Board Render Error              | rendering-metrics.ts:11                | `context` (thumbnail/card/full-board/feed), `renderer` (svg/wasm) | SVG/WebAssembly render failed (max 5 per session)   |
+| Board Worker Rendering Disabled | rendering-metrics.ts:22                | `reason` (load-failed/construct-failed)                           | Web Worker initialization failed (once per session) |
+| Beta Caption Copied/Failed      | attach-beta-link-form.tsx:157+         | `boardType`, `climbUuid`, `surface` (card/drawer)                 | User copied beta share caption                      |
 
-### 2.9 Sessions / Collab (4 events)
+### 2.9 Sessions / Collab (3 events)
 
-| Event Name                      | File:Line                   | Properties                                                                              | Context                               |
-| ------------------------------- | --------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------- |
-| Session Started                 | start-sesh-drawer.tsx:356   | `boardName`, `hasGoal`, `isDiscoverable`, `generatedQueueCount`, `generatedWorkoutType` | Host created session                  |
-| Session Joined                  | board-session-bridge.tsx:59 | `session_id`, `board_name`, `layout_id`                                                 | Guest joined via link/QR              |
-| Session Queue Generated Cleared | start-sesh-drawer.tsx:270   | (no properties)                                                                         | Host dismissed generated queue        |
-| Mirror Climb (in sessions)      | use-climb-actions.ts:174    | `climbUuid`, `boardLayout`                                                              | User mirrored climb in shared session |
+| Event Name                 | File:Line                   | Properties                                                                              | Context                               |
+| -------------------------- | --------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------- |
+| Session Started            | start-sesh-drawer.tsx:356   | `boardName`, `hasGoal`, `isDiscoverable`, `generatedQueueCount`, `generatedWorkoutType` | Host created session                  |
+| Session Joined             | board-session-bridge.tsx:59 | `session_id`, `board_name`, `layout_id`                                                 | Guest joined via link/QR              |
+| Mirror Climb (in sessions) | use-climb-actions.ts:174    | `climbUuid`, `boardLayout`                                                              | User mirrored climb in shared session |
 
 ### 2.10 Server-Side Cache (1 event)
 

--- a/docs/queue-control-bar-pivot.md
+++ b/docs/queue-control-bar-pivot.md
@@ -152,7 +152,7 @@ _Goal:_ browsing stops mutating active state. The drawer lightbulb becomes the o
 - Add a lightbulb action to the Play View Drawer's bottom action row. Pressing it triggers what used to be `setCurrentClimb` — claims driver, sends to board (solo), or broadcasts to party.
 - _The bar no longer carries a lightbulb._ Its job is to mirror the wall (climb name + driver avatar) and expose prev/next. The driver indicator on the bar lives on the driver's avatar (lit-bulb badge in the `AvatarGroup`) — not on a separate bar lightbulb.
 - Change `setCurrentClimb` in `QueueContext.tsx:383` so it no longer fires on tap. The implicit append-to-queue side effect (`shouldAddToQueue: true, insertAfterCurrent: true`) fires from the lightbulb path only.
-- List-row clicks (`Climb List Row Clicked`, `Climb List Cover Clicked`) continue to open the drawer; they no longer call `setCurrentClimb`.
+- List-row and cover taps continue to open the drawer; they no longer call `setCurrentClimb`.
 - Solo default: lightbulb auto-engages once BLE is connected (so quickstart-from-home → first tap → first lightbulb press feels like the old tap-to-send flow).
 - Party default: lightbulb is in "take wall" state on join; user presses to take a turn.
 - Yank-on-press in party: pressing lightbulb sends a `TakeControl` message; server broadcasts new driver to all members. Previous driver's lightbulb releases.

--- a/docs/ui/09-queue-control-bar.md
+++ b/docs/ui/09-queue-control-bar.md
@@ -222,7 +222,7 @@ Buttons are laid out in a horizontal `Stack` with 4px spacing. Visibility depend
 | Attempt        | Hidden          | Hidden                                | Visible              |
 | Tick           | Visible         | Visible                               | Visible (saves tick) |
 
-**Mirror button:** `SyncOutlined` icon. When mirrored state is active: purple background (`themeTokens.colors.purple`), white icon, primary color. Calls `mirrorClimb()` and tracks `'Mirror Climb Toggled'`.
+**Mirror button:** `SyncOutlined` icon. When mirrored state is active: purple background (`themeTokens.colors.purple`), white icon, primary color. Calls `mirrorClimb()`.
 
 **Play mode link:** `OpenInFullOutlined` icon wrapped in `LocaleLink` to the play URL. Tracks `'Play Mode Entered'`.
 

--- a/docs/view-page-removal-pivot.md
+++ b/docs/view-page-removal-pivot.md
@@ -20,7 +20,7 @@ Both surfaces compose the _same_ underlying pieces (`ClimbCard` for the board im
 
 - **Two layouts to maintain.** `ClimbDetailPageServer` (full page) and `PlayViewDrawer` (drawer) drift independently. The drawer has `SwipeBoardCarousel`, prev/next, swipe-as-preview, tick FAB, mirror, favorite, share, angle selector, queue badge, climb actions menu, playlist selector, and nested queue drawer. The full page has none of that and would have to grow each one separately if we kept it.
 - **Two interaction models.** Tapping a list row opens the drawer (party-safe, browse-doesn't-yank). Following an external link opens the full page (no drawer chrome, no swipe, no in-context navigation). A user who lands from a share link cannot prev/next through suggestions without going back to the list first.
-- **Two analytics surfaces, one event.** `Climb List Row Clicked` fires from the list. The full page is silently entered without an equivalent event. `Set Active Climb` semantics differ between surfaces (the drawer just opens; the page does not auto-set).
+- **Two analytics surfaces, different semantics.** Drawer opens, shared search-result selections, and `Set Active Climb` mean different things depending on the route. The drawer just opens; the full page does not auto-set a climb.
 
 ## The pivot
 
@@ -186,7 +186,7 @@ Files: both `view/[climb_uuid]/page.tsx` files, `board-page-climbs-list.tsx`, po
 
 - In `useDrawerUrlSync`, when the climb changes (effect on `displayedClimbUuid`), call `history.replaceState` with the new view URL.
 - Make sure the URL helper used here matches `constructClimbViewUrlWithSlugs` (slug form) when board names are available, and falls back to numeric otherwise.
-- Confirm that the existing `Climb List Row Clicked` analytics event continues to fire correctly when row-tap also pushes a URL. No double-fire.
+- Confirm that row-tap still opens the drawer without adding duplicate click telemetry.
 - Add a small `Climb View URL Sync` analytics event (or extend `Queue Navigation` properties) so we can measure how often users actually use the shareable URL vs how often it just decorates.
 
 Files: `use-drawer-url-sync.ts`, possibly `packages/web/app/lib/analytics.ts` for the new event signature.

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -12,19 +12,19 @@
 // State comes from `@boardsesh/board-presence-react`'s split current/feed
 // contexts, which are inert when the `board-presence` flag is off — so this sheet
 // is only ever opened from the board glyph when the flag is on. This wrapper keeps
-// current/feed reads ONLY for the now-playing + history-view analytics; the panel
-// owns the volatile action state so the always-mounted wrapper doesn't re-render
-// in ways that interfere with the native present()/dismiss() coordination.
+// current/feed reads only for visible-history filtering and history-view
+// analytics; the panel owns the volatile action state so the always-mounted
+// wrapper doesn't re-render in ways that interfere with the native
+// present()/dismiss() coordination.
 //
 // `NowOnTheWallPanel` (the presence-consuming hero/stats/history list) is gated on
 // `isPresented` so a dismissed sheet mounts none of it and does zero list/hero
 // work. `isPresented` flips true SYNCHRONOUSLY in `present()` (before the sheet's
 // own animation starts) and false once the dismiss has fully SETTLED (see
 // `handleFullyDismissed`); `handleSheetChange` re-arms it as a backstop for a
-// re-present queued inside the dismiss settle window. `BoardNowPlayingReceived`
-// telemetry stays unconditional (fires while dismissed); `BoardHistoryViewed`
-// fires once per presentation, keyed on `isPresented` — kept in this sheet-only
-// wrapper so the inline iPad column never double-fires it.
+// re-present queued inside the dismiss settle window. `BoardHistoryViewed` fires
+// once per presentation, keyed on `isPresented` — kept in this sheet-only wrapper
+// so the inline iPad column never double-fires it.
 
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { Platform, StyleSheet } from 'react-native';
@@ -101,9 +101,10 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   // animation has fully settled — see `handleFullyDismissed`.
   const [isPresented, setIsPresented] = useState(false);
 
-  // Current/feed reads kept here ONLY for the now-playing + history-view
-  // analytics; the panel owns the wall-feed content and the volatile action
-  // state, so those re-renders don't reach this always-mounted wrapper.
+  // Current/feed reads kept here only for visible-history filtering and
+  // history-view analytics; the panel owns the wall-feed content and the
+  // volatile action state, so those re-renders don't reach this always-mounted
+  // wrapper.
   const { currentClimb } = useBoardPresenceCurrent();
   const { history } = useBoardPresenceFeed();
   const { boardId: boardPresenceBoardId } = useBoardPresenceControls();
@@ -134,26 +135,6 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       itemCount: visibleHistory.length,
     });
   }, [isPresented, visibleHistory.length]);
-
-  const lastReceivedWallClimbRef = useRef<string | null>(null);
-  // `seq` rides along in the telemetry payload but must NOT trigger the effect —
-  // a same-uuid seq bump (e.g. a backfill merge) shouldn't re-evaluate the
-  // "new climb on the wall" event. Read it from a ref so the effect keys only on
-  // the climb uuid.
-  const currentClimbSeqRef = useRef(currentClimb?.seq);
-  currentClimbSeqRef.current = currentClimb?.seq;
-  useEffect(() => {
-    const currentClimbUuid = currentClimb?.climbUuid;
-    if (!currentClimbUuid) return;
-    if (lastReceivedWallClimbRef.current === currentClimbUuid) return;
-    lastReceivedWallClimbRef.current = currentClimbUuid;
-    track(SHARED_EVENTS.BoardNowPlayingReceived, {
-      boardId: boardPresenceBoardIdRef.current ?? undefined,
-      climbUuid: currentClimbUuid,
-      // `seq` lets PostHog spot gaps in the live stream (a jump = dropped pushes).
-      seq: currentClimbSeqRef.current ?? undefined,
-    });
-  }, [currentClimb?.climbUuid]);
 
   const snapPoints = useMemo(() => ['55%', '92%'], []);
 
@@ -210,6 +191,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
     },
     [managedOnChange],
   );
+  const sheetDismissProps = useMemo(() => ({ onFullyDismissed: managed.onFullyDismissed }), [managed.onFullyDismissed]);
 
   return (
     <BottomSheetModal
@@ -222,7 +204,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       enableDynamicSizing={false}
       enablePanDownToClose
       onChange={handleSheetChange}
-      onFullyDismissed={managed.onFullyDismissed}
+      {...sheetDismissProps}
       handleIndicatorStyle={sheet.handleStyle}
       style={styles.sheet}
     >

--- a/packages/mobile/src/lib/__tests__/posthog-client.test.ts
+++ b/packages/mobile/src/lib/__tests__/posthog-client.test.ts
@@ -36,11 +36,7 @@ describe('registerMobileUserAgent', () => {
   });
 });
 
-// Guards the fix for the install/open identity race: the party-profile UUID
-// must reach the PostHog constructor as `bootstrap.distinctId` so
-// captureAppLifecycleEvents (which fires during construction) lands on the
-// same id PartyProfileProvider later identifies/aliases, instead of a
-// transient SDK-generated anonymous id that never reliably reconnects.
+// Guards the stable anonymous identity used by explicit screen/action events.
 describe('buildPostHogOptions', () => {
   it('bootstraps the anonymous distinct_id from a resolved party-profile UUID', () => {
     const options = buildPostHogOptions('https://us.i.posthog.com', 'party-profile-uuid');
@@ -60,5 +56,10 @@ describe('buildPostHogOptions', () => {
       maskAllImages: true,
       captureLog: true,
     });
+  });
+
+  it('disables native lifecycle autocapture', () => {
+    const options = buildPostHogOptions('https://us.i.posthog.com', null);
+    expect(options.captureAppLifecycleEvents).toBe(false);
   });
 });

--- a/packages/mobile/src/lib/posthog-client.ts
+++ b/packages/mobile/src/lib/posthog-client.ts
@@ -14,7 +14,9 @@ export const MOBILE_USER_AGENT = 'Boardsesh Mobile';
 // Best-effort: a failure must never block analytics init.
 export function registerMobileUserAgent(client: Pick<PostHog, 'register'>): void {
   try {
-    client.register({ $raw_user_agent: MOBILE_USER_AGENT });
+    void Promise.resolve(client.register({ $raw_user_agent: MOBILE_USER_AGENT })).catch((error: unknown) => {
+      if (__DEV__) console.warn('[analytics] failed to register $raw_user_agent super property', error);
+    });
   } catch (error) {
     if (__DEV__) console.warn('[analytics] failed to register $raw_user_agent super property', error);
   }
@@ -47,6 +49,10 @@ export function buildPostHogOptions(postHogHost: string, bootstrapDistinctId: st
   return {
     host: postHogHost,
     bootstrap: bootstrapDistinctId ? { distinctId: bootstrapDistinctId, isIdentifiedId: false } : undefined,
+    // The app already emits explicit $screen events plus reviewed product
+    // events. SDK lifecycle autocapture adds high-volume foreground/background
+    // noise and does not help answer product or BLE reliability questions.
+    captureAppLifecycleEvents: false,
     // `enableSessionReplay` defaults false, so the SDK never auto-records.
     // Capture only begins when setSessionRecordingEnabled() calls
     // startSessionRecording(), which lazily initialises the native replay SDK.
@@ -66,21 +72,11 @@ export function getPostHogClient(): PostHog | null {
   if (client) return client;
   if (initAttempted) return null;
   initAttempted = true;
-  // captureAppLifecycleEvents defaults on (Application Opened/Backgrounded etc.);
-  // expo-device + expo-application (installed) enrich events with $device_model,
-  // $os_version, $app_version. Screen autocapture is handled in AnalyticsProvider.
-  //
-  // This client is constructed at AnalyticsProvider mount (top of the tree),
-  // before PartyProfileProvider has loaded the party-profile UUID and run
-  // identify()/alias() with it — so captureAppLifecycleEvents would otherwise
-  // fire Application Installed/Opened under PostHog's own transient anonymous
-  // id, an id the later alias-to-user step never reliably reconnects.
   // getAnalyticsBootstrapId() reads a slot that analytics-bootstrap.ts (wired
   // up in app/_layout.tsx, ahead of anything that imports this module)
-  // resolves synchronously via expo-secure-store's JSI sync API — passing it
-  // as `bootstrap` seeds the SDK's anonymous id with it before
-  // captureAppLifecycleEvents runs, so those events land on the same id
-  // PartyProfileProvider later identifies/aliases.
+  // resolves synchronously via expo-secure-store's JSI sync API. We still pass
+  // it as `bootstrap` so the SDK's anonymous id is stable before explicit
+  // screen/action events start flowing.
   const bootstrapDistinctId = getAnalyticsBootstrapId();
   client = new PostHog(apiKey, buildPostHogOptions(host, bootstrapDistinctId));
   registerMobileUserAgent(client);

--- a/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, act, waitFor } from '@testing-library/react';
 import { createElement, useEffect, type ReactNode } from 'react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import type { BoardPresenceClimb, ClimbQueueItemInput, ResolvedBoard } from '@boardsesh/shared-schema';
+import type { ClimbQueueItemInput, ResolvedBoard } from '@boardsesh/shared-schema';
 
 const transport = vi.hoisted(() => ({
   resolveBoardForSerial: vi.fn(
@@ -24,12 +24,6 @@ const transport = vi.hoisted(() => ({
 const sharedProvider = vi.hoisted(() => ({
   lastBoardId: undefined as number | null | undefined,
   lastOnCatchUp: undefined as ((info: { reason: string; recoveredThroughSeqDelta: number }) => void) | undefined,
-}));
-// Drives the mocked `useBoardPresenceCurrent` — controls what
-// `BoardPresenceInstrument` (rendered inside the provider, independent of any
-// sheet UI) sees as the wall's current climb.
-const presence = vi.hoisted(() => ({
-  currentClimb: null as BoardPresenceClimb | null,
 }));
 // The refresh action exposed by the (mocked) shared actions context, and a track
 // spy — so we can assert the foreground sync and catch-up telemetry wiring.
@@ -100,8 +94,6 @@ vi.mock('@boardsesh/board-presence-react', () => ({
   },
   // BoardPresenceForegroundSync (rendered inside the provider) reads this.
   useBoardPresenceActions: () => ({ refresh: refreshMock }),
-  // BoardPresenceInstrument (rendered inside the provider) reads this.
-  useBoardPresenceCurrent: () => ({ currentClimb: presence.currentClimb }),
 }));
 
 import { MobileBoardPresenceProvider, useBoardPresenceControls } from '../board-presence-provider';
@@ -150,7 +142,6 @@ describe('MobileBoardPresenceProvider', () => {
     transport.reportClimb.mockResolvedValue(true);
     sharedProvider.lastBoardId = undefined;
     sharedProvider.lastOnCatchUp = undefined;
-    presence.currentClimb = null;
     refreshMock.mockClear();
     trackMock.mockClear();
     appState.addEventListener.mockClear();
@@ -531,11 +522,8 @@ describe('MobileBoardPresenceProvider', () => {
     });
   });
 
-  it('tracks BoardNowPlayingReceived from the provider-level instrument, independent of any sheet UI', async () => {
-    // No BoardSheet is mounted anywhere in this tree — `BoardPresenceInstrument`
-    // lives inside `MobileBoardPresenceProvider` itself (see the provider), so
-    // this telemetry fires whether or not a sheet happens to be presented.
-    const rendered = renderProvider();
+  it('does not track catch-up telemetry when no wall events were recovered', async () => {
+    renderProvider();
     await act(async () => {
       await capturedControls?.resolveAndBindBoard({
         serial: 'SERIAL-1',
@@ -548,48 +536,8 @@ describe('MobileBoardPresenceProvider', () => {
     await waitFor(() => expect(sharedProvider.lastBoardId).toBe(42));
 
     trackMock.mockClear();
-    presence.currentClimb = {
-      climbUuid: 'wall-climb-1',
-      seq: 7,
-      sentAt: '2026-06-09T00:00:00.000Z',
-      name: 'Wall Climb',
-      angle: 40,
-    } as BoardPresenceClimb;
-    act(() => {
-      rendered.rerender(createElement(MobileBoardPresenceProvider, null, createElement(Probe)));
-    });
+    act(() => sharedProvider.lastOnCatchUp?.({ reason: 'foreground', recoveredThroughSeqDelta: 0 }));
 
-    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.BoardNowPlayingReceived, {
-      boardId: 42,
-      climbUuid: 'wall-climb-1',
-      seq: 7,
-    });
-  });
-
-  it('does not re-track the same wall climb on a re-render (dedup by climbUuid)', async () => {
-    const rendered = renderProvider();
-    presence.currentClimb = {
-      climbUuid: 'wall-climb-1',
-      seq: 7,
-      sentAt: '2026-06-09T00:00:00.000Z',
-      name: 'Wall Climb',
-      angle: 40,
-    } as BoardPresenceClimb;
-    act(() => {
-      rendered.rerender(createElement(MobileBoardPresenceProvider, null, createElement(Probe)));
-    });
-    expect(trackMock).toHaveBeenCalledWith(
-      SHARED_EVENTS.BoardNowPlayingReceived,
-      expect.objectContaining({ climbUuid: 'wall-climb-1' }),
-    );
-
-    trackMock.mockClear();
-    // A same-uuid seq bump (e.g. a backfill merge) must not re-fire.
-    presence.currentClimb = { ...presence.currentClimb, seq: 8 };
-    act(() => {
-      rendered.rerender(createElement(MobileBoardPresenceProvider, null, createElement(Probe)));
-    });
-
-    expect(trackMock).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardNowPlayingReceived, expect.anything());
+    expect(trackMock).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryCatchUp, expect.anything());
   });
 });

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -648,11 +648,6 @@ export function BluetoothProvider({
       lastAcceptedWallSignatureRef.current = presenceClimbReportSignature(wallCurrentClimbRef.current);
       undoWallChangeTargetRef.current = undoTarget;
       const showUndoToast = consumeUndoWallChangeToastArm(undoToastArmId);
-      track(SHARED_EVENTS.BoardClimbReported, {
-        boardId,
-        climbUuid: item.climb.uuid,
-        inSession: sessionIdRef.current != null,
-      });
       if (showUndoToast && undoTarget?.frames) {
         showUndoWallChangeSnackbarRef.current();
       }
@@ -1068,11 +1063,6 @@ export function BluetoothProvider({
 
     lastAcceptedReportSignatureRef.current = presenceClimbReportSignature(undoTarget);
     undoWallChangeTargetRef.current = null;
-    track(SHARED_EVENTS.BoardClimbReported, {
-      boardId,
-      climbUuid: undoTarget.climbUuid,
-      inSession: sessionIdRef.current != null,
-    });
     return true;
   }, [sendFramesToBoard]);
 
@@ -1118,11 +1108,6 @@ export function BluetoothProvider({
       }
 
       lastAcceptedReportSignatureRef.current = presenceClimbReportSignature(climb);
-      track(SHARED_EVENTS.BoardClimbReported, {
-        boardId,
-        climbUuid: climb.climbUuid,
-        inSession: sessionIdRef.current != null,
-      });
       return true;
     },
     [sendFramesToBoard],

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -25,7 +25,6 @@ import { AppState } from 'react-native';
 import {
   BoardPresenceProvider,
   useBoardPresenceActions,
-  useBoardPresenceCurrent,
   type BoardPresenceCatchUpInfo,
 } from '@boardsesh/board-presence-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -325,11 +324,12 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
     setPendingDisambiguation(null);
   }, []);
 
-  // Telemetry for every catch-up. `recoveredThroughSeqDelta > 0` means the live
-  // feed silently dropped pushes (Redis pub/sub has no replay) and we just
-  // recovered them — the measurable "history was slow to update" signal. Stable
-  // identity (reads boardIdRef) so it never re-binds the presence subscription.
+  // Telemetry only when a catch-up recovered missed wall events. Foreground and
+  // reconnect catch-ups with a zero delta happen often and add no product signal.
+  // Stable identity (reads boardIdRef) so it never re-binds the presence
+  // subscription.
   const handleCatchUp = useCallback((info: BoardPresenceCatchUpInfo) => {
+    if (info.recoveredThroughSeqDelta <= 0) return;
     track(SHARED_EVENTS.BoardHistoryCatchUp, {
       boardId: boardIdRef.current ?? undefined,
       reason: info.reason,
@@ -364,7 +364,6 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
     <BoardPresenceControlsContext.Provider value={controls}>
       <BoardPresenceProvider boardId={boardId} client={client} onCatchUp={handleCatchUp}>
         <BoardPresenceForegroundSync />
-        <BoardPresenceInstrument boardId={boardId} />
         {children}
       </BoardPresenceProvider>
       <BoardDisambiguationSheet
@@ -396,41 +395,6 @@ function BoardPresenceForegroundSync(): null {
     });
     return () => subscription.remove();
   }, [refresh]);
-  return null;
-}
-
-/**
- * Fires `BoardNowPlayingReceived` once per distinct wall climb received from
- * the live feed — instrumenting the "viewed the wall" signal. Lives as a
- * null-rendering child of `BoardPresenceProvider` (mirroring web's
- * `BoardNowPlayingInstrument`) rather than inside `BoardSheet`, so it keeps
- * firing regardless of whether the sheet is presented — `BoardSheet` now
- * unmounts its presence-consuming content while dismissed (see
- * `BoardSheetContent` there), and this telemetry must NOT depend on that.
- */
-function BoardPresenceInstrument({ boardId }: { boardId: number | null }) {
-  const { currentClimb } = useBoardPresenceCurrent();
-  const boardIdRef = useRef(boardId);
-  boardIdRef.current = boardId;
-  const lastReceivedWallClimbRef = useRef<string | null>(null);
-  // `seq` rides along in the telemetry payload but must NOT trigger the effect
-  // — a same-uuid seq bump (e.g. a backfill merge) shouldn't re-evaluate the
-  // "new climb on the wall" event. Read it from a ref so the effect keys only
-  // on the climb uuid (matching `boardId` being read via a ref too).
-  const currentClimbSeqRef = useRef(currentClimb?.seq);
-  currentClimbSeqRef.current = currentClimb?.seq;
-  useEffect(() => {
-    const currentClimbUuid = currentClimb?.climbUuid;
-    if (!currentClimbUuid) return;
-    if (lastReceivedWallClimbRef.current === currentClimbUuid) return;
-    lastReceivedWallClimbRef.current = currentClimbUuid;
-    track(SHARED_EVENTS.BoardNowPlayingReceived, {
-      boardId: boardIdRef.current ?? undefined,
-      climbUuid: currentClimbUuid,
-      // `seq` lets PostHog spot gaps in the live stream (a jump = dropped pushes).
-      seq: currentClimbSeqRef.current ?? undefined,
-    });
-  }, [currentClimb?.climbUuid]);
   return null;
 }
 

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -182,10 +182,9 @@ export const SHARED_EVENTS = {
   BetaVideoAdded: 'Beta Video Added',
   // Board presence — "now on the wall" (board-level collaboration, keyed on the
   // shared board_id resolved from the BLE serial). `boardId` is attached as an
-  // event PROPERTY at the call sites — never the raw serial. These self-instrument
-  // the previously-invisible "viewed the wall" / "reported to the wall" behaviour.
-  BoardClimbReported: 'Board Climb Reported',
-  BoardNowPlayingReceived: 'Board Now Playing Received',
+  // event PROPERTY at the call sites — never the raw serial. Keep these to user
+  // intent and explicit history actions; per-climb send/receive echoes are too
+  // noisy for PostHog's event budget.
   BoardSheetOpened: 'Board Sheet Opened',
   BoardHistoryViewed: 'Board History Viewed',
   BoardSwapInvokedFromSheet: 'Board Swap Invoked From Sheet',

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
@@ -8,7 +8,6 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
-import { track } from '@/app/lib/analytics';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import { executeGraphQL } from '@/app/lib/graphql/client';
 import {
@@ -186,7 +185,6 @@ export default function LikedClimbsList({ boardDetails, angle }: LikedClimbsList
   const handleViewModeChange = useCallback((mode: ViewMode) => {
     setViewMode(mode);
     void setPreference('likedClimbsViewMode', mode);
-    track('Liked Climbs View Mode Changed', { mode });
   }, []);
 
   const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage, isLoading, error } = useInfiniteQuery({
@@ -235,12 +233,8 @@ export default function LikedClimbsList({ boardDetails, angle }: LikedClimbsList
   }, [allClimbs, angle]);
 
   const handleLoadMore = useCallback(() => {
-    track('Liked Climbs Infinite Scroll Load More', {
-      currentCount: allClimbs.length,
-      hasMore: hasNextPage,
-    });
     void fetchNextPage();
-  }, [allClimbs.length, hasNextPage, fetchNextPage]);
+  }, [fetchNextPage]);
 
   const { sentinelRef } = useInfiniteScroll({
     onLoadMore: handleLoadMore,
@@ -264,10 +258,6 @@ export default function LikedClimbsList({ boardDetails, angle }: LikedClimbsList
     (climb: Climb) => {
       setSelectedClimbUuid(climb.uuid);
       previewClimbFromBrowse(climb);
-      track('Liked Climb Card Clicked', {
-        climbUuid: climb.uuid,
-        angle: climb.angle,
-      });
     },
     [previewClimbFromBrowse],
   );

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -140,7 +140,6 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
 
   const handleCopyAndOpenInstagram = async () => {
     if (!instagramCaption || isLaunchingInstagram) return;
-    track('Beta Caption Copy Clicked', { boardType, climbUuid, surface });
     setIsLaunchingInstagram(true);
     let result: { copied: boolean; opened: boolean };
     try {

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -636,7 +636,6 @@ export function BluetoothProvider({
         return;
       }
       const previousWallClimb = currentWallClimbRef.current;
-      const boardIdAtReport = presenceBoardIdRef.current;
       pendingReportSignatureRef.current = sendSignature;
       const climbInput = toClimbQueueItemInput(item);
       const angle = item.climb.angle ?? null;
@@ -651,11 +650,6 @@ export function BluetoothProvider({
             return;
           }
           lastAcceptedReportSignatureRef.current = sendSignature;
-          track(SHARED_EVENTS.BoardClimbReported, {
-            boardId: boardIdAtReport,
-            climbUuid,
-            inSession: sessionIdRef.current != null,
-          });
           // Offer a one-tap Undo of the wall change YOU just caused — the
           // deliberate replacement for the dropped pre-send confirm step. The
           // action re-sends the climb that was on the wall before this report,

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -8,7 +8,6 @@ import AlertTitle from '@mui/material/AlertTitle';
 import AppsOutlined from '@mui/icons-material/AppsOutlined';
 import FormatListBulletedOutlined from '@mui/icons-material/FormatListBulletedOutlined';
 import { usePathname } from 'next/navigation';
-import { track } from '@/app/lib/analytics';
 import dynamic from 'next/dynamic';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import { useDrawerDragResize } from '@/app/hooks/use-drawer-drag-resize';
@@ -393,19 +392,14 @@ const ClimbsList = ({
   const handleViewModeChange = useCallback((mode: ViewMode) => {
     setViewMode(mode);
     setPreference(VIEW_MODE_PREFERENCE_KEY, mode).catch(() => {});
-    track('View Mode Changed', { mode });
   }, []);
 
   const handleListView = useCallback(() => handleViewModeChange('list'), [handleViewModeChange]);
   const handleGridView = useCallback(() => handleViewModeChange('grid'), [handleViewModeChange]);
 
   const handleLoadMore = useCallback(() => {
-    track('Infinite Scroll Load More', {
-      currentCount: climbs.length,
-      hasMore,
-    });
     onLoadMore();
-  }, [climbs.length, hasMore, onLoadMore]);
+  }, [onLoadMore]);
 
   const { sentinelRef } = useInfiniteScroll({
     onLoadMore: handleLoadMore,
@@ -430,7 +424,6 @@ const ClimbsList = ({
       // the tour can advance, not fall into the play view.
       if (tourStepRef.current === 'climb-list') {
         dispatchTourClimbListPick();
-        track('Climb List Row Clicked', { climbUuid: climb.uuid });
         return;
       }
       if (onClimbSelectRef.current) {
@@ -445,7 +438,6 @@ const ClimbsList = ({
         // listening to PLAY_DRAWER_EVENT may handle it).
         dispatchOpenPlayDrawer(climb);
       }
-      track('Climb List Row Clicked', { climbUuid: climb.uuid });
     },
     [climbs, unsupportedClimbs],
   );

--- a/packages/web/app/components/board-presence/__tests__/board-presence-context.test.tsx
+++ b/packages/web/app/components/board-presence/__tests__/board-presence-context.test.tsx
@@ -332,4 +332,23 @@ describe('WebBoardPresenceProvider', () => {
       recoveredThroughSeqDelta: 2,
     });
   });
+
+  it('does not track catch-up telemetry when no wall events were recovered', async () => {
+    renderProvider();
+    await act(async () => {
+      await capturedControls?.resolveAndBindBoard({
+        serial: 'SERIAL-1',
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+      });
+    });
+    await waitFor(() => expect(sharedProvider.lastBoardId).toBe(42));
+
+    trackMock.mockClear();
+    act(() => sharedProvider.lastOnCatchUp?.({ reason: 'foreground', recoveredThroughSeqDelta: 0 }));
+
+    expect(trackMock).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryCatchUp, expect.anything());
+  });
 });

--- a/packages/web/app/components/board-presence/board-presence-context.tsx
+++ b/packages/web/app/components/board-presence/board-presence-context.tsx
@@ -196,12 +196,12 @@ export function WebBoardPresenceProvider({ children }: { children: ReactNode }) 
     [boardId, resolveAndBindBoard, reportDisconnect],
   );
 
-  // Telemetry for every catch-up. `recoveredThroughSeqDelta > 0` means the live
-  // feed silently dropped pushes (Redis pub/sub has no replay) and we just
-  // recovered them — the measurable "history was slow to update" signal.
+  // Telemetry only when a catch-up recovered missed wall events. Foreground and
+  // reconnect catch-ups with a zero delta happen often and add no product signal.
   // Mirrors the mobile provider's `handleCatchUp`. Stable identity (reads
   // boardIdRef) so it never re-binds the presence subscription.
   const handleCatchUp = useCallback((info: BoardPresenceCatchUpInfo) => {
+    if (info.recoveredThroughSeqDelta <= 0) return;
     track(SHARED_EVENTS.BoardHistoryCatchUp, {
       boardId: boardIdRef.current ?? undefined,
       reason: info.reason,
@@ -212,7 +212,6 @@ export function WebBoardPresenceProvider({ children }: { children: ReactNode }) 
   return (
     <BoardPresenceControlsContext.Provider value={controls}>
       <BoardPresenceProvider boardId={boardId} client={presenceClient} onCatchUp={handleCatchUp}>
-        <BoardNowPlayingInstrument boardId={boardId} />
         <WebBoardPresenceForegroundSync />
         {children}
       </BoardPresenceProvider>
@@ -243,30 +242,6 @@ function WebBoardPresenceForegroundSync(): null {
     document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
   }, [refresh]);
-  return null;
-}
-
-/**
- * Fires `BoardNowPlayingReceived` once per distinct wall climb received from the
- * live feed — instrumenting the "viewed the wall" signal that's invisible
- * today. Lives as a child of `BoardPresenceProvider` so it can read the wall's
- * current climb without the host provider subscribing to it (and re-rendering
- * the whole tree on every wall change). `boardId` is attached as a property,
- * never the raw serial.
- */
-function BoardNowPlayingInstrument({ boardId }: { boardId: number | null }) {
-  const context = useContext(BoardPresenceCurrentContext);
-  const currentClimb = context?.currentClimb ?? null;
-  const lastReceivedRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!currentClimb) return;
-    if (lastReceivedRef.current === currentClimb.climbUuid) return;
-    lastReceivedRef.current = currentClimb.climbUuid;
-    track(SHARED_EVENTS.BoardNowPlayingReceived, {
-      boardId: boardId ?? undefined,
-      climbUuid: currentClimb.climbUuid,
-    });
-  }, [currentClimb, boardId]);
   return null;
 }
 

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -12,7 +12,6 @@ import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
 import DynamicFeedOutlined from '@mui/icons-material/DynamicFeedOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
-import { track } from '@/app/lib/analytics';
 import type { BoardDetails, BoardName, BoardRouteIdentity } from '@/app/lib/types';
 import {
   constructClimbListWithSlugs,
@@ -219,12 +218,10 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
         url = `${url}${separator}session=${activeSession.sessionId}`;
       }
       router.push(url);
-      track('Bottom Tab Bar', { tab: 'climbs' });
       return;
     }
     setIsBoardSelectorRendered(true);
     setIsBoardSelectorOpen(true);
-    track('Bottom Tab Bar', { tab: 'climbs', action: 'open_selector' });
   }, [activeSession?.sessionId, router]);
 
   const handleCreateFallback = useCallback(() => {
@@ -344,7 +341,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           value="home"
           component={LocaleLink}
           href="/"
-          onClick={() => track('Bottom Tab Bar', { tab: 'home' })}
           sx={actionSx}
         />
         {climbsHref ? (
@@ -354,7 +350,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
             value="climbs"
             component={LocaleLink}
             href={climbsHref}
-            onClick={() => track('Bottom Tab Bar', { tab: 'climbs' })}
             sx={actionSx}
           />
         ) : (
@@ -374,7 +369,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           value="library"
           component={LocaleLink}
           href={playlistsUrl}
-          onClick={() => track('Bottom Tab Bar', { tab: 'library' })}
           sx={actionSx}
         />
         <BottomNavigationAction
@@ -383,7 +377,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           value="feed"
           component={LocaleLink}
           href="/feed"
-          onClick={() => track('Bottom Tab Bar', { tab: 'feed' })}
           sx={actionSx}
         />
         {createClimbHref ? (
@@ -393,7 +386,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
             value="create"
             component={LocaleLink}
             href={createClimbHref}
-            onClick={() => track('Bottom Tab Bar', { tab: 'create' })}
             sx={actionSx}
           />
         ) : (
@@ -402,7 +394,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
             icon={<AddOutlined sx={{ fontSize: 20 }} />}
             value="create"
             onClick={() => {
-              track('Bottom Tab Bar', { tab: 'create', action: 'open_selector' });
               handleCreateFallback();
             }}
             sx={actionSx}
@@ -429,7 +420,6 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
               });
               return;
             }
-            track('Bottom Tab Bar', { tab: 'you' });
           }}
           sx={actionSx}
         />

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -1387,12 +1387,7 @@ export default function CreateClimbForm({
 
   const handleToggleHeatmap = useCallback(() => {
     if (boardType !== 'aurora' || !boardDetails) return;
-    setShowHeatmap((prev) => {
-      track(`Create Climb Heatmap ${!prev ? 'Shown' : 'Hidden'}`, {
-        boardLayout: boardDetails.layout_name || '',
-      });
-      return !prev;
-    });
+    setShowHeatmap((prev) => !prev);
   }, [boardType, boardDetails]);
 
   // Rightmost save icon button. Collapses every state (saving, just-saved,

--- a/packages/web/app/components/playlist-generator/__tests__/playlist-generator-drawer.test.tsx
+++ b/packages/web/app/components/playlist-generator/__tests__/playlist-generator-drawer.test.tsx
@@ -119,16 +119,16 @@ const boardDetails = {
   set_ids: [1, 2],
 } as unknown as BoardDetails;
 
-function findCancelledCall() {
-  return trackMock.mock.calls.find(([event]) => event === 'Workout Generator Cancelled');
+function findEventCall(eventName: string) {
+  return trackMock.mock.calls.find(([event]) => event === eventName);
 }
 
-describe('PlaylistGeneratorDrawer cancellation analytics', () => {
+describe('PlaylistGeneratorDrawer analytics', () => {
   beforeEach(() => {
     trackMock.mockClear();
   });
 
-  it('fires Cancelled (stage=select, no workoutType) when dismissed from the type-select screen', async () => {
+  it('fires Opened when the drawer opens', () => {
     render(
       <PlaylistGeneratorDrawer
         open
@@ -140,19 +140,27 @@ describe('PlaylistGeneratorDrawer cancellation analytics', () => {
       />,
     );
 
-    // Drawer mounts in 'select' state and emits Opened. Close immediately.
-    fireEvent.click(screen.getByTestId('drawer-close'));
-
-    const call = findCancelledCall();
-    expect(call).toBeDefined();
-    const [, payload] = call!;
-    expect(payload).toMatchObject({ targetType: 'session', stage: 'select' });
-    // `workoutType` must be ABSENT (not null) so downstream dashboards
-    // don't widen the property's type from WorkoutType to WorkoutType|null.
-    expect(payload).not.toHaveProperty('workoutType');
+    expect(findEventCall('Workout Generator Opened')).toBeDefined();
   });
 
-  it('fires Cancelled (stage=configure, workoutType=volume) when dismissed from the configure screen', async () => {
+  it('does not fire cancellation telemetry when dismissed from the type-select screen', () => {
+    render(
+      <PlaylistGeneratorDrawer
+        open
+        onClose={vi.fn()}
+        boardDetails={boardDetails}
+        defaultAngle={40}
+        onAddClimb={vi.fn(async () => {})}
+        targetType="session"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('drawer-close'));
+
+    expect(findEventCall('Workout Generator Cancelled')).toBeUndefined();
+  });
+
+  it('does not fire cancellation telemetry when dismissed from the configure screen', () => {
     render(
       <PlaylistGeneratorDrawer
         open
@@ -170,17 +178,10 @@ describe('PlaylistGeneratorDrawer cancellation analytics', () => {
     // Dismiss.
     fireEvent.click(screen.getByTestId('drawer-close'));
 
-    const call = findCancelledCall();
-    expect(call).toBeDefined();
-    const [, payload] = call!;
-    expect(payload).toMatchObject({
-      targetType: 'playlist',
-      workoutType: 'volume',
-      stage: 'configure',
-    });
+    expect(findEventCall('Workout Generator Cancelled')).toBeUndefined();
   });
 
-  it('does NOT fire Cancelled after a generation run completes (even with 0 climbs saved)', async () => {
+  it('fires Generated after a generation run completes even with 0 climbs saved', async () => {
     render(
       <PlaylistGeneratorDrawer
         open
@@ -203,11 +204,9 @@ describe('PlaylistGeneratorDrawer cancellation analytics', () => {
     });
 
     await waitFor(() => {
-      expect(trackMock.mock.calls.some(([event]) => event === 'Workout Generated')).toBe(true);
+      expect(findEventCall('Workout Generated')).toBeDefined();
     });
 
-    // No Cancelled event should ever fire on this path — neither during
-    // handleGenerate's raw onClose, nor on any subsequent dismissal.
-    expect(findCancelledCall()).toBeUndefined();
+    expect(findEventCall('Workout Generator Cancelled')).toBeUndefined();
   });
 });

--- a/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
+++ b/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useTranslation } from 'react-i18next';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
@@ -72,14 +72,6 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
   const [generating, setGenerating] = useState(false);
   const [progress, setProgress] = useState({ current: 0, total: 0 });
 
-  // Tracks whether the user reached the end of a generation run during this
-  // open session. Lets us distinguish "closed before running anything"
-  // (cancellation) from "closed after the run finished" (no extra event).
-  // A 0-climbs run still counts as completed — we already fired a
-  // `Workout Generated` event for that path; firing `Cancelled` on top
-  // would double-count the same outcome.
-  const runCompletedRef = useRef(false);
-
   useEffect(() => {
     if (open) {
       setDrawerState('select');
@@ -88,7 +80,6 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
       setTargetAngle(defaultAngle);
       setGenerating(false);
       setProgress({ current: 0, total: 0 });
-      runCompletedRef.current = false;
       track(SHARED_EVENTS.WorkoutGeneratorOpened, {
         targetType,
         boardName: boardDetails.board_name,
@@ -107,48 +98,21 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
       setSelectedType(type);
       setOptions(getDefaultOptions(type, defaultTargetGrade));
       setDrawerState('configure');
-      track('Workout Type Selected', {
-        targetType,
-        workoutType: type,
-        boardName: boardDetails.board_name,
-      });
     },
-    [defaultTargetGrade, targetType, boardDetails.board_name],
+    [defaultTargetGrade],
   );
 
   const handleBack = useCallback(() => {
     if (drawerState === 'configure') {
-      track('Workout Generator Back Clicked', {
-        targetType,
-        workoutType: selectedType,
-        boardName: boardDetails.board_name,
-      });
       setDrawerState('select');
       setSelectedType(null);
       setOptions(null);
     }
-  }, [drawerState, targetType, selectedType, boardDetails.board_name]);
+  }, [drawerState]);
 
-  // Wrap onClose so dismissals before any generation run fire a cancellation
-  // event. The generating phase blocks dismissal via the
-  // `onClose={generating ? undefined : ...}` guard below — but both the
-  // workout-type-select screen and the configure screen are dismissable.
-  //
-  // `workoutType` is omitted when the user dismisses from the select screen
-  // (no type picked yet). Emitting `null` would widen the event's property
-  // type and trip downstream dashboards that assume the property is always
-  // a valid `WorkoutType`. Treat absence as absence.
   const handleClose = useCallback(() => {
-    if (!generating && !runCompletedRef.current) {
-      track('Workout Generator Cancelled', {
-        targetType,
-        ...(selectedType ? { workoutType: selectedType } : {}),
-        stage: drawerState,
-        boardName: boardDetails.board_name,
-      });
-    }
     onClose();
-  }, [drawerState, generating, targetType, selectedType, boardDetails.board_name, onClose]);
+  }, [onClose]);
 
   const handleReset = useCallback(() => {
     if (selectedType) {
@@ -234,13 +198,6 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
         break;
     }
 
-    track('Workout Generator Generate Clicked', {
-      targetType,
-      boardName: boardDetails.board_name,
-      plannedCount: plannedSlots.length,
-      ...optionsSnapshot,
-    });
-
     const startedAt = performance.now();
 
     setGenerating(true);
@@ -294,10 +251,8 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
 
     const added = plannedSlots.length - failedSlots.length;
     // Any reached-the-end-of-loop counts as a completed run, even when 0
-    // climbs were saved. We fire `Workout Generated` (below) with
-    // savedCount=0 for that outcome; firing `Cancelled` from the
-    // subsequent onClose would double-count it.
-    runCompletedRef.current = true;
+    // climbs were saved. We fire `Workout Generated` below with savedCount=0
+    // for that outcome.
     const durationMs = Math.round(performance.now() - startedAt);
 
     track(SHARED_EVENTS.WorkoutGenerated, {

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1167,10 +1167,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                           id="button-mirror"
                           onClick={() => {
                             mirrorClimb();
-                            track('Mirror Climb Toggled', {
-                              boardLayout: boardDetails.layout_name || '',
-                              mirrored: !displayedClimb?.mirrored,
-                            });
                           }}
                           color={displayedClimb?.mirrored ? 'primary' : 'default'}
                           sx={

--- a/packages/web/app/components/search-drawer/climb-search-form.tsx
+++ b/packages/web/app/components/search-drawer/climb-search-form.tsx
@@ -473,11 +473,7 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
             <IconButton
               size="small"
               onClick={() => {
-                const nextShowHeatmap = !showHeatmap;
-                setShowHeatmap(nextShowHeatmap);
-                track(`Heatmap ${nextShowHeatmap ? 'Shown' : 'Hidden'}`, {
-                  boardLayout: boardDetails.layout_name || '',
-                });
+                setShowHeatmap((currentShowHeatmap) => !currentShowHeatmap);
               }}
               aria-label={showHeatmap ? t('search.holds.hideHeatmap') : t('search.holds.showHeatmap')}
             >

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -260,14 +260,9 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
 
   const handleClearGenerated = useCallback(() => {
     if (generatedQueue.length === 0) return;
-    track('Session Queue Generated Cleared', {
-      workoutType: generatedWorkoutType,
-      savedCount: generatedQueue.length,
-      boardName: generatorBoardDetails?.board_name ?? '',
-    });
     setGeneratedQueue([]);
     setGeneratedWorkoutType(null);
-  }, [generatedQueue.length, generatedWorkoutType, generatorBoardDetails]);
+  }, [generatedQueue.length]);
 
   const handleSubmit = async (formData: SessionCreationFormData) => {
     let boardPath: string | undefined;


### PR DESCRIPTION
## Summary
- Removes high-volume board echo analytics for `Board Climb Reported` and `Board Now Playing Received` while keeping `Climb Sent to Board Success` for BLE reliability tracking.
- Suppresses zero-delta board-history catch-up events and disables mobile PostHog lifecycle autocapture.
- Drops lower-value UI interaction events from list view toggles, infinite-scroll load-more, heatmap toggles, bottom tabs, workout generator micro-steps, session generated clear, beta-caption copy click, and mirror toggle tracking.
- Updates the PostHog inventory/docs and keeps queue outcome/navigation events intact after review.

## Validation
- `vp staged` passed.
- `vp test run packages/mobile/src/lib/__tests__/posthog-client.test.ts packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx packages/web/app/components/board-presence/__tests__/board-presence-context.test.tsx packages/web/app/components/playlist-generator/__tests__/playlist-generator-drawer.test.tsx packages/web/app/components/climb-actions/__tests__/use-climb-actions.test.ts packages/web/app/components/queue-control/__tests__/queue-nav-button-wall-advance.test.tsx` passed: 6 files, 63 tests.
- `git diff --check` passed.

## Notes
- PostHog MCP was requested for production event ranking, but no PostHog MCP connector/tool or PostHog API credentials were available in this session. This cleanup is based on the noisy event sample plus the local analytics inventory/code audit.