### PR TITLE
fix(mobile): My gyms review fixes — uuid handoff, fresh list, wider page

### DIFF
--- a/packages/mobile/app/gyms/__tests__/mine.test.tsx
+++ b/packages/mobile/app/gyms/__tests__/mine.test.tsx
@@ -203,13 +203,24 @@ describe('MyGymsScreen', () => {
     expect(setKioskHintSeen).toHaveBeenCalledWith(true);
   });
 
-  it('toasts a "not set up yet" message when a gym has no slug to manage', () => {
+  it('falls back to the gym uuid when the slug is null', () => {
     state.myGyms = { data: { gyms: [makeGym({ slug: null })] }, isLoading: false, isError: false };
     const { getByRole } = render(<MyGymsScreen />);
     fireEvent.click(getByRole('button', { name: 'manage-g1' }));
+    // The web manage route resolves a uuid too, so a slugless gym still opens.
+    expect(openUrl.openValidatedUrl).toHaveBeenCalledWith(
+      'https://www.boardsesh.com/gym/g1/manage',
+      expect.any(Function),
+    );
+  });
+
+  it('toasts a "not set up yet" message when a gym has neither slug nor uuid', () => {
+    state.myGyms = { data: { gyms: [makeGym({ slug: null, uuid: '' })] }, isLoading: false, isError: false };
+    const { getByRole } = render(<MyGymsScreen />);
+    // The stub keys its manage button off the uuid, so target an empty-uuid gym
+    // by the "manage-" prefix.
+    fireEvent.click(getByRole('button', { name: 'manage-' }));
     expect(openUrl.openValidatedUrl).not.toHaveBeenCalled();
-    // A slug-less gym has no manage URL — a browser can't help, so we don't reuse
-    // the "try a browser" copy.
     expect(toastMock.showToast).toHaveBeenCalledWith('This gym is not set up for kiosks yet', 'error');
   });
 

--- a/packages/mobile/app/gyms/mine.tsx
+++ b/packages/mobile/app/gyms/mine.tsx
@@ -21,10 +21,12 @@ import { iosSystemColors } from '../../src/theme/ios-colors';
 import { spacing, borderRadius } from '../../src/theme/tokens';
 
 // Kiosk/TV management is web-only by design; the mobile row hands off to the
-// browser console at /gym/{slug}/manage. `WEB_BASE_URL` respects the
-// EXPO_PUBLIC_WEB_URL override, so it points at whatever web build we're testing.
-function buildManageUrl(slug: string): string {
-  return `${WEB_BASE_URL}/gym/${encodeURIComponent(slug)}/manage`;
+// browser console at /gym/{slug|uuid}/manage. The web route resolves either a
+// slug or a uuid, so a slugless legacy gym still reaches setup via its uuid.
+// `WEB_BASE_URL` respects the EXPO_PUBLIC_WEB_URL override, so it points at
+// whatever web build we're testing.
+function buildManageUrl(slugOrUuid: string): string {
+  return `${WEB_BASE_URL}/gym/${encodeURIComponent(slugOrUuid)}/manage`;
 }
 
 /**
@@ -76,9 +78,12 @@ export default function MyGymsScreen() {
 
   const manageKiosks = useCallback(
     async (gym: Gym) => {
-      // A gym without a slug has no manage URL at all — that's a "not set up yet"
-      // state, not a failed open, so the "try a browser" copy would be wrong advice.
-      if (!gym.slug) {
+      // Prefer the slug, fall back to the uuid: the web manage route resolves
+      // either, so a slugless legacy gym still opens its kiosk setup. Only a gym
+      // with neither (a data-corruption edge — uuid is normally always present)
+      // is genuinely unmanageable.
+      const slugOrUuid = gym.slug ?? gym.uuid;
+      if (!slugOrUuid) {
         showToast(t('mobile.myGyms.manageUnavailable'), 'error');
         return;
       }
@@ -88,7 +93,7 @@ export default function MyGymsScreen() {
       hapticSelection();
       // openURL (never canOpenURL — false for https on Android 11+ package
       // visibility); a genuine failure rejects and we toast.
-      const opened = await openValidatedUrl(buildManageUrl(gym.slug), (url) => url.startsWith(WEB_BASE_URL));
+      const opened = await openValidatedUrl(buildManageUrl(slugOrUuid), (url) => url.startsWith(WEB_BASE_URL));
       if (!opened) showToast(t('mobile.myGyms.manageError'), 'error');
     },
     [kioskHintSeen, setKioskHintSeen, showToast, t],

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -250,11 +250,15 @@ export function useGym(gymUuid: string | null) {
  * help run). Backs the "My gyms" screen off the More tab. The `myGyms` query
  * scopes to the caller server-side, so no owner filter is passed here. Disabled
  * until signed in — an anonymous caller has no gyms and the query would 401.
+ *
+ * Requests the server-max page (50) in one shot rather than paginating: an owner
+ * runs a handful of gyms, so 50 clears every realistic case and keeps the screen a
+ * plain list instead of an `onEndReached` drain.
  */
 export function useMyGyms(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ['myGyms'],
-    queryFn: () => getHttpClient().request<GetMyGymsQueryResponse>(GET_MY_GYMS, { input: {} }),
+    queryFn: () => getHttpClient().request<GetMyGymsQueryResponse>(GET_MY_GYMS, { input: { limit: 50 } }),
     select: (data) => data.myGyms,
     enabled: options?.enabled ?? true,
   });
@@ -470,7 +474,8 @@ export function useUpdateBoard() {
  * for one of its board types — the server enforces the access check). Invalidate
  * the single-gym cache plus the nearby-gym search results so the wall finder's
  * list/pins reflect the rename or visibility change without a manual reload.
- * Also refresh the board lists, whose rows render the gym's name (`gymName`).
+ * Also refresh the board lists, whose rows render the gym's name (`gymName`), and
+ * the My gyms list, whose rows render the gym's name/address.
  */
 export function useUpdateGym() {
   const queryClient = useQueryClient();
@@ -484,6 +489,7 @@ export function useUpdateGym() {
       void queryClient.invalidateQueries({ queryKey: ['nearbyGyms'] });
       void queryClient.invalidateQueries({ queryKey: ['nearbyBoards'] });
       void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
+      void queryClient.invalidateQueries({ queryKey: ['myGyms'] });
     },
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to #3674 (merged before these review fixes landed). Addresses the three P2 automated-review notes on the My gyms screen:

1. **UUID hand-off for slugless gyms** — the web manage route (`resolveManageGym`) resolves `/gym/<slug|uuid>/manage` by slug *or* uuid, so the mobile hand-off now builds the URL from `gym.slug ?? gym.uuid`. A legacy gym with a null slug opens its kiosk console instead of dead-ending on a toast. The `manageUnavailable` copy is kept only for the impossible neither-slug-nor-uuid case.
2. **Fresh list after edits** — `useUpdateGym` now invalidates `['myGyms']`, so a rename/address change made in the gym editor is reflected when the owner returns to My gyms (previously stale for the 5-min window / while the screen stayed mounted).
3. **Wider page** — `useMyGyms` requests the server-max page (`limit: 50`, the `MyGymsInputSchema` cap) so owners/operators with more than the default 20 gyms don't silently lose rows. 50 clears every realistic case without adding `onEndReached` pagination to what is a small, plain list.

## Release Notes

- [x] No release note needed (internal / technical change)

<!-- Refines the still-unreleased My gyms feature; its user-facing note shipped with #3674. -->

## Test plan

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile` (My gyms + graphql/hooks) — 77 tests pass, incl. updated null-slug → uuid-fallback case and a new neither-slug-nor-uuid case
- `vp check` — my files clean (the only flagged file, `packages/web/package.json`, is a pre-existing format drift already on `main`, untouched here)
- i18n `catalog-completeness` — 60 pass (en-US / es / fr parity)