### PR TITLE
feat(web): owner Insights tab for gyms — gymStats query + manage console tab

### DIFF
--- a/packages/backend/src/__tests__/gym-insights.test.ts
+++ b/packages/backend/src/__tests__/gym-insights.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialGymInsightsQueries } from '../graphql/resolvers/social/gym-insights';
+
+/**
+ * Real-DB coverage for the owner Insights query (gymStats):
+ *   - the read gate (owner / gym admin / gym editor allowed; plain member,
+ *     stranger, anon rejected);
+ *   - the current-vs-previous-window aggregation (unique climbers, ascents,
+ *     top climbs with resolved name + consensus grade, busiest days);
+ *   - the scoping guards: only the gym's boards count, only flash/send ticks
+ *     count, and ticks outside both windows are excluded;
+ *   - the empty-gym path (no boards / no ticks → zeros + empty lists).
+ *
+ * Seeds via raw SQL and calls the resolver directly against the per-worker test
+ * DB, mirroring gym-kiosks.test.ts.
+ */
+
+const OWNER = 'gi-owner';
+const ADMIN = 'gi-admin';
+const EDITOR = 'gi-editor';
+const MEMBER = 'gi-member';
+const RANDOM = 'gi-random';
+const ALL_USERS = [OWNER, ADMIN, EDITOR, MEMBER, RANDOM];
+
+const CLIMB_PREFIX = 'gym-insights-test-climb-';
+const BOARD_TYPE = 'kilter';
+
+let connectionCounter = 0;
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}-${connectionCounter++}`, isAuthenticated: true, userId }) as ConnectionContext;
+const anonCtx = (): ConnectionContext =>
+  ({ connectionId: `conn-anon-${connectionCounter++}`, isAuthenticated: false }) as ConnectionContext;
+
+const daysAgoIso = (days: number): string => new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+const insertGym = async (opts: {
+  ownerId: string;
+  name: string;
+  slug: string;
+  isPublic?: boolean;
+}): Promise<{ id: number; uuid: string; slug: string }> => {
+  const { ownerId, name, slug, isPublic = true } = opts;
+  const uuid = uuidv4();
+  const result = await db.execute(sql`
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${name}, ${slug}, ${ownerId}, ${isPublic}, now(), now())
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid, slug };
+};
+
+let boardConfigCounter = 0;
+const insertBoard = async (opts: {
+  gymId: number;
+  ownerId: string;
+  name: string;
+}): Promise<{ id: number; uuid: string }> => {
+  const { gymId, ownerId, name } = opts;
+  const uuid = uuidv4();
+  const sizeId = 100 + boardConfigCounter++;
+  const result = await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, gym_id, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${ownerId}, ${BOARD_TYPE}, 1, ${sizeId}, '1,2', ${name}, ${gymId}, true, now(), now())
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
+};
+
+const insertGymMember = (gymId: number, userId: string, role: string) =>
+  db.execute(sql`
+    INSERT INTO gym_members (gym_id, user_id, role, created_at)
+    VALUES (${gymId}, ${userId}, ${role}, now())
+  `);
+
+const insertClimb = (uuid: string, name: string) =>
+  db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, name, is_listed, is_draft)
+    VALUES (${uuid}, ${BOARD_TYPE}, 1, ${name}, true, false)
+    ON CONFLICT (uuid) DO NOTHING
+  `);
+
+const insertClimbStats = (climbUuid: string, angle: number, displayDifficulty: number) =>
+  db.execute(sql`
+    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty)
+    VALUES (${BOARD_TYPE}, ${climbUuid}, ${angle}, ${displayDifficulty})
+  `);
+
+const insertGrade = (difficulty: number, boulderName: string) =>
+  db.execute(sql`
+    INSERT INTO board_difficulty_grades (board_type, difficulty, boulder_name, is_listed)
+    VALUES (${BOARD_TYPE}, ${difficulty}, ${boulderName}, true)
+    ON CONFLICT (board_type, difficulty) DO UPDATE SET boulder_name = excluded.boulder_name
+  `);
+
+const insertTick = (opts: {
+  userId: string;
+  boardId: number;
+  climbUuid: string;
+  climbedAt: string;
+  status?: 'flash' | 'send' | 'attempt';
+  angle?: number;
+}) =>
+  db.execute(sql`
+    INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status, attempt_count, climbed_at, board_id)
+    VALUES (
+      ${uuidv4()}, ${opts.userId}, ${BOARD_TYPE}, ${opts.climbUuid}, ${opts.angle ?? 40},
+      ${opts.status ?? 'send'}, 1, ${opts.climbedAt}::timestamptz, ${opts.boardId}
+    )
+  `);
+
+const CLIMB_X = `${CLIMB_PREFIX}x`;
+const CLIMB_Y = `${CLIMB_PREFIX}y`;
+
+let publicGym: { id: number; uuid: string; slug: string };
+let boardA: { id: number; uuid: string };
+let boardB: { id: number; uuid: string };
+let otherGymBoard: { id: number; uuid: string };
+
+beforeEach(async () => {
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "gym_kiosks", "gym_members", "gym_follows", "gym_claims",
+      "board_follows", "boardsesh_ticks", "user_boards", "gyms"
+    RESTART IDENTITY CASCADE
+  `);
+  await db.execute(sql`DELETE FROM board_climb_stats WHERE climb_uuid LIKE ${CLIMB_PREFIX + '%'}`);
+  await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${CLIMB_PREFIX + '%'}`);
+  await db.execute(sql`DELETE FROM board_difficulty_grades WHERE board_type = ${BOARD_TYPE} AND difficulty = 13`);
+
+  await Promise.all(ALL_USERS.map(insertUser));
+
+  publicGym = await insertGym({ ownerId: OWNER, name: 'Insights Gym', slug: 'insights-gym' });
+  await insertGymMember(publicGym.id, ADMIN, 'admin');
+  await insertGymMember(publicGym.id, EDITOR, 'editor');
+  await insertGymMember(publicGym.id, MEMBER, 'member');
+  boardA = await insertBoard({ gymId: publicGym.id, ownerId: OWNER, name: 'A Wall' });
+  boardB = await insertBoard({ gymId: publicGym.id, ownerId: OWNER, name: 'B Wall' });
+
+  const otherGym = await insertGym({ ownerId: RANDOM, name: 'Other Gym', slug: 'other-gym' });
+  otherGymBoard = await insertBoard({ gymId: otherGym.id, ownerId: RANDOM, name: 'Elsewhere Wall' });
+
+  // Catalog: two climbs; CLIMB_X carries a consensus grade (display 13.2 → 13 → "V4").
+  await insertClimb(CLIMB_X, 'Crimpy Traverse');
+  await insertClimb(CLIMB_Y, 'Sloper Heaven');
+  await insertClimbStats(CLIMB_X, 40, 13.2);
+  await insertGrade(13, 'V4');
+
+  // Current window (last 7 days): 3 ascents, 3 distinct climbers, CLIMB_X twice.
+  await insertTick({ userId: OWNER, boardId: boardA.id, climbUuid: CLIMB_X, climbedAt: daysAgoIso(1) });
+  await insertTick({
+    userId: ADMIN,
+    boardId: boardA.id,
+    climbUuid: CLIMB_X,
+    climbedAt: daysAgoIso(2),
+    status: 'flash',
+  });
+  await insertTick({ userId: EDITOR, boardId: boardB.id, climbUuid: CLIMB_Y, climbedAt: daysAgoIso(3) });
+
+  // Previous window (7–14 days ago): 2 ascents, 2 distinct climbers.
+  await insertTick({ userId: OWNER, boardId: boardA.id, climbUuid: CLIMB_X, climbedAt: daysAgoIso(9) });
+  await insertTick({ userId: MEMBER, boardId: boardA.id, climbUuid: CLIMB_Y, climbedAt: daysAgoIso(11) });
+
+  // Excluded: too old, an attempt, and a tick on another gym's board.
+  await insertTick({ userId: OWNER, boardId: boardA.id, climbUuid: CLIMB_X, climbedAt: daysAgoIso(20) });
+  await insertTick({
+    userId: OWNER,
+    boardId: boardA.id,
+    climbUuid: CLIMB_X,
+    climbedAt: daysAgoIso(1),
+    status: 'attempt',
+  });
+  await insertTick({ userId: RANDOM, boardId: otherGymBoard.id, climbUuid: CLIMB_X, climbedAt: daysAgoIso(1) });
+});
+
+describe('gymStats access guard', () => {
+  it('lets the owner, a gym admin, and a gym editor read stats', async () => {
+    for (const user of [OWNER, ADMIN, EDITOR]) {
+      const stats = await socialGymInsightsQueries.gymStats({}, { input: { gymUuid: publicGym.uuid } }, authCtx(user));
+      expect(stats.gymUuid).toBe(publicGym.uuid);
+    }
+  });
+
+  it('rejects a plain member', async () => {
+    await expect(
+      socialGymInsightsQueries.gymStats({}, { input: { gymUuid: publicGym.uuid } }, authCtx(MEMBER)),
+    ).rejects.toThrow(/not authorized/i);
+  });
+
+  it('rejects a stranger', async () => {
+    await expect(
+      socialGymInsightsQueries.gymStats({}, { input: { gymUuid: publicGym.uuid } }, authCtx(RANDOM)),
+    ).rejects.toThrow(/not authorized/i);
+  });
+
+  it('rejects an anonymous caller', async () => {
+    await expect(
+      socialGymInsightsQueries.gymStats({}, { input: { gymUuid: publicGym.uuid } }, anonCtx()),
+    ).rejects.toThrow(/authentication required/i);
+  });
+});
+
+describe('gymStats aggregation', () => {
+  it('reports current and previous window counts, scoped to the gym and flash/send', async () => {
+    const stats = await socialGymInsightsQueries.gymStats({}, { input: { gymUuid: publicGym.uuid } }, authCtx(OWNER));
+
+    expect(stats.periodDays).toBe(7);
+    // Current: 3 flash/send ascents by OWNER, ADMIN, EDITOR. The attempt and the
+    // other-gym board tick are excluded.
+    expect(stats.current.ascentCount).toBe(3);
+    expect(stats.current.uniqueClimbers).toBe(3);
+    // Previous: 2 ascents by OWNER + MEMBER (the 20-days-ago tick is out of range).
+    expect(stats.previous.ascentCount).toBe(2);
+    expect(stats.previous.uniqueClimbers).toBe(2);
+  });
+
+  it('ranks top climbs by ascents with resolved name and consensus grade', async () => {
+    const stats = await socialGymInsightsQueries.gymStats({}, { input: { gymUuid: publicGym.uuid } }, authCtx(OWNER));
+
+    expect(stats.topClimbs.length).toBe(2);
+    const [top, second] = stats.topClimbs;
+    expect(top.climbUuid).toBe(CLIMB_X);
+    expect(top.ascentCount).toBe(2);
+    expect(top.name).toBe('Crimpy Traverse');
+    expect(top.gradeName).toBe('V4');
+    expect(top.angle).toBe(40);
+
+    expect(second.climbUuid).toBe(CLIMB_Y);
+    expect(second.ascentCount).toBe(1);
+    // CLIMB_Y has no stats row → grade falls back to null (safe degradation).
+    expect(second.gradeName).toBeNull();
+  });
+
+  it('buckets busiest days so they sum to the current ascent count', async () => {
+    const stats = await socialGymInsightsQueries.gymStats({}, { input: { gymUuid: publicGym.uuid } }, authCtx(OWNER));
+
+    const total = stats.busiestDays.reduce((sum, day) => sum + day.ascentCount, 0);
+    expect(total).toBe(stats.current.ascentCount);
+    for (const day of stats.busiestDays) {
+      expect(day.dayOfWeek).toBeGreaterThanOrEqual(0);
+      expect(day.dayOfWeek).toBeLessThanOrEqual(6);
+    }
+  });
+
+  it('honours the month period (30-day window)', async () => {
+    const stats = await socialGymInsightsQueries.gymStats(
+      {},
+      { input: { gymUuid: publicGym.uuid, period: 'month' } },
+      authCtx(OWNER),
+    );
+    expect(stats.periodDays).toBe(30);
+    // The 30-day current window now also captures the two prior-week ticks and
+    // the 20-days-ago tick: 3 + 2 + 1 = 6 flash/send ascents on gym boards.
+    expect(stats.current.ascentCount).toBe(6);
+  });
+});
+
+describe('gymStats empty gym', () => {
+  it('returns zeros and empty lists for a gym with no boards', async () => {
+    const emptyGym = await insertGym({ ownerId: OWNER, name: 'Empty Gym', slug: 'empty-gym' });
+    const stats = await socialGymInsightsQueries.gymStats({}, { input: { gymUuid: emptyGym.uuid } }, authCtx(OWNER));
+    expect(stats.current).toEqual({ uniqueClimbers: 0, ascentCount: 0 });
+    expect(stats.previous).toEqual({ uniqueClimbers: 0, ascentCount: 0 });
+    expect(stats.topClimbs).toEqual([]);
+    expect(stats.busiestDays).toEqual([]);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -38,6 +38,7 @@ import { socialVoteQueries, socialVoteMutations } from './social/votes';
 import { socialBoardQueries, socialBoardMutations } from './social/boards';
 import { socialGymQueries, socialGymMutations } from './social/gyms';
 import { socialGymKioskQueries, socialGymKioskMutations } from './social/gym-kiosks';
+import { socialGymInsightsQueries } from './social/gym-insights';
 import { socialGymClaimQueries, socialGymClaimMutations } from './social/gym-claims';
 import {
   socialNotificationQueries,
@@ -84,6 +85,7 @@ export const resolvers = {
     ...socialBoardQueries,
     ...socialGymQueries,
     ...socialGymKioskQueries,
+    ...socialGymInsightsQueries,
     ...socialGymClaimQueries,
     ...activityFeedQueries,
     ...sessionFeedQueries,

--- a/packages/backend/src/graphql/resolvers/social/gym-insights.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-insights.ts
@@ -1,0 +1,183 @@
+import { eq, and, or, isNull, inArray, count, asc, sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
+import { GymStatsInputSchema } from '../../../validation/schemas';
+import {
+  consensusGradeTable,
+  consensusGradeJoinCondition,
+  consensusDifficultyNameExpr,
+} from '../shared/sql-expressions';
+import { requireGymEditAccess } from './gyms';
+
+// Reads share the gymBoards ceiling: an owner refreshing the Insights tab (or a
+// wall of manage tabs behind one gym NAT) shouldn't outrun the limit, and the
+// query sits behind the gym-edit gate anyway.
+const RATE_LIMIT_GYM_STATS = 30;
+
+// How many days each window spans, by period. The comparison window is always
+// the equally-long span immediately before the current one.
+const WINDOW_DAYS: Record<'week' | 'month', number> = { week: 7, month: 30 };
+
+const TOP_CLIMBS_LIMIT = 10;
+
+// flash + send only — an attempt isn't an ascent. Mirrors boardLeaderboard so
+// the Insights numbers line up with the kiosk leaderboard rail.
+const flashOrSend = or(eq(dbSchema.boardseshTicks.status, 'flash'), eq(dbSchema.boardseshTicks.status, 'send'))!;
+
+type CountsRow = {
+  currentUnique: number;
+  currentAscents: number;
+  previousUnique: number;
+  previousAscents: number;
+};
+
+const emptyStats = (gymUuid: string, periodDays: number) => ({
+  gymUuid,
+  periodDays,
+  current: { uniqueClimbers: 0, ascentCount: 0 },
+  previous: { uniqueClimbers: 0, ascentCount: 0 },
+  topClimbs: [],
+  busiestDays: [],
+});
+
+export const socialGymInsightsQueries = {
+  /**
+   * A gym owner's activity snapshot: unique climbers, total ascents, the top-10
+   * climbs, and busiest weekdays for the current window, plus the counts for the
+   * equally-long window before it (for week-over-week deltas). Requires gym edit
+   * access (owner, gym admin/editor, or a covering community admin/leader).
+   *
+   * Every aggregate is bounded to the gym's linked board ids AND a time window,
+   * riding the `boardsesh_ticks_board_climbed_at_idx` (board_id, climbed_at)
+   * index — the same filter shape boardLeaderboard uses, never an unbounded tick
+   * scan. The scalar counts for both windows come from a SINGLE 2×-window scan
+   * with FILTER clauses; top climbs and busiest days are computed for the current
+   * window only (that's all the dashboard renders).
+   */
+  gymStats: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_GYM_STATS, 'gymStats');
+    const { gymUuid, period } = validateInput(GymStatsInputSchema, input, 'input');
+    const userId = ctx.userId!;
+
+    // Gate FIRST: a caller without edit access never reaches the tick tables.
+    const gym = await requireGymEditAccess(gymUuid, userId);
+
+    const windowDays = WINDOW_DAYS[period];
+
+    // gym → boards traversal (the same join boardLeaderboard does per board, done
+    // once for the whole gym). No linked boards → nothing to aggregate.
+    const boardRows = await db
+      .select({ id: dbSchema.userBoards.id })
+      .from(dbSchema.userBoards)
+      .where(and(eq(dbSchema.userBoards.gymId, gym.id), isNull(dbSchema.userBoards.deletedAt)));
+    const boardIds = boardRows.map((row) => row.id);
+    if (boardIds.length === 0) {
+      return emptyStats(gym.uuid, windowDays);
+    }
+
+    // Window boundaries. `make_interval(days => n)` keeps the day count a bound,
+    // typed param (::int) rather than string-built SQL. currentStart splits the
+    // 2×-window scan into "current" (>= currentStart) and "previous" (< it).
+    const currentStart = sql`NOW() - make_interval(days => ${windowDays}::int)`;
+    const outerStart = sql`NOW() - make_interval(days => ${windowDays * 2}::int)`;
+
+    const inGymBoards = inArray(dbSchema.boardseshTicks.boardId, boardIds);
+    const dayOfWeekExpr = sql<number>`EXTRACT(DOW FROM ${dbSchema.boardseshTicks.climbedAt})::int`;
+
+    const [countsRows, topClimbRows, busiestDayRows] = await Promise.all([
+      // Both windows in one scan of the last 2×windowDays days.
+      db
+        .select({
+          currentUnique: sql<number>`COUNT(DISTINCT ${dbSchema.boardseshTicks.userId}) FILTER (WHERE ${dbSchema.boardseshTicks.climbedAt} >= ${currentStart})`,
+          currentAscents: sql<number>`COUNT(*) FILTER (WHERE ${dbSchema.boardseshTicks.climbedAt} >= ${currentStart})`,
+          previousUnique: sql<number>`COUNT(DISTINCT ${dbSchema.boardseshTicks.userId}) FILTER (WHERE ${dbSchema.boardseshTicks.climbedAt} < ${currentStart})`,
+          previousAscents: sql<number>`COUNT(*) FILTER (WHERE ${dbSchema.boardseshTicks.climbedAt} < ${currentStart})`,
+        })
+        .from(dbSchema.boardseshTicks)
+        .where(and(inGymBoards, flashOrSend, sql`${dbSchema.boardseshTicks.climbedAt} >= ${outerStart}`)),
+
+      // Top climbs (current window). Grade name falls back to null when the climb
+      // has no catalog row or no consensus grade — the UI degrades gracefully.
+      db
+        .select({
+          climbUuid: dbSchema.boardseshTicks.climbUuid,
+          boardType: dbSchema.boardseshTicks.boardType,
+          angle: dbSchema.boardseshTicks.angle,
+          name: dbSchema.boardClimbs.name,
+          gradeName: consensusDifficultyNameExpr,
+          ascentCount: count(),
+        })
+        .from(dbSchema.boardseshTicks)
+        .leftJoin(
+          dbSchema.boardClimbs,
+          and(
+            eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbs.uuid),
+            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbs.boardType),
+          ),
+        )
+        .leftJoin(
+          dbSchema.boardClimbStats,
+          and(
+            eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbStats.climbUuid),
+            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbStats.boardType),
+            eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
+          ),
+        )
+        .leftJoin(consensusGradeTable, consensusGradeJoinCondition)
+        .where(and(inGymBoards, flashOrSend, sql`${dbSchema.boardseshTicks.climbedAt} >= ${currentStart}`))
+        .groupBy(
+          dbSchema.boardseshTicks.climbUuid,
+          dbSchema.boardseshTicks.boardType,
+          dbSchema.boardseshTicks.angle,
+          dbSchema.boardClimbs.name,
+          consensusGradeTable.boulderName,
+        )
+        // COUNT(*) DESC, then climb UUID for a deterministic tie order.
+        .orderBy(sql`COUNT(*) DESC`, asc(dbSchema.boardseshTicks.climbUuid))
+        .limit(TOP_CLIMBS_LIMIT),
+
+      // Ascents per day of week (current window). Only non-empty days appear.
+      db
+        .select({ dayOfWeek: dayOfWeekExpr, ascentCount: count() })
+        .from(dbSchema.boardseshTicks)
+        .where(and(inGymBoards, flashOrSend, sql`${dbSchema.boardseshTicks.climbedAt} >= ${currentStart}`))
+        .groupBy(dayOfWeekExpr)
+        .orderBy(dayOfWeekExpr),
+    ]);
+
+    const counts = (countsRows[0] ?? {
+      currentUnique: 0,
+      currentAscents: 0,
+      previousUnique: 0,
+      previousAscents: 0,
+    }) as CountsRow;
+
+    return {
+      gymUuid: gym.uuid,
+      periodDays: windowDays,
+      current: {
+        uniqueClimbers: Number(counts.currentUnique),
+        ascentCount: Number(counts.currentAscents),
+      },
+      previous: {
+        uniqueClimbers: Number(counts.previousUnique),
+        ascentCount: Number(counts.previousAscents),
+      },
+      topClimbs: topClimbRows.map((row) => ({
+        climbUuid: row.climbUuid,
+        boardType: row.boardType,
+        angle: Number(row.angle),
+        name: row.name ?? null,
+        gradeName: row.gradeName ?? null,
+        ascentCount: Number(row.ascentCount),
+      })),
+      busiestDays: busiestDayRows.map((row) => ({
+        dayOfWeek: Number(row.dayOfWeek),
+        ascentCount: Number(row.ascentCount),
+      })),
+    };
+  },
+};

--- a/packages/backend/src/validation/schemas/gyms.ts
+++ b/packages/backend/src/validation/schemas/gyms.ts
@@ -202,3 +202,13 @@ export const LinkBoardToGymInputSchema = z.object({
   boardUuid: UUIDSchema,
   gymUuid: UUIDSchema.optional().nullable(),
 });
+
+/**
+ * Gym insights (owner activity dashboard) input validation schema. `period`
+ * chooses the window length; the resolver derives the day count and the equally
+ * long prior comparison window from it.
+ */
+export const GymStatsInputSchema = z.object({
+  gymUuid: UUIDSchema,
+  period: z.enum(['week', 'month']).optional().default('week'),
+});

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2994,6 +2994,101 @@ input PendingGymClaimsInput {
 }
 
 # ============================================
+# Gym Insights (owner activity dashboard)
+# ============================================
+
+"""
+One climb from the gym's top-10 for the current window, ranked by ascents.
+A row is keyed by (climbUuid, boardType, angle) — the same key board_climb_stats
+uses — so the same holds set at two angles shows as two rows with their own
+grades. `name` and `gradeName` are best-effort: a climb missing its catalog
+row (unsynced) or its consensus grade (MoonBoard, too few ascents) returns null
+and the UI falls back gracefully.
+"""
+type GymTopClimb {
+  "The climb's UUID."
+  climbUuid: ID!
+  "Board type (kilter, tension, moonboard, ...)."
+  boardType: String!
+  "The angle the ticks were logged at."
+  angle: Int!
+  "Climb display name (null when the catalog row is missing)."
+  name: String
+  "Consensus grade name, e.g. \"V4\" (null when no grade is resolvable)."
+  gradeName: String
+  "Ascents (flash + send) on this climb in the current window."
+  ascentCount: Int!
+}
+
+"""
+Ascents bucketed by day of week for the current window. `dayOfWeek` follows
+Postgres EXTRACT(DOW): 0 = Sunday … 6 = Saturday. Only days with at least one
+ascent appear; the UI fills the missing days with zero.
+"""
+type GymDayActivity {
+  "Day of week, 0 = Sunday … 6 = Saturday."
+  dayOfWeek: Int!
+  "Ascents (flash + send) on that weekday in the current window."
+  ascentCount: Int!
+}
+
+"""
+The two deltable counts for one window (current or previous). Kept separate
+from the top-climb / busiest-day lists because only these scalars feed the
+week-over-week deltas; the lists are only rendered for the current window.
+"""
+type GymStatsWindow {
+  "Distinct climbers with a flash/send on the gym's boards in this window."
+  uniqueClimbers: Int!
+  "Total ascents (flash + send) on the gym's boards in this window."
+  ascentCount: Int!
+}
+
+"""
+A gym owner's activity snapshot for the current window and the window
+immediately before it (same length), for week-over-week deltas. Every
+aggregate is bounded to the gym's linked boards and the time window — no
+unbounded tick scans. `topClimbs` and `busiestDays` cover the CURRENT window
+only (that's all the dashboard renders). Requires gym edit access.
+"""
+type GymStats {
+  "The gym these stats are for."
+  gymUuid: ID!
+  "Window length in days (7 for the default week)."
+  periodDays: Int!
+  "Counts for the current window (last `periodDays` days)."
+  current: GymStatsWindow!
+  "Counts for the window immediately before the current one (same length)."
+  previous: GymStatsWindow!
+  "Top 10 climbs by ascents in the current window."
+  topClimbs: [GymTopClimb!]!
+  "Ascents per day of week in the current window (only non-empty days)."
+  busiestDays: [GymDayActivity!]!
+}
+
+"""
+Input for the gym Insights query. `period` sets the window length: `week`
+(7 days, the default) or `month` (30 days). The comparison window is always the
+equally-long span immediately before it.
+"""
+input GymStatsInput {
+  "The gym to report on. The caller must have gym edit access."
+  gymUuid: ID!
+  "Window length: week (7 days, default) or month (30 days)."
+  period: GymStatsPeriod
+}
+
+"""
+Supported Insights window lengths.
+"""
+enum GymStatsPeriod {
+  "Rolling last 7 days."
+  week
+  "Rolling last 30 days."
+  month
+}
+
+# ============================================
 # Gym Kiosk Types (smart-TV wall dashboard)
 # ============================================
 
@@ -4972,6 +5067,15 @@ type Query {
   List pending gym ownership claims for the admin review queue (admin only).
   """
   pendingGymClaims(input: PendingGymClaimsInput): GymClaimConnection!
+
+  """
+  A gym owner's activity snapshot: unique climbers, ascents, top climbs, and
+  busiest weekdays for the current window plus the equally-long window before
+  it (for week-over-week deltas). Requires gym edit access (owner, gym
+  admin/editor, or a covering community admin/leader). Every aggregate is
+  bounded to the gym's linked boards and the time window.
+  """
+  gymStats(input: GymStatsInput!): GymStats!
 
   # ============================================
   # Gym Kiosk Queries

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2168,6 +2168,19 @@ export type GymConnection = {
 };
 
 /**
+ * Ascents bucketed by day of week for the current window. `dayOfWeek` follows
+ * Postgres EXTRACT(DOW): 0 = Sunday … 6 = Saturday. Only days with at least one
+ * ascent appear; the UI fills the missing days with zero.
+ */
+export type GymDayActivity = {
+  __typename?: 'GymDayActivity';
+  /** Ascents (flash + send) on that weekday in the current window. */
+  ascentCount: Scalars['Int']['output'];
+  /** Day of week, 0 = Sunday … 6 = Saturday. */
+  dayOfWeek: Scalars['Int']['output'];
+};
+
+/**
  * A gym kiosk: a preset-based smart-TV wall dashboard, addressed publicly as
  * `/kiosk/{gym-slug}/{kiosk-slug}`. The `layout` is the stored preset config —
  * 1–4 board slots plus an optional leaderboard rail — validated on write against
@@ -2274,6 +2287,85 @@ export type GymMembersInput = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** Offset for pagination */
   offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/**
+ * A gym owner's activity snapshot for the current window and the window
+ * immediately before it (same length), for week-over-week deltas. Every
+ * aggregate is bounded to the gym's linked boards and the time window — no
+ * unbounded tick scans. `topClimbs` and `busiestDays` cover the CURRENT window
+ * only (that's all the dashboard renders). Requires gym edit access.
+ */
+export type GymStats = {
+  __typename?: 'GymStats';
+  /** Ascents per day of week in the current window (only non-empty days). */
+  busiestDays: Array<GymDayActivity>;
+  /** Counts for the current window (last `periodDays` days). */
+  current: GymStatsWindow;
+  /** The gym these stats are for. */
+  gymUuid: Scalars['ID']['output'];
+  /** Window length in days (7 for the default week). */
+  periodDays: Scalars['Int']['output'];
+  /** Counts for the window immediately before the current one (same length). */
+  previous: GymStatsWindow;
+  /** Top 10 climbs by ascents in the current window. */
+  topClimbs: Array<GymTopClimb>;
+};
+
+/**
+ * Input for the gym Insights query. `period` sets the window length: `week`
+ * (7 days, the default) or `month` (30 days). The comparison window is always the
+ * equally-long span immediately before it.
+ */
+export type GymStatsInput = {
+  /** The gym to report on. The caller must have gym edit access. */
+  gymUuid: Scalars['ID']['input'];
+  /** Window length: week (7 days, default) or month (30 days). */
+  period?: InputMaybe<GymStatsPeriod>;
+};
+
+/** Supported Insights window lengths. */
+export type GymStatsPeriod =
+  /** Rolling last 30 days. */
+  | 'month'
+  /** Rolling last 7 days. */
+  | 'week';
+
+/**
+ * The two deltable counts for one window (current or previous). Kept separate
+ * from the top-climb / busiest-day lists because only these scalars feed the
+ * week-over-week deltas; the lists are only rendered for the current window.
+ */
+export type GymStatsWindow = {
+  __typename?: 'GymStatsWindow';
+  /** Total ascents (flash + send) on the gym's boards in this window. */
+  ascentCount: Scalars['Int']['output'];
+  /** Distinct climbers with a flash/send on the gym's boards in this window. */
+  uniqueClimbers: Scalars['Int']['output'];
+};
+
+/**
+ * One climb from the gym's top-10 for the current window, ranked by ascents.
+ * A row is keyed by (climbUuid, boardType, angle) — the same key board_climb_stats
+ * uses — so the same holds set at two angles shows as two rows with their own
+ * grades. `name` and `gradeName` are best-effort: a climb missing its catalog
+ * row (unsynced) or its consensus grade (MoonBoard, too few ascents) returns null
+ * and the UI falls back gracefully.
+ */
+export type GymTopClimb = {
+  __typename?: 'GymTopClimb';
+  /** The angle the ticks were logged at. */
+  angle: Scalars['Int']['output'];
+  /** Ascents (flash + send) on this climb in the current window. */
+  ascentCount: Scalars['Int']['output'];
+  /** Board type (kilter, tension, moonboard, ...). */
+  boardType: Scalars['String']['output'];
+  /** The climb's UUID. */
+  climbUuid: Scalars['ID']['output'];
+  /** Consensus grade name, e.g. "V4" (null when no grade is resolvable). */
+  gradeName?: Maybe<Scalars['String']['output']>;
+  /** Climb display name (null when the catalog row is missing). */
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 /** A scanned post whose climb name matched multiple climbs — the user picks one. */
@@ -4169,6 +4261,14 @@ export type Query = {
   /** Get members of a gym. */
   gymMembers: GymMemberConnection;
   /**
+   * A gym owner's activity snapshot: unique climbers, ascents, top climbs, and
+   * busiest weekdays for the current window plus the equally-long window before
+   * it (for week-over-week deltas). Requires gym edit access (owner, gym
+   * admin/editor, or a covering community admin/leader). Every aggregate is
+   * bounded to the gym's linked boards and the time window.
+   */
+  gymStats: GymStats;
+  /**
    * Resolve scraped Instagram posts against Boardsesh: which beta videos are
    * missing, already linked, ambiguous, or unmatched. Read-only — the client
    * attaches the missing ones via the attachBetaLink mutation.
@@ -4710,6 +4810,11 @@ export type QueryGymKiosksArgs = {
 /** Root query type for all read operations. */
 export type QueryGymMembersArgs = {
   input: GymMembersInput;
+};
+
+/** Root query type for all read operations. */
+export type QueryGymStatsArgs = {
+  input: GymStatsInput;
 };
 
 /** Root query type for all read operations. */
@@ -7245,12 +7350,18 @@ export type ResolversTypes = ResolversObject<{
   GymClaimRequestStatus: GymClaimRequestStatus;
   GymClaimStatus: GymClaimStatus;
   GymConnection: ResolverTypeWrapper<GymConnection>;
+  GymDayActivity: ResolverTypeWrapper<GymDayActivity>;
   GymKiosk: ResolverTypeWrapper<GymKiosk>;
   GymKioskBoard: ResolverTypeWrapper<GymKioskBoard>;
   GymMember: ResolverTypeWrapper<GymMember>;
   GymMemberConnection: ResolverTypeWrapper<GymMemberConnection>;
   GymMemberRole: GymMemberRole;
   GymMembersInput: GymMembersInput;
+  GymStats: ResolverTypeWrapper<GymStats>;
+  GymStatsInput: GymStatsInput;
+  GymStatsPeriod: GymStatsPeriod;
+  GymStatsWindow: ResolverTypeWrapper<GymStatsWindow>;
+  GymTopClimb: ResolverTypeWrapper<GymTopClimb>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   InstagramBetaAmbiguous: ResolverTypeWrapper<InstagramBetaAmbiguous>;
   InstagramBetaCandidate: ResolverTypeWrapper<InstagramBetaCandidate>;
@@ -7560,11 +7671,16 @@ export type ResolversParentTypes = ResolversObject<{
   GymClaim: GymClaim;
   GymClaimConnection: GymClaimConnection;
   GymConnection: GymConnection;
+  GymDayActivity: GymDayActivity;
   GymKiosk: GymKiosk;
   GymKioskBoard: GymKioskBoard;
   GymMember: GymMember;
   GymMemberConnection: GymMemberConnection;
   GymMembersInput: GymMembersInput;
+  GymStats: GymStats;
+  GymStatsInput: GymStatsInput;
+  GymStatsWindow: GymStatsWindow;
+  GymTopClimb: GymTopClimb;
   ID: Scalars['ID']['output'];
   InstagramBetaAmbiguous: InstagramBetaAmbiguous;
   InstagramBetaCandidate: InstagramBetaCandidate;
@@ -8769,6 +8885,15 @@ export type GymConnectionResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GymDayActivityResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['GymDayActivity'] = ResolversParentTypes['GymDayActivity'],
+> = ResolversObject<{
+  ascentCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  dayOfWeek?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type GymKioskResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['GymKiosk'] = ResolversParentTypes['GymKiosk'],
@@ -8819,6 +8944,41 @@ export type GymMemberConnectionResolvers<
   hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   members?: Resolver<Array<ResolversTypes['GymMember']>, ParentType, ContextType>;
   totalCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GymStatsResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['GymStats'] = ResolversParentTypes['GymStats'],
+> = ResolversObject<{
+  busiestDays?: Resolver<Array<ResolversTypes['GymDayActivity']>, ParentType, ContextType>;
+  current?: Resolver<ResolversTypes['GymStatsWindow'], ParentType, ContextType>;
+  gymUuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  periodDays?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  previous?: Resolver<ResolversTypes['GymStatsWindow'], ParentType, ContextType>;
+  topClimbs?: Resolver<Array<ResolversTypes['GymTopClimb']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GymStatsWindowResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['GymStatsWindow'] = ResolversParentTypes['GymStatsWindow'],
+> = ResolversObject<{
+  ascentCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  uniqueClimbers?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GymTopClimbResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['GymTopClimb'] = ResolversParentTypes['GymTopClimb'],
+> = ResolversObject<{
+  angle?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  ascentCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  boardType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  climbUuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  gradeName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -10180,6 +10340,7 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QueryGymMembersArgs, 'input'>
   >;
+  gymStats?: Resolver<ResolversTypes['GymStats'], ParentType, ContextType, RequireFields<QueryGymStatsArgs, 'input'>>;
   instagramBetaScan?: Resolver<
     ResolversTypes['InstagramBetaScanResult'],
     ParentType,
@@ -11608,10 +11769,14 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   GymClaim?: GymClaimResolvers<ContextType>;
   GymClaimConnection?: GymClaimConnectionResolvers<ContextType>;
   GymConnection?: GymConnectionResolvers<ContextType>;
+  GymDayActivity?: GymDayActivityResolvers<ContextType>;
   GymKiosk?: GymKioskResolvers<ContextType>;
   GymKioskBoard?: GymKioskBoardResolvers<ContextType>;
   GymMember?: GymMemberResolvers<ContextType>;
   GymMemberConnection?: GymMemberConnectionResolvers<ContextType>;
+  GymStats?: GymStatsResolvers<ContextType>;
+  GymStatsWindow?: GymStatsWindowResolvers<ContextType>;
+  GymTopClimb?: GymTopClimbResolvers<ContextType>;
   InstagramBetaAmbiguous?: InstagramBetaAmbiguousResolvers<ContextType>;
   InstagramBetaCandidate?: InstagramBetaCandidateResolvers<ContextType>;
   InstagramBetaMatch?: InstagramBetaMatchResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -407,4 +407,99 @@ export const gymsTypeDefs = /* GraphQL */ `
     "Offset for pagination"
     offset: Int
   }
+
+  # ============================================
+  # Gym Insights (owner activity dashboard)
+  # ============================================
+
+  """
+  One climb from the gym's top-10 for the current window, ranked by ascents.
+  A row is keyed by (climbUuid, boardType, angle) — the same key board_climb_stats
+  uses — so the same holds set at two angles shows as two rows with their own
+  grades. \`name\` and \`gradeName\` are best-effort: a climb missing its catalog
+  row (unsynced) or its consensus grade (MoonBoard, too few ascents) returns null
+  and the UI falls back gracefully.
+  """
+  type GymTopClimb {
+    "The climb's UUID."
+    climbUuid: ID!
+    "Board type (kilter, tension, moonboard, ...)."
+    boardType: String!
+    "The angle the ticks were logged at."
+    angle: Int!
+    "Climb display name (null when the catalog row is missing)."
+    name: String
+    "Consensus grade name, e.g. \\"V4\\" (null when no grade is resolvable)."
+    gradeName: String
+    "Ascents (flash + send) on this climb in the current window."
+    ascentCount: Int!
+  }
+
+  """
+  Ascents bucketed by day of week for the current window. \`dayOfWeek\` follows
+  Postgres EXTRACT(DOW): 0 = Sunday … 6 = Saturday. Only days with at least one
+  ascent appear; the UI fills the missing days with zero.
+  """
+  type GymDayActivity {
+    "Day of week, 0 = Sunday … 6 = Saturday."
+    dayOfWeek: Int!
+    "Ascents (flash + send) on that weekday in the current window."
+    ascentCount: Int!
+  }
+
+  """
+  The two deltable counts for one window (current or previous). Kept separate
+  from the top-climb / busiest-day lists because only these scalars feed the
+  week-over-week deltas; the lists are only rendered for the current window.
+  """
+  type GymStatsWindow {
+    "Distinct climbers with a flash/send on the gym's boards in this window."
+    uniqueClimbers: Int!
+    "Total ascents (flash + send) on the gym's boards in this window."
+    ascentCount: Int!
+  }
+
+  """
+  A gym owner's activity snapshot for the current window and the window
+  immediately before it (same length), for week-over-week deltas. Every
+  aggregate is bounded to the gym's linked boards and the time window — no
+  unbounded tick scans. \`topClimbs\` and \`busiestDays\` cover the CURRENT window
+  only (that's all the dashboard renders). Requires gym edit access.
+  """
+  type GymStats {
+    "The gym these stats are for."
+    gymUuid: ID!
+    "Window length in days (7 for the default week)."
+    periodDays: Int!
+    "Counts for the current window (last \`periodDays\` days)."
+    current: GymStatsWindow!
+    "Counts for the window immediately before the current one (same length)."
+    previous: GymStatsWindow!
+    "Top 10 climbs by ascents in the current window."
+    topClimbs: [GymTopClimb!]!
+    "Ascents per day of week in the current window (only non-empty days)."
+    busiestDays: [GymDayActivity!]!
+  }
+
+  """
+  Input for the gym Insights query. \`period\` sets the window length: \`week\`
+  (7 days, the default) or \`month\` (30 days). The comparison window is always the
+  equally-long span immediately before it.
+  """
+  input GymStatsInput {
+    "The gym to report on. The caller must have gym edit access."
+    gymUuid: ID!
+    "Window length: week (7 days, default) or month (30 days)."
+    period: GymStatsPeriod
+  }
+
+  """
+  Supported Insights window lengths.
+  """
+  enum GymStatsPeriod {
+    "Rolling last 7 days."
+    week
+    "Rolling last 30 days."
+    month
+  }
 `;

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -593,6 +593,15 @@ export const queriesTypeDefs = /* GraphQL */ `
     """
     pendingGymClaims(input: PendingGymClaimsInput): GymClaimConnection!
 
+    """
+    A gym owner's activity snapshot: unique climbers, ascents, top climbs, and
+    busiest weekdays for the current window plus the equally-long window before
+    it (for week-over-week deltas). Requires gym edit access (owner, gym
+    admin/editor, or a covering community admin/leader). Every aggregate is
+    bounded to the gym's linked boards and the time window.
+    """
+    gymStats(input: GymStatsInput!): GymStats!
+
     # ============================================
     # Gym Kiosk Queries
     # ============================================

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -198,3 +198,45 @@ export type LinkBoardToGymInput = {
   boardUuid: string;
   gymUuid?: string | null;
 };
+
+// ============================================
+// Gym Insights (owner activity dashboard)
+// ============================================
+
+export type GymStatsPeriod = 'week' | 'month';
+
+export type GymTopClimb = {
+  climbUuid: string;
+  boardType: string;
+  angle: number;
+  name?: string | null;
+  gradeName?: string | null;
+  ascentCount: number;
+};
+
+export type GymDayActivity = {
+  /** Postgres EXTRACT(DOW): 0 = Sunday … 6 = Saturday. */
+  dayOfWeek: number;
+  ascentCount: number;
+};
+
+export type GymStatsWindow = {
+  uniqueClimbers: number;
+  ascentCount: number;
+};
+
+export type GymStats = {
+  gymUuid: string;
+  periodDays: number;
+  current: GymStatsWindow;
+  previous: GymStatsWindow;
+  /** Top 10 climbs by ascents in the current window. */
+  topClimbs: GymTopClimb[];
+  /** Ascents per day of week in the current window (non-empty days only). */
+  busiestDays: GymDayActivity[];
+};
+
+export type GymStatsInput = {
+  gymUuid: string;
+  period?: GymStatsPeriod;
+};

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2165,6 +2165,19 @@ export type GymConnection = {
 };
 
 /**
+ * Ascents bucketed by day of week for the current window. `dayOfWeek` follows
+ * Postgres EXTRACT(DOW): 0 = Sunday … 6 = Saturday. Only days with at least one
+ * ascent appear; the UI fills the missing days with zero.
+ */
+export type GymDayActivity = {
+  __typename?: 'GymDayActivity';
+  /** Ascents (flash + send) on that weekday in the current window. */
+  ascentCount: Scalars['Int']['output'];
+  /** Day of week, 0 = Sunday … 6 = Saturday. */
+  dayOfWeek: Scalars['Int']['output'];
+};
+
+/**
  * A gym kiosk: a preset-based smart-TV wall dashboard, addressed publicly as
  * `/kiosk/{gym-slug}/{kiosk-slug}`. The `layout` is the stored preset config —
  * 1–4 board slots plus an optional leaderboard rail — validated on write against
@@ -2271,6 +2284,85 @@ export type GymMembersInput = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** Offset for pagination */
   offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/**
+ * A gym owner's activity snapshot for the current window and the window
+ * immediately before it (same length), for week-over-week deltas. Every
+ * aggregate is bounded to the gym's linked boards and the time window — no
+ * unbounded tick scans. `topClimbs` and `busiestDays` cover the CURRENT window
+ * only (that's all the dashboard renders). Requires gym edit access.
+ */
+export type GymStats = {
+  __typename?: 'GymStats';
+  /** Ascents per day of week in the current window (only non-empty days). */
+  busiestDays: Array<GymDayActivity>;
+  /** Counts for the current window (last `periodDays` days). */
+  current: GymStatsWindow;
+  /** The gym these stats are for. */
+  gymUuid: Scalars['ID']['output'];
+  /** Window length in days (7 for the default week). */
+  periodDays: Scalars['Int']['output'];
+  /** Counts for the window immediately before the current one (same length). */
+  previous: GymStatsWindow;
+  /** Top 10 climbs by ascents in the current window. */
+  topClimbs: Array<GymTopClimb>;
+};
+
+/**
+ * Input for the gym Insights query. `period` sets the window length: `week`
+ * (7 days, the default) or `month` (30 days). The comparison window is always the
+ * equally-long span immediately before it.
+ */
+export type GymStatsInput = {
+  /** The gym to report on. The caller must have gym edit access. */
+  gymUuid: Scalars['ID']['input'];
+  /** Window length: week (7 days, default) or month (30 days). */
+  period?: InputMaybe<GymStatsPeriod>;
+};
+
+/** Supported Insights window lengths. */
+export type GymStatsPeriod =
+  /** Rolling last 30 days. */
+  | 'month'
+  /** Rolling last 7 days. */
+  | 'week';
+
+/**
+ * The two deltable counts for one window (current or previous). Kept separate
+ * from the top-climb / busiest-day lists because only these scalars feed the
+ * week-over-week deltas; the lists are only rendered for the current window.
+ */
+export type GymStatsWindow = {
+  __typename?: 'GymStatsWindow';
+  /** Total ascents (flash + send) on the gym's boards in this window. */
+  ascentCount: Scalars['Int']['output'];
+  /** Distinct climbers with a flash/send on the gym's boards in this window. */
+  uniqueClimbers: Scalars['Int']['output'];
+};
+
+/**
+ * One climb from the gym's top-10 for the current window, ranked by ascents.
+ * A row is keyed by (climbUuid, boardType, angle) — the same key board_climb_stats
+ * uses — so the same holds set at two angles shows as two rows with their own
+ * grades. `name` and `gradeName` are best-effort: a climb missing its catalog
+ * row (unsynced) or its consensus grade (MoonBoard, too few ascents) returns null
+ * and the UI falls back gracefully.
+ */
+export type GymTopClimb = {
+  __typename?: 'GymTopClimb';
+  /** The angle the ticks were logged at. */
+  angle: Scalars['Int']['output'];
+  /** Ascents (flash + send) on this climb in the current window. */
+  ascentCount: Scalars['Int']['output'];
+  /** Board type (kilter, tension, moonboard, ...). */
+  boardType: Scalars['String']['output'];
+  /** The climb's UUID. */
+  climbUuid: Scalars['ID']['output'];
+  /** Consensus grade name, e.g. "V4" (null when no grade is resolvable). */
+  gradeName?: Maybe<Scalars['String']['output']>;
+  /** Climb display name (null when the catalog row is missing). */
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 /** A scanned post whose climb name matched multiple climbs — the user picks one. */
@@ -4166,6 +4258,14 @@ export type Query = {
   /** Get members of a gym. */
   gymMembers: GymMemberConnection;
   /**
+   * A gym owner's activity snapshot: unique climbers, ascents, top climbs, and
+   * busiest weekdays for the current window plus the equally-long window before
+   * it (for week-over-week deltas). Requires gym edit access (owner, gym
+   * admin/editor, or a covering community admin/leader). Every aggregate is
+   * bounded to the gym's linked boards and the time window.
+   */
+  gymStats: GymStats;
+  /**
    * Resolve scraped Instagram posts against Boardsesh: which beta videos are
    * missing, already linked, ambiguous, or unmatched. Read-only — the client
    * attaches the missing ones via the attachBetaLink mutation.
@@ -4707,6 +4807,11 @@ export type QueryGymKiosksArgs = {
 /** Root query type for all read operations. */
 export type QueryGymMembersArgs = {
   input: GymMembersInput;
+};
+
+/** Root query type for all read operations. */
+export type QueryGymStatsArgs = {
+  input: GymStatsInput;
 };
 
 /** Root query type for all read operations. */

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -20,6 +20,8 @@ import type {
   PendingGymClaimsInput,
   GymClaimConnection,
   UserBoard,
+  GymStats,
+  GymStatsInput,
 } from '@boardsesh/shared-schema';
 
 // ============================================
@@ -143,6 +145,37 @@ export const GET_GYM_BOARDS = gql`
   query GetGymBoards($gymUuid: ID!) {
     gymBoards(gymUuid: $gymUuid) {
       ${GYM_BOARD_FIELDS}
+    }
+  }
+`;
+
+// Owner Insights dashboard: current + prior window counts (for week-over-week
+// deltas), the top-10 climbs, and busiest weekdays. Requires gym edit access.
+export const GET_GYM_STATS = gql`
+  query GetGymStats($input: GymStatsInput!) {
+    gymStats(input: $input) {
+      gymUuid
+      periodDays
+      current {
+        uniqueClimbers
+        ascentCount
+      }
+      previous {
+        uniqueClimbers
+        ascentCount
+      }
+      topClimbs {
+        climbUuid
+        boardType
+        angle
+        name
+        gradeName
+        ascentCount
+      }
+      busiestDays {
+        dayOfWeek
+        ascentCount
+      }
     }
   }
 `;
@@ -310,6 +343,14 @@ export type GetGymBoardsQueryVariables = {
 
 export type GetGymBoardsQueryResponse = {
   gymBoards: UserBoard[];
+};
+
+export type GetGymStatsQueryVariables = {
+  input: GymStatsInput;
+};
+
+export type GetGymStatsQueryResponse = {
+  gymStats: GymStats;
 };
 
 export type CreateGymMutationVariables = {

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -45,20 +45,18 @@
     "poweredBy": "Powered by"
   },
   "embed": {
-    "metadata": {
-      "boardTitle": "{{boardName}} — live board view",
-      "boardDescription": "See what's lit on {{boardName}} right now. Powered by Boardsesh.",
-      "boardFallbackTitle": "Live board view",
-      "boardFallbackDescription": "Live climbing board widget. Powered by Boardsesh.",
-      "leaderboardTitle": "{{gymName}} — leaderboard",
-      "leaderboardDescription": "Who's sending at {{gymName}}. Powered by Boardsesh.",
-      "leaderboardFallbackTitle": "Gym leaderboard",
-      "leaderboardFallbackDescription": "Gym leaderboard widget. Powered by Boardsesh."
-    },
-    "leaderboard": {
-      "errorTitle": "Leaderboard unavailable",
-      "errorBody": "Couldn't load the latest sends. It'll retry on its own."
-    }
+    "boardButton": "Embed this board",
+    "railButton": "Embed leaderboard",
+    "boardDialogTitle": "Embed {{name}}",
+    "railDialogTitle": "Embed the {{name}} leaderboard",
+    "copy": "Copy",
+    "copied": "Copied to clipboard.",
+    "copyFailed": "Couldn't copy — select the code and copy it manually.",
+    "periodNote": "The period parameter accepts day, week, or month.",
+    "docsHint": "Paste into any HTML page — it stays live.",
+    "close": "Close",
+    "publicOnlyBoard": "Only public boards can be embedded.",
+    "publicOnlyGym": "Only public gyms can embed the leaderboard."
   },
   "gymPage": {
     "metaTitle": "{{gymName}} climbing gym",
@@ -81,7 +79,29 @@
       "kiosks": "Kiosks",
       "branding": "Branding",
       "boards": "Boards",
-      "members": "Members"
+      "members": "Members",
+      "insights": "Insights"
+    },
+    "insights": {
+      "subtitle": "How your boards did this week compared with last.",
+      "uniqueClimbers": "Climbers",
+      "ascents": "Sends",
+      "busiestDay": "Busiest day",
+      "byDay": "Sends by day",
+      "byDayAria": "Sends per day of the week",
+      "topClimbs": "What everyone's projecting",
+      "noTopClimbs": "No sends logged yet this week.",
+      "unnamedClimb": "Unnamed climb",
+      "ascentsCount_one": "{{count}} send",
+      "ascentsCount_other": "{{count}} sends",
+      "deltaUp": "+{{count}} vs last week",
+      "deltaDown": "−{{count}} vs last week",
+      "deltaFlat": "Same as last week",
+      "loadError": "Couldn't load this week's numbers.",
+      "empty": {
+        "title": "No sends this week",
+        "body": "Time to reset the wall? As soon as climbers log a send here, you'll see who showed up and what they're projecting."
+      }
     },
     "navGuard": {
       "title": "Discard unsaved changes?",
@@ -267,19 +287,5 @@
       "cancel": "Cancel",
       "done": "Branding reset."
     }
-  },
-  "embed": {
-    "boardButton": "Embed this board",
-    "railButton": "Embed leaderboard",
-    "boardDialogTitle": "Embed {{name}}",
-    "railDialogTitle": "Embed the {{name}} leaderboard",
-    "copy": "Copy",
-    "copied": "Copied to clipboard.",
-    "copyFailed": "Couldn't copy — select the code and copy it manually.",
-    "periodNote": "The period parameter accepts day, week, or month.",
-    "docsHint": "Paste into any HTML page — it stays live.",
-    "close": "Close",
-    "publicOnlyBoard": "Only public boards can be embedded.",
-    "publicOnlyGym": "Only public gyms can embed the leaderboard."
   }
 }

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -45,20 +45,18 @@
     "poweredBy": "Con la tecnología de"
   },
   "embed": {
-    "metadata": {
-      "boardTitle": "{{boardName}} — vista del plafón en directo",
-      "boardDescription": "Mira qué está encendido en {{boardName}} ahora mismo. Con la tecnología de Boardsesh.",
-      "boardFallbackTitle": "Vista del plafón en directo",
-      "boardFallbackDescription": "Widget del plafón en directo. Con la tecnología de Boardsesh.",
-      "leaderboardTitle": "{{gymName}} — clasificación",
-      "leaderboardDescription": "Quién está encadenando en {{gymName}}. Con la tecnología de Boardsesh.",
-      "leaderboardFallbackTitle": "Clasificación del rocódromo",
-      "leaderboardFallbackDescription": "Widget de clasificación del rocódromo. Con la tecnología de Boardsesh."
-    },
-    "leaderboard": {
-      "errorTitle": "Clasificación no disponible",
-      "errorBody": "No se han podido cargar los últimos encadenes. Se reintentará automáticamente."
-    }
+    "boardButton": "Insertar este plafón",
+    "railButton": "Insertar la clasificación",
+    "boardDialogTitle": "Insertar {{name}}",
+    "railDialogTitle": "Insertar la clasificación de {{name}}",
+    "copy": "Copiar",
+    "copied": "Copiado al portapapeles.",
+    "copyFailed": "No se pudo copiar: selecciona el código y cópialo a mano.",
+    "periodNote": "El parámetro period acepta day, week o month.",
+    "docsHint": "Pégalo en cualquier página HTML: se mantiene en directo.",
+    "close": "Cerrar",
+    "publicOnlyBoard": "Solo los plafones públicos se pueden insertar.",
+    "publicOnlyGym": "Solo los rocódromos públicos pueden insertar la clasificación."
   },
   "gymPage": {
     "metaTitle": "Rocódromo {{gymName}}",
@@ -81,7 +79,29 @@
       "kiosks": "Kioscos",
       "branding": "Marca",
       "boards": "Plafones",
-      "members": "Miembros"
+      "members": "Miembros",
+      "insights": "Estadísticas"
+    },
+    "insights": {
+      "subtitle": "Cómo fueron tus plafones esta semana frente a la anterior.",
+      "uniqueClimbers": "Escaladores",
+      "ascents": "Encadenes",
+      "busiestDay": "Día más activo",
+      "byDay": "Encadenes por día",
+      "byDayAria": "Encadenes por día de la semana",
+      "topClimbs": "Lo que todos están proyectando",
+      "noTopClimbs": "Aún no hay encadenes esta semana.",
+      "unnamedClimb": "Bloque sin nombre",
+      "ascentsCount_one": "{{count}} encadene",
+      "ascentsCount_other": "{{count}} encadenes",
+      "deltaUp": "+{{count}} frente a la semana pasada",
+      "deltaDown": "−{{count}} frente a la semana pasada",
+      "deltaFlat": "Igual que la semana pasada",
+      "loadError": "No se pudieron cargar los datos de esta semana.",
+      "empty": {
+        "title": "Sin encadenes esta semana",
+        "body": "¿Toca renovar el muro? En cuanto los escaladores registren un encadene aquí, verás quién vino y qué están proyectando."
+      }
     },
     "navGuard": {
       "title": "¿Descartar los cambios sin guardar?",
@@ -267,19 +287,5 @@
       "cancel": "Cancelar",
       "done": "Marca restablecida."
     }
-  },
-  "embed": {
-    "boardButton": "Insertar este plafón",
-    "railButton": "Insertar la clasificación",
-    "boardDialogTitle": "Insertar {{name}}",
-    "railDialogTitle": "Insertar la clasificación de {{name}}",
-    "copy": "Copiar",
-    "copied": "Copiado al portapapeles.",
-    "copyFailed": "No se pudo copiar: selecciona el código y cópialo a mano.",
-    "periodNote": "El parámetro period acepta day, week o month.",
-    "docsHint": "Pégalo en cualquier página HTML: se mantiene en directo.",
-    "close": "Cerrar",
-    "publicOnlyBoard": "Solo los plafones públicos se pueden insertar.",
-    "publicOnlyGym": "Solo los rocódromos públicos pueden insertar la clasificación."
   }
 }

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -45,20 +45,18 @@
     "poweredBy": "Propulsé par"
   },
   "embed": {
-    "metadata": {
-      "boardTitle": "{{boardName}} — vue de la board en direct",
-      "boardDescription": "Ce qui est allumé sur {{boardName}} en ce moment. Propulsé par Boardsesh.",
-      "boardFallbackTitle": "Vue de la board en direct",
-      "boardFallbackDescription": "Widget de board en direct. Propulsé par Boardsesh.",
-      "leaderboardTitle": "{{gymName}} — classement",
-      "leaderboardDescription": "Qui enchaîne à {{gymName}}. Propulsé par Boardsesh.",
-      "leaderboardFallbackTitle": "Classement de la salle",
-      "leaderboardFallbackDescription": "Widget de classement de salle. Propulsé par Boardsesh."
-    },
-    "leaderboard": {
-      "errorTitle": "Classement indisponible",
-      "errorBody": "Impossible de charger les dernières croix. Le widget réessaie tout seul."
-    }
+    "boardButton": "Intégrer cette board",
+    "railButton": "Intégrer le classement",
+    "boardDialogTitle": "Intégrer {{name}}",
+    "railDialogTitle": "Intégrer le classement de {{name}}",
+    "copy": "Copier",
+    "copied": "Copié dans le presse-papiers.",
+    "copyFailed": "Impossible de copier : sélectionne le code et copie-le à la main.",
+    "periodNote": "Le paramètre period accepte day, week ou month.",
+    "docsHint": "Colle-le dans n'importe quelle page HTML : ça reste en direct.",
+    "close": "Fermer",
+    "publicOnlyBoard": "Seules les boards publiques peuvent être intégrées.",
+    "publicOnlyGym": "Seules les salles publiques peuvent intégrer le classement."
   },
   "gymPage": {
     "metaTitle": "Salle d'escalade {{gymName}}",
@@ -81,7 +79,29 @@
       "kiosks": "Bornes",
       "branding": "Identité",
       "boards": "Boards",
-      "members": "Membres"
+      "members": "Membres",
+      "insights": "Statistiques"
+    },
+    "insights": {
+      "subtitle": "Comment tes boards ont tourné cette semaine par rapport à la dernière.",
+      "uniqueClimbers": "Grimpeurs",
+      "ascents": "Croix",
+      "busiestDay": "Jour le plus actif",
+      "byDay": "Croix par jour",
+      "byDayAria": "Croix par jour de la semaine",
+      "topClimbs": "Ce que tout le monde projette",
+      "noTopClimbs": "Pas encore de croix cette semaine.",
+      "unnamedClimb": "Bloc sans nom",
+      "ascentsCount_one": "{{count}} croix",
+      "ascentsCount_other": "{{count}} croix",
+      "deltaUp": "+{{count}} par rapport à la semaine dernière",
+      "deltaDown": "−{{count}} par rapport à la semaine dernière",
+      "deltaFlat": "Comme la semaine dernière",
+      "loadError": "Impossible de charger les chiffres de cette semaine.",
+      "empty": {
+        "title": "Pas de croix cette semaine",
+        "body": "Il est temps de refaire le mur ? Dès que les grimpeurs enregistrent une croix ici, tu verras qui est passé et ce qu'ils projettent."
+      }
     },
     "navGuard": {
       "title": "Abandonner les modifications non enregistrées ?",
@@ -267,19 +287,5 @@
       "cancel": "Annuler",
       "done": "Identité rétablie."
     }
-  },
-  "embed": {
-    "boardButton": "Intégrer cette board",
-    "railButton": "Intégrer le classement",
-    "boardDialogTitle": "Intégrer {{name}}",
-    "railDialogTitle": "Intégrer le classement de {{name}}",
-    "copy": "Copier",
-    "copied": "Copié dans le presse-papiers.",
-    "copyFailed": "Impossible de copier : sélectionne le code et copie-le à la main.",
-    "periodNote": "Le paramètre period accepte day, week ou month.",
-    "docsHint": "Colle-le dans n'importe quelle page HTML : ça reste en direct.",
-    "close": "Fermer",
-    "publicOnlyBoard": "Seules les boards publiques peuvent être intégrées.",
-    "publicOnlyGym": "Seules les salles publiques peuvent intégrer le classement."
   }
 }

--- a/packages/web/app/components/gym-entity/manage/__tests__/insights-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/insights-tab.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { Gym, GymStats } from '@boardsesh/shared-schema';
+import InsightsTab, { computeWowDelta, busiestDayOfWeek } from '../insights-tab';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'user-owner' } }, status: 'authenticated' }),
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+// The real CssBarChart pulls in @mui/x-charts; stub it so the tab test stays
+// focused on stat cards / deltas / empty state.
+vi.mock('@/app/components/charts/css-bar-chart', () => ({
+  CssBarChart: ({ ariaLabel }: { ariaLabel?: string }) => <div role="img" aria-label={ariaLabel} />,
+}));
+
+const gym = { uuid: 'gym-uuid-1', name: 'Test Gym', slug: 'test-gym', ownerId: 'user-owner' } as unknown as Gym;
+
+function renderTab() {
+  return render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <InsightsTab gym={gym} onGymChange={vi.fn()} />
+    </QueryClientProvider>,
+  );
+}
+
+function makeStats(overrides: Partial<GymStats>): GymStats {
+  return {
+    gymUuid: gym.uuid,
+    periodDays: 7,
+    current: { uniqueClimbers: 8, ascentCount: 20 },
+    previous: { uniqueClimbers: 5, ascentCount: 25 },
+    topClimbs: [
+      { climbUuid: 'c-x', boardType: 'kilter', angle: 40, name: 'Crimpy Traverse', gradeName: 'V4', ascentCount: 9 },
+      { climbUuid: 'c-y', boardType: 'kilter', angle: 40, name: null, gradeName: null, ascentCount: 4 },
+    ],
+    busiestDays: [
+      { dayOfWeek: 2, ascentCount: 6 },
+      { dayOfWeek: 4, ascentCount: 14 },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockRequest.mockReset();
+});
+
+describe('computeWowDelta', () => {
+  it('classifies up, down and flat', () => {
+    expect(computeWowDelta(8, 5)).toEqual({ diff: 3, direction: 'up' });
+    expect(computeWowDelta(20, 25)).toEqual({ diff: -5, direction: 'down' });
+    expect(computeWowDelta(7, 7)).toEqual({ diff: 0, direction: 'flat' });
+  });
+});
+
+describe('busiestDayOfWeek', () => {
+  it('returns the weekday with the most ascents, or null when empty', () => {
+    expect(
+      busiestDayOfWeek([
+        { dayOfWeek: 2, ascentCount: 6 },
+        { dayOfWeek: 4, ascentCount: 14 },
+      ]),
+    ).toBe(4);
+    expect(busiestDayOfWeek([])).toBeNull();
+  });
+});
+
+describe('InsightsTab', () => {
+  it('renders stat values and week-over-week deltas', async () => {
+    mockRequest.mockResolvedValue({ gymStats: makeStats({}) });
+    renderTab();
+
+    // Stat values.
+    expect(await screen.findByText('8')).toBeTruthy();
+    expect(screen.getByText('20')).toBeTruthy();
+
+    // Up delta on unique climbers (+3), down delta on ascents (−5).
+    const climbersDelta = screen.getByTestId('insights-delta-climbers');
+    expect(climbersDelta.textContent).toMatch(/3/);
+    expect(climbersDelta.textContent).toMatch(/vs last week/i);
+
+    const ascentsDelta = screen.getByTestId('insights-delta-ascents');
+    expect(ascentsDelta.textContent).toMatch(/5/);
+    expect(ascentsDelta.textContent).toMatch(/vs last week/i);
+
+    // Top climbs list resolves name + grade.
+    expect(screen.getByText('Crimpy Traverse')).toBeTruthy();
+    expect(screen.getByTestId('insights-top-climbs').textContent).toMatch(/V4/);
+  });
+
+  it('shows a flat delta when nothing changed', async () => {
+    mockRequest.mockResolvedValue({
+      gymStats: makeStats({
+        current: { uniqueClimbers: 5, ascentCount: 20 },
+        previous: { uniqueClimbers: 5, ascentCount: 12 },
+      }),
+    });
+    renderTab();
+
+    const climbersDelta = await screen.findByTestId('insights-delta-climbers');
+    expect(climbersDelta.textContent).toMatch(/same as last week/i);
+  });
+
+  it('renders the climber-voice empty state when there are no sends this week', async () => {
+    mockRequest.mockResolvedValue({
+      gymStats: makeStats({ current: { uniqueClimbers: 0, ascentCount: 0 }, topClimbs: [], busiestDays: [] }),
+    });
+    renderTab();
+
+    expect(await screen.findByText('No sends this week')).toBeTruthy();
+    expect(screen.getByText(/time to reset the wall/i)).toBeTruthy();
+    // The stat cards must not render in the empty state.
+    expect(screen.queryByTestId('insights-delta-climbers')).toBeNull();
+  });
+
+  it('surfaces a load error state', async () => {
+    mockRequest.mockRejectedValue(new Error('boom'));
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText(/couldn't load this week/i)).toBeTruthy();
+    });
+  });
+});

--- a/packages/web/app/components/gym-entity/manage/__tests__/insights-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/insights-tab.test.tsx
@@ -109,7 +109,7 @@ describe('InsightsTab', () => {
     expect(screen.getByTestId('insights-top-climbs').textContent).toMatch(/V4/);
   });
 
-  it('shows a flat delta when nothing changed', async () => {
+  it('shows a flat delta on a metric that did not change week-over-week', async () => {
     mockRequest.mockResolvedValue({
       gymStats: makeStats({
         current: { uniqueClimbers: 5, ascentCount: 20 },

--- a/packages/web/app/components/gym-entity/manage/insights-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/insights-tab.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Skeleton from '@mui/material/Skeleton';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import Chip from '@mui/material/Chip';
+import TrendingUpOutlined from '@mui/icons-material/TrendingUpOutlined';
+import TrendingDownOutlined from '@mui/icons-material/TrendingDownOutlined';
+import TrendingFlatOutlined from '@mui/icons-material/TrendingFlatOutlined';
+import BarChartOutlined from '@mui/icons-material/BarChartOutlined';
+import {
+  GET_GYM_STATS,
+  type GetGymStatsQueryResponse,
+  type GetGymStatsQueryVariables,
+} from '@boardsesh/graphql/operations';
+import type { GymStats } from '@boardsesh/shared-schema';
+import { boardTypeLabel } from '@boardsesh/board-constants';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { CssBarChart, type CssBarChartBar } from '@/app/components/charts/css-bar-chart';
+import { EmptyState } from '@/app/components/ui/empty-state';
+import { themeTokens } from '@/app/theme/theme-config';
+import type { GymManageTabProps } from './tab-props';
+
+// Display weekdays Monday-first; Postgres EXTRACT(DOW) is 0 = Sunday … 6 = Saturday.
+const WEEK_ORDER = [1, 2, 3, 4, 5, 6, 0] as const;
+
+// 2024-01-07 is a Sunday, so +dow lands on the matching weekday. Labels come from
+// Intl so they follow the viewer's locale without seven hand-kept i18n keys.
+function weekdayLabel(dayOfWeek: number, locale: string, style: 'short' | 'long'): string {
+  const date = new Date(Date.UTC(2024, 0, 7 + dayOfWeek));
+  return new Intl.DateTimeFormat(locale, { weekday: style, timeZone: 'UTC' }).format(date);
+}
+
+export type WowDelta = {
+  diff: number;
+  direction: 'up' | 'down' | 'flat';
+};
+
+/** Week-over-week change of a scalar count. Pure so the delta logic is testable. */
+export function computeWowDelta(current: number, previous: number): WowDelta {
+  const diff = current - previous;
+  if (diff > 0) return { diff, direction: 'up' };
+  if (diff < 0) return { diff, direction: 'down' };
+  return { diff: 0, direction: 'flat' };
+}
+
+/** The weekday with the most ascents (Postgres DOW), or null when the window is empty. */
+export function busiestDayOfWeek(busiestDays: GymStats['busiestDays']): number | null {
+  let best: { dayOfWeek: number; ascentCount: number } | null = null;
+  for (const day of busiestDays) {
+    if (!best || day.ascentCount > best.ascentCount) best = day;
+  }
+  return best ? best.dayOfWeek : null;
+}
+
+function DeltaLabel({ delta, testId }: { delta: WowDelta; testId: string }) {
+  const { t } = useTranslation('kiosk');
+  const iconSx = { fontSize: 16 };
+  let color: string;
+  let icon: React.ReactNode;
+  let label: string;
+  if (delta.direction === 'up') {
+    color = themeTokens.colors.success;
+    icon = <TrendingUpOutlined sx={iconSx} />;
+    label = t('manage.insights.deltaUp', { count: delta.diff });
+  } else if (delta.direction === 'down') {
+    color = themeTokens.colors.error;
+    icon = <TrendingDownOutlined sx={iconSx} />;
+    label = t('manage.insights.deltaDown', { count: Math.abs(delta.diff) });
+  } else {
+    color = themeTokens.neutral[500];
+    icon = <TrendingFlatOutlined sx={iconSx} />;
+    label = t('manage.insights.deltaFlat');
+  }
+  return (
+    <Box data-testid={testId} sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, color }}>
+      {icon}
+      <Typography variant="caption" sx={{ color: 'inherit', fontWeight: themeTokens.typography.fontWeight.semibold }}>
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+function StatCard({
+  value,
+  label,
+  delta,
+  deltaTestId,
+}: {
+  value: React.ReactNode;
+  label: string;
+  delta?: WowDelta;
+  deltaTestId?: string;
+}) {
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        minWidth: 0,
+        borderRadius: `${themeTokens.borderRadius.md}px`,
+        bgcolor: 'var(--neutral-100)',
+        p: 1.5,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 0.5,
+        textAlign: 'center',
+      }}
+    >
+      <Typography
+        variant="h5"
+        component="span"
+        sx={{ fontWeight: themeTokens.typography.fontWeight.bold, lineHeight: 1 }}
+      >
+        {value}
+      </Typography>
+      <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.2 }}>
+        {label}
+      </Typography>
+      {delta && deltaTestId && <DeltaLabel delta={delta} testId={deltaTestId} />}
+    </Box>
+  );
+}
+
+function InsightsSkeleton() {
+  return (
+    <Box data-testid="insights-loading">
+      <Box sx={{ display: 'flex', gap: 1, mb: 3 }}>
+        {[0, 1, 2].map((index) => (
+          <Skeleton
+            key={index}
+            variant="rounded"
+            height={96}
+            sx={{ flex: 1, borderRadius: `${themeTokens.borderRadius.md}px` }}
+          />
+        ))}
+      </Box>
+      <Skeleton variant="text" width={160} sx={{ mb: 1 }} />
+      {[0, 1, 2, 3, 4].map((index) => (
+        <Skeleton key={index} variant="text" height={32} />
+      ))}
+      <Skeleton variant="rounded" height={160} sx={{ mt: 3, borderRadius: `${themeTokens.borderRadius.md}px` }} />
+    </Box>
+  );
+}
+
+export default function InsightsTab({ gym }: GymManageTabProps) {
+  const { t, i18n } = useTranslation('kiosk');
+  const { token, isLoading: isTokenLoading } = useWsAuthToken();
+  const { data: session } = useSession();
+  // Editor-scoped read: key on viewer so an in-session login/logout doesn't
+  // serve the previous viewer's cache entry.
+  const viewerUserId = session?.user?.id ?? 'anonymous';
+  const locale = i18n.language || 'en-US';
+
+  const {
+    data: stats,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: ['gymStats', gym.uuid, viewerUserId],
+    queryFn: async () => {
+      const client = createGraphQLHttpClient(token);
+      const response = await client.request<GetGymStatsQueryResponse, GetGymStatsQueryVariables>(GET_GYM_STATS, {
+        input: { gymUuid: gym.uuid, period: 'week' },
+      });
+      return response.gymStats;
+    },
+    enabled: !!token,
+  });
+
+  const dayBars = useMemo<CssBarChartBar[]>(() => {
+    if (!stats) return [];
+    const countByDow = new Map(stats.busiestDays.map((day) => [day.dayOfWeek, day.ascentCount]));
+    return WEEK_ORDER.map((dow) => ({
+      key: String(dow),
+      label: weekdayLabel(dow, locale, 'short'),
+      segments: [
+        { value: countByDow.get(dow) ?? 0, color: themeTokens.colors.primary, label: t('manage.insights.ascents') },
+      ],
+    }));
+  }, [stats, locale, t]);
+
+  if (isTokenLoading || isPending) {
+    return <InsightsSkeleton />;
+  }
+
+  if (isError || !stats) {
+    return <EmptyState description={t('manage.insights.loadError')} />;
+  }
+
+  const uniqueDelta = computeWowDelta(stats.current.uniqueClimbers, stats.previous.uniqueClimbers);
+  const ascentDelta = computeWowDelta(stats.current.ascentCount, stats.previous.ascentCount);
+  const busiestDow = busiestDayOfWeek(stats.busiestDays);
+
+  if (stats.current.ascentCount === 0) {
+    return (
+      <EmptyState
+        icon={<BarChartOutlined fontSize="inherit" />}
+        description={
+          <Box sx={{ textAlign: 'center' }}>
+            <Typography variant="h6" sx={{ fontWeight: themeTokens.typography.fontWeight.bold, mb: 0.5 }}>
+              {t('manage.insights.empty.title')}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {t('manage.insights.empty.body')}
+            </Typography>
+          </Box>
+        }
+      />
+    );
+  }
+
+  return (
+    <Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        {t('manage.insights.subtitle')}
+      </Typography>
+
+      <Box sx={{ display: 'flex', gap: 1, mb: 3 }}>
+        <StatCard
+          value={stats.current.uniqueClimbers}
+          label={t('manage.insights.uniqueClimbers')}
+          delta={uniqueDelta}
+          deltaTestId="insights-delta-climbers"
+        />
+        <StatCard
+          value={stats.current.ascentCount}
+          label={t('manage.insights.ascents')}
+          delta={ascentDelta}
+          deltaTestId="insights-delta-ascents"
+        />
+        <StatCard
+          value={busiestDow === null ? '—' : weekdayLabel(busiestDow, locale, 'short')}
+          label={t('manage.insights.busiestDay')}
+        />
+      </Box>
+
+      <Typography variant="subtitle2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold, mb: 1 }}>
+        {t('manage.insights.byDay')}
+      </Typography>
+      <CssBarChart
+        bars={dayBars}
+        height={160}
+        mobileHeight={120}
+        showLegend={false}
+        ariaLabel={t('manage.insights.byDayAria')}
+      />
+
+      <Typography variant="subtitle2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold, mt: 3, mb: 1 }}>
+        {t('manage.insights.topClimbs')}
+      </Typography>
+      {stats.topClimbs.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          {t('manage.insights.noTopClimbs')}
+        </Typography>
+      ) : (
+        <List disablePadding data-testid="insights-top-climbs">
+          {stats.topClimbs.map((climb, index) => (
+            <ListItem
+              key={`${climb.climbUuid}-${climb.angle}`}
+              disableGutters
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                py: 0.75,
+                borderBottom: index < stats.topClimbs.length - 1 ? `1px solid var(--neutral-200)` : 'none',
+              }}
+            >
+              <Typography
+                variant="body2"
+                sx={{
+                  width: 24,
+                  color: 'text.secondary',
+                  fontWeight: themeTokens.typography.fontWeight.semibold,
+                  flexShrink: 0,
+                }}
+              >
+                {index + 1}
+              </Typography>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontWeight: themeTokens.typography.fontWeight.medium,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {climb.name ?? t('manage.insights.unnamedClimb')}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {boardTypeLabel(climb.boardType)}
+                  {climb.gradeName ? ` · ${climb.gradeName}` : ''}
+                  {` · ${climb.angle}°`}
+                </Typography>
+              </Box>
+              <Chip
+                size="small"
+                variant="outlined"
+                label={t('manage.insights.ascentsCount', { count: climb.ascentCount })}
+                sx={{ flexShrink: 0 }}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/insights-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/insights-tab.tsx
@@ -31,6 +31,14 @@ import type { GymManageTabProps } from './tab-props';
 // Display weekdays Monday-first; Postgres EXTRACT(DOW) is 0 = Sunday … 6 = Saturday.
 const WEEK_ORDER = [1, 2, 3, 4, 5, 6, 0] as const;
 
+// The dashboard reads the rolling week today. Kept as a constant so it stays in
+// the query key alongside the query input — a future period toggle can flip both
+// without silently serving a cached window under the wrong label.
+const INSIGHTS_PERIOD = 'week' as const;
+
+// Rolling weekly aggregate — no need to refetch on every tab remount.
+const INSIGHTS_STALE_MS = 5 * 60_000;
+
 // 2024-01-07 is a Sunday, so +dow lands on the matching weekday. Labels come from
 // Intl so they follow the viewer's locale without seven hand-kept i18n keys.
 function weekdayLabel(dayOfWeek: number, locale: string, style: 'short' | 'long'): string {
@@ -167,15 +175,16 @@ export default function InsightsTab({ gym }: GymManageTabProps) {
     isPending,
     isError,
   } = useQuery({
-    queryKey: ['gymStats', gym.uuid, viewerUserId],
+    queryKey: ['gymStats', gym.uuid, viewerUserId, INSIGHTS_PERIOD],
     queryFn: async () => {
       const client = createGraphQLHttpClient(token);
       const response = await client.request<GetGymStatsQueryResponse, GetGymStatsQueryVariables>(GET_GYM_STATS, {
-        input: { gymUuid: gym.uuid, period: 'week' },
+        input: { gymUuid: gym.uuid, period: INSIGHTS_PERIOD },
       });
       return response.gymStats;
     },
     enabled: !!token,
+    staleTime: INSIGHTS_STALE_MS,
   });
 
   const dayBars = useMemo<CssBarChartBar[]>(() => {
@@ -189,6 +198,13 @@ export default function InsightsTab({ gym }: GymManageTabProps) {
       ],
     }));
   }, [stats, locale, t]);
+
+  // Token settled with no token: the disabled query stays isPending forever, so
+  // treat it as an error rather than an eternal skeleton (the tab is auth-gated,
+  // so this only trips on a silent auth-token fetch failure).
+  if (!isTokenLoading && !token) {
+    return <EmptyState description={t('manage.insights.loadError')} />;
+  }
 
   if (isTokenLoading || isPending) {
     return <InsightsSkeleton />;

--- a/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
@@ -19,13 +19,14 @@ import GymMemberManagement from '@/app/components/gym-entity/gym-member-manageme
 import { canManageGymBoards } from '@/app/components/gym-entity/manage/gym-board-permissions';
 import GymBoardsTab from '@/app/components/gym-entity/manage/gym-boards-tab';
 import KiosksTab from '@/app/components/gym-entity/manage/kiosks-tab';
+import InsightsTab from '@/app/components/gym-entity/manage/insights-tab';
 import BrandingTab from '@/app/components/gym-entity/manage/branding-tab';
 import GymSlugGuard from '@/app/components/gym-entity/manage/gym-slug-guard';
 import ConfirmDialog from '@/app/components/gym-entity/manage/confirm-dialog';
 import { decideManageNavigation, type ManageNavigation } from '@/app/components/gym-entity/manage/manage-nav-guard';
 
-type ManageTab = 'kiosks' | 'branding' | 'boards' | 'members';
-const VALID_TABS: ManageTab[] = ['kiosks', 'branding', 'boards', 'members'];
+type ManageTab = 'kiosks' | 'insights' | 'branding' | 'boards' | 'members';
+const VALID_TABS: ManageTab[] = ['kiosks', 'insights', 'branding', 'boards', 'members'];
 const DEFAULT_TAB: ManageTab = 'kiosks';
 
 export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
@@ -131,12 +132,14 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
         sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}
       >
         <Tab value="kiosks" label={t('manage.tabs.kiosks')} sx={{ textTransform: 'none' }} />
+        <Tab value="insights" label={t('manage.tabs.insights')} sx={{ textTransform: 'none' }} />
         <Tab value="branding" label={t('manage.tabs.branding')} sx={{ textTransform: 'none' }} />
         <Tab value="boards" label={t('manage.tabs.boards')} sx={{ textTransform: 'none' }} />
         <Tab value="members" label={t('manage.tabs.members')} sx={{ textTransform: 'none' }} />
       </Tabs>
 
       {activeTab === 'kiosks' && <KiosksTab gym={gym} onGymChange={setGym} onDirtyChange={setIsActiveTabDirty} />}
+      {activeTab === 'insights' && <InsightsTab gym={gym} onGymChange={setGym} />}
       {activeTab === 'branding' && <BrandingTab gym={gym} onGymChange={setGym} onDirtyChange={setIsActiveTabDirty} />}
       {activeTab === 'boards' && <GymBoardsTab gym={gym} onGymChange={setGym} />}
       {activeTab === 'members' && (


### PR DESCRIPTION
## Summary

Gym owners get an **Insights** tab in the manage console: a simple weekly picture of who's actually using the board corner.

- **Backend `gymStats` query** (`packages/backend/.../social/gym-insights.ts`), guarded by the existing `requireGymEditAccess`. It reuses `boardLeaderboard`'s filter shape — gym boards → `boardsesh_ticks` filtered by `board_id IN (...)`, `status IN (flash, send)`, and a bounded `climbed_at` window on the `(board_id, climbed_at)` index. No unbounded scans, no schema changes. Returns, for the current 7-day window **and** the prior one (for week-over-week deltas):
  - `uniqueClimbers` (distinct climbers) and `ascentCount` — both windows, one 2×-window scan with `FILTER`
  - `topClimbs` (top 10 by ascents, with resolved name + consensus grade) — current window
  - `busiestDays` (ascents per weekday) — current window
  - `period` input (`week` default / `month`)
- **Shared schema**: `GymStats` / `GymStatsWindow` / `GymTopClimb` / `GymDayActivity` types, `GymStatsInput` / `GymStatsPeriod`, and the `GET_GYM_STATS` operation.
- **Web Insights tab** (`packages/web/app/components/gym-entity/manage/insights-tab.tsx`): three stat cards (climbers, sends, busiest day) with WoW deltas, a per-day bar (reuses the existing MUI-based `CssBarChart` — no new chart dep), and a top-10 list. Loading skeletons + a climber-voice empty state. Registered in `manage-gym-content.tsx` with a minimal one-import / one-tab-entry diff.
- **i18n**: en-US / es / fr (glossary-correct: _rocódromo/plafón/encadenes_, _salle/croix/grimpeurs_).

## Release Notes

- Gym owners get an Insights tab — see how many climbers hit your boards this week, the climbs everyone's projecting, and your busiest nights, all with a week-over-week read on whether the wall's picking up.

## Test plan

- `vp run typecheck` — pass
- `vp check` — 0 errors
- `vp run check:i18n` — OK; i18n catalog-completeness — 60/60 (en/es/fr parity)
- Backend `gym-insights.test.ts` (isolated pool) — 9/9: access guard (owner/admin/editor allowed; member/stranger/anon rejected), current-vs-previous aggregation, gym-board + flash/send + time-window scoping, top-climb name/grade resolution, empty-gym path
- Web `insights-tab.test.tsx` — 6/6: WoW up/down/flat deltas, top-climb name+grade, empty state, load error
- Full suites: web 5231/5231; backend 2362 passed (5 files hit a pre-existing worker-DB init flake, all green on re-run)