### PR TITLE
fix(backend): restore boardseshGrade test mocks broken by grade leftJoin

### DIFF
--- a/packages/backend/src/__tests__/boardsesh-grade.test.ts
+++ b/packages/backend/src/__tests__/boardsesh-grade.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 // Mock the read client: capture what the resolver selects and feed it canned
-// rows. The chain mirrors dbRead.select().from().where().limit().
+// rows. The chain mirrors dbRead.select().from().leftJoin().where().limit().
 const { selectRows, dbReadMock } = vi.hoisted(() => {
   const state: { rows: unknown[] } = { rows: [] };
   const chain = {
     from: vi.fn(() => chain),
+    leftJoin: vi.fn(() => chain),
     where: vi.fn(() => chain),
     limit: vi.fn(async () => state.rows),
   };

--- a/packages/backend/src/__tests__/boardsesh-grades-for-angles.test.ts
+++ b/packages/backend/src/__tests__/boardsesh-grades-for-angles.test.ts
@@ -3,11 +3,12 @@ import { asc } from 'drizzle-orm';
 import * as dbSchema from '@boardsesh/db/schema';
 
 // Mock the read client: capture what the resolver selects and feed it canned
-// rows. The chain mirrors dbRead.select().from().where().orderBy().
+// rows. The chain mirrors dbRead.select().from().leftJoin().where().orderBy().
 const { selectRows, dbReadMock } = vi.hoisted(() => {
   const state: { rows: unknown[] } = { rows: [] };
   const chain = {
     from: vi.fn(() => chain),
+    leftJoin: vi.fn(() => chain),
     where: vi.fn(() => chain),
     orderBy: vi.fn(async () => state.rows),
   };


### PR DESCRIPTION
## Summary

`test-backend` has been red on `main` since the Climb2Vec grade series (#3588–#3592) added a `.leftJoin` on `board_climb_embeddings` to the `boardseshGrade` / `boardseshGradesForAngles` resolvers (`queries.ts:419`, `:470`). The `dbRead` chain mocks in these two tests only stubbed `from`/`where`/`limit`(`orderBy`), so every case threw:

```
TypeError: dbRead.select(...).from(...).leftJoin is not a function
```

This adds `leftJoin: vi.fn(() => chain)` to both mock chains. Test-only change — no resolver/runtime change.

- `boardsesh-grade.test.ts` — 9 failing → passing
- `boardsesh-grades-for-angles.test.ts` — restored

Locally: **17 passed (was 9 failed / 8 passed)**; `vp check` clean.

## Release Notes

- [x] No release note needed (internal / technical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8P4Qxqtcu89vBJfLPjvqo