### PR TITLE
feat(db): carry board, de-herded label, and benchmark grade in the Climb2Vec extract

### DIFF
--- a/packages/db/scripts/extract-training-matrix.ts
+++ b/packages/db/scripts/extract-training-matrix.ts
@@ -23,6 +23,7 @@ import {
   type ClimbStatLite,
   type HoldLite,
 } from '../src/queries/hold-features/index.js';
+import { DEFAULT_ECHO_FRACTION } from '../src/queries/grade-model/index.js';
 
 const DEFAULT_OUT = 'ml/climb2vec/data/kilter-train.jsonl';
 const DEFAULT_MIN_ASCENTS = 20;
@@ -71,7 +72,8 @@ async function loadStats(db: Db, options: Options): Promise<ClimbStatLite[]> {
   });
   return (await db.execute(sql`
     SELECT st.climb_uuid AS climb_uuid, st.angle AS angle, COALESCE(st.difficulty_average, 0) AS label,
-           COALESCE(st.ascensionist_count, 0) AS n, c.layout_id AS layout_id, c.hold_fingerprint AS fingerprint
+           COALESCE(st.ascensionist_count, 0) AS n, c.layout_id AS layout_id, c.hold_fingerprint AS fingerprint,
+           st.display_difficulty AS display, st.benchmark_difficulty AS benchmark
     FROM board_climb_stats st
     JOIN board_climbs c ON c.uuid = st.climb_uuid
     WHERE st.board_type = ${options.board}
@@ -83,6 +85,35 @@ async function loadStats(db: Db, options: Options): Promise<ClimbStatLite[]> {
     ORDER BY st.climb_uuid, st.angle
     ${limitClause}
   `)) as unknown as ClimbStatLite[];
+}
+
+/**
+ * The board's quick-log echo share (λ) from the freshest coefficient set, so the
+ * extract de-herds crowd labels exactly as the grade pipeline does. Mirrors the
+ * freshest-coeff_version subquery in `loadFrozenCoefficients` (refresh-climb-grades.ts),
+ * scoped to this board's echo_fraction row; falls back to the model default when
+ * no coefficients are stored yet. Unlike the grade pipeline it skips the
+ * COEFF_MAX_AGE_DAYS staleness guard — the extract runs right after the nightly
+ * refresh, and a slightly stale λ beats refitting from ticks here.
+ */
+async function loadEchoFraction(db: Db, board: string): Promise<number> {
+  const rows = (await db.execute(sql`
+    SELECT payload
+    FROM board_grade_coefficients
+    WHERE kind = 'echo_fraction'
+      AND key = ${board}
+      AND coeff_version = (
+        SELECT coeff_version
+        FROM board_grade_coefficients
+        WHERE kind <> 'gate_results'
+        GROUP BY coeff_version
+        ORDER BY MAX(created_at) DESC
+        LIMIT 1
+      )
+    LIMIT 1
+  `)) as unknown as Array<{ payload: { lambda?: number } | null }>;
+  const lambda = rows[0]?.payload?.lambda;
+  return typeof lambda === 'number' && Number.isFinite(lambda) ? lambda : DEFAULT_ECHO_FRACTION;
 }
 
 async function loadHoldsByClimb(db: Db, options: Options): Promise<Map<string, HoldLite[]>> {
@@ -155,14 +186,16 @@ async function main(): Promise<void> {
     // segments so a big sort can't exhaust the server's /dev/shm (matches the
     // grade pipeline's guard). Session-scoped on the single script connection.
     await db.execute(sql`SET max_parallel_workers_per_gather = 0`);
-    const [features, stats, holdsByClimb] = await Promise.all([
+    const [features, stats, holdsByClimb, echoFraction] = await Promise.all([
       loadFeatures(db, options.board),
       loadStats(db, options),
       loadHoldsByClimb(db, options),
+      loadEchoFraction(db, options.board),
     ]);
     if (features.size === 0) {
       throw new Error(`board_hold_features is empty for ${options.board} — run refresh-hold-features.ts first.`);
     }
+    console.log(`[extract] echo fraction λ=${echoFraction.toFixed(3)} for ${options.board}`);
 
     mkdirSync(dirname(options.out), { recursive: true });
     const stream = createWriteStream(options.out, { encoding: 'utf8' });
@@ -171,7 +204,7 @@ async function main(): Promise<void> {
     for (const stat of stats) {
       const holds = holdsByClimb.get(stat.climb_uuid);
       if (!holds || holds.length === 0) continue;
-      const row = buildTrainingRow(stat, holds, features);
+      const row = buildTrainingRow(stat, holds, features, options.board, echoFraction);
       if (row.holds.length === 0) continue;
       stream.write(`${JSON.stringify(row)}\n`);
       written++;

--- a/packages/db/scripts/extract-training-matrix.ts
+++ b/packages/db/scripts/extract-training-matrix.ts
@@ -96,9 +96,9 @@ async function loadStats(db: Db, options: Options): Promise<ClimbStatLite[]> {
  * COEFF_MAX_AGE_DAYS staleness guard — the extract runs right after the nightly
  * refresh, and a slightly stale λ beats refitting from ticks here.
  */
-async function loadEchoFraction(db: Db, board: string): Promise<number> {
+async function loadEchoFraction(db: Db, board: string): Promise<{ lambda: number; ageDays: number | null }> {
   const rows = (await db.execute(sql`
-    SELECT payload
+    SELECT payload, created_at
     FROM board_grade_coefficients
     WHERE kind = 'echo_fraction'
       AND key = ${board}
@@ -111,9 +111,17 @@ async function loadEchoFraction(db: Db, board: string): Promise<number> {
         LIMIT 1
       )
     LIMIT 1
-  `)) as unknown as Array<{ payload: { lambda?: number } | null }>;
+  `)) as unknown as Array<{ payload: { lambda?: number } | null; created_at: string | Date | null }>;
   const lambda = rows[0]?.payload?.lambda;
-  return typeof lambda === 'number' && Number.isFinite(lambda) ? lambda : DEFAULT_ECHO_FRACTION;
+  if (typeof lambda !== 'number' || !Number.isFinite(lambda)) {
+    return { lambda: DEFAULT_ECHO_FRACTION, ageDays: null };
+  }
+  const createdAt = rows[0]?.created_at ? new Date(rows[0].created_at) : null;
+  const ageDays =
+    createdAt && Number.isFinite(createdAt.getTime())
+      ? Math.round((Date.now() - createdAt.getTime()) / 86_400_000)
+      : null;
+  return { lambda, ageDays };
 }
 
 async function loadHoldsByClimb(db: Db, options: Options): Promise<Map<string, HoldLite[]>> {
@@ -186,7 +194,7 @@ async function main(): Promise<void> {
     // segments so a big sort can't exhaust the server's /dev/shm (matches the
     // grade pipeline's guard). Session-scoped on the single script connection.
     await db.execute(sql`SET max_parallel_workers_per_gather = 0`);
-    const [features, stats, holdsByClimb, echoFraction] = await Promise.all([
+    const [features, stats, holdsByClimb, echo] = await Promise.all([
       loadFeatures(db, options.board),
       loadStats(db, options),
       loadHoldsByClimb(db, options),
@@ -195,7 +203,9 @@ async function main(): Promise<void> {
     if (features.size === 0) {
       throw new Error(`board_hold_features is empty for ${options.board} — run refresh-hold-features.ts first.`);
     }
-    console.log(`[extract] echo fraction λ=${echoFraction.toFixed(3)} for ${options.board}`);
+    const echoFraction = echo.lambda;
+    const echoAge = echo.ageDays === null ? 'model default (no frozen row)' : `${echo.ageDays}d old`;
+    console.log(`[extract] echo fraction λ=${echoFraction.toFixed(3)} for ${options.board} (${echoAge})`);
 
     mkdirSync(dirname(options.out), { recursive: true });
     const stream = createWriteStream(options.out, { encoding: 'utf8' });

--- a/packages/db/scripts/refresh-climb-grades.ts
+++ b/packages/db/scripts/refresh-climb-grades.ts
@@ -19,8 +19,14 @@
  * Flags: --refit-coefficients (force a refit), --dry-run (gates + stats only),
  * --validate-only (read-only gates report, works without the grade tables),
  * --allow-empty-backtest (dev DBs without stats history: skip the backtest
- * instead of blocking — never use in prod).
+ * instead of blocking — never use in prod),
+ * --content-prior-file=<path> (score CANDIDATE content priors from an offline
+ * JSONL file instead of board_climb_embeddings — pair with --validate-only or
+ * --dry-run to keep it read-only; adds the report-only content_prior_backtest
+ * gate per board present in the file).
  */
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
 import { sql } from 'drizzle-orm';
 import { createScriptDb } from './db-connection.js';
 import { boardClimbGrades, boardGradeCoefficients } from '../src/schema/app/climb-grades.js';
@@ -46,6 +52,7 @@ import {
   buildTauSampleSql,
   buildTensionBenchmarkHoldoutSql,
   computePosteriorGrade,
+  contentPriorKey,
   createDisplayDeltaHygieneStats,
   deherdCrowdMean,
   estimateAngleSurface,
@@ -57,8 +64,10 @@ import {
   estimateSigmaWithin,
   estimateTauSquared,
   evaluateBacktest,
+  evaluateContentPriorBacktest,
   evaluateDisplayDeltaHygiene,
   evaluateFingerprintGate,
+  parseContentPriorLine,
   evaluateTensionBenchmarkHoldout,
   echoFractionFor,
   effectiveN,
@@ -80,6 +89,7 @@ import {
   type BoardOffsetSampleRow,
   type ConfidenceTier,
   type ClimbAngleObservation,
+  type ContentPriorEntry,
   type EchoRateRow,
   type DisplayDeltaHygieneStats,
   type GateResult,
@@ -334,15 +344,6 @@ interface ComputedRow {
   holdFingerprint: string | null;
 }
 
-interface ContentPriorEntry {
-  contentPrior: number;
-  contentSd: number | null;
-}
-
-function contentPriorKey(climbUuid: string, angle: number): string {
-  return `${climbUuid} ${angle}`;
-}
-
 /** Load the Climb2Vec content-model estimates (board_climb_embeddings) for a board. */
 async function loadContentPriors(db: Db, boardType: string): Promise<Map<string, ContentPriorEntry>> {
   const rows = rowsOf<{ climb_uuid: string; angle: number; content_prior: number | null; content_sd: number | null }>(
@@ -359,6 +360,43 @@ async function loadContentPriors(db: Db, boardType: string): Promise<Map<string,
       contentSd: row.content_sd === null ? null : Number(row.content_sd),
     });
   }
+  return map;
+}
+
+/**
+ * Load CANDIDATE content priors for a board from an offline JSONL file (records
+ * `{climbUuid, angle, contentPrior, contentSd?, board?}`), instead of the DB
+ * embeddings table. Records tagged with a different `board` are skipped;
+ * malformed lines are counted and skipped rather than crashing the run. Read-only
+ * — this never touches board_climb_embeddings.
+ */
+async function loadContentPriorsFromFile(filePath: string, boardType: string): Promise<Map<string, ContentPriorEntry>> {
+  const reader = createInterface({ input: createReadStream(filePath, { encoding: 'utf8' }), crlfDelay: Infinity });
+  const map = new Map<string, ContentPriorEntry>();
+  let total = 0;
+  let malformed = 0;
+  try {
+    for await (const line of reader) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      total += 1;
+      const parsed = parseContentPriorLine(trimmed, boardType);
+      if (parsed.status === 'malformed') {
+        malformed += 1;
+        continue;
+      }
+      if (parsed.status === 'skip') continue;
+      map.set(parsed.key, parsed.entry);
+    }
+  } finally {
+    reader.close();
+  }
+  if (malformed > 0) {
+    console.warn(`[grades]   content-prior file ${filePath}: skipped ${malformed} malformed line(s) of ${total}`);
+  }
+  console.log(
+    `[grades]   content-prior file ${filePath}: loaded ${map.size} ${boardType} candidate(s) from ${total} line(s)`,
+  );
   return map;
 }
 
@@ -1016,7 +1054,7 @@ function blockingGates(gates: GateResult[]): GateResult[] {
  * run the input-side gates, compute every board, evaluate the in-memory gates,
  * and print the report. Writes nothing.
  */
-async function validateOnly(db: Db, allowEmptyBacktest: boolean): Promise<void> {
+async function validateOnly(db: Db, allowEmptyBacktest: boolean, contentPriorFile: string | undefined): Promise<void> {
   const coefficients = await refitCoefficients(db, { persist: false });
   const baselineCoefficients = withoutStage2Coefficients(coefficients);
   const stage2Evidence = await loadStage2Evidence(db, coefficients);
@@ -1068,7 +1106,9 @@ async function validateOnly(db: Db, allowEmptyBacktest: boolean): Promise<void> 
   }
   const computedByBoard = new Map<string, ComputedRow[]>();
   for (const boardType of CROWD_MEAN_BOARDS) {
-    const contentPriors = await loadContentPriors(db, boardType);
+    const contentPriors = contentPriorFile
+      ? await loadContentPriorsFromFile(contentPriorFile, boardType)
+      : await loadContentPriors(db, boardType);
     const { computed, isotonicStats, displayDeltaHygieneStats } = await computeBoard(
       db,
       boardType,
@@ -1090,6 +1130,17 @@ async function validateOnly(db: Db, allowEmptyBacktest: boolean): Promise<void> 
     console.log(
       `[grades]   ${boardType}: ${computed.length} rows, tiers=${JSON.stringify(tiers)}; isotonic moved ${isotonicStats.movedRows} rows (${isotonicStats.residualInversions} residual inversions); no_shock ${noShock.passed ? 'PASS' : 'FAIL'} (${noShock.detail}); fingerprint ${fingerprint.passed ? 'PASS' : 'FAIL'} (${fingerprint.detail}); display_delta_hygiene ${displayDeltaHygiene.passed ? 'PASS' : 'FAIL'} (${displayDeltaHygiene.detail})`,
     );
+    if (contentPriorFile && backtestRows.length > 0 && contentPriors.size > 0) {
+      const contentBacktest = evaluateContentPriorBacktest(
+        backtestRows.filter((row) => row.board_type === boardType),
+        contentPriors,
+        coefficients,
+      );
+      gates.push(contentBacktest.gate);
+      console.log(
+        `[grades]   content_prior_backtest: ${contentBacktest.gate.passed ? 'PASS' : 'FAIL'} — ${contentBacktest.gate.detail}`,
+      );
+    }
   }
   const baselineTension = await computeBoard(db, 'tension', baselineCoefficients, new Map(), { applyStage2: false });
   const holdoutRows = rowsOf<TensionBenchmarkHoldoutRow>(await db.execute(buildTensionBenchmarkHoldoutSql()));
@@ -1115,10 +1166,20 @@ async function main(): Promise<void> {
   const forceRefit = process.argv.includes('--refit-coefficients');
   const dryRun = process.argv.includes('--dry-run');
   const allowEmptyBacktest = process.argv.includes('--allow-empty-backtest');
+  const contentPriorFile = process.argv
+    .find((arg) => arg.startsWith('--content-prior-file='))
+    ?.slice('--content-prior-file='.length);
+  // A candidate file is a diagnostic input — never let it flow into a real
+  // publish run, where it would persist un-vetted priors to board_climb_grades.
+  if (contentPriorFile && !dryRun && !process.argv.includes('--validate-only')) {
+    console.error('[grades] --content-prior-file requires --validate-only or --dry-run; refusing a write run with candidate priors.');
+    process.exitCode = 1;
+    return;
+  }
   const { db, close } = createScriptDb();
   try {
     if (process.argv.includes('--validate-only')) {
-      await validateOnly(db, allowEmptyBacktest);
+      await validateOnly(db, allowEmptyBacktest, contentPriorFile);
       return;
     }
     let coefficients = forceRefit ? null : await loadFrozenCoefficients(db);
@@ -1199,7 +1260,9 @@ async function main(): Promise<void> {
     const displayDeltaHygieneStats = createDisplayDeltaHygieneStats();
     for (const boardType of CROWD_MEAN_BOARDS) {
       console.log(`[grades] computing ${boardType}…`);
-      const contentPriors = await loadContentPriors(db, boardType);
+      const contentPriors = contentPriorFile
+        ? await loadContentPriorsFromFile(contentPriorFile, boardType)
+        : await loadContentPriors(db, boardType);
       const {
         computed,
         isotonicStats,
@@ -1210,6 +1273,17 @@ async function main(): Promise<void> {
       console.log(
         `[grades]   ${computed.length} climb+angle rows (isotonic moved ${isotonicStats.movedRows}, ${isotonicStats.residualInversions} residual inversions; display-delta hygiene downgraded ${boardDisplayDeltaHygieneStats.downgradedRows})`,
       );
+      if (contentPriorFile && backtestRows.length > 0 && contentPriors.size > 0) {
+        const contentBacktest = evaluateContentPriorBacktest(
+          backtestRows.filter((row) => row.board_type === boardType),
+          contentPriors,
+          coefficients,
+        );
+        gates.push(contentBacktest.gate);
+        console.log(
+          `[grades]   content_prior_backtest: ${contentBacktest.gate.passed ? 'PASS' : 'FAIL'} — ${contentBacktest.gate.detail}`,
+        );
+      }
     }
     const allComputed = [...computedByBoard.values()].flat();
     const noShockGate = evaluateNoShock(allComputed);

--- a/packages/db/scripts/refresh-climb-grades.ts
+++ b/packages/db/scripts/refresh-climb-grades.ts
@@ -1172,7 +1172,9 @@ async function main(): Promise<void> {
   // A candidate file is a diagnostic input — never let it flow into a real
   // publish run, where it would persist un-vetted priors to board_climb_grades.
   if (contentPriorFile && !dryRun && !process.argv.includes('--validate-only')) {
-    console.error('[grades] --content-prior-file requires --validate-only or --dry-run; refusing a write run with candidate priors.');
+    console.error(
+      '[grades] --content-prior-file requires --validate-only or --dry-run; refusing a write run with candidate priors.',
+    );
     process.exitCode = 1;
     return;
   }

--- a/packages/db/src/queries/grade-model/__tests__/content-prior-backtest.test.ts
+++ b/packages/db/src/queries/grade-model/__tests__/content-prior-backtest.test.ts
@@ -1,0 +1,218 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  contentPriorKey,
+  evaluateContentPriorBacktest,
+  parseContentPriorLine,
+  type BacktestSampleRow,
+  type ContentPriorEntry,
+} from '../gates';
+import type { GradeCoefficients } from '../types';
+
+/** Minimal coefficient set — the content-prior backtest only reads echoFraction. */
+function makeCoefficients(echoFraction: Record<string, number>): GradeCoefficients {
+  return {
+    coeffVersion: 'test',
+    echoFraction,
+    sigmaWithin: {},
+    tauSquared: {},
+    angleOffset: {},
+    boardOffset: {},
+    raterModel: {},
+    behaviorModel: {},
+    bridgeReadiness: {},
+  };
+}
+
+function makeRow(partial: Partial<BacktestSampleRow>): BacktestSampleRow {
+  return {
+    board_type: 'kilter',
+    climb_uuid: 'climb-1',
+    angle: 40,
+    snap_avg: 20,
+    snap_display: 20,
+    snap_count: 1,
+    final_avg: 20,
+    sibling_states: [],
+    ...partial,
+  };
+}
+
+/** Build a per-board content-prior map keyed exactly like the DB/file loaders. */
+function priorMap(entries: Array<{ climbUuid: string; angle: number; contentPrior: number; contentSd?: number }>) {
+  const map = new Map<string, ContentPriorEntry>();
+  for (const { climbUuid, angle, contentPrior, contentSd } of entries) {
+    map.set(contentPriorKey(climbUuid, angle), { contentPrior, contentSd: contentSd ?? null });
+  }
+  return map;
+}
+
+function approx(actual: number, expected: number, tolerance = 1e-9): void {
+  assert.ok(Math.abs(actual - expected) <= tolerance, `${actual} !~= ${expected}`);
+}
+
+void describe('evaluateContentPriorBacktest', () => {
+  void test('a candidate that tracks truth beats the honest display baseline', () => {
+    const coefficients = makeCoefficients({ kilter: 0.8 });
+    const rows: BacktestSampleRow[] = [];
+    const priors: Array<{ climbUuid: string; angle: number; contentPrior: number }> = [];
+    for (let i = 0; i < 10; i++) {
+      const climbUuid = `climb-${i}`;
+      rows.push(makeRow({ climb_uuid: climbUuid, final_avg: 20, snap_display: 23, snap_avg: 22 }));
+      priors.push({ climbUuid, angle: 40, contentPrior: 20.1 });
+    }
+    const summary = evaluateContentPriorBacktest(rows, priorMap(priors), coefficients);
+
+    assert.equal(summary.gate.gate, 'content_prior_backtest');
+    assert.equal(summary.gate.passed, true); // report-only, never blocks
+    assert.equal(summary.boardType, 'kilter');
+    approx(summary.coverage, 1);
+    assert.equal(summary.matchedRows, 10);
+    assert.equal(summary.totalRows, 10);
+    approx(summary.overall.contentMae, 0.1, 1e-9);
+    approx(summary.overall.earlyDisplayMae, 3, 1e-9);
+    approx(summary.overall.earlyCrowdMae, 2, 1e-9);
+    assert.ok(summary.overall.contentMae < summary.overall.earlyDisplayMae);
+    assert.ok(summary.overall.contentMae < summary.overall.earlyCrowdMae);
+  });
+
+  void test('stays report-only (passed) even when the candidate is worse than both baselines', () => {
+    const coefficients = makeCoefficients({ kilter: 0.8 });
+    const rows = [makeRow({ climb_uuid: 'c1', final_avg: 20, snap_display: 20, snap_avg: 20 })];
+    const summary = evaluateContentPriorBacktest(
+      rows,
+      priorMap([{ climbUuid: 'c1', angle: 40, contentPrior: 30 }]),
+      coefficients,
+    );
+    approx(summary.overall.contentMae, 10, 1e-9);
+    approx(summary.overall.earlyDisplayMae, 0, 1e-9);
+    assert.equal(summary.gate.passed, true);
+  });
+
+  void test('coverage reflects unmatched rows (candidates absent)', () => {
+    const coefficients = makeCoefficients({ kilter: 0.8 });
+    const rows = [
+      makeRow({ climb_uuid: 'a' }),
+      makeRow({ climb_uuid: 'b' }),
+      makeRow({ climb_uuid: 'c' }),
+      makeRow({ climb_uuid: 'd' }),
+    ];
+    // Only two of the four rows have a candidate prior.
+    const summary = evaluateContentPriorBacktest(
+      rows,
+      priorMap([
+        { climbUuid: 'a', angle: 40, contentPrior: 20 },
+        { climbUuid: 'c', angle: 40, contentPrior: 20 },
+      ]),
+      coefficients,
+    );
+    assert.equal(summary.totalRows, 4);
+    assert.equal(summary.matchedRows, 2);
+    approx(summary.coverage, 0.5);
+  });
+
+  void test('null snap_display rows drop out of both baselines but keep content coverage', () => {
+    const coefficients = makeCoefficients({ kilter: 0.8 });
+    const rows: BacktestSampleRow[] = [];
+    const priors: Array<{ climbUuid: string; angle: number; contentPrior: number }> = [];
+    // 2 display-comparable rows: crowd error 1 each.
+    for (let i = 0; i < 2; i++) {
+      const climbUuid = `disp-${i}`;
+      rows.push(makeRow({ climb_uuid: climbUuid, final_avg: 20, snap_display: 21, snap_avg: 21 }));
+      priors.push({ climbUuid, angle: 40, contentPrior: 20 });
+    }
+    // 3 null-display rows: a wild crowd error that must NOT leak into earlyCrowdMae.
+    for (let i = 0; i < 3; i++) {
+      const climbUuid = `nulldisp-${i}`;
+      rows.push(makeRow({ climb_uuid: climbUuid, final_avg: 20, snap_display: null, snap_avg: 30 }));
+      priors.push({ climbUuid, angle: 40, contentPrior: 20 });
+    }
+    const summary = evaluateContentPriorBacktest(rows, priorMap(priors), coefficients);
+
+    assert.equal(summary.matchedRows, 5);
+    assert.equal(summary.overall.displayNullRows, 3);
+    assert.equal(summary.overall.displayComparableRows, 2);
+    // Baselines are measured only on the 2 display-comparable rows.
+    approx(summary.overall.earlyDisplayMae, 1, 1e-9);
+    approx(summary.overall.earlyCrowdMae, 1, 1e-9);
+    // Content is scored on all 5 matched rows (all exactly right here → 0).
+    approx(summary.overall.contentMae, 0, 1e-9);
+  });
+
+  void test('stratifies by n_eff bucket at the boundaries (echo=0 ⇒ n_eff = snap_count)', () => {
+    const coefficients = makeCoefficients({ kilter: 0 });
+    const specs: Array<{ climbUuid: string; snapCount: number; bucket: string }> = [
+      { climbUuid: 'z0', snapCount: 0, bucket: '<1' }, // effectiveN(0) = 0
+      { climbUuid: 'a1', snapCount: 1, bucket: '[1,3)' }, // n_eff 1 (lower bound in-bucket)
+      { climbUuid: 'a2', snapCount: 2, bucket: '[1,3)' },
+      { climbUuid: 'b3', snapCount: 3, bucket: '[3,10)' }, // n_eff 3 crosses into next bucket
+      { climbUuid: 'b9', snapCount: 9, bucket: '[3,10)' },
+      { climbUuid: 'c10', snapCount: 10, bucket: '>=10' }, // n_eff 10 crosses again
+    ];
+    const rows = specs.map((spec) => makeRow({ climb_uuid: spec.climbUuid, snap_count: spec.snapCount }));
+    const priors = specs.map((spec) => ({ climbUuid: spec.climbUuid, angle: 40, contentPrior: 20 }));
+    const summary = evaluateContentPriorBacktest(rows, priorMap(priors), coefficients);
+
+    const byBucket = new Map(summary.buckets.map((bucket) => [bucket.bucket, bucket.n]));
+    assert.deepEqual(
+      summary.buckets.map((bucket) => bucket.bucket),
+      ['<1', '[1,3)', '[3,10)', '>=10'],
+    );
+    assert.equal(byBucket.get('<1'), 1);
+    assert.equal(byBucket.get('[1,3)'), 2);
+    assert.equal(byBucket.get('[3,10)'), 2);
+    assert.equal(byBucket.get('>=10'), 1);
+    assert.equal(summary.matchedRows, 6);
+  });
+
+  void test('empty input yields zeroed report, still report-only', () => {
+    const summary = evaluateContentPriorBacktest([], new Map(), makeCoefficients({ kilter: 0.8 }));
+    assert.equal(summary.totalRows, 0);
+    assert.equal(summary.matchedRows, 0);
+    approx(summary.coverage, 0);
+    assert.equal(summary.gate.passed, true);
+  });
+});
+
+void describe('parseContentPriorLine (candidate file loader)', () => {
+  void test('parses a well-formed record and defaults a missing contentSd to null', () => {
+    const result = parseContentPriorLine('{"climbUuid":"abc","angle":40,"contentPrior":21.5}', 'kilter');
+    assert.equal(result.status, 'ok');
+    if (result.status !== 'ok') return;
+    assert.equal(result.key, contentPriorKey('abc', 40));
+    assert.equal(result.entry.contentPrior, 21.5);
+    assert.equal(result.entry.contentSd, null);
+  });
+
+  void test('keeps a provided contentSd', () => {
+    const result = parseContentPriorLine(
+      '{"climbUuid":"abc","angle":40,"contentPrior":21.5,"contentSd":0.7}',
+      'kilter',
+    );
+    assert.equal(result.status, 'ok');
+    if (result.status !== 'ok') return;
+    assert.equal(result.entry.contentSd, 0.7);
+  });
+
+  void test('accepts a board-tagged record for the matching board', () => {
+    const result = parseContentPriorLine('{"climbUuid":"x","angle":50,"contentPrior":18,"board":"kilter"}', 'kilter');
+    assert.equal(result.status, 'ok');
+  });
+
+  void test('skips a record tagged for a different board', () => {
+    const result = parseContentPriorLine('{"climbUuid":"x","angle":50,"contentPrior":18,"board":"tension"}', 'kilter');
+    assert.equal(result.status, 'skip');
+  });
+
+  void test('flags malformed JSON and records missing required fields', () => {
+    assert.equal(parseContentPriorLine('{not json', 'kilter').status, 'malformed');
+    assert.equal(parseContentPriorLine('[]', 'kilter').status, 'malformed');
+    assert.equal(parseContentPriorLine('{"climbUuid":"x","contentPrior":18}', 'kilter').status, 'malformed'); // no angle
+    assert.equal(parseContentPriorLine('{"angle":40,"contentPrior":18}', 'kilter').status, 'malformed'); // no uuid
+    assert.equal(parseContentPriorLine('{"climbUuid":"x","angle":40}', 'kilter').status, 'malformed'); // no contentPrior
+    assert.equal(
+      parseContentPriorLine('{"climbUuid":"x","angle":40,"contentPrior":"soft"}', 'kilter').status,
+      'malformed',
+    ); // non-numeric contentPrior
+  });
+});

--- a/packages/db/src/queries/grade-model/gates.ts
+++ b/packages/db/src/queries/grade-model/gates.ts
@@ -6,7 +6,7 @@ import {
   GATE_RESIDUAL_PAIRED_GAP,
   GATE_TAIL_MAE_IMPROVEMENT,
 } from './constants';
-import { computePosteriorGrade } from './blend';
+import { computePosteriorGrade, echoFractionFor, effectiveN } from './blend';
 import type { BoardOffsetSampleRow } from './coefficients';
 import type { ClimbAngleObservation, GateResult, GradeCoefficients } from './types';
 
@@ -284,4 +284,228 @@ export function evaluateBacktest(rows: BacktestSampleRow[], coefficients: GradeC
       singleAngle: { n: single.n, rawMae: singleRawMae, shrunkMae: singleShrunkMae },
     },
   };
+}
+
+/**
+ * One offline Climb2Vec content-model estimate for a climb+angle. Mirrors the
+ * board_climb_embeddings columns the nightly refresh reads, so the file-injection
+ * path (candidate scoring) and the DB path share the same value shape and key.
+ */
+export interface ContentPriorEntry {
+  contentPrior: number;
+  contentSd: number | null;
+}
+
+/**
+ * Map key for a content prior. Deliberately board-less: callers hold a per-board
+ * map, so a climb+angle uniquely identifies a row within it. The NUL separator
+ * is safe because climb UUIDs never contain one.
+ */
+export function contentPriorKey(climbUuid: string, angle: number): string {
+  return `${climbUuid} ${angle}`;
+}
+
+/** n_eff strata for the content-prior backtest. Snapshot counts are 1–3, so on
+ * high-echo boards nearly all mass lands in [1,3); the wider buckets exist for
+ * low-echo boards (small λ) where n_eff(snap_count) can reach 3+. */
+const CONTENT_PRIOR_NEFF_BUCKETS = ['<1', '[1,3)', '[3,10)', '>=10'] as const;
+
+function contentPriorNEffBucket(nEff: number): (typeof CONTENT_PRIOR_NEFF_BUCKETS)[number] {
+  if (nEff < 1) return '<1';
+  if (nEff < 3) return '[1,3)';
+  if (nEff < 10) return '[3,10)';
+  return '>=10';
+}
+
+/** Per-bucket (and overall) error stats for the content-prior backtest report. */
+export interface ContentPriorBucketReport {
+  /** One of the n_eff buckets, or 'overall'. */
+  bucket: string;
+  /** Matched candidate rows in this bucket (the content/coverage denominator). */
+  n: number;
+  /** Mean |contentPrior − final_avg| over the n matched rows. */
+  contentMae: number;
+  /** Mean |snap_avg − final_avg| over display-comparable rows (raw early crowd). */
+  earlyCrowdMae: number;
+  /** Mean |snap_display − final_avg| over display-comparable rows (honest no-content baseline). */
+  earlyDisplayMae: number;
+  /** Matched rows with a non-null snap_display (the shared baseline denominator). */
+  displayComparableRows: number;
+  /** Matched rows whose snap_display was null (excluded from both baselines, counted here). */
+  displayNullRows: number;
+}
+
+export interface ContentPriorBacktestSummary {
+  boardType: string;
+  /** Backtest sample rows scored for this board (coverage denominator). */
+  totalRows: number;
+  /** Rows that had a candidate content prior in the file. */
+  matchedRows: number;
+  /** matchedRows / totalRows. */
+  coverage: number;
+  overall: ContentPriorBucketReport;
+  /** The four n_eff buckets in fixed order. */
+  buckets: ContentPriorBucketReport[];
+  /** Report-only gate ('content_prior_backtest', always passed) for the run's gate list. */
+  gate: GateResult;
+}
+
+interface ContentPriorAccumulator {
+  matched: number;
+  contentAbs: number;
+  displayComparable: number;
+  crowdAbs: number;
+  displayAbs: number;
+  displayNull: number;
+}
+
+function makeContentPriorAccumulator(): ContentPriorAccumulator {
+  return { matched: 0, contentAbs: 0, displayComparable: 0, crowdAbs: 0, displayAbs: 0, displayNull: 0 };
+}
+
+function toContentPriorBucketReport(bucket: string, acc: ContentPriorAccumulator): ContentPriorBucketReport {
+  return {
+    bucket,
+    n: acc.matched,
+    contentMae: acc.matched > 0 ? acc.contentAbs / acc.matched : 0,
+    earlyCrowdMae: acc.displayComparable > 0 ? acc.crowdAbs / acc.displayComparable : 0,
+    earlyDisplayMae: acc.displayComparable > 0 ? acc.displayAbs / acc.displayComparable : 0,
+    displayComparableRows: acc.displayComparable,
+    displayNullRows: acc.displayNull,
+  };
+}
+
+/**
+ * Score a CANDIDATE content-prior set against the same pre-registered backtest
+ * sample the crowd model is graded on. For every history snapshot whose series
+ * later reached ≥50 ascents (final_avg = truth), and for which the candidate
+ * file supplies a prior, we compare three errors against that truth:
+ *
+ *  - content: |contentPrior − final_avg| (the candidate)
+ *  - early-crowd: |snap_avg − final_avg| (the raw 1–3-ascent mean)
+ *  - display: |snap_display − final_avg| (what users saw pre-crowd — the honest
+ *    no-content baseline)
+ *
+ * The candidate is scored on every matched row; the two BASELINES share a
+ * denominator of rows with a non-null snap_display, so crowd-vs-display stays an
+ * apples-to-apples pair and null-display rows are reported separately rather than
+ * silently inflating either baseline. Errors are stratified by the snapshot's
+ * n_eff bucket (effectiveN(snap_count, echoFraction)).
+ *
+ * The map is keyed by contentPriorKey (board-less) — pass a per-board map and
+ * rows already filtered to that board (see refresh-climb-grades). The returned
+ * gate is REPORT-ONLY (never blocks): the backtest truth is itself herded toward
+ * the early label, so this is a diagnostic, not a pass/fail bar.
+ */
+export function evaluateContentPriorBacktest(
+  rows: BacktestSampleRow[],
+  contentPriors: Map<string, ContentPriorEntry>,
+  coefficients: GradeCoefficients,
+): ContentPriorBacktestSummary {
+  const boardType = rows[0]?.board_type ?? 'unknown';
+  const overall = makeContentPriorAccumulator();
+  const byBucket = new Map<string, ContentPriorAccumulator>();
+  for (const bucket of CONTENT_PRIOR_NEFF_BUCKETS) byBucket.set(bucket, makeContentPriorAccumulator());
+
+  let matchedRows = 0;
+  for (const row of rows) {
+    const entry = contentPriors.get(contentPriorKey(row.climb_uuid, Number(row.angle)));
+    if (!entry || !Number.isFinite(entry.contentPrior)) continue;
+    matchedRows += 1;
+
+    const finalAvg = Number(row.final_avg);
+    const contentError = Math.abs(Number(entry.contentPrior) - finalAvg);
+    const crowdError = Math.abs(Number(row.snap_avg) - finalAvg);
+    const hasDisplay = row.snap_display !== null && Number.isFinite(Number(row.snap_display));
+    const displayError = hasDisplay ? Math.abs(Number(row.snap_display) - finalAvg) : 0;
+
+    const nEff = effectiveN(Number(row.snap_count), echoFractionFor(coefficients, row.board_type));
+    const bucketKey = contentPriorNEffBucket(nEff);
+    let bucketAcc = byBucket.get(bucketKey);
+    if (!bucketAcc) {
+      bucketAcc = makeContentPriorAccumulator();
+      byBucket.set(bucketKey, bucketAcc);
+    }
+
+    for (const acc of [overall, bucketAcc]) {
+      acc.matched += 1;
+      acc.contentAbs += contentError;
+      if (hasDisplay) {
+        acc.displayComparable += 1;
+        acc.crowdAbs += crowdError;
+        acc.displayAbs += displayError;
+      } else {
+        acc.displayNull += 1;
+      }
+    }
+  }
+
+  const overallReport = toContentPriorBucketReport('overall', overall);
+  const buckets = CONTENT_PRIOR_NEFF_BUCKETS.map((bucket) =>
+    toContentPriorBucketReport(bucket, byBucket.get(bucket) ?? makeContentPriorAccumulator()),
+  );
+  const totalRows = rows.length;
+  const coverage = totalRows > 0 ? matchedRows / totalRows : 0;
+
+  const bucketTable =
+    buckets
+      .filter((bucket) => bucket.n > 0)
+      .map(
+        (bucket) =>
+          `${bucket.bucket} n=${bucket.n} c${bucket.contentMae.toFixed(2)}/d${bucket.earlyDisplayMae.toFixed(2)}/x${bucket.earlyCrowdMae.toFixed(2)}`,
+      )
+      .join(' | ') || 'none';
+
+  const gate: GateResult = {
+    gate: 'content_prior_backtest',
+    passed: true,
+    detail:
+      `${boardType}: coverage ${(coverage * 100).toFixed(1)}% (${matchedRows}/${totalRows}); ` +
+      `content MAE ${overallReport.contentMae.toFixed(3)} vs display ${overallReport.earlyDisplayMae.toFixed(3)} ` +
+      `vs early-crowd ${overallReport.earlyCrowdMae.toFixed(3)} over ${overallReport.displayComparableRows} ` +
+      `display-comparable rows (${overallReport.displayNullRows} null-display); buckets [${bucketTable}]`,
+    metrics: {
+      totalRows,
+      matchedRows,
+      coverage,
+      contentMae: overallReport.contentMae,
+      earlyCrowdMae: overallReport.earlyCrowdMae,
+      earlyDisplayMae: overallReport.earlyDisplayMae,
+      displayComparableRows: overallReport.displayComparableRows,
+      displayNullRows: overallReport.displayNullRows,
+    },
+  };
+
+  return { boardType, totalRows, matchedRows, coverage, overall: overallReport, buckets, gate };
+}
+
+/** Outcome of parsing one JSONL line of a candidate content-prior file. */
+export type ContentPriorLineResult =
+  | { status: 'ok'; key: string; entry: ContentPriorEntry }
+  | { status: 'skip' }
+  | { status: 'malformed' };
+
+/**
+ * Parse one JSONL record `{climbUuid, angle, contentPrior, contentSd?, board?}`
+ * from a candidate content-prior file. Bad JSON or a missing/invalid required
+ * field → 'malformed'; a well-formed record whose `board` names a different
+ * board → 'skip'; otherwise 'ok' with the map key + entry. Pure so the file
+ * loader (refresh-climb-grades) can stream lines through it and stay testable.
+ */
+export function parseContentPriorLine(line: string, boardType: string): ContentPriorLineResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return { status: 'malformed' };
+  }
+  if (typeof parsed !== 'object' || parsed === null) return { status: 'malformed' };
+  const record = parsed as Record<string, unknown>;
+  const { climbUuid, angle, contentPrior, contentSd, board } = record;
+  if (typeof climbUuid !== 'string' || climbUuid.length === 0) return { status: 'malformed' };
+  if (typeof angle !== 'number' || !Number.isFinite(angle)) return { status: 'malformed' };
+  if (typeof contentPrior !== 'number' || !Number.isFinite(contentPrior)) return { status: 'malformed' };
+  if (typeof board === 'string' && board !== boardType) return { status: 'skip' };
+  const sd = typeof contentSd === 'number' && Number.isFinite(contentSd) ? contentSd : null;
+  return { status: 'ok', key: contentPriorKey(climbUuid, angle), entry: { contentPrior, contentSd: sd } };
 }

--- a/packages/db/src/queries/hold-features/__tests__/extract-training-matrix.test.ts
+++ b/packages/db/src/queries/hold-features/__tests__/extract-training-matrix.test.ts
@@ -17,8 +17,20 @@ const feature = (placementId: number, overrides: Record<string, unknown> = {}) =
   ...overrides,
 });
 
+// A Kilter-ish echo share; matches the model default so the de-herd is exercised.
+const ECHO = 0.85;
+
 void describe('buildTrainingRow', () => {
-  const stat = { climb_uuid: 'abc', angle: 40, label: 18.5, n: 120, layout_id: 1, fingerprint: 'fp1' };
+  const stat = {
+    climb_uuid: 'abc',
+    angle: 40,
+    label: 18.5,
+    n: 120,
+    layout_id: 1,
+    fingerprint: 'fp1',
+    display: 17,
+    benchmark: null,
+  };
 
   test('joins holds to their features and maps roles', () => {
     const features = new Map([
@@ -33,6 +45,8 @@ void describe('buildTrainingRow', () => {
         { placement_id: 30, hold_state: 'STARTING' }, // no feature row → nulls, still a hand hold
       ],
       features,
+      'kilter',
+      ECHO,
     );
     assert.equal(row.climbUuid, 'abc');
     assert.equal(row.angle, 40);
@@ -56,7 +70,71 @@ void describe('buildTrainingRow', () => {
         { placement_id: 11, hold_state: 'NaN=undefined' }, // known bad-parse rows
       ],
       new Map([[10, feature(10)]]),
+      'kilter',
+      ECHO,
     );
     assert.equal(row.holds.length, 1);
+  });
+
+  test('tags every row with the board', () => {
+    const row = buildTrainingRow(
+      { ...stat, display: null },
+      [{ placement_id: 10, hold_state: 'HAND' }],
+      new Map([[10, feature(10)]]),
+      'tension',
+      ECHO,
+    );
+    assert.equal(row.board, 'tension');
+  });
+
+  test('passes the benchmark grade through, null when absent', () => {
+    const holds = [{ placement_id: 10, hold_state: 'HAND' }];
+    const features = new Map([[10, feature(10)]]);
+    const withBenchmark = buildTrainingRow({ ...stat, benchmark: 21 }, holds, features, 'tension', ECHO);
+    assert.equal(withBenchmark.benchmark, 21);
+    const withoutBenchmark = buildTrainingRow({ ...stat, benchmark: null }, holds, features, 'tension', ECHO);
+    assert.equal(withoutBenchmark.benchmark, null);
+  });
+
+  test('de-herds the crowd label when the evidence is eligible', () => {
+    // label 18.5 sits above display 17; with λ=0.85 the display-anchored delta is
+    // divided out (17 + 1.5/0.15 = 27) then capped at ±0.75 from the observed mean
+    // (STAGE2_DEECHO_MAX_MOVE) → 19.25. Mirrors applyCappedStage2Evidence.
+    const row = buildTrainingRow(
+      { ...stat, label: 18.5, display: 17, n: 120 },
+      [{ placement_id: 10, hold_state: 'HAND' }],
+      new Map([[10, feature(10)]]),
+      'kilter',
+      ECHO,
+    );
+    assert.equal(row.deherdedLabel, 19.25);
+    assert.equal((row.deherdedLabel as number) > row.label, true);
+  });
+
+  test('de-echo division is exact when the move stays inside the cap', () => {
+    // A small display-anchored delta (0.09) de-echoes to a ~0.6 move — inside the
+    // ±0.75 observed cap, so this pins the 1/(1−λ) division itself, not the cap.
+    // A wrong λ would land elsewhere and fail here where the capped case can't.
+    const row = buildTrainingRow(
+      { ...stat, label: 17.09, display: 17, n: 120 },
+      [{ placement_id: 10, hold_state: 'HAND' }],
+      new Map([[10, feature(10)]]),
+      'kilter',
+      ECHO,
+    );
+    const expected = 17 + (17.09 - 17) / (1 - ECHO);
+    assert.equal(row.deherdedLabel, expected);
+    assert.equal(Math.abs((row.deherdedLabel as number) - 17.09) < 0.75, true);
+  });
+
+  test('deherdedLabel falls back to the raw label when the de-herd is ineligible', () => {
+    const holds = [{ placement_id: 10, hold_state: 'HAND' }];
+    const features = new Map([[10, feature(10)]]);
+    // No display grade to anchor to → de-herd passes the observed mean straight through.
+    const noDisplay = buildTrainingRow({ ...stat, display: null }, holds, features, 'kilter', ECHO);
+    assert.equal(noDisplay.deherdedLabel, noDisplay.label);
+    // Too few independent opinions (effectiveN < 3) → thin-evidence passthrough.
+    const thin = buildTrainingRow({ ...stat, n: 5 }, holds, features, 'kilter', ECHO);
+    assert.equal(thin.deherdedLabel, thin.label);
   });
 });

--- a/packages/db/src/queries/hold-features/training-matrix.ts
+++ b/packages/db/src/queries/hold-features/training-matrix.ts
@@ -3,7 +3,14 @@
  * stat row to its holds and each hold's generated board_hold_features. The I/O
  * (SQL + JSONL) lives in `packages/db/scripts/extract-training-matrix.ts`; this
  * module is the testable core.
+ *
+ * DB-free by construction: the de-echo math reuses the pure grade-model helpers
+ * (`deherdCrowdMean`, `effectiveN`), so `deherdedLabel` here matches production's
+ * Stage-2 de-herd (see `applyCappedStage2Evidence` in refresh-climb-grades.ts).
  */
+import { effectiveN } from '../grade-model/blend.js';
+import { STAGE2_DEECHO_MAX_MOVE } from '../grade-model/constants.js';
+import { deherdCrowdMean } from '../grade-model/deherded.js';
 
 /** A placement's generated features, as read from board_hold_features. */
 export interface HoldFeatureLite {
@@ -27,6 +34,10 @@ export interface ClimbStatLite {
   n: number;
   layout_id: number | null;
   fingerprint: string | null;
+  /** display_difficulty: the anchor the crowd echoes; de-herd needs it. Null when unset. */
+  display: number | null;
+  /** benchmark_difficulty: setter-trusted grade held out for validation. Null for most climbs. */
+  benchmark: number | null;
 }
 
 /** A hold on a climb after resolving its board-specific storage id to a placement id. */
@@ -58,6 +69,12 @@ export interface TrainingRow {
   ascents: number;
   layoutId: number | null;
   fingerprint: string | null;
+  /** Which board this row came from, so mixed-board datasets stay separable. */
+  board: string;
+  /** Crowd mean with the echo (quick-log copies of the display grade) divided out; falls back to `label` when the de-herd can't apply. Null only when there is no observed mean. */
+  deherdedLabel: number | null;
+  /** Setter-trusted benchmark grade for held-out validation; null for un-benchmarked climbs. */
+  benchmark: number | null;
   holds: TrainingHold[];
 }
 
@@ -67,11 +84,26 @@ function toNumber(value: unknown): number {
   return typeof value === 'number' ? value : Number(value);
 }
 
-/** Join a stat row to its holds and their features into one training example. */
+/** Coerce a possibly-null / string-typed numeric column to a finite number or null. */
+function toNumberOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Join a stat row to its holds and their features into one training example.
+ *
+ * `board` tags the row; `echoFraction` is the board's quick-log echo share (λ)
+ * used to de-herd the crowd label — mirror of production's Stage-2 de-herd so
+ * `deherdedLabel` is train-on-able without re-running the grade pipeline.
+ */
 export function buildTrainingRow(
   stat: ClimbStatLite,
   holds: readonly HoldLite[],
   featureByPlacement: ReadonlyMap<number, HoldFeatureLite>,
+  board: string,
+  echoFraction: number,
 ): TrainingRow {
   const trainingHolds: TrainingHold[] = [];
   for (const hold of holds) {
@@ -93,13 +125,35 @@ export function buildTrainingRow(
       footSet: feature?.coarse_type === 'foot',
     });
   }
+
+  const observedMean = toNumber(stat.label);
+  const ascents = toNumber(stat.n);
+  // Same de-herd as applyCappedStage2Evidence: discount the crowd count for echo,
+  // divide the display-anchored delta out, cap the move. deherdCrowdMean already
+  // returns `observedMean` for the non-eligible branches (thin evidence, no
+  // display, no echo) and null only when the observed mean itself is missing —
+  // so `.grade` reproduces production's `finite ? grade : observedMean` exactly.
+  const rawEffectiveN = effectiveN(ascents, echoFraction);
+  const deherded = deherdCrowdMean(
+    {
+      observedMean,
+      displayGrade: toNumberOrNull(stat.display),
+      echoFraction,
+      independentWeight: rawEffectiveN,
+    },
+    { maxMoveFromObserved: STAGE2_DEECHO_MAX_MOVE },
+  );
+
   return {
     climbUuid: stat.climb_uuid,
     angle: toNumber(stat.angle),
-    label: toNumber(stat.label),
-    ascents: toNumber(stat.n),
+    label: observedMean,
+    ascents,
     layoutId: stat.layout_id === null ? null : toNumber(stat.layout_id),
     fingerprint: stat.fingerprint,
+    board,
+    deherdedLabel: deherded.grade,
+    benchmark: toNumberOrNull(stat.benchmark),
     holds: trainingHolds,
   };
 }

--- a/packages/db/src/queries/hold-features/training-matrix.ts
+++ b/packages/db/src/queries/hold-features/training-matrix.ts
@@ -141,6 +141,8 @@ export function buildTrainingRow(
       echoFraction,
       independentWeight: rawEffectiveN,
     },
+    // Same value as the option's default — spelled out only to mirror the
+    // applyCappedStage2Evidence call site verbatim; every other option is default.
     { maxMoveFromObserved: STAGE2_DEECHO_MAX_MOVE },
   );
 


### PR DESCRIPTION
## Summary

Two related pieces of Climb2Vec Stage-3 evaluation infrastructure:

**1. Extract fields** — three additive per-row fields in the training extract so the offline model can train on the de-echoed crowd mean, hold out manufacturer benchmarks (Tension: 2,867 curated; Moon: 2,893) as trusted validation, and mix boards in one dataset:
- **`board`** — the `--board` CLI arg on every row (pids collide across boards; identity must key on `(board, pid)`).
- **`deherdedLabel`** — `deherdCrowdMean` with the board's frozen `echo_fraction` — an exact mirror of the nightly pipeline's de-herd.
- **`benchmark`** — `board_climb_stats.benchmark_difficulty` passthrough.

**2. Content-prior gate battery** — a `--content-prior-file=<path>` flag on `db:refresh-climb-grades` injects candidate priors (JSONL) at the existing `computeBoard` seam, and a new report-only `content_prior_backtest` gate scores them on the pre-registered early-snapshot-vs-settled backtest sample against the early-display and early-crowd baselines, bucketed by effective-N. Restricted to `--validate-only`/`--dry-run` — a real publish run with a candidate file is refused. Read-only end to end.

First full-coverage run (kilter, n=245 backtest rows, 96.5% coverage):

| candidate | MAE vs settled mean |
|---|---|
| early setter display | 0.758 |
| early crowd (1–3 ascents) | 0.757 |
| GBM on hold features | 1.284 |
| shipped net prior | 1.586 |

All blocking gates PASS with either candidate injected (content only enters Regime 3). Follow-up analysis (echo-decontaminated target) is in progress before any pipeline change is proposed.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:db` clean; grade-model suite 83/83 (incl. 11 new `content-prior-backtest` tests) via `node --import tsx --test`; touched-suite extract tests 7/7.
- Two QA review passes (extract fields; backtest/injection) — both approve; advisories applied (write-run guard, staleness-log, direct imports, tighter de-echo test).
- Live `--validate-only` runs against prod (read-only) with both candidate files: all gates PASS, `validate-only done (nothing written)`.
- Note: `vp run test:db`'s glob currently never collects `src/queries/grade-model/__tests__/*` (pre-existing collection gap, verified) — the suite passes via the direct runner; worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHTC497LJUWygVAye2wchm