### PR TITLE
fix(shared): insert peer-activated climb after current, not at queue end

### DIFF
--- a/packages/backend/src/__tests__/queue-navigation.test.ts
+++ b/packages/backend/src/__tests__/queue-navigation.test.ts
@@ -17,8 +17,9 @@
  *  3. `item: null` → `pushRecentClimb` is not called. The ring buffer only
  *     accepts authoritative wall climbs; a clear is not one.
  *  4. `item: <climb>, shouldAddToQueue: true, not in queue` → publishes
- *     `FullSync` with the appended queue (regression guard for the original
- *     `addedToQueue` path).
+ *     `FullSync` whose queue has the new climb inserted immediately after the
+ *     current climb (issue #2217), falling back to append when there is no
+ *     current climb to anchor to.
  *  5. `item: <climb>, shouldAddToQueue: true, already in queue` → publishes
  *     `CurrentClimbChanged` (no second copy of the queue item).
  *  6. `clientId` / `correlationId` flow through to `CurrentClimbChanged`
@@ -174,6 +175,81 @@ describe('setCurrentClimbAndPublish — non-null item', () => {
     expect(event.state.queue).toEqual([item]);
     expect(event.state.currentClimbQueueItem).toEqual(item);
     expect(roomManager.pushRecentClimb).toHaveBeenCalledWith('session-1', 'climb-1');
+  });
+
+  it('inserts a new climb immediately after the current climb, not at the end (issue #2217)', async () => {
+    const climbA = makeClimb('item-a', 'climb-a');
+    const climbB = makeClimb('item-b', 'climb-b');
+    const climbC = makeClimb('item-c', 'climb-c');
+    const newClimb = makeClimb('item-x', 'climb-x');
+    const roomManager = makeRoomManager({ queue: [climbA, climbB, climbC], currentClimb: climbA });
+
+    await setCurrentClimbAndPublish(
+      'session-1',
+      newClimb,
+      true,
+      roomManager as unknown as RoomManager,
+      pubsub as unknown as typeof PubSubInstance,
+    );
+
+    const event = pubsub.publishQueueEvent.mock.calls[0][1];
+    expect(event.__typename).toBe('FullSync');
+    // New climb slots in right after the current climb (A), pushing A into
+    // history — NOT appended after C.
+    expect(event.state.queue).toEqual([climbA, newClimb, climbB, climbC]);
+    expect(event.state.currentClimbQueueItem).toEqual(newClimb);
+    // The persisted queue matches the published order.
+    expect(roomManager.updateQueueState).toHaveBeenCalledWith(
+      'session-1',
+      [climbA, newClimb, climbB, climbC],
+      newClimb,
+      0,
+    );
+  });
+
+  it('falls back to appending when there is no current climb to anchor the insertion', async () => {
+    const climbA = makeClimb('item-a', 'climb-a');
+    const climbB = makeClimb('item-b', 'climb-b');
+    const newClimb = makeClimb('item-x', 'climb-x');
+    const roomManager = makeRoomManager({ queue: [climbA, climbB], currentClimb: null });
+
+    await setCurrentClimbAndPublish(
+      'session-1',
+      newClimb,
+      true,
+      roomManager as unknown as RoomManager,
+      pubsub as unknown as typeof PubSubInstance,
+    );
+
+    const event = pubsub.publishQueueEvent.mock.calls[0][1];
+    expect(event.__typename).toBe('FullSync');
+    expect(event.state.queue).toEqual([climbA, climbB, newClimb]);
+    // The persisted queue matches the published order (append fallback).
+    expect(roomManager.updateQueueState).toHaveBeenCalledWith('session-1', [climbA, climbB, newClimb], newClimb, 0);
+  });
+
+  it('inserts after current regardless of the suggested flag (web peek-promotion shape)', async () => {
+    // Web's setCurrentClimbQueueItem promotes a suggested/peek climb via
+    // setCurrentClimb(item, suggested). The positioning here is driven purely by
+    // the current-climb anchor, NOT by `suggested` — pin that so a future change
+    // can't accidentally special-case suggested climbs back to appending.
+    const climbA = makeClimb('item-a', 'climb-a');
+    const climbB = makeClimb('item-b', 'climb-b');
+    const suggestedClimb = { ...makeClimb('item-x', 'climb-x'), suggested: true } as ClimbQueueItem;
+    const roomManager = makeRoomManager({ queue: [climbA, climbB], currentClimb: climbA });
+
+    await setCurrentClimbAndPublish(
+      'session-1',
+      suggestedClimb,
+      true,
+      roomManager as unknown as RoomManager,
+      pubsub as unknown as typeof PubSubInstance,
+    );
+
+    const event = pubsub.publishQueueEvent.mock.calls[0][1];
+    expect(event.__typename).toBe('FullSync');
+    expect(event.state.queue).toEqual([climbA, suggestedClimb, climbB]);
+    expect(event.state.currentClimbQueueItem).toEqual(suggestedClimb);
   });
 
   it('publishes CurrentClimbChanged when shouldAddToQueue=true but the climb is already queued', async () => {

--- a/packages/backend/src/services/queue-navigation.ts
+++ b/packages/backend/src/services/queue-navigation.ts
@@ -38,7 +38,20 @@ export async function setCurrentClimbAndPublish(
     let addedInThisAttempt = false;
 
     if (item !== null && shouldAddToQueue && !queue.some((i) => i.uuid === item.uuid)) {
-      queue = [...queue, item];
+      // Insert the new climb immediately after the current climb (issue #2217)
+      // instead of appending it to the end. Activating a climb via the light
+      // bulb should slot it into the "up next" position and push the current
+      // climb into history — exactly like the local "set climb active" flow.
+      // Appending to the end and then broadcasting a FullSync with that order
+      // reordered every peer's queue and jumped the current pointer to the
+      // bottom. Fall back to append when there is no current climb (or it is no
+      // longer in the queue) to anchor the insertion to.
+      const currentItem = currentState.currentClimbQueueItem;
+      const currentIndex = currentItem ? queue.findIndex((i) => i.uuid === currentItem.uuid) : -1;
+      queue =
+        currentIndex === -1
+          ? [...queue, item]
+          : [...queue.slice(0, currentIndex + 1), item, ...queue.slice(currentIndex + 1)];
       addedInThisAttempt = true;
     }
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
@@ -308,6 +308,37 @@ describe('QueueProvider local solo queue', () => {
     expect(http.request).not.toHaveBeenCalled();
   });
 
+  it('inserts an activated new climb right after the current climb, not at the end (issue #2217)', async () => {
+    const itemA = makeQueueItem('item-a');
+    const itemB = makeQueueItem('item-b');
+    const itemC = makeQueueItem('item-c');
+    queueSnapshotStore.getStoredQueueSnapshot.mockResolvedValue(storedSnapshot([itemA, itemB, itemC], itemA));
+
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((entry) => entry.uuid)).toEqual(['item-a', 'item-b', 'item-c']);
+      expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('item-a');
+    });
+
+    act(() => {
+      snapshots.at(-1)?.setCurrentClimb(makeQueueItem('item-x'));
+    });
+
+    // The freshly activated climb slots in right after the current climb (A),
+    // pushing A into history — it is NOT appended after C.
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((entry) => entry.uuid)).toEqual([
+        'item-a',
+        'item-x',
+        'item-b',
+        'item-c',
+      ]);
+      expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('item-x');
+    });
+  });
+
   it('persists the solo queue after mutations (debounced)', async () => {
     const snapshots: Snapshot[] = [];
     renderProvider((snapshot) => snapshots.push(snapshot));

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -736,14 +736,29 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // CurrentClimbChanged event (same id in `serverCorrelationId`) is suppressed
   // instead of re-applied.
   const dispatchSetCurrent = useCallback(
-    (item: ClimbQueueItem, shouldAddToQueue: boolean, playlistSuggestionSource?: PlaylistSuggestionSource | null) => {
+    (
+      item: ClimbQueueItem,
+      shouldAddToQueue: boolean,
+      playlistSuggestionSource?: PlaylistSuggestionSource | null,
+      insertAfterCurrent?: boolean,
+    ) => {
       const correlationId = coordinator.generateCorrelationId();
       dispatch({
         type: 'DELTA_UPDATE_CURRENT_CLIMB',
         // playlistSuggestionSource is client-only state — when present the
         // reducer sets it + prunes suggested-after-current; when undefined it's
         // left unchanged. It is intentionally NOT sent to the server mutation.
-        payload: { item, shouldAddToQueue, isServerEvent: false, correlationId, playlistSuggestionSource },
+        // insertAfterCurrent keeps the optimistic queue in step with the server
+        // (issue #2217): a newly activated climb slots in right after the
+        // current climb, not at the end.
+        payload: {
+          item,
+          shouldAddToQueue,
+          isServerEvent: false,
+          correlationId,
+          playlistSuggestionSource,
+          insertAfterCurrent,
+        },
       });
       coordinator.trackPendingMutation(correlationId);
       mutations.setCurrentClimb(item, shouldAddToQueue, correlationId).catch(() => {
@@ -773,12 +788,16 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         layoutId: activeBoardRef.current?.layoutId,
         source: 'mobile',
       });
-      // Append (fresh-uuid items add to the queue; the reducer's uuid dedup makes
-      // re-selecting an existing queue item a no-op add). Re-tapping a playlist
-      // climb thus starts a fresh pass — forward-swipe re-appends the rest of the
-      // playlist (queue grows 1..10, 1..10), driven by
-      // findNextQueueItemWithSuggestions anchoring on the current climb.
-      dispatchSetCurrent(item, true, options?.playlistSuggestionSource);
+      // Activating a climb slots it right after the current climb (issue #2217),
+      // pushing the current climb into history — matching the local "set climb
+      // active" intent instead of bumping the new climb to the bottom. Fresh-uuid
+      // items add to the queue; the reducer's uuid dedup makes re-selecting an
+      // existing queue item a no-op add. During a playlist forward-swipe the
+      // current climb is already the queue tail, so insert-after-current is
+      // equivalent to append there and the "queue grows 1..10, 1..10" pass
+      // (driven by findNextQueueItemWithSuggestions anchoring on the current
+      // climb) is preserved.
+      dispatchSetCurrent(item, true, options?.playlistSuggestionSource, true);
     },
     [dispatchSetCurrent],
   );

--- a/packages/shared/queue/src/__tests__/reducer.test.ts
+++ b/packages/shared/queue/src/__tests__/reducer.test.ts
@@ -352,6 +352,48 @@ describe('DELTA_UPDATE_CURRENT_CLIMB', () => {
     expect(result.pendingCurrentClimbUpdates).toContain('local-corr-1');
     expect(result.currentClimbQueueItem?.uuid).toBe('new-climb');
   });
+
+  // Issue #2217: a peer (or the local light bulb) activating a NEW climb should
+  // slot it right after the current climb, pushing the current climb into
+  // history — not append it to the end and jump the current pointer there.
+  it('inserts a not-yet-queued climb right after the current climb when insertAfterCurrent is set', () => {
+    const itemA = makeClimbQueueItem({ uuid: 'item-a' });
+    const itemB = makeClimbQueueItem({ uuid: 'item-b' });
+    const itemC = makeClimbQueueItem({ uuid: 'item-c' });
+    const itemX = makeClimbQueueItem({ uuid: 'item-x' });
+    const state = makeState({ queue: [itemA, itemB, itemC], currentClimbQueueItem: itemA });
+
+    const result = queueReducer(state, {
+      type: 'DELTA_UPDATE_CURRENT_CLIMB',
+      payload: {
+        item: itemX,
+        shouldAddToQueue: true,
+        insertAfterCurrent: true,
+        isServerEvent: true,
+      },
+    });
+
+    expect(result.queue.map((queueItem) => queueItem.uuid)).toEqual(['item-a', 'item-x', 'item-b', 'item-c']);
+    expect(result.currentClimbQueueItem?.uuid).toBe('item-x');
+  });
+
+  it('appends a not-yet-queued climb to the end when insertAfterCurrent is NOT set (documents the pre-#2217 behaviour the mapper now avoids)', () => {
+    const itemA = makeClimbQueueItem({ uuid: 'item-a' });
+    const itemB = makeClimbQueueItem({ uuid: 'item-b' });
+    const itemX = makeClimbQueueItem({ uuid: 'item-x' });
+    const state = makeState({ queue: [itemA, itemB], currentClimbQueueItem: itemA });
+
+    const result = queueReducer(state, {
+      type: 'DELTA_UPDATE_CURRENT_CLIMB',
+      payload: {
+        item: itemX,
+        shouldAddToQueue: true,
+        isServerEvent: true,
+      },
+    });
+
+    expect(result.queue.map((queueItem) => queueItem.uuid)).toEqual(['item-a', 'item-b', 'item-x']);
+  });
 });
 
 describe('REGRADE_CLIMBS', () => {

--- a/packages/shared/queue/src/__tests__/sync-coordinator.test.ts
+++ b/packages/shared/queue/src/__tests__/sync-coordinator.test.ts
@@ -8,6 +8,7 @@ import {
   type SyncQueueEvent,
 } from '../sync-coordinator';
 import type { Climb, ClimbQueueItem, QueueAction } from '../types';
+import { queueReducer, initialState } from '../reducer';
 
 const makeClimb = (uuid: string, name = 'Test Climb'): Climb => ({
   uuid,
@@ -127,6 +128,9 @@ describe('mapQueueEventToAction', () => {
           // Always request insertion when an incoming item is present —
           // reducer's idempotent guard skips climbs already in the queue.
           shouldAddToQueue: true,
+          // And when it does need inserting, slot it after the current climb
+          // rather than at the end (issue #2217).
+          insertAfterCurrent: true,
         },
       });
     });
@@ -182,6 +186,35 @@ describe('mapQueueEventToAction', () => {
     expect(result.kind).toBe('dispatch');
     if (result.kind !== 'dispatch') return;
     expect(result.action).toMatchObject({ payload: { mirroredUuid: null } });
+  });
+});
+
+describe('issue #2217 — peer takes control (map → reducer end-to-end)', () => {
+  it('slots a peer-activated new climb after the current climb, not at the end', () => {
+    const itemA = makeItem('item-a');
+    const itemB = makeItem('item-b');
+    const itemC = makeItem('item-c');
+    const state = {
+      ...initialState({}),
+      queue: [itemA, itemB, itemC],
+      currentClimbQueueItem: itemA,
+    };
+
+    // A peer lights up a brand-new climb → server broadcasts CurrentClimbChanged.
+    const peerItem = makeItem('item-x');
+    const event: SyncQueueEvent = {
+      __typename: 'CurrentClimbChanged',
+      currentItem: peerItem,
+      clientId: 'peer-1',
+    };
+
+    const mapped = mapQueueEventToAction(event, { myClientId: 'me' });
+    expect(mapped.kind).toBe('dispatch');
+    if (mapped.kind !== 'dispatch') return;
+
+    const next = queueReducer(state, mapped.action);
+    expect(next.queue.map((queueItem) => queueItem.uuid)).toEqual(['item-a', 'item-x', 'item-b', 'item-c']);
+    expect(next.currentClimbQueueItem?.uuid).toBe('item-x');
   });
 });
 

--- a/packages/shared/queue/src/sync-coordinator.ts
+++ b/packages/shared/queue/src/sync-coordinator.ts
@@ -151,6 +151,10 @@ export function mapQueueEventToAction<TSearchParams extends QueueSearchParams = 
       //   2. Browsing-only navigations on web already pass non-suggested items
       //      that exist in the queue, so the idempotent guard makes
       //      shouldAddToQueue:true a no-op there.
+      // When the item does need inserting (not already queued), place it right
+      // after the current climb, not at the end (issue #2217) — a peer lighting
+      // up a new climb should slot it into the "up next" position, matching the
+      // local "set climb active" behaviour instead of bumping it to the bottom.
       return {
         kind: 'dispatch',
         eventType: 'CurrentClimbChanged',
@@ -160,6 +164,7 @@ export function mapQueueEventToAction<TSearchParams extends QueueSearchParams = 
           payload: {
             item: incoming,
             shouldAddToQueue: incoming != null,
+            insertAfterCurrent: true,
             isServerEvent: true,
             eventClientId: event.clientId ?? undefined,
             myClientId: context?.myClientId ?? undefined,


### PR DESCRIPTION
## Summary

Fixes #2217. In a party session, when someone activated a climb via the light bulb, the new climb was appended to the **end** of everyone's queue and the current pointer jumped to the bottom. It should behave like the standard "set climb active": slot the new climb in right **after** the current climb (pushing the current climb into history) and leave the rest of the up-next order untouched.

Root cause was the backend `setCurrentClimbAndPublish` (`packages/backend/src/services/queue-navigation.ts`): when `shouldAddToQueue` was true and the climb wasn't already queued, it did `queue = [...queue, item]` (append) and then broadcast a `FullSync` carrying that end-appended order, so every client adopted the wrong order. This is the single-mutation path the **mobile light bulb** uses (`setCurrentClimb(item, shouldAddToQueue: true)`); the web board-route path already inserted correctly via a separate `addQueueItem(position)` call, which is why it wasn't reproducible web-to-web.

Three coordinated changes:

- **Backend** — `setCurrentClimbAndPublish` now inserts the new climb immediately after the current climb's index, falling back to append only when there's no current climb to anchor to. The `FullSync` it broadcasts now carries the correct order for all peers.
- **Shared `@boardsesh/queue`** — `mapQueueEventToAction`'s `CurrentClimbChanged` mapping now sets `insertAfterCurrent: true`, so any peer-applied current-climb add lands after current rather than at the end (defensive; the reducer already supported this flag — the web path uses it).
- **Mobile** — the light bulb `setCurrentClimb` path threads `insertAfterCurrent: true` into its optimistic dispatch so the initiator's own queue matches immediately (no flash before the server echo), mirroring web's `queue-actions-core`. `nextClimb`/`previousClimb` are unchanged (their items are already queued, and the playlist forward-swipe keeps the current climb at the queue tail where insert-after-current equals append).

### Note: web peek-promotion behavior change (intentional)

The backend fix also touches web's `setCurrentClimbQueueItem` peek/suggested-climb promotion, which calls `setCurrentClimb(item, suggested)`. Promoting a not-yet-queued suggested climb now inserts it after current instead of appending. During a normal playlist forward-swipe the current climb is already the queue tail, so the two are identical and there's no visible change — but flagging it since it's a second path the backend change affects. Final state is the more-correct insert-after-current.

## Release Notes

- Party mode: when someone else lights up a climb, it now slots in right after the current climb instead of getting bumped to the bottom of the queue — everyone's up-next order stays put.

## Test plan

- `vp test run --project queue --reporter=agent` — 106 passed. New reducer tests reproduce the exact peer-takeover interleaving (`[A,B,C]`/current `A` + activate `X` → `[A,X,B,C]`, current `X`), a guard documenting the pre-fix append behavior, and an end-to-end `mapQueueEventToAction → queueReducer` "peer takes control" case.
- `SKIP_TEST_INFRA=1 vp test run --project backend --reporter=agent queue-navigation` — 8 passed. New cases: insert-after-current with a populated queue + current climb, and the no-current-climb append fallback.
- `vp test run --project mobile --reporter=agent queue-provider-local-queue` — 9 passed. New case renders the provider, seeds `[A,B,C]`/current `A`, calls `setCurrentClimb(X)`, asserts `[A,X,B,C]`/current `X`.
- `vp run typecheck` — clean (exit 0).
