### PR TITLE
fix(mobile): quiet the board picker on mid-session reconnects

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -50,7 +50,7 @@ vi.mock('@boardsesh/ble-protocol', () => ({
 
 import { RNBleAdapter } from '../adapter';
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
-import { splitMessages } from '@boardsesh/ble-protocol';
+import { parseSerialNumber, splitMessages } from '@boardsesh/ble-protocol';
 import { State } from 'react-native-ble-plx';
 
 // ── Helpers ─────────────────────────────────────────────────────────────
@@ -930,6 +930,73 @@ describe('RNBleAdapter', () => {
         const error = await settled;
         expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toMatch(/no boards found/i);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('reconnects silently when the target re-advertises past the old 4s window but within the grace (#3609)', async () => {
+      vi.useFakeTimers();
+      try {
+        mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
+        mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
+
+        // Capture the scan callback so the test controls WHEN the board re-advertises.
+        const captured: Array<(error: unknown, device: unknown) => void> = [];
+        mockBleManager.startDeviceScan.mockImplementation(
+          (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
+            captured.push(callback);
+          },
+        );
+
+        // The re-advertised board parses to the reconnect target serial.
+        vi.mocked(parseSerialNumber).mockReturnValue('NEEDLE-SERIAL');
+
+        // A connectable board so the post-selection connect flow completes.
+        const characteristic = {
+          uuid: 'uart-write-uuid',
+          isWritableWithoutResponse: true,
+          writeWithoutResponse: vi.fn().mockResolvedValue(undefined),
+          writeWithResponse: vi.fn().mockResolvedValue(undefined),
+        };
+        const deviceWithServices = {
+          id: 'needle-device',
+          characteristicsForService: vi.fn().mockResolvedValue([characteristic]),
+          requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
+          discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
+        };
+        mockBleManager.connectToDevice.mockResolvedValue({
+          id: 'needle-device',
+          requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
+          discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(deviceWithServices),
+        });
+
+        let pickerOpened = false;
+        const devicePicker: DevicePickerFn = () => {
+          pickerOpened = true;
+          return new Promise<string>(() => {});
+        };
+        const adapter = new RNBleAdapter(devicePicker);
+        const connectPromise = adapter.requestAndConnect('NEEDLE-SERIAL');
+        await Promise.resolve();
+
+        // 6s in — past the OLD 4s grace, before the new 10s grace. With the old
+        // value the picker would already have flashed; it must not now (#3609).
+        await vi.advanceTimersByTimeAsync(6_000);
+        expect(pickerOpened).toBe(false);
+
+        // The board finally re-advertises → silent auto-select, still no picker.
+        captured[0](null, {
+          id: 'needle-device',
+          localName: 'Kilter Board#NEEDLE@3',
+          name: 'Kilter Board#NEEDLE@3',
+          rssi: -40,
+          serviceUUIDs: ['aurora-uuid'],
+        });
+
+        const connection = await connectPromise;
+        expect(pickerOpened).toBe(false);
+        expect(connection.deviceId).toBe('needle-device');
       } finally {
         vi.useRealTimers();
       }

--- a/packages/mobile/src/lib/ble/__tests__/last-connected-board-store.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/last-connected-board-store.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  let storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+      __reset: () => {
+        storage = {};
+      },
+    },
+  };
+});
+
+const board = { serial: 'ABC123', configKey: 'kilter::1::2' };
+
+describe('last-connected-board-store', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __reset: () => void;
+    };
+    asyncStorage.__reset();
+  });
+
+  it('round-trips the remembered board through storage', async () => {
+    const { getStoredLastConnectedBoard, setStoredLastConnectedBoard } = await import('../last-connected-board-store');
+    await setStoredLastConnectedBoard(board);
+    await expect(getStoredLastConnectedBoard()).resolves.toEqual(board);
+  });
+
+  it('returns null when nothing is stored', async () => {
+    const { getStoredLastConnectedBoard } = await import('../last-connected-board-store');
+    await expect(getStoredLastConnectedBoard()).resolves.toBeNull();
+  });
+
+  it('clears the remembered board (a deliberate disconnect forgets it)', async () => {
+    const { getStoredLastConnectedBoard, setStoredLastConnectedBoard, clearStoredLastConnectedBoard } =
+      await import('../last-connected-board-store');
+    await setStoredLastConnectedBoard(board);
+    await clearStoredLastConnectedBoard();
+    await expect(getStoredLastConnectedBoard()).resolves.toBeNull();
+  });
+
+  it('overwrites a previously remembered board', async () => {
+    const { getStoredLastConnectedBoard, setStoredLastConnectedBoard } = await import('../last-connected-board-store');
+    await setStoredLastConnectedBoard(board);
+    const other = { serial: 'XYZ789', configKey: 'tension::8::17' };
+    await setStoredLastConnectedBoard(other);
+    await expect(getStoredLastConnectedBoard()).resolves.toEqual(other);
+  });
+
+  it('ignores a malformed stored payload rather than returning garbage', async () => {
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default;
+    // A value from an older/foreign schema that parses but isn't a board shape.
+    await asyncStorage.setItem('boardsesh_last_connected_board_v1', JSON.stringify({ serial: 42 }));
+    const { getStoredLastConnectedBoard } = await import('../last-connected-board-store');
+    await expect(getStoredLastConnectedBoard()).resolves.toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -92,6 +92,16 @@ vi.mock('../adapter', () => ({
   RNBleAdapter: vi.fn(),
 }));
 
+// The remembered-board persistence store pulls in AsyncStorage transitively;
+// mock it so the hook's persist/hydrate wiring can be asserted without a native
+// module, and so its behaviour is observable via these spies (#3609).
+const mockLastConnectedBoardStore = vi.hoisted(() => ({
+  getStoredLastConnectedBoard: vi.fn(async (): Promise<{ serial: string; configKey: string } | null> => null),
+  setStoredLastConnectedBoard: vi.fn(async () => {}),
+  clearStoredLastConnectedBoard: vi.fn(async () => {}),
+}));
+vi.mock('../last-connected-board-store', () => mockLastConnectedBoardStore);
+
 // Spy on reportHandledError (keep the real noise-policy/other exports) so a
 // connect failure's Sentry tags can be asserted (#3480).
 vi.mock('../../error-reporting', async (importOriginal) => {
@@ -1333,6 +1343,97 @@ describe('useBoardBluetooth config-switch teardown', () => {
     });
     expect(fakeAdapter.disconnect).toHaveBeenCalled();
     expect(result.current.isConnected).toBe(false);
+  });
+});
+
+describe('useBoardBluetooth remembered-board persistence (#3609)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetReactNativePermissionHarness();
+    mockBleManager.state.mockResolvedValue('PoweredOn');
+    // Default device name 'Kilter Board#123@3' parses to serial '123'.
+    vi.mocked(parseSerialNumber).mockImplementation((name?: string) => name?.match(/#([^@]+)/)?.[1]);
+    // Reset the store spies (including any leftover once-implementations) to a
+    // clean "nothing stored" default so each test starts from the same baseline.
+    mockLastConnectedBoardStore.getStoredLastConnectedBoard.mockReset();
+    mockLastConnectedBoardStore.getStoredLastConnectedBoard.mockResolvedValue(null);
+    mockLastConnectedBoardStore.setStoredLastConnectedBoard.mockReset();
+    mockLastConnectedBoardStore.setStoredLastConnectedBoard.mockResolvedValue(undefined);
+    mockLastConnectedBoardStore.clearStoredLastConnectedBoard.mockReset();
+    mockLastConnectedBoardStore.clearStoredLastConnectedBoard.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.mocked(parseSerialNumber).mockReset();
+  });
+
+  it('persists the board on a successful connect', async () => {
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.reconnectSerialForCurrentBoard).toBe('123');
+    expect(mockLastConnectedBoardStore.setStoredLastConnectedBoard).toHaveBeenCalledWith({
+      serial: '123',
+      configKey: 'kilter::1::1',
+    });
+  });
+
+  it('clears the persisted board on a deliberate disconnect', async () => {
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    expect(result.current.reconnectSerialForCurrentBoard).toBe('123');
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(mockLastConnectedBoardStore.clearStoredLastConnectedBoard).toHaveBeenCalled();
+    expect(result.current.reconnectSerialForCurrentBoard).toBeNull();
+  });
+
+  it('rehydrates a stored board on mount, guarded by the active config', async () => {
+    // A board remembered for kilter/2/1 in a previous session (cold start).
+    mockLastConnectedBoardStore.getStoredLastConnectedBoard.mockResolvedValueOnce({
+      serial: '999',
+      configKey: 'kilter::2::1',
+    });
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result, rerender } = renderHook((props) => useBoardBluetooth(props), {
+      initialProps: { boardName: 'kilter', layoutId: 1, sizeId: 1 },
+    });
+
+    // While looking at a different config the stored board is never offered.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.reconnectSerialForCurrentBoard).toBeNull();
+
+    // Switching to the stored board's config offers the silent reconnect —
+    // hydrated from storage, no connect needed.
+    await act(async () => {
+      rerender({ boardName: 'kilter', layoutId: 2, sizeId: 1 });
+    });
+    await waitFor(() => expect(result.current.reconnectSerialForCurrentBoard).toBe('999'));
   });
 });
 

--- a/packages/mobile/src/lib/ble/last-connected-board-store.ts
+++ b/packages/mobile/src/lib/ble/last-connected-board-store.ts
@@ -1,0 +1,46 @@
+// The last board we held a BLE link to — its serial plus the board config it was
+// paired against — persisted in **unsecure** AsyncStorage (via preference-store)
+// so a one-tap silent reconnect survives a cold start or provider remount, not
+// just the in-memory session (#3609).
+//
+// This ONLY remembers the reconnect *target*; it never auto-connects. The
+// lightbulb tap reads it and reconnects by serial, keeping the deliberate,
+// user-initiated, no-auto-reconnect policy (bluetooth-provider.tsx) intact — so
+// it can't fight another climber for a last-connection-wins box.
+//
+// A deliberate disconnect forgets the board (clears this), matching the
+// in-memory `lastConnectedBoard` semantics in use-board-bluetooth.ts. Only an
+// involuntary drop or a config switch keeps the memory alive.
+//
+// The stored `configKey` is `boardConfigKey(boardName, layoutId, sizeId)`. The
+// caller only rehydrates when it matches the board currently in view, so a
+// serial recorded against a different board is never offered as a reconnect
+// target for the wrong config.
+
+import { getPreference, setPreference, removePreference } from '../preference-store';
+
+const LAST_CONNECTED_BOARD_KEY = 'boardsesh_last_connected_board_v1';
+
+export type StoredLastConnectedBoard = {
+  serial: string;
+  configKey: string;
+};
+
+function isStoredLastConnectedBoard(value: unknown): value is StoredLastConnectedBoard {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.serial === 'string' && typeof candidate.configKey === 'string';
+}
+
+export async function getStoredLastConnectedBoard(): Promise<StoredLastConnectedBoard | null> {
+  const stored = await getPreference<unknown>(LAST_CONNECTED_BOARD_KEY);
+  return isStoredLastConnectedBoard(stored) ? stored : null;
+}
+
+export function setStoredLastConnectedBoard(board: StoredLastConnectedBoard): Promise<void> {
+  return setPreference(LAST_CONNECTED_BOARD_KEY, board);
+}
+
+export function clearStoredLastConnectedBoard(): Promise<void> {
+  return removePreference(LAST_CONNECTED_BOARD_KEY);
+}

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -44,6 +44,11 @@ import { track } from '../analytics';
 import { reportHandledError } from '../error-reporting';
 import { clearBleDiagnosticsTags, setBleDiagnosticsTags } from '../sentry';
 import { buildHoldColorOverrideSignature, type HoldColorOverrides } from '../hold-color-overrides';
+import {
+  clearStoredLastConnectedBoard,
+  getStoredLastConnectedBoard,
+  setStoredLastConnectedBoard,
+} from './last-connected-board-store';
 
 // Exported for testing. Decides how a connect-failure category reaches error
 // tracking:
@@ -332,6 +337,20 @@ export function useBoardBluetooth({
   const [lastConnectedBoard, setLastConnectedBoard] = useState<{ serial: string; configKey: string } | null>(null);
   const lastConnectedBoardRef = useRef(lastConnectedBoard);
   lastConnectedBoardRef.current = lastConnectedBoard;
+
+  // Persist / forget the remembered board alongside the in-memory state so a
+  // one-tap silent reconnect survives a cold start or provider remount, not just
+  // the current session (#3609). Storage writes are fire-and-forget: a failure
+  // just means the next launch falls back to the picker, never a thrown error.
+  const rememberConnectedBoard = useCallback((serial: string, configKey: string) => {
+    const board = { serial, configKey };
+    setLastConnectedBoard(board);
+    void setStoredLastConnectedBoard(board).catch(() => {});
+  }, []);
+  const forgetConnectedBoard = useCallback(() => {
+    setLastConnectedBoard(null);
+    void clearStoredLastConnectedBoard().catch(() => {});
+  }, []);
 
   const adapterRef = useRef<BluetoothAdapter | null>(null);
   const apiLevelRef = useRef<number>(3);
@@ -839,7 +858,7 @@ export function useBoardBluetooth({
         // serial. Without a full config there is no usable key (and the
         // reconnect comparison against currentConfigKey could never match).
         if (parsedSerial && layoutId !== undefined && sizeId !== undefined) {
-          setLastConnectedBoard({ serial: parsedSerial, configKey: boardConfigKey(boardName, layoutId, sizeId) });
+          rememberConnectedBoard(parsedSerial, boardConfigKey(boardName, layoutId, sizeId));
         }
 
         // Send initial frames if provided; seed the AutoSender's dedup with
@@ -998,6 +1017,7 @@ export function useBoardBluetooth({
       onConnectionChange,
       onConnectSuccess,
       getConnectedViaMismatchOverride,
+      rememberConnectedBoard,
       sendFramesToBoard,
       sanitizedColorOverrides,
       colorSignature,
@@ -1032,10 +1052,11 @@ export function useBoardBluetooth({
 
   const disconnect = useCallback(async () => {
     // A deliberate disconnect forgets the board — only an involuntary drop or a
-    // config switch keeps the silent same-board reconnect memory alive.
-    setLastConnectedBoard(null);
+    // config switch keeps the silent same-board reconnect memory alive. Clears
+    // the persisted copy too so the next launch doesn't resurrect it.
+    forgetConnectedBoard();
     await teardownConnection();
-  }, [teardownConnection]);
+  }, [forgetConnectedBoard, teardownConnection]);
 
   // If the active board config changes while a connection is live, tear it down.
   // BluetoothProvider is mounted once globally; without this a board/layout/size
@@ -1118,7 +1139,7 @@ export function useBoardBluetooth({
 
       const serial = deviceName ? (parseSerialNumber(deviceName) ?? null) : (rememberedBoard?.serial ?? null);
       if (serial) {
-        setLastConnectedBoard({ serial, configKey: currentConfigKey });
+        rememberConnectedBoard(serial, currentConfigKey);
       }
       connectedConfigKeyRef.current = currentConfigKey;
       lastDisconnectInfoRef.current = null;
@@ -1169,6 +1190,7 @@ export function useBoardBluetooth({
     handleDisconnection,
     onConnectionChange,
     onConnectSuccess,
+    rememberConnectedBoard,
     sanitizedColorOverrides,
   ]);
 
@@ -1207,6 +1229,25 @@ export function useBoardBluetooth({
     lastConnectedBoard && currentConfigKey && lastConnectedBoard.configKey === currentConfigKey
       ? lastConnectedBoard.serial
       : null;
+
+  // Rehydrate the remembered board from storage on mount so a one-tap silent
+  // reconnect survives a cold start / provider remount, not just the in-memory
+  // session (#3609). A live connect that lands during the async read wins — only
+  // seed when nothing has been remembered yet. reconnectSerialForCurrentBoard
+  // self-guards on configKey, so a stored board for a different config is simply
+  // never offered as a reconnect target. This only sets the target for a user
+  // tap; it never auto-connects, so the no-auto-reconnect policy is untouched.
+  useEffect(() => {
+    let cancelled = false;
+    void getStoredLastConnectedBoard().then((stored) => {
+      if (cancelled || !stored) return;
+      if (lastConnectedBoardRef.current) return;
+      setLastConnectedBoard(stored);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Clean up on unmount
   useEffect(() => {

--- a/packages/shared/ble-protocol/src/__tests__/scan-constants.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/scan-constants.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '../scan-constants';
+
+describe('scan constants', () => {
+  it('gives a reconnecting board enough time to re-advertise before the picker (#3609)', () => {
+    // Aurora boxes routinely take longer than a few seconds to re-advertise
+    // after a link loss. The grace must be generous enough that a present board
+    // reconnects silently, or the "silent" reconnect flashes the picker on most
+    // mid-session reconnects.
+    expect(SERIAL_RECONNECT_GRACE_MS).toBe(10_000);
+  });
+
+  it('keeps the grace window well inside the overall scan window', () => {
+    // A genuinely-absent board must still reach the picker with live-scan time
+    // to spare. If a future edit ever inverts these two, the picker would only
+    // appear as the scan ends (or never), so pin the ordering.
+    expect(SERIAL_RECONNECT_GRACE_MS).toBeLessThan(SCAN_TIMEOUT_MS);
+  });
+});

--- a/packages/shared/ble-protocol/src/__tests__/scan-constants.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/scan-constants.test.ts
@@ -7,8 +7,10 @@ describe('scan constants', () => {
     // Aurora boxes routinely take longer than a few seconds to re-advertise
     // after a link loss. The grace must be generous enough that a present board
     // reconnects silently, or the "silent" reconnect flashes the picker on most
-    // mid-session reconnects.
-    expect(SERIAL_RECONNECT_GRACE_MS).toBe(10_000);
+    // mid-session reconnects. A lower bound guards against a regression back to
+    // the old 4s value without pinning an exact literal a deliberate future tune
+    // would trip.
+    expect(SERIAL_RECONNECT_GRACE_MS).toBeGreaterThanOrEqual(8_000);
   });
 
   it('keeps the grace window well inside the overall scan window', () => {

--- a/packages/shared/ble-protocol/src/scan-constants.ts
+++ b/packages/shared/ble-protocol/src/scan-constants.ts
@@ -3,10 +3,18 @@
 // no platform APIs.
 
 // How long a reconnect-by-serial waits for the stored board to advertise before
-// falling back to the picker. Short enough that a missing board surfaces the
-// picker quickly; long enough that a present board (which advertises within a
-// second or two) reconnects silently without the picker ever flashing.
-export const SERIAL_RECONNECT_GRACE_MS = 4_000;
+// falling back to the picker. Long enough that a present board reconnects
+// silently without the picker ever flashing, short enough that a genuinely
+// absent board still surfaces the picker well inside the scan window.
+//
+// Was 4s, but Aurora boxes routinely take longer than that to re-advertise
+// after a link loss, so the "silent" reconnect degraded into the device picker
+// on most mid-session reconnects (#3609). During this window the lightbulb shows
+// its pending state and no picker is mounted, so a longer grace is just a
+// slightly longer "connecting…", not a worse experience. Kept well below
+// SCAN_TIMEOUT_MS so a truly-gone board still reaches the picker with plenty of
+// live-scan time to spare.
+export const SERIAL_RECONNECT_GRACE_MS = 10_000;
 
 // How long the overall scan runs before it stops to avoid indefinite battery
 // drain. By this point a reconnect-by-serial has already handed off to the


### PR DESCRIPTION
## Summary

Fixes #3609 — the board picker popping up over and over mid-session on mobile.

The BLE link genuinely drops sometimes (RF, another climber grabbing a last-connection-wins box, the 26.5.x write stalls of #3235). That part is expected. The bug this fixes is the **recovery path**: a mid-session reconnect degraded into the full device picker far too eagerly, so sending a handful of climbs cost a dozen picker dismissals (replay `019f196f`: 16 climbs → 12 picker appearances; the healthy shape `019f61a2` is 1 connect / 51 sends / 1 disconnect).

Two JS-only fixes, both shippable over OTA:

1. **Stop the picker flashing 4s into a still-live scan.** A reconnect-by-serial silently degraded to the picker after only `SERIAL_RECONNECT_GRACE_MS = 4_000`, even though the scan keeps running for 30s and the remembered serial would still match a moment later. Aurora boxes routinely take longer than 4s to re-advertise after a link loss, so the "silent" reconnect flashed the picker on most reconnects. Bumped the grace to **10s** — during that window the lightbulb shows its pending state and no picker is mounted, so it's just a slightly longer "connecting…", and a genuinely-absent board still reaches the picker with 20s of live scan to spare.
2. **Remember the board across a cold start / provider remount.** `lastConnectedBoard` was in-memory only, so an app restart or remount dropped straight to the picker. Now persisted (AsyncStorage, config-keyed) so a one-tap silent reconnect survives. It only sets the reconnect *target* for a user tap — it never auto-connects, so the deliberate, no-auto-reconnect policy (and the two-phone ping-pong concern) is untouched. A deliberate disconnect still forgets the board (clears the persisted copy too).

### Evidence (PostHog, 14d, `$lib=posthog-react-native`)

- Reconnect scans: 2,304 across 562 sessions (~4 per reconnecting session), 26% of all BLE scans — the mid-session reconnect loop.
- `user_cancelled` picker dismissals are 79% of all connection failures (1,290 of 1,646).
- Sessions with a reconnect scan dismiss the picker ~0.70×/session vs 0.45× for those without — despite already holding the serial to reconnect silently. So the churn is the recovery degrading, not lost memory.

### Not in scope (deliberate)

- **No auto-reconnect.** The no-auto-reconnect policy (`bluetooth-provider.tsx`, native `BoardBleManager.swift`) stays. Every change here keeps reconnect a user-initiated lightbulb tap.
- The shared grace constant is re-exported by web (`packages/web/app/lib/ble/scan-constants.ts`), which has the same reconnect fallback, so web benefits identically. Web adapter tests reference the constant symbolically, so nothing pins the old literal.

### Follow-ups (not done here)

- **MoonBoard silent reconnect.** MoonBoard device names carry no parseable serial, so reconnect-by-serial can never fire for them (consistent with 41/65 `board_not_found` being MoonBoard). A serial-free identity from advertisement manufacturer/service data (`advertisement-recon.ts`) is the hook — separate issue, needs device validation.
- **Adaptive grace** (extend only while a correct-family board is visible) — only if the flat 10s proves insufficient in telemetry.

### Open question for @marcodejongh (UX call, follow-up)

About half the mid-session churn is **user-initiated** disconnects (1,103 of 2,322 in churn sessions carry `reason='user'`). The likely mechanism: when connected, a lightbulb tap = disconnect, and users appear to cycle the link as a workaround for dark sends. Compounding it, a deliberate disconnect *forgets* the remembered board, so the very next re-tap goes through the full picker. We intentionally did **not** change that semantic in this PR. The lever, if you want it: keep the remembered board for the same board config across a deliberate disconnect, so an off→on tap reconnects silently instead of re-picking. That's a UX behaviour change (disconnect currently means "forget"), so it's your call as a follow-up.

## Release Notes

- Reconnecting to your board mid-session is quieter now — tap the lightbulb and it slips back onto the same box instead of throwing the board picker at you every few climbs, and it remembers your board across app restarts.

## Test plan

- `vp run typecheck:mobile` — green.
- `vp run test:mobile` — green (new: remembered-board persistence cases in `use-board-bluetooth.test.ts`; silent-reconnect-within-grace regression in `adapter.test.ts`; new `last-connected-board-store.test.ts`).
- `vp test run` for `@boardsesh/ble-protocol` scan-constants invariant test and web `capacitor-adapter.test.ts` (shared constant) — green.
- `vp run check:mobile-bundle` — green.
- Changes are JS-only → ships via OTA; no native rebuild needed.
