### PR TITLE
feat(web): make /gym/[slug] the real gym destination

### DIFF
--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -71,7 +71,10 @@
     "boardCount_other": "{{count}} boards",
     "visitWebsite": "Visit website",
     "noBoardsYet": "No boards listed here yet.",
-    "exploreFeed": "See what climbers are sending"
+    "exploreFeed": "See what climbers are sending",
+    "claimTitle": "Is this your gym?",
+    "claimBody": "Claim it to run the boards, the branding, and what shows up on the wall.",
+    "claimCta": "Claim this gym"
   },
   "manage": {
     "title": "Manage {{gymName}}",

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -71,7 +71,10 @@
     "boardCount_other": "{{count}} plafones",
     "visitWebsite": "Visitar el sitio web",
     "noBoardsYet": "Aún no hay plafones aquí.",
-    "exploreFeed": "Mira qué están encadenando otros escaladores"
+    "exploreFeed": "Mira qué están encadenando otros escaladores",
+    "claimTitle": "¿Es tuyo este rocódromo?",
+    "claimBody": "Reclámalo para gestionar los plafones, la marca y lo que se ve en el muro.",
+    "claimCta": "Reclamar este rocódromo"
   },
   "manage": {
     "title": "Gestionar {{gymName}}",

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -71,7 +71,10 @@
     "boardCount_other": "{{count}} boards",
     "visitWebsite": "Visiter le site web",
     "noBoardsYet": "Aucune board ici pour l'instant.",
-    "exploreFeed": "Voir ce que les grimpeurs enchaînent"
+    "exploreFeed": "Voir ce que les grimpeurs enchaînent",
+    "claimTitle": "C'est ta salle ?",
+    "claimBody": "Revendique-la pour gérer les boards, l'identité visuelle et ce qui s'affiche sur le mur.",
+    "claimCta": "Revendiquer cette salle"
   },
   "manage": {
     "title": "Gérer {{gymName}}",

--- a/packages/web/app/components/gym-entity/__tests__/gym-card.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/gym-card.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { Gym } from '@boardsesh/shared-schema';
+import GymCard from '../gym-card';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+function makeGym(overrides: Partial<Gym> = {}): Gym {
+  return {
+    uuid: 'gym-uuid-1',
+    slug: 'garage-gym',
+    name: 'Garage Gym',
+    address: '123 Boulder St',
+    boardCount: 3,
+    memberCount: 12,
+    followerCount: 5,
+    ...overrides,
+  } as unknown as Gym;
+}
+
+describe('GymCard', () => {
+  it('renders the gym name as a crawlable link to the public gym page', () => {
+    render(<GymCard gym={makeGym()} onClick={vi.fn()} />);
+    const link = screen.getByRole('link', { name: 'Garage Gym' });
+    expect(link.getAttribute('href')).toBe('/gym/garage-gym');
+  });
+
+  it('does not open the preview sheet when the name link is tapped, but does for the rest of the card', () => {
+    const onClick = vi.fn();
+    render(<GymCard gym={makeGym()} onClick={onClick} />);
+
+    // The name link goes to the full page; stopPropagation keeps the sheet closed.
+    fireEvent.click(screen.getByRole('link', { name: 'Garage Gym' }));
+    expect(onClick).not.toHaveBeenCalled();
+
+    // Tapping elsewhere on the card keeps the open-the-sheet behaviour.
+    fireEvent.click(screen.getByText('123 Boulder St'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to plain text when the gym has no slug (no public page to link to)', () => {
+    render(<GymCard gym={makeGym({ slug: null })} onClick={vi.fn()} />);
+    expect(screen.queryByRole('link', { name: 'Garage Gym' })).toBeNull();
+    expect(screen.getByText('Garage Gym')).toBeTruthy();
+  });
+});

--- a/packages/web/app/components/gym-entity/__tests__/gym-detail.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/gym-detail.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { Gym } from '@boardsesh/shared-schema';
+import GymDetail from '../gym-detail';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+// The sheet is a portal-backed MUI drawer; render its children inline when open
+// so the header markup is queryable without the transition/touch machinery.
+vi.mock('@/app/components/swipeable-drawer/swipeable-drawer', () => ({
+  default: ({ open, children }: { open: boolean; children: React.ReactNode }) => (open ? <div>{children}</div> : null),
+}));
+
+// Heavy interactive children have their own hooks/subscriptions — stub them so
+// this test stays focused on the header's new "view full page" link.
+vi.mock('@/app/components/ui/follow-button', () => ({ default: () => <div data-testid="follow-button" /> }));
+vi.mock('@/app/components/social/comment-section', () => ({ default: () => <div data-testid="comment-section" /> }));
+vi.mock('../gym-member-management', () => ({ default: () => <div data-testid="member-management" /> }));
+vi.mock('../claim-gym-dialog', () => ({ default: () => null }));
+vi.mock('../edit-gym-form', () => ({ default: () => null }));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null }),
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'viewer-1' } }, status: 'authenticated' }),
+}));
+
+vi.mock('@/app/components/providers/feature-flags-provider', () => ({
+  useFeatureFlag: () => false,
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+function makeGym(overrides: Partial<Gym> = {}): Gym {
+  return {
+    uuid: 'gym-uuid-1',
+    slug: 'test-gym',
+    ownerId: 'owner-1',
+    ownerDisplayName: 'Owner',
+    name: 'Test Gym',
+    website: null,
+    boardCount: 2,
+    memberCount: 4,
+    followerCount: 1,
+    commentCount: 0,
+    isFollowedByMe: false,
+    canEdit: false,
+    canClaim: false,
+    ...overrides,
+  } as unknown as Gym;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GymDetail header link', () => {
+  it('links the gym name in the header to the public gym page', async () => {
+    mockRequest.mockResolvedValue({ gym: makeGym() });
+    render(<GymDetail gymUuid="gym-uuid-1" open onClose={vi.fn()} />);
+
+    const link = await screen.findByRole('link', { name: 'Test Gym' });
+    expect(link.getAttribute('href')).toBe('/gym/test-gym');
+  });
+
+  it('renders the name as plain text when the gym has no slug', async () => {
+    mockRequest.mockResolvedValue({ gym: makeGym({ slug: null }) });
+    render(<GymDetail gymUuid="gym-uuid-1" open onClose={vi.fn()} />);
+
+    expect(await screen.findByText('Test Gym')).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'Test Gym' })).toBeNull();
+  });
+});

--- a/packages/web/app/components/gym-entity/gym-card.tsx
+++ b/packages/web/app/components/gym-entity/gym-card.tsx
@@ -7,6 +7,7 @@ import CardActionArea from '@mui/material/CardActionArea';
 import CardContent from '@mui/material/CardContent';
 import Box from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
+import MuiLink from '@mui/material/Link';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
 import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
@@ -14,6 +15,7 @@ import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import type { Gym } from '@boardsesh/shared-schema';
 import { themeTokens } from '@/app/theme/theme-config';
 import StatItem from '@/app/components/ui/stat-item';
+import LocaleLink from '@/app/components/i18n/locale-link';
 
 type GymCardProps = {
   gym: Gym;
@@ -32,7 +34,11 @@ export default function GymCard({ gym, onClick }: GymCardProps) {
         transition: themeTokens.transitions.fast,
       }}
     >
-      <CardActionArea onClick={() => onClick?.(gym)} disabled={!onClick}>
+      {/* Rendered as a div (not the default <button>) so the crawlable gym-name
+          <a> can nest inside it without invalid interactive-in-button markup.
+          ButtonBase still adds role="button" + keyboard handling for the card
+          tap that opens the preview sheet. */}
+      <CardActionArea component="div" onClick={() => onClick?.(gym)} disabled={!onClick}>
         <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
           <Box
             sx={{
@@ -43,18 +49,41 @@ export default function GymCard({ gym, onClick }: GymCardProps) {
             }}
           >
             <Box sx={{ flex: 1, minWidth: 0 }}>
-              <MuiTypography
-                variant="subtitle1"
-                sx={{
-                  fontWeight: themeTokens.typography.fontWeight.semibold,
-                  lineHeight: themeTokens.typography.lineHeight.tight,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {gym.name}
-              </MuiTypography>
+              {gym.slug ? (
+                <MuiLink
+                  component={LocaleLink}
+                  href={`/gym/${gym.slug}`}
+                  // Let the name link go to the full gym page without also
+                  // opening the card's preview sheet.
+                  onClick={(event: React.MouseEvent) => event.stopPropagation()}
+                  underline="hover"
+                  color="inherit"
+                  variant="subtitle1"
+                  sx={{
+                    display: 'block',
+                    fontWeight: themeTokens.typography.fontWeight.semibold,
+                    lineHeight: themeTokens.typography.lineHeight.tight,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {gym.name}
+                </MuiLink>
+              ) : (
+                <MuiTypography
+                  variant="subtitle1"
+                  sx={{
+                    fontWeight: themeTokens.typography.fontWeight.semibold,
+                    lineHeight: themeTokens.typography.lineHeight.tight,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {gym.name}
+                </MuiTypography>
+              )}
               {gym.address && (
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
                   <LocationOnOutlined sx={{ fontSize: 14, color: 'var(--neutral-400)' }} />

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -51,6 +51,7 @@ import { GYM_KIOSK_FLAG } from '@/app/flags';
 import EditGymForm from './edit-gym-form';
 import GymMemberManagement from './gym-member-management';
 import ClaimGymDialog from './claim-gym-dialog';
+import GymStatChip from './gym-stat-chip';
 import CommentSection from '@/app/components/social/comment-section';
 
 type GymDetailProps = {
@@ -166,9 +167,22 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
             }}
           >
             <Box sx={{ flex: 1, minWidth: 0 }}>
-              <MuiTypography variant="h5" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
-                {gym.name}
-              </MuiTypography>
+              {gym.slug ? (
+                <MuiLink
+                  component={LocaleLink}
+                  href={`/gym/${gym.slug}`}
+                  underline="hover"
+                  color="inherit"
+                  variant="h5"
+                  sx={{ display: 'block', fontWeight: themeTokens.typography.fontWeight.bold }}
+                >
+                  {gym.name}
+                </MuiLink>
+              ) : (
+                <MuiTypography variant="h5" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+                  {gym.name}
+                </MuiTypography>
+              )}
               {gym.address && (
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
                   <LocationOnOutlined sx={{ fontSize: 16, color: 'var(--neutral-400)' }} />
@@ -212,22 +226,22 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
 
           {/* Stats */}
           <Box sx={{ display: 'flex', gap: 2.5, mt: 2, flexWrap: 'wrap' }}>
-            <StatChip
+            <GymStatChip
               icon={<FitnessCenterOutlined sx={{ fontSize: 16 }} />}
               value={gym.boardCount}
               label={t('gymEntity.stats.boards')}
             />
-            <StatChip
+            <GymStatChip
               icon={<PersonOutlined sx={{ fontSize: 16 }} />}
               value={gym.memberCount}
               label={t('gymEntity.stats.members')}
             />
-            <StatChip
+            <GymStatChip
               icon={<PeopleOutlined sx={{ fontSize: 16 }} />}
               value={gym.followerCount}
               label={t('gymEntity.stats.followers')}
             />
-            <StatChip
+            <GymStatChip
               icon={<ChatBubbleOutlined sx={{ fontSize: 16 }} />}
               value={gym.commentCount}
               label={t('gymEntity.stats.comments')}
@@ -360,19 +374,5 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
         </DialogActions>
       </Dialog>
     </>
-  );
-}
-
-function StatChip({ icon, value, label }: { icon: React.ReactNode; value: number; label: string }) {
-  return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-      <Box sx={{ color: 'var(--neutral-400)', display: 'flex' }}>{icon}</Box>
-      <MuiTypography variant="body2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
-        {value}
-      </MuiTypography>
-      <MuiTypography variant="body2" color="text.secondary">
-        {label}
-      </MuiTypography>
-    </Box>
   );
 }

--- a/packages/web/app/components/gym-entity/gym-stat-chip.tsx
+++ b/packages/web/app/components/gym-entity/gym-stat-chip.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import MuiTypography from '@mui/material/Typography';
+import { themeTokens } from '@/app/theme/theme-config';
+
+type GymStatChipProps = {
+  icon: React.ReactNode;
+  value: number;
+  label: string;
+};
+
+/**
+ * Icon + count + label chip shared by the gym preview sheet (GymDetail) and the
+ * public gym page. Presentational only (no directive), so it renders in the
+ * server page and inside the client sheet alike.
+ */
+export default function GymStatChip({ icon, value, label }: GymStatChipProps) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <Box sx={{ color: 'var(--neutral-400)', display: 'flex' }}>{icon}</Box>
+      <MuiTypography variant="body2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+        {value}
+      </MuiTypography>
+      <MuiTypography variant="body2" color="text.secondary">
+        {label}
+      </MuiTypography>
+    </Box>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import VerifiedUserOutlined from '@mui/icons-material/VerifiedUserOutlined';
+import ClaimGymDialog from '@/app/components/gym-entity/claim-gym-dialog';
+import { themeTokens } from '@/app/theme/theme-config';
+
+type GymClaimCtaProps = {
+  gymUuid: string;
+  gymName: string;
+  website?: string | null;
+};
+
+/**
+ * Client island: the prominent "claim this gym" call-out on the public gym
+ * page. The server only renders it when the viewer can actually claim the gym
+ * (gym.canClaim), and it reuses the exact ClaimGymDialog the preview sheet opens.
+ */
+export default function GymClaimCta({ gymUuid, gymName, website }: GymClaimCtaProps) {
+  const { t } = useTranslation('kiosk');
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Box
+      sx={{
+        border: '1px solid var(--neutral-200)',
+        borderRadius: `${themeTokens.borderRadius.lg}px`,
+        p: 2.5,
+        mb: 3,
+      }}
+    >
+      <Typography variant="subtitle1" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+        {t('gymPage.claimTitle')}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, mb: 1.5 }}>
+        {t('gymPage.claimBody')}
+      </Typography>
+      <Button
+        variant="contained"
+        startIcon={<VerifiedUserOutlined />}
+        onClick={() => setOpen(true)}
+        sx={{ textTransform: 'none' }}
+      >
+        {t('gymPage.claimCta')}
+      </Button>
+      <ClaimGymDialog
+        gymUuid={gymUuid}
+        gymName={gymName}
+        website={website}
+        open={open}
+        onClose={() => setOpen(false)}
+      />
+    </Box>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/gym-follow-button.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-follow-button.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSession } from 'next-auth/react';
+import { FOLLOW_GYM, UNFOLLOW_GYM } from '@boardsesh/graphql/operations';
+import FollowButton from '@/app/components/ui/follow-button';
+
+type GymFollowButtonProps = {
+  gymUuid: string;
+  ownerId: string;
+  isFollowedByMe: boolean;
+};
+
+/**
+ * Client island: the Follow control on the public gym page. Reuses the same
+ * FollowButton the preview sheet mounts, so the state, optimistic toggle, and
+ * copy stay identical. Hidden for the gym's owner (you don't follow your own
+ * gym) and, via FollowButton itself, for signed-out visitors.
+ */
+export default function GymFollowButton({ gymUuid, ownerId, isFollowedByMe }: GymFollowButtonProps) {
+  const { t } = useTranslation('boards');
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id ?? null;
+
+  if (currentUserId && currentUserId === ownerId) {
+    return null;
+  }
+
+  return (
+    <FollowButton
+      entityId={gymUuid}
+      initialIsFollowing={isFollowedByMe}
+      followMutation={FOLLOW_GYM}
+      unfollowMutation={UNFOLLOW_GYM}
+      entityLabel={t('gymEntity.follow.entityLabel')}
+      getFollowVariables={(id) => ({ input: { gymUuid: id } })}
+    />
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -11,6 +11,9 @@ import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import LanguageOutlined from '@mui/icons-material/LanguageOutlined';
 import TvOutlined from '@mui/icons-material/TvOutlined';
 import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
+import PersonOutlined from '@mui/icons-material/PersonOutlined';
+import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
+import ChatBubbleOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import type { Gym, UserBoard } from '@boardsesh/shared-schema';
 import {
   GET_GYM_BY_SLUG,
@@ -31,7 +34,11 @@ import { safeExternalHref } from '@/app/lib/safe-external-url';
 import { themeTokens } from '@/app/theme/theme-config';
 import I18nProvider from '@/app/components/providers/i18n-provider';
 import LocaleLink from '@/app/components/i18n/locale-link';
+import GymStatChip from '@/app/components/gym-entity/gym-stat-chip';
+import CommentSection from '@/app/components/social/comment-section';
 import GymPageManageButton from './gym-page-manage-button';
+import GymFollowButton from './gym-follow-button';
+import GymClaimCta from './gym-claim-cta';
 import { getPublicBackendHttpUrl } from '@/app/lib/backend-url';
 import { resolveGymLogoDisplayUrl } from '@/app/lib/gym-logo-display-url';
 
@@ -107,7 +114,7 @@ export default async function GymPage(props: GymRouteProps) {
   }
 
   const locale = await getLocale();
-  const { t } = await getServerTranslation('kiosk');
+  const [{ t }, { t: tBoards }] = await Promise.all([getServerTranslation('kiosk'), getServerTranslation('boards')]);
   const [kiosk, boards] = await Promise.all([fetchDefaultKiosk(gym_slug, token), fetchGymBoards(gym.uuid, token)]);
 
   // Stored logo paths are backend-relative; resolve for the browser (also
@@ -176,7 +183,31 @@ export default async function GymPage(props: GymRouteProps) {
           </Typography>
         )}
 
+        <Box sx={{ display: 'flex', gap: 2.5, flexWrap: 'wrap', mb: 3 }}>
+          <GymStatChip
+            icon={<FitnessCenterOutlined sx={{ fontSize: 18 }} />}
+            value={gym.boardCount}
+            label={tBoards('gymEntity.stats.boards')}
+          />
+          <GymStatChip
+            icon={<PersonOutlined sx={{ fontSize: 18 }} />}
+            value={gym.memberCount}
+            label={tBoards('gymEntity.stats.members')}
+          />
+          <GymStatChip
+            icon={<PeopleOutlined sx={{ fontSize: 18 }} />}
+            value={gym.followerCount}
+            label={tBoards('gymEntity.stats.followers')}
+          />
+          <GymStatChip
+            icon={<ChatBubbleOutlined sx={{ fontSize: 18 }} />}
+            value={gym.commentCount}
+            label={tBoards('gymEntity.stats.comments')}
+          />
+        </Box>
+
         <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', mb: 3 }}>
+          <GymFollowButton gymUuid={gym.uuid} ownerId={gym.ownerId} isFollowedByMe={gym.isFollowedByMe} />
           {kiosk && (
             <Button
               component={LocaleLink}
@@ -202,6 +233,8 @@ export default async function GymPage(props: GymRouteProps) {
           )}
           {gym.canEdit && <GymPageManageButton gymSlug={gym_slug} />}
         </Box>
+
+        {gym.canClaim && <GymClaimCta gymUuid={gym.uuid} gymName={gym.name} website={gym.website} />}
 
         <Divider sx={{ mb: 3 }} />
 
@@ -244,6 +277,10 @@ export default async function GymPage(props: GymRouteProps) {
             ))}
           </Box>
         )}
+
+        <Divider sx={{ my: 4 }} />
+
+        <CommentSection entityType="gym" entityId={gym.uuid} title={tBoards('gymEntity.comments.title')} />
 
         <Box sx={{ mt: 4 }}>
           <MuiLink component={LocaleLink} href="/feed" underline="hover" sx={{ color: themeTokens.colors.primary }}>


### PR DESCRIPTION
## Summary

Makes `/gym/[slug]` the real gym destination. Gym search cards and the GymDetail preview sheet now link into the page, and the page absorbs the social surface that previously lived only in the sheet.

- `GymCard`: the gym name is a crawlable `LocaleLink` to `/gym/[slug]` (stopPropagation keeps the rest of the card opening the preview sheet; renders as valid HTML via `CardActionArea component="div"`)
- `GymDetail` sheet: header gym name links to the full page
- `/gym/[slug]` page: stats row, Follow button, prominent claim CTA (`canClaim`-gated), and comments — reusing the exact components the sheet mounts; the sheet's private StatChip was extracted to a shared `GymStatChip`
- Interactivity via two small client islands (`gym-follow-button`, `gym-claim-cta`); the page stays a server component with meaningful first-HTML copy
- Not added to the sitemap yet (deferred until the duplicate-gym cleanup lands)
- i18n: all new strings in en-US / es / fr

Tests: 5 new tests covering the name-link href, stopPropagation vs card tap, and slug-null fallbacks in card + sheet.

## Release Notes

- Gym pages are real pages now — tap a gym's name anywhere to see its walls, follow it, claim it, and join the conversation.