### PR TITLE
feat(web): kiosk heartbeat — owners see whether their TVs are live

### DIFF
--- a/packages/backend/src/__tests__/kiosk-heartbeat.test.ts
+++ b/packages/backend/src/__tests__/kiosk-heartbeat.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vite-plus/test';
+import Redis from 'ioredis';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialGymKioskQueries, socialGymKioskMutations } from '../graphql/resolvers/social/gym-kiosks';
+import { _setKioskHeartbeatRedisForTests } from '../services/kiosk-heartbeat';
+
+/**
+ * Real-DB + real-Redis coverage for the kiosk heartbeat path:
+ *   - kioskHeartbeat write → gymKiosks read roundtrip surfaces a fresh
+ *     lastSeenAt;
+ *   - a kiosk that never checked in reads back null (vs a set one);
+ *   - a heartbeat for a non-existent (kiosk, gym) pair returns false and writes
+ *     nothing;
+ *   - the per-client rate limit trips after the ceiling.
+ *
+ * Redis is injected via the store's test seam (mirrors distributed-state.test.ts
+ * driving real Redis) so the resolver path runs end-to-end without booting the
+ * whole redisClientManager singleton. Redis-dependent tests skip when Redis is
+ * unavailable.
+ */
+
+const OWNER = 'kh-owner';
+const RANDOM = 'kh-random';
+const ALL_USERS = [OWNER, RANDOM];
+
+let connectionCounter = 0;
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}-${connectionCounter++}`, isAuthenticated: true, userId }) as ConnectionContext;
+const anonCtx = (): ConnectionContext =>
+  ({ connectionId: `conn-anon-${connectionCounter++}`, isAuthenticated: false }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+const insertGym = async (opts: {
+  ownerId: string;
+  name: string;
+  slug: string;
+}): Promise<{ id: number; uuid: string; slug: string }> => {
+  const uuid = uuidv4();
+  const result = await db.execute(sql`
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${opts.name}, ${opts.slug}, ${opts.ownerId}, true, now(), now())
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid, slug: opts.slug };
+};
+
+const emptyLayout = () => JSON.stringify({ version: 1, boards: [], leaderboard: null });
+
+const insertKiosk = async (opts: { gymId: number; slug: string; name: string }): Promise<{ uuid: string }> => {
+  const uuid = uuidv4();
+  const result = await db.execute(sql`
+    INSERT INTO gym_kiosks (uuid, gym_id, slug, name, layout, created_at, updated_at)
+    VALUES (${uuid}, ${opts.gymId}, ${opts.slug}, ${opts.name}, ${emptyLayout()}::jsonb, now(), now())
+    RETURNING id
+  `);
+  // Touch the returned row so the INSERT is materialised before we read back.
+  void Array.from(result as Iterable<{ id: number }>);
+  return { uuid };
+};
+
+let gym: { id: number; uuid: string; slug: string };
+let kioskA: { uuid: string };
+let kioskB: { uuid: string };
+
+async function resetAndSeed(): Promise<void> {
+  await db.execute(sql`TRUNCATE TABLE "gym_kiosks", "gym_members", "user_boards", "gyms" RESTART IDENTITY CASCADE`);
+  await Promise.all(ALL_USERS.map(insertUser));
+  gym = await insertGym({ ownerId: OWNER, name: 'Heartbeat Gym', slug: 'heartbeat-gym' });
+  kioskA = await insertKiosk({ gymId: gym.id, slug: 'front-wall', name: 'Front Wall' });
+  kioskB = await insertKiosk({ gymId: gym.id, slug: 'back-wall', name: 'Back Wall' });
+}
+
+// ---------------------------------------------------------------------------
+// Real-Redis roundtrip
+// ---------------------------------------------------------------------------
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6380';
+
+async function isRedisAvailable(): Promise<boolean> {
+  const probe = new Redis(REDIS_URL, { connectTimeout: 1000, maxRetriesPerRequest: 0, lazyConnect: true });
+  try {
+    await probe.connect();
+    await probe.ping();
+    await probe.quit();
+    return true;
+  } catch {
+    try {
+      await probe.quit();
+    } catch {
+      // ignore
+    }
+    return false;
+  }
+}
+
+const redisAvailable = await isRedisAvailable();
+
+describe.skipIf(!redisAvailable)('kiosk heartbeat roundtrip (real Redis)', () => {
+  let redis: Redis;
+
+  beforeAll(async () => {
+    redis = new Redis(REDIS_URL);
+    await new Promise<void>((resolve) => redis.once('ready', resolve));
+    _setKioskHeartbeatRedisForTests(redis);
+  });
+
+  afterAll(async () => {
+    _setKioskHeartbeatRedisForTests(null);
+    await redis.quit();
+  });
+
+  beforeEach(async () => {
+    const keys = await redis.keys('boardsesh:kiosk:*');
+    if (keys.length > 0) await redis.del(...keys);
+    await resetAndSeed();
+  });
+
+  it('records a heartbeat that the manage list reads back as a fresh lastSeenAt', async () => {
+    const recorded = await socialGymKioskMutations.kioskHeartbeat(
+      null,
+      { input: { kioskUuid: kioskA.uuid, gymUuid: gym.uuid, viewportWidth: 1920, viewportHeight: 1080 } },
+      anonCtx(),
+    );
+    expect(recorded).toBe(true);
+
+    const kiosks = await socialGymKioskQueries.gymKiosks(null, { gymUuid: gym.uuid }, authCtx(OWNER));
+    const seen = kiosks.find((kiosk) => kiosk.uuid === kioskA.uuid);
+    expect(seen).toBeDefined();
+    expect(seen!.lastSeenAt).not.toBeNull();
+    // Fresh: within a few seconds of now.
+    expect(Date.now() - Date.parse(seen!.lastSeenAt!)).toBeLessThan(5000);
+  });
+
+  it('leaves an un-checked-in kiosk null while the checked-in one is set', async () => {
+    await socialGymKioskMutations.kioskHeartbeat(
+      null,
+      { input: { kioskUuid: kioskA.uuid, gymUuid: gym.uuid } },
+      anonCtx(),
+    );
+
+    const kiosks = await socialGymKioskQueries.gymKiosks(null, { gymUuid: gym.uuid }, authCtx(OWNER));
+    const seen = kiosks.find((kiosk) => kiosk.uuid === kioskA.uuid);
+    const unseen = kiosks.find((kiosk) => kiosk.uuid === kioskB.uuid);
+
+    expect(seen!.lastSeenAt).not.toBeNull();
+    expect(unseen!.lastSeenAt).toBeNull();
+  });
+
+  it('does not record — and returns false — for a kiosk/gym pair that does not resolve', async () => {
+    // Right gym, wrong (random) kiosk uuid.
+    const strayKiosk = await socialGymKioskMutations.kioskHeartbeat(
+      null,
+      { input: { kioskUuid: uuidv4(), gymUuid: gym.uuid } },
+      anonCtx(),
+    );
+    expect(strayKiosk).toBe(false);
+
+    // Real kiosk, wrong gym uuid — the cross-tenant keyspace must not accept it.
+    const wrongGym = await socialGymKioskMutations.kioskHeartbeat(
+      null,
+      { input: { kioskUuid: kioskA.uuid, gymUuid: uuidv4() } },
+      anonCtx(),
+    );
+    expect(wrongGym).toBe(false);
+
+    const kiosks = await socialGymKioskQueries.gymKiosks(null, { gymUuid: gym.uuid }, authCtx(OWNER));
+    expect(kiosks.every((kiosk) => kiosk.lastSeenAt === null)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate limiting (Redis-independent — the heartbeat bucket is in-memory per IP)
+// ---------------------------------------------------------------------------
+
+describe('kioskHeartbeat rate limiting', () => {
+  beforeEach(async () => {
+    await resetAndSeed();
+  });
+
+  it('trips the per-client rate limit past the ceiling', async () => {
+    // A single fixed connection so the in-memory bucket accumulates. The
+    // heartbeat ceiling is 60/min; the 61st call must be throttled.
+    const ctx: ConnectionContext = {
+      connectionId: 'kh-rate-limit-conn',
+      isAuthenticated: false,
+    } as ConnectionContext;
+
+    for (let call = 0; call < 60; call++) {
+      await socialGymKioskMutations.kioskHeartbeat(null, { input: { kioskUuid: kioskA.uuid, gymUuid: gym.uuid } }, ctx);
+    }
+
+    await expect(
+      socialGymKioskMutations.kioskHeartbeat(null, { input: { kioskUuid: kioskA.uuid, gymUuid: gym.uuid } }, ctx),
+    ).rejects.toThrow(/Rate limit exceeded/);
+  });
+});

--- a/packages/backend/src/__tests__/kiosk-heartbeat.test.ts
+++ b/packages/backend/src/__tests__/kiosk-heartbeat.test.ts
@@ -57,13 +57,10 @@ const emptyLayout = () => JSON.stringify({ version: 1, boards: [], leaderboard: 
 
 const insertKiosk = async (opts: { gymId: number; slug: string; name: string }): Promise<{ uuid: string }> => {
   const uuid = uuidv4();
-  const result = await db.execute(sql`
+  await db.execute(sql`
     INSERT INTO gym_kiosks (uuid, gym_id, slug, name, layout, created_at, updated_at)
     VALUES (${uuid}, ${opts.gymId}, ${opts.slug}, ${opts.name}, ${emptyLayout()}::jsonb, now(), now())
-    RETURNING id
   `);
-  // Touch the returned row so the INSERT is materialised before we read back.
-  void Array.from(result as Iterable<{ id: number }>);
   return { uuid };
 };
 
@@ -138,6 +135,23 @@ describe.skipIf(!redisAvailable)('kiosk heartbeat roundtrip (real Redis)', () =>
     expect(seen!.lastSeenAt).not.toBeNull();
     // Fresh: within a few seconds of now.
     expect(Date.now() - Date.parse(seen!.lastSeenAt!)).toBeLessThan(5000);
+  });
+
+  it('never leaks liveness through the PUBLIC gymKiosk read, even after a heartbeat', async () => {
+    // Pins the invariant that only the edit-guarded gymKiosks query exposes
+    // lastSeenAt. kioskA is the oldest kiosk, so the slug-less public read
+    // returns it — and even with a fresh heartbeat recorded, the public payload
+    // must carry no liveness. Today that holds only because resolveKioskView
+    // omits the field; this guards against it regressing into a public leak.
+    await socialGymKioskMutations.kioskHeartbeat(
+      null,
+      { input: { kioskUuid: kioskA.uuid, gymUuid: gym.uuid } },
+      anonCtx(),
+    );
+
+    const publicKiosk = await socialGymKioskQueries.gymKiosk(null, { gymSlug: gym.slug }, anonCtx());
+    expect(publicKiosk).not.toBeNull();
+    expect((publicKiosk as { lastSeenAt?: string | null }).lastSeenAt ?? null).toBeNull();
   });
 
   it('leaves an un-checked-in kiosk null while the checked-in one is set', async () => {

--- a/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
@@ -35,9 +35,13 @@ const RATE_LIMIT_CREATE_GYM_KIOSK = 60;
 const RATE_LIMIT_UPDATE_GYM_KIOSK = 60;
 const RATE_LIMIT_DELETE_GYM_KIOSK = 60;
 // Heartbeats are unauthenticated (TVs aren't logged in), so this bucket is
-// keyed per client IP in-memory (see applyRateLimit). A live TV checks in once
-// per config-poll cycle (~5 min); 60/min leaves generous headroom for a whole
-// gym's worth of screens behind one NAT while still capping a runaway client.
+// keyed per client (in-memory; see applyRateLimit). A live TV checks in once
+// per config-poll cycle (~5 min), so 60/min leaves generous headroom for a
+// whole gym's worth of screens behind one NAT. This is a best-effort throttle:
+// it reins in a well-behaved client, not a determined one — robust client-IP
+// identification is tracked separately as platform work. Since the write only
+// stamps an ephemeral, non-sensitive timestamp, a loose ceiling here is
+// acceptable.
 const RATE_LIMIT_KIOSK_HEARTBEAT = 60;
 
 // Same slug shape gymBySlug accepts — a public URL segment.

--- a/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-kiosks.ts
@@ -6,8 +6,19 @@ import { MAX_KIOSKS_PER_GYM, emptyKioskLayout, parseKioskLayoutLenient, type Kio
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
-import { CreateGymKioskInputSchema, UpdateGymKioskInputSchema, UUIDSchema } from '../../../validation/schemas';
+import {
+  CreateGymKioskInputSchema,
+  UpdateGymKioskInputSchema,
+  KioskHeartbeatInputSchema,
+  UUIDSchema,
+} from '../../../validation/schemas';
 import { isUniqueViolation } from '../../../utils/postgres-errors';
+import {
+  recordKioskHeartbeat,
+  readKioskLastSeen,
+  isKioskExistenceCached,
+  cacheKioskExistence,
+} from '../../../services/kiosk-heartbeat';
 import { enrichGym, requireGymEditAccess, userCanEditGym, resolveCanonicalGymBySlug } from './gyms';
 import { enrichBoards } from './boards';
 
@@ -23,6 +34,11 @@ const RATE_LIMIT_GYM_KIOSKS = 60;
 const RATE_LIMIT_CREATE_GYM_KIOSK = 60;
 const RATE_LIMIT_UPDATE_GYM_KIOSK = 60;
 const RATE_LIMIT_DELETE_GYM_KIOSK = 60;
+// Heartbeats are unauthenticated (TVs aren't logged in), so this bucket is
+// keyed per client IP in-memory (see applyRateLimit). A live TV checks in once
+// per config-poll cycle (~5 min); 60/min leaves generous headroom for a whole
+// gym's worth of screens behind one NAT while still capping a runaway client.
+const RATE_LIMIT_KIOSK_HEARTBEAT = 60;
 
 // Same slug shape gymBySlug accepts — a public URL segment.
 const GYM_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
@@ -223,6 +239,34 @@ async function loadKioskForWrite(kioskUuid: string): Promise<{ kiosk: KioskRow; 
   return { kiosk, gym };
 }
 
+/**
+ * Cheap "does this live kiosk belong to this gym?" check for the public
+ * heartbeat path. Tries the Redis existence cache first (heartbeats are hot),
+ * falls back to one indexed join, and caches a positive result. Both UUIDs must
+ * match — nothing from the unauthenticated input is trusted beyond this lookup.
+ */
+async function kioskExistsForGym(kioskUuid: string, gymUuid: string): Promise<boolean> {
+  if (await isKioskExistenceCached(gymUuid, kioskUuid)) return true;
+
+  const [row] = await db
+    .select({ id: dbSchema.gymKiosks.id })
+    .from(dbSchema.gymKiosks)
+    .innerJoin(dbSchema.gyms, eq(dbSchema.gymKiosks.gymId, dbSchema.gyms.id))
+    .where(
+      and(
+        eq(dbSchema.gymKiosks.uuid, kioskUuid),
+        isNull(dbSchema.gymKiosks.deletedAt),
+        eq(dbSchema.gyms.uuid, gymUuid),
+        isNull(dbSchema.gyms.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  if (!row) return false;
+  await cacheKioskExistence(gymUuid, kioskUuid);
+  return true;
+}
+
 /** Verify every board referenced by a layout is alive and linked to this gym. */
 async function assertLayoutBoardsInGym(gymId: number, layout: KioskLayout): Promise<void> {
   const referenced = new Set<string>(layout.boards.map((slot) => slot.boardUuid));
@@ -323,7 +367,17 @@ export const socialGymKioskQueries = {
     // The viewer just passed requireGymEditAccess, so they're a gym editor.
     // Every kiosk shares this one gym — enrich it once, not once per kiosk.
     const enrichedGym = await enrichGym(gym, userId);
-    return Promise.all(kiosks.map((kiosk) => resolveKioskView(kiosk, enrichedGym, userId, true)));
+    const resolved = await Promise.all(kiosks.map((kiosk) => resolveKioskView(kiosk, enrichedGym, userId, true)));
+
+    // Attach ephemeral liveness from Redis in one batch MGET. A missing signal
+    // reads as null ("No signal yet") — never an error and never proof a TV is
+    // down (see services/kiosk-heartbeat.ts). Only this edit-guarded query
+    // exposes liveness; the public `gymKiosk` read leaves lastSeenAt null.
+    const lastSeenByUuid = await readKioskLastSeen(
+      gym.uuid,
+      resolved.map((kiosk) => kiosk.uuid),
+    );
+    return resolved.map((kiosk) => ({ ...kiosk, lastSeenAt: lastSeenByUuid.get(kiosk.uuid) ?? null }));
   },
 };
 
@@ -459,6 +513,36 @@ export const socialGymKioskMutations = {
     }
 
     await db.update(dbSchema.gymKiosks).set({ deletedAt: new Date() }).where(eq(dbSchema.gymKiosks.id, kiosk.id));
+
+    return true;
+  },
+
+  /**
+   * Public, UNAUTHENTICATED kiosk check-in. Called by the kiosk TV pages on load
+   * and on their config-poll cadence. Rate-limited per client IP, validates the
+   * (kiosk, gym) pair against a live kiosk, then records an ephemeral last-seen
+   * timestamp in Redis. Returns false — never an error — when the pair doesn't
+   * resolve, so a TV showing a since-deleted kiosk just stops being counted
+   * live instead of surfacing a fault.
+   */
+  kioskHeartbeat: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
+    await applyRateLimit(ctx, RATE_LIMIT_KIOSK_HEARTBEAT, 'kioskHeartbeat');
+    const validated = validateInput(KioskHeartbeatInputSchema, input, 'input');
+
+    if (!(await kioskExistsForGym(validated.kioskUuid, validated.gymUuid))) {
+      return false;
+    }
+
+    const viewport =
+      validated.viewportWidth != null && validated.viewportHeight != null
+        ? `${validated.viewportWidth}x${validated.viewportHeight}`
+        : null;
+
+    await recordKioskHeartbeat({
+      gymUuid: validated.gymUuid,
+      kioskUuid: validated.kioskUuid,
+      viewport,
+    });
 
     return true;
   },

--- a/packages/backend/src/services/kiosk-heartbeat.ts
+++ b/packages/backend/src/services/kiosk-heartbeat.ts
@@ -1,0 +1,143 @@
+import type Redis from 'ioredis';
+import { redisClientManager } from '../redis/client';
+import { logger } from '../utils/logger';
+
+/**
+ * Kiosk liveness heartbeats, stored in Redis (NOT Postgres) on purpose.
+ *
+ * A heartbeat is EPHEMERAL operational state written on a hot, public,
+ * unauthenticated path (every open TV re-reports on its ~5-minute config-poll
+ * cadence). Keeping it out of Postgres avoids a migration and the write
+ * amplification a per-poll UPDATE would cause. The trade-off is that a Redis
+ * restart drops every heartbeat — which is fine: each live kiosk re-reports
+ * within one poll cycle, so the manage UI briefly shows "No signal yet" until
+ * the next check-in rather than a false "dead".
+ *
+ * IMPORTANT for readers: a missing/expired signal means "unknown", never "this
+ * TV is definitely down". Treat null as an absence of information.
+ */
+
+/** 30 days — comfortably longer than any realistic gym closure so a kiosk that
+ * goes quiet still reads as "last seen 3 weeks ago" rather than falling off. */
+const HEARTBEAT_TTL_SECONDS = 30 * 24 * 60 * 60;
+/** How long a positive kiosk-existence lookup is cached, to spare the DB on the
+ * hot heartbeat path. Short enough that a deleted kiosk stops accepting
+ * heartbeats within the hour. */
+const EXISTS_CACHE_TTL_SECONDS = 60 * 60;
+
+function heartbeatKey(gymUuid: string, kioskUuid: string): string {
+  return `boardsesh:kiosk:heartbeat:${gymUuid}:${kioskUuid}`;
+}
+
+function existsCacheKey(gymUuid: string, kioskUuid: string): string {
+  return `boardsesh:kiosk:exists:${gymUuid}:${kioskUuid}`;
+}
+
+/** The JSON value stored per kiosk. `lastSeenAt` is epoch millis. */
+type HeartbeatValue = { lastSeenAt: number; viewport?: string };
+
+// Test seam: the roundtrip suite injects a real Redis client here (mirrors how
+// distributed-state.test.ts drives real Redis) so the resolver path can be
+// exercised without booting the whole redisClientManager singleton.
+let clientOverrideForTests: Redis | null = null;
+
+/** @internal test-only — inject/clear the Redis client the heartbeat store uses. */
+export function _setKioskHeartbeatRedisForTests(client: Redis | null): void {
+  clientOverrideForTests = client;
+}
+
+/**
+ * The Redis client to use, or null when Redis isn't available. Null makes every
+ * operation a graceful no-op: writes drop, reads return "unknown".
+ */
+function resolveClient(): Redis | null {
+  if (clientOverrideForTests) return clientOverrideForTests;
+  if (!redisClientManager.isRedisConnected()) return null;
+  return redisClientManager.getClients().publisher;
+}
+
+/** Record that a kiosk just checked in. No-op when Redis is unavailable. */
+export async function recordKioskHeartbeat(params: {
+  gymUuid: string;
+  kioskUuid: string;
+  viewport?: string | null;
+}): Promise<void> {
+  const client = resolveClient();
+  if (!client) return;
+
+  const value: HeartbeatValue = { lastSeenAt: Date.now() };
+  if (params.viewport) value.viewport = params.viewport;
+
+  try {
+    await client.set(
+      heartbeatKey(params.gymUuid, params.kioskUuid),
+      JSON.stringify(value),
+      'EX',
+      HEARTBEAT_TTL_SECONDS,
+    );
+  } catch (error) {
+    // A dropped heartbeat is inconsequential — the next poll re-reports.
+    logger.warn('[KioskHeartbeat] Failed to record heartbeat', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** True when a prior positive existence check is still cached. */
+export async function isKioskExistenceCached(gymUuid: string, kioskUuid: string): Promise<boolean> {
+  const client = resolveClient();
+  if (!client) return false;
+  try {
+    return (await client.exists(existsCacheKey(gymUuid, kioskUuid))) === 1;
+  } catch {
+    return false;
+  }
+}
+
+/** Cache a positive kiosk-existence result so repeat heartbeats skip the DB. */
+export async function cacheKioskExistence(gymUuid: string, kioskUuid: string): Promise<void> {
+  const client = resolveClient();
+  if (!client) return;
+  try {
+    await client.set(existsCacheKey(gymUuid, kioskUuid), '1', 'EX', EXISTS_CACHE_TTL_SECONDS);
+  } catch {
+    // Best-effort cache; a miss just costs one indexed lookup next time.
+  }
+}
+
+/**
+ * Batch-read last-seen timestamps for a gym's kiosks (single MGET). Every
+ * requested uuid appears in the result: an ISO 8601 string when a live
+ * heartbeat exists, or null for "no signal" (never reported, expired, corrupt
+ * value, or Redis unavailable).
+ */
+export async function readKioskLastSeen(gymUuid: string, kioskUuids: string[]): Promise<Map<string, string | null>> {
+  const lastSeenByUuid = new Map<string, string | null>();
+  for (const uuid of kioskUuids) lastSeenByUuid.set(uuid, null);
+  if (kioskUuids.length === 0) return lastSeenByUuid;
+
+  const client = resolveClient();
+  if (!client) return lastSeenByUuid;
+
+  try {
+    const keys = kioskUuids.map((uuid) => heartbeatKey(gymUuid, uuid));
+    const rawValues = await client.mget(...keys);
+    kioskUuids.forEach((uuid, index) => {
+      const raw = rawValues[index];
+      if (!raw) return;
+      try {
+        const parsed = JSON.parse(raw) as HeartbeatValue;
+        if (typeof parsed.lastSeenAt === 'number' && Number.isFinite(parsed.lastSeenAt)) {
+          lastSeenByUuid.set(uuid, new Date(parsed.lastSeenAt).toISOString());
+        }
+      } catch {
+        // Corrupt/legacy value: leave it null rather than surface a bad date.
+      }
+    });
+  } catch (error) {
+    logger.warn('[KioskHeartbeat] Failed to read heartbeats', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return lastSeenByUuid;
+}

--- a/packages/backend/src/services/kiosk-heartbeat.ts
+++ b/packages/backend/src/services/kiosk-heartbeat.ts
@@ -15,6 +15,15 @@ import { logger } from '../utils/logger';
  *
  * IMPORTANT for readers: a missing/expired signal means "unknown", never "this
  * TV is definitely down". Treat null as an absence of information.
+ *
+ * ACCEPTED RISK — forged heartbeats. Kiosk and gym UUIDs are public by design:
+ * they're serialized into the kiosk page HTML and embed URLs, so anyone can
+ * replay a valid pair and mark a kiosk "live" without a TV actually running.
+ * This is deliberately tolerated (low severity): the only impact is griefing a
+ * liveness indicator — a dead screen could read as live — with no data exposure
+ * and nothing mutated in Postgres. Optional future hardening, if it ever needs
+ * closing, is a server-rendered per-kiosk HMAC token the heartbeat must echo,
+ * not a change to this store.
  */
 
 /** 30 days — comfortably longer than any realistic gym closure so a kiosk that
@@ -33,7 +42,11 @@ function existsCacheKey(gymUuid: string, kioskUuid: string): string {
   return `boardsesh:kiosk:exists:${gymUuid}:${kioskUuid}`;
 }
 
-/** The JSON value stored per kiosk. `lastSeenAt` is epoch millis. */
+/**
+ * The JSON value stored per kiosk. `lastSeenAt` is epoch millis. `viewport`
+ * (e.g. "1920x1080") is a coarse client marker persisted for future ops/debug
+ * use — it is intentionally write-only today, not surfaced by any read.
+ */
 type HeartbeatValue = { lastSeenAt: number; viewport?: string };
 
 // Test seam: the roundtrip suite injects a real Redis client here (mirrors how

--- a/packages/backend/src/validation/schemas/gym-kiosks.ts
+++ b/packages/backend/src/validation/schemas/gym-kiosks.ts
@@ -38,3 +38,16 @@ export const UpdateGymKioskInputSchema = z.object({
   slug: KioskSlugSchema.optional(),
   layout: KioskLayoutSchema.optional(),
 });
+
+/**
+ * Public, unauthenticated kiosk check-in input. Nothing here is trusted beyond
+ * the two UUIDs, which are matched against a live kiosk before any write. The
+ * viewport marker is a coarse client hint, clamped to a sane pixel range so a
+ * hostile TV can't stuff arbitrary values into the ephemeral record.
+ */
+export const KioskHeartbeatInputSchema = z.object({
+  kioskUuid: UUIDSchema,
+  gymUuid: UUIDSchema,
+  viewportWidth: z.number().int().min(1).max(20000).optional(),
+  viewportHeight: z.number().int().min(1).max(20000).optional(),
+});

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -3153,6 +3153,14 @@ type GymKiosk {
   createdAt: String!
   "When the kiosk was last updated (ISO 8601)."
   updatedAt: String!
+  """
+  When a live TV last checked in (ISO 8601), or null when it never has — or its
+  ephemeral signal has expired. Populated only on the edit-guarded `gymKiosks`
+  query; the public `gymKiosk` read never exposes liveness. Backed by Redis
+  with a generous TTL, so a null here means "no signal", never "definitely
+  down".
+  """
+  lastSeenAt: String
 }
 
 """
@@ -3185,6 +3193,24 @@ input UpdateGymKioskInput {
   slug: String
   "New preset layout config (@boardsesh/kiosk KioskLayoutSchema). Persisted as the schema-parsed output."
   layout: JSON
+}
+
+"""
+Input for a kiosk check-in. Sent by the PUBLIC kiosk TV pages (unauthenticated)
+on load and on each config-poll tick so owners can see which screens are live.
+`gymUuid` scopes the ephemeral keyspace; both UUIDs are validated against a
+live kiosk before anything is recorded — nothing here is trusted beyond that
+lookup. `viewportWidth`/`viewportHeight` are an optional coarse client marker.
+"""
+input KioskHeartbeatInput {
+  "The kiosk that's checking in."
+  kioskUuid: ID!
+  "The gym the kiosk belongs to (keyspace scoping)."
+  gymUuid: ID!
+  "Optional viewport width in CSS pixels."
+  viewportWidth: Int
+  "Optional viewport height in CSS pixels."
+  viewportHeight: Int
 }
 
 # ============================================
@@ -5882,6 +5908,15 @@ type Mutation {
   Soft-delete a kiosk. Requires gym edit access. The slug is freed for reuse.
   """
   deleteGymKiosk(kioskUuid: ID!): Boolean!
+
+  """
+  Public, unauthenticated kiosk check-in. A kiosk TV page calls this on load
+  and on its config-poll cadence; after validating the kiosk exists, the
+  backend records an ephemeral last-seen timestamp (Redis, ~30-day TTL) that
+  the edit-guarded gymKiosks query surfaces. Returns false when the
+  kiosk/gym pair doesn't resolve to a live kiosk. Rate-limited per client.
+  """
+  kioskHeartbeat(input: KioskHeartbeatInput!): Boolean!
 
   """
   Record that an explicitly-created session has been mirrored to Apple HealthKit,

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2200,6 +2200,14 @@ export type GymKiosk = {
   createdAt: Scalars['String']['output'];
   /** The owning gym, enriched with branding for the kiosk chrome. */
   gym: Gym;
+  /**
+   * When a live TV last checked in (ISO 8601), or null when it never has — or its
+   * ephemeral signal has expired. Populated only on the edit-guarded `gymKiosks`
+   * query; the public `gymKiosk` read never exposes liveness. Backed by Redis
+   * with a generous TTL, so a null here means "no signal", never "definitely
+   * down".
+   */
+  lastSeenAt?: Maybe<Scalars['String']['output']>;
   /** Preset layout config (@boardsesh/kiosk KioskLayoutSchema): 1–4 board slots + optional leaderboard rail. Read leniently. */
   layout: Scalars['JSON']['output'];
   /** Kiosk display name. */
@@ -2474,6 +2482,24 @@ export type IntegrationStatus = {
   status?: Maybe<Scalars['String']['output']>;
 };
 
+/**
+ * Input for a kiosk check-in. Sent by the PUBLIC kiosk TV pages (unauthenticated)
+ * on load and on each config-poll tick so owners can see which screens are live.
+ * `gymUuid` scopes the ephemeral keyspace; both UUIDs are validated against a
+ * live kiosk before anything is recorded — nothing here is trusted beyond that
+ * lookup. `viewportWidth`/`viewportHeight` are an optional coarse client marker.
+ */
+export type KioskHeartbeatInput = {
+  /** The gym the kiosk belongs to (keyspace scoping). */
+  gymUuid: Scalars['ID']['input'];
+  /** The kiosk that's checking in. */
+  kioskUuid: Scalars['ID']['input'];
+  /** Optional viewport height in CSS pixels. */
+  viewportHeight?: InputMaybe<Scalars['Int']['input']>;
+  /** Optional viewport width in CSS pixels. */
+  viewportWidth?: InputMaybe<Scalars['Int']['input']>;
+};
+
 /** Statistics for a specific board layout. */
 export type LayoutStats = {
   __typename?: 'LayoutStats';
@@ -2712,6 +2738,14 @@ export type Mutation = {
    * Returns the session with current state.
    */
   joinSession: Session;
+  /**
+   * Public, unauthenticated kiosk check-in. A kiosk TV page calls this on load
+   * and on its config-poll cadence; after validating the kiosk exists, the
+   * backend records an ephemeral last-seen timestamp (Redis, ~30-day TTL) that
+   * the edit-guarded gymKiosks query surfaces. Returns false when the
+   * kiosk/gym pair doesn't resolve to a live kiosk. Rate-limited per client.
+   */
+  kioskHeartbeat: Scalars['Boolean']['output'];
   /** Leave the current session. */
   leaveSession: Scalars['Boolean']['output'];
   /** Link or unlink a board to/from a gym. */
@@ -3201,6 +3235,11 @@ export type MutationJoinSessionArgs = {
   sessionId: Scalars['ID']['input'];
   sessionName?: InputMaybe<Scalars['String']['input']>;
   username?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Root mutation type for all write operations. */
+export type MutationKioskHeartbeatArgs = {
+  input: KioskHeartbeatInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -7381,6 +7420,7 @@ export type ResolversTypes = ResolversObject<{
   IntegrationProvider: IntegrationProvider;
   IntegrationStatus: ResolverTypeWrapper<IntegrationStatus>;
   JSON: ResolverTypeWrapper<Scalars['JSON']['output']>;
+  KioskHeartbeatInput: KioskHeartbeatInput;
   LayoutStats: ResolverTypeWrapper<LayoutStats>;
   LeaderChanged: ResolverTypeWrapper<LeaderChanged>;
   LedCommand: ResolverTypeWrapper<LedCommand>;
@@ -7699,6 +7739,7 @@ export type ResolversParentTypes = ResolversObject<{
   IntegrationExportResult: IntegrationExportResult;
   IntegrationStatus: IntegrationStatus;
   JSON: Scalars['JSON']['output'];
+  KioskHeartbeatInput: KioskHeartbeatInput;
   LayoutStats: LayoutStats;
   LeaderChanged: LeaderChanged;
   LedCommand: LedCommand;
@@ -8908,6 +8949,7 @@ export type GymKioskResolvers<
   boards?: Resolver<Array<ResolversTypes['GymKioskBoard']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   gym?: Resolver<ResolversTypes['Gym'], ParentType, ContextType>;
+  lastSeenAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   layout?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -9375,6 +9417,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationJoinSessionArgs, 'boardPath' | 'sessionId'>
+  >;
+  kioskHeartbeat?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationKioskHeartbeatArgs, 'input'>
   >;
   leaveSession?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   linkBoardToGym?: Resolver<

--- a/packages/shared-schema/src/schema/gym-kiosks.ts
+++ b/packages/shared-schema/src/schema/gym-kiosks.ts
@@ -64,6 +64,14 @@ export const gymKiosksTypeDefs = /* GraphQL */ `
     createdAt: String!
     "When the kiosk was last updated (ISO 8601)."
     updatedAt: String!
+    """
+    When a live TV last checked in (ISO 8601), or null when it never has — or its
+    ephemeral signal has expired. Populated only on the edit-guarded \`gymKiosks\`
+    query; the public \`gymKiosk\` read never exposes liveness. Backed by Redis
+    with a generous TTL, so a null here means "no signal", never "definitely
+    down".
+    """
+    lastSeenAt: String
   }
 
   """
@@ -96,5 +104,23 @@ export const gymKiosksTypeDefs = /* GraphQL */ `
     slug: String
     "New preset layout config (@boardsesh/kiosk KioskLayoutSchema). Persisted as the schema-parsed output."
     layout: JSON
+  }
+
+  """
+  Input for a kiosk check-in. Sent by the PUBLIC kiosk TV pages (unauthenticated)
+  on load and on each config-poll tick so owners can see which screens are live.
+  \`gymUuid\` scopes the ephemeral keyspace; both UUIDs are validated against a
+  live kiosk before anything is recorded — nothing here is trusted beyond that
+  lookup. \`viewportWidth\`/\`viewportHeight\` are an optional coarse client marker.
+  """
+  input KioskHeartbeatInput {
+    "The kiosk that's checking in."
+    kioskUuid: ID!
+    "The gym the kiosk belongs to (keyspace scoping)."
+    gymUuid: ID!
+    "Optional viewport width in CSS pixels."
+    viewportWidth: Int
+    "Optional viewport height in CSS pixels."
+    viewportHeight: Int
   }
 `;

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -562,6 +562,15 @@ export const mutationsTypeDefs = /* GraphQL */ `
     deleteGymKiosk(kioskUuid: ID!): Boolean!
 
     """
+    Public, unauthenticated kiosk check-in. A kiosk TV page calls this on load
+    and on its config-poll cadence; after validating the kiosk exists, the
+    backend records an ephemeral last-seen timestamp (Redis, ~30-day TTL) that
+    the edit-guarded gymKiosks query surfaces. Returns false when the
+    kiosk/gym pair doesn't resolve to a live kiosk. Rate-limited per client.
+    """
+    kioskHeartbeat(input: KioskHeartbeatInput!): Boolean!
+
+    """
     Record that an explicitly-created session has been mirrored to Apple HealthKit,
     storing the workout UUID for de-duplication and UI status.
     Must be a participant of the session.

--- a/packages/shared-schema/src/types/gym-kiosks.ts
+++ b/packages/shared-schema/src/types/gym-kiosks.ts
@@ -34,6 +34,12 @@ export type GymKiosk = {
   boards: GymKioskBoard[];
   createdAt: string;
   updatedAt: string;
+  /**
+   * When a live TV last checked in (ISO 8601), or null when it never has / its
+   * ephemeral Redis signal has expired. Populated only on the edit-guarded
+   * `gymKiosks` query — a null means "no signal", never "definitely down".
+   */
+  lastSeenAt: string | null;
 };
 
 export type CreateGymKioskInput = {
@@ -47,4 +53,11 @@ export type UpdateGymKioskInput = {
   name?: string;
   slug?: string;
   layout?: unknown;
+};
+
+export type KioskHeartbeatInput = {
+  kioskUuid: string;
+  gymUuid: string;
+  viewportWidth?: number | null;
+  viewportHeight?: number | null;
 };

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2197,6 +2197,14 @@ export type GymKiosk = {
   createdAt: Scalars['String']['output'];
   /** The owning gym, enriched with branding for the kiosk chrome. */
   gym: Gym;
+  /**
+   * When a live TV last checked in (ISO 8601), or null when it never has — or its
+   * ephemeral signal has expired. Populated only on the edit-guarded `gymKiosks`
+   * query; the public `gymKiosk` read never exposes liveness. Backed by Redis
+   * with a generous TTL, so a null here means "no signal", never "definitely
+   * down".
+   */
+  lastSeenAt?: Maybe<Scalars['String']['output']>;
   /** Preset layout config (@boardsesh/kiosk KioskLayoutSchema): 1–4 board slots + optional leaderboard rail. Read leniently. */
   layout: Scalars['JSON']['output'];
   /** Kiosk display name. */
@@ -2471,6 +2479,24 @@ export type IntegrationStatus = {
   status?: Maybe<Scalars['String']['output']>;
 };
 
+/**
+ * Input for a kiosk check-in. Sent by the PUBLIC kiosk TV pages (unauthenticated)
+ * on load and on each config-poll tick so owners can see which screens are live.
+ * `gymUuid` scopes the ephemeral keyspace; both UUIDs are validated against a
+ * live kiosk before anything is recorded — nothing here is trusted beyond that
+ * lookup. `viewportWidth`/`viewportHeight` are an optional coarse client marker.
+ */
+export type KioskHeartbeatInput = {
+  /** The gym the kiosk belongs to (keyspace scoping). */
+  gymUuid: Scalars['ID']['input'];
+  /** The kiosk that's checking in. */
+  kioskUuid: Scalars['ID']['input'];
+  /** Optional viewport height in CSS pixels. */
+  viewportHeight?: InputMaybe<Scalars['Int']['input']>;
+  /** Optional viewport width in CSS pixels. */
+  viewportWidth?: InputMaybe<Scalars['Int']['input']>;
+};
+
 /** Statistics for a specific board layout. */
 export type LayoutStats = {
   __typename?: 'LayoutStats';
@@ -2709,6 +2735,14 @@ export type Mutation = {
    * Returns the session with current state.
    */
   joinSession: Session;
+  /**
+   * Public, unauthenticated kiosk check-in. A kiosk TV page calls this on load
+   * and on its config-poll cadence; after validating the kiosk exists, the
+   * backend records an ephemeral last-seen timestamp (Redis, ~30-day TTL) that
+   * the edit-guarded gymKiosks query surfaces. Returns false when the
+   * kiosk/gym pair doesn't resolve to a live kiosk. Rate-limited per client.
+   */
+  kioskHeartbeat: Scalars['Boolean']['output'];
   /** Leave the current session. */
   leaveSession: Scalars['Boolean']['output'];
   /** Link or unlink a board to/from a gym. */
@@ -3198,6 +3232,11 @@ export type MutationJoinSessionArgs = {
   sessionId: Scalars['ID']['input'];
   sessionName?: InputMaybe<Scalars['String']['input']>;
   username?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Root mutation type for all write operations. */
+export type MutationKioskHeartbeatArgs = {
+  input: KioskHeartbeatInput;
 };
 
 /** Root mutation type for all write operations. */

--- a/packages/shared/graphql/src/operations/gym-kiosks.ts
+++ b/packages/shared/graphql/src/operations/gym-kiosks.ts
@@ -1,5 +1,11 @@
 import { gql } from 'graphql-request';
-import type { Gym, GymKiosk, CreateGymKioskInput, UpdateGymKioskInput } from '@boardsesh/shared-schema';
+import type {
+  Gym,
+  GymKiosk,
+  CreateGymKioskInput,
+  UpdateGymKioskInput,
+  KioskHeartbeatInput,
+} from '@boardsesh/shared-schema';
 
 // ============================================
 // Gym Kiosk Operations
@@ -56,10 +62,15 @@ export const GET_GYM_KIOSK = gql`
   }
 `;
 
+// The manage list additionally reads per-kiosk liveness (edit-guarded). The
+// public GET_GYM_KIOSK deliberately omits lastSeenAt — the resolver never
+// populates it there, and owners are the only ones who should see whether a
+// screen is live.
 export const GET_GYM_KIOSKS = gql`
   query GetGymKiosks($gymUuid: ID!) {
     gymKiosks(gymUuid: $gymUuid) {
       ${GYM_KIOSK_FIELDS}
+      lastSeenAt
     }
   }
 `;
@@ -86,6 +97,15 @@ export const DELETE_GYM_KIOSK = gql`
   }
 `;
 
+// Public, unauthenticated check-in fired by the kiosk TV pages. Returns a plain
+// boolean — recorded / not recorded — so a since-deleted kiosk just stops being
+// counted live without erroring the page.
+export const KIOSK_HEARTBEAT = gql`
+  mutation KioskHeartbeat($input: KioskHeartbeatInput!) {
+    kioskHeartbeat(input: $input)
+  }
+`;
+
 // ============================================
 // Query/Mutation Variable Types
 // ============================================
@@ -109,8 +129,16 @@ export type GymKioskOperationGym = Pick<
   | 'canEdit'
 >;
 
-/** A GymKiosk as returned by these operations: full kiosk, narrowed gym. */
-export type GymKioskOperationResult = Omit<GymKiosk, 'gym'> & { gym: GymKioskOperationGym };
+/**
+ * A GymKiosk as returned by the shared selection: full kiosk minus `lastSeenAt`
+ * (only the edit-guarded manage list selects that), with a narrowed gym. Both
+ * omissions keep a consumer honest — reading a field the query didn't select is
+ * a compile error rather than an `undefined` at runtime.
+ */
+export type GymKioskOperationResult = Omit<GymKiosk, 'gym' | 'lastSeenAt'> & { gym: GymKioskOperationGym };
+
+/** The manage-list variant: the shared result plus per-kiosk liveness. */
+export type GymKioskManageResult = GymKioskOperationResult & Pick<GymKiosk, 'lastSeenAt'>;
 
 export type GetGymKioskQueryVariables = {
   gymSlug: string;
@@ -126,7 +154,7 @@ export type GetGymKiosksQueryVariables = {
 };
 
 export type GetGymKiosksQueryResponse = {
-  gymKiosks: GymKioskOperationResult[];
+  gymKiosks: GymKioskManageResult[];
 };
 
 export type CreateGymKioskMutationVariables = {
@@ -151,4 +179,12 @@ export type DeleteGymKioskMutationVariables = {
 
 export type DeleteGymKioskMutationResponse = {
   deleteGymKiosk: boolean;
+};
+
+export type KioskHeartbeatMutationVariables = {
+  input: KioskHeartbeatInput;
+};
+
+export type KioskHeartbeatMutationResponse = {
+  kioskHeartbeat: boolean;
 };

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -175,7 +175,26 @@
       "deleteConfirm": "Delete",
       "cancel": "Cancel",
       "deleted": "Kiosk deleted.",
-      "deleteFailed": "Couldn't delete the kiosk."
+      "deleteFailed": "Couldn't delete the kiosk.",
+      "liveness": {
+        "live": "Live",
+        "lastSeenMinutes_one": "Last seen {{count}} minute ago",
+        "lastSeenMinutes_other": "Last seen {{count}} minutes ago",
+        "lastSeenHours_one": "Last seen {{count}} hour ago",
+        "lastSeenHours_other": "Last seen {{count}} hours ago",
+        "noSignalDays_one": "No signal for {{count}} day",
+        "noSignalDays_other": "No signal for {{count}} days",
+        "noSignalYet": "No signal yet",
+        "reinstall": "Reinstall on TV"
+      },
+      "reinstall": {
+        "title": "Get this screen back up",
+        "body": "Open this URL in the TV's browser to bring “{{name}}” back, or scan it with a phone to send it over.",
+        "scanHint": "Scan to open on a phone",
+        "openTv": "Open TV view",
+        "close": "Done",
+        "noUrl": "Set your gym's URL slug first — then this kiosk gets a link you can put on any screen."
+      }
     },
     "boards": {
       "heading": "Boards at this gym",

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -175,7 +175,26 @@
       "deleteConfirm": "Eliminar",
       "cancel": "Cancelar",
       "deleted": "Kiosco eliminado.",
-      "deleteFailed": "No se pudo eliminar el kiosco."
+      "deleteFailed": "No se pudo eliminar el kiosco.",
+      "liveness": {
+        "live": "En directo",
+        "lastSeenMinutes_one": "Visto hace {{count}} minuto",
+        "lastSeenMinutes_other": "Visto hace {{count}} minutos",
+        "lastSeenHours_one": "Visto hace {{count}} hora",
+        "lastSeenHours_other": "Visto hace {{count}} horas",
+        "noSignalDays_one": "Sin señal desde hace {{count}} día",
+        "noSignalDays_other": "Sin señal desde hace {{count}} días",
+        "noSignalYet": "Sin señal todavía",
+        "reinstall": "Volver a abrir en la TV"
+      },
+      "reinstall": {
+        "title": "Vuelve a poner esta pantalla en marcha",
+        "body": "Abre esta URL en el navegador del televisor para recuperar «{{name}}», o escanéala con el móvil para enviarla.",
+        "scanHint": "Escanea para abrir en el móvil",
+        "openTv": "Abrir vista de TV",
+        "close": "Listo",
+        "noUrl": "Primero define el slug de URL de tu rocódromo; luego este kiosco tendrá un enlace para cualquier pantalla."
+      }
     },
     "boards": {
       "heading": "Plafones de este rocódromo",

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -175,7 +175,26 @@
       "deleteConfirm": "Supprimer",
       "cancel": "Annuler",
       "deleted": "Borne supprimée.",
-      "deleteFailed": "Impossible de supprimer la borne."
+      "deleteFailed": "Impossible de supprimer la borne.",
+      "liveness": {
+        "live": "En direct",
+        "lastSeenMinutes_one": "Vu il y a {{count}} minute",
+        "lastSeenMinutes_other": "Vu il y a {{count}} minutes",
+        "lastSeenHours_one": "Vu il y a {{count}} heure",
+        "lastSeenHours_other": "Vu il y a {{count}} heures",
+        "noSignalDays_one": "Aucun signal depuis {{count}} jour",
+        "noSignalDays_other": "Aucun signal depuis {{count}} jours",
+        "noSignalYet": "Aucun signal pour l’instant",
+        "reinstall": "Rouvrir sur la TV"
+      },
+      "reinstall": {
+        "title": "Remets cet écran en marche",
+        "body": "Ouvre cette URL dans le navigateur du téléviseur pour récupérer « {{name}} », ou scanne-la avec un téléphone pour l’envoyer.",
+        "scanHint": "Scanne pour ouvrir sur un téléphone",
+        "openTv": "Ouvrir la vue TV",
+        "close": "Terminé",
+        "noUrl": "Définis d’abord le slug d’URL de ta salle ; cette borne aura alors un lien à mettre sur n’importe quel écran."
+      }
     },
     "boards": {
       "heading": "Boards de cette salle",

--- a/packages/shared/kiosk/src/constants.ts
+++ b/packages/shared/kiosk/src/constants.ts
@@ -28,6 +28,16 @@ export const MAX_KIOSK_BOARDS = 4;
 export const MAX_KIOSKS_PER_GYM = 10;
 
 /**
+ * How often a live kiosk TV checks in with the backend. The heartbeat rides the
+ * existing config poll, so this is one cadence: config refresh AND heartbeat.
+ * The manage-UI "Live" liveness window is DERIVED from this (2×, see
+ * `KIOSK_LIVE_THRESHOLD_MS`) so a single dropped poll never flips a healthy TV
+ * to "Last seen …". Keep the two linked through this constant rather than
+ * hand-tuning twin magic numbers in two files.
+ */
+export const KIOSK_HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
  * Preset layout names, indexed by board count (1 board → 'single', 4 → 'quad').
  * The preset is DERIVED from `layout.boards.length` rather than stored, so there
  * is no picker and no way for the stored count and the named preset to disagree.

--- a/packages/web/app/components/gym-entity/manage/__tests__/kiosk-liveness.test.ts
+++ b/packages/web/app/components/gym-entity/manage/__tests__/kiosk-liveness.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { KIOSK_HEARTBEAT_INTERVAL_MS } from '@boardsesh/kiosk';
 import { bucketKioskLiveness, KIOSK_LIVE_THRESHOLD_MS, KIOSK_STALE_THRESHOLD_MS } from '../kiosk-liveness';
 
 const NOW = Date.parse('2026-07-16T12:00:00.000Z');
@@ -14,19 +15,26 @@ describe('bucketKioskLiveness', () => {
     expect(bucketKioskLiveness('not-a-date', NOW)).toEqual({ status: 'never' });
   });
 
-  it('reports "live" under the 5-minute threshold, including a skewed future time', () => {
+  it('reports "live" under the threshold, including a skewed future time', () => {
     expect(bucketKioskLiveness(at(0), NOW)).toEqual({ status: 'live' });
     expect(bucketKioskLiveness(at(KIOSK_LIVE_THRESHOLD_MS - 1), NOW)).toEqual({ status: 'live' });
     // Clock skew: the TV's timestamp is slightly in the future.
     expect(bucketKioskLiveness(at(-30 * 1000), NOW)).toEqual({ status: 'live' });
   });
 
-  it('reports "recent" in minutes between 5 and 60 minutes', () => {
+  it('stays "live" across a single missed poll — the window is 2x the cadence', () => {
+    // Anti-flap: a healthy TV's write-to-write gap is one cadence, and one
+    // late/dropped poll (just over a cadence) must not flip it to "recent".
+    expect(KIOSK_LIVE_THRESHOLD_MS).toBe(2 * KIOSK_HEARTBEAT_INTERVAL_MS);
+    expect(bucketKioskLiveness(at(KIOSK_HEARTBEAT_INTERVAL_MS + 30 * 1000), NOW)).toEqual({ status: 'live' });
+  });
+
+  it('reports "recent" in minutes from the live threshold up to 60 minutes', () => {
     // Exactly at the live threshold flips to recent.
     expect(bucketKioskLiveness(at(KIOSK_LIVE_THRESHOLD_MS), NOW)).toEqual({
       status: 'recent',
       unit: 'minutes',
-      count: 5,
+      count: Math.floor(KIOSK_LIVE_THRESHOLD_MS / MINUTE),
     });
     expect(bucketKioskLiveness(at(42 * MINUTE), NOW)).toEqual({ status: 'recent', unit: 'minutes', count: 42 });
     expect(bucketKioskLiveness(at(59 * MINUTE + 59 * 1000), NOW)).toEqual({

--- a/packages/web/app/components/gym-entity/manage/__tests__/kiosk-liveness.test.ts
+++ b/packages/web/app/components/gym-entity/manage/__tests__/kiosk-liveness.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { bucketKioskLiveness, KIOSK_LIVE_THRESHOLD_MS, KIOSK_STALE_THRESHOLD_MS } from '../kiosk-liveness';
+
+const NOW = Date.parse('2026-07-16T12:00:00.000Z');
+const at = (msAgo: number): string => new Date(NOW - msAgo).toISOString();
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe('bucketKioskLiveness', () => {
+  it('reports "never" for a null / unparseable signal', () => {
+    expect(bucketKioskLiveness(null, NOW)).toEqual({ status: 'never' });
+    expect(bucketKioskLiveness('not-a-date', NOW)).toEqual({ status: 'never' });
+  });
+
+  it('reports "live" under the 5-minute threshold, including a skewed future time', () => {
+    expect(bucketKioskLiveness(at(0), NOW)).toEqual({ status: 'live' });
+    expect(bucketKioskLiveness(at(KIOSK_LIVE_THRESHOLD_MS - 1), NOW)).toEqual({ status: 'live' });
+    // Clock skew: the TV's timestamp is slightly in the future.
+    expect(bucketKioskLiveness(at(-30 * 1000), NOW)).toEqual({ status: 'live' });
+  });
+
+  it('reports "recent" in minutes between 5 and 60 minutes', () => {
+    // Exactly at the live threshold flips to recent.
+    expect(bucketKioskLiveness(at(KIOSK_LIVE_THRESHOLD_MS), NOW)).toEqual({
+      status: 'recent',
+      unit: 'minutes',
+      count: 5,
+    });
+    expect(bucketKioskLiveness(at(42 * MINUTE), NOW)).toEqual({ status: 'recent', unit: 'minutes', count: 42 });
+    expect(bucketKioskLiveness(at(59 * MINUTE + 59 * 1000), NOW)).toEqual({
+      status: 'recent',
+      unit: 'minutes',
+      count: 59,
+    });
+  });
+
+  it('reports "recent" in hours from 1 hour up to the 48-hour threshold', () => {
+    expect(bucketKioskLiveness(at(60 * MINUTE), NOW)).toEqual({ status: 'recent', unit: 'hours', count: 1 });
+    expect(bucketKioskLiveness(at(25 * HOUR), NOW)).toEqual({ status: 'recent', unit: 'hours', count: 25 });
+    expect(bucketKioskLiveness(at(KIOSK_STALE_THRESHOLD_MS - 1), NOW)).toEqual({
+      status: 'recent',
+      unit: 'hours',
+      count: 47,
+    });
+  });
+
+  it('reports "stale" in days at and beyond 48 hours', () => {
+    expect(bucketKioskLiveness(at(KIOSK_STALE_THRESHOLD_MS), NOW)).toEqual({ status: 'stale', days: 2 });
+    expect(bucketKioskLiveness(at(9 * DAY + 5 * HOUR), NOW)).toEqual({ status: 'stale', days: 9 });
+  });
+});

--- a/packages/web/app/components/gym-entity/manage/kiosk-liveness-chip.tsx
+++ b/packages/web/app/components/gym-entity/manage/kiosk-liveness-chip.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+// Per-kiosk liveness chip for the Kiosks tab. Turns the kiosk's last-seen signal
+// into an at-a-glance status: Live / Last seen X ago / No signal for X days
+// (with a "Reinstall on TV" nudge) / No signal yet. The bucketing lives in the
+// pure `kiosk-liveness.ts` so it's testable; this component only maps a bucket
+// to MUI + copy.
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Button from '@mui/material/Button';
+import Tooltip from '@mui/material/Tooltip';
+import ReplayOutlined from '@mui/icons-material/ReplayOutlined';
+import type { TFunction } from 'i18next';
+import { bucketKioskLiveness, type KioskLiveness } from './kiosk-liveness';
+import KioskTvQrDialog from './kiosk-tv-qr-dialog';
+
+type KioskLivenessChipProps = {
+  lastSeenAt: string | null;
+  kioskName: string;
+  /** The kiosk's TV path (null when the gym has no slug) — for the reinstall QR. */
+  tvPath: string | null;
+};
+
+type ChipColor = 'success' | 'warning' | 'default';
+
+function livenessLabel(liveness: KioskLiveness, t: TFunction<'kiosk'>): string {
+  switch (liveness.status) {
+    case 'live':
+      return t('manage.kiosks.liveness.live');
+    case 'recent':
+      return liveness.unit === 'minutes'
+        ? t('manage.kiosks.liveness.lastSeenMinutes', { count: liveness.count })
+        : t('manage.kiosks.liveness.lastSeenHours', { count: liveness.count });
+    case 'stale':
+      return t('manage.kiosks.liveness.noSignalDays', { count: liveness.days });
+    case 'never':
+      return t('manage.kiosks.liveness.noSignalYet');
+  }
+}
+
+function livenessColor(liveness: KioskLiveness): ChipColor {
+  switch (liveness.status) {
+    case 'live':
+      return 'success';
+    case 'stale':
+      return 'warning';
+    case 'recent':
+    case 'never':
+      return 'default';
+  }
+}
+
+export default function KioskLivenessChip({ lastSeenAt, kioskName, tvPath }: KioskLivenessChipProps) {
+  const { t } = useTranslation('kiosk');
+  const [reinstallOpen, setReinstallOpen] = useState(false);
+
+  const liveness = bucketKioskLiveness(lastSeenAt, Date.now());
+  const color = livenessColor(liveness);
+  const label = livenessLabel(liveness, t);
+
+  const chip = (
+    <Chip
+      size="small"
+      color={color}
+      // Filled for the two states an owner acts on (live is reassuring, stale is
+      // a warning); outlined for the in-between "last seen …" and "no signal yet".
+      variant={liveness.status === 'live' || liveness.status === 'stale' ? 'filled' : 'outlined'}
+      label={label}
+    />
+  );
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+      {lastSeenAt === null ? chip : <Tooltip title={new Date(lastSeenAt).toLocaleString()}>{chip}</Tooltip>}
+      {liveness.status === 'stale' && (
+        <>
+          <Button
+            size="small"
+            color="warning"
+            startIcon={<ReplayOutlined />}
+            onClick={() => setReinstallOpen(true)}
+            sx={{ textTransform: 'none' }}
+          >
+            {t('manage.kiosks.liveness.reinstall')}
+          </Button>
+          <KioskTvQrDialog
+            open={reinstallOpen}
+            kioskName={kioskName}
+            tvPath={tvPath}
+            onClose={() => setReinstallOpen(false)}
+          />
+        </>
+      )}
+    </Box>
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/kiosk-liveness.ts
+++ b/packages/web/app/components/gym-entity/manage/kiosk-liveness.ts
@@ -4,11 +4,19 @@
 //
 // Buckets (elapsed = now − lastSeenAt):
 //   never  — no signal at all (null / unparseable)
-//   live   — < 5 min: a TV checking in on its ~5-minute poll cadence
-//   recent — 5 min … 48 h: "last seen X ago" (minutes, then hours)
+//   live   — a TV checking in on cadence (see the threshold below)
+//   recent — up to 48 h: "last seen X ago" (minutes, then hours)
 //   stale  — ≥ 48 h: "no signal for X days" — worth a nudge
 
-export const KIOSK_LIVE_THRESHOLD_MS = 5 * 60 * 1000;
+import { KIOSK_HEARTBEAT_INTERVAL_MS } from '@boardsesh/kiosk';
+
+/**
+ * "Live" window: TWO heartbeat cadences. A healthy TV's write-to-write gap is
+ * one cadence, so a single late/dropped poll still lands inside 2× rather than
+ * flipping a working screen to "Last seen 7 minutes ago". Derived from the
+ * shared cadence, never a hand-tuned twin of it.
+ */
+export const KIOSK_LIVE_THRESHOLD_MS = 2 * KIOSK_HEARTBEAT_INTERVAL_MS;
 export const KIOSK_STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
 
 const MS_PER_MINUTE = 60 * 1000;

--- a/packages/web/app/components/gym-entity/manage/kiosk-liveness.ts
+++ b/packages/web/app/components/gym-entity/manage/kiosk-liveness.ts
@@ -1,0 +1,45 @@
+// Pure bucketing for a kiosk's last-seen signal into the four status a gym owner
+// cares about. Kept free of `Date.now()`/React so it's unit-testable without
+// fake timers: the caller passes the current time in.
+//
+// Buckets (elapsed = now − lastSeenAt):
+//   never  — no signal at all (null / unparseable)
+//   live   — < 5 min: a TV checking in on its ~5-minute poll cadence
+//   recent — 5 min … 48 h: "last seen X ago" (minutes, then hours)
+//   stale  — ≥ 48 h: "no signal for X days" — worth a nudge
+
+export const KIOSK_LIVE_THRESHOLD_MS = 5 * 60 * 1000;
+export const KIOSK_STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+
+const MS_PER_MINUTE = 60 * 1000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+export type KioskLiveness =
+  | { status: 'never' }
+  | { status: 'live' }
+  | { status: 'recent'; unit: 'minutes' | 'hours'; count: number }
+  | { status: 'stale'; days: number };
+
+/**
+ * Bucket a kiosk's last-seen ISO timestamp against `nowMs`. A future timestamp
+ * (clock skew between the TV and the server) counts as `live` rather than a
+ * negative age. Unparseable or null input is `never`.
+ */
+export function bucketKioskLiveness(lastSeenAt: string | null, nowMs: number): KioskLiveness {
+  if (lastSeenAt === null) return { status: 'never' };
+
+  const lastSeenMs = Date.parse(lastSeenAt);
+  if (Number.isNaN(lastSeenMs)) return { status: 'never' };
+
+  const elapsedMs = nowMs - lastSeenMs;
+  if (elapsedMs < KIOSK_LIVE_THRESHOLD_MS) return { status: 'live' };
+
+  if (elapsedMs < KIOSK_STALE_THRESHOLD_MS) {
+    const minutes = Math.floor(elapsedMs / MS_PER_MINUTE);
+    if (minutes < 60) return { status: 'recent', unit: 'minutes', count: minutes };
+    return { status: 'recent', unit: 'hours', count: Math.floor(elapsedMs / MS_PER_HOUR) };
+  }
+
+  return { status: 'stale', days: Math.floor(elapsedMs / MS_PER_DAY) };
+}

--- a/packages/web/app/components/gym-entity/manage/kiosk-tv-qr-dialog.tsx
+++ b/packages/web/app/components/gym-entity/manage/kiosk-tv-qr-dialog.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+// "Reinstall on TV" helper: surfaces a kiosk's public TV URL as scannable QR +
+// copyable text so an owner can walk a dead screen back to life — open the URL
+// in the TV's browser, or scan it with a phone to hand it over. Opened from the
+// warning chip on a kiosk that's gone quiet.
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { QRCodeSVG } from 'qrcode.react';
+import Box from '@mui/material/Box';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import LaunchOutlined from '@mui/icons-material/LaunchOutlined';
+import { absoluteUrl } from '@/app/lib/seo/base-url';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { themeTokens } from '@/app/theme/theme-config';
+
+type KioskTvQrDialogProps = {
+  open: boolean;
+  kioskName: string;
+  /** The kiosk's TV path, or null when the gym still has no URL slug. */
+  tvPath: string | null;
+  onClose: () => void;
+};
+
+export default function KioskTvQrDialog({ open, kioskName, tvPath, onClose }: KioskTvQrDialogProps) {
+  const { t } = useTranslation('kiosk');
+  const tvUrl = tvPath === null ? null : absoluteUrl(tvPath);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{t('manage.kiosks.reinstall.title')}</DialogTitle>
+      <DialogContent>
+        {tvUrl === null ? (
+          <Typography variant="body2" color="text.secondary">
+            {t('manage.kiosks.reinstall.noUrl')}
+          </Typography>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+            <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+              {t('manage.kiosks.reinstall.body', { name: kioskName })}
+            </Typography>
+            {/* A QR needs a light quiet zone to scan — always render black modules
+                on a white tile regardless of the manage theme. */}
+            <Box
+              sx={{
+                backgroundColor: themeTokens.semantic.surface,
+                borderRadius: themeTokens.borderRadius.md,
+                p: 2,
+                lineHeight: 0,
+              }}
+            >
+              <QRCodeSVG value={tvUrl} size={196} level="M" marginSize={1} aria-hidden />
+            </Box>
+            <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
+              {t('manage.kiosks.reinstall.scanHint')}
+            </Typography>
+            <Typography variant="body2" sx={{ wordBreak: 'break-all', textAlign: 'center' }}>
+              {tvUrl}
+            </Typography>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        {tvPath !== null && (
+          <Button
+            component={LocaleLink}
+            href={tvPath}
+            target="_blank"
+            rel="noopener"
+            startIcon={<LaunchOutlined />}
+            sx={{ textTransform: 'none' }}
+          >
+            {t('manage.kiosks.reinstall.openTv')}
+          </Button>
+        )}
+        <Button onClick={onClose} sx={{ textTransform: 'none' }}>
+          {t('manage.kiosks.reinstall.close')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/kiosks-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/kiosks-tab.tsx
@@ -31,6 +31,7 @@ import {
   type GetGymBoardsQueryVariables,
   type GetGymKiosksQueryResponse,
   type GetGymKiosksQueryVariables,
+  type GymKioskManageResult,
   type GymKioskOperationResult,
 } from '@boardsesh/graphql/operations';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
@@ -44,6 +45,7 @@ import ManageTabEmptyState from './manage-tab-empty-state';
 import ConfirmDialog from './confirm-dialog';
 import KioskCreateDialog from './kiosk-create-dialog';
 import KioskEditor from './kiosk-editor';
+import KioskLivenessChip from './kiosk-liveness-chip';
 import type { GymManageTabProps } from './tab-props';
 
 /**
@@ -114,9 +116,12 @@ export default function KiosksTab({ gym, onDirtyChange }: GymManageTabProps) {
   );
 
   const handleCreated = (kiosk: GymKioskOperationResult) => {
-    queryClient.setQueryData<GymKioskOperationResult[]>(kiosksQueryKey, (previous) =>
-      previous ? [...previous, kiosk] : [kiosk],
-    );
+    // A fresh kiosk has never checked in — seed lastSeenAt null so the card
+    // shows "No signal yet" until it's opened on a TV.
+    queryClient.setQueryData<GymKioskManageResult[]>(kiosksQueryKey, (previous) => {
+      const created: GymKioskManageResult = { ...kiosk, lastSeenAt: null };
+      return previous ? [...previous, created] : [created];
+    });
     setCreateDialogOpen(false);
     showMessage(t('manage.createDialog.created', { slug: kiosk.slug }), 'success');
     // Straight into the editor — a fresh kiosk has no boards yet.
@@ -124,8 +129,14 @@ export default function KiosksTab({ gym, onDirtyChange }: GymManageTabProps) {
   };
 
   const handleSaved = (kiosk: GymKioskOperationResult) => {
-    queryClient.setQueryData<GymKioskOperationResult[]>(kiosksQueryKey, (previous) =>
-      previous ? previous.map((existing) => (existing.uuid === kiosk.uuid ? kiosk : existing)) : [kiosk],
+    // The update response doesn't carry liveness — keep whatever last-seen we
+    // already had for this kiosk so an edit doesn't blank its status chip.
+    queryClient.setQueryData<GymKioskManageResult[]>(kiosksQueryKey, (previous) =>
+      previous
+        ? previous.map((existing) =>
+            existing.uuid === kiosk.uuid ? { ...kiosk, lastSeenAt: existing.lastSeenAt } : existing,
+          )
+        : [{ ...kiosk, lastSeenAt: null }],
     );
   };
 
@@ -135,7 +146,7 @@ export default function KiosksTab({ gym, onDirtyChange }: GymManageTabProps) {
     setDeleteTarget(null);
     const result = await deleteMutation.execute({ kioskUuid: target.uuid });
     if (result) {
-      queryClient.setQueryData<GymKioskOperationResult[]>(kiosksQueryKey, (previous) =>
+      queryClient.setQueryData<GymKioskManageResult[]>(kiosksQueryKey, (previous) =>
         previous ? previous.filter((existing) => existing.uuid !== target.uuid) : previous,
       );
     }
@@ -276,6 +287,9 @@ export default function KiosksTab({ gym, onDirtyChange }: GymManageTabProps) {
                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
                   {tvPath ?? t('manage.kiosks.urlPending', { slug: kiosk.slug })}
                 </Typography>
+                <Box sx={{ mb: 1 }}>
+                  <KioskLivenessChip lastSeenAt={kiosk.lastSeenAt} kioskName={kiosk.name} tvPath={tvPath} />
+                </Box>
                 <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
                   <Chip
                     size="small"

--- a/packages/web/app/components/gym-entity/manage/kiosks-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/kiosks-tab.tsx
@@ -94,6 +94,9 @@ export default function KiosksTab({ gym, onDirtyChange }: GymManageTabProps) {
       return response.gymKiosks;
     },
     enabled: !!token,
+    // Re-poll while the tab is open so the liveness chips reflect current
+    // check-ins instead of freezing at load-time data on a parked tab.
+    refetchInterval: 60_000,
   });
 
   // The editor needs the gym's full board list (editors see private/unlisted

--- a/packages/web/app/components/kiosk/kiosk-page-renderer.tsx
+++ b/packages/web/app/components/kiosk/kiosk-page-renderer.tsx
@@ -160,7 +160,13 @@ export default async function KioskPageRenderer({ gymSlug, kioskSlug }: { gymSlu
     <I18nProvider locale={locale} namespaces={['common', 'kiosk']}>
       <KioskThemeScope gym={kiosk.gym}>
         <KioskAnalytics />
-        <KioskReliability gymSlug={gymSlug} kioskSlug={kioskSlug} initialUpdatedAt={kiosk.updatedAt} />
+        <KioskReliability
+          gymSlug={gymSlug}
+          kioskSlug={kioskSlug}
+          kioskUuid={kiosk.uuid}
+          gymUuid={kiosk.gym.uuid}
+          initialUpdatedAt={kiosk.updatedAt}
+        />
         <KioskPresenceHub boardIds={distinctBoardIds}>
           <div className={layoutStyles.root}>
             <KioskHeader

--- a/packages/web/app/components/kiosk/kiosk-reliability.tsx
+++ b/packages/web/app/components/kiosk/kiosk-reliability.tsx
@@ -31,6 +31,7 @@ import {
   type KioskHeartbeatMutationResponse,
   type KioskHeartbeatMutationVariables,
 } from '@boardsesh/graphql/operations';
+import { KIOSK_HEARTBEAT_INTERVAL_MS } from '@boardsesh/kiosk';
 import { executeGraphQL } from '@/app/lib/graphql/client';
 import { useWakeLock } from '../board-bluetooth-control/use-wake-lock';
 import { evaluateKioskConfigPoll } from './kiosk-config-poll';
@@ -38,8 +39,13 @@ import type { KioskBoardSnapshot } from './presence/use-kiosk-board-presence';
 
 /** How often each board re-reads the durable history to repair silent drops. */
 const BOARD_FEED_CATCH_UP_INTERVAL_MS = 5 * 60 * 1000;
-/** How often the kiosk config is re-fetched to detect a re-configured layout. */
-const CONFIG_POLL_INTERVAL_MS = 5 * 60 * 1000;
+/**
+ * How often the kiosk config is re-fetched to detect a re-configured layout.
+ * The heartbeat rides this poll (fires on each completed fetch), so it's the
+ * kiosk's single check-in cadence — sourced from the shared constant the
+ * manage-UI liveness window also derives from, so the two never drift.
+ */
+const CONFIG_POLL_INTERVAL_MS = KIOSK_HEARTBEAT_INTERVAL_MS;
 /**
  * Minimum page age before a config mismatch may reload. The server render is
  * cached with `revalidate: 60`, so right after an edit a reload can serve the
@@ -171,13 +177,16 @@ export default function KioskReliability({
   // generous, so a brief gap never reads as "dead".
   useEffect(() => {
     if (dataUpdatedAt === 0) return;
+    // Viewport is a best-effort coarse marker: only send it when the browser
+    // reports real dimensions. A headless/hidden context can report 0 — the
+    // backend's `min(1)` would reject the whole heartbeat, so omit the fields
+    // rather than lose the check-in.
+    const viewport =
+      window.innerWidth > 0 && window.innerHeight > 0
+        ? { viewportWidth: window.innerWidth, viewportHeight: window.innerHeight }
+        : {};
     void executeGraphQL<KioskHeartbeatMutationResponse, KioskHeartbeatMutationVariables>(KIOSK_HEARTBEAT, {
-      input: {
-        kioskUuid,
-        gymUuid,
-        viewportWidth: window.innerWidth,
-        viewportHeight: window.innerHeight,
-      },
+      input: { kioskUuid, gymUuid, ...viewport },
     }).catch(() => {
       // Swallow — the next poll tick re-reports.
     });

--- a/packages/web/app/components/kiosk/kiosk-reliability.tsx
+++ b/packages/web/app/components/kiosk/kiosk-reliability.tsx
@@ -24,7 +24,13 @@ import {
   useBoardPresenceCurrent,
   useBoardPresenceFeed,
 } from '@boardsesh/board-presence-react';
-import { GET_GYM_KIOSK, type GetGymKioskQueryResponse } from '@boardsesh/graphql/operations';
+import {
+  GET_GYM_KIOSK,
+  KIOSK_HEARTBEAT,
+  type GetGymKioskQueryResponse,
+  type KioskHeartbeatMutationResponse,
+  type KioskHeartbeatMutationVariables,
+} from '@boardsesh/graphql/operations';
 import { executeGraphQL } from '@/app/lib/graphql/client';
 import { useWakeLock } from '../board-bluetooth-control/use-wake-lock';
 import { evaluateKioskConfigPoll } from './kiosk-config-poll';
@@ -89,10 +95,18 @@ export function KioskBoardFeedBridge({
 export default function KioskReliability({
   gymSlug,
   kioskSlug,
+  kioskUuid,
+  gymUuid,
   initialUpdatedAt,
 }: {
   gymSlug: string;
   kioskSlug: string | null;
+  /** The kiosk's UUID — the heartbeat key (only the display pages send one; the
+   * manage preview builds its own tree without this component, so heartbeats are
+   * display-only by construction). */
+  kioskUuid: string;
+  /** The owning gym's UUID — scopes the heartbeat keyspace. */
+  gymUuid: string;
   /** The kiosk's `updatedAt` at server-render time; any change forces a reload. */
   initialUpdatedAt: string;
 }) {
@@ -146,6 +160,28 @@ export default function KioskReliability({
     decide();
     return () => clearTimeout(recheckTimeoutId);
   }, [kioskConfigData, dataUpdatedAt, initialUpdatedAt, mountedAtMs]);
+
+  // Heartbeat: check in so owners can see this TV is live, straight from the
+  // Kiosks tab. Piggybacks the config poll's cadence rather than adding a second
+  // timer — `dataUpdatedAt` advances on the first successful fetch (initial
+  // load) and on every 5-minute refetch, which is exactly when we want to
+  // report. Tying it to a completed poll also means "live" reflects the TV
+  // actually reaching the backend, not just a mounted component. A failed send
+  // is inconsequential: the next poll re-reports, and the backend TTL is
+  // generous, so a brief gap never reads as "dead".
+  useEffect(() => {
+    if (dataUpdatedAt === 0) return;
+    void executeGraphQL<KioskHeartbeatMutationResponse, KioskHeartbeatMutationVariables>(KIOSK_HEARTBEAT, {
+      input: {
+        kioskUuid,
+        gymUuid,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      },
+    }).catch(() => {
+      // Swallow — the next poll tick re-reports.
+    });
+  }, [dataUpdatedAt, kioskUuid, gymUuid]);
 
   useEffect(() => {
     const now = new Date();


### PR DESCRIPTION
## Summary

Gym owners find out a kiosk TV is dead the worst way: an annoyed member tells them. This adds a lightweight heartbeat so they can see, from the Kiosks tab, which screens are live and which need a nudge.

- **Heartbeat write (backend).** New public, unauthenticated `kioskHeartbeat(input)` mutation. It validates the `(kioskUuid, gymUuid)` pair against a live kiosk (cheap indexed join, with a short-lived Redis existence cache on the hot path), then writes a last-seen timestamp to Redis. Rate-limited per client IP (60/min, in-memory — the same bucket pattern anon reads use). Nothing from the input is trusted beyond the UUID lookup; a coarse `viewport` marker is stored when supplied.
- **No DB migration — Redis on purpose.** Heartbeats are ephemeral operational state on a hot poll path, so they live in Redis (30-day TTL), not Postgres. A Redis restart just means "no signal yet" until each open TV re-reports on its next poll — documented where the value is read, and a null is treated as "unknown", never "definitely down".
- **Heartbeat send (web).** The kiosk TV pages piggyback their existing 5-minute config poll: one aligned cadence, no second timer, and "live" reflects the TV actually reaching the backend. The manage preview builds its own tree without `KioskReliability`, so heartbeats are display-page-only by construction.
- **Liveness read (backend).** The edit-guarded `gymKiosks` query batch-reads liveness (one MGET) and exposes `lastSeenAt`; the public `gymKiosk` read never does.
- **Owner UI (web).** A per-kiosk status chip on the Kiosks tab: **Live** (<5m) / **Last seen X ago** (5m–48h) / **No signal for X days** (>48h, warning colour + a "Reinstall on TV" QR to walk the screen back up) / **No signal yet**. The bucketing is a pure, unit-tested function.

## Release Notes

- Your kiosk TVs now check in — see at a glance which screens are live and which need a nudge, straight from the Kiosks tab.

## Test plan

- `vp check` — 0 errors.
- `vp run typecheck` — passes across the monorepo.
- Backend (`VITEST_POOL_ID=solo-p11 vp test run --project backend`): new `kiosk-heartbeat.test.ts` covers the write→read roundtrip against real Redis, set-vs-null liveness, a non-resolving `(kiosk, gym)` pair (returns false, writes nothing, incl. cross-tenant gym uuid), and the rate-limit ceiling. `gym-kiosks`, `apply-rate-limit`, and `operations-schema-validation` suites all green.
- Web (`vp test run --project web`): new `kiosk-liveness.test.ts` covers every bucket boundary (live / recent-minutes / recent-hours / stale / never + clock skew). The only full-suite failures were pre-existing timing flakes (quick-tick-bar, start-sesh-drawer, aurora-credentials) that pass in isolation.
- `vp run check:i18n`, `check:i18n:orphans`, and i18n `catalog-completeness` all pass (keys added to en-US / es / fr, following the es "rocódromo" and fr "salle/borne" catalog conventions).
