### PR TITLE
fix(shared): run snapshot ATTACH on the exclusive transaction's own connection

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -220,6 +220,16 @@ pre-import empty result set.
 
 ## Mobile wiring
 
+- **Per-connection ATTACH invariant (BOARDSESH-AA)**: expo-sqlite's
+  `withExclusiveTransactionAsync` runs its task on a **new native connection**
+  (`useNewConnection: true`), and SQLite `ATTACH`es are per-connection — anything attached on the
+  main connection does not exist inside the task. The bootstrap therefore attaches, verifies, and
+  imports entirely on the transaction's own connection (`snapshot-bootstrap.ts`, see the
+  COMMIT → ATTACH → `BEGIN EXCLUSIVE` bracket). The node test double mirrors this: a **file-backed**
+  `createTestDatabase(path)` opens a separate connection for exclusive transactions, so any suite
+  exercising ATTACH/temp-table/PRAGMA state inside a transaction must be file-backed — the
+  in-memory double's same-connection transactions are what let this bug ship at 100% test green.
+
 - **`EXPO_PUBLIC_SNAPSHOT_BASE_URL`** (`packages/mobile/src/lib/env.ts`) — base URL for
   `<base>/manifest.json`; each manifest entry carries its own absolute artifact URL, so this constant is
   only used for the manifest fetch. There is deliberately **no production fallback**: if the env var is

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -264,7 +264,12 @@ let db: TestSqliteDb;
 
 beforeEach(async () => {
   workDir = mkdtempSync(join(tmpdir(), 'snapshot-bootstrap-'));
-  db = createTestDatabase();
+  // FILE-backed, deliberately: the adapter then mirrors expo-sqlite's
+  // withExclusiveTransactionAsync running its task on a SEPARATE connection,
+  // where a main-connection ATTACH does not exist. The in-memory double's
+  // same-connection transactions hid exactly that and let the BOARDSESH-AA
+  // "no such table: bs_snapshot.board_climb_stats" ship.
+  db = createTestDatabase(join(workDir, 'client.db'));
   await runMigrations(db);
   await ensureMutationQueueTable(db);
   __resetDrainerStateForTests();
@@ -563,17 +568,24 @@ describe('bootstrapScopeFromSnapshot', () => {
     // Flip the real wipe epoch the moment the stats INSERT runs (after the climbs
     // INSERT already executed inside the transaction), simulating a full sign-out
     // wipe cycle in flight. The final in-txn epoch check must then roll everything
-    // back — no imported rows, no checkpoints.
-    const realRunAsync = db.runAsync.bind(db);
+    // back — no imported rows, no checkpoints. Spy on the adapter PROTOTYPE: the
+    // import runs on the transaction's own connection (a separate adapter
+    // instance, mirroring expo), so an instance spy on `db` would never fire.
+    const adapterPrototype = Object.getPrototypeOf(db) as { runAsync: typeof db.runAsync };
+    const realRunAsync = adapterPrototype.runAsync;
     let wiped = false;
-    vi.spyOn(db, 'runAsync').mockImplementation((async (source: string, ...rest: unknown[]) => {
+    vi.spyOn(adapterPrototype, 'runAsync').mockImplementation(async function (
+      this: unknown,
+      source: string,
+      ...rest: unknown[]
+    ) {
       if (!wiped && source.includes('INSERT OR REPLACE INTO main.board_climb_stats')) {
         wiped = true;
         setSigningOut(true);
         setSigningOut(false); // epoch stays bumped; isSigningOut back to false
       }
-      return realRunAsync(source, ...(rest as never[]));
-    }) as typeof db.runAsync);
+      return realRunAsync.call(this, source, ...(rest as never[]));
+    } as typeof db.runAsync);
 
     await expect(
       bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath }),
@@ -598,17 +610,23 @@ describe('bootstrapScopeFromSnapshot', () => {
     // Flip the wipe epoch during the quick_check read — BEFORE the import
     // transaction opens. The epoch captured before the first await must catch a
     // wipe cycle that starts AND finishes inside the integrity checks; nothing
-    // may be imported into the freshly wiped DB.
-    const realGetAllAsync = db.getAllAsync.bind(db);
+    // may be imported into the freshly wiped DB. Prototype spy: the integrity
+    // checks now run on the transaction connection's own adapter instance.
+    const adapterPrototype = Object.getPrototypeOf(db) as { getAllAsync: typeof db.getAllAsync };
+    const realGetAllAsync = adapterPrototype.getAllAsync;
     let wiped = false;
-    vi.spyOn(db, 'getAllAsync').mockImplementation((async (source: string, ...rest: unknown[]) => {
+    vi.spyOn(adapterPrototype, 'getAllAsync').mockImplementation(async function (
+      this: unknown,
+      source: string,
+      ...rest: unknown[]
+    ) {
       if (!wiped && source.includes('quick_check')) {
         wiped = true;
         setSigningOut(true);
         setSigningOut(false); // epoch stays bumped; isSigningOut back to false
       }
-      return realGetAllAsync(source, ...(rest as never[]));
-    }) as typeof db.getAllAsync);
+      return realGetAllAsync.call(this, source, ...(rest as never[]));
+    } as typeof db.getAllAsync);
 
     await expect(
       bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath }),

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -468,9 +468,21 @@ async function verifySnapshotMeta(db: SqlExecutor): Promise<void> {
  * checks it, verifies the meta, then in ONE exclusive transaction imports the
  * scoped climbs + stats, reconciles stale scoped rows absent from the artifact,
  * and stamps both resume checkpoints at the scoped imported-row watermarks.
- * ATTACH/DETACH bracket the transaction (SQLite forbids ATTACH inside one).
  * A wipe that starts (or completes) mid-import rolls the transaction back and
  * throws SnapshotWipedError — no rows, no checkpoints.
+ *
+ * CONNECTION INVARIANT (BOARDSESH-AA): expo-sqlite's
+ * `withExclusiveTransactionAsync` runs its task on a NEW native connection
+ * (`useNewConnection: true`), and SQLite ATTACHes are per-connection — an
+ * ATTACH issued on the main connection does not exist inside the task. So
+ * EVERYTHING that touches the snapshot alias (attach, quick_check, meta
+ * verification, watermarks, reconcile, import) runs inside the task, on the
+ * transaction's own connection. SQLite forbids ATTACH inside a transaction and
+ * the expo wrapper opens a deferred BEGIN before the task runs, so the task
+ * first COMMITs that empty transaction, attaches in autocommit mode, then opens
+ * the real `BEGIN EXCLUSIVE` — which the wrapper's trailing COMMIT/ROLLBACK
+ * closes. The wrapper tears the connection down afterwards, which implicitly
+ * detaches the artifact on every path (success, import failure, or wipe).
  */
 export async function bootstrapScopeFromSnapshot(params: {
   db: OfflineDatabase;
@@ -489,28 +501,38 @@ export async function bootstrapScopeFromSnapshot(params: {
   // a wipe cycle that completes during the integrity checks is caught.
   const startEpoch = getWipeEpoch();
 
-  let attached = false;
+  let watermarks: Record<SnapshotTableName, SyncCheckpoint> | null = null;
   try {
-    // Defensive detach first: a failed DETACH from a previous scope in this run
-    // (swallowed in the finally below) would leave the alias attached and make
-    // this ATTACH fail for every remaining scope. Clearing it here confines a
-    // DETACH failure to its own scope.
-    await db.execAsync(`DETACH DATABASE ${SNAPSHOT_ALIAS}`).catch(() => {});
-    await db.execAsync(`ATTACH DATABASE '${filePath.replace(/'/g, "''")}' AS ${SNAPSHOT_ALIAS}`);
-    attached = true;
-
-    const integrity = await db.getAllAsync<{ quick_check: string }>(`PRAGMA ${SNAPSHOT_ALIAS}.quick_check`);
-    if (integrity.length !== 1 || integrity[0].quick_check !== 'ok') {
-      throw new Error(`snapshot bootstrap: quick_check failed: ${integrity.map((row) => row.quick_check).join('; ')}`);
-    }
-
-    await verifySnapshotMeta(db);
-    const watermarks = await scopedWatermarks(db, scope);
-
-    if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
-
     await db.withExclusiveTransactionAsync(async (txn) => {
-      if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
+      // Close the wrapper's (empty, deferred) transaction so ATTACH is legal,
+      // then re-open below. Every throw in this autocommit window must restore
+      // an open transaction first — the wrapper's unconditional ROLLBACK would
+      // otherwise itself fail and mask the real error (which the caller
+      // dispatches on, e.g. SnapshotSchemaStaleError vs a counted failure).
+      await txn.execAsync('COMMIT');
+      try {
+        await txn.execAsync(`ATTACH DATABASE '${filePath.replace(/'/g, "''")}' AS ${SNAPSHOT_ALIAS}`);
+
+        const integrity = await txn.getAllAsync<{ quick_check: string }>(`PRAGMA ${SNAPSHOT_ALIAS}.quick_check`);
+        if (integrity.length !== 1 || integrity[0].quick_check !== 'ok') {
+          throw new Error(
+            `snapshot bootstrap: quick_check failed: ${integrity.map((row) => row.quick_check).join('; ')}`,
+          );
+        }
+
+        await verifySnapshotMeta(txn);
+        watermarks = await scopedWatermarks(txn, scope);
+
+        if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
+
+        // The import can take seconds on a big layout; don't let a concurrent
+        // write on the app's main connection fail it with SQLITE_BUSY.
+        await txn.execAsync('PRAGMA busy_timeout = 5000');
+        await txn.execAsync('BEGIN EXCLUSIVE');
+      } catch (preTransactionError) {
+        await txn.execAsync('BEGIN').catch(() => {});
+        throw preTransactionError;
+      }
 
       await reconcileScope(txn, scope, watermarks);
       await importScope(txn, scope, onSchemaDrift);
@@ -534,11 +556,15 @@ export async function bootstrapScopeFromSnapshot(params: {
           : watermarks.board_climb_stats;
       await rewindDeletionsCheckpoint(txn, minWatermark);
     });
-
-    return { climbsWatermark: watermarks.board_climbs, statsWatermark: watermarks.board_climb_stats };
   } finally {
-    if (attached) {
-      await db.execAsync(`DETACH DATABASE ${SNAPSHOT_ALIAS}`).catch(() => {});
-    }
+    // On expo the wrapper's connection teardown already detached; this covers
+    // same-connection OfflineDatabase implementations (the node test double's
+    // in-memory mode), where the alias would otherwise leak across scopes.
+    await db.execAsync(`DETACH DATABASE ${SNAPSHOT_ALIAS}`).catch(() => {});
   }
+
+  // Unreachable null: the transaction either set watermarks or threw.
+  if (!watermarks) throw new Error('snapshot bootstrap: transaction completed without watermarks');
+  const finalWatermarks: Record<SnapshotTableName, SyncCheckpoint> = watermarks;
+  return { climbsWatermark: finalWatermarks.board_climbs, statsWatermark: finalWatermarks.board_climb_stats };
 }

--- a/packages/shared/offline-sync/src/testing/sqlite-test-db.ts
+++ b/packages/shared/offline-sync/src/testing/sqlite-test-db.ts
@@ -22,10 +22,12 @@ function normalizeParams(params: (SqlBindValue | SqlBindValue[])[]): SqlBindValu
 
 class NodeSqliteAdapter {
   private readonly db: DatabaseSync;
+  private readonly location: string;
   private inTransaction = false;
 
-  constructor(db: DatabaseSync) {
+  constructor(db: DatabaseSync, location: string) {
     this.db = db;
+    this.location = location;
   }
 
   async execAsync(source: string): Promise<void> {
@@ -53,13 +55,43 @@ class NodeSqliteAdapter {
   }
 
   async withExclusiveTransactionAsync(task: (txn: NodeSqliteAdapter) => Promise<void>): Promise<void> {
-    // node:sqlite has no separate transaction connection; model the contract with
-    // BEGIN/COMMIT on this connection and roll back on failure. Nesting is guarded
-    // because our code never nests exclusive transactions.
     if (this.inTransaction) {
       await task(this);
       return;
     }
+
+    // File-backed databases mirror expo-sqlite EXACTLY: withExclusiveTransactionAsync
+    // opens a NEW native connection (`useNewConnection: true`) for the task, so
+    // per-connection state from the main connection — ATTACHed databases, temp
+    // tables, PRAGMAs — is NOT visible inside it, and the wrapper's shape is
+    // BEGIN → task → COMMIT (ROLLBACK on throw) → close. Snapshot bootstrap
+    // shipped with an ATTACH the transaction couldn't see because the old
+    // same-connection model here hid the difference (Sentry BOARDSESH-AA) —
+    // suites exercising cross-connection behaviour must use a file-backed DB.
+    if (this.location !== ':memory:') {
+      const transactionDb = new DatabaseSync(this.location);
+      const transactionAdapter = new NodeSqliteAdapter(transactionDb, this.location);
+      transactionAdapter.inTransaction = true;
+      let taskError: unknown;
+      try {
+        transactionDb.exec('BEGIN');
+        await task(transactionAdapter);
+        transactionDb.exec('COMMIT');
+      } catch (error) {
+        // Mirror expo: ROLLBACK runs unconditionally; if it throws (no open
+        // transaction), THAT error propagates and masks the task's — the exact
+        // behaviour bootstrap's restore-BEGIN guard exists for.
+        transactionDb.exec('ROLLBACK');
+        taskError = error;
+      } finally {
+        transactionDb.close();
+      }
+      if (taskError) throw taskError;
+      return;
+    }
+
+    // In-memory databases can't be opened from a second connection; model the
+    // contract with BEGIN/COMMIT on this connection and roll back on failure.
     this.inTransaction = true;
     this.db.exec('BEGIN');
     try {
@@ -80,9 +112,16 @@ class NodeSqliteAdapter {
 
 export type TestSqliteDb = NodeSqliteAdapter & OfflineDatabase;
 
-/** Opens a fresh in-memory database adapted to the OfflineDatabase surface. */
-export function createTestDatabase(): TestSqliteDb {
-  const adapter = new NodeSqliteAdapter(new DatabaseSync(':memory:'));
+/**
+ * Opens a database adapted to the OfflineDatabase surface. Defaults to
+ * in-memory; pass a file path to get expo-faithful exclusive-transaction
+ * semantics (the task runs on a SEPARATE connection — see
+ * withExclusiveTransactionAsync above). Any suite touching ATTACH, temp
+ * tables, or per-connection PRAGMAs inside a transaction must be file-backed
+ * or it tests semantics the device doesn't have.
+ */
+export function createTestDatabase(location: string = ':memory:'): TestSqliteDb {
+  const adapter = new NodeSqliteAdapter(new DatabaseSync(location), location);
   // The adapter's variadic methods satisfy OfflineDatabase's overload pair
   // behaviorally; cast through unknown so call sites get the interface type.
   return adapter as unknown as TestSqliteDb;


### PR DESCRIPTION
Fixes [BOARDSESH-AA](https://boardsesh.sentry.io/issues/7611694682/) — snapshot bootstrap failed on every device with `no such table: bs_snapshot.board_climb_stats`, which is why the flag ramp was rolled back to 0%.

**Root cause**: expo-sqlite's `withExclusiveTransactionAsync` runs its task on a **new native connection** (`useNewConnection: true` — `Transaction.createAsync` in expo-sqlite 57). SQLite `ATTACH`es are per-connection, so the artifact attached on the main connection didn't exist inside the import transaction. The first alias reference in the transaction is the stats reconcile `DELETE ... NOT EXISTS (SELECT ... FROM bs_snapshot.board_climb_stats)` — the exact Sentry error. All 200 tests were green because the node double ran transactions on the same connection.

**Fix**: the bootstrap now attaches, quick_checks, verifies meta, computes watermarks, and imports entirely on the transaction's own connection. The expo wrapper opens a deferred `BEGIN` before the task and `ATTACH` is illegal inside a transaction, so the task COMMITs the empty wrapper transaction, attaches in autocommit mode, then opens the real `BEGIN EXCLUSIVE` that the wrapper's COMMIT/ROLLBACK closes. Connection teardown implicitly detaches on every path. Every throw in the autocommit window restores an open transaction first, so the wrapper's unconditional ROLLBACK can't mask typed errors the caller dispatches on (`SnapshotSchemaStaleError`, `SnapshotWipedError`).

**Regression net**: the node test double now mirrors expo exactly for file-backed databases — exclusive transactions run on a separate connection with the same BEGIN/COMMIT/ROLLBACK/close shape — and the snapshot suite runs file-backed. Reverting just the engine fix makes 14 tests fail with the verbatim production error.

Post-merge plan: verify one real bootstrap on the iOS simulator against the production manifest, then re-enable the `offline-snapshot-bootstrap` flag.

## Release Notes

- Downloading a board for offline use now completes in seconds instead of minutes — the app grabs a pre-built copy of the catalog instead of crawling it climb by climb. (This fixes the fast path so it actually kicks in.)