### PR TITLE
feat(web): public gym page and manage-gym shell

### DIFF
--- a/packages/board-constants/src/board-type-labels.ts
+++ b/packages/board-constants/src/board-type-labels.ts
@@ -1,0 +1,20 @@
+/**
+ * Brand display names for board types — proper nouns, never translated.
+ * Shared home for the map that was previously copy-pasted per component;
+ * older call sites (board-detail, board cards, discovery scroll) still carry
+ * local copies — migrate them here as they're touched.
+ */
+export const BOARD_TYPE_LABELS: Record<string, string> = {
+  kilter: 'Kilter',
+  tension: 'Tension',
+  moonboard: 'MoonBoard',
+  decoy: 'Decoy',
+  touchstone: 'Touchstone',
+  grasshopper: 'Grasshopper',
+  soill: 'So iLL',
+};
+
+/** Display label for a board type, falling back to the raw type string. */
+export function boardTypeLabel(boardType: string): string {
+  return BOARD_TYPE_LABELS[boardType] ?? boardType;
+}

--- a/packages/board-constants/src/index.ts
+++ b/packages/board-constants/src/index.ts
@@ -7,3 +7,4 @@ export * from './grade-conversion';
 export * from './size-comparison';
 export * from './moonboard';
 export * from './readable-text-color';
+export * from './board-type-labels';

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -122,6 +122,7 @@ export const GET_GYM_MEMBERS = gql`
 const GYM_BOARD_FIELDS = `
   uuid
   slug
+  ownerId
   name
   boardType
   layoutId

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -67,7 +67,8 @@
     "boardCount_one": "{{count}} board",
     "boardCount_other": "{{count}} boards",
     "visitWebsite": "Visit website",
-    "noBoardsYet": "No boards listed here yet."
+    "noBoardsYet": "No boards listed here yet.",
+    "exploreFeed": "See what climbers are sending"
   },
   "manage": {
     "title": "Manage {{gymName}}",
@@ -108,6 +109,8 @@
       "empty": "No boards linked yet. Add one to get started.",
       "loadError": "Couldn't load this gym's boards.",
       "unlink": "Unlink",
+      "onlyOwnerCanUnlink": "Only the board's owner can unlink it",
+      "readOnlyHint": "Only the gym owner or an admin can link boards.",
       "unlinkTitle": "Unlink this board?",
       "unlinkBody": "\"{{name}}\" stops showing on this gym's page and kiosks. You can re-link it anytime.",
       "unlinkConfirm": "Unlink",

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -56,5 +56,79 @@
       "errorTitle": "Leaderboard unavailable",
       "errorBody": "Couldn't load the latest sends. It'll retry on its own."
     }
+  },
+  "gymPage": {
+    "metaTitle": "{{gymName}} climbing gym",
+    "metaDescription": "See the boards and live wall at {{gymName}} on Boardsesh.",
+    "breadcrumbHome": "Boardsesh",
+    "manageGym": "Manage gym",
+    "seeOnTheWall": "See what's on the wall",
+    "boardsHeading": "Boards",
+    "boardCount_one": "{{count}} board",
+    "boardCount_other": "{{count}} boards",
+    "visitWebsite": "Visit website",
+    "noBoardsYet": "No boards listed here yet."
+  },
+  "manage": {
+    "title": "Manage {{gymName}}",
+    "backToGym": "Back to gym page",
+    "accessDenied": "You don't have permission to manage this gym.",
+    "tabs": {
+      "kiosks": "Kiosks",
+      "branding": "Branding",
+      "boards": "Boards",
+      "members": "Members"
+    },
+    "slugGuard": {
+      "title": "Give this gym a web address",
+      "body": "Your kiosk and public gym page need a short URL slug before anyone can open them.",
+      "label": "URL slug",
+      "helper": "boardsesh.com/gym/{{slug}}",
+      "placeholder": "your-gym",
+      "save": "Save slug",
+      "errorEmpty": "Enter a slug.",
+      "errorInvalid": "Use lowercase letters, numbers, and hyphens only.",
+      "saved": "Slug saved.",
+      "saveFailed": "Couldn't save the slug."
+    },
+    "kiosks": {
+      "emptyTitle": "Kiosk setup lands here soon",
+      "emptyBody": "Point a screen at your wall and show what's lit. The kiosk editor arrives in the next update.",
+      "cta": "Set up a kiosk"
+    },
+    "branding": {
+      "emptyTitle": "Branding lands here soon",
+      "emptyBody": "Add your logo and colours so the wall display looks like your gym. Coming in the next update.",
+      "cta": "Customise branding"
+    },
+    "boards": {
+      "heading": "Boards at this gym",
+      "description": "Link the boards you own so they show up on your gym page and kiosks.",
+      "addBoard": "Add a board",
+      "empty": "No boards linked yet. Add one to get started.",
+      "loadError": "Couldn't load this gym's boards.",
+      "unlink": "Unlink",
+      "unlinkTitle": "Unlink this board?",
+      "unlinkBody": "\"{{name}}\" stops showing on this gym's page and kiosks. You can re-link it anytime.",
+      "unlinkConfirm": "Unlink",
+      "cancel": "Cancel",
+      "linked": "Board linked.",
+      "linkFailed": "Couldn't link the board.",
+      "unlinked": "Board unlinked.",
+      "unlinkFailed": "Couldn't unlink the board.",
+      "visibility": {
+        "public": "Public",
+        "unlisted": "Unlisted",
+        "private": "Private"
+      },
+      "addDialog": {
+        "title": "Add one of your boards",
+        "body": "Pick a board you own to link to this gym.",
+        "empty": "You don't have any boards left to link.",
+        "loading": "Loading your boards…",
+        "link": "Link",
+        "close": "Close"
+      }
+    }
   }
 }

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -56,5 +56,79 @@
       "errorTitle": "Clasificación no disponible",
       "errorBody": "No se han podido cargar los últimos encadenes. Se reintentará automáticamente."
     }
+  },
+  "gymPage": {
+    "metaTitle": "Rocódromo {{gymName}}",
+    "metaDescription": "Mira los plafones y el muro en directo de {{gymName}} en Boardsesh.",
+    "breadcrumbHome": "Boardsesh",
+    "manageGym": "Gestionar rocódromo",
+    "seeOnTheWall": "Mira qué hay en el muro",
+    "boardsHeading": "Plafones",
+    "boardCount_one": "{{count}} plafón",
+    "boardCount_other": "{{count}} plafones",
+    "visitWebsite": "Visitar el sitio web",
+    "noBoardsYet": "Aún no hay plafones aquí."
+  },
+  "manage": {
+    "title": "Gestionar {{gymName}}",
+    "backToGym": "Volver a la página del rocódromo",
+    "accessDenied": "No tienes permiso para gestionar este rocódromo.",
+    "tabs": {
+      "kiosks": "Kioscos",
+      "branding": "Marca",
+      "boards": "Plafones",
+      "members": "Miembros"
+    },
+    "slugGuard": {
+      "title": "Dale una dirección web a este rocódromo",
+      "body": "Tu kiosco y la página pública del rocódromo necesitan un slug de URL corto antes de que alguien pueda abrirlos.",
+      "label": "Slug de URL",
+      "helper": "boardsesh.com/gym/{{slug}}",
+      "placeholder": "tu-rocodromo",
+      "save": "Guardar slug",
+      "errorEmpty": "Escribe un slug.",
+      "errorInvalid": "Usa solo minúsculas, números y guiones.",
+      "saved": "Slug guardado.",
+      "saveFailed": "No se pudo guardar el slug."
+    },
+    "kiosks": {
+      "emptyTitle": "La configuración del kiosco llega pronto",
+      "emptyBody": "Apunta una pantalla a tu muro y muestra qué está encendido. El editor de kioscos llega en la próxima actualización.",
+      "cta": "Configurar un kiosco"
+    },
+    "branding": {
+      "emptyTitle": "La personalización de marca llega pronto",
+      "emptyBody": "Añade tu logo y tus colores para que la pantalla del muro se vea como tu rocódromo. Llega en la próxima actualización.",
+      "cta": "Personalizar la marca"
+    },
+    "boards": {
+      "heading": "Plafones de este rocódromo",
+      "description": "Vincula los plafones que posees para que aparezcan en la página de tu rocódromo y en los kioscos.",
+      "addBoard": "Añadir un plafón",
+      "empty": "Aún no hay plafones vinculados. Añade uno para empezar.",
+      "loadError": "No se pudieron cargar los plafones de este rocódromo.",
+      "unlink": "Desvincular",
+      "unlinkTitle": "¿Desvincular este plafón?",
+      "unlinkBody": "«{{name}}» dejará de aparecer en la página y los kioscos de este rocódromo. Puedes volver a vincularlo cuando quieras.",
+      "unlinkConfirm": "Desvincular",
+      "cancel": "Cancelar",
+      "linked": "Plafón vinculado.",
+      "linkFailed": "No se pudo vincular el plafón.",
+      "unlinked": "Plafón desvinculado.",
+      "unlinkFailed": "No se pudo desvincular el plafón.",
+      "visibility": {
+        "public": "Público",
+        "unlisted": "No listado",
+        "private": "Privado"
+      },
+      "addDialog": {
+        "title": "Añade uno de tus plafones",
+        "body": "Elige un plafón que poseas para vincularlo a este rocódromo.",
+        "empty": "No te quedan plafones para vincular.",
+        "loading": "Cargando tus plafones…",
+        "link": "Vincular",
+        "close": "Cerrar"
+      }
+    }
   }
 }

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -67,7 +67,8 @@
     "boardCount_one": "{{count}} plafón",
     "boardCount_other": "{{count}} plafones",
     "visitWebsite": "Visitar el sitio web",
-    "noBoardsYet": "Aún no hay plafones aquí."
+    "noBoardsYet": "Aún no hay plafones aquí.",
+    "exploreFeed": "Mira qué están encadenando otros escaladores"
   },
   "manage": {
     "title": "Gestionar {{gymName}}",
@@ -108,6 +109,8 @@
       "empty": "Aún no hay plafones vinculados. Añade uno para empezar.",
       "loadError": "No se pudieron cargar los plafones de este rocódromo.",
       "unlink": "Desvincular",
+      "onlyOwnerCanUnlink": "Solo el propietario del plafón puede desvincularlo",
+      "readOnlyHint": "Solo el propietario del rocódromo o un administrador puede vincular plafones.",
       "unlinkTitle": "¿Desvincular este plafón?",
       "unlinkBody": "«{{name}}» dejará de aparecer en la página y los kioscos de este rocódromo. Puedes volver a vincularlo cuando quieras.",
       "unlinkConfirm": "Desvincular",

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -56,5 +56,79 @@
       "errorTitle": "Classement indisponible",
       "errorBody": "Impossible de charger les dernières croix. Le widget réessaie tout seul."
     }
+  },
+  "gymPage": {
+    "metaTitle": "Salle d'escalade {{gymName}}",
+    "metaDescription": "Découvre les boards et le mur en direct de {{gymName}} sur Boardsesh.",
+    "breadcrumbHome": "Boardsesh",
+    "manageGym": "Gérer la salle",
+    "seeOnTheWall": "Voir ce qui est sur le mur",
+    "boardsHeading": "Boards",
+    "boardCount_one": "{{count}} board",
+    "boardCount_other": "{{count}} boards",
+    "visitWebsite": "Visiter le site web",
+    "noBoardsYet": "Aucune board ici pour l'instant."
+  },
+  "manage": {
+    "title": "Gérer {{gymName}}",
+    "backToGym": "Retour à la page de la salle",
+    "accessDenied": "Tu n'as pas la permission de gérer cette salle.",
+    "tabs": {
+      "kiosks": "Bornes",
+      "branding": "Identité",
+      "boards": "Boards",
+      "members": "Membres"
+    },
+    "slugGuard": {
+      "title": "Donne une adresse web à cette salle",
+      "body": "Ta borne et la page publique de la salle ont besoin d'un slug d'URL court avant que quiconque puisse les ouvrir.",
+      "label": "Slug d'URL",
+      "helper": "boardsesh.com/gym/{{slug}}",
+      "placeholder": "ta-salle",
+      "save": "Enregistrer le slug",
+      "errorEmpty": "Saisis un slug.",
+      "errorInvalid": "Utilise uniquement des minuscules, des chiffres et des tirets.",
+      "saved": "Slug enregistré.",
+      "saveFailed": "Impossible d'enregistrer le slug."
+    },
+    "kiosks": {
+      "emptyTitle": "La configuration des bornes arrive bientôt",
+      "emptyBody": "Pointe un écran vers ton mur et montre ce qui est allumé. L'éditeur de bornes arrive dans la prochaine mise à jour.",
+      "cta": "Configurer une borne"
+    },
+    "branding": {
+      "emptyTitle": "L'identité visuelle arrive bientôt",
+      "emptyBody": "Ajoute ton logo et tes couleurs pour que l'affichage du mur ressemble à ta salle. Ça arrive dans la prochaine mise à jour.",
+      "cta": "Personnaliser l'identité"
+    },
+    "boards": {
+      "heading": "Boards de cette salle",
+      "description": "Relie les boards que tu possèdes pour qu'elles apparaissent sur la page de ta salle et sur les bornes.",
+      "addBoard": "Ajouter une board",
+      "empty": "Aucune board reliée pour l'instant. Ajoutes-en une pour commencer.",
+      "loadError": "Impossible de charger les boards de cette salle.",
+      "unlink": "Détacher",
+      "unlinkTitle": "Détacher cette board ?",
+      "unlinkBody": "« {{name}} » n'apparaîtra plus sur la page ni sur les bornes de cette salle. Tu peux la relier à tout moment.",
+      "unlinkConfirm": "Détacher",
+      "cancel": "Annuler",
+      "linked": "Board reliée.",
+      "linkFailed": "Impossible de relier la board.",
+      "unlinked": "Board détachée.",
+      "unlinkFailed": "Impossible de détacher la board.",
+      "visibility": {
+        "public": "Publique",
+        "unlisted": "Non répertoriée",
+        "private": "Privée"
+      },
+      "addDialog": {
+        "title": "Ajoute une de tes boards",
+        "body": "Choisis une board que tu possèdes pour la relier à cette salle.",
+        "empty": "Il ne te reste aucune board à relier.",
+        "loading": "Chargement de tes boards…",
+        "link": "Relier",
+        "close": "Fermer"
+      }
+    }
   }
 }

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -67,7 +67,8 @@
     "boardCount_one": "{{count}} board",
     "boardCount_other": "{{count}} boards",
     "visitWebsite": "Visiter le site web",
-    "noBoardsYet": "Aucune board ici pour l'instant."
+    "noBoardsYet": "Aucune board ici pour l'instant.",
+    "exploreFeed": "Voir ce que les grimpeurs enchaînent"
   },
   "manage": {
     "title": "Gérer {{gymName}}",
@@ -108,6 +109,8 @@
       "empty": "Aucune board reliée pour l'instant. Ajoutes-en une pour commencer.",
       "loadError": "Impossible de charger les boards de cette salle.",
       "unlink": "Détacher",
+      "onlyOwnerCanUnlink": "Seul le propriétaire de la board peut la détacher",
+      "readOnlyHint": "Seul le propriétaire de la salle ou un admin peut relier des boards.",
       "unlinkTitle": "Détacher cette board ?",
       "unlinkBody": "« {{name}} » n'apparaîtra plus sur la page ni sur les bornes de cette salle. Tu peux la relier à tout moment.",
       "unlinkConfirm": "Détacher",

--- a/packages/web/app/__test-helpers__/i18n-mock.ts
+++ b/packages/web/app/__test-helpers__/i18n-mock.ts
@@ -30,6 +30,7 @@ import enBoards from '@boardsesh/i18n/locales/en-US/boards.json';
 import enClimbs from '@boardsesh/i18n/locales/en-US/climbs.json';
 import enCommon from '@boardsesh/i18n/locales/en-US/common.json';
 import enFeed from '@boardsesh/i18n/locales/en-US/feed.json';
+import enKiosk from '@boardsesh/i18n/locales/en-US/kiosk.json';
 import enMarketing from '@boardsesh/i18n/locales/en-US/marketing.json';
 import enNotifications from '@boardsesh/i18n/locales/en-US/notifications.json';
 import enPlaylists from '@boardsesh/i18n/locales/en-US/playlists.json';
@@ -46,6 +47,7 @@ const CATALOGS: Record<string, unknown> = {
   climbs: enClimbs,
   common: enCommon,
   feed: enFeed,
+  kiosk: enKiosk,
   marketing: enMarketing,
   notifications: enNotifications,
   playlists: enPlaylists,

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -19,6 +19,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import LanguageOutlined from '@mui/icons-material/LanguageOutlined';
 import EditOutlined from '@mui/icons-material/EditOutlined';
+import SettingsOutlined from '@mui/icons-material/SettingsOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import VerifiedUserOutlined from '@mui/icons-material/VerifiedUserOutlined';
 import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
@@ -43,6 +44,9 @@ import {
 import { useSession } from 'next-auth/react';
 import { themeTokens } from '@/app/theme/theme-config';
 import FollowButton from '@/app/components/ui/follow-button';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
+import { GYM_KIOSK_FLAG } from '@/app/flags';
 import EditGymForm from './edit-gym-form';
 import GymMemberManagement from './gym-member-management';
 import ClaimGymDialog from './claim-gym-dialog';
@@ -58,6 +62,8 @@ type GymDetailProps = {
 
 export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 'bottom' }: GymDetailProps) {
   const { t } = useTranslation('boards');
+  const { t: tKiosk } = useTranslation('kiosk');
+  const kioskFlag = useFeatureFlag(GYM_KIOSK_FLAG);
   const [gym, setGym] = useState<Gym | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [activeTab, setActiveTab] = useState(0);
@@ -249,6 +255,18 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
                 sx={{ textTransform: 'none' }}
               >
                 {t('gymEntity.actions.edit')}
+              </MuiButton>
+            )}
+            {gym.canEdit && kioskFlag && (
+              <MuiButton
+                component={LocaleLink}
+                href={`/gym/${gym.slug ?? gym.uuid}/manage`}
+                variant="outlined"
+                size="small"
+                startIcon={<SettingsOutlined />}
+                sx={{ textTransform: 'none' }}
+              >
+                {tKiosk('gymPage.manageGym')}
               </MuiButton>
             )}
             {gym.canClaim && (

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -31,6 +31,7 @@ import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer'
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { safeExternalHref } from '@/app/lib/safe-external-url';
 import {
   GET_GYM,
   DELETE_GYM,
@@ -176,17 +177,17 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
                   </MuiTypography>
                 </Box>
               )}
-              {gym.website && (
+              {safeExternalHref(gym.website) && (
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
                   <LanguageOutlined sx={{ fontSize: 16, color: 'var(--neutral-400)' }} />
                   <MuiLink
-                    href={gym.website}
+                    href={safeExternalHref(gym.website) ?? undefined}
                     target="_blank"
                     rel="noopener noreferrer"
                     variant="body2"
                     underline="hover"
                   >
-                    {gym.website.replace(/^https?:\/\//, '').replace(/\/$/, '')}
+                    {(gym.website ?? '').replace(/^https?:\/\//, '').replace(/\/$/, '')}
                   </MuiLink>
                 </Box>
               )}

--- a/packages/web/app/components/gym-entity/manage/__tests__/gym-board-permissions.test.ts
+++ b/packages/web/app/components/gym-entity/manage/__tests__/gym-board-permissions.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { canManageGymBoards, canUnlinkBoard, linkableBoards } from '../gym-board-permissions';
+
+const GYM_UUID = 'gym-1';
+const OWNER = 'user-owner';
+const OTHER = 'user-other';
+
+describe('canManageGymBoards', () => {
+  it('allows the gym owner', () => {
+    expect(canManageGymBoards({ ownerId: OWNER, myRole: null }, OWNER)).toBe(true);
+  });
+
+  it('allows a gym admin who is not the owner', () => {
+    expect(canManageGymBoards({ ownerId: OWNER, myRole: 'admin' }, OTHER)).toBe(true);
+  });
+
+  it('denies a gym editor (backend linkBoardToGym requires owner/admin)', () => {
+    expect(canManageGymBoards({ ownerId: OWNER, myRole: 'editor' }, OTHER)).toBe(false);
+  });
+
+  it('denies a signed-out viewer', () => {
+    expect(canManageGymBoards({ ownerId: OWNER, myRole: 'admin' }, null)).toBe(false);
+  });
+});
+
+describe('canUnlinkBoard', () => {
+  it('allows the board owner', () => {
+    expect(canUnlinkBoard({ ownerId: OWNER }, OWNER)).toBe(true);
+  });
+
+  it('denies everyone else, including gym admins', () => {
+    expect(canUnlinkBoard({ ownerId: OWNER }, OTHER)).toBe(false);
+    expect(canUnlinkBoard({ ownerId: OWNER }, null)).toBe(false);
+  });
+});
+
+describe('linkableBoards', () => {
+  const boards = [
+    { uuid: 'b1', ownerId: OWNER, gymUuid: null }, // linkable
+    { uuid: 'b2', ownerId: OTHER, gymUuid: null }, // followed board, not owned
+    { uuid: 'b3', ownerId: OWNER, gymUuid: GYM_UUID }, // already on this gym
+    { uuid: 'b4', ownerId: OWNER, gymUuid: 'gym-2' }, // owned, on another gym — still offerable
+    { uuid: 'b5', ownerId: OWNER, gymUuid: null }, // in linkedBoardUuids (fresh link)
+  ];
+
+  it('keeps only owned boards not already on this gym', () => {
+    const result = linkableBoards(boards, GYM_UUID, new Set(['b5']), OWNER);
+    expect(result.map((board) => board.uuid)).toEqual(['b1', 'b4']);
+  });
+
+  it('returns nothing for a signed-out viewer', () => {
+    expect(linkableBoards(boards, GYM_UUID, new Set(), null)).toEqual([]);
+  });
+});

--- a/packages/web/app/components/gym-entity/manage/__tests__/gym-boards-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/gym-boards-tab.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { Gym, UserBoard } from '@boardsesh/shared-schema';
+import GymBoardsTab from '../gym-boards-tab';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null }),
+}));
+
+const mockSessionUserId = { current: 'user-owner' };
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: mockSessionUserId.current } }, status: 'authenticated' }),
+}));
+
+// One shared execute mock for both link and unlink useEntityMutation instances;
+// tests control its resolution to exercise the success and failure paths.
+const mockExecute = vi.fn();
+vi.mock('@/app/hooks/use-entity-mutation', () => ({
+  useEntityMutation: () => ({ execute: mockExecute, token: 'test-token' }),
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+const GYM_UUID = 'gym-uuid-1';
+
+const gym = {
+  uuid: GYM_UUID,
+  ownerId: 'user-owner',
+  myRole: 'admin',
+  name: 'Test Gym',
+  slug: 'test-gym',
+} as unknown as Gym;
+
+function makeBoard(overrides: Partial<UserBoard>): UserBoard {
+  return {
+    uuid: 'board-1',
+    slug: 'board-1',
+    ownerId: 'user-owner',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 1,
+    setIds: '1',
+    name: 'Garage Board',
+    isPublic: true,
+    isUnlisted: false,
+    hideLocation: false,
+    isOwned: true,
+    angle: 40,
+    isAngleAdjustable: true,
+    createdAt: '2026-01-01',
+    totalAscents: 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+    ...overrides,
+  } as UserBoard;
+}
+
+/** Routes the shared request mock by operation: gymBoards list vs myBoards. */
+function stubRequests({ gymBoards, myBoards }: { gymBoards: UserBoard[]; myBoards: UserBoard[] }) {
+  mockRequest.mockImplementation(async (document: string) => {
+    if (typeof document === 'string' && document.includes('gymBoards')) {
+      return { gymBoards };
+    }
+    return { myBoards: { boards: myBoards, totalCount: myBoards.length, hasMore: false } };
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSessionUserId.current = 'user-owner';
+});
+
+describe('GymBoardsTab — add-board dialog', () => {
+  const candidate = makeBoard({ uuid: 'board-new', name: 'New Wall', gymUuid: null });
+
+  async function openDialogWithCandidate() {
+    stubRequests({ gymBoards: [], myBoards: [candidate] });
+    render(<GymBoardsTab gym={gym} onGymChange={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: /add a board/i }));
+    await screen.findByText('New Wall');
+  }
+
+  it('keeps the candidate visible when the link mutation fails, so the user can retry', async () => {
+    await openDialogWithCandidate();
+    mockExecute.mockResolvedValueOnce(null); // useEntityMutation resolves null on failure
+
+    fireEvent.click(screen.getByRole('button', { name: /^link$/i }));
+
+    await waitFor(() => expect(mockExecute).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('New Wall')).toBeTruthy();
+  });
+
+  it('removes the candidate after a successful link', async () => {
+    await openDialogWithCandidate();
+    mockExecute.mockResolvedValueOnce({ linkBoardToGym: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /^link$/i }));
+
+    await waitFor(() => expect(screen.queryByText('New Wall')).toBeNull());
+  });
+});
+
+describe('GymBoardsTab — permission gating', () => {
+  it('hides Unlink and shows the owner-only note for boards the viewer does not own', async () => {
+    stubRequests({
+      gymBoards: [makeBoard({ uuid: 'board-foreign', name: 'Foreign Board', ownerId: 'someone-else' })],
+      myBoards: [],
+    });
+    render(<GymBoardsTab gym={gym} onGymChange={vi.fn()} />);
+
+    await screen.findByText('Foreign Board');
+    expect(screen.queryByRole('button', { name: /unlink/i })).toBeNull();
+    expect(screen.getByText(/only the board's owner can unlink it/i)).toBeTruthy();
+  });
+
+  it('hides the add-board affordance for gym editors and shows the read-only hint', async () => {
+    mockSessionUserId.current = 'user-editor';
+    const editorGym = { ...gym, ownerId: 'user-owner', myRole: 'editor' } as unknown as Gym;
+    stubRequests({ gymBoards: [], myBoards: [] });
+    render(<GymBoardsTab gym={editorGym} onGymChange={vi.fn()} />);
+
+    await screen.findByText(/no boards linked yet/i);
+    expect(screen.queryByRole('button', { name: /add a board/i })).toBeNull();
+    expect(screen.getByText(/only the gym owner or an admin can link boards/i)).toBeTruthy();
+  });
+});

--- a/packages/web/app/components/gym-entity/manage/__tests__/slug-utils.test.ts
+++ b/packages/web/app/components/gym-entity/manage/__tests__/slug-utils.test.ts
@@ -10,6 +10,11 @@ describe('sanitizeSlugInput', () => {
     expect(sanitizeSlugInput('boulder-lab')).toBe('boulder-lab');
   });
 
+  it('collapses consecutive hyphens (backend SlugSchema rejects them)', () => {
+    expect(sanitizeSlugInput('my--gym')).toBe('my-gym');
+    expect(sanitizeSlugInput('a---b--c')).toBe('a-b-c');
+  });
+
   it('caps length at the backend maximum', () => {
     const long = 'a'.repeat(GYM_SLUG_MAX_LENGTH + 40);
     expect(sanitizeSlugInput(long)).toHaveLength(GYM_SLUG_MAX_LENGTH);
@@ -29,6 +34,10 @@ describe('gymSlugValidationError', () => {
 
   it('flags uppercase or spaces as invalid', () => {
     expect(gymSlugValidationError('My Gym')).toBe('invalid');
+  });
+
+  it('flags consecutive hyphens as invalid, matching backend SlugSchema', () => {
+    expect(gymSlugValidationError('my--gym')).toBe('invalid');
   });
 
   it('accepts a well-formed slug', () => {

--- a/packages/web/app/components/gym-entity/manage/__tests__/slug-utils.test.ts
+++ b/packages/web/app/components/gym-entity/manage/__tests__/slug-utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { sanitizeSlugInput, gymSlugValidationError, looksLikeGymUuid, GYM_SLUG_MAX_LENGTH } from '../slug-utils';
+
+describe('sanitizeSlugInput', () => {
+  it('lowercases and strips illegal characters', () => {
+    expect(sanitizeSlugInput('My Gym! 123')).toBe('mygym123');
+  });
+
+  it('keeps hyphens', () => {
+    expect(sanitizeSlugInput('boulder-lab')).toBe('boulder-lab');
+  });
+
+  it('caps length at the backend maximum', () => {
+    const long = 'a'.repeat(GYM_SLUG_MAX_LENGTH + 40);
+    expect(sanitizeSlugInput(long)).toHaveLength(GYM_SLUG_MAX_LENGTH);
+  });
+});
+
+describe('gymSlugValidationError', () => {
+  it('flags an empty slug', () => {
+    expect(gymSlugValidationError('')).toBe('empty');
+    expect(gymSlugValidationError('   ')).toBe('empty');
+  });
+
+  it('flags a leading or trailing hyphen as invalid', () => {
+    expect(gymSlugValidationError('-gym')).toBe('invalid');
+    expect(gymSlugValidationError('gym-')).toBe('invalid');
+  });
+
+  it('flags uppercase or spaces as invalid', () => {
+    expect(gymSlugValidationError('My Gym')).toBe('invalid');
+  });
+
+  it('accepts a well-formed slug', () => {
+    expect(gymSlugValidationError('boulder-lab-2')).toBeNull();
+    expect(gymSlugValidationError('kilter')).toBeNull();
+  });
+});
+
+describe('looksLikeGymUuid', () => {
+  it('matches a canonical UUID', () => {
+    expect(looksLikeGymUuid('a7af2c7f-6abc-4c2c-9e4c-9f43a74d2ea9')).toBe(true);
+  });
+
+  it('rejects a word slug', () => {
+    expect(looksLikeGymUuid('boulder-lab')).toBe(false);
+  });
+});

--- a/packages/web/app/components/gym-entity/manage/branding-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/branding-tab.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import PaletteOutlined from '@mui/icons-material/PaletteOutlined';
+import ManageTabEmptyState from './manage-tab-empty-state';
+import type { GymManageTabProps } from './tab-props';
+
+/**
+ * Placeholder for the Branding tab. PR I replaces this body with the logo
+ * uploader + colour fields; the shell keeps passing {@link GymManageTabProps},
+ * so nothing above this component changes.
+ */
+export default function BrandingTab(_props: GymManageTabProps) {
+  const { t } = useTranslation('kiosk');
+  return (
+    <ManageTabEmptyState
+      icon={<PaletteOutlined sx={{ fontSize: 40 }} />}
+      title={t('manage.branding.emptyTitle')}
+      body={t('manage.branding.emptyBody')}
+      ctaLabel={t('manage.branding.cta')}
+    />
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/gym-board-permissions.ts
+++ b/packages/web/app/components/gym-entity/manage/gym-board-permissions.ts
@@ -1,0 +1,35 @@
+// Pure permission helpers for the manage-gym Boards tab, mirroring the backend
+// linkBoardToGym contract: BOTH link and unlink require the viewer to own the
+// board (`board.ownerId === userId`), and linking additionally requires the
+// viewer to be the gym's owner or an admin (requireGymOwnerOrAdmin). Gym
+// editors can open the tab (canEdit) but see the board list read-only.
+
+import type { Gym, UserBoard } from '@boardsesh/shared-schema';
+
+/** True when the viewer may link boards to this gym (gym owner or gym admin). */
+export function canManageGymBoards(gym: Pick<Gym, 'ownerId' | 'myRole'>, viewerUserId: string | null): boolean {
+  if (!viewerUserId) return false;
+  return gym.ownerId === viewerUserId || gym.myRole === 'admin';
+}
+
+/** True when the viewer may unlink this board (they own the board itself). */
+export function canUnlinkBoard(board: Pick<UserBoard, 'ownerId'>, viewerUserId: string | null): boolean {
+  return !!viewerUserId && board.ownerId === viewerUserId;
+}
+
+/**
+ * Boards from the viewer's myBoards list that can be offered in the "Add a
+ * board" dialog: owned by the viewer (myBoards also contains followed boards),
+ * and not already on this gym.
+ */
+export function linkableBoards<BoardShape extends Pick<UserBoard, 'uuid' | 'ownerId' | 'gymUuid'>>(
+  myBoards: readonly BoardShape[],
+  gymUuid: string,
+  linkedBoardUuids: ReadonlySet<string>,
+  viewerUserId: string | null,
+): BoardShape[] {
+  if (!viewerUserId) return [];
+  return myBoards.filter(
+    (board) => board.ownerId === viewerUserId && board.gymUuid !== gymUuid && !linkedBoardUuids.has(board.uuid),
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import List from '@mui/material/List';
@@ -32,27 +32,10 @@ import {
   type LinkBoardToGymMutationVariables,
 } from '@boardsesh/graphql/operations';
 import type { UserBoard } from '@boardsesh/shared-schema';
+import { boardTypeLabel } from '@boardsesh/board-constants';
 import { themeTokens } from '@/app/theme/theme-config';
 import { canManageGymBoards, canUnlinkBoard, linkableBoards } from './gym-board-permissions';
 import type { GymManageTabProps } from './tab-props';
-
-// Brand display names — proper nouns, not translated copy.
-// TODO: this map is duplicated across board-detail, board cards, and the public
-// gym page — extract a shared helper (e.g. @boardsesh/board-constants) instead
-// of adding a seventh copy.
-const BOARD_TYPE_LABELS: Record<string, string> = {
-  kilter: 'Kilter',
-  tension: 'Tension',
-  moonboard: 'MoonBoard',
-  decoy: 'Decoy',
-  touchstone: 'Touchstone',
-  grasshopper: 'Grasshopper',
-  soill: 'So iLL',
-};
-
-function boardTypeLabel(boardType: string): string {
-  return BOARD_TYPE_LABELS[boardType] ?? boardType;
-}
 
 function VisibilityChip({ board }: { board: Pick<UserBoard, 'isPublic' | 'isUnlisted'> }) {
   const { t } = useTranslation('kiosk');
@@ -79,6 +62,9 @@ export default function GymBoardsTab({ gym }: GymManageTabProps) {
   // owning the board. Editors (canEdit) still see the list, read-only.
   const canLinkBoards = canManageGymBoards(gym, viewerUserId);
 
+  // Link and unlink are the SAME backend mutation — LINK_BOARD_TO_GYM with
+  // gymUuid: null performs the unlink. Two instances only so each direction
+  // gets its own success/error toast copy.
   const linkMutation = useEntityMutation<LinkBoardToGymMutationResponse, LinkBoardToGymMutationVariables>(
     LINK_BOARD_TO_GYM,
     { successMessage: t('manage.boards.linked'), errorMessage: t('manage.boards.linkFailed') },
@@ -118,11 +104,15 @@ export default function GymBoardsTab({ gym }: GymManageTabProps) {
     }
   };
 
-  const handleLink = async (boardUuid: string) => {
+  // Returns whether the link succeeded so the dialog only drops the candidate
+  // on an actual success (useEntityMutation resolves null on failure).
+  const handleLink = async (boardUuid: string): Promise<boolean> => {
     const result = await linkMutation.execute({ input: { boardUuid, gymUuid: gym.uuid } });
     if (result) {
       await fetchBoards();
+      return true;
     }
+    return false;
   };
 
   return (
@@ -242,7 +232,8 @@ type AddBoardDialogProps = {
   viewerUserId: string | null;
   linkedBoardUuids: Set<string>;
   onClose: () => void;
-  onLink: (boardUuid: string) => Promise<void>;
+  /** Resolves true when the link mutation succeeded. */
+  onLink: (boardUuid: string) => Promise<boolean>;
 };
 
 function AddBoardDialog({ open, gymUuid, viewerUserId, linkedBoardUuids, onClose, onLink }: AddBoardDialogProps) {
@@ -250,6 +241,16 @@ function AddBoardDialog({ open, gymUuid, viewerUserId, linkedBoardUuids, onClose
   const { token } = useWsAuthToken();
   const [candidates, setCandidates] = useState<UserBoard[] | null>(null);
   const [linkingUuid, setLinkingUuid] = useState<string | null>(null);
+
+  // The candidates fetch runs once per dialog open. `linkedBoardUuids` changes
+  // after every successful link (the parent refetches gymBoards), so reading it
+  // through a ref keeps it out of the effect deps — otherwise each link would
+  // re-fetch myBoards and blank the open dialog behind a spinner. While the
+  // dialog is open the list is maintained optimistically in handleLinkClick.
+  const linkedBoardUuidsRef = useRef(linkedBoardUuids);
+  useEffect(() => {
+    linkedBoardUuidsRef.current = linkedBoardUuids;
+  }, [linkedBoardUuids]);
 
   useEffect(() => {
     if (!open || !token) return;
@@ -264,7 +265,7 @@ function AddBoardDialog({ open, gymUuid, viewerUserId, linkedBoardUuids, onClose
         if (cancelled) return;
         // ownerId, not isOwned — myBoards includes followed boards, and isOwned
         // is the physical-ownership column, not the account that may link it.
-        setCandidates(linkableBoards(data.myBoards.boards, gymUuid, linkedBoardUuids, viewerUserId));
+        setCandidates(linkableBoards(data.myBoards.boards, gymUuid, linkedBoardUuidsRef.current, viewerUserId));
       } catch (error) {
         console.error('Failed to load your boards:', error);
         if (!cancelled) setCandidates([]);
@@ -273,13 +274,16 @@ function AddBoardDialog({ open, gymUuid, viewerUserId, linkedBoardUuids, onClose
     return () => {
       cancelled = true;
     };
-  }, [open, token, gymUuid, linkedBoardUuids, viewerUserId]);
+  }, [open, token, gymUuid, viewerUserId]);
 
   const handleLinkClick = async (boardUuid: string) => {
     setLinkingUuid(boardUuid);
     try {
-      await onLink(boardUuid);
-      setCandidates((prev) => (prev === null ? prev : prev.filter((board) => board.uuid !== boardUuid)));
+      const linked = await onLink(boardUuid);
+      // Keep the candidate on failure so the user can retry without reopening.
+      if (linked) {
+        setCandidates((prev) => (prev === null ? prev : prev.filter((board) => board.uuid !== boardUuid)));
+      }
     } finally {
       setLinkingUuid(null);
     }

--- a/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Chip from '@mui/material/Chip';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import AddOutlined from '@mui/icons-material/AddOutlined';
+import LinkOffOutlined from '@mui/icons-material/LinkOffOutlined';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { useEntityMutation } from '@/app/hooks/use-entity-mutation';
+import {
+  GET_GYM_BOARDS,
+  GET_MY_BOARDS,
+  LINK_BOARD_TO_GYM,
+  type GetGymBoardsQueryResponse,
+  type GetGymBoardsQueryVariables,
+  type GetMyBoardsQueryResponse,
+  type LinkBoardToGymMutationResponse,
+  type LinkBoardToGymMutationVariables,
+} from '@boardsesh/graphql/operations';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { themeTokens } from '@/app/theme/theme-config';
+import type { GymManageTabProps } from './tab-props';
+
+// Brand display names — proper nouns, not translated copy.
+const BOARD_TYPE_LABELS: Record<string, string> = {
+  kilter: 'Kilter',
+  tension: 'Tension',
+  moonboard: 'MoonBoard',
+  decoy: 'Decoy',
+  touchstone: 'Touchstone',
+  grasshopper: 'Grasshopper',
+  soill: 'So iLL',
+};
+
+function boardTypeLabel(boardType: string): string {
+  return BOARD_TYPE_LABELS[boardType] ?? boardType;
+}
+
+function VisibilityChip({ board }: { board: Pick<UserBoard, 'isPublic' | 'isUnlisted'> }) {
+  const { t } = useTranslation('kiosk');
+  if (board.isPublic) {
+    return <Chip size="small" color="success" variant="outlined" label={t('manage.boards.visibility.public')} />;
+  }
+  if (board.isUnlisted) {
+    return <Chip size="small" color="warning" variant="outlined" label={t('manage.boards.visibility.unlisted')} />;
+  }
+  return <Chip size="small" variant="outlined" label={t('manage.boards.visibility.private')} />;
+}
+
+export default function GymBoardsTab({ gym }: GymManageTabProps) {
+  const { t } = useTranslation('kiosk');
+  const { token } = useWsAuthToken();
+  const [boards, setBoards] = useState<UserBoard[] | null>(null);
+  const [loadError, setLoadError] = useState(false);
+  const [unlinkTarget, setUnlinkTarget] = useState<UserBoard | null>(null);
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const linkedBoardUuids = useMemo(() => new Set((boards ?? []).map((board) => board.uuid)), [boards]);
+
+  const linkMutation = useEntityMutation<LinkBoardToGymMutationResponse, LinkBoardToGymMutationVariables>(
+    LINK_BOARD_TO_GYM,
+    { successMessage: t('manage.boards.linked'), errorMessage: t('manage.boards.linkFailed') },
+  );
+  const unlinkMutation = useEntityMutation<LinkBoardToGymMutationResponse, LinkBoardToGymMutationVariables>(
+    LINK_BOARD_TO_GYM,
+    { successMessage: t('manage.boards.unlinked'), errorMessage: t('manage.boards.unlinkFailed') },
+  );
+
+  const fetchBoards = useCallback(async () => {
+    if (!token) return;
+    setLoadError(false);
+    try {
+      const client = createGraphQLHttpClient(token);
+      const data = await client.request<GetGymBoardsQueryResponse, GetGymBoardsQueryVariables>(GET_GYM_BOARDS, {
+        gymUuid: gym.uuid,
+      });
+      setBoards(data.gymBoards ?? []);
+    } catch (error) {
+      console.error('Failed to load gym boards:', error);
+      setLoadError(true);
+      setBoards([]);
+    }
+  }, [token, gym.uuid]);
+
+  useEffect(() => {
+    void fetchBoards();
+  }, [fetchBoards]);
+
+  const handleUnlinkConfirm = async () => {
+    if (!unlinkTarget) return;
+    const target = unlinkTarget;
+    setUnlinkTarget(null);
+    const result = await unlinkMutation.execute({ input: { boardUuid: target.uuid, gymUuid: null } });
+    if (result) {
+      await fetchBoards();
+    }
+  };
+
+  const handleLink = async (boardUuid: string) => {
+    const result = await linkMutation.execute({ input: { boardUuid, gymUuid: gym.uuid } });
+    if (result) {
+      await fetchBoards();
+    }
+  };
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 2, mb: 1 }}>
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+            {t('manage.boards.heading')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {t('manage.boards.description')}
+          </Typography>
+        </Box>
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<AddOutlined />}
+          onClick={() => setAddDialogOpen(true)}
+          sx={{ textTransform: 'none', flexShrink: 0 }}
+        >
+          {t('manage.boards.addBoard')}
+        </Button>
+      </Box>
+
+      {boards === null ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : loadError ? (
+        <Typography variant="body2" color="error" sx={{ py: 2 }}>
+          {t('manage.boards.loadError')}
+        </Typography>
+      ) : boards.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+          {t('manage.boards.empty')}
+        </Typography>
+      ) : (
+        <List disablePadding>
+          {boards.map((board) => (
+            <ListItem
+              key={board.uuid}
+              divider
+              disableGutters
+              secondaryAction={
+                <Button
+                  size="small"
+                  color="error"
+                  startIcon={<LinkOffOutlined />}
+                  onClick={() => setUnlinkTarget(board)}
+                  sx={{ textTransform: 'none' }}
+                >
+                  {t('manage.boards.unlink')}
+                </Button>
+              }
+            >
+              <ListItemText
+                primary={
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                    <Typography component="span" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+                      {board.name}
+                    </Typography>
+                    <VisibilityChip board={board} />
+                  </Box>
+                }
+                secondary={`${boardTypeLabel(board.boardType)} · ${board.angle}°`}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+
+      <Dialog open={unlinkTarget !== null} onClose={() => setUnlinkTarget(null)}>
+        <DialogTitle>{t('manage.boards.unlinkTitle')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{t('manage.boards.unlinkBody', { name: unlinkTarget?.name ?? '' })}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setUnlinkTarget(null)} sx={{ textTransform: 'none' }}>
+            {t('manage.boards.cancel')}
+          </Button>
+          <Button onClick={handleUnlinkConfirm} color="error" autoFocus sx={{ textTransform: 'none' }}>
+            {t('manage.boards.unlinkConfirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <AddBoardDialog
+        open={addDialogOpen}
+        gymUuid={gym.uuid}
+        linkedBoardUuids={new Set((boards ?? []).map((board) => board.uuid))}
+        onClose={() => setAddDialogOpen(false)}
+        onLink={handleLink}
+      />
+    </Box>
+  );
+}
+
+type AddBoardDialogProps = {
+  open: boolean;
+  gymUuid: string;
+  linkedBoardUuids: Set<string>;
+  onClose: () => void;
+  onLink: (boardUuid: string) => Promise<void>;
+};
+
+function AddBoardDialog({ open, gymUuid, linkedBoardUuids, onClose, onLink }: AddBoardDialogProps) {
+  const { t } = useTranslation('kiosk');
+  const { token } = useWsAuthToken();
+  const [candidates, setCandidates] = useState<UserBoard[] | null>(null);
+  const [linkingUuid, setLinkingUuid] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !token) return;
+    let cancelled = false;
+    setCandidates(null);
+    (async () => {
+      try {
+        const client = createGraphQLHttpClient(token);
+        const data = await client.request<GetMyBoardsQueryResponse>(GET_MY_BOARDS, {
+          input: { limit: 50, offset: 0 },
+        });
+        if (cancelled) return;
+        // Only boards the viewer owns that aren't already on this gym.
+        const linkable = data.myBoards.boards.filter(
+          (board) => board.isOwned && board.gymUuid !== gymUuid && !linkedBoardUuids.has(board.uuid),
+        );
+        setCandidates(linkable);
+      } catch (error) {
+        console.error('Failed to load your boards:', error);
+        if (!cancelled) setCandidates([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, token, gymUuid, linkedBoardUuids]);
+
+  const handleLinkClick = async (boardUuid: string) => {
+    setLinkingUuid(boardUuid);
+    try {
+      await onLink(boardUuid);
+      setCandidates((prev) => (prev === null ? prev : prev.filter((board) => board.uuid !== boardUuid)));
+    } finally {
+      setLinkingUuid(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>{t('manage.boards.addDialog.title')}</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 1 }}>{t('manage.boards.addDialog.body')}</DialogContentText>
+        {candidates === null ? (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 2 }}>
+            <CircularProgress size={18} />
+            <Typography variant="body2" color="text.secondary">
+              {t('manage.boards.addDialog.loading')}
+            </Typography>
+          </Box>
+        ) : candidates.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+            {t('manage.boards.addDialog.empty')}
+          </Typography>
+        ) : (
+          <List disablePadding>
+            {candidates.map((board) => (
+              <ListItem
+                key={board.uuid}
+                disableGutters
+                secondaryAction={
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    disabled={linkingUuid !== null}
+                    onClick={() => handleLinkClick(board.uuid)}
+                    sx={{ textTransform: 'none' }}
+                  >
+                    {linkingUuid === board.uuid ? (
+                      <CircularProgress size={16} color="inherit" />
+                    ) : (
+                      t('manage.boards.addDialog.link')
+                    )}
+                  </Button>
+                }
+              >
+                <ListItemText primary={board.name} secondary={`${boardTypeLabel(board.boardType)} · ${board.angle}°`} />
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} sx={{ textTransform: 'none' }}>
+          {t('manage.boards.addDialog.close')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
@@ -17,6 +17,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import LinkOffOutlined from '@mui/icons-material/LinkOffOutlined';
+import { useSession } from 'next-auth/react';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { useEntityMutation } from '@/app/hooks/use-entity-mutation';
@@ -32,9 +33,13 @@ import {
 } from '@boardsesh/graphql/operations';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { themeTokens } from '@/app/theme/theme-config';
+import { canManageGymBoards, canUnlinkBoard, linkableBoards } from './gym-board-permissions';
 import type { GymManageTabProps } from './tab-props';
 
 // Brand display names — proper nouns, not translated copy.
+// TODO: this map is duplicated across board-detail, board cards, and the public
+// gym page — extract a shared helper (e.g. @boardsesh/board-constants) instead
+// of adding a seventh copy.
 const BOARD_TYPE_LABELS: Record<string, string> = {
   kilter: 'Kilter',
   tension: 'Tension',
@@ -63,11 +68,16 @@ function VisibilityChip({ board }: { board: Pick<UserBoard, 'isPublic' | 'isUnli
 export default function GymBoardsTab({ gym }: GymManageTabProps) {
   const { t } = useTranslation('kiosk');
   const { token } = useWsAuthToken();
+  const { data: session } = useSession();
+  const viewerUserId = session?.user?.id ?? null;
   const [boards, setBoards] = useState<UserBoard[] | null>(null);
   const [loadError, setLoadError] = useState(false);
   const [unlinkTarget, setUnlinkTarget] = useState<UserBoard | null>(null);
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const linkedBoardUuids = useMemo(() => new Set((boards ?? []).map((board) => board.uuid)), [boards]);
+  // Backend contract: linking requires gym owner/admin; unlinking requires
+  // owning the board. Editors (canEdit) still see the list, read-only.
+  const canLinkBoards = canManageGymBoards(gym, viewerUserId);
 
   const linkMutation = useEntityMutation<LinkBoardToGymMutationResponse, LinkBoardToGymMutationVariables>(
     LINK_BOARD_TO_GYM,
@@ -126,16 +136,23 @@ export default function GymBoardsTab({ gym }: GymManageTabProps) {
             {t('manage.boards.description')}
           </Typography>
         </Box>
-        <Button
-          variant="contained"
-          size="small"
-          startIcon={<AddOutlined />}
-          onClick={() => setAddDialogOpen(true)}
-          sx={{ textTransform: 'none', flexShrink: 0 }}
-        >
-          {t('manage.boards.addBoard')}
-        </Button>
+        {canLinkBoards && (
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<AddOutlined />}
+            onClick={() => setAddDialogOpen(true)}
+            sx={{ textTransform: 'none', flexShrink: 0 }}
+          >
+            {t('manage.boards.addBoard')}
+          </Button>
+        )}
       </Box>
+      {!canLinkBoards && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+          {t('manage.boards.readOnlyHint')}
+        </Typography>
+      )}
 
       {boards === null ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
@@ -157,15 +174,21 @@ export default function GymBoardsTab({ gym }: GymManageTabProps) {
               divider
               disableGutters
               secondaryAction={
-                <Button
-                  size="small"
-                  color="error"
-                  startIcon={<LinkOffOutlined />}
-                  onClick={() => setUnlinkTarget(board)}
-                  sx={{ textTransform: 'none' }}
-                >
-                  {t('manage.boards.unlink')}
-                </Button>
+                canUnlinkBoard(board, viewerUserId) ? (
+                  <Button
+                    size="small"
+                    color="error"
+                    startIcon={<LinkOffOutlined />}
+                    onClick={() => setUnlinkTarget(board)}
+                    sx={{ textTransform: 'none' }}
+                  >
+                    {t('manage.boards.unlink')}
+                  </Button>
+                ) : (
+                  <Typography variant="caption" color="text.secondary">
+                    {t('manage.boards.onlyOwnerCanUnlink')}
+                  </Typography>
+                )
               }
             >
               <ListItemText
@@ -199,13 +222,16 @@ export default function GymBoardsTab({ gym }: GymManageTabProps) {
         </DialogActions>
       </Dialog>
 
-      <AddBoardDialog
-        open={addDialogOpen}
-        gymUuid={gym.uuid}
-        linkedBoardUuids={new Set((boards ?? []).map((board) => board.uuid))}
-        onClose={() => setAddDialogOpen(false)}
-        onLink={handleLink}
-      />
+      {canLinkBoards && (
+        <AddBoardDialog
+          open={addDialogOpen}
+          gymUuid={gym.uuid}
+          viewerUserId={viewerUserId}
+          linkedBoardUuids={linkedBoardUuids}
+          onClose={() => setAddDialogOpen(false)}
+          onLink={handleLink}
+        />
+      )}
     </Box>
   );
 }
@@ -213,12 +239,13 @@ export default function GymBoardsTab({ gym }: GymManageTabProps) {
 type AddBoardDialogProps = {
   open: boolean;
   gymUuid: string;
+  viewerUserId: string | null;
   linkedBoardUuids: Set<string>;
   onClose: () => void;
   onLink: (boardUuid: string) => Promise<void>;
 };
 
-function AddBoardDialog({ open, gymUuid, linkedBoardUuids, onClose, onLink }: AddBoardDialogProps) {
+function AddBoardDialog({ open, gymUuid, viewerUserId, linkedBoardUuids, onClose, onLink }: AddBoardDialogProps) {
   const { t } = useTranslation('kiosk');
   const { token } = useWsAuthToken();
   const [candidates, setCandidates] = useState<UserBoard[] | null>(null);
@@ -228,18 +255,16 @@ function AddBoardDialog({ open, gymUuid, linkedBoardUuids, onClose, onLink }: Ad
     if (!open || !token) return;
     let cancelled = false;
     setCandidates(null);
-    (async () => {
+    void (async () => {
       try {
         const client = createGraphQLHttpClient(token);
         const data = await client.request<GetMyBoardsQueryResponse>(GET_MY_BOARDS, {
           input: { limit: 50, offset: 0 },
         });
         if (cancelled) return;
-        // Only boards the viewer owns that aren't already on this gym.
-        const linkable = data.myBoards.boards.filter(
-          (board) => board.isOwned && board.gymUuid !== gymUuid && !linkedBoardUuids.has(board.uuid),
-        );
-        setCandidates(linkable);
+        // ownerId, not isOwned — myBoards includes followed boards, and isOwned
+        // is the physical-ownership column, not the account that may link it.
+        setCandidates(linkableBoards(data.myBoards.boards, gymUuid, linkedBoardUuids, viewerUserId));
       } catch (error) {
         console.error('Failed to load your boards:', error);
         if (!cancelled) setCandidates([]);
@@ -248,7 +273,7 @@ function AddBoardDialog({ open, gymUuid, linkedBoardUuids, onClose, onLink }: Ad
     return () => {
       cancelled = true;
     };
-  }, [open, token, gymUuid, linkedBoardUuids]);
+  }, [open, token, gymUuid, linkedBoardUuids, viewerUserId]);
 
   const handleLinkClick = async (boardUuid: string) => {
     setLinkingUuid(boardUuid);

--- a/packages/web/app/components/gym-entity/manage/gym-slug-guard.tsx
+++ b/packages/web/app/components/gym-entity/manage/gym-slug-guard.tsx
@@ -15,7 +15,7 @@ import {
   type UpdateGymMutationResponse,
 } from '@boardsesh/graphql/operations';
 import type { Gym } from '@boardsesh/shared-schema';
-import { sanitizeSlugInput, gymSlugValidationError } from './slug-utils';
+import { sanitizeSlugInput, gymSlugValidationError, GYM_SLUG_MAX_LENGTH } from './slug-utils';
 
 type GymSlugGuardProps = {
   gym: Gym;
@@ -86,7 +86,7 @@ export default function GymSlugGuard({ gym, onSlugSet }: GymSlugGuardProps) {
           placeholder={t('manage.slugGuard.placeholder')}
           helperText={helperText}
           error={validationError !== null}
-          slotProps={{ htmlInput: { maxLength: 120 } }}
+          slotProps={{ htmlInput: { maxLength: GYM_SLUG_MAX_LENGTH } }}
           sx={{ minWidth: 240 }}
         />
         <Button type="submit" variant="contained" disabled={isSaving} sx={{ mt: 0.25, textTransform: 'none' }}>

--- a/packages/web/app/components/gym-entity/manage/gym-slug-guard.tsx
+++ b/packages/web/app/components/gym-entity/manage/gym-slug-guard.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import { useEntityMutation } from '@/app/hooks/use-entity-mutation';
+import {
+  UPDATE_GYM,
+  type UpdateGymMutationVariables,
+  type UpdateGymMutationResponse,
+} from '@boardsesh/graphql/operations';
+import type { Gym } from '@boardsesh/shared-schema';
+import { sanitizeSlugInput, gymSlugValidationError } from './slug-utils';
+
+type GymSlugGuardProps = {
+  gym: Gym;
+  /** Called with the updated gym once a slug is saved. */
+  onSlugSet: (gym: Gym) => void;
+};
+
+/**
+ * Prominent banner shown in the manage shell when a gym has no URL slug. Kiosk
+ * and public gym pages are keyed on the slug, so nothing is reachable until one
+ * is set. Slug format is validated client-side; uniqueness is enforced by
+ * updateGym, whose conflict message the mutation surfaces verbatim.
+ */
+export default function GymSlugGuard({ gym, onSlugSet }: GymSlugGuardProps) {
+  const { t } = useTranslation('kiosk');
+  const [slug, setSlug] = useState('');
+  const [validationError, setValidationError] = useState<'empty' | 'invalid' | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const { execute } = useEntityMutation<UpdateGymMutationResponse, UpdateGymMutationVariables>(UPDATE_GYM, {
+    successMessage: t('manage.slugGuard.saved'),
+    errorMessage: t('manage.slugGuard.saveFailed'),
+  });
+
+  const handleSave = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const error = gymSlugValidationError(slug);
+    if (error) {
+      setValidationError(error);
+      return;
+    }
+    setValidationError(null);
+    setIsSaving(true);
+    try {
+      const data = await execute({ input: { gymUuid: gym.uuid, slug: slug.trim() } });
+      if (data) {
+        onSlugSet(data.updateGym);
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  let helperText = t('manage.slugGuard.helper', { slug: slug || '…' });
+  if (validationError === 'empty') {
+    helperText = t('manage.slugGuard.errorEmpty');
+  } else if (validationError === 'invalid') {
+    helperText = t('manage.slugGuard.errorInvalid');
+  }
+
+  return (
+    <Alert severity="warning" sx={{ mb: 3 }}>
+      <AlertTitle>{t('manage.slugGuard.title')}</AlertTitle>
+      {t('manage.slugGuard.body')}
+      <Box
+        component="form"
+        onSubmit={handleSave}
+        sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mt: 1.5, flexWrap: 'wrap' }}
+      >
+        <TextField
+          label={t('manage.slugGuard.label')}
+          value={slug}
+          onChange={(event) => {
+            setSlug(sanitizeSlugInput(event.target.value));
+            setValidationError(null);
+          }}
+          size="small"
+          placeholder={t('manage.slugGuard.placeholder')}
+          helperText={helperText}
+          error={validationError !== null}
+          slotProps={{ htmlInput: { maxLength: 120 } }}
+          sx={{ minWidth: 240 }}
+        />
+        <Button type="submit" variant="contained" disabled={isSaving} sx={{ mt: 0.25, textTransform: 'none' }}>
+          {isSaving ? <CircularProgress size={20} color="inherit" /> : t('manage.slugGuard.save')}
+        </Button>
+      </Box>
+    </Alert>
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/kiosks-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/kiosks-tab.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import TvOutlined from '@mui/icons-material/TvOutlined';
+import ManageTabEmptyState from './manage-tab-empty-state';
+import type { GymManageTabProps } from './tab-props';
+
+/**
+ * Placeholder for the Kiosks tab. PR I replaces this body with the kiosk list +
+ * editor; the shell keeps passing {@link GymManageTabProps}, so nothing above
+ * this component changes.
+ */
+export default function KiosksTab(_props: GymManageTabProps) {
+  const { t } = useTranslation('kiosk');
+  return (
+    <ManageTabEmptyState
+      icon={<TvOutlined sx={{ fontSize: 40 }} />}
+      title={t('manage.kiosks.emptyTitle')}
+      body={t('manage.kiosks.emptyBody')}
+      ctaLabel={t('manage.kiosks.cta')}
+    />
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/manage-tab-empty-state.tsx
+++ b/packages/web/app/components/gym-entity/manage/manage-tab-empty-state.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { themeTokens } from '@/app/theme/theme-config';
+
+type ManageTabEmptyStateProps = {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+  /** Disabled CTA hinting at the feature that lands in a later PR. */
+  ctaLabel: string;
+};
+
+/**
+ * Shared empty-state for the manage-gym placeholder tabs. Icon + one line of
+ * copy + a disabled affordance, per the shell contract PR I fills in.
+ */
+export default function ManageTabEmptyState({ icon, title, body, ctaLabel }: ManageTabEmptyStateProps) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        gap: 1.5,
+        py: 6,
+        px: 2,
+        maxWidth: 440,
+        mx: 'auto',
+      }}
+    >
+      <Box sx={{ color: themeTokens.neutral[400], display: 'flex' }}>{icon}</Box>
+      <Typography variant="h6" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+        {title}
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        {body}
+      </Typography>
+      <Button variant="outlined" size="small" disabled sx={{ textTransform: 'none', mt: 1 }}>
+        {ctaLabel}
+      </Button>
+    </Box>
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/slug-utils.ts
+++ b/packages/web/app/components/gym-entity/manage/slug-utils.ts
@@ -1,0 +1,40 @@
+// Pure slug helpers shared by the manage-gym slug guard. Mirrors the backend
+// gym-slug format (lowercase alphanumeric + hyphens, no leading/trailing hyphen,
+// ≤120 chars) so the client rejects obviously-bad input before the mutation.
+// Uniqueness is enforced server-side — updateGym surfaces a conflict message the
+// slug guard shows verbatim, so there's no client-side availability check here.
+
+export const GYM_SLUG_MAX_LENGTH = 120;
+
+const GYM_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+/** Normalize raw text-field input to slug-legal characters as the user types. */
+export function sanitizeSlugInput(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '')
+    .slice(0, GYM_SLUG_MAX_LENGTH);
+}
+
+export type GymSlugError = 'empty' | 'invalid';
+
+/** Returns which validation error a candidate slug has, or null when it's valid. */
+export function gymSlugValidationError(slug: string): GymSlugError | null {
+  const trimmed = slug.trim();
+  if (trimmed.length === 0) {
+    return 'empty';
+  }
+  if (trimmed.length > GYM_SLUG_MAX_LENGTH || !GYM_SLUG_PATTERN.test(trimmed)) {
+    return 'invalid';
+  }
+  return null;
+}
+
+/**
+ * True when a route param is a gym UUID rather than a slug. The manage page
+ * resolves slug-less (legacy) gyms by UUID so its slug guard is reachable; the
+ * two never collide because generated slugs are word-based, never UUID-shaped.
+ */
+export function looksLikeGymUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}

--- a/packages/web/app/components/gym-entity/manage/slug-utils.ts
+++ b/packages/web/app/components/gym-entity/manage/slug-utils.ts
@@ -1,18 +1,22 @@
 // Pure slug helpers shared by the manage-gym slug guard. Mirrors the backend
-// gym-slug format (lowercase alphanumeric + hyphens, no leading/trailing hyphen,
-// ≤120 chars) so the client rejects obviously-bad input before the mutation.
-// Uniqueness is enforced server-side — updateGym surfaces a conflict message the
-// slug guard shows verbatim, so there's no client-side availability check here.
+// SlugSchema format: lowercase alphanumeric segments joined by single hyphens
+// (consecutive hyphens are rejected server-side too). Uniqueness is enforced
+// server-side — updateGym surfaces a conflict message the slug guard shows
+// verbatim, so there's no client-side availability check here.
 
+// The backend SlugSchema allows up to 200 chars, but the gymBySlug LOOKUP guard
+// rejects slugs over 120 — a longer slug would save fine and then never resolve.
+// Cap client input at the lookup guard so every saved slug stays reachable.
 export const GYM_SLUG_MAX_LENGTH = 120;
 
-const GYM_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const GYM_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 /** Normalize raw text-field input to slug-legal characters as the user types. */
 export function sanitizeSlugInput(raw: string): string {
   return raw
     .toLowerCase()
     .replace(/[^a-z0-9-]/g, '')
+    .replace(/-{2,}/g, '-')
     .slice(0, GYM_SLUG_MAX_LENGTH);
 }
 

--- a/packages/web/app/components/gym-entity/manage/tab-props.ts
+++ b/packages/web/app/components/gym-entity/manage/tab-props.ts
@@ -1,0 +1,15 @@
+import type { Gym } from '@boardsesh/shared-schema';
+
+/**
+ * Contract every manage-gym tab body implements. The shell (manage-gym-content)
+ * owns the Gym in state and passes it to each tab; a tab that mutates the gym
+ * (branding, and later the kiosk editor) calls `onGymChange` so the shell and
+ * sibling tabs see the update.
+ *
+ * PR I fills the kiosks and branding placeholders in place — same file path,
+ * same props — so the shell never has to change.
+ */
+export type GymManageTabProps = {
+  gym: Gym;
+  onGymChange: (gym: Gym) => void;
+};

--- a/packages/web/app/components/kiosk/kiosk-header.module.css
+++ b/packages/web/app/components/kiosk/kiosk-header.module.css
@@ -17,6 +17,13 @@
   min-width: 0;
 }
 
+/* Crawlable link to the public gym page; visually identical to the plain
+ * brand block — a TV audience never interacts with it. */
+.brandLink {
+  color: inherit;
+  text-decoration: none;
+}
+
 .logo {
   height: 48px;
   width: auto;

--- a/packages/web/app/components/kiosk/kiosk-header.tsx
+++ b/packages/web/app/components/kiosk/kiosk-header.tsx
@@ -13,10 +13,15 @@ export default function KioskHeader({
   gymName,
   logoUrl,
   kioskName,
+  gymSlug = null,
 }: {
   gymName: string;
   logoUrl: string | null;
   kioskName: string;
+  /** When set, the brand block links to the public gym page. The kiosk page is
+   * noindex,follow, so this server-rendered <a> is what lets crawlers reach
+   * /gym/{slug} (gym pages aren't in the sitemap yet). Visually inert on a TV. */
+  gymSlug?: string | null;
 }) {
   const { t } = useTranslation('kiosk');
   const connectionStatus = useKioskConnectionStatus();
@@ -32,7 +37,13 @@ export default function KioskHeader({
 
   return (
     <header className={styles.header}>
-      <div className={styles.brand}>{brandContent}</div>
+      {gymSlug ? (
+        <a className={`${styles.brand} ${styles.brandLink}`} href={`/gym/${gymSlug}`}>
+          {brandContent}
+        </a>
+      ) : (
+        <div className={styles.brand}>{brandContent}</div>
+      )}
       <div className={styles.meta}>
         {connectionStatus === 'reconnecting' ? (
           <span className={styles.reconnectChip} role="status">

--- a/packages/web/app/components/kiosk/kiosk-header.tsx
+++ b/packages/web/app/components/kiosk/kiosk-header.tsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import LocaleLink from '@/app/components/i18n/locale-link';
 import { useKioskConnectionStatus } from './presence/use-kiosk-board-presence';
 import styles from './kiosk-header.module.css';
 
@@ -19,8 +20,9 @@ export default function KioskHeader({
   logoUrl: string | null;
   kioskName: string;
   /** When set, the brand block links to the public gym page. The kiosk page is
-   * noindex,follow, so this server-rendered <a> is what lets crawlers reach
-   * /gym/{slug} (gym pages aren't in the sitemap yet). Visually inert on a TV. */
+   * noindex,follow, so this server-rendered anchor is what lets crawlers reach
+   * the gym page (gym pages aren't in the sitemap yet). LocaleLink keeps the
+   * active locale, so /es/kiosk/... links to /es/gym/... Visually inert on a TV. */
   gymSlug?: string | null;
 }) {
   const { t } = useTranslation('kiosk');
@@ -38,9 +40,9 @@ export default function KioskHeader({
   return (
     <header className={styles.header}>
       {gymSlug ? (
-        <a className={`${styles.brand} ${styles.brandLink}`} href={`/gym/${gymSlug}`}>
+        <LocaleLink className={`${styles.brand} ${styles.brandLink}`} href={`/gym/${gymSlug}`} prefetch={false}>
           {brandContent}
-        </a>
+        </LocaleLink>
       ) : (
         <div className={styles.brand}>{brandContent}</div>
       )}

--- a/packages/web/app/components/kiosk/kiosk-page-renderer.tsx
+++ b/packages/web/app/components/kiosk/kiosk-page-renderer.tsx
@@ -153,7 +153,12 @@ export default async function KioskPageRenderer({ gymSlug, kioskSlug }: { gymSlu
         <KioskReliability gymSlug={gymSlug} kioskSlug={kioskSlug} initialUpdatedAt={kiosk.updatedAt} />
         <KioskPresenceHub boardIds={distinctBoardIds}>
           <div className={layoutStyles.root}>
-            <KioskHeader gymName={kiosk.gym.name} logoUrl={kiosk.gym.logoUrl ?? null} kioskName={kiosk.name} />
+            <KioskHeader
+              gymName={kiosk.gym.name}
+              logoUrl={kiosk.gym.logoUrl ?? null}
+              kioskName={kiosk.name}
+              gymSlug={kiosk.gym.slug ?? null}
+            />
             {preset === null ? (
               <div className={layoutStyles.setupPlaceholder}>
                 <h1 className={layoutStyles.setupTitle}>{t('setup.title')}</h1>

--- a/packages/web/app/gym/[gym_slug]/gym-page-manage-button.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-page-manage-button.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Button from '@mui/material/Button';
+import SettingsOutlined from '@mui/icons-material/SettingsOutlined';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
+import { GYM_KIOSK_FLAG } from '@/app/flags';
+
+/**
+ * Client island: the "Manage gym" entry on the public gym page. The server only
+ * renders this for viewers who can edit the gym; the kiosk flag gates it further
+ * so the manage surface stays hidden until the feature ships broadly.
+ */
+export default function GymPageManageButton({ gymSlug }: { gymSlug: string }) {
+  const { t } = useTranslation('kiosk');
+  const kioskFlag = useFeatureFlag(GYM_KIOSK_FLAG);
+  if (!kioskFlag) {
+    return null;
+  }
+  return (
+    <Button
+      component={LocaleLink}
+      href={`/gym/${gymSlug}/manage`}
+      variant="outlined"
+      startIcon={<SettingsOutlined />}
+      sx={{ textTransform: 'none' }}
+    >
+      {t('gymPage.manageGym')}
+    </Button>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import Container from '@mui/material/Container';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import MuiLink from '@mui/material/Link';
+import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined';
+import type { Gym } from '@boardsesh/shared-schema';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
+import { themeTokens } from '@/app/theme/theme-config';
+import GymMemberManagement from '@/app/components/gym-entity/gym-member-management';
+import GymBoardsTab from '@/app/components/gym-entity/manage/gym-boards-tab';
+import KiosksTab from '@/app/components/gym-entity/manage/kiosks-tab';
+import BrandingTab from '@/app/components/gym-entity/manage/branding-tab';
+import GymSlugGuard from '@/app/components/gym-entity/manage/gym-slug-guard';
+
+type ManageTab = 'kiosks' | 'branding' | 'boards' | 'members';
+const VALID_TABS: ManageTab[] = ['kiosks', 'branding', 'boards', 'members'];
+const DEFAULT_TAB: ManageTab = 'kiosks';
+
+export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
+  const { t } = useTranslation('kiosk');
+  const [gym, setGym] = useState<Gym>(initialGym);
+  const searchParams = useSearchParams();
+  const router = useLocaleRouter();
+  const basePath = usePathnameWithoutLocale();
+  const { data: session } = useSession();
+
+  const currentUserId = session?.user?.id ?? null;
+  const isOwnerOrAdmin = (!!currentUserId && gym.ownerId === currentUserId) || gym.myRole === 'admin';
+
+  const tabParam = searchParams.get('tab');
+  const activeTab: ManageTab = VALID_TABS.includes(tabParam as ManageTab) ? (tabParam as ManageTab) : DEFAULT_TAB;
+
+  const handleTabChange = (_event: React.SyntheticEvent, value: ManageTab) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === DEFAULT_TAB) {
+      params.delete('tab');
+    } else {
+      params.set('tab', value);
+    }
+    const query = params.toString();
+    router.push(query ? `${basePath}?${query}` : basePath, { scroll: false });
+  };
+
+  const handleSlugSet = (updatedGym: Gym) => {
+    setGym(updatedGym);
+    // Move to the canonical slug URL so kiosk/public links resolve from here on.
+    const query = activeTab === DEFAULT_TAB ? '' : `?tab=${activeTab}`;
+    router.replace(`/gym/${updatedGym.slug}/manage${query}`, { scroll: false });
+  };
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+      {gym.slug && (
+        <Box sx={{ mb: 1.5 }}>
+          <MuiLink
+            component={LocaleLink}
+            href={`/gym/${gym.slug}`}
+            underline="hover"
+            sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, color: themeTokens.colors.primary }}
+          >
+            <ArrowBackOutlined sx={{ fontSize: 16 }} />
+            {t('manage.backToGym')}
+          </MuiLink>
+        </Box>
+      )}
+
+      <Typography variant="h4" component="h1" sx={{ fontWeight: themeTokens.typography.fontWeight.bold, mb: 3 }}>
+        {t('manage.title', { gymName: gym.name })}
+      </Typography>
+
+      {!gym.slug && <GymSlugGuard gym={gym} onSlugSet={handleSlugSet} />}
+
+      <Tabs
+        value={activeTab}
+        onChange={handleTabChange}
+        variant="scrollable"
+        scrollButtons="auto"
+        sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}
+      >
+        <Tab value="kiosks" label={t('manage.tabs.kiosks')} sx={{ textTransform: 'none' }} />
+        <Tab value="branding" label={t('manage.tabs.branding')} sx={{ textTransform: 'none' }} />
+        <Tab value="boards" label={t('manage.tabs.boards')} sx={{ textTransform: 'none' }} />
+        <Tab value="members" label={t('manage.tabs.members')} sx={{ textTransform: 'none' }} />
+      </Tabs>
+
+      {activeTab === 'kiosks' && <KiosksTab gym={gym} onGymChange={setGym} />}
+      {activeTab === 'branding' && <BrandingTab gym={gym} onGymChange={setGym} />}
+      {activeTab === 'boards' && <GymBoardsTab gym={gym} onGymChange={setGym} />}
+      {activeTab === 'members' && (
+        <GymMemberManagement
+          gymUuid={gym.uuid}
+          isOwnerOrAdmin={isOwnerOrAdmin}
+          canGrantAccess={gym.canGrantAccess ?? false}
+        />
+      )}
+    </Container>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
@@ -16,6 +16,7 @@ import LocaleLink from '@/app/components/i18n/locale-link';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 import { themeTokens } from '@/app/theme/theme-config';
 import GymMemberManagement from '@/app/components/gym-entity/gym-member-management';
+import { canManageGymBoards } from '@/app/components/gym-entity/manage/gym-board-permissions';
 import GymBoardsTab from '@/app/components/gym-entity/manage/gym-boards-tab';
 import KiosksTab from '@/app/components/gym-entity/manage/kiosks-tab';
 import BrandingTab from '@/app/components/gym-entity/manage/branding-tab';
@@ -34,7 +35,7 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
   const { data: session } = useSession();
 
   const currentUserId = session?.user?.id ?? null;
-  const isOwnerOrAdmin = (!!currentUserId && gym.ownerId === currentUserId) || gym.myRole === 'admin';
+  const isOwnerOrAdmin = canManageGymBoards(gym, currentUserId);
 
   const tabParam = searchParams.get('tab');
   const activeTab: ManageTab = VALID_TABS.includes(tabParam as ManageTab) ? (tabParam as ManageTab) : DEFAULT_TAB;

--- a/packages/web/app/gym/[gym_slug]/manage/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/page.tsx
@@ -1,0 +1,105 @@
+import React, { cache } from 'react';
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import Container from '@mui/material/Container';
+import Alert from '@mui/material/Alert';
+import type { Gym } from '@boardsesh/shared-schema';
+import {
+  GET_GYM,
+  GET_GYM_BY_SLUG,
+  type GetGymQueryResponse,
+  type GetGymBySlugQueryResponse,
+} from '@boardsesh/graphql/operations';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { executeAuthenticatedGraphQL } from '@/app/lib/graphql/server-graphql';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import { looksLikeGymUuid } from '@/app/components/gym-entity/manage/slug-utils';
+import ManageGymContent from './manage-gym-content';
+
+// Per-user, cookie-gated management surface — never static, never indexed.
+export const dynamic = 'force-dynamic';
+
+type ManageGymRouteProps = {
+  params: Promise<{ gym_slug: string }>;
+};
+
+/**
+ * Resolve the gym for the manage shell by slug first, then by UUID. Slug-less
+ * (legacy) gyms are addressed by UUID so their slug-guard banner is reachable;
+ * generated slugs are never UUID-shaped, so the two never collide. Request-deduped
+ * so generateMetadata and the page body share one round-trip.
+ */
+const resolveManageGym = cache(async (slugOrUuid: string, token: string): Promise<Gym | null> => {
+  try {
+    const bySlug = await executeAuthenticatedGraphQL<GetGymBySlugQueryResponse>(
+      GET_GYM_BY_SLUG,
+      { slug: slugOrUuid },
+      token,
+    );
+    if (bySlug.gymBySlug) {
+      return bySlug.gymBySlug;
+    }
+  } catch (error) {
+    console.error('resolveManageGym by slug failed:', error);
+  }
+
+  if (looksLikeGymUuid(slugOrUuid)) {
+    try {
+      const byUuid = await executeAuthenticatedGraphQL<GetGymQueryResponse>(GET_GYM, { gymUuid: slugOrUuid }, token);
+      return byUuid.gym ?? null;
+    } catch (error) {
+      console.error('resolveManageGym by uuid failed:', error);
+    }
+  }
+  return null;
+});
+
+export async function generateMetadata(props: ManageGymRouteProps): Promise<Metadata> {
+  const { gym_slug } = await props.params;
+  const { t, locale } = await getServerTranslation('kiosk');
+  const token = await getServerAuthToken();
+  const gym = token ? await resolveManageGym(gym_slug, token) : null;
+  const title = gym ? t('manage.title', { gymName: gym.name }) : t('metadata.fallbackTitle');
+  return createNoIndexMetadata({
+    title,
+    description: t('metadata.fallbackDescription'),
+    path: `/gym/${gym_slug}/manage`,
+    locale,
+  });
+}
+
+export default async function ManageGymPage(props: ManageGymRouteProps) {
+  const { gym_slug } = await props.params;
+  const token = await getServerAuthToken();
+
+  if (!token) {
+    redirect(`/auth/login?callbackUrl=${encodeURIComponent(`/gym/${gym_slug}/manage`)}`);
+  }
+
+  const gym = await resolveManageGym(gym_slug, token);
+  if (!gym) {
+    notFound();
+  }
+
+  const locale = await getLocale();
+
+  if (!gym.canEdit) {
+    const { t } = await getServerTranslation('kiosk');
+    return (
+      <I18nProvider locale={locale} namespaces={['common', 'boards', 'kiosk']}>
+        <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+          <Alert severity="error">{t('manage.accessDenied')}</Alert>
+        </Container>
+      </I18nProvider>
+    );
+  }
+
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'boards', 'kiosk']}>
+      <ManageGymContent initialGym={gym} />
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/manage/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/page.tsx
@@ -62,7 +62,10 @@ export async function generateMetadata(props: ManageGymRouteProps): Promise<Meta
   const { t, locale } = await getServerTranslation('kiosk');
   const token = await getServerAuthToken();
   const gym = token ? await resolveManageGym(gym_slug, token) : null;
-  const title = gym ? t('manage.title', { gymName: gym.name }) : t('metadata.fallbackTitle');
+  // Only editors get the gym's name in the title — gymBySlug returns private
+  // gyms to any authenticated viewer, and the name must not leak through
+  // metadata for a page whose body 404s them.
+  const title = gym && gym.canEdit ? t('manage.title', { gymName: gym.name }) : t('metadata.fallbackTitle');
   return createNoIndexMetadata({
     title,
     description: t('metadata.fallbackDescription'),
@@ -80,12 +83,16 @@ export default async function ManageGymPage(props: ManageGymRouteProps) {
   }
 
   const gym = await resolveManageGym(gym_slug, token);
-  if (!gym) {
+  // Match the public page's visibility contract: a private gym must be
+  // indistinguishable from a missing one for viewers who can't edit it — a 403
+  // here would confirm the gym exists.
+  if (!gym || (!gym.isPublic && !gym.canEdit)) {
     notFound();
   }
 
   const locale = await getLocale();
 
+  // Public gym, but this viewer can't manage it.
   if (!gym.canEdit) {
     const { t } = await getServerTranslation('kiosk');
     return (

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -11,7 +11,7 @@ import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import LanguageOutlined from '@mui/icons-material/LanguageOutlined';
 import TvOutlined from '@mui/icons-material/TvOutlined';
 import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
-import type { Gym, GymKiosk, UserBoard } from '@boardsesh/shared-schema';
+import type { Gym, UserBoard } from '@boardsesh/shared-schema';
 import {
   GET_GYM_BY_SLUG,
   GET_GYM_BOARDS,
@@ -19,30 +19,19 @@ import {
   type GetGymBySlugQueryResponse,
   type GetGymBoardsQueryResponse,
   type GetGymKioskQueryResponse,
+  type GymKioskOperationResult,
 } from '@boardsesh/graphql/operations';
+import { boardTypeLabel } from '@boardsesh/board-constants';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { executeAuthenticatedGraphQL } from '@/app/lib/graphql/server-graphql';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createPageMetadata, createNoIndexMetadata, absoluteUrl } from '@/app/lib/seo/metadata';
+import { safeExternalHref } from '@/app/lib/safe-external-url';
 import { themeTokens } from '@/app/theme/theme-config';
 import I18nProvider from '@/app/components/providers/i18n-provider';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import GymPageManageButton from './gym-page-manage-button';
-
-// Brand display names — proper nouns, not translated copy.
-// TODO: this map is duplicated across board-detail, board cards, and the manage
-// Boards tab — extract a shared helper (e.g. @boardsesh/board-constants) instead
-// of adding another copy.
-const BOARD_TYPE_LABELS: Record<string, string> = {
-  kilter: 'Kilter',
-  tension: 'Tension',
-  moonboard: 'MoonBoard',
-  decoy: 'Decoy',
-  touchstone: 'Touchstone',
-  grasshopper: 'Grasshopper',
-  soill: 'So iLL',
-};
 
 type GymRouteProps = {
   params: Promise<{ gym_slug: string }>;
@@ -58,7 +47,10 @@ const fetchGymBySlug = cache(async (slug: string, token: string | undefined): Pr
   }
 });
 
-async function fetchDefaultKiosk(gymSlug: string, token: string | undefined): Promise<GymKiosk | null> {
+async function fetchDefaultKiosk(
+  gymSlug: string,
+  token: string | undefined,
+): Promise<GymKioskOperationResult | null> {
   try {
     const response = await executeAuthenticatedGraphQL<GetGymKioskQueryResponse>(
       GET_GYM_KIOSK,
@@ -120,6 +112,9 @@ export default async function GymPage(props: GymRouteProps) {
   const [kiosk, boards] = await Promise.all([fetchDefaultKiosk(gym_slug, token), fetchGymBoards(gym.uuid, token)]);
 
   const logoSrc = gym.logoUrl ?? gym.imageUrl ?? null;
+  // Render-side XSS guard: only http(s) URLs become clickable (legacy rows may
+  // predate the backend's GymWebsiteSchema scheme check).
+  const websiteHref = safeExternalHref(gym.website);
 
   const jsonLd = gym.isPublic
     ? {
@@ -129,7 +124,7 @@ export default async function GymPage(props: GymRouteProps) {
         url: absoluteUrl(`/gym/${gym_slug}`),
         ...(gym.description ? { description: gym.description } : {}),
         ...(gym.address ? { address: gym.address } : {}),
-        ...(gym.website ? { sameAs: gym.website } : {}),
+        ...(websiteHref ? { sameAs: websiteHref } : {}),
         ...(logoSrc ? { image: logoSrc } : {}),
       }
     : null;
@@ -192,9 +187,9 @@ export default async function GymPage(props: GymRouteProps) {
               {t('gymPage.seeOnTheWall')}
             </Button>
           )}
-          {gym.website && (
+          {websiteHref && (
             <MuiLink
-              href={gym.website}
+              href={websiteHref}
               target="_blank"
               rel="noopener noreferrer"
               underline="hover"
@@ -241,7 +236,7 @@ export default async function GymPage(props: GymRouteProps) {
                     {board.name}
                   </Typography>
                   <Typography component="span" variant="body2" color="text.secondary">
-                    {`${BOARD_TYPE_LABELS[board.boardType] ?? board.boardType} · ${board.angle}°`}
+                    {`${boardTypeLabel(board.boardType)} · ${board.angle}°`}
                   </Typography>
                 </MuiLink>
               </Box>

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -1,0 +1,249 @@
+import React, { cache } from 'react';
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import Container from '@mui/material/Container';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import MuiLink from '@mui/material/Link';
+import Divider from '@mui/material/Divider';
+import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
+import LanguageOutlined from '@mui/icons-material/LanguageOutlined';
+import TvOutlined from '@mui/icons-material/TvOutlined';
+import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
+import type { Gym, GymKiosk, UserBoard } from '@boardsesh/shared-schema';
+import {
+  GET_GYM_BY_SLUG,
+  GET_GYM_BOARDS,
+  GET_GYM_KIOSK,
+  type GetGymBySlugQueryResponse,
+  type GetGymBoardsQueryResponse,
+  type GetGymKioskQueryResponse,
+} from '@boardsesh/graphql/operations';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { executeAuthenticatedGraphQL } from '@/app/lib/graphql/server-graphql';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { createPageMetadata, createNoIndexMetadata, absoluteUrl } from '@/app/lib/seo/metadata';
+import { themeTokens } from '@/app/theme/theme-config';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import GymPageManageButton from './gym-page-manage-button';
+
+// Brand display names — proper nouns, not translated copy.
+const BOARD_TYPE_LABELS: Record<string, string> = {
+  kilter: 'Kilter',
+  tension: 'Tension',
+  moonboard: 'MoonBoard',
+  decoy: 'Decoy',
+  touchstone: 'Touchstone',
+  grasshopper: 'Grasshopper',
+  soill: 'So iLL',
+};
+
+type GymRouteProps = {
+  params: Promise<{ gym_slug: string }>;
+};
+
+const fetchGymBySlug = cache(async (slug: string, token: string | undefined): Promise<Gym | null> => {
+  try {
+    const response = await executeAuthenticatedGraphQL<GetGymBySlugQueryResponse>(GET_GYM_BY_SLUG, { slug }, token);
+    return response.gymBySlug ?? null;
+  } catch (error) {
+    console.error('fetchGymBySlug failed:', error);
+    return null;
+  }
+});
+
+async function fetchDefaultKiosk(gymSlug: string, token: string | undefined): Promise<GymKiosk | null> {
+  try {
+    const response = await executeAuthenticatedGraphQL<GetGymKioskQueryResponse>(
+      GET_GYM_KIOSK,
+      { gymSlug, kioskSlug: null },
+      token,
+    );
+    return response.gymKiosk ?? null;
+  } catch (error) {
+    console.error('fetchDefaultKiosk failed:', error);
+    return null;
+  }
+}
+
+async function fetchGymBoards(gymUuid: string, token: string | undefined): Promise<UserBoard[]> {
+  try {
+    const response = await executeAuthenticatedGraphQL<GetGymBoardsQueryResponse>(GET_GYM_BOARDS, { gymUuid }, token);
+    return response.gymBoards ?? [];
+  } catch (error) {
+    console.error('fetchGymBoards failed:', error);
+    return [];
+  }
+}
+
+/** A gym is viewable when it's public, or the viewer can edit it (private preview). */
+function isGymViewable(gym: Gym | null): gym is Gym {
+  return gym !== null && (gym.isPublic || gym.canEdit);
+}
+
+export async function generateMetadata(props: GymRouteProps): Promise<Metadata> {
+  const { gym_slug } = await props.params;
+  const token = await getServerAuthToken();
+  const [gym, { t, locale }] = await Promise.all([fetchGymBySlug(gym_slug, token), getServerTranslation('kiosk')]);
+
+  if (!isGymViewable(gym)) {
+    return createNoIndexMetadata({
+      title: t('metadata.fallbackTitle'),
+      description: t('metadata.fallbackDescription'),
+      locale,
+    });
+  }
+
+  const title = t('gymPage.metaTitle', { gymName: gym.name });
+  const description = gym.description?.trim() || t('gymPage.metaDescription', { gymName: gym.name });
+  const options = { title, description, path: `/gym/${gym_slug}`, locale };
+  return gym.isPublic ? createPageMetadata(options) : createNoIndexMetadata(options);
+}
+
+export default async function GymPage(props: GymRouteProps) {
+  const { gym_slug } = await props.params;
+  const token = await getServerAuthToken();
+  const gym = await fetchGymBySlug(gym_slug, token);
+
+  if (!isGymViewable(gym)) {
+    notFound();
+  }
+
+  const locale = await getLocale();
+  const { t } = await getServerTranslation('kiosk');
+  const [kiosk, boards] = await Promise.all([fetchDefaultKiosk(gym_slug, token), fetchGymBoards(gym.uuid, token)]);
+
+  const logoSrc = gym.logoUrl ?? gym.imageUrl ?? null;
+
+  const jsonLd = gym.isPublic
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'SportsActivityLocation',
+        name: gym.name,
+        url: absoluteUrl(`/gym/${gym_slug}`),
+        ...(gym.description ? { description: gym.description } : {}),
+        ...(gym.address ? { address: gym.address } : {}),
+        ...(gym.website ? { sameAs: gym.website } : {}),
+        ...(logoSrc ? { image: logoSrc } : {}),
+      }
+    : null;
+
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'boards', 'kiosk']}>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          // JSON.stringify escapes quotes; guard the one XSS vector for inline JSON-LD.
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
+        />
+      )}
+      <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+        <Box sx={{ mb: 2 }}>
+          <MuiLink component={LocaleLink} href="/" underline="hover" sx={{ color: themeTokens.colors.primary }}>
+            {t('gymPage.breadcrumbHome')}
+          </MuiLink>
+        </Box>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap', mb: 2 }}>
+          {logoSrc && (
+            <Box
+              component="img"
+              src={logoSrc}
+              alt={gym.name}
+              sx={{ width: 72, height: 72, borderRadius: 2, objectFit: 'contain', flexShrink: 0 }}
+            />
+          )}
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="h3" component="h1" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+              {gym.name}
+            </Typography>
+            {gym.address && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+                <LocationOnOutlined sx={{ fontSize: 18, color: themeTokens.neutral[400] }} />
+                <Typography variant="body1" color="text.secondary">
+                  {gym.address}
+                </Typography>
+              </Box>
+            )}
+          </Box>
+        </Box>
+
+        {gym.description && (
+          <Typography variant="body1" sx={{ mb: 3, color: themeTokens.neutral[700] }}>
+            {gym.description}
+          </Typography>
+        )}
+
+        <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', mb: 3 }}>
+          {kiosk && (
+            <Button
+              component={LocaleLink}
+              href={`/kiosk/${gym_slug}`}
+              variant="contained"
+              startIcon={<TvOutlined />}
+              sx={{ textTransform: 'none' }}
+            >
+              {t('gymPage.seeOnTheWall')}
+            </Button>
+          )}
+          {gym.website && (
+            <MuiLink
+              href={gym.website}
+              target="_blank"
+              rel="noopener noreferrer"
+              underline="hover"
+              sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, color: themeTokens.colors.primary }}
+            >
+              <LanguageOutlined sx={{ fontSize: 18 }} />
+              {t('gymPage.visitWebsite')}
+            </MuiLink>
+          )}
+          {gym.canEdit && <GymPageManageButton gymSlug={gym_slug} />}
+        </Box>
+
+        <Divider sx={{ mb: 3 }} />
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+          <FitnessCenterOutlined sx={{ fontSize: 20, color: themeTokens.neutral[400] }} />
+          <Typography variant="h5" component="h2" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+            {t('gymPage.boardsHeading')}
+          </Typography>
+          {boards.length > 0 && (
+            <Typography variant="body2" color="text.secondary">
+              {t('gymPage.boardCount', { count: boards.length })}
+            </Typography>
+          )}
+        </Box>
+
+        {boards.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            {t('gymPage.noBoardsYet')}
+          </Typography>
+        ) : (
+          <Box component="ul" sx={{ listStyle: 'none', p: 0, m: 0, display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {boards.map((board) => (
+              <Box component="li" key={board.uuid}>
+                <MuiLink
+                  component={LocaleLink}
+                  href={`/b/${board.slug}`}
+                  underline="hover"
+                  sx={{ display: 'inline-flex', alignItems: 'baseline', gap: 1, color: themeTokens.colors.primary }}
+                >
+                  <Typography component="span" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+                    {board.name}
+                  </Typography>
+                  <Typography component="span" variant="body2" color="text.secondary">
+                    {`${BOARD_TYPE_LABELS[board.boardType] ?? board.boardType} · ${board.angle}°`}
+                  </Typography>
+                </MuiLink>
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Container>
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -31,6 +31,9 @@ import LocaleLink from '@/app/components/i18n/locale-link';
 import GymPageManageButton from './gym-page-manage-button';
 
 // Brand display names — proper nouns, not translated copy.
+// TODO: this map is duplicated across board-detail, board cards, and the manage
+// Boards tab — extract a shared helper (e.g. @boardsesh/board-constants) instead
+// of adding another copy.
 const BOARD_TYPE_LABELS: Record<string, string> = {
   kilter: 'Kilter',
   tension: 'Tension',
@@ -218,6 +221,8 @@ export default async function GymPage(props: GymRouteProps) {
           )}
         </Box>
 
+        {/* Together with the breadcrumb above, this keeps the page at ≥2
+            crawlable internal links even for a gym with no boards or kiosk. */}
         {boards.length === 0 ? (
           <Typography variant="body2" color="text.secondary">
             {t('gymPage.noBoardsYet')}
@@ -243,6 +248,12 @@ export default async function GymPage(props: GymRouteProps) {
             ))}
           </Box>
         )}
+
+        <Box sx={{ mt: 4 }}>
+          <MuiLink component={LocaleLink} href="/feed" underline="hover" sx={{ color: themeTokens.colors.primary }}>
+            {t('gymPage.exploreFeed')}
+          </MuiLink>
+        </Box>
       </Container>
     </I18nProvider>
   );

--- a/packages/web/app/lib/__tests__/safe-external-url.test.ts
+++ b/packages/web/app/lib/__tests__/safe-external-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { safeExternalHref } from '../safe-external-url';
+
+describe('safeExternalHref', () => {
+  it('passes http and https URLs through unchanged', () => {
+    expect(safeExternalHref('https://example.com')).toBe('https://example.com');
+    expect(safeExternalHref('http://example.com/path?a=1')).toBe('http://example.com/path?a=1');
+  });
+
+  it('rejects javascript: URIs (clickable XSS that rel=noopener does not block)', () => {
+    expect(safeExternalHref('javascript:alert(1)')).toBeNull();
+    // URL() strips leading control characters/whitespace, so this still parses
+    // as a javascript: URL — the protocol check must catch it.
+    expect(safeExternalHref(' javascript:alert(1)')).toBeNull();
+    expect(safeExternalHref('JavaScript:alert(1)')).toBeNull();
+  });
+
+  it('rejects other non-http schemes', () => {
+    expect(safeExternalHref('data:text/html,<script>alert(1)</script>')).toBeNull();
+    expect(safeExternalHref('vbscript:msgbox(1)')).toBeNull();
+    expect(safeExternalHref('ftp://example.com')).toBeNull();
+    expect(safeExternalHref('file:///etc/passwd')).toBeNull();
+  });
+
+  it('rejects schemeless and malformed values', () => {
+    expect(safeExternalHref('example.com')).toBeNull();
+    expect(safeExternalHref('//example.com')).toBeNull();
+    expect(safeExternalHref('not a url')).toBeNull();
+  });
+
+  it('returns null for null, undefined, and empty input', () => {
+    expect(safeExternalHref(null)).toBeNull();
+    expect(safeExternalHref(undefined)).toBeNull();
+    expect(safeExternalHref('')).toBeNull();
+  });
+});

--- a/packages/web/app/lib/safe-external-url.ts
+++ b/packages/web/app/lib/safe-external-url.ts
@@ -1,0 +1,29 @@
+/**
+ * Render-side guard for externally-sourced hrefs (gym websites, user links).
+ *
+ * The backend's GymWebsiteSchema already rejects non-http(s) schemes at write
+ * time, but rows written before that schema existed — or through any future
+ * ingest path that skips GraphQL validation — could still hold arbitrary
+ * strings. A `javascript:` URI in an href is a clickable XSS vector that
+ * `rel="noopener"` does not block, so every externally-sourced href must pass
+ * through here before rendering.
+ */
+
+/**
+ * Returns the URL when it parses with an http/https protocol, else null
+ * (callers skip rendering the link entirely). The original string is returned
+ * rather than URL#href so display text derived from it stays unchanged.
+ */
+export function safeExternalHref(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return null;
+  }
+  return raw;
+}

--- a/packages/web/app/sitemap.ts
+++ b/packages/web/app/sitemap.ts
@@ -17,6 +17,10 @@ type StaticEntry = {
   lastModified: Date;
 };
 
+// Public gym pages (/gym/[slug]) are not listed yet: there is no
+// public-gyms enumeration query (only searchGyms/myGyms, both input-driven).
+// Tracked follow-up on the gym-kiosk epic — until then gym pages are reached
+// through crawlable links from kiosk pages and board pages.
 const STATIC_ENTRIES: StaticEntry[] = [
   { path: '/', changeFrequency: 'weekly', priority: 1.0, lastModified: new Date('2026-04-30') },
   { path: '/aurora-migration', changeFrequency: 'weekly', priority: 0.9, lastModified: new Date('2026-04-30') },


### PR DESCRIPTION
## Summary

PR H of the gym-kiosk-dashboard epic. Adds the public gym page and the manage-gym shell (stacked on the kiosk foundation, PR F).

- **Public gym page** `app/gym/[gym_slug]/page.tsx` — server-rendered, indexable when the gym is public (`createPageMetadata`, title leads with the gym name), `createNoIndexMetadata` + private-preview access for editors, `notFound()` when missing or private-and-not-editor. Shows logo (logoUrl → imageUrl fallback), name (h1), address, description, the gym's boards (linked to `/b/{slug}`), a website link (`rel="noopener"`), a "See what's on the wall" button when the gym has a default kiosk (`gymKiosk(gymSlug)` non-null), a "Manage gym" island gated by `canEdit` + `useFeatureFlag(GYM_KIOSK_FLAG)`, and `SportsActivityLocation` JSON-LD. Fetched via `executeAuthenticatedGraphQL` with an optional token so `canEdit` resolves for logged-in viewers.
- **Manage shell** `app/gym/[gym_slug]/manage/page.tsx` — `force-dynamic`, noindex. Server gate: no token → `redirect('/auth/login?callbackUrl=…')`; token → resolve gym; `!canEdit` → 403 `<Alert>`. Client shell has MUI Tabs (Kiosks | Branding | Boards | Members) synced to `?tab=`.
  - **Kiosks + Branding**: placeholder empty-states (icon + copy + disabled affordance). PR I fills `kiosks-tab.tsx` / `branding-tab.tsx` in place — same file path, same `GymManageTabProps` — so the shell never changes.
  - **Boards**: lists the gym's boards (`GET_GYM_BOARDS`, editors see all with Public/Unlisted/Private badges), unlink-with-confirm, and an "Add a board" dialog that links the viewer's own unlinked boards (`GET_MY_BOARDS` → `LINK_BOARD_TO_GYM` via `useEntityMutation`).
  - **Members**: reuses `GymMemberManagement` unchanged.
  - **Slug guard**: when `gym.slug` is null, a prominent banner with an inline form sets the slug via `UPDATE_GYM`, then routes to the canonical slug URL.
- **Entry points**: "Manage gym" in `gym-detail.tsx` next to Edit, gated `canEdit` + kiosk flag.
- **i18n**: all new copy in the `kiosk` namespace (`kiosk.gymPage.*`, `kiosk.manage.*`) across en-US, es (board = plafón), fr.

### Deviation from spec
The manage route resolves the gym by **slug OR uuid**. Slug-less (legacy) gyms have no slug-based URL, so the manage entry point links to `/gym/{uuid}/manage` for them; this is the only way the slug-guard banner is reachable. Generated slugs are never UUID-shaped, so the two never collide.

### Tab-shell contract for PR I
- Swap `packages/web/app/components/gym-entity/manage/kiosks-tab.tsx` and `branding-tab.tsx` — keep the default export accepting `GymManageTabProps` (`{ gym, onGymChange }` from `manage/tab-props.ts`). The shell (`app/gym/[gym_slug]/manage/manage-gym-content.tsx`) passes both and never needs edits.
- `onGymChange(updatedGym)` propagates gym mutations (branding logo/colours) back to the shell + sibling tabs.

## Release Notes

- Every gym now has a public page — logo, boards, and a one-tap link to the live wall.
- Gym owners get a manage hub to link boards and manage their crew (kiosk and branding setup arrive with the editor update).

## Test plan

- `vp check` — clean (the 3 `packages/db` test errors are pre-existing repo debt).
- `vp run typecheck:web` — pass.
- `vp run check:i18n` + `vp run check:i18n:orphans` — pass.
- `vp test run --project web …/manage/__tests__/slug-utils.test.ts` — 9 passed.
- `@boardsesh/i18n` catalog-completeness — 30 passed (en-US/es/fr parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaW2zXJkhwXJhyxYzSv9iH