### PR TITLE
fix(ci): unbreak main after kiosk epic (dev-db kiosk dep + formatting)

### DIFF
--- a/packages/db/docker/Dockerfile.dev-db
+++ b/packages/db/docker/Dockerfile.dev-db
@@ -76,15 +76,16 @@ COPY packages/db/tsconfig.json /app/tsconfig.json
 #
 # @boardsesh/board-config (used by the runtime required_set_ids helpers),
 # @boardsesh/board-constants (grade/size helpers used by create-climb-filters
-# and recommendations) and sharp (used only by the cell-set generator) are
-# stripped too — none is loaded by the scripts this build runs
-# (import-aurora-board-unified + import-moonboard-problems + create-test-user +
-# seed-social + migrate), and the workspace "*" / native sharp dep would
-# otherwise break the standalone install. MoonBoard required_set_ids are
-# populated by the backfill, run from the full monorepo against the live DB,
-# not in this image.
+# and recommendations), @boardsesh/kiosk (only a type-only import for the
+# gym_kiosks.layout $type<KioskLayout>, never loaded at runtime) and sharp (used
+# only by the cell-set generator) are stripped too — none is loaded by the
+# scripts this build runs (import-aurora-board-unified + import-moonboard-problems
+# + create-test-user + seed-social + migrate), and the workspace "*" / native
+# sharp dep would otherwise break the standalone install. MoonBoard
+# required_set_ids are populated by the backfill, run from the full monorepo
+# against the live DB, not in this image.
 RUN cd /app && \
-    sed -i -e '/"@boardsesh\/shared-schema"/d' -e '/"@boardsesh\/board-config"/d' -e '/"@boardsesh\/board-constants"/d' -e '/"sharp"/d' package.json && \
+    sed -i -e '/"@boardsesh\/shared-schema"/d' -e '/"@boardsesh\/board-config"/d' -e '/"@boardsesh\/board-constants"/d' -e '/"@boardsesh\/kiosk"/d' -e '/"sharp"/d' package.json && \
     curl -fsSL https://bun.sh/install | bash && \
     ln -s /root/.bun/bin/bun /usr/local/bin/bun && \
     ln -s /root/.bun/bin/bunx /usr/local/bin/bunx && \

--- a/packages/web/app/components/gym-entity/manage/kiosks-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/kiosks-tab.tsx
@@ -114,7 +114,9 @@ export default function KiosksTab({ gym, onDirtyChange }: GymManageTabProps) {
   );
 
   const handleCreated = (kiosk: GymKioskOperationResult) => {
-    queryClient.setQueryData<GymKioskOperationResult[]>(kiosksQueryKey, (previous) => (previous ? [...previous, kiosk] : [kiosk]));
+    queryClient.setQueryData<GymKioskOperationResult[]>(kiosksQueryKey, (previous) =>
+      previous ? [...previous, kiosk] : [kiosk],
+    );
     setCreateDialogOpen(false);
     showMessage(t('manage.createDialog.created', { slug: kiosk.slug }), 'success');
     // Straight into the editor — a fresh kiosk has no boards yet.

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -49,10 +49,7 @@ const fetchGymBySlug = cache(async (slug: string, token: string | undefined): Pr
   }
 });
 
-async function fetchDefaultKiosk(
-  gymSlug: string,
-  token: string | undefined,
-): Promise<GymKioskOperationResult | null> {
+async function fetchDefaultKiosk(gymSlug: string, token: string | undefined): Promise<GymKioskOperationResult | null> {
   try {
     const response = await executeAuthenticatedGraphQL<GetGymKioskQueryResponse>(
       GET_GYM_KIOSK,


### PR DESCRIPTION
Post-merge fixes for the two red main CI jobs after the gym-kiosk epic:

1. **build-dev-db**: packages/db now type-depends on @boardsesh/kiosk (gym_kiosks.layout type-only \$type<KioskLayout>). The dev-db Dockerfile strips workspace deps before a standalone bun install; added @boardsesh/kiosk to the strip list (404s against npm otherwise).
2. **lint (format)**: kiosks-tab.tsx + gym/[gym_slug]/page.tsx merged unformatted; ran the formatter.

No native files, no migration change.

## Release Notes

- [x] No release note needed (internal / technical change)