### PR TITLE
feat(ci): wire snapshot storage to the public Tigris bucket

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -81,6 +81,10 @@ env:
   # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
   # false, so every track() silently no-ops (the app shipped zero events before).
   EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
+  # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
+  # export-board-snapshots.yml.
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
   # Pin RN's fetch as the global `fetch` (not expo/fetch), which crashes Hermes by
   # tearing down JSI promises off-thread (Sentry 7595562195). Bundle-only flag — it
   # doesn't enter the resolved config, so it never moves the fingerprint. Kept in
@@ -144,6 +148,7 @@ jobs:
           EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
           EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
           EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
+          EXPO_PUBLIC_SNAPSHOT_BASE_URL=$EXPO_PUBLIC_SNAPSHOT_BASE_URL
           EXPO_PUBLIC_USE_RN_FETCH=$EXPO_PUBLIC_USE_RN_FETCH
           EOF
 
@@ -254,6 +259,7 @@ jobs:
           EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
           EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
           EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
+          EXPO_PUBLIC_SNAPSHOT_BASE_URL=$EXPO_PUBLIC_SNAPSHOT_BASE_URL
           EXPO_PUBLIC_USE_RN_FETCH=$EXPO_PUBLIC_USE_RN_FETCH
           EOF
 

--- a/.github/workflows/export-board-snapshots.yml
+++ b/.github/workflows/export-board-snapshots.yml
@@ -52,6 +52,12 @@ jobs:
           # as fallback for any other S3-compatible store.
           AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL_S3 || secrets.AWS_ENDPOINT_URL }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || secrets.AWS_DEFAULT_REGION }}
+          # Tigris serves public objects only on the bucket's virtual-host
+          # domain — the S3 endpoint's path-style URLs 403 unauthenticated GETs
+          # even on a public bucket, so manifest entry URLs must be built here.
+          # Not a secret (it's in every manifest the app fetches). Keep in sync
+          # with EXPO_PUBLIC_SNAPSHOT_BASE_URL in the mobile workflows.
+          SNAPSHOT_PUBLIC_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io
           # Keep the export's stability window in lockstep with the backend if
           # it's ever configured off-default (empty → the shared 30s default).
           SYNC_STABILITY_WINDOW_SECONDS: ${{ vars.SYNC_STABILITY_WINDOW_SECONDS }}

--- a/.github/workflows/export-board-snapshots.yml
+++ b/.github/workflows/export-board-snapshots.yml
@@ -47,8 +47,11 @@ jobs:
           AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          # Accept the Tigris console's exported names (AWS_ENDPOINT_URL_S3 /
+          # AWS_REGION) so rotating keys stays copy-paste, with the plain names
+          # as fallback for any other S3-compatible store.
+          AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL_S3 || secrets.AWS_ENDPOINT_URL }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || secrets.AWS_DEFAULT_REGION }}
           # Keep the export's stability window in lockstep with the backend if
           # it's ever configured off-default (empty → the shared 30s default).
           SYNC_STABILITY_WINDOW_SECONDS: ${{ vars.SYNC_STABILITY_WINDOW_SECONDS }}

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -57,6 +57,10 @@ env:
   # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
   # false, so every track() silently no-ops (the app shipped zero events before).
   EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
+  # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
+  # export-board-snapshots.yml.
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
   # Pin RN's fetch as the global `fetch` (not expo/fetch), which crashes Hermes by
   # tearing down JSI promises off-thread (Sentry 7595562195). Bundle-only flag — it
   # doesn't enter the resolved config, so it never moves the fingerprint. Kept in
@@ -109,6 +113,7 @@ jobs:
           EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
           EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
           EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
+          EXPO_PUBLIC_SNAPSHOT_BASE_URL=$EXPO_PUBLIC_SNAPSHOT_BASE_URL
           EXPO_PUBLIC_USE_RN_FETCH=$EXPO_PUBLIC_USE_RN_FETCH
           EOF
 
@@ -194,6 +199,7 @@ jobs:
           EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
           EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
           EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
+          EXPO_PUBLIC_SNAPSHOT_BASE_URL=$EXPO_PUBLIC_SNAPSHOT_BASE_URL
           EXPO_PUBLIC_USE_RN_FETCH=$EXPO_PUBLIC_USE_RN_FETCH
           EOF
 

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -61,6 +61,10 @@ env:
   EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
   EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
   EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
+  # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
+  # export-board-snapshots.yml.
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
   EXPO_UPDATES_CHANNEL: production
   EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
   # Pin RN's fetch as the global `fetch` (not expo/fetch), which crashes Hermes by
@@ -192,6 +196,7 @@ jobs:
           EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
           EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
           EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
+          EXPO_PUBLIC_SNAPSHOT_BASE_URL=$EXPO_PUBLIC_SNAPSHOT_BASE_URL
           EXPO_PUBLIC_USE_RN_FETCH=$EXPO_PUBLIC_USE_RN_FETCH
           EOF
 

--- a/.github/workflows/mobile-ota-check.yml
+++ b/.github/workflows/mobile-ota-check.yml
@@ -57,6 +57,10 @@ env:
   EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
   EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
   EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
+  # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
+  # export-board-snapshots.yml.
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
   EXPO_UPDATES_CHANNEL: production
   EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
   # Pin RN's fetch as the global `fetch` (not expo/fetch), which crashes Hermes by

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -77,6 +77,10 @@ env:
   EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
   EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
   EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
+  # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
+  # export-board-snapshots.yml.
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
   EXPO_UPDATES_CHANNEL: production
   EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
   # Pin RN's fetch as the global `fetch` (not expo/fetch), which crashes Hermes by

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -77,6 +77,10 @@ env:
   EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
   EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
   EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
+  # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
+  # export-board-snapshots.yml.
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
   # Baked into the binary by `expo prebuild`; the server maps this channel to a
   # same-named branch. Part of the resolved config, so it's fingerprint-relevant.
   EXPO_UPDATES_CHANNEL: production
@@ -165,6 +169,7 @@ jobs:
           EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
           EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
           EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
+          EXPO_PUBLIC_SNAPSHOT_BASE_URL=$EXPO_PUBLIC_SNAPSHOT_BASE_URL
           EXPO_PUBLIC_USE_RN_FETCH=$EXPO_PUBLIC_USE_RN_FETCH
           EOF
 

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -286,9 +286,23 @@ node --import tsx src/scripts/export-board-snapshots.ts [--dry-run] [--gzip] [--
 
 Set on the `Production` GitHub environment (referenced by the workflow): `DATABASE_URL`,
 `AWS_S3_BUCKET_NAME`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL`,
-`AWS_DEFAULT_REGION`. `SYNC_STABILITY_WINDOW_SECONDS` is an optional `vars.*` passthrough (only needed if
-the backend's stability window is ever configured off its 30s default — the export reads the same env var
-so the two stay in lockstep).
+`AWS_DEFAULT_REGION`. The workflow also accepts the Tigris console's exported names
+(`AWS_ENDPOINT_URL_S3`, `AWS_REGION`) so rotating keys stays copy-paste. `SYNC_STABILITY_WINDOW_SECONDS`
+is an optional `vars.*` passthrough (only needed if the backend's stability window is ever configured off
+its 30s default — the export reads the same env var so the two stay in lockstep).
+
+The Production environment restricts deployments to `main`, so `workflow_dispatch` runs of the export
+must be dispatched from `main` — a feature-branch dispatch fails immediately with a branch-policy
+rejection and zero log output.
+
+**Public URL base (Tigris quirk)**: the manifest's per-artifact `url` fields must be fetchable
+unauthenticated. Tigris serves public objects **only** on the bucket's virtual-host domain
+(`https://<bucket>.t3.tigrisfiles.io/<key>`); the S3 endpoint's path-style form that `getPublicUrl`
+builds (`https://t3.storage.dev/<bucket>/<key>`) returns 403 for anonymous GETs even on a public
+bucket. The workflow therefore sets `SNAPSHOT_PUBLIC_BASE_URL` (not a secret — it appears in every
+manifest) and the export re-bases entry URLs onto it. Keep it consistent with
+`EXPO_PUBLIC_SNAPSHOT_BASE_URL` in the mobile workflows: the mobile value is
+`${SNAPSHOT_PUBLIC_BASE_URL}/board-snapshots/v1`.
 
 ### Kill switches
 

--- a/packages/backend/src/__tests__/snapshot-export-run.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-run.test.ts
@@ -304,3 +304,31 @@ describe('runExport — stale-artifact pruning', () => {
     await expect(runExport([])).resolves.toBeUndefined();
   });
 });
+
+describe('runExport — SNAPSHOT_PUBLIC_BASE_URL', () => {
+  // Tigris only serves public objects on the bucket's virtual-host domain; the
+  // S3 endpoint's path-style URLs (what getPublicUrl builds) 403 unauthenticated
+  // GETs even on a public bucket. The env var re-bases entry URLs onto the
+  // public host so the app can actually download what the manifest points at.
+  it('builds manifest entry URLs on the public base when set (trailing slash tolerated)', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    process.env.SNAPSHOT_PUBLIC_BASE_URL = 'https://boardsesh-board-snapshots.t3.tigrisfiles.io/';
+    try {
+      await runExport([]);
+    } finally {
+      delete process.env.SNAPSHOT_PUBLIC_BASE_URL;
+    }
+
+    const entry = uploadedManifest().entries[0];
+    expect(entry.url).toBe(`https://boardsesh-board-snapshots.t3.tigrisfiles.io/${entry.key}`);
+  });
+
+  it('falls back to the store URL when unset', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+
+    await runExport([]);
+
+    const entry = uploadedManifest().entries[0];
+    expect(entry.url).toBe(`https://cdn.example/${entry.key}`);
+  });
+});

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -57,6 +57,22 @@ const MANIFEST_KEY = `${SNAPSHOT_KEY_PREFIX}/manifest.json`;
 const MANIFEST_CACHE_CONTROL = 'public, max-age=300';
 const ARTIFACT_CONTENT_TYPE = 'application/x-sqlite3';
 
+// Public base for the manifest's artifact URLs. Tigris serves PUBLIC objects
+// only on the bucket's virtual-host domain (https://<bucket>.t3.tigrisfiles.io);
+// the S3 endpoint's path-style URL that getPublicUrl builds returns 403 for
+// unauthenticated GETs even on a public bucket. When set (no trailing slash
+// needed), entry URLs become `${base}/${key}`; unset falls back to getPublicUrl
+// for S3-compatible stores whose endpoint serves public reads directly. Read
+// lazily (not at module load) so tests can set it per-run.
+function snapshotPublicBaseUrl(): string {
+  return (process.env.SNAPSHOT_PUBLIC_BASE_URL ?? '').trim().replace(/\/+$/, '');
+}
+
+function publicUrlForKey(key: string): string {
+  const publicBase = snapshotPublicBaseUrl();
+  return publicBase ? `${publicBase}/${key}` : getPublicUrl(key);
+}
+
 // How long a superseded (manifest-unreferenced) artifact survives before the
 // unfiltered nightly run prunes it. The manifest is CDN-cached for max-age=300,
 // but a client may hold a fetched manifest much longer before starting the
@@ -653,9 +669,10 @@ export async function runExport(argv: string[]): Promise<void> {
           });
           newEntries.push(
             buildManifestEntry(result, {
-              // getPublicUrl instantiates the S3 client, so only call it when S3 is
-              // configured — a dry-run must work with no AWS credentials at all.
-              url: isS3Configured() ? getPublicUrl(key) : `dry-run:${key}`,
+              // publicUrlForKey may fall back to getPublicUrl, which instantiates
+              // the S3 client — so only call it when S3 is configured. A dry-run
+              // must work with no AWS credentials at all.
+              url: isS3Configured() || snapshotPublicBaseUrl() ? publicUrlForKey(key) : `dry-run:${key}`,
               key,
               bytes: uploadBody.length,
               contentEncoding,
@@ -680,7 +697,7 @@ export async function runExport(argv: string[]): Promise<void> {
           });
           newEntries.push(
             buildManifestEntry(result, {
-              url: uploaded.url,
+              url: publicUrlForKey(uploaded.key),
               key: uploaded.key,
               bytes: uploadBody.length,
               contentEncoding,

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -67,6 +67,10 @@ const SHARED_ENV_KEYS = [
   // off-thread and crashes Hermes (Sentry 7595562195). If it drifts out of one
   // workflow, that channel silently reverts to the crashing expo/fetch.
   'EXPO_PUBLIC_USE_RN_FETCH',
+  // Bundle-only: manifest base for the offline snapshot bootstrap. Drift ships
+  // an OTA whose fresh-board downloads silently fall back to the paged crawl
+  // (or fetch a stale bucket) — a behaviour change, not a delivery failure.
+  'EXPO_PUBLIC_SNAPSHOT_BASE_URL',
   'EXPO_UPDATES_CHANNEL',
   'EXPO_UPDATES_URL',
 ] as const;


### PR DESCRIPTION
Connects the merged offline-snapshot pipeline (#3559/#3560/#3562) to the real bucket, `boardsesh-board-snapshots` on Tigris.

- **Export workflow accepts Tigris-exported secret names** (`AWS_ENDPOINT_URL_S3`, `AWS_REGION`) with the plain names as fallback, so key rotation stays copy-paste from the Tigris console.
- **`SNAPSHOT_PUBLIC_BASE_URL`** — Tigris serves public objects only on the bucket's virtual-host domain (`https://<bucket>.t3.tigrisfiles.io`); anonymous path-style GETs on the S3 endpoint return 403 even for a public bucket (verified empirically). The export now re-bases manifest entry URLs onto this public host; unset falls back to `getPublicUrl` for stores whose endpoint serves public reads. Covered by two new `runExport` tests.
- **`EXPO_PUBLIC_SNAPSHOT_BASE_URL`** (`https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1`) baked into all six mobile fingerprint workflows — workflow-level env plus every `.env` writer block — and added to `SHARED_ENV_KEYS` in the env-parity test. Bundle-only; no fingerprint movement, so it ships to existing builds via OTA.
- Runbook updated: Tigris public-URL quirk, secret-name aliases, and the Production environment's main-only dispatch restriction.

Still gated: the `offline-snapshot-bootstrap` PostHog flag is at 0%, so behaviour is unchanged for all users until the ramp.

## Release Notes

none