### PR TITLE
feat(web): per-board app-install QR code on the kiosk

### DIFF
--- a/packages/backend/src/__tests__/gym-kiosks.test.ts
+++ b/packages/backend/src/__tests__/gym-kiosks.test.ts
@@ -515,6 +515,8 @@ describe('updateGymKiosk layout validation', () => {
     );
     expect(updated.boards.map((b) => b.boardUuid)).toEqual([boardPub1.uuid, boardPub2.uuid]);
     expect(updated.boards.every((b) => b.boardId != null)).toBe(true);
+    // The install-QR needs each board's public slug. insertBoard seeds slug = uuid.
+    expect(updated.boards.map((b) => b.slug)).toEqual([boardPub1.uuid, boardPub2.uuid]);
   });
 
   it('persists the schema-parsed layout, stripping unknown keys', async () => {
@@ -643,6 +645,8 @@ describe('gymKiosk public read', () => {
     );
     // The private board is dropped from the resolved boards...
     expect(kiosk!.boards.map((b) => b.boardUuid)).toEqual([boardPub1.uuid]);
+    // ...and the surviving public board exposes its slug for the install QR.
+    expect(kiosk!.boards.map((b) => b.slug)).toEqual([boardPub1.uuid]);
     // ...but the layout JSON still records the slot (renderer degrades the preset).
     expect(kiosk!.layout.boards.map((slot) => slot.boardUuid)).toEqual([boardPub1.uuid, boardPriv.uuid]);
   });

--- a/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
@@ -81,6 +81,7 @@ async function deriveUniqueKioskSlug(gymId: number, name: string): Promise<strin
 type ResolvedKioskBoard = {
   boardId: number;
   boardUuid: string;
+  slug: string;
   name: string;
   boardType: string;
   layoutId: number;
@@ -143,6 +144,7 @@ async function resolveKioskView(
         visibleByUuid.set(row.uuid, {
           boardId: row.id,
           boardUuid: row.uuid,
+          slug: row.slug,
           name: row.name,
           boardType: row.boardType,
           layoutId: Number(row.layoutId),
@@ -161,6 +163,7 @@ async function resolveKioskView(
         visibleByUuid.set(board.uuid, {
           boardId: board.boardId,
           boardUuid: board.uuid,
+          slug: board.slug,
           name: board.name,
           boardType: board.boardType,
           layoutId: board.layoutId,

--- a/packages/db/src/schema/app/gym-kiosks.ts
+++ b/packages/db/src/schema/app/gym-kiosks.ts
@@ -36,7 +36,18 @@ export const gymKiosks = pgTable(
     // would pull @boardsesh/kiosk (TS `main`) into the compiled drizzle output,
     // breaking `drizzle-kit generate` (it loads dist as JS). A layout-version
     // bump is a documented hard cutover and must update this literal in lockstep.
-    layout: jsonb('layout').$type<KioskLayout>().default({ version: 1, boards: [], leaderboard: null }).notNull(),
+    //
+    // `showInstallQr` (an additive, optional field) is deliberately omitted from
+    // this literal: the lenient reader defaults an absent value to false, so a
+    // row created from this column default reads correctly without carrying the
+    // key — and keeping the literal byte-identical means the additive field
+    // needs no column-default migration. New kiosks are inserted with
+    // emptyKioskLayout() (which sets it) by the resolver regardless. The cast
+    // reconciles the intentionally-partial literal with the full KioskLayout type.
+    layout: jsonb('layout')
+      .$type<KioskLayout>()
+      .default({ version: 1, boards: [], leaderboard: null } as unknown as KioskLayout)
+      .notNull(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
     deletedAt: timestamp('deleted_at'),

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2983,6 +2983,8 @@ type GymKioskBoard {
   boardId: Int!
   "The board's immutable UUID (stable across board renames)."
   boardUuid: ID!
+  "Public URL slug (userBoards.slug) — the kiosk's per-board install QR deep-links to /b/{slug}."
+  slug: String!
   "Board display name."
   name: String!
   "Board type (kilter, tension, moonboard, ...)."

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2228,6 +2228,8 @@ export type GymKioskBoard = {
   setIds: Scalars['String']['output'];
   /** Product size ID. */
   sizeId: Scalars['Int']['output'];
+  /** Public URL slug (userBoards.slug) — the kiosk's per-board install QR deep-links to /b/{slug}. */
+  slug: Scalars['String']['output'];
 };
 
 /** A member of a gym. */
@@ -8718,6 +8720,7 @@ export type GymKioskBoardResolvers<
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   setIds?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   sizeId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/packages/shared-schema/src/schema/gym-kiosks.ts
+++ b/packages/shared-schema/src/schema/gym-kiosks.ts
@@ -21,6 +21,8 @@ export const gymKiosksTypeDefs = /* GraphQL */ `
     boardId: Int!
     "The board's immutable UUID (stable across board renames)."
     boardUuid: ID!
+    "Public URL slug (userBoards.slug) — the kiosk's per-board install QR deep-links to /b/{slug}."
+    slug: String!
     "Board display name."
     name: String!
     "Board type (kilter, tension, moonboard, ...)."

--- a/packages/shared-schema/src/types/gym-kiosks.ts
+++ b/packages/shared-schema/src/types/gym-kiosks.ts
@@ -10,6 +10,8 @@ import type { Gym } from './gyms';
 export type GymKioskBoard = {
   boardId: number;
   boardUuid: string;
+  /** Public URL slug (userBoards.slug) — the kiosk's per-board install QR deep-links to /b/{slug}. */
+  slug: string;
   name: string;
   boardType: string;
   layoutId: number;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2225,6 +2225,8 @@ export type GymKioskBoard = {
   setIds: Scalars['String']['output'];
   /** Product size ID. */
   sizeId: Scalars['Int']['output'];
+  /** Public URL slug (userBoards.slug) — the kiosk's per-board install QR deep-links to /b/{slug}. */
+  slug: Scalars['String']['output'];
 };
 
 /** A member of a gym. */

--- a/packages/shared/graphql/src/operations/gym-kiosks.ts
+++ b/packages/shared/graphql/src/operations/gym-kiosks.ts
@@ -10,6 +10,7 @@ import type { Gym, GymKiosk, CreateGymKioskInput, UpdateGymKioskInput } from '@b
 const GYM_KIOSK_BOARD_FIELDS = `
   boardId
   boardUuid
+  slug
   name
   boardType
   layoutId

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -22,6 +22,9 @@
     "litBy": "lit by {{name}}",
     "unnamedClimb": "Unnamed climb"
   },
+  "installQr": {
+    "caption": "Scan to log this wall"
+  },
   "leaderboard": {
     "periodSession": "Session leaderboard",
     "periodLast24h": "Last 24 hours",
@@ -212,6 +215,9 @@
       "previewUnavailable": "{{name}} can't render here",
       "slotDuplicateError": "This board is already on another slot.",
       "scopeInvalidError": "Pick one of the kiosk's boards.",
+      "installQrHeading": "App-install QR",
+      "installQrSwitch": "Show the app-install QR on each board",
+      "installQrHelper": "Each board shows a code climbers scan to get Boardsesh and log their sends on that wall.",
       "discardTitle": "Discard changes?",
       "discardBody": "Your layout edits aren't saved yet.",
       "keepEditing": "Keep editing",

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -22,6 +22,9 @@
     "litBy": "encendido por {{name}}",
     "unnamedClimb": "Bloque sin nombre"
   },
+  "installQr": {
+    "caption": "Escanea para registrar este muro"
+  },
   "leaderboard": {
     "periodSession": "Clasificación de la sesión",
     "periodLast24h": "Últimas 24 horas",
@@ -212,6 +215,9 @@
       "previewUnavailable": "{{name}} no se puede mostrar aquí",
       "slotDuplicateError": "Este plafón ya está en otra posición.",
       "scopeInvalidError": "Elige uno de los plafones del kiosco.",
+      "installQrHeading": "QR de instalación",
+      "installQrSwitch": "Mostrar el QR de instalación en cada plafón",
+      "installQrHelper": "Cada plafón muestra un código que los escaladores escanean para conseguir Boardsesh y registrar sus encadenes en ese muro.",
       "discardTitle": "¿Descartar los cambios?",
       "discardBody": "Tus cambios de diseño aún no están guardados.",
       "keepEditing": "Seguir editando",

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -22,6 +22,9 @@
     "litBy": "allumé par {{name}}",
     "unnamedClimb": "Bloc sans nom"
   },
+  "installQr": {
+    "caption": "Scanne pour enregistrer ce mur"
+  },
   "leaderboard": {
     "periodSession": "Classement de la séance",
     "periodLast24h": "Dernières 24 heures",
@@ -212,6 +215,9 @@
       "previewUnavailable": "{{name}} ne peut pas s'afficher ici",
       "slotDuplicateError": "Cette board occupe déjà un autre emplacement.",
       "scopeInvalidError": "Choisis une des boards de la borne.",
+      "installQrHeading": "QR d'installation",
+      "installQrSwitch": "Afficher le QR d'installation sur chaque board",
+      "installQrHelper": "Chaque board affiche un code que les grimpeurs scannent pour installer Boardsesh et enregistrer leurs croix sur ce mur.",
       "discardTitle": "Abandonner les modifications ?",
       "discardBody": "Tes changements de disposition ne sont pas encore enregistrés.",
       "keepEditing": "Continuer à modifier",

--- a/packages/shared/kiosk/src/__tests__/kiosk-config.test.ts
+++ b/packages/shared/kiosk/src/__tests__/kiosk-config.test.ts
@@ -121,6 +121,37 @@ describe('KioskLayoutSchema (strict writer)', () => {
     expect(KioskLayoutSchema.safeParse({ version: 2, boards: [], leaderboard: null }).success).toBe(false);
   });
 
+  it('defaults showInstallQr to false when omitted', () => {
+    const parsed = KioskLayoutSchema.safeParse({ version: KIOSK_LAYOUT_VERSION, boards: [], leaderboard: null });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.showInstallQr).toBe(false);
+    }
+  });
+
+  it('accepts an explicit showInstallQr toggle', () => {
+    const parsed = KioskLayoutSchema.safeParse({
+      version: KIOSK_LAYOUT_VERSION,
+      boards: [slot(BOARD_A)],
+      leaderboard: null,
+      showInstallQr: true,
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.showInstallQr).toBe(true);
+    }
+  });
+
+  it('rejects a non-boolean showInstallQr', () => {
+    const parsed = KioskLayoutSchema.safeParse({
+      version: KIOSK_LAYOUT_VERSION,
+      boards: [],
+      leaderboard: null,
+      showInstallQr: 'yes',
+    });
+    expect(parsed.success).toBe(false);
+  });
+
   it('accepts a rail scoped to all boards (boardUuid null)', () => {
     const parsed = KioskLayoutSchema.safeParse({
       version: KIOSK_LAYOUT_VERSION,
@@ -347,6 +378,35 @@ describe('parseKioskLayoutLenient (forward-compat reader)', () => {
     });
     expect(result.layout.leaderboard).toEqual({ boardUuid: BOARD_B, period: 'day' });
     expect(result.droppedLeaderboard).toBe(false);
+  });
+
+  it('defaults showInstallQr to false when the field is absent', () => {
+    const result = parseKioskLayoutLenient({
+      version: KIOSK_LAYOUT_VERSION,
+      boards: [slot(BOARD_A)],
+      leaderboard: null,
+    });
+    expect(result.layout.showInstallQr).toBe(false);
+  });
+
+  it('keeps an explicit showInstallQr: true', () => {
+    const result = parseKioskLayoutLenient({
+      version: KIOSK_LAYOUT_VERSION,
+      boards: [slot(BOARD_A)],
+      leaderboard: null,
+      showInstallQr: true,
+    });
+    expect(result.layout.showInstallQr).toBe(true);
+  });
+
+  it('drops a malformed showInstallQr to false', () => {
+    const result = parseKioskLayoutLenient({
+      version: KIOSK_LAYOUT_VERSION,
+      boards: [slot(BOARD_A)],
+      leaderboard: null,
+      showInstallQr: 'yes',
+    });
+    expect(result.layout.showInstallQr).toBe(false);
   });
 
   it('produces a layout the strict schema re-accepts', () => {

--- a/packages/shared/kiosk/src/__tests__/kiosk-config.test.ts
+++ b/packages/shared/kiosk/src/__tests__/kiosk-config.test.ts
@@ -213,6 +213,10 @@ describe('KioskLayoutSchema (strict writer)', () => {
       version: KIOSK_LAYOUT_VERSION,
       boards: [slot(BOARD_A)],
       leaderboard: { boardUuid: BOARD_A, period: 'week' },
+      // showInstallQr is a KNOWN writer-schema field (default false), so it
+      // rides along in the parsed output — the unknown keys (theme/variant/
+      // style) are what this test pins as stripped.
+      showInstallQr: false,
     });
   });
 });

--- a/packages/shared/kiosk/src/kiosk-config.ts
+++ b/packages/shared/kiosk/src/kiosk-config.ts
@@ -52,6 +52,11 @@ export const KioskLayoutSchema = z
     version: z.literal(KIOSK_LAYOUT_VERSION),
     boards: z.array(KioskBoardSlotSchema).max(MAX_KIOSK_BOARDS),
     leaderboard: KioskLeaderboardSchema.nullable().default(null),
+    // Per-kiosk toggle: when true, every board renders its own "install
+    // Boardsesh" QR (a deep link to that board) so climbers on the wall can get
+    // the app and feed the screen. Additive + defaulted, so older stored layouts
+    // (and the lenient reader below) read it as false without a version bump.
+    showInstallQr: z.boolean().default(false),
   })
   .superRefine((layout, ctx) => {
     const seen = new Set<string>();
@@ -84,7 +89,7 @@ export type KioskLayout = z.infer<typeof KioskLayoutSchema>;
 
 /** The default empty layout a freshly created kiosk row stores. */
 export function emptyKioskLayout(): KioskLayout {
-  return { version: KIOSK_LAYOUT_VERSION, boards: [], leaderboard: null };
+  return { version: KIOSK_LAYOUT_VERSION, boards: [], leaderboard: null, showInstallQr: false };
 }
 
 export interface LenientKioskLayoutResult {
@@ -124,7 +129,12 @@ export function parseKioskLayoutLenient(value: unknown): LenientKioskLayoutResul
     return { layout: emptyKioskLayout(), droppedBoardCount: 0, droppedLeaderboard: false };
   }
 
-  const record = value as { version?: unknown; boards?: unknown; leaderboard?: unknown };
+  const record = value as {
+    version?: unknown;
+    boards?: unknown;
+    leaderboard?: unknown;
+    showInstallQr?: unknown;
+  };
 
   if (record.version !== KIOSK_LAYOUT_VERSION) {
     // Wholesale discard: the layout is uninterpretable under this code, but the
@@ -135,6 +145,10 @@ export function parseKioskLayoutLenient(value: unknown): LenientKioskLayoutResul
       droppedLeaderboard: record.leaderboard !== null && record.leaderboard !== undefined,
     };
   }
+
+  // Booleans need no repair: an absent field or any non-`true` value (including a
+  // malformed one) reads as false — the safe off default for a new toggle.
+  const showInstallQr = record.showInstallQr === true;
 
   const boards: KioskBoardSlot[] = [];
   let droppedBoardCount = 0;
@@ -174,7 +188,7 @@ export function parseKioskLayoutLenient(value: unknown): LenientKioskLayoutResul
   }
 
   return {
-    layout: { version: KIOSK_LAYOUT_VERSION, boards, leaderboard },
+    layout: { version: KIOSK_LAYOUT_VERSION, boards, leaderboard, showInstallQr },
     droppedBoardCount,
     droppedLeaderboard,
   };

--- a/packages/web/app/components/gym-entity/manage/__tests__/kiosk-editor-state.test.ts
+++ b/packages/web/app/components/gym-entity/manage/__tests__/kiosk-editor-state.test.ts
@@ -7,6 +7,7 @@ import {
   moveBoardSlot,
   removeBoardSlot,
   serializeKioskLayout,
+  setInstallQrEnabled,
   setLeaderboardEnabled,
   setLeaderboardPeriod,
   setLeaderboardScope,
@@ -20,8 +21,12 @@ const boardC = '33333333-3333-4333-8333-333333333333';
 const boardD = '44444444-4444-4444-8444-444444444444';
 const boardE = '55555555-5555-4555-8555-555555555555';
 
-function stateWith(boardUuids: string[], leaderboard: KioskEditorState['leaderboard'] = null): KioskEditorState {
-  return { boardUuids, leaderboard };
+function stateWith(
+  boardUuids: string[],
+  leaderboard: KioskEditorState['leaderboard'] = null,
+  showInstallQr = false,
+): KioskEditorState {
+  return { boardUuids, leaderboard, showInstallQr };
 }
 
 describe('editorStateFromLayout', () => {
@@ -36,8 +41,22 @@ describe('editorStateFromLayout', () => {
   });
 
   it('degrades corrupt input to an empty state instead of throwing', () => {
-    expect(editorStateFromLayout('garbage')).toEqual({ boardUuids: [], leaderboard: null });
-    expect(editorStateFromLayout(emptyKioskLayout())).toEqual({ boardUuids: [], leaderboard: null });
+    expect(editorStateFromLayout('garbage')).toEqual({ boardUuids: [], leaderboard: null, showInstallQr: false });
+    expect(editorStateFromLayout(emptyKioskLayout())).toEqual({
+      boardUuids: [],
+      leaderboard: null,
+      showInstallQr: false,
+    });
+  });
+
+  it('reads the showInstallQr toggle', () => {
+    const state = editorStateFromLayout({
+      version: 1,
+      boards: [{ boardUuid: boardA }],
+      leaderboard: null,
+      showInstallQr: true,
+    });
+    expect(state.showInstallQr).toBe(true);
   });
 });
 
@@ -116,7 +135,12 @@ describe('removeBoardSlot', () => {
   it('turns the rail off when the last board goes (editor invariant)', () => {
     const initial = stateWith([boardA], { boardUuid: null, period: 'session' });
     const state = removeBoardSlot(initial, 0);
-    expect(state).toEqual({ boardUuids: [], leaderboard: null });
+    expect(state).toEqual({ boardUuids: [], leaderboard: null, showInstallQr: false });
+  });
+
+  it('preserves the install-QR toggle when the last board goes', () => {
+    const initial = stateWith([boardA], { boardUuid: null, period: 'session' }, true);
+    expect(removeBoardSlot(initial, 0).showInstallQr).toBe(true);
   });
 });
 
@@ -160,12 +184,39 @@ describe('serializeKioskLayout', () => {
       version: 1,
       boards: [{ boardUuid: boardA }, { boardUuid: boardB }],
       leaderboard: { boardUuid: boardA, period: 'day' },
+      showInstallQr: false,
     });
   });
 
+  it('serialises the install-QR toggle', () => {
+    const layout = serializeKioskLayout(stateWith([boardA], null, true));
+    expect(layout.showInstallQr).toBe(true);
+    expect(() => KioskLayoutSchema.parse(layout)).not.toThrow();
+  });
+
   it('round-trips through editorStateFromLayout', () => {
-    const state = stateWith([boardC, boardA], { boardUuid: null, period: 'month' });
+    const state = stateWith([boardC, boardA], { boardUuid: null, period: 'month' }, true);
     expect(editorStateFromLayout(serializeKioskLayout(state))).toEqual(state);
+  });
+});
+
+describe('setInstallQrEnabled', () => {
+  it('turns the toggle on and off', () => {
+    const off = stateWith([boardA]);
+    const on = setInstallQrEnabled(off, true);
+    expect(on.showInstallQr).toBe(true);
+    expect(setInstallQrEnabled(on, false).showInstallQr).toBe(false);
+  });
+
+  it('is a no-op (same reference) when the value is unchanged', () => {
+    const state = stateWith([boardA], null, true);
+    expect(setInstallQrEnabled(state, true)).toBe(state);
+  });
+
+  it('is independent of board count and the rail', () => {
+    // No boards, no rail — still togglable (QR is per-board, not per-slot).
+    const empty = stateWith([]);
+    expect(setInstallQrEnabled(empty, true).showInstallQr).toBe(true);
   });
 });
 
@@ -177,5 +228,11 @@ describe('editorStatesEqual', () => {
     expect(editorStatesEqual(first, stateWith([boardA]))).toBe(false);
     expect(editorStatesEqual(first, stateWith([boardA], { boardUuid: null, period: 'day' }))).toBe(false);
     expect(editorStatesEqual(first, stateWith([boardB], { boardUuid: null, period: 'session' }))).toBe(false);
+  });
+
+  it('treats a changed install-QR toggle as dirty', () => {
+    const off = stateWith([boardA], { boardUuid: null, period: 'session' }, false);
+    const on = stateWith([boardA], { boardUuid: null, period: 'session' }, true);
+    expect(editorStatesEqual(off, on)).toBe(false);
   });
 });

--- a/packages/web/app/components/gym-entity/manage/kiosk-editor-state.ts
+++ b/packages/web/app/components/gym-entity/manage/kiosk-editor-state.ts
@@ -34,6 +34,8 @@ export type KioskEditorState = {
   boardUuids: string[];
   /** Leaderboard rail config, or null when the rail is off. */
   leaderboard: KioskEditorLeaderboard | null;
+  /** When true, every board on the kiosk renders its own install-Boardsesh QR. */
+  showInstallQr: boolean;
 };
 
 /**
@@ -46,6 +48,7 @@ export function editorStateFromLayout(layout: unknown): KioskEditorState {
   return {
     boardUuids: parsed.boards.map((slot) => slot.boardUuid),
     leaderboard: parsed.leaderboard === null ? null : { ...parsed.leaderboard },
+    showInstallQr: parsed.showInstallQr,
   };
 }
 
@@ -70,7 +73,11 @@ export function setSlotBoard(state: KioskEditorState, index: number, boardUuid: 
 
   const boardUuids = state.boardUuids.slice();
   boardUuids[index] = boardUuid;
-  return { boardUuids, leaderboard: widenScopeIfDangling(state.leaderboard, boardUuids) };
+  return {
+    ...state,
+    boardUuids,
+    leaderboard: widenScopeIfDangling(state.leaderboard, boardUuids),
+  };
 }
 
 /**
@@ -96,9 +103,13 @@ export function removeBoardSlot(state: KioskEditorState, index: number): KioskEd
   if (index < 0 || index >= state.boardUuids.length) return state;
   const boardUuids = state.boardUuids.filter((_, slotIndex) => slotIndex !== index);
   if (boardUuids.length === 0) {
-    return { boardUuids, leaderboard: null };
+    return { ...state, boardUuids, leaderboard: null };
   }
-  return { boardUuids, leaderboard: widenScopeIfDangling(state.leaderboard, boardUuids) };
+  return {
+    ...state,
+    boardUuids,
+    leaderboard: widenScopeIfDangling(state.leaderboard, boardUuids),
+  };
 }
 
 /**
@@ -129,12 +140,19 @@ export function setLeaderboardPeriod(state: KioskEditorState, period: KioskLeade
   return { ...state, leaderboard: { ...state.leaderboard, period } };
 }
 
+/** Toggle the per-board install QR. Independent of board count and the rail. */
+export function setInstallQrEnabled(state: KioskEditorState, enabled: boolean): KioskEditorState {
+  if (state.showInstallQr === enabled) return state;
+  return { ...state, showInstallQr: enabled };
+}
+
 /** Serialise editor state to the wire/storage `KioskLayout` shape. */
 export function serializeKioskLayout(state: KioskEditorState): KioskLayout {
   return {
     version: KIOSK_LAYOUT_VERSION,
     boards: state.boardUuids.map((boardUuid) => ({ boardUuid })),
     leaderboard: state.leaderboard === null ? null : { ...state.leaderboard },
+    showInstallQr: state.showInstallQr,
   };
 }
 
@@ -142,6 +160,7 @@ export function serializeKioskLayout(state: KioskEditorState): KioskLayout {
 export function editorStatesEqual(first: KioskEditorState, second: KioskEditorState): boolean {
   if (first.boardUuids.length !== second.boardUuids.length) return false;
   if (first.boardUuids.some((uuid, index) => uuid !== second.boardUuids[index])) return false;
+  if (first.showInstallQr !== second.showInstallQr) return false;
   if (first.leaderboard === null || second.leaderboard === null) {
     return first.leaderboard === second.leaderboard;
   }

--- a/packages/web/app/components/gym-entity/manage/kiosk-editor.tsx
+++ b/packages/web/app/components/gym-entity/manage/kiosk-editor.tsx
@@ -7,7 +7,7 @@
 // strict KioskLayoutSchema (the same gate the backend applies) and persists
 // via updateGymKiosk.
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -34,6 +34,7 @@ import {
   moveBoardSlot,
   removeBoardSlot,
   serializeKioskLayout,
+  setInstallQrEnabled,
   setLeaderboardEnabled,
   setLeaderboardPeriod,
   setLeaderboardScope,
@@ -45,6 +46,7 @@ import ConfirmDialog from './confirm-dialog';
 import KioskBoardSlots, { type KioskEditorSlot } from './kiosk-board-slots';
 import KioskLayoutBadge from './kiosk-layout-badge';
 import KioskLeaderboardSettings from './kiosk-leaderboard-settings';
+import KioskInstallQrSettings from './kiosk-install-qr-settings';
 import KioskPreview from './kiosk-preview';
 import EmbedCodeDialog, { type EmbedCodeDialogState } from './embed-code-dialog';
 
@@ -127,15 +129,28 @@ export default function KioskEditor({
   // Single slot→board resolution feeding the rows, the save gate, and the
   // leaderboard settings, so "board no longer at this gym" can't be judged
   // differently by different panels. board === null means unknown board.
-  const slotBoards: KioskEditorSlot[] = editorState.boardUuids.map((boardUuid) => ({
-    boardUuid,
-    board: gymBoards?.find((gymBoard) => gymBoard.uuid === boardUuid) ?? null,
-  }));
-  const assignedBoards = slotBoards.map((slot) => slot.board).filter((board): board is UserBoard => board !== null);
+  // Memoised on the slot uuids + gym board list so a leaderboard-only or
+  // install-QR-only edit doesn't rebuild these arrays and defeat the child
+  // memoisation downstream.
+  const slotBoards: KioskEditorSlot[] = useMemo(
+    () =>
+      editorState.boardUuids.map((boardUuid) => ({
+        boardUuid,
+        board: gymBoards?.find((gymBoard) => gymBoard.uuid === boardUuid) ?? null,
+      })),
+    [editorState.boardUuids, gymBoards],
+  );
+  const assignedBoards = useMemo(
+    () => slotBoards.map((slot) => slot.board).filter((board): board is UserBoard => board !== null),
+    [slotBoards],
+  );
 
   // Slots whose board isn't (or no longer is) one of the gym's boards can't
   // save — the backend rejects layouts naming boards not linked to the gym.
-  const hasUnknownSlots = gymBoards !== null && slotBoards.some((slot) => slot.board === null);
+  const hasUnknownSlots = useMemo(
+    () => gymBoards !== null && slotBoards.some((slot) => slot.board === null),
+    [gymBoards, slotBoards],
+  );
 
   const handleSave = async () => {
     const parsed = KioskLayoutSchema.safeParse(serializeKioskLayout(editorState));
@@ -274,6 +289,18 @@ export default function KioskEditor({
                 })
               }
               isGymPublic={gym.isPublic}
+            />
+          </Box>
+
+          <Divider />
+
+          <Box>
+            <Typography variant="subtitle1" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold, mb: 1 }}>
+              {t('manage.editor.installQrHeading')}
+            </Typography>
+            <KioskInstallQrSettings
+              showInstallQr={editorState.showInstallQr}
+              onToggle={(enabled) => applyStateChange(setInstallQrEnabled(editorState, enabled))}
             />
           </Box>
         </Box>

--- a/packages/web/app/components/gym-entity/manage/kiosk-install-qr-settings.tsx
+++ b/packages/web/app/components/gym-entity/manage/kiosk-install-qr-settings.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+// Install-QR setting for the kiosk editor: a single on/off switch. When on,
+// every board on the kiosk renders its own "install Boardsesh" QR that
+// deep-links to that board, so climbers on the wall can get the app and feed
+// the screen with their sends. Independent of board count and the leaderboard
+// rail — the QR is per-board, not per-kiosk-slot.
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormHelperText from '@mui/material/FormHelperText';
+
+type KioskInstallQrSettingsProps = {
+  showInstallQr: boolean;
+  onToggle: (enabled: boolean) => void;
+};
+
+export default function KioskInstallQrSettings({ showInstallQr, onToggle }: KioskInstallQrSettingsProps) {
+  const { t } = useTranslation('kiosk');
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+      <FormControlLabel
+        control={<Switch checked={showInstallQr} onChange={(event) => onToggle(event.target.checked)} />}
+        label={t('manage.editor.installQrSwitch')}
+      />
+      <FormHelperText>{t('manage.editor.installQrHelper')}</FormHelperText>
+    </Box>
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/kiosk-preview.tsx
+++ b/packages/web/app/components/gym-entity/manage/kiosk-preview.tsx
@@ -56,6 +56,7 @@ function toGymKioskBoard(board: UserBoard): GymKioskBoard | null {
   return {
     boardId: board.boardId,
     boardUuid: board.uuid,
+    slug: board.slug,
     name: board.name,
     boardType: board.boardType,
     layoutId: board.layoutId,
@@ -172,6 +173,8 @@ export default function KioskPreview({ gym, kioskName, state, gymBoards }: Kiosk
                           initialClimb={null}
                           initialClimbImageUrl={null}
                           bareBoardImageUrl={slot.bareBoardImageUrl}
+                          slug={slot.board.slug}
+                          showInstallQr={state.showInstallQr}
                         />
                       ) : (
                         <div key={`${slot.boardUuid}-${slotIndex}`} className={styles.missingSlot}>

--- a/packages/web/app/components/kiosk/__tests__/kiosk-view-model.test.ts
+++ b/packages/web/app/components/kiosk/__tests__/kiosk-view-model.test.ts
@@ -93,6 +93,14 @@ describe('buildKioskViewModel', () => {
     expect(viewModel.leaderboard).toBeNull();
   });
 
+  it('propagates showInstallQr from the layout (default false when absent)', () => {
+    const boards = [makeBoard(UUID_A, 1)];
+    expect(buildKioskViewModel({ layout: layoutFor([UUID_A]), boards }).showInstallQr).toBe(false);
+    expect(
+      buildKioskViewModel({ layout: { ...layoutFor([UUID_A]), showInstallQr: true }, boards }).showInstallQr,
+    ).toBe(true);
+  });
+
   it('tolerates a corrupt layout (rail dropped, boards still render)', () => {
     const boards = [makeBoard(UUID_A, 1)];
     const viewModel = buildKioskViewModel({ layout: 'not json at all', boards });

--- a/packages/web/app/components/kiosk/__tests__/kiosk-view-model.test.ts
+++ b/packages/web/app/components/kiosk/__tests__/kiosk-view-model.test.ts
@@ -96,9 +96,9 @@ describe('buildKioskViewModel', () => {
   it('propagates showInstallQr from the layout (default false when absent)', () => {
     const boards = [makeBoard(UUID_A, 1)];
     expect(buildKioskViewModel({ layout: layoutFor([UUID_A]), boards }).showInstallQr).toBe(false);
-    expect(
-      buildKioskViewModel({ layout: { ...layoutFor([UUID_A]), showInstallQr: true }, boards }).showInstallQr,
-    ).toBe(true);
+    expect(buildKioskViewModel({ layout: { ...layoutFor([UUID_A]), showInstallQr: true }, boards }).showInstallQr).toBe(
+      true,
+    );
   });
 
   it('tolerates a corrupt layout (rail dropped, boards still render)', () => {

--- a/packages/web/app/components/kiosk/__tests__/kiosk-view-model.test.ts
+++ b/packages/web/app/components/kiosk/__tests__/kiosk-view-model.test.ts
@@ -6,6 +6,7 @@ function makeBoard(boardUuid: string, boardId: number): GymKioskBoard {
   return {
     boardId,
     boardUuid,
+    slug: `board-${boardId}`,
     name: `Board ${boardId}`,
     boardType: 'kilter',
     layoutId: 1,

--- a/packages/web/app/components/kiosk/board-slot/__tests__/board-install-qr.test.tsx
+++ b/packages/web/app/components/kiosk/board-slot/__tests__/board-install-qr.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vite-plus/test';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { SITE_URL } from '@/app/lib/seo/base-url';
 import BoardInstallQr from '../board-install-qr';
 
 vi.mock('react-i18next', () => ({
@@ -20,7 +21,9 @@ vi.mock('qrcode.react', () => ({
 describe('BoardInstallQr', () => {
   it('encodes /b/{slug} against the canonical site URL', () => {
     render(<BoardInstallQr slug="main-kilter" />);
-    expect(screen.getByTestId('qr').getAttribute('data-value')).toBe('https://www.boardsesh.com/b/main-kilter');
+    // Derived from SITE_URL rather than a hardcoded domain, so the assertion
+    // tracks the base URL instead of pinning the production host.
+    expect(screen.getByTestId('qr').getAttribute('data-value')).toBe(`${SITE_URL}/b/main-kilter`);
   });
 
   it('renders the install caption from the kiosk catalog', () => {

--- a/packages/web/app/components/kiosk/board-slot/__tests__/board-install-qr.test.tsx
+++ b/packages/web/app/components/kiosk/board-slot/__tests__/board-install-qr.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import BoardInstallQr from '../board-install-qr';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+// Capture the QRCodeSVG `value` so we can assert the encoded deep-link target
+// without decoding the rendered matrix.
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: ({ value }: { value: string }) => <svg data-testid="qr" data-value={value} />,
+}));
+
+describe('BoardInstallQr', () => {
+  it('encodes /b/{slug} against the canonical site URL', () => {
+    render(<BoardInstallQr slug="main-kilter" />);
+    expect(screen.getByTestId('qr').getAttribute('data-value')).toBe('https://www.boardsesh.com/b/main-kilter');
+  });
+
+  it('renders the install caption from the kiosk catalog', () => {
+    render(<BoardInstallQr slug="main-kilter" />);
+    expect(screen.getByText(tFromCatalog('kiosk', 'installQr.caption') as string)).toBeTruthy();
+  });
+});

--- a/packages/web/app/components/kiosk/board-slot/__tests__/board-slot.test.tsx
+++ b/packages/web/app/components/kiosk/board-slot/__tests__/board-slot.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import type { BoardDetails } from '@/app/lib/types';
+import BoardSlot from '../board-slot';
+
+// No live presence -> the img (raster) branch renders and BoardRenderer stays
+// out of the tree; keeps this focused on the install-QR conditional.
+vi.mock('@/app/components/kiosk/presence/use-kiosk-board-presence', () => ({
+  useKioskBoardPresence: () => null,
+}));
+vi.mock('@/app/components/board-renderer/board-renderer', () => ({
+  default: () => <div data-testid="board-renderer" />,
+}));
+vi.mock('@/app/components/kiosk/board-slot/board-identity', () => ({
+  default: () => <div data-testid="board-identity" />,
+}));
+vi.mock('@/app/components/kiosk/board-slot/board-install-qr', () => ({
+  default: ({ slug }: { slug: string }) => <div data-testid="install-qr" data-slug={slug} />,
+}));
+
+const boardDetails = { board_name: 'kilter' } as unknown as BoardDetails;
+
+function renderSlot(overrides: Partial<React.ComponentProps<typeof BoardSlot>> = {}) {
+  return render(
+    <BoardSlot
+      boardId={1}
+      boardName="Main Kilter"
+      angle={40}
+      boardDetails={boardDetails}
+      initialClimb={null}
+      initialClimbImageUrl={null}
+      bareBoardImageUrl="/bare.webp"
+      slug="main-kilter"
+      showInstallQr
+      {...overrides}
+    />,
+  );
+}
+
+describe('BoardSlot install QR', () => {
+  it('renders the QR (with the board slug) when the toggle is on and a slug is present', () => {
+    renderSlot();
+    expect(screen.getByTestId('install-qr').getAttribute('data-slug')).toBe('main-kilter');
+  });
+
+  it('hides the QR when the toggle is off', () => {
+    renderSlot({ showInstallQr: false });
+    expect(screen.queryByTestId('install-qr')).toBeNull();
+  });
+
+  it('hides the QR when the slug is empty', () => {
+    renderSlot({ slug: '' });
+    expect(screen.queryByTestId('install-qr')).toBeNull();
+  });
+});

--- a/packages/web/app/components/kiosk/board-slot/board-install-qr.module.css
+++ b/packages/web/app/components/kiosk/board-slot/board-install-qr.module.css
@@ -1,0 +1,37 @@
+/* Per-board install QR, absolutely positioned in a corner of the board slot.
+ * The tile is ALWAYS white regardless of the (always-dark) kiosk surface — a QR
+ * needs a light quiet zone to scan, so black modules + dark caption sit on a
+ * white card. Compact but scannable; the QR shrinks on the denser presets via
+ * clamp(). No container queries (old TV browsers). */
+
+.tile {
+  position: absolute;
+  top: var(--spacing-3);
+  right: var(--spacing-3);
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-2);
+  background: #ffffff;
+  border-radius: var(--border-radius-md);
+  box-shadow: 0 2px 10px var(--overlay-dark);
+}
+
+.qr {
+  display: block;
+  width: clamp(84px, 9vh, 128px);
+  height: clamp(84px, 9vh, 128px);
+}
+
+.caption {
+  max-width: clamp(84px, 9vh, 128px);
+  font-size: var(--kiosk-font-small);
+  font-weight: 600;
+  line-height: 1.1;
+  text-align: center;
+  /* Dark text on the white tile — deliberately NOT a kiosk text token (those
+   * are light, for the dark surface). */
+  color: #111111;
+}

--- a/packages/web/app/components/kiosk/board-slot/board-install-qr.tsx
+++ b/packages/web/app/components/kiosk/board-slot/board-install-qr.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+// Per-board "install Boardsesh" QR for the kiosk. Encodes /b/{slug} for THIS
+// board so a climber on the wall can scan, get the app, and have their sends
+// light up the screen. Rendered in a corner of the board slot when the kiosk's
+// showInstallQr toggle is on and the board has a slug.
+//
+// The QR must sit on a WHITE tile: a bare dark QR on the dark kiosk surface
+// won't scan (a QR needs a light quiet zone), so we render black modules on a
+// white card and keep the caption dark-on-white too.
+//
+// TARGET NOTE: /b/{slug} opens the WEB board page (which carries install CTAs)
+// everywhere, and is iOS-universal-link eligible. It does NOT yet open the
+// mobile app straight to the board — that needs a native mobile app/b/[slug]
+// route + an Android /b autoVerify intent filter (see the tracked follow-up
+// issue). The web board page is the current fallback.
+
+import React from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { useTranslation } from 'react-i18next';
+import { absoluteUrl } from '@/app/lib/seo/base-url';
+import styles from './board-install-qr.module.css';
+
+export default function BoardInstallQr({ slug }: { slug: string }) {
+  const { t } = useTranslation('kiosk');
+  const installUrl = absoluteUrl(`/b/${slug}`);
+
+  return (
+    <div className={styles.tile}>
+      {/* Fixed internal resolution; CSS scales the SVG responsively via clamp(). */}
+      <QRCodeSVG className={styles.qr} value={installUrl} size={128} level="M" marginSize={1} aria-hidden />
+      <span className={styles.caption}>{t('installQr.caption')}</span>
+    </div>
+  );
+}

--- a/packages/web/app/components/kiosk/board-slot/board-slot.module.css
+++ b/packages/web/app/components/kiosk/board-slot/board-slot.module.css
@@ -10,8 +10,11 @@
 }
 
 /* Hero art region: takes all remaining height; art contain-fits inside it
- * (board aspect ratios run 0.43–1.81) and nothing is overlaid on it. */
+ * (board aspect ratios run 0.43–1.81). position: relative anchors the optional
+ * per-board install QR tile to a corner of this region (never overlapping the
+ * identity strip below). */
 .art {
+  position: relative;
   flex: 1;
   min-height: 0;
   display: flex;

--- a/packages/web/app/components/kiosk/board-slot/board-slot.tsx
+++ b/packages/web/app/components/kiosk/board-slot/board-slot.tsx
@@ -18,6 +18,7 @@ import BoardRenderer from '../../board-renderer/board-renderer';
 import { convertLitUpHoldsStringToMap, toFlatFrames } from '../../board-renderer/util';
 import { useKioskBoardPresence } from '../presence/use-kiosk-board-presence';
 import BoardIdentity from './board-identity';
+import BoardInstallQr from './board-install-qr';
 import styles from './board-slot.module.css';
 
 export type BoardSlotProps = {
@@ -33,6 +34,10 @@ export type BoardSlotProps = {
   initialClimbImageUrl: string | null;
   /** Raster URL for the bare board (idle placeholder). */
   bareBoardImageUrl: string;
+  /** The board's public slug (userBoards.slug) — the install-QR deep-link target. */
+  slug: string | null;
+  /** Whether this kiosk shows the per-board install QR (kiosk layout toggle). */
+  showInstallQr: boolean;
 };
 
 export default function BoardSlot({
@@ -43,6 +48,8 @@ export default function BoardSlot({
   initialClimb,
   initialClimbImageUrl,
   bareBoardImageUrl,
+  slug,
+  showInstallQr,
 }: BoardSlotProps) {
   const snapshot = useKioskBoardPresence(boardId);
 
@@ -65,6 +72,7 @@ export default function BoardSlot({
   return (
     <section className={styles.slot}>
       <div className={styles.art}>
+        {showInstallQr && slug !== null ? <BoardInstallQr slug={slug} /> : null}
         {hasLiveData ? (
           <BoardRenderer boardDetails={boardDetails} litUpHoldsMap={litUpHoldsMap} mirrored={false} fillHeight />
         ) : (

--- a/packages/web/app/components/kiosk/board-slot/board-slot.tsx
+++ b/packages/web/app/components/kiosk/board-slot/board-slot.tsx
@@ -34,8 +34,12 @@ export type BoardSlotProps = {
   initialClimbImageUrl: string | null;
   /** Raster URL for the bare board (idle placeholder). */
   bareBoardImageUrl: string;
-  /** The board's public slug (userBoards.slug) — the install-QR deep-link target. */
-  slug: string | null;
+  /**
+   * The board's public slug (userBoards.slug) — the install-QR deep-link target.
+   * Non-null to match GymKioskBoard.slug (`String!`); the truthy guard below is a
+   * belt-and-braces check against an empty slug, not a null one.
+   */
+  slug: string;
   /** Whether this kiosk shows the per-board install QR (kiosk layout toggle). */
   showInstallQr: boolean;
 };
@@ -72,7 +76,7 @@ export default function BoardSlot({
   return (
     <section className={styles.slot}>
       <div className={styles.art}>
-        {showInstallQr && slug !== null ? <BoardInstallQr slug={slug} /> : null}
+        {showInstallQr && slug ? <BoardInstallQr slug={slug} /> : null}
         {hasLiveData ? (
           <BoardRenderer boardDetails={boardDetails} litUpHoldsMap={litUpHoldsMap} mirrored={false} fillHeight />
         ) : (

--- a/packages/web/app/components/kiosk/kiosk-page-renderer.tsx
+++ b/packages/web/app/components/kiosk/kiosk-page-renderer.tsx
@@ -181,6 +181,8 @@ export default async function KioskPageRenderer({ gymSlug, kioskSlug }: { gymSlu
                     initialClimb={slot.initialClimb}
                     initialClimbImageUrl={slot.initialClimbImageUrl}
                     bareBoardImageUrl={slot.bareBoardImageUrl}
+                    slug={slot.board.slug}
+                    showInstallQr={viewModel.showInstallQr}
                   />
                 ))}
               </KioskLayout>

--- a/packages/web/app/components/kiosk/kiosk-view-model.ts
+++ b/packages/web/app/components/kiosk/kiosk-view-model.ts
@@ -32,6 +32,8 @@ export type KioskViewModel = {
   preset: KioskPreset | null;
   /** Leaderboard rail config, or null when the rail is off. */
   leaderboard: KioskLeaderboardConfig | null;
+  /** When true, every board renders its own "install Boardsesh" QR (deep link to that board). */
+  showInstallQr: boolean;
 };
 
 /**
@@ -74,5 +76,6 @@ export function buildKioskViewModel(kiosk: Pick<GymKiosk, 'layout' | 'boards'>):
     boards,
     preset: kioskPresetForBoardCount(boards.length),
     leaderboard,
+    showInstallQr: layout.showInstallQr,
   };
 }

--- a/packages/web/app/embed/board/[board_uuid]/page.tsx
+++ b/packages/web/app/embed/board/[board_uuid]/page.tsx
@@ -126,11 +126,17 @@ export default async function EmbedBoardPage(props: EmbedBoardRouteProps) {
           <BoardSlot
             boardId={board.boardId}
             boardName={board.name}
+            slug={board.slug}
             angle={board.angle}
             boardDetails={slotData.boardDetails}
             initialClimb={slotData.initialClimb}
             initialClimbImageUrl={slotData.initialClimbImageUrl}
             bareBoardImageUrl={slotData.bareBoardImageUrl}
+            // Standalone embed widget: display-only, no kiosk layout and no
+            // manage toggle, so the per-board install QR stays off here (the
+            // QR is a kiosk-surface feature driven by the layout's
+            // showInstallQr). Keeps embeds identical to before this feature.
+            showInstallQr={false}
           />
         </KioskPresenceHub>
       </EmbedShell>


### PR DESCRIPTION
## Summary

Adds a per-board **install Boardsesh** QR to the gym kiosk (smart-TV wall dashboard). The kiosk only shows climbs from Boardsesh users, so each board now gets its own scannable code that deep-links to **that** board — climbers scan it, get the app, and their sends feed the screen.

Gated behind a per-kiosk toggle: when a gym flips **"Show app-install QR on each board"** on, every board on the kiosk renders its own QR. Off by default.

**Stacks on the kiosk epic** — base is `feat/gym-kiosk-editor`, not `main`.

### What's in it

- **`@boardsesh/kiosk`** — additive optional `showInstallQr: boolean` (default `false`) on `KioskLayoutSchema`, threaded through `emptyKioskLayout()` and the lenient reader (an absent or malformed value reads as `false`, no version bump). Tests cover strict parse with/without the field and the lenient default.
- **Backend** — `GymKioskBoard` now exposes `slug: String!` (the public `userBoards.slug`) so the QR has a target; populated in the kiosk read resolver, added to `GYM_KIOSK_FIELDS`, codegen regenerated. Resolver test asserts `slug` on both the write-then-resolve and the anon read path. Visibility gate unchanged (slug is public, same gate as the rest of `GymKioskBoard`).
- **Web render** — new `BoardInstallQr` (`qrcode.react`'s pure-SVG `QRCodeSVG`, SSR-safe) on a **white** rounded tile (a QR needs a light quiet zone; a bare dark QR on the dark kiosk surface won't scan) with a scan caption. Positioned in a corner of the board art region, never overlapping the identity strip. Rendered only when `showInstallQr` is on **and** the board has a slug. `showInstallQr` threads config → renderer → `BoardSlot`; `slug` threads off `GymKioskBoard`.
- **Manage editor** — a MUI `Switch` next to the leaderboard settings, wired into the editor's dirty state + `KioskLayoutSchema` save gate; the live preview reflects it. Also memoises `slotBoards` / `assignedBoards` / `hasUnknownSlots` (addresses the #3637 review perf nit — they were recomputed every render, defeating child memoisation).
- **i18n** — caption + toggle strings in `en-US` / `es` (plafón) / `fr` (croix / mur conventions).

### QR target

`${SITE_URL}/b/{slug}` (built from `SITE_URL`, not hardcoded). This opens the **web board page** everywhere (Android / desktop) and is iOS-universal-link eligible.

It does **not** yet open the mobile **app** straight to the board — that needs native work (a mobile `app/b/[slug]` Expo Router route + an Android `/b` `autoVerify` intent filter). Tracked as a follow-up: #3657. The web board page (which carries install CTAs) is the current fallback.

## Release Notes

- Your gym's wall screen can now show a scannable code on every board — climbers scan it to get Boardsesh, and their sends light up the screen.

## Test plan

- `vp run typecheck` — clean.
- `vp test run --project kiosk` — 36 pass (new `showInstallQr` strict + lenient cases).
- `vp test run --project web` for `board-install-qr`, `kiosk-editor-state`, `kiosk-view-model` — pass (new QR-target, toggle-serialisation, dirty-flag, and per-transition-preservation cases).
- `vp test run --project backend src/__tests__/gym-kiosks.test.ts` — 26 pass (new `slug` assertions).
- `vp run check:i18n` + `check:i18n:orphans` — OK; catalog completeness parity test passes.
- `vp check` — my files clean (3 pre-existing `no-floating-promises` errors in unrelated `packages/db` test files, unchanged vs base).
- Confirmed zero unintended `packages/db` diffs: only the `gym_kiosks` schema comment/cast; the SQL column default stays byte-identical (additive field, lenient reader covers absence), so no migration/snapshot churn.
