### PR TITLE
feat(web): embeddable board and leaderboard widgets for gym websites

### DIFF
--- a/packages/shared/graphql/src/operations/boards.ts
+++ b/packages/shared/graphql/src/operations/boards.ts
@@ -54,6 +54,7 @@ const BOARD_FIELDS = `
   distanceMeters
   serialNumber
   canEdit
+  boardId
 `;
 
 export const GET_BOARD = gql`

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -40,5 +40,21 @@
   },
   "attribution": {
     "poweredBy": "Powered by"
+  },
+  "embed": {
+    "metadata": {
+      "boardTitle": "{{boardName}} — live board view",
+      "boardDescription": "See what's lit on {{boardName}} right now. Powered by Boardsesh.",
+      "boardFallbackTitle": "Live board view",
+      "boardFallbackDescription": "Live climbing board widget. Powered by Boardsesh.",
+      "leaderboardTitle": "{{gymName}} — leaderboard",
+      "leaderboardDescription": "Who's sending at {{gymName}}. Powered by Boardsesh.",
+      "leaderboardFallbackTitle": "Gym leaderboard",
+      "leaderboardFallbackDescription": "Gym leaderboard widget. Powered by Boardsesh."
+    },
+    "leaderboard": {
+      "errorTitle": "Leaderboard unavailable",
+      "errorBody": "Couldn't load the latest sends. It'll retry on its own."
+    }
   }
 }

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -40,5 +40,21 @@
   },
   "attribution": {
     "poweredBy": "Con la tecnología de"
+  },
+  "embed": {
+    "metadata": {
+      "boardTitle": "{{boardName}} — vista del plafón en directo",
+      "boardDescription": "Mira qué está encendido en {{boardName}} ahora mismo. Con la tecnología de Boardsesh.",
+      "boardFallbackTitle": "Vista del plafón en directo",
+      "boardFallbackDescription": "Widget del plafón en directo. Con la tecnología de Boardsesh.",
+      "leaderboardTitle": "{{gymName}} — clasificación",
+      "leaderboardDescription": "Quién está encadenando en {{gymName}}. Con la tecnología de Boardsesh.",
+      "leaderboardFallbackTitle": "Clasificación del rocódromo",
+      "leaderboardFallbackDescription": "Widget de clasificación del rocódromo. Con la tecnología de Boardsesh."
+    },
+    "leaderboard": {
+      "errorTitle": "Clasificación no disponible",
+      "errorBody": "No se han podido cargar los últimos encadenes. Se reintentará automáticamente."
+    }
   }
 }

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -40,5 +40,21 @@
   },
   "attribution": {
     "poweredBy": "Propulsé par"
+  },
+  "embed": {
+    "metadata": {
+      "boardTitle": "{{boardName}} — vue de la board en direct",
+      "boardDescription": "Ce qui est allumé sur {{boardName}} en ce moment. Propulsé par Boardsesh.",
+      "boardFallbackTitle": "Vue de la board en direct",
+      "boardFallbackDescription": "Widget de board en direct. Propulsé par Boardsesh.",
+      "leaderboardTitle": "{{gymName}} — classement",
+      "leaderboardDescription": "Qui enchaîne à {{gymName}}. Propulsé par Boardsesh.",
+      "leaderboardFallbackTitle": "Classement de la salle",
+      "leaderboardFallbackDescription": "Widget de classement de salle. Propulsé par Boardsesh."
+    },
+    "leaderboard": {
+      "errorTitle": "Classement indisponible",
+      "errorBody": "Impossible de charger les dernières croix. Le widget réessaie tout seul."
+    }
   }
 }

--- a/packages/web/app/components/analytics-client.tsx
+++ b/packages/web/app/components/analytics-client.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react';
 import { usePathname } from 'next/navigation';
 import { onCLS, onFCP, onINP, onLCP, type Metric } from 'web-vitals';
 import { capturePosthog, pageview } from '@/app/lib/analytics';
-import { analyticsPathname, isAdminAnalyticsUrl } from '@/app/lib/analytics-paths';
+import { analyticsPathname, isAdminAnalyticsUrl, isEmbedAnalyticsUrl } from '@/app/lib/analytics-paths';
 
 // PostHog's Web Vitals dashboard widget surfaces LCP, CLS, FCP, INP and
 // expects a single batched `$web_vitals` event per page with metric-prefixed
@@ -34,7 +34,9 @@ function flushVitalsBuffer(buffer: VitalsBuffer): void {
   buffer.metrics = new Map();
   buffer.pageUrl = null;
 
-  if (!pageUrl || isAdminAnalyticsUrl(pageUrl)) return;
+  // No web-vitals off /admin, and none off /embed/** — embeds run inside
+  // third-party sites with no consent surface (see isEmbedAnalyticsUrl).
+  if (!pageUrl || isAdminAnalyticsUrl(pageUrl) || isEmbedAnalyticsUrl(pageUrl)) return;
 
   const props: Record<string, string | number | boolean | null> = {
     $current_url: analyticsPathname(pageUrl),
@@ -60,6 +62,11 @@ export default function AnalyticsClient() {
     // StrictMode's effect re-run can't double-register them and double-count
     // each metric.
     if (vitalsRegistered.current) return;
+    // /embed/** widgets are full-document loads with no in-app navigation
+    // away, so skipping registration at mount disables web-vitals capture
+    // there entirely (GDPR: no consent surface inside a third-party iframe —
+    // see isEmbedAnalyticsUrl). The flush-time check above is the backstop.
+    if (isEmbedAnalyticsUrl(window.location.href)) return;
     vitalsRegistered.current = true;
 
     const reportVital = (metric: Metric): void => {
@@ -91,6 +98,9 @@ export default function AnalyticsClient() {
   useEffect(() => {
     if (!pathname) return;
     if (isAdminAnalyticsUrl(pathname)) return;
+    // No PostHog pageviews off /embed/** (third-party iframe, no consent
+    // surface — see isEmbedAnalyticsUrl). Kiosk keeps first-party telemetry.
+    if (isEmbedAnalyticsUrl(pathname)) return;
 
     // Flush metrics buffered against the previous URL before recording the new
     // pageview, so each `$web_vitals` event stays bound to the page it

--- a/packages/web/app/components/kiosk/board-slot-data.ts
+++ b/packages/web/app/components/kiosk/board-slot-data.ts
@@ -1,0 +1,92 @@
+// Server-side data assembly for one BoardSlot: resolve the board's render
+// details, seed the latest climb from boardRecentClimbs (anonymous HTTP,
+// uncached — this is "what's lit right now"), and pre-build the raster
+// placeholder URLs the slot paints before its live subscription attaches.
+// Shared by the kiosk page renderer and the /embed/board/[board_uuid] widget.
+
+import 'server-only';
+import { BOARD_RECENT_CLIMBS } from '@boardsesh/graphql/operations';
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
+import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
+import type { BoardDetails } from '@/app/lib/types';
+import { buildBoardRenderUrl, toFlatFrames } from '../board-renderer/util';
+
+/** The board-config subset a slot needs; satisfied by both `GymKioskBoard` and `UserBoard`. */
+export type BoardSlotSource = {
+  /** Numeric board-presence channel id (userBoards.id). */
+  boardId: number;
+  /** For diagnostics only — never rendered. */
+  boardUuid: string;
+  boardType: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+};
+
+export type BoardSlotData = {
+  boardDetails: BoardDetails;
+  /** Latest climb seen on the wall (boardRecentClimbs[0]) or null. */
+  initialClimb: BoardPresenceClimb | null;
+  /** Raster URL for the initial climb's frames (null when no initial climb). */
+  initialClimbImageUrl: string | null;
+  /** Raster URL for the bare board (idle placeholder). */
+  bareBoardImageUrl: string;
+};
+
+function resolveBoardDetails(board: BoardSlotSource): BoardDetails | null {
+  try {
+    return getBoardDetailsForBoard({
+      board_name: board.boardType,
+      layout_id: board.layoutId,
+      size_id: board.sizeId,
+      set_ids: board.setIds.split(',').map(Number),
+    });
+  } catch (error) {
+    // An unknown layout/size/set combination (e.g. stale board config) drops
+    // the slot instead of crashing the surface; callers degrade gracefully.
+    console.warn(`[kiosk] Skipping board ${board.boardUuid}: no board details`, error);
+    return null;
+  }
+}
+
+/** Latest climbs for a board (newest first; index 0 = current). Anonymous,
+ * uncached — this is the SSR seed for what's lit right now. */
+async function fetchInitialClimbs(boardId: number): Promise<BoardPresenceClimb[]> {
+  try {
+    const response = await fetch(getGraphQLHttpUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: BOARD_RECENT_CLIMBS, variables: { boardId } }),
+      cache: 'no-store',
+    });
+    if (!response.ok) return [];
+    const payload = (await response.json()) as { data?: { boardRecentClimbs?: BoardPresenceClimb[] | null } };
+    return payload.data?.boardRecentClimbs ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Everything a `BoardSlot` needs beyond its identity props. Returns null when
+ * the board's config can't be resolved to render details — the caller drops
+ * the slot (kiosk presets degrade; the embed 404s).
+ */
+export async function buildBoardSlotData(board: BoardSlotSource): Promise<BoardSlotData | null> {
+  const boardDetails = resolveBoardDetails(board);
+  if (boardDetails === null) return null;
+
+  const recentClimbs = await fetchInitialClimbs(board.boardId);
+  const initialClimb = recentClimbs[0] ?? null;
+  const flatFrames = toFlatFrames(initialClimb?.frames, boardDetails.board_name);
+  return {
+    boardDetails,
+    initialClimb,
+    initialClimbImageUrl:
+      initialClimb === null || flatFrames.length === 0
+        ? null
+        : buildBoardRenderUrl(boardDetails, flatFrames, { includeBackground: true }),
+    bareBoardImageUrl: buildBoardRenderUrl(boardDetails, '', { includeBackground: true }),
+  };
+}

--- a/packages/web/app/components/kiosk/embed/__tests__/embed-access.test.ts
+++ b/packages/web/app/components/kiosk/embed/__tests__/embed-access.test.ts
@@ -1,0 +1,158 @@
+// Pins the /embed/** access-control decisions. These are SECURITY tests: the
+// backend `board(boardUuid)` / `gym(gymUuid)` resolvers serve PRIVATE entities
+// fully enriched to anonymous callers, so the embed layer's own gates are the
+// only thing between a guessable uuid and a private board/gym leaking through
+// a frameable, cookieless page.
+
+import { describe, expect, it } from 'vitest';
+import type { Gym, UserBoard } from '@boardsesh/shared-schema';
+import {
+  DEFAULT_EMBED_LEADERBOARD_PERIOD,
+  embedAttributionHref,
+  parseEmbedLeaderboardPeriod,
+  resolveEmbedBrandGym,
+  resolveEmbedLeaderboardScope,
+  resolveEmbeddableBoard,
+} from '../embed-access';
+
+function makeBoard(overrides: Partial<UserBoard> = {}): UserBoard {
+  return {
+    uuid: 'board-uuid-1',
+    slug: 'main-kilter',
+    ownerId: 'owner-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '1,20',
+    name: 'Main Kilter',
+    isPublic: true,
+    isUnlisted: false,
+    hideLocation: false,
+    isOwned: true,
+    angle: 40,
+    isAngleAdjustable: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    totalAscents: 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+    boardId: 42,
+    ...overrides,
+  };
+}
+
+function makeGym(overrides: Partial<Gym> = {}): Gym {
+  return {
+    uuid: 'gym-uuid-1',
+    slug: 'boulder-barn',
+    ownerId: 'owner-1',
+    name: 'Boulder Barn',
+    isPublic: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    boardCount: 1,
+    boardTypes: ['kilter'],
+    memberCount: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+    isMember: false,
+    canEdit: false,
+    canGrantAccess: false,
+    canClaim: false,
+    ...overrides,
+  };
+}
+
+describe('resolveEmbeddableBoard', () => {
+  it('passes a public board with a presence id through, narrowed', () => {
+    const embeddable = resolveEmbeddableBoard(makeBoard());
+    expect(embeddable).not.toBeNull();
+    expect(embeddable?.boardId).toBe(42);
+  });
+
+  it('SECURITY: rejects a PRIVATE board even though the resolver returned it', () => {
+    expect(resolveEmbeddableBoard(makeBoard({ isPublic: false }))).toBeNull();
+  });
+
+  it('SECURITY: rejects a private board that somehow still carries a boardId', () => {
+    expect(resolveEmbeddableBoard(makeBoard({ isPublic: false, boardId: 42 }))).toBeNull();
+  });
+
+  it('defense in depth: rejects a board with a null/absent presence id', () => {
+    expect(resolveEmbeddableBoard(makeBoard({ boardId: null }))).toBeNull();
+    expect(resolveEmbeddableBoard(makeBoard({ boardId: undefined }))).toBeNull();
+  });
+
+  it('rejects a missing board', () => {
+    expect(resolveEmbeddableBoard(null)).toBeNull();
+  });
+
+  it('unlisted-but-public boards stay embeddable (unlisted = link-only, and the embed IS the link)', () => {
+    expect(resolveEmbeddableBoard(makeBoard({ isUnlisted: true }))).not.toBeNull();
+  });
+});
+
+describe('resolveEmbedBrandGym', () => {
+  it('passes a public gym through', () => {
+    expect(resolveEmbedBrandGym(makeGym())?.name).toBe('Boulder Barn');
+  });
+
+  it('SECURITY: strips a PRIVATE gym — no name/logo/colours on any embed', () => {
+    expect(resolveEmbedBrandGym(makeGym({ isPublic: false }))).toBeNull();
+  });
+
+  it('handles an absent gym', () => {
+    expect(resolveEmbedBrandGym(null)).toBeNull();
+  });
+});
+
+describe('embedAttributionHref', () => {
+  it('points at the public gym page when the gym has a slug', () => {
+    expect(embedAttributionHref(makeGym())).toBe('/gym/boulder-barn');
+  });
+
+  it('falls back to the homepage for a slugless gym or no gym', () => {
+    expect(embedAttributionHref(makeGym({ slug: null }))).toBe('https://boardsesh.com');
+    expect(embedAttributionHref(null)).toBe('https://boardsesh.com');
+  });
+});
+
+describe('parseEmbedLeaderboardPeriod', () => {
+  it('accepts the three period modes', () => {
+    expect(parseEmbedLeaderboardPeriod('day')).toBe('day');
+    expect(parseEmbedLeaderboardPeriod('week')).toBe('week');
+    expect(parseEmbedLeaderboardPeriod('month')).toBe('month');
+  });
+
+  it('defaults to week, and NEVER yields session (embeds stay WebSocket-free)', () => {
+    expect(DEFAULT_EMBED_LEADERBOARD_PERIOD).toBe('week');
+    expect(parseEmbedLeaderboardPeriod(undefined)).toBe('week');
+    expect(parseEmbedLeaderboardPeriod('session')).toBe('week');
+    expect(parseEmbedLeaderboardPeriod('yesterday')).toBe('week');
+    expect(parseEmbedLeaderboardPeriod('')).toBe('week');
+  });
+});
+
+describe('resolveEmbedLeaderboardScope', () => {
+  const kilter = makeBoard({ uuid: 'board-uuid-1', name: 'Main Kilter' });
+  const tension = makeBoard({ uuid: 'board-uuid-2', name: 'Tension Wall' });
+
+  it('scopes to a board that is in the visible list', () => {
+    const { scopedBoard, scopedBoards } = resolveEmbedLeaderboardScope([kilter, tension], 'board-uuid-2');
+    expect(scopedBoard?.name).toBe('Tension Wall');
+    expect(scopedBoards).toEqual([tension]);
+  });
+
+  it('widens to all boards when no scope is given', () => {
+    const { scopedBoard, scopedBoards } = resolveEmbedLeaderboardScope([kilter, tension], undefined);
+    expect(scopedBoard).toBeNull();
+    expect(scopedBoards).toEqual([kilter, tension]);
+  });
+
+  it('SECURITY: widens to all boards when the uuid is not viewer-visible (e.g. a private board pasted into the query string)', () => {
+    const { scopedBoard, scopedBoards } = resolveEmbedLeaderboardScope([kilter, tension], 'private-board-uuid');
+    expect(scopedBoard).toBeNull();
+    expect(scopedBoards).toEqual([kilter, tension]);
+  });
+});

--- a/packages/web/app/components/kiosk/embed/__tests__/embed-fetchers.server.test.ts
+++ b/packages/web/app/components/kiosk/embed/__tests__/embed-fetchers.server.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+
+// Pins the transient-vs-null discrimination contract of the embed fetchers:
+// transport failures, HTTP errors, GraphQL errors, and malformed payloads are
+// { status: 'error' } (→ the page's self-healing retry screen), while ONLY a
+// successful response resolving the entity (possibly to null) is
+// { status: 'ok' } (→ the page's own isPublic gates decide notFound()).
+// A regression that flips an error into an ok/null would silently 404
+// working embeds; one that flips ok/null into error would mask the security
+// gates behind the retry screen — both directions matter.
+
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/app/lib/graphql/client', () => ({
+  getGraphQLHttpUrl: () => 'http://backend.test/graphql',
+}));
+
+import { fetchBoardForEmbed, fetchGymBoardsForEmbed, fetchGymForEmbed } from '../embed-fetchers';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// React's `cache()` memoizes per argument, so every test uses a fresh uuid to
+// keep calls independent.
+let uuidCounter = 0;
+function nextUuid(): string {
+  uuidCounter += 1;
+  return `00000000-0000-4000-8000-${String(uuidCounter).padStart(12, '0')}`;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('fetchBoardForEmbed — transient failures are errors, never ok/null', () => {
+  it('maps a non-2xx HTTP response to error', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: null }, 500));
+    expect(await fetchBoardForEmbed(nextUuid())).toEqual({ status: 'error' });
+  });
+
+  it('maps a thrown fetch (network down) to error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    expect(await fetchBoardForEmbed(nextUuid())).toEqual({ status: 'error' });
+  });
+
+  it('maps data: null to error', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: null }));
+    expect(await fetchBoardForEmbed(nextUuid())).toEqual({ status: 'error' });
+  });
+
+  it('maps a missing data key to error', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+    expect(await fetchBoardForEmbed(nextUuid())).toEqual({ status: 'error' });
+  });
+
+  it('maps a GraphQL errors array to error even when data is present', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ data: { board: { uuid: 'x' } }, errors: [{ message: 'resolver blew up' }] }),
+    );
+    expect(await fetchBoardForEmbed(nextUuid())).toEqual({ status: 'error' });
+  });
+
+  it('maps a payload missing the queried field (picker → undefined) to error', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: { somethingElse: 1 } }));
+    expect(await fetchBoardForEmbed(nextUuid())).toEqual({ status: 'error' });
+  });
+
+  it('maps unparseable JSON to error', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('<html>gateway timeout</html>', { status: 200 }));
+    expect(await fetchBoardForEmbed(nextUuid())).toEqual({ status: 'error' });
+  });
+});
+
+describe('fetchBoardForEmbed — successful resolutions are ok', () => {
+  it('a successful null board is ok/null (→ the page notFound()s, not the retry screen)', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: { board: null } }));
+    expect(await fetchBoardForEmbed(nextUuid())).toEqual({ status: 'ok', entity: null });
+  });
+
+  it('a successful board is ok with the entity', async () => {
+    const board = { uuid: 'board-1', name: 'Main Kilter', isPublic: true, boardId: 42 };
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: { board } }));
+    expect(await fetchBoardForEmbed(nextUuid())).toEqual({ status: 'ok', entity: board });
+  });
+
+  it('sends an ANONYMOUS request (no auth header) with the 5-minute shared cache', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: { board: null } }));
+    await fetchBoardForEmbed(nextUuid());
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [requestUrl, requestInit] = mockFetch.mock.calls[0] as [string, RequestInit & { next?: unknown }];
+    expect(requestUrl).toBe('http://backend.test/graphql');
+    expect(requestInit.headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(requestInit.next).toEqual({ revalidate: 300 });
+  });
+});
+
+describe('fetchGymForEmbed / fetchGymBoardsForEmbed share the same contract', () => {
+  it('gym: successful null is ok/null; failure is error', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: { gym: null } }));
+    expect(await fetchGymForEmbed(nextUuid())).toEqual({ status: 'ok', entity: null });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: null, errors: [{ message: 'NOT_FOUND' }] }));
+    expect(await fetchGymForEmbed(nextUuid())).toEqual({ status: 'error' });
+  });
+
+  it('gymBoards: a successful list is ok; a masked private gym (GraphQL error) is error', async () => {
+    const boards = [{ uuid: 'board-1', name: 'Main Kilter' }];
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: { gymBoards: boards } }));
+    expect(await fetchGymBoardsForEmbed(nextUuid())).toEqual({ status: 'ok', entity: boards });
+
+    // gymBoards masks private/missing gyms as a NOT_FOUND GraphQL error —
+    // callers gate on the public gym first, so this maps to the retry screen.
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: null, errors: [{ message: 'Gym not found' }] }));
+    expect(await fetchGymBoardsForEmbed(nextUuid())).toEqual({ status: 'error' });
+  });
+});

--- a/packages/web/app/components/kiosk/embed/embed-access.ts
+++ b/packages/web/app/components/kiosk/embed/embed-access.ts
@@ -1,0 +1,79 @@
+// Pure access-control and param-parsing decisions for the /embed/** widgets.
+// Kept free of fetching/React so the security gates are unit-testable.
+//
+// THE gate everything else hangs off: the backend `board(boardUuid)` resolver
+// serves PRIVATE boards fully enriched to anonymous callers (see
+// packages/backend/.../social/boards.ts — a tracked follow-up), so the embed
+// layer MUST enforce visibility itself. Same for `gym(gymUuid)`, which returns
+// private gyms to anon.
+
+import type { Gym, UserBoard } from '@boardsesh/shared-schema';
+
+/** A board the embed is allowed to render: public, with a presence-channel id. */
+export type EmbeddableBoard = UserBoard & { boardId: number };
+
+/**
+ * SECURITY: decide whether `/embed/board/[board_uuid]` may render this board.
+ *
+ * - `board.isPublic` must be true — the `board(boardUuid)` resolver does NOT
+ *   gate private boards for anonymous callers, so skipping this check would
+ *   leak a private board's name/config/location to anyone who learns its uuid.
+ * - `board.boardId` must be a number — defense in depth: the resolver nulls
+ *   the presence-channel id unless the board is public (or the viewer can
+ *   edit), so a null here means the visibility rules disagree and we bail.
+ *
+ * Returns the board narrowed to `EmbeddableBoard`, or null → the page 404s.
+ */
+export function resolveEmbeddableBoard(board: UserBoard | null): EmbeddableBoard | null {
+  if (board === null) return null;
+  if (board.isPublic !== true) return null;
+  if (typeof board.boardId !== 'number') return null;
+  return { ...board, boardId: board.boardId };
+}
+
+/**
+ * SECURITY: a gym only contributes branding (name, logo, colours, /gym link)
+ * to an embed when it is PUBLIC — `gym(gymUuid)` returns private gyms to
+ * anonymous callers, and an embed must never render a private gym's identity.
+ * Private/absent gym → null → unbranded default-dark shell.
+ */
+export function resolveEmbedBrandGym(gym: Gym | null): Gym | null {
+  if (gym === null) return null;
+  if (gym.isPublic !== true) return null;
+  return gym;
+}
+
+/** Where the non-removable attribution points: the gym's public Boardsesh page
+ * when there is one, else the homepage. Callers pass the PUBLIC gym only. */
+export function embedAttributionHref(publicGym: Pick<Gym, 'slug'> | null): string {
+  if (publicGym?.slug) return `/gym/${publicGym.slug}`;
+  return 'https://boardsesh.com';
+}
+
+/** Embed leaderboards are WS-free: period modes only, no 'session'. */
+export const EMBED_LEADERBOARD_PERIODS = ['day', 'week', 'month'] as const;
+export type EmbedLeaderboardPeriod = (typeof EMBED_LEADERBOARD_PERIODS)[number];
+export const DEFAULT_EMBED_LEADERBOARD_PERIOD: EmbedLeaderboardPeriod = 'week';
+
+/** `?period=` parse: day|week|month, anything else → the default (week). */
+export function parseEmbedLeaderboardPeriod(raw: string | undefined): EmbedLeaderboardPeriod {
+  return (EMBED_LEADERBOARD_PERIODS as readonly string[]).includes(raw ?? '')
+    ? (raw as EmbedLeaderboardPeriod)
+    : DEFAULT_EMBED_LEADERBOARD_PERIOD;
+}
+
+/**
+ * `?board=` scope parse: the uuid must be one of the gym's viewer-visible
+ * boards (the anonymous `gymBoards` result — public + listed only), otherwise
+ * the scope silently widens to all boards. This also means a private board's
+ * uuid pasted into the query string scopes to nothing it shouldn't: it isn't
+ * in the anonymous list, so it is ignored.
+ */
+export function resolveEmbedLeaderboardScope(
+  boards: UserBoard[],
+  scopedBoardUuid: string | undefined,
+): { scopedBoard: UserBoard | null; scopedBoards: UserBoard[] } {
+  const scopedBoard =
+    scopedBoardUuid === undefined ? null : (boards.find((board) => board.uuid === scopedBoardUuid) ?? null);
+  return { scopedBoard, scopedBoards: scopedBoard === null ? boards : [scopedBoard] };
+}

--- a/packages/web/app/components/kiosk/embed/embed-fetchers.ts
+++ b/packages/web/app/components/kiosk/embed/embed-fetchers.ts
@@ -1,0 +1,97 @@
+// Anonymous, request-deduped (React cache) server fetchers for the /embed/**
+// widgets. Mirrors `fetchGymKiosk` in kiosk-page-renderer.tsx: plain HTTP
+// GraphQL with NO auth header — embeds are display-only, cookieless surfaces,
+// and everything they show must be resolvable anonymously.
+//
+// Transient-vs-null discrimination (same contract as fetchGymKiosk): a failed
+// transport, HTTP error, or GraphQL resolver error is `{ status: 'error' }` —
+// the page renders the self-healing retry screen, because an embed on a gym's
+// website is as unattended as a TV and must not brick on a backend blip. Only
+// a SUCCESSFUL response resolving the entity to null means "doesn't exist /
+// not visible" — that (and the page's own isPublic gates) is what notFound()s.
+//
+// revalidate 300: embeds are pasted into gym CMS pages and fetched by every
+// visitor — a 5-minute shared cache keeps the load rate-limit friendly while
+// board/gym config changes still land within minutes. Live climb data does NOT
+// ride these fetches (the board embed's presence hub and the leaderboard's
+// client refetch carry freshness).
+
+import 'server-only';
+import { cache } from 'react';
+import {
+  GET_BOARD,
+  GET_GYM,
+  GET_GYM_BOARDS,
+  type GetBoardQueryResponse,
+  type GetGymBoardsQueryResponse,
+  type GetGymQueryResponse,
+} from '@boardsesh/graphql/operations';
+import type { Gym, UserBoard } from '@boardsesh/shared-schema';
+import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
+
+const EMBED_REVALIDATE_SECONDS = 300;
+
+export type EmbedFetchResult<Entity> = { status: 'ok'; entity: Entity } | { status: 'error' };
+
+/**
+ * One anonymous GraphQL query; `readEntity` picks the entity off the response
+ * data. `undefined` from the picker means the field itself was missing —
+ * that's a malformed/errored response, not a null entity, so it maps to
+ * 'error' alongside any GraphQL errors.
+ */
+async function fetchEmbedGraphQL<ResponseData, Entity>(
+  query: string,
+  variables: Record<string, string>,
+  readEntity: (responseData: ResponseData) => Entity | undefined,
+): Promise<EmbedFetchResult<Entity>> {
+  try {
+    const response = await fetch(getGraphQLHttpUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, variables }),
+      next: { revalidate: EMBED_REVALIDATE_SECONDS },
+    });
+    if (!response.ok) return { status: 'error' };
+    const payload = (await response.json()) as { data?: ResponseData | null; errors?: unknown[] };
+    if (payload.data === undefined || payload.data === null || (payload.errors?.length ?? 0) > 0) {
+      return { status: 'error' };
+    }
+    const entity = readEntity(payload.data);
+    if (entity === undefined) return { status: 'error' };
+    return { status: 'ok', entity };
+  } catch {
+    return { status: 'error' };
+  }
+}
+
+/** The raw board (null = doesn't exist) — the CALLER must gate visibility via
+ * `resolveEmbeddableBoard` (the resolver serves private boards to anon). */
+export const fetchBoardForEmbed = cache(async (boardUuid: string): Promise<EmbedFetchResult<UserBoard | null>> => {
+  return fetchEmbedGraphQL<GetBoardQueryResponse, UserBoard | null>(
+    GET_BOARD,
+    { boardUuid },
+    (responseData) => responseData.board,
+  );
+});
+
+/** The raw gym (null = doesn't exist) — the CALLER must gate visibility via
+ * `resolveEmbedBrandGym` (the resolver serves private gyms to anon). */
+export const fetchGymForEmbed = cache(async (gymUuid: string): Promise<EmbedFetchResult<Gym | null>> => {
+  return fetchEmbedGraphQL<GetGymQueryResponse, Gym | null>(GET_GYM, { gymUuid }, (responseData) => responseData.gym);
+});
+
+/**
+ * The gym's boards as the anonymous viewer sees them — the backend restricts
+ * this to public, LISTED boards. NOTE: `gymBoards` masks a private/missing gym
+ * as a GraphQL NOT_FOUND error, which lands in 'error' here; callers gate on
+ * the public gym FIRST (fetchGymForEmbed + resolveEmbedBrandGym), so by the
+ * time this runs an error really is transient (or a just-flipped-private gym,
+ * where a retry screen that heals when the 5-min cache rolls is acceptable).
+ */
+export const fetchGymBoardsForEmbed = cache(async (gymUuid: string): Promise<EmbedFetchResult<UserBoard[]>> => {
+  return fetchEmbedGraphQL<GetGymBoardsQueryResponse, UserBoard[]>(
+    GET_GYM_BOARDS,
+    { gymUuid },
+    (responseData) => responseData.gymBoards,
+  );
+});

--- a/packages/web/app/components/kiosk/embed/embed-leaderboard.module.css
+++ b/packages/web/app/components/kiosk/embed/embed-leaderboard.module.css
@@ -1,0 +1,89 @@
+/* Embed leaderboard panel — the kiosk rail's visual language at full widget
+ * width, sized for the recommended 520px-tall iframe. */
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  background: var(--kiosk-surface-raised);
+  border: 1px solid var(--kiosk-border);
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4) var(--spacing-4) var(--spacing-3);
+  border-bottom: 1px solid var(--kiosk-border);
+}
+
+.title {
+  font-size: var(--kiosk-font-large);
+  font-weight: 700;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.scope {
+  font-size: var(--kiosk-font-small);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--kiosk-accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rows {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  list-style: none;
+  margin: 0;
+  padding: var(--spacing-2) var(--spacing-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.empty {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  text-align: center;
+  padding: var(--spacing-5);
+}
+
+.emptyTitle {
+  font-size: var(--kiosk-font-large);
+  font-weight: 700;
+  margin: 0;
+}
+
+.emptyBody {
+  font-size: var(--kiosk-font-base);
+  color: var(--kiosk-text-muted);
+  margin: 0;
+  max-width: 26em;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: var(--spacing-2) var(--spacing-4);
+  border-top: 1px solid var(--kiosk-border);
+  font-size: var(--kiosk-font-small);
+  color: var(--kiosk-text-muted);
+  min-height: 2em;
+}

--- a/packages/web/app/components/kiosk/embed/embed-leaderboard.tsx
+++ b/packages/web/app/components/kiosk/embed/embed-leaderboard.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+// The gym-website leaderboard widget: the kiosk rail's period modes rendered
+// full-width inside the embed shell. Deliberately WS-free — no presence hub,
+// no graphql-ws client, no session mode — so an embed on a gym's homepage
+// costs one anonymous HTTP query per scoped board every five minutes.
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePeriodLeaderboard } from '../leaderboard-rail/use-period-leaderboard';
+import LeaderboardRow from '../leaderboard-rail/leaderboard-row';
+import type { EmbedLeaderboardPeriod } from './embed-access';
+import styles from './embed-leaderboard.module.css';
+
+/** Rate-limit friendly: kiosks poll at 60s, embeds at 5 minutes. */
+const EMBED_PERIOD_REFETCH_MS = 5 * 60_000;
+/** Mirrors the kiosk rail: a one-climber "ranking" reads broken, show the
+ * empty-state invitation instead. */
+const MIN_RANKED_CLIMBERS = 2;
+
+export default function EmbedLeaderboard({
+  boardUuids,
+  scopeName,
+  period,
+}: {
+  /** The scoped boards' uuids (already viewer-visible; see embed-access.ts). */
+  boardUuids: string[];
+  /** Single-board scope's display name, or null when scoped to all boards. */
+  scopeName: string | null;
+  period: EmbedLeaderboardPeriod;
+}) {
+  const { t, i18n } = useTranslation('kiosk');
+  const { rows, isError, updatedAtMs } = usePeriodLeaderboard(boardUuids, period, boardUuids.length > 0, {
+    refetchIntervalMs: EMBED_PERIOD_REFETCH_MS,
+  });
+
+  const showError = isError && rows.length === 0;
+  const showEmptyState = !showError && rows.length < MIN_RANKED_CLIMBERS;
+
+  const updatedAtLabel =
+    updatedAtMs === null
+      ? null
+      : new Date(updatedAtMs).toLocaleTimeString(i18n.language, { hour: '2-digit', minute: '2-digit' });
+
+  // Literal keys only (the i18n linter rejects t(variable)); 'day' is a
+  // ROLLING 24 hours, so the copy says "Last 24 hours", never "Today".
+  const periodTitle =
+    period === 'day'
+      ? t('leaderboard.periodLast24h')
+      : period === 'week'
+        ? t('leaderboard.periodWeek')
+        : t('leaderboard.periodMonth');
+
+  return (
+    <section className={styles.panel}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>{periodTitle}</h1>
+        <span className={styles.scope}>{scopeName ?? t('leaderboard.allBoards')}</span>
+      </header>
+
+      {showError ? (
+        <div className={styles.empty}>
+          <p className={styles.emptyTitle}>{t('embed.leaderboard.errorTitle')}</p>
+          <p className={styles.emptyBody}>{t('embed.leaderboard.errorBody')}</p>
+        </div>
+      ) : showEmptyState ? (
+        <div className={styles.empty}>
+          <p className={styles.emptyTitle}>{t('leaderboard.emptyTitle')}</p>
+          <p className={styles.emptyBody}>{t('leaderboard.emptyBody')}</p>
+        </div>
+      ) : (
+        <ol className={styles.rows}>
+          {rows.map((row, index) => (
+            <LeaderboardRow key={row.key} rank={index + 1} row={row} />
+          ))}
+        </ol>
+      )}
+
+      <footer className={styles.footer}>
+        {updatedAtLabel !== null ? t('leaderboard.updatedAt', { time: updatedAtLabel }) : null}
+      </footer>
+    </section>
+  );
+}

--- a/packages/web/app/components/kiosk/embed/embed-retry.tsx
+++ b/packages/web/app/components/kiosk/embed/embed-retry.tsx
@@ -1,0 +1,21 @@
+// Transient-failure state shared by both embed routes: the self-healing
+// KioskRetryScreen rendered INSIDE the embed shell, so the non-removable
+// "Powered by Boardsesh" bar stays visible even while the widget is
+// recovering from a backend blip. Unbranded theme on purpose — the gym
+// branding lives in the payload the page just failed to fetch.
+
+import React from 'react';
+import type { Locale } from '@/app/lib/i18n/config';
+import I18nProvider from '../../providers/i18n-provider';
+import KioskRetryScreen from '../kiosk-retry-screen';
+import EmbedShell from './embed-shell';
+
+export default function EmbedRetryState({ locale }: { locale: Locale }) {
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'kiosk']}>
+      <EmbedShell brandGym={null} attributionHref="https://boardsesh.com">
+        <KioskRetryScreen fill="container" />
+      </EmbedShell>
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/components/kiosk/embed/embed-shell.module.css
+++ b/packages/web/app/components/kiosk/embed/embed-shell.module.css
@@ -1,0 +1,21 @@
+/* Embed widget frame. The iframe gives us a fixed viewport (recommended
+ * snippets: board 640px tall, leaderboard 520px), so the shell fills exactly
+ * 100dvh — content column + slim attribution bar — and never scrolls. */
+
+.shell {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+/* Single-cell grid: whatever widget lands here (board slot, leaderboard
+ * panel) stretches to fill the remaining height above the attribution bar. */
+.content {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: grid;
+  grid-template: minmax(0, 1fr) / minmax(0, 1fr);
+  padding: var(--spacing-3);
+}

--- a/packages/web/app/components/kiosk/embed/embed-shell.tsx
+++ b/packages/web/app/components/kiosk/embed/embed-shell.tsx
@@ -1,0 +1,41 @@
+// EmbedShell — the common frame for /embed/** widgets: the always-dark kiosk
+// theme scope (branded only by a PUBLIC gym; see resolveEmbedBrandGym) around
+// a fixed-height single-cell content area, closed by the non-removable
+// "Powered by Boardsesh" footer bar. Server-safe; the widget content decides
+// what (if anything) goes live client-side.
+//
+// Review rule for everything under app/embed/**: display-only, cookieless, no
+// authenticated action and no auth-dependent UI — these pages are framed by
+// third-party sites (frame-ancestors *), so nothing on them may depend on or
+// solicit Boardsesh credentials.
+
+import React, { type ReactNode } from 'react';
+import type { Gym } from '@boardsesh/shared-schema';
+import KioskThemeScope from '../kiosk-theme-scope';
+import KioskAttribution from '../kiosk-attribution';
+import styles from './embed-shell.module.css';
+
+const UNBRANDED_EMBED_THEME: Pick<Gym, 'brandAccentColor' | 'brandPrimaryColor'> = {
+  brandAccentColor: null,
+  brandPrimaryColor: null,
+};
+
+export default function EmbedShell({
+  brandGym,
+  attributionHref,
+  children,
+}: {
+  /** The PUBLIC gym whose branding applies, or null for the default-dark shell. */
+  brandGym: Pick<Gym, 'brandAccentColor' | 'brandPrimaryColor'> | null;
+  attributionHref: string;
+  children: ReactNode;
+}) {
+  return (
+    <KioskThemeScope gym={brandGym ?? UNBRANDED_EMBED_THEME}>
+      <div className={styles.shell}>
+        <div className={styles.content}>{children}</div>
+        <KioskAttribution variant="embed" href={attributionHref} />
+      </div>
+    </KioskThemeScope>
+  );
+}

--- a/packages/web/app/components/kiosk/kiosk-attribution.module.css
+++ b/packages/web/app/components/kiosk/kiosk-attribution.module.css
@@ -31,3 +31,21 @@
     bottom: calc(var(--kiosk-rail-height) + var(--spacing-4) + var(--spacing-3));
   }
 }
+
+/* Embed variant: slim, full-width, in-flow footer bar at the bottom of the
+ * widget (not a fixed overlay — the iframe height budget includes it). */
+.embedBar {
+  /* block + text-align (not flex): flex layout would swallow the literal
+   * space between the "Powered by" text node and the brand span. */
+  display: block;
+  flex-shrink: 0;
+  width: 100%;
+  text-align: center;
+  font-size: var(--kiosk-font-small);
+  color: var(--kiosk-text-muted);
+  background: var(--kiosk-surface-raised);
+  border-top: 1px solid var(--kiosk-border);
+  padding: var(--spacing-1) var(--spacing-3);
+  text-decoration: none;
+  white-space: nowrap;
+}

--- a/packages/web/app/components/kiosk/kiosk-attribution.tsx
+++ b/packages/web/app/components/kiosk/kiosk-attribution.tsx
@@ -1,8 +1,14 @@
 'use client';
 
-// Non-removable "Powered by Boardsesh" mark, fixed bottom-right. The brand
-// name stays untranslated (trademark convention); only the "Powered by"
-// prefix localizes.
+// Non-removable "Powered by Boardsesh" mark. The brand name stays untranslated
+// (trademark convention); only the "Powered by" prefix localizes.
+//
+// Variants:
+//  - 'overlay' (kiosk TVs): floating pill fixed bottom-right over the layout;
+//    `hasRail` shifts it clear of the leaderboard rail.
+//  - 'embed' (iframe widgets): slim full-width in-flow footer bar, so the
+//    attribution is part of the widget's fixed height and can't be cropped by
+//    the host page's iframe sizing.
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -10,12 +16,23 @@ import styles from './kiosk-attribution.module.css';
 
 const BRAND_NAME = 'Boardsesh';
 
-export default function KioskAttribution({ hasRail = false }: { hasRail?: boolean }) {
+export default function KioskAttribution({
+  variant = 'overlay',
+  hasRail = false,
+  href = 'https://boardsesh.com',
+}: {
+  variant?: 'overlay' | 'embed';
+  /** Overlay variant only: offset the mark clear of the leaderboard rail. */
+  hasRail?: boolean;
+  /** Attribution link target — embeds point at the gym's public Boardsesh page when it has one. */
+  href?: string;
+}) {
   const { t } = useTranslation('kiosk');
+  const overlayClassName = hasRail ? `${styles.attribution} ${styles.withRail}` : styles.attribution;
   return (
     <a
-      className={hasRail ? `${styles.attribution} ${styles.withRail}` : styles.attribution}
-      href="https://boardsesh.com"
+      className={variant === 'embed' ? styles.embedBar : overlayClassName}
+      href={href}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/packages/web/app/components/kiosk/kiosk-page-renderer.tsx
+++ b/packages/web/app/components/kiosk/kiosk-page-renderer.tsx
@@ -10,16 +10,14 @@
 import React, { cache } from 'react';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
-import { BOARD_RECENT_CLIMBS, GET_GYM_KIOSK } from '@boardsesh/graphql/operations';
-import type { BoardPresenceClimb, GymKiosk, GymKioskBoard } from '@boardsesh/shared-schema';
+import { GET_GYM_KIOSK } from '@boardsesh/graphql/operations';
+import type { GymKiosk, GymKioskBoard } from '@boardsesh/shared-schema';
 import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
-import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
-import type { BoardDetails } from '@/app/lib/types';
 import I18nProvider from '../providers/i18n-provider';
-import { buildBoardRenderUrl, toFlatFrames } from '../board-renderer/util';
+import { buildBoardSlotData, type BoardSlotData } from './board-slot-data';
 import { buildKioskViewModel } from './kiosk-view-model';
 import KioskThemeScope from './kiosk-theme-scope';
 import KioskPresenceHub from './presence/kiosk-presence-hub';
@@ -72,24 +70,6 @@ export const fetchGymKiosk = cache(async (gymSlug: string, kioskSlug: string | n
   }
 });
 
-/** Latest climbs for a board (newest first; index 0 = current). Anonymous,
- * uncached — this is the SSR seed for what's lit right now. */
-async function fetchInitialClimbs(boardId: number): Promise<BoardPresenceClimb[]> {
-  try {
-    const response = await fetch(getGraphQLHttpUrl(), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query: BOARD_RECENT_CLIMBS, variables: { boardId } }),
-      cache: 'no-store',
-    });
-    if (!response.ok) return [];
-    const payload = (await response.json()) as { data?: { boardRecentClimbs?: BoardPresenceClimb[] | null } };
-    return payload.data?.boardRecentClimbs ?? [];
-  } catch {
-    return [];
-  }
-}
-
 export async function buildKioskMetadata(gymSlug: string, kioskSlug: string | null): Promise<Metadata> {
   const [{ t, locale }, fetchResult] = await Promise.all([
     getServerTranslation('kiosk'),
@@ -113,29 +93,7 @@ export async function buildKioskMetadata(gymSlug: string, kioskSlug: string | nu
   });
 }
 
-type RenderableSlot = {
-  board: GymKioskBoard;
-  boardDetails: BoardDetails;
-  initialClimb: BoardPresenceClimb | null;
-  initialClimbImageUrl: string | null;
-  bareBoardImageUrl: string;
-};
-
-function resolveBoardDetails(board: GymKioskBoard): BoardDetails | null {
-  try {
-    return getBoardDetailsForBoard({
-      board_name: board.boardType,
-      layout_id: board.layoutId,
-      size_id: board.sizeId,
-      set_ids: board.setIds.split(',').map(Number),
-    });
-  } catch (error) {
-    // An unknown layout/size/set combination (e.g. stale board config) drops
-    // the slot instead of crashing the whole TV; the preset degrades below.
-    console.warn(`[kiosk] Skipping board ${board.boardUuid}: no board details`, error);
-    return null;
-  }
-}
+type RenderableSlot = { board: GymKioskBoard } & BoardSlotData;
 
 export default async function KioskPageRenderer({ gymSlug, kioskSlug }: { gymSlug: string; kioskSlug: string | null }) {
   const fetchResult = await fetchGymKiosk(gymSlug, kioskSlug);
@@ -166,22 +124,9 @@ export default async function KioskPageRenderer({ gymSlug, kioskSlug }: { gymSlu
   const slots: RenderableSlot[] = (
     await Promise.all(
       kiosk.boards.map(async (board): Promise<RenderableSlot | null> => {
-        const boardDetails = resolveBoardDetails(board);
-        if (boardDetails === null) return null;
-
-        const recentClimbs = await fetchInitialClimbs(board.boardId);
-        const initialClimb = recentClimbs[0] ?? null;
-        const flatFrames = toFlatFrames(initialClimb?.frames, boardDetails.board_name);
-        return {
-          board,
-          boardDetails,
-          initialClimb,
-          initialClimbImageUrl:
-            initialClimb === null || flatFrames.length === 0
-              ? null
-              : buildBoardRenderUrl(boardDetails, flatFrames, { includeBackground: true }),
-          bareBoardImageUrl: buildBoardRenderUrl(boardDetails, '', { includeBackground: true }),
-        };
+        const slotData = await buildBoardSlotData(board);
+        if (slotData === null) return null;
+        return { board, ...slotData };
       }),
     )
   ).filter((slot): slot is RenderableSlot => slot !== null);

--- a/packages/web/app/components/kiosk/kiosk-retry-screen.module.css
+++ b/packages/web/app/components/kiosk/kiosk-retry-screen.module.css
@@ -10,6 +10,12 @@
   padding: var(--spacing-8);
 }
 
+/* Embed variant: fill the shell's content cell (which already budgets for the
+ * attribution bar) instead of the whole viewport. */
+.containerFill {
+  height: 100%;
+}
+
 .title {
   font-size: var(--kiosk-font-hero);
   font-weight: 700;

--- a/packages/web/app/components/kiosk/kiosk-retry-screen.tsx
+++ b/packages/web/app/components/kiosk/kiosk-retry-screen.tsx
@@ -23,7 +23,14 @@ export function retryDelayMs(attempt: number): number {
   return Math.min(BASE_RETRY_DELAY_MS * 2 ** attempt, MAX_RETRY_DELAY_MS);
 }
 
-export default function KioskRetryScreen() {
+export default function KioskRetryScreen({
+  fill = 'viewport',
+}: {
+  /** 'viewport' fills 100dvh (kiosk TVs, rendered bare); 'container' fills the
+   * parent (embeds, rendered inside EmbedShell's content cell so the
+   * non-removable attribution bar stays visible during error states). */
+  fill?: 'viewport' | 'container';
+}) {
   const { t } = useTranslation('kiosk');
   const router = useRouter();
   const [attempt, setAttempt] = useState(0);
@@ -37,7 +44,7 @@ export default function KioskRetryScreen() {
   }, [attempt, router]);
 
   return (
-    <div className={styles.screen}>
+    <div className={fill === 'container' ? `${styles.screen} ${styles.containerFill}` : styles.screen}>
       <h1 className={styles.title}>{t('retry.title')}</h1>
       <p className={styles.body}>{t('retry.body')}</p>
       <span className={styles.pulse} aria-hidden="true" />

--- a/packages/web/app/components/kiosk/leaderboard-rail/use-period-leaderboard.ts
+++ b/packages/web/app/components/kiosk/leaderboard-rail/use-period-leaderboard.ts
@@ -25,6 +25,9 @@ import { mergeSettledPeriodLeaderboards, type KioskLeaderboardRowData } from './
 
 export type KioskPeriodLeaderboardPeriod = Exclude<KioskLeaderboardPeriod, 'session'>;
 
+/** Kiosk default: an unattended gym TV refreshes every minute. Embeds pass a
+ * gentler interval (they run on arbitrary gym websites, one per visitor tab,
+ * so their polling is deliberately rate-limit friendly). */
 const PERIOD_REFETCH_MS = 60_000;
 /** Per-board fetch depth: enough that a 10-row merged ranking can't miss a
  * climber who is mid-pack on every individual board. */
@@ -41,11 +44,12 @@ export function usePeriodLeaderboard(
   boardUuids: string[],
   period: KioskPeriodLeaderboardPeriod,
   enabled: boolean,
+  options: { refetchIntervalMs?: number } = {},
 ): PeriodLeaderboardResult {
   const { data, isError, dataUpdatedAt } = useQuery({
     queryKey: ['kioskPeriodLeaderboard', period, boardUuids],
     enabled: enabled && boardUuids.length > 0,
-    refetchInterval: PERIOD_REFETCH_MS,
+    refetchInterval: options.refetchIntervalMs ?? PERIOD_REFETCH_MS,
     refetchIntervalInBackground: true,
     queryFn: async (): Promise<KioskLeaderboardRowData[]> => {
       const settled = await Promise.allSettled(

--- a/packages/web/app/components/providers/vercel-telemetry.tsx
+++ b/packages/web/app/components/providers/vercel-telemetry.tsx
@@ -3,26 +3,30 @@
 import React from 'react';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
-import { isAdminAnalyticsUrl } from '@/app/lib/analytics-paths';
+import { isAdminAnalyticsUrl, isEmbedAnalyticsUrl } from '@/app/lib/analytics-paths';
 
-// Function props (the beforeSend filter that drops /admin pageviews) cannot
-// be passed from a Server Component (RootLayout) to a Client Component
+// Function props (the beforeSend filter that drops /admin and /embed events)
+// cannot be passed from a Server Component (RootLayout) to a Client Component
 // because React Flight tries to JSON-serialize them across the boundary,
 // throwing: "Functions cannot be passed directly to Client Components
 // unless you explicitly expose it by marking it with 'use server'."
 //
 // Regression fixed in #2043 / re-guarded in #2061 (Sentry BOARDSESH-65).
-// Keep `dropAdminEvents` module-scoped and the exported wrappers prop-less
+// Keep `dropFilteredEvents` module-scoped and the exported wrappers prop-less
 // — never re-shape these to accept a `beforeSend` from the caller, or the
 // home route SSR will break for every visitor on the next deploy.
-const dropAdminEvents = <Event extends { url: string }>(event: Event): Event | null => {
-  return isAdminAnalyticsUrl(event.url) ? null : event;
+//
+// /embed/** events are dropped for consent reasons: embeds run inside
+// third-party gym websites where visitors never saw a Boardsesh consent
+// surface (see isEmbedAnalyticsUrl for the GDPR rationale).
+const dropFilteredEvents = <Event extends { url: string }>(event: Event): Event | null => {
+  return isAdminAnalyticsUrl(event.url) || isEmbedAnalyticsUrl(event.url) ? null : event;
 };
 
 export function VercelAnalytics() {
-  return <Analytics beforeSend={dropAdminEvents} />;
+  return <Analytics beforeSend={dropFilteredEvents} />;
 }
 
 export function VercelSpeedInsights() {
-  return <SpeedInsights beforeSend={dropAdminEvents} />;
+  return <SpeedInsights beforeSend={dropFilteredEvents} />;
 }

--- a/packages/web/app/embed/board/[board_uuid]/page.tsx
+++ b/packages/web/app/embed/board/[board_uuid]/page.tsx
@@ -1,0 +1,147 @@
+// /embed/board/[board_uuid] — the live board view as an iframe widget for gym
+// websites. Anonymous, cookieless, display-only; served with
+// `Content-Security-Policy: frame-ancestors *` and WITHOUT X-Frame-Options
+// (see next.config.mjs headers() + the middleware /embed carve-out).
+//
+// Recommended snippet (fixed-height design):
+//   <iframe src="https://boardsesh.com/embed/board/<uuid>"
+//           width="100%" height="640" title="Live board view"></iframe>
+//
+// Keyed by the board's immutable uuid (not its slug — slugs are user-editable
+// and a rename would kill every embed pasted into a gym CMS).
+
+import React from 'react';
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import { buildBoardSlotData } from '@/app/components/kiosk/board-slot-data';
+import BoardSlot from '@/app/components/kiosk/board-slot/board-slot';
+import KioskPresenceHub from '@/app/components/kiosk/presence/kiosk-presence-hub';
+import KioskThemeScope from '@/app/components/kiosk/kiosk-theme-scope';
+import KioskRetryScreen from '@/app/components/kiosk/kiosk-retry-screen';
+import EmbedShell from '@/app/components/kiosk/embed/embed-shell';
+import {
+  embedAttributionHref,
+  resolveEmbedBrandGym,
+  resolveEmbeddableBoard,
+  type EmbeddableBoard,
+} from '@/app/components/kiosk/embed/embed-access';
+import { fetchBoardForEmbed, fetchGymForEmbed } from '@/app/components/kiosk/embed/embed-fetchers';
+
+type EmbedBoardRouteProps = {
+  params: Promise<{ board_uuid: string }>;
+};
+
+type EmbeddableBoardResult = { status: 'error' } | { status: 'ok'; board: EmbeddableBoard | null };
+
+/**
+ * SECURITY GATE — the `board(boardUuid)` resolver serves PRIVATE boards fully
+ * enriched to anonymous callers, so this page (and its metadata) must decide
+ * visibility itself: not public, or missing a presence-channel id, or not
+ * found at all → `board: null` (the page notFound()s). See
+ * resolveEmbeddableBoard for the rule; embed-access.test.ts pins it. A
+ * transient fetch failure stays distinguishable ('error' → retry screen).
+ */
+async function fetchEmbeddableBoard(boardUuid: string): Promise<EmbeddableBoardResult> {
+  const fetchResult = await fetchBoardForEmbed(boardUuid);
+  if (fetchResult.status === 'error') return { status: 'error' };
+  return { status: 'ok', board: resolveEmbeddableBoard(fetchResult.entity) };
+}
+
+export async function generateMetadata(props: EmbedBoardRouteProps): Promise<Metadata> {
+  const { board_uuid } = await props.params;
+  const [{ t, locale }, boardResult] = await Promise.all([
+    getServerTranslation('kiosk'),
+    fetchEmbeddableBoard(board_uuid),
+  ]);
+  const path = `/embed/board/${board_uuid}`;
+  const board = boardResult.status === 'ok' ? boardResult.board : null;
+  // A non-embeddable (or unfetchable) board gets the generic fallback — a
+  // private board's name must not leak through metadata either.
+  if (board === null) {
+    return createNoIndexMetadata({
+      title: t('embed.metadata.boardFallbackTitle'),
+      description: t('embed.metadata.boardFallbackDescription'),
+      path,
+      locale,
+    });
+  }
+  return createNoIndexMetadata({
+    title: t('embed.metadata.boardTitle', { boardName: board.name }),
+    description: t('embed.metadata.boardDescription', { boardName: board.name }),
+    path,
+    locale,
+  });
+}
+
+export default async function EmbedBoardPage(props: EmbedBoardRouteProps) {
+  const { board_uuid } = await props.params;
+
+  const boardResult = await fetchEmbeddableBoard(board_uuid);
+
+  // Transient failure (backend blip): the self-healing retry screen, exactly
+  // like the kiosk — an embed on a gym's website is unattended too, and a
+  // 404'd iframe would stay dead until a visitor reloads the host page.
+  // Unbranded theme: the branding lives in the payload we failed to fetch.
+  if (boardResult.status === 'error') {
+    const retryLocale = await getLocale();
+    return (
+      <I18nProvider locale={retryLocale} namespaces={['common', 'kiosk']}>
+        <KioskThemeScope gym={{}}>
+          <KioskRetryScreen />
+        </KioskThemeScope>
+      </I18nProvider>
+    );
+  }
+
+  const board = boardResult.board;
+  if (board === null) {
+    // Successfully resolved but nonexistent, PRIVATE, or without a presence
+    // id — all masked as not-found (see fetchEmbeddableBoard).
+    notFound();
+  }
+
+  // Branding rides along ONLY for a public gym; a private/absent gym renders
+  // the unbranded default-dark shell (its name/logo/colours must not leak).
+  // A TRANSIENT gym-fetch failure also degrades to unbranded rather than
+  // blocking the board view — branding is cosmetic, the wall is the widget.
+  const gymResult = board.gymUuid ? await fetchGymForEmbed(board.gymUuid) : null;
+  const brandGym = gymResult !== null && gymResult.status === 'ok' ? resolveEmbedBrandGym(gymResult.entity) : null;
+
+  const slotData = await buildBoardSlotData({
+    boardId: board.boardId,
+    boardUuid: board.uuid,
+    boardType: board.boardType,
+    layoutId: board.layoutId,
+    sizeId: board.sizeId,
+    setIds: board.setIds,
+  });
+  if (slotData === null) {
+    // Board config resolves to no renderable layout — deterministic, not
+    // transient: nothing to embed.
+    notFound();
+  }
+
+  const locale = await getLocale();
+
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'kiosk']}>
+      <EmbedShell brandGym={brandGym} attributionHref={embedAttributionHref(brandGym)}>
+        <KioskPresenceHub boardIds={[board.boardId]}>
+          <BoardSlot
+            boardId={board.boardId}
+            boardName={board.name}
+            angle={board.angle}
+            boardDetails={slotData.boardDetails}
+            initialClimb={slotData.initialClimb}
+            initialClimbImageUrl={slotData.initialClimbImageUrl}
+            bareBoardImageUrl={slotData.bareBoardImageUrl}
+          />
+        </KioskPresenceHub>
+      </EmbedShell>
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/embed/board/[board_uuid]/page.tsx
+++ b/packages/web/app/embed/board/[board_uuid]/page.tsx
@@ -20,9 +20,8 @@ import I18nProvider from '@/app/components/providers/i18n-provider';
 import { buildBoardSlotData } from '@/app/components/kiosk/board-slot-data';
 import BoardSlot from '@/app/components/kiosk/board-slot/board-slot';
 import KioskPresenceHub from '@/app/components/kiosk/presence/kiosk-presence-hub';
-import KioskThemeScope from '@/app/components/kiosk/kiosk-theme-scope';
-import KioskRetryScreen from '@/app/components/kiosk/kiosk-retry-screen';
 import EmbedShell from '@/app/components/kiosk/embed/embed-shell';
+import EmbedRetryState from '@/app/components/kiosk/embed/embed-retry';
 import {
   embedAttributionHref,
   resolveEmbedBrandGym,
@@ -82,19 +81,12 @@ export default async function EmbedBoardPage(props: EmbedBoardRouteProps) {
 
   const boardResult = await fetchEmbeddableBoard(board_uuid);
 
-  // Transient failure (backend blip): the self-healing retry screen, exactly
-  // like the kiosk — an embed on a gym's website is unattended too, and a
-  // 404'd iframe would stay dead until a visitor reloads the host page.
-  // Unbranded theme: the branding lives in the payload we failed to fetch.
+  // Transient failure (backend blip): the self-healing retry screen inside
+  // the embed shell (attribution bar stays up) — an embed on a gym's website
+  // is as unattended as a TV, and a 404'd iframe would stay dead until a
+  // visitor reloads the host page.
   if (boardResult.status === 'error') {
-    const retryLocale = await getLocale();
-    return (
-      <I18nProvider locale={retryLocale} namespaces={['common', 'kiosk']}>
-        <KioskThemeScope gym={{}}>
-          <KioskRetryScreen />
-        </KioskThemeScope>
-      </I18nProvider>
-    );
+    return <EmbedRetryState locale={await getLocale()} />;
   }
 
   const board = boardResult.board;

--- a/packages/web/app/embed/gym/[gym_uuid]/leaderboard/page.tsx
+++ b/packages/web/app/embed/gym/[gym_uuid]/leaderboard/page.tsx
@@ -19,15 +19,13 @@ import React from 'react';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import type { Gym } from '@boardsesh/shared-schema';
-import type { Locale } from '@/app/lib/i18n/config';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import I18nProvider from '@/app/components/providers/i18n-provider';
-import KioskThemeScope from '@/app/components/kiosk/kiosk-theme-scope';
-import KioskRetryScreen from '@/app/components/kiosk/kiosk-retry-screen';
 import EmbedShell from '@/app/components/kiosk/embed/embed-shell';
 import EmbedLeaderboard from '@/app/components/kiosk/embed/embed-leaderboard';
+import EmbedRetryState from '@/app/components/kiosk/embed/embed-retry';
 import {
   embedAttributionHref,
   parseEmbedLeaderboardPeriod,
@@ -79,26 +77,17 @@ export async function generateMetadata(props: EmbedGymLeaderboardRouteProps): Pr
   });
 }
 
-function EmbedRetryScreen({ locale }: { locale: Locale }) {
-  return (
-    <I18nProvider locale={locale} namespaces={['common', 'kiosk']}>
-      <KioskThemeScope gym={{}}>
-        <KioskRetryScreen />
-      </KioskThemeScope>
-    </I18nProvider>
-  );
-}
-
 export default async function EmbedGymLeaderboardPage(props: EmbedGymLeaderboardRouteProps) {
   const [{ gym_uuid }, searchParams] = await Promise.all([props.params, props.searchParams]);
 
   const gymResult = await fetchPublicGym(gym_uuid);
 
-  // Transient failure (backend blip): the self-healing retry screen, exactly
-  // like the kiosk — an embed on a gym's website is unattended too, and a
-  // 404'd iframe would stay dead until a visitor reloads the host page.
+  // Transient failure (backend blip): the self-healing retry screen inside
+  // the embed shell (attribution bar stays up) — an embed on a gym's website
+  // is as unattended as a TV, and a 404'd iframe would stay dead until a
+  // visitor reloads the host page.
   if (gymResult.status === 'error') {
-    return <EmbedRetryScreen locale={await getLocale()} />;
+    return <EmbedRetryState locale={await getLocale()} />;
   }
 
   const publicGym = gymResult.gym;
@@ -114,7 +103,7 @@ export default async function EmbedGymLeaderboardPage(props: EmbedGymLeaderboard
   // renders the retry screen too.
   const boardsResult = await fetchGymBoardsForEmbed(gym_uuid);
   if (boardsResult.status === 'error') {
-    return <EmbedRetryScreen locale={await getLocale()} />;
+    return <EmbedRetryState locale={await getLocale()} />;
   }
 
   const period = parseEmbedLeaderboardPeriod(searchParams.period);

--- a/packages/web/app/embed/gym/[gym_uuid]/leaderboard/page.tsx
+++ b/packages/web/app/embed/gym/[gym_uuid]/leaderboard/page.tsx
@@ -1,0 +1,137 @@
+// /embed/gym/[gym_uuid]/leaderboard — the gym leaderboard as an iframe widget
+// for gym websites. Anonymous, cookieless, display-only; served with
+// `Content-Security-Policy: frame-ancestors *` and WITHOUT X-Frame-Options
+// (see next.config.mjs headers() + the middleware /embed carve-out).
+//
+//   ?period=day|week|month   default week ('day' = rolling "Last 24 hours").
+//                            NO session mode here — embeds stay WebSocket-free.
+//   ?board=<board uuid>      optional single-board scope; must be one of the
+//                            gym's publicly listed boards, else widened to all.
+//
+// Recommended snippet (fixed-height design):
+//   <iframe src="https://boardsesh.com/embed/gym/<uuid>/leaderboard"
+//           width="100%" height="520" title="Gym leaderboard"></iframe>
+//
+// Keyed by the gym's immutable uuid (gym slugs are nullable AND editable — a
+// rename would kill every embed pasted into a gym CMS).
+
+import React from 'react';
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import type { Gym } from '@boardsesh/shared-schema';
+import type { Locale } from '@/app/lib/i18n/config';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import KioskThemeScope from '@/app/components/kiosk/kiosk-theme-scope';
+import KioskRetryScreen from '@/app/components/kiosk/kiosk-retry-screen';
+import EmbedShell from '@/app/components/kiosk/embed/embed-shell';
+import EmbedLeaderboard from '@/app/components/kiosk/embed/embed-leaderboard';
+import {
+  embedAttributionHref,
+  parseEmbedLeaderboardPeriod,
+  resolveEmbedBrandGym,
+  resolveEmbedLeaderboardScope,
+} from '@/app/components/kiosk/embed/embed-access';
+import { fetchGymBoardsForEmbed, fetchGymForEmbed } from '@/app/components/kiosk/embed/embed-fetchers';
+
+type EmbedGymLeaderboardRouteProps = {
+  params: Promise<{ gym_uuid: string }>;
+  searchParams: Promise<{ period?: string; board?: string }>;
+};
+
+type PublicGymResult = { status: 'error' } | { status: 'ok'; gym: Gym | null };
+
+/**
+ * SECURITY GATE — `gym(gymUuid)` returns PRIVATE gyms fully enriched to
+ * anonymous callers, so this page (and its metadata) must gate on
+ * `gym.isPublic` itself: private or absent → `gym: null` (the page
+ * notFound()s). A transient fetch failure stays distinguishable ('error' →
+ * retry screen).
+ */
+async function fetchPublicGym(gymUuid: string): Promise<PublicGymResult> {
+  const fetchResult = await fetchGymForEmbed(gymUuid);
+  if (fetchResult.status === 'error') return { status: 'error' };
+  return { status: 'ok', gym: resolveEmbedBrandGym(fetchResult.entity) };
+}
+
+export async function generateMetadata(props: EmbedGymLeaderboardRouteProps): Promise<Metadata> {
+  const { gym_uuid } = await props.params;
+  const [{ t, locale }, gymResult] = await Promise.all([getServerTranslation('kiosk'), fetchPublicGym(gym_uuid)]);
+  const path = `/embed/gym/${gym_uuid}/leaderboard`;
+  const publicGym = gymResult.status === 'ok' ? gymResult.gym : null;
+  // A private/absent (or unfetchable) gym gets the generic fallback — its
+  // name must not leak through metadata either.
+  if (publicGym === null) {
+    return createNoIndexMetadata({
+      title: t('embed.metadata.leaderboardFallbackTitle'),
+      description: t('embed.metadata.leaderboardFallbackDescription'),
+      path,
+      locale,
+    });
+  }
+  return createNoIndexMetadata({
+    title: t('embed.metadata.leaderboardTitle', { gymName: publicGym.name }),
+    description: t('embed.metadata.leaderboardDescription', { gymName: publicGym.name }),
+    path,
+    locale,
+  });
+}
+
+function EmbedRetryScreen({ locale }: { locale: Locale }) {
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'kiosk']}>
+      <KioskThemeScope gym={{}}>
+        <KioskRetryScreen />
+      </KioskThemeScope>
+    </I18nProvider>
+  );
+}
+
+export default async function EmbedGymLeaderboardPage(props: EmbedGymLeaderboardRouteProps) {
+  const [{ gym_uuid }, searchParams] = await Promise.all([props.params, props.searchParams]);
+
+  const gymResult = await fetchPublicGym(gym_uuid);
+
+  // Transient failure (backend blip): the self-healing retry screen, exactly
+  // like the kiosk — an embed on a gym's website is unattended too, and a
+  // 404'd iframe would stay dead until a visitor reloads the host page.
+  if (gymResult.status === 'error') {
+    return <EmbedRetryScreen locale={await getLocale()} />;
+  }
+
+  const publicGym = gymResult.gym;
+  if (publicGym === null) {
+    // Successfully resolved but nonexistent or PRIVATE — masked as not-found
+    // (see fetchPublicGym).
+    notFound();
+  }
+
+  // Anonymous gymBoards is server-restricted to the gym's public, LISTED
+  // boards — the widget can't enumerate anything a logged-out visitor
+  // couldn't. The leaderboard IS the boards, so a transient failure here
+  // renders the retry screen too.
+  const boardsResult = await fetchGymBoardsForEmbed(gym_uuid);
+  if (boardsResult.status === 'error') {
+    return <EmbedRetryScreen locale={await getLocale()} />;
+  }
+
+  const period = parseEmbedLeaderboardPeriod(searchParams.period);
+  const { scopedBoard, scopedBoards } = resolveEmbedLeaderboardScope(boardsResult.entity, searchParams.board);
+
+  const locale = await getLocale();
+
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'kiosk']}>
+      <EmbedShell brandGym={publicGym} attributionHref={embedAttributionHref(publicGym)}>
+        {/* Client side mounts React Query only — no websocket, no presence hub. */}
+        <EmbedLeaderboard
+          boardUuids={scopedBoards.map((board) => board.uuid)}
+          scopeName={scopedBoard?.name ?? null}
+          period={period}
+        />
+      </EmbedShell>
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/lib/__tests__/analytics-paths.test.ts
+++ b/packages/web/app/lib/__tests__/analytics-paths.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { analyticsPathname, isAdminAnalyticsUrl, stripAnalyticsLocalePrefix } from '../analytics-paths';
+import {
+  analyticsPathname,
+  isAdminAnalyticsUrl,
+  isEmbedAnalyticsUrl,
+  stripAnalyticsLocalePrefix,
+} from '../analytics-paths';
 
 describe('analyticsPathname', () => {
   it('keeps only the pathname for absolute and relative URLs', () => {
@@ -34,5 +39,27 @@ describe('isAdminAnalyticsUrl', () => {
     expect(isAdminAnalyticsUrl('/b/admin')).toBe(false);
     expect(isAdminAnalyticsUrl('/fr/admin_panel')).toBe(false);
     expect(isAdminAnalyticsUrl('/?next=/admin')).toBe(false);
+  });
+});
+
+describe('isEmbedAnalyticsUrl', () => {
+  it('matches embed widget paths — no analytics inside third-party iframes', () => {
+    expect(isEmbedAnalyticsUrl('/embed')).toBe(true);
+    expect(isEmbedAnalyticsUrl('/embed/board/abc?x=1')).toBe(true);
+    expect(isEmbedAnalyticsUrl('https://boardsesh.com/embed/gym/abc/leaderboard?period=day')).toBe(true);
+  });
+
+  it('is case-insensitive, mirroring the case-insensitive header matchers', () => {
+    // Next's header source patterns compile case-insensitively, so
+    // /EMBED/board/x receives the frameable embed headers — the analytics
+    // suppression must cover the same set of paths.
+    expect(isEmbedAnalyticsUrl('/EMBED/board/abc')).toBe(true);
+    expect(isEmbedAnalyticsUrl('/Embed/gym/abc/leaderboard')).toBe(true);
+  });
+
+  it('does not match lookalikes or the kiosk (kiosk keeps first-party telemetry)', () => {
+    expect(isEmbedAnalyticsUrl('/embedded')).toBe(false);
+    expect(isEmbedAnalyticsUrl('/kiosk/some-gym')).toBe(false);
+    expect(isEmbedAnalyticsUrl('/?next=/embed/board/abc')).toBe(false);
   });
 });

--- a/packages/web/app/lib/analytics-paths.ts
+++ b/packages/web/app/lib/analytics-paths.ts
@@ -26,3 +26,20 @@ export function isAdminAnalyticsUrl(url: string, baseUrl = DEFAULT_ANALYTICS_BAS
   const pathname = stripAnalyticsLocalePrefix(analyticsPathname(url, baseUrl));
   return pathname === '/admin' || pathname.startsWith('/admin/');
 }
+
+/**
+ * /embed/** — iframe widgets running INSIDE third-party gym websites. Those
+ * visitors never saw Boardsesh, its privacy policy, or any consent surface,
+ * so no analytics (PostHog pageviews/web-vitals, Vercel Analytics, Speed
+ * Insights) may capture there — GDPR/ePrivacy consent can't be assumed from
+ * an embedded widget. First-party surfaces (including /kiosk/**) keep their
+ * telemetry.
+ *
+ * Case-insensitive and locale-stripped to cover every path variant the
+ * middleware carve-out and the case-insensitive header matchers accept
+ * (e.g. /EMBED/board/x).
+ */
+export function isEmbedAnalyticsUrl(url: string, baseUrl = DEFAULT_ANALYTICS_BASE_URL): boolean {
+  const pathname = stripAnalyticsLocalePrefix(analyticsPathname(url, baseUrl)).toLowerCase();
+  return pathname === '/embed' || pathname.startsWith('/embed/');
+}

--- a/packages/web/e2e/embed-headers.spec.ts
+++ b/packages/web/e2e/embed-headers.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect, type APIResponse } from '@playwright/test';
+
+/**
+ * Security headers for the /embed/** iframe widgets (board view + gym
+ * leaderboard) — the ONLY routes Boardsesh serves without a frame-denying
+ * X-Frame-Options.
+ *
+ * Contract under test (next.config.mjs headers() + middleware.ts carve-out):
+ *  - /embed/** responses carry `Content-Security-Policy: frame-ancestors *`,
+ *    NO X-Frame-Options, and NO Set-Cookie (embeds are cookieless: the
+ *    middleware bypasses locale detection, so the sticky-locale cookie can
+ *    never be written on an embed response).
+ *  - Every other route (including 404s) keeps X-Frame-Options: SAMEORIGIN.
+ *  - Locale-prefixed embed paths 308 to the un-prefixed path, because the
+ *    header matcher sees the ORIGINAL request path — /es/embed/** served
+ *    directly would dodge the embed rule and arrive frame-denying.
+ *
+ * The assertions run against nonexistent uuids on purpose: next.config
+ * `headers()` match the request PATH, not the response status, so they
+ * exercise the exact header split without needing seeded embed data. The
+ * status differs by environment — 404 when the GraphQL backend is up (the
+ * resolver answers "no such board/gym"), 200 when it's down (the embed's
+ * transient-failure retry screen renders instead of bricking the iframe) —
+ * so status assertions accept both; the HEADER contract is identical.
+ */
+
+const MISSING_BOARD_UUID = '00000000-0000-4000-8000-000000000000';
+const MISSING_GYM_UUID = '00000000-0000-4000-8000-000000000001';
+
+function headerValue(response: APIResponse, name: string): string | undefined {
+  return response.headers()[name];
+}
+
+function setCookieValues(response: APIResponse): string[] {
+  return response
+    .headersArray()
+    .filter((header) => header.name.toLowerCase() === 'set-cookie')
+    .map((header) => header.value);
+}
+
+test.describe('embed security headers', () => {
+  test('board embed is frameable, cookieless, and drops X-Frame-Options (even on 404)', async ({ request }) => {
+    const response = await request.get(`/embed/board/${MISSING_BOARD_UUID}`, { maxRedirects: 0 });
+
+    // Nonexistent board → 404 (backend up) or the retry screen (backend
+    // down); the route headers apply either way.
+    expect([200, 404]).toContain(response.status());
+    expect(headerValue(response, 'content-security-policy')).toContain('frame-ancestors *');
+    expect(headerValue(response, 'x-frame-options')).toBeUndefined();
+    expect(setCookieValues(response)).toEqual([]);
+    // The rest of the security-header set still rides along on embeds.
+    expect(headerValue(response, 'x-content-type-options')).toBe('nosniff');
+    expect(headerValue(response, 'referrer-policy')).toBe('strict-origin-when-cross-origin');
+  });
+
+  test('gym leaderboard embed carries the same frameable, cookieless headers', async ({ request }) => {
+    const response = await request.get(`/embed/gym/${MISSING_GYM_UUID}/leaderboard?period=day`, { maxRedirects: 0 });
+
+    expect([200, 404]).toContain(response.status());
+    expect(headerValue(response, 'content-security-policy')).toContain('frame-ancestors *');
+    expect(headerValue(response, 'x-frame-options')).toBeUndefined();
+    expect(setCookieValues(response)).toEqual([]);
+  });
+
+  test('non-embed routes keep X-Frame-Options: SAMEORIGIN', async ({ request }) => {
+    const homeResponse = await request.get('/', { maxRedirects: 0 });
+    expect(homeResponse.status()).toBe(200);
+    expect(headerValue(homeResponse, 'x-frame-options')).toBe('SAMEORIGIN');
+
+    // A kiosk TV page (here a nonexistent one → 404) is NOT frameable either —
+    // only /embed/** opted out of the frame-denying default.
+    const kioskResponse = await request.get('/kiosk/whatever', { maxRedirects: 0 });
+    expect(headerValue(kioskResponse, 'x-frame-options')).toBe('SAMEORIGIN');
+    expect(headerValue(kioskResponse, 'content-security-policy') ?? '').not.toContain('frame-ancestors *');
+  });
+
+  test('an embed-lookalike path outside /embed/ keeps the frame-denying default', async ({ request }) => {
+    // Regex sanity for the `/((?!embed/).*)` exclusion: only the /embed/**
+    // subtree opts out, not paths merely starting with the word "embed".
+    const response = await request.get('/embedded', { maxRedirects: 0 });
+    expect(headerValue(response, 'x-frame-options')).toBe('SAMEORIGIN');
+  });
+
+  test('locale-prefixed embed paths 308 to the un-prefixed embed path, cookieless', async ({ request }) => {
+    const spanishResponse = await request.get('/es/embed/board/x', { maxRedirects: 0 });
+    expect(spanishResponse.status()).toBe(308);
+    expect(new URL(spanishResponse.headers()['location'], 'http://localhost').pathname).toBe('/embed/board/x');
+    expect(setCookieValues(spanishResponse)).toEqual([]);
+
+    const frenchResponse = await request.get(`/fr/embed/gym/${MISSING_GYM_UUID}/leaderboard?period=day&board=abc`, {
+      maxRedirects: 0,
+    });
+    expect(frenchResponse.status()).toBe(308);
+    const frenchLocation = new URL(frenchResponse.headers()['location'], 'http://localhost');
+    expect(frenchLocation.pathname).toBe(`/embed/gym/${MISSING_GYM_UUID}/leaderboard`);
+    // The redirect preserves the widget's query string.
+    expect(frenchLocation.search).toBe('?period=day&board=abc');
+  });
+});

--- a/packages/web/e2e/embed-headers.spec.ts
+++ b/packages/web/e2e/embed-headers.spec.ts
@@ -81,6 +81,32 @@ test.describe('embed security headers', () => {
     expect(headerValue(response, 'x-frame-options')).toBe('SAMEORIGIN');
   });
 
+  test('/embed exact (no child segment) keeps the frame-denying default, without the embed CSP', async ({
+    request,
+  }) => {
+    // The exclusion regex `(?!embed/)` only skips paths with the trailing
+    // slash, so bare /embed matches the SAMEORIGIN rule; the embed rule uses
+    // `:path+` so it does NOT also match — one response must never carry the
+    // contradictory XFO SAMEORIGIN + frame-ancestors * pair.
+    const response = await request.get('/embed', { maxRedirects: 0 });
+    expect(headerValue(response, 'x-frame-options')).toBe('SAMEORIGIN');
+    expect(headerValue(response, 'content-security-policy') ?? '').not.toContain('frame-ancestors');
+    // The middleware still treats it as an embed path (no cookies).
+    expect(setCookieValues(response)).toEqual([]);
+  });
+
+  test('case-drifted embed paths stay cookieless (header matchers are case-insensitive)', async ({ request }) => {
+    // Next compiles header `source` patterns case-INsensitively, so
+    // /EMBED/board/x gets the frameable embed headers. The middleware
+    // carve-out must therefore be case-insensitive too — otherwise this
+    // request would run the full pipeline and the ?session= branch would
+    // Set-Cookie on a frameable response.
+    const response = await request.get('/EMBED/board/x?session=abc', { maxRedirects: 0 });
+    expect(headerValue(response, 'content-security-policy')).toContain('frame-ancestors *');
+    expect(headerValue(response, 'x-frame-options')).toBeUndefined();
+    expect(setCookieValues(response)).toEqual([]);
+  });
+
   test('locale-prefixed embed paths 308 to the un-prefixed embed path, cookieless', async ({ request }) => {
     const spanishResponse = await request.get('/es/embed/board/x', { maxRedirects: 0 });
     expect(spanishResponse.status()).toBe(308);

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -20,19 +20,34 @@ export function middleware(request: NextRequest) {
   }
 
   // /embed/** — iframe widgets for gym websites: display-only, cookieless,
-  // anonymous. Bypass BEFORE locale detection so no sticky-locale cookie (or
-  // any other cookie) is ever set on an embed response, and no locale
-  // redirect/rewrite can move the request off the /embed/** path that the
-  // next.config.mjs `frame-ancestors *` header rule matches on.
-  if (pathname === '/embed' || pathname.startsWith('/embed/')) {
-    return NextResponse.next();
+  // anonymous. Bypass BEFORE the ?session= branch and locale detection so no
+  // sticky-locale/session cookie (or any other cookie) is ever set on an
+  // embed response, and no locale redirect/rewrite can move the request off
+  // the /embed/** path that the next.config.mjs `frame-ancestors *` header
+  // rule matches on.
+  //
+  // Case-INsensitive on purpose: next.config `headers()` sources compile
+  // case-insensitively, so /EMBED/board/x already receives the frameable
+  // embed headers — this carve-out must cover the same set of paths or a
+  // case-drifted request (e.g. /EMBED/...?session=abc) would run the full
+  // pipeline and could Set-Cookie on a frameable response.
+  const lowercasePathname = pathname.toLowerCase();
+  if (lowercasePathname === '/embed' || lowercasePathname.startsWith('/embed/')) {
+    // Embeds render en-US only: overwrite the locale request header instead
+    // of forwarding it, so a crafted client-supplied x-boardsesh-locale can't
+    // pick the rendered locale (everywhere else the middleware overwrites
+    // this header; the carve-out must too).
+    const embedRequestHeaders = new Headers(request.headers);
+    embedRequestHeaders.set(LOCALE_HEADER, DEFAULT_LOCALE);
+    return NextResponse.next({ request: { headers: embedRequestHeaders } });
   }
 
   // Locale-prefixed embed URLs are 308'd to the un-prefixed path: headers()
   // matches the ORIGINAL request path, so /es/embed/** would dodge the embed
   // header rule and be served frame-DENYING X-Frame-Options: SAMEORIGIN.
-  // Embeds are en-US-only by design.
-  const localePrefixedEmbed = pathname.match(/^\/(es|fr)\/embed\//);
+  // Embeds are en-US-only by design. Case-insensitive to match the
+  // case-insensitive header rules (see above).
+  const localePrefixedEmbed = pathname.match(/^\/(es|fr)\/embed\//i);
   if (localePrefixedEmbed) {
     const unprefixedEmbedUrl = request.nextUrl.clone();
     unprefixedEmbedUrl.pathname = pathname.slice(localePrefixedEmbed[1].length + 1);

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -19,6 +19,26 @@ export function middleware(request: NextRequest) {
     });
   }
 
+  // /embed/** — iframe widgets for gym websites: display-only, cookieless,
+  // anonymous. Bypass BEFORE locale detection so no sticky-locale cookie (or
+  // any other cookie) is ever set on an embed response, and no locale
+  // redirect/rewrite can move the request off the /embed/** path that the
+  // next.config.mjs `frame-ancestors *` header rule matches on.
+  if (pathname === '/embed' || pathname.startsWith('/embed/')) {
+    return NextResponse.next();
+  }
+
+  // Locale-prefixed embed URLs are 308'd to the un-prefixed path: headers()
+  // matches the ORIGINAL request path, so /es/embed/** would dodge the embed
+  // header rule and be served frame-DENYING X-Frame-Options: SAMEORIGIN.
+  // Embeds are en-US-only by design.
+  const localePrefixedEmbed = pathname.match(/^\/(es|fr)\/embed\//);
+  if (localePrefixedEmbed) {
+    const unprefixedEmbedUrl = request.nextUrl.clone();
+    unprefixedEmbedUrl.pathname = pathname.slice(localePrefixedEmbed[1].length + 1);
+    return NextResponse.redirect(unprefixedEmbedUrl, 308);
+  }
+
   // Check API routes
   if (pathname.startsWith('/api/v1/')) {
     const pathParts = pathname.split('/');

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -3,10 +3,26 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { SUPPORTED_BOARDS } from './app/lib/board-data';
 import { getListPageCacheTTL } from './app/lib/list-page-cache';
 import { CLIMB_SESSION_COOKIE } from './app/lib/climb-session-cookie';
-import { DEFAULT_LOCALE, LOCALE_COOKIE, LOCALE_HEADER, isSupportedLocale } from './app/lib/i18n/config';
+import {
+  DEFAULT_LOCALE,
+  LOCALE_COOKIE,
+  LOCALE_HEADER,
+  SUPPORTED_LOCALES,
+  isSupportedLocale,
+} from './app/lib/i18n/config';
 import { detectLocale } from './app/lib/i18n/detect-locale';
 
 const SPECIAL_ROUTES = ['angles', 'grades']; // routes that don't need board validation
+
+// Locale-prefixed embed URLs (/es/embed/..., /fr/embed/...) are 308'd to the
+// un-prefixed path (see the carve-out below). Derived from SUPPORTED_LOCALES
+// so adding a locale can't silently leave its prefixed embeds on the
+// frame-denying header rule. Case-insensitive to match the case-insensitive
+// next.config header matchers.
+const LOCALE_PREFIXED_EMBED_PATTERN = new RegExp(
+  `^/(${SUPPORTED_LOCALES.filter((locale) => locale !== DEFAULT_LOCALE).join('|')})/embed/`,
+  'i',
+);
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -45,9 +61,8 @@ export function middleware(request: NextRequest) {
   // Locale-prefixed embed URLs are 308'd to the un-prefixed path: headers()
   // matches the ORIGINAL request path, so /es/embed/** would dodge the embed
   // header rule and be served frame-DENYING X-Frame-Options: SAMEORIGIN.
-  // Embeds are en-US-only by design. Case-insensitive to match the
-  // case-insensitive header rules (see above).
-  const localePrefixedEmbed = pathname.match(/^\/(es|fr)\/embed\//i);
+  // Embeds are en-US-only by design.
+  const localePrefixedEmbed = pathname.match(LOCALE_PREFIXED_EMBED_PATTERN);
   if (localePrefixedEmbed) {
     const unprefixedEmbedUrl = request.nextUrl.clone();
     unprefixedEmbedUrl.pathname = pathname.slice(localePrefixedEmbed[1].length + 1);

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -79,9 +79,30 @@ const nextConfig = {
         headers: [{ key: 'Content-Type', value: 'application/json' }],
       },
       {
-        source: '/:path*',
+        // Every route EXCEPT /embed/** keeps the frame-denying default.
+        // If this exclusion ever regresses, the fail-safe is SAMEORIGIN
+        // (embeds break visibly rather than the whole site becoming frameable).
+        source: '/((?!embed/).*)',
         headers: [
           { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+        ],
+      },
+      {
+        // /embed/** — iframe widgets for gym websites (live board view, gym
+        // leaderboard). Display-only, cookieless, no authenticated action;
+        // review rule: no auth-dependent UI under app/embed/**. They must be
+        // frameable by ANY origin, hence `frame-ancestors *` and NO
+        // X-Frame-Options (frame-ancestors takes precedence over XFO in
+        // modern browsers; omitting XFO keeps legacy browsers from denying).
+        // The middleware 308s locale-prefixed /es|fr/embed/** to the
+        // un-prefixed path because this matcher sees the ORIGINAL request
+        // path — a prefixed variant would fall into the SAMEORIGIN rule above.
+        source: '/embed/:path*',
+        headers: [
+          { key: 'Content-Security-Policy', value: 'frame-ancestors *' },
           { key: 'X-Content-Type-Options', value: 'nosniff' },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -100,7 +100,12 @@ const nextConfig = {
         // The middleware 308s locale-prefixed /es|fr/embed/** to the
         // un-prefixed path because this matcher sees the ORIGINAL request
         // path — a prefixed variant would fall into the SAMEORIGIN rule above.
-        source: '/embed/:path*',
+        // `:path+` (one or more segments), NOT `:path*`: the exclusion regex
+        // above only skips paths starting `embed/` (with slash), so a bare
+        // `/embed` matches the SAMEORIGIN rule — with `:path*` it would match
+        // BOTH rules and ship contradictory XFO + frame-ancestors on one
+        // response. `/embed` exact is not a route; it stays frame-denying.
+        source: '/embed/:path+',
         headers: [
           { key: 'Content-Security-Policy', value: 'frame-ancestors *' },
           { key: 'X-Content-Type-Options', value: 'nosniff' },


### PR DESCRIPTION
Embeddable iframe widgets for gym websites — PR G of the gym-kiosk-dashboard epic (v2), stacked on `feat/web-kiosk-foundation`.

## What's here

### Two embed routes (uuid-keyed, anonymous, cookieless, display-only)

- **`/embed/board/[board_uuid]`** — the live board view: one `BoardSlot` (SSR raster placeholder → live presence feed over a single-board `KioskPresenceHub`), gym branding when the linked gym is public, and the non-removable "Powered by Boardsesh" footer. Recommended snippet: `width="100%" height="640"`.
- **`/embed/gym/[gym_uuid]/leaderboard?period=day|week|month&board=<uuid>`** — the period leaderboard (default `week`; `day` is the rolling "Last 24 hours"). **No session mode** — embeds stay WebSocket-free; the client mounts React Query only, refetching every **5 minutes** (kiosk polls at 60s). `?board=` must be one of the gym's publicly listed boards, else the scope widens to all. Snippet: `height="520"`.

Both are keyed by immutable uuids (board slugs are user-editable, gym slugs nullable+editable — renames must not kill embeds pasted into a gym CMS).

### Security gates (the load-bearing part)

- The backend `board(boardUuid)` resolver serves **private boards fully enriched to anonymous callers** — the board embed gates `board.isPublic` itself and `notFound()`s otherwise, plus defense-in-depth on `board.boardId` being non-null (the resolver nulls the presence id for anon-on-private). Same for `gym(gymUuid)`: branding renders **only** when `gym.isPublic`; a private/absent gym gets the unbranded default-dark shell, and the leaderboard embed 404s. Gates live in pure `embed-access.ts` and are pinned by `embed-access.test.ts`; private names never leak through `generateMetadata` either.
- Transient-vs-null discrimination mirrors the foundation's `fetchGymKiosk`: backend blip → the self-healing `KioskRetryScreen`; only a *successful* null/private resolution 404s.

### Header split + middleware carve-out

`next.config.mjs` `headers()`:

- `source: '/((?!embed/).*)'` — everything except `/embed/**` keeps the existing four headers (XFO `SAMEORIGIN`, nosniff, HSTS, Referrer-Policy). Fail-safe: if the exclusion ever regresses, embeds get `SAMEORIGIN` and break visibly — the site never becomes frameable by accident.
- `source: '/embed/:path*'` — `Content-Security-Policy: frame-ancestors *` + nosniff + HSTS + Referrer-Policy, **no X-Frame-Options** (frame-ancestors wins over XFO in modern browsers; omitting XFO keeps legacy browsers from denying).
- The `.well-known/apple-app-site-association` entry is unchanged.

`middleware.ts`:

- `/embed/**` bypasses locale detection entirely — no sticky-locale cookie (or any cookie) is ever set on an embed response.
- `/es|fr/embed/**` **308**s to the un-prefixed path: `headers()` matches the ORIGINAL request path, so a locale-prefixed embed would dodge the embed rule and arrive frame-denying.

### E2E (`packages/web/e2e/embed-headers.spec.ts`)

Asserts: embed routes carry `frame-ancestors *`, no `x-frame-options`, no `set-cookie` (against nonexistent uuids — headers match the path, not the status); `/` and `/kiosk/*` keep `SAMEORIGIN`; an embed-lookalike path (`/embedded`) keeps `SAMEORIGIN`; `/es/embed/...` and `/fr/embed/...` 308 to the un-prefixed path preserving the query string, cookieless. 5/5 passing locally via `vp run test:e2e -- embed-headers.spec.ts`.

### Reuse / refactors

- Extracted `board-slot-data.ts` (board-details + `boardRecentClimbs` seed + raster URLs) out of `kiosk-page-renderer.tsx`; both the kiosk and the board embed build slots through it.
- `KioskAttribution` gains `variant='embed'` (slim full-width in-flow footer bar) + `href` (points at `/gym/{slug}` for public gyms with a slug); the kiosk overlay variant (incl. the rail offset) is untouched.
- `usePeriodLeaderboard` gains an optional `refetchIntervalMs` (kiosk default 60s unchanged).
- `GET_BOARD`'s shared `BOARD_FIELDS` now includes `boardId` (already in the SDL from the backend PR; anon-gated in `enrichBoard`).
- New `kiosk` namespace i18n keys (embed metadata + leaderboard error state) in en-US, es, fr (es «plafón», fr «la board» / «croix» per the glossaries).

### Review rule

**No auth-dependent UI under `app/embed/**`** — these pages are framed by third-party sites (`frame-ancestors *`); nothing on them may depend on or solicit Boardsesh credentials. Chrome gating (`GlobalHeader`/`RootBottomBar`) already covers `/embed` via `isChromeLessPath()` on the foundation branch.

## Validation

- `vp run typecheck` — all packages pass
- `vp test run --project web` — 387 files / 5098 tests pass (incl. new `embed-access.test.ts`)
- `vp run check:i18n` + `check:i18n:orphans` — pass
- `vp run test:e2e -- embed-headers.spec.ts` — 5/5 pass
- `vp check` — 3 pre-existing lint errors in `scripts/__tests__/with-screenshot-dev-menu.test.ts` (identical on `main`, untouched here); no findings in changed files
- Live smoke against the dev stack: public-board embed renders (raster + attribution + headers), private-board embed 404s with the backend up, missing gym 404s

## Release Notes

- Gyms can now embed a live board view and a gym leaderboard straight into their own website — paste one iframe snippet and visitors see what's lit on the wall and who's been sending, powered by Boardsesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaW2zXJkhwXJhyxYzSv9iH
