### PR TITLE
fix(mobile): classify Android BLE connect failures by ble-plx errorCode

### DIFF
--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -12,6 +12,7 @@ import {
 import { getMoonboardBluetoothPacket, isMoonboardDeviceName } from '@boardsesh/ble-protocol/moonboard';
 import { getMoonBoardGeometryByLayoutId } from '@boardsesh/board-config';
 import {
+  blePlxErrorCodes,
   classifyBleFailure,
   classifyBleFailureReason,
   isDisconnectionError,
@@ -974,6 +975,10 @@ export function useBoardBluetooth({
           layoutId,
           sizeId,
           failureReason: failureCategory === 'unknown' ? classifyBleFailureReason(error) : failureCategory,
+          // Raw ble-plx codes (Android) so the real connect-failure cause and the
+          // low-level GATT status are visible for re-measurement (#3608). Empty on
+          // web / native iOS.
+          ...blePlxErrorCodes(error),
         });
       } finally {
         connectInFlightRef.current = false;

--- a/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  blePlxErrorCodes,
   classifyBleFailure,
   classifyBleFailureReason,
   isBleWriteRecoveryFailedError,
@@ -17,6 +18,27 @@ const WRITE_RECOVERY_FAILED_MESSAGE =
 function bleError(message: string): Error {
   const error = new Error(message);
   error.name = 'BleError';
+  return error;
+}
+
+// Mimics a react-native-ble-plx BleError that also carries a numeric BleErrorCode
+// (and, optionally, the low-level platform codes) — the shape the connect path
+// receives from `connectToDevice()`. The classifier prefers the code over the
+// message on these.
+function bleErrorWithCode(
+  errorCode: number,
+  message: string,
+  extra?: { androidErrorCode?: number; iosErrorCode?: number },
+): Error {
+  const error = new Error(message) as Error & {
+    errorCode: number;
+    androidErrorCode?: number;
+    iosErrorCode?: number;
+  };
+  error.name = 'BleError';
+  error.errorCode = errorCode;
+  if (extra?.androidErrorCode !== undefined) error.androidErrorCode = extra.androidErrorCode;
+  if (extra?.iosErrorCode !== undefined) error.iosErrorCode = extra.iosErrorCode;
   return error;
 }
 
@@ -276,4 +298,131 @@ describe('classifyBleFailureReason', () => {
       expect(classifyBleFailureReason(error)).toBe(expected);
     });
   }
+});
+
+describe('classifyBleFailure — ble-plx BleErrorCode (#3608)', () => {
+  // ble-plx (Android) puts a numeric BleErrorCode on every thrown BleError. It is
+  // authoritative and must win over ble-plx's English message, which matches none
+  // of the message patterns and used to fall through to `unknown` — then get
+  // re-bucketed as the write-path `disconnected` reason, hiding the real cause.
+  const cases: Array<{ name: string; error: unknown; expected: BleFailureCategory }> = [
+    // 201 DeviceDisconnected is the dominant Android mis-bucket: its message
+    // ("… was disconnected") previously classified as `unknown` -> `disconnected`.
+    {
+      name: 'DeviceDisconnected (201) on connect',
+      error: bleErrorWithCode(201, 'Device 5C:F8 was disconnected'),
+      expected: 'connect_failed',
+    },
+    {
+      name: 'DeviceConnectionFailed (200)',
+      error: bleErrorWithCode(200, 'Device 5C:F8 was not able to connect'),
+      expected: 'connect_failed',
+    },
+    {
+      name: 'DeviceNotConnected (205)',
+      error: bleErrorWithCode(205, 'Device 5C:F8 is not connected'),
+      expected: 'connect_failed',
+    },
+    { name: 'OperationTimedOut (3)', error: bleErrorWithCode(3, 'Operation timed out'), expected: 'connect_failed' },
+    {
+      name: 'DeviceMTUChangeFailed (206)',
+      error: bleErrorWithCode(206, 'MTU change failed for device 5C:F8'),
+      expected: 'connect_failed',
+    },
+    // Code beats a misleading "unavailable" in the message.
+    {
+      name: 'DeviceNotFound (204) with a misleading message',
+      error: bleErrorWithCode(204, 'Device 5C:F8 is unavailable'),
+      expected: 'board_not_found',
+    },
+    // Discovery failures whose message names no "... not found" — the message
+    // alone would fall through to unknown.
+    {
+      name: 'ServicesDiscoveryFailed (300)',
+      error: bleErrorWithCode(300, 'Services discovery failed for device 5C:F8'),
+      expected: 'service_missing',
+    },
+    { name: 'ServiceNotFound (302)', error: bleErrorWithCode(302, 'opaque'), expected: 'service_missing' },
+    {
+      name: 'CharacteristicsDiscoveryFailed (400)',
+      error: bleErrorWithCode(400, 'Characteristics discovery failed'),
+      expected: 'service_missing',
+    },
+    { name: 'CharacteristicNotFound (404)', error: bleErrorWithCode(404, 'opaque'), expected: 'service_missing' },
+    // Radio / permission / OS state.
+    { name: 'BluetoothPoweredOff (102)', error: bleErrorWithCode(102, 'opaque'), expected: 'unavailable' },
+    { name: 'BluetoothUnauthorized (101)', error: bleErrorWithCode(101, 'opaque'), expected: 'unavailable' },
+    { name: 'BluetoothUnsupported (100)', error: bleErrorWithCode(100, 'opaque'), expected: 'unavailable' },
+    { name: 'BluetoothResetting (104)', error: bleErrorWithCode(104, 'opaque'), expected: 'unavailable' },
+    {
+      name: 'LocationServicesDisabled (601)',
+      error: bleErrorWithCode(601, 'Location services are disabled'),
+      expected: 'unavailable',
+    },
+    // Fallthrough preserved: UnknownError (0) and unmapped codes defer to the
+    // message ladder (here no pattern matches → unknown).
+    {
+      name: 'UnknownError (0) falls through to the message',
+      error: bleErrorWithCode(0, 'Cannot connect to device 5C:F8'),
+      expected: 'unknown',
+    },
+    // OperationCancelled (2) is intentionally NOT mapped to user_cancelled (it can
+    // be our own connect-timeout cancelDeviceConnection) — it defers to the message.
+    {
+      name: 'OperationCancelled (2) is not silenced as user_cancelled',
+      error: bleErrorWithCode(2, 'Operation was cancelled'),
+      expected: 'unknown',
+    },
+  ];
+
+  for (const { name, error, expected } of cases) {
+    it(`classifies: ${name} -> ${expected}`, () => {
+      expect(classifyBleFailure(error)).toBe(expected);
+    });
+  }
+
+  it('ignores a numeric errorCode on a non-BleError (e.g. an iOS CBError)', () => {
+    // A foreign error whose numeric `errorCode` collides with the ble-plx enum
+    // must not be read against it — the name gate blocks it, so it classifies by
+    // message only (here: unknown).
+    const cbError = new Error('peripheral is gone') as Error & { errorCode: number };
+    cbError.name = 'CBError';
+    cbError.errorCode = 201; // would be DeviceDisconnected -> connect_failed if misread
+    expect(classifyBleFailure(cbError)).toBe('unknown');
+  });
+
+  it('the numeric code wins over the message when both point to different categories', () => {
+    // 302 ServiceNotFound with a message that reads like a board-not-found: the
+    // code branch runs first, so it classifies as service_missing.
+    expect(classifyBleFailure(bleErrorWithCode(302, 'device not found'))).toBe('service_missing');
+  });
+});
+
+describe('blePlxErrorCodes (#3608)', () => {
+  it('extracts the ble-plx code and the low-level Android GATT status', () => {
+    const error = bleErrorWithCode(201, 'Device 5C:F8 was disconnected', { androidErrorCode: 133 });
+    expect(blePlxErrorCodes(error)).toEqual({ bleErrorCode: 201, androidErrorCode: 133 });
+  });
+
+  it('includes iosErrorCode when present (ble-plx iOS path)', () => {
+    const error = bleErrorWithCode(201, 'disconnected', { iosErrorCode: 7 });
+    expect(blePlxErrorCodes(error)).toEqual({ bleErrorCode: 201, iosErrorCode: 7 });
+  });
+
+  it('omits platform codes that are absent', () => {
+    expect(blePlxErrorCodes(bleErrorWithCode(204, 'not found'))).toEqual({ bleErrorCode: 204 });
+  });
+
+  it('returns {} for a non-ble-plx error (web / native iOS)', () => {
+    expect(blePlxErrorCodes(new Error('GATT operation failed'))).toEqual({});
+    expect(blePlxErrorCodes(new DOMException('boom', 'NetworkError'))).toEqual({});
+    expect(blePlxErrorCodes('a plain string')).toEqual({});
+  });
+
+  it('ignores a numeric errorCode on a non-BleError name', () => {
+    const cbError = new Error('boom') as Error & { errorCode: number };
+    cbError.name = 'CBError';
+    cbError.errorCode = 7;
+    expect(blePlxErrorCodes(cbError)).toEqual({});
+  });
 });

--- a/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
@@ -342,18 +342,31 @@ describe('classifyBleFailure — ble-plx BleErrorCode (#3608)', () => {
       error: bleErrorWithCode(300, 'Services discovery failed for device 5C:F8'),
       expected: 'service_missing',
     },
+    {
+      name: 'IncludedServicesDiscoveryFailed (301)',
+      error: bleErrorWithCode(301, 'opaque'),
+      expected: 'service_missing',
+    },
     { name: 'ServiceNotFound (302)', error: bleErrorWithCode(302, 'opaque'), expected: 'service_missing' },
+    { name: 'ServicesNotDiscovered (303)', error: bleErrorWithCode(303, 'opaque'), expected: 'service_missing' },
     {
       name: 'CharacteristicsDiscoveryFailed (400)',
       error: bleErrorWithCode(400, 'Characteristics discovery failed'),
       expected: 'service_missing',
     },
     { name: 'CharacteristicNotFound (404)', error: bleErrorWithCode(404, 'opaque'), expected: 'service_missing' },
+    {
+      name: 'CharacteristicsNotDiscovered (405)',
+      error: bleErrorWithCode(405, 'opaque'),
+      expected: 'service_missing',
+    },
     // Radio / permission / OS state.
     { name: 'BluetoothPoweredOff (102)', error: bleErrorWithCode(102, 'opaque'), expected: 'unavailable' },
     { name: 'BluetoothUnauthorized (101)', error: bleErrorWithCode(101, 'opaque'), expected: 'unavailable' },
     { name: 'BluetoothUnsupported (100)', error: bleErrorWithCode(100, 'opaque'), expected: 'unavailable' },
+    { name: 'BluetoothInUnknownState (103)', error: bleErrorWithCode(103, 'opaque'), expected: 'unavailable' },
     { name: 'BluetoothResetting (104)', error: bleErrorWithCode(104, 'opaque'), expected: 'unavailable' },
+    { name: 'BluetoothStateChangeFailed (105)', error: bleErrorWithCode(105, 'opaque'), expected: 'unavailable' },
     {
       name: 'LocationServicesDisabled (601)',
       error: bleErrorWithCode(601, 'Location services are disabled'),

--- a/packages/shared/ble-protocol/src/connection-error.ts
+++ b/packages/shared/ble-protocol/src/connection-error.ts
@@ -55,6 +55,66 @@ function errorMessage(error: unknown): string {
   return String(error);
 }
 
+// The three numeric codes `react-native-ble-plx` puts on every thrown `BleError`.
+// Read structurally (this package is platform-agnostic pure TS and must not depend
+// on react-native-ble-plx) after gating on the error name below.
+type BlePlxErrorShape = {
+  errorCode?: unknown;
+  androidErrorCode?: unknown;
+  iosErrorCode?: unknown;
+};
+
+// ble-plx's `BleError extends Error` sets `name = 'BleError'` — the reliable
+// discriminator. Gating on it stops a foreign numeric `errorCode` (e.g. an iOS
+// CBError surfaced by the native adapter) from being read against the ble-plx enum.
+const BLE_PLX_ERROR_NAME = 'BleError';
+
+function isBlePlxError(error: unknown): error is BlePlxErrorShape {
+  return errorName(error) === BLE_PLX_ERROR_NAME;
+}
+
+/**
+ * Maps a ble-plx (`react-native-ble-plx`) numeric `BleErrorCode` to a connect
+ * failure category. The code is a far more reliable signal than ble-plx's English
+ * message, which matches none of the Web-Bluetooth / CoreBluetooth patterns below
+ * and so used to fall through to `unknown` — then get re-bucketed as the write-path
+ * `disconnected` reason, hiding the real Android connect-failure cause (#3608).
+ *
+ * SOURCE OF TRUTH: `react-native-ble-plx@3.5.x` `src/BleError.js` `BleErrorCode`.
+ * Mirrored as literals because this package can't depend on react-native-ble-plx.
+ * Codes we can't confidently attribute to a connect-side category are deliberately
+ * omitted so they fall through to the message ladder, preserving existing
+ * behaviour: `0` UnknownError, `2` OperationCancelled (can be our own connect-
+ * timeout `cancelDeviceConnection`, not a user cancel), and the write / read /
+ * descriptor / scan-start codes (not connect-side).
+ */
+const BLE_PLX_CODE_TO_CATEGORY: Record<number, BleFailureCategory> = {
+  // Radio / permission / OS state — the board can't be reached at all.
+  100: 'unavailable', // BluetoothUnsupported
+  101: 'unavailable', // BluetoothUnauthorized
+  102: 'unavailable', // BluetoothPoweredOff
+  103: 'unavailable', // BluetoothInUnknownState
+  104: 'unavailable', // BluetoothResetting
+  105: 'unavailable', // BluetoothStateChangeFailed
+  601: 'unavailable', // LocationServicesDisabled (Android scan needs location on)
+  // The target board never showed up during the scan.
+  204: 'board_not_found', // DeviceNotFound
+  // The GATT link couldn't be established / dropped mid-connect / timed out.
+  3: 'connect_failed', // OperationTimedOut
+  200: 'connect_failed', // DeviceConnectionFailed
+  201: 'connect_failed', // DeviceDisconnected — the dominant Android mis-bucket
+  205: 'connect_failed', // DeviceNotConnected
+  206: 'connect_failed', // DeviceMTUChangeFailed
+  // Connected, but the UART service / write characteristic wasn't discovered.
+  300: 'service_missing', // ServicesDiscoveryFailed
+  301: 'service_missing', // IncludedServicesDiscoveryFailed
+  302: 'service_missing', // ServiceNotFound
+  303: 'service_missing', // ServicesNotDiscovered
+  400: 'service_missing', // CharacteristicsDiscoveryFailed
+  404: 'service_missing', // CharacteristicNotFound
+  405: 'service_missing', // CharacteristicsNotDiscovered
+};
+
 /**
  * Classify a thrown error from a connect attempt. `pairingStage` is the stage
  * tag the hook tracks; we use `gatt_connect` as a fallback signal for
@@ -66,6 +126,15 @@ function errorMessage(error: unknown): string {
 export function classifyBleFailure(error: unknown, pairingStage?: string): BleFailureCategory {
   const name = errorName(error);
   const message = errorMessage(error);
+
+  // ble-plx (Android) carries a numeric BleErrorCode that's far more reliable than
+  // its English message. Consume it before the message ladder; an unmapped code
+  // (incl. UnknownError) falls straight through, so web / native-iOS classification
+  // — which has no ble-plx numeric errorCode — is unchanged.
+  if (isBlePlxError(error) && typeof error.errorCode === 'number') {
+    const codeCategory = BLE_PLX_CODE_TO_CATEGORY[error.errorCode];
+    if (codeCategory) return codeCategory;
+  }
 
   // User dismissed the picker. Match only explicit user-cancel signals — a bare
   // "cancel" would also swallow real failures like CoreBluetooth's
@@ -112,6 +181,30 @@ export function classifyBleFailure(error: unknown, pairingStage?: string): BleFa
   }
 
   return 'unknown';
+}
+
+/** Raw ble-plx numeric codes, attached to a connect-failure analytics event. */
+export type BlePlxErrorCodes = {
+  bleErrorCode?: number; // react-native-ble-plx BleErrorCode enum value
+  androidErrorCode?: number; // low-level Android GATT status (e.g. 133 / 8 / 19)
+  iosErrorCode?: number; // iOS CBError code (present only on the ble-plx iOS path)
+};
+
+/**
+ * Pull the raw numeric codes off a thrown ble-plx `BleError` for analytics, so a
+ * connect failure's real cause — the `BleErrorCode` and the low-level Android GATT
+ * status — is visible in PostHog and the Android connect-failure distribution can
+ * be re-measured (#3608). Returns `{}` for any non-ble-plx error (web / native
+ * iOS), and omits any platform code that isn't a number. Mirrors the field-reading
+ * `RNBleAdapter` already does on its disconnect path (`bleErrorToDisconnectInfo`).
+ */
+export function blePlxErrorCodes(error: unknown): BlePlxErrorCodes {
+  if (!isBlePlxError(error)) return {};
+  const codes: BlePlxErrorCodes = {};
+  if (typeof error.errorCode === 'number') codes.bleErrorCode = error.errorCode;
+  if (typeof error.androidErrorCode === 'number') codes.androidErrorCode = error.androidErrorCode;
+  if (typeof error.iosErrorCode === 'number') codes.iosErrorCode = error.iosErrorCode;
+  return codes;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #3608.

Connecting to the board fails ~4× more often on Android than iOS (9.5% vs 2.3% over 30d, user-cancels stripped), and until now we couldn't say *why* — the reason we logged for Android was wrong.

On Android, `react-native-ble-plx` rejects a failed `connectToDevice()` with a raw `BleError` (e.g. `errorCode: 201` DeviceDisconnected, message `"Device … was disconnected"`). That error reached `classifyBleFailure()` untouched, but the classifier only matches Web-Bluetooth / CoreBluetooth **message strings**, so ble-plx messages fell through to `unknown` and were then re-bucketed as the write-path reason `disconnected` — the dominant, wrong Android bucket (162 events / 79 users). iOS records the exact same failure mode correctly as `connect_failed`.

**This PR (step 1 of the issue):**

- **`classifyBleFailure` now consumes the numeric `BleError.errorCode`.** A `BleErrorCode → BleFailureCategory` map (e.g. `201`/`200`/`205`/`3` → `connect_failed`, `204` → `board_not_found`, `300`/`302`/`400`/`404` → `service_missing`, `100`–`105`/`601` → `unavailable`) is consulted before the message ladder. The codes are mirrored as literals because `@boardsesh/ble-protocol` is platform-agnostic and can't depend on react-native-ble-plx. Gated on `name === 'BleError'` so a foreign numeric `errorCode` (e.g. an iOS CBError) can't be misread against the enum. Unmapped/`UnknownError` codes and non-ble-plx errors fall straight through to the existing message ladder — **web and native-iOS classification is unchanged.**
- **Raw codes are emitted on the `Bluetooth Connection Failed` event** (`bleErrorCode` + the low-level `androidErrorCode` GATT status) via a new `blePlxErrorCodes()` helper — so the new bucketing can be re-measured against real GATT statuses.

**Deliberately out of scope:** step 2 (connect-side recovery for the ble-plx path) is measurement-gated — decide after the new buckets land. Per the issue, Android has **zero** write failures, so porting the iOS write-stall recovery (#3181) would fix nothing. Web `failureReason` emission (#3088) stays separate.

This is pure JS/TS (no native code, no new deps), so it ships to the Android fleet via **OTA** and re-measurement can start as soon as it rolls out.

## Release Notes

- When a board won't connect on Android, you now get the real reason — Bluetooth off, board not found, or a connection that dropped — instead of a blanket "unknown error".

## Test plan

- `vp test run --project ble-protocol` — 255 passed, incl. new cases: **201 DeviceDisconnected → `connect_failed`** (the headline regression-lock), the full code→category table, the `name !== 'BleError'` scoping guard, `UnknownError` fallthrough, and `blePlxErrorCodes` extraction.
- `vp run test:mobile` — 3831 passed (the `use-board-bluetooth` suite still green).
- `vp run typecheck:ble-protocol`, `vp run typecheck:mobile` — clean.
- `vp check` on the 3 changed files — no lint/format/type errors.
- `vp run check:mobile-bundle` — Android bundle OK.
- No BLE hardware in CI/sim, so the classifier (pure) is covered by unit tests; the real re-measurement happens in PostHog once the OTA reaches the Android fleet (issue step 2 input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ty8XosMsVnMRGRtCus7d1