### PR TITLE
fix(backend): capture real pg error in updateProfile, stop SQL leaking to clients

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -61,9 +61,16 @@ Two rules to remember when adding an `error` log:
 - **Pass the underlying `Error` as the trailing arg.** `logger.error('Auth check failed:', err)` reaches Sentry. `logger.error('Auth check failed')` does not — message-only error logs are intentionally skipped to keep Sentry quiet, since most are operational status lines. Wrap raw strings in `new Error(...)` if you want them captured.
 - **`logger.warn` is never forwarded.** Use `logger.error` (with an `Error`) for events that should page; keep `logger.warn` for noisy operational lines (origin rejections, retry counters, etc.).
 
-The transport itself is gated to `NODE_ENV === 'production'`, matching the `Sentry.init({ enabled: isProduction })` gate in `instrument.ts`, so dev and test runs do not emit Sentry events even when an `Error` is attached.
+The transport is gated to prod-like environments (`!isLocalDevelopment() && !isTestEnvironment()`, from `@boardsesh/db/client/config`), matching the same gate on `Sentry.init({ enabled })` in `instrument.ts`, so dev and test runs do not emit Sentry events even when an `Error` is attached. This is deliberately **not** a bare `NODE_ENV === 'production'` check: the Railway backend deploy leaves `NODE_ENV` unset, so the old equality gate silently disabled Sentry in production (issues #3603 / #3183).
 
 Specialised error paths still call `Sentry.captureException` directly (`graphql/yoga.ts`, `websocket/setup.ts`, `handlers/sync.ts`, `index.ts`) — those exist to attach finer-grained tags or filter out noisy client-input `GraphQLError`s before capture. The winston transport is the default; direct capture is the exception.
+
+### Dedup and DB-error masking
+
+Two small helpers keep the direct-capture paths from double-reporting and from leaking SQL:
+
+- **`utils/sentry-dedupe.ts`** — a resolver that captures a failure itself (e.g. `updateProfile`, `createSession`) calls `markErrorReported(err)`; the generic `graphql/yoga.ts` handler checks `wasErrorReported(err)` (which also inspects a `GraphQLError`'s `originalError`) and skips its own capture, so one failure yields one Sentry event. If you see a backend error reported exactly once with rich tags, that's this marker at work.
+- **`graphql/mask-error.ts`** — in prod-like environments `graphql/yoga.ts` installs a targeted `maskError`. It sanitizes **only** raw database errors (drizzle's `Failed query: …` wrapper, or anything with a PostgresError code on its cause chain) into a generic `GraphQLError`, captures the real cause to Sentry (deduped as above), and passes every other error through unchanged. Global masking stays off so intentional `throw new Error(message)` resolver copy still reaches clients.
 
 ## Out of scope
 

--- a/packages/backend/src/__tests__/mask-error.test.ts
+++ b/packages/backend/src/__tests__/mask-error.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the targeted graphql-yoga maskError (issues #3183 / #3603).
+ *
+ * The mask sanitizes ONLY raw database errors — drizzle's "Failed query: ..."
+ * wrapper or anything carrying a PostgresError code — so internal SQL never
+ * reaches clients, while every other error (including intentional GraphQLErrors
+ * with a stable extensions.code) passes through untouched.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { GraphQLError } from 'graphql';
+import { isDatabaseLeakError, maskDatabaseError } from '../graphql/mask-error';
+import { markErrorReported, wasErrorReported } from '../utils/sentry-dedupe';
+
+const { sentryCaptureMock } = vi.hoisted(() => ({ sentryCaptureMock: vi.fn() }));
+vi.mock('@sentry/node', () => ({ captureException: sentryCaptureMock }));
+
+function makePgError(code: string): Error {
+  return Object.assign(new Error('canceling statement due to statement timeout'), { code });
+}
+
+function makeDrizzleError(cause: Error): Error {
+  return Object.assign(new Error('Failed query: select "id" from "users" where "users"."id" = $1'), { cause });
+}
+
+describe('isDatabaseLeakError', () => {
+  it('flags a bare drizzle "Failed query:" error', () => {
+    expect(isDatabaseLeakError(makeDrizzleError(makePgError('57014')))).toBe(true);
+  });
+
+  it('flags a located GraphQLError wrapping a drizzle error', () => {
+    const drizzle = makeDrizzleError(makePgError('40P01'));
+    const located = new GraphQLError(drizzle.message, { originalError: drizzle });
+    expect(isDatabaseLeakError(located)).toBe(true);
+  });
+
+  it('flags a bare PostgresError by its code even without the SQL prefix', () => {
+    expect(isDatabaseLeakError(makePgError('23505'))).toBe(true);
+  });
+
+  it('does not flag an intentional GraphQLError with an extensions code', () => {
+    expect(isDatabaseLeakError(new GraphQLError('Rate limited', { extensions: { code: 'RATE_LIMITED' } }))).toBe(false);
+  });
+
+  it('does not flag a plain resolver Error', () => {
+    expect(isDatabaseLeakError(new Error('Board not found'))).toBe(false);
+  });
+});
+
+describe('maskDatabaseError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('replaces a DB-cause error with a generic, SQL-free GraphQLError', () => {
+    const pgError = makePgError('57014');
+    const drizzle = makeDrizzleError(pgError);
+    const located = new GraphQLError(drizzle.message, { originalError: drizzle });
+
+    const masked = maskDatabaseError(located);
+
+    expect(masked).toBeInstanceOf(GraphQLError);
+    expect(masked.message).not.toMatch(/select|Failed query|users/i);
+    expect((masked as GraphQLError).extensions?.code).toBe('INTERNAL_SERVER_ERROR');
+
+    // Captured the real pg cause with the code as a tag, and marked reported.
+    expect(sentryCaptureMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureMock).toHaveBeenCalledWith(
+      pgError,
+      expect.objectContaining({ tags: expect.objectContaining({ source: 'graphql-yoga-mask', pgCode: '57014' }) }),
+    );
+    expect(wasErrorReported(located)).toBe(true);
+  });
+
+  it('does not re-capture an error already reported by a resolver catch', () => {
+    const drizzle = makeDrizzleError(makePgError('57014'));
+    markErrorReported(drizzle);
+
+    maskDatabaseError(drizzle);
+
+    expect(sentryCaptureMock).not.toHaveBeenCalled();
+  });
+
+  it('passes an intentional GraphQLError through unchanged', () => {
+    const intentional = new GraphQLError('Rate limited', { extensions: { code: 'RATE_LIMITED' } });
+
+    const masked = maskDatabaseError(intentional);
+
+    expect(masked).toBe(intentional);
+    expect(sentryCaptureMock).not.toHaveBeenCalled();
+  });
+
+  it('passes a plain resolver Error through with its message intact', () => {
+    const plain = new Error('Board not found');
+
+    const masked = maskDatabaseError(plain);
+
+    expect(masked).toBe(plain);
+    expect(masked.message).toBe('Board not found');
+    expect(sentryCaptureMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/mask-error.test.ts
+++ b/packages/backend/src/__tests__/mask-error.test.ts
@@ -72,7 +72,10 @@ describe('maskDatabaseError', () => {
     expect(wasErrorReported(located)).toBe(true);
   });
 
-  it('does not re-capture an error already reported by a resolver catch', () => {
+  it('does not re-capture an error already marked reported (idempotent / prior capture)', () => {
+    // Guards the mask's own idempotency: if the same error passes through
+    // maskError twice (envelop plugin + handleError), or a resolver already
+    // captured and marked the raw DB error, the second pass must not re-report.
     const drizzle = makeDrizzleError(makePgError('57014'));
     markErrorReported(drizzle);
 

--- a/packages/backend/src/__tests__/update-profile.test.ts
+++ b/packages/backend/src/__tests__/update-profile.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the updateProfile mutation (issue #3603).
+ *
+ * Verifies that:
+ * - Authentication and input validation are enforced.
+ * - The happy path upserts only the fields the caller sent and returns the
+ *   merged profile (displayName / avatarUrl / favoriteCount).
+ * - Empty input takes the no-write path (an empty `set` would be invalid SQL).
+ * - A transient DB failure is caught: the client gets a generic
+ *   PROFILE_UPDATE_FAILED GraphQLError with NO raw SQL, while the real
+ *   PostgresError cause (with its pg code) is captured to Sentry and the error
+ *   is marked reported so the generic Yoga handler doesn't double-report it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { GraphQLError } from 'graphql';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { userMutations } from '../graphql/resolvers/users/mutations';
+import { wasErrorReported } from '../utils/sentry-dedupe';
+
+const { mockDb, sentryCaptureMock, txState } = vi.hoisted(() => {
+  const txState = {
+    insertCalled: false,
+    insertValues: undefined as Record<string, unknown> | undefined,
+    upsertSet: undefined as Record<string, unknown> | undefined,
+    selectRow: undefined as Record<string, unknown> | undefined,
+    failWith: undefined as Error | undefined,
+  };
+
+  const makeTx = () => ({
+    insert: vi.fn(() => ({
+      values: vi.fn((values: Record<string, unknown>) => {
+        txState.insertCalled = true;
+        txState.insertValues = values;
+        return {
+          onConflictDoUpdate: vi.fn((config: { set: Record<string, unknown> }) => {
+            txState.upsertSet = config.set;
+            return Promise.resolve(undefined);
+          }),
+        };
+      }),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        leftJoin: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(() => Promise.resolve(txState.selectRow ? [txState.selectRow] : [])),
+          })),
+        })),
+      })),
+    })),
+  });
+
+  const mockDb = {
+    transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+      if (txState.failWith) throw txState.failWith;
+      return callback(makeTx());
+    }),
+  };
+
+  return { mockDb, sentryCaptureMock: vi.fn(), txState };
+});
+
+vi.mock('../db/client', () => ({ db: mockDb }));
+vi.mock('@sentry/node', () => ({ captureException: sentryCaptureMock }));
+vi.mock('../graphql/resolvers/users/tester', () => ({ userIsTester: vi.fn().mockResolvedValue(false) }));
+
+function makeAuthCtx(userId = 'user-1'): ConnectionContext {
+  return {
+    connectionId: `http-${userId}`,
+    transport: 'http',
+    sessionId: undefined,
+    userId,
+    isAuthenticated: true,
+  };
+}
+
+function makeAnonCtx(): ConnectionContext {
+  return {
+    connectionId: 'http-anon',
+    transport: 'http',
+    sessionId: undefined,
+    userId: undefined,
+    isAuthenticated: false,
+  };
+}
+
+// DrizzleQueryError shape (drizzle-orm >= 0.44): the "Failed query: ..." wrapper
+// with the real PostgresError on `.cause`. 57014 = statement_timeout.
+function wrapLikeDrizzle(driverError: Error): Error {
+  return Object.assign(
+    new Error('Failed query: select "id", "email", "name" from "users" where "users"."id" = $1 limit $2'),
+    { cause: driverError },
+  );
+}
+
+const SUCCESS_ROW = {
+  id: 'user-1',
+  email: 'user1@example.com',
+  name: 'Legacy Name',
+  image: 'https://img/legacy.png',
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  displayName: 'New Name',
+  avatarUrl: 'https://cdn/new.png',
+  favoriteCount: 7,
+};
+
+describe('updateProfile mutation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    txState.insertCalled = false;
+    txState.insertValues = undefined;
+    txState.upsertSet = undefined;
+    txState.selectRow = { ...SUCCESS_ROW };
+    txState.failWith = undefined;
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    await expect(userMutations.updateProfile({}, { input: { displayName: 'Nope' } }, makeAnonCtx())).rejects.toThrow();
+  });
+
+  it('rejects an invalid avatarUrl', async () => {
+    await expect(
+      userMutations.updateProfile({}, { input: { avatarUrl: 'not-a-url' } }, makeAuthCtx()),
+    ).rejects.toThrow();
+  });
+
+  it('rejects an over-long displayName', async () => {
+    await expect(
+      userMutations.updateProfile({}, { input: { displayName: 'a'.repeat(101) } }, makeAuthCtx()),
+    ).rejects.toThrow();
+  });
+
+  it('returns the merged profile on success', async () => {
+    const result = await userMutations.updateProfile(
+      {},
+      { input: { displayName: 'New Name', avatarUrl: 'https://cdn/new.png' } },
+      makeAuthCtx(),
+    );
+
+    expect(result).toMatchObject({
+      id: 'user-1',
+      email: 'user1@example.com',
+      displayName: 'New Name',
+      avatarUrl: 'https://cdn/new.png',
+      favoriteCount: 7,
+    });
+  });
+
+  it('upserts only the fields present in the input', async () => {
+    await userMutations.updateProfile({}, { input: { displayName: 'Only Name' } }, makeAuthCtx());
+
+    expect(txState.insertCalled).toBe(true);
+    expect(txState.insertValues).toEqual({ userId: 'user-1', displayName: 'Only Name' });
+    // avatarUrl was omitted, so it must NOT appear in the conflict `set` —
+    // that preserves the existing avatar instead of nulling it.
+    expect(txState.upsertSet).toEqual({ displayName: 'Only Name' });
+    expect(txState.upsertSet).not.toHaveProperty('avatarUrl');
+  });
+
+  it('takes the no-write path when the input is empty', async () => {
+    const result = await userMutations.updateProfile({}, { input: {} }, makeAuthCtx());
+
+    expect(txState.insertCalled).toBe(false);
+    expect(result.id).toBe('user-1');
+  });
+
+  it('masks a transient DB failure and captures the real pg cause', async () => {
+    const pgError = Object.assign(new Error('canceling statement due to statement timeout'), { code: '57014' });
+    txState.failWith = wrapLikeDrizzle(pgError);
+
+    let thrown: unknown;
+    try {
+      await userMutations.updateProfile({}, { input: { displayName: 'Boom' } }, makeAuthCtx('user-42'));
+      throw new Error('expected updateProfile to reject');
+    } catch (error) {
+      thrown = error;
+    }
+
+    // Client sees a generic, SQL-free GraphQLError.
+    expect(thrown).toBeInstanceOf(GraphQLError);
+    const graphqlError = thrown as GraphQLError;
+    expect(graphqlError.extensions?.code).toBe('PROFILE_UPDATE_FAILED');
+    expect(graphqlError.message).not.toMatch(/select|Failed query|user_favorites/i);
+
+    // The real PostgresError cause is captured to Sentry with the pg code.
+    expect(sentryCaptureMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureMock).toHaveBeenCalledWith(
+      pgError,
+      expect.objectContaining({
+        tags: expect.objectContaining({ source: 'updateProfile', pgCode: '57014' }),
+        extra: expect.objectContaining({ userId: 'user-42', hasDisplayName: true, hasAvatarUrl: false }),
+      }),
+    );
+
+    // Marked reported so the generic graphql-yoga handler won't double-report.
+    expect(wasErrorReported(thrown)).toBe(true);
+  });
+});

--- a/packages/backend/src/__tests__/update-profile.test.ts
+++ b/packages/backend/src/__tests__/update-profile.test.ts
@@ -165,6 +165,24 @@ describe('updateProfile mutation', () => {
     expect(result.id).toBe('user-1');
   });
 
+  it('returns USER_NOT_FOUND (no SQL, no Sentry) when the user row is gone', async () => {
+    txState.selectRow = undefined; // authenticated user vanished mid-request
+
+    let thrown: unknown;
+    try {
+      await userMutations.updateProfile({}, { input: { displayName: 'Ghost' } }, makeAuthCtx());
+      throw new Error('expected updateProfile to reject');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(GraphQLError);
+    expect((thrown as GraphQLError).extensions?.code).toBe('USER_NOT_FOUND');
+    expect((thrown as GraphQLError).message).not.toMatch(/select|Failed query/i);
+    // An intentional client-safe error, not a DB failure — nothing to capture.
+    expect(sentryCaptureMock).not.toHaveBeenCalled();
+  });
+
   it('masks a transient DB failure and captures the real pg cause', async () => {
     const pgError = Object.assign(new Error('canceling statement due to statement timeout'), { code: '57014' });
     txState.failWith = wrapLikeDrizzle(pgError);

--- a/packages/backend/src/graphql/mask-error.ts
+++ b/packages/backend/src/graphql/mask-error.ts
@@ -1,0 +1,81 @@
+import { GraphQLError } from 'graphql';
+import * as Sentry from '@sentry/node';
+import { getPostgresErrorCode } from '../utils/postgres-errors';
+import { markErrorReported, wasErrorReported } from '../utils/sentry-dedupe';
+
+// drizzle-orm surfaces a driver failure as an Error whose message is the raw
+// SQL ("Failed query: select ...") with the real PostgresError on `.cause`.
+// graphql-js then wraps the resolver throw, so the leaking text can arrive as
+// the top-level error or on its GraphQL `originalError`.
+const FAILED_QUERY_PREFIX = 'Failed query:';
+
+function getOriginalError(error: unknown): unknown {
+  if (error && typeof error === 'object' && 'originalError' in error) {
+    return (error as { originalError?: unknown }).originalError;
+  }
+  return undefined;
+}
+
+function messageLeaksQuery(error: unknown): boolean {
+  return error instanceof Error && typeof error.message === 'string' && error.message.startsWith(FAILED_QUERY_PREFIX);
+}
+
+/**
+ * True when this error (or its GraphQL `originalError`) is a raw database/driver
+ * failure whose message would leak SQL to the client — either drizzle's
+ * "Failed query: ..." wrapper or anything carrying a PostgresError code on its
+ * cause chain.
+ */
+export function isDatabaseLeakError(error: unknown): boolean {
+  for (const candidate of [error, getOriginalError(error)]) {
+    if (candidate === undefined || candidate === null) continue;
+    if (messageLeaksQuery(candidate)) return true;
+    if (getPostgresErrorCode(candidate) !== undefined) return true;
+  }
+  return false;
+}
+
+function unwrapCause(error: unknown): unknown {
+  const original = getOriginalError(error) ?? error;
+  if (original instanceof Error && original.cause !== undefined && original.cause !== null) {
+    return original.cause;
+  }
+  return original;
+}
+
+/**
+ * graphql-yoga `maskError` that sanitizes ONLY the raw-database-error class so
+ * internal SQL and schema never reach clients (issue #3183), while every other
+ * error passes through untouched.
+ *
+ * We deliberately do NOT flip on global masking: that would turn the many
+ * intentional `throw new Error(message)` sites across the resolvers into a
+ * useless generic string for clients. This targeted mask fixes the info-leak
+ * without that regression.
+ *
+ * The real cause is captured to Sentry (deduped against a resolver-level catch
+ * that may have already reported it), then a generic GraphQLError is returned.
+ */
+export function maskDatabaseError(error: unknown): Error {
+  if (isDatabaseLeakError(error)) {
+    if (!wasErrorReported(error)) {
+      // Resolve the pg code through the GraphQL `originalError` wrapper too, so
+      // it lands on the tag even when the top-level error is the located
+      // GraphQLError (whose own cause chain doesn't reach the driver error).
+      const pgCode = getPostgresErrorCode(getOriginalError(error) ?? error);
+      Sentry.captureException(unwrapCause(error), {
+        tags: { source: 'graphql-yoga-mask', pgCode: pgCode ?? 'unknown' },
+      });
+      markErrorReported(error);
+    }
+    return new GraphQLError('Something went wrong on our end. Please try again.', {
+      extensions: { code: 'INTERNAL_SERVER_ERROR' },
+    });
+  }
+
+  // Not a DB leak — preserve the pre-existing pass-through behaviour so
+  // intentional resolver messages still reach the client verbatim.
+  if (error instanceof Error) return error;
+  if (typeof error === 'string') return new GraphQLError(error);
+  return new GraphQLError(String(error));
+}

--- a/packages/backend/src/graphql/resolvers/users/__tests__/mutations.test.ts
+++ b/packages/backend/src/graphql/resolvers/users/__tests__/mutations.test.ts
@@ -1,31 +1,35 @@
 /**
  * Unit tests for userMutations.updateProfile — covers the cohort-property
- * fields added for issue #3399 (createdAt, favoriteCount) on both the
- * insert (no existing profile row) and update paths. The db client is
- * mocked, mirroring tester.test.ts / queries.test.ts.
+ * fields added for issue #3399 (createdAt, favoriteCount) mapped from the
+ * merged profile read. Since #3603 the resolver runs a single transaction
+ * (one upsert + one leftJoin select), so the db client is mocked at the
+ * transaction boundary. The failure-handling and no-write paths are covered
+ * separately in src/__tests__/update-profile.test.ts.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 
-const { limitMock, insertValuesMock, updateSetMock } = vi.hoisted(() => ({
+const { onConflictMock, limitMock } = vi.hoisted(() => ({
+  onConflictMock: vi.fn(async () => undefined),
   limitMock: vi.fn(),
-  insertValuesMock: vi.fn(async () => undefined),
-  updateSetMock: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
 }));
 
 vi.mock('../../../../db/client', () => ({
   db: {
-    select: () => {
-      const chain = {
-        from: () => chain,
-        where: () => chain,
-        limit: () => Promise.resolve(limitMock()),
-      };
-      return chain;
-    },
-    insert: () => ({ values: insertValuesMock }),
-    update: () => ({ set: updateSetMock }),
+    transaction: async (callback: (tx: unknown) => Promise<unknown>) =>
+      callback({
+        insert: () => ({ values: () => ({ onConflictDoUpdate: onConflictMock }) }),
+        select: () => {
+          const chain = {
+            from: () => chain,
+            leftJoin: () => chain,
+            where: () => chain,
+            limit: () => Promise.resolve(limitMock()),
+          };
+          return chain;
+        },
+      }),
   },
 }));
 
@@ -42,49 +46,47 @@ function makeCtx(userId = 'user-1'): ConnectionContext {
   return { connectionId: `http-${userId}`, userId, isAuthenticated: true };
 }
 
-const REFRESHED_USER_ROW = {
+const JOINED_ROW = {
   id: 'user-1',
   email: 'climber@example.com',
   name: 'Climber',
   image: null,
   createdAt: new Date('2024-02-02T00:00:00.000Z'),
+  displayName: 'New Name',
+  avatarUrl: null,
   favoriteCount: 3,
 };
 
 describe('userMutations.updateProfile', () => {
   beforeEach(() => {
+    onConflictMock.mockClear();
     limitMock.mockReset();
-    insertValuesMock.mockClear();
-    updateSetMock.mockClear();
     userIsTesterMock.mockReset();
     userIsTesterMock.mockResolvedValue(false);
   });
 
-  it('updates an existing profile row and maps createdAt/favoriteCount from the refreshed select', async () => {
-    limitMock
-      .mockReturnValueOnce([{ userId: 'user-1', displayName: 'Old Name', avatarUrl: null }]) // existing profile check
-      .mockReturnValueOnce([REFRESHED_USER_ROW]) // refreshed users select
-      .mockReturnValueOnce([{ userId: 'user-1', displayName: 'New Name', avatarUrl: null }]); // refreshed profiles select
+  it('upserts the profile and maps createdAt/favoriteCount/displayName from the joined row', async () => {
+    limitMock.mockReturnValueOnce([JOINED_ROW]);
 
     const result = await userMutations.updateProfile(undefined, { input: { displayName: 'New Name' } }, makeCtx());
 
-    expect(updateSetMock).toHaveBeenCalledOnce();
-    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(onConflictMock).toHaveBeenCalledOnce();
     expect(result.createdAt).toBe('2024-02-02T00:00:00.000Z');
     expect(result.favoriteCount).toBe(3);
     expect(result.displayName).toBe('New Name');
   });
 
-  it('creates a new profile row when none exists yet, still returning createdAt/favoriteCount', async () => {
-    limitMock
-      .mockReturnValueOnce([]) // no existing profile row
-      .mockReturnValueOnce([REFRESHED_USER_ROW])
-      .mockReturnValueOnce([{ userId: 'user-1', displayName: 'First Name', avatarUrl: null }]);
+  it('still returns createdAt/favoriteCount when only avatarUrl changes', async () => {
+    limitMock.mockReturnValueOnce([{ ...JOINED_ROW, avatarUrl: 'https://cdn/pic.png' }]);
 
-    const result = await userMutations.updateProfile(undefined, { input: { displayName: 'First Name' } }, makeCtx());
+    const result = await userMutations.updateProfile(
+      undefined,
+      { input: { avatarUrl: 'https://cdn/pic.png' } },
+      makeCtx(),
+    );
 
-    expect(insertValuesMock).toHaveBeenCalledOnce();
-    expect(updateSetMock).not.toHaveBeenCalled();
+    expect(onConflictMock).toHaveBeenCalledOnce();
+    expect(result.avatarUrl).toBe('https://cdn/pic.png');
     expect(result.createdAt).toBe('2024-02-02T00:00:00.000Z');
     expect(result.favoriteCount).toBe(3);
   });

--- a/packages/backend/src/graphql/resolvers/users/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/users/mutations.ts
@@ -1,5 +1,6 @@
 import { eq, and } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
+import * as Sentry from '@sentry/node';
 import type {
   ConnectionContext,
   UserProfile,
@@ -11,6 +12,9 @@ import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, validateInput } from '../shared/helpers';
 import { userIsTester } from './tester';
 import { FAVORITE_COUNT_SUBQUERY } from './favorite-count';
+import { logger } from '../../../utils/logger';
+import { markErrorReported } from '../../../utils/sentry-dedupe';
+import { getPostgresErrorCode } from '../../../utils/postgres-errors';
 import {
   UpdateProfileInputSchema,
   SaveAuroraCredentialInputSchema,
@@ -49,63 +53,90 @@ export const userMutations = {
 
     const userId = ctx.userId!;
 
-    // Check if profile exists
-    const existingProfile = await db
-      .select()
-      .from(dbSchema.userProfiles)
-      .where(eq(dbSchema.userProfiles.userId, userId))
-      .limit(1);
+    try {
+      const row = await db.transaction(async (tx) => {
+        // Upsert only the fields the caller actually sent, so an omitted field
+        // keeps its existing value (partial-update semantics). Both fields are
+        // optional in the input schema; with neither present there is nothing
+        // to write, and an empty `set` would be invalid SQL — so skip the
+        // write entirely in that case.
+        const profileUpdates: { displayName?: string; avatarUrl?: string } = {};
+        if (input.displayName !== undefined) profileUpdates.displayName = input.displayName;
+        if (input.avatarUrl !== undefined) profileUpdates.avatarUrl = input.avatarUrl;
 
-    if (existingProfile.length === 0) {
-      // Create new profile
-      await db.insert(dbSchema.userProfiles).values({
-        userId,
-        displayName: input.displayName,
-        avatarUrl: input.avatarUrl,
+        if (Object.keys(profileUpdates).length > 0) {
+          await tx
+            .insert(dbSchema.userProfiles)
+            .values({ userId, ...profileUpdates })
+            .onConflictDoUpdate({ target: dbSchema.userProfiles.userId, set: profileUpdates });
+        }
+
+        // One round trip to load the merged profile, mirroring the `profile`
+        // query so both stay a single correlated-subquery select instead of the
+        // previous 4 sequential, un-transactioned round trips (issue #3603).
+        const [loadedRow] = await tx
+          .select({
+            id: dbSchema.users.id,
+            email: dbSchema.users.email,
+            name: dbSchema.users.name,
+            image: dbSchema.users.image,
+            createdAt: dbSchema.users.createdAt,
+            displayName: dbSchema.userProfiles.displayName,
+            avatarUrl: dbSchema.userProfiles.avatarUrl,
+            favoriteCount: FAVORITE_COUNT_SUBQUERY,
+          })
+          .from(dbSchema.users)
+          .leftJoin(dbSchema.userProfiles, eq(dbSchema.userProfiles.userId, dbSchema.users.id))
+          .where(eq(dbSchema.users.id, userId))
+          .limit(1);
+
+        return loadedRow;
       });
-    } else {
-      // Update existing profile
-      await db
-        .update(dbSchema.userProfiles)
-        .set({
-          displayName: input.displayName ?? existingProfile[0].displayName,
-          avatarUrl: input.avatarUrl ?? existingProfile[0].avatarUrl,
-        })
-        .where(eq(dbSchema.userProfiles.userId, userId));
+
+      if (!row) {
+        // The authenticated user row vanished mid-request — return a clean,
+        // client-safe error instead of dereferencing undefined.
+        throw new GraphQLError('Your account could not be found.', {
+          extensions: { code: 'USER_NOT_FOUND' },
+        });
+      }
+
+      return {
+        id: row.id,
+        email: row.email,
+        displayName: row.displayName || row.name || undefined,
+        avatarUrl: row.avatarUrl || row.image || undefined,
+        isTester: await userIsTester(row.id),
+        createdAt: row.createdAt.toISOString(),
+        favoriteCount: row.favoriteCount,
+      };
+    } catch (error) {
+      // A GraphQLError here is already client-safe and intentional (the
+      // USER_NOT_FOUND above) — let it through untouched.
+      if (error instanceof GraphQLError) throw error;
+
+      // drizzle masks the driver failure as "Failed query: <sql>" and keeps the
+      // real PostgresError on `.cause`. Capture the true cause (with its pg
+      // code) to Sentry, and hand the client a generic message rather than the
+      // raw SQL that used to leak straight through (issues #3603, #3183).
+      const pgCode = getPostgresErrorCode(error);
+      logger.error('[updateProfile] db failure', { userId, pgCode, error });
+      Sentry.captureException(error instanceof Error ? (error.cause ?? error) : error, {
+        tags: { source: 'updateProfile', transport: ctx.transport, pgCode: pgCode ?? 'unknown' },
+        extra: {
+          userId,
+          hasDisplayName: input.displayName !== undefined,
+          hasAvatarUrl: input.avatarUrl !== undefined,
+        },
+      });
+      const clientSafeError = new GraphQLError('Could not save your profile. Please try again.', {
+        extensions: { code: 'PROFILE_UPDATE_FAILED' },
+      });
+      // Dedupe: the generic graphql-yoga error handler skips errors already
+      // reported here, so this failure yields a single Sentry event.
+      markErrorReported(clientSafeError);
+      throw clientSafeError;
     }
-
-    // Fetch and return updated profile
-    const users = await db
-      .select({
-        id: dbSchema.users.id,
-        email: dbSchema.users.email,
-        name: dbSchema.users.name,
-        image: dbSchema.users.image,
-        createdAt: dbSchema.users.createdAt,
-        favoriteCount: FAVORITE_COUNT_SUBQUERY,
-      })
-      .from(dbSchema.users)
-      .where(eq(dbSchema.users.id, userId))
-      .limit(1);
-
-    const profiles = await db
-      .select()
-      .from(dbSchema.userProfiles)
-      .where(eq(dbSchema.userProfiles.userId, userId))
-      .limit(1);
-
-    const user = users[0];
-    const profile = profiles[0];
-
-    return {
-      id: user.id,
-      email: user.email,
-      displayName: profile?.displayName || user.name || undefined,
-      avatarUrl: profile?.avatarUrl || user.image || undefined,
-      isTester: await userIsTester(user.id),
-      createdAt: user.createdAt.toISOString(),
-      favoriteCount: user.favoriteCount,
-    };
   },
 
   /**

--- a/packages/backend/src/graphql/resolvers/users/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/users/mutations.ts
@@ -132,8 +132,10 @@ export const userMutations = {
       const clientSafeError = new GraphQLError('Could not save your profile. Please try again.', {
         extensions: { code: 'PROFILE_UPDATE_FAILED' },
       });
-      // Dedupe: the generic graphql-yoga error handler skips errors already
-      // reported here, so this failure yields a single Sentry event.
+      // Defensive dedupe: we've already captured above, so mark the thrown
+      // error reported. The targeted maskError leaves this clean GraphQLError
+      // untouched (not a DB-leak), so no other capture path fires for it today
+      // — but if one ever logs it, `wasErrorReported` keeps it to one event.
       markErrorReported(clientSafeError);
       throw clientSafeError;
     }

--- a/packages/backend/src/graphql/yoga.ts
+++ b/packages/backend/src/graphql/yoga.ts
@@ -7,8 +7,10 @@ import { validateToken } from '../middleware/auth';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { maxDepthPlugin } from '@escape.tech/graphql-armor-max-depth';
 import { costLimitPlugin } from '@escape.tech/graphql-armor-cost-limit';
+import { isLocalDevelopment, isTestEnvironment } from '@boardsesh/db/client/config';
 import { logger } from '../utils/logger';
 import { wasErrorReported } from '../utils/sentry-dedupe';
+import { maskDatabaseError } from './mask-error';
 
 /**
  * Create and configure the GraphQL Yoga instance
@@ -95,9 +97,12 @@ export function createYogaInstance() {
         }
       },
     },
-    // In development/test, show all errors
-    // In production, errors will be masked by default
-    maskedErrors: process.env.NODE_ENV === 'production',
+    // In local dev / tests, show all errors raw for debugging. In any prod-like
+    // deploy (Railway leaves NODE_ENV unset, so a `=== 'production'` gate was
+    // silently off — issue #3183), enable a TARGETED mask: it sanitizes only
+    // raw database errors so internal SQL never leaks to clients, and lets
+    // every other error through unchanged (see mask-error.ts).
+    maskedErrors: !isLocalDevelopment() && !isTestEnvironment() ? { maskError: maskDatabaseError } : false,
   });
 
   return yoga;

--- a/packages/backend/src/instrument.ts
+++ b/packages/backend/src/instrument.ts
@@ -39,20 +39,33 @@ applyGeneratedDevDbEnv();
 dotenv.config({ path: '.env.development.local', override: true });
 
 import * as Sentry from '@sentry/node';
+// Leaf config module — pure env-detection helpers with no side effects and no
+// postgres/driver imports, so pulling it in here can't defeat the OTel patching
+// this file must run before.
+import { isLocalDevelopment, isTestEnvironment } from '@boardsesh/db/client/config';
 
-const isProduction = process.env.NODE_ENV === 'production';
+// Enable in any prod-like environment, not only NODE_ENV === 'production':
+// Railway leaves NODE_ENV unset, so the old `=== 'production'` gate meant the
+// backend never reported to Sentry in production (issue #3603 / #3183).
+const dsn =
+  process.env.SENTRY_DSN ??
+  'https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400';
+const isProductionLike = !isLocalDevelopment() && !isTestEnvironment();
 
 Sentry.init({
-  dsn: 'https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400',
-  enabled: isProduction,
+  dsn,
+  enabled: isProductionLike && Boolean(dsn),
   enableLogs: true,
   // Matches the web service. Backend tags events with userId / clientIp from
   // ConnectionContext for incident triage; the data is already in our own
   // logs and is not exfiltrated beyond Sentry.
   sendDefaultPii: true,
-  // Read SENTRY_ENVIRONMENT (Sentry's standard env var) with NODE_ENV as
-  // fallback. Deliberately platform-neutral — no RAILWAY_*-style branching.
-  environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV ?? 'development',
+  // Read SENTRY_ENVIRONMENT (Sentry's standard env var) first. Otherwise fall
+  // back to 'production' when prod-like (NODE_ENV is unset on Railway), so
+  // real prod events aren't mislabelled 'development'. Platform-neutral — no
+  // RAILWAY_*-style branching.
+  environment:
+    process.env.SENTRY_ENVIRONMENT ?? (isProductionLike ? 'production' : (process.env.NODE_ENV ?? 'development')),
   serverName: 'boardsesh-backend',
 });
 

--- a/packages/backend/src/utils/sentry-transport.ts
+++ b/packages/backend/src/utils/sentry-transport.ts
@@ -1,5 +1,20 @@
 import TransportStream from 'winston-transport';
 import * as Sentry from '@sentry/node';
+import { isLocalDevelopment, isTestEnvironment } from '@boardsesh/db/client/config';
+
+// Mirrors the `Sentry.init({ enabled })` gate in instrument.ts: capture in any
+// prod-like environment (Railway leaves NODE_ENV unset), but never in local dev
+// or under the test runner.
+//
+// The optional `nodeEnv` seam lets tests assert the gate without mutating
+// process.env; when supplied it fully determines the decision, so a test that
+// runs with VITEST=1 can still exercise the "production" branch.
+function isSentryLoggingEnabled(nodeEnvOverride?: string): boolean {
+  if (nodeEnvOverride !== undefined) {
+    return nodeEnvOverride !== 'development' && nodeEnvOverride !== 'test';
+  }
+  return !isLocalDevelopment() && !isTestEnvironment();
+}
 
 const SPLAT = Symbol.for('splat');
 // Mirrors the `ERROR_INSTANCE` symbol set by `appendSplatFormat` in logger.ts.
@@ -47,7 +62,7 @@ function extractError(info: LogInfo): Error | null {
  * instance to Sentry via `captureException`. Other levels and message-only
  * error logs are ignored.
  *
- * Gated to NODE_ENV === 'production' to mirror the `Sentry.init({ enabled })`
+ * Gated to prod-like environments to mirror the `Sentry.init({ enabled })`
  * gate in `instrument.ts` — keeps dev/test runs from emitting events.
  */
 export class SentryWinstonTransport extends TransportStream {
@@ -58,7 +73,7 @@ export class SentryWinstonTransport extends TransportStream {
 
   constructor(options: SentryWinstonTransportOptions = {}) {
     super({ ...options, level: 'error' });
-    this.enabled = (options.nodeEnv ?? process.env.NODE_ENV) === 'production';
+    this.enabled = isSentryLoggingEnabled(options.nodeEnv);
     this.capture = options.capture;
   }
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -41,6 +41,11 @@
       "import": "./src/client/index.ts",
       "default": "./src/client/index.ts"
     },
+    "./client/config": {
+      "types": "./src/client/config.ts",
+      "import": "./src/client/config.ts",
+      "default": "./src/client/config.ts"
+    },
     "./queries": {
       "types": "./src/queries/index.ts",
       "import": "./src/queries/index.ts",


### PR DESCRIPTION
## Summary

`updateProfile` was failing intermittently for ~14 users since ~July 8, and when it failed the client got a wall of raw SQL instead of a usable error. This fixes both the failure surface and the info-leak.

**What changed in `updateProfile`:**
- Collapsed the old **4 sequential, un-transactioned round trips** (SELECT existing → INSERT/UPDATE → SELECT user → SELECT profile) into **one `db.transaction`**: a single upsert (`onConflictDoUpdate`) that writes only the fields the caller sent, plus one `leftJoin` select that mirrors the healthy `profile` query (users fields + `userProfiles.displayName/avatarUrl` + `favoriteCount` via the shared `FAVORITE_COUNT_SUBQUERY`). Omitted fields keep their existing value; empty input takes a no-write path (an empty `set` is invalid SQL).
- Wrapped the DB work in a try/catch (mirroring the `createSession` pattern): on failure it unwraps the real `PostgresError` via `getPostgresErrorCode` (drizzle keeps it on `.cause`), captures it to **Sentry** with `source: updateProfile` + `pgCode`, marks it reported (so the generic Yoga handler doesn't double-report), and throws a client-safe `PROFILE_UPDATE_FAILED` GraphQLError — **no SQL**.

**Supporting fixes (also close #3183):**
- **Backend Sentry was dark in production.** Both `Sentry.init({ enabled })` and the winston Sentry transport gated on `NODE_ENV === 'production'`, but the Railway backend deploy never sets `NODE_ENV`. Switched both to prod-like detection (`!isLocalDevelopment() && !isTestEnvironment()`, from `@boardsesh/db/client/config`) + a DSN check. Dev/test behaviour is unchanged.
- **Raw SQL leaked to clients.** `graphql-yoga`'s `maskedErrors` gated on the same never-set `NODE_ENV`, so masking was effectively off in prod. Added a **targeted** `maskError` (`mask-error.ts`) that sanitizes **only** the raw-DB-error class (drizzle `Failed query: …` or anything with a pg code on its cause chain) and passes every other error through untouched, then Sentry-captures the cause (deduped).

## Root cause

The failure is a **transient DB error, not a query bug**. The failing statement is byte-identical to the `profile` query's select (same `FAVORITE_COUNT_SUBQUERY`), which is healthy — so the correlated subquery is exonerated. The commits the issue suspected (`613035e9a`, `ea6eab8c7`, both July 3) predate the July-8 onset, and that select still serves the working profile load. The `x-hikari-trace` / pooler signals in #3183 and the tight per-user failure windows point at PgBouncer connection recycling / statement timeout under pool contention. Until now the real code was masked as `Failed query: <sql>` with the driver error buried on `.cause`, so we couldn't see it — this PR makes it visible in Sentry and hardens the resolver to one transaction instead of four round trips.

> **⚠️ Infra flag for Marco:** the deeper reason both Sentry and error-masking were off in prod is that **`NODE_ENV` is unset in the Railway backend deploy** (`Dockerfile.backend` / `railway.toml`). This PR takes the surgical code path (prod-like detection, no global masking flip — 167 intentional `throw new Error` sites would otherwise degrade to a generic string). The alternative is setting `NODE_ENV=production` in Railway — your infra call. If you set it, these code gates still behave correctly.

**Follow-up (not in this PR):** harden the pool with an explicit `statement_timeout` so a slow query fails fast and predictably instead of hanging on a recycled connection.

## Release Notes

- Changing your display name or avatar saves reliably again.
- And if a save ever does hiccup, you'll get a plain "couldn't save, try again" instead of a wall of database text.

## Test plan

- `vp run typecheck:backend` — clean.
- `vp test run --project backend` — new `update-profile.test.ts` + `mask-error.test.ts` and the existing `sentry-transport.test.ts`: **27 passed / 27** (3 files). Covers: auth + input validation, success mapping, upsert-omits-absent-keys, empty-input no-write path, and the transient-failure path (asserts `PROFILE_UPDATE_FAILED`, no SQL in the message, Sentry captures the unwrapped pg cause with `pgCode: 57014`, error marked reported). Mask tests assert DB-leak errors get sanitized + captured while intentional GraphQLErrors and plain resolver Errors pass through unchanged.
- `vp check` — format + lint clean.

Fixes #3603
Fixes #3183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va
