### PR TITLE
fix(web): finish the scheme-var migration on flash surfaces + chart legend

### DIFF
--- a/packages/web/app/components/charts/session-grade-bars.ts
+++ b/packages/web/app/components/charts/session-grade-bars.ts
@@ -5,8 +5,9 @@ import { formatVGrade } from '@/app/lib/grade-colors';
 // Legend colours (60% opacity). Scheme-neutral mid-tones so the bars stay
 // legible on both the light and the dark card surface — the brand success/error tones
 // are tuned per scheme and would wash out in the other one (these feed chart data, not
-// CSS, so a scheme-aware var() can't be used here). Attempt matches the light-scheme
-// neutral-300 lavender for the same reason.
+// CSS, so a scheme-aware var() can't be used here). All three are deliberately FROZEN
+// snapshots, not token-derived: a future palette retune must not silently recolour
+// historical chart data. Attempt happens to match today's light neutral-300 lavender.
 const FLASH_COLOR = '#10b98199';
 const SEND_COLOR = '#ef444499';
 const ATTEMPT_COLOR = '#ad9ecc99';

--- a/packages/web/app/components/charts/session-grade-bars.ts
+++ b/packages/web/app/components/charts/session-grade-bars.ts
@@ -1,15 +1,15 @@
 import type { SessionGradeDistributionItem } from '@boardsesh/shared-schema';
 import type { CssBarChartBar } from './css-bar-chart';
 import { formatVGrade } from '@/app/lib/grade-colors';
-import { themeTokens } from '@/app/theme/theme-config';
 
-// Flash/send legend colours (60% opacity). Scheme-neutral mid-tones so the bars stay
+// Legend colours (60% opacity). Scheme-neutral mid-tones so the bars stay
 // legible on both the light and the dark card surface — the brand success/error tones
 // are tuned per scheme and would wash out in the other one (these feed chart data, not
-// CSS, so a scheme-aware var() can't be used here).
+// CSS, so a scheme-aware var() can't be used here). Attempt matches the light-scheme
+// neutral-300 lavender for the same reason.
 const FLASH_COLOR = '#10b98199';
 const SEND_COLOR = '#ef444499';
-const ATTEMPT_COLOR = `${themeTokens.neutral[300]}99`;
+const ATTEMPT_COLOR = '#ad9ecc99';
 
 export const SESSION_GRADE_LEGEND = [
   { label: 'Flash', color: FLASH_COLOR },

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -16,6 +16,10 @@
   --color-accent: #ff8a3d;
   --color-on-accent: #16111f;
 
+  /* Flash/benchmark data yellow (badges, star ratings) — scheme-invariant by design,
+     distinct from the brand accent. Pair with --color-on-accent for text. */
+  --color-amber: #fbbf24;
+
   /* Lit-climb status hue — "now on the wall". Its own role (not --color-warning) so a
      future warning retune can't silently shift the board-presence affordance. */
   --color-live: #b45309;
@@ -188,6 +192,7 @@ html[data-theme='dark'] {
   --color-on-primary: #ffffff;
   --color-accent: #ff8a3d;
   --color-on-accent: #16111f;
+  --color-amber: #fbbf24;
   /* Lit-climb status hue lifts to the brighter amber on dark surfaces. */
   --color-live: #fbbf24;
   --color-info: #a5abd6;

--- a/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/tick-button.test.tsx
@@ -220,6 +220,16 @@ describe('TickButton', () => {
       expect(button!.className).toContain('MuiIconButton');
     });
 
+    it('flash state rides the scheme vars, not direct theme tokens', () => {
+      render(<TickButton {...defaultProps} tickBarActive isFlash />);
+      const button = document.getElementById('button-tick')!;
+      const style = window.getComputedStyle(button);
+      // Amber ships as --color-amber (parity-guarded); text pairs via --color-on-accent
+      // so a future amber retune propagates instead of stranding a stale literal here.
+      expect(style.backgroundColor).toBe('var(--color-amber)');
+      expect(style.color).toBe('var(--color-on-accent)');
+    });
+
     it('renders the tick button when tickBarActive and not isFlash', () => {
       render(<TickButton {...defaultProps} tickBarActive isFlash={false} />);
       const button = document.getElementById('button-tick');

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -110,15 +110,15 @@ export const TickButton: React.FC<TickButtonProps> = ({
       backgroundColor = 'var(--color-error)';
       hoverBackgroundColor = 'var(--color-error)';
     } else if (isFlashVariant) {
-      backgroundColor = themeTokens.colors.amber;
-      hoverBackgroundColor = themeTokens.colors.amber;
+      backgroundColor = 'var(--color-amber)';
+      hoverBackgroundColor = 'var(--color-amber)';
     } else {
       backgroundColor = 'var(--color-success)';
       hoverBackgroundColor = 'var(--color-success-hover)';
     }
     buttonSx = {
       backgroundColor,
-      color: isFlashVariant ? themeTokens.neutral[900] : 'common.white',
+      color: isFlashVariant ? 'var(--color-on-accent)' : 'common.white',
       transition: 'background-color 150ms ease, color 150ms ease',
       '&:hover': {
         backgroundColor: hoverBackgroundColor,

--- a/packages/web/app/components/play-view/play-view-tick-bar.tsx
+++ b/packages/web/app/components/play-view/play-view-tick-bar.tsx
@@ -12,7 +12,6 @@ import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutl
 import { TickIcon, TickButtonWithLabel } from '../logbook/tick-icon';
 import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import { useBoardProvider } from '../board-provider/board-provider-context';
-import { themeTokens } from '@/app/theme/theme-config';
 import { QuickTickBar, type QuickTickBarHandle } from '../logbook/quick-tick-bar';
 import { hasPriorHistoryForClimb } from '@/app/hooks/use-tick-save';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
@@ -237,11 +236,11 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
                   id="button-tick"
                   onClick={(e) => quickTickBarRef.current?.save(e.currentTarget)}
                   sx={{
-                    backgroundColor: isFlash ? themeTokens.colors.amber : 'var(--color-success)',
-                    color: isFlash ? themeTokens.neutral[900] : 'common.white',
+                    backgroundColor: isFlash ? 'var(--color-amber)' : 'var(--color-success)',
+                    color: isFlash ? 'var(--color-on-accent)' : 'common.white',
                     transition: 'background-color 150ms ease, color 150ms ease',
                     '&:hover': {
-                      backgroundColor: isFlash ? themeTokens.colors.amber : 'var(--color-success-hover)',
+                      backgroundColor: isFlash ? 'var(--color-amber)' : 'var(--color-success-hover)',
                     },
                   }}
                   aria-label={t('playView.tickBar.saveTickAria')}

--- a/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
+++ b/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
@@ -68,6 +68,7 @@ describe('index.css ↔ theme-config parity', () => {
     ['--color-on-primary', themeTokens.colors.onPrimary, themeTokens.colors.onPrimary],
     ['--color-accent', themeTokens.colors.accent, themeTokens.colors.accent],
     ['--color-on-accent', themeTokens.colors.onAccent, themeTokens.colors.onAccent],
+    ['--color-amber', themeTokens.colors.amber, themeTokens.colors.amber],
     ['--color-live', themeTokens.colors.live, darkTokens.colors.live],
     ['--color-info', themeTokens.colors.info, darkTokens.colors.info],
     ['--color-success', themeTokens.colors.success, darkTokens.colors.success],


### PR DESCRIPTION
## Summary

Follow-up to the #3678 review (items landed after the merge):

- **Flash tick states** read `themeTokens.colors.amber` directly while sibling branches were already on CSS vars. Amber now ships as `--color-amber` (scheme-invariant data yellow, added to the parity table), and the flash badge text rides `--color-on-accent` instead of a static neutral — so a future amber retune propagates and the dark-on-amber text stays scheme-stable.
- **Session grade chart**: the attempt bar was the one legend colour still token-derived; it's now a hardcoded scheme-neutral hex like its flash/send siblings (chart data can't resolve `var()`), with the rationale comment extended.

Note: the review also cited `inline-list-tick-bar.tsx`, but on merged main that file has no direct token reads — the flagged patterns all lived in `tick-button.tsx`.

## Release Notes

none

## Test plan

- `vp check` clean on all touched files; `vp run typecheck:web` green.
- Theme parity suite (35 tests) green incl. the new `--color-amber` row; logbook + charts component tests 155/155 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHy7Edddxsv5oztCTmGP4s