### PR TITLE
feat(mobile): follow on find, offer offline, easier My Boards management

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -12,7 +12,9 @@ import { useLocalePreference } from '../../../src/providers/i18n-provider';
 import { resolveLanguage, type LocaleOverride } from '../../../src/lib/i18n/locale-preference';
 import { openExternalUrl } from '../../../src/lib/open-url';
 import { useAuth } from '../../../src/providers/auth-provider';
-import { useProfile } from '../../../src/lib/graphql/hooks';
+import { useProfile, useMyBoards } from '../../../src/lib/graphql/hooks';
+import { useBoardDownloads } from '../../../src/offline/use-board-downloads';
+import { useSetting, setSetting } from '../../../src/settings';
 import { useConfirm } from '../../../src/providers/dialog-provider';
 import { useIsOffline } from '../../../src/hooks/use-is-offline';
 import {
@@ -75,6 +77,14 @@ export default function MoreScreen() {
   const garminWatchEnabled = useFeatureFlag('garmin-watch') === true;
   const offlineEnabled = useOfflineDownloadsEnabled();
   const confirm = useConfirm();
+
+  // "Keep boards offline by default" toggle. Turning it on downloads every board
+  // already in My Boards now (user chose this over a future-only default), and the
+  // adopt-on-select flow auto-downloads new boards from then on.
+  const [autoOfflineBoards] = useSetting('autoOfflineBoards');
+  const { enableBoardsOffline } = useBoardDownloads();
+  const { data: myBoardsConnection } = useMyBoards(undefined, { enabled: offlineEnabled && !!profile });
+  const myBoards = myBoardsConnection?.boards ?? [];
 
   // Offline sync-issues surface. Poll the dead-letter count only while online (the
   // section is hidden offline — a pending write offline is expected, not a "stuck"
@@ -392,6 +402,33 @@ export default function MoreScreen() {
         : []),
     ],
   });
+
+  // Offline — keep boards available with no signal. Gated by the offline feature
+  // flag (the whole offline surface is flag-gated). Turning it on downloads every
+  // current board now; future boards auto-download via the adopt-on-select flow.
+  if (offlineEnabled) {
+    sections.push({
+      key: 'offline',
+      title: t('mobile.more.offline.title'),
+      rows: [
+        {
+          kind: 'toggle',
+          key: 'autoOfflineBoards',
+          label: t('mobile.more.offline.autoDownload'),
+          subtitle: t('mobile.more.offline.autoDownloadDescription'),
+          value: autoOfflineBoards,
+          onValueChange: (next) => {
+            hapticSelection();
+            setSetting('autoOfflineBoards', next);
+            if (next && myBoards.length > 0) {
+              enableBoardsOffline(myBoards);
+              showToast(t('mobile.more.offline.downloadingAll', { count: myBoards.length }), 'info');
+            }
+          },
+        },
+      ],
+    });
+  }
 
   // Accessibility (nav).
   sections.push({

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { router } from 'expo-router';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
@@ -14,7 +14,7 @@ import { openExternalUrl } from '../../../src/lib/open-url';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useProfile, useMyBoards } from '../../../src/lib/graphql/hooks';
 import { useBoardDownloads } from '../../../src/offline/use-board-downloads';
-import { useSetting, setSetting } from '../../../src/settings';
+import { useSetting, setSetting, getSetting, offlineBoardKeyForBoard } from '../../../src/settings';
 import { useConfirm } from '../../../src/providers/dialog-provider';
 import { useIsOffline } from '../../../src/hooks/use-is-offline';
 import {
@@ -85,6 +85,17 @@ export default function MoreScreen() {
   const { enableBoardsOffline } = useBoardDownloads();
   const { data: myBoardsConnection } = useMyBoards(undefined, { enabled: offlineEnabled && !!profile });
   const myBoards = myBoardsConnection?.boards ?? [];
+
+  // With the default on, keep every board offline. Runs on mount and once My Boards
+  // resolves, so flipping the toggle before the list loaded still downloads
+  // everything. Only enables boards not already opted in, so once they're all in
+  // it's a no-op — no repeated sync kicks.
+  useEffect(() => {
+    if (!offlineEnabled || !autoOfflineBoards || myBoards.length === 0) return;
+    const enabled = new Set(getSetting('syncEnabledBoards'));
+    const missing = myBoards.filter((board) => !enabled.has(offlineBoardKeyForBoard(board)));
+    if (missing.length > 0) enableBoardsOffline(missing);
+  }, [offlineEnabled, autoOfflineBoards, myBoards, enableBoardsOffline]);
 
   // Offline sync-issues surface. Poll the dead-letter count only while online (the
   // section is hidden offline — a pending write offline is expected, not a "stuck"
@@ -419,10 +430,15 @@ export default function MoreScreen() {
           value: autoOfflineBoards,
           onValueChange: (next) => {
             hapticSelection();
+            // The effect above does the enabling + download (robust to a not-yet-
+            // loaded list); here we just persist and surface how many will pull down.
             setSetting('autoOfflineBoards', next);
-            if (next && myBoards.length > 0) {
-              enableBoardsOffline(myBoards);
-              showToast(t('mobile.more.offline.downloadingAll', { count: myBoards.length }), 'info');
+            if (next) {
+              const enabled = new Set(getSetting('syncEnabledBoards'));
+              const missing = myBoards.filter((board) => !enabled.has(offlineBoardKeyForBoard(board)));
+              if (missing.length > 0) {
+                showToast(t('mobile.more.offline.downloadingAll', { count: missing.length }), 'info');
+              }
             }
           },
         },

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { router } from 'expo-router';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
@@ -88,16 +88,22 @@ export default function MoreScreen() {
   // offline effect below depends on this array and shouldn't re-run every render.
   const myBoards = useMemo(() => myBoardsConnection?.boards ?? [], [myBoardsConnection]);
 
+  // Boards in My Boards not yet opted into offline (single source of truth for both
+  // the effect that enables them and the toast that reports the count).
+  const missingOfflineBoards = useCallback(() => {
+    const enabled = new Set(getSetting('syncEnabledBoards'));
+    return myBoards.filter((board) => !enabled.has(offlineBoardKeyForBoard(board)));
+  }, [myBoards]);
+
   // With the default on, keep every board offline. Runs on mount and once My Boards
   // resolves, so flipping the toggle before the list loaded still downloads
   // everything. Only enables boards not already opted in, so once they're all in
   // it's a no-op — no repeated sync kicks.
   useEffect(() => {
     if (!offlineEnabled || !autoOfflineBoards || myBoards.length === 0) return;
-    const enabled = new Set(getSetting('syncEnabledBoards'));
-    const missing = myBoards.filter((board) => !enabled.has(offlineBoardKeyForBoard(board)));
+    const missing = missingOfflineBoards();
     if (missing.length > 0) enableBoardsOffline(missing);
-  }, [offlineEnabled, autoOfflineBoards, myBoards, enableBoardsOffline]);
+  }, [offlineEnabled, autoOfflineBoards, myBoards, missingOfflineBoards, enableBoardsOffline]);
 
   // Offline sync-issues surface. Poll the dead-letter count only while online (the
   // section is hidden offline — a pending write offline is expected, not a "stuck"
@@ -436,8 +442,7 @@ export default function MoreScreen() {
             // loaded list); here we just persist and surface how many will pull down.
             setSetting('autoOfflineBoards', next);
             if (next) {
-              const enabled = new Set(getSetting('syncEnabledBoards'));
-              const missing = myBoards.filter((board) => !enabled.has(offlineBoardKeyForBoard(board)));
+              const missing = missingOfflineBoards();
               if (missing.length > 0) {
                 showToast(t('mobile.more.offline.downloadingAll', { count: missing.length }), 'info');
               }

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { router } from 'expo-router';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
@@ -84,7 +84,9 @@ export default function MoreScreen() {
   const [autoOfflineBoards] = useSetting('autoOfflineBoards');
   const { enableBoardsOffline } = useBoardDownloads();
   const { data: myBoardsConnection } = useMyBoards(undefined, { enabled: offlineEnabled && !!profile });
-  const myBoards = myBoardsConnection?.boards ?? [];
+  // Memoized so the empty-while-loading fallback keeps a stable identity — the
+  // offline effect below depends on this array and shouldn't re-run every render.
+  const myBoards = useMemo(() => myBoardsConnection?.boards ?? [], [myBoardsConnection]);
 
   // With the default on, keep every board offline. Runs on mount and once My Boards
   // resolves, so flipping the toggle before the list loaded still downloads

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -6,6 +6,7 @@ import type BottomSheet from '@expo/ui/community/bottom-sheet';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { useMyBoards, usePopularBoardConfigs, useNearbyBoards } from '../../src/lib/graphql/hooks';
 import { useActiveBoard, useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
+import { useAdoptFoundBoard } from '../../src/lib/board-discovery/use-adopt-found-board';
 import { useDeviceLocation } from '../../src/lib/use-device-location';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useToast } from '../../src/providers/toast-provider';
@@ -43,6 +44,7 @@ export default function BoardSelection() {
   const scrollBottomPadding = bottomChrome.scrollBottomPadding;
 
   const setActiveBoard = useSetActiveBoard();
+  const adoptFoundBoard = useAdoptFoundBoard();
   const { data: activeBoard } = useActiveBoard();
 
   const {
@@ -92,11 +94,15 @@ export default function BoardSelection() {
         // there opened it (replaces with that tab if it isn't already underneath,
         // e.g. opened from a deep link).
         router.dismissTo(boardReturnTo);
+        // Follow the board if it's new to the user (so it lands in My Boards) and
+        // offer/auto-run its offline download. The isNew guard makes re-selecting a
+        // board already in My Boards a no-op for follow.
+        void adoptFoundBoard(board);
       } catch {
         showToast(t('mobile.boardSwitchError'), 'error');
       }
     },
-    [setActiveBoard, router, boardReturnTo, showToast, t, fromOnboarding],
+    [setActiveBoard, adoptFoundBoard, router, boardReturnTo, showToast, t, fromOnboarding],
   );
 
   const myBoardItems = useMemo(

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -96,7 +96,9 @@ export default function BoardSelection() {
         router.dismissTo(boardReturnTo);
         // Follow the board if it's new to the user (so it lands in My Boards) and
         // offer/auto-run its offline download. The isNew guard makes re-selecting a
-        // board already in My Boards a no-op for follow.
+        // board already in My Boards a no-op for follow. Fire-and-forget: its own
+        // errors are handled inside and intentionally don't reach the catch below
+        // (which only guards the board-switch write above).
         void adoptFoundBoard(board);
       } catch {
         showToast(t('mobile.boardSwitchError'), 'error');

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useMemo } from 'react';
-import { RefreshControl, StyleSheet, View } from 'react-native';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { Pressable, RefreshControl, StyleSheet, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
-import { useRouter } from 'expo-router';
+import { useNavigation, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSQLiteContext } from 'expo-sqlite';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { useMyBoards, useProfile, useDeleteBoard, useUnfollowBoard } from '../../src/lib/graphql/hooks';
 import { useActiveBoard, useClearActiveBoard } from '../../src/lib/graphql/use-active-board';
@@ -14,10 +14,9 @@ import { useConfirm } from '../../src/providers/dialog-provider';
 import { useTheme } from '../../src/providers/theme-provider';
 import { useOfflineDownloadsEnabled } from '../../src/providers/feature-flags-provider';
 import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
-import { useSyncStatus, setSyncProgress } from '../../src/sync';
-import { getDownloadedScopeKeys, type GraphQLFetch } from '@boardsesh/offline-sync';
-import { triggerSync, drainMutationQueue } from '../../src/offline/offline-sync-adapter';
-import { useSnapshotSource } from '../../src/offline/use-snapshot-source';
+import { useSyncStatus } from '../../src/sync';
+import { getDownloadedScopeKeys } from '@boardsesh/offline-sync';
+import { useBoardDownloads } from '../../src/offline/use-board-downloads';
 import {
   getSetting,
   useSetting,
@@ -25,7 +24,7 @@ import {
   offlineBoardKeyForBoard,
   offlineBoardScopeForBoard,
 } from '../../src/settings';
-import { getHttpClient } from '../../src/lib/graphql/client';
+import { hapticSelection } from '../../src/lib/haptics';
 import { Text } from '../../src/components/Text';
 import { Icon } from '../../src/components/Icon';
 import { Button } from '../../src/components/Button';
@@ -43,6 +42,7 @@ const getItemType = (item: ManageItem) => item.type;
 
 export default function ManageBoards() {
   const router = useRouter();
+  const navigation = useNavigation();
   const { t } = useTranslation('boards');
   const { isAuthenticated, refreshAuthState } = useAuth();
   const { systemColors, brandColors } = useTheme();
@@ -50,6 +50,11 @@ export default function ManageBoards() {
   const confirm = useConfirm();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[4];
+
+  // Traditional iOS-style edit mode: an "Edit"/"Done" header button reveals a
+  // persistent per-row remove control, so unfollow/delete never depend on the
+  // (hard-to-hit) swipe alone.
+  const [isEditing, setIsEditing] = useState(false);
 
   const {
     data: profile,
@@ -85,9 +90,8 @@ export default function ManageBoards() {
   // flush (see OfflineSyncBridge). This screen stays the only writer of
   // syncEnabledBoards.
   const offlineDownloadsEnabled = useOfflineDownloadsEnabled();
-  const snapshotSource = useSnapshotSource();
+  const { enableBoardsOffline } = useBoardDownloads();
   const db = useSQLiteContext();
-  const queryClient = useQueryClient();
   const syncStatus = useSyncStatus();
   const [enabledBoards] = useSetting('syncEnabledBoards');
   const enabledSet = useMemo(() => new Set(enabledBoards), [enabledBoards]);
@@ -109,12 +113,6 @@ export default function ManageBoards() {
     if (offlineDownloadsEnabled && !isSyncing) void refetchDownloaded();
   }, [offlineDownloadsEnabled, isSyncing, refetchDownloaded]);
 
-  const graphqlFetch = useMemo<GraphQLFetch>(() => (query, variables) => getHttpClient().request(query, variables), []);
-  const drainQueue = useCallback(
-    () => drainMutationQueue(db, queryClient, graphqlFetch),
-    [db, queryClient, graphqlFetch],
-  );
-
   const handleToggleOffline = useCallback(
     async (board: UserBoard) => {
       const scope = offlineBoardScopeForBoard(board);
@@ -133,17 +131,11 @@ export default function ManageBoards() {
         cancelLabel: t('mobile.manage.cancel'),
       });
       if (!confirmed) return;
-      setOfflineBoardEnabled(scope, true);
-      // Kick a sync now so the download starts immediately rather than waiting for
-      // the next foreground/reconnect trigger. triggerSync → runSync is single-flight
-      // (one in-flight run + at most one queued follow-up), so enabling several boards
-      // in quick succession collapses into one cycle that reads the latest setting.
-      triggerSync(db, queryClient, graphqlFetch, () => getSetting('syncEnabledBoards'), drainQueue, {
-        onProgress: setSyncProgress,
-        snapshotSource,
-      });
+      // Enable + kick a download now via the shared hook (single-flight, reads the
+      // latest syncEnabledBoards setting).
+      enableBoardsOffline(board);
     },
-    [confirm, t, db, queryClient, graphqlFetch, drainQueue, snapshotSource],
+    [confirm, t, enableBoardsOffline],
   );
 
   // See boards/index.tsx: a hard 401 clears tokens without flipping
@@ -241,6 +233,7 @@ export default function ManageBoards() {
           board={item.board}
           isOwned={item.isOwned}
           isActive={item.isActive}
+          isEditing={isEditing}
           isMutating={isMutating}
           downloadState={downloadState}
           downloadCount={downloadCount}
@@ -257,6 +250,7 @@ export default function ManageBoards() {
       deleteBoard.variables,
       unfollowBoard.isPending,
       unfollowBoard.variables,
+      isEditing,
       offlineDownloadsEnabled,
       enabledSet,
       isSyncing,
@@ -270,6 +264,33 @@ export default function ManageBoards() {
       handleToggleOffline,
     ],
   );
+
+  // Edit / Done lives in the native header. Only offered when there are boards to
+  // manage; collapse edit mode if the list empties out (last board removed).
+  const hasBoards = myBoards.length > 0;
+  useEffect(() => {
+    if (!hasBoards && isEditing) setIsEditing(false);
+  }, [hasBoards, isEditing]);
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: hasBoards
+        ? () => (
+            <Pressable
+              onPress={() => {
+                hapticSelection();
+                setIsEditing((prev) => !prev);
+              }}
+              hitSlop={8}
+              accessibilityRole="button"
+            >
+              <Text variant="body" color={brandColors.primary}>
+                {isEditing ? t('mobile.manage.done') : t('mobile.manage.edit')}
+              </Text>
+            </Pressable>
+          )
+        : undefined,
+    });
+  }, [navigation, hasBoards, isEditing, t, brandColors.primary]);
 
   if (!isAuthenticated) {
     return (

--- a/packages/mobile/app/gyms/index.tsx
+++ b/packages/mobile/app/gyms/index.tsx
@@ -7,6 +7,7 @@ import type { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
 import type { BoardName, Gym, UserBoard } from '@boardsesh/shared-schema';
 import { useNearbyBoards, useNearbyGyms } from '../../src/lib/graphql/hooks';
 import { useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
+import { useAdoptFoundBoard } from '../../src/lib/board-discovery/use-adopt-found-board';
 import { useDeviceLocation, type Coords } from '../../src/lib/use-device-location';
 import { useGeocodePlace } from '../../src/lib/use-place-search';
 import { useToast } from '../../src/providers/toast-provider';
@@ -72,6 +73,7 @@ export default function GymDiscovery() {
   const location = useDeviceLocation();
   const { geocode, isGeocoding } = useGeocodePlace();
   const setActiveBoard = useSetActiveBoard();
+  const adoptFoundBoard = useAdoptFoundBoard();
   const { returnTo } = useLocalSearchParams<{ returnTo?: string }>();
   const boardReturnTo = resolveBoardReturnTo(returnTo);
   const [expandedGymUuid, setExpandedGymUuid] = useState<string | null>(null);
@@ -255,11 +257,15 @@ export default function GymDiscovery() {
       try {
         await setActiveBoard(board);
         router.dismissTo(boardReturnTo);
+        // Follow the board (so it lands in My Boards) and offer to make it available
+        // offline. Fire-and-forget after navigating — the follow is idempotent and the
+        // offline confirm rides the root dialog, which survives the dismiss.
+        void adoptFoundBoard(board);
       } catch {
         showToast(t('mobile.boardSwitchError'), 'error');
       }
     },
-    [setActiveBoard, router, boardReturnTo, showToast, t],
+    [setActiveBoard, adoptFoundBoard, router, boardReturnTo, showToast, t],
   );
 
   // Edit a board / gym the viewer can edit (the row only renders the pencil when

--- a/packages/mobile/app/gyms/index.tsx
+++ b/packages/mobile/app/gyms/index.tsx
@@ -259,7 +259,9 @@ export default function GymDiscovery() {
         router.dismissTo(boardReturnTo);
         // Follow the board (so it lands in My Boards) and offer to make it available
         // offline. Fire-and-forget after navigating — the follow is idempotent and the
-        // offline confirm rides the root dialog, which survives the dismiss.
+        // offline confirm rides the root dialog, which survives the dismiss. Its own
+        // errors are handled inside (follow onError toast); they intentionally don't
+        // reach this catch, which is only for the board-switch write above.
         void adoptFoundBoard(board);
       } catch {
         showToast(t('mobile.boardSwitchError'), 'error');

--- a/packages/mobile/src/components/SwipeableRow.tsx
+++ b/packages/mobile/src/components/SwipeableRow.tsx
@@ -12,7 +12,9 @@ import type { IconName } from './icon-map';
 import { iosSystemColors } from '../theme/ios-colors';
 import { hapticMedium } from '../lib/haptics';
 
-const SWIPE_OPEN_THRESHOLD = -80;
+// A short deliberate drag opens the action (was -80, which felt stiff inside a
+// scrolling FlashList).
+const SWIPE_OPEN_THRESHOLD = -56;
 const ACTION_BUTTON_WIDTH = 80;
 const CLOSE_SPRING = { damping: 20, stiffness: 200 };
 
@@ -90,8 +92,11 @@ function SwipeableRowComponent({
     () =>
       Gesture.Pan()
         .enabled(enabled)
-        .activeOffsetX([-10, 10])
-        .failOffsetY([-5, 5])
+        // Activate on a small horizontal move, and only bail when the drag is
+        // clearly vertical — the old [-5,5] failed on the tiniest vertical drift,
+        // so the swipe almost never engaged over a scrolling list.
+        .activeOffsetX([-8, 8])
+        .failOffsetY([-20, 20])
         .onUpdate((event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
           // Only allow swiping left.
           if (event.translationX > 0) {

--- a/packages/mobile/src/components/SwipeableRow.tsx
+++ b/packages/mobile/src/components/SwipeableRow.tsx
@@ -92,11 +92,14 @@ function SwipeableRowComponent({
     () =>
       Gesture.Pan()
         .enabled(enabled)
-        // Activate on a small horizontal move, and only bail when the drag is
-        // clearly vertical — the old [-5,5] failed on the tiniest vertical drift,
-        // so the swipe almost never engaged over a scrolling list.
-        .activeOffsetX([-8, 8])
-        .failOffsetY([-20, 20])
+        // Activate once the drag is clearly horizontal (10px), and bail once it's
+        // clearly vertical (14px). The old [-5,5] vertical bail was so tight that
+        // the normal wobble of a horizontal swipe tripped it, so the swipe almost
+        // never engaged; 14px tolerates that wobble while still ceding to a real
+        // vertical scroll (which crosses 14px in Y well before 10px in X). The
+        // Edit button is the guaranteed-reliable path regardless of this feel.
+        .activeOffsetX([-10, 10])
+        .failOffsetY([-14, 14])
         .onUpdate((event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
           // Only allow swiping left.
           if (event.translationX > 0) {

--- a/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { Pressable, View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { toBoardName } from '@boardsesh/board-config';
@@ -23,6 +23,12 @@ type BoardManageRowProps = {
   /** True when the user owns this board (edit/delete); false for followed boards (unfollow). */
   isOwned: boolean;
   isActive: boolean;
+  /**
+   * Edit mode (from the header "Edit" button): show a persistent leading remove
+   * control (Delete for owned, Unfollow for followed) and disable the swipe, so the
+   * destructive action never depends on the hard-to-hit swipe gesture.
+   */
+  isEditing?: boolean;
   /** A mutation targeting this row is in flight — show a spinner and disable the swipe. */
   isMutating: boolean;
   /**
@@ -57,6 +63,7 @@ function BoardManageRowComponent({
   board,
   isOwned,
   isActive,
+  isEditing = false,
   isMutating,
   downloadState,
   downloadCount,
@@ -114,6 +121,22 @@ function BoardManageRowComponent({
 
   const content = (
     <View style={[styles.row, { backgroundColor: systemColors.background, borderBottomColor: systemColors.separator }]}>
+      {isEditing ? (
+        <Pressable
+          onPress={isOwned ? () => onDelete(board) : () => onUnfollow(board)}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={
+            isOwned
+              ? t('mobile.manage.deleteAria', { name: board.name })
+              : t('mobile.manage.unfollowAria', { name: board.name })
+          }
+          style={({ pressed }) => [styles.removeControl, pressed && styles.pressed]}
+        >
+          <Icon name="minus.circle" size={24} color={iosSystemColors.systemRed} />
+        </Pressable>
+      ) : null}
+
       <View
         style={[
           styles.thumb,
@@ -180,7 +203,7 @@ function BoardManageRowComponent({
 
       {isMutating ? (
         <ActivityIndicator size="small" />
-      ) : isOwned ? (
+      ) : !isEditing && isOwned ? (
         <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
       ) : null}
     </View>
@@ -188,8 +211,8 @@ function BoardManageRowComponent({
 
   return (
     <SwipeableRow
-      onPress={isOwned ? () => onEdit(board) : undefined}
-      pressAccessibilityLabel={isOwned ? t('mobile.manage.editAria', { name: board.name }) : undefined}
+      onPress={isOwned && !isEditing ? () => onEdit(board) : undefined}
+      pressAccessibilityLabel={isOwned && !isEditing ? t('mobile.manage.editAria', { name: board.name }) : undefined}
       onAction={isOwned ? () => onDelete(board) : () => onUnfollow(board)}
       actionLabel={
         isOwned
@@ -198,7 +221,7 @@ function BoardManageRowComponent({
       }
       actionIcon={isOwned ? 'delete' : 'minus.circle'}
       actionColor={isOwned ? iosSystemColors.systemRed : iosSystemColors.systemOrange}
-      enabled={!isMutating}
+      enabled={!isMutating && !isEditing}
       resetKey={board.uuid}
     >
       {content}
@@ -216,6 +239,14 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
     paddingHorizontal: spacing[4],
     borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  removeControl: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: 28,
+  },
+  pressed: {
+    opacity: 0.5,
   },
   thumb: {
     width: THUMB_SIZE,

--- a/packages/mobile/src/components/board-discovery/__tests__/board-manage-row.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-manage-row.test.tsx
@@ -12,6 +12,15 @@ const offlineToggleProps = vi.hoisted(() => ({ last: null as Record<string, unkn
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
 
@@ -121,5 +130,30 @@ describe('BoardManageRow offline toggle gating', () => {
     const { queryByText } = render(<BoardManageRow {...rowProps} downloadState="downloading" downloadCount={42} />);
     expect(queryByText('mobile.offline.downloadingCount')).not.toBeNull();
     expect(queryByText('mobile.offline.bootstrapping')).toBeNull();
+  });
+});
+
+describe('BoardManageRow edit mode', () => {
+  it('renders no persistent remove control outside edit mode', () => {
+    const { queryByLabelText } = render(<BoardManageRow {...rowProps} isOwned={false} downloadState={undefined} />);
+    expect(queryByLabelText('mobile.manage.unfollowAria')).toBeNull();
+  });
+
+  it('unfollows a followed board via the persistent remove control in edit mode', () => {
+    const onUnfollow = vi.fn();
+    const { getByLabelText } = render(
+      <BoardManageRow {...rowProps} isOwned={false} isEditing onUnfollow={onUnfollow} downloadState={undefined} />,
+    );
+    getByLabelText('mobile.manage.unfollowAria').click();
+    expect(onUnfollow).toHaveBeenCalledWith(board);
+  });
+
+  it('deletes an owned board via the persistent remove control in edit mode', () => {
+    const onDelete = vi.fn();
+    const { getByLabelText } = render(
+      <BoardManageRow {...rowProps} isOwned isEditing onDelete={onDelete} downloadState={undefined} />,
+    );
+    getByLabelText('mobile.manage.deleteAria').click();
+    expect(onDelete).toHaveBeenCalledWith(board);
   });
 });

--- a/packages/mobile/src/lib/board-discovery/__tests__/adopt-found-board-decision.test.ts
+++ b/packages/mobile/src/lib/board-discovery/__tests__/adopt-found-board-decision.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { decideAdoptFoundBoard, type AdoptFoundBoardParams } from '../adopt-found-board-decision';
+
+const base: AdoptFoundBoardParams = {
+  isOwned: false,
+  isFollowedByMe: false,
+  offlineEnabled: false,
+  autoOffline: false,
+  alreadyEnabledOffline: false,
+};
+
+describe('decideAdoptFoundBoard', () => {
+  describe('follow', () => {
+    it('follows a board that is new to the user (not owned, not followed)', () => {
+      expect(decideAdoptFoundBoard(base).follow).toBe(true);
+    });
+
+    it('does not follow a board the user already follows', () => {
+      expect(decideAdoptFoundBoard({ ...base, isFollowedByMe: true }).follow).toBe(false);
+    });
+
+    it('does not follow a board the user owns', () => {
+      expect(decideAdoptFoundBoard({ ...base, isOwned: true }).follow).toBe(false);
+    });
+  });
+
+  describe('offline offer', () => {
+    it('does nothing about offline when the feature flag is off', () => {
+      expect(decideAdoptFoundBoard({ ...base, offlineEnabled: false }).offline).toBe('none');
+    });
+
+    it('asks for a freshly-found board when the flag is on and auto-offline is off', () => {
+      expect(decideAdoptFoundBoard({ ...base, offlineEnabled: true }).offline).toBe('ask');
+    });
+
+    it('auto-downloads a freshly-found board when auto-offline is on', () => {
+      expect(decideAdoptFoundBoard({ ...base, offlineEnabled: true, autoOffline: true }).offline).toBe('auto');
+    });
+
+    it('never asks when the board is already enabled for offline', () => {
+      expect(decideAdoptFoundBoard({ ...base, offlineEnabled: true, alreadyEnabledOffline: true }).offline).toBe(
+        'none',
+      );
+    });
+
+    it('does not nag when re-selecting an already-followed board (auto-offline off)', () => {
+      expect(decideAdoptFoundBoard({ ...base, isFollowedByMe: true, offlineEnabled: true }).offline).toBe('none');
+    });
+
+    it('auto-downloads an already-followed board when auto-offline is on and it is not enabled yet', () => {
+      const decision = decideAdoptFoundBoard({
+        ...base,
+        isFollowedByMe: true,
+        offlineEnabled: true,
+        autoOffline: true,
+      });
+      expect(decision.follow).toBe(false);
+      expect(decision.offline).toBe('auto');
+    });
+  });
+});

--- a/packages/mobile/src/lib/board-discovery/__tests__/use-adopt-found-board.test.tsx
+++ b/packages/mobile/src/lib/board-discovery/__tests__/use-adopt-found-board.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, cleanup } from '@testing-library/react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+// Wires the pure decision (decideAdoptFoundBoard, imported real) to follow +
+// offline. We mock every I/O dep and assert which side effects fire per scenario,
+// including the follow toast/error paths that ride useFollowBoard's config
+// callbacks (they fire after the picker screen unmounts on navigation).
+
+const cfg = vi.hoisted(() => ({
+  offlineEnabled: false,
+  autoOffline: false,
+  syncEnabled: [] as string[],
+  confirmResult: true,
+}));
+
+const spies = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  enableBoardsOffline: vi.fn(),
+  showToast: vi.fn(),
+  confirm: vi.fn((): Promise<boolean> => Promise.resolve(cfg.confirmResult)),
+  reportError: vi.fn(),
+  followOptions: null as {
+    onFollowed?: (board: Pick<UserBoard, 'uuid' | 'name'>) => void;
+    onFollowError?: (board: Pick<UserBoard, 'uuid' | 'name'>, error: unknown) => void;
+  } | null,
+}));
+
+vi.mock('../../graphql/hooks', () => ({
+  useFollowBoard: (options: NonNullable<typeof spies.followOptions>) => {
+    spies.followOptions = options;
+    return { mutate: spies.mutate };
+  },
+}));
+vi.mock('../../../offline/use-board-downloads', () => ({
+  useBoardDownloads: () => ({ enableBoardsOffline: spies.enableBoardsOffline }),
+}));
+vi.mock('../../../providers/dialog-provider', () => ({ useConfirm: () => spies.confirm }));
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: spies.showToast }) }));
+vi.mock('../../../providers/feature-flags-provider', () => ({
+  useOfflineDownloadsEnabled: () => cfg.offlineEnabled,
+}));
+vi.mock('../../../settings', () => ({
+  useSetting: () => [cfg.autoOffline],
+  getSetting: () => cfg.syncEnabled,
+  offlineBoardKeyForBoard: (board: UserBoard) => `${board.boardType}:${board.layoutId}:${board.sizeId}`,
+}));
+vi.mock('../../error-reporting', () => ({ reportError: spies.reportError }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+import { useAdoptFoundBoard } from '../use-adopt-found-board';
+
+const makeBoard = (over: Partial<UserBoard> = {}): UserBoard =>
+  ({
+    uuid: 'b1',
+    name: 'Garage Kilter',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    isOwned: false,
+    isFollowedByMe: false,
+    ...over,
+  }) as unknown as UserBoard;
+
+beforeEach(() => {
+  cfg.offlineEnabled = false;
+  cfg.autoOffline = false;
+  cfg.syncEnabled = [];
+  cfg.confirmResult = true;
+  spies.mutate.mockClear();
+  spies.enableBoardsOffline.mockClear();
+  spies.showToast.mockClear();
+  spies.confirm.mockClear();
+  spies.reportError.mockClear();
+  spies.followOptions = null;
+});
+
+afterEach(() => cleanup());
+
+describe('useAdoptFoundBoard', () => {
+  it('follows a new board and makes no offline offer when the flag is off', async () => {
+    const { result } = renderHook(() => useAdoptFoundBoard());
+    const board = makeBoard();
+    await result.current(board);
+    expect(spies.mutate).toHaveBeenCalledWith(board);
+    expect(spies.confirm).not.toHaveBeenCalled();
+    expect(spies.enableBoardsOffline).not.toHaveBeenCalled();
+  });
+
+  it('does not follow a board the user already owns', async () => {
+    const { result } = renderHook(() => useAdoptFoundBoard());
+    await result.current(makeBoard({ isOwned: true }));
+    expect(spies.mutate).not.toHaveBeenCalled();
+  });
+
+  it('does not follow a board the user already follows', async () => {
+    const { result } = renderHook(() => useAdoptFoundBoard());
+    await result.current(makeBoard({ isFollowedByMe: true }));
+    expect(spies.mutate).not.toHaveBeenCalled();
+  });
+
+  it('asks before downloading a new board when the flag is on and auto-offline is off', async () => {
+    cfg.offlineEnabled = true;
+    const { result } = renderHook(() => useAdoptFoundBoard());
+    const board = makeBoard();
+    await result.current(board);
+    expect(spies.confirm).toHaveBeenCalledTimes(1);
+    expect(spies.enableBoardsOffline).toHaveBeenCalledWith(board);
+  });
+
+  it('does not download when the confirm is declined', async () => {
+    cfg.offlineEnabled = true;
+    cfg.confirmResult = false;
+    const { result } = renderHook(() => useAdoptFoundBoard());
+    await result.current(makeBoard());
+    expect(spies.confirm).toHaveBeenCalledTimes(1);
+    expect(spies.enableBoardsOffline).not.toHaveBeenCalled();
+  });
+
+  it('auto-downloads without asking when auto-offline is on', async () => {
+    cfg.offlineEnabled = true;
+    cfg.autoOffline = true;
+    const { result } = renderHook(() => useAdoptFoundBoard());
+    const board = makeBoard();
+    await result.current(board);
+    expect(spies.confirm).not.toHaveBeenCalled();
+    expect(spies.enableBoardsOffline).toHaveBeenCalledWith(board);
+  });
+
+  it('never re-offers a board whose scope is already enabled for offline', async () => {
+    cfg.offlineEnabled = true;
+    cfg.syncEnabled = ['kilter:1:10'];
+    const { result } = renderHook(() => useAdoptFoundBoard());
+    await result.current(makeBoard());
+    expect(spies.mutate).toHaveBeenCalledTimes(1); // still follows
+    expect(spies.confirm).not.toHaveBeenCalled();
+    expect(spies.enableBoardsOffline).not.toHaveBeenCalled();
+  });
+
+  it('shows a success toast via the follow onFollowed callback', async () => {
+    const { result } = renderHook(() => useAdoptFoundBoard());
+    const board = makeBoard();
+    await result.current(board);
+    spies.followOptions?.onFollowed?.(board);
+    expect(spies.showToast).toHaveBeenCalledWith('mobile.discovery.followed', 'success');
+  });
+
+  it('surfaces a toast and reports the error when the follow fails', async () => {
+    const { result } = renderHook(() => useAdoptFoundBoard());
+    const board = makeBoard();
+    await result.current(board);
+    const error = new Error('network');
+    spies.followOptions?.onFollowError?.(board, error);
+    expect(spies.reportError).toHaveBeenCalledWith(error);
+    expect(spies.showToast).toHaveBeenCalledWith('mobile.discovery.followError', 'error');
+  });
+});

--- a/packages/mobile/src/lib/board-discovery/adopt-found-board-decision.ts
+++ b/packages/mobile/src/lib/board-discovery/adopt-found-board-decision.ts
@@ -1,0 +1,48 @@
+// Pure decision for what "adopting" a board found in discovery entails. Kept
+// renderer/hook-free so it can be unit-tested without the GraphQL/offline plumbing.
+
+export type AdoptOfflineAction = 'auto' | 'ask' | 'none';
+
+export type AdoptDecision = {
+  /** Follow the board server-side so it lands in My Boards. */
+  follow: boolean;
+  /** What to do about offline availability. */
+  offline: AdoptOfflineAction;
+};
+
+export type AdoptFoundBoardParams = {
+  /** Viewer owns this board. */
+  isOwned: boolean;
+  /** Viewer already follows this board. */
+  isFollowedByMe: boolean;
+  /** The `offline-board-downloads` feature flag is on. */
+  offlineEnabled: boolean;
+  /** The user's "keep all boards offline by default" setting. */
+  autoOffline: boolean;
+  /** This board's scope is already in `syncEnabledBoards`. */
+  alreadyEnabledOffline: boolean;
+};
+
+/**
+ * Decide what adopting a found board means: follow it when it's genuinely new to
+ * the user, and — when offline downloads are available — either auto-download it
+ * (global default on), ask the user, or do nothing.
+ *
+ * The offline offer only *asks* for freshly-found boards. Re-selecting a board you
+ * already own/follow never nags; a global auto-offline default still silently
+ * ensures any not-yet-enabled board gets downloaded.
+ */
+export function decideAdoptFoundBoard({
+  isOwned,
+  isFollowedByMe,
+  offlineEnabled,
+  autoOffline,
+  alreadyEnabledOffline,
+}: AdoptFoundBoardParams): AdoptDecision {
+  const isNew = !isOwned && !isFollowedByMe;
+  const follow = isNew;
+
+  if (!offlineEnabled || alreadyEnabledOffline) return { follow, offline: 'none' };
+  if (autoOffline) return { follow, offline: 'auto' };
+  return { follow, offline: isNew ? 'ask' : 'none' };
+}

--- a/packages/mobile/src/lib/board-discovery/use-adopt-found-board.ts
+++ b/packages/mobile/src/lib/board-discovery/use-adopt-found-board.ts
@@ -7,6 +7,7 @@ import { useConfirm } from '../../providers/dialog-provider';
 import { useToast } from '../../providers/toast-provider';
 import { useOfflineDownloadsEnabled } from '../../providers/feature-flags-provider';
 import { getSetting, useSetting, offlineBoardKeyForBoard } from '../../settings';
+import { reportError } from '../error-reporting';
 import { decideAdoptFoundBoard } from './adopt-found-board-decision';
 
 /**
@@ -24,6 +25,10 @@ export function useAdoptFoundBoard() {
   // screen unmounts on navigation); a per-call mutate callback would be dropped.
   const followBoard = useFollowBoard({
     onFollowed: (board) => showToast(t('mobile.discovery.followed', { name: board.name }), 'success'),
+    onFollowError: (board, error) => {
+      reportError(error);
+      showToast(t('mobile.discovery.followError', { name: board.name }), 'error');
+    },
   });
   const { enableBoardsOffline } = useBoardDownloads();
   const confirm = useConfirm();

--- a/packages/mobile/src/lib/board-discovery/use-adopt-found-board.ts
+++ b/packages/mobile/src/lib/board-discovery/use-adopt-found-board.ts
@@ -1,0 +1,61 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { useFollowBoard } from '../graphql/hooks';
+import { useBoardDownloads } from '../../offline/use-board-downloads';
+import { useConfirm } from '../../providers/dialog-provider';
+import { useToast } from '../../providers/toast-provider';
+import { useOfflineDownloadsEnabled } from '../../providers/feature-flags-provider';
+import { getSetting, useSetting, offlineBoardKeyForBoard } from '../../settings';
+import { decideAdoptFoundBoard } from './adopt-found-board-decision';
+
+/**
+ * Adopt a board the user just picked from discovery (gym finder / Nearby): follow
+ * it so it lands in My Boards, then — when offline downloads are available — offer
+ * (or auto-run) the download per the user's "keep boards offline by default"
+ * setting. Follow is fire-and-forget (idempotent server-side) so it never blocks
+ * navigation; the offline confirm rides the root dialog, which survives the modal
+ * dismiss that navigating away from the picker triggers.
+ */
+export function useAdoptFoundBoard() {
+  const followBoard = useFollowBoard();
+  const { enableBoardsOffline } = useBoardDownloads();
+  const confirm = useConfirm();
+  const { showToast } = useToast();
+  const offlineEnabled = useOfflineDownloadsEnabled();
+  const [autoOffline] = useSetting('autoOfflineBoards');
+  const { t } = useTranslation('boards');
+
+  return useCallback(
+    async (board: UserBoard) => {
+      const decision = decideAdoptFoundBoard({
+        isOwned: board.isOwned,
+        isFollowedByMe: board.isFollowedByMe,
+        offlineEnabled,
+        autoOffline,
+        alreadyEnabledOffline: getSetting('syncEnabledBoards').includes(offlineBoardKeyForBoard(board)),
+      });
+
+      if (decision.follow) {
+        followBoard.mutate(board.uuid, {
+          onSuccess: () => showToast(t('mobile.discovery.followed', { name: board.name }), 'success'),
+        });
+      }
+
+      if (decision.offline === 'auto') {
+        enableBoardsOffline(board);
+        return;
+      }
+      if (decision.offline === 'ask') {
+        const confirmed = await confirm({
+          title: t('mobile.offline.enableTitle', { name: board.name }),
+          message: t('mobile.offline.enableMessage'),
+          confirmLabel: t('mobile.offline.enableConfirm'),
+          cancelLabel: t('mobile.manage.cancel'),
+        });
+        if (confirmed) enableBoardsOffline(board);
+      }
+    },
+    [followBoard, enableBoardsOffline, confirm, showToast, offlineEnabled, autoOffline, t],
+  );
+}

--- a/packages/mobile/src/lib/board-discovery/use-adopt-found-board.ts
+++ b/packages/mobile/src/lib/board-discovery/use-adopt-found-board.ts
@@ -18,13 +18,17 @@ import { decideAdoptFoundBoard } from './adopt-found-board-decision';
  * dismiss that navigating away from the picker triggers.
  */
 export function useAdoptFoundBoard() {
-  const followBoard = useFollowBoard();
+  const { showToast } = useToast();
+  const { t } = useTranslation('boards');
+  // The toast rides useFollowBoard's config-level onSuccess (it fires after this
+  // screen unmounts on navigation); a per-call mutate callback would be dropped.
+  const followBoard = useFollowBoard({
+    onFollowed: (board) => showToast(t('mobile.discovery.followed', { name: board.name }), 'success'),
+  });
   const { enableBoardsOffline } = useBoardDownloads();
   const confirm = useConfirm();
-  const { showToast } = useToast();
   const offlineEnabled = useOfflineDownloadsEnabled();
   const [autoOffline] = useSetting('autoOfflineBoards');
-  const { t } = useTranslation('boards');
 
   return useCallback(
     async (board: UserBoard) => {
@@ -37,9 +41,7 @@ export function useAdoptFoundBoard() {
       });
 
       if (decision.follow) {
-        followBoard.mutate(board.uuid, {
-          onSuccess: () => showToast(t('mobile.discovery.followed', { name: board.name }), 'success'),
-        });
+        followBoard.mutate(board);
       }
 
       if (decision.offline === 'auto') {
@@ -56,6 +58,8 @@ export function useAdoptFoundBoard() {
         if (confirmed) enableBoardsOffline(board);
       }
     },
-    [followBoard, enableBoardsOffline, confirm, showToast, offlineEnabled, autoOffline, t],
+    // followBoard.mutate is stable; depending on the whole `followBoard` object
+    // (fresh each render) would churn this callback and every onSelect built on it.
+    [followBoard.mutate, enableBoardsOffline, confirm, offlineEnabled, autoOffline, t],
   );
 }

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -572,7 +572,10 @@ export function useDeleteBoard() {
  * callback (gated on the observer still having listeners) would be dropped. UI
  * concerns (toast copy) stay with the caller via this injected callback.
  */
-export function useFollowBoard(options?: { onFollowed?: (board: Pick<UserBoard, 'uuid' | 'name'>) => void }) {
+export function useFollowBoard(options?: {
+  onFollowed?: (board: Pick<UserBoard, 'uuid' | 'name'>) => void;
+  onFollowError?: (board: Pick<UserBoard, 'uuid' | 'name'>, error: unknown) => void;
+}) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (board: Pick<UserBoard, 'uuid' | 'name'>) => {
@@ -584,6 +587,11 @@ export function useFollowBoard(options?: { onFollowed?: (board: Pick<UserBoard, 
     onSuccess: (_followed, board) => {
       void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
       options?.onFollowed?.(board);
+    },
+    // Config-level (survives unmount, like onSuccess). A rejected follow otherwise
+    // fails silently after we've navigated away — surface it to the caller.
+    onError: (error, board) => {
+      options?.onFollowError?.(board, error);
     },
   });
 }

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -65,10 +65,12 @@ import {
 import {
   UPDATE_BOARD,
   DELETE_BOARD,
+  FOLLOW_BOARD,
   UNFOLLOW_BOARD,
   GET_BOARD_BY_SLUG,
   type UpdateBoardMutationResponse,
   type DeleteBoardMutationResponse,
+  type FollowBoardMutationResponse,
   type UnfollowBoardMutationResponse,
   type GetBoardBySlugQueryResponse,
 } from '@boardsesh/graphql/operations/boards';
@@ -553,6 +555,28 @@ export function useDeleteBoard() {
     onSuccess: (_deleted, boardUuid) => {
       void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
       void queryClient.invalidateQueries({ queryKey: ['board', boardUuid] });
+    },
+  });
+}
+
+/**
+ * Follow someone else's public board so it lands in the user's My Boards list.
+ * Wraps the uuid in `{ input: { boardUuid } }` like `unfollowBoard`. Idempotent
+ * on the server (`onConflictDoNothing`), so callers can fire it without first
+ * checking whether the board is already followed. Invalidates `myBoards` so the
+ * newly-followed board shows up.
+ */
+export function useFollowBoard() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (boardUuid: string) => {
+      const response = await getHttpClient().request<FollowBoardMutationResponse>(FOLLOW_BOARD, {
+        input: { boardUuid },
+      });
+      return response.followBoard;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
     },
   });
 }

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -561,22 +561,29 @@ export function useDeleteBoard() {
 
 /**
  * Follow someone else's public board so it lands in the user's My Boards list.
- * Wraps the uuid in `{ input: { boardUuid } }` like `unfollowBoard`. Idempotent
- * on the server (`onConflictDoNothing`), so callers can fire it without first
- * checking whether the board is already followed. Invalidates `myBoards` so the
- * newly-followed board shows up.
+ * Takes the board (uuid + name) rather than a bare uuid so `onFollowed` can name
+ * it. Idempotent on the server (`onConflictDoNothing`), so callers can fire it
+ * without first checking whether the board is already followed. Invalidates
+ * `myBoards` so the newly-followed board shows up.
+ *
+ * `onFollowed` runs from the config-level `onSuccess` — which the mutation itself
+ * invokes, so it still fires after the calling screen unmounts. The adopt flow
+ * navigates away before the follow resolves, so a per-call `mutate(_, {onSuccess})`
+ * callback (gated on the observer still having listeners) would be dropped. UI
+ * concerns (toast copy) stay with the caller via this injected callback.
  */
-export function useFollowBoard() {
+export function useFollowBoard(options?: { onFollowed?: (board: Pick<UserBoard, 'uuid' | 'name'>) => void }) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (boardUuid: string) => {
+    mutationFn: async (board: Pick<UserBoard, 'uuid' | 'name'>) => {
       const response = await getHttpClient().request<FollowBoardMutationResponse>(FOLLOW_BOARD, {
-        input: { boardUuid },
+        input: { boardUuid: board.uuid },
       });
       return response.followBoard;
     },
-    onSuccess: () => {
+    onSuccess: (_followed, board) => {
       void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
+      options?.onFollowed?.(board);
     },
   });
 }

--- a/packages/mobile/src/offline/use-board-downloads.ts
+++ b/packages/mobile/src/offline/use-board-downloads.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo } from 'react';
+import { useSQLiteContext } from 'expo-sqlite';
+import { useQueryClient } from '@tanstack/react-query';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import type { GraphQLFetch } from '@boardsesh/offline-sync';
+import { getSetting, setOfflineBoardEnabled, offlineBoardScopeForBoard } from '../settings';
+import { getHttpClient } from '../lib/graphql/client';
+import { setSyncProgress } from '../sync';
+import { triggerSync, drainMutationQueue } from './offline-sync-adapter';
+import { useSnapshotSource } from './use-snapshot-source';
+
+/**
+ * Enable one or more boards for offline and kick a single sync so their catalogs
+ * download now. This centralises the plumbing that lived inline in the My Boards
+ * screen (`handleToggleOffline`) so the discovery/adopt flow and the "download all"
+ * settings toggle can trigger downloads without re-deriving the db / snapshot /
+ * drain wiring. `triggerSync → runSync` is single-flight, so enabling several
+ * boards in quick succession collapses into one cycle that reads the latest
+ * `syncEnabledBoards` setting — hence the batch variant is just "enable all, kick
+ * once".
+ *
+ * Callers must be inside the root SQLite + snapshot providers (every screen is).
+ * This only owns the *enable + download* side; the reactive read of the setting
+ * (`useOfflineBoardEnabled`, `getDownloadedScopeKeys`) stays with the UI.
+ */
+export function useBoardDownloads() {
+  const db = useSQLiteContext();
+  const queryClient = useQueryClient();
+  const snapshotSource = useSnapshotSource();
+
+  const graphqlFetch = useMemo<GraphQLFetch>(() => (query, variables) => getHttpClient().request(query, variables), []);
+  const drainQueue = useCallback(
+    () => drainMutationQueue(db, queryClient, graphqlFetch),
+    [db, queryClient, graphqlFetch],
+  );
+
+  const enableBoardsOffline = useCallback(
+    (boards: UserBoard | UserBoard[]) => {
+      const list = Array.isArray(boards) ? boards : [boards];
+      if (list.length === 0) return;
+      for (const board of list) {
+        setOfflineBoardEnabled(offlineBoardScopeForBoard(board), true);
+      }
+      triggerSync(db, queryClient, graphqlFetch, () => getSetting('syncEnabledBoards'), drainQueue, {
+        onProgress: setSyncProgress,
+        snapshotSource,
+      });
+    },
+    [db, queryClient, graphqlFetch, drainQueue, snapshotSource],
+  );
+
+  return { enableBoardsOffline };
+}

--- a/packages/mobile/src/settings/defaults.ts
+++ b/packages/mobile/src/settings/defaults.ts
@@ -3,6 +3,7 @@ import type { AppSettings } from './types';
 export const DEFAULT_SETTINGS: AppSettings = {
   defaultBoardUuid: null,
   syncEnabledBoards: [],
+  autoOfflineBoards: false,
   autoConnectBle: true,
   keepScreenAwake: true,
   theme: 'system',

--- a/packages/mobile/src/settings/types.ts
+++ b/packages/mobile/src/settings/types.ts
@@ -1,6 +1,8 @@
 export type AppSettings = {
   defaultBoardUuid: string | null;
   syncEnabledBoards: string[];
+  /** Keep every board the user follows/uses available offline by default. */
+  autoOfflineBoards: boolean;
   autoConnectBle: boolean;
   keepScreenAwake: boolean;
   theme: 'system' | 'light' | 'dark';

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -101,7 +101,8 @@
       "popularTitle": "Popular setups",
       "findGym": "Find gym",
       "create": "Create board",
-      "followed": "Added {{name}} to your boards"
+      "followed": "Added {{name}} to your boards",
+      "followError": "Couldn't add {{name}} to your boards"
     },
     "create": {
       "screenTitle": "Set up your board",

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -78,7 +78,9 @@
       "unfollowError": "Couldn't unfollow that board. Try again.",
       "editAria": "Edit {{name}}",
       "deleteAria": "Delete {{name}}",
-      "unfollowAria": "Unfollow {{name}}"
+      "unfollowAria": "Unfollow {{name}}",
+      "edit": "Edit",
+      "done": "Done"
     },
     "emptyTitle": "No boards yet",
     "emptySubtitle": "Search for a board to get started",
@@ -98,7 +100,8 @@
       "yourBoardsTitle": "Your boards",
       "popularTitle": "Popular setups",
       "findGym": "Find gym",
-      "create": "Create board"
+      "create": "Create board",
+      "followed": "Added {{name}} to your boards"
     },
     "create": {
       "screenTitle": "Set up your board",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -105,6 +105,13 @@
         "boardseshGrades": "Show Boardsesh grades",
         "boardseshGradesDescription": "Grades built from real sends across boards. The setter's grade stays until enough sends come in."
       },
+      "offline": {
+        "title": "Offline",
+        "autoDownload": "Keep boards offline",
+        "autoDownloadDescription": "Download every board you use so you can browse and log sends with no signal. New boards download automatically.",
+        "downloadingAll_one": "Downloading 1 board for offline",
+        "downloadingAll_other": "Downloading {{count}} boards for offline"
+      },
       "language": {
         "title": "Language",
         "system": "System",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -101,7 +101,8 @@
       "popularTitle": "Configuraciones populares",
       "findGym": "Buscar gimnasio",
       "create": "Crear plafón",
-      "followed": "{{name}} añadido a tus plafones"
+      "followed": "{{name}} añadido a tus plafones",
+      "followError": "No se pudo añadir {{name}} a tus plafones"
     },
     "create": {
       "screenTitle": "Configura tu plafón",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -78,7 +78,9 @@
       "unfollowError": "No se pudo dejar de seguir ese plafón. Inténtalo de nuevo.",
       "editAria": "Editar {{name}}",
       "deleteAria": "Eliminar {{name}}",
-      "unfollowAria": "Dejar de seguir {{name}}"
+      "unfollowAria": "Dejar de seguir {{name}}",
+      "edit": "Editar",
+      "done": "Listo"
     },
     "emptyTitle": "Aún no tienes plafones",
     "emptySubtitle": "Busca un plafón para empezar",
@@ -98,7 +100,8 @@
       "yourBoardsTitle": "Tus plafones",
       "popularTitle": "Configuraciones populares",
       "findGym": "Buscar gimnasio",
-      "create": "Crear plafón"
+      "create": "Crear plafón",
+      "followed": "{{name}} añadido a tus plafones"
     },
     "create": {
       "screenTitle": "Configura tu plafón",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -306,6 +306,13 @@
         "boardseshGrades": "Mostrar grados Boardsesh",
         "boardseshGradesDescription": "Grados calculados a partir de encadenes reales en varios plafones. El grado del setter se mantiene hasta que haya suficientes encadenes."
       },
+      "offline": {
+        "title": "Sin conexión",
+        "autoDownload": "Mantener los plafones sin conexión",
+        "autoDownloadDescription": "Descarga todos los plafones que usas para explorarlos y registrar tus ascensos sin conexión. Los plafones nuevos se descargan automáticamente.",
+        "downloadingAll_one": "Descargando 1 plafón para usarlo sin conexión",
+        "downloadingAll_other": "Descargando {{count}} plafones para usarlos sin conexión"
+      },
       "language": {
         "title": "Idioma",
         "system": "Sistema",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -78,7 +78,9 @@
       "unfollowError": "Impossible de te désabonner de cette board. Réessaie.",
       "editAria": "Modifier {{name}}",
       "deleteAria": "Supprimer {{name}}",
-      "unfollowAria": "Se désabonner de {{name}}"
+      "unfollowAria": "Se désabonner de {{name}}",
+      "edit": "Modifier",
+      "done": "Terminé"
     },
     "emptyTitle": "Aucune board pour le moment",
     "emptySubtitle": "Cherche une board pour commencer",
@@ -98,7 +100,8 @@
       "yourBoardsTitle": "Tes boards",
       "popularTitle": "Configurations populaires",
       "findGym": "Trouver une salle",
-      "create": "Créer une board"
+      "create": "Créer une board",
+      "followed": "{{name}} ajoutée à tes boards"
     },
     "create": {
       "screenTitle": "Configure ta board",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -101,7 +101,8 @@
       "popularTitle": "Configurations populaires",
       "findGym": "Trouver une salle",
       "create": "Créer une board",
-      "followed": "{{name}} ajoutée à tes boards"
+      "followed": "{{name}} ajoutée à tes boards",
+      "followError": "Impossible d'ajouter {{name}} à tes boards"
     },
     "create": {
       "screenTitle": "Configure ta board",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -105,6 +105,13 @@
         "boardseshGrades": "Afficher les grades Boardsesh",
         "boardseshGradesDescription": "Des grades calculés à partir de vraies croix sur plusieurs boards. Le grade de l'ouvreur reste affiché tant qu'il n'y a pas assez de croix."
       },
+      "offline": {
+        "title": "Hors ligne",
+        "autoDownload": "Garder les boards hors ligne",
+        "autoDownloadDescription": "Télécharge toutes les boards que tu utilises pour les parcourir et enregistrer tes croix hors ligne. Les nouvelles boards se téléchargent automatiquement.",
+        "downloadingAll_one": "Téléchargement d'1 board pour le hors ligne",
+        "downloadingAll_other": "Téléchargement de {{count}} boards pour le hors ligne"
+      },
       "language": {
         "title": "Langue",
         "system": "Système",


### PR DESCRIPTION
## Summary

Finding a board you don't own now **adopts** it end to end:

- **Follow on find.** Picking a board from the gym finder (`/gyms`) or the *Nearby* carousel in the board picker now follows it, so it lands in **My Boards** instead of just becoming the local active board. Mobile had no follow hook at all before this (only unfollow) — added `useFollowBoard` on top of the existing idempotent `followBoard` mutation.
- **Offer offline on select.** Right after you pick a new board, we ask whether to make it available offline (reusing the existing download confirm). If you don't have its data yet, one tap downloads the whole catalog.
- **"Keep boards offline by default" setting.** New toggle in More → Offline. Turning it on downloads every board already in My Boards immediately, and every board you find from then on downloads automatically with no prompt.
- **Easier My Boards management.** Added a traditional iOS-style **Edit / Done** button in the header that shows a persistent per-row remove control (Unfollow for followed boards, Delete for owned), so removing a board no longer depends on the swipe. The swipe itself was also loosened — the old vertical-drift tolerance made it almost impossible to trigger over a scrolling list.

The offline offer, the settings toggle, and the auto-download are all gated behind the existing `offline-board-downloads` feature flag. The offline enable + sync-kick logic was extracted out of the My Boards screen into a shared `useBoardDownloads` hook so the adopt flow and the settings toggle reuse it.

## Release Notes

- Find a new wall and it drops straight into your boards, ready to pull down for offline.
- Turn on "Keep boards offline" in Settings to download every board you use so browsing and logging sends works with no signal.
- Manage your boards the easy way: tap Edit to unfollow or delete, or swipe — the swipe actually catches now.

## Test plan

Validated on this branch:
- `vp run typecheck:mobile` — clean
- `vp test run --project mobile` — 3808 tests pass (incl. new `adopt-found-board-decision` tests + edit-mode `board-manage-row` tests)
- i18n catalog completeness — 28 tests pass (new keys in en-US/es/fr, plural + ICU parity)
- `vp run check:mobile-bundle` — OK (13.9 MB)
- `vp check` — format clean, no new lint issues

On-device QA to exercise (simulator/emulator):
- **Find Gym / Nearby**: pick a board you don't own → it appears in My Boards (followed) with a toast; with the offline flag on and auto-offline off, the "Download <board>?" dialog appears on the landing screen; confirming shows the row go Downloading → Available offline in My Boards. Picking a board you already own/follow does **not** re-prompt.
- **Settings toggle**: turn on "Keep boards offline" → every current My Board starts downloading; finding a new board then auto-downloads with no prompt. Toggling off stops future auto-downloads but keeps existing ones.
- **My Boards**: the swipe now catches with a natural drag; Edit reveals the red remove control per row → Unfollow (followed) and Delete-with-confirm (owned) both work; Done restores the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EagWAd48Bs5MuftajqZm7Y