### PR TITLE
fix(mobile): tick from the reaction menu on /play no longer closes itself

### DIFF
--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -45,6 +45,12 @@ type ClimbReactionMenuProps = {
    *  stacks above the `/play` modal (#3505). Receives the climb/board snapshot the
    *  menu was opened for. */
   onAddBetaVideo?: (climb: Climb, boardConfig: BoardConfig) => void;
+  /** When provided, the "Tick" action runs this instead of opening the root
+   *  LogAscent sheet — the play drawer passes its own in-tree opener so the tick
+   *  sheet stacks above the `/play` modal. Without it, presenting the root sheet
+   *  forces UIKit to dismiss `/play` and the tick sheet closes immediately.
+   *  Receives the climb/board snapshot the menu was opened for. */
+  onTick?: (climb: Climb, boardConfig: BoardConfig) => void;
   /** Read once at the app root (resolved) and passed in, so the mount-time enter
    *  animation uses the real value rather than useReduceMotion's conservative default. */
   reduceMotion: boolean;
@@ -87,6 +93,7 @@ export function ClimbReactionMenu({
   isAuthenticated,
   onEditEntry,
   onAddBetaVideo,
+  onTick,
   reduceMotion,
   onClose,
 }: ClimbReactionMenuProps) {
@@ -140,6 +147,7 @@ export function ClimbReactionMenu({
     onAfterAction: dismiss,
     onSelectPlaylist: openPlaylist,
     onAddBetaVideo,
+    onTick,
   });
 
   const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;

--- a/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
@@ -181,6 +181,33 @@ describe('useClimbActions colours and dispatch', () => {
     expect(onAfterAction).toHaveBeenCalledTimes(1);
   });
 
+  it('tick.run opens the root LogAscent sheet and fires onAfterAction by default', () => {
+    const onAfterAction = vi.fn();
+    const { result } = renderHook(() =>
+      useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false, onAfterAction }),
+    );
+    result.current.find((action) => action.id === 'tick')?.run();
+    expect(openers.openLogAscent).toHaveBeenCalledWith(
+      expect.objectContaining({ climbUuid: 'climb-1', boardName: 'kilter', angle: 40 }),
+    );
+    expect(onAfterAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('tick.run calls onTick (in-tree) instead of the root sheet when provided', () => {
+    const onTick = vi.fn();
+    const onAfterAction = vi.fn();
+    const { result } = renderHook(() =>
+      useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false, onTick, onAfterAction }),
+    );
+    result.current.find((action) => action.id === 'tick')?.run();
+    // Same climb/board snapshot the root path uses, so a live queue change can't retarget it.
+    expect(onTick).toHaveBeenCalledWith(climb, kilterBoard);
+    // The play drawer's own in-tree sheet takes over — the root opener (which would
+    // pop the /play modal) is skipped, but the reaction menu still dismisses.
+    expect(openers.openLogAscent).not.toHaveBeenCalled();
+    expect(onAfterAction).toHaveBeenCalledTimes(1);
+  });
+
   it('share.run opens the native share sheet', () => {
     const { result } = renderHook(() => useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false }));
     result.current.find((action) => action.id === 'share')?.run();

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -81,6 +81,16 @@ type UseClimbActionsArgs = {
    * the menu is open can't retarget it. Omit it and beta opens the root sheet.
    */
   onAddBetaVideo?: (climb: Climb, boardConfig: BoardConfig) => void;
+  /**
+   * In-tree opener for the "Tick" action. The play drawer passes its own opener
+   * so the tick sheet stacks above the `/play` transparentModal. The root
+   * `openLogAscent` sheet mounts BEHIND `/play`; presenting it forces UIKit to
+   * dismiss `/play`, dragging the tick sheet down with it — the "tick sheet
+   * closes immediately" bug. Same fix shape as `onAddBetaVideo` (#3505). Receives
+   * the same `climb`/`boardConfig` snapshot the fallback path uses. Omit it and
+   * ticking opens the root sheet (correct off `/play`, where nothing conflicts).
+   */
+  onTick?: (climb: Climb, boardConfig: BoardConfig) => void;
 };
 
 // Mirrors web's constructClimbInfoUrl: Kilter no longer has a public app URL.
@@ -99,6 +109,7 @@ export function useClimbActions({
   onAfterAction,
   onSelectPlaylist,
   onAddBetaVideo,
+  onTick,
 }: UseClimbActionsArgs): ClimbActionItem[] {
   const { t } = useTranslation('climbs');
   const router = useRouter();
@@ -231,17 +242,25 @@ export function useClimbActions({
       color: successColor,
       run: () => {
         track(SHARED_EVENTS.QuickTickOpened, { climbUuid: climb.uuid, layoutId, source: 'climb_actions' });
-        openLogAscent({
-          climbUuid: climb.uuid,
-          boardName,
-          angle,
-          isMirror: false,
-          isBenchmark: !!climb.benchmark_difficulty,
-          layoutId,
-          sizeId,
-          setIds,
-          consensusGradeName: climb.difficulty,
-        });
+        // In-tree opener (play drawer) stacks the tick sheet above the `/play`
+        // modal; the root sheet can't — presenting it dismisses `/play` and the
+        // tick sheet closes immediately. Both take the climb/board snapshot so a
+        // live queue change can't retarget it.
+        if (onTick) {
+          onTick(climb, boardConfig);
+        } else {
+          openLogAscent({
+            climbUuid: climb.uuid,
+            boardName,
+            angle,
+            isMirror: false,
+            isBenchmark: !!climb.benchmark_difficulty,
+            layoutId,
+            sizeId,
+            setIds,
+            consensusGradeName: climb.difficulty,
+          });
+        }
         after();
       },
     });
@@ -362,6 +381,7 @@ export function useClimbActions({
     onEditEntry,
     onSelectPlaylist,
     onAddBetaVideo,
+    onTick,
     after,
     t,
     actionColors,

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -232,6 +232,10 @@ export function PlayDrawer({
   // Pinned climb/board the reaction menu opened the beta sheet for; null falls back
   // to the live displayedClimb (the "+" button path). See #3505.
   const [betaVideoTarget, setBetaVideoTarget] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
+  // Pinned climb/board the reaction menu opened the tick sheet for; null falls back
+  // to the live displayedClimb (the FAB path). Mirrors betaVideoTarget so a party-
+  // session queue/angle change mid-menu can't retarget the sheet.
+  const [tickTarget, setTickTarget] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const [belowFoldContentRequested, setBelowFoldContentRequested] = useState(false);
   const resetZoomRef = useRef<(() => void) | null>(null);
 
@@ -658,6 +662,17 @@ export function PlayDrawer({
     setAddBetaVideoOpen(true);
   }, []);
 
+  // Reaction-menu tick: open the drawer's OWN in-tree tick sheet (it stacks above
+  // the `/play` modal) instead of the root LogAscent sheet, which mounts behind
+  // `/play` — presenting it dismisses `/play` and the tick sheet closes on its own.
+  // Pin the climb/board the menu was opened for so a mid-menu queue change can't
+  // retarget it. QuickTickOpened is tracked by useClimbActions (source climb_actions).
+  const handleOpenTickForClimb = useCallback((targetClimb: Climb, targetBoardConfig: BoardConfig) => {
+    resetZoomRef.current?.();
+    setTickTarget({ climb: targetClimb, boardConfig: targetBoardConfig });
+    setIsTickBarActive(true);
+  }, []);
+
   // Don't clear betaVideoTarget here: the sheet is still animating out and reads
   // from it, so nulling it mid-dismiss would swap the shown climb for a frame. The
   // next open overwrites it (the "+" path to null, the reaction path to its snapshot).
@@ -672,11 +687,14 @@ export function PlayDrawer({
       // Hand the reaction menu the drawer's OWN beta opener so the share-your-beta
       // sheet presents inside the `/play` modal (above it) rather than the root
       // sheet, which can't stack over the fullScreenModal (#3505).
-      onOpenClimbActions(displayedClimb, undefined, { onAddBetaVideo: handleOpenAddBetaVideoForClimb });
+      onOpenClimbActions(displayedClimb, undefined, {
+        onAddBetaVideo: handleOpenAddBetaVideoForClimb,
+        onTick: handleOpenTickForClimb,
+      });
       return;
     }
     setActiveSubDrawer('actions');
-  }, [onOpenClimbActions, displayedClimb, handleOpenAddBetaVideoForClimb]);
+  }, [onOpenClimbActions, displayedClimb, handleOpenAddBetaVideoForClimb, handleOpenTickForClimb]);
 
   const handleScrollTowardBelowFold = useCallback(() => {
     setBelowFoldContentRequested(true);
@@ -705,6 +723,8 @@ export function PlayDrawer({
   const handleTickFabPress = useCallback(() => {
     resetZoomRef.current?.();
     trackTickOpened();
+    // Null target → the in-tree tick sheet tracks the live displayedClimb.
+    setTickTarget(null);
     setIsTickBarActive(true);
   }, [trackTickOpened]);
 
@@ -1046,26 +1066,33 @@ export function PlayDrawer({
       {/* Tick sheet — a 60% sub-drawer so the climb image stays visible while
           logging. Presents over the player route. The displayedClimb guard stays;
           the host is mounted on first open. */}
-      {mountLogAscent && displayedClimb && (
-        <LogAscentSheet
-          visible={isTickBarActive}
-          onClose={handleTickBarDismiss}
-          climbUuid={displayedClimb.uuid}
-          boardName={boardName}
-          angle={angle}
-          isMirror={isMirrored}
-          isBenchmark={displayedClimb.benchmark_difficulty != null}
-          layoutId={layoutId}
-          sizeId={sizeId}
-          setIds={setIds}
-          sessionId={sessionId}
-          // The tick picker opens on the Boardsesh grade (when the toggle is on and
-          // a trusted one exists) instead of the Aurora consensus, so a logged grade
-          // defaults to what the app now shows. Only the DEFAULT changes — the saved
-          // tick value stays on the Aurora scale and null until the climber picks.
-          consensusGradeName={resolveTickDefaultGradeName(displayedClimb, boardseshActive) ?? displayedClimb.difficulty}
-        />
-      )}
+      {mountLogAscent &&
+        displayedClimb &&
+        (() => {
+          // The reaction-menu path pins its own climb/board snapshot; the FAB path
+          // leaves tickTarget null and tracks the live displayedClimb + active board.
+          const tickClimb = tickTarget?.climb ?? displayedClimb;
+          return (
+            <LogAscentSheet
+              visible={isTickBarActive}
+              onClose={handleTickBarDismiss}
+              climbUuid={tickClimb.uuid}
+              boardName={tickTarget?.boardConfig.boardName ?? boardName}
+              angle={tickTarget?.boardConfig.angle ?? angle}
+              isMirror={isMirrored}
+              isBenchmark={tickClimb.benchmark_difficulty != null}
+              layoutId={tickTarget?.boardConfig.layoutId ?? layoutId}
+              sizeId={tickTarget?.boardConfig.sizeId ?? sizeId}
+              setIds={tickTarget?.boardConfig.setIds ?? setIds}
+              sessionId={sessionId}
+              // The tick picker opens on the Boardsesh grade (when the toggle is on and
+              // a trusted one exists) instead of the Aurora consensus, so a logged grade
+              // defaults to what the app now shows. Only the DEFAULT changes — the saved
+              // tick value stays on the Aurora scale and null until the climber picks.
+              consensusGradeName={resolveTickDefaultGradeName(tickClimb, boardseshActive) ?? tickClimb.difficulty}
+            />
+          );
+        })()}
 
       {/* BLE controls (Re-light / Turn off all lights / Disconnect), opened by the
           lightbulb long-press. Hosted here so it presents ABOVE the player route

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -62,6 +62,13 @@ export type OpenClimbActionsOptions = {
    *  above the `/play` fullScreenModal (a root-tree sheet can't — see #3505). It
    *  receives the climb/board snapshot the menu was opened for. */
   onAddBetaVideo?: (climb: Climb, boardConfig: BoardConfig) => void;
+  /** When set, the "Tick" action runs this instead of opening the root LogAscent
+   *  sheet. The play drawer passes its own in-tree opener so the tick sheet stacks
+   *  above the `/play` transparentModal — the root sheet mounts BEHIND it, and
+   *  presenting it forces UIKit to dismiss `/play`, dragging the tick sheet down
+   *  with it (the "tick sheet closes immediately" bug). Same fix shape as
+   *  `onAddBetaVideo` (#3505). Receives the climb/board snapshot the menu opened for. */
+  onTick?: (climb: Climb, boardConfig: BoardConfig) => void;
 };
 
 export type LogAscentInput = {
@@ -327,6 +334,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     boardConfig: BoardConfig;
     onEditEntry?: () => void;
     onAddBetaVideo?: (climb: Climb, boardConfig: BoardConfig) => void;
+    onTick?: (climb: Climb, boardConfig: BoardConfig) => void;
   } | null>(null);
   const { addToQueue, setSessionBoardPath, setCurrentClimb } = useQueueActions();
   const { sessionId } = useQueueSessionControls();
@@ -515,6 +523,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         boardConfig,
         onEditEntry: options?.onEditEntry,
         onAddBetaVideo: options?.onAddBetaVideo,
+        onTick: options?.onTick,
       });
     },
     [],
@@ -905,6 +914,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
             isAuthenticated={isAuthenticated}
             onEditEntry={climbActions.onEditEntry}
             onAddBetaVideo={climbActions.onAddBetaVideo}
+            onTick={climbActions.onTick}
             reduceMotion={reduceMotion}
             onClose={closeClimbActions}
           />


### PR DESCRIPTION
## Summary

On iOS, ticking a climb from the long-press **reaction menu** while on the player (`/play`) route caused the tick sheet to close on its own ~2 seconds after opening — the climber could never log the ascent. Reported by a user (Michael, iOS 26.5.2, app 2.2.2); PostHog confirmed the pattern across 3 stuck users on 2.2.2.

**Root cause.** `/play` is a `transparentModal`. The reaction menu's tick action opened the **root** `LogAscent` sheet, which is mounted *behind* `/play`. Presenting a root `@expo/ui` bottom-sheet while `/play` is presented forces UIKit to dismiss `/play` — dragging the just-opened tick sheet down with it (a non-self dismiss → all-false `QuickTickDismissed`, zero saves). The telemetry ordering is unambiguous: `Quick Tick Opened` on `/play` → the next `$screen` flips to `/climbs`//`/home` (the route pops) → then the tick sheet dismisses.

The FAB tick (`play_fab`) was **not** affected — it already drives the play drawer's own **in-tree** `LogAscent` sheet, which stacks above `/play`. Only the reaction-menu path fell back to the root sheet.

**Fix.** Thread an in-tree `onTick` override, exactly mirroring the #3505 beta-video fix. When the play drawer opens the reaction menu it now hands over its own tick opener (pinning the climb/board snapshot so a mid-menu queue change can't retarget it), so the tick sheet stacks above `/play` instead of popping it. Reaction menus opened **off** `/play` (climb list rows on `/climbs`, `/home`) pass no override and keep using the root sheet, where nothing conflicts — no behavior change there.

Scoped to the drawer-ellipsis reaction menu (the reported path). QueueSheet-row reaction menus on `/play` are intentionally out of scope.

## Release Notes

- Log a tick from a climb's long-press menu on the player screen without the tick sheet snapping shut before you can save it.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 3757 passed, incl. 2 new `useClimbActions` tests asserting the in-tree `onTick` is used (and the root `openLogAscent`, which pops `/play`, is not) when provided
- `vp run check:mobile-bundle` — OK
- `vp check` (lint + format) on all changed files — clean
- **Manual (iOS 26, device or sim):** open `/play` → long-press a climb → **Tick** → the sheet stays up and saves. Also verified the FAB tick and off-`/play` list-row ticks are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)