### PR TITLE
perf(mobile): keep Android/iPad tab trees resident; freeze blurred iOS tabs

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -159,7 +159,8 @@ vi.mock('expo-router', () => {
           'data-tabs-material': 'true',
           // Surface the #3153 residency props so tests can pin the platform matrix.
           'data-detach-inactive-screens': detachInactiveScreens === undefined ? 'unset' : String(detachInactiveScreens),
-          'data-freeze-on-blur': screenOptions?.freezeOnBlur === undefined ? 'unset' : String(screenOptions.freezeOnBlur),
+          'data-freeze-on-blur':
+            screenOptions?.freezeOnBlur === undefined ? 'unset' : String(screenOptions.freezeOnBlur),
         },
         children,
       ),

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -144,7 +144,25 @@ vi.mock('../../../src/hooks/use-bottom-accessory', () => ({
 // Stub the Material-variant path so it doesn't pull in native modules.
 vi.mock('expo-router', () => {
   const Tabs = Object.assign(
-    ({ children }: { children?: ReactNode }) => createElement('nav', { 'data-tabs-material': 'true' }, children),
+    ({
+      children,
+      detachInactiveScreens,
+      screenOptions,
+    }: {
+      children?: ReactNode;
+      detachInactiveScreens?: boolean;
+      screenOptions?: { freezeOnBlur?: boolean };
+    }) =>
+      createElement(
+        'nav',
+        {
+          'data-tabs-material': 'true',
+          // Surface the #3153 residency props so tests can pin the platform matrix.
+          'data-detach-inactive-screens': detachInactiveScreens === undefined ? 'unset' : String(detachInactiveScreens),
+          'data-freeze-on-blur': screenOptions?.freezeOnBlur === undefined ? 'unset' : String(screenOptions.freezeOnBlur),
+        },
+        children,
+      ),
     {
       Screen: ({ name, options }: { name: string; options?: { lazy?: boolean } }) => {
         const screen = { name, options };
@@ -597,6 +615,53 @@ describe('TabLayout', () => {
     render(<TabLayout />);
 
     expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options).toMatchObject({ lazy: false });
+  });
+
+  // #3153: Android/iPad keep blurred tabs' native trees resident (detach off) so a
+  // switch is a re-attach, not a Fabric rebuild; iOS < 26 iPhones stay on default
+  // detach where freezeOnBlur actually takes effect.
+  it('keeps Android tabs resident with freeze declared (#3153)', () => {
+    cfg.variant = 'material';
+    cfg.platformOS = 'android';
+
+    const { container } = render(<TabLayout />);
+    const materialNav = container.querySelector('[data-tabs-material="true"]');
+
+    expect(materialNav?.getAttribute('data-detach-inactive-screens')).toBe('false');
+    expect(materialNav?.getAttribute('data-freeze-on-blur')).toBe('true');
+  });
+
+  it('leaves iOS < 26 iPhones on default detach with freeze active (#3153)', () => {
+    cfg.variant = 'liquidGlass';
+    cfg.glassCapable = false;
+    cfg.platformOS = 'ios';
+
+    const { container } = render(<TabLayout />);
+    const materialNav = container.querySelector('[data-tabs-material="true"]');
+
+    expect(materialNav?.getAttribute('data-detach-inactive-screens')).toBe('unset');
+    expect(materialNav?.getAttribute('data-freeze-on-blur')).toBe('true');
+  });
+
+  it('keeps iPad shell tabs resident (#3153)', () => {
+    cfg.widthClass = 'regular';
+
+    const { container } = render(<TabLayout />);
+    const materialNav = container.querySelector('[data-tabs-material="true"]');
+
+    expect(materialNav?.getAttribute('data-detach-inactive-screens')).toBe('false');
+    expect(materialNav?.getAttribute('data-freeze-on-blur')).toBe('true');
+  });
+
+  it('keeps residency props off the iOS 26 NativeTabs path (#3153)', () => {
+    cfg.variant = 'liquidGlass';
+    cfg.glassCapable = true;
+    cfg.platformOS = 'ios';
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-tabs="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-tabs-material="true"]')).toBeNull();
   });
 
   it('renders the Record badge when a session is active', () => {

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -50,6 +50,13 @@ const materialTabIcon =
 // navigation), while the navigator still owns routing + per-tab state.
 const renderHiddenTabBar = () => null;
 
+// freezeOnBlur only takes effect where inactive screens stay detach-managed
+// (iOS < 26 iPhone). It's inert where detachInactiveScreens={false} below, because
+// react-native-screens' Screen.js gates DelayedFreeze behind `enabled` (the detach
+// flag): enabled=false renders a plain display:none View, skipping freeze
+// (react-native-screens Screen.js:63,123).
+const JS_TABS_SCREEN_OPTIONS = { headerShown: false, freezeOnBlur: true } as const;
+
 /**
  * Bottom tabs. The system Liquid Glass tab bar (`expo-router/unstable-native-tabs`)
  * — with a native `BottomAccessory` platter for the current climb + tick — is used
@@ -92,6 +99,11 @@ export default function TabLayout() {
   const onAccessorySurface = useOnAccessorySurface();
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
   const eagerMountRecord = Platform.OS === 'android';
+  // Keep blurred tabs' native (Fabric) trees resident on Android so a tab switch is a
+  // re-attach, not a createNode/completeRoot rebuild (#3153). Android-only: on iOS < 26
+  // iPhones keeping every tab resident would add to the 4GB-device board-art OOM risk
+  // (#3479, docs/react-native-performance.md §7), so those stay on the default + freeze.
+  const keepInactiveTabsResident = Platform.OS === 'android';
   // Regular-width iPad opts into the sidebar shell; compact width (every iPhone,
   // a narrow iPad split) keeps the native / Material tab bars below verbatim.
   // (deviceLayout.expanded is computed but intentionally unconsumed here — it's
@@ -233,7 +245,10 @@ export default function TabLayout() {
     const tabsNavigator = (
       <Tabs
         tabBar={isRegular ? renderHiddenTabBar : (props) => <MaterialTabBar {...props} />}
-        screenOptions={{ headerShown: false }}
+        screenOptions={JS_TABS_SCREEN_OPTIONS}
+        // iPads have the RAM headroom, and the sidebar shell hits the same
+        // detach-and-rebuild cost on every destination change (#3153).
+        detachInactiveScreens={false}
       >
         {tabScreens}
       </Tabs>
@@ -276,7 +291,11 @@ export default function TabLayout() {
 
   if (!nativeTabBar) {
     return (
-      <Tabs tabBar={(props) => <MaterialTabBar {...props} />} screenOptions={{ headerShown: false }}>
+      <Tabs
+        tabBar={(props) => <MaterialTabBar {...props} />}
+        screenOptions={JS_TABS_SCREEN_OPTIONS}
+        detachInactiveScreens={keepInactiveTabsResident ? false : undefined}
+      >
         {tabScreens}
       </Tabs>
     );


### PR DESCRIPTION
## Summary

Fixes #3153. Supersedes PR #3318 (same core fix, authored before the tabs-file restructure and now `CONFLICTING`; this rebuild also covers the iPad shell — see below).

On Android, switching bottom tabs destroys and rebuilds each tab's native (Fabric) view tree — a `createNode`/`completeRoot`/`appendChild` burst on every switch, worst on the You tab's ~5 SVG charts. Profiling on a physical Pixel 8 (Hermes CPU sampling) showed the tab-nav flow spending ~61% of JS-thread wall time on that Fabric node work. Root cause: expo-router's vendored bottom-tabs defaults `detachInactiveScreens` to `true` on Android, so a blurred tab's native subtree is detached/destroyed and rebuilt on re-focus.

## What changed (`packages/mobile/app/(tabs)/_layout.tsx`)

- `detachInactiveScreens={false}` on the JS `Tabs` navigators for **Android phones** and **both iPad shell chromes** — inactive tabs stay resident, so a switch is a cheap re-attach instead of a full rebuild.
- `freezeOnBlur: true` in the shared `JS_TABS_SCREEN_OPTIONS` — active on the **iOS < 26 iPhone** path, where screens stay detach-managed.
- iOS 26 `NativeTabs` path and the Record-tab `lazy: false` Android workaround: untouched.

## ⚠️ Correction to the issue's proposed pairing (and PR #3318's composition claim)

The issue proposed `freezeOnBlur: true` + `detachInactiveScreens: false` as a *pair* ("freeze keeps the resident tree from wasting CPU"). **In this stack that pairing is self-defeating:** `detachInactiveScreens={false}` passes `enabled={false}` to every `<Screen>`, and react-native-screens `Screen.js` only runs the `DelayedFreeze` path inside `if (enabled && isNativePlatformSupported)` (line 63; `freeze = freezeOnBlur && shouldFreeze` at line 123). With `enabled=false` it renders a plain `display:none` `Animated.View` — `freezeOnBlur` is never read. Verified against the exact vendored versions this app resolves (`expo-router@57.0.3`, `react-native-screens@4.25.2`; the repo's RNS patch touches only iOS native scroll/tabs-host files, not this JS logic).

So: the real fix on Android/iPad is `detachInactiveScreens:false` alone (resident trees toggled via `display:none`); `freezeOnBlur:true` is kept where it actually applies (iOS < 26). Documented inline in the code.

## Result matrix

| Path | detach | freeze | Effect |
|---|---|---|---|
| Android phone (Material JS tabs) | `false` | declared (inert) | resident trees — re-attach, no rebuild |
| iPad shell (both chromes) | `false` | declared (inert) | resident trees — sidebar/Material switches stop rebuilding |
| iOS < 26 iPhone (JS fallback) | default (`true`) | **active** | blurred tabs stop processing; default detach keeps the 4GB-device board-art OOM surface (#3479) unchanged |
| iOS 26 NativeTabs | n/a | n/a | untouched (UIKit-managed) |

## Safety

All live-session state (BLE, session timer, WebSocket queue sync, Live Activity) lives in root providers **above** `(tabs)` in `app/_layout.tsx` — hiding/freezing a tab screen can't break a session; refocus re-renders from live provider state. Memory growth is bounded to *visited* tabs (lazy stays default-on for all but Record-on-Android).

## Tests

`tab-layout.test.tsx` — widened the expo-router `Tabs` mock to surface the residency props, then pinned the matrix: Android → detach `false` + freeze `true`; iOS < 26 → detach unset + freeze `true`; iPad shell → detach `false`; NativeTabs path renders no JS-Tabs nav (scope guard). 31/31 pass.

## Validation

- `vp run typecheck:mobile` ✓
- `vp run test:mobile` — tab-layout 31/31 ✓; full suite 473/475 files, the 2 failures are `EditProfileScreen`/`licenses` 5s-timeout flakes under a load-avg-~100 shared box (fail differently across runs, untouched by this diff — CI is the clean arbiter)
- `vp run check:mobile-bundle` ✓
- Pre-commit `vp check --fix` ✓

## Delivery & follow-ups

- **OTA-deliverable**: JS-only, no fingerprint change — rides the production OTA on merge.
- **@marcodejongh**: the definitive before/after `createNode`/`completeRoot` reduction needs a Hermes CPU re-profile on your Pixel 8 post-merge (Linux CI can't do it). The issue's own note about a release-build re-profile still applies.
- **Non-goal** (explicitly out of scope): the `discover/index.tsx` focus-refetch staleness guard from the issue's "minor adjacent" note — orthogonal to the Fabric rebuild, deserves its own small PR.
- PR #3318 can be closed in favor of this one.

## Release Notes

**Android: instant tab switching.** Hopping between Home, Climbs, and You no longer rebuilds the screen every time — the app keeps each tab ready, so switching is immediate instead of stuttering on the charts-heavy You tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va
