### PR TITLE
fix(mobile): close displaced sheets so they never re-present uninvited

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -30,9 +30,10 @@ Examples: `QueueSheet`, `BoardSheet`, `LogAscentSheet`, `AngleSelectorSheet`,
 (declarative `Sheet`s).
 
 Prefer the controlled `visible` prop over an imperative ref + a local `isPresentedRef`: the
-coordinator reconciles present/dismiss from `visible`, and `onClose` fires only on a genuine user
-pan-down / backdrop (not on coordinator-driven closes), so parent state can't be cleared behind
-your back. `AddToPlaylistSheet` is the reference.
+coordinator reconciles present/dismiss from `visible`, and `onClose` fires only when the sheet is
+genuinely going away out from under the parent — a user pan-down / backdrop, or a displacement by
+another sheet in the group — never for a close the parent itself drove, so parent state can't be
+cleared behind your back. `AddToPlaylistSheet` is the reference.
 
 **Stacking above everything:** a **custom, non-sheet** overlay (Reanimated + plain views) can
 render in a higher iOS window via react-native-screens' `FullWindowOverlay` — that's how
@@ -75,7 +76,12 @@ custom chrome that renders the raw `BottomSheetModal`/`BottomSheet` directly mus
 drive present/dismiss with `useManagedSheet` (see `QueueSheet`, `BoardSheet`,
 `LogAscentSheet`). The coordinator serializes transitions per **presenter group**
 (default `'root'`) and auto-sequences a sheet-over-sheet open as
-dismiss(A) → settle → present(B). Two exceptions, both documented in-file:
+dismiss(A) → settle → present(B). **A displaced sheet is closed, not suspended**:
+the coordinator clears its desired-open flag and fires `onDisplaced`, which
+`useManagedSheet` delivers as the sheet's `onClose` (same contract as a user
+pan-down), so the parent clears the state that drove `open`. Never design a flow
+that expects a displaced sheet to come back by itself when the displacer closes —
+that implicit resume was the phantom-tick-sheet bug (PR #3595). Two exceptions, both documented in-file:
 `CreateDrawer` (a route-primary drawer that renders the raw `BottomSheet` without the
 coordinator — it opens once as the create-climb route's primary sheet, and its only sub-sheet,
 `HoldRoleSheet`, presents from its own sibling SwiftUI host, so the two never contend for the same

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -230,6 +230,7 @@ export function useClimbActions({
       icon: 'tick',
       color: successColor,
       run: () => {
+        track(SHARED_EVENTS.QuickTickOpened, { climbUuid: climb.uuid, layoutId, source: 'climb_actions' });
         openLogAscent({
           climbUuid: climb.uuid,
           boardName,

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -692,15 +692,25 @@ export function PlayDrawer({
 
   const handleTickFabPress = useCallback(() => {
     resetZoomRef.current?.();
+    track(SHARED_EVENTS.QuickTickOpened, {
+      climbUuid: displayedClimb?.uuid ?? null,
+      layoutId: layoutId ?? null,
+      source: 'play_fab',
+    });
     setIsTickBarActive(true);
-  }, []);
+  }, [displayedClimb?.uuid, layoutId]);
 
   // Long-press now opens the same QuickTickBar as a short press; LogAscentSheet
   // has been retired in favour of a single ticking surface (see PR #2366).
   const handleTickFabLongPress = useCallback(() => {
     resetZoomRef.current?.();
+    track(SHARED_EVENTS.QuickTickOpened, {
+      climbUuid: displayedClimb?.uuid ?? null,
+      layoutId: layoutId ?? null,
+      source: 'play_fab',
+    });
     setIsTickBarActive(true);
-  }, []);
+  }, [displayedClimb?.uuid, layoutId]);
 
   const handleTickBarDismiss = useCallback(() => {
     setIsTickBarActive(false);

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -708,13 +708,9 @@ export function PlayDrawer({
     setIsTickBarActive(true);
   }, [trackTickOpened]);
 
-  // Long-press now opens the same QuickTickBar as a short press; LogAscentSheet
+  // Long-press opens the same QuickTickBar as a short press; LogAscentSheet
   // has been retired in favour of a single ticking surface (see PR #2366).
-  const handleTickFabLongPress = useCallback(() => {
-    resetZoomRef.current?.();
-    trackTickOpened();
-    setIsTickBarActive(true);
-  }, [trackTickOpened]);
+  const handleTickFabLongPress = handleTickFabPress;
 
   const handleTickBarDismiss = useCallback(() => {
     setIsTickBarActive(false);

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -690,27 +690,31 @@ export function PlayDrawer({
     setActiveSubDrawer('none');
   }, []);
 
-  const handleTickFabPress = useCallback(() => {
-    resetZoomRef.current?.();
+  // Track only when a climb is displayed: the sheet itself is gated on
+  // `displayedClimb`, and a null climbUuid would pollute the
+  // Dismissed + Saved <= Opened watchdog this event exists to power.
+  const trackTickOpened = useCallback(() => {
+    if (!displayedClimb) return;
     track(SHARED_EVENTS.QuickTickOpened, {
-      climbUuid: displayedClimb?.uuid ?? null,
+      climbUuid: displayedClimb.uuid,
       layoutId: layoutId ?? null,
       source: 'play_fab',
     });
+  }, [displayedClimb, layoutId]);
+
+  const handleTickFabPress = useCallback(() => {
+    resetZoomRef.current?.();
+    trackTickOpened();
     setIsTickBarActive(true);
-  }, [displayedClimb?.uuid, layoutId]);
+  }, [trackTickOpened]);
 
   // Long-press now opens the same QuickTickBar as a short press; LogAscentSheet
   // has been retired in favour of a single ticking surface (see PR #2366).
   const handleTickFabLongPress = useCallback(() => {
     resetZoomRef.current?.();
-    track(SHARED_EVENTS.QuickTickOpened, {
-      climbUuid: displayedClimb?.uuid ?? null,
-      layoutId: layoutId ?? null,
-      source: 'play_fab',
-    });
+    trackTickOpened();
     setIsTickBarActive(true);
-  }, [displayedClimb?.uuid, layoutId]);
+  }, [trackTickOpened]);
 
   const handleTickBarDismiss = useCallback(() => {
     setIsTickBarActive(false);

--- a/packages/mobile/src/components/queue-control/use-log-ascent-action.ts
+++ b/packages/mobile/src/components/queue-control/use-log-ascent-action.ts
@@ -3,6 +3,8 @@ import { useAnimatedStyle, useSharedValue, withSequence, withSpring } from 'reac
 import type { Climb } from '@boardsesh/queue';
 import { useOptionalBoardActions, useOptionalBoardLogbook } from '@boardsesh/board-react';
 import { useTranslation } from 'react-i18next';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../../lib/analytics';
 import { useTheme } from '../../providers/theme-provider';
 import { useQueueSessionId } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
@@ -68,6 +70,11 @@ export function useLogAscentAction(climb: Climb) {
     if (!boardConfig) return;
     pendingRef.current = true;
     hapticSelection();
+    track(SHARED_EVENTS.QuickTickOpened, {
+      climbUuid: climb.uuid,
+      layoutId: boardConfig.layoutId ?? null,
+      source: 'queue_bar',
+    });
     openLogAscent({
       climbUuid: climb.uuid,
       boardName: boardConfig.boardName,

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -549,13 +549,12 @@ describe('BluetoothProvider wall-confirm integration', () => {
     queue.currentClimbQueueItem = firstItem;
     const { rerender } = renderProvider();
 
+    // Wait on the report itself (like the pending-report test above) — the
+    // BoardClimbReported track call this used to wait on was removed in the
+    // PostHog noise cleanup (054be4d55).
     await waitFor(() => {
-      expect(analytics.track).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({ climbUuid: 'climb-1' }),
-      );
+      expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
     });
-    expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
 
     queue.currentClimbQueueItem = { ...firstItem };
     rerender(

--- a/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
@@ -242,7 +242,7 @@ describe('SheetPresentationProvider coordinator', () => {
   // The phantom-sheet bug: a sheet displaced by a handoff used to keep its
   // desired-open flag, so it re-presented "at random" when the displacing sheet
   // closed (tick sheet reopening after the BLE device picker went away).
-  it('closes a displaced sheet: onDisplaced fires and it never re-presents after the displacer closes', () => {
+  it('closes a displaced sheet: onDisplaced fires and it never re-presents after the displacer closes', async () => {
     const a = { ...makeSheet(), onDisplaced: vi.fn() };
     const b = makeSheet();
     coordinator.register({ id: 'a', group: 'root', ...a });
@@ -253,6 +253,7 @@ describe('SheetPresentationProvider coordinator', () => {
 
     coordinator.setDesiredOpen('b', true); // displaces a
     expect(a.dismiss).toHaveBeenCalledTimes(1);
+    await Promise.resolve(); // onDisplaced is delivered via microtask
     expect(a.onDisplaced).toHaveBeenCalledTimes(1);
 
     vi.advanceTimersByTime(SETTLE_MS); // a's dismiss settles → b presents
@@ -268,7 +269,31 @@ describe('SheetPresentationProvider coordinator', () => {
     expect(coordinator.isBusy('root')).toBe(false);
   });
 
-  it('does not fire onDisplaced for a handoff whose first sheet already closed itself', () => {
+  it('displaces a sheet whose present is still in flight when the displacer wins the group', async () => {
+    const a = { ...makeSheet(), onDisplaced: vi.fn() };
+    const b = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.register({ id: 'b', group: 'root', ...b });
+
+    coordinator.setDesiredOpen('a', true);
+    coordinator.setDesiredOpen('b', true); // while a's present is in flight
+    await Promise.resolve();
+    expect(a.onDisplaced).not.toHaveBeenCalled(); // nothing until a's present settles
+
+    vi.advanceTimersByTime(SETTLE_MS); // a's present settles → pump displaces it
+    expect(a.dismiss).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(a.onDisplaced).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(SETTLE_MS); // a's dismiss settles → b presents
+    vi.advanceTimersByTime(SETTLE_MS); // b's present settles
+    coordinator.setDesiredOpen('b', false);
+    vi.advanceTimersByTime(SETTLE_MS);
+    expect(a.present).toHaveBeenCalledTimes(1); // no resurrection here either
+    expect(coordinator.isBusy('root')).toBe(false);
+  });
+
+  it('does not fire onDisplaced for a handoff whose first sheet already closed itself', async () => {
     const a = { ...makeSheet(), onDisplaced: vi.fn() };
     const b = makeSheet();
     coordinator.register({ id: 'a', group: 'root', ...a });
@@ -281,6 +306,7 @@ describe('SheetPresentationProvider coordinator', () => {
     // next one. The parent drove the close — no displacement notification.
     coordinator.setDesiredOpen('a', false);
     coordinator.setDesiredOpen('b', true);
+    await Promise.resolve();
     expect(a.onDisplaced).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(SETTLE_MS); // a's dismiss settles
@@ -357,7 +383,7 @@ describe('useManagedSheet bridge', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it('a displacement fires onClose exactly once so the controlled parent clears its open state', () => {
+  it('a displacement fires onClose exactly once so the controlled parent clears its open state', async () => {
     const onCloseA = vi.fn();
     let managedA: ReturnType<typeof useManagedSheet> | null = null;
     let managedB: ReturnType<typeof useManagedSheet> | null = null;
@@ -391,6 +417,7 @@ describe('useManagedSheet bridge', () => {
     vi.advanceTimersByTime(SETTLE_MS); // A presented
 
     rerender(createElement(Harness, { openB: true })); // B displaces A
+    await act(async () => {}); // flush the onDisplaced microtask
     // The parent is told A is closed (this is what clears e.g. isTickBarActive)...
     expect(onCloseA).toHaveBeenCalledTimes(1);
     expect(sheetApiA.dismiss).toHaveBeenCalledTimes(1);

--- a/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
@@ -238,6 +238,54 @@ describe('SheetPresentationProvider coordinator', () => {
     vi.advanceTimersByTime(SETTLE_MS);
     expect(b.present).toHaveBeenCalledTimes(1);
   });
+
+  // The phantom-sheet bug: a sheet displaced by a handoff used to keep its
+  // desired-open flag, so it re-presented "at random" when the displacing sheet
+  // closed (tick sheet reopening after the BLE device picker went away).
+  it('closes a displaced sheet: onDisplaced fires and it never re-presents after the displacer closes', () => {
+    const a = { ...makeSheet(), onDisplaced: vi.fn() };
+    const b = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.register({ id: 'b', group: 'root', ...b });
+
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS); // a presented
+
+    coordinator.setDesiredOpen('b', true); // displaces a
+    expect(a.dismiss).toHaveBeenCalledTimes(1);
+    expect(a.onDisplaced).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(SETTLE_MS); // a's dismiss settles → b presents
+    vi.advanceTimersByTime(SETTLE_MS); // b's present settles
+    expect(coordinator.isPresented('b')).toBe(true);
+
+    coordinator.setDesiredOpen('b', false); // displacer goes away
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    // The displaced sheet was closed, not suspended: no resurrection.
+    expect(a.present).toHaveBeenCalledTimes(1);
+    expect(coordinator.isPresented('a')).toBe(false);
+    expect(coordinator.isBusy('root')).toBe(false);
+  });
+
+  it('does not fire onDisplaced for a handoff whose first sheet already closed itself', () => {
+    const a = { ...makeSheet(), onDisplaced: vi.fn() };
+    const b = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.register({ id: 'b', group: 'root', ...b });
+
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS); // a presented
+
+    // The climb-actions pattern: the action closes its own sheet and opens the
+    // next one. The parent drove the close — no displacement notification.
+    coordinator.setDesiredOpen('a', false);
+    coordinator.setDesiredOpen('b', true);
+    expect(a.onDisplaced).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(SETTLE_MS); // a's dismiss settles
+    expect(b.present).toHaveBeenCalledTimes(1);
+  });
 });
 
 // The bridge consumers actually use. The selfDismissRef gate here is what tells a
@@ -307,5 +355,62 @@ describe('useManagedSheet bridge', () => {
       managed?.onChange(-1); // the synchronous native callback that dismiss() triggers
     });
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('a displacement fires onClose exactly once so the controlled parent clears its open state', () => {
+    const onCloseA = vi.fn();
+    let managedA: ReturnType<typeof useManagedSheet> | null = null;
+    let managedB: ReturnType<typeof useManagedSheet> | null = null;
+    const sheetApiA = makeSheetApi();
+    const sheetApiB = makeSheetApi();
+
+    function SheetA({ open }: { open: boolean }) {
+      const sheetRef = useRef(sheetApiA as unknown as BottomSheetMethods);
+      managedA = useManagedSheet({
+        open,
+        sheetRef: sheetRef as RefObject<BottomSheetMethods | null>,
+        onClose: onCloseA,
+      });
+      return null;
+    }
+    function SheetB({ open }: { open: boolean }) {
+      const sheetRef = useRef(sheetApiB as unknown as BottomSheetMethods);
+      managedB = useManagedSheet({ open, sheetRef: sheetRef as RefObject<BottomSheetMethods | null> });
+      return null;
+    }
+    function Harness({ openB }: { openB: boolean }) {
+      return createElement(
+        SheetPresentationProvider,
+        null,
+        createElement(SheetA, { open: true }),
+        createElement(SheetB, { open: openB }),
+      );
+    }
+
+    const { rerender } = render(createElement(Harness, { openB: false }));
+    vi.advanceTimersByTime(SETTLE_MS); // A presented
+
+    rerender(createElement(Harness, { openB: true })); // B displaces A
+    // The parent is told A is closed (this is what clears e.g. isTickBarActive)...
+    expect(onCloseA).toHaveBeenCalledTimes(1);
+    expect(sheetApiA.dismiss).toHaveBeenCalledTimes(1);
+
+    // ...and the native close callback the dismiss triggers is still classified
+    // as coordinator-driven, so onClose does not fire a second time.
+    act(() => {
+      managedA?.onChange(-1);
+    });
+    expect(onCloseA).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(SETTLE_MS); // A dismiss settles
+    expect(sheetApiB.snapToIndex).toHaveBeenCalledWith(0); // B presents
+    vi.advanceTimersByTime(SETTLE_MS); // B present settles
+
+    // B closes → A must NOT come back.
+    act(() => {
+      managedB?.handle.dismiss();
+    });
+    vi.advanceTimersByTime(SETTLE_MS);
+    expect(sheetApiA.snapToIndex).toHaveBeenCalledTimes(1); // only the original present
   });
 });

--- a/packages/mobile/src/providers/sheet-presentation-provider.tsx
+++ b/packages/mobile/src/providers/sheet-presentation-provider.tsx
@@ -18,7 +18,10 @@
  *      not merely "JS asked it to close."
  *   3. One active sheet per exclusive group: presenting B while A is open
  *      auto-sequences dismiss(A) → settle → present(B). This makes sheet-over-
- *      sheet handoffs safe and enforces docs hard-rule 1 at runtime.
+ *      sheet handoffs safe and enforces docs hard-rule 1 at runtime. A sheet
+ *      displaced this way is CLOSED, not suspended — its parent is notified
+ *      (onDisplaced → onClose) and its desired-open flag cleared, so it never
+ *      re-presents by itself when B later closes.
  *
  * "Settled" is detected two ways. On iOS the real post-animation signal arrives
  * via `notifyFullyDismissed`: our `@expo/ui` patch forwards SwiftUI's
@@ -61,6 +64,13 @@ type Registration = {
   present: () => void;
   dismiss: () => void;
   onFullyDismissed?: () => void;
+  /** The coordinator displaced this sheet to present another one in the same
+   * group. A displaced sheet is CLOSED, not suspended: the parent must clear
+   * whatever state drove `open`, exactly as it does for a user pan-down.
+   * Without this, the parent's stale open-state left the sheet flagged as
+   * desired-open, and it re-presented "at random" when the displacing sheet
+   * closed (the phantom tick-sheet bug). */
+  onDisplaced?: () => void;
 };
 
 type InFlight = {
@@ -187,7 +197,23 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
       if (have !== null) {
         // Must clear the currently-presented sheet first (plain close OR the
         // dismiss half of a handoff). present(want) runs after this settles.
+        const haveDesired = desired.current.get(have);
+        const displaced = want !== null && haveDesired?.open === true;
+        if (displaced) {
+          // Displacement: `have` is still flagged open but a different sheet won
+          // the group. Treat the displaced sheet as closed — clear its desired
+          // flag so computeWant can never resurrect it once `want` goes away,
+          // and tell its parent so the state that drove `open` is cleared too.
+          // (A plain close, want === null, or a handoff whose first sheet already
+          // closed itself needs neither: the parent drove those.)
+          desired.current.set(have, { open: false, seq: haveDesired.seq });
+        }
         startTransition(group, 'dismiss', have);
+        // Notify AFTER the dismiss is in flight: onDisplaced runs parent code
+        // that may synchronously re-enter the coordinator (setDesiredOpen /
+        // handle.dismiss), and the inFlight guard must already be up so a
+        // re-entrant pump can't start a second transition for this group.
+        if (displaced) registrations.current.get(have)?.onDisplaced?.();
       } else {
         startTransition(group, 'present', want as string);
       }
@@ -200,6 +226,7 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
           present: reg.present,
           dismiss: reg.dismiss,
           onFullyDismissed: reg.onFullyDismissed,
+          onDisplaced: reg.onDisplaced,
         });
         groupState(reg.group);
         return () => {
@@ -349,10 +376,25 @@ export function useManagedSheet({
   const fireFullyDismissed = useCallback(() => {
     onFullyDismissedRef.current?.();
   }, []);
+  // Displaced by another sheet in the group: closed, not suspended. Fire the
+  // same onClose a user pan-down fires so the parent clears the state that
+  // drove `open` — otherwise the sheet re-presents when the displacer closes.
+  // No notifyClosed here: the coordinator is driving this dismiss itself.
+  const fireDisplaced = useCallback(() => {
+    onCloseRef.current?.();
+  }, []);
 
   useEffect(
-    () => coordinator.register({ id, group, present, dismiss, onFullyDismissed: fireFullyDismissed }),
-    [coordinator, id, group, present, dismiss, fireFullyDismissed],
+    () =>
+      coordinator.register({
+        id,
+        group,
+        present,
+        dismiss,
+        onFullyDismissed: fireFullyDismissed,
+        onDisplaced: fireDisplaced,
+      }),
+    [coordinator, id, group, present, dismiss, fireFullyDismissed, fireDisplaced],
   );
 
   // Controlled mode only: an imperative consumer leaves `open` undefined so this

--- a/packages/mobile/src/providers/sheet-presentation-provider.tsx
+++ b/packages/mobile/src/providers/sheet-presentation-provider.tsx
@@ -209,11 +209,17 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
           desired.current.set(have, { open: false, seq: haveDesired.seq });
         }
         startTransition(group, 'dismiss', have);
-        // Notify AFTER the dismiss is in flight: onDisplaced runs parent code
-        // that may synchronously re-enter the coordinator (setDesiredOpen /
-        // handle.dismiss), and the inFlight guard must already be up so a
-        // re-entrant pump can't start a second transition for this group.
-        if (displaced) registrations.current.get(have)?.onDisplaced?.();
+        // Notify via microtask, AFTER the dismiss is in flight. Deferring keeps
+        // the parent's setState (onDisplaced → onClose) out of whatever context
+        // pump() ran in (an event handler or another component's effect), and
+        // the inFlight guard is already up so a re-entrant pump from the parent
+        // can't start a second transition for this group. Re-resolve the
+        // registration inside the task: if the sheet unmounted meanwhile, the
+        // notification is correctly a no-op.
+        if (displaced) {
+          const displacedId = have;
+          queueMicrotask(() => registrations.current.get(displacedId)?.onDisplaced?.());
+        }
       } else {
         startTransition(group, 'present', want as string);
       }

--- a/packages/mobile/src/providers/sheet-presentation-provider.tsx
+++ b/packages/mobile/src/providers/sheet-presentation-provider.tsx
@@ -215,7 +215,11 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
         // the inFlight guard is already up so a re-entrant pump from the parent
         // can't start a second transition for this group. Re-resolve the
         // registration inside the task: if the sheet unmounted meanwhile, the
-        // notification is correctly a no-op.
+        // notification is correctly a no-op. A parent that responds to
+        // onDisplaced/onClose by re-opening (setDesiredOpen true) queues a
+        // legitimate re-present after the displacer closes — that's the
+        // deliberate escape hatch for a sheet that truly must resume; nothing
+        // uses it today.
         if (displaced) {
           const displacedId = have;
           queueMicrotask(() => registrations.current.get(displacedId)?.onDisplaced?.());

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -84,6 +84,11 @@ export const SHARED_EVENTS = {
   LogbookEntryEdited: 'Logbook Entry Edited',
   LogbookEntryDeleted: 'Logbook Entry Deleted',
   // Ticks / logbook
+  // Mobile-only: fired at every explicit tick-sheet open (play-drawer FAB,
+  // climb-actions menu, queue bar), with a `source` prop. Gives the invariant
+  // Dismissed + Saved <= Opened; a violation means the sheet presented without
+  // user intent (the phantom-reopen bug this event was added to watchdog).
+  QuickTickOpened: 'Quick Tick Opened',
   TickButtonClicked: 'Tick Button Clicked',
   QuickTickSaved: 'Quick Tick Saved',
   QuickTickFailed: 'Quick Tick Failed',


### PR DESCRIPTION
## Summary

A user (Android, app 2.2.2) reported "a random sheet keeps opening". PostHog forensics on their sessions showed the tick sheet presenting without any user intent: 5× `Quick Tick Dismissed` with completely untouched forms vs 1 save, two dismissals 2.5 s apart for the same climb (dismissed → reopened → dismissed), and two dismissals for climbs the user never selected. Every cluster coincided with BLE device-picker activity during failing connect attempts. Project-wide, 320 dismissals from 173 users in 30 days show the same shape on iOS and Android.

**Root cause** (`sheet-presentation-provider.tsx`): when sheet B presents while sheet A is up in the same presenter group, the coordinator's handoff dismisses A natively — but deliberately without firing A's `onClose` (that gate exists so parent-driven closes aren't double-reported). In a displacement the parent did *not* drive the close, so A's parent state and its `desired`-open flag both stayed true, and `computeWant()` re-presented A the moment B went away. The common displacer is the BLE device picker (mounts on every connect needing device selection — 13 failed connects in the reporter's session); the common victim is the tick sheet, the only sheet users leave open while tapping other controls.

**Fix**: displacement now *closes* the displaced sheet instead of implicitly suspending it. `pump()` clears the desired flag and fires a new `onDisplaced` registration callback; `useManagedSheet` wires it to the same `onClose` a user pan-down fires so controlled parents (`isTickBarActive`, `useDeferredSheetData`, picker state) reconcile. The notification fires after the dismiss transition is in flight so re-entrant coordinator calls from parent `onClose` handlers can't double-start a transition. An audit confirmed no flow relied on the implicit resume — real handoffs (climb-actions → log-ascent) already close their first sheet explicitly.

Also adds a `Quick Tick Opened` event (`source: play_fab | climb_actions | queue_bar`), giving the production invariant `Dismissed + Saved ≤ Opened` — a watchdog that phantom opens stay gone.

## Release Notes

- Fixed the log-ascent sheet popping back open uninvited after connecting to a board

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — all pass. The `bluetooth-provider-wall-confirm` test that has been red on main CI since 07-09 is repaired here: it waited on the `BoardClimbReported` track call that 054be4d55 (PostHog noise cleanup) removed, and now waits on `reportClimbForBoard` — so this PR also returns main's `test-default` job to green
- `vp run check:mobile-bundle` — Android bundle OK
- New coordinator tests: displaced sheet fires `onDisplaced`, never re-presents after the displacer closes; parent-driven handoffs don't fire it; bridge-level test that a displacement fires `onClose` exactly once (the coordinator-driven native close callback stays gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgpPvQ8PxH7PPFcpx1r6NH
