### PR TITLE
ci(mobile): bounded shard-level retry for flaky iOS screenshot capture

### DIFF
--- a/.github/workflows/mobile-screenshots-ios.yml
+++ b/.github/workflows/mobile-screenshots-ios.yml
@@ -266,16 +266,41 @@ jobs:
         # and es-MX for this device, so the 9 shards together produce all four App
         # Store locales × 3 devices. --shutdown is belt-and-suspenders (a shard only
         # boots this one sim, so there's nothing to accumulate).
+        #
+        # Bounded shard-level retry: the simulator/Maestro capture is flaky — a leg
+        # intermittently never reaches the home screen ("app did not reach the home
+        # screen") and one failed leg reds the whole nightly (it leaves a locale
+        # short, failing ios-finalize's dimension gate). The script already relaunches
+        # the app 3× within one boot; when that isn't enough the fix is a *fresh* boot.
+        # Each `vp run mobile:screenshots` invocation boots its own sim + Metro, so we
+        # shut down all sims between attempts and re-run once. --shutdown keeps a
+        # failed attempt from leaving a booted sim behind.
         run: |
-          set -euo pipefail
-          vp run mobile:screenshots -- \
-            --platform ios \
-            --flow "${{ inputs.flow || 'app-store' }}" \
-            --backend prod \
-            --device "${{ matrix.device.name }}" \
-            --locales "${{ matrix.locale }}" \
-            --shutdown \
-            --app-path packages/mobile/.app-cache/Boardsesh.app
+          set -uo pipefail
+          attempts=2
+          for attempt in $(seq 1 "$attempts"); do
+            echo "::group::Capture attempt $attempt/$attempts (${{ matrix.locale }} · ${{ matrix.device.slug }})"
+            if vp run mobile:screenshots -- \
+              --platform ios \
+              --flow "${{ inputs.flow || 'app-store' }}" \
+              --backend prod \
+              --device "${{ matrix.device.name }}" \
+              --locales "${{ matrix.locale }}" \
+              --shutdown \
+              --app-path packages/mobile/.app-cache/Boardsesh.app; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "Capture attempt $attempt/$attempts failed."
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "Shutting down all simulators before a fresh-boot retry..."
+              xcrun simctl shutdown all 2>/dev/null || true
+              sleep 5
+            fi
+          done
+          echo "All $attempts capture attempts failed for ${{ matrix.locale }} · ${{ matrix.device.slug }}."
+          exit 1
 
       # On a capture failure, save Maestro's debug output (the failure screenshot +
       # view hierarchy) and the simulator's Boardsesh logs, so we can see what was

--- a/.github/workflows/mobile-screenshots-ios.yml
+++ b/.github/workflows/mobile-screenshots-ios.yml
@@ -276,7 +276,7 @@ jobs:
         # shut down all sims between attempts and re-run once. --shutdown keeps a
         # failed attempt from leaving a booted sim behind.
         run: |
-          set -uo pipefail
+          set -euo pipefail
           attempts=2
           for attempt in $(seq 1 "$attempts"); do
             echo "::group::Capture attempt $attempt/$attempts (${{ matrix.locale }} · ${{ matrix.device.slug }})"


### PR DESCRIPTION
## Summary

The nightly **`Mobile Screenshots (iOS)`** workflow fails on nearly every scheduled run (07-07, 07-08, 07-09 all red). Root cause is flaky simulator/Maestro capture: a leg intermittently never reaches the home screen —

```
[mobile:screenshots] FAILED: app did not reach the home screen (auto sign-in / bundle load).
```

— and a single short leg reds the whole run, because it leaves a locale missing a device folder and `ios-finalize`'s dimension gate fails loudly on the incomplete set. The failing legs **vary run to run** (different locale/device each night), so it's flaky capture, not a systematic break. The successful legs prove the app loads fine.

The capture script already relaunches the app **3×** within one sim boot; when that's not enough, the reset that actually works is a **fresh boot**. This wraps the per-shard capture in a bounded **2-attempt** loop: on failure, shut down all sims and re-run once. Each `vp run mobile:screenshots` invocation boots its own sim + Metro, so attempt 2 is a clean fresh-boot + fresh-Metro. Worst case ≈ 2×15 min, well under the shard job's 60-minute timeout.

Implemented as plain bash in the existing step — no new third-party action to vet/SHA-pin.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- YAML parses; retry control flow unit-checked with stubs (success→no retry, both-fail→exit 1, fail-then-succeed→exit 0).
- `if: failure()` debug-collection and `always()` artifact-upload semantics are preserved: the step only "fails" after *both* attempts fail, so debug artifacts are still collected exactly when the whole shard is lost.
- Can't reproduce macOS-simulator behavior off-macOS; final validation is a `workflow_dispatch` run of this workflow (I can trigger it on this branch on request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwUTr6NsVUN1M3Zuk3yCQL