### PR TITLE
ci: gate screenshot workflows behind the Production environment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Code owners for security-sensitive CI/CD.
+#
+# Anything that can read a repo secret, run on a runner, or change the
+# build/deploy pipeline needs a maintainer's review. This only *enforces* a
+# blocking review once branch protection on `main` has "Require review from Code
+# Owners" enabled (Settings -> Branches). Until then it still routes review
+# requests, just without the hard gate.
+#
+# Swap @marcodejongh for a @boardsesh/<team> once a maintainers team exists, so
+# ownership survives any single account.
+
+# CI/CD workflows, Dependabot config, and this file itself
+/.github/                       @marcodejongh
+
+# Build/deploy/release tooling invoked by those workflows
+/scripts/                       @marcodejongh

--- a/.github/workflows/mobile-screenshots-android.yml
+++ b/.github/workflows/mobile-screenshots-android.yml
@@ -56,6 +56,13 @@ permissions:
 
 jobs:
   android:
+    # Gate the crown-jewel secret (OTA_PUSH_APP_PRIVATE_KEY — a GitHub App key on
+    # main's PR-bypass allowlist) behind the Production environment, whose main-only
+    # branch policy fences it off from a pushed branch. Only a commit_to_main
+    # dispatch mints/uses the token, so cron and capture-only runs resolve to '' (no
+    # environment) and never wait on a future required reviewer — see the
+    # conditional-vs-bare note at android-apk-rn.yml (gate job).
+    environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.commit_to_main) && 'Production' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 75
 
@@ -101,7 +108,9 @@ jobs:
       # commit.
       - name: Mint push token
         id: push_token
-        if: vars.OTA_PUSH_APP_ID != ''
+        # Only a commit_to_main dispatch pushes back, so only it needs the app
+        # token — the COMMIT_RUN guard keeps the nightly cron from minting it.
+        if: env.COMMIT_RUN == 'true' && vars.OTA_PUSH_APP_ID != ''
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ vars.OTA_PUSH_APP_ID }}

--- a/.github/workflows/mobile-screenshots-ios.yml
+++ b/.github/workflows/mobile-screenshots-ios.yml
@@ -345,6 +345,13 @@ jobs:
     # Run even if a capture shard failed, so the dimension gate still reports the
     # gap (a missing locale fails it loudly rather than uploading a partial set).
     if: ${{ always() }}
+    # Gate the App Store Connect secrets behind the Production environment — its
+    # main-only branch policy fences them off from anyone who can push a branch and
+    # workflow_dispatch it. The APP_STORE_CONNECT_* secrets are only referenced in
+    # the `UPLOAD_RUN == 'true'` steps, so cron and capture-only runs resolve to ''
+    # (no environment) and never wait on a future required reviewer — see the
+    # conditional-vs-bare note at android-apk-rn.yml (gate job).
+    environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.upload) && 'Production' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Why

Issue #3128 (P0 security). On this repo, **write access = read every repo-level secret**: push a branch, `workflow_dispatch` a workflow that references a secret, and GitHub injects it. Most release workflows already carry `environment: Production` (android-apk-rn, ios-testflight-rn, mobile-store-metadata/draft, testflight-feedback-issues, mobile-auto-version-bump, mobile-ota-production), and the Production environment has a **main-only deployment-branch policy** — the real fence. Two workflows were the last ungated consumers of crown-jewel secrets:

- **mobile-screenshots-ios.yml** — `APP_STORE_CONNECT_API_KEY_BASE64 / _ID / ISSUER_ID`.
- **mobile-screenshots-android.yml** — `OTA_PUSH_APP_PRIVATE_KEY` (a GitHub App key that sits on main's PR-bypass allowlist — i.e. it can push straight to `main`).

Env-scoped secrets shadow same-named repo-level ones for env-gated jobs, so gating these jobs on Production lets the admin later delete the repo-level copies.

## What

- **ios-finalize** (`mobile-screenshots-ios.yml`): `environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.upload) && 'Production' || '' }}`. The App Store secrets are only referenced in the `UPLOAD_RUN == 'true'` steps, so the nightly cron and capture-only runs resolve to `''` (no environment).
- **android** job (`mobile-screenshots-android.yml`): `environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.commit_to_main) && 'Production' || '' }}`, **plus** the GitHub-App token-mint step now also guards on `env.COMMIT_RUN == 'true'` so the nightly cron never mints the OTA push token. (The commit-back step already gated on `COMMIT_RUN`.)
- **.github/CODEOWNERS** (new, minimal): `@marcodejongh` owns `/.github/` (workflows + this file) and `/scripts/`. Needed for a future "Require review from Code Owners" branch setting to have any effect.

**Conditional vs. bare `environment` trade-off.** A bare `environment: Production` would pause the nightly cron the moment a required reviewer is added to the Production environment — the run would hang waiting for approval. The conditional `${{ cond && 'Production' || '' }}` idiom resolves to an **empty-string environment for non-upload runs, which means the job runs with NO environment** (documented behavior) and no approval wait. The same idiom is already live at `android-apk-rn.yml` (gate job).

## Admin runbook (@marcodejongh — settings/secrets, run after this merges)

**Phase A (safe NOW — these are already shadowed by Production copies that gated workflows are actively consuming):** `gh secret delete` the repo-level copies of

```
ANDROID_KEYSTORE_BASE64
ANDROID_KEYSTORE_PASSWORD
ANDROID_KEY_ALIAS
ANDROID_KEY_PASSWORD
GOOGLE_PLAY_SERVICE_ACCOUNT_JSON
IOS_P12_CERTIFICATE_BASE64
IOS_P12_PASSWORD
IOS_APP_PROVISIONING_PROFILE_BASE64
IOS_WIDGETS_PROVISIONING_PROFILE_BASE64
```

plus the dead orphan `IOS_PROVISIONING_PROFILE_BASE64`, and optionally the unreferenced `EXPO_PUBLIC_EAS_PROJECT_ID`. Then re-run **android-apk-rn**, **ios-testflight-rn**, **mobile-store-metadata/draft** from main to confirm they still resolve the Production copies.

**Phase B (only AFTER this PR merges):**
1. Delete repo-level `APP_STORE_CONNECT_API_KEY_BASE64` / `APP_STORE_CONNECT_API_KEY_ID` / `APP_STORE_CONNECT_ISSUER_ID`.
2. Seed the OTA key into Production (it is NOT in Production today): `gh secret set OTA_PUSH_APP_PRIVATE_KEY --env Production < boardsesh-repo-bot.private-key.pem` (needs the original `.pem`).
3. Verify **mobile-ota-production** + **mobile-auto-version-bump** + a `commit_to_main` **screenshots-android** run.
4. THEN delete the repo-level `OTA_PUSH_APP_PRIVATE_KEY`.

**Settings:**
- Delete the stray empty environment `boardsesh / production` (lowercase — not the real `Production`).
- Enable required status checks + "Require review from Code Owners" on `main` (needs this PR's CODEOWNERS to exist first).
- Add a Required reviewer on the Production environment. Note: `can_admins_bypass=true`, so it's advisory for admins.
- `EXPO_TOKEN` stays repo-level by design (preview workflows run on non-main pushes). Whether to split it into a separate lower-privilege token is your call.

**Risks:**
- **R1** — cron hang: avoided by the conditional-environment form (bare form would pause nightly once a required reviewer exists).
- **R2** — ordering: don't delete `APP_STORE_CONNECT_*` / the OTA key before this PR merges AND the OTA key is seeded into Production.
- **R3** — the Production main-only branch policy is the actual fence; don't widen it.
- **R4** — admin bypass is on, so a required reviewer is advisory for admins.
- **R5** — secret VALUES can't be verified from here; the fact that gated workflows already consume the Production copies is the live proof for the Phase A names.

**Acceptance:** no repo-level secret is duplicated by a Production one —

```
comm -12 <(gh secret list --repo boardsesh/boardsesh | cut -f1 | sort) \
         <(gh secret list --env Production --repo boardsesh/boardsesh | cut -f1 | sort)
```

returns empty.

Part of #3128

## Release Notes

none (internal CI hardening)
