### PR TITLE
fix(backend): reorder climbs now sticks (Postgres type error)

### DIFF
--- a/packages/backend/src/__tests__/playlist-reorder-integration.test.ts
+++ b/packages/backend/src/__tests__/playlist-reorder-integration.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { playlistMutations } from '../graphql/resolvers/playlists/mutations';
+
+// Integration test (real DB) for #3607: the batched reorder UPDATE cast its
+// CASE `THEN` positions as untyped params, so Postgres typed the CASE `text` and
+// rejected the assignment to the integer `position` column (42804). The mocked
+// playlist-reorder.test.ts only checks the `.set()` shape, never running the SQL
+// — this drives the real statement. Seeds use raw `sql` because the test DB is a
+// minimal DDL (schema-sql.ts), so a builder insert over-specifies columns.
+
+const PLAYLIST_UUID = 'pl-reorder-3607';
+const OWNER_ID = 'user-123'; // seeded by setup.ts
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: true,
+    userId: OWNER_ID,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+async function orderedClimbs(): Promise<string[]> {
+  const result = await db.execute(sql`
+    SELECT climb_uuid FROM playlist_climbs
+    WHERE playlist_id = 1
+    ORDER BY position ASC, added_at ASC
+  `);
+  return Array.from(result as Iterable<{ climb_uuid: string }>).map((row) => row.climb_uuid);
+}
+
+describe('reorderPlaylistClimb — real DB (#3607)', () => {
+  // Playlist tables aren't in setup.ts's per-file reset list, so own the reset.
+  // RESTART IDENTITY frees id=1 for a stable, trivially-referenced playlist.
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+    await db.execute(sql`
+      INSERT INTO playlists (id, uuid, board_type, layout_id, name, is_public)
+      VALUES (1, ${PLAYLIST_UUID}, 'kilter', 1, 'Reorder', true)
+    `);
+    await db.execute(sql`
+      INSERT INTO playlist_ownership (playlist_id, user_id)
+      VALUES (1, ${OWNER_ID})
+    `);
+    await db.execute(sql`
+      INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+      VALUES (1, 'climb-a', 40, 0), (1, 'climb-b', 40, 1), (1, 'climb-c', 40, 2)
+    `);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+  });
+
+  it('persists a move to the front (the batched CASE update that threw 42804)', async () => {
+    const result = await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-c', newIndex: 0 } },
+      makeCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(await orderedClimbs()).toEqual(['climb-c', 'climb-a', 'climb-b']);
+  });
+
+  it('persists an interior move', async () => {
+    const result = await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-a', newIndex: 2 } },
+      makeCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(await orderedClimbs()).toEqual(['climb-b', 'climb-c', 'climb-a']);
+  });
+
+  it('is a no-op when the climb is already at the target index', async () => {
+    const result = await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-a', newIndex: 0 } },
+      makeCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(await orderedClimbs()).toEqual(['climb-a', 'climb-b', 'climb-c']);
+  });
+
+  it('rejects a non-owner and leaves the order untouched', async () => {
+    await expect(
+      playlistMutations.reorderPlaylistClimb(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-c', newIndex: 0 } },
+        makeCtx({ userId: 'not-the-owner' }),
+      ),
+    ).rejects.toThrow('do not have permission');
+
+    expect(await orderedClimbs()).toEqual(['climb-a', 'climb-b', 'climb-c']);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -458,8 +458,10 @@ export const playlistMutations = {
       // unique constraint, so the intermediate state never collides.
       if (writes.length > 0) {
         const idColumn = dbSchema.playlistClimbs.id;
+        // Cast each THEN so the CASE is typed `integer`: untyped params make
+        // Postgres resolve the CASE to `text`, which the integer column rejects (42804).
         const positionCase = sql`case ${idColumn} ${sql.join(
-          writes.map((write) => sql`when ${write.id} then ${write.position}`),
+          writes.map((write) => sql`when ${write.id} then ${write.position}::integer`),
           sql` `,
         )} end`;
         await tx


### PR DESCRIPTION
## Summary

Reordering a climb in a playlist you own never stuck. Every reorder with a non-empty write set failed server-side and rolled back, so the order snapped straight back — on web and mobile alike.

`reorderPlaylistClimb` renumbers positions in one batched statement:

```sql
UPDATE playlist_climbs SET position = CASE id WHEN .. THEN .. END WHERE id IN (..)
```

Each `THEN` value bound as an **untyped** parameter (postgres.js sends a JS number as OID 0). With every `THEN` branch untyped, Postgres resolves the `CASE` result type to `text`, and assigning that to the `integer` `position` column is rejected with `column "position" is of type integer but expression is of type text` (SQLSTATE 42804).

The fix casts each branch to `::integer` so the `CASE` is typed `integer`.

This regressed in `013eca5b6` ("batch reorder writes"), which replaced a per-row loop (`.set({ position: index })` — a plain number against a known column type) with the batched `CASE`. CI missed it because `playlist-reorder.test.ts` mocks the DB client wholesale and only asserts the shape of the `.set()` argument — the generated SQL was never run against Postgres. This PR adds a real-Postgres integration test that drives the actual statement.

Out of scope (tracked in #3183): the `maskedErrors` gate that echoes the raw SQL to clients, and `graphiql` in prod. I'll leave a note on #3183 that its "transient pool blip" conclusion for this PostHog bucket was wrong — this was a deterministic query bug.

Closes #3607

## Release Notes

- Reorder climbs in a playlist and the new order sticks.

## Test plan

- New `packages/backend/src/__tests__/playlist-reorder-integration.test.ts` runs the real resolver against the test Postgres (owner seeded, three climbs). Verified it **fails on the unfixed resolver** with the exact `42804` error (`parameters` shows position params at OID `0`), then **passes after the cast**.
- Move-to-front, interior move, no-op move, and non-owner-rejected cases all covered.
- `vp test run --project backend playlist-reorder` — 16 tests pass (integration + mocked + math).
- `vp run typecheck:backend` — clean.
- `vp check` on the two changed files — no warnings, lint, or type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAGEj45DdfBeP3tSPgW8Cu
