### PR TITLE
fix(backend): drop stale sessionId instead of failing the tick insert

### DIFF
--- a/packages/backend/src/__tests__/sync-mutations.test.ts
+++ b/packages/backend/src/__tests__/sync-mutations.test.ts
@@ -15,6 +15,7 @@ import { db } from '../db/client';
 import { tickMutations } from '../graphql/resolvers/ticks/mutations';
 import { favoriteMutations } from '../graphql/resolvers/favorites/mutations';
 import { playlistMutations } from '../graphql/resolvers/playlists/mutations';
+import { logger } from '../utils/logger';
 
 const USER_ID = 'sync-mut-user';
 
@@ -37,7 +38,7 @@ async function insertUser(id: string): Promise<void> {
   `);
 }
 
-type TickRow = { uuid: string; status: string; comment: string };
+type TickRow = { uuid: string; status: string; comment: string; sessionId: string | null };
 
 const fixedUuid = '11111111-1111-4111-8111-111111111111';
 
@@ -230,6 +231,79 @@ describe('saveTick idempotent replay', () => {
 
     expect(a.uuid).not.toBe(b.uuid);
     expect(recomputeSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// Regression coverage for #2386: a stale/unknown sessionId must never lose the
+// tick to a raw FK violation. Runs against the real Postgres FK so a
+// regression here reproduces the original bug (INSERT rejected), not just a
+// mock mismatch.
+describe('saveTick with a stale sessionId (#2386)', () => {
+  const baseInput = {
+    boardType: 'kilter',
+    climbUuid: 'tick-climb-session-fk',
+    angle: 40,
+    isMirror: false,
+    status: 'attempt' as const,
+    attemptCount: 1,
+    isBenchmark: false,
+    comment: 'session fk regression',
+    climbedAt: new Date('2026-05-25T02:43:00Z').toISOString(),
+  };
+
+  async function insertSession(id: string): Promise<void> {
+    await db.execute(sql`
+      INSERT INTO "board_sessions" (id, board_path)
+      VALUES (${id}, ${'/kilter/1/2/3/40'})
+      ON CONFLICT (id) DO NOTHING
+    `);
+  }
+
+  async function deleteSession(id: string): Promise<void> {
+    await db.execute(sql`DELETE FROM "board_sessions" WHERE id = ${id}`);
+  }
+
+  it('drops a nonexistent sessionId and still saves the tick', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    const staleSessionId = 'session-that-never-existed-2386';
+
+    const result = (await tickMutations.saveTick(
+      undefined,
+      { input: { ...baseInput, sessionId: staleSessionId } },
+      ctx(),
+    )) as TickRow;
+
+    expect(result.sessionId).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(staleSessionId));
+
+    const rows = await db.execute(sql`
+      SELECT session_id FROM boardsesh_ticks WHERE uuid = ${result.uuid}
+    `);
+    expect((rows as unknown as Array<{ session_id: string | null }>)[0].session_id).toBeNull();
+
+    warnSpy.mockRestore();
+  });
+
+  it('keeps a real sessionId association', async () => {
+    const sessionId = 'session-2386-real';
+    await insertSession(sessionId);
+
+    try {
+      const result = (await tickMutations.saveTick(
+        undefined,
+        { input: { ...baseInput, sessionId } },
+        ctx(),
+      )) as TickRow;
+
+      expect(result.sessionId).toBe(sessionId);
+
+      const rows = await db.execute(sql`
+        SELECT session_id FROM boardsesh_ticks WHERE uuid = ${result.uuid}
+      `);
+      expect((rows as unknown as Array<{ session_id: string | null }>)[0].session_id).toBe(sessionId);
+    } finally {
+      await deleteSession(sessionId);
+    }
   });
 });
 

--- a/packages/backend/src/__tests__/sync-mutations.test.ts
+++ b/packages/backend/src/__tests__/sync-mutations.test.ts
@@ -239,17 +239,19 @@ describe('saveTick idempotent replay', () => {
 // regression here reproduces the original bug (INSERT rejected), not just a
 // mock mismatch.
 describe('saveTick with a stale sessionId (#2386)', () => {
-  const baseInput = {
-    boardType: 'kilter',
-    climbUuid: 'tick-climb-session-fk',
-    angle: 40,
-    isMirror: false,
-    status: 'attempt' as const,
-    attemptCount: 1,
-    isBenchmark: false,
-    comment: 'session fk regression',
-    climbedAt: new Date('2026-05-25T02:43:00Z').toISOString(),
-  };
+  function buildInput(climbUuid: string) {
+    return {
+      boardType: 'kilter',
+      climbUuid,
+      angle: 40,
+      isMirror: false,
+      status: 'attempt' as const,
+      attemptCount: 1,
+      isBenchmark: false,
+      comment: 'session fk regression',
+      climbedAt: new Date('2026-05-25T02:43:00Z').toISOString(),
+    };
+  }
 
   async function insertSession(id: string): Promise<void> {
     await db.execute(sql`
@@ -263,35 +265,44 @@ describe('saveTick with a stale sessionId (#2386)', () => {
     await db.execute(sql`DELETE FROM "board_sessions" WHERE id = ${id}`);
   }
 
+  async function deleteTick(uuid: string): Promise<void> {
+    await db.execute(sql`DELETE FROM boardsesh_ticks WHERE uuid = ${uuid}`);
+  }
+
   it('drops a nonexistent sessionId and still saves the tick', async () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
     const staleSessionId = 'session-that-never-existed-2386';
 
-    const result = (await tickMutations.saveTick(
-      undefined,
-      { input: { ...baseInput, sessionId: staleSessionId } },
-      ctx(),
-    )) as TickRow;
+    let result: TickRow | undefined;
+    try {
+      result = (await tickMutations.saveTick(
+        undefined,
+        { input: { ...buildInput('tick-climb-session-fk-missing'), sessionId: staleSessionId } },
+        ctx(),
+      )) as TickRow;
 
-    expect(result.sessionId).toBeNull();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(staleSessionId));
+      expect(result.sessionId).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(staleSessionId));
 
-    const rows = await db.execute(sql`
-      SELECT session_id FROM boardsesh_ticks WHERE uuid = ${result.uuid}
-    `);
-    expect((rows as unknown as Array<{ session_id: string | null }>)[0].session_id).toBeNull();
-
-    warnSpy.mockRestore();
+      const rows = await db.execute(sql`
+        SELECT session_id FROM boardsesh_ticks WHERE uuid = ${result.uuid}
+      `);
+      expect((rows as unknown as Array<{ session_id: string | null }>)[0].session_id).toBeNull();
+    } finally {
+      warnSpy.mockRestore();
+      if (result) await deleteTick(result.uuid);
+    }
   });
 
   it('keeps a real sessionId association', async () => {
     const sessionId = 'session-2386-real';
     await insertSession(sessionId);
 
+    let result: TickRow | undefined;
     try {
-      const result = (await tickMutations.saveTick(
+      result = (await tickMutations.saveTick(
         undefined,
-        { input: { ...baseInput, sessionId } },
+        { input: { ...buildInput('tick-climb-session-fk-real'), sessionId } },
         ctx(),
       )) as TickRow;
 
@@ -302,6 +313,7 @@ describe('saveTick with a stale sessionId (#2386)', () => {
       `);
       expect((rows as unknown as Array<{ session_id: string | null }>)[0].session_id).toBe(sessionId);
     } finally {
+      if (result) await deleteTick(result.uuid);
       await deleteSession(sessionId);
     }
   });

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -554,6 +554,34 @@ export const tickMutations = {
       );
     }
 
+    // Resolve session_id. sessionId is a client-supplied string (SaveTickInputSchema
+    // has no format/existence/ownership check) that can outlive its session — the
+    // party session it names may have already ended, or (for an offline-replayed
+    // tick) may never have existed on this backend at all: the offline mutation
+    // outbox has no session-create entry, so a queued tick's sessionId is never
+    // guaranteed server-side. boardsesh_ticks.session_id has ON DELETE SET NULL,
+    // but that only protects rows that already reference a session at the moment
+    // it's deleted — it does nothing for a fresh INSERT naming an id that's
+    // already gone, which raises a raw FK violation and loses the whole tick
+    // (issue #2386). Same best-effort trade-off as the boardUuid/boardId
+    // resolution above: a stale/unknown sessionId records the tick unassociated
+    // rather than rejecting it. No ownership check — party-mode ticks legitimately
+    // reference sessions other users created.
+    let resolvedSessionId: string | null = null;
+    if (validatedInput.sessionId) {
+      const [session] = await db
+        .select({ id: dbSchema.boardSessions.id })
+        .from(dbSchema.boardSessions)
+        .where(eq(dbSchema.boardSessions.id, validatedInput.sessionId))
+        .limit(1);
+
+      if (session) {
+        resolvedSessionId = session.id;
+      } else {
+        logger.warn(`[saveTick] Dropping stale sessionId ${validatedInput.sessionId} — session not found`);
+      }
+    }
+
     // Run write-time beta-link validation before opening the transaction so a
     // bad video URL doesn't leave a half-state. Zod already validated the
     // surface shape; Instagram gets deep public/caption validation, while
@@ -611,7 +639,7 @@ export const tickMutations = {
           climbedAt,
           createdAt: now,
           updatedAt: now,
-          sessionId: validatedInput.sessionId ?? null,
+          sessionId: resolvedSessionId,
           boardId,
           // Aurora sync fields are null - will be populated by periodic sync job
           auroraType: null,
@@ -626,8 +654,8 @@ export const tickMutations = {
 
       if (!createdTick) return [];
 
-      if (validatedInput.sessionId) {
-        await tx.update(sessions).set({ lastActivity: new Date() }).where(eq(sessions.id, validatedInput.sessionId));
+      if (resolvedSessionId) {
+        await tx.update(sessions).set({ lastActivity: new Date() }).where(eq(sessions.id, resolvedSessionId));
       }
 
       // Attach the video URL as community beta for this climb if the user

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -554,19 +554,11 @@ export const tickMutations = {
       );
     }
 
-    // Resolve session_id. sessionId is a client-supplied string (SaveTickInputSchema
-    // has no format/existence/ownership check) that can outlive its session — the
-    // party session it names may have already ended, or (for an offline-replayed
-    // tick) may never have existed on this backend at all: the offline mutation
-    // outbox has no session-create entry, so a queued tick's sessionId is never
-    // guaranteed server-side. boardsesh_ticks.session_id has ON DELETE SET NULL,
-    // but that only protects rows that already reference a session at the moment
-    // it's deleted — it does nothing for a fresh INSERT naming an id that's
-    // already gone, which raises a raw FK violation and loses the whole tick
-    // (issue #2386). Same best-effort trade-off as the boardUuid/boardId
-    // resolution above: a stale/unknown sessionId records the tick unassociated
-    // rather than rejecting it. No ownership check — party-mode ticks legitimately
-    // reference sessions other users created.
+    // A stale/unknown sessionId (session ended, or never existed on this
+    // backend — e.g. an offline-replayed tick) would otherwise FK-violate the
+    // insert and lose the whole tick (#2386). Same best-effort drop-the-ref
+    // trade-off as the boardUuid/boardId resolution above; no ownership check,
+    // since party-mode ticks legitimately reference sessions other users made.
     let resolvedSessionId: string | null = null;
     if (validatedInput.sessionId) {
       const [session] = await db


### PR DESCRIPTION
## Summary

Fixes #2386. `saveTick` inserted `boardsesh_ticks.session_id` straight from client input (`sessionId: z.string().optional()` — no existence/ownership check), so a stale or never-created session id hit a raw Postgres FK violation and lost the whole tick. Traced the actual write paths (native `saveTick`, Aurora-sync `apply-user-logbook.ts`, MoonBoard import) — only `saveTick` ever sets `session_id`, and the FK is already `ON DELETE SET NULL` (both in `packages/db/src/schema/app/ascents.ts` and the applied migration `0025_fix_missing_tables.sql`), which only protects rows that already reference a session at delete time — it does nothing for a fresh `INSERT` naming an id that's already gone.

Fix mirrors the existing `boardUuid`/`boardId` best-effort resolution already in `saveTick`: look the session up before inserting, and if it doesn't exist, drop the reference (log a warning) instead of rejecting the tick. No schema/migration change — the FK behavior was already correct, just unused by the write path.

Scope note: no ownership check on the resolved session — party-mode ticks legitimately reference sessions other users created (matches the existing `entity-validation.ts` session-existence check, which is also ownership-agnostic).

**Escalation path if this recurs:** if the Sentry FK-violation signature from #2386 fires again after this ships, that would prove a live delete-race exists (session deleted between the validate lookup and the insert) rather than the stale/never-created-id cause this fix targets — at that point, catch Postgres `23503` on the `boardsesh_ticks_session_id_board_sessions_id_fk` constraint and retry the insert with `session_id: null` (needs a cause-chain-aware `isForeignKeyViolation` helper in `packages/backend/src/utils/postgres-errors.ts`, since drizzle-orm ≥0.44 wraps driver errors and the existing `room-manager/types.ts` version doesn't walk `.cause`). Deliberately not added speculatively — no code path in this repo hard-deletes a `board_sessions` row outside test cleanup SQL today.

## Release Notes

- Fixed a rare bug where logging a tick right as a party session wrapped up could silently fail to save — your tick is saved every time now, even if the session link can't be kept.

## Test plan

- Added `packages/backend/src/__tests__/sync-mutations.test.ts` — `describe('saveTick with a stale sessionId (#2386)', ...)`, real-Postgres integration tests:
  - a nonexistent `sessionId` is dropped and the tick still saves (`session_id IS NULL`), with a warning logged
  - a real `sessionId` keeps its association (regression/happy-path check)
- `vp run typecheck:backend`
- `vp test run --project backend`
- `vp check`