### PR TITLE
fix(shared): ride out GraphQL rate limits on reconnect (#2655)

### DIFF
--- a/packages/shared/graphql-client/src/__tests__/errors.test.ts
+++ b/packages/shared/graphql-client/src/__tests__/errors.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { GraphQLOperationError, parseRateLimitError, isRateLimitedError } from '../errors';
+
+describe('parseRateLimitError', () => {
+  it('reads retryAfterSeconds from the structured RATE_LIMITED extension', () => {
+    const error = new GraphQLOperationError([
+      {
+        message: 'Rate limit exceeded. Try again in 4 seconds.',
+        extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 4 },
+      },
+    ]);
+    expect(parseRateLimitError(error)).toEqual({ retryAfterSeconds: 4 });
+    expect(isRateLimitedError(error)).toBe(true);
+  });
+
+  it('finds a RATE_LIMITED error even when it is not the first in the array', () => {
+    const error = new GraphQLOperationError([
+      { message: 'other' },
+      {
+        message: 'Rate limit exceeded. Try again in 9 seconds.',
+        extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 9 },
+      },
+    ]);
+    expect(parseRateLimitError(error)).toEqual({ retryAfterSeconds: 9 });
+  });
+
+  it('falls back to the message when there is no extension code (legacy server)', () => {
+    const error = new GraphQLOperationError([{ message: 'Rate limit exceeded. Try again in 6 seconds.' }]);
+    expect(parseRateLimitError(error)).toEqual({ retryAfterSeconds: 6 });
+  });
+
+  it('parses a plain Error whose message matches the rate-limit shape', () => {
+    expect(parseRateLimitError(new Error('Rate limit exceeded. Try again in 2 seconds.'))).toEqual({
+      retryAfterSeconds: 2,
+    });
+  });
+
+  it('returns null for a non-rate-limit GraphQL error', () => {
+    const error = new GraphQLOperationError([{ message: 'nope', extensions: { code: 'BAD_USER_INPUT' } }]);
+    expect(parseRateLimitError(error)).toBeNull();
+    expect(isRateLimitedError(error)).toBe(false);
+  });
+
+  it('returns null for unrelated errors and non-errors', () => {
+    expect(parseRateLimitError(new Error('network down'))).toBeNull();
+    expect(parseRateLimitError('rate limit exceeded. try again in 1 seconds.')).toBeNull();
+    expect(parseRateLimitError(null)).toBeNull();
+  });
+});

--- a/packages/shared/graphql-client/src/__tests__/execute.test.ts
+++ b/packages/shared/graphql-client/src/__tests__/execute.test.ts
@@ -100,3 +100,149 @@ describe('execute', () => {
     clearSpy.mockRestore();
   });
 });
+
+// Scripted client: delivers the next scripted response on each `subscribe` call
+// (one per execute attempt), via a microtask so it lands after `execute` wires
+// its sink. Runs with real timers — the retry `sleep` is injected as immediate.
+type ScriptResponse =
+  | { kind: 'data'; data: unknown }
+  | { kind: 'errors'; errors: Array<{ message: string; extensions?: Record<string, unknown> }> };
+
+function makeScriptedClient(script: ScriptResponse[]) {
+  let call = 0;
+  const subscribeSpy = vi.fn((_op: unknown, sink: Sink) => {
+    const response = script[Math.min(call, script.length - 1)];
+    call += 1;
+    queueMicrotask(() => {
+      if (response.kind === 'data') {
+        sink.next?.({ data: response.data } as Parameters<NonNullable<Sink['next']>>[0]);
+        sink.complete?.();
+      } else {
+        sink.next?.({ data: null, errors: response.errors } as Parameters<NonNullable<Sink['next']>>[0]);
+      }
+    });
+    return vi.fn();
+  });
+  const client = {
+    subscribe: subscribeSpy,
+    on: () => () => {},
+    iterate: () => {
+      throw new Error('not used');
+    },
+    dispose: async () => {},
+    terminate: () => {},
+  } as unknown as Client;
+  return { client, subscribeSpy };
+}
+
+const immediateSleep = () => Promise.resolve();
+
+const rateLimited = (retryAfterSeconds: number): ScriptResponse => ({
+  kind: 'errors',
+  errors: [
+    {
+      message: `Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`,
+      extensions: { code: 'RATE_LIMITED', retryAfterSeconds },
+    },
+  ],
+});
+
+describe('execute — rate-limit retry (#2655)', () => {
+  it('retries a RATE_LIMITED rejection and resolves on the retry, honouring retryAfterSeconds', async () => {
+    const { client, subscribeSpy } = makeScriptedClient([rateLimited(1), { kind: 'data', data: { ok: true } }]);
+    const onRateLimited = vi.fn();
+
+    const result = await execute<{ ok: boolean }>(
+      client,
+      { query: 'mutation Foo { ok }' },
+      { sleep: immediateSleep, rateLimitJitterMs: 0, onRateLimited },
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(subscribeSpy).toHaveBeenCalledTimes(2);
+    expect(onRateLimited).toHaveBeenCalledTimes(1);
+    expect(onRateLimited).toHaveBeenCalledWith({
+      attempt: 1,
+      maxAttempts: 2,
+      retryAfterMs: 1000,
+      operationName: 'Foo',
+    });
+  });
+
+  it('caps the retry wait at maxRateLimitDelayMs', async () => {
+    const { client } = makeScriptedClient([rateLimited(120), { kind: 'data', data: { ok: true } }]);
+    const onRateLimited = vi.fn();
+
+    await execute(
+      client,
+      { query: 'mutation Foo { ok }' },
+      { sleep: immediateSleep, rateLimitJitterMs: 0, maxRateLimitDelayMs: 30_000, onRateLimited },
+    );
+
+    expect(onRateLimited).toHaveBeenCalledWith(expect.objectContaining({ retryAfterMs: 30_000 }));
+  });
+
+  it('gives up after the retry budget and rejects with the classifiable error', async () => {
+    const { client, subscribeSpy } = makeScriptedClient([rateLimited(2)]);
+
+    const promise = execute(
+      client,
+      { query: 'mutation Foo { ok }' },
+      { rateLimitRetries: 2, sleep: immediateSleep, rateLimitJitterMs: 0 },
+    );
+
+    await expect(promise).rejects.toBeInstanceOf(GraphQLOperationError);
+    await expect(promise).rejects.toMatchObject({ extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 2 } });
+    // initial attempt + 2 retries
+    expect(subscribeSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a non-rate-limit GraphQL error', async () => {
+    const { client, subscribeSpy } = makeScriptedClient([
+      { kind: 'errors', errors: [{ message: 'boom', extensions: { code: 'NOPE' } }] },
+    ]);
+
+    await expect(execute(client, { query: 'mutation Foo { ok }' }, { sleep: immediateSleep })).rejects.toMatchObject({
+      extensions: { code: 'NOPE' },
+    });
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rateLimitRetries: 0 surfaces the rate-limit error immediately', async () => {
+    const { client, subscribeSpy } = makeScriptedClient([rateLimited(3)]);
+
+    await expect(
+      execute(client, { query: 'mutation Foo { ok }' }, { rateLimitRetries: 0, sleep: immediateSleep }),
+    ).rejects.toBeInstanceOf(GraphQLOperationError);
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('recognises a legacy message-only rate limit (no extension) and retries', async () => {
+    const { client } = makeScriptedClient([
+      { kind: 'errors', errors: [{ message: 'Rate limit exceeded. Try again in 5 seconds.' }] },
+      { kind: 'data', data: { ok: true } },
+    ]);
+    const onRateLimited = vi.fn();
+
+    const result = await execute<{ ok: boolean }>(
+      client,
+      { query: 'mutation Foo { ok }' },
+      { sleep: immediateSleep, rateLimitJitterMs: 0, onRateLimited },
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(onRateLimited).toHaveBeenCalledWith(expect.objectContaining({ retryAfterMs: 5000 }));
+  });
+
+  it('gives each attempt a fresh timeout so the back-off wait cannot trip it', async () => {
+    const { client } = makeScriptedClient([rateLimited(1), { kind: 'data', data: { ok: true } }]);
+    // Short per-attempt timeout; the retry still succeeds because attempt 2 gets
+    // its own timer and the wait happens outside any timer.
+    const result = await execute<{ ok: boolean }>(
+      client,
+      { query: 'mutation Foo { ok }' },
+      { timeoutMs: 50, sleep: immediateSleep, rateLimitJitterMs: 0 },
+    );
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/packages/shared/graphql-client/src/__tests__/subscribe.test.ts
+++ b/packages/shared/graphql-client/src/__tests__/subscribe.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Client, Sink } from 'graphql-ws';
+import { subscribe } from '../subscribe';
+import { GraphQLOperationError, isRateLimitedError } from '../errors';
+
+type FakeClient = Client & {
+  emit: (payload: Parameters<NonNullable<Sink['next']>>[0]) => void;
+  emitError: (err: unknown) => void;
+};
+
+function makeFakeClient(): FakeClient {
+  let currentSink: Sink | null = null;
+  const client = {
+    subscribe: (_op: unknown, sink: Sink) => {
+      currentSink = sink;
+      return vi.fn();
+    },
+    on: () => () => {},
+    iterate: () => {
+      throw new Error('not used');
+    },
+    dispose: async () => {},
+    terminate: () => {},
+  } as unknown as Client;
+
+  return Object.assign(client, {
+    emit: (payload: Parameters<NonNullable<Sink['next']>>[0]) => currentSink?.next?.(payload),
+    emitError: (err: unknown) => currentSink?.error?.(err),
+  }) as FakeClient;
+}
+
+function makeSink(): Sink<unknown> {
+  return { next: vi.fn(), error: vi.fn(), complete: vi.fn() };
+}
+
+describe('subscribe', () => {
+  it('forwards data to sink.next', () => {
+    const client = makeFakeClient();
+    const sink = makeSink();
+    subscribe(client, { query: 'subscription Foo { ok }' }, sink);
+
+    client.emit({ data: { ok: true } });
+
+    expect(sink.next).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('forwards data.errors as a classifiable GraphQLOperationError (RATE_LIMITED preserved)', () => {
+    const client = makeFakeClient();
+    const sink = makeSink();
+    subscribe(client, { query: 'subscription Foo { ok }' }, sink);
+
+    client.emit({
+      data: null,
+      errors: [
+        {
+          message: 'Rate limit exceeded. Try again in 7 seconds.',
+          extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 7 },
+        },
+      ],
+    });
+
+    expect(sink.error).toHaveBeenCalledWith(expect.any(GraphQLOperationError));
+    const forwarded = (sink.error as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(isRateLimitedError(forwarded)).toBe(true);
+    expect(forwarded).toMatchObject({ extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 7 } });
+  });
+
+  it('preserves non-rate-limit extensions in the forwarded error', () => {
+    const client = makeFakeClient();
+    const sink = makeSink();
+    subscribe(client, { query: 'subscription Foo { ok }' }, sink);
+
+    client.emit({ data: null, errors: [{ message: 'bad', extensions: { code: 'NOPE' } }] });
+
+    expect(sink.error).toHaveBeenCalledWith(expect.any(GraphQLOperationError));
+    expect((sink.error as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({ extensions: { code: 'NOPE' } });
+  });
+
+  it('forwards an error-callback GraphQLError array as GraphQLOperationError', () => {
+    const client = makeFakeClient();
+    const sink = makeSink();
+    subscribe(client, { query: 'subscription Foo { ok }' }, sink);
+
+    client.emitError([
+      {
+        message: 'Rate limit exceeded. Try again in 3 seconds.',
+        extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 3 },
+      },
+    ]);
+
+    const forwarded = (sink.error as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(forwarded).toBeInstanceOf(GraphQLOperationError);
+    expect(isRateLimitedError(forwarded)).toBe(true);
+  });
+
+  it('coerces a raw DOM error event into a proper Error', () => {
+    const client = makeFakeClient();
+    const sink = makeSink();
+    subscribe(client, { query: 'subscription Foo { ok }' }, sink);
+
+    client.emitError({ type: 'error' });
+
+    const forwarded = (sink.error as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(forwarded).toBeInstanceOf(Error);
+    expect(forwarded).not.toBeInstanceOf(GraphQLOperationError);
+  });
+});

--- a/packages/shared/graphql-client/src/constants.ts
+++ b/packages/shared/graphql-client/src/constants.ts
@@ -15,3 +15,29 @@ export const KEEP_ALIVE_MS = 5000;
 
 /** Default timeout applied to a single `execute()` call. */
 export const MUTATION_TIMEOUT_MS = 30_000;
+
+/**
+ * How many times `execute()` re-sends a mutation the backend rejected with
+ * `RATE_LIMITED`. Safe to retry because the rate-limit gate throws BEFORE the
+ * resolver does any work (see `applyRateLimit` in the backend), so a throttled
+ * attempt has no side effect. Bounded so a persistently-throttled op still
+ * fails rather than hammering the server forever.
+ */
+export const RATE_LIMIT_MAX_RETRIES = 2;
+
+/** Wait before the first rate-limit retry when the server sent no `retryAfterSeconds` (ms). */
+export const RATE_LIMIT_FALLBACK_DELAY_MS = 1000;
+
+/** Upper bound on a single rate-limit retry wait, even if the server asks for longer (ms). */
+export const RATE_LIMIT_MAX_WAIT_MS = 30_000;
+
+/** Random jitter added to each rate-limit retry wait so a burst of clients de-syncs (ms). */
+export const RATE_LIMIT_RETRY_JITTER_MS = 250;
+
+/**
+ * Fraction of the transport reconnect backoff turned into random jitter, so a
+ * fleet of clients that all dropped at once (backend restart) doesn't reconnect
+ * in lockstep and re-trip the rate limiter in synchronized waves. A value of
+ * 0.5 spreads each attempt over [0.5·delay, delay].
+ */
+export const RECONNECT_JITTER_RATIO = 0.5;

--- a/packages/shared/graphql-client/src/create-client.ts
+++ b/packages/shared/graphql-client/src/create-client.ts
@@ -1,5 +1,11 @@
 import { type Client, createClient } from 'graphql-ws';
-import { INITIAL_RETRY_DELAY_MS, MAX_RETRY_DELAY_MS, BACKOFF_MULTIPLIER, KEEP_ALIVE_MS } from './constants';
+import {
+  INITIAL_RETRY_DELAY_MS,
+  MAX_RETRY_DELAY_MS,
+  BACKOFF_MULTIPLIER,
+  KEEP_ALIVE_MS,
+  RECONNECT_JITTER_RATIO,
+} from './constants';
 
 export type ExtendedClient = {
   onReconnect?: (callback: () => void) => void;
@@ -73,7 +79,12 @@ export function createGraphQLClient(options: CreateGraphQLClientOptions): Extend
     retryAttempts: 10,
     shouldRetry: shouldRetry ?? (() => true),
     retryWait: async (retryCount) => {
-      const delay = Math.min(INITIAL_RETRY_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, retryCount), MAX_RETRY_DELAY_MS);
+      // Exponential backoff with jitter. Without the jitter, a fleet that all
+      // dropped at once (backend restart) reconnects in lockstep and re-trips
+      // the per-user rate limiter in synchronized waves; spreading each attempt
+      // over [0.5·delay, delay] de-syncs the herd (#2655).
+      const base = Math.min(INITIAL_RETRY_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, retryCount), MAX_RETRY_DELAY_MS);
+      const delay = base - Math.random() * RECONNECT_JITTER_RATIO * base;
       await new Promise((resolve) => setTimeout(resolve, delay));
     },
     lazy: true,

--- a/packages/shared/graphql-client/src/errors.ts
+++ b/packages/shared/graphql-client/src/errors.ts
@@ -66,3 +66,49 @@ export class GraphQLOperationError extends Error {
     this.extensions = coded?.extensions ?? graphqlErrors[0]?.extensions ?? null;
   }
 }
+
+/**
+ * Legacy message shape the backend emits alongside the `RATE_LIMITED` code —
+ * kept as a fallback so a pre-#2763 server (code-less throw) or a subscription
+ * error that arrives message-only is still recognised as a rate limit. Mirrors
+ * `RateLimitError`'s message in `packages/backend/src/utils/rate-limiter.ts`.
+ */
+const RATE_LIMIT_MESSAGE_RE = /rate limit exceeded\.\s*try again in (\d+)\s*seconds?\./i;
+
+export type ParsedRateLimit = {
+  /** Seconds until the window resets, or null when the server didn't say. */
+  retryAfterSeconds: number | null;
+};
+
+/**
+ * Classify an error thrown by `execute()`/`subscribe()` as a rate-limit
+ * rejection. Prefers the structured `RATE_LIMITED` extension (with
+ * `retryAfterSeconds`), falling back to the human-readable message so a
+ * pre-#2763 server is still handled. Returns `null` for anything that isn't a
+ * rate limit — callers use that to decide whether to back off and retry.
+ */
+export function parseRateLimitError(error: unknown): ParsedRateLimit | null {
+  if (error instanceof GraphQLOperationError) {
+    if (isRateLimitedExtension(error.extensions)) {
+      return { retryAfterSeconds: error.extensions.retryAfterSeconds ?? null };
+    }
+    for (const graphqlError of error.graphqlErrors) {
+      if (graphqlError.extensions?.code === 'RATE_LIMITED') {
+        const { retryAfterSeconds } = graphqlError.extensions;
+        return { retryAfterSeconds: typeof retryAfterSeconds === 'number' ? retryAfterSeconds : null };
+      }
+    }
+    const messageMatch = error.message.match(RATE_LIMIT_MESSAGE_RE);
+    return messageMatch ? { retryAfterSeconds: Number(messageMatch[1]) } : null;
+  }
+  if (error instanceof Error) {
+    const messageMatch = error.message.match(RATE_LIMIT_MESSAGE_RE);
+    if (messageMatch) return { retryAfterSeconds: Number(messageMatch[1]) };
+  }
+  return null;
+}
+
+/** Convenience boolean form of {@link parseRateLimitError}. */
+export function isRateLimitedError(error: unknown): boolean {
+  return parseRateLimitError(error) !== null;
+}

--- a/packages/shared/graphql-client/src/execute.ts
+++ b/packages/shared/graphql-client/src/execute.ts
@@ -1,7 +1,59 @@
 import type { Client } from 'graphql-ws';
-import { GraphQLOperationError } from './errors';
+import { GraphQLOperationError, parseRateLimitError } from './errors';
 import { getOperationName } from './operation-name';
-import { MUTATION_TIMEOUT_MS } from './constants';
+import {
+  MUTATION_TIMEOUT_MS,
+  RATE_LIMIT_MAX_RETRIES,
+  RATE_LIMIT_FALLBACK_DELAY_MS,
+  RATE_LIMIT_MAX_WAIT_MS,
+  RATE_LIMIT_RETRY_JITTER_MS,
+} from './constants';
+
+/** Payload handed to `onRateLimited` before each rate-limit retry wait. */
+export type RateLimitRetryEvent = {
+  /** 1-based retry number (1 = first retry after the initial rejection). */
+  attempt: number;
+  /** Total retries `execute` will make before giving up. */
+  maxAttempts: number;
+  /** How long this attempt waits before re-sending (ms, jitter included). */
+  retryAfterMs: number;
+  /** Operation name parsed from the query (for logging / UX copy). */
+  operationName: string;
+};
+
+export type ExecuteOptions = {
+  /** Per-attempt wall-clock timeout (ms). Reset on every retry. */
+  timeoutMs?: number;
+  /** Retries on `RATE_LIMITED` before giving up. Set 0 to disable. */
+  rateLimitRetries?: number;
+  /** Ceiling on a single retry wait, ignoring a larger server hint (ms). */
+  maxRateLimitDelayMs?: number;
+  /** Random jitter added to each retry wait (ms). */
+  rateLimitJitterMs?: number;
+  /** Notified before each retry wait — web wires a "catching up" snackbar here. */
+  onRateLimited?: (event: RateLimitRetryEvent) => void;
+  /** Injectable sleep (tests pass an immediate/controlled resolver). */
+  sleep?: (ms: number) => Promise<void>;
+};
+
+function normalizeExecuteOptions(timeoutOrOptions: number | ExecuteOptions | undefined): Required<ExecuteOptions> {
+  const options = typeof timeoutOrOptions === 'number' ? { timeoutMs: timeoutOrOptions } : (timeoutOrOptions ?? {});
+  return {
+    timeoutMs: options.timeoutMs ?? MUTATION_TIMEOUT_MS,
+    rateLimitRetries: options.rateLimitRetries ?? RATE_LIMIT_MAX_RETRIES,
+    maxRateLimitDelayMs: options.maxRateLimitDelayMs ?? RATE_LIMIT_MAX_WAIT_MS,
+    rateLimitJitterMs: options.rateLimitJitterMs ?? RATE_LIMIT_RETRY_JITTER_MS,
+    onRateLimited: options.onRateLimited ?? (() => {}),
+    sleep: options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
+  };
+}
+
+function computeRateLimitWait(retryAfterSeconds: number | null, options: Required<ExecuteOptions>): number {
+  const requested = retryAfterSeconds === null ? RATE_LIMIT_FALLBACK_DELAY_MS : Math.max(0, retryAfterSeconds * 1000);
+  const capped = Math.min(requested, options.maxRateLimitDelayMs);
+  const jitter = options.rateLimitJitterMs > 0 ? Math.round(Math.random() * options.rateLimitJitterMs) : 0;
+  return capped + jitter;
+}
 
 /**
  * Execute a GraphQL mutation (or one-shot query) over a graphql-ws client.
@@ -9,70 +61,108 @@ import { MUTATION_TIMEOUT_MS } from './constants';
  * graphql-ws models everything as subscriptions: a mutation emits one `next`
  * payload, then `complete`. We resolve with the captured payload on
  * `complete`, reject on `error`, and apply a wall-clock timeout to keep the
- * caller from hanging if the connection is wedged. Caller can pass a custom
- * `timeoutMs` for long-running queries.
+ * caller from hanging if the connection is wedged.
+ *
+ * A `RATE_LIMITED` rejection is retried (bounded) after waiting the server's
+ * `retryAfterSeconds` (capped, plus jitter). Each attempt gets a FRESH timeout
+ * so the back-off wait can't itself trip the mutation timeout. This is the
+ * quiet path for reconnect bursts (e.g. offline-reconciliation replaying
+ * buffered adds) — the throttled request did no work, so re-sending is safe.
+ *
+ * Back-compat: the third arg may be a plain `timeoutMs` number (legacy callers)
+ * or an `ExecuteOptions` object.
  */
 export function execute<TData = unknown, TVariables = Record<string, unknown>>(
   client: Client,
   operation: { query: string; variables?: TVariables },
-  timeoutMs: number = MUTATION_TIMEOUT_MS,
+  timeoutOrOptions: number | ExecuteOptions = MUTATION_TIMEOUT_MS,
 ): Promise<TData> {
   const opName = getOperationName(operation, 'mutation');
+  const options = normalizeExecuteOptions(timeoutOrOptions);
 
-  return new Promise<TData>((resolve, reject) => {
-    let result: TData | undefined;
-    let hasResolved = false;
-    let unsubscribe: (() => void) | undefined;
+  function executeOnce(): Promise<TData> {
+    return new Promise<TData>((resolve, reject) => {
+      let result: TData | undefined;
+      let hasResolved = false;
+      let unsubscribe: (() => void) | undefined;
 
-    const timer = setTimeout(() => {
-      settle(() => reject(new Error(`GraphQL mutation '${opName}' timed out after ${timeoutMs}ms`)));
-    }, timeoutMs);
+      const timer = setTimeout(() => {
+        settle(() => reject(new Error(`GraphQL mutation '${opName}' timed out after ${options.timeoutMs}ms`)));
+      }, options.timeoutMs);
 
-    function settle(fn: () => void) {
-      if (hasResolved) return;
-      hasResolved = true;
-      clearTimeout(timer);
-      unsubscribe?.();
-      fn();
+      function settle(fn: () => void) {
+        if (hasResolved) return;
+        hasResolved = true;
+        clearTimeout(timer);
+        unsubscribe?.();
+        fn();
+      }
+
+      unsubscribe = client.subscribe<TData>(
+        { query: operation.query, variables: operation.variables as Record<string, unknown> },
+        {
+          next: (data) => {
+            if ('data' in data) {
+              result = data.data as TData;
+            }
+            if (data.errors) {
+              const errors = data.errors;
+              settle(() => reject(new GraphQLOperationError(errors)));
+            }
+          },
+          error: (err) => {
+            settle(() => {
+              // graphql-ws also reports server-emitted GraphQL errors through the
+              // error callback when the server closes the stream with them (e.g.
+              // single-error mutation rejects). Preserve extensions in that path
+              // too, otherwise fall back to a generic Error.
+              if (Array.isArray(err) && err.length > 0 && typeof err[0]?.message === 'string') {
+                reject(new GraphQLOperationError(err));
+              } else if (err instanceof Error) {
+                reject(err);
+              } else {
+                reject(new Error(String(err)));
+              }
+            });
+          },
+          complete: () => {
+            settle(() => {
+              if (result === undefined) {
+                reject(new Error(`GraphQL operation '${opName}' completed without data`));
+                return;
+              }
+              resolve(result);
+            });
+          },
+        },
+      );
+    });
+  }
+
+  async function executeWithRetries(): Promise<TData> {
+    let retriesUsed = 0;
+    for (;;) {
+      try {
+        return await executeOnce();
+      } catch (error) {
+        const rateLimit = parseRateLimitError(error);
+        if (!rateLimit || retriesUsed >= options.rateLimitRetries) {
+          // Not throttled, or out of retries — surface the original error so
+          // callers keep the classifiable `GraphQLOperationError` extensions.
+          throw error;
+        }
+        retriesUsed += 1;
+        const retryAfterMs = computeRateLimitWait(rateLimit.retryAfterSeconds, options);
+        options.onRateLimited({
+          attempt: retriesUsed,
+          maxAttempts: options.rateLimitRetries,
+          retryAfterMs,
+          operationName: opName,
+        });
+        await options.sleep(retryAfterMs);
+      }
     }
+  }
 
-    unsubscribe = client.subscribe<TData>(
-      { query: operation.query, variables: operation.variables as Record<string, unknown> },
-      {
-        next: (data) => {
-          if ('data' in data) {
-            result = data.data as TData;
-          }
-          if (data.errors) {
-            const errors = data.errors;
-            settle(() => reject(new GraphQLOperationError(errors)));
-          }
-        },
-        error: (err) => {
-          settle(() => {
-            // graphql-ws also reports server-emitted GraphQL errors through the
-            // error callback when the server closes the stream with them (e.g.
-            // single-error mutation rejects). Preserve extensions in that path
-            // too, otherwise fall back to a generic Error.
-            if (Array.isArray(err) && err.length > 0 && typeof err[0]?.message === 'string') {
-              reject(new GraphQLOperationError(err));
-            } else if (err instanceof Error) {
-              reject(err);
-            } else {
-              reject(new Error(String(err)));
-            }
-          });
-        },
-        complete: () => {
-          settle(() => {
-            if (result === undefined) {
-              reject(new Error(`GraphQL operation '${opName}' completed without data`));
-              return;
-            }
-            resolve(result);
-          });
-        },
-      },
-    );
-  });
+  return executeWithRetries();
 }

--- a/packages/shared/graphql-client/src/index.ts
+++ b/packages/shared/graphql-client/src/index.ts
@@ -7,13 +7,25 @@ export {
   MAX_TRANSIENT_RETRIES,
   KEEP_ALIVE_MS,
   MUTATION_TIMEOUT_MS,
+  RATE_LIMIT_MAX_RETRIES,
+  RATE_LIMIT_FALLBACK_DELAY_MS,
+  RATE_LIMIT_MAX_WAIT_MS,
+  RATE_LIMIT_RETRY_JITTER_MS,
+  RECONNECT_JITTER_RATIO,
 } from './constants';
 
-export type { GraphQLErrorExtensions } from './errors';
-export { GraphQLOperationError, isClimbDuplicateExtension, isRateLimitedExtension } from './errors';
+export type { GraphQLErrorExtensions, ParsedRateLimit } from './errors';
+export {
+  GraphQLOperationError,
+  isClimbDuplicateExtension,
+  isRateLimitedExtension,
+  parseRateLimitError,
+  isRateLimitedError,
+} from './errors';
 
 export { getOperationName } from './operation-name';
 
+export type { ExecuteOptions, RateLimitRetryEvent } from './execute';
 export { execute } from './execute';
 export { subscribe } from './subscribe';
 

--- a/packages/shared/graphql-client/src/subscribe.ts
+++ b/packages/shared/graphql-client/src/subscribe.ts
@@ -1,10 +1,21 @@
 import type { Client, Sink } from 'graphql-ws';
+import { GraphQLOperationError } from './errors';
+
+/** True for a graphql-ws error payload shaped like `GraphQLError[]`. */
+function isGraphQLErrorArray(
+  value: unknown,
+): value is Array<{ message: string; extensions?: Record<string, unknown> }> {
+  return Array.isArray(value) && value.length > 0 && typeof value[0]?.message === 'string';
+}
 
 /**
  * Subscribe to a GraphQL subscription and receive events via callback.
  * Returns an unsubscribe function. Wraps `Client.subscribe` to coerce
  * graphql-ws's raw DOM error events into proper `Error` instances and to
- * flatten `data.errors` arrays into the `error` sink.
+ * forward `data.errors` (and error-callback arrays) as `GraphQLOperationError`
+ * so callers can classify them — e.g. a rate-limited board-presence
+ * subscription surfaces its `RATE_LIMITED` extension via `isRateLimitedError`
+ * instead of being flattened into a message-only `Error`.
  */
 export function subscribe<TData = unknown, TVariables = Record<string, unknown>>(
   client: Client,
@@ -19,14 +30,20 @@ export function subscribe<TData = unknown, TVariables = Record<string, unknown>>
           sink.next?.(data.data);
         }
         if (data.errors) {
-          sink.error?.(new Error(data.errors.map((e) => e.message).join(', ')));
+          sink.error?.(new GraphQLOperationError(data.errors));
         }
       },
       error: (error) => {
         // graphql-ws passes raw DOM Events (ErrorEvent/CloseEvent) when the WebSocket
-        // connection fails. Always forward a proper Error so callers and Sentry never
-        // receive "Event `Event` (type=error) captured as promise rejection".
-        sink.error?.(error instanceof Error ? error : new Error(String(error)));
+        // connection fails, and a `GraphQLError[]` when the server closes the stream
+        // with errors. Preserve extensions in the latter case (so RATE_LIMITED stays
+        // classifiable); otherwise always forward a proper Error so callers and Sentry
+        // never receive "Event `Event` (type=error) captured as promise rejection".
+        if (isGraphQLErrorArray(error)) {
+          sink.error?.(new GraphQLOperationError(error));
+        } else {
+          sink.error?.(error instanceof Error ? error : new Error(String(error)));
+        }
       },
       complete: () => {
         sink.complete?.();

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -299,7 +299,8 @@
     "tickHistoryClimb": "Log a tick for {{name}}"
   },
   "queueProvider": {
-    "offlineLimitReached": "You've hit the offline up-next limit. Reconnect to sync your climbs."
+    "offlineLimitReached": "You've hit the offline up-next limit. Reconnect to sync your climbs.",
+    "rateLimitCatchUp": "Catching up on your changes…"
   },
   "mobile": {
     "logbook": {

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -299,7 +299,8 @@
     "tickHistoryClimb": "Registrar un tick para {{name}}"
   },
   "queueProvider": {
-    "offlineLimitReached": "Has alcanzado el límite de la cola sin conexión. Vuelve a conectarte para sincronizar tus vías."
+    "offlineLimitReached": "Has alcanzado el límite de la cola sin conexión. Vuelve a conectarte para sincronizar tus vías.",
+    "rateLimitCatchUp": "Sincronizando tus cambios…"
   },
   "mobile": {
     "logbook": {

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -299,7 +299,8 @@
     "tickHistoryClimb": "Enregistrer une croix pour {{name}}"
   },
   "queueProvider": {
-    "offlineLimitReached": "Tu as atteint la limite hors ligne de la file d'attente. Reconnecte-toi pour synchroniser tes blocs."
+    "offlineLimitReached": "Tu as atteint la limite hors ligne de la file d'attente. Reconnecte-toi pour synchroniser tes blocs.",
+    "rateLimitCatchUp": "Synchronisation de tes modifications…"
   },
   "mobile": {
     "logbook": {

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -22,7 +22,7 @@
 // setSessionBoardSerial, setSessionBoardPath) no-op on BOTH platforms when
 // there is no active session.
 
-import type { Client } from '@boardsesh/graphql-client';
+import type { Client, RateLimitRetryEvent } from '@boardsesh/graphql-client';
 import { execute } from '@boardsesh/graphql-client';
 import type { ClimbQueueItemInput } from '@boardsesh/shared-schema';
 import { createSetCurrentClimbCoalescer } from '@boardsesh/queue-runtime';
@@ -75,6 +75,13 @@ export type QueueMutationsDeps<TItem> = {
   ensureReady?: (capturedSessionId: string | null) => Promise<string | null>;
   /** Sink for swallowed transport errors (best-effort actions + coalescer drains). */
   onBestEffortError?: (action: string, error: unknown) => void;
+  /**
+   * Notified when a queue mutation is throttled and `execute` is backing off to
+   * retry it (not on the final give-up). Web wires a debounced "catching up"
+   * snackbar here so a burst of buffered adds replaying on reconnect reads as
+   * pacing, not failure (#2655). Fires per mutation, per retry attempt.
+   */
+  onRateLimited?: (event: RateLimitRetryEvent) => void;
 };
 
 export type QueueMutationsActions<TItem> = {
@@ -125,9 +132,21 @@ export type QueueMutationsActions<TItem> = {
 };
 
 export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): QueueMutationsActions<TItem> {
-  const { getClient, getSessionId, toQueueItemInput, ensureReady, onBestEffortError } = deps;
+  const { getClient, getSessionId, toQueueItemInput, ensureReady, onBestEffortError, onRateLimited } = deps;
 
   type Ready = { client: Client; sessionId: string };
+
+  // Every queue mutation goes through here so the shared `execute` retry loop
+  // (bounded back-off on RATE_LIMITED) and the `onRateLimited` notifier apply
+  // uniformly — no per-call-site wiring.
+  function runMutation<TData = unknown>(
+    client: Client,
+    operation: { query: string; variables?: Record<string, unknown> },
+  ): Promise<TData> {
+    // Only pass options when there's something to inject, so callers/tests that
+    // assert the two-arg `execute(client, op)` shape stay green.
+    return onRateLimited ? execute<TData>(client, operation, { onRateLimited }) : execute<TData>(client, operation);
+  }
 
   // Core mutating actions. Web (no ensureReady) THROWS when disconnected;
   // mobile (ensureReady) silently no-ops by returning null. `allowCreate`
@@ -189,7 +208,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
         // session is fatal (throws), unlike mobile which lazily creates above.
         throw new Error(NOT_CONNECTED);
       }
-      await execute(client, {
+      await runMutation(client, {
         query: SET_CURRENT_CLIMB,
         variables: {
           item: args.item ? toQueueItemInput(args.item) : null,
@@ -208,7 +227,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
         const sessionId = await ensureReady(capturedSessionId);
         if (!sessionId) return;
       }
-      await execute(client, {
+      await runMutation(client, {
         query: ADD_QUEUE_ITEM,
         variables: { item: toQueueItemInput(item) },
       });
@@ -221,7 +240,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     addQueueItem: async (item, position) => {
       const ready = await resolveCore({ allowCreate: true });
       if (!ready) return;
-      await execute(ready.client, {
+      await runMutation(ready.client, {
         query: ADD_QUEUE_ITEM,
         variables: { item: toQueueItemInput(item), position },
       });
@@ -230,13 +249,13 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     removeQueueItem: async (uuid) => {
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
-      await execute(ready.client, { query: REMOVE_QUEUE_ITEM, variables: { uuid } });
+      await runMutation(ready.client, { query: REMOVE_QUEUE_ITEM, variables: { uuid } });
     },
 
     reorderQueueItem: async (uuid, oldIndex, newIndex) => {
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
-      await execute(ready.client, { query: REORDER_QUEUE_ITEM, variables: { uuid, oldIndex, newIndex } });
+      await runMutation(ready.client, { query: REORDER_QUEUE_ITEM, variables: { uuid, oldIndex, newIndex } });
     },
 
     setCurrentClimb: async (item, shouldAddToQueue, correlationId) => {
@@ -251,7 +270,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     mirrorCurrentClimb: async (mirrored) => {
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
-      await execute(ready.client, { query: MIRROR_CURRENT_CLIMB, variables: { mirrored } });
+      await runMutation(ready.client, { query: MIRROR_CURRENT_CLIMB, variables: { mirrored } });
     },
 
     publishPlaybackState: async (input) => {
@@ -261,7 +280,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       const ready = await resolveCurrent();
       if (!ready) return;
       try {
-        await execute(ready.client, { query: PUBLISH_PLAYBACK_STATE, variables: { input } });
+        await runMutation(ready.client, { query: PUBLISH_PLAYBACK_STATE, variables: { input } });
       } catch (error) {
         // Best-effort — losing one broadcast just means peers briefly run out
         // of sync until the next event. Don't surface to user.
@@ -272,7 +291,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     setQueue: async (queue, currentClimbQueueItem) => {
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
-      await execute(ready.client, {
+      await runMutation(ready.client, {
         query: SET_QUEUE,
         variables: {
           queue: queue.map(toQueueItemInput),
@@ -284,7 +303,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     replaceQueueItem: async (uuid, item) => {
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
-      await execute(ready.client, {
+      await runMutation(ready.client, {
         query: REPLACE_QUEUE_ITEM,
         variables: { uuid, item: toQueueItemInput(item) },
       });
@@ -294,7 +313,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       const ready = await resolveCurrent();
       if (!ready) return;
       try {
-        await execute(ready.client, { query: CONFIRM_CLIMB_ON_WALL, variables: { climbUuid } });
+        await runMutation(ready.client, { query: CONFIRM_CLIMB_ON_WALL, variables: { climbUuid } });
       } catch (error) {
         onBestEffortError?.('confirmClimbOnWall', error);
       }
@@ -304,7 +323,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       const ready = await resolveCurrent();
       if (!ready) return;
       try {
-        await execute(ready.client, { query: REPORT_WALL_DISCONNECT, variables: {} });
+        await runMutation(ready.client, { query: REPORT_WALL_DISCONNECT, variables: {} });
       } catch (error) {
         onBestEffortError?.('reportWallDisconnect', error);
       }
@@ -314,7 +333,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       const ready = await resolveCurrent();
       if (!ready) return;
       try {
-        await execute(ready.client, { query: SET_SESSION_BOARD_SERIAL, variables: { serial } });
+        await runMutation(ready.client, { query: SET_SESSION_BOARD_SERIAL, variables: { serial } });
       } catch (error) {
         onBestEffortError?.('setSessionBoardSerial', error);
       }
@@ -324,7 +343,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       const ready = await resolveCurrent();
       if (!ready) return;
       try {
-        await execute(ready.client, { query: SET_SESSION_BOARD_PATH, variables: { boardPath } });
+        await runMutation(ready.client, { query: SET_SESSION_BOARD_PATH, variables: { boardPath } });
       } catch (error) {
         onBestEffortError?.('setSessionBoardPath', error);
       }

--- a/packages/shared/queue-react/src/use-queue-mutations.ts
+++ b/packages/shared/queue-react/src/use-queue-mutations.ts
@@ -35,6 +35,7 @@ export function useQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Queue
           ? (capturedSessionId) => depsRef.current.ensureReady!(capturedSessionId)
           : undefined,
         onBestEffortError: (action, error) => depsRef.current.onBestEffortError?.(action, error),
+        onRateLimited: (event) => depsRef.current.onRateLimited?.(event),
       }),
     [hasEnsureReady],
   );

--- a/packages/shared/queue-runtime/src/session-connection.ts
+++ b/packages/shared/queue-runtime/src/session-connection.ts
@@ -249,6 +249,9 @@ export type SessionConnectionDeps<
    *  `setTimeout`/`clearTimeout`. */
   scheduleTimer?: (callback: () => void, delayMs: number) => SessionConnectionTimerHandle;
   clearTimer?: (handle: SessionConnectionTimerHandle) => void;
+  /** Injectable randomness for the reconnect-backoff jitter. Defaults to
+   *  `Math.random`; tests pass a constant to assert exact delays. */
+  random?: () => number;
 };
 
 export type SessionConnectionController = {
@@ -275,6 +278,14 @@ export type SessionConnectionController = {
  *  exported: this is purely internal control flow, not a capability callers
  *  need. */
 class JoinReturnedNoPayloadError extends Error {}
+
+/**
+ * Fraction of the reconnect backoff turned into random jitter — spreads each
+ * retry over [0.5·delay, delay] so a fleet that all dropped at once doesn't
+ * re-join in lockstep (#2655). Mirrors `RECONNECT_JITTER_RATIO` in
+ * `@boardsesh/graphql-client`; kept local so queue-runtime needn't depend on it.
+ */
+const RECONNECT_JITTER_RATIO = 0.5;
 
 export function createSessionConnectionController<
   TClient extends SessionConnectionClient,
@@ -343,10 +354,16 @@ export function createSessionConnectionController<
   }
 
   function computeBackoffDelay(attempt: number): number {
-    return Math.min(
+    const base = Math.min(
       deps.retryPolicy.initialRetryDelayMs * Math.pow(deps.retryPolicy.backoffMultiplier, attempt - 1),
       deps.retryPolicy.maxRetryDelayMs,
     );
+    // Jitter over [0.5·base, base] so a fleet whose sessions all dropped at once
+    // (backend restart) doesn't re-join in lockstep and re-trip the joinSession
+    // rate limit in synchronized waves (#2655). `deps.random` is injectable for
+    // deterministic tests; defaults to `Math.random`.
+    const random = deps.random ?? Math.random;
+    return base - random() * RECONNECT_JITTER_RATIO * base;
   }
 
   /** Mirrors `scheduleSubscriptionRecovery` (`use-session-lifecycle.ts:613-643`). */

--- a/packages/web/app/components/graphql-queue/hooks/__tests__/use-offline-reconciliation.test.ts
+++ b/packages/web/app/components/graphql-queue/hooks/__tests__/use-offline-reconciliation.test.ts
@@ -1,9 +1,25 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { renderHook, act } from '@testing-library/react';
+import { GraphQLOperationError } from '@boardsesh/graphql-client';
 import { useOfflineReconciliation, type UseOfflineReconciliationParams } from '../use-offline-reconciliation';
 import type { ClimbQueueItem } from '../../../queue-control/types';
 import type { Climb } from '@/app/lib/types';
 import type { SubscriptionQueueEvent, SessionUser } from '@boardsesh/shared-schema';
+
+function rateLimitError() {
+  return new GraphQLOperationError([
+    {
+      message: 'Rate limit exceeded. Try again in 3 seconds.',
+      extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 3 },
+    },
+  ]);
+}
+
+const FULL_SYNC_MULTI_USER: SubscriptionQueueEvent = {
+  __typename: 'FullSync',
+  sequence: 10,
+  state: { queue: [] as never[], currentClimbQueueItem: null, stateHash: 'abc', sequence: 10 },
+};
 
 const mockClimb: Climb = {
   uuid: 'climb-1',
@@ -101,6 +117,7 @@ describe('useOfflineReconciliation', () => {
         },
         currentQueue: overrides.currentQueue ?? [],
         currentClimbQueueItem: overrides.currentClimbQueueItem ?? null,
+        replayPacingMs: 0,
       },
     });
   }
@@ -133,6 +150,7 @@ describe('useOfflineReconciliation', () => {
       },
       currentQueue: overrides.currentQueue ?? [],
       currentClimbQueueItem: overrides.currentClimbQueueItem ?? null,
+      replayPacingMs: 0,
     });
   }
 
@@ -541,6 +559,115 @@ describe('useOfflineReconciliation', () => {
       expect(callCount).toBeGreaterThanOrEqual(1);
       // No setQueue should have been called (multi-user, sequence changed)
       expect(mockSetQueue).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- Rate-limit resilience (#2655) ---
+
+  describe('rate-limit resilience (#2655)', () => {
+    function renderRateLimitCase(params: {
+      items: ClimbQueueItem[];
+      bufferAddition: (item: ClimbQueueItem) => void;
+      replayPacingMs?: number;
+      sleep?: (ms: number) => Promise<void>;
+    }) {
+      const offlineBuffer = {
+        getBufferedAdditions: mockGetBufferedAdditions,
+        clearBuffer: mockClearBuffer,
+        hasPendingAdditions: true,
+        bufferAddition: params.bufferAddition,
+      };
+      const persistentSession = {
+        addQueueItem: mockAddQueueItem,
+        setQueue: mockSetQueue,
+        setCurrentClimb: mockSetCurrentClimb,
+        subscribeToQueueEvents: mockSubscribeToQueueEvents,
+      };
+      const baseProps: UseOfflineReconciliationParams = {
+        offlineBuffer,
+        isDisconnected: true,
+        isPersistentSessionActive: true,
+        hasConnected: true,
+        users: [createUser('me'), createUser('other')],
+        lastReceivedSequenceRef: mockLastReceivedSequenceRef,
+        persistentSession,
+        currentQueue: [],
+        currentClimbQueueItem: null,
+        replayPacingMs: params.replayPacingMs ?? 0,
+        sleep: params.sleep,
+      };
+      // eslint-disable-next-line typescript/no-invalid-void-type -- hook returns void.
+      const hook = renderHook<void, UseOfflineReconciliationParams>((props) => useOfflineReconciliation(props), {
+        initialProps: baseProps,
+      });
+      hook.rerender({ ...baseProps, isDisconnected: false });
+      return hook;
+    }
+
+    it('re-buffers a rate-limited addition instead of dropping it', async () => {
+      const item1 = createItem('offline-1');
+      const item2 = createItem('offline-2');
+      const item3 = createItem('offline-3');
+      mockGetBufferedAdditions.mockReturnValue([item1, item2, item3]);
+      mockAddQueueItem
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(rateLimitError())
+        .mockResolvedValueOnce(undefined);
+      const mockBufferAddition = vi.fn();
+
+      renderRateLimitCase({ items: [item1, item2, item3], bufferAddition: mockBufferAddition });
+
+      await act(async () => {
+        subscriberCallback!(FULL_SYNC_MULTI_USER);
+      });
+
+      // All three attempted; the throttled one is re-buffered, not lost.
+      expect(mockAddQueueItem).toHaveBeenCalledTimes(3);
+      expect(mockClearBuffer).toHaveBeenCalled();
+      expect(mockBufferAddition).toHaveBeenCalledTimes(1);
+      expect(mockBufferAddition).toHaveBeenCalledWith(item2);
+    });
+
+    it('does NOT re-buffer a non-rate-limit failure', async () => {
+      const item1 = createItem('offline-1');
+      const item2 = createItem('offline-2');
+      mockGetBufferedAdditions.mockReturnValue([item1, item2]);
+      mockAddQueueItem.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('Network error'));
+      const mockBufferAddition = vi.fn();
+
+      renderRateLimitCase({ items: [item1, item2], bufferAddition: mockBufferAddition });
+
+      await act(async () => {
+        subscriberCallback!(FULL_SYNC_MULTI_USER);
+      });
+
+      expect(mockClearBuffer).toHaveBeenCalled();
+      expect(mockBufferAddition).not.toHaveBeenCalled();
+    });
+
+    it('paces replayed additions between sends but not after the last', async () => {
+      // `vi.clearAllMocks()` in beforeEach only clears call history, not the
+      // persistent `mockImplementation` an earlier test left on addQueueItem —
+      // override it so every replayed add resolves.
+      mockAddQueueItem.mockReset();
+      mockAddQueueItem.mockResolvedValue(undefined);
+      const items = [createItem('p-1'), createItem('p-2'), createItem('p-3')];
+      mockGetBufferedAdditions.mockReturnValue(items);
+      const sleepCalls: number[] = [];
+      const sleep = (ms: number) => {
+        sleepCalls.push(ms);
+        return Promise.resolve();
+      };
+
+      renderRateLimitCase({ items, bufferAddition: vi.fn(), replayPacingMs: 80, sleep });
+
+      await act(async () => {
+        subscriberCallback!(FULL_SYNC_MULTI_USER);
+      });
+
+      expect(mockAddQueueItem).toHaveBeenCalledTimes(3);
+      // Spaced between the 3 sends (2 gaps), never after the final one.
+      expect(sleepCalls).toEqual([80, 80]);
     });
   });
 });

--- a/packages/web/app/components/graphql-queue/hooks/use-offline-reconciliation.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-offline-reconciliation.ts
@@ -1,8 +1,17 @@
 import { useEffect, useRef, type MutableRefObject } from 'react';
 import type { SubscriptionQueueEvent, SessionUser } from '@boardsesh/shared-schema';
+import { isRateLimitedError } from '@boardsesh/graphql-client';
 import type { ClimbQueueItem } from '../../queue-control/types';
 
 const RECONCILIATION_TIMEOUT_MS = 15000;
+
+// Space out replayed additions so a big buffered batch (built up while offline)
+// can't fire faster than the per-user rate limit allows on reconnect (#2655).
+// `execute` also retries an individual throttled add, but pacing keeps us from
+// tripping the limit in the first place.
+const DEFAULT_REPLAY_PACING_MS = 80;
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 export type UseOfflineReconciliationParams = {
   offlineBuffer: {
@@ -24,6 +33,11 @@ export type UseOfflineReconciliationParams = {
   };
   currentQueue: ClimbQueueItem[];
   currentClimbQueueItem: ClimbQueueItem | null;
+  /** Delay between replayed additions (ms). Defaults to ~80ms; tests pass 0 to
+   *  disable pacing so replays are synchronous. */
+  replayPacingMs?: number;
+  /** Injectable sleep for the pacing delay (tests). */
+  sleep?: (ms: number) => Promise<void>;
 };
 
 /**
@@ -54,6 +68,8 @@ export function useOfflineReconciliation({
   persistentSession,
   currentQueue,
   currentClimbQueueItem,
+  replayPacingMs = DEFAULT_REPLAY_PACING_MS,
+  sleep = defaultSleep,
 }: UseOfflineReconciliationParams) {
   const wasDisconnectedRef = useRef(isDisconnected);
   const currentQueueRef = useRef(currentQueue);
@@ -107,6 +123,7 @@ export function useOfflineReconciliation({
     async function reconcileClientWins() {
       const localQueue = currentQueueRef.current;
       const localCurrentClimb = currentClimbRef.current;
+      let stillRateLimited = false;
       try {
         if (isSuperseded()) return;
         await persistentSession.setQueue(localQueue, localCurrentClimb);
@@ -114,9 +131,13 @@ export function useOfflineReconciliation({
           await persistentSession.setCurrentClimb(localCurrentClimb, false);
         }
       } catch (error) {
+        // Throttled even after `execute`'s own retries — keep the buffer so a
+        // later reconnect re-pushes instead of dropping the offline additions
+        // (#2655). Any other failure clears as before (nothing more we can do).
+        stillRateLimited = isRateLimitedError(error);
         console.error('[OfflineReconciliation] Failed to push full local state:', error);
       }
-      if (!isSuperseded()) {
+      if (!isSuperseded() && !stillRateLimited) {
         offlineBuffer.clearBuffer();
       }
     }
@@ -124,19 +145,35 @@ export function useOfflineReconciliation({
     async function reconcileAdditionsOnly(serverQueue: ClimbQueueItem[]) {
       const pending = offlineBuffer.getBufferedAdditions();
       const serverUuids = new Set(serverQueue.map((item) => item.uuid));
+      // Items the server is still throttling after `execute`'s retries — kept
+      // buffered so the next reconnect replays them instead of losing them.
+      const stillThrottled: ClimbQueueItem[] = [];
 
-      for (const item of pending) {
+      for (let index = 0; index < pending.length; index++) {
+        const item = pending[index];
         if (isSuperseded()) return;
         if (serverUuids.has(item.uuid)) continue;
         try {
           await persistentSession.addQueueItem(item);
         } catch (error) {
-          console.error('[OfflineReconciliation] Failed to add buffered item:', item.climb?.name, error);
+          if (isRateLimitedError(error)) {
+            stillThrottled.push(item);
+          } else {
+            console.error('[OfflineReconciliation] Failed to add buffered item:', item.climb?.name, error);
+          }
+        }
+        // Pace the batch so it can't blow the per-minute budget in one burst.
+        if (replayPacingMs > 0 && index < pending.length - 1 && !isSuperseded()) {
+          await sleep(replayPacingMs);
         }
       }
 
       if (!isSuperseded()) {
         offlineBuffer.clearBuffer();
+        // Re-seed anything still throttled so it survives to the next reconnect.
+        for (const item of stillThrottled) {
+          offlineBuffer.bufferAddition(item);
+        }
       }
     }
 

--- a/packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts
@@ -3,6 +3,7 @@ import {
   useQueueMutations as useSharedQueueMutations,
   type QueueMutationsActions as SharedQueueMutationsActions,
 } from '@boardsesh/queue-react';
+import type { RateLimitRetryEvent } from '@boardsesh/graphql-client';
 import type { Client } from '../../graphql-queue/graphql-client';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
 import { type Session, toClimbQueueItemInput } from '../types';
@@ -10,6 +11,9 @@ import { type Session, toClimbQueueItemInput } from '../types';
 type UseQueueMutationsArgs = {
   client: Client | null;
   session: Session | null;
+  /** Fired while a throttled mutation backs off to retry — see the caller's
+   *  "catching up" snackbar wiring (#2655). */
+  onRateLimited?: (event: RateLimitRetryEvent) => void;
 };
 
 // The queue-session mutations, typed with the web's own ClimbQueueItem. The
@@ -19,13 +23,15 @@ type UseQueueMutationsArgs = {
 // the coalescer + cross-session-leak semantics.
 export type QueueMutationsActions = SharedQueueMutationsActions<LocalClimbQueueItem>;
 
-export function useQueueMutations({ client, session }: UseQueueMutationsArgs): QueueMutationsActions {
+export function useQueueMutations({ client, session, onRateLimited }: UseQueueMutationsArgs): QueueMutationsActions {
   // Refs keep the injected getters reading live values without recreating the
   // shared hook's callbacks on every render.
   const clientRef = useRef(client);
   const sessionRef = useRef(session);
+  const onRateLimitedRef = useRef(onRateLimited);
   clientRef.current = client;
   sessionRef.current = session;
+  onRateLimitedRef.current = onRateLimited;
 
   // No `ensureReady`: web sessions are already joined (see use-session-lifecycle),
   // so the core actions throw 'Not connected to session' when disconnected —
@@ -37,5 +43,6 @@ export function useQueueMutations({ client, session }: UseQueueMutationsArgs): Q
     onBestEffortError: (action, error) => {
       console.error(`Failed to ${action}:`, error);
     },
+    onRateLimited: (event) => onRateLimitedRef.current?.(event),
   });
 }

--- a/packages/web/app/components/persistent-session/hooks/use-rate-limit-snackbar.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-rate-limit-snackbar.ts
@@ -1,0 +1,37 @@
+import { useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { RateLimitRetryEvent } from '@boardsesh/graphql-client';
+import { useSnackbar } from '../../providers/snackbar-provider';
+
+// A single-retry recovery is fast enough to stay silent — only surface the
+// snackbar once a SECOND retry is needed (the burst is genuinely being paced).
+const CATCH_UP_MIN_ATTEMPT = 2;
+// Debounce so a batch of throttled adds replaying on reconnect shows one gentle
+// note instead of a stack of them.
+const CATCH_UP_DEBOUNCE_MS = 4000;
+const CATCH_UP_SNACKBAR_DURATION_MS = 3000;
+
+/**
+ * Returns an `onRateLimited` handler that shows a debounced "catching up"
+ * snackbar while queue mutations back off on `RATE_LIMITED`. Wired into the
+ * queue-mutations hook so a reconnect burst (offline-reconciliation replaying
+ * buffered adds) reads as pacing, not the alarming generic failure toast
+ * (#2655). The mutation's optimistic local state already applied; this is
+ * purely reassurance while `execute` retries.
+ */
+export function useRateLimitSnackbar(): (event: RateLimitRetryEvent) => void {
+  const { t } = useTranslation('session');
+  const { showMessage } = useSnackbar();
+  const lastShownAtRef = useRef(0);
+
+  return useCallback(
+    (event: RateLimitRetryEvent) => {
+      if (event.attempt < CATCH_UP_MIN_ATTEMPT) return;
+      const now = Date.now();
+      if (now - lastShownAtRef.current < CATCH_UP_DEBOUNCE_MS) return;
+      lastShownAtRef.current = now;
+      showMessage(t('queueProvider.rateLimitCatchUp'), 'info', undefined, CATCH_UP_SNACKBAR_DURATION_MS);
+    },
+    [t, showMessage],
+  );
+}

--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -20,6 +20,7 @@ import type {
 import { useEventProcessor } from './hooks/use-event-processor';
 import { useQueueStorage } from './hooks/use-queue-storage';
 import { useQueueMutations } from './hooks/use-queue-mutations';
+import { useRateLimitSnackbar } from './hooks/use-rate-limit-snackbar';
 import { useSessionSubscriptions } from './hooks/use-session-subscriptions';
 import { useSessionLifecycle } from './hooks/use-session-lifecycle';
 import { usePendingUpdateCleanup } from './hooks/use-pending-update-cleanup';
@@ -159,10 +160,15 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
     dispatch: eventProcessor.dispatch,
   });
 
-  // 4. Queue mutations: GraphQL mutation wrappers
+  // 4. Queue mutations: GraphQL mutation wrappers. `onRateLimited` surfaces a
+  // debounced "catching up" snackbar while a throttled mutation backs off to
+  // retry (e.g. a reconnect burst of buffered adds), instead of the alarming
+  // generic failure toast (#2655).
+  const onRateLimited = useRateLimitSnackbar();
   const mutations = useQueueMutations({
     client: lifecycle.client,
     session: lifecycle.session,
+    onRateLimited,
   });
 
   // 5. Session subscriptions: periodic verification, event subscriptions, corruption checks


### PR DESCRIPTION
## Summary

Completes the revival of #2184 (Fixes #2655). After a network flap the GraphQL-WS
socket reconnects and offline-reconciliation replays buffered queue mutations,
which can trip the per-user backend rate limit — today that surfaces as a raw
`Rate limit exceeded. Try again in N seconds.` failure and, on the web offline
path, the buffered add was **silently dropped**.

The backend half of #2184 already shipped separately via **#2763** (`applyRateLimit`
throws a structured `GraphQLError` with `extensions: { code: "RATE_LIMITED",
retryAfterSeconds }`), and mobile already downgrades/handles it. This PR adds the
client-side resilience the issue asked for so the round trip stays quiet.

**What changed**

- **`@boardsesh/graphql-client` `execute()`** — bounded retry on a `RATE_LIMITED`
  rejection (default 2), honouring `retryAfterSeconds` (capped at 30s, plus jitter),
  with a **fresh timeout per attempt** so the back-off wait can't trip the mutation
  timeout. New `parseRateLimitError` / `isRateLimitedError` and an injected
  `onRateLimited` notifier (kept renderer-agnostic). Retrying is safe because the
  backend throws at the rate-limit gate **before** any resolver work runs, so a
  throttled attempt has no side effect.
- **`subscribe()`** — forwards `data.errors` / error-callback arrays as
  `GraphQLOperationError` so a rate-limited subscription (e.g. `boardNowPlaying`)
  stays classifiable instead of being flattened into a message-only `Error`.
- **Reconnect jitter** — both back-off paths (`create-client` `retryWait` and the
  session-connection controller's `computeBackoffDelay`) now spread each attempt
  over `[0.5·delay, delay]`, so a fleet that all dropped at once (backend restart)
  doesn't re-join in lockstep and re-trip the limiter in synchronized waves.
- **Web offline-reconciliation** — paces replayed buffered adds (~80ms apart) and
  **re-buffers** an add the server is still throttling instead of dropping it; same
  "keep the buffer" guard on the client-wins `setQueue` push.
- **Web "catching up" snackbar** — a debounced `session.queueProvider.rateLimitCatchUp`
  info snackbar shows while a throttled mutation backs off (only once a 2nd retry is
  actually needed), replacing the alarming generic failure toast. New key added to
  `en-US` / `es` / `fr`.

**Behaviour change (intended):** a buffered offline addition that the server is
still rate-limiting after `execute`'s retries is now **kept in the buffer** for the
next reconnect instead of being silently dropped.

**Supersedes** two stale branches (safe to delete): `codex/issue-2655-rate-limit-reconnect`
(pre-#2763, ~1 month stale) and `claude/queue-mutation-rate-limit-toasts-5vbx22`.

**Deliberately out of scope (follow-ups):**
- Mobile offline-sync drainer (`@boardsesh/offline-sync`) back-off on `RATE_LIMITED`.
- Wiring the `onRateLimited` notifier into mobile `queue-provider.tsx` (skipped to
  avoid a 3-way conflict with the agents on #2217 and #3297); mobile already shows a
  per-mutation rate-limit toast.

## Release Notes

- Party queues now ride out rate limits. If the app buffers a burst of queue changes while you're offline and replays them the moment you reconnect, they land smoothly with a brief "catching up" note instead of a raw "Rate limit exceeded" error — and a change that's still being throttled is kept and retried instead of lost.

## Test plan

- `vp test run --project shared` graphql-client (30), queue-react (28), queue-runtime (101) — green.
- New `execute` retry tests (retry+resolve, cap, budget-exhaustion surfaces the classifiable error, no-retry on non-rate-limit, `rateLimitRetries: 0`, legacy message-only, fresh-timeout-per-attempt), new `subscribe` extension-forwarding tests, new `parseRateLimitError` unit tests.
- Web `use-offline-reconciliation.test.ts` (14) — existing behaviour plus new pacing, re-buffer, and "don't re-buffer non-rate-limit" cases.
- `vp run typecheck:shared` green; `vp run typecheck:web` (Next build) run; `vp check` (format+lint) clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va
