### PR TITLE
fix(backend): atomic reconnect/leave transitions + reconnect-grace queue mutations

### DIFF
--- a/packages/backend/src/__tests__/disconnect-reconnect-orchestration.test.ts
+++ b/packages/backend/src/__tests__/disconnect-reconnect-orchestration.test.ts
@@ -166,7 +166,10 @@ describe('disconnectClient reconnect/expiry orchestration (#2135)', () => {
     ]);
 
     expect(distributedState.evictGhostParticipant).toHaveBeenCalledWith(SESSION_ID, USER);
-    expect(onExpired).toHaveBeenCalledWith(SESSION_ID, USER, { leaderId: 'new-participant', leaderConnectionId: 'new-conn' });
+    expect(onExpired).toHaveBeenCalledWith(SESSION_ID, USER, {
+      leaderId: 'new-participant',
+      leaderConnectionId: 'new-conn',
+    });
     expect(newLeader).toEqual({ leaderId: 'new-participant', leaderConnectionId: 'new-conn' });
   });
 });

--- a/packages/backend/src/__tests__/disconnect-reconnect-orchestration.test.ts
+++ b/packages/backend/src/__tests__/disconnect-reconnect-orchestration.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Orchestration tests for the room-manager side of the #2135 atomic
+ * reconnect/expiry wiring. The Lua-level behaviour is covered against real
+ * Redis in `session-reconnect-atomicity.test.ts`; here we mock the distributed
+ * state and assert that `disconnectClient` forwards the atomic results
+ * correctly: skipping the RECONNECTING presence broadcast when a reconnect
+ * already landed, and firing `onParticipantExpired` with the elected leader
+ * when the grace timer evicts a leader ghost.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { disconnectClient, type ExpiredParticipantLeader } from '../services/room-manager/client-lifecycle';
+import type { ConnectedClient, LocalSessionParticipant, RoomManagerDeps } from '../services/room-manager/types';
+import type { RedisSessionStore } from '../services/redis-session-store';
+import type { DistributedStateManager } from '../services/distributed-state';
+import type { WriteScheduler } from '../services/room-manager/write-scheduler';
+
+type MockedDistState = Pick<
+  DistributedStateManager,
+  | 'removeConnection'
+  | 'getSessionMemberCount'
+  | 'markParticipantReconnectingIfIdle'
+  | 'evictGhostParticipant'
+  | 'getConnection'
+>;
+
+const SESSION_ID = 'sess-orchestration';
+const CONN = 'conn-auth';
+const USER = 'user-auth';
+
+describe('disconnectClient reconnect/expiry orchestration (#2135)', () => {
+  let clients: Map<string, ConnectedClient>;
+  let sessionsMap: Map<string, Set<string>>;
+  let sessionParticipants: Map<string, Map<string, LocalSessionParticipant>>;
+  let sessionGraceTimers: Map<string, NodeJS.Timeout>;
+
+  function makeDeps(distributedState: MockedDistState, graceMs: number): RoomManagerDeps {
+    return {
+      clients,
+      sessions: sessionsMap,
+      sessionParticipants,
+      redisStore: { markInactive: vi.fn().mockResolvedValue(undefined) } as unknown as RedisSessionStore,
+      distributedState: distributedState as unknown as DistributedStateManager,
+      writeScheduler: { cancelPendingWrites: vi.fn() } as unknown as WriteScheduler,
+      sessionGraceTimers,
+      pendingJoinPersists: new Map(),
+      sessionGracePeriodMs: graceMs,
+    };
+  }
+
+  beforeEach(() => {
+    clients = new Map();
+    sessionsMap = new Map();
+    sessionParticipants = new Map();
+    sessionGraceTimers = new Map();
+
+    clients.set(CONN, {
+      connectionId: CONN,
+      sessionId: SESSION_ID,
+      participantId: USER,
+      userId: USER,
+      username: 'Auth',
+      isLeader: false,
+      connectedAt: new Date(),
+      avatarUrl: undefined,
+    });
+    sessionsMap.set(SESSION_ID, new Set([CONN]));
+    sessionParticipants.set(
+      SESSION_ID,
+      new Map([
+        [
+          USER,
+          {
+            id: USER,
+            username: 'Auth',
+            userId: USER,
+            avatarUrl: undefined,
+            isLeader: false,
+            connectionState: 'CONNECTED',
+            connectionIds: new Set([CONN]),
+          },
+        ],
+      ]),
+    );
+  });
+
+  it('skips the RECONNECTING presence broadcast when a reconnect already landed (crit D)', async () => {
+    const distributedState: MockedDistState = {
+      removeConnection: vi.fn().mockResolvedValue({
+        sessionId: SESSION_ID,
+        participantId: USER,
+        wasLeader: false,
+        newLeaderId: null,
+        newLeaderParticipantId: null,
+        remainingParticipantConnections: 0,
+      }),
+      getSessionMemberCount: vi.fn().mockResolvedValue(1),
+      markParticipantReconnectingIfIdle: vi.fn().mockResolvedValue({ status: 'has-live' }),
+      evictGhostParticipant: vi.fn(),
+      getConnection: vi.fn(),
+    };
+
+    const onExpired = vi.fn();
+    const result = await disconnectClient(makeDeps(distributedState, 60_000), CONN, onExpired);
+
+    expect(distributedState.markParticipantReconnectingIfIdle).toHaveBeenCalledWith(SESSION_ID, USER);
+    // No presence event owed, and no grace timer armed for a live participant.
+    expect(result?.presenceUser).toBeUndefined();
+    expect(sessionParticipants.get(SESSION_ID)?.get(USER)?.reconnectTimer).toBeUndefined();
+    expect(onExpired).not.toHaveBeenCalled();
+  });
+
+  it('emits a RECONNECTING presence and, on grace expiry, fires onParticipantExpired with the elected leader', async () => {
+    // A replacement leader connection lives locally so resolveLeaderParticipantId
+    // maps the elected connectionId back to its stable participantId.
+    clients.set('new-conn', {
+      connectionId: 'new-conn',
+      sessionId: SESSION_ID,
+      participantId: 'new-participant',
+      userId: 'new-participant',
+      username: 'Next',
+      isLeader: false,
+      connectedAt: new Date(),
+      avatarUrl: undefined,
+    });
+
+    const distributedState: MockedDistState = {
+      removeConnection: vi.fn().mockResolvedValue({
+        sessionId: SESSION_ID,
+        participantId: USER,
+        wasLeader: false,
+        newLeaderId: null,
+        newLeaderParticipantId: null,
+        remainingParticipantConnections: 0,
+      }),
+      getSessionMemberCount: vi.fn().mockResolvedValue(1),
+      markParticipantReconnectingIfIdle: vi.fn().mockResolvedValue({
+        status: 'reconnecting',
+        user: {
+          id: USER,
+          username: 'Auth',
+          isLeader: false,
+          avatarUrl: undefined,
+          userId: USER,
+          connectionState: 'RECONNECTING',
+        },
+      }),
+      evictGhostParticipant: vi.fn().mockResolvedValue({ status: 'evicted', newLeaderId: 'new-conn' }),
+      getConnection: vi.fn(),
+    };
+
+    let resolveExpired: (leader?: ExpiredParticipantLeader) => void;
+    const expiredFired = new Promise<ExpiredParticipantLeader | undefined>((resolve) => {
+      resolveExpired = resolve;
+    });
+    const onExpired = vi.fn((_sessionId: string, _participantId: string, newLeader?: ExpiredParticipantLeader) => {
+      resolveExpired(newLeader);
+    });
+
+    const result = await disconnectClient(makeDeps(distributedState, 10), CONN, onExpired);
+    // Passive disconnect parks the participant as RECONNECTING for peers.
+    expect(result?.presenceUser?.connectionState).toBe('RECONNECTING');
+
+    const newLeader = await Promise.race([
+      expiredFired,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('grace timer never fired')), 2000)),
+    ]);
+
+    expect(distributedState.evictGhostParticipant).toHaveBeenCalledWith(SESSION_ID, USER);
+    expect(onExpired).toHaveBeenCalledWith(SESSION_ID, USER, { leaderId: 'new-participant', leaderConnectionId: 'new-conn' });
+    expect(newLeader).toEqual({ leaderId: 'new-participant', leaderConnectionId: 'new-conn' });
+  });
+});

--- a/packages/backend/src/__tests__/helpers/mock-redis.ts
+++ b/packages/backend/src/__tests__/helpers/mock-redis.ts
@@ -1,5 +1,10 @@
 import { vi } from 'vite-plus/test';
 import type Redis from 'ioredis';
+import {
+  LEAVE_SESSION_SCRIPT,
+  MARK_RECONNECTING_IF_IDLE_SCRIPT,
+  EVICT_PARTICIPANT_IF_GHOST_SCRIPT,
+} from '../../services/distributed-state/lua-scripts';
 
 export type MockRedis = Redis & {
   _store: Map<string, string>;
@@ -242,6 +247,124 @@ export const createMockRedis = (): MockRedis => {
       return chainable;
     }),
     eval: vi.fn(async (_script: string, numkeys: number, ...args: unknown[]) => {
+      // Script-identity dispatch first, for scripts whose (numkeys, args.length)
+      // shape collides with another script the mock already handles. These MUST
+      // precede the shape-based branches below:
+      //   - MARK_RECONNECTING_IF_IDLE (numkeys=3, 2 ARGV) collides with
+      //     REMOVE_PARTICIPANT_CONNECTION (numkeys=3, 2 ARGV).
+      //   - LEAVE_SESSION (now numkeys=4) collides with REMOVE_PARTICIPANT
+      //     (numkeys=4).
+      //   - EVICT_PARTICIPANT_IF_GHOST (numkeys=5) has no shape branch at all.
+      const connLive = (connectionId: string) => hashes.has(`boardsesh:conn:${connectionId}`);
+      const connectedAtOf = (connectionId: string) => Number(hashes.get(`boardsesh:conn:${connectionId}`)?.connectedAt);
+      const clearConnSession = (connectionId: string) => {
+        const cd = hashes.get(`boardsesh:conn:${connectionId}`);
+        if (cd) {
+          cd.sessionId = '';
+          cd.participantId = '';
+          cd.isLeader = 'false';
+        }
+      };
+
+      if (_script === MARK_RECONNECTING_IF_IDLE_SCRIPT) {
+        const participantKey = args[0] as string;
+        const participantConnectionsKey = args[1] as string;
+        const now = args[3] as string;
+        if (!hashes.has(participantKey)) return 'MISSING';
+        const connIds = sets.get(participantConnectionsKey) ? Array.from(sets.get(participantConnectionsKey)!) : [];
+        if (connIds.some(connLive)) return 'HAS_LIVE';
+        const hash = hashes.get(participantKey)!;
+        hash.connectionState = 'RECONNECTING';
+        hash.lastSeenAt = now;
+        return 'RECONNECTING';
+      }
+
+      if (_script === EVICT_PARTICIPANT_IF_GHOST_SCRIPT) {
+        const sessionParticipantsKey = args[0] as string;
+        const participantKey = args[1] as string;
+        const participantConnectionsKey = args[2] as string;
+        const sessionMembersKey = args[3] as string;
+        const leaderKey = args[4] as string;
+        const participantId = args[5] as string;
+
+        if (!hashes.has(participantKey)) return ['MISSING', ''];
+        if (hashes.get(participantKey)!.connectionState !== 'RECONNECTING') return ['NOT_RECONNECTING', ''];
+        const connIds = sets.get(participantConnectionsKey) ? Array.from(sets.get(participantConnectionsKey)!) : [];
+        if (connIds.some(connLive)) return ['HAS_LIVE', ''];
+
+        sets.get(sessionParticipantsKey)?.delete(participantId);
+        hashes.delete(participantKey);
+        sets.delete(participantConnectionsKey);
+        const memberSet = sets.get(sessionMembersKey);
+        for (const cid of connIds) {
+          memberSet?.delete(cid);
+          clearConnSession(cid);
+        }
+
+        const currentLeader = store.get(leaderKey);
+        const leaderStale = currentLeader
+          ? !connLive(currentLeader) || !(memberSet?.has(currentLeader) ?? false)
+          : false;
+        if (!currentLeader || !leaderStale) return ['EVICTED', ''];
+
+        const candidates = (memberSet ? Array.from(memberSet) : [])
+          .map((mid) => ({ mid, at: connectedAtOf(mid) }))
+          .filter((candidate) => !Number.isNaN(candidate.at))
+          .sort((a, b) => a.at - b.at);
+        if (candidates.length === 0) {
+          store.delete(leaderKey);
+          return ['EVICTED', ''];
+        }
+        const newLeaderId = candidates[0].mid;
+        store.set(leaderKey, newLeaderId);
+        const newLeaderConn = hashes.get(`boardsesh:conn:${newLeaderId}`);
+        if (newLeaderConn) newLeaderConn.isLeader = 'true';
+        return ['EVICTED', newLeaderId];
+      }
+
+      if (_script === LEAVE_SESSION_SCRIPT) {
+        const connKey = args[0] as string;
+        const sessionMembersKey = args[1] as string;
+        const leaderKey = args[2] as string;
+        const participantConnectionsKey = args[3] as string;
+        const connectionId = args[4] as string;
+
+        // Clear (not delete) the leaving connection's session fields, mirroring
+        // the real script's conditional HMSET.
+        if (hashes.has(connKey)) {
+          const cd = hashes.get(connKey)!;
+          cd.sessionId = '';
+          cd.participantId = '';
+          cd.isLeader = 'false';
+        }
+        const memberSet = sets.get(sessionMembersKey);
+        if (memberSet) memberSet.delete(connectionId);
+
+        if (store.get(leaderKey) !== connectionId) return null; // wasn't leader
+
+        // Same-participant preference (#2135 crit C): keep leadership with a
+        // sibling connection of the leaving participant when one remains.
+        const sameParticipantConns =
+          participantConnectionsKey && sets.get(participantConnectionsKey)
+            ? new Set(Array.from(sets.get(participantConnectionsKey)!))
+            : new Set<string>();
+        const candidates = (memberSet ? Array.from(memberSet) : [])
+          .filter((mid) => mid !== connectionId)
+          .map((mid) => ({ mid, at: connectedAtOf(mid) }))
+          .filter((candidate) => !Number.isNaN(candidate.at));
+        const preferred = candidates.filter((candidate) => sameParticipantConns.has(candidate.mid));
+        const pool = (preferred.length > 0 ? preferred : candidates).sort((a, b) => a.at - b.at);
+        if (pool.length === 0) {
+          store.delete(leaderKey);
+          return '';
+        }
+        const newLeaderId = pool[0].mid;
+        store.set(leaderKey, newLeaderId);
+        const newLeaderConn = hashes.get(`boardsesh:conn:${newLeaderId}`);
+        if (newLeaderConn) newLeaderConn.isLeader = 'true';
+        return newLeaderId;
+      }
+
       // numkeys=1 covers three scripts; dispatch on args.length:
       //   RELEASE_LOCK_SCRIPT: args.length === 2 (key, expectedValue)
       //   REFRESH_TTL_SCRIPT:  args.length === 3 (connKey, connTTL, sessionTTL)

--- a/packages/backend/src/__tests__/require-session-reconnect-grace.test.ts
+++ b/packages/backend/src/__tests__/require-session-reconnect-grace.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+
+// Unit test for the #2397 reconnect-grace guard. `getContext` (live
+// per-connection context) and `getDistributedState` are the two signals the
+// guard polls; mock both so we can drive the "JOIN hasn't landed yet, then
+// lands" timeline deterministically without a socket. vi.hoisted keeps the mock
+// fns available to the hoisted vi.mock factories (and typechecks cleanly).
+const { getContextMock, getDistributedStateMock } = vi.hoisted(() => ({
+  getContextMock: vi.fn(),
+  getDistributedStateMock: vi.fn(),
+}));
+
+vi.mock('../graphql/context', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../graphql/context')>()),
+  getContext: getContextMock,
+}));
+
+vi.mock('../services/distributed-state', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/distributed-state')>()),
+  getDistributedState: getDistributedStateMock,
+}));
+
+import { requireSessionWithReconnectGrace } from '../graphql/resolvers/shared/helpers';
+
+const makeCtx = (sessionId: string | null): ConnectionContext =>
+  ({ connectionId: 'conn-test', sessionId }) as unknown as ConnectionContext;
+
+describe('requireSessionWithReconnectGrace (#2397)', () => {
+  beforeEach(() => {
+    getContextMock.mockReset();
+    getDistributedStateMock.mockReset();
+    getDistributedStateMock.mockReturnValue(null);
+  });
+
+  it('returns immediately when ctx.sessionId is already bound (no polling on the hot path)', async () => {
+    const result = await requireSessionWithReconnectGrace(makeCtx('sess-hot'));
+    expect(result).toBe('sess-hot');
+    expect(getContextMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves once JOIN binds the live per-connection context mid-wait', async () => {
+    getContextMock
+      .mockReturnValueOnce(undefined) // JOIN not landed yet
+      .mockReturnValue({ connectionId: 'conn-test', sessionId: 'sess-joined' });
+
+    const result = await requireSessionWithReconnectGrace(makeCtx(null), 4, 1);
+    expect(result).toBe('sess-joined');
+    expect(getContextMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('resolves via distributed state for a cross-instance connection', async () => {
+    getContextMock.mockReturnValue(undefined);
+    getDistributedStateMock.mockReturnValue({
+      getConnection: vi.fn().mockResolvedValue({ sessionId: 'sess-cross' }),
+    });
+
+    const result = await requireSessionWithReconnectGrace(makeCtx(null), 4, 1);
+    expect(result).toBe('sess-cross');
+  });
+
+  it('throws the same error as requireSession after the grace budget expires', async () => {
+    getContextMock.mockReturnValue(undefined);
+    getDistributedStateMock.mockReturnValue(null);
+
+    await expect(requireSessionWithReconnectGrace(makeCtx(null), 3, 1)).rejects.toThrow(
+      /Must be in a session to perform this operation/,
+    );
+  });
+
+  it('keeps waiting through a transient distributed-state error rather than failing early', async () => {
+    getContextMock
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(undefined)
+      .mockReturnValue({ connectionId: 'conn-test', sessionId: 'sess-after-blip' });
+    getDistributedStateMock.mockReturnValue({
+      getConnection: vi.fn().mockRejectedValueOnce(new Error('redis blip')).mockResolvedValue(null),
+    });
+
+    const result = await requireSessionWithReconnectGrace(makeCtx(null), 4, 1);
+    expect(result).toBe('sess-after-blip');
+  });
+});

--- a/packages/backend/src/__tests__/session-reconnect-atomicity.test.ts
+++ b/packages/backend/src/__tests__/session-reconnect-atomicity.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vite-plus/test';
+import Redis from 'ioredis';
+import { DistributedStateManager, forceResetDistributedState } from '../services/distributed-state';
+import { KEYS } from '../services/distributed-state/constants';
+
+// Integration tests: exercise the atomic reconnect/leave/expiry Lua transitions
+// added for #2135 against a real Redis. Skips when Redis isn't reachable (same
+// pattern as distributed-state.test.ts). Backend test infra auto-starts Redis.
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6380';
+
+async function isRedisAvailable(): Promise<boolean> {
+  const testRedis = new Redis(REDIS_URL, { connectTimeout: 1000, maxRetriesPerRequest: 0, lazyConnect: true });
+  try {
+    await testRedis.connect();
+    await testRedis.ping();
+    await testRedis.quit();
+    return true;
+  } catch {
+    try {
+      await testRedis.quit();
+    } catch {
+      // ignore
+    }
+    return false;
+  }
+}
+
+const redisAvailable = await isRedisAvailable();
+
+describe.skipIf(!redisAvailable)('session reconnect/leave atomicity (#2135)', () => {
+  let redis: Redis;
+  let manager: DistributedStateManager;
+
+  beforeAll(async () => {
+    redis = new Redis(REDIS_URL);
+    await new Promise<void>((resolve) => redis.once('ready', resolve));
+  });
+
+  afterAll(async () => {
+    forceResetDistributedState();
+    await redis.quit();
+  });
+
+  beforeEach(async () => {
+    forceResetDistributedState();
+    const keys = await redis.keys('boardsesh:*');
+    if (keys.length > 0) {
+      await redis.del(...keys);
+    }
+    manager = new DistributedStateManager(redis, 'test-instance-atomicity');
+  });
+
+  afterEach(async () => {
+    await manager.stop();
+    forceResetDistributedState();
+  });
+
+  describe('markParticipantReconnectingIfIdle — passive disconnect cannot overwrite CONNECTED (crit D)', () => {
+    it('marks RECONNECTING when the participant has no live connection', async () => {
+      const session = 'sess-mark-1';
+      await manager.registerConnection('mc-a', 'Ann', 'user-P');
+      await manager.joinSession('mc-a', session, 'Ann', undefined, 'user-P');
+
+      // Last connection drops: removeConnection dels the conn hash and srems it
+      // from participantConnections, leaving the participant hash behind.
+      await manager.removeConnection('mc-a', false);
+
+      const result = await manager.markParticipantReconnectingIfIdle(session, 'user-P');
+      expect(result.status).toBe('reconnecting');
+      if (result.status === 'reconnecting') {
+        expect(result.user.id).toBe('user-P');
+        expect(result.user.connectionState).toBe('RECONNECTING');
+      }
+      expect(await redis.hget(KEYS.participant(session, 'user-P'), 'connectionState')).toBe('RECONNECTING');
+    });
+
+    it('skips the mark when a reconnect already landed on another connection', async () => {
+      const session = 'sess-mark-2';
+      await manager.registerConnection('mc-a', 'Ann', 'user-P');
+      await manager.joinSession('mc-a', session, 'Ann', undefined, 'user-P');
+      // Reconnect lands on a second connection for the same participant.
+      await manager.registerConnection('mc-b', 'Ann', 'user-P');
+      await manager.joinSession('mc-b', session, 'Ann', undefined, 'user-P');
+
+      // The original connection's passive disconnect is now being processed.
+      await manager.removeConnection('mc-a', false);
+
+      const result = await manager.markParticipantReconnectingIfIdle(session, 'user-P');
+      expect(result.status).toBe('has-live');
+      // The fresher CONNECTED state is preserved, not clobbered to RECONNECTING.
+      expect(await redis.hget(KEYS.participant(session, 'user-P'), 'connectionState')).toBe('CONNECTED');
+    });
+
+    it('reports missing when the participant hash is already gone', async () => {
+      const result = await manager.markParticipantReconnectingIfIdle('sess-mark-3', 'ghost-P');
+      expect(result.status).toBe('missing');
+    });
+  });
+
+  describe('evictGhostParticipant — expiry atomicity (crit B) + expiry leader election', () => {
+    it('evicts a ghost that is still RECONNECTING with no live connections', async () => {
+      const session = 'sess-evict-1';
+      await manager.registerConnection('ev-a', 'Ann', 'user-P');
+      await manager.joinSession('ev-a', session, 'Ann', undefined, 'user-P');
+      await manager.removeConnection('ev-a', false);
+      await manager.markParticipantReconnectingIfIdle(session, 'user-P');
+
+      const result = await manager.evictGhostParticipant(session, 'user-P');
+      expect(result.status).toBe('evicted');
+      expect(await redis.exists(KEYS.participant(session, 'user-P'))).toBe(0);
+      const members = await manager.getSessionMembers(session);
+      expect(members.find((member) => member.id === 'user-P')).toBeUndefined();
+    });
+
+    it('spares a participant that reconnected during the grace window (reconnect-before-expiry)', async () => {
+      const session = 'sess-evict-2';
+      await manager.registerConnection('ev-a', 'Ann', 'user-P');
+      await manager.joinSession('ev-a', session, 'Ann', undefined, 'user-P');
+      await manager.removeConnection('ev-a', false);
+      await manager.markParticipantReconnectingIfIdle(session, 'user-P'); // → RECONNECTING
+
+      // Grace-window reconnect on a fresh connection, same participant.
+      await manager.registerConnection('ev-b', 'Ann', 'user-P');
+      await manager.joinSession('ev-b', session, 'Ann', undefined, 'user-P');
+
+      const result = await manager.evictGhostParticipant(session, 'user-P');
+      // NOT evicted — the reconnect saved it. (JOIN flips it back to CONNECTED,
+      // so the script returns not-reconnecting; either not-reconnecting or
+      // has-live means "spared".)
+      expect(['not-reconnecting', 'has-live']).toContain(result.status);
+      expect(await redis.exists(KEYS.participant(session, 'user-P'))).toBe(1);
+      expect(await manager.getParticipantLiveConnectionCount(session, 'user-P')).toBe(1);
+    });
+
+    it('re-elects a leader in the same transition when evicting a stale leader ghost', async () => {
+      const session = 'sess-evict-3';
+      // Leader participant P (lead-a) joins first, member participant Q (mem-b) after.
+      await manager.registerConnection('lead-a', 'Leader', 'user-P');
+      await manager.joinSession('lead-a', session, 'Leader', undefined, 'user-P');
+      await manager.registerConnection('mem-b', 'Member', 'user-Q');
+      await manager.joinSession('mem-b', session, 'Member', undefined, 'user-Q');
+      expect(await manager.getSessionLeader(session)).toBe('lead-a');
+
+      // Simulate the leader connection dropping WITHOUT removeConnection's
+      // election (an instance crash between the connection delete and its
+      // election), leaving the leader key pointing at a now-dead connection and
+      // the participant parked RECONNECTING.
+      await redis.del(KEYS.connection('lead-a'));
+      await redis.srem(KEYS.sessionMembers(session), 'lead-a');
+      await redis.srem(KEYS.participantConnections(session, 'user-P'), 'lead-a');
+      await redis.hset(KEYS.participant(session, 'user-P'), 'connectionState', 'RECONNECTING');
+      expect(await manager.getSessionLeader(session)).toBe('lead-a'); // still stale
+
+      const result = await manager.evictGhostParticipant(session, 'user-P');
+      expect(result.status).toBe('evicted');
+      expect(result.newLeaderId).toBe('mem-b');
+      expect(await manager.getSessionLeader(session)).toBe('mem-b');
+      const memberConn = await manager.getConnection('mem-b');
+      expect(memberConn?.isLeader).toBe(true);
+    });
+
+    it('does not re-elect when leadership already moved to a live member', async () => {
+      const session = 'sess-evict-4';
+      await manager.registerConnection('lead-a', 'Leader', 'user-P');
+      await manager.joinSession('lead-a', session, 'Leader', undefined, 'user-P');
+      await manager.registerConnection('mem-b', 'Member', 'user-Q');
+      await manager.joinSession('mem-b', session, 'Member', undefined, 'user-Q');
+
+      // The real disconnect path re-elects a live leader immediately.
+      await manager.removeConnection('lead-a', true);
+      expect(await manager.getSessionLeader(session)).toBe('mem-b');
+      await manager.markParticipantReconnectingIfIdle(session, 'user-P');
+
+      const result = await manager.evictGhostParticipant(session, 'user-P');
+      expect(result.status).toBe('evicted');
+      expect(result.newLeaderId).toBeNull(); // leader already healthy — no change
+      expect(await manager.getSessionLeader(session)).toBe('mem-b');
+    });
+  });
+
+  describe('leaveSession — same-participant leader preference (crit C)', () => {
+    it('keeps leadership with the same participant when a multi-tab leader leaves one connection', async () => {
+      const session = 'sess-leave-1';
+      // Participant P holds two connections (two tabs); a different participant Q
+      // holds one, connected between P's two tabs.
+      await manager.registerConnection('p-tab1', 'Pat', 'user-P');
+      await manager.joinSession('p-tab1', session, 'Pat', undefined, 'user-P'); // leader (joined first)
+      await manager.registerConnection('q-only', 'Quinn', 'user-Q');
+      await manager.joinSession('q-only', session, 'Quinn', undefined, 'user-Q');
+      await manager.registerConnection('p-tab2', 'Pat', 'user-P');
+      await manager.joinSession('p-tab2', session, 'Pat', undefined, 'user-P');
+
+      // Deterministic connectedAt ordering tab1 < q-only < tab2, so a naive
+      // earliest-connectedAt election would hand leadership to Q.
+      await redis.hset(KEYS.connection('p-tab1'), 'connectedAt', '1000');
+      await redis.hset(KEYS.connection('q-only'), 'connectedAt', '2000');
+      await redis.hset(KEYS.connection('p-tab2'), 'connectedAt', '3000');
+      expect(await manager.getSessionLeader(session)).toBe('p-tab1');
+
+      // P leaves the leader tab while its other tab stays open.
+      const result = await manager.leaveSession('p-tab1', session, 'user-P');
+
+      // Leadership stays with participant P (its own p-tab2), NOT Q.
+      expect(result.newLeaderId).toBe('p-tab2');
+      expect(await manager.getSessionLeader(session)).toBe('p-tab2');
+    });
+
+    it('falls back to earliest-connectedAt when the leaving participant has no sibling connection', async () => {
+      const session = 'sess-leave-2';
+      await manager.registerConnection('lead', 'Lead', 'user-P');
+      await manager.joinSession('lead', session, 'Lead', undefined, 'user-P');
+      await manager.registerConnection('other', 'Other', 'user-Q');
+      await manager.joinSession('other', session, 'Other', undefined, 'user-Q');
+      await redis.hset(KEYS.connection('lead'), 'connectedAt', '1000');
+      await redis.hset(KEYS.connection('other'), 'connectedAt', '2000');
+
+      const result = await manager.leaveSession('lead', session, 'user-P');
+      expect(result.newLeaderId).toBe('other');
+      expect(await manager.getSessionLeader(session)).toBe('other');
+    });
+  });
+});

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -3,7 +3,7 @@ import { roomManager, VersionConflictError } from '../../../services/room-manage
 import { pubsub } from '../../../pubsub/index';
 import { setCurrentClimbAndPublish } from '../../../services/queue-navigation';
 import {
-  requireSession,
+  requireSessionWithReconnectGrace,
   applyRateLimit,
   validateInput,
   MAX_RETRIES,
@@ -38,7 +38,7 @@ export const queueMutations = {
   ) => {
     const startTime = performance.now();
     await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
-    const sessionId = requireSession(ctx);
+    const sessionId = await requireSessionWithReconnectGrace(ctx);
 
     // Validate input
     validateInput(ClimbQueueItemSchema, item, 'item');
@@ -138,7 +138,7 @@ export const queueMutations = {
   removeQueueItem: async (_: unknown, { uuid }: { uuid: string }, ctx: ConnectionContext) => {
     const startTime = performance.now();
     await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
-    const sessionId = requireSession(ctx);
+    const sessionId = await requireSessionWithReconnectGrace(ctx);
 
     // Validate input
     validateInput(QueueItemIdSchema, uuid, 'uuid');
@@ -180,7 +180,7 @@ export const queueMutations = {
   ) => {
     const startTime = performance.now();
     await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
-    const sessionId = requireSession(ctx);
+    const sessionId = await requireSessionWithReconnectGrace(ctx);
 
     // Validate inputs
     validateInput(QueueItemIdSchema, uuid, 'uuid');
@@ -241,7 +241,7 @@ export const queueMutations = {
   ) => {
     const startTime = performance.now();
     await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
-    const sessionId = requireSession(ctx);
+    const sessionId = await requireSessionWithReconnectGrace(ctx);
 
     // Validate input
     if (item !== null) {
@@ -292,7 +292,7 @@ export const queueMutations = {
   mirrorCurrentClimb: async (_: unknown, { mirrored }: { mirrored: boolean }, ctx: ConnectionContext) => {
     const startTime = performance.now();
     await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
-    const sessionId = requireSession(ctx);
+    const sessionId = await requireSessionWithReconnectGrace(ctx);
 
     const currentState = await roomManager.getQueueState(sessionId);
     let currentClimb = currentState.currentClimbQueueItem;
@@ -347,7 +347,7 @@ export const queueMutations = {
   ) => {
     const startTime = performance.now();
     await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
-    const sessionId = requireSession(ctx);
+    const sessionId = await requireSessionWithReconnectGrace(ctx);
 
     // Validate input
     validateInput(QueueItemIdSchema, uuid, 'uuid');
@@ -390,7 +390,7 @@ export const queueMutations = {
   ) => {
     const startTime = performance.now();
     await applyRateLimit(ctx, RATE_LIMIT_SET_QUEUE, RATE_LIMIT_SET_QUEUE_OP);
-    const sessionId = requireSession(ctx);
+    const sessionId = await requireSessionWithReconnectGrace(ctx);
 
     // Validate queue size to prevent memory exhaustion
     validateInput(QueueArraySchema, queue, 'queue');
@@ -470,7 +470,7 @@ export const queueMutations = {
     ctx: ConnectionContext,
   ) => {
     await applyRateLimit(ctx, RATE_LIMIT_PLAYBACK, RATE_LIMIT_PLAYBACK_OP);
-    const sessionId = requireSession(ctx);
+    const sessionId = await requireSessionWithReconnectGrace(ctx);
 
     const currentState = await roomManager.getQueueState(sessionId);
 

--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -77,6 +77,90 @@ export function requireSession(ctx: ConnectionContext): string {
 }
 
 /**
+ * Grace budget for `requireSessionWithReconnectGrace`. Four checks with
+ * exponential backoff between them: 50 + 100 + 200 = ~350ms of total waiting
+ * (the last check doesn't sleep), plus a final re-check. Well under the mutation
+ * timeout, and above realistic reconnect + JOIN_SESSION latency.
+ */
+export const RECONNECT_GRACE_RETRY_CONFIG = {
+  maxRetries: 4,
+  initialDelayMs: 50,
+} as const;
+
+/**
+ * Reconnect-tolerant `requireSession` for QUEUE mutations (#2397).
+ *
+ * On a socket drop graphql-ws auto-reconnects and the client re-issues
+ * JOIN_SESSION on the fresh connection — but a queue mutation buffered by
+ * graphql-ws can flush onto that new socket *before* its JOIN_SESSION binds
+ * `ctx.sessionId`, tripping the synchronous `requireSession` guard even though
+ * the client is legitimately (re)joining. The mutation carries no sessionId and
+ * the fresh connection isn't bound until JOIN lands, so the server can't
+ * recover it — but since the client always re-joins on the same connection
+ * after a reconnect, the binding lands within a few ms.
+ *
+ * So when `ctx.sessionId` is already set (the overwhelmingly common case) we
+ * return immediately — zero added latency on the hot path. When it's unset we
+ * briefly poll the live per-connection context (and distributed state, for the
+ * cross-instance case) for the imminent JOIN, mirroring `requireSessionMember`'s
+ * subscription-side retry. If the budget expires we throw the same error
+ * `requireSession` does, so a genuine "not in a session" caller still fails —
+ * just after a bounded wait.
+ */
+export async function requireSessionWithReconnectGrace(
+  ctx: ConnectionContext,
+  maxRetries: number = RECONNECT_GRACE_RETRY_CONFIG.maxRetries,
+  initialDelayMs: number = RECONNECT_GRACE_RETRY_CONFIG.initialDelayMs,
+): Promise<string> {
+  // Hot path: sessionId already bound on the operation's context.
+  if (ctx.sessionId) {
+    return ctx.sessionId;
+  }
+
+  for (let i = 0; i < maxRetries; i++) {
+    // JOIN_SESSION binds sessionId via updateContext on the live per-connection
+    // context; re-read it rather than trusting the (possibly pre-join) snapshot
+    // this resolver was invoked with.
+    const latestCtx = getContext(ctx.connectionId);
+    if (latestCtx?.sessionId) {
+      return latestCtx.sessionId;
+    }
+
+    // Cross-instance: the fresh connection may be tracked on another instance,
+    // where JOIN wrote the binding into distributed state first.
+    const distributedState = getDistributedState();
+    if (distributedState) {
+      try {
+        const distributedConnection = await distributedState.getConnection(ctx.connectionId);
+        if (distributedConnection?.sessionId) {
+          return distributedConnection.sessionId;
+        }
+      } catch {
+        // A Redis blip can't grant a session, but it mustn't end the wait
+        // early either — fall through and retry / eventually throw.
+      }
+    }
+
+    if (i < maxRetries - 1) {
+      const delay = initialDelayMs * Math.pow(2, i);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  // Final re-check after the last backoff, then give up with the same error
+  // `requireSession` throws.
+  const finalCtx = getContext(ctx.connectionId);
+  if (finalCtx?.sessionId) {
+    return finalCtx.sessionId;
+  }
+
+  logger.warn('[Auth] requireSessionWithReconnectGrace failed after grace window', {
+    connectionId: ctx.connectionId,
+  });
+  throw new Error(`Must be in a session to perform this operation (connectionId: ${ctx.connectionId})`);
+}
+
+/**
  * Helper to require authentication.
  * Throws if the user is not authenticated.
  * Used for operations that require a logged-in user (e.g., creating sessions).

--- a/packages/backend/src/services/distributed-state/distributed-state.ts
+++ b/packages/backend/src/services/distributed-state/distributed-state.ts
@@ -27,8 +27,12 @@ import {
   cleanupStaleSessionMembers,
   cleanupEmptySession,
   markParticipantPresence,
+  markParticipantReconnectingIfIdle,
+  evictGhostParticipant,
   removeParticipant,
   removeParticipantConnection,
+  type ReconnectingMarkResult,
+  type EvictGhostResult,
 } from './session-ops';
 import { logger } from '../../utils/logger';
 import {
@@ -159,12 +163,15 @@ export class DistributedStateManager {
     return joinSession(this.redis, connectionId, sessionId, username, avatarUrl, participantId);
   }
 
-  /** Leave a session. Handles leader election if leaving member was leader. */
+  /** Leave a session. Handles leader election if leaving member was leader.
+   *  `participantId` (when known) lets the election keep leadership with the
+   *  leaving participant if it still has a sibling connection (#2135 crit C). */
   async leaveSession(
     connectionId: string,
     sessionId: string,
+    participantId?: string | null,
   ): Promise<{ newLeaderId: string | null; newLeaderParticipantId?: string | null }> {
-    return leaveSession(this.redis, connectionId, sessionId);
+    return leaveSession(this.redis, connectionId, sessionId, participantId);
   }
 
   /** Get all members of a session as SessionUser objects. */
@@ -266,6 +273,26 @@ export class DistributedStateManager {
     connectionState: 'CONNECTED' | 'RECONNECTING',
   ): Promise<SessionUser | null> {
     return markParticipantPresence(this.redis, sessionId, participantId, connectionState);
+  }
+
+  /**
+   * Conditionally mark a participant RECONNECTING on passive disconnect — only
+   * when it has no live connection, so a reconnect that landed on another
+   * connection during cleanup isn't clobbered back to RECONNECTING (#2135 crit
+   * D). Returns whether the mark happened (`reconnecting`, with the presence
+   * payload), was skipped (`has-live`), or the participant was gone (`missing`).
+   */
+  async markParticipantReconnectingIfIdle(sessionId: string, participantId: string): Promise<ReconnectingMarkResult> {
+    return markParticipantReconnectingIfIdle(this.redis, sessionId, participantId);
+  }
+
+  /**
+   * Atomically evict a grace-window ghost — only when it is still RECONNECTING
+   * with zero live connections — and re-elect a leader in the same transition
+   * when the ghost held leadership (#2135 crit B + expiry leader election).
+   */
+  async evictGhostParticipant(sessionId: string, participantId: string): Promise<EvictGhostResult> {
+    return evictGhostParticipant(this.redis, sessionId, participantId);
   }
 
   /** Remove a stable participant from a session. */

--- a/packages/backend/src/services/distributed-state/lua-scripts.ts
+++ b/packages/backend/src/services/distributed-state/lua-scripts.ts
@@ -98,6 +98,10 @@ export const LEAVE_SESSION_SCRIPT = `
   local connKey = KEYS[1]
   local sessionMembersKey = KEYS[2]
   local leaderKey = KEYS[3]
+  -- participantConnections set of the LEAVING participant. '' when the caller
+  -- didn't supply a participant identity (see the same-participant preference
+  -- in the election below).
+  local participantConnectionsKey = KEYS[4]
   local connectionId = ARGV[1]
   local membersTTL = tonumber(ARGV[2])
   local leaderTTL = tonumber(ARGV[3])
@@ -125,28 +129,56 @@ export const LEAVE_SESSION_SCRIPT = `
 
   -- Was leader, need to elect new one
   local members = redis.call('SMEMBERS', sessionMembersKey)
+
+  -- Same-participant preference (#2135 crit C): when the leader CONNECTION
+  -- leaves but its participant still holds another live connection (e.g. a
+  -- multi-tab authenticated user leaving one tab), keep leadership with that
+  -- same participant. SessionUser.isLeader is derived from the leader
+  -- connection's participantId, so moving the leader key to a sibling
+  -- connection of the same participant produces NO user-facing LeaderChanged,
+  -- instead of spuriously handing leadership to a different participant who
+  -- happens to have connected earlier.
+  local sameParticipantConns = {}
+  if participantConnectionsKey and participantConnectionsKey ~= '' then
+    local pconns = redis.call('SMEMBERS', participantConnectionsKey)
+    for _, id in ipairs(pconns) do
+      sameParticipantConns[id] = true
+    end
+  end
+
   local candidates = {}
+  local preferred = {}
 
   for _, memberId in ipairs(members) do
     if memberId ~= connectionId then
       local memberConnKey = 'boardsesh:conn:' .. memberId
       local connectedAt = redis.call('HGET', memberConnKey, 'connectedAt')
       if connectedAt then
-        table.insert(candidates, {memberId, tonumber(connectedAt)})
+        local entry = {memberId, tonumber(connectedAt)}
+        table.insert(candidates, entry)
+        if sameParticipantConns[memberId] then
+          table.insert(preferred, entry)
+        end
       end
     end
   end
 
+  -- Prefer a sibling connection of the leaving participant when one exists.
+  local pool = candidates
+  if #preferred > 0 then
+    pool = preferred
+  end
+
   -- No candidates left
-  if #candidates == 0 then
+  if #pool == 0 then
     redis.call('DEL', leaderKey)
     return ''  -- Empty string means was leader but no new leader
   end
 
   -- Sort by connectedAt (earliest first)
-  table.sort(candidates, function(a, b) return a[2] < b[2] end)
+  table.sort(pool, function(a, b) return a[2] < b[2] end)
 
-  local newLeaderId = candidates[1][1]
+  local newLeaderId = pool[1][1]
 
   -- Set new leader with TTL
   redis.call('SET', leaderKey, newLeaderId, 'EX', leaderTTL)
@@ -518,4 +550,169 @@ export const PRUNE_STALE_SESSION_MEMBERS_SCRIPT = `
   end
 
   return staleCount
+`;
+
+/**
+ * Lua script to mark a participant RECONNECTING, but ONLY when it currently has
+ * no live connection (#2135 crit D — "passive disconnect cannot overwrite a
+ * fresher connected state").
+ *
+ * A passive WebSocket drop parks the participant in the grace window. But a
+ * reconnect that lands on ANOTHER connection during the disconnect cleanup
+ * (common on flaky networks / two-tab users) has already promoted the
+ * participant back to CONNECTED via JOIN_SESSION_SCRIPT. Marking RECONNECTING
+ * afterwards would clobber that fresher state and emit a spurious
+ * UserPresenceChanged. Reading the live-connection presence and doing the
+ * conditional write in one round-trip closes that read-then-write window.
+ *
+ * KEYS[1] = participant hash
+ * KEYS[2] = participantConnections set
+ * KEYS[3] = sessionParticipants set
+ * ARGV[1] = now (ms, for lastSeenAt)
+ * ARGV[2] = session TTL
+ * Returns: 'MISSING' (no participant hash), 'HAS_LIVE' (a live connection
+ *          exists — not marked), or 'RECONNECTING' (marked).
+ */
+export const MARK_RECONNECTING_IF_IDLE_SCRIPT = `
+  local participantKey = KEYS[1]
+  local participantConnectionsKey = KEYS[2]
+  local sessionParticipantsKey = KEYS[3]
+  local now = ARGV[1]
+  local sessionTTL = tonumber(ARGV[2])
+
+  if redis.call('EXISTS', participantKey) == 0 then
+    return 'MISSING'
+  end
+
+  -- A live connection means a reconnect already promoted this participant back
+  -- to CONNECTED. Leave it alone.
+  local connectionIds = redis.call('SMEMBERS', participantConnectionsKey)
+  for _, connectionId in ipairs(connectionIds) do
+    if redis.call('EXISTS', 'boardsesh:conn:' .. connectionId) == 1 then
+      return 'HAS_LIVE'
+    end
+  end
+
+  redis.call('HSET', participantKey, 'connectionState', 'RECONNECTING', 'lastSeenAt', now)
+  redis.call('EXPIRE', participantKey, sessionTTL)
+  redis.call('EXPIRE', sessionParticipantsKey, sessionTTL)
+  return 'RECONNECTING'
+`;
+
+/**
+ * Lua script for atomic, conditional grace-timer eviction (#2135 crit B +
+ * expiry leader election). Ties the "is this participant still a ghost?" check
+ * and the removal + leader re-election into a single round-trip.
+ *
+ * The prior code checked live-connection count OUTSIDE the delete
+ * (getParticipantLiveConnectionCount -> removeParticipant), so a reconnect that
+ * added a live connection between the check and the unconditional delete was
+ * wiped out — a zombie connection whose next mutation trips requireSession, and
+ * the participant vanished from the roster. This script only evicts when the
+ * participant is STILL parked RECONNECTING with zero live connections, all
+ * evaluated atomically. And because REMOVE_PARTICIPANT_SCRIPT never touched the
+ * leader key, evicting a ghost that held leadership left the session leaderless
+ * with no LeaderChanged; this re-elects the earliest-connected remaining member
+ * in the same transition so no LeaderChanged is missed.
+ *
+ * KEYS[1] = sessionParticipants set
+ * KEYS[2] = participant hash
+ * KEYS[3] = participantConnections set
+ * KEYS[4] = sessionMembers set
+ * KEYS[5] = sessionLeader key
+ * ARGV[1] = participantId being evicted
+ * ARGV[2] = session TTL (also used as the new leader key TTL)
+ * Returns: { status, newLeaderId }
+ *   status = 'MISSING' | 'NOT_RECONNECTING' | 'HAS_LIVE' | 'EVICTED'
+ *   newLeaderId = connectionId of a newly elected leader, or '' (no change /
+ *                 none remaining / participant wasn't leader).
+ */
+export const EVICT_PARTICIPANT_IF_GHOST_SCRIPT = `
+  local sessionParticipantsKey = KEYS[1]
+  local participantKey = KEYS[2]
+  local participantConnectionsKey = KEYS[3]
+  local sessionMembersKey = KEYS[4]
+  local leaderKey = KEYS[5]
+  local participantId = ARGV[1]
+  local sessionTTL = tonumber(ARGV[2])
+
+  if redis.call('EXISTS', participantKey) == 0 then
+    return { 'MISSING', '' }
+  end
+
+  -- Only evict a participant still parked in the grace window. A concurrent
+  -- rejoin that already flipped it back to CONNECTED must not be evicted.
+  if redis.call('HGET', participantKey, 'connectionState') ~= 'RECONNECTING' then
+    return { 'NOT_RECONNECTING', '' }
+  end
+
+  -- Any live connection means a reconnect landed after the grace timer armed —
+  -- this is the reconnect-before-expiry race. Spare the participant.
+  local connectionIds = redis.call('SMEMBERS', participantConnectionsKey)
+  for _, connectionId in ipairs(connectionIds) do
+    if redis.call('EXISTS', 'boardsesh:conn:' .. connectionId) == 1 then
+      return { 'HAS_LIVE', '' }
+    end
+  end
+
+  -- Ghost confirmed. Remove the participant and detach every connection from
+  -- the member set.
+  redis.call('SREM', sessionParticipantsKey, participantId)
+  redis.call('DEL', participantKey)
+  redis.call('DEL', participantConnectionsKey)
+  for _, connectionId in ipairs(connectionIds) do
+    redis.call('SREM', sessionMembersKey, connectionId)
+    local connKey = 'boardsesh:conn:' .. connectionId
+    if redis.call('EXISTS', connKey) == 1 then
+      redis.call('HMSET', connKey, 'sessionId', '', 'participantId', '', 'isLeader', 'false')
+    end
+  end
+
+  -- Re-elect only when removal left a STALE leader: the leader key points at a
+  -- connection that is no longer a live member (typically the ghost's own dead
+  -- connection). We can't reliably match the leader back to the evicted
+  -- participant by its connection set — a normal disconnect already SREM'd its
+  -- connections from participantConnections before the grace timer fires, so
+  -- that set is usually empty here. Checking the leader key's liveness directly
+  -- is both correct for that case and a no-op when leadership already moved to a
+  -- live member (e.g. removeConnection re-elected on disconnect). A nil leader
+  -- is left alone — the next join elects.
+  local currentLeader = redis.call('GET', leaderKey)
+  local needElection = false
+  if currentLeader then
+    if redis.call('EXISTS', 'boardsesh:conn:' .. currentLeader) == 0
+       or redis.call('SISMEMBER', sessionMembersKey, currentLeader) == 0 then
+      needElection = true
+    end
+  end
+
+  if not needElection then
+    return { 'EVICTED', '' }
+  end
+
+  -- Elect a replacement leader in the same round-trip: earliest-connectedAt
+  -- among the remaining members.
+  local remaining = redis.call('SMEMBERS', sessionMembersKey)
+  local candidates = {}
+  for _, memberId in ipairs(remaining) do
+    local connKey = 'boardsesh:conn:' .. memberId
+    local connectedAt = redis.call('HGET', connKey, 'connectedAt')
+    if connectedAt then
+      table.insert(candidates, {memberId, tonumber(connectedAt)})
+    end
+  end
+
+  if #candidates == 0 then
+    redis.call('DEL', leaderKey)
+    return { 'EVICTED', '' }
+  end
+
+  table.sort(candidates, function(a, b) return a[2] < b[2] end)
+  local newLeaderId = candidates[1][1]
+  redis.call('SET', leaderKey, newLeaderId, 'EX', sessionTTL)
+  redis.call('HSET', 'boardsesh:conn:' .. newLeaderId, 'isLeader', 'true')
+  if sessionTTL and sessionTTL > 0 then
+    redis.call('EXPIRE', sessionMembersKey, sessionTTL)
+  end
+  return { 'EVICTED', newLeaderId }
 `;

--- a/packages/backend/src/services/distributed-state/session-ops.ts
+++ b/packages/backend/src/services/distributed-state/session-ops.ts
@@ -18,6 +18,8 @@ import {
   PRUNE_STALE_SESSION_MEMBERS_SCRIPT,
   REMOVE_PARTICIPANT_CONNECTION_SCRIPT,
   REMOVE_PARTICIPANT_SCRIPT,
+  MARK_RECONNECTING_IF_IDLE_SCRIPT,
+  EVICT_PARTICIPANT_IF_GHOST_SCRIPT,
 } from './lua-scripts';
 import { electNewLeaderAfterRemoval } from './leader-election';
 import { logger } from '../../utils/logger';
@@ -92,17 +94,24 @@ export async function leaveSession(
   redis: Redis,
   connectionId: string,
   sessionId: string,
+  participantId?: string | null,
 ): Promise<{ newLeaderId: string | null; newLeaderParticipantId?: string | null }> {
   validateConnectionId(connectionId);
   validateSessionId(sessionId);
 
   try {
+    // Pass the leaving participant's connection set so the election can keep
+    // leadership with that participant when it still has a sibling connection
+    // (#2135 crit C). '' when no participant identity was supplied — the script
+    // then falls back to the plain earliest-connectedAt election.
+    const participantConnectionsKey = participantId ? KEYS.participantConnections(sessionId, participantId) : '';
     const result = (await redis.eval(
       LEAVE_SESSION_SCRIPT,
-      3,
+      4,
       KEYS.connection(connectionId),
       KEYS.sessionMembers(sessionId),
       KEYS.sessionLeader(sessionId),
+      participantConnectionsKey,
       connectionId,
       TTL.sessionMembership.toString(),
       TTL.sessionMembership.toString(),
@@ -444,6 +453,120 @@ export async function markParticipantPresence(
     userId: data.userId || null,
     connectionState,
   };
+}
+
+/**
+ * Outcome of a conditional RECONNECTING mark.
+ * - `reconnecting`: the participant was parked in the grace window; `user`
+ *   carries the `UserPresenceChanged` payload peers should see.
+ * - `has-live`: a reconnect already promoted the participant back to CONNECTED
+ *   on another connection — nothing was written and no presence event is owed.
+ * - `missing`: the participant hash is gone (already left/expired).
+ */
+export type ReconnectingMarkResult =
+  | { status: 'reconnecting'; user: SessionUser }
+  | { status: 'has-live' }
+  | { status: 'missing' };
+
+/**
+ * Conditionally mark a participant RECONNECTING (passive-disconnect grace),
+ * only when it has no live connection. See MARK_RECONNECTING_IF_IDLE_SCRIPT for
+ * why the read + write must be atomic (#2135 crit D). On a genuine mark this
+ * reads back the participant fields to build the `UserPresenceChanged` payload,
+ * matching `markParticipantPresence`'s shape.
+ */
+export async function markParticipantReconnectingIfIdle(
+  redis: Redis,
+  sessionId: string,
+  participantId: string,
+): Promise<ReconnectingMarkResult> {
+  validateSessionId(sessionId);
+  validateParticipantId(participantId);
+
+  const status = (await redis.eval(
+    MARK_RECONNECTING_IF_IDLE_SCRIPT,
+    3,
+    KEYS.participant(sessionId, participantId),
+    KEYS.participantConnections(sessionId, participantId),
+    KEYS.sessionParticipants(sessionId),
+    Date.now().toString(),
+    TTL.sessionMembership.toString(),
+  )) as string;
+
+  if (status === 'HAS_LIVE') {
+    return { status: 'has-live' };
+  }
+  if (status !== 'RECONNECTING') {
+    return { status: 'missing' };
+  }
+
+  const data = await redis.hgetall(KEYS.participant(sessionId, participantId));
+  if (!data || !data.participantId) {
+    // Raced away between the mark and this read — treat as missing.
+    return { status: 'missing' };
+  }
+  const leaderParticipantId = await getLeaderParticipantId(redis, sessionId);
+  return {
+    status: 'reconnecting',
+    user: {
+      id: data.participantId,
+      username: data.username || `User-${data.participantId.slice(0, 6)}`,
+      isLeader: leaderParticipantId === data.participantId,
+      avatarUrl: data.avatarUrl || undefined,
+      userId: data.userId || null,
+      connectionState: 'RECONNECTING',
+    },
+  };
+}
+
+/**
+ * Result of a conditional grace-timer eviction.
+ * - `status`: whether the participant was evicted, spared (still has a live
+ *   connection / already CONNECTED), or already gone.
+ * - `newLeaderId`: connectionId of a leader elected by the SAME transition that
+ *   evicted a leader ghost, or null when leadership didn't move.
+ */
+export type EvictGhostResult = {
+  status: 'evicted' | 'has-live' | 'not-reconnecting' | 'missing';
+  newLeaderId: string | null;
+};
+
+/**
+ * Atomically evict a participant ONLY if it's still a ghost (RECONNECTING, zero
+ * live connections), re-electing a leader in the same round-trip when the ghost
+ * held leadership. See EVICT_PARTICIPANT_IF_GHOST_SCRIPT (#2135 crit B + expiry
+ * leader election).
+ */
+export async function evictGhostParticipant(
+  redis: Redis,
+  sessionId: string,
+  participantId: string,
+): Promise<EvictGhostResult> {
+  validateSessionId(sessionId);
+  validateParticipantId(participantId);
+
+  const result = (await redis.eval(
+    EVICT_PARTICIPANT_IF_GHOST_SCRIPT,
+    5,
+    KEYS.sessionParticipants(sessionId),
+    KEYS.participant(sessionId, participantId),
+    KEYS.participantConnections(sessionId, participantId),
+    KEYS.sessionMembers(sessionId),
+    KEYS.sessionLeader(sessionId),
+    participantId,
+    TTL.sessionMembership.toString(),
+  )) as [string, string];
+
+  const [status, newLeaderId] = result;
+  const mapped: EvictGhostResult['status'] =
+    status === 'EVICTED'
+      ? 'evicted'
+      : status === 'HAS_LIVE'
+        ? 'has-live'
+        : status === 'NOT_RECONNECTING'
+          ? 'not-reconnecting'
+          : 'missing';
+  return { status: mapped, newLeaderId: newLeaderId ? newLeaderId : null };
 }
 
 export async function removeParticipantConnection(

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -822,16 +822,20 @@ async function beginParticipantGraceWindow(
       // don't arm a timer, don't emit a spurious RECONNECTING presence.
       return null;
     }
-    // 'reconnecting' carries the fresh presence payload; 'missing' means the
-    // Redis participant hash already expired — fall back to the local snapshot
-    // so peers still see a RECONNECTING event during the grace window (without
-    // it the only signal would be the eventual UserLeft).
+    // Flip local state to RECONNECTING BEFORE building any fallback, so the
+    // local snapshot reports RECONNECTING (matching the pre-change behaviour).
+    participant.connectionState = 'RECONNECTING';
+    // 'reconnecting' carries the fresh Redis presence payload; 'missing' means
+    // the Redis participant hash was pruned (e.g. its TTL lapsed, or a
+    // concurrent roster read swept it as a zero-connection CONNECTED entry
+    // before we could mark it) — fall back to the local snapshot so peers still
+    // see a RECONNECTING event during the grace window (without it the only
+    // signal would be the eventual UserLeft).
     presenceUser = result.status === 'reconnecting' ? result.user : localParticipantToSessionUser(participant);
   } else {
+    participant.connectionState = 'RECONNECTING';
     presenceUser = localParticipantToSessionUser(participant);
   }
-
-  participant.connectionState = 'RECONNECTING';
 
   if (participant.reconnectTimer) {
     clearTimeout(participant.reconnectTimer);

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -333,7 +333,10 @@ export async function leaveSession(deps: RoomManagerDeps, connectionId: string):
   let newLeaderParticipantId: string | undefined;
 
   if (distributedState) {
-    const result = await distributedState.leaveSession(connectionId, sessionId);
+    // Pass participantId so leader re-election prefers a sibling connection of
+    // the same participant when this leader connection leaves but the
+    // participant stays (multi-tab) — #2135 crit C.
+    const result = await distributedState.leaveSession(connectionId, sessionId, participantId);
     if (result.newLeaderId) {
       newLeaderId = result.newLeaderId;
       // Populated when the leave went through the fallback election (which
@@ -393,13 +396,27 @@ export async function leaveSession(deps: RoomManagerDeps, connectionId: string):
 }
 
 /**
+ * New-leader payload handed to `onParticipantExpired` so the caller can
+ * broadcast a `LeaderChanged` alongside `UserLeft` when a grace-timer eviction
+ * removed a ghost that still held leadership (#2135 expiry leader election).
+ */
+export type ExpiredParticipantLeader = { leaderId: string; leaderConnectionId: string };
+
+/**
+ * Fired when the grace timer expires and the participant is confirmed gone.
+ * `newLeader` is set only when the evicted participant held leadership and a
+ * replacement was elected in the same atomic transition.
+ */
+type OnParticipantExpired = (sessionId: string, participantId: string, newLeader?: ExpiredParticipantLeader) => void;
+
+/**
  * Handle an unintentional WebSocket disconnect without treating the participant
  * as having explicitly left the session.
  */
 export async function disconnectClient(
   deps: RoomManagerDeps,
   connectionId: string,
-  onParticipantExpired?: (sessionId: string, participantId: string) => void,
+  onParticipantExpired?: OnParticipantExpired,
 ): Promise<SessionDisconnectResult | null> {
   const { clients, sessionParticipants, distributedState } = deps;
 
@@ -529,7 +546,12 @@ export async function disconnectClient(
   // contract and the Redis-failure conservatism comments, moved verbatim.
   const presenceUser = await beginParticipantGraceWindow(deps, sessionId, participant, onParticipantExpired);
 
-  return { sessionId, participantId, presenceUser, newLeaderId, newLeaderParticipantId };
+  // `presenceUser` is null when a reconnect already promoted this participant
+  // back to CONNECTED on another connection during cleanup (#2135 crit D): no
+  // grace window was armed and no UserPresenceChanged is owed — the reconnect's
+  // own join emitted the CONNECTED state. Coerce to undefined so the WS-close
+  // handler's `result?.presenceUser` guard skips the broadcast.
+  return { sessionId, participantId, presenceUser: presenceUser ?? undefined, newLeaderId, newLeaderParticipantId };
 }
 
 /**
@@ -772,33 +794,44 @@ function electLocalLeaderFallback(
  * its own get-or-create lookup, and re-deriving here would just repeat that
  * map lookup for no benefit.
  *
- * ORDERING CONTRACT: sets `connectionState = 'RECONNECTING'` before the
- * presence broadcast so `markParticipantPresence`/the local fallback both
- * report the state peers should see during the grace window. Arms the
- * reconnect timer last, after clearing any pre-existing one, so a rapid
- * disconnect/reconnect/disconnect sequence never leaves two timers racing
- * for the same participant.
+ * ORDERING CONTRACT: the RECONNECTING mark is CONDITIONAL (#2135 crit D) —
+ * `markParticipantReconnectingIfIdle` skips the write (and returns 'has-live')
+ * when a reconnect already promoted this participant back to CONNECTED on
+ * another connection during cleanup, so a passive disconnect can't clobber the
+ * fresher state. In that case this returns `null`: no local state change, no
+ * timer armed, and the caller emits no UserPresenceChanged. Otherwise it sets
+ * `connectionState = 'RECONNECTING'` and arms the reconnect timer last, after
+ * clearing any pre-existing one, so a rapid disconnect/reconnect/disconnect
+ * sequence never leaves two timers racing for the same participant.
  */
 async function beginParticipantGraceWindow(
   deps: RoomManagerDeps,
   sessionId: string,
   participant: LocalSessionParticipant,
-  onParticipantExpired?: (sessionId: string, participantId: string) => void,
-): Promise<SessionUser> {
+  onParticipantExpired?: OnParticipantExpired,
+): Promise<SessionUser | null> {
   const { distributedState, sessionGracePeriodMs: SESSION_GRACE_PERIOD_MS } = deps;
   const participantId = participant.id;
 
+  let presenceUser: SessionUser;
+  if (distributedState) {
+    const result = await distributedState.markParticipantReconnectingIfIdle(sessionId, participantId);
+    if (result.status === 'has-live') {
+      // A reconnect landed on another connection during this disconnect's
+      // cleanup — the participant is CONNECTED elsewhere. Don't park a ghost,
+      // don't arm a timer, don't emit a spurious RECONNECTING presence.
+      return null;
+    }
+    // 'reconnecting' carries the fresh presence payload; 'missing' means the
+    // Redis participant hash already expired — fall back to the local snapshot
+    // so peers still see a RECONNECTING event during the grace window (without
+    // it the only signal would be the eventual UserLeft).
+    presenceUser = result.status === 'reconnecting' ? result.user : localParticipantToSessionUser(participant);
+  } else {
+    presenceUser = localParticipantToSessionUser(participant);
+  }
+
   participant.connectionState = 'RECONNECTING';
-  // markParticipantPresence returns null when the Redis participant hash has
-  // already expired (TTL elapsed before the disconnect cleanup ran). Fall
-  // back to the local participant snapshot so peers always see a
-  // UserPresenceChanged event during the grace window — without this
-  // fallback the only signal they'd get is the eventual UserLeft, with no
-  // RECONNECTING state in between.
-  const presenceUser =
-    (distributedState
-      ? await distributedState.markParticipantPresence(sessionId, participantId, 'RECONNECTING')
-      : localParticipantToSessionUser(participant)) || localParticipantToSessionUser(participant);
 
   if (participant.reconnectTimer) {
     clearTimeout(participant.reconnectTimer);
@@ -813,75 +846,69 @@ async function beginParticipantGraceWindow(
 /**
  * Timer body for `beginParticipantGraceWindow`: runs `SESSION_GRACE_PERIOD_MS`
  * after the timer was armed, unless a reconnect within the window cancelled
- * it first. Disambiguates "still reconnecting" from "ghost" and, if the
- * participant is a ghost, evicts them from both distributed and local state.
+ * it first. Decides "still reconnecting" vs. "ghost" and, if a ghost, evicts
+ * them from distributed and local state.
  *
  * ORIGINAL SOURCE (post-B4 numbering): `disconnectClient` lines 631-696 —
  * body of the reconnect-grace-window `setTimeout` callback.
  *
- * The Redis-error handling here is intentionally NOT the same "default to
- * conservative" pattern used elsewhere in this file. A failed
- * `getSessionMembers` previously returned `[]`, the participant looked
- * absent, and we expelled them — the exact opposite of what the grace
- * period is for. On infra failure, keep the participant alive and let the
- * next reconnect run the grace logic again.
+ * The distributed decision + removal is now ONE atomic Lua call
+ * (`evictGhostParticipant`, #2135 crit B): the prior code read the
+ * live-connection count OUTSIDE the delete, so a reconnect that added a live
+ * connection between the check and the unconditional `removeParticipant` was
+ * silently wiped (zombie connection + vanished participant). The script only
+ * evicts a participant STILL parked RECONNECTING with zero live connections,
+ * and — because the old delete never touched the leader key — re-elects a
+ * replacement in the same transition when the ghost held leadership, so peers
+ * don't miss a `LeaderChanged` (expiry leader election).
+ *
+ * The Redis-error handling here is intentionally NOT the "default to
+ * conservative" pattern used elsewhere in this file. On infra failure, keep the
+ * participant alive and let the next reconnect run the grace logic again —
+ * expelling a participant we can't verify is absent is the opposite of what the
+ * grace period is for.
  */
 async function evictParticipantIfGhost(
   deps: RoomManagerDeps,
   sessionId: string,
   participantId: string,
-  onParticipantExpired?: (sessionId: string, participantId: string) => void,
+  onParticipantExpired?: OnParticipantExpired,
 ): Promise<void> {
-  const { distributedState, sessionParticipants } = deps;
+  const { clients, distributedState, sessionParticipants } = deps;
+
+  // `didEvict` gates the UserLeft/LeaderChanged broadcast. Single-instance
+  // (no Redis) keeps the original behaviour: the local zero-connection gate
+  // below is the authority. Distributed mode narrows it to a genuine eviction.
+  let didEvict = true;
+  let expiredLeader: ExpiredParticipantLeader | undefined;
 
   if (distributedState) {
-    let users;
+    let result;
     try {
-      users = await distributedState.getSessionMembers(sessionId);
+      result = await distributedState.evictGhostParticipant(sessionId, participantId);
     } catch (err) {
       logger.error(
-        `[RoomManager] Grace timer failed to query session ${sessionId.slice(0, 8)} members; keeping participant ${participantId.slice(0, 8)} alive:`,
+        `[RoomManager] Grace timer failed to evaluate participant ${participantId.slice(0, 8)}; keeping them alive:`,
         err,
       );
       return;
     }
-    const currentUser = users.find((user) => user.id === participantId);
-    // The participant might be present in the user list as RECONNECTING
-    // with zero live connections — `getSessionParticipants` intentionally
-    // retains those entries so peers continue to see the RECONNECTING
-    // badge during the grace window. So "present in user list" alone
-    // does NOT mean "still reconnecting"; it could equally mean "ghost".
-    // Disambiguate by querying the actual live-connection count.
-    //
-    // - CONNECTED user → live conns > 0 → spare (active participant).
-    // - RECONNECTING + live conns > 0 → in-flight reconnect, spare.
-    // - RECONNECTING + 0 live conns → ghost, evict.
-    // - Not in user list at all → already cleaned up, fall through.
-    if (currentUser?.connectionState === 'CONNECTED') {
+
+    // Spared: a reconnect promoted them back to CONNECTED (has-live) or they
+    // were already CONNECTED (not-reconnecting). Leave local state as-is.
+    if (result.status === 'has-live' || result.status === 'not-reconnecting') {
       return;
     }
-    if (currentUser?.connectionState === 'RECONNECTING') {
-      let liveConnectionCount: number;
-      try {
-        liveConnectionCount = await distributedState.getParticipantLiveConnectionCount(sessionId, participantId);
-      } catch (err) {
-        // Same conservative behaviour as the getSessionMembers failure
-        // above: if Redis can't answer, don't expel; the next reconnect
-        // will run the grace logic again.
-        logger.error(
-          `[RoomManager] Grace timer failed to count live connections for participant ${participantId.slice(0, 8)}; keeping them alive:`,
-          err,
-        );
-        return;
-      }
-      if (liveConnectionCount > 0) {
-        return; // In-flight reconnect; let the rejoin promote them back to CONNECTED.
-      }
-      // Fall through to eviction: RECONNECTING with no live connections is a ghost.
+
+    // 'evicted' — we removed them (and possibly elected a leader). 'missing' —
+    // someone else already removed them, so no new broadcast is owed; just
+    // reconcile local state below.
+    didEvict = result.status === 'evicted';
+    if (result.status === 'evicted' && result.newLeaderId) {
+      const leaderConnectionId = result.newLeaderId;
+      const leaderParticipantId = await resolveLeaderParticipantId(leaderConnectionId, clients, distributedState);
+      expiredLeader = { leaderId: leaderParticipantId, leaderConnectionId };
     }
-    await distributedState.removeParticipant(sessionId, participantId).catch((err) => {
-      logger.error(`[RoomManager] Failed to expire participant ${participantId.slice(0, 8)}:`, err);
-    });
   }
 
   const currentParticipants = sessionParticipants.get(sessionId);
@@ -891,7 +918,9 @@ async function evictParticipantIfGhost(
     if (currentParticipants?.size === 0) {
       sessionParticipants.delete(sessionId);
     }
-    onParticipantExpired?.(sessionId, participantId);
+    if (didEvict) {
+      onParticipantExpired?.(sessionId, participantId, expiredLeader);
+    }
   }
 }
 

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -357,11 +357,21 @@ class RoomManager {
   }
 
   async disconnectClient(connectionId: string): Promise<SessionDisconnectResult | null> {
-    return disconnectClientFn(this.deps(), connectionId, (sessionId, participantId) => {
+    return disconnectClientFn(this.deps(), connectionId, (sessionId, participantId, newLeader) => {
       pubsub.publishSessionEvent(sessionId, {
         __typename: 'UserLeft',
         userId: participantId,
       });
+      // A grace-timer eviction of a leader ghost re-elects a replacement in the
+      // same atomic transition (#2135 expiry leader election); broadcast it so
+      // clients don't miss the LeaderChanged.
+      if (newLeader) {
+        pubsub.publishSessionEvent(sessionId, {
+          __typename: 'LeaderChanged',
+          leaderId: newLeader.leaderId,
+          leaderConnectionId: newLeader.leaderConnectionId,
+        });
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Closes #2397 and #2135 — two related party-session lifecycle races, both fixed server-side in `packages/backend`.

**#2397 — JOIN_SESSION reconnect race.** On a socket drop graphql-ws auto-reconnects and the client re-issues `JOIN_SESSION` on the fresh connection, but a queue mutation buffered by graphql-ws can flush onto that new socket *before* the JOIN binds `ctx.sessionId`, tripping the synchronous `requireSession` guard even though the client is legitimately rejoining. The mutation carries no sessionId and the fresh connection isn't bound until JOIN lands, so the client-side epoch gate can't fully close the window. New `requireSessionWithReconnectGrace` briefly polls the live per-connection context (and distributed state for the cross-instance case) for the imminent JOIN before throwing — the same retry pattern `requireSessionMember` already uses for subscriptions. Hot path (sessionId already bound) returns immediately with zero added latency; budget ~350ms/4 checks. Applied to all eight queue mutations.

**#2135 — atomic reconnect/leave transitions.** Three lifecycle transitions were read-then-write across `await` boundaries; each is now a single-round-trip conditional Lua script:

- **Passive disconnect can't overwrite a fresher CONNECTED state** (crit D): `markParticipantReconnectingIfIdle` only writes RECONNECTING when the participant has no live connection, so a reconnect that landed on another connection during cleanup isn't clobbered (and no spurious `UserPresenceChanged` is emitted).
- **Expiry can't delete a reconnected participant** (crit B): `evictGhostParticipant` only evicts a participant still parked RECONNECTING with zero live connections — closing the TOCTOU where a grace-window reconnect was wiped into a zombie connection + vanished roster entry.
- **Expiry leader election** (crit A): the old unconditional delete never touched the leader key, so evicting a leader ghost left the session leaderless with no `LeaderChanged`. The eviction now re-elects the earliest-connected remaining member in the same transition when removal leaves a stale leader, broadcast via `onParticipantExpired` → `LeaderChanged`.
- **Explicit-leave leader stability** (crit C): `LEAVE_SESSION_SCRIPT`'s election now prefers a sibling connection of the leaving participant, so a multi-tab leader leaving one tab keeps leadership with the same participant instead of spuriously handing it to a different one.

### Deferred follow-up (not in this PR, per plan)
Web client-side epoch-gate parity with mobile — an `onClosed` hook in `@boardsesh/graphql-client` + a web `ensureReady` wired to the session-connection controller's join tracker. This is hygiene (it reduces how often the server has to wait), not correctness — the server-side grace above closes the race on both platforms. Intentionally kept out to avoid touching `create-client.ts` / `session-connection.ts` / `use-session-lifecycle.ts`, which overlap the in-flight #2385/#2355 work.

## Release Notes

- Party sessions ride out a mid-action reconnect cleanly: queueing or switching a climb right as your connection blips no longer throws an error.
- A crew member who drops and rejoins won't flicker out of the roster, and the session won't be left without a leader.

## Test plan

Backend Vitest (auto-starts Postgres + Redis). All green:

- `session-reconnect-atomicity.test.ts` (real-Redis Lua behaviour): marks RECONNECTING only when idle / skips on a live reconnect; evicts a ghost, spares a reconnect-before-expiry, re-elects a leader on evicting a stale leader ghost, no-ops when leadership already moved; same-participant leave preference + earliest-connectedAt fallback.
- `disconnect-reconnect-orchestration.test.ts`: room-manager wiring — skips the RECONNECTING broadcast on `has-live`, fires `onParticipantExpired` with the elected leader on grace expiry.
- `require-session-reconnect-grace.test.ts`: the #2397 guard — hot-path short-circuit, resolves once the context binds mid-wait, cross-instance via distributed state, survives a transient Redis blip, throws after the budget.
- Existing `distributed-state` + `leave-session-multi-instance` suites unchanged and green (the `LEAVE_SESSION_SCRIPT` KEYS change is backward-compatible).

Commands: `vp test run --project backend ... --reporter=agent`, `vp run typecheck:backend` (backend tsconfig includes test files), `vp check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va