### PR TITLE
fix(ci): unbreak the push-to-main full-repo lint (TS2741 NODE_ENV)

### DIFF
--- a/scripts/__tests__/with-screenshot-dev-menu.test.ts
+++ b/scripts/__tests__/with-screenshot-dev-menu.test.ts
@@ -1,16 +1,19 @@
+/// <reference types="node" />
 import { createRequire } from 'node:module';
 
 import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 
+// The plugin reads env loosely (only `env.BOARDSESH_METRO_PORT`, defaulting to
+// process.env), so model the param as a bare env-like record rather than
+// NodeJS.ProcessEnv — the latter now requires NODE_ENV under @types/node, which
+// would reject the `{}` / partial-env fixtures the tests pass.
+type EnvLike = Record<string, string | undefined>;
 type ScreenshotDevMenuPlugin = {
-  applyScreenshotDevMenuInfoPlist: (
-    infoPlist: Record<string, unknown>,
-    env?: NodeJS.ProcessEnv,
-  ) => Record<string, unknown>;
-  resolveScreenshotMetroPort: (env?: NodeJS.ProcessEnv) => number;
-  resolveScreenshotMetroUrl: (env?: NodeJS.ProcessEnv) => string;
+  applyScreenshotDevMenuInfoPlist: (infoPlist: Record<string, unknown>, env?: EnvLike) => Record<string, unknown>;
+  resolveScreenshotMetroPort: (env?: EnvLike) => number;
+  resolveScreenshotMetroUrl: (env?: EnvLike) => string;
 };
 
 const plugin = require('../../packages/mobile/plugins/with-screenshot-dev-menu.js') as ScreenshotDevMenuPlugin;


### PR DESCRIPTION
## Summary

The **`Lint full repo (main)`** step of the `CI` workflow has failed on **every push to `main` since #3562** — main has been red for days. Three type-aware lint errors, all in one file:

```
× typescript(TS2741): Property 'NODE_ENV' is missing in type '{}' but required in type 'ProcessEnv'.
  scripts/__tests__/with-screenshot-dev-menu.test.ts:20 / :21 / :25
```

`with-screenshot-dev-menu.test.ts` hand-models the JS plugin's API as `env?: NodeJS.ProcessEnv`, then passes `{}` / `{ BOARDSESH_METRO_PORT: '8091' }` in its assertions. Under the current `@types/node`, `ProcessEnv` requires `NODE_ENV`, so those fixtures no longer type-check. The plugin (`packages/mobile/plugins/with-screenshot-dev-menu.js`) reads env loosely — only `env.BOARDSESH_METRO_PORT`, defaulting to `process.env` — so the honest parameter type is a bare `Record<string, string | undefined>`. Switched the test's model to that.

Also added `/// <reference types="node" />` so the **pre-commit** single-file `vp check --fix` resolves `node:module` / node globals without the full project graph (it otherwise reports a phantom TS2591 in isolation).

**Why it slipped through:** the PR-lint step lints only the diff and explicitly excludes `scripts/`; the full-repo `vp check` on `main` is the only place type-aware errors in `scripts/` are caught.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` (the exact `Lint full repo (main)` command) locally: **0 errors, 257 warnings** — was **3 errors, 257 warnings**. The 257 warnings are the pre-existing repo baseline, unchanged.
- Pre-commit hook (single-file `vp check --fix` on the changed test) passes with the node reference.
- Change is test-model-only; no production type is weakened (the param was always looser than `NodeJS.ProcessEnv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwUTr6NsVUN1M3Zuk3yCQL