### PR TITLE
fix(mobile): iOS web-OAuth fallback — replace openAuthSessionAsync with a browser deep-link race

### DIFF
--- a/packages/mobile/app/+native-intent.ts
+++ b/packages/mobile/app/+native-intent.ts
@@ -9,6 +9,24 @@ import { getShareExtensionKey } from 'expo-share-intent';
 // through an ACTION_SEND intent (no deep-link path), so it falls through here
 // unchanged and the provider handles it the same way.
 export function redirectSystemPath({ path, initial }: { path: string; initial: boolean }): string {
+  // The browser-OAuth fallback (src/lib/auth.ts signInWithProviderWeb via
+  // raceBrowserSignIn) races a Linking 'url' listener against the in-app browser:
+  // the web callback page deep-links back to com.boardsesh.app://auth/callback?
+  // transferToken=… and that listener owns the URL. Expo Router ALSO sees this
+  // deep link and would try to navigate to a non-existent /auth/callback route,
+  // flashing +not-found under the browser before the race dismisses it. Return ''
+  // to skip that navigation. Verified safe against vendored expo-router@57.0.3:
+  // build/link/linking.js subscribe() does `if (href) listener(href)` (warm) and
+  // build/getLinkingConfig.js guards the cold-start getInitialURL the same way, so
+  // a falsy path cleanly no-ops navigation. redirectSystemPath receives the FULL
+  // deep-link URL as `path` (scheme + host, e.g. com.boardsesh.app://auth/callback
+  // — Expo's own docs read it via `new URL(path)`), so match the callback host
+  // form; the leading-slash form is a defensive belt-and-braces for a future Expo
+  // that normalises to a bare path. Checked BEFORE the share-intent branch (pure
+  // string ops, can't throw) so a getShareExtensionKey() throw can't bypass it.
+  if (path.includes('://auth/callback') || path.startsWith('/auth/callback')) {
+    return '';
+  }
   try {
     if (path.includes(`dataUrl=${getShareExtensionKey()}`)) {
       // Cold start (initial): bootstrap to the home route — the ShareTargetProvider

--- a/packages/mobile/app/+native-intent.ts
+++ b/packages/mobile/app/+native-intent.ts
@@ -9,22 +9,15 @@ import { getShareExtensionKey } from 'expo-share-intent';
 // through an ACTION_SEND intent (no deep-link path), so it falls through here
 // unchanged and the provider handles it the same way.
 export function redirectSystemPath({ path, initial }: { path: string; initial: boolean }): string {
-  // The browser-OAuth fallback (src/lib/auth.ts signInWithProviderWeb via
-  // raceBrowserSignIn) races a Linking 'url' listener against the in-app browser:
-  // the web callback page deep-links back to com.boardsesh.app://auth/callback?
-  // transferToken=… and that listener owns the URL. Expo Router ALSO sees this
-  // deep link and would try to navigate to a non-existent /auth/callback route,
-  // flashing +not-found under the browser before the race dismisses it. Return ''
-  // to skip that navigation. Verified safe against vendored expo-router@57.0.3:
-  // build/link/linking.js subscribe() does `if (href) listener(href)` (warm) and
-  // build/getLinkingConfig.js guards the cold-start getInitialURL the same way, so
-  // a falsy path cleanly no-ops navigation. redirectSystemPath receives the FULL
-  // deep-link URL as `path` (scheme + host, e.g. com.boardsesh.app://auth/callback
-  // — Expo's own docs read it via `new URL(path)`), so match the callback host
-  // form; the leading-slash form is a defensive belt-and-braces for a future Expo
-  // that normalises to a bare path. Checked BEFORE the share-intent branch (pure
-  // string ops, can't throw) so a getShareExtensionKey() throw can't bypass it.
-  if (path.includes('://auth/callback') || path.startsWith('/auth/callback')) {
+  // The browser-OAuth fallback's Linking listener owns this deep link (see
+  // src/lib/auth.ts raceBrowserSignIn); return '' so Expo Router doesn't flash
+  // +not-found on the non-existent /auth/callback route under the browser. Safe:
+  // vendored expo-router@57.0.3 gates navigation on a truthy path (warm subscribe
+  // in build/link/linking.js, cold getInitialURL in build/getLinkingConfig.js).
+  // `path` is the full deep-link URL (scheme + host); the bare-path form is a
+  // defensive fallback. Checked before the share-intent branch — pure string ops
+  // that can't throw — so a getShareExtensionKey() throw can't bypass it.
+  if (path.startsWith('com.boardsesh.app://auth/callback') || path.startsWith('/auth/callback')) {
     return '';
   }
   try {

--- a/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
@@ -36,13 +36,20 @@ vi.mock('react-native', () => ({ Platform: platform }));
 
 const { useNativeOAuthSignIn } = await import('../use-native-oauth-sign-in');
 
-type TrackedEvent = { event: unknown; flow: unknown; reason: unknown; recoverable: unknown };
+type TrackedEvent = {
+  event: unknown;
+  flow: unknown;
+  reason: unknown;
+  recoverable: unknown;
+  mechanism: unknown;
+};
 function trackedEvents(): TrackedEvent[] {
   return trackMock.mock.calls.map(([event, props]) => ({
     event,
     flow: (props as { flow?: unknown })?.flow,
     reason: (props as { failure_reason?: unknown })?.failure_reason,
     recoverable: (props as { recoverable?: unknown })?.recoverable,
+    mechanism: (props as { fallback_mechanism?: unknown })?.fallback_mechanism,
   }));
 }
 
@@ -81,12 +88,14 @@ describe('useNativeOAuthSignIn — Google web fallback (iOS)', () => {
       flow: 'web_fallback',
       reason: undefined,
       recoverable: undefined,
+      mechanism: 'browser_deeplink',
     });
     expect(events).toContainEqual({
       event: 'Login Succeeded',
       flow: 'web_fallback',
       reason: undefined,
       recoverable: undefined,
+      mechanism: 'browser_deeplink',
     });
     // The native throw is logged recoverable on iOS so the failure metric excludes it.
     expect(events).toContainEqual({ event: 'Login Failed', flow: 'native', reason: 'exception', recoverable: true });
@@ -141,7 +150,32 @@ describe('useNativeOAuthSignIn — Google web fallback (iOS)', () => {
       event: 'Login Failed',
       flow: 'web_fallback',
       reason: 'invalid_oauth_token',
+      mechanism: 'browser_deeplink',
     });
+  });
+
+  it('treats browser_unavailable as a Login Failed (not a cancel) and reports it', async () => {
+    // The iOS 26 dead-end: the fallback's in-app browser fails to present, so
+    // signInWithProviderWeb returns { error: 'browser_unavailable' }. Unlike a
+    // user closing the browser (a silent cancel), this is a real failure — it must
+    // surface an error, report to tracking, and stay out of the Cancelled bucket.
+    signInWithGoogleMock.mockRejectedValue(new Error('Unable to open Safari'));
+    signInWithGoogleWebMock.mockResolvedValue({ success: false, status: null, error: 'browser_unavailable' });
+
+    const setError = await runSignIn('google');
+
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+    expect(setError).toHaveBeenLastCalledWith('nativeStart.oauthError');
+    const events = trackedEvents();
+    expect(events).toContainEqual({
+      event: 'Login Failed',
+      flow: 'web_fallback',
+      reason: 'browser_unavailable',
+      recoverable: undefined,
+      mechanism: 'browser_deeplink',
+    });
+    // A browser that never opened is a failure, not the user backing out.
+    expect(events).not.toContainEqual(expect.objectContaining({ event: 'Login Cancelled', flow: 'web_fallback' }));
   });
 });
 
@@ -170,8 +204,20 @@ describe('useNativeOAuthSignIn — Apple web fallback (iOS)', () => {
     expect(reportErrorMock).not.toHaveBeenCalled();
     expect(setError).toHaveBeenLastCalledWith(null);
     const events = trackedEvents();
-    expect(events).toContainEqual({ event: 'Login Attempted', flow: 'web_fallback', reason: undefined });
-    expect(events).toContainEqual({ event: 'Login Succeeded', flow: 'web_fallback', reason: undefined });
+    expect(events).toContainEqual({
+      event: 'Login Attempted',
+      flow: 'web_fallback',
+      reason: undefined,
+      recoverable: undefined,
+      mechanism: 'browser_deeplink',
+    });
+    expect(events).toContainEqual({
+      event: 'Login Succeeded',
+      flow: 'web_fallback',
+      reason: undefined,
+      recoverable: undefined,
+      mechanism: 'browser_deeplink',
+    });
   });
 
   it('falls back and signs in when native Apple returns a non-cancel failure', async () => {
@@ -183,7 +229,13 @@ describe('useNativeOAuthSignIn — Apple web fallback (iOS)', () => {
     expect(signInWithAppleWebMock).toHaveBeenCalledTimes(1);
     expect(reportErrorMock).not.toHaveBeenCalled();
     expect(setError).toHaveBeenLastCalledWith(null);
-    expect(trackedEvents()).toContainEqual({ event: 'Login Succeeded', flow: 'web_fallback', reason: undefined });
+    expect(trackedEvents()).toContainEqual({
+      event: 'Login Succeeded',
+      flow: 'web_fallback',
+      reason: undefined,
+      recoverable: undefined,
+      mechanism: 'browser_deeplink',
+    });
   });
 
   it('does NOT fall back when the user cancels native Apple, and logs a cancel (not a failure)', async () => {
@@ -222,6 +274,7 @@ describe('useNativeOAuthSignIn — Apple web fallback (iOS)', () => {
       flow: 'web_fallback',
       reason: undefined,
       recoverable: undefined,
+      mechanism: 'browser_deeplink',
     });
     expect(events).not.toContainEqual(expect.objectContaining({ event: 'Login Failed', flow: 'web_fallback' }));
   });
@@ -242,6 +295,7 @@ describe('useNativeOAuthSignIn — Apple web fallback (iOS)', () => {
       event: 'Login Failed',
       flow: 'web_fallback',
       reason: 'invalid_oauth_token',
+      mechanism: 'browser_deeplink',
     });
   });
 });

--- a/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
+++ b/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
@@ -65,7 +65,12 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
       };
       const runWebFallback = async (): Promise<void> => {
         const fallbackStartedAt = Date.now();
-        track(SHARED_EVENTS.LoginAttempted, { auth_method: provider, flow: 'web_fallback', ...registrationProps });
+        track(SHARED_EVENTS.LoginAttempted, {
+          auth_method: provider,
+          flow: 'web_fallback',
+          fallback_mechanism: 'browser_deeplink',
+          ...registrationProps,
+        });
         let fallback: OAuthSignInResult;
         try {
           fallback = await webFallbackFor[provider]();
@@ -73,6 +78,7 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
           track(SHARED_EVENTS.LoginFailed, {
             auth_method: provider,
             flow: 'web_fallback',
+            fallback_mechanism: 'browser_deeplink',
             failure_reason: 'exception',
             failure_detail: fallbackError instanceof Error ? fallbackError.message : undefined,
             duration_ms: Date.now() - fallbackStartedAt,
@@ -85,7 +91,12 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
           return;
         }
         if (fallback.success) {
-          track(SHARED_EVENTS.LoginSucceeded, { auth_method: provider, flow: 'web_fallback', ...registrationProps });
+          track(SHARED_EVENTS.LoginSucceeded, {
+            auth_method: provider,
+            flow: 'web_fallback',
+            fallback_mechanism: 'browser_deeplink',
+            ...registrationProps,
+          });
           setError(null);
           // AuthProvider flips isAuthenticated and the redirect handles navigation.
           return;
@@ -96,6 +107,7 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
           track(SHARED_EVENTS.LoginCancelled, {
             auth_method: provider,
             flow: 'web_fallback',
+            fallback_mechanism: 'browser_deeplink',
             duration_ms: Date.now() - fallbackStartedAt,
             ...registrationProps,
           });
@@ -105,6 +117,7 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
         track(SHARED_EVENTS.LoginFailed, {
           auth_method: provider,
           flow: 'web_fallback',
+          fallback_mechanism: 'browser_deeplink',
           failure_reason: fallbackReason,
           failure_detail: fallback.error,
           duration_ms: Date.now() - fallbackStartedAt,

--- a/packages/mobile/src/lib/__tests__/auth-google-web.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-google-web.test.ts
@@ -2,8 +2,33 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // auth.ts pulls in several native modules at import time. Mock them so the
 // browser-OAuth fallback can be exercised in a plain node test. The real
-// deep-link parser is kept (it's pure — no native imports).
-vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+// deep-link parser and the real raceBrowserSignIn are kept (both pure — no
+// native imports).
+//
+// The fallback now drives an openBrowserAsync + OS deep-link race (raceBrowserSignIn)
+// instead of the broken WebBrowser.openAuthSessionAsync (see auth.ts). So the
+// harness captures the Linking 'url' listener the race registers and controls
+// the browser promise, letting each test fire the deep link, close the browser,
+// or fail it to open — in any order.
+let urlListener: ((event: { url: string }) => void) | null = null;
+let resolveBrowser: (() => void) | null = null;
+let rejectBrowser: ((reason: unknown) => void) | null = null;
+
+const removeListenerMock = vi.fn(() => {
+  urlListener = null;
+});
+const addEventListenerMock = vi.fn((_event: string, listener: (event: { url: string }) => void) => {
+  urlListener = listener;
+  return { remove: removeListenerMock };
+});
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  Linking: {
+    addEventListener: (event: string, listener: (event: { url: string }) => void) =>
+      addEventListenerMock(event, listener),
+  },
+}));
 vi.mock('expo-apple-authentication', () => ({}));
 vi.mock('expo-crypto', () => ({
   getRandomBytes: () => new Uint8Array(16),
@@ -25,45 +50,85 @@ vi.mock('../auth-store', () => ({
   getRefreshToken: vi.fn(),
 }));
 
-const openAuthSessionAsyncMock = vi.fn();
+// Plain vi.fn() (no inline implementation) so the wrapper's spread call stays
+// permissively typed — an implemented vi.fn narrows the param list and CI's
+// test-inclusive typecheck rejects the spread (TS2556). resetMocks() gives
+// dismissBrowser its resolved-promise behaviour.
+const openBrowserAsyncMock = vi.fn();
+const dismissBrowserMock = vi.fn();
 vi.mock('expo-web-browser', () => ({
-  openAuthSessionAsync: (...args: unknown[]) => openAuthSessionAsyncMock(...args),
+  openBrowserAsync: (...args: unknown[]) => openBrowserAsyncMock(...args),
+  dismissBrowser: (...args: unknown[]) => dismissBrowserMock(...args),
 }));
 
 const { signInWithGoogleWeb, signInWithAppleWeb } = await import('../auth');
+
+// Keep in sync with the web app's NATIVE_OAUTH_CALLBACK_SCHEME
+// (packages/web/app/lib/auth/native-oauth-config.ts) and auth.ts's
+// NATIVE_OAUTH_REDIRECT — the scheme the race listens for and the server's
+// /api/auth/native/callback deep-links back to. If web changes it, this must
+// change too, or the race never captures the token and the browser hangs open.
+const CALLBACK_SCHEME = 'com.boardsesh.app://auth/callback';
+
+// raceBrowserSignIn's executor runs synchronously: it registers the url listener
+// and calls openBrowserAsync (left pending here) before signInWithProviderWeb's
+// await suspends. So after calling the sign-in fn — before awaiting it — the
+// listener is captured and the browser is open; each helper then drives one edge.
+function armBrowser() {
+  openBrowserAsyncMock.mockImplementation(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        resolveBrowser = resolve;
+        rejectBrowser = reject;
+      }),
+  );
+}
+const fireDeepLink = (url: string) => urlListener?.({ url });
+const closeBrowser = () => resolveBrowser?.();
+const failBrowser = (reason: unknown) => rejectBrowser?.(reason);
 
 const okExchange = () =>
   new Response(JSON.stringify({ jwt: 'jwt-1', refreshToken: 'refresh-1', expiresAt: '2026-01-01T00:00:00.000Z' }), {
     status: 200,
   });
 
+function resetMocks() {
+  urlListener = null;
+  resolveBrowser = null;
+  rejectBrowser = null;
+  openBrowserAsyncMock.mockReset();
+  dismissBrowserMock.mockReset();
+  dismissBrowserMock.mockResolvedValue(undefined);
+  removeListenerMock.mockClear();
+  addEventListenerMock.mockClear();
+  storeTokensMock.mockReset();
+  armBrowser();
+}
+
 describe('signInWithGoogleWeb', () => {
-  beforeEach(() => {
-    openAuthSessionAsyncMock.mockReset();
-    storeTokensMock.mockReset();
-  });
+  beforeEach(resetMocks);
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it('drives the web native-start handoff and exchanges the transfer token into a stored session', async () => {
-    openAuthSessionAsyncMock.mockResolvedValue({
-      type: 'success',
-      url: 'com.boardsesh.app://auth/callback?transferToken=tok-123&next=%2F',
-    });
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(okExchange());
 
-    const result = await signInWithGoogleWeb();
+    const racePromise = signInWithGoogleWeb();
+    // A non-callback deep link must be ignored — pins the exact callback scheme
+    // (the race would settle on the wrong URL if the prefix were too loose).
+    fireDeepLink('com.boardsesh.app://join/some-session');
+    fireDeepLink(`${CALLBACK_SCHEME}?transferToken=tok-123&next=%2F`);
+    const result = await racePromise;
 
     expect(result).toEqual({ success: true });
-    const [startUrl, redirect] = openAuthSessionAsyncMock.mock.calls[0];
+    const [startUrl] = openBrowserAsyncMock.mock.calls[0];
     expect(startUrl).toContain('https://web.test/auth/native-start?provider=google');
     expect(startUrl).toContain(encodeURIComponent('https://web.test/api/auth/native/callback?next=%2F'));
-    // Keep in sync with the web app's NATIVE_OAUTH_CALLBACK_SCHEME
-    // (packages/web/app/lib/auth/native-oauth-config.ts) — the redirect the web
-    // /api/auth/native/callback route deep-links back to. If web changes it, this
-    // must change too, or openAuthSessionAsync never captures the token.
-    expect(redirect).toBe('com.boardsesh.app://auth/callback');
+    // The captured callback dismisses the browser left open under the deep-link
+    // hand-off, and the listener is torn down after the race settles.
+    expect(dismissBrowserMock).toHaveBeenCalledTimes(1);
+    expect(removeListenerMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
       'https://backend.test/auth/native/exchange',
       expect.objectContaining({ method: 'POST', body: JSON.stringify({ transferToken: 'tok-123' }) }),
@@ -71,41 +136,55 @@ describe('signInWithGoogleWeb', () => {
     expect(storeTokensMock).toHaveBeenCalledWith('jwt-1', 'refresh-1', '2026-01-01T00:00:00.000Z');
   });
 
-  it('treats a dismissed browser as a cancellation and never exchanges', async () => {
-    openAuthSessionAsyncMock.mockResolvedValue({ type: 'dismiss' });
+  it('treats a closed browser (no callback deep link) as a cancellation and never exchanges', async () => {
     const fetchMock = vi.spyOn(global, 'fetch');
 
-    expect(await signInWithGoogleWeb()).toEqual({ success: false, cancelled: true });
+    const racePromise = signInWithGoogleWeb();
+    closeBrowser();
+
+    expect(await racePromise).toEqual({ success: false, cancelled: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(dismissBrowserMock).not.toHaveBeenCalled();
+  });
+
+  it('reports browser_unavailable (not a cancel, not network) when the browser fails to open', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch');
+
+    const racePromise = signInWithGoogleWeb();
+    // The iOS 26 dead-end this fixes: the in-app browser rejects instead of
+    // presenting. Must be a distinct terminal reason, not a silent cancel.
+    failBrowser(new Error('Another WebBrowser is already being presented.'));
+
+    expect(await racePromise).toEqual({ success: false, status: null, error: 'browser_unavailable' });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('surfaces an error param from the callback redirect without exchanging', async () => {
-    openAuthSessionAsyncMock.mockResolvedValue({
-      type: 'success',
-      url: 'com.boardsesh.app://auth/callback?error=session_missing',
-    });
     const fetchMock = vi.spyOn(global, 'fetch');
 
-    expect(await signInWithGoogleWeb()).toEqual({ success: false, status: null, error: 'session_missing' });
+    const racePromise = signInWithGoogleWeb();
+    fireDeepLink(`${CALLBACK_SCHEME}?error=session_missing`);
+
+    expect(await racePromise).toEqual({ success: false, status: null, error: 'session_missing' });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('returns no_transfer_token when the redirect carries neither a token nor an error', async () => {
-    openAuthSessionAsyncMock.mockResolvedValue({ type: 'success', url: 'com.boardsesh.app://auth/callback' });
+    const racePromise = signInWithGoogleWeb();
+    fireDeepLink(CALLBACK_SCHEME);
 
-    expect(await signInWithGoogleWeb()).toEqual({ success: false, status: null, error: 'no_transfer_token' });
+    expect(await racePromise).toEqual({ success: false, status: null, error: 'no_transfer_token' });
   });
 
   it('maps a non-ok exchange to the server status + error message', async () => {
-    openAuthSessionAsyncMock.mockResolvedValue({
-      type: 'success',
-      url: 'com.boardsesh.app://auth/callback?transferToken=expired',
-    });
     vi.spyOn(global, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ error: 'Invalid or expired transfer token' }), { status: 401 }),
     );
 
-    expect(await signInWithGoogleWeb()).toEqual({
+    const racePromise = signInWithGoogleWeb();
+    fireDeepLink(`${CALLBACK_SCHEME}?transferToken=expired`);
+
+    expect(await racePromise).toEqual({
       success: false,
       status: 401,
       error: 'Invalid or expired transfer token',
@@ -114,59 +193,45 @@ describe('signInWithGoogleWeb', () => {
   });
 
   it('returns invalid_response when a 200 exchange body is not JSON', async () => {
-    openAuthSessionAsyncMock.mockResolvedValue({
-      type: 'success',
-      url: 'com.boardsesh.app://auth/callback?transferToken=tok',
-    });
     vi.spyOn(global, 'fetch').mockResolvedValue(new Response('not json', { status: 200 }));
 
-    expect(await signInWithGoogleWeb()).toEqual({ success: false, status: 200, error: 'invalid_response' });
+    const racePromise = signInWithGoogleWeb();
+    fireDeepLink(`${CALLBACK_SCHEME}?transferToken=tok`);
+
+    expect(await racePromise).toEqual({ success: false, status: 200, error: 'invalid_response' });
     expect(storeTokensMock).not.toHaveBeenCalled();
   });
 
   it('maps an exchange network rejection to a network failure', async () => {
-    openAuthSessionAsyncMock.mockResolvedValue({
-      type: 'success',
-      url: 'com.boardsesh.app://auth/callback?transferToken=tok',
-    });
     vi.spyOn(global, 'fetch').mockRejectedValue(new TypeError('Network request failed'));
 
-    expect(await signInWithGoogleWeb()).toEqual({ success: false, status: null, error: 'network' });
-  });
+    const racePromise = signInWithGoogleWeb();
+    fireDeepLink(`${CALLBACK_SCHEME}?transferToken=tok`);
 
-  it('maps an openAuthSessionAsync throw (no browser) to a network failure', async () => {
-    openAuthSessionAsyncMock.mockRejectedValue(new Error('no browser'));
-
-    expect(await signInWithGoogleWeb()).toEqual({ success: false, status: null, error: 'network' });
+    expect(await racePromise).toEqual({ success: false, status: null, error: 'network' });
   });
 });
 
 // signInWithAppleWeb shares signInWithProviderWeb's body with signInWithGoogleWeb
-// (the redirect, deep-link parse, and token exchange are provider-agnostic), so
-// this only pins the one per-provider difference — the native-start provider
-// param — plus the happy path, rather than re-running every shared branch.
+// (the race, deep-link parse, and token exchange are provider-agnostic), so this
+// only pins the one per-provider difference — the native-start provider param —
+// plus the happy path, rather than re-running every shared branch.
 describe('signInWithAppleWeb', () => {
-  beforeEach(() => {
-    openAuthSessionAsyncMock.mockReset();
-    storeTokensMock.mockReset();
-  });
+  beforeEach(resetMocks);
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it('opens native-start with provider=apple and exchanges the transfer token into a stored session', async () => {
-    openAuthSessionAsyncMock.mockResolvedValue({
-      type: 'success',
-      url: 'com.boardsesh.app://auth/callback?transferToken=apple-tok&next=%2F',
-    });
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(okExchange());
 
-    const result = await signInWithAppleWeb();
+    const racePromise = signInWithAppleWeb();
+    fireDeepLink(`${CALLBACK_SCHEME}?transferToken=apple-tok&next=%2F`);
+    const result = await racePromise;
 
     expect(result).toEqual({ success: true });
-    const [startUrl, redirect] = openAuthSessionAsyncMock.mock.calls[0];
+    const [startUrl] = openBrowserAsyncMock.mock.calls[0];
     expect(startUrl).toContain('https://web.test/auth/native-start?provider=apple');
-    expect(redirect).toBe('com.boardsesh.app://auth/callback');
     expect(fetchMock).toHaveBeenCalledWith(
       'https://backend.test/auth/native/exchange',
       expect.objectContaining({ method: 'POST', body: JSON.stringify({ transferToken: 'apple-tok' }) }),
@@ -174,11 +239,13 @@ describe('signInWithAppleWeb', () => {
     expect(storeTokensMock).toHaveBeenCalledWith('jwt-1', 'refresh-1', '2026-01-01T00:00:00.000Z');
   });
 
-  it('treats a dismissed browser as a cancellation and never exchanges', async () => {
-    openAuthSessionAsyncMock.mockResolvedValue({ type: 'dismiss' });
+  it('treats a closed browser as a cancellation and never exchanges', async () => {
     const fetchMock = vi.spyOn(global, 'fetch');
 
-    expect(await signInWithAppleWeb()).toEqual({ success: false, cancelled: true });
+    const racePromise = signInWithAppleWeb();
+    closeBrowser();
+
+    expect(await racePromise).toEqual({ success: false, cancelled: true });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/__tests__/auth-session-race.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-session-race.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+import { raceBrowserSignIn, type AuthSessionRaceIo } from '../auth-session-race';
+
+const CALLBACK_PREFIX = 'com.boardsesh.app://auth/callback';
+const AUTH_URL = 'https://www.boardsesh.com/auth/native-start?provider=apple';
+
+// Harness exposing the registered URL listener and a controllable browser
+// promise, so each test can fire the deep link / close the browser in any order.
+function createIoHarness() {
+  let urlListener: ((event: { url: string }) => void) | null = null;
+  let resolveBrowser: (() => void) | null = null;
+  let rejectBrowser: ((reason: unknown) => void) | null = null;
+
+  const removeListener = vi.fn(() => {
+    urlListener = null;
+  });
+  const dismissBrowser = vi.fn(() => Promise.resolve());
+  const io: AuthSessionRaceIo = {
+    addUrlListener: (listener) => {
+      urlListener = listener;
+      return { remove: removeListener };
+    },
+    openBrowser: () =>
+      new Promise<void>((resolve, reject) => {
+        resolveBrowser = resolve;
+        rejectBrowser = reject;
+      }),
+    dismissBrowser,
+  };
+
+  return {
+    io,
+    removeListener,
+    dismissBrowser,
+    fireDeepLink: (url: string) => urlListener?.({ url }),
+    closeBrowser: () => resolveBrowser?.(),
+    failBrowser: (reason: unknown) => rejectBrowser?.(reason),
+  };
+}
+
+describe('raceBrowserSignIn', () => {
+  it('resolves success with the callback URL and dismisses the browser when the deep link arrives', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    const callbackUrl = `${CALLBACK_PREFIX}?transferToken=tok-1`;
+    harness.fireDeepLink(callbackUrl);
+
+    await expect(racePromise).resolves.toEqual({ type: 'success', url: callbackUrl });
+    expect(harness.dismissBrowser).toHaveBeenCalledTimes(1);
+    expect(harness.removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores deep links that are not the auth callback', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    harness.fireDeepLink('com.boardsesh.app://join/some-session');
+    harness.fireDeepLink(`${CALLBACK_PREFIX}?transferToken=tok-2`);
+
+    await expect(racePromise).resolves.toEqual({
+      type: 'success',
+      url: `${CALLBACK_PREFIX}?transferToken=tok-2`,
+    });
+  });
+
+  it('resolves cancel when the browser closes without a callback deep link', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    harness.closeBrowser();
+
+    await expect(racePromise).resolves.toEqual({ type: 'cancel' });
+    expect(harness.dismissBrowser).not.toHaveBeenCalled();
+    expect(harness.removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the success result when the dismissed browser later resolves', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    harness.fireDeepLink(`${CALLBACK_PREFIX}?transferToken=tok-3`);
+    // dismissBrowser() closing the browser resolves openBrowser afterwards.
+    harness.closeBrowser();
+
+    await expect(racePromise).resolves.toEqual({
+      type: 'success',
+      url: `${CALLBACK_PREFIX}?transferToken=tok-3`,
+    });
+  });
+
+  it('resolves error with the message when the browser fails to open', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    harness.failBrowser(new Error('Another WebBrowser is already being presented.'));
+
+    await expect(racePromise).resolves.toEqual({
+      type: 'error',
+      message: 'Another WebBrowser is already being presented.',
+    });
+    expect(harness.removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a generic message for non-Error rejections', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    harness.failBrowser('boom');
+
+    await expect(racePromise).resolves.toEqual({ type: 'error', message: 'browser failed to open' });
+  });
+});

--- a/packages/mobile/src/lib/__tests__/auth.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.test.ts
@@ -29,6 +29,16 @@ describe('classifyNativeAuthFailureReason', () => {
     );
   });
 
+  // The web-OAuth fallback's in-app browser failing to present (iOS 26) returns
+  // { error: 'browser_unavailable', status: null }. It must classify off the
+  // sentinel string, not fall through to 'http_error' — a null status would
+  // otherwise land in the final bucket.
+  it('classifies a browser-unavailable web-fallback failure by its sentinel error, not its null status', () => {
+    expect(
+      classifyNativeAuthFailureReason({ success: false, status: null, error: 'browser_unavailable' }, 'oauth'),
+    ).toBe('browser_unavailable');
+  });
+
   // Regression: the classifier used to string-match the 401 body against
   // 'Invalid credentials', but the backend says 'Invalid email or password' —
   // every real wrong-password attempt was mislabelled. Classify by endpoint.

--- a/packages/mobile/src/lib/__tests__/native-intent.test.ts
+++ b/packages/mobile/src/lib/__tests__/native-intent.test.ts
@@ -39,4 +39,41 @@ describe('redirectSystemPath', () => {
     });
     expect(redirectSystemPath({ path: JOIN_LINK, initial: true })).toBe(JOIN_LINK);
   });
+
+  // The browser-OAuth fallback (src/lib/auth.ts raceBrowserSignIn) owns the
+  // auth/callback deep link via its own Linking listener; redirectSystemPath must
+  // return '' so Expo Router doesn't flash +not-found on the non-existent route.
+  const CALLBACK = 'com.boardsesh.app://auth/callback?transferToken=tok-1&next=%2F';
+
+  it('skips navigation for the OAuth callback deep link on cold start', () => {
+    getShareExtensionKeyMock.mockReturnValue('SHAREKEY');
+    expect(redirectSystemPath({ path: CALLBACK, initial: true })).toBe('');
+  });
+
+  it('skips navigation for the OAuth callback deep link on a warm open', () => {
+    getShareExtensionKeyMock.mockReturnValue('SHAREKEY');
+    expect(redirectSystemPath({ path: CALLBACK, initial: false })).toBe('');
+  });
+
+  it('also matches the bare-path callback form (defensive against Expo normalising the URL)', () => {
+    getShareExtensionKeyMock.mockReturnValue('SHAREKEY');
+    expect(redirectSystemPath({ path: '/auth/callback?transferToken=tok-2', initial: false })).toBe('');
+  });
+
+  it('suppresses the callback even when getShareExtensionKey throws (guard runs before the share branch)', () => {
+    // The load-bearing property: the callback guard is checked before the
+    // throwing getShareExtensionKey() call, so an off-native throw can't let the
+    // callback fall through to navigation.
+    getShareExtensionKeyMock.mockImplementation(() => {
+      throw new Error('native module not loaded');
+    });
+    expect(redirectSystemPath({ path: CALLBACK, initial: true })).toBe('');
+  });
+
+  it('does not treat a non-callback deep link on the same scheme as the callback', () => {
+    getShareExtensionKeyMock.mockReturnValue('SHAREKEY');
+    expect(redirectSystemPath({ path: 'com.boardsesh.app://join/some-session', initial: true })).toBe(
+      'com.boardsesh.app://join/some-session',
+    );
+  });
 });

--- a/packages/mobile/src/lib/auth-session-race.ts
+++ b/packages/mobile/src/lib/auth-session-race.ts
@@ -1,0 +1,61 @@
+// Drives the iOS sign-in hand-off: open the OAuth page in an in-app browser
+// and wait for the OS deep link that the server's callback page fires
+// (com.boardsesh.app://auth/callback?transferToken=...). All platform I/O is
+// injected so unit tests need no expo-web-browser or react-native mocks.
+//
+// Why not WebBrowser.openAuthSessionAsync: its ASWebAuthenticationSession can
+// fail to present (observed as 100–250ms failures on iOS 26 devices — expo's
+// presentation anchor is the deprecated UIApplication.shared.keyWindow), and
+// expo-web-browser collapses every such failure into {type: 'cancel'},
+// indistinguishable from the user closing the sheet. SFSafariViewController +
+// an OS deep link is the same hand-off the legacy Capacitor app shipped with,
+// and the server's deep-link callback page was built for it.
+
+export type AuthSessionRaceResult =
+  | { type: 'success'; url: string }
+  | { type: 'cancel' }
+  | { type: 'error'; message: string };
+
+type UrlEventSubscription = { remove: () => void };
+
+export type AuthSessionRaceIo = {
+  addUrlListener: (listener: (event: { url: string }) => void) => UrlEventSubscription;
+  openBrowser: (url: string) => Promise<unknown>;
+  dismissBrowser: () => Promise<unknown>;
+};
+
+export function raceBrowserSignIn(
+  io: AuthSessionRaceIo,
+  authUrl: string,
+  callbackUrlPrefix: string,
+): Promise<AuthSessionRaceResult> {
+  return new Promise((resolve) => {
+    let subscription: UrlEventSubscription | null = null;
+    let settled = false;
+    const settle = (result: AuthSessionRaceResult) => {
+      if (settled) return;
+      settled = true;
+      subscription?.remove();
+      resolve(result);
+    };
+
+    subscription = io.addUrlListener(({ url }) => {
+      if (!url.startsWith(callbackUrlPrefix)) return;
+      // Close the browser left behind under the deep-link hand-off. Best-effort:
+      // its own resolution below is a no-op once settled.
+      io.dismissBrowser().catch(() => {});
+      settle({ type: 'success', url });
+    });
+
+    io.openBrowser(authUrl).then(
+      // Resolves when the browser closes. Reaching this un-settled means no
+      // callback deep link arrived — the user closed it without finishing.
+      () => settle({ type: 'cancel' }),
+      (openBrowserError: unknown) =>
+        settle({
+          type: 'error',
+          message: openBrowserError instanceof Error ? openBrowserError.message : 'browser failed to open',
+        }),
+    );
+  });
+}

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -1,10 +1,11 @@
-import { Platform } from 'react-native';
+import { Linking, Platform } from 'react-native';
 import * as AppleAuthentication from 'expo-apple-authentication';
 import * as WebBrowser from 'expo-web-browser';
 import { getRandomBytes, digestStringAsync, CryptoDigestAlgorithm, CryptoEncoding } from 'expo-crypto';
 import { GoogleSignin, statusCodes } from '@react-native-google-signin/google-signin';
 import { createTimeoutSignal } from './abort-timeout';
 import { storeTokens, clearTokens, getRefreshToken } from './auth-store';
+import { raceBrowserSignIn } from './auth-session-race';
 import { nativeSignInErrorCode } from './native-auth-analytics';
 import { parseDeepLinkQueryParams } from './deep-link-query';
 import { BACKEND_URL, WEB_BASE_URL } from './env';
@@ -247,14 +248,25 @@ async function exchangeTransferToken(transferToken: string): Promise<OAuthSignIn
 /**
  * Browser-based OAuth sign-in — the fallback for when the native provider SDK
  * can't complete on the device. Opens the web app's /auth/native-start page in an
- * auth-session browser, which runs the proven NextAuth flow for `provider`, mints
- * a single-use transfer token on success, and redirects back to
+ * in-app browser, which runs the proven NextAuth flow for `provider`, mints a
+ * single-use transfer token on success, and deep-links back to
  * NATIVE_OAUTH_REDIRECT; we then exchange that token for our JWT pair. Reuses the
  * same handoff the web app already serves (the Strava/Aurora pattern), with no
  * native OAuth SDK involvement, so it's immune to the native SDK's per-OS-version
  * breakage. The web /auth/native-start page already allows both 'google' and
  * 'apple' (its ALLOWED_PROVIDERS), and the callback + exchange are
  * provider-agnostic, so the only per-provider difference is this query param.
+ *
+ * Uses raceBrowserSignIn (openBrowserAsync + an OS deep-link race), NOT
+ * WebBrowser.openAuthSessionAsync: the latter's ASWebAuthenticationSession fails
+ * to present on iOS 26 (PostHog shows sub-second web_fallback "cancels" en masse
+ * with only a handful of successes), and expo collapses that failure into an
+ * indistinguishable {type: 'cancel'}. openBrowserAsync opens an
+ * SFSafariViewController that presents reliably, and the server's callback page
+ * (packages/web/app/api/auth/native/callback/route.ts) deep-links back via a
+ * JS/meta-refresh redirect built for exactly this hand-off — the same one the
+ * legacy Capacitor app shipped with. This is the restoration of the proven flow
+ * from PR #2721, scoped to the fallback.
  *
  * Never throws: every outcome maps to an OAuthSignInResult (success / cancelled /
  * failure) so the caller treats it exactly like the native path.
@@ -263,18 +275,28 @@ async function signInWithProviderWeb(provider: AuthProvider): Promise<OAuthSignI
   const nativeCallbackUrl = `${WEB_BASE_URL}/api/auth/native/callback?next=${encodeURIComponent('/')}`;
   const startUrl = `${WEB_BASE_URL}/auth/native-start?provider=${provider}&callbackUrl=${encodeURIComponent(nativeCallbackUrl)}`;
 
-  let result: WebBrowser.WebBrowserAuthSessionResult;
-  try {
-    result = await WebBrowser.openAuthSessionAsync(startUrl, NATIVE_OAUTH_REDIRECT);
-  } catch {
-    // The auth-session browser couldn't open — treat as a network-class failure.
-    return { success: false, status: null, error: 'network' };
-  }
+  // Register the Linking url-listener BEFORE opening the browser (raceBrowserSignIn
+  // does this) so no deep link can arrive un-listened. dismissBrowser is async-
+  // wrapped so a synchronous throw from it can't reject the race's success branch.
+  const race = await raceBrowserSignIn(
+    {
+      addUrlListener: (listener) => Linking.addEventListener('url', listener),
+      openBrowser: (url) => WebBrowser.openBrowserAsync(url),
+      dismissBrowser: async () => WebBrowser.dismissBrowser(),
+    },
+    startUrl,
+    NATIVE_OAUTH_REDIRECT,
+  );
 
-  // Dismissed before the redirect was captured — the user backed out.
-  if (result.type !== 'success') return { success: false, cancelled: true };
+  // The in-app browser failed to present. This is the iOS 26 dead-end we're
+  // fixing — a real "couldn't open the browser", not a user cancel and not a
+  // network-class server failure. Its own analytics reason so it's visible.
+  if (race.type === 'error') return { success: false, status: null, error: 'browser_unavailable' };
 
-  const params = parseDeepLinkQueryParams(result.url);
+  // The user closed the browser before the callback deep link arrived.
+  if (race.type === 'cancel') return { success: false, cancelled: true };
+
+  const params = parseDeepLinkQueryParams(race.url);
   const error = params.get('error');
   if (error) return { success: false, status: null, error };
   const transferToken = params.get('transferToken');

--- a/packages/mobile/src/lib/native-auth-analytics.ts
+++ b/packages/mobile/src/lib/native-auth-analytics.ts
@@ -1,5 +1,6 @@
 export type NativeAuthFailureReason =
   | 'network'
+  | 'browser_unavailable'
   | 'invalid_credentials'
   | 'invalid_oauth_token'
   | 'invalid_request'
@@ -23,6 +24,9 @@ export function classifyNativeAuthFailureReason(
   source: NativeAuthFailureSource,
 ): NativeAuthFailureReason {
   if (failure.error === 'network') return 'network';
+  // The web-OAuth fallback's in-app browser couldn't present (iOS 26). Carries no
+  // HTTP status — classify off the sentinel error string before the status checks.
+  if (failure.error === 'browser_unavailable') return 'browser_unavailable';
   if (failure.status === 400) return 'invalid_request';
   if (failure.status === 401) {
     return source === 'credentials' ? 'invalid_credentials' : 'invalid_oauth_token';


### PR DESCRIPTION
## Summary

The native Google/Apple sign-in web fallback dead-ended on iOS 26.5.1, and the fallback it dropped into rescued almost no one.

**Root cause.** The fallback `signInWithProviderWeb` was built on `WebBrowser.openAuthSessionAsync` — the exact primitive PR #2721 (`d281745f2`) proved broken on iOS 26. Its `ASWebAuthenticationSession` fails to present (expo's presentation anchor is the deprecated `UIApplication.shared.keyWindow`), and expo-web-browser collapses every such failure into `{type:'cancel'}`, indistinguishable from the user closing the sheet. On top of that, any thrown error from opening the browser was miscoded as a `'network'` failure (`auth.ts:269`).

**Evidence (45d PostHog, `flow=web_fallback`).** Google fallback: 189 + 95 sub-second "cancels"; Apple fallback: 95 sub-second "cancels". **3 total** fallback successes across the whole window. Sub-second durations mean the browser never actually presented — these aren't users backing out, they're the OS failing to open the sheet. The chunk of native failures previously bucketed as `'network'` were mostly this same bug (the miscoded throw), with a small genuine `ws.boardsesh.com` exchange-failure tail (see follow-up below).

**The fix.** Restore PR #2721's proven mechanism — `openBrowserAsync` (an `SFSafariViewController` that presents reliably) raced against the OS deep link the server's callback page fires — scoped to the fallback only. The native SDK path is untouched.

- New `src/lib/auth-session-race.ts` (`raceBrowserSignIn`): registers the `Linking` url-listener **before** opening the browser, resolves `success` on the matching `com.boardsesh.app://auth/callback` deep link (and dismisses the browser), `cancel` when the browser closes with no deep link, and `error` when the browser fails to open. All platform I/O is injected, so it's pure and unit-tested.
- `signInWithProviderWeb` now drives `openBrowserAsync` + the race. A browser-open failure maps to a **new `browser_unavailable` reason** — not `'network'`, not a silent cancel — so the iOS-26 dead-end is finally visible in telemetry and surfaces the OAuth error to the user.
- `+native-intent.ts` `redirectSystemPath` returns `''` for the `auth/callback` deep link, so the race's `Linking` listener owns the URL and Expo Router doesn't flash `+not-found` under the browser. Verified safe against vendored `expo-router@57.0.3` (`build/link/linking.js` `subscribe()` does `if (href) listener(href)`; `getLinkingConfig.js` guards cold-start `getInitialURL` the same way — a falsy path cleanly no-ops navigation).
- Every `web_fallback` analytics event now carries `fallback_mechanism: 'browser_deeplink'`.

**No server change.** `packages/web/app/api/auth/native/callback/route.ts` already returns the JS + `meta`-refresh deep-link redirect purpose-built for this hand-off (the same one the legacy Capacitor app shipped with).

**UX trade-off (accepted).** `openBrowserAsync` shows the system "Open in Boardsesh?" prompt on the deep-link hop, where the (broken) `ASWebAuthenticationSession` would not have. This is the price of a browser that actually presents, and it matches the legacy Capacitor app's behaviour that shipped to these same users for years.

**Delivery.** JS-only, no native change → no fingerprint change. Ships to the live store/TestFlight binary via production OTA.

**Telemetry plan.** Post-OTA, filter `flow=web_fallback` `fallback_mechanism=browser_deeplink`: `Login Succeeded` should climb from ~3/45d toward the native-failure volume, and `browser_unavailable` should be near-zero. If sub-second `Login Cancelled` persists on `browser_deeplink`, the browser still isn't presenting.

**Follow-up (out of scope).** The small genuine `ws.boardsesh.com` `/auth/native/exchange` failure tail (a real network/backend error, distinct from the presentation bug) is worth a separate look. Android's fallback gap is #3100 — a separate task, not touched here.

## Device-test checklist for @marcodejongh (iOS 26.5.1)

- [ ] **Apple** fallback: force the native failure, browser presents, complete sign-in, land signed in.
- [ ] **Google** fallback: same — present, complete, signed in.
- [ ] No `+not-found` flash on the `com.boardsesh.app://auth/callback` return.
- [ ] Real cancel: close the browser without finishing, returns to login silently, no error toast, logged as `Login Cancelled` (not `Login Failed`).
- [ ] iOS 18 regression check: native Apple/Google path still completes without ever hitting the fallback.
- [ ] Post-OTA PostHog: `flow=web_fallback` `fallback_mechanism=browser_deeplink` shows real `Login Succeeded`, `browser_unavailable` near zero.

## Release Notes

- Sign in with Apple and Google now go through reliably on the latest iOS — no more bouncing straight back to the login screen.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 3876 tests pass, incl. restored `auth-session-race.test.ts`, rewritten `auth-google-web.test.ts` (openBrowserAsync + Linking-driven deep link, real cancel, error param, no_transfer_token, exchange failure, and the new `browser_unavailable` path; scheme-parity anchored on `com.boardsesh.app://auth/callback`), hook `fallback_mechanism` + `browser_unavailable` coverage, and the `browser_unavailable` classifier case.
- `vp run check:mobile-bundle` — Metro bundle OK.
- `vp check` — 0 errors.

Fixes #3120
