### PR TITLE
fix(db): guard Climb2Vec extract/similarity for prod scale

### DIFF
--- a/ml/climb2vec/similarity_export.py
+++ b/ml/climb2vec/similarity_export.py
@@ -41,33 +41,33 @@ def main():
     for idx, row in enumerate(rows):
         groups[(row["layoutId"], row["angle"])].append(idx)
 
+    # Row-blocked so the biggest (layout, angle) group can't allocate an m×m
+    # matrix (a full Kilter angle is tens of thousands of climbs → 10s of GB).
+    block = 2000
     written = 0
     with open(args.out, "w") as out:
         for (layout_id, angle), members in groups.items():
-            if len(members) < 2:
+            m = len(members)
+            if m < 2:
                 continue
             matrix = np.array([rows[i]["embedding"] for i in members], dtype=np.float32)
-            norms = np.linalg.norm(matrix, axis=1, keepdims=True)
-            matrix = matrix / np.clip(norms, 1e-9, None)
-            sims = matrix @ matrix.T
-            np.fill_diagonal(sims, -np.inf)
-            k = min(args.k, len(members) - 1)
-            # Top-k neighbour indices per row (argpartition, then order the k).
-            top = np.argpartition(-sims, kth=k - 1, axis=1)[:, :k]
-            for local_i, member_idx in enumerate(members):
-                order = top[local_i][np.argsort(-sims[local_i, top[local_i]])]
-                neighbours = [[rows[members[j]]["climbUuid"], round(float(sims[local_i, j]), 5)] for j in order]
-                out.write(
-                    json.dumps(
-                        {
-                            "climbUuid": rows[member_idx]["climbUuid"],
-                            "angle": angle,
-                            "neighbours": neighbours,
-                        }
+            matrix = matrix / np.clip(np.linalg.norm(matrix, axis=1, keepdims=True), 1e-9, None)
+            k = min(args.k, m - 1)
+            for start in range(0, m, block):
+                sims = matrix[start : start + block] @ matrix.T  # [b, m]
+                for i in range(sims.shape[0]):
+                    sims[i, start + i] = -np.inf  # exclude self
+                part = np.argpartition(-sims, kth=k - 1, axis=1)[:, :k]
+                for i in range(sims.shape[0]):
+                    order = part[i][np.argsort(-sims[i, part[i]])]
+                    neighbours = [[rows[members[j]]["climbUuid"], round(float(sims[i, j]), 5)] for j in order]
+                    out.write(
+                        json.dumps(
+                            {"climbUuid": rows[members[start + i]]["climbUuid"], "angle": angle, "neighbours": neighbours}
+                        )
+                        + "\n"
                     )
-                    + "\n"
-                )
-                written += 1
+                    written += 1
     print(f"[similarity] wrote {written} climb neighbour lists → {args.out}")
 
 

--- a/packages/db/scripts/extract-training-matrix.ts
+++ b/packages/db/scripts/extract-training-matrix.ts
@@ -126,6 +126,10 @@ async function main(): Promise<void> {
     `[extract] board=${options.board} minAscents=${options.minAscents} angle=${options.angle ?? 'all'} → ${options.out}`,
   );
   try {
+    // Score mode sorts the full catalog; disable parallel-worker shared-memory
+    // segments so a big sort can't exhaust the server's /dev/shm (matches the
+    // grade pipeline's guard). Session-scoped on the single script connection.
+    await db.execute(sql`SET max_parallel_workers_per_gather = 0`);
     const [features, stats, holdsByClimb] = await Promise.all([
       loadFeatures(db, options.board),
       loadStats(db, options),


### PR DESCRIPTION
## Summary

Prod-run hotfix for the Climb2Vec content-model pipeline (the `refresh-content-model` workflow failed at the extract step on prod).

- **Extract**: the full-catalog score extract sorts ~400k Kilter climb-angles, allocating a large parallel-worker shared-memory segment that exhausted prod's `/dev/shm` (`could not resize shared memory segment … No space left on device`, 53100). Adds `SET max_parallel_workers_per_gather = 0` (mirrors the grade pipeline's guard).
- **Similarity**: row-blocks the numpy top-K so the biggest `(layout, angle)` group can't allocate an m×m matrix and OOM the runner.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:db` clean. Re-dispatch `refresh-content-model` on prod after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)