### PR TITLE
feat(web): My Gyms drawer + user-drawer entry

### DIFF
--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -390,6 +390,19 @@
     "ariaCreateBoard": "Create a board",
     "empty": "No boards yet. Create one from the board selector to get started."
   },
+  "myGyms": {
+    "title": "My Gyms",
+    "empty": "Your gym might already be on Boardsesh. Find it to manage your boards and crew.",
+    "findGym": "Find your gym",
+    "ariaFindGym": "Find your gym",
+    "roleOwner": "Owner",
+    "roleAdmin": "Admin",
+    "roleEditor": "Editor",
+    "roleMember": "Member",
+    "manage": "Manage",
+    "view": "View",
+    "loadError": "We couldn't load your gyms. Give it another go."
+  },
   "userDrawer": {
     "signIn": "Sign in",
     "signInModalTitle": "Sign in to Boardsesh",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -63,6 +63,19 @@
     "ariaCreateBoard": "Crear plafón",
     "empty": "Aún no tienes plafones. Crea uno desde el selector de plafones."
   },
+  "myGyms": {
+    "title": "Mis gimnasios",
+    "empty": "Puede que tu gimnasio ya esté en Boardsesh. Encuéntralo para gestionar tus plafones y tu grupo.",
+    "findGym": "Encuentra tu gimnasio",
+    "ariaFindGym": "Encuentra tu gimnasio",
+    "roleOwner": "Propietario",
+    "roleAdmin": "Administrador",
+    "roleEditor": "Editor",
+    "roleMember": "Miembro",
+    "manage": "Gestionar",
+    "view": "Ver",
+    "loadError": "No pudimos cargar tus gimnasios. Inténtalo de nuevo."
+  },
   "userDrawer": {
     "signIn": "Iniciar sesión",
     "signInModalTitle": "Inicia sesión en Boardsesh",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -65,7 +65,7 @@
   },
   "myGyms": {
     "title": "Mis gimnasios",
-    "empty": "Puede que tu gimnasio ya esté en Boardsesh. Encuéntralo para gestionar tus plafones y tu grupo.",
+    "empty": "Puede que tu gimnasio ya esté en Boardsesh. Encuéntralo para gestionar tus plafones y tu equipo.",
     "findGym": "Encuentra tu gimnasio",
     "ariaFindGym": "Encuentra tu gimnasio",
     "roleOwner": "Propietario",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -390,6 +390,19 @@
     "ariaCreateBoard": "Créer une board",
     "empty": "Aucune board pour le moment. Créez-en une depuis le sélecteur."
   },
+  "myGyms": {
+    "title": "Mes salles",
+    "empty": "Ta salle est peut-être déjà sur Boardsesh. Trouve-la pour gérer tes boards et ta crew.",
+    "findGym": "Trouve ta salle",
+    "ariaFindGym": "Trouve ta salle",
+    "roleOwner": "Propriétaire",
+    "roleAdmin": "Admin",
+    "roleEditor": "Éditeur",
+    "roleMember": "Membre",
+    "manage": "Gérer",
+    "view": "Voir",
+    "loadError": "Impossible de charger tes salles. Réessaie."
+  },
   "userDrawer": {
     "signIn": "Se connecter",
     "signInModalTitle": "Se connecter à Boardsesh",

--- a/packages/web/app/components/my-gyms-drawer/__tests__/my-gyms-drawer.test.tsx
+++ b/packages/web/app/components/my-gyms-drawer/__tests__/my-gyms-drawer.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import MyGymsDrawer from '../my-gyms-drawer';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+// jsdom/happy-dom doesn't implement IntersectionObserver, which the infinite-scroll
+// hook in MyGymsDrawer instantiates on mount. Provide a no-op stub so the effect
+// doesn't throw during render.
+class IntersectionObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+globalThis.IntersectionObserver = IntersectionObserverStub as unknown as typeof IntersectionObserver;
+
+// Mock data
+let mockGyms: Array<Record<string, unknown>> = [];
+let mockIsLoading = false;
+let mockError: string | null = null;
+let mockUserId: string | null = 'user-1';
+
+vi.mock('@/app/hooks/use-my-gyms', () => ({
+  useMyGyms: () => ({
+    gyms: mockGyms,
+    isLoading: mockIsLoading,
+    isFetchingMore: false,
+    hasMore: false,
+    loadMore: vi.fn(),
+    error: mockError,
+  }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: mockUserId ? { user: { id: mockUserId } } : null }),
+}));
+
+vi.mock('../../swipeable-drawer/swipeable-drawer', () => ({
+  default: ({
+    open,
+    children,
+    title,
+    extra,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+    title: React.ReactNode;
+    extra?: React.ReactNode;
+    onClose: () => void;
+  }) =>
+    open ? (
+      <div data-testid="drawer">
+        <div data-testid="drawer-header">
+          <span data-testid="drawer-title">{title}</span>
+          {extra && <span data-testid="drawer-extra">{extra}</span>}
+        </div>
+        {children}
+      </div>
+    ) : null,
+}));
+
+vi.mock('../../search-drawer/unified-search-drawer', () => ({
+  default: ({ open, defaultCategory }: { open: boolean; defaultCategory?: string }) =>
+    open ? (
+      <div data-testid="gym-search">
+        <span>Category: {defaultCategory}</span>
+      </div>
+    ) : null,
+}));
+
+vi.mock('@/app/components/i18n/locale-link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children?: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('../my-gyms-drawer.module.css', () => ({
+  default: new Proxy(
+    {},
+    {
+      get: (_target, prop) => String(prop),
+    },
+  ),
+}));
+
+function makeGym(overrides?: Record<string, unknown>) {
+  return {
+    uuid: 'gym-1',
+    slug: 'boulder-project',
+    ownerId: 'user-1',
+    name: 'Boulder Project',
+    address: '123 Crux St',
+    isPublic: true,
+    boardCount: 3,
+    memberCount: 12,
+    followerCount: 8,
+    commentCount: 0,
+    isFollowedByMe: false,
+    isMember: true,
+    myRole: 'admin',
+    canEdit: true,
+    canGrantAccess: true,
+    canClaim: false,
+    createdAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('MyGymsDrawer', () => {
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGyms = [];
+    mockIsLoading = false;
+    mockError = null;
+    mockUserId = 'user-1';
+  });
+
+  it('does not render when closed', () => {
+    render(<MyGymsDrawer open={false} onClose={mockOnClose} />);
+    expect(screen.queryByTestId('drawer')).toBeNull();
+  });
+
+  it('renders loading state', () => {
+    mockIsLoading = true;
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+    expect(screen.getByTestId('my-gyms-loading')).toBeDefined();
+  });
+
+  it('renders empty state with a find-your-gym action when no gyms', () => {
+    mockGyms = [];
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+    expect(screen.getByTestId('my-gyms-empty')).toBeDefined();
+    expect(screen.getByText(/might already be on Boardsesh/)).toBeDefined();
+    expect(screen.getByTestId('my-gyms-find')).toBeDefined();
+  });
+
+  it('renders gym list with gyms', () => {
+    mockGyms = [makeGym(), makeGym({ uuid: 'gym-2', name: 'Send Town', slug: 'send-town' })];
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+    expect(screen.getByTestId('my-gyms-list')).toBeDefined();
+    expect(screen.getByText('Boulder Project')).toBeDefined();
+    expect(screen.getByText('Send Town')).toBeDefined();
+  });
+
+  it('shows the Owner chip when the viewer owns the gym', () => {
+    mockUserId = 'user-1';
+    mockGyms = [makeGym({ ownerId: 'user-1' })];
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+    expect(screen.getByText('Owner')).toBeDefined();
+  });
+
+  it('shows the role chip from myRole when the viewer is not the owner', () => {
+    mockUserId = 'user-2';
+    mockGyms = [makeGym({ ownerId: 'someone-else', myRole: 'editor' })];
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+    expect(screen.getByText('Editor')).toBeDefined();
+    expect(screen.queryByText('Owner')).toBeNull();
+  });
+
+  it('shows Manage and View actions with correct hrefs when canEdit', () => {
+    mockGyms = [makeGym({ slug: 'boulder-project', canEdit: true })];
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+
+    const manageLink = screen.getByTestId('gym-manage-gym-1');
+    const viewLink = screen.getByTestId('gym-view-gym-1');
+    expect(manageLink.getAttribute('href')).toBe('/gym/boulder-project/manage');
+    expect(viewLink.getAttribute('href')).toBe('/gym/boulder-project');
+  });
+
+  it('hides the Manage action when the viewer cannot edit', () => {
+    mockUserId = 'user-2';
+    mockGyms = [makeGym({ ownerId: 'someone-else', myRole: 'member', canEdit: false })];
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+    expect(screen.queryByTestId('gym-manage-gym-1')).toBeNull();
+    expect(screen.getByTestId('gym-view-gym-1')).toBeDefined();
+  });
+
+  it('addresses the manage route by uuid but hides View when the slug is null', () => {
+    // The manage route resolves a bare UUID (legacy slug-less gyms); the public
+    // gym page resolves only by slug, so View has nothing to link to.
+    mockGyms = [makeGym({ slug: null, canEdit: true })];
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+    expect(screen.getByTestId('gym-manage-gym-1').getAttribute('href')).toBe('/gym/gym-1/manage');
+    expect(screen.queryByTestId('gym-view-gym-1')).toBeNull();
+  });
+
+  it('renders error state when fetch fails', () => {
+    mockError = 'boom';
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+    expect(screen.getByTestId('my-gyms-error')).toBeDefined();
+    expect(screen.getByText(/couldn't load your gyms/)).toBeDefined();
+  });
+
+  it('opens the gym search from the header search icon', () => {
+    mockGyms = [makeGym()];
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+    expect(screen.queryByTestId('gym-search')).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('Find your gym'));
+
+    const search = screen.getByTestId('gym-search');
+    expect(search).toBeDefined();
+    expect(screen.getByText('Category: gyms')).toBeDefined();
+  });
+
+  it('opens the gym search from the empty-state button', () => {
+    mockGyms = [];
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+
+    fireEvent.click(screen.getByTestId('my-gyms-find'));
+
+    expect(screen.getByTestId('gym-search')).toBeDefined();
+  });
+});

--- a/packages/web/app/components/my-gyms-drawer/__tests__/my-gyms-drawer.test.tsx
+++ b/packages/web/app/components/my-gyms-drawer/__tests__/my-gyms-drawer.test.tsx
@@ -30,6 +30,7 @@ let mockGyms: Array<Record<string, unknown>> = [];
 let mockIsLoading = false;
 let mockError: string | null = null;
 let mockUserId: string | null = 'user-1';
+let mockKioskFlag = true;
 
 vi.mock('@/app/hooks/use-my-gyms', () => ({
   useMyGyms: () => ({
@@ -40,6 +41,10 @@ vi.mock('@/app/hooks/use-my-gyms', () => ({
     loadMore: vi.fn(),
     error: mockError,
   }),
+}));
+
+vi.mock('@/app/components/providers/feature-flags-provider', () => ({
+  useFeatureFlag: () => mockKioskFlag,
 }));
 
 vi.mock('next-auth/react', () => ({
@@ -128,6 +133,7 @@ describe('MyGymsDrawer', () => {
     mockIsLoading = false;
     mockError = null;
     mockUserId = 'user-1';
+    mockKioskFlag = true;
   });
 
   it('does not render when closed', () => {
@@ -188,6 +194,27 @@ describe('MyGymsDrawer', () => {
     render(<MyGymsDrawer open onClose={mockOnClose} />);
     expect(screen.queryByTestId('gym-manage-gym-1')).toBeNull();
     expect(screen.getByTestId('gym-view-gym-1')).toBeDefined();
+  });
+
+  it('hides Manage behind the gym-kiosk kill switch but keeps View', () => {
+    mockKioskFlag = false;
+    mockGyms = [makeGym({ slug: 'boulder-project', canEdit: true })];
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+    expect(screen.queryByTestId('gym-manage-gym-1')).toBeNull();
+    expect(screen.getByTestId('gym-view-gym-1')).toBeDefined();
+  });
+
+  it('still renders the row (name + role chip) when the flag is off and the gym is slug-less', () => {
+    // Kiosk flag off + no slug: Manage is gated away and View has no slug to link
+    // to, so the row carries zero actions — it stays as an informational entry.
+    mockKioskFlag = false;
+    mockGyms = [makeGym({ slug: null, canEdit: true, ownerId: 'user-1' })];
+    render(<MyGymsDrawer open onClose={mockOnClose} />);
+    expect(screen.getByTestId('gym-item-gym-1')).toBeDefined();
+    expect(screen.getByText('Boulder Project')).toBeDefined();
+    expect(screen.getByText('Owner')).toBeDefined();
+    expect(screen.queryByTestId('gym-manage-gym-1')).toBeNull();
+    expect(screen.queryByTestId('gym-view-gym-1')).toBeNull();
   });
 
   it('addresses the manage route by uuid but hides View when the slug is null', () => {

--- a/packages/web/app/components/my-gyms-drawer/my-gyms-drawer.module.css
+++ b/packages/web/app/components/my-gyms-drawer/my-gyms-drawer.module.css
@@ -1,0 +1,83 @@
+.gymList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.gymItem {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 8px;
+}
+
+.gymItemIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background: var(--neutral-200);
+  flex-shrink: 0;
+  color: var(--neutral-600);
+}
+
+.gymItemInfo {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+}
+
+.gymItemHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.gymItemName {
+  font-size: 15px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gymItemMeta {
+  font-size: 13px;
+  color: var(--neutral-500);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gymItemActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 32px 16px;
+  text-align: center;
+}
+
+.loadingState {
+  display: flex;
+  justify-content: center;
+  padding: 32px 0;
+}
+
+.loadingMore {
+  display: flex;
+  justify-content: center;
+  padding: 12px 0;
+}

--- a/packages/web/app/components/my-gyms-drawer/my-gyms-drawer.tsx
+++ b/packages/web/app/components/my-gyms-drawer/my-gyms-drawer.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSession } from 'next-auth/react';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import MuiButton from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
+import SearchOutlined from '@mui/icons-material/SearchOutlined';
+import SettingsOutlined from '@mui/icons-material/SettingsOutlined';
+import VisibilityOutlined from '@mui/icons-material/VisibilityOutlined';
+import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
+import UnifiedSearchDrawer from '../search-drawer/unified-search-drawer';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { useMyGyms } from '@/app/hooks/use-my-gyms';
+import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
+import type { Gym } from '@boardsesh/shared-schema';
+import styles from './my-gyms-drawer.module.css';
+
+type MyGymsDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  onTransitionEnd?: (open: boolean) => void;
+};
+
+type GymRoleKind = 'owner' | 'admin' | 'editor' | 'member';
+
+type ChipColor = 'primary' | 'secondary' | 'default';
+
+const ROLE_CHIP_COLOR: Record<GymRoleKind, ChipColor> = {
+  owner: 'primary',
+  admin: 'secondary',
+  editor: 'default',
+  member: 'default',
+};
+
+/**
+ * Resolve the viewer's standing at a gym. The owner outranks the `myRole`
+ * field (owners are reported as gym admins by the backend), so the owner check
+ * comes first. Returns null for a gym the viewer only follows.
+ */
+function resolveGymRole(gym: Gym, currentUserId: string | null): GymRoleKind | null {
+  if (currentUserId && gym.ownerId === currentUserId) return 'owner';
+  if (gym.myRole === 'admin') return 'admin';
+  if (gym.myRole === 'editor') return 'editor';
+  if (gym.myRole === 'member') return 'member';
+  return null;
+}
+
+export default function MyGymsDrawer({ open, onClose, onTransitionEnd }: MyGymsDrawerProps) {
+  const { t } = useTranslation('common');
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id ?? null;
+  const { gyms, isLoading, isFetchingMore, hasMore, loadMore, error } = useMyGyms(open);
+  const { sentinelRef } = useInfiniteScroll({ onLoadMore: loadMore, hasMore, isFetching: isFetchingMore });
+  const [showSearch, setShowSearch] = useState(false);
+  const [searchRendered, setSearchRendered] = useState(false);
+
+  const roleLabel = useCallback(
+    (role: GymRoleKind): string => {
+      switch (role) {
+        case 'owner':
+          return t('myGyms.roleOwner');
+        case 'admin':
+          return t('myGyms.roleAdmin');
+        case 'editor':
+          return t('myGyms.roleEditor');
+        case 'member':
+          return t('myGyms.roleMember');
+      }
+    },
+    [t],
+  );
+
+  const openSearch = useCallback(() => {
+    setSearchRendered(true);
+    setShowSearch(true);
+  }, []);
+
+  const handleSearchTransitionEnd = useCallback((searchOpen: boolean) => {
+    if (!searchOpen) setSearchRendered(false);
+  }, []);
+
+  const headerExtra = (
+    <IconButton size="small" onClick={openSearch} aria-label={t('myGyms.ariaFindGym')}>
+      <SearchOutlined fontSize="small" />
+    </IconButton>
+  );
+
+  const renderContent = () => {
+    if (error && gyms.length === 0) {
+      return (
+        <div className={styles.emptyState} data-testid="my-gyms-error">
+          <Alert severity="error" sx={{ width: '100%' }}>
+            {t('myGyms.loadError')}
+          </Alert>
+        </div>
+      );
+    }
+    if (isLoading && gyms.length === 0) {
+      return (
+        <div className={styles.loadingState} data-testid="my-gyms-loading">
+          <CircularProgress size={32} />
+        </div>
+      );
+    }
+    if (gyms.length === 0) {
+      return (
+        <div className={styles.emptyState} data-testid="my-gyms-empty">
+          <FitnessCenterOutlined sx={{ fontSize: 48, color: 'var(--neutral-300)' }} />
+          <Typography variant="body2" color="text.secondary">
+            {t('myGyms.empty')}
+          </Typography>
+          <MuiButton variant="contained" startIcon={<SearchOutlined />} onClick={openSearch} data-testid="my-gyms-find">
+            {t('myGyms.findGym')}
+          </MuiButton>
+        </div>
+      );
+    }
+    return (
+      <div className={styles.gymList} data-testid="my-gyms-list">
+        {gyms.map((gym) => {
+          const role = resolveGymRole(gym, currentUserId);
+          // The manage route resolves a bare UUID (slug-less legacy gyms), but the
+          // public gym page only resolves by slug — so "View" is offered only when
+          // the gym has a public slug to link to.
+          const manageHref = `/gym/${gym.slug ?? gym.uuid}/manage`;
+          const viewHref = gym.slug ? `/gym/${gym.slug}` : null;
+          return (
+            <div key={gym.uuid} className={styles.gymItem} data-testid={`gym-item-${gym.uuid}`}>
+              <div className={styles.gymItemIcon}>
+                <FitnessCenterOutlined />
+              </div>
+              <div className={styles.gymItemInfo}>
+                <div className={styles.gymItemHeader}>
+                  <span className={styles.gymItemName}>{gym.name}</span>
+                  {role && <Chip size="small" label={roleLabel(role)} color={ROLE_CHIP_COLOR[role]} />}
+                </div>
+                {gym.address && <div className={styles.gymItemMeta}>{gym.address}</div>}
+              </div>
+              <div className={styles.gymItemActions}>
+                {gym.canEdit && (
+                  <MuiButton
+                    component={LocaleLink}
+                    href={manageHref}
+                    onClick={onClose}
+                    size="small"
+                    variant="outlined"
+                    startIcon={<SettingsOutlined />}
+                    sx={{ textTransform: 'none' }}
+                    data-testid={`gym-manage-${gym.uuid}`}
+                  >
+                    {t('myGyms.manage')}
+                  </MuiButton>
+                )}
+                {viewHref && (
+                  <MuiButton
+                    component={LocaleLink}
+                    href={viewHref}
+                    onClick={onClose}
+                    size="small"
+                    variant="text"
+                    startIcon={<VisibilityOutlined />}
+                    sx={{ textTransform: 'none' }}
+                    data-testid={`gym-view-${gym.uuid}`}
+                  >
+                    {t('myGyms.view')}
+                  </MuiButton>
+                )}
+              </div>
+            </div>
+          );
+        })}
+        <div ref={sentinelRef} />
+        {isFetchingMore && (
+          <div className={styles.loadingMore}>
+            <CircularProgress size={20} />
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <SwipeableDrawer
+        title={t('myGyms.title')}
+        placement="bottom"
+        open={open}
+        onClose={onClose}
+        onTransitionEnd={onTransitionEnd}
+        height="100%"
+        fullHeight
+        extra={headerExtra}
+        styles={{ body: { padding: 0 } }}
+      >
+        {renderContent()}
+      </SwipeableDrawer>
+
+      {searchRendered && (
+        <UnifiedSearchDrawer
+          open={showSearch}
+          onClose={() => setShowSearch(false)}
+          onTransitionEnd={handleSearchTransitionEnd}
+          defaultCategory="gyms"
+          allowedCategories={['gyms']}
+          showCloseButton
+        />
+      )}
+    </>
+  );
+}

--- a/packages/web/app/components/my-gyms-drawer/my-gyms-drawer.tsx
+++ b/packages/web/app/components/my-gyms-drawer/my-gyms-drawer.tsx
@@ -16,6 +16,8 @@ import VisibilityOutlined from '@mui/icons-material/VisibilityOutlined';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import UnifiedSearchDrawer from '../search-drawer/unified-search-drawer';
 import LocaleLink from '@/app/components/i18n/locale-link';
+import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
+import { GYM_KIOSK_FLAG } from '@/app/flags';
 import { useMyGyms } from '@/app/hooks/use-my-gyms';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import type { Gym } from '@boardsesh/shared-schema';
@@ -42,6 +44,8 @@ const ROLE_CHIP_COLOR: Record<GymRoleKind, ChipColor> = {
  * Resolve the viewer's standing at a gym. The owner outranks the `myRole`
  * field (owners are reported as gym admins by the backend), so the owner check
  * comes first. Returns null for a gym the viewer only follows.
+ * Admin/editor rows only become reachable once `myGyms` includes gym_members
+ * (staff-roles PR); until then every listed gym resolves to `owner`.
  */
 function resolveGymRole(gym: Gym, currentUserId: string | null): GymRoleKind | null {
   if (currentUserId && gym.ownerId === currentUserId) return 'owner';
@@ -55,6 +59,10 @@ export default function MyGymsDrawer({ open, onClose, onTransitionEnd }: MyGymsD
   const { t } = useTranslation('common');
   const { data: session } = useSession();
   const currentUserId = session?.user?.id ?? null;
+  // Kill switch for the manage surface — mirrors gym-detail.tsx and the public
+  // gym page's Manage button, which both hide manage entry points until the
+  // gym-kiosk feature ships broadly. The drawer and View action stay ungated.
+  const kioskFlag = useFeatureFlag(GYM_KIOSK_FLAG);
   const { gyms, isLoading, isFetchingMore, hasMore, loadMore, error } = useMyGyms(open);
   const { sentinelRef } = useInfiniteScroll({ onLoadMore: loadMore, hasMore, isFetching: isFetchingMore });
   const [showSearch, setShowSearch] = useState(false);
@@ -143,7 +151,7 @@ export default function MyGymsDrawer({ open, onClose, onTransitionEnd }: MyGymsD
                 {gym.address && <div className={styles.gymItemMeta}>{gym.address}</div>}
               </div>
               <div className={styles.gymItemActions}>
-                {gym.canEdit && (
+                {gym.canEdit && kioskFlag && (
                   <MuiButton
                     component={LocaleLink}
                     href={manageHref}

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/app/lib/url-utils';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
 import DashboardOutlined from '@mui/icons-material/DashboardOutlined';
+import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
 import BuildOutlined from '@mui/icons-material/BuildOutlined';
 import DeveloperBoardOutlined from '@mui/icons-material/DeveloperBoardOutlined';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
@@ -52,6 +53,7 @@ import { StoreReviewPromptDialog } from '../feedback/store-review-prompt-dialog'
 import BoardDiscoveryScroll from '../board-scroll/board-discovery-scroll';
 import BoardSelectorDrawer from '../board-selector-drawer/board-selector-drawer';
 import MyBoardsDrawer from '../my-boards-drawer/my-boards-drawer';
+import MyGymsDrawer from '../my-gyms-drawer/my-gyms-drawer';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
 import type { BoardDetails, BoardName, BoardRouteIdentity } from '@/app/lib/types';
 import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
@@ -97,6 +99,8 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
   const [customBoardRendered, setCustomBoardRendered] = useState(false);
   const [showMyBoards, setShowMyBoards] = useState(false);
   const [myBoardsRendered, setMyBoardsRendered] = useState(false);
+  const [showMyGyms, setShowMyGyms] = useState(false);
+  const [myGymsRendered, setMyGymsRendered] = useState(false);
   const [recentSessions, setRecentSessions] = useState<StoredSession[]>([]);
   const [showDevUrl, setShowDevUrl] = useState(false);
   const { isAvailable: devUrlAvailable } = useDevUrl();
@@ -153,6 +157,9 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
   }, []);
   const handleMyBoardsTransitionEnd = useCallback((open: boolean) => {
     if (!open) setMyBoardsRendered(false);
+  }, []);
+  const handleMyGymsTransitionEnd = useCallback((open: boolean) => {
+    if (!open) setMyGymsRendered(false);
   }, []);
 
   const handleChangeBoardClick = useCallback(
@@ -342,6 +349,23 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
                     <DashboardOutlined />
                   </span>
                   <span className={styles.menuItemLabel}>{t('myBoards.title')}</span>
+                </button>
+              )}
+
+              {session?.user && (
+                <button
+                  type="button"
+                  className={styles.menuItem}
+                  onClick={() => {
+                    handleClose();
+                    setMyGymsRendered(true);
+                    setShowMyGyms(true);
+                  }}
+                >
+                  <span className={styles.menuItemIcon}>
+                    <FitnessCenterOutlined />
+                  </span>
+                  <span className={styles.menuItemLabel}>{t('myGyms.title')}</span>
                 </button>
               )}
 
@@ -617,6 +641,14 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
             setCustomBoardRendered(true);
             setShowCustomBoard(true);
           }}
+        />
+      )}
+
+      {myGymsRendered && (
+        <MyGymsDrawer
+          open={showMyGyms}
+          onClose={() => setShowMyGyms(false)}
+          onTransitionEnd={handleMyGymsTransitionEnd}
         />
       )}
 

--- a/packages/web/app/hooks/use-my-gyms.ts
+++ b/packages/web/app/hooks/use-my-gyms.ts
@@ -57,7 +57,6 @@ export function useMyGyms(enabled: boolean, limit = 50) {
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, isAuthenticated, token, limit]);
 
   const loadMore = useCallback(() => {

--- a/packages/web/app/hooks/use-my-gyms.ts
+++ b/packages/web/app/hooks/use-my-gyms.ts
@@ -1,0 +1,87 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { GET_MY_GYMS, type GetMyGymsQueryResponse, type GetMyGymsQueryVariables } from '@boardsesh/graphql/operations';
+import type { Gym } from '@boardsesh/shared-schema';
+
+/**
+ * Fetches the gyms the current user runs (owner/admin/editor) via GraphQL.
+ * Gyms are fetched when `enabled` becomes true and the user is authenticated.
+ *
+ * Call `loadMore` to fetch the next page; `hasMore` indicates whether more pages exist.
+ * Mirrors {@link import('./use-my-boards').useMyBoards} so the My Gyms drawer follows
+ * the same load/paginate/error shape as My Boards.
+ */
+export function useMyGyms(enabled: boolean, limit = 50) {
+  const { token, isAuthenticated } = useWsAuthToken();
+  const [gyms, setGyms] = useState<Gym[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const offsetRef = useRef(0);
+  // Synchronous guard prevents double-fires from the IntersectionObserver
+  const isFetchingMoreRef = useRef(false);
+  const hasDataRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || !isAuthenticated || !token) return;
+
+    let cancelled = false;
+    if (!hasDataRef.current) {
+      setIsLoading(true);
+    }
+    setError(null);
+    offsetRef.current = 0;
+
+    const client = createGraphQLHttpClient(token);
+    client
+      .request<GetMyGymsQueryResponse, GetMyGymsQueryVariables>(GET_MY_GYMS, { input: { limit, offset: 0 } })
+      .then((response) => {
+        if (!cancelled) {
+          setGyms(response.myGyms.gyms);
+          setHasMore(response.myGyms.hasMore);
+          offsetRef.current = response.myGyms.gyms.length;
+          hasDataRef.current = true;
+        }
+      })
+      .catch((requestError) => {
+        console.error('Failed to fetch gyms:', requestError);
+        if (!cancelled) setError('Failed to load your gyms');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, isAuthenticated, token, limit]);
+
+  const loadMore = useCallback(() => {
+    if (!hasMore || isFetchingMoreRef.current || !token || !isAuthenticated) return;
+
+    isFetchingMoreRef.current = true;
+    setIsFetchingMore(true);
+    const offset = offsetRef.current;
+    const client = createGraphQLHttpClient(token);
+    client
+      .request<GetMyGymsQueryResponse, GetMyGymsQueryVariables>(GET_MY_GYMS, { input: { limit, offset } })
+      .then((response) => {
+        setGyms((prev) => [...prev, ...response.myGyms.gyms]);
+        setHasMore(response.myGyms.hasMore);
+        offsetRef.current = offset + response.myGyms.gyms.length;
+      })
+      .catch((requestError) => {
+        console.error('Failed to load more gyms:', requestError);
+      })
+      .finally(() => {
+        isFetchingMoreRef.current = false;
+        setIsFetchingMore(false);
+      });
+  }, [hasMore, token, isAuthenticated, limit]);
+
+  return { gyms, isLoading, isFetchingMore, hasMore, loadMore, error };
+}

--- a/packages/web/app/hooks/use-my-gyms.ts
+++ b/packages/web/app/hooks/use-my-gyms.ts
@@ -5,7 +5,11 @@ import { GET_MY_GYMS, type GetMyGymsQueryResponse, type GetMyGymsQueryVariables 
 import type { Gym } from '@boardsesh/shared-schema';
 
 /**
- * Fetches the gyms the current user runs (owner/admin/editor) via GraphQL.
+ * Fetches the gyms the current user owns via GraphQL. Membership-based listing
+ * (admin/editor) arrives with the staff-roles PR — today the `myGyms` resolver
+ * only returns gyms where `ownerId = userId` (no gym_members join). The role-chip
+ * logic already handles admin/editor rows; they become reachable once `myGyms`
+ * includes gym_members.
  * Gyms are fetched when `enabled` becomes true and the user is authenticated.
  *
  * Call `loadMore` to fetch the next page; `hasMore` indicates whether more pages exist.


### PR DESCRIPTION
## Summary

There was no way to click your way to anything gym-related in the app — a gym owner couldn't reach their own gym console. This adds a **My Gyms** entry to the user drawer for every signed-in user, right below **My Boards**, cloning that established pattern.

Tapping it opens a nested drawer that lists the gyms you run:

- Each row shows the gym name and a role chip (Owner / Admin / Editor / Member).
- **Manage** (only when you can edit) jumps to `/gym/[slug]/manage`; **View** opens the public `/gym/[slug]`. Both are real `LocaleLink`s.
- Empty state nudges you that your gym might already be on Boardsesh, with a **Find your gym** action that opens the existing global search pre-set to the Gyms category (no new search UI).

Consumes the existing `myGyms` GraphQL query (previously used only by the board-linking selector) via a new `useMyGyms` hook that mirrors `useMyBoards`. Owner is resolved by comparing `ownerId` to the signed-in user, since the backend reports owners as gym admins in `myRole`.

## Release Notes

- Your gyms are one tap away — open the menu and hit **My gyms** to jump straight into managing kiosks, boards, and your crew.

## Test plan

- `vp check` — 0 errors (pre-existing warnings only)
- `vp run typecheck:web` — clean
- `vp test run --project web --reporter=agent` — all green (new `my-gyms-drawer` suite: 12 tests; `user-drawer` suite still passing)
- `vp run check:i18n` — no hardcoded strings
- `@boardsesh/i18n` catalog completeness — parity across en-US / es / fr

Manual flows to exercise:
- Signed-in user with 0 gyms: empty state + "Find your gym" opens gym search.
- Signed-in user who owns a gym: Owner chip, Manage → `/gym/[slug]/manage`, View → `/gym/[slug]`.
- Non-editor: Manage hidden, only View shown.
