### PR TITLE
fix(mobile): rotate the snapshot bootstrap flag key to -v2

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -240,8 +240,8 @@ pre-import empty result set.
 - **PostHog flags** (`packages/mobile/src/providers/feature-flags-provider.tsx`):
   - `offline-board-downloads` — the whole offline engine (downloads, local-first reads, queued
     offline writes, background sync). Missing/undefined reads as **off**.
-  - `offline-snapshot-bootstrap` — nested under the flag above: whether a freshly-enabled scope warms
-    from the snapshot at all. With `offline-board-downloads` on and `offline-snapshot-bootstrap` off, a
+  - `offline-snapshot-bootstrap-v2` — nested under the flag above: whether a freshly-enabled scope warms
+    from the snapshot at all. With `offline-board-downloads` on and `offline-snapshot-bootstrap-v2` off, a
     fresh board still downloads — just via the paged crawl. `OfflineSyncBridge`
     (`packages/mobile/src/components/offline-sync-bridge.tsx`) only passes `mobileSnapshotSource` to the
     sync scheduler when `useSnapshotBootstrapEnabled()` is true **and** `EXPO_PUBLIC_SNAPSHOT_BASE_URL` is
@@ -319,7 +319,7 @@ manifest) and the export re-bases entry URLs onto it. Keep it consistent with
 
 ### Kill switches
 
-- **Fastest, no deploy**: flip the `offline-snapshot-bootstrap` PostHog flag off. Every client falls back
+- **Fastest, no deploy**: flip the `offline-snapshot-bootstrap-v2` PostHog flag off. Every client falls back
   to the paged crawl for newly-enabled boards; nothing already bootstrapped is affected (it's already past
   the eligibility check).
 - **Nuclear, affects every client regardless of flag state after cache expiry**: delete the
@@ -388,7 +388,7 @@ page — that's the trigger to prioritize the fix.
 
 ## Rollout plan
 
-1. **Internal testers**: flip `offline-snapshot-bootstrap` on for the `tester` PostHog cohort only.
+1. **Internal testers**: flip `offline-snapshot-bootstrap-v2` on for the `tester` PostHog cohort only.
 2. **Two pre-ramp manual verifications** (do both before any percentage ramp):
    - Confirm `EXPO_PUBLIC_SNAPSHOT_BASE_URL` is set to the real Tigris bucket URL in the build that will
      ship to testers. With the env var missing, the flag is inert and the app intentionally uses the paged

--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -111,7 +111,10 @@ function makeQueryClient() {
 
 const FLAG_ON: FeatureFlags = { 'offline-board-downloads': true };
 const FLAG_OFF: FeatureFlags = { 'offline-board-downloads': false };
-const FLAG_ON_WITH_SNAPSHOT: FeatureFlags = { 'offline-board-downloads': true, 'offline-snapshot-bootstrap': true };
+const FLAG_ON_WITH_SNAPSHOT: FeatureFlags = {
+  'offline-board-downloads': true,
+  'offline-snapshot-bootstrap-v2': true,
+};
 function getStartSyncSchedulerSnapshotSource(): unknown {
   const call = startSyncSchedulerMock.mock.calls[0] as unknown[] | undefined;
   expect(call).toBeDefined();

--- a/packages/mobile/src/offline/use-snapshot-source.ts
+++ b/packages/mobile/src/offline/use-snapshot-source.ts
@@ -5,7 +5,7 @@ import { mobileSnapshotSource } from './snapshot-source';
 
 /**
  * The one gate for handing the engine snapshot I/O: the
- * `offline-snapshot-bootstrap` flag (nested under `offline-board-downloads`)
+ * `offline-snapshot-bootstrap-v2` flag (nested under `offline-board-downloads`)
  * AND a real build-time manifest URL. `undefined` otherwise, which makes
  * `pullSync` skip the bootstrap phase entirely — a freshly-enabled board still
  * downloads, just through the paged crawl. Every caller that starts or

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -59,7 +59,12 @@ export const FEATURE_FLAG_DEFINITIONS = [
       'The whole offline engine: board downloads, local-first climb reads, queued offline ticks/favorites, background sync. Off fully disables it (previously-queued writes still flush).',
   },
   {
-    key: 'offline-snapshot-bootstrap',
+    // v2, deliberately a NEW PostHog key: bundles published before the
+    // BOARDSESH-AA connection fix (739d92a3c) read `offline-snapshot-bootstrap`,
+    // where bootstrap always failed and burned two artifact downloads per fresh
+    // board. That key stays at 0% forever so broken bundles can never re-enter
+    // the snapshot path; only fixed bundles know this key.
+    key: 'offline-snapshot-bootstrap-v2',
     label: 'Offline snapshot bootstrap',
     description:
       'Warm a freshly-enabled board from the nightly pre-built SQLite snapshot instead of paging the whole catalog over GraphQL. Requires offline-board-downloads to also be on; off falls back to the plain paged crawl.',
@@ -148,7 +153,7 @@ export function useOfflineDownloadsEnabled(): boolean {
  * consults this when the offline engine itself is already on.
  */
 export function useSnapshotBootstrapEnabled(): boolean {
-  return useFeatureFlag('offline-snapshot-bootstrap') === true;
+  return useFeatureFlag('offline-snapshot-bootstrap-v2') === true;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #3618. Re-enabling `offline-snapshot-bootstrap` would also re-enable the snapshot path on every bundle still running the pre-fix JS, where bootstrap always fails (BOARDSESH-AA) and burns two artifact downloads per fresh board before falling back.

Fixed bundles now read **`offline-snapshot-bootstrap-v2`**; the old key stays at 0% forever, so broken bundles can never re-enter the snapshot path — the flag key itself becomes the fix-version gate. JS-only, ships OTA.

PostHog side (done separately, not in this diff): `offline-snapshot-bootstrap-v2` created at 0%; the old flag's description updated to mark it permanently dead.

## Release Notes

none