### PR TITLE
fix(backend): unwrap drizzle-wrapped postgres errors in unique-violation handlers

### DIFF
--- a/packages/backend/src/__tests__/postgres-errors.test.ts
+++ b/packages/backend/src/__tests__/postgres-errors.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { getPostgresConstraintName, getPostgresErrorCode, isUniqueViolation } from '../utils/postgres-errors';
+
+function makePostgresError(constraintField: 'constraint' | 'constraint_name'): Error {
+  return Object.assign(new Error('duplicate key value violates unique constraint "user_boards_unique_slug"'), {
+    code: '23505',
+    [constraintField]: 'user_boards_unique_slug',
+  });
+}
+
+// Shape thrown by drizzle-orm >= 0.44: a DrizzleQueryError wrapping the
+// original driver error on `cause`, with no code/constraint of its own.
+function wrapLikeDrizzle(driverError: Error): Error {
+  return Object.assign(new Error('Failed query: insert into "user_boards" ...'), {
+    cause: driverError,
+  });
+}
+
+describe('postgres-errors', () => {
+  it('matches a bare PostgresError (postgres.js constraint_name field)', () => {
+    const bareError = makePostgresError('constraint_name');
+    expect(getPostgresErrorCode(bareError)).toBe('23505');
+    expect(getPostgresConstraintName(bareError)).toBe('user_boards_unique_slug');
+    expect(isUniqueViolation(bareError, 'user_boards_unique_slug')).toBe(true);
+  });
+
+  it('matches a bare PostgresError (node-postgres constraint field)', () => {
+    const bareError = makePostgresError('constraint');
+    expect(isUniqueViolation(bareError, 'user_boards_unique_slug')).toBe(true);
+  });
+
+  it('unwraps a DrizzleQueryError-style wrapper via the cause chain', () => {
+    const wrappedError = wrapLikeDrizzle(makePostgresError('constraint_name'));
+    expect(getPostgresErrorCode(wrappedError)).toBe('23505');
+    expect(getPostgresConstraintName(wrappedError)).toBe('user_boards_unique_slug');
+    expect(isUniqueViolation(wrappedError, 'user_boards_unique_slug')).toBe(true);
+    expect(isUniqueViolation(wrappedError)).toBe(true);
+  });
+
+  it('unwraps a doubly-nested cause chain', () => {
+    const doublyWrapped = wrapLikeDrizzle(wrapLikeDrizzle(makePostgresError('constraint_name')));
+    expect(isUniqueViolation(doublyWrapped, 'user_boards_unique_slug')).toBe(true);
+  });
+
+  it('rejects a different constraint name', () => {
+    const wrappedError = wrapLikeDrizzle(makePostgresError('constraint_name'));
+    expect(isUniqueViolation(wrappedError, 'user_boards_unique_owner_serial')).toBe(false);
+  });
+
+  it('rejects non-unique-violation codes', () => {
+    const foreignKeyError = Object.assign(new Error('violates foreign key constraint'), { code: '23503' });
+    expect(isUniqueViolation(wrapLikeDrizzle(foreignKeyError))).toBe(false);
+  });
+
+  it('handles non-error inputs and cyclic cause chains without hanging', () => {
+    expect(isUniqueViolation(null)).toBe(false);
+    expect(isUniqueViolation(undefined)).toBe(false);
+    expect(isUniqueViolation('duplicate key')).toBe(false);
+    const cyclic: Record<string, unknown> = { message: 'wrapper' };
+    cyclic.cause = cyclic;
+    expect(isUniqueViolation(cyclic)).toBe(false);
+  });
+});

--- a/packages/backend/src/utils/postgres-errors.ts
+++ b/packages/backend/src/utils/postgres-errors.ts
@@ -4,16 +4,33 @@ function asErrorRecord(error: unknown): ErrorRecord | null {
   return typeof error === 'object' && error !== null ? (error as ErrorRecord) : null;
 }
 
+// drizzle-orm >= 0.44 wraps driver failures in a DrizzleQueryError whose
+// `cause` holds the original PostgresError, so the code/constraint fields no
+// longer live on the thrown error itself. Walk the cause chain (bounded, in
+// case of cycles) so unique-violation race handlers keep matching.
+function* errorChain(error: unknown): Generator<ErrorRecord> {
+  let currentRecord = asErrorRecord(error);
+  let depth = 0;
+  while (currentRecord && depth < 5) {
+    yield currentRecord;
+    currentRecord = asErrorRecord(currentRecord.cause);
+    depth += 1;
+  }
+}
+
 export function getPostgresErrorCode(error: unknown): string | undefined {
-  const errorRecord = asErrorRecord(error);
-  const code = errorRecord?.code;
-  return typeof code === 'string' ? code : undefined;
+  for (const errorRecord of errorChain(error)) {
+    if (typeof errorRecord.code === 'string') return errorRecord.code;
+  }
+  return undefined;
 }
 
 export function getPostgresConstraintName(error: unknown): string | undefined {
-  const errorRecord = asErrorRecord(error);
-  const constraint = errorRecord?.constraint ?? errorRecord?.constraint_name;
-  return typeof constraint === 'string' ? constraint : undefined;
+  for (const errorRecord of errorChain(error)) {
+    const constraint = errorRecord.constraint ?? errorRecord.constraint_name;
+    if (typeof constraint === 'string') return constraint;
+  }
+  return undefined;
 }
 
 export function isUniqueViolation(error: unknown, constraintName?: string): boolean {


### PR DESCRIPTION
## What

`isUniqueViolation()` / `getPostgresErrorCode()` / `getPostgresConstraintName()` only inspected the top-level thrown error. Since the drizzle-orm 0.44+ bump, driver failures are wrapped in `DrizzleQueryError` with the original `PostgresError` on `.cause`, so every unique-violation race handler (`resolveSharedBoardForConfig`, `resolveBoardForSerial` serial races, social board creation) stopped matching and rethrew instead of recovering by re-selecting the winner.

## Why now

Surfaced as a flaky CI failure on #3624 (`board-presence.test.ts > converges concurrent serial-less config creates onto one normalized shared board` — duplicate key on `user_boards_unique_slug` escaping the catch that explicitly handles that constraint). The race only triggers when two creates actually collide at insert time, which is why it flakes rather than failing consistently.

## How

Walk the error `cause` chain (bounded at depth 5, cycle-safe) when extracting the postgres error code and constraint name. New unit tests cover bare `PostgresError` (both `constraint` and `constraint_name` field spellings), single- and double-wrapped errors, wrong-constraint/wrong-code rejection, and cyclic cause chains.

## Validation

- `SKIP_TEST_INFRA=1 vp test run --project backend --reporter=agent postgres-errors` — 7/7 pass
- `vp check` — no findings in touched files (3 pre-existing errors in untouched `scripts/__tests__/with-screenshot-dev-menu.test.ts`)

## Release Notes

- [x] No release note needed (internal / technical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaW2zXJkhwXJhyxYzSv9iH