### PR TITLE
fix(web): guard the hold heatmap + regression-gate the count guard (#2378)

### DIFF
--- a/packages/db/src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts
@@ -39,6 +39,12 @@ const PARAMS: BoardRouteParams = {
   angle: 40,
 };
 
+// PARAMS with no set-id restriction. Dropping the `required_set_ids <@ …`
+// selectivity removes the GIN bitmap that keeps the count's board_climbs scan
+// cheap, which is what tips countClimbs' plan from a serial bitmap scan to the
+// Parallel Hash Join + Parallel Seq Scan that exhausted /dev/shm in #2378.
+const BROAD_PARAMS: BoardRouteParams = { ...PARAMS, set_ids: [] };
+
 type PlanNode = { type: string; index?: string; rel?: string };
 
 function collectNodes(plan: Record<string, unknown>, acc: PlanNode[] = []): PlanNode[] {
@@ -70,12 +76,25 @@ if (!EXPLAIN_DB_URL) {
   const tableSelects = (statements: Captured[]) =>
     statements.filter((c) => /select/i.test(c.query) && /board_climb/i.test(c.query) && !/^\s*explain/i.test(c.query));
 
-  async function explainNodes(query: string, params: unknown[], standard: boolean): Promise<PlanNode[]> {
+  // Planner GUCs applied as SET LOCAL (inside a transaction) before EXPLAIN.
+  // GUARD mirrors the runtime guard standardSearch / countClimbs wrap their query
+  // in. FORCE_PARALLEL makes the planner strongly prefer a parallel plan so the
+  // "unguarded" control in the count regression is non-vacuous regardless of the
+  // dev DB's default parallelism tuning.
+  const GUARD = ['SET LOCAL max_parallel_workers_per_gather = 0'];
+  const FORCE_PARALLEL = [
+    'SET LOCAL max_parallel_workers_per_gather = 4',
+    'SET LOCAL parallel_setup_cost = 0',
+    'SET LOCAL parallel_tuple_cost = 0',
+    'SET LOCAL min_parallel_table_scan_size = 0',
+    'SET LOCAL min_parallel_index_scan_size = 0',
+  ];
+
+  async function explainNodes(query: string, params: unknown[], sessionSetup: string[] = []): Promise<PlanNode[]> {
     let rows: postgres.RowList<Record<string, unknown>[]>;
-    if (standard) {
-      // Mirror the runtime planner settings of standardSearch's transaction.
+    if (sessionSetup.length > 0) {
       rows = await client.begin(async (tx) => {
-        await tx.unsafe('SET LOCAL max_parallel_workers_per_gather = 0');
+        for (const statement of sessionSetup) await tx.unsafe(statement);
         return tx.unsafe(`EXPLAIN (FORMAT JSON) ${query}`, params as never[]);
       });
     } else {
@@ -93,8 +112,11 @@ if (!EXPLAIN_DB_URL) {
 
   // Reconstruct countClimbs' query shape (it lives in packages/backend and can't be
   // imported here). Keep in sync with packages/backend/.../count-climbs.ts.
-  function buildCountSql(searchParams: ClimbSearchParams): { text: string; params: unknown[] } {
-    const filters = createClimbFilters(PARAMS, searchParams, undefined);
+  function buildCountSql(
+    searchParams: ClimbSearchParams,
+    params: BoardRouteParams = PARAMS,
+  ): { text: string; params: unknown[] } {
+    const filters = createClimbFilters(params, searchParams, undefined);
     const isDraftsQuery = filters.isOnlyDrafts;
     const whereConditions = [
       ...filters.getClimbWhereConditions(),
@@ -142,7 +164,7 @@ if (!EXPLAIN_DB_URL) {
     void it('hot path (ascents DESC, page 0) is a pure index-ordered scan: no sort, no Gather', async () => {
       const selects = tableSelects(await runSearch({ page: 0, pageSize: 20, sortBy: 'ascents', sortOrder: 'desc' }));
       assert.ok(selects.length >= 1, 'expected a stats-driven SELECT');
-      const nodes = await explainNodes(selects[0].query, selects[0].params, false);
+      const nodes = await explainNodes(selects[0].query, selects[0].params);
       assert.ok(
         indexNames(nodes).some((n) => /ascents_covering_v2/.test(n)),
         `hot path should use the v2 ascents covering index; saw: ${indexNames(nodes).join(', ')}`,
@@ -158,7 +180,7 @@ if (!EXPLAIN_DB_URL) {
     void it('quality DESC page 0 is a pure index-ordered scan: no sort, no Gather', async () => {
       const selects = tableSelects(await runSearch({ page: 0, pageSize: 20, sortBy: 'quality', sortOrder: 'desc' }));
       assert.ok(selects.length >= 1);
-      const nodes = await explainNodes(selects[0].query, selects[0].params, false);
+      const nodes = await explainNodes(selects[0].query, selects[0].params);
       assert.ok(
         indexNames(nodes).some((n) => /quality_covering_v2/.test(n)),
         `quality path should use the v2 quality covering index; saw: ${indexNames(nodes).join(', ')}`,
@@ -172,7 +194,7 @@ if (!EXPLAIN_DB_URL) {
     void it('stats-driven deep page (page 3) still uses the ascents covering index', async () => {
       const selects = tableSelects(await runSearch({ page: 3, pageSize: 20, sortBy: 'ascents', sortOrder: 'desc' }));
       assert.ok(selects.length >= 1);
-      const nodes = await explainNodes(selects[0].query, selects[0].params, false);
+      const nodes = await explainNodes(selects[0].query, selects[0].params);
       assert.ok(indexNames(nodes).some((n) => /ascents_covering/.test(n)));
     });
 
@@ -185,7 +207,7 @@ if (!EXPLAIN_DB_URL) {
       assert.ok(setLocalIdx >= 0, 'standard path must issue SET LOCAL max_parallel_workers_per_gather = 0');
       assert.ok(setLocalIdx < selectIdx, 'SET LOCAL must run before the SELECT');
       const selects = tableSelects(statements);
-      const nodes = await explainNodes(selects[0].query, selects[0].params, true);
+      const nodes = await explainNodes(selects[0].query, selects[0].params, GUARD);
       assert.equal(
         nodes.some((n) => /Gather/.test(n.type)),
         false,
@@ -222,7 +244,7 @@ if (!EXPLAIN_DB_URL) {
 
     void it('count without stats filters drops the board_climb_stats LEFT JOIN (PG join elimination)', async () => {
       const { text, params } = buildCountSql({ page: 0, pageSize: 20 });
-      const nodes = await explainNodes(text, params, false);
+      const nodes = await explainNodes(text, params);
       assert.equal(
         nodes.some((n) => /board_climb_stats/.test(n.rel ?? '')),
         false,
@@ -232,7 +254,7 @@ if (!EXPLAIN_DB_URL) {
 
     void it('count with a stats filter keeps the board_climb_stats join', async () => {
       const { text, params } = buildCountSql({ page: 0, pageSize: 20, minAscents: 50 });
-      const nodes = await explainNodes(text, params, false);
+      const nodes = await explainNodes(text, params);
       assert.ok(
         nodes.some((n) => /board_climb_stats/.test(n.rel ?? '')),
         'a minAscents count must still join board_climb_stats',
@@ -241,10 +263,37 @@ if (!EXPLAIN_DB_URL) {
 
     void it('count with projectsOnly keeps the board_climb_stats join (stats column referenced in WHERE)', async () => {
       const { text, params } = buildCountSql({ page: 0, pageSize: 20, projectsOnly: true });
-      const nodes = await explainNodes(text, params, false);
+      const nodes = await explainNodes(text, params);
       assert.ok(
         nodes.some((n) => /board_climb_stats/.test(n.rel ?? '')),
         'projectsOnly references stats.ascensionist_count via COALESCE — join must be retained',
+      );
+    });
+
+    void it('broad count goes parallel unguarded but the countClimbs SET LOCAL guard eliminates the Gather (#2378 DSM regression)', async () => {
+      // set_ids: [] removes the required_set_ids GIN bitmap; minAscents keeps the
+      // board_climb_stats join (PG can't eliminate it), so the planner's cheapest
+      // plan is a Parallel Hash Join + Parallel Seq Scan on board_climbs — the plan
+      // that allocated one /dev/shm DSM segment per worker and raised "could not
+      // resize shared memory segment" in #2378.
+      const { text, params } = buildCountSql({ page: 0, pageSize: 20, minAscents: 1 }, BROAD_PARAMS);
+
+      // Control: when parallelism is available the planner DOES pick a Gather here,
+      // so the guarded assertion below is a real gate, not a vacuous pass.
+      const unguarded = await explainNodes(text, params, FORCE_PARALLEL);
+      assert.equal(
+        hasGatherNode(unguarded),
+        true,
+        `control: the broad count must go parallel when unguarded; saw: ${unguarded.map((n) => n.type).join(', ')}`,
+      );
+
+      // countClimbs runs this exact shape inside a transaction with
+      // SET LOCAL max_parallel_workers_per_gather = 0 — no Gather, no per-worker DSM.
+      const guarded = await explainNodes(text, params, GUARD);
+      assert.equal(
+        hasGatherNode(guarded),
+        false,
+        'the countClimbs SET LOCAL guard must eliminate the parallel Gather that exhausted /dev/shm in #2378',
       );
     });
 

--- a/packages/web/app/lib/db/queries/climbs/__tests__/holds-heatmap.test.ts
+++ b/packages/web/app/lib/db/queries/climbs/__tests__/holds-heatmap.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import type { ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/types';
+
+// Shared mock state for the fake read-DB. Hoisted so the vi.mock factory below can
+// reference it (vi.mock is hoisted above the imports).
+const dbMock = vi.hoisted(() => {
+  const callOrder: string[] = [];
+  const executed: unknown[] = [];
+  const selectedFields: Record<string, unknown>[] = [];
+
+  // Stand-in for a drizzle query builder: every chain method returns the same
+  // object, and awaiting it records that the aggregate ran — so a test can assert
+  // the aggregate executed AFTER the SET LOCAL guard, not before or instead of it.
+  const makeBuilder = () => {
+    const builder: Record<string, unknown> = {};
+    for (const method of ['from', 'innerJoin', 'leftJoin', 'where', 'groupBy']) {
+      builder[method] = () => builder;
+    }
+    // A real, spec-compliant thenable: accepts both settle callbacks and returns a
+    // genuine Promise, so drizzle's internal `await` can't swallow a rejection.
+    builder.then = (
+      onFulfilled?: ((value: unknown) => unknown) | null,
+      onRejected?: ((reason: unknown) => unknown) | null,
+    ) => {
+      callOrder.push('aggregate');
+      return Promise.resolve([]).then(onFulfilled, onRejected);
+    };
+    return builder;
+  };
+
+  const tx = {
+    execute: (statement: unknown) => {
+      callOrder.push('execute');
+      executed.push(statement);
+      return Promise.resolve([]);
+    },
+    select: (fields: Record<string, unknown>) => {
+      selectedFields.push(fields);
+      return makeBuilder();
+    },
+  };
+
+  return {
+    callOrder,
+    executed,
+    selectedFields,
+    reset: () => {
+      callOrder.length = 0;
+      executed.length = 0;
+      selectedFields.length = 0;
+    },
+    dbzRead: {
+      transaction: (callback: (transactionDb: typeof tx) => unknown) => callback(tx),
+    },
+  };
+});
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/app/lib/db/db', () => ({
+  dbzRead: dbMock.dbzRead,
+  executeRows: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock('@boardsesh/db/queries', () => ({
+  createClimbFilters: () => ({
+    getClimbHoldsJoinConditions: () => [],
+    getHoldHeatmapClimbStatsConditions: () => [],
+    getClimbWhereConditions: () => [],
+    getSizeConditions: () => [],
+    getClimbStatsConditions: () => [],
+  }),
+}));
+
+vi.mock('@/lib/db/queries/util/table-select', () => ({
+  UNIFIED_TABLES: {
+    climbs: {},
+    climbStats: { ascensionistCount: {}, displayDifficulty: {} },
+    climbHolds: { holdId: {}, climbUuid: {}, holdState: {} },
+  },
+}));
+
+vi.mock('@/app/lib/db/schema', () => ({ boardseshTicks: {} }));
+
+import { getHoldHeatmapData } from '../holds-heatmap';
+
+const PARAMS: ParsedBoardRouteParameters = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 10,
+  set_ids: [1, 20],
+  angle: 40,
+};
+
+function makeSearch(overrides: Partial<SearchRequestPagination> = {}): SearchRequestPagination {
+  return {
+    page: 0,
+    pageSize: 20,
+    sortBy: 'ascents',
+    sortOrder: 'desc',
+    settername: [],
+    holdsFilter: {},
+    zoneBox: null,
+    zoneMode: 'allHolds',
+    ...overrides,
+  } as SearchRequestPagination;
+}
+
+const dialect = new PgDialect();
+function renderedGuards(): string[] {
+  return dbMock.executed.map((statement) => dialect.sqlToQuery(statement as SQL).sql);
+}
+function renderedTotalAscents(): string {
+  const fields = dbMock.selectedFields[0];
+  return dialect.sqlToQuery(fields.totalAscents as SQL).sql.toLowerCase();
+}
+const GUARD_PATTERN = /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i;
+
+describe('getHoldHeatmapData — DSM parallelism guard (#2378)', () => {
+  beforeEach(() => {
+    dbMock.reset();
+  });
+
+  it('runs the community aggregate inside a transaction that disables per-gather parallelism first', async () => {
+    await getHoldHeatmapData(PARAMS, makeSearch(), undefined);
+
+    // The heavy GROUP BY runs inside a transaction, and the very first statement is
+    // the parallelism guard — before the aggregate, so no parallel worker can spawn.
+    expect(dbMock.callOrder).toEqual(['execute', 'aggregate']);
+    expect(renderedGuards().some((statement) => GUARD_PATTERN.test(statement))).toBe(true);
+    // Community branch: totalAscents sums ascents, not a per-user distinct climb count.
+    expect(renderedTotalAscents()).toContain('sum');
+    expect(renderedTotalAscents()).not.toContain('distinct');
+  });
+
+  it('runs the personal-progress aggregate inside the same guarded transaction', async () => {
+    await getHoldHeatmapData(PARAMS, makeSearch({ hideCompleted: true }), 'user-1');
+
+    expect(dbMock.callOrder).toEqual(['execute', 'aggregate']);
+    expect(renderedGuards().some((statement) => GUARD_PATTERN.test(statement))).toBe(true);
+    // Personal branch: totalAscents counts the user's distinct climbs per hold.
+    expect(renderedTotalAscents()).toContain('count(distinct');
+  });
+});

--- a/packages/web/app/lib/db/queries/climbs/holds-heatmap.ts
+++ b/packages/web/app/lib/db/queries/climbs/holds-heatmap.ts
@@ -1,4 +1,4 @@
-import { and, sql } from 'drizzle-orm';
+import { and, sql, type SQL } from 'drizzle-orm';
 import { dbzRead as db, executeRows } from '@/app/lib/db/db';
 import type { ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/types';
 import { UNIFIED_TABLES } from '@/lib/db/queries/util/table-select';
@@ -38,60 +38,52 @@ export const getHoldHeatmapData = async (
 
     let holdStats: Record<string, unknown>[];
 
+    // This GROUP BY over board_climb_holds (millions of rows) LEFT JOIN
+    // board_climb_stats is the same plan-shape class that exhausted Postgres
+    // /dev/shm in #2378: on a broad filter the planner fans it out into a
+    // parallel hash join whose workers each allocate a dynamic-shared-memory
+    // segment, and an under-provisioned shared-memory container then raises
+    // "could not resize shared memory segment". Run it with per-gather
+    // parallelism disabled inside a transaction (SET LOCAL needs one; the pool
+    // runs prepare:false behind PgBouncer transaction pooling), mirroring the
+    // searchClimbs / countClimbs guards in @boardsesh/db.
+    const heatmapWhere = and(
+      ...filters.getClimbWhereConditions(),
+      ...filters.getSizeConditions(),
+      ...filters.getClimbStatsConditions(),
+    );
+
+    // Both the personal-progress and community branches run the identical shape;
+    // only the totalAscents column differs. Share one runner so the guard and the
+    // join/where/groupBy stay in lockstep across both.
+    const runHeatmapAggregate = (totalAscents: SQL<number>) =>
+      db.transaction(async (tx) => {
+        await tx.execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
+        return tx
+          .select({
+            holdId: climbHolds.holdId,
+            totalUses: sql<number>`COUNT(DISTINCT ${climbHolds.climbUuid})`,
+            totalAscents,
+            startingUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'STARTING' THEN 1 ELSE 0 END)`,
+            handUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'HAND' THEN 1 ELSE 0 END)`,
+            footUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FOOT' THEN 1 ELSE 0 END)`,
+            finishUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FINISH' THEN 1 ELSE 0 END)`,
+            averageDifficulty: sql<number>`AVG(${climbStats.displayDifficulty})`,
+          })
+          .from(climbHolds)
+          .innerJoin(climbs, and(...filters.getClimbHoldsJoinConditions()))
+          .leftJoin(climbStats, and(...filters.getHoldHeatmapClimbStatsConditions()))
+          .where(heatmapWhere)
+          .groupBy(climbHolds.holdId);
+      });
+
     if (personalProgressFiltersEnabled && userId) {
-      // When personal progress filters are active, we need to compute user-specific hold statistics
-      // Since the filters already limit climbs to user's attempted/completed ones,
-      // we can use the same base query but the results will be user-filtered
-      const baseQuery = db
-        .select({
-          holdId: climbHolds.holdId,
-          totalUses: sql<number>`COUNT(DISTINCT ${climbHolds.climbUuid})`,
-          totalAscents: sql<number>`COUNT(DISTINCT ${climbHolds.climbUuid})`, // For user mode, this represents user's climb count per hold
-          startingUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'STARTING' THEN 1 ELSE 0 END)`,
-          handUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'HAND' THEN 1 ELSE 0 END)`,
-          footUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FOOT' THEN 1 ELSE 0 END)`,
-          finishUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FINISH' THEN 1 ELSE 0 END)`,
-          averageDifficulty: sql<number>`AVG(${climbStats.displayDifficulty})`,
-        })
-        .from(climbHolds)
-        .innerJoin(climbs, and(...filters.getClimbHoldsJoinConditions()))
-        .leftJoin(climbStats, and(...filters.getHoldHeatmapClimbStatsConditions()))
-        .where(
-          and(
-            ...filters.getClimbWhereConditions(),
-            ...filters.getSizeConditions(),
-            ...filters.getClimbStatsConditions(),
-          ),
-        )
-        .groupBy(climbHolds.holdId);
-
-      holdStats = await baseQuery;
+      // The filters already limit climbs to the user's attempted/completed ones, so
+      // totalAscents is the user's climb count per hold (same shape as totalUses).
+      holdStats = await runHeatmapAggregate(sql<number>`COUNT(DISTINCT ${climbHolds.climbUuid})`);
     } else {
-      // Use global community stats when no personal progress filters are active
-      const baseQuery = db
-        .select({
-          holdId: climbHolds.holdId,
-          totalUses: sql<number>`COUNT(DISTINCT ${climbHolds.climbUuid})`,
-          totalAscents: sql<number>`SUM(${climbStats.ascensionistCount})`,
-          startingUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'STARTING' THEN 1 ELSE 0 END)`,
-          handUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'HAND' THEN 1 ELSE 0 END)`,
-          footUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FOOT' THEN 1 ELSE 0 END)`,
-          finishUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FINISH' THEN 1 ELSE 0 END)`,
-          averageDifficulty: sql<number>`AVG(${climbStats.displayDifficulty})`,
-        })
-        .from(climbHolds)
-        .innerJoin(climbs, and(...filters.getClimbHoldsJoinConditions()))
-        .leftJoin(climbStats, and(...filters.getHoldHeatmapClimbStatsConditions()))
-        .where(
-          and(
-            ...filters.getClimbWhereConditions(),
-            ...filters.getSizeConditions(),
-            ...filters.getClimbStatsConditions(),
-          ),
-        )
-        .groupBy(climbHolds.holdId);
-
-      holdStats = await baseQuery;
+      // Global community stats: sum ascents across the matching climbs per hold.
+      holdStats = await runHeatmapAggregate(sql<number>`SUM(${climbStats.ascensionistCount})`);
     }
 
     // Add user-specific data only if not already computed in the main query

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -31,9 +31,15 @@ export default defineConfig({
     },
   },
   resolve: {
+    // Mirror packages/web/tsconfig.json "paths". Order matters: vite matches the
+    // first alias whose key prefixes the import, so the specific @/lib and @/c
+    // aliases must come before the catch-all @ — otherwise @/lib/x resolves to
+    // ./lib/x instead of ./app/lib/x.
     alias: {
-      '@': resolve(__dirname, '.'),
+      '@/lib': resolve(__dirname, './app/lib'),
+      '@/c': resolve(__dirname, './app/components'),
       '@/app': resolve(__dirname, './app'),
+      '@': resolve(__dirname, '.'),
     },
   },
 });


### PR DESCRIPTION
Fixes #2378.

## What this is

Issue #2378 (P1, "climb search/count failing — Postgres shared memory exhausted") is **already fixed on `main`** — the count-path guard landed in **PR #2735** (2026-06-11), 11 days *after* the issue was bulk-filed from a 2026-05-24 → 05-30 Railway log window. This PR closes the issue with evidence and hardens the two remaining loose ends:

- **Gap A — a regression gate for the count guard.** The `SET LOCAL max_parallel_workers_per_gather = 0` guard in `countClimbs` is load-bearing (proven below), but the EXPLAIN harness only asserted join-elimination on the count, never that the guard suppresses the parallel plan. A refactor could have deleted the guard and every test would have stayed green while prod DSM-exhausted again. New two-sided assertion: the broad count **does** go parallel unguarded, and the guard **eliminates** the Gather.
- **Gap B — the hold-heatmap aggregation, same bug class, was unguarded.** `getHoldHeatmapData` runs a `GROUP BY holdId` over `board_climb_holds` (millions of rows) `⋈ board_climbs ⋈ board_climb_stats` with no parallelism guard. On a broad filter the planner picks a `Gather Merge → Parallel Hash Join → Parallel Seq Scan` — the exact `/dev/shm`-exhausting shape from #2378, on a different endpoint. Both aggregate branches now run inside a transaction with the same `SET LOCAL` guard, plus a unit test.

No schema/migration change — every index this relies on already exists.

## Staleness verdict (why #2378 closes)

| Fix | Merged | Covers |
|---|---|---|
| PR #1969 `fix_postgres_drama` | 2026-05-05 | stats-driven search path + `SET LOCAL` guard on the standard-search LEFT JOIN |
| PR #2735 search hot-path hardening | **2026-06-11** | `SET LOCAL` guard on `countClimbs`; covering-index-v2 (climb_uuid trailing key → stats-driven scan is pure index-ordered, no parallel Gather Merge); `MAX_SEARCH_PAGE=500`; holdsFilter cap; 120/min resolver rate limit |

The 84× `searchClimbs` errors inside the issue window were the v1 covering indexes forcing an Incremental Sort + parallel Gather Merge on the stats-driven path (fixed by covering-index-v2); the 5× `countClimbs` errors were the count path having no guard until #2735.

## Dev-DB EXPLAIN plan shapes (local full-data dev DB, PG 17.9, `dynamic_shared_memory_type = posix`, `max_parallel_workers_per_gather = 2` — reproduces the prod condition)

| Query | Unguarded plan | With `SET LOCAL …_per_gather = 0` |
|---|---|---|
| Broad count (`minAscents ≥ 1`, no set-id selectivity) | `Finalize Aggregate → Gather → Parallel Hash Join → Parallel Seq Scan` **(DSM segment per worker — the incident)** | serial `Aggregate → Hash Join → Seq Scan` |
| Issue's projectsOnly count (`required_set_ids <@`, `@> size`) | serial Bitmap-AND + Hash Right Join (GIN + covering index; no Gather even unguarded) | identical |
| Search hot path (ascents/quality DESC, page 0) | `Index Only Scan …_covering_v2_idx` — no Gather, no Sort | n/a (no guard needed) |
| **Hold heatmap** (`GROUP BY holdId`, broad filter) | `GroupAggregate → Gather Merge → Parallel Hash Left Join → Parallel Hash Join → Parallel Seq Scan` **(unguarded before this PR)** | serial `GroupAggregate → Hash Join` |

The broad count and the heatmap are the two plans that still fan out into per-worker `/dev/shm` DSM segments; both are now guarded.

## Testing

- Extended the opt-in EXPLAIN harness (`search-climbs-explain.integration.test.ts`, `EXPLAIN_DB_URL`-gated, self-skips in CI): new two-sided `#2378` count regression + a `force-parallel` control so the assertion can't go vacuous. 11/11 pass against the full-data dev DB.
- New `holds-heatmap.test.ts`: both branches run the aggregate inside a transaction whose first statement is the parallelism guard.
- `vite.config.ts` (web) now mirrors tsconfig's `@/lib` / `@/c` path aliases so `holds-heatmap.ts` resolves under vitest (it had no test loading it before).

## For @marcodejongh — optional, read-only prod confirmation (nothing here mutates data; `EXPLAIN` without `ANALYZE` executes nothing)

- [ ] Broad count still needs its guard on the prod replica:
  ```sql
  EXPLAIN SELECT count(*) FROM board_climbs
  LEFT JOIN board_climb_stats ON board_climb_stats.climb_uuid = board_climbs.uuid
    AND board_climb_stats.board_type='kilter' AND board_climb_stats.angle=40
  WHERE board_climbs.board_type='kilter' AND board_climbs.is_listed AND NOT board_climbs.is_draft
    AND board_climb_stats.ascensionist_count >= 1;
  ```
  Expect `Gather`/`Parallel Hash Join`; re-run inside `BEGIN; SET LOCAL max_parallel_workers_per_gather=0;` and confirm it's serial.
- [ ] Heatmap parallel plan on prod:
  ```sql
  EXPLAIN SELECT ch.hold_id, COUNT(DISTINCT ch.climb_uuid), SUM(s.ascensionist_count), AVG(s.display_difficulty)
  FROM board_climb_holds ch
  JOIN board_climbs c ON c.uuid=ch.climb_uuid AND c.board_type='kilter'
  LEFT JOIN board_climb_stats s ON s.climb_uuid=c.uuid AND s.board_type='kilter' AND s.angle=40
  WHERE c.board_type='kilter' AND c.layout_id=1 AND c.is_listed AND NOT c.is_draft
    AND c.compatible_size_ids @> ARRAY[10]::int[]
  GROUP BY ch.hold_id;
  ```
  Expect `Gather Merge` + parallel hash joins — confirms Gap B was a real latent risk.

## Non-code follow-up (infra, Marco's call)

The durable belt-and-suspenders is at the Railway Postgres layer, independent of these code guards: set `dynamic_shared_memory_type = mmap` (moves DSM segments off `/dev/shm` to disk-backed files) and/or raise the container `shm_size`. The code guards cover the known parallel plan shapes; this would catch any future one we haven't guarded. Not required to close #2378.

## Release Notes

Hold heatmaps keep loading even when the busiest boards are getting hammered — no more failed heatmap loads under heavy search traffic.
