### PR TITLE
feat(mobile): Android tablet support — Material 3 adaptive shell

### DIFF
--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -310,16 +310,64 @@ borderless)` builds a Pressable `android_ripple` config at that state-layer opac
 
 ---
 
-## iPad adaptive layout
+## Large-screen adaptive layout (iPad + Android tablet)
 
-iPad (only — no Android tablets) gets a multi-column shell; every iPhone, and an iPad in a narrow
-split, falls through to the phone UI **verbatim**. The size class is pure and unit-tested in
-`theme/size-class.ts` (`resolveDeviceLayout`), fed window width by `hooks/use-device-layout.ts`:
+A **tablet** — an iPad, or an Android tablet — gets a multi-column shell; every phone, and a tablet in
+a narrow split, falls through to the phone UI **verbatim**. The shell is drawn in each platform's own
+chrome: **Liquid Glass** on iPad (the glass `IpadSidebar` rail), **Material 3** on an Android tablet
+(the `MaterialNavigationRail`), routed by variant through `TabletSidebar` (`createVariantComponent`).
+The size class is pure and unit-tested in `theme/size-class.ts` (`resolveDeviceLayout`), fed window
+width by `hooks/use-device-layout.ts`:
 
-- **`compact`** — every iPhone, plus an iPad window narrower than `REGULAR_WIDTH_BREAKPOINT` (700pt:
-  Slide Over / a narrow Split View). Renders today's phone UI; no phase may regress it.
-- **`regular`** — an iPad window wide enough for the glass sidebar (`IpadSidebar`, replacing the bottom
-  tab bar) + a content column + a detail pane. `expanded` (≥1024pt) is a flag on top.
+- **`compact`** — every phone, plus a tablet window narrower than `REGULAR_WIDTH_BREAKPOINT` (700dp:
+  iPad Slide Over / a narrow Split View, Android split-screen / freeform / DeX). Renders today's phone
+  UI; no phase may regress it.
+- **`regular`** — a tablet window wide enough for the sidebar rail (replacing the bottom tab bar) + a
+  content column + a detail pane. `expanded` (≥1024dp) is a flag on top.
+
+**Eligibility, not idiom.** The shell admits iPad (`Platform.isPad`) **and** Android tablets — a
+device whose smallest physical-screen width clears **600dp** (`resolveIsTablet`, Android's own
+`sw600dp` tablet qualifier), fed to the same `resolveDeviceLayout`. The signal is launch-fixed (the
+physical screen, not the window), so a tablet in a small multi-window/DeX split is still a tablet but
+reads `compact` from the live width — identical to an iPad in a narrow Split View. The breakpoints
+(700/1024dp) are **shared across both variants**, so iPad and Android tablets resolve identically at
+the same dp. They map onto M3's window size classes as a stricter-than-minimum floor (we need room for
+two panes, not just a rail): M3 **Compact** `<600` → phone UI; M3 **Medium** `600–840` → our `regular`
+admits at ≥700; M3 **Expanded** `≥840` → our `expanded` flag fires at ≥1024. A cheap 10" Android
+tablet (≈800dp portrait / ≈1280dp landscape) always clears `regular`; a 7–8" tablet is `compact` in
+portrait (genuinely too narrow for two panes) and `regular` in landscape.
+
+**The rail is variant-skinned, IA-identical.** The Material `MaterialNavigationRail` mirrors
+`MaterialTabBar`'s M3 roles laid out vertically — a `secondaryContainer` active-indicator pill
+(`material.navRail`, 56×32), `onSecondaryContainer` glyph, `onSurface` active label, `onSurfaceVariant`
+inactive, active/inactive glyph pairs matching the bottom bar — on an `m3SurfaceContainers.low` surface
+(depth by tone, flat, no cast). It shares the **96dp** `SIDEBAR_WIDTH` with the glass rail (96 ≥ M3's
+80dp minimum), because that width is injected into every master-detail width-budget resolver and a
+per-variant width would fork the budget. Same destinations, same top-tablist / bottom-pinned-Profile
+structure. **No rail FAB / no header** — an IA-parity guardrail: the glass rail has neither, so a
+Material-only rail FAB would fork information architecture between the two tablet variants; if ever
+wanted, add it to both together.
+
+**Panes read M3 depth by tone, not iOS hairlines.** On the Material variant the shell column
+separators come from `m3.outlineVariant` (the M3 faint-divider role), and the panes' `GlassSurface`
+degrades to an opaque M3 tonal surface (`useEffectiveSurfaceMode` → `material` on Android). Frame the
+detail (play) pane as an M3 **List-Detail** detail pane and the wall column as an M3 **Supporting
+pane**.
+
+**The live wall reaches Android tablets too.** `resolveWallDeviceClass` marks any Android tablet
+`panel-capable` — there is **no** dp physical-size floor on Android (the iPad points floor
+`WALL_PANEL_MIN_DEVICE_LONG_SIDE` exists only because iPad points can't separate a mini from a Pro at
+the same size class; density-bucketed Android dp isn't comparable to it, and the live width budget in
+`resolveWallSurface` already decides column/strip/none). So a 10" Android tablet in landscape gets the
+dedicated wall column, a narrower one gets the strip. The kiosk hero-type distance scale skips the
+iPad points-per-inch estimate on Android (no reliable ppi from RN JS) and falls back to the pane short
+side. True Android distance-DPI calibration (native `DisplayMetrics.xdpi`) and Material You dynamic
+color are follow-ups.
+
+**Android tablets must rotate.** The app is portrait-locked app-wide; the `with-android-tablet-orientation`
+config plugin lets `sw600dp` tablets rotate to landscape (the shell's whole point) while phones stay
+portrait — the Android counterpart to the iOS `~ipad` orientation override. It's a native change, so it
+ships in a native build, not an OTA.
 
 **The right column is master-detail, not status.** At `regular` width the shell is
 `sidebar · active-tab content · detail pane` (`(tabs)/_layout.tsx`). The detail pane (`IpadPlayPane` →
@@ -367,13 +415,15 @@ tab-bar analogue, so its active row follows the same chrome-glyph rule as `Nativ
 pill as the active affordance — not a brand-violet tint. Brand colour stays for genuine accents, per the
 chrome-glyph rule documented under Iconography.
 
-**The shell is width-adaptive, not idiom-adaptive.** Size class is driven by `Platform.isPad` (fixed at
-process launch) plus the live window width; only width is live. The guarantee is "the right layout for
-the current window width on iPad," not a layout that re-derives the device idiom across Stage Manager or
-an external display. Note also the deliberate choice of a bespoke 96pt icon-over-label rail instead of a
-`UISplitViewController` sidebar: a Phase-1 call that keeps the rail simple but means it won't inherit
-system sidebar behaviours (collapse control, pointer magnetism). Revisit in Phase 2+ whether to adopt a
-true wide text sidebar or the iPadOS 18 floating-tab-bar-to-sidebar pattern.
+**The shell is width-adaptive, not idiom-adaptive.** Size class is driven by the launch-fixed tablet
+flag (`Platform.isPad`, or Android `sw600dp`) plus the live window width; only width is live. The
+guarantee is "the right layout for the current window width on a tablet," not a layout that re-derives
+the device idiom across Stage Manager, DeX, or an external display. Note also the deliberate choice of a
+bespoke 96dp icon-over-label rail instead of a `UISplitViewController` sidebar (iOS) / a full Material
+navigation **drawer** (Android, `expanded` width): a Phase-1 call that keeps the rail simple but means
+it won't inherit system sidebar behaviours (collapse control, pointer magnetism). Revisit in Phase 2+
+whether to adopt a true wide text sidebar / the iPadOS 18 floating-tab-bar-to-sidebar pattern, and the
+M3 navigation drawer at expanded width.
 
 ---
 

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -527,6 +527,11 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
       // Play device filtering. Unconditional (EAS-safe) — it's a pure manifest
       // addition with no signing/credential implications.
       './plugins/with-android-bluetooth-feature',
+      // Lets sw600dp tablets rotate to landscape (the adaptive-shell canvas) while
+      // phones stay portrait — the Android counterpart to the iOS `~ipad`
+      // orientation override, set at runtime in MainActivity since
+      // android:screenOrientation can't be resource-qualified by screen size.
+      './plugins/with-android-tablet-orientation',
       // Declares com.android.vending as a visible package under Android 11+
       // package-visibility filtering, so the Play Install Referrer native module
       // (packages/mobile/modules/install-referrer) can bind to the Play Store

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -135,7 +135,9 @@ vi.mock('../../../src/providers/theme-provider', () => ({
     systemColors: {
       label: '#F5F2FB',
       secondaryLabel: '#A9A2B6',
+      separator: 'rgba(60,55,75,0.18)',
     },
+    m3: { outlineVariant: '#49454F' },
   }),
 }));
 
@@ -429,6 +431,27 @@ describe('TabLayout', () => {
     // The detail pane mounts alongside the list and the dedicated wall column — the
     // pixel widths of each are covered by size-class.test.ts (resolveDetailPaneWidth,
     // WALL_COLUMN_WIDTH), so assert the surfaces are present, not their arithmetic.
+    expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();
+  });
+
+  it('shows the dedicated wall column on a landscape Android tablet with a bound board', () => {
+    // The chosen v1 scope: a wide Android tablet is panel-capable (no dp floor), so
+    // the wall graduates to its own column beside the browse list + detail pane —
+    // exactly the wall-mounted-gym-tablet scenario, in Material dress.
+    cfg.platformOS = 'android';
+    cfg.variant = 'material';
+    cfg.glassCapable = false;
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 1280;
+    cfg.wallDeviceClass = 'panel-capable';
+    cfg.boardPresenceEnabled = true;
+    cfg.boardPresenceBoardId = 1;
+    cfg.activeBoard = { uuid: 'board-1' };
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-ipad-wall-column="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-tablet-sidebar="true"]')).not.toBeNull();
     expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();
   });
 

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -18,11 +18,11 @@ const cfg = vi.hoisted(() => ({
   // (Material, plus Liquid Glass on iOS < 26 / Android) takes the JS tab bar.
   glassCapable: true,
   platformOS: 'ios' as 'ios' | 'android',
-  // 'regular' takes the iPad sidebar shell; 'compact' keeps the phone tab bars.
+  // 'regular' takes the tablet sidebar shell; 'compact' keeps the phone tab bars.
   widthClass: 'compact' as 'compact' | 'regular',
-  // iPad in a narrow split: compact width but still an iPad, which the shell keeps on
-  // JS Tabs (never NativeTabs). Independent of widthClass; 'regular' always implies iPad.
-  isPad: false,
+  // Tablet in a narrow split: compact width but still a tablet, which the shell keeps on
+  // JS Tabs (never NativeTabs). Independent of widthClass; 'regular' always implies tablet.
+  isTablet: false,
   // Window width drives the wall surface in the regular shell: a dedicated column
   // (landscape) vs a strip atop the pane (portrait) — see resolveWallSurface.
   windowWidth: 1024,
@@ -87,12 +87,12 @@ vi.mock('../../../src/hooks/use-on-accessory-surface', () => ({
 }));
 
 vi.mock('../../../src/hooks/use-device-layout', () => ({
-  // `regular` is only ever reached on an iPad (an iPhone is always compact), so it
-  // always implies isPad; cfg.isPad additionally models an iPad in a narrow split.
+  // `regular` is only ever reached on a tablet (a phone is always compact), so it
+  // always implies isTablet; cfg.isTablet additionally models a tablet in a narrow split.
   useDeviceLayout: () => ({
     widthClass: cfg.widthClass,
     expanded: false,
-    isPad: cfg.widthClass === 'regular' || cfg.isPad,
+    isTablet: cfg.widthClass === 'regular' || cfg.isTablet,
     wallDeviceClass: cfg.wallDeviceClass,
   }),
 }));
@@ -238,7 +238,7 @@ describe('TabLayout', () => {
     cfg.glassCapable = true;
     cfg.platformOS = 'ios';
     cfg.widthClass = 'compact';
-    cfg.isPad = false;
+    cfg.isTablet = false;
     cfg.windowWidth = 1024;
     cfg.boardPresenceEnabled = false;
     cfg.boardPresenceBoardId = null;
@@ -303,7 +303,7 @@ describe('TabLayout', () => {
     // shell routes it through JS Tabs + the Material bar so a resize across the 700pt
     // boundary doesn't swap navigator types — NativeTabs never renders on iPad, and
     // there's no rail at compact width.
-    cfg.isPad = true;
+    cfg.isTablet = true;
     cfg.widthClass = 'compact';
     cfg.variant = 'liquidGlass';
     cfg.glassCapable = true;

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -450,6 +450,9 @@ describe('TabLayout', () => {
 
     const { container } = render(<TabLayout />);
 
+    // `data-ipad-*` markers keep the shared components' names: IpadPlayPane /
+    // IpadWallColumn are variant-agnostic and render on Android too (only the glass
+    // IpadSidebar is iOS-specific, swapped for the rail via TabletSidebar).
     expect(container.querySelector('[data-ipad-wall-column="true"]')).not.toBeNull();
     expect(container.querySelector('[data-tablet-sidebar="true"]')).not.toBeNull();
     expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -355,6 +355,48 @@ describe('TabLayout', () => {
     expect(cfg.materialScreens.find((screen) => screen.name === 'wall')?.options).toMatchObject({ href: null });
   });
 
+  it('mounts the same shell on an Android tablet (Material variant, regular width, no NativeTabs)', () => {
+    // An Android tablet resolves the Material variant and, at regular width, takes the
+    // adaptive-shell branch exactly like an iPad: the rail (TabletSidebar → the M3
+    // navigation rail) carries navigation over a hidden JS Tabs bar, with the detail
+    // pane beside it. The native glass tab bar never exists on Android.
+    cfg.platformOS = 'android';
+    cfg.variant = 'material';
+    cfg.glassCapable = false;
+    cfg.widthClass = 'regular';
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-tablet-sidebar="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-tabs="true"]')).toBeNull();
+    expect(cfg.materialScreens.map((screen) => screen.name)).toEqual([
+      'home',
+      'climbs',
+      'record',
+      'wall',
+      'discover',
+      'profile',
+    ]);
+  });
+
+  it('keeps a compact Android tablet (small multi-window split) on the Material bar, no rail', () => {
+    // A tablet in a small freeform / split-screen window is still a tablet (sw600dp,
+    // launch-fixed) but reads `compact` from the live width — so it stays on the single
+    // JS Tabs navigator + Material bar with no rail, mirroring an iPad in a narrow split.
+    cfg.platformOS = 'android';
+    cfg.variant = 'material';
+    cfg.glassCapable = false;
+    cfg.widthClass = 'compact';
+    cfg.isTablet = true;
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-tabs-material="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-tablet-sidebar="true"]')).toBeNull();
+    expect(container.querySelector('[data-tabs="true"]')).toBeNull();
+  });
+
   it('suppresses the detail pane on the tightest regular portraits, keeping the list full width', () => {
     // iPad mini portrait (744): sidebar (96) + the pane's 320pt floor would leave the
     // browse list ~328pt — below the 400pt readable floor — so resolveDetailPaneSurface

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -97,9 +97,12 @@ vi.mock('../../../src/hooks/use-device-layout', () => ({
   }),
 }));
 
-vi.mock('../../../src/components/navigation/IpadSidebar', () => ({
-  IpadSidebar: ({ showWallCell = true }: { showWallCell?: boolean }) =>
-    createElement('aside', { 'data-ipad-sidebar': 'true', 'data-show-wall-cell': String(showWallCell) }),
+// The shell renders TabletSidebar (the variant router → IpadSidebar glass rail or
+// MaterialNavigationRail); mock it so the layout tests don't reach into either rail's
+// native surface. The per-variant routing is covered by the variant-component tests.
+vi.mock('../../../src/components/navigation/TabletSidebar', () => ({
+  TabletSidebar: ({ showWallCell = true }: { showWallCell?: boolean }) =>
+    createElement('aside', { 'data-tablet-sidebar': 'true', 'data-show-wall-cell': String(showWallCell) }),
 }));
 
 vi.mock('../../../src/components/play-drawer/IpadPlayPane', () => ({
@@ -312,7 +315,7 @@ describe('TabLayout', () => {
 
     expect(container.querySelector('[data-tabs-material="true"]')).not.toBeNull();
     expect(container.querySelector('[data-tabs="true"]')).toBeNull();
-    expect(container.querySelector('[data-ipad-sidebar="true"]')).toBeNull();
+    expect(container.querySelector('[data-tablet-sidebar="true"]')).toBeNull();
     expect(cfg.materialScreens.map((screen) => screen.name)).toEqual([
       'home',
       'climbs',
@@ -331,13 +334,13 @@ describe('TabLayout', () => {
 
     const { container } = render(<TabLayout />);
 
-    expect(container.querySelector('[data-ipad-sidebar="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-tablet-sidebar="true"]')).not.toBeNull();
     // The right column hosts the PlayDrawer pane (replaces the floating accessory bar).
     expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();
     // At narrow-regular width (1024) the wall has no room for a column, so it stays
     // the sidebar cell — no dedicated column, rail cell shown.
     expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
-    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
+    expect(container.querySelector('[data-tablet-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
     expect(container.querySelector('[data-tabs="true"]')).toBeNull();
     expect(cfg.materialScreens.map((screen) => screen.name)).toEqual([
       'home',
@@ -361,7 +364,7 @@ describe('TabLayout', () => {
 
     const { container } = render(<TabLayout />);
 
-    expect(container.querySelector('[data-ipad-sidebar="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-tablet-sidebar="true"]')).not.toBeNull();
     expect(container.querySelector('[data-ipad-play-pane="true"]')).toBeNull();
     // No room for a wall column at this width either — the wall stays the sidebar cell.
     expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
@@ -380,7 +383,7 @@ describe('TabLayout', () => {
     const { container } = render(<TabLayout />);
 
     expect(container.querySelector('[data-ipad-wall-column="true"]')).not.toBeNull();
-    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('false');
+    expect(container.querySelector('[data-tablet-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('false');
     // The detail pane mounts alongside the list and the dedicated wall column — the
     // pixel widths of each are covered by size-class.test.ts (resolveDetailPaneWidth,
     // WALL_COLUMN_WIDTH), so assert the surfaces are present, not their arithmetic.
@@ -402,7 +405,7 @@ describe('TabLayout', () => {
 
     expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
     // No rich wall surface on this device → the ambient sidebar cell stays the launcher.
-    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
+    expect(container.querySelector('[data-tablet-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
   });
 
   it('hides the wall column while the "On the Wall" tab is the focused destination', () => {
@@ -424,7 +427,7 @@ describe('TabLayout', () => {
     expect(container.querySelector('[data-ipad-play-pane="true"]')).toBeNull();
     // The surface still EXISTS for this layout, so the sidebar cell stays hidden — it
     // doesn't pop back in merely because the wall tab is open.
-    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('false');
+    expect(container.querySelector('[data-tablet-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('false');
     // Kiosk stays lit while the wall tab is focused.
     expect(keepAwake.activate).toHaveBeenCalledWith('wall');
   });
@@ -452,7 +455,7 @@ describe('TabLayout', () => {
 
     expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();
     expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
-    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('false');
+    expect(container.querySelector('[data-tablet-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('false');
   });
 
   it('keeps the sidebar wall cell when tight regular width suppresses the play pane', () => {
@@ -468,7 +471,7 @@ describe('TabLayout', () => {
 
     expect(container.querySelector('[data-ipad-play-pane="true"]')).toBeNull();
     expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
-    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
+    expect(container.querySelector('[data-tablet-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
   });
 
   it('keeps the sidebar wall cell in portrait while the active board config is unresolved', () => {
@@ -484,7 +487,7 @@ describe('TabLayout', () => {
 
     expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();
     expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
-    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
+    expect(container.querySelector('[data-tablet-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
   });
 
   it('keeps the wall as the sidebar cell (no column) when no board is bound', () => {
@@ -499,7 +502,7 @@ describe('TabLayout', () => {
     const { container } = render(<TabLayout />);
 
     expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
-    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
+    expect(container.querySelector('[data-tablet-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
   });
 
   it('does not reserve a wall column when a board is BLE-bound but no active board is resolved', () => {
@@ -515,7 +518,7 @@ describe('TabLayout', () => {
     const { container } = render(<TabLayout />);
 
     expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
-    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
+    expect(container.querySelector('[data-tablet-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
   });
 
   it('does not render the Record badge when no status is active', () => {

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -228,7 +228,7 @@ export default function TabLayout() {
   // never uses NativeTabs (that would swap navigator *types* on the boundary cross
   // and remount); NativeTabs stays the iPhone-only glass path below. The `content`
   // View carries a stable key so the navigator survives the chrome swap.
-  if (deviceLayout.isPad) {
+  if (deviceLayout.isTablet) {
     const isRegular = deviceLayout.widthClass === 'regular';
     const tabsNavigator = (
       <Tabs

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -14,7 +14,7 @@ import { brandColors } from '../../src/theme/colors';
 import { useNativeAccessoryActive, useNativeTabBar } from '../../src/hooks/use-bottom-accessory';
 import { useOnAccessorySurface } from '../../src/hooks/use-on-accessory-surface';
 import { useDeviceLayout } from '../../src/hooks/use-device-layout';
-import { IpadSidebar } from '../../src/components/navigation/IpadSidebar';
+import { TabletSidebar } from '../../src/components/navigation/TabletSidebar';
 import { IpadPlayPane } from '../../src/components/play-drawer/IpadPlayPane';
 import { IpadWallColumn } from '../../src/components/board-presence/IpadWallColumn';
 import { useBoardPresenceControls } from '../../src/providers/board-presence-provider';
@@ -240,7 +240,7 @@ export default function TabLayout() {
     );
     return (
       <View style={isRegular ? styles.shell : styles.shellCompact}>
-        {isRegular ? <IpadSidebar key="sidebar" showWallCell={!showRichWallSurface} /> : null}
+        {isRegular ? <TabletSidebar key="sidebar" showWallCell={!showRichWallSurface} /> : null}
         <View key="content" style={styles.shellContent}>
           {tabsNavigator}
         </View>

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -10,6 +10,7 @@ import { useStickyAccessoryPresence } from '../../src/hooks/use-sticky-accessory
 import { QueueBottomAccessory } from '../../src/components/queue-control/QueueBottomAccessory';
 import { MaterialTabBar } from '../../src/components/navigation/MaterialTabBar';
 import { useTheme } from '../../src/providers/theme-provider';
+import { selectByVariant } from '../../src/theme/variants/select-by-variant';
 import { brandColors } from '../../src/theme/colors';
 import { useNativeAccessoryActive, useNativeTabBar } from '../../src/hooks/use-bottom-accessory';
 import { useOnAccessorySurface } from '../../src/hooks/use-on-accessory-surface';
@@ -62,8 +63,14 @@ export default function TabLayout() {
   const { t } = useTranslation('common');
   const { t: tPlaylists } = useTranslation('playlists');
   const { t: tSession } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, variant, m3 } = useTheme();
   const nativeTabBar = useNativeTabBar();
+  // Shell column separators: an M3 faint divider (outlineVariant) on Material, the
+  // system hairline on Liquid Glass — so the panes read as M3 depth on Android.
+  const shellDividerColor = selectByVariant(variant, {
+    liquidGlass: systemColors.separator,
+    material: m3.outlineVariant,
+  });
   const nativeAccessoryActive = useNativeAccessoryActive();
 
   // Record-tab status cue: a badge when a board is connected over Bluetooth or a
@@ -253,7 +260,7 @@ export default function TabLayout() {
             content pane, so a persistent (usually empty) detail pane there just squeezes
             it — same redundancy guard as the wall column below. */}
         {isRegular && showDetailPane && !onWallTab ? (
-          <View key="pane" style={[styles.playPane, { width: playPaneWidth, borderLeftColor: systemColors.separator }]}>
+          <View key="pane" style={[styles.playPane, { width: playPaneWidth, borderLeftColor: shellDividerColor }]}>
             <IpadPlayPane />
           </View>
         ) : null}
@@ -265,7 +272,7 @@ export default function TabLayout() {
         {isRegular && showWallColumn && !onWallTab ? (
           <View
             key="wall"
-            style={[styles.wallColumn, { width: WALL_COLUMN_WIDTH, borderLeftColor: systemColors.separator }]}
+            style={[styles.wallColumn, { width: WALL_COLUMN_WIDTH, borderLeftColor: shellDividerColor }]}
           >
             <IpadWallColumn />
           </View>

--- a/packages/mobile/plugins/with-android-tablet-orientation.js
+++ b/packages/mobile/plugins/with-android-tablet-orientation.js
@@ -26,8 +26,11 @@ function addTabletOrientation(contents) {
     return contents;
   }
   // Anchor on the `super.onCreate(...)` call inside onCreate and inject right
-  // after it, preserving the surrounding indentation.
-  const anchor = contents.match(/^([ \t]*)super\.onCreate\([^\n)]*\)[ \t]*$/m);
+  // after it, preserving the surrounding indentation. The greedy `.*\)` (rather
+  // than `[^)]*`) tolerates a nested closing paren in the argument — e.g.
+  // `super.onCreate(savedInstanceState ?: Bundle())` — while `[ \t]*$` keeps it
+  // pinned to the whole statement line.
+  const anchor = contents.match(/^([ \t]*)super\.onCreate\(.*\)[ \t]*$/m);
   if (!anchor) {
     throw new Error(
       'with-android-tablet-orientation: could not find `super.onCreate(...)` in MainActivity — ' +

--- a/packages/mobile/plugins/with-android-tablet-orientation.js
+++ b/packages/mobile/plugins/with-android-tablet-orientation.js
@@ -1,0 +1,62 @@
+const { createRunOncePlugin, withMainActivity } = require('expo/config-plugins');
+
+// Marker so a second prebuild pass (or a double-registered plugin) is a no-op.
+const MARKER = 'boardsesh-tablet-orientation';
+
+/**
+ * Injects a size-conditional orientation guard into `MainActivity.onCreate` so
+ * `sw600dp` tablets rotate freely — the landscape master-detail shell is their
+ * whole point — while phones stay portrait, mirroring the iOS
+ * `UISupportedInterfaceOrientations~ipad` override. Android's
+ * `android:screenOrientation` manifest attribute can't be resource-qualified by
+ * screen size, so this is set at runtime from `smallestScreenWidthDp`. Runs once
+ * at activity creation; the app already declares `orientation|screenSize|...` in
+ * `android:configChanges`, so a rotation doesn't recreate the activity and the
+ * value sticks.
+ *
+ * Kotlin only (Expo SDK 57 templates); fully-qualified `ActivityInfo` avoids
+ * adding an import. Pure string transform over the MainActivity source for
+ * testability; idempotent via the marker comment.
+ *
+ * @param {string} contents MainActivity.kt source
+ * @returns {string}
+ */
+function addTabletOrientation(contents) {
+  if (contents.includes(MARKER)) {
+    return contents;
+  }
+  // Anchor on the `super.onCreate(...)` call inside onCreate and inject right
+  // after it, preserving the surrounding indentation.
+  const anchor = contents.match(/^([ \t]*)super\.onCreate\([^\n)]*\)[ \t]*$/m);
+  if (!anchor) {
+    throw new Error(
+      'with-android-tablet-orientation: could not find `super.onCreate(...)` in MainActivity — ' +
+        'the Expo template may have changed; update the anchor.',
+    );
+  }
+  const indent = anchor[1];
+  const guard =
+    `\n${indent}// ${MARKER}: sw600dp tablets rotate freely; phones stay portrait (mirrors iOS ~ipad).` +
+    `\n${indent}requestedOrientation =` +
+    `\n${indent}  if (resources.configuration.smallestScreenWidthDp >= 600)` +
+    `\n${indent}    android.content.pm.ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED` +
+    `\n${indent}  else` +
+    `\n${indent}    android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT`;
+  return contents.replace(anchor[0], `${anchor[0]}${guard}`);
+}
+
+function withAndroidTabletOrientation(config) {
+  return withMainActivity(config, (modConfig) => {
+    if (modConfig.modResults.language !== 'kt') {
+      throw new Error(
+        `with-android-tablet-orientation: expected a Kotlin MainActivity, got '${modConfig.modResults.language}'.`,
+      );
+    }
+    modConfig.modResults.contents = addTabletOrientation(modConfig.modResults.contents);
+    return modConfig;
+  });
+}
+
+module.exports = createRunOncePlugin(withAndroidTabletOrientation, 'with-android-tablet-orientation', '1.0.0');
+module.exports.addTabletOrientation = addTabletOrientation;
+module.exports.MARKER = MARKER;

--- a/packages/mobile/src/components/board-presence/wall-kiosk/useWallKioskLayout.ts
+++ b/packages/mobile/src/components/board-presence/wall-kiosk/useWallKioskLayout.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Dimensions, type LayoutChangeEvent } from 'react-native';
+import { Dimensions, Platform, type LayoutChangeEvent } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { resolveWallKioskLayout, type WallKioskInsets, type WallKioskLayout } from './wall-kiosk-layout';
 import {
@@ -71,7 +71,12 @@ export function useWallKioskLayout(boardAspectRatio: number | null): WallKioskLa
   const resolved = useMemo(() => {
     const shortSide = pane ? Math.min(pane.width, pane.height) : 0;
     const screen = Dimensions.get('screen');
-    const physicalLongSideMm = estimatePhysicalLongSideMm(Math.max(screen.width, screen.height));
+    // The physical-size estimate assumes iPad points-per-inch. On Android
+    // `Dimensions` returns density-bucketed dp with no reliable ppi, so pass null and
+    // let resolveHeroScale fall back to the pane short side (the external-display /
+    // unknown-model path) rather than compute a wrong physical size.
+    const physicalLongSideMm =
+      Platform.OS === 'ios' ? estimatePhysicalLongSideMm(Math.max(screen.width, screen.height)) : null;
     const heroScale = resolveHeroScale({ physicalLongSideMm, paneShortSide: shortSide });
     const baseType = resolveWallKioskTypeScale(shortSide, heroScale);
 

--- a/packages/mobile/src/components/navigation/IpadSidebar.tsx
+++ b/packages/mobile/src/components/navigation/IpadSidebar.tsx
@@ -177,7 +177,12 @@ function IpadSidebarComponent({ showWallCell = true }: { showWallCell?: boolean 
           when the shell shows the full wall column (landscape) so there's one
           wall surface per layout. */}
       {showWallCell ? <SidebarWallCell /> : null}
-      <SidebarItem destination={account} focused={account.segment === activeSegment} onPress={handleNavigate} />
+      {/* Profile is a nav destination too, so its `tab` role must live inside a
+          tablist — its own here, keeping the ambient wall cell (a plain button)
+          outside so it doesn't split the primary tab run. */}
+      <View style={styles.accountGroup} accessibilityRole="tablist">
+        <SidebarItem destination={account} focused={account.segment === activeSegment} onPress={handleNavigate} />
+      </View>
     </View>
   );
 }
@@ -195,6 +200,10 @@ const styles = StyleSheet.create({
     width: '100%',
     alignItems: 'center',
     gap: spacing[1],
+  },
+  accountGroup: {
+    width: '100%',
+    alignItems: 'center',
   },
   item: {
     alignItems: 'center',

--- a/packages/mobile/src/components/navigation/MaterialNavigationRail.tsx
+++ b/packages/mobile/src/components/navigation/MaterialNavigationRail.tsx
@@ -1,0 +1,225 @@
+import { memo, useCallback, useMemo, type ComponentProps } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useRouter, useSegments } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { PressableSurface } from '../PressableSurface';
+import { SidebarWallCell } from './SidebarWallCell';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { hapticSelection } from '../../lib/haptics';
+import { tabsActiveSegment } from '../../lib/route-segments';
+import { SIDEBAR_WIDTH } from '../../theme/layout';
+import { material, spacing } from '../../theme/tokens';
+
+/**
+ * Material 3 navigation rail — the Material-variant impl of the tablet
+ * adaptive-shell sidebar (the Liquid Glass impl is `IpadSidebar`); the two are
+ * routed by variant through `TabletSidebar`. It replaces the bottom tab bar at
+ * `regular` width on an Android tablet (or on any tablet the user has switched to
+ * the Material variant), and mirrors `MaterialTabBar`'s M3 roles laid out
+ * vertically so the rail and the phone's bottom bar read as one nav system: a
+ * `secondaryContainer` active-indicator pill behind the focused icon
+ * (`onSecondaryContainer` glyph), the label lifting to `onSurface`, inactive
+ * destinations in `onSurfaceVariant`.
+ *
+ * It drives navigation through the global Expo Router `router` (no tab-navigator
+ * context needed) and reads the focused tab from `useSegments()` via
+ * `tabsActiveSegment`. Compact width never mounts this; `_layout.tsx` renders the
+ * Material tab bar there, so the phone UI is unchanged.
+ */
+
+type MaterialIconName = ComponentProps<typeof MaterialCommunityIcons>['name'];
+
+type RailDestination = {
+  /** Tab route segment under `(tabs)` — also the active-state key. */
+  segment: string;
+  /** Router path (typed routes are off, so a plain string is the href). */
+  href: string;
+  /** Focused (filled) glyph. */
+  icon: MaterialIconName;
+  /** Inactive (outline) glyph. */
+  iconInactive: MaterialIconName;
+  label: string;
+};
+
+const RAIL_ICON_SIZE = 24;
+
+function RailItem({
+  destination,
+  focused,
+  onPress,
+}: {
+  destination: RailDestination;
+  focused: boolean;
+  onPress: (destination: RailDestination) => void;
+}) {
+  const { m3, brandColors } = useTheme();
+  // M3 nav-rail roles, identical to MaterialTabBar: the focused destination's icon
+  // sits on a secondaryContainer active-indicator pill (onSecondaryContainer glyph),
+  // its label lifts to onSurface; inactive destinations use onSurfaceVariant for both.
+  const iconColor = focused ? m3.onSecondaryContainer : m3.onSurfaceVariant;
+  const labelColor = focused ? m3.onSurface : m3.onSurfaceVariant;
+  const glyph = focused ? destination.icon : destination.iconInactive;
+  const handlePress = useCallback(() => onPress(destination), [onPress, destination]);
+
+  return (
+    <PressableSurface
+      onPress={handlePress}
+      feedback="none"
+      rippleColor={brandColors.primary}
+      rippleBorderless
+      accessibilityRole="tab"
+      accessibilityState={{ selected: focused }}
+      accessibilityLabel={destination.label}
+      // Locale-independent handle for an Android tablet screenshot/maestro flow.
+      testID={`tablet-rail-${destination.segment}`}
+      style={styles.item}
+    >
+      <View style={[styles.indicator, focused ? { backgroundColor: m3.secondaryContainer } : null]}>
+        <MaterialCommunityIcons name={glyph} size={RAIL_ICON_SIZE} color={iconColor} />
+      </View>
+      <Text variant="caption2" color={labelColor} numberOfLines={2} style={styles.label}>
+        {destination.label}
+      </Text>
+    </PressableSurface>
+  );
+}
+
+function MaterialNavigationRailComponent({ showWallCell = true }: { showWallCell?: boolean }) {
+  const { t } = useTranslation('common');
+  const { t: tSession } = useTranslation('session');
+  const { t: tPlaylists } = useTranslation('playlists');
+  const router = useRouter();
+  const segments = useSegments();
+  const insets = useSafeAreaInsets();
+  const { m3, m3SurfaceContainers } = useTheme();
+
+  const activeSegment = tabsActiveSegment(segments) ?? 'home';
+
+  // Same destinations and i18n keys as IpadSidebar / MaterialTabBar so the rail,
+  // the glass rail, and the phone bottom bar stay one nav system. Active/inactive
+  // glyphs mirror the bottom bar's `materialTabIcon` pairs (Wall gets the bulb).
+  const primary = useMemo<RailDestination[]>(
+    () => [
+      { segment: 'home', href: '/home', icon: 'home', iconInactive: 'home-outline', label: t('mobile.nav.home') },
+      { segment: 'climbs', href: '/climbs', icon: 'magnify', iconInactive: 'magnify', label: t('mobile.nav.climbs') },
+      {
+        segment: 'record',
+        href: '/record',
+        icon: 'record-circle',
+        iconInactive: 'record-circle-outline',
+        label: tSession('mobile.session.recordTab'),
+      },
+      // "On the Wall" sits with Record — the two "I'm at the board" activities.
+      // Tablet-only: it's a rail row here, never a phone tab.
+      {
+        segment: 'wall',
+        href: '/wall',
+        icon: 'lightbulb-on',
+        iconInactive: 'lightbulb-on-outline',
+        label: t('mobile.nav.wall'),
+      },
+      {
+        segment: 'discover',
+        href: '/discover',
+        icon: 'bookmark-multiple',
+        iconInactive: 'bookmark-multiple-outline',
+        label: tPlaylists('bottomTabBar.discover'),
+      },
+    ],
+    [t, tSession, tPlaylists],
+  );
+  const account = useMemo<RailDestination>(
+    () => ({
+      segment: 'profile',
+      href: '/profile',
+      icon: 'account-circle',
+      iconInactive: 'account-circle-outline',
+      label: t('mobile.nav.profile'),
+    }),
+    [t],
+  );
+
+  const handleNavigate = useCallback(
+    (destination: RailDestination) => {
+      hapticSelection();
+      router.navigate(destination.href);
+    },
+    [router],
+  );
+
+  return (
+    <View
+      style={[
+        styles.rail,
+        {
+          width: SIDEBAR_WIDTH,
+          paddingTop: insets.top + spacing[3],
+          paddingBottom: insets.bottom + spacing[3],
+          // M3 depth by tone: the rail is chrome, a step above the content canvas.
+          backgroundColor: m3SurfaceContainers.low,
+          borderRightColor: m3.outlineVariant,
+        },
+      ]}
+    >
+      {/* Primary destinations form one tab group; the account row and the wall cell
+          are labelled siblings outside it, so screen readers read a coherent set. */}
+      <View style={styles.navGroup} accessibilityRole="tablist">
+        {primary.map((destination) => (
+          <RailItem
+            key={destination.segment}
+            destination={destination}
+            focused={destination.segment === activeSegment}
+            onPress={handleNavigate}
+          />
+        ))}
+      </View>
+      <View style={styles.spacer} />
+      {/* Ambient "now on the wall" anchor, pinned above the account row. Hidden when
+          the shell shows the full wall column/strip so there's one wall surface per
+          layout. Reads the Material tonal `systemColors` on Android. */}
+      {showWallCell ? <SidebarWallCell /> : null}
+      <RailItem destination={account} focused={account.segment === activeSegment} onPress={handleNavigate} />
+    </View>
+  );
+}
+
+export const MaterialNavigationRail = memo(MaterialNavigationRailComponent);
+
+const styles = StyleSheet.create({
+  rail: {
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: spacing[1],
+    borderRightWidth: StyleSheet.hairlineWidth,
+  },
+  navGroup: {
+    width: '100%',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  item: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing[2],
+    gap: 4,
+    width: '100%',
+  },
+  // M3 nav-rail active-indicator pill — fixed size, tonal fill only when focused.
+  indicator: {
+    width: material.navRail.activeIndicatorWidth,
+    height: material.navRail.activeIndicatorHeight,
+    borderRadius: material.navRail.activeIndicatorRadius,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    textAlign: 'center',
+    paddingHorizontal: spacing[1],
+  },
+  spacer: {
+    flex: 1,
+  },
+});

--- a/packages/mobile/src/components/navigation/MaterialNavigationRail.tsx
+++ b/packages/mobile/src/components/navigation/MaterialNavigationRail.tsx
@@ -46,7 +46,10 @@ type RailDestination = {
 
 const RAIL_ICON_SIZE = 24;
 
-function RailItem({
+// Memoized so a focus change (navigation) only re-renders the two items whose
+// `focused` flipped, not all six — the parent passes referentially-stable
+// `destination`/`onPress`. Matches the "row is React.memo'd" nav-chrome guidance.
+const RailItem = memo(function RailItem({
   destination,
   focused,
   onPress,
@@ -85,7 +88,7 @@ function RailItem({
       </Text>
     </PressableSurface>
   );
-}
+});
 
 function MaterialNavigationRailComponent({ showWallCell = true }: { showWallCell?: boolean }) {
   const { t } = useTranslation('common');
@@ -104,6 +107,10 @@ function MaterialNavigationRailComponent({ showWallCell = true }: { showWallCell
   const primary = useMemo<RailDestination[]>(
     () => [
       { segment: 'home', href: '/home', icon: 'home', iconInactive: 'home-outline', label: t('mobile.nav.home') },
+      // Climbs (search) deliberately uses the same glyph for both states — matching
+      // MaterialTabBar's `materialTabIcon('magnify', 'magnify')`; MaterialCommunityIcons
+      // has no filled `magnify` that reads as "search selected". The active pill carries
+      // the focus state instead.
       { segment: 'climbs', href: '/climbs', icon: 'magnify', iconInactive: 'magnify', label: t('mobile.nav.climbs') },
       {
         segment: 'record',

--- a/packages/mobile/src/components/navigation/MaterialNavigationRail.tsx
+++ b/packages/mobile/src/components/navigation/MaterialNavigationRail.tsx
@@ -188,7 +188,12 @@ function MaterialNavigationRailComponent({ showWallCell = true }: { showWallCell
           the shell shows the full wall column/strip so there's one wall surface per
           layout. Reads the Material tonal `systemColors` on Android. */}
       {showWallCell ? <SidebarWallCell /> : null}
-      <RailItem destination={account} focused={account.segment === activeSegment} onPress={handleNavigate} />
+      {/* Profile is a nav destination too, so its `tab` role must live inside a
+          tablist — its own here, keeping the ambient wall cell (a plain button)
+          outside so it doesn't split the primary tab run. */}
+      <View style={styles.accountGroup} accessibilityRole="tablist">
+        <RailItem destination={account} focused={account.segment === activeSegment} onPress={handleNavigate} />
+      </View>
     </View>
   );
 }
@@ -206,6 +211,10 @@ const styles = StyleSheet.create({
     width: '100%',
     alignItems: 'center',
     gap: spacing[1],
+  },
+  accountGroup: {
+    width: '100%',
+    alignItems: 'center',
   },
   item: {
     alignItems: 'center',

--- a/packages/mobile/src/components/navigation/TabletSidebar.tsx
+++ b/packages/mobile/src/components/navigation/TabletSidebar.tsx
@@ -1,0 +1,16 @@
+import { createVariantComponent } from '../../theme/variants/create-variant-component';
+import { IpadSidebar } from './IpadSidebar';
+import { MaterialNavigationRail } from './MaterialNavigationRail';
+
+/**
+ * The tablet adaptive-shell sidebar, routed by UI variant: the Liquid Glass rail
+ * (`IpadSidebar`) on iOS/glass, the Material 3 navigation rail
+ * (`MaterialNavigationRail`) on Android/Material. Both expose the same
+ * `{ showWallCell }` prop API, so `_layout.tsx` renders one component and each
+ * platform/variant gets its native chrome. See `theme/variants/README.md` for the
+ * routing rule (whole-subtree swap → `createVariantComponent`).
+ */
+export const TabletSidebar = createVariantComponent('TabletSidebar', {
+  liquidGlass: IpadSidebar,
+  material: MaterialNavigationRail,
+});

--- a/packages/mobile/src/components/navigation/__tests__/MaterialNavigationRail.test.tsx
+++ b/packages/mobile/src/components/navigation/__tests__/MaterialNavigationRail.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const cfg = vi.hoisted(() => ({
+  segments: ['(tabs)', 'home'] as readonly string[],
+  navigate: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({
+  // Android context: `theme/colors` (pulled in transitively via `theme/tokens`)
+  // branches on `Platform.OS` and only calls `PlatformColor` on iOS.
+  Platform: { OS: 'android', select: (spec: Record<string, unknown>) => spec.android ?? spec.default },
+  PlatformColor: (name: string) => name,
+  View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+    createElement('div', { 'data-style': style == null ? '' : JSON.stringify(style) }, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ navigate: cfg.navigate }),
+  useSegments: () => cfg.segments,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 24, bottom: 16, left: 0, right: 0 }),
+}));
+
+// PressableSurface → a button exposing the testID, the selected a11y state, and press.
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({
+    children,
+    testID,
+    accessibilityState,
+    onPress,
+  }: {
+    children?: ReactNode;
+    testID?: string;
+    accessibilityState?: { selected?: boolean };
+    onPress?: () => void;
+  }) =>
+    createElement(
+      'button',
+      { 'data-testid': testID, 'data-selected': String(Boolean(accessibilityState?.selected)), onClick: onPress },
+      children,
+    ),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', {}, children),
+}));
+
+vi.mock('../SidebarWallCell', () => ({
+  SidebarWallCell: () => createElement('aside', { 'data-wall-cell': 'true' }),
+}));
+
+vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({
+  default: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    m3: {
+      secondaryContainer: '#4A3C6B',
+      onSecondaryContainer: '#E7DEFF',
+      onSurface: '#E6E0EC',
+      onSurfaceVariant: '#C9C2D4',
+      outlineVariant: '#49454F',
+    },
+    m3SurfaceContainers: { lowest: '#0F0B16', low: '#1A1420', base: '#221A2E', high: '#2C2438', highest: '#372E44' },
+    brandColors: { primary: '#A78BFA' },
+  }),
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+
+import { MaterialNavigationRail } from '../MaterialNavigationRail';
+
+const SEGMENTS = ['home', 'climbs', 'record', 'wall', 'discover', 'profile'];
+
+describe('MaterialNavigationRail', () => {
+  beforeEach(() => {
+    cfg.segments = ['(tabs)', 'home'];
+    cfg.navigate.mockClear();
+  });
+
+  it('renders all six destinations (five primary + pinned profile)', () => {
+    const { container } = render(<MaterialNavigationRail />);
+    for (const segment of SEGMENTS) {
+      expect(container.querySelector(`[data-testid="tablet-rail-${segment}"]`)).not.toBeNull();
+    }
+  });
+
+  it('marks only the focused destination selected', () => {
+    cfg.segments = ['(tabs)', 'climbs'];
+    const { container } = render(<MaterialNavigationRail />);
+    expect(container.querySelector('[data-testid="tablet-rail-climbs"]')?.getAttribute('data-selected')).toBe('true');
+    expect(container.querySelector('[data-testid="tablet-rail-home"]')?.getAttribute('data-selected')).toBe('false');
+    expect(container.querySelector('[data-testid="tablet-rail-profile"]')?.getAttribute('data-selected')).toBe('false');
+  });
+
+  it('shows the ambient wall cell only when showWallCell is set', () => {
+    const shown = render(<MaterialNavigationRail showWallCell />);
+    expect(shown.container.querySelector('[data-wall-cell="true"]')).not.toBeNull();
+
+    const hidden = render(<MaterialNavigationRail showWallCell={false} />);
+    expect(hidden.container.querySelector('[data-wall-cell="true"]')).toBeNull();
+  });
+
+  it('navigates to a destination href on press', () => {
+    const { container } = render(<MaterialNavigationRail />);
+    fireEvent.click(container.querySelector('[data-testid="tablet-rail-wall"]')!);
+    expect(cfg.navigate).toHaveBeenCalledWith('/wall');
+  });
+
+  it('shows the focused (filled) glyph for the active destination and outline for the rest', () => {
+    cfg.segments = ['(tabs)', 'home'];
+    const { container } = render(<MaterialNavigationRail />);
+    // Active home → filled 'home'; inactive discover → 'bookmark-multiple-outline'.
+    expect(container.querySelector('[data-icon="home"]')).not.toBeNull();
+    expect(container.querySelector('[data-icon="bookmark-multiple-outline"]')).not.toBeNull();
+  });
+});

--- a/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
@@ -13,13 +13,13 @@ const cfg = vi.hoisted(() => ({
   nativeTabs: {} as unknown,
   bottomAccessory: {} as unknown,
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
-  // 'regular' models the iPad sidebar shell (no native tab bar); 'compact' is
+  // 'regular' models the tablet sidebar shell (no native tab bar); 'compact' is
   // every phone and the default for these variant/capability tests.
   widthClass: 'compact' as 'compact' | 'regular',
-  // iPad in a narrow split: compact width but still an iPad, which the shell keeps
-  // on JS Tabs (never NativeTabs). Independent of widthClass so this case is
-  // expressible; a 'regular' width always implies an iPad too.
-  isPad: false,
+  // Tablet in a narrow split: compact width but still a tablet, which the shell
+  // keeps on JS Tabs (never NativeTabs). Independent of widthClass so this case is
+  // expressible; a 'regular' width always implies a tablet too.
+  isTablet: false,
 }));
 
 vi.mock('react-native', () => ({
@@ -55,12 +55,12 @@ vi.mock('../../providers/theme-provider', () => ({
 }));
 
 vi.mock('../use-device-layout', () => ({
-  // A 'regular' width only ever resolves on an iPad, so isPad is true there; the
-  // explicit cfg.isPad covers the iPad-in-a-narrow-split (compact) case.
+  // A 'regular' width only ever resolves on a tablet, so isTablet is true there; the
+  // explicit cfg.isTablet covers the tablet-in-a-narrow-split (compact) case.
   useDeviceLayout: () => ({
     widthClass: cfg.widthClass,
     expanded: false,
-    isPad: cfg.widthClass === 'regular' || cfg.isPad,
+    isTablet: cfg.widthClass === 'regular' || cfg.isTablet,
   }),
 }));
 
@@ -76,7 +76,7 @@ describe('use-bottom-accessory', () => {
     cfg.bottomAccessory = {};
     cfg.variant = 'liquidGlass';
     cfg.widthClass = 'compact';
-    cfg.isPad = false;
+    cfg.isTablet = false;
   });
 
   it('uses the native BottomAccessory export as the capability check', () => {
@@ -194,12 +194,12 @@ describe('use-bottom-accessory', () => {
       expect(result.current).toBe(false);
     });
 
-    it('is false on an iPad in a narrow split (compact width), even when glass-capable', () => {
-      // The single-navigator shell keeps an iPad on JS Tabs + the Material bar at
+    it('is false on a tablet in a narrow split (compact width), even when glass-capable', () => {
+      // The single-navigator shell keeps a tablet on JS Tabs + the Material bar at
       // compact width too (never NativeTabs), so the native bar is not on screen.
       // If this returned true, the bottom-chrome metrics would suppress the JS queue
       // bar for a native accessory that never mounts — dropping the now-playing bar.
-      cfg.isPad = true;
+      cfg.isTablet = true;
       cfg.widthClass = 'compact';
 
       const { result } = renderHook(() => useNativeTabBar());

--- a/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
@@ -206,6 +206,21 @@ describe('use-bottom-accessory', () => {
 
       expect(result.current).toBe(false);
     });
+
+    it('is false on an Android tablet (Material variant) — the shell rail carries nav', () => {
+      // Android resolves the Material variant and is never glass-capable, so it was
+      // already false; the tablet shell also renders JS Tabs at every width. Either way
+      // the native glass tab bar / bottom accessory never mounts on an Android tablet.
+      cfg.platformOS = 'android';
+      cfg.variant = 'material';
+      cfg.glassEffectApiAvailable = false;
+      cfg.isTablet = true;
+      cfg.widthClass = 'regular';
+
+      const { result } = renderHook(() => useNativeTabBar());
+
+      expect(result.current).toBe(false);
+    });
   });
 
   it('keeps the accessory and the native tab bar consistent when the glass APIs diverge', () => {

--- a/packages/mobile/src/hooks/use-bottom-accessory.ts
+++ b/packages/mobile/src/hooks/use-bottom-accessory.ts
@@ -25,19 +25,20 @@ export function isBottomAccessoryAvailable(): boolean {
 export function useNativeTabBar(): boolean {
   const { variant } = useTheme();
   const glassCapable = useGlassCapability();
-  const { isPad } = useDeviceLayout();
-  // The iPad adaptive shell renders JS `Tabs` at EVERY iPad width — a glass rail at
-  // regular width, the Material bar in a narrow split (Slide Over / Split View) — and
-  // never `NativeTabs`, so a resize across the breakpoint keeps one navigator mounted
-  // (see `_layout`). So the native tab bar — and the bottom accessory + tab-bar search
-  // role it hosts — is never on screen on iPad. Everything that branches on this
-  // predicate (the climb-list search mode, the accessory mount, bottom-chrome
-  // geometry) must treat iPad as "no native tab bar", or it reaches for a native
-  // accessory / search bar that has no bar to live in — and on an iPad in a narrow
-  // split that would skip the native accessory AND suppress the JS PersistentQueueBar,
-  // dropping the now-playing bar entirely. (`isPad` subsumes the old regular-width
-  // check, since a `regular` width only ever resolves on an iPad.)
-  if (isPad) return false;
+  const { isTablet } = useDeviceLayout();
+  // The tablet adaptive shell renders JS `Tabs` at EVERY tablet width — a rail at
+  // regular width, the Material bar in a narrow split (Slide Over / Split View /
+  // Android multi-window) — and never `NativeTabs`, so a resize across the breakpoint
+  // keeps one navigator mounted (see `_layout`). So the native tab bar — and the
+  // bottom accessory + tab-bar search role it hosts — is never on screen on a tablet.
+  // Everything that branches on this predicate (the climb-list search mode, the
+  // accessory mount, bottom-chrome geometry) must treat a tablet as "no native tab
+  // bar", or it reaches for a native accessory / search bar that has no bar to live
+  // in — and on a tablet in a narrow split that would skip the native accessory AND
+  // suppress the JS PersistentQueueBar, dropping the now-playing bar entirely.
+  // (`isTablet` subsumes the old regular-width check, since a `regular` width only
+  // ever resolves on a tablet. Android is always false below via the variant check.)
+  if (isTablet) return false;
   return variant === 'liquidGlass' && glassCapable;
 }
 

--- a/packages/mobile/src/hooks/use-device-layout.ts
+++ b/packages/mobile/src/hooks/use-device-layout.ts
@@ -45,7 +45,10 @@ export function useDeviceLayout(): DeviceLayout & { isTablet: boolean; wallDevic
   // so an Android tablet in a small multi-window/DeX split is still a tablet but reads
   // `compact` from the live width — exactly like an iPad in a narrow Split View.
   const isTablet = resolveIsTablet({ platformOS: Platform.OS, isPad, screenShortSide });
-  const wallDeviceClass = resolveWallDeviceClass({ screenLongSide, isPad });
+  // Android tablets are panel-capable regardless of the dp long side (the width
+  // budget decides the surface); only iPad consults the points floor.
+  const isAndroidTablet = Platform.OS === 'android' && isTablet;
+  const wallDeviceClass = resolveWallDeviceClass({ screenLongSide, isPad, isAndroidTablet });
   return useMemo(
     () => ({ ...resolveDeviceLayout({ width, isTablet }), isTablet, wallDeviceClass }),
     [width, isTablet, wallDeviceClass],

--- a/packages/mobile/src/hooks/use-device-layout.ts
+++ b/packages/mobile/src/hooks/use-device-layout.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { Dimensions, Platform, useWindowDimensions } from 'react-native';
 import {
   resolveDeviceLayout,
+  resolveIsTablet,
   resolveWallDeviceClass,
   type DeviceLayout,
   type WallDeviceClass,
@@ -18,27 +19,32 @@ import {
  * `isTablet` is surfaced alongside the size class so the shell can keep a tablet
  * on a single JS `Tabs` navigator across the regular↔compact boundary (a tablet
  * in a narrow split is `compact` but must NOT swap to NativeTabs, or the boundary
- * cross would remount the navigator). It is launch-fixed, unlike `widthClass`,
- * which is live. (Android tablet detection is wired in a later step; today
- * `isTablet` equals the iPad flag.)
+ * cross would remount the navigator). It is launch-fixed — an iPad (`Platform.isPad`)
+ * or an Android tablet (`sw600dp`, see `resolveIsTablet`) — unlike `widthClass`,
+ * which is live.
  *
  * `wallDeviceClass` is the other launch-fixed axis: whether the device is
  * physically large enough for the persistent wall panel, from the screen long
- * side (see `resolveWallDeviceClass`). It's read from `Dimensions.get('screen')`
+ * side (see `resolveWallDeviceClass`). Both the long side (wall panel) and the
+ * short side (Android tablet eligibility) are read from `Dimensions.get('screen')`
  * — the PHYSICAL screen, not the app window (which shrinks under Split View /
- * Stage Manager) — and rotation-invariant via `max`, so it's memoized once.
+ * multi-window / DeX) — and rotation-invariant via `max`/`min`, so memoized once.
  */
 export function useDeviceLayout(): DeviceLayout & { isTablet: boolean; wallDeviceClass: WallDeviceClass } {
   const { width } = useWindowDimensions();
   // `Platform.isPad` is iOS-only (undefined on Android), so guard on the OS too.
   const isPad = Platform.OS === 'ios' && Platform.isPad === true;
-  const screenLongSide = useMemo(() => {
+  const { screenLongSide, screenShortSide } = useMemo(() => {
     const screen = Dimensions.get('screen');
-    return Math.max(screen.width, screen.height);
+    return {
+      screenLongSide: Math.max(screen.width, screen.height),
+      screenShortSide: Math.min(screen.width, screen.height),
+    };
   }, []);
-  // Adaptive-shell eligibility. Android tablets join here in a later step; for now
-  // this is exactly the iPad flag, so behavior is unchanged off iPad.
-  const isTablet = isPad;
+  // Adaptive-shell eligibility: an iPad, or an Android tablet at sw600dp. Launch-fixed,
+  // so an Android tablet in a small multi-window/DeX split is still a tablet but reads
+  // `compact` from the live width — exactly like an iPad in a narrow Split View.
+  const isTablet = resolveIsTablet({ platformOS: Platform.OS, isPad, screenShortSide });
   const wallDeviceClass = resolveWallDeviceClass({ screenLongSide, isPad });
   return useMemo(
     () => ({ ...resolveDeviceLayout({ width, isTablet }), isTablet, wallDeviceClass }),

--- a/packages/mobile/src/hooks/use-device-layout.ts
+++ b/packages/mobile/src/hooks/use-device-layout.ts
@@ -9,17 +9,18 @@ import {
 
 /**
  * The adaptive shell's size class, recomputed as the app window resizes —
- * rotation, Stage Manager, Split View / Slide Over. iPhone is always `compact`;
- * an iPad is `regular` once its window is wide enough for the sidebar plus a
- * content pane, and falls back to `compact` (the phone UI verbatim) in a narrow
- * split. The arithmetic lives in the pure `resolveDeviceLayout` so it is
- * unit-tested without react-native.
+ * rotation, Stage Manager, Split View / Slide Over, Android multi-window. A phone
+ * is always `compact`; a tablet is `regular` once its window is wide enough for
+ * the sidebar plus a content pane, and falls back to `compact` (the phone UI
+ * verbatim) in a narrow split. The arithmetic lives in the pure
+ * `resolveDeviceLayout` so it is unit-tested without react-native.
  *
- * `isPad` is surfaced alongside the size class so the shell can keep iPad on a
- * single JS `Tabs` navigator across the regular↔compact boundary (an iPad in a
- * narrow split is `compact` but must NOT swap to NativeTabs, or the boundary
- * cross would remount the navigator). It is launch-fixed (`Platform.isPad`),
- * unlike `widthClass`, which is live.
+ * `isTablet` is surfaced alongside the size class so the shell can keep a tablet
+ * on a single JS `Tabs` navigator across the regular↔compact boundary (a tablet
+ * in a narrow split is `compact` but must NOT swap to NativeTabs, or the boundary
+ * cross would remount the navigator). It is launch-fixed, unlike `widthClass`,
+ * which is live. (Android tablet detection is wired in a later step; today
+ * `isTablet` equals the iPad flag.)
  *
  * `wallDeviceClass` is the other launch-fixed axis: whether the device is
  * physically large enough for the persistent wall panel, from the screen long
@@ -27,7 +28,7 @@ import {
  * — the PHYSICAL screen, not the app window (which shrinks under Split View /
  * Stage Manager) — and rotation-invariant via `max`, so it's memoized once.
  */
-export function useDeviceLayout(): DeviceLayout & { isPad: boolean; wallDeviceClass: WallDeviceClass } {
+export function useDeviceLayout(): DeviceLayout & { isTablet: boolean; wallDeviceClass: WallDeviceClass } {
   const { width } = useWindowDimensions();
   // `Platform.isPad` is iOS-only (undefined on Android), so guard on the OS too.
   const isPad = Platform.OS === 'ios' && Platform.isPad === true;
@@ -35,9 +36,12 @@ export function useDeviceLayout(): DeviceLayout & { isPad: boolean; wallDeviceCl
     const screen = Dimensions.get('screen');
     return Math.max(screen.width, screen.height);
   }, []);
+  // Adaptive-shell eligibility. Android tablets join here in a later step; for now
+  // this is exactly the iPad flag, so behavior is unchanged off iPad.
+  const isTablet = isPad;
   const wallDeviceClass = resolveWallDeviceClass({ screenLongSide, isPad });
   return useMemo(
-    () => ({ ...resolveDeviceLayout({ width, isPad }), isPad, wallDeviceClass }),
-    [width, isPad, wallDeviceClass],
+    () => ({ ...resolveDeviceLayout({ width, isTablet }), isTablet, wallDeviceClass }),
+    [width, isTablet, wallDeviceClass],
   );
 }

--- a/packages/mobile/src/lib/__tests__/android-tablet-orientation-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/android-tablet-orientation-plugin.test.ts
@@ -1,0 +1,57 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+type OrientationPlugin = {
+  addTabletOrientation(contents: string): string;
+  MARKER: string;
+};
+
+const plugin = require('../../../plugins/with-android-tablet-orientation.js') as OrientationPlugin;
+
+const MAIN_ACTIVITY = `package com.boardsesh.app
+
+import android.os.Bundle
+import com.facebook.react.ReactActivity
+
+class MainActivity : ReactActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    setTheme(R.style.AppTheme)
+    super.onCreate(null)
+  }
+}
+`;
+
+describe('with-android-tablet-orientation', () => {
+  it('injects a sw600dp orientation guard after super.onCreate', () => {
+    const result = plugin.addTabletOrientation(MAIN_ACTIVITY);
+
+    expect(result).toContain(plugin.MARKER);
+    expect(result).toContain('smallestScreenWidthDp >= 600');
+    expect(result).toContain('SCREEN_ORIENTATION_UNSPECIFIED');
+    expect(result).toContain('SCREEN_ORIENTATION_PORTRAIT');
+    // The guard follows the super.onCreate call, not precedes it.
+    expect(result.indexOf('super.onCreate(null)')).toBeLessThan(result.indexOf('smallestScreenWidthDp'));
+  });
+
+  it('preserves the onCreate indentation', () => {
+    const result = plugin.addTabletOrientation(MAIN_ACTIVITY);
+    // super.onCreate sits at 4-space indent, so the injected requestedOrientation does too.
+    expect(result).toContain('\n    requestedOrientation =');
+  });
+
+  it('is idempotent — a second pass adds no duplicate guard', () => {
+    const once = plugin.addTabletOrientation(MAIN_ACTIVITY);
+    const twice = plugin.addTabletOrientation(once);
+
+    expect(twice).toBe(once);
+    expect(twice.match(new RegExp(plugin.MARKER, 'g'))).toHaveLength(1);
+  });
+
+  it('throws if the super.onCreate anchor is missing (Expo template drift)', () => {
+    const drifted = 'class MainActivity : ReactActivity() {\n}\n';
+    expect(() => plugin.addTabletOrientation(drifted)).toThrow(/super\.onCreate/);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/android-tablet-orientation-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/android-tablet-orientation-plugin.test.ts
@@ -54,4 +54,14 @@ describe('with-android-tablet-orientation', () => {
     const drifted = 'class MainActivity : ReactActivity() {\n}\n';
     expect(() => plugin.addTabletOrientation(drifted)).toThrow(/super\.onCreate/);
   });
+
+  it('anchors even when the super.onCreate argument has a nested closing paren', () => {
+    // Some template variants pass `savedInstanceState ?: Bundle()` — the greedy
+    // anchor must still match the whole statement line.
+    const nested = MAIN_ACTIVITY.replace('super.onCreate(null)', 'super.onCreate(savedInstanceState ?: Bundle())');
+    const result = plugin.addTabletOrientation(nested);
+    expect(result).toContain(plugin.MARKER);
+    expect(result).toContain('smallestScreenWidthDp >= 600');
+    expect(result.indexOf('Bundle())')).toBeLessThan(result.indexOf('smallestScreenWidthDp'));
+  });
 });

--- a/packages/mobile/src/theme/__tests__/size-class.test.ts
+++ b/packages/mobile/src/theme/__tests__/size-class.test.ts
@@ -116,10 +116,10 @@ describe('resolveWallSurface', () => {
 });
 
 describe('resolveWallDeviceClass', () => {
-  it('is always sheet-only off iPad, whatever the screen size', () => {
+  it('is always sheet-only on a phone, whatever the screen size', () => {
     // Phones never mount the persistent wall panel — the wall lives in the sheet.
     for (const screenLongSide of [844, 932, 1133, 1366]) {
-      expect(resolveWallDeviceClass({ screenLongSide, isPad: false })).toBe('sheet-only');
+      expect(resolveWallDeviceClass({ screenLongSide, isPad: false, isAndroidTablet: false })).toBe('sheet-only');
     }
   });
 
@@ -127,14 +127,23 @@ describe('resolveWallDeviceClass', () => {
     // Below the 11" Pro's long side (1194): iPad mini (1133), base iPad and Air
     // 11" (1180), and one point under the floor.
     for (const screenLongSide of [1133, 1180, WALL_PANEL_MIN_DEVICE_LONG_SIDE - 1]) {
-      expect(resolveWallDeviceClass({ screenLongSide, isPad: true })).toBe('sheet-only');
+      expect(resolveWallDeviceClass({ screenLongSide, isPad: true, isAndroidTablet: false })).toBe('sheet-only');
     }
   });
 
   it('keeps the panel on the 11" Pro and every 13"', () => {
     // 11" Pro (1194 / M4 1210) and all 13" (12.9" 1366, M4 13" 1376).
     for (const screenLongSide of [WALL_PANEL_MIN_DEVICE_LONG_SIDE, 1210, 1366, 1376]) {
-      expect(resolveWallDeviceClass({ screenLongSide, isPad: true })).toBe('panel-capable');
+      expect(resolveWallDeviceClass({ screenLongSide, isPad: true, isAndroidTablet: false })).toBe('panel-capable');
+    }
+  });
+
+  it('is panel-capable on any Android tablet regardless of the dp long side', () => {
+    // No iPad-points floor on Android: the live width budget (resolveWallSurface)
+    // decides column/strip/none, so even a small tablet is panel-capable here and
+    // gets a strip (not a column) when the width is tight.
+    for (const screenLongSide of [960, 1024, 1280, 1600]) {
+      expect(resolveWallDeviceClass({ screenLongSide, isPad: false, isAndroidTablet: true })).toBe('panel-capable');
     }
   });
 });

--- a/packages/mobile/src/theme/__tests__/size-class.test.ts
+++ b/packages/mobile/src/theme/__tests__/size-class.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   resolveDeviceLayout,
+  resolveIsTablet,
   resolveWallSurface,
   resolveWallDeviceClass,
   resolveEffectiveWallSurface,
@@ -9,50 +10,80 @@ import {
   REGULAR_WIDTH_BREAKPOINT,
   EXPANDED_WIDTH_BREAKPOINT,
   WALL_PANEL_MIN_DEVICE_LONG_SIDE,
+  TABLET_MIN_SHORT_SIDE_DP,
 } from '../size-class';
 
 const SIDEBAR_WIDTH = 96;
 
 describe('resolveDeviceLayout', () => {
-  it('keeps every iPhone compact regardless of width', () => {
-    // An iPhone is never an iPad, so even a wide landscape phone stays compact
+  it('keeps every phone compact regardless of width', () => {
+    // A phone is never a tablet, so even a wide landscape phone stays compact
     // (renders the phone UI verbatim).
-    expect(resolveDeviceLayout({ width: 932, isPad: false })).toEqual({ widthClass: 'compact', expanded: false });
-    expect(resolveDeviceLayout({ width: 430, isPad: false })).toEqual({ widthClass: 'compact', expanded: false });
+    expect(resolveDeviceLayout({ width: 932, isTablet: false })).toEqual({ widthClass: 'compact', expanded: false });
+    expect(resolveDeviceLayout({ width: 430, isTablet: false })).toEqual({ widthClass: 'compact', expanded: false });
   });
 
-  it('keeps an iPad compact in a narrow split (Slide Over / ⅓ / ½)', () => {
+  it('keeps a tablet compact in a narrow split (Slide Over / ⅓ / ½ / small multi-window)', () => {
     // 12.9" iPad split widths: Slide Over ~320, ½ ~507, ⅔ ~664 — all below 700.
     for (const width of [320, 375, 507, 664, REGULAR_WIDTH_BREAKPOINT - 1]) {
-      expect(resolveDeviceLayout({ width, isPad: true })).toEqual({ widthClass: 'compact', expanded: false });
+      expect(resolveDeviceLayout({ width, isTablet: true })).toEqual({ widthClass: 'compact', expanded: false });
     }
   });
 
-  it('is regular but not expanded for a narrow-regular iPad window', () => {
+  it('is regular but not expanded for a narrow-regular tablet window', () => {
     // 11" iPad portrait (834) and a ⅔ split that clears 700 but not 1024.
-    expect(resolveDeviceLayout({ width: 834, isPad: true })).toEqual({ widthClass: 'regular', expanded: false });
-    expect(resolveDeviceLayout({ width: REGULAR_WIDTH_BREAKPOINT, isPad: true })).toEqual({
+    expect(resolveDeviceLayout({ width: 834, isTablet: true })).toEqual({ widthClass: 'regular', expanded: false });
+    expect(resolveDeviceLayout({ width: REGULAR_WIDTH_BREAKPOINT, isTablet: true })).toEqual({
       widthClass: 'regular',
       expanded: false,
     });
-    expect(resolveDeviceLayout({ width: EXPANDED_WIDTH_BREAKPOINT - 1, isPad: true })).toEqual({
+    expect(resolveDeviceLayout({ width: EXPANDED_WIDTH_BREAKPOINT - 1, isTablet: true })).toEqual({
       widthClass: 'regular',
       expanded: false,
     });
   });
 
-  it('is regular but not expanded across the tightest real iPad portraits', () => {
+  it('is regular but not expanded across the tightest real tablet portraits', () => {
     // iPad mini portrait (744), 9.7"/10.2" portrait (768/810) — the narrow-regular
     // band where a persistent detail pane squeezes the browse list. All clear 700
     // (sidebar shows) but not 1024 (no master+detail). See resolveDetailPaneSurface.
     for (const width of [744, 768, 810]) {
-      expect(resolveDeviceLayout({ width, isPad: true })).toEqual({ widthClass: 'regular', expanded: false });
+      expect(resolveDeviceLayout({ width, isTablet: true })).toEqual({ widthClass: 'regular', expanded: false });
     }
   });
 
-  it('is expanded for a full-screen iPad (portrait 1024+ and any landscape)', () => {
+  it('is expanded for a full-screen tablet (portrait 1024+ and any landscape)', () => {
     for (const width of [EXPANDED_WIDTH_BREAKPOINT, 1194, 1366]) {
-      expect(resolveDeviceLayout({ width, isPad: true })).toEqual({ widthClass: 'regular', expanded: true });
+      expect(resolveDeviceLayout({ width, isTablet: true })).toEqual({ widthClass: 'regular', expanded: true });
+    }
+  });
+});
+
+describe('resolveIsTablet', () => {
+  it('is always true on iPad, whatever the screen size', () => {
+    for (const screenShortSide of [768, 820, 1024]) {
+      expect(resolveIsTablet({ platformOS: 'ios', isPad: true, screenShortSide })).toBe(true);
+    }
+  });
+
+  it('is false on an iPhone regardless of a wide landscape short side', () => {
+    // An iPhone is never a tablet; the sw600 rule only applies to Android.
+    expect(resolveIsTablet({ platformOS: 'ios', isPad: false, screenShortSide: 430 })).toBe(false);
+    expect(resolveIsTablet({ platformOS: 'ios', isPad: false, screenShortSide: 932 })).toBe(false);
+  });
+
+  it('is false on an Android phone (short side below sw600dp)', () => {
+    // Typical Android phone smallest widths: 360–420dp; a folded foldable outer
+    // display ~360dp — all below the tablet threshold.
+    for (const screenShortSide of [360, 411, TABLET_MIN_SHORT_SIDE_DP - 1]) {
+      expect(resolveIsTablet({ platformOS: 'android', isPad: false, screenShortSide })).toBe(false);
+    }
+  });
+
+  it('is true on an Android tablet at or above sw600dp', () => {
+    // 7" (~600dp), 10" (~800dp), unfolded foldable inner display — all tablets.
+    for (const screenShortSide of [TABLET_MIN_SHORT_SIDE_DP, 720, 800]) {
+      expect(resolveIsTablet({ platformOS: 'android', isPad: false, screenShortSide })).toBe(true);
     }
   });
 });

--- a/packages/mobile/src/theme/size-class.ts
+++ b/packages/mobile/src/theme/size-class.ts
@@ -43,16 +43,50 @@ export type DeviceLayout = {
 };
 
 /**
- * Resolve the size class from the app window width and whether the device is an
- * iPad. Only iPad opts into the adaptive shell — every iPhone stays `compact`
- * regardless of width — and an iPad in a narrow split is `compact` too, so the
- * sidebar appears only when there is genuinely room for two columns.
+ * Resolve the size class from the app window width and whether the device is a
+ * tablet (an iPad, or an Android tablet — see {@link resolveIsTablet}). Only a
+ * tablet opts into the adaptive shell — every phone stays `compact` regardless of
+ * width — and a tablet in a narrow split is `compact` too, so the sidebar appears
+ * only when there is genuinely room for two columns.
  */
-export function resolveDeviceLayout({ width, isPad }: { width: number; isPad: boolean }): DeviceLayout {
-  if (!isPad || width < REGULAR_WIDTH_BREAKPOINT) {
+export function resolveDeviceLayout({ width, isTablet }: { width: number; isTablet: boolean }): DeviceLayout {
+  if (!isTablet || width < REGULAR_WIDTH_BREAKPOINT) {
     return { widthClass: 'compact', expanded: false };
   }
   return { widthClass: 'regular', expanded: width >= EXPANDED_WIDTH_BREAKPOINT };
+}
+
+/**
+ * Android's tablet threshold: a device whose smallest screen width is at least
+ * this many dp is a tablet. This is the `sw600dp` resource qualifier Android and
+ * Material 3 use to switch to tablet layouts, so we match the platform's own line.
+ */
+export const TABLET_MIN_SHORT_SIDE_DP = 600;
+
+/**
+ * Whether this device opts into the adaptive shell: an iPad, or an Android tablet
+ * whose smallest screen width clears {@link TABLET_MIN_SHORT_SIDE_DP}. Pure (the
+ * platform and the physical-screen short side are injected) so it unit-tests
+ * without react-native, mirroring the width resolvers; the React wrapper reads
+ * `Platform.OS` / `Dimensions.get('screen')` in `use-device-layout.ts`.
+ *
+ * Launch-fixed like `Platform.isPad` — the short side comes from the PHYSICAL
+ * screen, not the app window (which shrinks under Split View / multi-window / DeX),
+ * so an Android tablet in a small freeform window is still a tablet (`isTablet`
+ * true) but resolves `compact` from the live width, exactly like an iPad in a
+ * narrow Split View. The mount decision must not flip the navigator type
+ * mid-session; the live axis is `widthClass`.
+ */
+export function resolveIsTablet({
+  platformOS,
+  isPad,
+  screenShortSide,
+}: {
+  platformOS: string;
+  isPad: boolean;
+  screenShortSide: number;
+}): boolean {
+  return isPad || (platformOS === 'android' && screenShortSide >= TABLET_MIN_SHORT_SIDE_DP);
 }
 
 /**

--- a/packages/mobile/src/theme/size-class.ts
+++ b/packages/mobile/src/theme/size-class.ts
@@ -64,6 +64,14 @@ export function resolveDeviceLayout({ width, isTablet }: { width: number; isTabl
 export const TABLET_MIN_SHORT_SIDE_DP = 600;
 
 /**
+ * A structural mirror of react-native's `Platform.OS` union, kept local so this
+ * module stays react-native-free (it unit-tests as plain functions). `Platform.OS`
+ * is assignable to it, and typing the param this way — rather than `string` —
+ * catches a mistyped OS branch at the call site instead of silently never matching.
+ */
+export type PlatformOS = 'ios' | 'android' | 'windows' | 'macos' | 'web';
+
+/**
  * Whether this device opts into the adaptive shell: an iPad, or an Android tablet
  * whose smallest screen width clears {@link TABLET_MIN_SHORT_SIDE_DP}. Pure (the
  * platform and the physical-screen short side are injected) so it unit-tests
@@ -82,7 +90,7 @@ export function resolveIsTablet({
   isPad,
   screenShortSide,
 }: {
-  platformOS: string;
+  platformOS: PlatformOS;
   isPad: boolean;
   screenShortSide: number;
 }): boolean {

--- a/packages/mobile/src/theme/size-class.ts
+++ b/packages/mobile/src/theme/size-class.ts
@@ -98,19 +98,30 @@ export type WallDeviceClass = 'panel-capable' | 'sheet-only';
 
 /**
  * Resolve the wall device class from the physical screen long side (see
- * {@link WALL_PANEL_MIN_DEVICE_LONG_SIDE}). Non-iPad is always `sheet-only` —
- * phones never mount the panel — so this is only consulted on iPad. Pure (the
- * long side is injected), so it unit-tests without react-native like the width
- * resolvers; the React wrapper reads `Dimensions.get('screen')` in
- * `use-device-layout.ts`.
+ * {@link WALL_PANEL_MIN_DEVICE_LONG_SIDE}).
+ *
+ * - **Android tablets are always `panel-capable`.** The iPad points floor exists
+ *   only because iPad points can't separate an iPad mini from an 11" Pro at the
+ *   same size class; on Android the live width budget (`resolveWallSurface`)
+ *   already decides column/strip/none, and density-bucketed dp isn't comparable to
+ *   the iPad point floor anyway. So the floor is iOS-only.
+ * - **iPad** keeps the launch-fixed points floor.
+ * - **Phones** are always `sheet-only` — they never mount the panel.
+ *
+ * Pure (the long side + device flags are injected), so it unit-tests without
+ * react-native like the width resolvers; the React wrapper reads
+ * `Dimensions.get('screen')` in `use-device-layout.ts`.
  */
 export function resolveWallDeviceClass({
   screenLongSide,
   isPad,
+  isAndroidTablet,
 }: {
   screenLongSide: number;
   isPad: boolean;
+  isAndroidTablet: boolean;
 }): WallDeviceClass {
+  if (isAndroidTablet) return 'panel-capable';
   if (!isPad || screenLongSide < WALL_PANEL_MIN_DEVICE_LONG_SIDE) return 'sheet-only';
   return 'panel-capable';
 }

--- a/packages/mobile/src/theme/tokens.ts
+++ b/packages/mobile/src/theme/tokens.ts
@@ -145,6 +145,13 @@ export const material = {
     /** Resting elevation of the solid Android nav surface (M3 nav bar = level 2). */
     surfaceElevation: 2,
   },
+  navRail: {
+    /** Tonal pill behind the focused rail item's icon (M3 navigation-rail spec:
+     *  56×32 — narrower than the 64-wide bottom-nav pill). */
+    activeIndicatorWidth: 56,
+    activeIndicatorHeight: 32,
+    activeIndicatorRadius: 16,
+  },
   sheet: {
     /** M3 bottom-sheet top corner radius (iOS keeps borderRadius.xl = 16). */
     cornerRadius: 28,


### PR DESCRIPTION
## Summary

Makes an Android tablet a first-class wall device. Today the app has a full **iPad** adaptive shell — a left rail replacing the bottom tabs, a master-detail play pane that follows your selection, and a live "Now on the wall" column — but every Android device, phone or 10" tablet, fell through to the phone UI stretched edge-to-edge. Oleg at Sandbox Bouldering asked whether a cheap Android tablet bolted to the gym wall would work; the honest answer was "no."

Now an Android tablet mounts the same adaptive shell, drawn in **platform-native Material 3**: a Material navigation rail instead of the glass sidebar, opaque M3 tonal surfaces instead of glass, M3 dividers between panes. A ~$150 10" Android tablet on the wall gets the two-pane browse-light-and-see-what's-lit experience, not a blown-up phone screen — including the live wall column in landscape.

**How it works** (mostly wiring — the shell is already width-driven, not OS-driven):
- **Detection** — `resolveIsTablet` admits an iPad **or** an Android tablet whose smallest physical-screen width clears 600dp (Android's own `sw600dp` tablet qualifier), launch-fixed. The single `isPad` gate is generalized to `isTablet`; the pure size-class resolvers were already device-agnostic.
- **Material 3 rail** — new `MaterialNavigationRail` mirrors `MaterialTabBar`'s M3 roles laid out vertically (secondaryContainer active-indicator pill, onSecondaryContainer glyph, active/inactive glyph pairs matching the bottom bar), routed by variant via `TabletSidebar = createVariantComponent(IpadSidebar, MaterialNavigationRail)`. Shares the 96dp rail width so the master-detail width budget never forks per variant. No rail FAB — IA parity with the glass rail.
- **Rotation** — new `with-android-tablet-orientation` config plugin lets `sw600dp` tablets rotate to landscape (the shell's whole point) while phones stay portrait, mirroring the iOS `~ipad` override.
- **Live wall** — Android tablets are `panel-capable`, so the "Now on the wall" column/strip mounts beside the browse list (the live width budget picks column vs strip). The kiosk hero-type scale skips the iPad points-per-inch estimate on Android and falls back to the pane short side.

The breakpoints (700/1024dp) are unchanged and shared across both variants, so iPad and Android tablets resolve identically at the same dp. Phones and iOS are untouched.

## Release Notes

- Android tablets get the full wall layout: browse climbs and light them in two panes side by side, with a live "on the wall" column — built for a tablet bolted to the gym wall.
- The tablet layout now follows Material 3 on Android, with a navigation rail down the side instead of the phone's bottom tabs.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 3781 passed (adds Android cases to `size-class`, `tab-layout`, `use-bottom-accessory`; new `MaterialNavigationRail` + orientation-plugin tests).
- `vp run check:mobile-bundle` — Android bundle OK (13.8 MB).
- `vp run check:mobile-variants` — clean (rail routes through `createVariantComponent` / `selectByVariant`, no raw variant compares).
- **Android tablet emulator (Pixel Tablet AVD, 1280×800dp landscape)** — booted the shell against Metro and confirmed the full four-column Material 3 layout: the navigation rail replaces the bottom tabs (M3 active-indicator pill tracking the focused tab, "On the Wall" as a rail row), the master-detail board pane follows list selection (climb rendered with lit holds + playback controls), and the live "Now on the wall" column renders as an opaque M3 surface on the trailing edge. Verified across the Climbs and Profile tabs; panes are opaque Material tonal surfaces (no broken glass). Screenshots captured on the Pixel Tablet AVD and shared with the maintainer.

> **⚠ Native change — needs a native build, not an OTA.** The orientation config plugin edits the Android manifest/MainActivity, so this changes the runtime fingerprint. The JS shell alone could ride an OTA, but it's useless portrait-locked, so the whole feature ships in a native TestFlight/Play build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w5v5sDvvx5eTDP8Lekzvr
