### PR TITLE
feat(backend): gym kiosk CRUD and public kiosk read

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,7 @@
         "@boardsesh/graphql": "*",
         "@boardsesh/gym-claim": "*",
         "@boardsesh/kilter-sync": "*",
+        "@boardsesh/kiosk": "*",
         "@boardsesh/offline-sync": "*",
         "@boardsesh/queue": "*",
         "@boardsesh/shared-schema": "*",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,6 +33,7 @@
     "@boardsesh/graphql": "*",
     "@boardsesh/gym-claim": "*",
     "@boardsesh/kilter-sync": "*",
+    "@boardsesh/kiosk": "*",
     "@boardsesh/offline-sync": "*",
     "@boardsesh/queue": "*",
     "@boardsesh/shared-schema": "*",

--- a/packages/backend/src/__tests__/gym-kiosks.test.ts
+++ b/packages/backend/src/__tests__/gym-kiosks.test.ts
@@ -1,0 +1,602 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { MAX_KIOSKS_PER_GYM } from '@boardsesh/kiosk';
+import { db } from '../db/client';
+import { socialGymKioskQueries, socialGymKioskMutations } from '../graphql/resolvers/social/gym-kiosks';
+
+/**
+ * Real-DB coverage for PR E's gym-kiosk CRUD + public read surface:
+ *   - the write gate (owner / gym admin / gym editor allowed; plain member,
+ *     stranger, anon rejected) across create / update / delete;
+ *   - create slug derivation + per-gym uniqueness (clean error, not a 500) +
+ *     the MAX_KIOSKS_PER_GYM cap;
+ *   - update layout: strict validation (>4 boards / dup boards / out-of-scope
+ *     leaderboard), the alive-and-gym-linked board checks, and parsed-output
+ *     persistence (unknown keys stripped in the stored row);
+ *   - gymKiosk public read: oldest-kiosk default, private-gym visibility, anon
+ *     board filtering, dead-board degradation, lenient corrupt-layout read;
+ *   - the gymKiosks manage-list gate.
+ *
+ * Seeds via raw SQL and calls the resolvers directly against the per-worker test
+ * DB, mirroring gym-branding-and-boards.test.ts.
+ */
+
+const OWNER = 'gk-owner';
+const ADMIN = 'gk-admin';
+const EDITOR = 'gk-editor';
+const MEMBER = 'gk-member';
+const RANDOM = 'gk-random';
+const ALL_USERS = [OWNER, ADMIN, EDITOR, MEMBER, RANDOM];
+
+let connectionCounter = 0;
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}-${connectionCounter++}`, isAuthenticated: true, userId }) as ConnectionContext;
+const anonCtx = (): ConnectionContext =>
+  ({ connectionId: `conn-anon-${connectionCounter++}`, isAuthenticated: false }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+const insertGym = async (opts: {
+  ownerId: string;
+  name: string;
+  slug: string;
+  isPublic?: boolean;
+}): Promise<{ id: number; uuid: string; slug: string }> => {
+  const { ownerId, name, slug, isPublic = true } = opts;
+  const uuid = uuidv4();
+  const result = await db.execute(sql`
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${name}, ${slug}, ${ownerId}, ${isPublic}, now(), now())
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid, slug };
+};
+
+// Each board gets a distinct size_id so the (owner, type, layout, size, set_ids)
+// unique constraint never trips across the several boards a single owner has here.
+let boardConfigCounter = 0;
+const insertBoard = async (opts: {
+  gymId: number;
+  ownerId: string;
+  name: string;
+  isPublic: boolean;
+}): Promise<{ id: number; uuid: string }> => {
+  const { gymId, ownerId, name, isPublic } = opts;
+  const uuid = uuidv4();
+  const sizeId = 10 + boardConfigCounter++;
+  const result = await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, gym_id, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${ownerId}, 'kilter', 1, ${sizeId}, '1,2', ${name}, ${gymId}, ${isPublic}, now(), now())
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
+};
+
+const insertGymMember = (gymId: number, userId: string, role: string) =>
+  db.execute(sql`
+    INSERT INTO gym_members (gym_id, user_id, role, created_at)
+    VALUES (${gymId}, ${userId}, ${role}, now())
+  `);
+
+type KioskLayoutSeed = { version: number; boards: Array<{ boardUuid: string }>; leaderboard: unknown };
+
+const emptyLayoutSeed = (): KioskLayoutSeed => ({ version: 1, boards: [], leaderboard: null });
+
+const insertKiosk = async (opts: {
+  gymId: number;
+  slug: string;
+  name: string;
+  layout?: unknown;
+  createdAt?: Date;
+}): Promise<{ id: number; uuid: string }> => {
+  const uuid = uuidv4();
+  const layoutJson = JSON.stringify(opts.layout ?? emptyLayoutSeed());
+  // Bind the timestamp as an ISO string with an explicit cast — postgres.js
+  // rejects a raw JS Date param in a drizzle `sql` template.
+  const createdAtIso = (opts.createdAt ?? new Date()).toISOString();
+  const result = await db.execute(sql`
+    INSERT INTO gym_kiosks (uuid, gym_id, slug, name, layout, created_at, updated_at)
+    VALUES (${uuid}, ${opts.gymId}, ${opts.slug}, ${opts.name}, ${layoutJson}::jsonb, ${createdAtIso}::timestamptz, now())
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
+};
+
+// Public gym owned by OWNER with an admin/editor/member member set; two public
+// boards + one private board, all linked. Plus a private gym (OWNER) with a
+// single public board.
+let publicGym: { id: number; uuid: string; slug: string };
+let privateGym: { id: number; uuid: string; slug: string };
+let boardPub1: { id: number; uuid: string };
+let boardPub2: { id: number; uuid: string };
+let boardPriv: { id: number; uuid: string };
+let boardInPrivateGym: { id: number; uuid: string };
+
+beforeEach(async () => {
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "community_roles", "gym_kiosks", "gym_members", "gym_follows", "gym_claims",
+      "board_follows", "boardsesh_ticks", "user_boards", "gyms"
+    RESTART IDENTITY CASCADE
+  `);
+
+  await Promise.all(ALL_USERS.map(insertUser));
+
+  publicGym = await insertGym({ ownerId: OWNER, name: 'Public Gym', slug: 'public-gym' });
+  await insertGymMember(publicGym.id, ADMIN, 'admin');
+  await insertGymMember(publicGym.id, EDITOR, 'editor');
+  await insertGymMember(publicGym.id, MEMBER, 'member');
+  boardPub1 = await insertBoard({ gymId: publicGym.id, ownerId: OWNER, name: 'A Wall', isPublic: true });
+  boardPub2 = await insertBoard({ gymId: publicGym.id, ownerId: OWNER, name: 'B Wall', isPublic: true });
+  boardPriv = await insertBoard({ gymId: publicGym.id, ownerId: OWNER, name: 'C Private Wall', isPublic: false });
+
+  privateGym = await insertGym({ ownerId: OWNER, name: 'Private Gym', slug: 'private-gym', isPublic: false });
+  boardInPrivateGym = await insertBoard({
+    gymId: privateGym.id,
+    ownerId: OWNER,
+    name: 'Hidden Wall',
+    isPublic: true,
+  });
+});
+
+// ============================================================================
+// CRUD authorization gate matrix
+// ============================================================================
+
+describe('kiosk CRUD gate', () => {
+  it('lets the owner, a gym admin, and a gym editor create kiosks', async () => {
+    for (const [index, viewer] of [OWNER, ADMIN, EDITOR].entries()) {
+      const kiosk = await socialGymKioskMutations.createGymKiosk(
+        null,
+        { input: { gymUuid: publicGym.uuid, name: `Wall ${index}`, slug: `wall-${index}` } },
+        authCtx(viewer),
+      );
+      expect(kiosk.uuid).toBeTruthy();
+      expect(kiosk.slug).toBe(`wall-${index}`);
+    }
+  });
+
+  it('rejects create for a plain member, a stranger, and anon', async () => {
+    for (const viewer of [MEMBER, RANDOM]) {
+      await expect(
+        socialGymKioskMutations.createGymKiosk(
+          null,
+          { input: { gymUuid: publicGym.uuid, name: 'Nope', slug: 'nope' } },
+          authCtx(viewer),
+        ),
+      ).rejects.toThrow();
+    }
+    await expect(
+      socialGymKioskMutations.createGymKiosk(null, { input: { gymUuid: publicGym.uuid, name: 'Nope' } }, anonCtx()),
+    ).rejects.toThrow();
+  });
+
+  it('gates update + delete the same way', async () => {
+    const seeded = await insertKiosk({ gymId: publicGym.id, slug: 'gated', name: 'Gated' });
+
+    for (const viewer of [MEMBER, RANDOM]) {
+      await expect(
+        socialGymKioskMutations.updateGymKiosk(
+          null,
+          { input: { kioskUuid: seeded.uuid, name: 'Renamed' } },
+          authCtx(viewer),
+        ),
+      ).rejects.toThrow();
+      await expect(
+        socialGymKioskMutations.deleteGymKiosk(null, { kioskUuid: seeded.uuid }, authCtx(viewer)),
+      ).rejects.toThrow();
+    }
+    await expect(
+      socialGymKioskMutations.updateGymKiosk(null, { input: { kioskUuid: seeded.uuid, name: 'X' } }, anonCtx()),
+    ).rejects.toThrow();
+
+    // The editor may update; the owner may delete.
+    const updated = await socialGymKioskMutations.updateGymKiosk(
+      null,
+      { input: { kioskUuid: seeded.uuid, name: 'Renamed' } },
+      authCtx(EDITOR),
+    );
+    expect(updated.name).toBe('Renamed');
+
+    const deleted = await socialGymKioskMutations.deleteGymKiosk(null, { kioskUuid: seeded.uuid }, authCtx(OWNER));
+    expect(deleted).toBe(true);
+    // Gone from the manage list after a soft delete.
+    const remaining = await socialGymKioskQueries.gymKiosks(null, { gymUuid: publicGym.uuid }, authCtx(OWNER));
+    expect(remaining.find((k) => k.uuid === seeded.uuid)).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Create: slug derivation, uniqueness, and the per-gym cap
+// ============================================================================
+
+describe('createGymKiosk slug + cap', () => {
+  it('derives a slug from the name when none is given', async () => {
+    const kiosk = await socialGymKioskMutations.createGymKiosk(
+      null,
+      { input: { gymUuid: publicGym.uuid, name: 'My Cool Kiosk!' } },
+      authCtx(OWNER),
+    );
+    expect(kiosk.slug).toBe('my-cool-kiosk');
+  });
+
+  it('rejects a malformed explicit slug', async () => {
+    await expect(
+      socialGymKioskMutations.createGymKiosk(
+        null,
+        { input: { gymUuid: publicGym.uuid, name: 'Bad', slug: 'AB' } },
+        authCtx(OWNER),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('allows the same slug across two different gyms', async () => {
+    const a = await socialGymKioskMutations.createGymKiosk(
+      null,
+      { input: { gymUuid: publicGym.uuid, name: 'Main', slug: 'main' } },
+      authCtx(OWNER),
+    );
+    const b = await socialGymKioskMutations.createGymKiosk(
+      null,
+      { input: { gymUuid: privateGym.uuid, name: 'Main', slug: 'main' } },
+      authCtx(OWNER),
+    );
+    expect(a.slug).toBe('main');
+    expect(b.slug).toBe('main');
+  });
+
+  it('rejects a duplicate slug within one gym with a clean error (not a 500)', async () => {
+    await socialGymKioskMutations.createGymKiosk(
+      null,
+      { input: { gymUuid: publicGym.uuid, name: 'Main', slug: 'main' } },
+      authCtx(OWNER),
+    );
+    await expect(
+      socialGymKioskMutations.createGymKiosk(
+        null,
+        { input: { gymUuid: publicGym.uuid, name: 'Main Again', slug: 'main' } },
+        authCtx(OWNER),
+      ),
+    ).rejects.toMatchObject({ extensions: { code: 'KIOSK_SLUG_ALREADY_EXISTS' } });
+  });
+
+  it('auto-derives a unique slug when the base name collides', async () => {
+    const first = await socialGymKioskMutations.createGymKiosk(
+      null,
+      { input: { gymUuid: publicGym.uuid, name: 'Front Desk' } },
+      authCtx(OWNER),
+    );
+    const second = await socialGymKioskMutations.createGymKiosk(
+      null,
+      { input: { gymUuid: publicGym.uuid, name: 'Front Desk' } },
+      authCtx(OWNER),
+    );
+    expect(first.slug).toBe('front-desk');
+    expect(second.slug).toBe('front-desk-2');
+  });
+
+  it('enforces MAX_KIOSKS_PER_GYM', async () => {
+    for (let i = 0; i < MAX_KIOSKS_PER_GYM; i++) {
+      await socialGymKioskMutations.createGymKiosk(
+        null,
+        { input: { gymUuid: publicGym.uuid, name: `Kiosk ${i}`, slug: `kiosk-${i}` } },
+        authCtx(OWNER),
+      );
+    }
+    await expect(
+      socialGymKioskMutations.createGymKiosk(
+        null,
+        { input: { gymUuid: publicGym.uuid, name: 'One Too Many', slug: 'too-many' } },
+        authCtx(OWNER),
+      ),
+    ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } });
+  });
+});
+
+// ============================================================================
+// Update: strict layout validation + gym-linked board checks + persistence
+// ============================================================================
+
+describe('updateGymKiosk layout validation', () => {
+  const seedKiosk = () => insertKiosk({ gymId: publicGym.id, slug: 'editable', name: 'Editable' });
+
+  it('rejects a layout with more than four boards', async () => {
+    const kiosk = await seedKiosk();
+    const boards = Array.from({ length: 5 }, () => ({ boardUuid: uuidv4() }));
+    await expect(
+      socialGymKioskMutations.updateGymKiosk(
+        null,
+        { input: { kioskUuid: kiosk.uuid, layout: { version: 1, boards, leaderboard: null } } },
+        authCtx(OWNER),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('rejects a layout with duplicate boards', async () => {
+    const kiosk = await seedKiosk();
+    await expect(
+      socialGymKioskMutations.updateGymKiosk(
+        null,
+        {
+          input: {
+            kioskUuid: kiosk.uuid,
+            layout: {
+              version: 1,
+              boards: [{ boardUuid: boardPub1.uuid }, { boardUuid: boardPub1.uuid }],
+              leaderboard: null,
+            },
+          },
+        },
+        authCtx(OWNER),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('rejects an out-of-scope leaderboard board (not one of the slots)', async () => {
+    const kiosk = await seedKiosk();
+    await expect(
+      socialGymKioskMutations.updateGymKiosk(
+        null,
+        {
+          input: {
+            kioskUuid: kiosk.uuid,
+            layout: {
+              version: 1,
+              boards: [{ boardUuid: boardPub1.uuid }],
+              leaderboard: { boardUuid: boardPub2.uuid, period: 'session' },
+            },
+          },
+        },
+        authCtx(OWNER),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('rejects a slot board that is not linked to this gym', async () => {
+    const kiosk = await seedKiosk();
+    // A board that lives in the OTHER gym must not be usable here.
+    await expect(
+      socialGymKioskMutations.updateGymKiosk(
+        null,
+        {
+          input: {
+            kioskUuid: kiosk.uuid,
+            layout: { version: 1, boards: [{ boardUuid: boardInPrivateGym.uuid }], leaderboard: null },
+          },
+        },
+        authCtx(OWNER),
+      ),
+    ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } });
+  });
+
+  it('rejects a leaderboard board that is not linked to this gym', async () => {
+    const kiosk = await seedKiosk();
+    const stray = uuidv4();
+    await expect(
+      socialGymKioskMutations.updateGymKiosk(
+        null,
+        {
+          input: {
+            kioskUuid: kiosk.uuid,
+            layout: {
+              version: 1,
+              // `stray` is a slot (so it passes the in-slots refine) but isn't a
+              // gym board, so the gym-link check must reject it.
+              boards: [{ boardUuid: boardPub1.uuid }, { boardUuid: stray }],
+              leaderboard: { boardUuid: stray, period: 'week' },
+            },
+          },
+        },
+        authCtx(OWNER),
+      ),
+    ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } });
+  });
+
+  it('persists a valid layout and resolves its boards', async () => {
+    const kiosk = await seedKiosk();
+    const updated = await socialGymKioskMutations.updateGymKiosk(
+      null,
+      {
+        input: {
+          kioskUuid: kiosk.uuid,
+          layout: {
+            version: 1,
+            boards: [{ boardUuid: boardPub1.uuid }, { boardUuid: boardPub2.uuid }],
+            leaderboard: { boardUuid: boardPub1.uuid, period: 'week' },
+          },
+        },
+      },
+      authCtx(OWNER),
+    );
+    expect(updated.boards.map((b) => b.boardUuid)).toEqual([boardPub1.uuid, boardPub2.uuid]);
+    expect(updated.boards.every((b) => b.boardId != null)).toBe(true);
+  });
+
+  it('persists the schema-parsed layout, stripping unknown keys', async () => {
+    const kiosk = await seedKiosk();
+    await socialGymKioskMutations.updateGymKiosk(
+      null,
+      {
+        input: {
+          kioskUuid: kiosk.uuid,
+          layout: {
+            version: 1,
+            boards: [{ boardUuid: boardPub1.uuid, extra: 'strip-me' }],
+            leaderboard: null,
+            foo: 'strip-me-too',
+          },
+        },
+      },
+      authCtx(OWNER),
+    );
+
+    const rows = await db.execute(sql`SELECT layout FROM gym_kiosks WHERE uuid = ${kiosk.uuid}`);
+    const stored = Array.from(rows as Iterable<{ layout: Record<string, unknown> }>)[0].layout;
+    expect(Object.keys(stored)).not.toContain('foo');
+    const storedBoards = stored.boards as Array<Record<string, unknown>>;
+    expect(Object.keys(storedBoards[0])).toEqual(['boardUuid']);
+  });
+});
+
+// ============================================================================
+// Public read: gymKiosk
+// ============================================================================
+
+describe('gymKiosk public read', () => {
+  it('returns the oldest live kiosk when no kiosk slug is given', async () => {
+    await insertKiosk({
+      gymId: publicGym.id,
+      slug: 'old',
+      name: 'Old',
+      createdAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    await insertKiosk({ gymId: publicGym.id, slug: 'new', name: 'New', createdAt: new Date() });
+
+    const kiosk = await socialGymKioskQueries.gymKiosk(null, { gymSlug: publicGym.slug }, anonCtx());
+    expect(kiosk).not.toBeNull();
+    expect(kiosk!.slug).toBe('old');
+  });
+
+  it('returns the named kiosk when a kiosk slug is given', async () => {
+    await insertKiosk({ gymId: publicGym.id, slug: 'lobby', name: 'Lobby' });
+    const kiosk = await socialGymKioskQueries.gymKiosk(
+      null,
+      { gymSlug: publicGym.slug, kioskSlug: 'lobby' },
+      anonCtx(),
+    );
+    expect(kiosk!.slug).toBe('lobby');
+  });
+
+  it('hides a private gym from anon + strangers but shows it to an editor', async () => {
+    await insertKiosk({
+      gymId: privateGym.id,
+      slug: 'members',
+      name: 'Members',
+      layout: { version: 1, boards: [{ boardUuid: boardInPrivateGym.uuid }], leaderboard: null },
+    });
+
+    expect(await socialGymKioskQueries.gymKiosk(null, { gymSlug: privateGym.slug }, anonCtx())).toBeNull();
+    expect(await socialGymKioskQueries.gymKiosk(null, { gymSlug: privateGym.slug }, authCtx(RANDOM))).toBeNull();
+
+    const forOwner = await socialGymKioskQueries.gymKiosk(null, { gymSlug: privateGym.slug }, authCtx(OWNER));
+    expect(forOwner).not.toBeNull();
+    expect(forOwner!.boards.map((b) => b.boardUuid)).toEqual([boardInPrivateGym.uuid]);
+  });
+
+  it('filters non-public boards out of `boards` for anon but keeps them in `layout`', async () => {
+    await insertKiosk({
+      gymId: publicGym.id,
+      slug: 'mixed',
+      name: 'Mixed',
+      layout: {
+        version: 1,
+        boards: [{ boardUuid: boardPub1.uuid }, { boardUuid: boardPriv.uuid }],
+        leaderboard: null,
+      },
+    });
+
+    const kiosk = await socialGymKioskQueries.gymKiosk(
+      null,
+      { gymSlug: publicGym.slug, kioskSlug: 'mixed' },
+      anonCtx(),
+    );
+    // The private board is dropped from the resolved boards...
+    expect(kiosk!.boards.map((b) => b.boardUuid)).toEqual([boardPub1.uuid]);
+    // ...but the layout JSON still records the slot (renderer degrades the preset).
+    expect(kiosk!.layout.boards.map((slot) => slot.boardUuid)).toEqual([boardPub1.uuid, boardPriv.uuid]);
+  });
+
+  it('omits a dead board (quad degrades) but keeps its slot in the layout', async () => {
+    const boardPub3 = await insertBoard({ gymId: publicGym.id, ownerId: OWNER, name: 'D Wall', isPublic: true });
+    const boardPub4 = await insertBoard({ gymId: publicGym.id, ownerId: OWNER, name: 'E Wall', isPublic: true });
+    await insertKiosk({
+      gymId: publicGym.id,
+      slug: 'quad',
+      name: 'Quad',
+      layout: {
+        version: 1,
+        boards: [
+          { boardUuid: boardPub1.uuid },
+          { boardUuid: boardPub2.uuid },
+          { boardUuid: boardPub3.uuid },
+          { boardUuid: boardPub4.uuid },
+        ],
+        leaderboard: null,
+      },
+    });
+    // Soft-delete one of the four boards.
+    await db.execute(sql`UPDATE user_boards SET deleted_at = now() WHERE uuid = ${boardPub4.uuid}`);
+
+    const kiosk = await socialGymKioskQueries.gymKiosk(null, { gymSlug: publicGym.slug, kioskSlug: 'quad' }, anonCtx());
+    expect(kiosk!.boards).toHaveLength(3);
+    expect(kiosk!.layout.boards).toHaveLength(4);
+  });
+
+  it('reads a corrupted stored layout leniently as an empty layout', async () => {
+    await insertKiosk({
+      gymId: publicGym.id,
+      slug: 'corrupt',
+      name: 'Corrupt',
+      // Unrecognised version — the lenient reader returns an empty layout.
+      layout: { version: 99, boards: [{ nope: true }], leaderboard: { bad: 1 } },
+    });
+
+    const kiosk = await socialGymKioskQueries.gymKiosk(
+      null,
+      { gymSlug: publicGym.slug, kioskSlug: 'corrupt' },
+      anonCtx(),
+    );
+    expect(kiosk).not.toBeNull();
+    expect(kiosk!.layout.version).toBe(1);
+    expect(kiosk!.layout.boards).toEqual([]);
+    expect(kiosk!.boards).toEqual([]);
+  });
+
+  it('returns null for an unknown gym slug', async () => {
+    expect(await socialGymKioskQueries.gymKiosk(null, { gymSlug: 'no-such-gym' }, anonCtx())).toBeNull();
+  });
+
+  it('returns null when the gym has no kiosks', async () => {
+    expect(await socialGymKioskQueries.gymKiosk(null, { gymSlug: publicGym.slug }, anonCtx())).toBeNull();
+  });
+});
+
+// ============================================================================
+// Manage list: gymKiosks
+// ============================================================================
+
+describe('gymKiosks manage list', () => {
+  beforeEach(async () => {
+    await insertKiosk({
+      gymId: publicGym.id,
+      slug: 'first',
+      name: 'First',
+      createdAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    await insertKiosk({ gymId: publicGym.id, slug: 'second', name: 'Second', createdAt: new Date() });
+  });
+
+  it('lists a gym editor its kiosks, oldest first', async () => {
+    for (const viewer of [OWNER, ADMIN, EDITOR]) {
+      const kiosks = await socialGymKioskQueries.gymKiosks(null, { gymUuid: publicGym.uuid }, authCtx(viewer));
+      expect(kiosks.map((k) => k.slug)).toEqual(['first', 'second']);
+    }
+  });
+
+  it('rejects the manage list for a plain member, a stranger, and anon', async () => {
+    for (const viewer of [MEMBER, RANDOM]) {
+      await expect(
+        socialGymKioskQueries.gymKiosks(null, { gymUuid: publicGym.uuid }, authCtx(viewer)),
+      ).rejects.toThrow();
+    }
+    await expect(socialGymKioskQueries.gymKiosks(null, { gymUuid: publicGym.uuid }, anonCtx())).rejects.toThrow();
+  });
+});

--- a/packages/backend/src/__tests__/gym-kiosks.test.ts
+++ b/packages/backend/src/__tests__/gym-kiosks.test.ts
@@ -179,20 +179,22 @@ describe('kiosk CRUD gate', () => {
     ).rejects.toThrow();
   });
 
-  it('gates update + delete the same way', async () => {
+  it('gates update + delete the same way, masking authz failures as NOT_FOUND', async () => {
     const seeded = await insertKiosk({ gymId: publicGym.id, slug: 'gated', name: 'Gated' });
 
     for (const viewer of [MEMBER, RANDOM]) {
+      // An authenticated non-editor gets the SAME error (message + extensions)
+      // as a missing kiosk — no existence oracle for probers.
       await expect(
         socialGymKioskMutations.updateGymKiosk(
           null,
           { input: { kioskUuid: seeded.uuid, name: 'Renamed' } },
           authCtx(viewer),
         ),
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({ message: 'Kiosk not found', extensions: { code: 'NOT_FOUND' } });
       await expect(
         socialGymKioskMutations.deleteGymKiosk(null, { kioskUuid: seeded.uuid }, authCtx(viewer)),
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({ message: 'Kiosk not found', extensions: { code: 'NOT_FOUND' } });
     }
     await expect(
       socialGymKioskMutations.updateGymKiosk(null, { input: { kioskUuid: seeded.uuid, name: 'X' } }, anonCtx()),
@@ -226,6 +228,28 @@ describe('createGymKiosk slug + cap', () => {
       authCtx(OWNER),
     );
     expect(kiosk.slug).toBe('my-cool-kiosk');
+  });
+
+  it('derives a valid slug from a long name whose 50-char cut lands on a hyphen', async () => {
+    // 49 a's + ' bcd' → slugified 'aaa…a-bcd' → slice(0, 50) ends in '-' —
+    // without the post-slice re-trim the stored slug fails the slug pattern and
+    // the kiosk becomes unfetchable by slug.
+    const kiosk = await socialGymKioskMutations.createGymKiosk(
+      null,
+      { input: { gymUuid: publicGym.uuid, name: 'a'.repeat(49) + ' bcd' } },
+      authCtx(OWNER),
+    );
+    expect(kiosk.slug).toBe('a'.repeat(49));
+    expect(kiosk.slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+
+    // And the derived slug actually resolves through the public read.
+    const fetched = await socialGymKioskQueries.gymKiosk(
+      null,
+      { gymSlug: publicGym.slug, kioskSlug: kiosk.slug },
+      anonCtx(),
+    );
+    expect(fetched).not.toBeNull();
+    expect(fetched!.uuid).toBe(kiosk.uuid);
   });
 
   it('rejects a malformed explicit slug', async () => {
@@ -298,6 +322,43 @@ describe('createGymKiosk slug + cap', () => {
         authCtx(OWNER),
       ),
     ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } });
+  });
+
+  it('frees the slug for reuse after a soft delete', async () => {
+    const first = await socialGymKioskMutations.createGymKiosk(
+      null,
+      { input: { gymUuid: publicGym.uuid, name: 'Reusable', slug: 'reusable' } },
+      authCtx(OWNER),
+    );
+    await socialGymKioskMutations.deleteGymKiosk(null, { kioskUuid: first.uuid }, authCtx(OWNER));
+
+    const second = await socialGymKioskMutations.createGymKiosk(
+      null,
+      { input: { gymUuid: publicGym.uuid, name: 'Reusable Again', slug: 'reusable' } },
+      authCtx(OWNER),
+    );
+    expect(second.slug).toBe('reusable');
+    expect(second.uuid).not.toBe(first.uuid);
+  });
+
+  it('frees a MAX_KIOSKS_PER_GYM slot after a soft delete', async () => {
+    const created: string[] = [];
+    for (let i = 0; i < MAX_KIOSKS_PER_GYM; i++) {
+      const kiosk = await socialGymKioskMutations.createGymKiosk(
+        null,
+        { input: { gymUuid: publicGym.uuid, name: `Kiosk ${i}`, slug: `kiosk-${i}` } },
+        authCtx(OWNER),
+      );
+      created.push(kiosk.uuid);
+    }
+    await socialGymKioskMutations.deleteGymKiosk(null, { kioskUuid: created[0] }, authCtx(OWNER));
+
+    const replacement = await socialGymKioskMutations.createGymKiosk(
+      null,
+      { input: { gymUuid: publicGym.uuid, name: 'Replacement', slug: 'replacement' } },
+      authCtx(OWNER),
+    );
+    expect(replacement.slug).toBe('replacement');
   });
 });
 
@@ -444,6 +505,42 @@ describe('updateGymKiosk layout validation', () => {
     const storedBoards = stored.boards as Array<Record<string, unknown>>;
     expect(Object.keys(storedBoards[0])).toEqual(['boardUuid']);
   });
+
+  it('strips unknown keys at the leaderboard level too', async () => {
+    const kiosk = await seedKiosk();
+    await socialGymKioskMutations.updateGymKiosk(
+      null,
+      {
+        input: {
+          kioskUuid: kiosk.uuid,
+          layout: {
+            version: 1,
+            boards: [{ boardUuid: boardPub1.uuid }],
+            leaderboard: { boardUuid: boardPub1.uuid, period: 'week', junk: 'strip-me' },
+          },
+        },
+      },
+      authCtx(OWNER),
+    );
+
+    const rows = await db.execute(sql`SELECT layout FROM gym_kiosks WHERE uuid = ${kiosk.uuid}`);
+    const stored = Array.from(rows as Iterable<{ layout: Record<string, unknown> }>)[0].layout;
+    const storedLeaderboard = stored.leaderboard as Record<string, unknown>;
+    expect(Object.keys(storedLeaderboard).sort()).toEqual(['boardUuid', 'period']);
+    expect(storedLeaderboard.period).toBe('week');
+  });
+
+  it('surfaces an update-path duplicate slug as a clean error (not a 500)', async () => {
+    await insertKiosk({ gymId: publicGym.id, slug: 'occupied', name: 'Occupied' });
+    const kiosk = await seedKiosk();
+    await expect(
+      socialGymKioskMutations.updateGymKiosk(
+        null,
+        { input: { kioskUuid: kiosk.uuid, slug: 'occupied' } },
+        authCtx(OWNER),
+      ),
+    ).rejects.toMatchObject({ extensions: { code: 'KIOSK_SLUG_ALREADY_EXISTS' } });
+  });
 });
 
 // ============================================================================
@@ -512,6 +609,55 @@ describe('gymKiosk public read', () => {
     expect(kiosk!.boards.map((b) => b.boardUuid)).toEqual([boardPub1.uuid]);
     // ...but the layout JSON still records the slot (renderer degrades the preset).
     expect(kiosk!.layout.boards.map((slot) => slot.boardUuid)).toEqual([boardPub1.uuid, boardPriv.uuid]);
+  });
+
+  it('shows a private slot board (with boardId) to a gym EDITOR member', async () => {
+    // Gym-level edit access drives slot visibility: an editor placing a private
+    // board on a kiosk must see it in `boards` (not a placeholder), even though
+    // the stricter per-board canEdit gate (used by UserBoard.boardId) says no.
+    await insertKiosk({
+      gymId: publicGym.id,
+      slug: 'editor-view',
+      name: 'Editor View',
+      layout: {
+        version: 1,
+        boards: [{ boardUuid: boardPub1.uuid }, { boardUuid: boardPriv.uuid }],
+        leaderboard: null,
+      },
+    });
+
+    const viaPublicRead = await socialGymKioskQueries.gymKiosk(
+      null,
+      { gymSlug: publicGym.slug, kioskSlug: 'editor-view' },
+      authCtx(EDITOR),
+    );
+    expect(viaPublicRead!.boards.map((b) => b.boardUuid)).toEqual([boardPub1.uuid, boardPriv.uuid]);
+    const privateEntry = viaPublicRead!.boards.find((b) => b.boardUuid === boardPriv.uuid);
+    expect(privateEntry!.boardId).toBe(boardPriv.id);
+
+    // Same through the manage list.
+    const manageList = await socialGymKioskQueries.gymKiosks(null, { gymUuid: publicGym.uuid }, authCtx(EDITOR));
+    const managed = manageList.find((k) => k.slug === 'editor-view');
+    expect(managed!.boards.map((b) => b.boardUuid)).toEqual([boardPub1.uuid, boardPriv.uuid]);
+  });
+
+  it('still filters the private slot board for a signed-in NON-editor', async () => {
+    await insertKiosk({
+      gymId: publicGym.id,
+      slug: 'rando-view',
+      name: 'Rando View',
+      layout: {
+        version: 1,
+        boards: [{ boardUuid: boardPub1.uuid }, { boardUuid: boardPriv.uuid }],
+        leaderboard: null,
+      },
+    });
+    const kiosk = await socialGymKioskQueries.gymKiosk(
+      null,
+      { gymSlug: publicGym.slug, kioskSlug: 'rando-view' },
+      authCtx(RANDOM),
+    );
+    expect(kiosk!.boards.map((b) => b.boardUuid)).toEqual([boardPub1.uuid]);
   });
 
   it('omits a dead board (quad degrades) but keeps its slot in the layout', async () => {

--- a/packages/backend/src/__tests__/gym-kiosks.test.ts
+++ b/packages/backend/src/__tests__/gym-kiosks.test.ts
@@ -324,6 +324,42 @@ describe('createGymKiosk slug + cap', () => {
     ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } });
   });
 
+  it('serializes concurrent creates at the cap boundary (exactly one wins)', async () => {
+    // Seed to one below the cap, then race two creates with distinct slugs.
+    // The transactional gym-row lock serializes them: the first insert takes
+    // the last slot, the second re-counts and hits BAD_USER_INPUT — never 11.
+    for (let i = 0; i < MAX_KIOSKS_PER_GYM - 1; i++) {
+      await insertKiosk({ gymId: publicGym.id, slug: `seed-${i}`, name: `Seed ${i}` });
+    }
+
+    const outcomes = await Promise.allSettled([
+      socialGymKioskMutations.createGymKiosk(
+        null,
+        { input: { gymUuid: publicGym.uuid, name: 'Racer A', slug: 'racer-a' } },
+        authCtx(OWNER),
+      ),
+      socialGymKioskMutations.createGymKiosk(
+        null,
+        { input: { gymUuid: publicGym.uuid, name: 'Racer B', slug: 'racer-b' } },
+        authCtx(ADMIN),
+      ),
+    ]);
+
+    const fulfilled = outcomes.filter((outcome) => outcome.status === 'fulfilled');
+    const rejected = outcomes.filter((outcome) => outcome.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({
+      extensions: { code: 'BAD_USER_INPUT' },
+    });
+
+    // And the DB really holds exactly MAX_KIOSKS_PER_GYM live kiosks.
+    const rows = await db.execute(
+      sql`SELECT count(*)::int AS live FROM gym_kiosks WHERE gym_id = ${publicGym.id} AND deleted_at IS NULL`,
+    );
+    expect(Number(Array.from(rows as Iterable<{ live: number }>)[0].live)).toBe(MAX_KIOSKS_PER_GYM);
+  });
+
   it('frees the slug for reuse after a soft delete', async () => {
     const first = await socialGymKioskMutations.createGymKiosk(
       null,

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -37,6 +37,7 @@ import { socialCommentQueries, socialCommentMutations } from './social/comments'
 import { socialVoteQueries, socialVoteMutations } from './social/votes';
 import { socialBoardQueries, socialBoardMutations } from './social/boards';
 import { socialGymQueries, socialGymMutations } from './social/gyms';
+import { socialGymKioskQueries, socialGymKioskMutations } from './social/gym-kiosks';
 import { socialGymClaimQueries, socialGymClaimMutations } from './social/gym-claims';
 import {
   socialNotificationQueries,
@@ -82,6 +83,7 @@ export const resolvers = {
     ...socialVoteQueries,
     ...socialBoardQueries,
     ...socialGymQueries,
+    ...socialGymKioskQueries,
     ...socialGymClaimQueries,
     ...activityFeedQueries,
     ...sessionFeedQueries,
@@ -114,6 +116,7 @@ export const resolvers = {
     ...socialVoteMutations,
     ...socialBoardMutations,
     ...socialGymMutations,
+    ...socialGymKioskMutations,
     ...socialGymClaimMutations,
     ...socialNotificationMutations,
     ...socialProposalMutations,

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -327,9 +327,11 @@ async function enrichBoard(
 
 /**
  * Batch-enrich multiple boards with computed fields using 6 total queries
- * instead of 6 per board. Used by list endpoints to avoid N+1.
+ * instead of 6 per board. Used by list endpoints to avoid N+1. Exported so the
+ * kiosk resolver resolves slot boards through the exact same `boardId` gate as
+ * every other board read (public or viewer-can-edit → id, else null).
  */
-async function enrichBoards(
+export async function enrichBoards(
   boards: Array<{ board: typeof dbSchema.userBoards.$inferSelect; distanceMeters?: number | null }>,
   authenticatedUserId?: string,
 ) {

--- a/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
@@ -41,7 +41,11 @@ function deriveKioskSlugBase(name: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-    .slice(0, 50);
+    .slice(0, 50)
+    // The slice can cut right after a hyphen (e.g. a 49-char word + space +
+    // more), leaving a trailing hyphen that KioskSlugSchema and the lookup
+    // pattern reject — the kiosk would be unfetchable by slug. Re-trim.
+    .replace(/^-+|-+$/g, '');
   return base.length >= 3 ? base : 'kiosk';
 }
 
@@ -74,30 +78,43 @@ async function deriveUniqueKioskSlug(gymId: number, name: string): Promise<strin
   return `${base}-${uuidv4().slice(0, 8)}`;
 }
 
+type ResolvedKioskBoard = {
+  boardId: number;
+  boardUuid: string;
+  name: string;
+  boardType: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
 /**
  * Build the public GymKiosk payload: the leniently-parsed layout, the resolved
  * slot boards (in slot order, dead/hidden slots dropped), and the branding-
- * carrying gym. A slot board is included only when it's alive, linked to this
- * gym, AND its presence-channel id is exposable to the viewer — GymKioskBoard's
- * boardId is non-null, so a filtered board is omitted rather than shown with a
- * null id. That reuses the exact `UserBoard.boardId` gate (public, or the viewer
- * can edit the board) via enrichBoards, and doubles as the "hide non-public
- * boards from anon" rule (the private board stays in `layout`, off `boards`).
+ * carrying gym.
+ *
+ * Board visibility follows the viewer's GYM-level access, matching the SDL
+ * docstring ("for a viewer without gym-edit access non-public boards are
+ * filtered out"):
+ *  - `viewerCanEditGym` (owner, gym admin/editor, or covering community
+ *    admin/leader — the same set that passes the kiosk write gate): every
+ *    alive, gym-linked slot board is included, private ones too, so the manage
+ *    UI never shows a placeholder for a board the editor just placed. Their
+ *    `boardId` is exposed directly — gym edit access is at least as strong a
+ *    trust signal as the per-board gate.
+ *  - everyone else: a slot board is included only when its presence-channel id
+ *    is exposable via the shared `UserBoard.boardId` gate in enrichBoards
+ *    (public, or the viewer can edit that board). GymKioskBoard's boardId is
+ *    non-null, so a filtered board is omitted rather than shown with a null id
+ *    (the private board stays in `layout`, off `boards`, and the kiosk client
+ *    degrades the preset).
  */
-async function resolveKioskView(kiosk: KioskRow, gym: GymRow, viewerId?: string) {
+async function resolveKioskView(kiosk: KioskRow, gym: GymRow, viewerId: string | undefined, viewerCanEditGym: boolean) {
   const parsed = parseKioskLayoutLenient(kiosk.layout);
   const slotUuids = parsed.layout.boards.map((slot) => slot.boardUuid);
 
-  const boards: Array<{
-    boardId: number;
-    boardUuid: string;
-    name: string;
-    boardType: string;
-    layoutId: number;
-    sizeId: number;
-    setIds: string;
-    angle: number;
-  }> = [];
+  const boards: ResolvedKioskBoard[] = [];
 
   if (slotUuids.length > 0) {
     const rows = await db
@@ -110,25 +127,45 @@ async function resolveKioskView(kiosk: KioskRow, gym: GymRow, viewerId?: string)
           isNull(dbSchema.userBoards.deletedAt),
         ),
       );
-    const enriched = await enrichBoards(
-      rows.map((board) => ({ board })),
-      viewerId,
-    );
-    const byUuid = new Map(enriched.map((board) => [board.uuid, board]));
+
+    const visibleByUuid = new Map<string, ResolvedKioskBoard>();
+    if (viewerCanEditGym) {
+      // Gym editors see every alive, gym-linked slot board (private included).
+      for (const row of rows) {
+        visibleByUuid.set(row.uuid, {
+          boardId: row.id,
+          boardUuid: row.uuid,
+          name: row.name,
+          boardType: row.boardType,
+          layoutId: Number(row.layoutId),
+          sizeId: Number(row.sizeId),
+          setIds: row.setIds,
+          angle: Number(row.angle),
+        });
+      }
+    } else {
+      const enriched = await enrichBoards(
+        rows.map((board) => ({ board })),
+        viewerId,
+      );
+      for (const board of enriched) {
+        if (board.boardId == null) continue;
+        visibleByUuid.set(board.uuid, {
+          boardId: board.boardId,
+          boardUuid: board.uuid,
+          name: board.name,
+          boardType: board.boardType,
+          layoutId: board.layoutId,
+          sizeId: board.sizeId,
+          setIds: board.setIds,
+          angle: board.angle,
+        });
+      }
+    }
 
     for (const slot of parsed.layout.boards) {
-      const board = byUuid.get(slot.boardUuid);
-      if (!board || board.boardId == null) continue;
-      boards.push({
-        boardId: board.boardId,
-        boardUuid: board.uuid,
-        name: board.name,
-        boardType: board.boardType,
-        layoutId: board.layoutId,
-        sizeId: board.sizeId,
-        setIds: board.setIds,
-        angle: board.angle,
-      });
+      const board = visibleByUuid.get(slot.boardUuid);
+      if (board) boards.push(board);
     }
   }
 
@@ -226,12 +263,14 @@ export const socialGymKioskQueries = {
     if (!gym) return null;
 
     const viewerId = ctx.isAuthenticated ? ctx.userId : undefined;
+    // Gym-level edit access drives both the private-gym visibility rule and the
+    // slot-board visibility inside resolveKioskView.
+    const viewerCanEdit = viewerId ? await userCanEditGym(gym, viewerId) : false;
 
     // Private gym: visible only to a viewer who can edit it; everyone else gets
     // null (indistinguishable from a missing gym/kiosk).
-    if (!gym.isPublic) {
-      const canEdit = viewerId ? await userCanEditGym(gym, viewerId) : false;
-      if (!canEdit) return null;
+    if (!gym.isPublic && !viewerCanEdit) {
+      return null;
     }
 
     const conditions = [eq(dbSchema.gymKiosks.gymId, gym.id), isNull(dbSchema.gymKiosks.deletedAt)];
@@ -242,16 +281,17 @@ export const socialGymKioskQueries = {
       conditions.push(eq(dbSchema.gymKiosks.slug, kioskSlug));
     }
 
-    // Named slug → that kiosk; no slug → the oldest live kiosk as the default.
+    // Named slug → that kiosk; no slug → the oldest live kiosk as the default
+    // (id tiebreak keeps same-millisecond rows deterministic).
     const [kiosk] = await db
       .select()
       .from(dbSchema.gymKiosks)
       .where(and(...conditions))
-      .orderBy(asc(dbSchema.gymKiosks.createdAt))
+      .orderBy(asc(dbSchema.gymKiosks.createdAt), asc(dbSchema.gymKiosks.id))
       .limit(1);
     if (!kiosk) return null;
 
-    return resolveKioskView(kiosk, gym, viewerId);
+    return resolveKioskView(kiosk, gym, viewerId, viewerCanEdit);
   },
 
   gymKiosks: async (_: unknown, { gymUuid }: { gymUuid: string }, ctx: ConnectionContext) => {
@@ -266,9 +306,10 @@ export const socialGymKioskQueries = {
       .select()
       .from(dbSchema.gymKiosks)
       .where(and(eq(dbSchema.gymKiosks.gymId, gym.id), isNull(dbSchema.gymKiosks.deletedAt)))
-      .orderBy(asc(dbSchema.gymKiosks.createdAt));
+      .orderBy(asc(dbSchema.gymKiosks.createdAt), asc(dbSchema.gymKiosks.id));
 
-    return Promise.all(kiosks.map((kiosk) => resolveKioskView(kiosk, gym, userId)));
+    // The viewer just passed requireGymEditAccess, so they're a gym editor.
+    return Promise.all(kiosks.map((kiosk) => resolveKioskView(kiosk, gym, userId, true)));
   },
 };
 
@@ -320,7 +361,8 @@ export const socialGymKioskMutations = {
       throw error;
     }
 
-    return resolveKioskView(created, gym, userId);
+    // The viewer just passed requireGymEditAccess, so they're a gym editor.
+    return resolveKioskView(created, gym, userId, true);
   },
 
   updateGymKiosk: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
@@ -332,7 +374,14 @@ export const socialGymKioskMutations = {
     const userId = ctx.userId!;
 
     const { kiosk, gym } = await loadKioskForWrite(validated.kioskUuid);
-    await requireGymEditAccess(gym.uuid, userId);
+    // Authorization failures are masked as the same NOT_FOUND the load path
+    // throws, so an authenticated prober can't tell a kiosk they may not edit
+    // apart from one that doesn't exist. userCanEditGym covers exactly the
+    // requireGymEditAccess set (owner, gym admin/editor, covering community
+    // admin/leader) without the distinguishable "Not authorized" error.
+    if (!(await userCanEditGym(gym, userId))) {
+      throw new GraphQLError('Kiosk not found', { extensions: { code: 'NOT_FOUND' } });
+    }
 
     const updateValues: Record<string, unknown> = { updatedAt: new Date() };
     if (validated.name !== undefined) updateValues.name = validated.name;
@@ -360,7 +409,8 @@ export const socialGymKioskMutations = {
       throw error;
     }
 
-    return resolveKioskView(updated, gym, userId);
+    // The viewer just passed the gym-edit gate above, so they're a gym editor.
+    return resolveKioskView(updated, gym, userId, true);
   },
 
   deleteGymKiosk: async (
@@ -374,7 +424,11 @@ export const socialGymKioskMutations = {
     const userId = ctx.userId!;
 
     const { kiosk, gym } = await loadKioskForWrite(kioskUuid);
-    await requireGymEditAccess(gym.uuid, userId);
+    // Same NOT_FOUND mask as updateGymKiosk: no existence oracle for
+    // authenticated probers.
+    if (!(await userCanEditGym(gym, userId))) {
+      throw new GraphQLError('Kiosk not found', { extensions: { code: 'NOT_FOUND' } });
+    }
 
     await db.update(dbSchema.gymKiosks).set({ deletedAt: new Date() }).where(eq(dbSchema.gymKiosks.id, kiosk.id));
 

--- a/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
@@ -89,10 +89,13 @@ type ResolvedKioskBoard = {
   angle: number;
 };
 
+type EnrichedGym = Awaited<ReturnType<typeof enrichGym>>;
+
 /**
  * Build the public GymKiosk payload: the leniently-parsed layout, the resolved
  * slot boards (in slot order, dead/hidden slots dropped), and the branding-
- * carrying gym.
+ * carrying gym (`enrichedGym` — enriched ONCE by the caller, since the manage
+ * list shares one gym across all its kiosks).
  *
  * Board visibility follows the viewer's GYM-level access, matching the SDL
  * docstring ("for a viewer without gym-edit access non-public boards are
@@ -110,7 +113,12 @@ type ResolvedKioskBoard = {
  *    (the private board stays in `layout`, off `boards`, and the kiosk client
  *    degrades the preset).
  */
-async function resolveKioskView(kiosk: KioskRow, gym: GymRow, viewerId: string | undefined, viewerCanEditGym: boolean) {
+async function resolveKioskView(
+  kiosk: KioskRow,
+  enrichedGym: EnrichedGym,
+  viewerId: string | undefined,
+  viewerCanEditGym: boolean,
+) {
   const parsed = parseKioskLayoutLenient(kiosk.layout);
   const slotUuids = parsed.layout.boards.map((slot) => slot.boardUuid);
 
@@ -176,7 +184,9 @@ async function resolveKioskView(kiosk: KioskRow, gym: GymRow, viewerId: string |
     // Return the leniently-parsed layout, never the raw stored jsonb: a corrupt
     // or future-version row surfaces as an empty layout, never an error.
     layout: parsed.layout,
-    gym: await enrichGym(gym, viewerId),
+    // Enriched once by the caller (the manage list shares one gym across all
+    // its kiosks — enriching per kiosk would fan the same queries out N times).
+    gym: enrichedGym,
     boards,
     createdAt: kiosk.createdAt.toISOString(),
     updatedAt: kiosk.updatedAt.toISOString(),
@@ -291,7 +301,7 @@ export const socialGymKioskQueries = {
       .limit(1);
     if (!kiosk) return null;
 
-    return resolveKioskView(kiosk, gym, viewerId, viewerCanEdit);
+    return resolveKioskView(kiosk, await enrichGym(gym, viewerId), viewerId, viewerCanEdit);
   },
 
   gymKiosks: async (_: unknown, { gymUuid }: { gymUuid: string }, ctx: ConnectionContext) => {
@@ -309,7 +319,9 @@ export const socialGymKioskQueries = {
       .orderBy(asc(dbSchema.gymKiosks.createdAt), asc(dbSchema.gymKiosks.id));
 
     // The viewer just passed requireGymEditAccess, so they're a gym editor.
-    return Promise.all(kiosks.map((kiosk) => resolveKioskView(kiosk, gym, userId, true)));
+    // Every kiosk shares this one gym — enrich it once, not once per kiosk.
+    const enrichedGym = await enrichGym(gym, userId);
+    return Promise.all(kiosks.map((kiosk) => resolveKioskView(kiosk, enrichedGym, userId, true)));
   },
 };
 
@@ -326,32 +338,44 @@ export const socialGymKioskMutations = {
 
     const gym = await requireGymEditAccess(validated.gymUuid, userId);
 
-    // Enforce the per-gym kiosk cap (live kiosks only; soft-deleted rows free a slot).
-    const [countRow] = await db
-      .select({ value: count() })
-      .from(dbSchema.gymKiosks)
-      .where(and(eq(dbSchema.gymKiosks.gymId, gym.id), isNull(dbSchema.gymKiosks.deletedAt)));
-    if (Number(countRow?.value ?? 0) >= MAX_KIOSKS_PER_GYM) {
-      throw new GraphQLError(`A gym can have at most ${MAX_KIOSKS_PER_GYM} kiosks`, {
-        extensions: { code: 'BAD_USER_INPUT' },
-      });
-    }
-
+    // Slug derivation stays outside the transaction: it's advisory (the partial
+    // unique index is the real guard; a race lands in the catch below).
     const slug = validated.slug ?? (await deriveUniqueKioskSlug(gym.id, validated.name));
 
     let created: KioskRow;
     try {
-      [created] = await db
-        .insert(dbSchema.gymKiosks)
-        .values({
-          uuid: uuidv4(),
-          gymId: gym.id,
-          slug,
-          name: validated.name,
-          // A fresh kiosk starts empty; boards are assigned via updateGymKiosk.
-          layout: emptyKioskLayout(),
-        })
-        .returning();
+      created = await db.transaction(async (tx) => {
+        // Serialize concurrent creates for the same gym: lock the gym row so
+        // the count-then-insert below can't race — without this, two calls one
+        // below MAX_KIOSKS_PER_GYM could both pass the check and leave the gym
+        // over the cap (the only DB invariant is the slug index).
+        await tx.select({ id: dbSchema.gyms.id }).from(dbSchema.gyms).where(eq(dbSchema.gyms.id, gym.id)).for('update');
+
+        // Enforce the per-gym kiosk cap (live kiosks only; a soft-deleted row
+        // frees its slot).
+        const [countRow] = await tx
+          .select({ value: count() })
+          .from(dbSchema.gymKiosks)
+          .where(and(eq(dbSchema.gymKiosks.gymId, gym.id), isNull(dbSchema.gymKiosks.deletedAt)));
+        if (Number(countRow?.value ?? 0) >= MAX_KIOSKS_PER_GYM) {
+          throw new GraphQLError(`A gym can have at most ${MAX_KIOSKS_PER_GYM} kiosks`, {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+
+        const [row] = await tx
+          .insert(dbSchema.gymKiosks)
+          .values({
+            uuid: uuidv4(),
+            gymId: gym.id,
+            slug,
+            name: validated.name,
+            // A fresh kiosk starts empty; boards are assigned via updateGymKiosk.
+            layout: emptyKioskLayout(),
+          })
+          .returning();
+        return row;
+      });
     } catch (error) {
       if (isUniqueViolation(error, 'gym_kiosks_unique_gym_slug')) {
         throw new GraphQLError('A kiosk with that slug already exists in this gym', {
@@ -362,7 +386,7 @@ export const socialGymKioskMutations = {
     }
 
     // The viewer just passed requireGymEditAccess, so they're a gym editor.
-    return resolveKioskView(created, gym, userId, true);
+    return resolveKioskView(created, await enrichGym(gym, userId), userId, true);
   },
 
   updateGymKiosk: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
@@ -383,7 +407,9 @@ export const socialGymKioskMutations = {
       throw new GraphQLError('Kiosk not found', { extensions: { code: 'NOT_FOUND' } });
     }
 
-    const updateValues: Record<string, unknown> = { updatedAt: new Date() };
+    // Typed against the table's insert shape so a key typo is a compile error
+    // instead of a silently ignored column.
+    const updateValues: Partial<typeof dbSchema.gymKiosks.$inferInsert> = { updatedAt: new Date() };
     if (validated.name !== undefined) updateValues.name = validated.name;
     if (validated.slug !== undefined) updateValues.slug = validated.slug;
 
@@ -410,7 +436,7 @@ export const socialGymKioskMutations = {
     }
 
     // The viewer just passed the gym-edit gate above, so they're a gym editor.
-    return resolveKioskView(updated, gym, userId, true);
+    return resolveKioskView(updated, await enrichGym(gym, userId), userId, true);
   },
 
   deleteGymKiosk: async (

--- a/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
@@ -1,0 +1,383 @@
+import { v4 as uuidv4 } from 'uuid';
+import { eq, and, or, isNull, asc, like, count, inArray } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { MAX_KIOSKS_PER_GYM, emptyKioskLayout, parseKioskLayoutLenient, type KioskLayout } from '@boardsesh/kiosk';
+import { db } from '../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
+import { CreateGymKioskInputSchema, UpdateGymKioskInputSchema, UUIDSchema } from '../../../validation/schemas';
+import { isUniqueViolation } from '../../../utils/postgres-errors';
+import { enrichGym, requireGymEditAccess, userCanEditGym } from './gyms';
+import { enrichBoards } from './boards';
+
+type GymRow = typeof dbSchema.gyms.$inferSelect;
+type KioskRow = typeof dbSchema.gymKiosks.$inferSelect;
+
+// Rate limits (requests/minute). Reads are generous because a kiosk TV polls its
+// config and the public read is shared with embeds; writes sit behind gym-edit
+// access and the 10-kiosks-per-gym cap, so a higher-than-createGym ceiling is
+// safe and lets the manage UI save a layout repeatedly while configuring.
+const RATE_LIMIT_GYM_KIOSK = 120;
+const RATE_LIMIT_GYM_KIOSKS = 60;
+const RATE_LIMIT_CREATE_GYM_KIOSK = 60;
+const RATE_LIMIT_UPDATE_GYM_KIOSK = 60;
+const RATE_LIMIT_DELETE_GYM_KIOSK = 60;
+
+// Same slug shape gymBySlug accepts — a public URL segment.
+const GYM_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+// Kiosk slug lookup guard (mirrors KioskSlugSchema, kept lenient on read so an
+// odd stored/legacy slug still matches rather than 500s).
+const KIOSK_SLUG_LOOKUP_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+/**
+ * Derive a slug base from a kiosk name: lowercase, non-alphanumeric runs → single
+ * hyphens, trimmed, capped short enough to leave room for a uniqueness suffix.
+ * Falls back to `kiosk` when the name has too few usable characters (the write
+ * schema floors slugs at 3 chars).
+ */
+function deriveKioskSlugBase(name: string): string {
+  const base = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+  return base.length >= 3 ? base : 'kiosk';
+}
+
+/**
+ * Derive a slug that's unique among the gym's live kiosks. Mirrors
+ * generateUniqueGymSlug: one query for the base + numeric-suffix variants, then
+ * pick the first free suffix in memory (no sequential DB probing). The partial
+ * unique index is still the source of truth — an explicit-slug create races
+ * through the resolver's unique-violation catch instead.
+ */
+async function deriveUniqueKioskSlug(gymId: number, name: string): Promise<string> {
+  const base = deriveKioskSlugBase(name);
+  const existing = await db
+    .select({ slug: dbSchema.gymKiosks.slug })
+    .from(dbSchema.gymKiosks)
+    .where(
+      and(
+        eq(dbSchema.gymKiosks.gymId, gymId),
+        isNull(dbSchema.gymKiosks.deletedAt),
+        or(eq(dbSchema.gymKiosks.slug, base), like(dbSchema.gymKiosks.slug, `${base}-%`)),
+      ),
+    );
+  const taken = new Set(existing.map((row) => row.slug));
+
+  if (!taken.has(base)) return base;
+  for (let suffix = 2; suffix <= 100; suffix++) {
+    const candidate = `${base}-${suffix}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return `${base}-${uuidv4().slice(0, 8)}`;
+}
+
+/**
+ * Build the public GymKiosk payload: the leniently-parsed layout, the resolved
+ * slot boards (in slot order, dead/hidden slots dropped), and the branding-
+ * carrying gym. A slot board is included only when it's alive, linked to this
+ * gym, AND its presence-channel id is exposable to the viewer — GymKioskBoard's
+ * boardId is non-null, so a filtered board is omitted rather than shown with a
+ * null id. That reuses the exact `UserBoard.boardId` gate (public, or the viewer
+ * can edit the board) via enrichBoards, and doubles as the "hide non-public
+ * boards from anon" rule (the private board stays in `layout`, off `boards`).
+ */
+async function resolveKioskView(kiosk: KioskRow, gym: GymRow, viewerId?: string) {
+  const parsed = parseKioskLayoutLenient(kiosk.layout);
+  const slotUuids = parsed.layout.boards.map((slot) => slot.boardUuid);
+
+  const boards: Array<{
+    boardId: number;
+    boardUuid: string;
+    name: string;
+    boardType: string;
+    layoutId: number;
+    sizeId: number;
+    setIds: string;
+    angle: number;
+  }> = [];
+
+  if (slotUuids.length > 0) {
+    const rows = await db
+      .select()
+      .from(dbSchema.userBoards)
+      .where(
+        and(
+          eq(dbSchema.userBoards.gymId, kiosk.gymId),
+          inArray(dbSchema.userBoards.uuid, slotUuids),
+          isNull(dbSchema.userBoards.deletedAt),
+        ),
+      );
+    const enriched = await enrichBoards(
+      rows.map((board) => ({ board })),
+      viewerId,
+    );
+    const byUuid = new Map(enriched.map((board) => [board.uuid, board]));
+
+    for (const slot of parsed.layout.boards) {
+      const board = byUuid.get(slot.boardUuid);
+      if (!board || board.boardId == null) continue;
+      boards.push({
+        boardId: board.boardId,
+        boardUuid: board.uuid,
+        name: board.name,
+        boardType: board.boardType,
+        layoutId: board.layoutId,
+        sizeId: board.sizeId,
+        setIds: board.setIds,
+        angle: board.angle,
+      });
+    }
+  }
+
+  return {
+    uuid: kiosk.uuid,
+    slug: kiosk.slug,
+    name: kiosk.name,
+    // Return the leniently-parsed layout, never the raw stored jsonb: a corrupt
+    // or future-version row surfaces as an empty layout, never an error.
+    layout: parsed.layout,
+    gym: await enrichGym(gym, viewerId),
+    boards,
+    createdAt: kiosk.createdAt.toISOString(),
+    updatedAt: kiosk.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Load a live kiosk plus its (live) gym for a write op. A kiosk whose gym was
+ * soft-deleted is treated as gone. NOT_FOUND is used uniformly so a caller can't
+ * probe which kiosks exist.
+ */
+async function loadKioskForWrite(kioskUuid: string): Promise<{ kiosk: KioskRow; gym: GymRow }> {
+  const [kiosk] = await db
+    .select()
+    .from(dbSchema.gymKiosks)
+    .where(and(eq(dbSchema.gymKiosks.uuid, kioskUuid), isNull(dbSchema.gymKiosks.deletedAt)))
+    .limit(1);
+  if (!kiosk) {
+    throw new GraphQLError('Kiosk not found', { extensions: { code: 'NOT_FOUND' } });
+  }
+
+  const [gym] = await db
+    .select()
+    .from(dbSchema.gyms)
+    .where(and(eq(dbSchema.gyms.id, kiosk.gymId), isNull(dbSchema.gyms.deletedAt)))
+    .limit(1);
+  if (!gym) {
+    throw new GraphQLError('Kiosk not found', { extensions: { code: 'NOT_FOUND' } });
+  }
+
+  return { kiosk, gym };
+}
+
+/** Verify every board referenced by a layout is alive and linked to this gym. */
+async function assertLayoutBoardsInGym(gymId: number, layout: KioskLayout): Promise<void> {
+  const referenced = new Set<string>(layout.boards.map((slot) => slot.boardUuid));
+  // The strict schema already forces a single-board leaderboard to be one of the
+  // slot boards, but re-collect it so the gym-link check covers it explicitly.
+  if (layout.leaderboard?.boardUuid) {
+    referenced.add(layout.leaderboard.boardUuid);
+  }
+  if (referenced.size === 0) return;
+
+  const aliveRows = await db
+    .select({ uuid: dbSchema.userBoards.uuid })
+    .from(dbSchema.userBoards)
+    .where(
+      and(
+        eq(dbSchema.userBoards.gymId, gymId),
+        inArray(dbSchema.userBoards.uuid, [...referenced]),
+        isNull(dbSchema.userBoards.deletedAt),
+      ),
+    );
+  const alive = new Set(aliveRows.map((row) => row.uuid));
+  const missing = [...referenced].filter((uuid) => !alive.has(uuid));
+  if (missing.length > 0) {
+    throw new GraphQLError(`Layout references board(s) not linked to this gym: ${missing.join(', ')}`, {
+      extensions: { code: 'BAD_USER_INPUT' },
+    });
+  }
+}
+
+// ============================================
+// Queries
+// ============================================
+
+export const socialGymKioskQueries = {
+  gymKiosk: async (
+    _: unknown,
+    { gymSlug, kioskSlug }: { gymSlug: string; kioskSlug?: string | null },
+    ctx: ConnectionContext,
+  ) => {
+    await applyRateLimit(ctx, RATE_LIMIT_GYM_KIOSK, 'gymKiosk');
+
+    if (!gymSlug || gymSlug.length > 120 || !GYM_SLUG_PATTERN.test(gymSlug)) {
+      return null;
+    }
+
+    const [gym] = await db
+      .select()
+      .from(dbSchema.gyms)
+      .where(and(eq(dbSchema.gyms.slug, gymSlug), isNull(dbSchema.gyms.deletedAt)))
+      .limit(1);
+    if (!gym) return null;
+
+    const viewerId = ctx.isAuthenticated ? ctx.userId : undefined;
+
+    // Private gym: visible only to a viewer who can edit it; everyone else gets
+    // null (indistinguishable from a missing gym/kiosk).
+    if (!gym.isPublic) {
+      const canEdit = viewerId ? await userCanEditGym(gym, viewerId) : false;
+      if (!canEdit) return null;
+    }
+
+    const conditions = [eq(dbSchema.gymKiosks.gymId, gym.id), isNull(dbSchema.gymKiosks.deletedAt)];
+    if (kioskSlug != null) {
+      if (kioskSlug.length > 60 || !KIOSK_SLUG_LOOKUP_PATTERN.test(kioskSlug)) {
+        return null;
+      }
+      conditions.push(eq(dbSchema.gymKiosks.slug, kioskSlug));
+    }
+
+    // Named slug → that kiosk; no slug → the oldest live kiosk as the default.
+    const [kiosk] = await db
+      .select()
+      .from(dbSchema.gymKiosks)
+      .where(and(...conditions))
+      .orderBy(asc(dbSchema.gymKiosks.createdAt))
+      .limit(1);
+    if (!kiosk) return null;
+
+    return resolveKioskView(kiosk, gym, viewerId);
+  },
+
+  gymKiosks: async (_: unknown, { gymUuid }: { gymUuid: string }, ctx: ConnectionContext) => {
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_GYM_KIOSKS, 'gymKiosks');
+    validateInput(UUIDSchema, gymUuid, 'gymUuid');
+    const userId = ctx.userId!;
+
+    const gym = await requireGymEditAccess(gymUuid, userId);
+
+    const kiosks = await db
+      .select()
+      .from(dbSchema.gymKiosks)
+      .where(and(eq(dbSchema.gymKiosks.gymId, gym.id), isNull(dbSchema.gymKiosks.deletedAt)))
+      .orderBy(asc(dbSchema.gymKiosks.createdAt));
+
+    return Promise.all(kiosks.map((kiosk) => resolveKioskView(kiosk, gym, userId)));
+  },
+};
+
+// ============================================
+// Mutations
+// ============================================
+
+export const socialGymKioskMutations = {
+  createGymKiosk: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_CREATE_GYM_KIOSK, 'createGymKiosk');
+    const validated = validateInput(CreateGymKioskInputSchema, input, 'input');
+    const userId = ctx.userId!;
+
+    const gym = await requireGymEditAccess(validated.gymUuid, userId);
+
+    // Enforce the per-gym kiosk cap (live kiosks only; soft-deleted rows free a slot).
+    const [countRow] = await db
+      .select({ value: count() })
+      .from(dbSchema.gymKiosks)
+      .where(and(eq(dbSchema.gymKiosks.gymId, gym.id), isNull(dbSchema.gymKiosks.deletedAt)));
+    if (Number(countRow?.value ?? 0) >= MAX_KIOSKS_PER_GYM) {
+      throw new GraphQLError(`A gym can have at most ${MAX_KIOSKS_PER_GYM} kiosks`, {
+        extensions: { code: 'BAD_USER_INPUT' },
+      });
+    }
+
+    const slug = validated.slug ?? (await deriveUniqueKioskSlug(gym.id, validated.name));
+
+    let created: KioskRow;
+    try {
+      [created] = await db
+        .insert(dbSchema.gymKiosks)
+        .values({
+          uuid: uuidv4(),
+          gymId: gym.id,
+          slug,
+          name: validated.name,
+          // A fresh kiosk starts empty; boards are assigned via updateGymKiosk.
+          layout: emptyKioskLayout(),
+        })
+        .returning();
+    } catch (error) {
+      if (isUniqueViolation(error, 'gym_kiosks_unique_gym_slug')) {
+        throw new GraphQLError('A kiosk with that slug already exists in this gym', {
+          extensions: { code: 'KIOSK_SLUG_ALREADY_EXISTS' },
+        });
+      }
+      throw error;
+    }
+
+    return resolveKioskView(created, gym, userId);
+  },
+
+  updateGymKiosk: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_UPDATE_GYM_KIOSK, 'updateGymKiosk');
+    // `layout`, when present, is strict-validated here (KioskLayoutSchema); the
+    // parsed output — unknown keys stripped at every level — is what we persist.
+    const validated = validateInput(UpdateGymKioskInputSchema, input, 'input');
+    const userId = ctx.userId!;
+
+    const { kiosk, gym } = await loadKioskForWrite(validated.kioskUuid);
+    await requireGymEditAccess(gym.uuid, userId);
+
+    const updateValues: Record<string, unknown> = { updatedAt: new Date() };
+    if (validated.name !== undefined) updateValues.name = validated.name;
+    if (validated.slug !== undefined) updateValues.slug = validated.slug;
+
+    if (validated.layout !== undefined) {
+      await assertLayoutBoardsInGym(kiosk.gymId, validated.layout);
+      // Backend is the layout schema authority: persist the schema-parsed output.
+      updateValues.layout = validated.layout;
+    }
+
+    let updated: KioskRow;
+    try {
+      [updated] = await db
+        .update(dbSchema.gymKiosks)
+        .set(updateValues)
+        .where(eq(dbSchema.gymKiosks.id, kiosk.id))
+        .returning();
+    } catch (error) {
+      if (isUniqueViolation(error, 'gym_kiosks_unique_gym_slug')) {
+        throw new GraphQLError('A kiosk with that slug already exists in this gym', {
+          extensions: { code: 'KIOSK_SLUG_ALREADY_EXISTS' },
+        });
+      }
+      throw error;
+    }
+
+    return resolveKioskView(updated, gym, userId);
+  },
+
+  deleteGymKiosk: async (
+    _: unknown,
+    { kioskUuid }: { kioskUuid: string },
+    ctx: ConnectionContext,
+  ): Promise<boolean> => {
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_DELETE_GYM_KIOSK, 'deleteGymKiosk');
+    validateInput(UUIDSchema, kioskUuid, 'kioskUuid');
+    const userId = ctx.userId!;
+
+    const { kiosk, gym } = await loadKioskForWrite(kioskUuid);
+    await requireGymEditAccess(gym.uuid, userId);
+
+    await db.update(dbSchema.gymKiosks).set({ deletedAt: new Date() }).where(eq(dbSchema.gymKiosks.id, kiosk.id));
+
+    return true;
+  },
+};

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -100,8 +100,10 @@ function mapRawGymRow(row: Record<string, unknown>): typeof dbSchema.gyms.$infer
 
 /**
  * Enrich a gym row with computed fields (counts, follow status, membership).
+ * Exported so the kiosk resolvers can attach the same branding-carrying `Gym`
+ * payload (logo + colours) to a public kiosk without duplicating the enrichment.
  */
-async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenticatedUserId?: string) {
+export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenticatedUserId?: string) {
   const [
     ownerResult,
     boardCountResult,
@@ -339,8 +341,13 @@ async function requireGymOwnerOrAdmin(gymUuid: string, userId: string): Promise<
  * editor member, or a community admin/leader whose role is global or scoped to
  * one of the gym's board types. Mirrors the `canEdit` computation in enrichGym
  * so the edit UI and the mutation agree. Editing details only — never membership.
+ * Exported so the kiosk CRUD mutations reuse the exact same edit gate as
+ * updateGym (a gym's kiosks are part of "editing the gym's own details").
  */
-async function requireGymEditAccess(gymUuid: string, userId: string): Promise<typeof dbSchema.gyms.$inferSelect> {
+export async function requireGymEditAccess(
+  gymUuid: string,
+  userId: string,
+): Promise<typeof dbSchema.gyms.$inferSelect> {
   const { gym, isOwner, memberRole } = await loadGymWithMemberRole(gymUuid, userId);
   if (isOwner || memberRole === 'admin' || memberRole === 'editor') {
     return gym;

--- a/packages/backend/src/validation/schemas/gym-kiosks.ts
+++ b/packages/backend/src/validation/schemas/gym-kiosks.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import { KioskLayoutSchema } from '@boardsesh/kiosk';
+import { UUIDSchema } from './primitives';
+
+/**
+ * Kiosk slug: lowercase alphanumeric with single hyphens between segments,
+ * 3–60 chars. Tighter than the generic `SlugSchema` (1–200) because kiosk slugs
+ * sit in a public URL (`/kiosk/{gym-slug}/{kiosk-slug}`) and are auto-derived
+ * from the name, so a floor keeps derived slugs meaningful and a lower ceiling
+ * keeps the URL readable.
+ */
+export const KioskSlugSchema = z
+  .string()
+  .min(3, 'Kiosk slug too short (min 3)')
+  .max(60, 'Kiosk slug too long (max 60)')
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Kiosk slug must be lowercase alphanumeric with hyphens');
+
+/**
+ * Create kiosk input. `slug` is optional — the resolver derives a unique one from
+ * `name` when it's absent.
+ */
+export const CreateGymKioskInputSchema = z.object({
+  gymUuid: UUIDSchema,
+  name: z.string().min(1, 'Kiosk name cannot be empty').max(100, 'Kiosk name too long'),
+  slug: KioskSlugSchema.optional(),
+});
+
+/**
+ * Update kiosk input. Every field is optional; `layout`, when present, is
+ * strict-validated against @boardsesh/kiosk's `KioskLayoutSchema` here so the
+ * resolver receives (and persists) the schema-parsed output — the backend is the
+ * layout schema authority, and `.parse()` strips unknown keys at every level.
+ * The alive-and-gym-linked board checks stay in the resolver (they need the DB).
+ */
+export const UpdateGymKioskInputSchema = z.object({
+  kioskUuid: UUIDSchema,
+  name: z.string().min(1, 'Kiosk name cannot be empty').max(100, 'Kiosk name too long').optional(),
+  slug: KioskSlugSchema.optional(),
+  layout: KioskLayoutSchema.optional(),
+});

--- a/packages/backend/src/validation/schemas/index.ts
+++ b/packages/backend/src/validation/schemas/index.ts
@@ -12,6 +12,7 @@ export * from './feeds';
 export * from './proposals';
 export * from './boards';
 export * from './gyms';
+export * from './gym-kiosks';
 export * from './feedback';
 export * from './board-presence';
 export * from './integrations';

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2971,9 +2971,12 @@ actually render on the TV: dead/unlinked slots are dropped, and for a viewer
 without gym-edit access non-public boards are filtered out entirely (the kiosk
 client renders a placeholder for the missing slot / degrades the preset).
 `boardId` is the numeric board-presence channel id (userBoards.id) and is
-always populated here — a board only appears in this list when it passes the
-same anon-readable gate as `UserBoard.boardId` (public, or the viewer can edit
-it), which is exactly when that id is safe to expose.
+always populated here. Visibility follows the viewer's GYM-level access: a gym
+editor (owner, gym admin/editor, or covering community admin/leader) sees every
+alive gym-linked slot board — private included, so the manage UI never shows a
+placeholder for a board they just placed; everyone else gets only boards
+passing the same anon-readable gate as `UserBoard.boardId` (public, or the
+viewer can edit that board), which is exactly when that id is safe to expose.
 """
 type GymKioskBoard {
   "Numeric board-presence channel id (userBoards.id) — feeds boardNowPlaying(boardId)."

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2962,6 +2962,100 @@ input PendingGymClaimsInput {
 }
 
 # ============================================
+# Gym Kiosk Types (smart-TV wall dashboard)
+# ============================================
+
+"""
+One resolved board shown on a kiosk, in slot order. These are the boards that
+actually render on the TV: dead/unlinked slots are dropped, and for a viewer
+without gym-edit access non-public boards are filtered out entirely (the kiosk
+client renders a placeholder for the missing slot / degrades the preset).
+`boardId` is the numeric board-presence channel id (userBoards.id) and is
+always populated here — a board only appears in this list when it passes the
+same anon-readable gate as `UserBoard.boardId` (public, or the viewer can edit
+it), which is exactly when that id is safe to expose.
+"""
+type GymKioskBoard {
+  "Numeric board-presence channel id (userBoards.id) — feeds boardNowPlaying(boardId)."
+  boardId: Int!
+  "The board's immutable UUID (stable across board renames)."
+  boardUuid: ID!
+  "Board display name."
+  name: String!
+  "Board type (kilter, tension, moonboard, ...)."
+  boardType: String!
+  "Layout ID."
+  layoutId: Int!
+  "Product size ID."
+  sizeId: Int!
+  "Comma-separated set IDs."
+  setIds: String!
+  "Default wall angle."
+  angle: Int!
+}
+
+"""
+A gym kiosk: a preset-based smart-TV wall dashboard, addressed publicly as
+`/kiosk/{gym-slug}/{kiosk-slug}`. The `layout` is the stored preset config —
+1–4 board slots plus an optional leaderboard rail — validated on write against
+@boardsesh/kiosk's `KioskLayoutSchema` and read back leniently (a corrupt or
+future-version stored layout degrades to an empty layout rather than erroring).
+`boards` is the RESOLVED slot list (see GymKioskBoard); it can be shorter than
+`layout.boards` when slots point at dead boards or boards the viewer may not
+see. `gym` carries the gym's branding (logo + colours) for the kiosk chrome.
+"""
+type GymKiosk {
+  "Unique identifier."
+  uuid: ID!
+  "URL slug (unique per gym among live kiosks)."
+  slug: String!
+  "Kiosk display name."
+  name: String!
+  "Preset layout config (@boardsesh/kiosk KioskLayoutSchema): 1–4 board slots + optional leaderboard rail. Read leniently."
+  layout: JSON!
+  "The owning gym, enriched with branding for the kiosk chrome."
+  gym: Gym!
+  "Resolved slot boards in slot order (dead/hidden slots omitted)."
+  boards: [GymKioskBoard!]!
+  "When the kiosk was created (ISO 8601)."
+  createdAt: String!
+  "When the kiosk was last updated (ISO 8601)."
+  updatedAt: String!
+}
+
+"""
+Input for creating a kiosk. `slug` is optional — when omitted it's derived
+from `name` and made unique within the gym. A kiosk can be created before the
+gym has a slug (the manage UI prompts for the gym slug the public kiosk URL
+needs); creation itself doesn't require one.
+"""
+input CreateGymKioskInput {
+  "The gym to create the kiosk under."
+  gymUuid: ID!
+  "Kiosk display name."
+  name: String!
+  "Optional URL slug (lowercase alphanumeric + hyphens, 3–60 chars). Derived from name when omitted."
+  slug: String
+}
+
+"""
+Input for updating a kiosk. Every field is optional; omitted fields are left
+untouched. When `layout` is present it's validated with the STRICT
+KioskLayoutSchema and every referenced board (slots + a single-board
+leaderboard) must be an alive board linked to this kiosk's gym.
+"""
+input UpdateGymKioskInput {
+  "The kiosk to update."
+  kioskUuid: ID!
+  "New display name."
+  name: String
+  "New URL slug (lowercase alphanumeric + hyphens, 3–60 chars; unique per gym)."
+  slug: String
+  "New preset layout config (@boardsesh/kiosk KioskLayoutSchema). Persisted as the schema-parsed output."
+  layout: JSON
+}
+
+# ============================================
 # Notification Types
 # ============================================
 
@@ -4843,6 +4937,28 @@ type Query {
   pendingGymClaims(input: PendingGymClaimsInput): GymClaimConnection!
 
   # ============================================
+  # Gym Kiosk Queries
+  # ============================================
+
+  """
+  A gym's public kiosk (smart-TV wall dashboard) by gym slug, with an optional
+  kiosk slug. Public read, rate-limited, no login: a public gym's kiosks are
+  visible to anyone; a private gym's are visible only to a viewer who can edit
+  it (everyone else gets null, indistinguishable from a missing gym/kiosk). When
+  `kioskSlug` is omitted the gym's oldest live kiosk is returned as the default.
+  Returns null when the gym or kiosk doesn't exist or isn't visible. The
+  `boards` list is resolved in slot order with dead/hidden slots dropped; the
+  `layout` JSON is read leniently (a corrupt stored layout degrades to empty).
+  """
+  gymKiosk(gymSlug: String!, kioskSlug: String): GymKiosk
+
+  """
+  All of a gym's live kiosks (oldest first) for the manage UI. Requires gym edit
+  access (owner, gym admin/editor, or a covering community admin/leader).
+  """
+  gymKiosks(gymUuid: ID!): [GymKiosk!]!
+
+  # ============================================
   # Notification Queries (require auth)
   # ============================================
 
@@ -5585,6 +5701,31 @@ type Mutation {
   ownership to the claimant.
   """
   reviewGymClaim(input: ReviewGymClaimInput!): Boolean!
+
+  # ============================================
+  # Gym Kiosk Mutations (require gym edit access)
+  # ============================================
+
+  """
+  Create a kiosk (smart-TV wall dashboard) under a gym. Requires gym edit
+  access. The slug is derived from the name (and made unique per gym) when
+  omitted. Starts with an empty layout — assign boards via updateGymKiosk. Fails
+  when the gym already has the maximum number of kiosks.
+  """
+  createGymKiosk(input: CreateGymKioskInput!): GymKiosk!
+
+  """
+  Update a kiosk's name, slug, and/or layout. Requires gym edit access. A
+  supplied layout is strictly validated (@boardsesh/kiosk KioskLayoutSchema) and
+  persisted as the schema-parsed output — every referenced board must be alive
+  and linked to this kiosk's gym.
+  """
+  updateGymKiosk(input: UpdateGymKioskInput!): GymKiosk!
+
+  """
+  Soft-delete a kiosk. Requires gym edit access. The slug is freed for reuse.
+  """
+  deleteGymKiosk(kioskUuid: ID!): Boolean!
 
   """
   Record that an explicitly-created session has been mirrored to Apple HealthKit,

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2203,9 +2203,12 @@ export type GymKiosk = {
  * without gym-edit access non-public boards are filtered out entirely (the kiosk
  * client renders a placeholder for the missing slot / degrades the preset).
  * `boardId` is the numeric board-presence channel id (userBoards.id) and is
- * always populated here — a board only appears in this list when it passes the
- * same anon-readable gate as `UserBoard.boardId` (public, or the viewer can edit
- * it), which is exactly when that id is safe to expose.
+ * always populated here. Visibility follows the viewer's GYM-level access: a gym
+ * editor (owner, gym admin/editor, or covering community admin/leader) sees every
+ * alive gym-linked slot board — private included, so the manage UI never shows a
+ * placeholder for a board they just placed; everyone else gets only boards
+ * passing the same anon-readable gate as `UserBoard.boardId` (public, or the
+ * viewer can edit that board), which is exactly when that id is safe to expose.
  */
 export type GymKioskBoard = {
   __typename?: 'GymKioskBoard';

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1316,6 +1316,21 @@ export type CreateGymInput = {
   website?: InputMaybe<Scalars['String']['input']>;
 };
 
+/**
+ * Input for creating a kiosk. `slug` is optional — when omitted it's derived
+ * from `name` and made unique within the gym. A kiosk can be created before the
+ * gym has a slug (the manage UI prompts for the gym slug the public kiosk URL
+ * needs); creation itself doesn't require one.
+ */
+export type CreateGymKioskInput = {
+  /** The gym to create the kiosk under. */
+  gymUuid: Scalars['ID']['input'];
+  /** Kiosk display name. */
+  name: Scalars['String']['input'];
+  /** Optional URL slug (lowercase alphanumeric + hyphens, 3–60 chars). Derived from name when omitted. */
+  slug?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** Input for creating a playlist. */
 export type CreatePlaylistInput = {
   /** Board type */
@@ -2152,6 +2167,66 @@ export type GymConnection = {
   totalCount: Scalars['Int']['output'];
 };
 
+/**
+ * A gym kiosk: a preset-based smart-TV wall dashboard, addressed publicly as
+ * `/kiosk/{gym-slug}/{kiosk-slug}`. The `layout` is the stored preset config —
+ * 1–4 board slots plus an optional leaderboard rail — validated on write against
+ * @boardsesh/kiosk's `KioskLayoutSchema` and read back leniently (a corrupt or
+ * future-version stored layout degrades to an empty layout rather than erroring).
+ * `boards` is the RESOLVED slot list (see GymKioskBoard); it can be shorter than
+ * `layout.boards` when slots point at dead boards or boards the viewer may not
+ * see. `gym` carries the gym's branding (logo + colours) for the kiosk chrome.
+ */
+export type GymKiosk = {
+  __typename?: 'GymKiosk';
+  /** Resolved slot boards in slot order (dead/hidden slots omitted). */
+  boards: Array<GymKioskBoard>;
+  /** When the kiosk was created (ISO 8601). */
+  createdAt: Scalars['String']['output'];
+  /** The owning gym, enriched with branding for the kiosk chrome. */
+  gym: Gym;
+  /** Preset layout config (@boardsesh/kiosk KioskLayoutSchema): 1–4 board slots + optional leaderboard rail. Read leniently. */
+  layout: Scalars['JSON']['output'];
+  /** Kiosk display name. */
+  name: Scalars['String']['output'];
+  /** URL slug (unique per gym among live kiosks). */
+  slug: Scalars['String']['output'];
+  /** When the kiosk was last updated (ISO 8601). */
+  updatedAt: Scalars['String']['output'];
+  /** Unique identifier. */
+  uuid: Scalars['ID']['output'];
+};
+
+/**
+ * One resolved board shown on a kiosk, in slot order. These are the boards that
+ * actually render on the TV: dead/unlinked slots are dropped, and for a viewer
+ * without gym-edit access non-public boards are filtered out entirely (the kiosk
+ * client renders a placeholder for the missing slot / degrades the preset).
+ * `boardId` is the numeric board-presence channel id (userBoards.id) and is
+ * always populated here — a board only appears in this list when it passes the
+ * same anon-readable gate as `UserBoard.boardId` (public, or the viewer can edit
+ * it), which is exactly when that id is safe to expose.
+ */
+export type GymKioskBoard = {
+  __typename?: 'GymKioskBoard';
+  /** Default wall angle. */
+  angle: Scalars['Int']['output'];
+  /** Numeric board-presence channel id (userBoards.id) — feeds boardNowPlaying(boardId). */
+  boardId: Scalars['Int']['output'];
+  /** Board type (kilter, tension, moonboard, ...). */
+  boardType: Scalars['String']['output'];
+  /** The board's immutable UUID (stable across board renames). */
+  boardUuid: Scalars['ID']['output'];
+  /** Layout ID. */
+  layoutId: Scalars['Int']['output'];
+  /** Board display name. */
+  name: Scalars['String']['output'];
+  /** Comma-separated set IDs. */
+  setIds: Scalars['String']['output'];
+  /** Product size ID. */
+  sizeId: Scalars['Int']['output'];
+};
+
 /** A member of a gym. */
 export type GymMember = {
   __typename?: 'GymMember';
@@ -2453,6 +2528,13 @@ export type Mutation = {
   /** Create a new gym. */
   createGym: Gym;
   /**
+   * Create a kiosk (smart-TV wall dashboard) under a gym. Requires gym edit
+   * access. The slug is derived from the name (and made unique per gym) when
+   * omitted. Starts with an empty layout — assign boards via updateGymKiosk. Fails
+   * when the gym already has the maximum number of kiosks.
+   */
+  createGymKiosk: GymKiosk;
+  /**
    * Mint a short-lived, single-use handoff code for starting the provider's
    * browser OAuth flow (GET /integrations/:provider/start?handoff=...). Keeps
    * the session token out of URLs, where it would persist in logs and browser
@@ -2486,6 +2568,8 @@ export type Mutation = {
   deleteDraftClimb: Scalars['Boolean']['output'];
   /** Soft-delete a gym. */
   deleteGym: Scalars['Boolean']['output'];
+  /** Soft-delete a kiosk. Requires gym edit access. The slug is freed for reuse. */
+  deleteGymKiosk: Scalars['Boolean']['output'];
   /** Delete a playlist (owner only). */
   deletePlaylist: Scalars['Boolean']['output'];
   /** Delete an accepted proposal and revert its effects (admin/leader only). */
@@ -2775,6 +2859,13 @@ export type Mutation = {
   updateComment: Comment;
   /** Update a gym's metadata. */
   updateGym: Gym;
+  /**
+   * Update a kiosk's name, slug, and/or layout. Requires gym edit access. A
+   * supplied layout is strictly validated (@boardsesh/kiosk KioskLayoutSchema) and
+   * persisted as the schema-parsed output — every referenced board must be alive
+   * and linked to this kiosk's gym.
+   */
+  updateGymKiosk: GymKiosk;
   /** Update playlist metadata. */
   updatePlaylist: Playlist;
   /** Update only lastAccessedAt for a playlist (does not update updatedAt). */
@@ -2859,6 +2950,11 @@ export type MutationCreateGymArgs = {
 };
 
 /** Root mutation type for all write operations. */
+export type MutationCreateGymKioskArgs = {
+  input: CreateGymKioskInput;
+};
+
+/** Root mutation type for all write operations. */
 export type MutationCreateIntegrationOAuthHandoffArgs = {
   provider: IntegrationProvider;
 };
@@ -2912,6 +3008,11 @@ export type MutationDeleteDraftClimbArgs = {
 /** Root mutation type for all write operations. */
 export type MutationDeleteGymArgs = {
   gymUuid: Scalars['ID']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationDeleteGymKioskArgs = {
+  kioskUuid: Scalars['ID']['input'];
 };
 
 /** Root mutation type for all write operations. */
@@ -3311,6 +3412,11 @@ export type MutationUpdateCommentArgs = {
 /** Root mutation type for all write operations. */
 export type MutationUpdateGymArgs = {
   input: UpdateGymInput;
+};
+
+/** Root mutation type for all write operations. */
+export type MutationUpdateGymKioskArgs = {
+  input: UpdateGymKioskInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -4023,6 +4129,22 @@ export type Query = {
   gymBoards: Array<UserBoard>;
   /** Get a gym by slug (for URL routing). */
   gymBySlug?: Maybe<Gym>;
+  /**
+   * A gym's public kiosk (smart-TV wall dashboard) by gym slug, with an optional
+   * kiosk slug. Public read, rate-limited, no login: a public gym's kiosks are
+   * visible to anyone; a private gym's are visible only to a viewer who can edit
+   * it (everyone else gets null, indistinguishable from a missing gym/kiosk). When
+   * `kioskSlug` is omitted the gym's oldest live kiosk is returned as the default.
+   * Returns null when the gym or kiosk doesn't exist or isn't visible. The
+   * `boards` list is resolved in slot order with dead/hidden slots dropped; the
+   * `layout` JSON is read leniently (a corrupt stored layout degrades to empty).
+   */
+  gymKiosk?: Maybe<GymKiosk>;
+  /**
+   * All of a gym's live kiosks (oldest first) for the manage UI. Requires gym edit
+   * access (owner, gym admin/editor, or a covering community admin/leader).
+   */
+  gymKiosks: Array<GymKiosk>;
   /** Get members of a gym. */
   gymMembers: GymMemberConnection;
   /**
@@ -4551,6 +4673,17 @@ export type QueryGymBoardsArgs = {
 /** Root query type for all read operations. */
 export type QueryGymBySlugArgs = {
   slug: Scalars['String']['input'];
+};
+
+/** Root query type for all read operations. */
+export type QueryGymKioskArgs = {
+  gymSlug: Scalars['String']['input'];
+  kioskSlug?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Root query type for all read operations. */
+export type QueryGymKiosksArgs = {
+  gymUuid: Scalars['ID']['input'];
 };
 
 /** Root query type for all read operations. */
@@ -6471,6 +6604,23 @@ export type UpdateGymInput = {
   website?: InputMaybe<Scalars['String']['input']>;
 };
 
+/**
+ * Input for updating a kiosk. Every field is optional; omitted fields are left
+ * untouched. When `layout` is present it's validated with the STRICT
+ * KioskLayoutSchema and every referenced board (slots + a single-board
+ * leaderboard) must be an alive board linked to this kiosk's gym.
+ */
+export type UpdateGymKioskInput = {
+  /** The kiosk to update. */
+  kioskUuid: Scalars['ID']['input'];
+  /** New preset layout config (@boardsesh/kiosk KioskLayoutSchema). Persisted as the schema-parsed output. */
+  layout?: InputMaybe<Scalars['JSON']['input']>;
+  /** New display name. */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** New URL slug (lowercase alphanumeric + hyphens, 3–60 chars; unique per gym). */
+  slug?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** Input for updating a playlist. */
 export type UpdatePlaylistInput = {
   /** New color */
@@ -6957,6 +7107,7 @@ export type ResolversTypes = ResolversObject<{
   ControllerRegistration: ResolverTypeWrapper<ControllerRegistration>;
   CreateBoardInput: CreateBoardInput;
   CreateGymInput: CreateGymInput;
+  CreateGymKioskInput: CreateGymKioskInput;
   CreatePlaylistInput: CreatePlaylistInput;
   CreateProposalInput: CreateProposalInput;
   CreateSessionInput: CreateSessionInput;
@@ -7019,6 +7170,8 @@ export type ResolversTypes = ResolversObject<{
   GymClaimRequestStatus: GymClaimRequestStatus;
   GymClaimStatus: GymClaimStatus;
   GymConnection: ResolverTypeWrapper<GymConnection>;
+  GymKiosk: ResolverTypeWrapper<GymKiosk>;
+  GymKioskBoard: ResolverTypeWrapper<GymKioskBoard>;
   GymMember: ResolverTypeWrapper<GymMember>;
   GymMemberConnection: ResolverTypeWrapper<GymMemberConnection>;
   GymMemberRole: GymMemberRole;
@@ -7178,6 +7331,7 @@ export type ResolversTypes = ResolversObject<{
   UpdateClimbResult: ResolverTypeWrapper<UpdateClimbResult>;
   UpdateCommentInput: UpdateCommentInput;
   UpdateGymInput: UpdateGymInput;
+  UpdateGymKioskInput: UpdateGymKioskInput;
   UpdatePlaylistInput: UpdatePlaylistInput;
   UpdateProfileInput: UpdateProfileInput;
   UpdateTickInput: UpdateTickInput;
@@ -7271,6 +7425,7 @@ export type ResolversParentTypes = ResolversObject<{
   ControllerRegistration: ControllerRegistration;
   CreateBoardInput: CreateBoardInput;
   CreateGymInput: CreateGymInput;
+  CreateGymKioskInput: CreateGymKioskInput;
   CreatePlaylistInput: CreatePlaylistInput;
   CreateProposalInput: CreateProposalInput;
   CreateSessionInput: CreateSessionInput;
@@ -7327,6 +7482,8 @@ export type ResolversParentTypes = ResolversObject<{
   GymClaim: GymClaim;
   GymClaimConnection: GymClaimConnection;
   GymConnection: GymConnection;
+  GymKiosk: GymKiosk;
+  GymKioskBoard: GymKioskBoard;
   GymMember: GymMember;
   GymMemberConnection: GymMemberConnection;
   GymMembersInput: GymMembersInput;
@@ -7473,6 +7630,7 @@ export type ResolversParentTypes = ResolversObject<{
   UpdateClimbResult: UpdateClimbResult;
   UpdateCommentInput: UpdateCommentInput;
   UpdateGymInput: UpdateGymInput;
+  UpdateGymKioskInput: UpdateGymKioskInput;
   UpdatePlaylistInput: UpdatePlaylistInput;
   UpdateProfileInput: UpdateProfileInput;
   UpdateTickInput: UpdateTickInput;
@@ -8530,6 +8688,36 @@ export type GymConnectionResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GymKioskResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['GymKiosk'] = ResolversParentTypes['GymKiosk'],
+> = ResolversObject<{
+  boards?: Resolver<Array<ResolversTypes['GymKioskBoard']>, ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  gym?: Resolver<ResolversTypes['Gym'], ParentType, ContextType>;
+  layout?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GymKioskBoardResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['GymKioskBoard'] = ResolversParentTypes['GymKioskBoard'],
+> = ResolversObject<{
+  angle?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  boardId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  boardType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  boardUuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  layoutId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  setIds?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  sizeId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type GymMemberResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['GymMember'] = ResolversParentTypes['GymMember'],
@@ -8777,6 +8965,12 @@ export type MutationResolvers<
     RequireFields<MutationCreateBoardArgs, 'input'>
   >;
   createGym?: Resolver<ResolversTypes['Gym'], ParentType, ContextType, RequireFields<MutationCreateGymArgs, 'input'>>;
+  createGymKiosk?: Resolver<
+    ResolversTypes['GymKiosk'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateGymKioskArgs, 'input'>
+  >;
   createIntegrationOAuthHandoff?: Resolver<
     ResolversTypes['String'],
     ParentType,
@@ -8842,6 +9036,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationDeleteGymArgs, 'gymUuid'>
+  >;
+  deleteGymKiosk?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteGymKioskArgs, 'kioskUuid'>
   >;
   deletePlaylist?: Resolver<
     ResolversTypes['Boolean'],
@@ -9271,6 +9471,12 @@ export type MutationResolvers<
     RequireFields<MutationUpdateCommentArgs, 'input'>
   >;
   updateGym?: Resolver<ResolversTypes['Gym'], ParentType, ContextType, RequireFields<MutationUpdateGymArgs, 'input'>>;
+  updateGymKiosk?: Resolver<
+    ResolversTypes['GymKiosk'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateGymKioskArgs, 'input'>
+  >;
   updatePlaylist?: Resolver<
     ResolversTypes['Playlist'],
     ParentType,
@@ -9867,6 +10073,18 @@ export type QueryResolvers<
     ParentType,
     ContextType,
     RequireFields<QueryGymBySlugArgs, 'slug'>
+  >;
+  gymKiosk?: Resolver<
+    Maybe<ResolversTypes['GymKiosk']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryGymKioskArgs, 'gymSlug'>
+  >;
+  gymKiosks?: Resolver<
+    Array<ResolversTypes['GymKiosk']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryGymKiosksArgs, 'gymUuid'>
   >;
   gymMembers?: Resolver<
     ResolversTypes['GymMemberConnection'],
@@ -11278,6 +11496,8 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   GymClaim?: GymClaimResolvers<ContextType>;
   GymClaimConnection?: GymClaimConnectionResolvers<ContextType>;
   GymConnection?: GymConnectionResolvers<ContextType>;
+  GymKiosk?: GymKioskResolvers<ContextType>;
+  GymKioskBoard?: GymKioskBoardResolvers<ContextType>;
   GymMember?: GymMemberResolvers<ContextType>;
   GymMemberConnection?: GymMemberConnectionResolvers<ContextType>;
   InstagramBetaAmbiguous?: InstagramBetaAmbiguousResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/gym-kiosks.ts
+++ b/packages/shared-schema/src/schema/gym-kiosks.ts
@@ -9,9 +9,12 @@ export const gymKiosksTypeDefs = /* GraphQL */ `
   without gym-edit access non-public boards are filtered out entirely (the kiosk
   client renders a placeholder for the missing slot / degrades the preset).
   \`boardId\` is the numeric board-presence channel id (userBoards.id) and is
-  always populated here — a board only appears in this list when it passes the
-  same anon-readable gate as \`UserBoard.boardId\` (public, or the viewer can edit
-  it), which is exactly when that id is safe to expose.
+  always populated here. Visibility follows the viewer's GYM-level access: a gym
+  editor (owner, gym admin/editor, or covering community admin/leader) sees every
+  alive gym-linked slot board — private included, so the manage UI never shows a
+  placeholder for a board they just placed; everyone else gets only boards
+  passing the same anon-readable gate as \`UserBoard.boardId\` (public, or the
+  viewer can edit that board), which is exactly when that id is safe to expose.
   """
   type GymKioskBoard {
     "Numeric board-presence channel id (userBoards.id) — feeds boardNowPlaying(boardId)."

--- a/packages/shared-schema/src/schema/gym-kiosks.ts
+++ b/packages/shared-schema/src/schema/gym-kiosks.ts
@@ -1,0 +1,95 @@
+export const gymKiosksTypeDefs = /* GraphQL */ `
+  # ============================================
+  # Gym Kiosk Types (smart-TV wall dashboard)
+  # ============================================
+
+  """
+  One resolved board shown on a kiosk, in slot order. These are the boards that
+  actually render on the TV: dead/unlinked slots are dropped, and for a viewer
+  without gym-edit access non-public boards are filtered out entirely (the kiosk
+  client renders a placeholder for the missing slot / degrades the preset).
+  \`boardId\` is the numeric board-presence channel id (userBoards.id) and is
+  always populated here — a board only appears in this list when it passes the
+  same anon-readable gate as \`UserBoard.boardId\` (public, or the viewer can edit
+  it), which is exactly when that id is safe to expose.
+  """
+  type GymKioskBoard {
+    "Numeric board-presence channel id (userBoards.id) — feeds boardNowPlaying(boardId)."
+    boardId: Int!
+    "The board's immutable UUID (stable across board renames)."
+    boardUuid: ID!
+    "Board display name."
+    name: String!
+    "Board type (kilter, tension, moonboard, ...)."
+    boardType: String!
+    "Layout ID."
+    layoutId: Int!
+    "Product size ID."
+    sizeId: Int!
+    "Comma-separated set IDs."
+    setIds: String!
+    "Default wall angle."
+    angle: Int!
+  }
+
+  """
+  A gym kiosk: a preset-based smart-TV wall dashboard, addressed publicly as
+  \`/kiosk/{gym-slug}/{kiosk-slug}\`. The \`layout\` is the stored preset config —
+  1–4 board slots plus an optional leaderboard rail — validated on write against
+  @boardsesh/kiosk's \`KioskLayoutSchema\` and read back leniently (a corrupt or
+  future-version stored layout degrades to an empty layout rather than erroring).
+  \`boards\` is the RESOLVED slot list (see GymKioskBoard); it can be shorter than
+  \`layout.boards\` when slots point at dead boards or boards the viewer may not
+  see. \`gym\` carries the gym's branding (logo + colours) for the kiosk chrome.
+  """
+  type GymKiosk {
+    "Unique identifier."
+    uuid: ID!
+    "URL slug (unique per gym among live kiosks)."
+    slug: String!
+    "Kiosk display name."
+    name: String!
+    "Preset layout config (@boardsesh/kiosk KioskLayoutSchema): 1–4 board slots + optional leaderboard rail. Read leniently."
+    layout: JSON!
+    "The owning gym, enriched with branding for the kiosk chrome."
+    gym: Gym!
+    "Resolved slot boards in slot order (dead/hidden slots omitted)."
+    boards: [GymKioskBoard!]!
+    "When the kiosk was created (ISO 8601)."
+    createdAt: String!
+    "When the kiosk was last updated (ISO 8601)."
+    updatedAt: String!
+  }
+
+  """
+  Input for creating a kiosk. \`slug\` is optional — when omitted it's derived
+  from \`name\` and made unique within the gym. A kiosk can be created before the
+  gym has a slug (the manage UI prompts for the gym slug the public kiosk URL
+  needs); creation itself doesn't require one.
+  """
+  input CreateGymKioskInput {
+    "The gym to create the kiosk under."
+    gymUuid: ID!
+    "Kiosk display name."
+    name: String!
+    "Optional URL slug (lowercase alphanumeric + hyphens, 3–60 chars). Derived from name when omitted."
+    slug: String
+  }
+
+  """
+  Input for updating a kiosk. Every field is optional; omitted fields are left
+  untouched. When \`layout\` is present it's validated with the STRICT
+  KioskLayoutSchema and every referenced board (slots + a single-board
+  leaderboard) must be an alive board linked to this kiosk's gym.
+  """
+  input UpdateGymKioskInput {
+    "The kiosk to update."
+    kioskUuid: ID!
+    "New display name."
+    name: String
+    "New URL slug (lowercase alphanumeric + hyphens, 3–60 chars; unique per gym)."
+    slug: String
+    "New preset layout config (@boardsesh/kiosk KioskLayoutSchema). Persisted as the schema-parsed output."
+    layout: JSON
+  }
+`;

--- a/packages/shared-schema/src/schema/index.ts
+++ b/packages/shared-schema/src/schema/index.ts
@@ -11,6 +11,7 @@ import { profileStatsTypeDefs } from './profile-stats';
 import { playlistsTypeDefs } from './playlists';
 import { boardEntitiesTypeDefs } from './board-entities';
 import { gymsTypeDefs } from './gyms';
+import { gymKiosksTypeDefs } from './gym-kiosks';
 import { notificationsTypeDefs } from './notifications';
 import { proposalsTypeDefs } from './proposals';
 import { socialTypeDefs } from './social';
@@ -41,6 +42,7 @@ export const typeDefs = [
   playlistsTypeDefs,
   boardEntitiesTypeDefs,
   gymsTypeDefs,
+  gymKiosksTypeDefs,
   notificationsTypeDefs,
   proposalsTypeDefs,
   socialTypeDefs,

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -527,6 +527,31 @@ export const mutationsTypeDefs = /* GraphQL */ `
     """
     reviewGymClaim(input: ReviewGymClaimInput!): Boolean!
 
+    # ============================================
+    # Gym Kiosk Mutations (require gym edit access)
+    # ============================================
+
+    """
+    Create a kiosk (smart-TV wall dashboard) under a gym. Requires gym edit
+    access. The slug is derived from the name (and made unique per gym) when
+    omitted. Starts with an empty layout — assign boards via updateGymKiosk. Fails
+    when the gym already has the maximum number of kiosks.
+    """
+    createGymKiosk(input: CreateGymKioskInput!): GymKiosk!
+
+    """
+    Update a kiosk's name, slug, and/or layout. Requires gym edit access. A
+    supplied layout is strictly validated (@boardsesh/kiosk KioskLayoutSchema) and
+    persisted as the schema-parsed output — every referenced board must be alive
+    and linked to this kiosk's gym.
+    """
+    updateGymKiosk(input: UpdateGymKioskInput!): GymKiosk!
+
+    """
+    Soft-delete a kiosk. Requires gym edit access. The slug is freed for reuse.
+    """
+    deleteGymKiosk(kioskUuid: ID!): Boolean!
+
     """
     Record that an explicitly-created session has been mirrored to Apple HealthKit,
     storing the workout UUID for de-duplication and UI status.

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -594,6 +594,28 @@ export const queriesTypeDefs = /* GraphQL */ `
     pendingGymClaims(input: PendingGymClaimsInput): GymClaimConnection!
 
     # ============================================
+    # Gym Kiosk Queries
+    # ============================================
+
+    """
+    A gym's public kiosk (smart-TV wall dashboard) by gym slug, with an optional
+    kiosk slug. Public read, rate-limited, no login: a public gym's kiosks are
+    visible to anyone; a private gym's are visible only to a viewer who can edit
+    it (everyone else gets null, indistinguishable from a missing gym/kiosk). When
+    \`kioskSlug\` is omitted the gym's oldest live kiosk is returned as the default.
+    Returns null when the gym or kiosk doesn't exist or isn't visible. The
+    \`boards\` list is resolved in slot order with dead/hidden slots dropped; the
+    \`layout\` JSON is read leniently (a corrupt stored layout degrades to empty).
+    """
+    gymKiosk(gymSlug: String!, kioskSlug: String): GymKiosk
+
+    """
+    All of a gym's live kiosks (oldest first) for the manage UI. Requires gym edit
+    access (owner, gym admin/editor, or a covering community admin/leader).
+    """
+    gymKiosks(gymUuid: ID!): [GymKiosk!]!
+
+    # ============================================
     # Notification Queries (require auth)
     # ============================================
 

--- a/packages/shared-schema/src/types/gym-kiosks.ts
+++ b/packages/shared-schema/src/types/gym-kiosks.ts
@@ -1,0 +1,48 @@
+// Gym kiosk (smart-TV wall dashboard) entity types.
+
+import type { Gym } from './gyms';
+
+/**
+ * One resolved board on a kiosk, in slot order. `boardId` is always present
+ * here because a board only makes it into the resolved list when its
+ * presence-channel id is safe to expose (public, or the viewer can edit it).
+ */
+export type GymKioskBoard = {
+  boardId: number;
+  boardUuid: string;
+  name: string;
+  boardType: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
+/**
+ * A gym kiosk. `layout` is intentionally typed `unknown` (the JSON scalar):
+ * stored layouts are read leniently, so consumers must parse with
+ * `parseKioskLayoutLenient` from @boardsesh/kiosk rather than trust the shape.
+ */
+export type GymKiosk = {
+  uuid: string;
+  slug: string;
+  name: string;
+  layout: unknown;
+  gym: Gym;
+  boards: GymKioskBoard[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateGymKioskInput = {
+  gymUuid: string;
+  name: string;
+  slug?: string;
+};
+
+export type UpdateGymKioskInput = {
+  kioskUuid: string;
+  name?: string;
+  slug?: string;
+  layout?: unknown;
+};

--- a/packages/shared-schema/src/types/index.ts
+++ b/packages/shared-schema/src/types/index.ts
@@ -9,6 +9,7 @@ export * from './ticks';
 export * from './profile-stats';
 export * from './board-entities';
 export * from './gyms';
+export * from './gym-kiosks';
 export * from './playlists';
 export * from './social';
 export * from './notifications';

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2200,9 +2200,12 @@ export type GymKiosk = {
  * without gym-edit access non-public boards are filtered out entirely (the kiosk
  * client renders a placeholder for the missing slot / degrades the preset).
  * `boardId` is the numeric board-presence channel id (userBoards.id) and is
- * always populated here — a board only appears in this list when it passes the
- * same anon-readable gate as `UserBoard.boardId` (public, or the viewer can edit
- * it), which is exactly when that id is safe to expose.
+ * always populated here. Visibility follows the viewer's GYM-level access: a gym
+ * editor (owner, gym admin/editor, or covering community admin/leader) sees every
+ * alive gym-linked slot board — private included, so the manage UI never shows a
+ * placeholder for a board they just placed; everyone else gets only boards
+ * passing the same anon-readable gate as `UserBoard.boardId` (public, or the
+ * viewer can edit that board), which is exactly when that id is safe to expose.
  */
 export type GymKioskBoard = {
   __typename?: 'GymKioskBoard';

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1313,6 +1313,21 @@ export type CreateGymInput = {
   website?: InputMaybe<Scalars['String']['input']>;
 };
 
+/**
+ * Input for creating a kiosk. `slug` is optional — when omitted it's derived
+ * from `name` and made unique within the gym. A kiosk can be created before the
+ * gym has a slug (the manage UI prompts for the gym slug the public kiosk URL
+ * needs); creation itself doesn't require one.
+ */
+export type CreateGymKioskInput = {
+  /** The gym to create the kiosk under. */
+  gymUuid: Scalars['ID']['input'];
+  /** Kiosk display name. */
+  name: Scalars['String']['input'];
+  /** Optional URL slug (lowercase alphanumeric + hyphens, 3–60 chars). Derived from name when omitted. */
+  slug?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** Input for creating a playlist. */
 export type CreatePlaylistInput = {
   /** Board type */
@@ -2149,6 +2164,66 @@ export type GymConnection = {
   totalCount: Scalars['Int']['output'];
 };
 
+/**
+ * A gym kiosk: a preset-based smart-TV wall dashboard, addressed publicly as
+ * `/kiosk/{gym-slug}/{kiosk-slug}`. The `layout` is the stored preset config —
+ * 1–4 board slots plus an optional leaderboard rail — validated on write against
+ * @boardsesh/kiosk's `KioskLayoutSchema` and read back leniently (a corrupt or
+ * future-version stored layout degrades to an empty layout rather than erroring).
+ * `boards` is the RESOLVED slot list (see GymKioskBoard); it can be shorter than
+ * `layout.boards` when slots point at dead boards or boards the viewer may not
+ * see. `gym` carries the gym's branding (logo + colours) for the kiosk chrome.
+ */
+export type GymKiosk = {
+  __typename?: 'GymKiosk';
+  /** Resolved slot boards in slot order (dead/hidden slots omitted). */
+  boards: Array<GymKioskBoard>;
+  /** When the kiosk was created (ISO 8601). */
+  createdAt: Scalars['String']['output'];
+  /** The owning gym, enriched with branding for the kiosk chrome. */
+  gym: Gym;
+  /** Preset layout config (@boardsesh/kiosk KioskLayoutSchema): 1–4 board slots + optional leaderboard rail. Read leniently. */
+  layout: Scalars['JSON']['output'];
+  /** Kiosk display name. */
+  name: Scalars['String']['output'];
+  /** URL slug (unique per gym among live kiosks). */
+  slug: Scalars['String']['output'];
+  /** When the kiosk was last updated (ISO 8601). */
+  updatedAt: Scalars['String']['output'];
+  /** Unique identifier. */
+  uuid: Scalars['ID']['output'];
+};
+
+/**
+ * One resolved board shown on a kiosk, in slot order. These are the boards that
+ * actually render on the TV: dead/unlinked slots are dropped, and for a viewer
+ * without gym-edit access non-public boards are filtered out entirely (the kiosk
+ * client renders a placeholder for the missing slot / degrades the preset).
+ * `boardId` is the numeric board-presence channel id (userBoards.id) and is
+ * always populated here — a board only appears in this list when it passes the
+ * same anon-readable gate as `UserBoard.boardId` (public, or the viewer can edit
+ * it), which is exactly when that id is safe to expose.
+ */
+export type GymKioskBoard = {
+  __typename?: 'GymKioskBoard';
+  /** Default wall angle. */
+  angle: Scalars['Int']['output'];
+  /** Numeric board-presence channel id (userBoards.id) — feeds boardNowPlaying(boardId). */
+  boardId: Scalars['Int']['output'];
+  /** Board type (kilter, tension, moonboard, ...). */
+  boardType: Scalars['String']['output'];
+  /** The board's immutable UUID (stable across board renames). */
+  boardUuid: Scalars['ID']['output'];
+  /** Layout ID. */
+  layoutId: Scalars['Int']['output'];
+  /** Board display name. */
+  name: Scalars['String']['output'];
+  /** Comma-separated set IDs. */
+  setIds: Scalars['String']['output'];
+  /** Product size ID. */
+  sizeId: Scalars['Int']['output'];
+};
+
 /** A member of a gym. */
 export type GymMember = {
   __typename?: 'GymMember';
@@ -2450,6 +2525,13 @@ export type Mutation = {
   /** Create a new gym. */
   createGym: Gym;
   /**
+   * Create a kiosk (smart-TV wall dashboard) under a gym. Requires gym edit
+   * access. The slug is derived from the name (and made unique per gym) when
+   * omitted. Starts with an empty layout — assign boards via updateGymKiosk. Fails
+   * when the gym already has the maximum number of kiosks.
+   */
+  createGymKiosk: GymKiosk;
+  /**
    * Mint a short-lived, single-use handoff code for starting the provider's
    * browser OAuth flow (GET /integrations/:provider/start?handoff=...). Keeps
    * the session token out of URLs, where it would persist in logs and browser
@@ -2483,6 +2565,8 @@ export type Mutation = {
   deleteDraftClimb: Scalars['Boolean']['output'];
   /** Soft-delete a gym. */
   deleteGym: Scalars['Boolean']['output'];
+  /** Soft-delete a kiosk. Requires gym edit access. The slug is freed for reuse. */
+  deleteGymKiosk: Scalars['Boolean']['output'];
   /** Delete a playlist (owner only). */
   deletePlaylist: Scalars['Boolean']['output'];
   /** Delete an accepted proposal and revert its effects (admin/leader only). */
@@ -2772,6 +2856,13 @@ export type Mutation = {
   updateComment: Comment;
   /** Update a gym's metadata. */
   updateGym: Gym;
+  /**
+   * Update a kiosk's name, slug, and/or layout. Requires gym edit access. A
+   * supplied layout is strictly validated (@boardsesh/kiosk KioskLayoutSchema) and
+   * persisted as the schema-parsed output — every referenced board must be alive
+   * and linked to this kiosk's gym.
+   */
+  updateGymKiosk: GymKiosk;
   /** Update playlist metadata. */
   updatePlaylist: Playlist;
   /** Update only lastAccessedAt for a playlist (does not update updatedAt). */
@@ -2856,6 +2947,11 @@ export type MutationCreateGymArgs = {
 };
 
 /** Root mutation type for all write operations. */
+export type MutationCreateGymKioskArgs = {
+  input: CreateGymKioskInput;
+};
+
+/** Root mutation type for all write operations. */
 export type MutationCreateIntegrationOAuthHandoffArgs = {
   provider: IntegrationProvider;
 };
@@ -2909,6 +3005,11 @@ export type MutationDeleteDraftClimbArgs = {
 /** Root mutation type for all write operations. */
 export type MutationDeleteGymArgs = {
   gymUuid: Scalars['ID']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationDeleteGymKioskArgs = {
+  kioskUuid: Scalars['ID']['input'];
 };
 
 /** Root mutation type for all write operations. */
@@ -3308,6 +3409,11 @@ export type MutationUpdateCommentArgs = {
 /** Root mutation type for all write operations. */
 export type MutationUpdateGymArgs = {
   input: UpdateGymInput;
+};
+
+/** Root mutation type for all write operations. */
+export type MutationUpdateGymKioskArgs = {
+  input: UpdateGymKioskInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -4020,6 +4126,22 @@ export type Query = {
   gymBoards: Array<UserBoard>;
   /** Get a gym by slug (for URL routing). */
   gymBySlug?: Maybe<Gym>;
+  /**
+   * A gym's public kiosk (smart-TV wall dashboard) by gym slug, with an optional
+   * kiosk slug. Public read, rate-limited, no login: a public gym's kiosks are
+   * visible to anyone; a private gym's are visible only to a viewer who can edit
+   * it (everyone else gets null, indistinguishable from a missing gym/kiosk). When
+   * `kioskSlug` is omitted the gym's oldest live kiosk is returned as the default.
+   * Returns null when the gym or kiosk doesn't exist or isn't visible. The
+   * `boards` list is resolved in slot order with dead/hidden slots dropped; the
+   * `layout` JSON is read leniently (a corrupt stored layout degrades to empty).
+   */
+  gymKiosk?: Maybe<GymKiosk>;
+  /**
+   * All of a gym's live kiosks (oldest first) for the manage UI. Requires gym edit
+   * access (owner, gym admin/editor, or a covering community admin/leader).
+   */
+  gymKiosks: Array<GymKiosk>;
   /** Get members of a gym. */
   gymMembers: GymMemberConnection;
   /**
@@ -4548,6 +4670,17 @@ export type QueryGymBoardsArgs = {
 /** Root query type for all read operations. */
 export type QueryGymBySlugArgs = {
   slug: Scalars['String']['input'];
+};
+
+/** Root query type for all read operations. */
+export type QueryGymKioskArgs = {
+  gymSlug: Scalars['String']['input'];
+  kioskSlug?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Root query type for all read operations. */
+export type QueryGymKiosksArgs = {
+  gymUuid: Scalars['ID']['input'];
 };
 
 /** Root query type for all read operations. */
@@ -6466,6 +6599,23 @@ export type UpdateGymInput = {
   slug?: InputMaybe<Scalars['String']['input']>;
   /** New website URL */
   website?: InputMaybe<Scalars['String']['input']>;
+};
+
+/**
+ * Input for updating a kiosk. Every field is optional; omitted fields are left
+ * untouched. When `layout` is present it's validated with the STRICT
+ * KioskLayoutSchema and every referenced board (slots + a single-board
+ * leaderboard) must be an alive board linked to this kiosk's gym.
+ */
+export type UpdateGymKioskInput = {
+  /** The kiosk to update. */
+  kioskUuid: Scalars['ID']['input'];
+  /** New preset layout config (@boardsesh/kiosk KioskLayoutSchema). Persisted as the schema-parsed output. */
+  layout?: InputMaybe<Scalars['JSON']['input']>;
+  /** New display name. */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** New URL slug (lowercase alphanumeric + hyphens, 3–60 chars; unique per gym). */
+  slug?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Input for updating a playlist. */

--- a/packages/shared/graphql/src/operations/gym-kiosks.ts
+++ b/packages/shared/graphql/src/operations/gym-kiosks.ts
@@ -1,5 +1,5 @@
 import { gql } from 'graphql-request';
-import type { GymKiosk, CreateGymKioskInput, UpdateGymKioskInput } from '@boardsesh/shared-schema';
+import type { Gym, GymKiosk, CreateGymKioskInput, UpdateGymKioskInput } from '@boardsesh/shared-schema';
 
 // ============================================
 // Gym Kiosk Operations
@@ -89,13 +89,35 @@ export const DELETE_GYM_KIOSK = gql`
 // Query/Mutation Variable Types
 // ============================================
 
+/**
+ * Exactly the gym fields these operations select (GYM_KIOSK_GYM_FIELDS). The
+ * response types narrow `gym` to this instead of the full `Gym` so a consumer
+ * reading an unselected field (ownerId, counts, ...) is a compile error rather
+ * than an `undefined` at runtime.
+ */
+export type GymKioskOperationGym = Pick<
+  Gym,
+  | 'uuid'
+  | 'slug'
+  | 'name'
+  | 'isPublic'
+  | 'logoUrl'
+  | 'brandPrimaryColor'
+  | 'brandAccentColor'
+  | 'brandBackgroundColor'
+  | 'canEdit'
+>;
+
+/** A GymKiosk as returned by these operations: full kiosk, narrowed gym. */
+export type GymKioskOperationResult = Omit<GymKiosk, 'gym'> & { gym: GymKioskOperationGym };
+
 export type GetGymKioskQueryVariables = {
   gymSlug: string;
   kioskSlug?: string | null;
 };
 
 export type GetGymKioskQueryResponse = {
-  gymKiosk: GymKiosk | null;
+  gymKiosk: GymKioskOperationResult | null;
 };
 
 export type GetGymKiosksQueryVariables = {
@@ -103,7 +125,7 @@ export type GetGymKiosksQueryVariables = {
 };
 
 export type GetGymKiosksQueryResponse = {
-  gymKiosks: GymKiosk[];
+  gymKiosks: GymKioskOperationResult[];
 };
 
 export type CreateGymKioskMutationVariables = {
@@ -111,7 +133,7 @@ export type CreateGymKioskMutationVariables = {
 };
 
 export type CreateGymKioskMutationResponse = {
-  createGymKiosk: GymKiosk;
+  createGymKiosk: GymKioskOperationResult;
 };
 
 export type UpdateGymKioskMutationVariables = {
@@ -119,7 +141,7 @@ export type UpdateGymKioskMutationVariables = {
 };
 
 export type UpdateGymKioskMutationResponse = {
-  updateGymKiosk: GymKiosk;
+  updateGymKiosk: GymKioskOperationResult;
 };
 
 export type DeleteGymKioskMutationVariables = {

--- a/packages/shared/graphql/src/operations/gym-kiosks.ts
+++ b/packages/shared/graphql/src/operations/gym-kiosks.ts
@@ -1,0 +1,131 @@
+import { gql } from 'graphql-request';
+import type { GymKiosk, CreateGymKioskInput, UpdateGymKioskInput } from '@boardsesh/shared-schema';
+
+// ============================================
+// Gym Kiosk Operations
+// ============================================
+
+// The resolved slot boards a kiosk renders. `boardId` is the presence-channel id
+// that feeds boardNowPlaying(boardId) on the kiosk/embed surfaces.
+const GYM_KIOSK_BOARD_FIELDS = `
+  boardId
+  boardUuid
+  name
+  boardType
+  layoutId
+  sizeId
+  setIds
+  angle
+`;
+
+// Gym fields the kiosk chrome + manage UI read: branding for the header, plus
+// slug/isPublic/canEdit for URL + gating decisions.
+const GYM_KIOSK_GYM_FIELDS = `
+  uuid
+  slug
+  name
+  isPublic
+  logoUrl
+  brandPrimaryColor
+  brandAccentColor
+  brandBackgroundColor
+  canEdit
+`;
+
+const GYM_KIOSK_FIELDS = `
+  uuid
+  slug
+  name
+  layout
+  createdAt
+  updatedAt
+  boards {
+    ${GYM_KIOSK_BOARD_FIELDS}
+  }
+  gym {
+    ${GYM_KIOSK_GYM_FIELDS}
+  }
+`;
+
+export const GET_GYM_KIOSK = gql`
+  query GetGymKiosk($gymSlug: String!, $kioskSlug: String) {
+    gymKiosk(gymSlug: $gymSlug, kioskSlug: $kioskSlug) {
+      ${GYM_KIOSK_FIELDS}
+    }
+  }
+`;
+
+export const GET_GYM_KIOSKS = gql`
+  query GetGymKiosks($gymUuid: ID!) {
+    gymKiosks(gymUuid: $gymUuid) {
+      ${GYM_KIOSK_FIELDS}
+    }
+  }
+`;
+
+export const CREATE_GYM_KIOSK = gql`
+  mutation CreateGymKiosk($input: CreateGymKioskInput!) {
+    createGymKiosk(input: $input) {
+      ${GYM_KIOSK_FIELDS}
+    }
+  }
+`;
+
+export const UPDATE_GYM_KIOSK = gql`
+  mutation UpdateGymKiosk($input: UpdateGymKioskInput!) {
+    updateGymKiosk(input: $input) {
+      ${GYM_KIOSK_FIELDS}
+    }
+  }
+`;
+
+export const DELETE_GYM_KIOSK = gql`
+  mutation DeleteGymKiosk($kioskUuid: ID!) {
+    deleteGymKiosk(kioskUuid: $kioskUuid)
+  }
+`;
+
+// ============================================
+// Query/Mutation Variable Types
+// ============================================
+
+export type GetGymKioskQueryVariables = {
+  gymSlug: string;
+  kioskSlug?: string | null;
+};
+
+export type GetGymKioskQueryResponse = {
+  gymKiosk: GymKiosk | null;
+};
+
+export type GetGymKiosksQueryVariables = {
+  gymUuid: string;
+};
+
+export type GetGymKiosksQueryResponse = {
+  gymKiosks: GymKiosk[];
+};
+
+export type CreateGymKioskMutationVariables = {
+  input: CreateGymKioskInput;
+};
+
+export type CreateGymKioskMutationResponse = {
+  createGymKiosk: GymKiosk;
+};
+
+export type UpdateGymKioskMutationVariables = {
+  input: UpdateGymKioskInput;
+};
+
+export type UpdateGymKioskMutationResponse = {
+  updateGymKiosk: GymKiosk;
+};
+
+export type DeleteGymKioskMutationVariables = {
+  kioskUuid: string;
+};
+
+export type DeleteGymKioskMutationResponse = {
+  deleteGymKiosk: boolean;
+};

--- a/packages/shared/graphql/src/operations/index.ts
+++ b/packages/shared/graphql/src/operations/index.ts
@@ -7,6 +7,7 @@ export * from './comments-votes';
 export * from './boards';
 export * from './board-presence';
 export * from './gyms';
+export * from './gym-kiosks';
 export * from './notifications';
 export * from './activity-feed';
 export * from './new-climb-feed';


### PR DESCRIPTION
## What & why

PR E of the gym-kiosk-dashboard epic: the backend GraphQL surface for gym kiosks (the preset smart-TV wall dashboard).

Adds:
- **`gymKiosk(gymSlug, kioskSlug?)`** — public, rate-limited, no-login read. Public gym → anyone; private gym → only a viewer who can edit it (else `null`, indistinguishable from missing). No `kioskSlug` → the gym's oldest live kiosk. The stored `layout` is read leniently (a corrupt/future-version row degrades to empty, never errors); `boards` is the resolved slot list — dead/unlinked slots dropped, and non-public boards filtered out for viewers without access (the private board stays in `layout`, off `boards`, so the client degrades the preset).
- **`gymKiosks(gymUuid)`** — manage-UI list, gym-edit-access gated, oldest first.
- **`createGymKiosk` / `updateGymKiosk` / `deleteGymKiosk`** — all `requireGymEditAccess`. Create derives a unique slug from the name (or takes an explicit one), enforces `MAX_KIOSKS_PER_GYM` (10) and per-gym slug uniqueness. Update strict-validates `layout` against `@boardsesh/kiosk`'s `KioskLayoutSchema`, persists the schema-parsed output (backend is the schema authority — unknown keys stripped at every level), and rejects any slot/leaderboard board that isn't an alive board linked to the kiosk's gym. Delete is a soft delete that frees the slug.

Board resolution reuses the shared `enrichBoards` `boardId` gate (public, or the viewer can edit the board) rather than the `gymBoards` listing rule — so unlisted-but-public boards still render on a kiosk; only non-public ones are filtered for anon.

Also hardens `isUniqueViolation` to walk the `DrizzleQueryError.cause` chain (drizzle 0.45 wraps driver errors), so the per-gym slug-uniqueness catch actually fires; a raw pg error still matches at depth 0.

## Stack

#3627 (`feat/gym-kiosk-db-schema`: `gym_kiosks` table + `@boardsesh/kiosk` v2 schema) → #3631 (`feat/gym-branding-logo-boards`: branding, `gymBoards`, `UserBoard.boardId`) → **this** (`feat/gym-kiosk-crud`).

## Validation

- `vp check` — format clean; the only lint errors are 3 pre-existing `no-floating-promises` in `packages/db/src/queries/__tests__/tick-offset-inference.test.ts` (untouched — zero diff under `packages/db`).
- `vp run typecheck` — passes.
- `packages/backend/src/__tests__/gym-kiosks.test.ts` — 26/26 passing (single-file run).
- Zero diffs under `packages/db`.

## Release Notes

- [x] No release note needed (internal / technical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaW2zXJkhwXJhyxYzSv9iH

