### PR TITLE
fix(backend): authorize WS subscriptions off durable membership + typed NOT_SESSION_MEMBER

### DIFF
--- a/packages/backend/src/__tests__/session-member-auth.test.ts
+++ b/packages/backend/src/__tests__/session-member-auth.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for `requireSessionMember` — the subscription-authorization gate
+ * (queueUpdates / sessionUpdates / eventsReplay). Covers the changes for
+ * issues #2355 and #2385:
+ *
+ *  1. **Durable fast-path (WS only).** An authenticated WebSocket connection
+ *     holding a `board_session_participants` row is authorized on the FIRST
+ *     check with zero backoff — even when its `ConnectionContext.sessionId` is
+ *     still undefined (the graphql-ws reconnect auto-replay race). HTTP callers
+ *     are deliberately excluded so `eventsReplay` over HTTP still proves active
+ *     connection membership.
+ *  2. **Typed denial.** The two terminal failure branches throw a
+ *     `GraphQLError` carrying `extensions.code = 'NOT_SESSION_MEMBER'` plus a
+ *     `reason` (`no-session-id` | `session-mismatch`) so clients can branch
+ *     without scraping the message string.
+ *  3. The pre-existing local-context / distributed-state / retry-propagation
+ *     paths are unchanged.
+ *
+ * Mirrors the mocking scaffold in `session-query-gate.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+import { GraphQLError } from 'graphql';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+
+// Local, same-instance WS connection tracking (module-level `connections` map
+// in graphql/context.ts). Tests populate this to simulate a same-instance WS
+// connection whose context already has `sessionId` set.
+const localContexts = vi.hoisted(() => new Map<string, { sessionId?: string }>());
+const getContextMock = vi.hoisted(() => vi.fn((connectionId: string) => localContexts.get(connectionId)));
+vi.mock('../graphql/context', () => ({
+  getContext: getContextMock,
+  updateContext: vi.fn(),
+}));
+
+// Cross-instance membership. `enabled: false` mirrors single-instance/no-Redis
+// deployments where `getDistributedState()` returns null.
+const distributedState = vi.hoisted(() => ({
+  enabled: false,
+  isConnectionInSession: vi.fn(),
+}));
+vi.mock('../services/distributed-state', () => ({
+  getDistributedState: () =>
+    distributedState.enabled ? { isConnectionInSession: distributedState.isConnectionInSession } : null,
+}));
+
+// Durable `board_session_participants` lookup (primary `db`). `limit` resolves
+// the row array; `[]` = no durable membership.
+const dbMock = vi.hoisted(() => {
+  const limit = vi.fn();
+  return {
+    limit,
+    client: {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit,
+    },
+  };
+});
+vi.mock('../db/client', () => ({ db: dbMock.client, dbRead: dbMock.client }));
+
+const { requireSessionMember, isDurableSessionMember } = await import('../graphql/resolvers/shared/helpers');
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-default',
+    transport: 'ws',
+    isAuthenticated: false,
+    ...overrides,
+  };
+}
+
+/** Drive a rejecting call to completion under fake timers (the retry loop can
+ *  burn up to ~6.35s of real backoff) and return the thrown error. */
+async function expectRejection(promise: Promise<void>): Promise<unknown> {
+  let caught: unknown;
+  const settled = promise.then(
+    () => {
+      throw new Error('expected requireSessionMember to reject');
+    },
+    (error: unknown) => {
+      caught = error;
+    },
+  );
+  // 10s comfortably flushes every pending backoff timer.
+  await vi.advanceTimersByTimeAsync(10_000);
+  await settled;
+  return caught;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localContexts.clear();
+  distributedState.enabled = false;
+  dbMock.limit.mockResolvedValue([]);
+  // clearAllMocks() clears call history but NOT a `mockImplementation` override
+  // a prior test installed — restore the default lookup so each test starts
+  // from a clean "reads localContexts" baseline.
+  getContextMock.mockImplementation((connectionId: string) => localContexts.get(connectionId));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('requireSessionMember — durable fast-path (issues #2355 / #2385)', () => {
+  it('authorizes an authenticated WS member from the durable row with no backoff, before the retry loop', async () => {
+    // Reconnect auto-replay race: the fresh connection has no local/distributed
+    // membership yet, but the durable participant row (from a prior join) is
+    // enough.
+    dbMock.limit.mockResolvedValueOnce([{ sessionId: 'session-1' }]);
+    const ctx = makeCtx({ connectionId: 'ws-reconnected', transport: 'ws', userId: 'user-1', isAuthenticated: true });
+
+    await expect(requireSessionMember(ctx, 'session-1')).resolves.toBeUndefined();
+
+    // Fast-path returns before ever touching the connection-state loop.
+    expect(dbMock.limit).toHaveBeenCalledTimes(1);
+    expect(getContextMock).not.toHaveBeenCalled();
+    expect(distributedState.isConnectionInSession).not.toHaveBeenCalled();
+  });
+
+  it('does NOT use the durable fast-path for an HTTP caller with a durable row (still rejects)', async () => {
+    // Preserves the pre-existing eventsReplay-over-HTTP strictness pinned by
+    // session-query-gate.test.ts: an HTTP request must prove active connection
+    // membership, not just a past-participant row.
+    vi.useFakeTimers();
+    dbMock.limit.mockResolvedValue([{ sessionId: 'session-1' }]);
+    const ctx = makeCtx({
+      connectionId: 'http-55555555',
+      transport: 'http',
+      userId: 'user-1',
+      isAuthenticated: true,
+    });
+
+    const error = await expectRejection(requireSessionMember(ctx, 'session-1'));
+
+    expect(error).toBeInstanceOf(GraphQLError);
+    expect((error as GraphQLError).extensions).toMatchObject({ code: 'NOT_SESSION_MEMBER', reason: 'no-session-id' });
+    // The WS gate skipped the durable check entirely — no participants read ran.
+    expect(dbMock.limit).not.toHaveBeenCalled();
+  });
+
+  it('skips the durable check for an anonymous caller (no userId) and falls through to the loop', async () => {
+    localContexts.set('ws-anon', { sessionId: 'session-1' });
+    const ctx = makeCtx({ connectionId: 'ws-anon', transport: 'ws' });
+
+    await expect(requireSessionMember(ctx, 'session-1')).resolves.toBeUndefined();
+
+    expect(dbMock.limit).not.toHaveBeenCalled();
+  });
+});
+
+describe('requireSessionMember — existing connection-state paths (unchanged)', () => {
+  it('authorizes via the local-context fast path (already joined on this instance)', async () => {
+    localContexts.set('ws-1', { sessionId: 'session-1' });
+    const ctx = makeCtx({ connectionId: 'ws-1', transport: 'ws' });
+
+    await expect(requireSessionMember(ctx, 'session-1')).resolves.toBeUndefined();
+    expect(distributedState.isConnectionInSession).not.toHaveBeenCalled();
+  });
+
+  it('authorizes via cross-instance distributed state', async () => {
+    distributedState.enabled = true;
+    distributedState.isConnectionInSession.mockResolvedValueOnce(true);
+    const ctx = makeCtx({ connectionId: 'ws-other-instance', transport: 'ws' });
+
+    await expect(requireSessionMember(ctx, 'session-1')).resolves.toBeUndefined();
+    expect(distributedState.isConnectionInSession).toHaveBeenCalledWith('ws-other-instance', 'session-1');
+  });
+
+  it('waits through the retry loop for a join that propagates mid-window', async () => {
+    vi.useFakeTimers();
+    // Context is empty on the first check, then the join lands and sets sessionId.
+    let checks = 0;
+    getContextMock.mockImplementation((connectionId: string) => {
+      void connectionId;
+      checks += 1;
+      return checks >= 2 ? { sessionId: 'session-1' } : undefined;
+    });
+    const ctx = makeCtx({ connectionId: 'ws-joining', transport: 'ws' });
+
+    const promise = requireSessionMember(ctx, 'session-1');
+    // First backoff is 50ms; flush it so the second check runs.
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(promise).resolves.toBeUndefined();
+  });
+});
+
+describe('requireSessionMember — typed denials', () => {
+  it('throws NOT_SESSION_MEMBER / no-session-id when the connection never joined', async () => {
+    vi.useFakeTimers();
+    const ctx = makeCtx({ connectionId: 'ws-stale', transport: 'ws' });
+
+    const error = await expectRejection(requireSessionMember(ctx, 'session-1'));
+
+    expect(error).toBeInstanceOf(GraphQLError);
+    expect((error as GraphQLError).message).toMatch(/not in any session/);
+    expect((error as GraphQLError).extensions).toMatchObject({ code: 'NOT_SESSION_MEMBER', reason: 'no-session-id' });
+  });
+
+  it('throws NOT_SESSION_MEMBER / session-mismatch when joined to a different session', async () => {
+    vi.useFakeTimers();
+    localContexts.set('ws-b', { sessionId: 'other-session' });
+    const ctx = makeCtx({ connectionId: 'ws-b', transport: 'ws' });
+
+    const error = await expectRejection(requireSessionMember(ctx, 'session-1'));
+
+    expect(error).toBeInstanceOf(GraphQLError);
+    expect((error as GraphQLError).message).toMatch(/session mismatch/);
+    expect((error as GraphQLError).extensions).toMatchObject({
+      code: 'NOT_SESSION_MEMBER',
+      reason: 'session-mismatch',
+    });
+  });
+});
+
+describe('isDurableSessionMember', () => {
+  it('returns true when a participant row exists', async () => {
+    dbMock.limit.mockResolvedValueOnce([{ sessionId: 'session-1' }]);
+    await expect(isDurableSessionMember('user-1', 'session-1')).resolves.toBe(true);
+  });
+
+  it('returns false when no participant row exists', async () => {
+    dbMock.limit.mockResolvedValueOnce([]);
+    await expect(isDurableSessionMember('user-1', 'session-1')).resolves.toBe(false);
+  });
+});

--- a/packages/backend/src/__tests__/session-query-gate.test.ts
+++ b/packages/backend/src/__tests__/session-query-gate.test.ts
@@ -374,12 +374,14 @@ describe('eventsReplay membership check is unaffected by the query gate', () => 
     expect(eventsSinceMock).toHaveBeenCalledWith('session-1', 0);
   });
 
-  it('still rejects an authenticated HTTP caller with a durable participant row — unlike the `session` query, requireSessionMember has no durable fallback', async () => {
-    // This is the key "unchanged" assertion: a caller who the NEW
-    // isSessionMember helper would treat as a member (durable participants
-    // row present) must still be rejected by eventsReplay, because it keeps
-    // using the throwing, retrying requireSessionMember — which only ever
-    // consults local/distributed connection state, never the durable table.
+  it('still rejects an authenticated HTTP caller with a durable participant row — requireSessionMember gates its durable fast-path to WS connections', async () => {
+    // requireSessionMember DID gain a durable fast-path (issues #2355/#2385),
+    // but it is deliberately WS-gated (`transport !== 'http'`): a stateless
+    // HTTP eventsReplay request must still prove active connection membership,
+    // not just a past-participant row. So a caller the `session` query's
+    // isSessionMember would admit via the durable table is still rejected here
+    // over HTTP — the fast-path never runs, and the throwing, retrying loop
+    // only consults local/distributed connection state.
     dbMock.limit.mockResolvedValueOnce([{ sessionId: 'session-1' }]);
     const ctx = makeCtx({
       connectionId: 'http-55555555-5555-5555-5555-555555555555',

--- a/packages/backend/src/__tests__/session-subscription-auth.test.ts
+++ b/packages/backend/src/__tests__/session-subscription-auth.test.ts
@@ -1,0 +1,73 @@
+// End-to-end integration tests for subscription/replay AUTHORIZATION against a
+// REAL backend (`startTestBackend`) — issues #2355 / #2385.
+//
+// `queueUpdates`, `sessionUpdates`, and `eventsReplay` all gate on
+// `requireSessionMember`. This suite proves, over the real wire:
+//   1. a member who joined is authorized (their queue subscription delivers its
+//      FullSync — `join()` only resolves once that lands);
+//   2. a connection that never joined is denied with a typed
+//      `NOT_SESSION_MEMBER` extension code (via `execute`, which preserves
+//      GraphQL error extensions — the subscription-path client wrapper does
+//      not yet, that's a separate in-flight change).
+
+import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { randomUUID } from 'crypto';
+import WS from 'ws';
+import { createGraphQLClient, execute, GraphQLOperationError } from '@boardsesh/graphql-client';
+import { EVENTS_REPLAY } from '@boardsesh/graphql/operations/queue-session';
+import { HeadlessParticipant, startTestBackend, type TestBackend } from './helpers/headless-queue-client';
+
+describe('Subscription/replay authorization ↔ real backend', () => {
+  let backend: TestBackend;
+
+  beforeAll(async () => {
+    backend = await startTestBackend();
+  });
+
+  afterAll(async () => {
+    await backend.teardown();
+  });
+
+  it('authorizes a joined member (queueUpdates FullSync is delivered)', async () => {
+    // join() opens the subscription then joins on the same socket and waits for
+    // the membership-gated FullSync — so its resolution IS proof that
+    // requireSessionMember authorized the member.
+    const participant = new HeadlessParticipant(backend.url, `subauth-${randomUUID().slice(0, 8)}`, 'Member');
+    try {
+      await participant.join();
+      expect(participant.users.map((u) => u.username)).toContain('Member');
+    } finally {
+      await participant.dispose();
+    }
+  }, 30_000);
+
+  it('denies an unjoined connection with a typed NOT_SESSION_MEMBER extension', async () => {
+    // Anonymous client, never joins. eventsReplay runs requireSessionMember,
+    // which exhausts its retry backoff (~6.4s) and rejects with the typed code.
+    const client = createGraphQLClient({
+      url: backend.url,
+      connectionName: 'stranger',
+      webSocketImpl: WS as unknown as typeof WebSocket,
+      shouldRetry: () => false,
+    });
+
+    try {
+      let caught: unknown;
+      try {
+        await execute(client, {
+          query: EVENTS_REPLAY,
+          variables: { sessionId: randomUUID(), sinceSequence: 0 },
+        });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(GraphQLOperationError);
+      const extensions = (caught as GraphQLOperationError).extensions;
+      expect(extensions?.code).toBe('NOT_SESSION_MEMBER');
+      expect(extensions?.reason).toBe('no-session-id');
+    } finally {
+      await client.dispose();
+    }
+  }, 30_000);
+});

--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -70,7 +70,14 @@ export const RATE_LIMIT_SET_QUEUE = 300;
  */
 export function requireSession(ctx: ConnectionContext): string {
   if (!ctx.sessionId) {
-    logger.warn('[Auth] requireSession failed', { connectionId: ctx.connectionId, sessionId: ctx.sessionId });
+    // Benign, high-volume race: a mutation fired on a connection that hasn't
+    // (re)joined yet — the client's optimistic local reducer already applied
+    // and the next reconnect FullSync reconciles. Logged at `debug` so it
+    // stays out of prod error/warn dashboards (issue #2385).
+    logger.debug('[Auth] requireSession denied: no session context', {
+      connectionId: ctx.connectionId,
+      reason: 'no-session-id' satisfies SessionMembershipDenialReason,
+    });
     throw new Error(`Must be in a session to perform this operation (connectionId: ${ctx.connectionId})`);
   }
   return ctx.sessionId;
@@ -88,6 +95,47 @@ export function requireAuthenticated(ctx: ConnectionContext): void {
 }
 
 /**
+ * Extension `code` on every membership-denial error thrown by
+ * `requireSessionMember`. Clients branch on this (via
+ * `GraphQLOperationError.extensions.code`) to distinguish "you are not a
+ * member of this session, stop retrying / clear it" from a transient
+ * transport failure — instead of matching the message string. Mirrors the
+ * `RATE_LIMITED` / `SESSION_ENDED` / `CLIMB_IS_DUPLICATE` extension pattern.
+ */
+export const NOT_SESSION_MEMBER_CODE = 'NOT_SESSION_MEMBER';
+
+/**
+ * Why a membership check was denied — carried in `extensions.reason` and the
+ * structured debug log for triage (issue #2385 asked for a per-reason
+ * breakdown). Kept deliberately coarse: the two cases below are the only ones
+ * the server can tell apart. "Never joined", "join too slow", and "stale
+ * subscriber to an emptied session" all present identically as `no-session-id`
+ * — there is no server-side signal that separates them.
+ */
+export type SessionMembershipDenialReason = 'no-session-id' | 'session-mismatch';
+
+/**
+ * Durable "was ever a member" check: a single PK-indexed read of
+ * `board_session_participants` for `(userId, sessionId)`. The row is written
+ * on join and **never deleted on leave** (see
+ * `room-manager/client-lifecycle.ts`), so this is a "was ever a member"
+ * signal, not "is currently connected". Uses the PRIMARY client (`db`, not
+ * `dbRead`) so a fresh join's row can't be missed via replica lag.
+ *
+ * Shared by the `session` query gate (`isSessionMember`, below) and
+ * `requireSessionMember`'s WS fast-path (above), so both agree on exactly one
+ * definition of durable membership.
+ */
+export async function isDurableSessionMember(userId: string, sessionId: string): Promise<boolean> {
+  const rows = await db
+    .select({ sessionId: boardSessionParticipants.sessionId })
+    .from(boardSessionParticipants)
+    .where(and(eq(boardSessionParticipants.userId, userId), eq(boardSessionParticipants.sessionId, sessionId)))
+    .limit(1);
+  return rows.length > 0;
+}
+
+/**
  * Helper to verify user is a member of the session they're trying to access.
  * Used for subscription authorization.
  *
@@ -95,6 +143,23 @@ export function requireAuthenticated(ctx: ConnectionContext): void {
  * where subscriptions may be authorized before joinSession has completed updating the context.
  *
  * In multi-instance mode, it also checks distributed state for cross-instance validation.
+ *
+ * A **durable fast-path** runs first for authenticated WebSocket connections:
+ * graphql-ws auto-replays an active subscription onto a brand-new connection
+ * after a socket drop, and that fresh `ConnectionContext.sessionId` is
+ * `undefined` until the client's rejoin lands. An authenticated caller who
+ * already holds a `board_session_participants` row (from a prior join) is a
+ * member regardless of the new connection's join state, so we authorize
+ * immediately instead of burning the full ~6.4s of retry backoff waiting for
+ * the rejoin to propagate. This is the same past-participant trust signal
+ * `isSessionMember` grants the `session` query (issues #2355 / #2385).
+ *
+ * HTTP callers are deliberately excluded from the fast-path (`transport
+ * !== 'http'` gate): a stateless HTTP `eventsReplay` request must still prove
+ * active connection membership, matching the pre-existing behavior pinned by
+ * `session-query-gate.test.ts`. Anonymous callers have no durable identity and
+ * fall through to the retry loop, which covers the legitimate first-join /
+ * anonymous-reconnect propagation window.
  *
  * @see SESSION_MEMBER_RETRY_CONFIG for timing configuration details
  */
@@ -104,6 +169,12 @@ export async function requireSessionMember(
   maxRetries = SESSION_MEMBER_RETRY_CONFIG.maxRetries,
   initialDelayMs = SESSION_MEMBER_RETRY_CONFIG.initialDelayMs,
 ): Promise<void> {
+  // Durable membership fast-path (authenticated WS connections only). See the
+  // JSDoc above for why this short-circuits the retry loop.
+  if (ctx.transport !== 'http' && ctx.userId && (await isDurableSessionMember(ctx.userId, sessionId))) {
+    return;
+  }
+
   for (let i = 0; i < maxRetries; i++) {
     // First check local context (fast path for same-instance)
     const latestCtx = getContext(ctx.connectionId);
@@ -144,20 +215,36 @@ export async function requireSessionMember(
   }
 
   if (!finalCtx?.sessionId) {
-    logger.warn('[Auth] requireSessionMember failed after retries: not in any session', {
+    // Benign, high-volume race (stale subscriber / anonymous reconnect / slow
+    // join). Logged at `debug` so it stays out of prod error/warn dashboards
+    // — clients now branch on `extensions.code` instead of scraping this line
+    // (issue #2385 suggestions 2 & 4).
+    const reason: SessionMembershipDenialReason = 'no-session-id';
+    logger.debug('[Auth] requireSessionMember denied: not in any session', {
       connectionId: ctx.connectionId,
       requestedSessionId: sessionId,
+      reason,
       maxRetries,
     });
-    throw new Error(`Unauthorized: not in any session (connectionId: ${ctx.connectionId}, requested: ${sessionId})`);
+    throw new GraphQLError(
+      `Unauthorized: not in any session (connectionId: ${ctx.connectionId}, requested: ${sessionId})`,
+      { extensions: { code: NOT_SESSION_MEMBER_CODE, reason } },
+    );
   }
   if (finalCtx.sessionId !== sessionId) {
-    logger.warn('[Auth] requireSessionMember failed: session mismatch', {
+    // Kept at `warn`: a connection joined to session A asking to subscribe to
+    // session B is genuinely unusual (client bug), unlike the benign
+    // no-session-id race above.
+    const reason: SessionMembershipDenialReason = 'session-mismatch';
+    logger.warn('[Auth] requireSessionMember denied: session mismatch', {
       connectionId: ctx.connectionId,
       currentSessionId: finalCtx.sessionId,
       requestedSessionId: sessionId,
+      reason,
     });
-    throw new Error(`Unauthorized: session mismatch (have: ${finalCtx.sessionId}, requested: ${sessionId})`);
+    throw new GraphQLError(`Unauthorized: session mismatch (have: ${finalCtx.sessionId}, requested: ${sessionId})`, {
+      extensions: { code: NOT_SESSION_MEMBER_CODE, reason },
+    });
   }
 }
 
@@ -219,22 +306,18 @@ export async function isSessionMember(ctx: ConnectionContext, sessionId: string)
   }
 
   if (ctx.userId) {
-    // Primary client (`db`, not `dbRead`), matching verifyWidgetSession: the
-    // participant row is written on join, and reading it from a lagging
-    // replica could demote a freshly-joined authenticated HTTP caller to the
-    // preview payload. A single PK-indexed row read is cheap on the primary.
+    // Durable participant-row check (`isDurableSessionMember`, primary `db`):
+    // the row is written on join, and reading it from a lagging replica could
+    // demote a freshly-joined authenticated HTTP caller to the preview
+    // payload. A single PK-indexed row read is cheap on the primary.
     //
     // Note this also grants the full payload to an authenticated WS
     // connection that holds a past-participant row but isn't currently
     // joined. Intentional: it's the same trust signal the HTTP resync path
     // accepts — that user could fetch the same payload over HTTP anyway,
-    // and could simply rejoin.
-    const rows = await db
-      .select({ sessionId: boardSessionParticipants.sessionId })
-      .from(boardSessionParticipants)
-      .where(and(eq(boardSessionParticipants.userId, ctx.userId), eq(boardSessionParticipants.sessionId, sessionId)))
-      .limit(1);
-    if (rows.length > 0) {
+    // and could simply rejoin. `requireSessionMember` reuses the exact same
+    // check for its WS subscription fast-path.
+    if (await isDurableSessionMember(ctx.userId, sessionId)) {
       return true;
     }
   }

--- a/packages/backend/src/websocket/setup.ts
+++ b/packages/backend/src/websocket/setup.ts
@@ -140,7 +140,18 @@ export function setupWebSocketServer(httpServer: HttpServer): {
           controllerMac,
         );
         await roomManager.registerClient(context.connectionId, undefined, authenticatedUserId);
-        logger.info(`Client connected: ${context.connectionId} (authenticated: ${isAuthenticated})`);
+        // Attribution for connectionId → client identity: a subscription-auth
+        // denial (see requireSessionMember) only carries the connectionId, so
+        // logging the User-Agent + remote address here makes it cheap to trace
+        // a noisy/stale client back to its build (issue #2355).
+        const upgradeRequest = ctx.extra.request;
+        logger.info(`Client connected: ${context.connectionId} (authenticated: ${isAuthenticated})`, {
+          connectionId: context.connectionId,
+          authenticated: isAuthenticated,
+          userAgent: upgradeRequest?.headers['user-agent'],
+          forwardedFor: upgradeRequest?.headers['x-forwarded-for'],
+          remoteAddress: upgradeRequest?.socket?.remoteAddress,
+        });
 
         // Store context in ctx.extra for access in other hooks
         ctx.extra.context = context;


### PR DESCRIPTION
## Summary

Fixes #2355. Fixes #2385.

WebSocket subscription auth (`queueUpdates` / `sessionUpdates` / `eventsReplay`) authorized callers only off **in-memory join state** (local `ConnectionContext.sessionId` + Redis distributed-state). When graphql-ws drops and reconnects, it **auto-replays** the active subscription onto a brand-new socket whose fresh `ConnectionContext.sessionId` is still `undefined` — so `requireSessionMember` burned its full ~6.4s exponential-backoff window waiting for the client's rejoin to land, then threw a plain `Error`. Railway logs showed **1226 failures over 6 days (~204/day)**, and per the issue's psql sampling **roughly half were sessions the caller was a genuine member of** (a real reconnect race, not a stale client).

This PR is the **backend half** of the fix (client-side branching lands in a follow-up — see Scope):

- **Durable-membership fast-path.** `requireSessionMember` now authorizes an authenticated WS caller who holds a `board_session_participants` row on the **first check, zero backoff** — regardless of whether the freshly-reconnected connection has finished rejoining. The row is written on join and survives reconnects, so it's exactly the signal that says "this user is already a member." Extracted as `isDurableSessionMember` and reused by the existing `session`-query gate (`isSessionMember`), so both agree on one definition of durable membership.
  - **HTTP callers stay excluded** (`transport !== 'http'`): a stateless HTTP `eventsReplay` request must still prove *active connection* membership, not just a past-participant row. This preserves the behavior pinned by `session-query-gate.test.ts`.
  - **Anonymous callers** (no `userId`) have no durable identity and fall through to the existing retry loop, which still covers the legitimate first-join / anonymous-reconnect propagation window.
- **Typed denials.** Both terminal failures now throw a `GraphQLError` with `extensions.code = "NOT_SESSION_MEMBER"` and a `reason` (`no-session-id` | `session-mismatch`), so clients can branch and stay silent instead of scraping the message string (mirrors the existing `RATE_LIMITED` / `SESSION_ENDED` extension pattern).
- **Log-noise cleanup.** The benign, high-volume `no-session-id` races (both `requireSession` and `requireSessionMember`) drop from `warn` → `debug` with a structured `reason` field; the genuinely-unusual `session-mismatch` stays `warn`.
- **Connection attribution.** The `Client connected` WS log now carries User-Agent + remote address, so a `connectionId` from a denial is cheap to trace back to a client build (issue #2355 asked for this).

### Design note — past-participant trade-off (intentional)

`board_session_participants` rows are written on join and **never deleted on leave**, so the durable fast-path authorizes a subscription for anyone who was *ever* a member of the session (including after they left). This is the **same trust signal `isSessionMember` already grants the `session` query** — consistent by design. The events are still gated to that one session, and a past member could rejoin trivially. Tightening this (deleting the row on explicit `leaveSession`) would also change the query gate's semantics and is out of scope.

### Scope / sequencing

- **Backend only.** Client-side branching on `NOT_SESSION_MEMBER` (mobile silent-clear, optional web force-clear) is a deliberate follow-up. It depends on the shared `subscribe()` wrapper preserving GraphQL error `extensions` — an in-flight change on **#2655**. Until that lands, subscription errors reach clients as a plain `Error` (message preserved), so today's client behavior is unchanged; the typed code is already asserted end-to-end here via `execute(eventsReplay)`, which does preserve extensions.
- Deliberately does **not** touch `packages/shared/graphql-client/src/subscribe.ts` (owned by #2655), `packages/mobile/.../use-session-realtime.ts` (owned by #3605), or the web session-connection ports.

### Follow-up (not in this PR)

- Client `NOT_SESSION_MEMBER` handling (after #2655 merges).
- Optional: a PostHog/metrics counter keyed on `reason` (structured logger fields ship here; a dedicated counter was scoped out).

## Release Notes

- [x] No release note needed (internal / technical change)

<!-- User-invisible: reconnecting party members are re-authorized instantly instead of after a multi-second stall, and backend auth-error log noise drops. No behavior a climber sees changes until the client-side follow-up ships. -->

## Test plan

Backend Vitest (`vp test run --project backend`), all green:

- **`session-member-auth.test.ts`** (new, unit) — durable fast-path authorizes an authed WS member with zero backoff and before the retry loop; HTTP caller with a durable row is still rejected (fast-path skipped); anonymous caller skips the durable check; local-context and distributed-state paths unchanged; a join that propagates mid-window still resolves; both denials throw `GraphQLError` with `code=NOT_SESSION_MEMBER` + the right `reason`.
- **`session-subscription-auth.test.ts`** (new, integration, real backend) — a joined member's `queueUpdates` FullSync is delivered; an unjoined anonymous `eventsReplay` is denied with the typed `NOT_SESSION_MEMBER` / `no-session-id` extension over the real wire.
- **`session-query-gate.test.ts`** — updated the "no durable fallback" assertion to reflect the new WS-gated fast-path (HTTP-rejection assertion unchanged, still green).
- Regression: `queue-client-session`, `integration`, `session-context`, `report-wall-disconnect`, `wall-confirm-and-board-serial`, `create-session-auth` pass. (The anonymous harness never triggers the durable fast-path — `userId` is unset — so multi-client convergence is unaffected.)

Validation: `vp run typecheck:backend` (test-inclusive, exit 0), `vp check` (0 errors).
