### PR TITLE
fix(sync): classify TB2 attempts by is_ascent, not array membership

### DIFF
--- a/packages/aurora-sync/src/sync/json-import.test.ts
+++ b/packages/aurora-sync/src/sync/json-import.test.ts
@@ -3,8 +3,10 @@ import { PgDialect } from 'drizzle-orm/pg-core';
 import {
   buildImportedClimbRow,
   buildJsonImportAscentTickRow,
+  exportAscentToAttempt,
   generateJsonImportAuroraId,
   importedPlaceholderConflictPolicy,
+  isExportAscentActuallyAttempt,
   publishedClimbKey,
   type AuroraExportAscent,
 } from './json-import';
@@ -49,6 +51,22 @@ describe('buildJsonImportAscentTickRow', () => {
     expect(row.quality).toBe(5);
   });
 
+  // #3301: the merged Aurora shape can omit stars/grade on an attempt-shaped
+  // `ascents` row. The builder must tolerate that (null quality/difficulty)
+  // rather than throw, while the legacy shape (always present) is unchanged.
+  it('tolerates a missing grade (merged shape) with null difficulty', () => {
+    const row = buildJsonImportAscentTickRow(
+      USER_ID,
+      'tension',
+      makeAscent({ grade: undefined, stars: undefined }),
+      CLIMB_UUID,
+      CLIMBED_AT,
+      NOW,
+    );
+    expect(row.difficulty).toBeNull();
+    expect(row.quality).toBeNull();
+  });
+
   it('builds the row with the deterministic json-import aurora id and matching sync timestamps', () => {
     const ascent = makeAscent();
     const row = buildJsonImportAscentTickRow(USER_ID, 'kilter', ascent, CLIMB_UUID, CLIMBED_AT, NOW);
@@ -64,6 +82,31 @@ describe('buildJsonImportAscentTickRow', () => {
     // timestamp here.
     expect(row.updatedAt).toBe(NOW);
     expect(row.auroraSyncedAt).toBe(NOW);
+  });
+});
+
+describe('merged-shape attempt reclassification (#3301)', () => {
+  it('flags only an explicit is_ascent=false as an attempt', () => {
+    expect(isExportAscentActuallyAttempt(makeAscent({ is_ascent: false }))).toBe(true);
+    // Legacy Kilter exports omit the flag → stays an ascent.
+    expect(isExportAscentActuallyAttempt(makeAscent())).toBe(false);
+    expect(isExportAscentActuallyAttempt(makeAscent({ is_ascent: true }))).toBe(false);
+  });
+
+  it('coerces a merged-shape attempt to the flat attempt shape, preferring tries over count', () => {
+    const attempt = exportAscentToAttempt(makeAscent({ is_ascent: false, count: 2, tries: 5 }));
+    expect(attempt).toEqual({
+      climb: 'Test Climb',
+      angle: 40,
+      count: 5,
+      climbed_at: '2026-06-01 10:00:00',
+      created_at: '2026-06-01 10:05:00',
+    });
+  });
+
+  it('falls back to count when tries is absent', () => {
+    const attempt = exportAscentToAttempt(makeAscent({ is_ascent: false, count: 3 }));
+    expect(attempt.count).toBe(3);
   });
 });
 

--- a/packages/aurora-sync/src/sync/json-import.ts
+++ b/packages/aurora-sync/src/sync/json-import.ts
@@ -35,10 +35,18 @@ const auroraExportAscentSchema = z.object({
   climb: z.string(),
   angle: z.number(),
   count: z.number(),
-  stars: z.number(),
+  // The legacy Kilter export always carries stars + grade on an ascent. The
+  // live Aurora backend (Tension / TB2) instead delivers the WHOLE logbook in
+  // `ascents` and flags a bid the user never sent with `is_ascent: false` —
+  // those attempt-shaped rows can lack stars/grade, so both are optional. A
+  // missing/true `is_ascent` keeps the row an ascent (legacy path unchanged);
+  // an explicit false reroutes it to the attempt path. #3301
+  stars: z.number().optional(),
   climbed_at: z.string(),
   created_at: z.string(),
-  grade: z.string(),
+  grade: z.string().optional(),
+  is_ascent: z.boolean().optional(),
+  tries: z.number().optional(),
 });
 
 export type AuroraExportAscent = z.infer<typeof auroraExportAscentSchema>;
@@ -50,6 +58,8 @@ const auroraExportAttemptSchema = z.object({
   climbed_at: z.string(),
   created_at: z.string(),
 });
+
+export type AuroraExportAttempt = z.infer<typeof auroraExportAttemptSchema>;
 
 const auroraExportCircuitSchema = z.object({
   name: z.string(),
@@ -197,7 +207,9 @@ export function buildJsonImportAscentTickRow(
     // Rows imported before this conversion existed were rescaled by the
     // backfill migration scoped to aurora_id LIKE 'json-import-%'.
     quality: convertQuality(ascent.stars),
-    difficulty: fontGradeToDifficultyId(ascent.grade),
+    // A merged-shape ascent can omit `grade`; fontGradeToDifficultyId('')
+    // intentionally returns null (unrecognised grade → no personal override).
+    difficulty: fontGradeToDifficultyId(ascent.grade ?? ''),
     isBenchmark: false,
     comment: '',
     climbedAt,
@@ -210,6 +222,32 @@ export function buildJsonImportAscentTickRow(
     auroraType: 'ascents' as const,
     auroraId: generateJsonImportAuroraId(userId, climbUuid, ascent.angle, climbedAt, 'ascents'),
     auroraSyncedAt: now,
+  };
+}
+
+/**
+ * An `ascents` entry that the current Aurora backend (Tension / TB2) marked as
+ * a bid the user never sent. The legacy Kilter export splits sends and attempts
+ * into separate top-level arrays and never sets this flag, so a missing or true
+ * `is_ascent` stays an ascent — the legacy path is byte-for-byte unchanged. Only
+ * an explicit `false` reroutes the record to the attempt path. #3301
+ */
+export function isExportAscentActuallyAttempt(ascent: AuroraExportAscent): boolean {
+  return ascent.is_ascent === false;
+}
+
+/**
+ * Coerce a merged-shape attempt (an `ascents` row with `is_ascent: false`) into
+ * the flat attempt shape the importer's attempt path consumes. In the merged
+ * shape `tries` is the bid count; fall back to `count` when it's absent.
+ */
+export function exportAscentToAttempt(ascent: AuroraExportAscent): AuroraExportAttempt {
+  return {
+    climb: ascent.climb,
+    angle: ascent.angle,
+    count: ascent.tries ?? ascent.count,
+    climbed_at: ascent.climbed_at,
+    created_at: ascent.created_at,
   };
 }
 
@@ -822,6 +860,91 @@ async function batchInsertTicks(
 }
 
 // ---------------------------------------------------------------------------
+// Self-healing remediation for #3301
+// ---------------------------------------------------------------------------
+
+/** Natural key of a merged-shape attempt whose earlier import may have created a mislabeled send. */
+type MislabeledAttemptKey = {
+  climbUuid: string;
+  angle: number;
+  climbedAt: string;
+  attemptCount: number;
+};
+
+/**
+ * Fix rows an earlier (pre-#3301) import mislabeled: a Tension/TB2 attempt that
+ * arrived inside the `ascents` array was written as a `send`. When the fixed
+ * importer now classifies the SAME record as an attempt, flip the stale row in
+ * place — status → 'attempt', clear the star/grade an attempt can't carry, and
+ * point aurora_type at 'bids'. Matched strictly on the natural key
+ * (climb_uuid, angle, climbed_at) of an existing json_import ascent for this
+ * user + board, so a legitimate send is never touched.
+ *
+ * This is an UPDATE only — it never deletes. `aurora_id` is intentionally left
+ * as the original `json-import-…` (ascents) hash: it's still a unique synthetic
+ * id, it stays claimable by the live Aurora pull (`aurora_id LIKE 'json-import-%'`),
+ * and rewriting it would risk colliding with the global aurora_id unique index.
+ * Returns the number of rows healed.
+ */
+async function healMislabeledJsonImportAttempts(
+  db: PgDatabase<PgQueryResultHKT, Record<string, unknown>>,
+  boardType: BoardType,
+  userId: string,
+  keys: MislabeledAttemptKey[],
+  now: string,
+): Promise<number> {
+  if (keys.length === 0) return 0;
+
+  let healed = 0;
+  for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+    const batch = keys.slice(i, i + BATCH_SIZE);
+    const payload = JSON.stringify(
+      batch.map((key) => ({
+        climb_uuid: key.climbUuid,
+        angle: key.angle,
+        climbed_at: key.climbedAt,
+        attempt_count: key.attemptCount,
+      })),
+    );
+
+    const result = await db.execute(sql`
+      UPDATE boardsesh_ticks AS t SET
+        -- String literals coerce to the column's type (enum in prod, text in the
+        -- test schema) by assignment, so no explicit ::enum cast is needed.
+        status = 'attempt',
+        quality = NULL,
+        difficulty = NULL,
+        attempt_count = u.attempt_count,
+        aurora_type = 'bids',
+        updated_at = ${now}::timestamp,
+        aurora_synced_at = ${now}::timestamp
+      FROM jsonb_to_recordset(${payload}::jsonb) AS u(
+        climb_uuid text,
+        angle integer,
+        climbed_at text,
+        attempt_count integer
+      )
+      WHERE t.user_id = ${userId}
+        AND t.board_type = ${boardType}
+        AND t.origin = 'json_import'
+        AND t.aurora_type = 'ascents'
+        AND t.status IN ('flash', 'send')
+        AND t.climb_uuid = u.climb_uuid
+        AND t.angle = u.angle
+        AND t.climbed_at = u.climbed_at::timestamp
+      RETURNING t.uuid
+    `);
+
+    // drizzle's execute() return shape differs by driver (postgres-js returns
+    // the rows array; Neon HTTP wraps them in { rows }), so normalize both.
+    const rows = Array.isArray(result) ? result : ((result as { rows?: unknown[] }).rows ?? []);
+    healed += rows.length;
+  }
+
+  return healed;
+}
+
+// ---------------------------------------------------------------------------
 // Main import function
 // ---------------------------------------------------------------------------
 
@@ -1071,16 +1194,25 @@ export async function importJsonExportData(
   });
   const nameToUuid = await resolveClimbNames(db, boardType, [...allClimbNames], userId);
 
+  // Split the `ascents` array into true sends and merged-shape attempts. The
+  // live Aurora backend (Tension / TB2) delivers a unified logbook in `ascents`
+  // and flags a never-sent bid with `is_ascent: false`; classifying purely by
+  // array membership stamped every one as a send (#3301). A missing/true flag —
+  // every legacy Kilter export — stays an ascent, so that path is unchanged.
+  const trueAscents = data.ascents.filter((ascent) => !isExportAscentActuallyAttempt(ascent));
+  const reclassifiedAttempts = data.ascents.filter(isExportAscentActuallyAttempt).map(exportAscentToAttempt);
+  const allAttempts = [...data.attempts, ...reclassifiedAttempts];
+
   // Track unresolved names, split per-source so the UI can show each section
   // separately (an ascent with an unmatched climb is a different user story
   // from a circuit referencing an unmatched climb).
   const unresolvedAscentSet = new Set<string>();
   const unresolvedAttemptSet = new Set<string>();
   const unresolvedCircuitSet = new Set<string>();
-  for (const ascent of data.ascents) {
+  for (const ascent of trueAscents) {
     if (!nameToUuid.has(ascent.climb)) unresolvedAscentSet.add(ascent.climb);
   }
-  for (const attempt of data.attempts) {
+  for (const attempt of allAttempts) {
     if (!nameToUuid.has(attempt.climb)) unresolvedAttemptSet.add(attempt.climb);
   }
   for (const circuit of data.circuits) {
@@ -1097,8 +1229,22 @@ export async function importJsonExportData(
   onProgress?.({ type: 'progress', step: 'dedup', message: 'Checking for duplicates...' });
   const existingKeys = await getExistingTickKeys(db, userId, boardType);
 
+  // Natural keys of the merged-shape attempts, used to heal any send an earlier
+  // (pre-#3301) import wrote for the same record (see self-heal below).
+  const reclassifiedAttemptKeys: MislabeledAttemptKey[] = [];
+  for (const attempt of reclassifiedAttempts) {
+    const climbUuid = nameToUuid.get(attempt.climb);
+    if (!climbUuid) continue;
+    reclassifiedAttemptKeys.push({
+      climbUuid,
+      angle: attempt.angle,
+      climbedAt: normalizeTimestamp(attempt.climbed_at),
+      attemptCount: attempt.count,
+    });
+  }
+
   // Step 5: Collect ascent rows to insert (in-memory dedup first)
-  const ascentRows = data.ascents.reduce<JsonImportTickRow[]>((rows, ascent) => {
+  const ascentRows = trueAscents.reduce<JsonImportTickRow[]>((rows, ascent) => {
     const climbUuid = nameToUuid.get(ascent.climb);
     if (!climbUuid) {
       result.ascents.failed++;
@@ -1117,8 +1263,9 @@ export async function importJsonExportData(
     return rows;
   }, []);
 
-  // Step 6: Collect attempt rows to insert
-  const attemptRows = data.attempts.reduce<JsonImportTickRow[]>((rows, attempt) => {
+  // Step 6: Collect attempt rows to insert (both native `attempts` and any
+  // merged-shape `is_ascent: false` records pulled out of `ascents` above).
+  const attemptRows = allAttempts.reduce<JsonImportTickRow[]>((rows, attempt) => {
     const climbUuid = nameToUuid.get(attempt.climb);
     if (!climbUuid) {
       result.attempts.failed++;
@@ -1157,7 +1304,9 @@ export async function importJsonExportData(
     return rows;
   }, []);
 
-  // Step 7: Batch-insert ascents and attempts in a transaction
+  // Step 7: Batch-insert ascents and attempts, plus self-heal any pre-#3301
+  // mislabeled sends, all in one transaction.
+  let healedMislabeledSends = 0;
   await db.transaction(async (tx) => {
     result.ascents.imported = await batchInsertTicks(
       tx,
@@ -1178,7 +1327,7 @@ export async function importJsonExportData(
         auroraSyncedAt: sql`excluded.aurora_synced_at`,
       },
       'ascents',
-      data.ascents.length,
+      trueAscents.length,
       onProgress,
     );
 
@@ -1194,10 +1343,28 @@ export async function importJsonExportData(
         auroraSyncedAt: sql`excluded.aurora_synced_at`,
       },
       'attempts',
-      data.attempts.length,
+      allAttempts.length,
       onProgress,
     );
+
+    // Remediation (#3301): flip any send a prior buggy import wrote for a record
+    // that is now correctly classified as an attempt. The dedup above already
+    // skips inserting a twin for these keys, so this UPDATE is what actually
+    // corrects the stale row. Never deletes.
+    healedMislabeledSends = await healMislabeledJsonImportAttempts(tx, boardType, userId, reclassifiedAttemptKeys, now);
   });
+
+  // Structured breadcrumb (info-level, not an error) so we can measure how often
+  // the merged-shape Aurora export path actually fires in prod — and confirm the
+  // #3301 discriminator assumption against real Tension/TB2 imports. Uses
+  // console (with key=value fields) rather than the backend winston logger on
+  // purpose: this shared package must not depend on `packages/backend`, and it
+  // already logs via console elsewhere. The backend captures stdout regardless.
+  if (reclassifiedAttempts.length > 0 || healedMislabeledSends > 0) {
+    console.info(
+      `[aurora-import][3301] merged-shape logbook: boardType=${boardType} reclassifiedAttempts=${reclassifiedAttempts.length} healedMislabeledSends=${healedMislabeledSends}`,
+    );
+  }
 
   // Fold this chunk's imported ascents into board_climb_stats. json_import
   // ticks don't add to the Boardsesh count (they're already upstream), but the
@@ -1209,6 +1376,16 @@ export async function importJsonExportData(
       boardType,
       climbUuid: row.climbUuid,
       angle: row.angle,
+    });
+  }
+  // A self-heal flips a send → attempt, which drops an ascent from that
+  // (climb, angle) — recompute those keys too so the ascensionist count and any
+  // stale Boardsesh crown follow the correction.
+  for (const key of reclassifiedAttemptKeys) {
+    importedAscentKeys.set(`${key.climbUuid} ${key.angle}`, {
+      boardType,
+      climbUuid: key.climbUuid,
+      angle: key.angle,
     });
   }
   const importedAscentKeyList = [...importedAscentKeys.values()];

--- a/packages/backend/src/__tests__/aurora-import-reclassify.test.ts
+++ b/packages/backend/src/__tests__/aurora-import-reclassify.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import { importJsonExportData } from '@boardsesh/aurora-sync/json-import';
+import { db } from '../db/client';
+import { setupWorkerDatabase } from './worker-db';
+
+/**
+ * #3301 — the live Aurora backend (Tension / TB2) delivers a unified logbook in
+ * the export's `ascents` array and flags a never-sent bid with `is_ascent:
+ * false`. The old importer classified purely by array membership, so every one
+ * of those attempts was imported as a `send`. These tests cover the fix
+ * (classify by the per-record flag) and the self-healing remediation (a
+ * re-import flips a previously-mislabeled send to an attempt in place).
+ */
+
+const USER_ID = 'ai3301-user';
+const BOARD = 'tension';
+const CLIMB_UUID = 'ai3301-climb-uuid';
+const CLIMB_NAME = 'Reclassify Test Climb';
+const ANGLE = 40;
+
+// A drizzle postgres-js handle satisfies importJsonExportData's PgDatabase
+// surface; the cast just crosses the generic boundary.
+const importDb = db as unknown as Parameters<typeof importJsonExportData>[0];
+
+type ExportOverrides = Partial<{
+  ascents: Array<Record<string, unknown>>;
+  attempts: Array<Record<string, unknown>>;
+}>;
+
+function exportPayload(overrides: ExportOverrides = {}) {
+  return {
+    user: { username: 'ai3301' },
+    ascents: overrides.ascents ?? [],
+    attempts: overrides.attempts ?? [],
+    circuits: [],
+    climbs: [],
+    likes: [],
+  } as unknown as Parameters<typeof importJsonExportData>[3];
+}
+
+function ascentRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    climb: CLIMB_NAME,
+    angle: ANGLE,
+    count: 2,
+    stars: 3,
+    climbed_at: '2026-06-01 10:00:00',
+    created_at: '2026-06-01 10:05:00',
+    grade: '7a',
+    ...overrides,
+  };
+}
+
+function attemptRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    climb: CLIMB_NAME,
+    angle: ANGLE,
+    count: 3,
+    climbed_at: '2026-06-02 11:00:00',
+    created_at: '2026-06-02 11:05:00',
+    ...overrides,
+  };
+}
+
+async function ticksForUser() {
+  const rows = (await db.execute(sql`
+    SELECT uuid, status, attempt_count, quality, difficulty, aurora_type, origin, climbed_at
+    FROM boardsesh_ticks
+    WHERE user_id = ${USER_ID} AND board_type = ${BOARD}
+    ORDER BY climbed_at
+  `)) as unknown as Array<{
+    uuid: string;
+    status: string;
+    attempt_count: number;
+    quality: number | null;
+    difficulty: number | null;
+    aurora_type: string | null;
+    origin: string;
+    climbed_at: string;
+  }>;
+  return Array.isArray(rows) ? rows : (((rows as { rows?: unknown[] }).rows as typeof rows) ?? []);
+}
+
+beforeAll(async () => {
+  await setupWorkerDatabase();
+  // importJsonExportData upserts ON CONFLICT (aurora_id); guarantee the arbiter
+  // index exists (canonically declared in schema-sql.ts) so the test doesn't
+  // depend on apply ordering.
+  await db.execute(
+    sql`CREATE UNIQUE INDEX IF NOT EXISTS boardsesh_ticks_aurora_id_unique ON boardsesh_ticks (aurora_id)`,
+  );
+  await db.execute(sql`
+    INSERT INTO users (id, email, name, created_at, updated_at)
+    VALUES (${USER_ID}, ${USER_ID + '@test.com'}, 'Reclassify Tester', now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+  // A listed catalog climb so the export's climb name resolves to a uuid.
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at)
+    VALUES (${CLIMB_UUID}, ${BOARD}, 1, 'test-setter', ${CLIMB_NAME}, 'p1r1', 1, false, true, 0, 100, 0, 150, '2024-01-01')
+    ON CONFLICT (uuid) DO NOTHING
+  `);
+});
+
+afterEach(async () => {
+  await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+});
+
+describe('aurora import — #3301 merged-shape reclassification', () => {
+  it('classifies an is_ascent=false record inside ascents as an attempt, not a send', async () => {
+    await importJsonExportData(
+      importDb,
+      USER_ID,
+      BOARD,
+      exportPayload({
+        ascents: [
+          ascentRecord({ is_ascent: true, climbed_at: '2026-06-01 10:00:00' }),
+          ascentRecord({ is_ascent: false, tries: 4, climbed_at: '2026-06-03 12:00:00' }),
+        ],
+      }),
+    );
+
+    const rows = await ticksForUser();
+    expect(rows).toHaveLength(2);
+
+    const send = rows.find((r) => r.climbed_at.startsWith('2026-06-01'));
+    const attempt = rows.find((r) => r.climbed_at.startsWith('2026-06-03'));
+
+    expect(send?.status === 'send' || send?.status === 'flash').toBe(true);
+    expect(send?.aurora_type).toBe('ascents');
+
+    // The is_ascent=false row must land as an attempt with no star/grade and the
+    // `tries` count, not a send.
+    expect(attempt?.status).toBe('attempt');
+    expect(attempt?.aurora_type).toBe('bids');
+    expect(attempt?.quality).toBeNull();
+    expect(attempt?.difficulty).toBeNull();
+    expect(attempt?.attempt_count).toBe(4);
+  });
+
+  it('leaves the legacy Kilter shape (separate arrays, no is_ascent) unchanged', async () => {
+    await importJsonExportData(
+      importDb,
+      USER_ID,
+      BOARD,
+      exportPayload({
+        ascents: [ascentRecord({ climbed_at: '2026-06-01 10:00:00' })],
+        attempts: [attemptRecord({ climbed_at: '2026-06-02 11:00:00' })],
+      }),
+    );
+
+    const rows = await ticksForUser();
+    expect(rows).toHaveLength(2);
+    const send = rows.find((r) => r.climbed_at.startsWith('2026-06-01'));
+    const attempt = rows.find((r) => r.climbed_at.startsWith('2026-06-02'));
+    expect(send?.status === 'send' || send?.status === 'flash').toBe(true);
+    expect(attempt?.status).toBe('attempt');
+  });
+
+  it('self-heals a previously-mislabeled send on re-import (UPDATE in place, never a delete or twin)', async () => {
+    // First import reproduces the OLD bug: the record arrives with no is_ascent
+    // flag, so it is written as a send.
+    await importJsonExportData(
+      importDb,
+      USER_ID,
+      BOARD,
+      exportPayload({
+        ascents: [ascentRecord({ climbed_at: '2026-06-05 09:00:00' })],
+      }),
+    );
+
+    let rows = await ticksForUser();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status === 'send' || rows[0].status === 'flash').toBe(true);
+    const originalUuid = rows[0].uuid;
+
+    // Re-import the SAME record, now correctly flagged is_ascent=false. The
+    // fixed importer classifies it as an attempt and heals the stale send.
+    const reimport = await importJsonExportData(
+      importDb,
+      USER_ID,
+      BOARD,
+      exportPayload({
+        ascents: [ascentRecord({ is_ascent: false, tries: 6, climbed_at: '2026-06-05 09:00:00' })],
+      }),
+    );
+
+    // The record dedups against the existing (now-healed) row, so it is skipped
+    // rather than inserted as a twin — the heal is the UPDATE, not an insert.
+    expect(reimport.attempts.imported).toBe(0);
+    expect(reimport.attempts.skipped).toBe(1);
+    expect(reimport.ascents.imported).toBe(0);
+
+    rows = await ticksForUser();
+    // No twin inserted — still exactly one row, and it's the SAME row (not deleted).
+    expect(rows).toHaveLength(1);
+    expect(rows[0].uuid).toBe(originalUuid);
+    // Flipped in place to an attempt.
+    expect(rows[0].status).toBe('attempt');
+    expect(rows[0].aurora_type).toBe('bids');
+    expect(rows[0].quality).toBeNull();
+    expect(rows[0].difficulty).toBeNull();
+    expect(rows[0].attempt_count).toBe(6);
+  });
+});

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -337,6 +337,12 @@ export const schemaSQL = `
     "kilter_sync_error" text,
     "kilter_detached_at" timestamp
   );
+  -- Mirror the prod cross-system unique indexes so the aurora/kilter sync and
+  -- JSON-import upserts (ON CONFLICT (aurora_id) / (kilter_id)) resolve an
+  -- arbiter index. Postgres allows many NULLs under a unique index, so pending
+  -- (unsynced) ticks are unaffected.
+  CREATE UNIQUE INDEX IF NOT EXISTS "boardsesh_ticks_aurora_id_unique" ON "boardsesh_ticks" ("aurora_id");
+  CREATE UNIQUE INDEX IF NOT EXISTS "boardsesh_ticks_kilter_id_unique" ON "boardsesh_ticks" ("kilter_id");
 
   DROP TABLE IF EXISTS "board_placements" CASCADE;
   CREATE TABLE IF NOT EXISTS "board_placements" (

--- a/packages/shared-schema/src/__tests__/aurora-import.test.ts
+++ b/packages/shared-schema/src/__tests__/aurora-import.test.ts
@@ -26,4 +26,41 @@ void describe('parseAuroraExportJson', () => {
 
     expect(parsed.boardMismatchLayoutName).toBe('Kilter Board Original');
   });
+
+  // #3301: merged-shape attempts (is_ascent=false) still sit in `ascents`, so
+  // the preview must count them as attempts, not sends. The data passthrough is
+  // untouched — the server does the authoritative reclassification.
+  it('counts is_ascent=false records in the preview as attempts, not sends', () => {
+    const parsed = parseAuroraExportJson(
+      {
+        user: { username: 'setter' },
+        ascents: [
+          { climb: 'A', angle: 40, count: 1, stars: 3, climbed_at: 't', created_at: 't', grade: '7a' },
+          { climb: 'B', angle: 40, count: 4, climbed_at: 't', created_at: 't', is_ascent: false },
+        ],
+        attempts: [{ climb: 'C', angle: 40, count: 2, climbed_at: 't', created_at: 't' }],
+      },
+      'tension',
+    );
+
+    expect(parsed.preview.ascents).toBe(1);
+    expect(parsed.preview.attempts).toBe(2);
+    // Data is passed through untouched — both records still live in `ascents`.
+    expect(parsed.data.ascents).toHaveLength(2);
+    expect(parsed.data.attempts).toHaveLength(1);
+  });
+
+  it('counts a pure legacy Kilter export unchanged', () => {
+    const parsed = parseAuroraExportJson(
+      {
+        user: { username: 'setter' },
+        ascents: [{ climb: 'A', angle: 40, count: 1, stars: 3, climbed_at: 't', created_at: 't', grade: '7a' }],
+        attempts: [{ climb: 'C', angle: 40, count: 2, climbed_at: 't', created_at: 't' }],
+      },
+      'kilter',
+    );
+
+    expect(parsed.preview.ascents).toBe(1);
+    expect(parsed.preview.attempts).toBe(1);
+  });
 });

--- a/packages/shared-schema/src/aurora-import.ts
+++ b/packages/shared-schema/src/aurora-import.ts
@@ -65,6 +65,18 @@ function readStringProperty(value: unknown, property: string): string | undefine
   return typeof record[property] === 'string' ? record[property] : undefined;
 }
 
+/**
+ * True for a merged-shape attempt: an `ascents` entry the live Aurora backend
+ * (Tension / TB2) flagged as a bid the user never sent (`is_ascent: false`).
+ * Legacy Kilter exports omit the flag, so those stay ascents. The server-side
+ * importer does the authoritative reclassification; this only keeps the preview
+ * counts honest. Exported so web's `parse-aurora-export.ts` shares one copy. #3301
+ */
+export function isMergedShapeAttempt(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  return (value as Record<string, unknown>).is_ascent === false;
+}
+
 function detectBoardFromLayoutName(layoutName: string): string | null {
   const normalizedLayoutName = layoutName.toLowerCase();
   for (const boardType of AURORA_BOARDS) {
@@ -86,6 +98,10 @@ export function parseAuroraExportJson(json: Record<string, unknown>, boardType: 
   const attempts = Array.isArray(json.attempts) ? json.attempts : [];
   const circuits = Array.isArray(json.circuits) ? json.circuits : [];
   const climbs = Array.isArray(json.climbs) ? json.climbs : [];
+
+  // Merged-shape attempts still live in `ascents` here — the server reclassifies
+  // them at import — but the preview should count them as attempts, not sends.
+  const mergedShapeAttemptCount = ascents.filter(isMergedShapeAttempt).length;
 
   let boardMismatchLayoutName: string | undefined;
   if (climbs.length > 0) {
@@ -112,8 +128,8 @@ export function parseAuroraExportJson(json: Record<string, unknown>, boardType: 
       climbs,
     },
     preview: {
-      ascents: ascents.length,
-      attempts: attempts.length,
+      ascents: ascents.length - mergedShapeAttemptCount,
+      attempts: attempts.length + mergedShapeAttemptCount,
       circuits: circuits.length,
       climbs: climbs.length,
       username,

--- a/packages/web/app/lib/data-sync/aurora/parse-aurora-export.ts
+++ b/packages/web/app/lib/data-sync/aurora/parse-aurora-export.ts
@@ -2,6 +2,8 @@
  * Utilities for parsing and preparing Aurora JSON export files for import.
  */
 
+import { isMergedShapeAttempt } from '@boardsesh/shared-schema';
+
 export type AuroraExportPreview = {
   ascents: number;
   attempts: number;
@@ -55,6 +57,12 @@ export function parseAuroraExport(json: Record<string, unknown>, boardType: stri
   const circuits = Array.isArray(json.circuits) ? (json.circuits as unknown[]) : [];
   const userClimbs = Array.isArray(json.climbs) ? (json.climbs as unknown[]) : [];
 
+  // The live Aurora backend (Tension / TB2) delivers a unified logbook in
+  // `ascents` and flags a never-sent bid with `is_ascent: false`. The server
+  // reclassifies those at import; here we only keep the preview counts honest so
+  // the dialog doesn't overstate sends. Legacy Kilter exports omit the flag. #3301
+  const mergedShapeAttemptCount = ascents.filter(isMergedShapeAttempt).length;
+
   return {
     data: {
       user: user as StrippedExportData['user'],
@@ -64,8 +72,8 @@ export function parseAuroraExport(json: Record<string, unknown>, boardType: stri
       climbs: userClimbs,
     },
     preview: {
-      ascents: ascents.length,
-      attempts: attempts.length,
+      ascents: ascents.length - mergedShapeAttemptCount,
+      attempts: attempts.length + mergedShapeAttemptCount,
       circuits: circuits.length,
       climbs: userClimbs.length,
       username: user.username,


### PR DESCRIPTION
## Summary

Fixes #3301 — imported Tension Board (TB2) attempts were logged as sends, inflating send counts and skewing every downstream stat.

**Root cause.** The JSON import classified each logbook record as send-vs-attempt purely by which top-level array it sat in (`ascents` → `send`, `attempts` → `attempt`). That holds for the legacy Kilter GDPR export (separate arrays), but the live Aurora backend that serves Tension/TB2 delivers the whole logbook inside `ascents` and flags a bid the user never sent with `is_ascent: false` (plus a `tries` count). Every one of those attempts was stamped `send`. (The linked-account live sync — `ascents`/`bids` tables → flash/send vs attempt — is correct and unchanged; it can't turn a bid into a send.)

**The fix** (server-side, shared by web + mobile import):
- Split `is_ascent: false` records out of `ascents` into the attempt path — `status: 'attempt'`, null quality/difficulty, `tries` as the attempt count. `stars`/`grade` are now optional so attempt-shaped rows still validate. A missing or `true` `is_ascent` stays a send, so **the legacy Kilter path is byte-for-byte unchanged**.
- **Self-healing remediation:** on re-import, a record now classified as an attempt heals any send an earlier (pre-fix) import wrote for the same natural key `(climb_uuid, angle, climbed_at)` — an in-place `UPDATE` to `attempt`, matched only against this user's `json_import` ascents. **Never a delete, never a twin.** Affected users just re-import their history.
- Structured info-level breadcrumb (`[aurora-import][3301]`) counts reclassifications + heals so we can measure how often the merged-shape path actually fires in prod.
- Import preview counts (shared-schema + web) now show merged attempts as attempts, not sends.
- Test schema (`schema-sql.ts`) gains the prod `aurora_id` / `kilter_id` unique indexes so the `ON CONFLICT` upserts resolve an arbiter index under the worker DB (the JSON import had no DB-integration coverage before).

## Release Notes

- Importing your Tension Board history now keeps attempts as attempts. Projects you tried but didn't send no longer show up as sends, so your send count and stats stay honest.
- Already imported before this fix? Just re-import your history — the mislabeled sends get corrected in place.

## Test plan

- `vp run typecheck` — green.
- `vp test run --project backend aurora-import-reclassify` — new DB-integration test (3/3): merged-shape `is_ascent:false` → attempt; legacy separate-array Kilter shape unchanged; **second-import self-heal** flips a stale send to an attempt in place (same row uuid, no twin, no delete).
- `vp test` for `packages/aurora-sync/src/sync/json-import.test.ts` + `packages/shared-schema/src/__tests__/aurora-import.test.ts` — helper + preview-count coverage (21 passing).
- Verified the updated `schema-sql.ts` applies cleanly to a fresh Postgres and both unique indexes are present.

---

### @marcodejongh — two follow-ups to lock this down

1. **Confirm the discriminator with a real TB2 export.** This ships defensively: the fix only triggers on an explicit `is_ascent: false`, so if the assumption is wrong it's a no-op (no behavior change). But to be certain the merged Tension/TB2 export really uses `is_ascent` (+ `tries`) and not a differently-named flag, can you drop a **sanitized TB2 `.json` export** (or the reporter's) so I can nail the field mapping and add a fixture from real data?

2. **Prod remediation checklist (read-only — bounds the blast radius).** Candidate rows an earlier buggy import mislabeled (over-counts, since genuine un-rated/un-graded sends also match — precise identification needs the discarded `is_ascent`, which is why the self-heal is re-import-driven):

   ```sql
   SELECT count(*) AS candidate_wrong_sends,
          count(DISTINCT user_id) AS users_affected
   FROM boardsesh_ticks
   WHERE board_type = 'tension'
     AND origin = 'json_import'
     AND aurora_type = 'ascents'
     AND status IN ('send','flash')
     AND quality IS NULL
     AND difficulty IS NULL;
   ```

   Preferred remediation is the self-heal in this PR (affected users re-import; UPDATE-only). If you'd rather sweep proactively, that's a separate follow-up needing your sign-off — no destructive change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va
