### PR TITLE
feat(web): homepage gym entry — owner card + gyms search pre-filter

### DIFF
--- a/packages/shared/i18n/locales/en-US/marketing.json
+++ b/packages/shared/i18n/locales/en-US/marketing.json
@@ -55,6 +55,16 @@
       "discordTitle": "Join the crew on Discord",
       "discordDescription": "Share beta, report bugs, and help shape what's next"
     },
+    "gymCard": {
+      "ownerSubtitle": "Your crew's gym, one tap away",
+      "manage": "Manage",
+      "viewPage": "View page",
+      "andMore": "and {{count}} more",
+      "findTitle": "Climb at a gym with boards?",
+      "findDescription": "Find it on Boardsesh — pull up its boards and log with your crew.",
+      "findCta": "Find your gym",
+      "dismiss": "Dismiss"
+    },
     "feed": {
       "callout": "Your friends are climbing.",
       "cta": "See the feed"

--- a/packages/shared/i18n/locales/es/marketing.json
+++ b/packages/shared/i18n/locales/es/marketing.json
@@ -55,6 +55,16 @@
       "discordTitle": "Únete al grupo en Discord",
       "discordDescription": "Comparte beta, reporta fallos y ayuda a decidir qué viene"
     },
+    "gymCard": {
+      "ownerSubtitle": "El gimnasio de tu equipo, a un toque",
+      "manage": "Gestionar",
+      "viewPage": "Ver página",
+      "andMore": "y {{count}} más",
+      "findTitle": "¿Escalas en un gimnasio con plafones?",
+      "findDescription": "Encuéntralo en Boardsesh: abre sus plafones y registra con tu equipo.",
+      "findCta": "Encuentra tu gimnasio",
+      "dismiss": "Descartar"
+    },
     "feed": {
       "callout": "Tus amigos están escalando.",
       "cta": "Ver el feed"

--- a/packages/shared/i18n/locales/fr/marketing.json
+++ b/packages/shared/i18n/locales/fr/marketing.json
@@ -55,6 +55,16 @@
       "discordTitle": "Rejoignez le crew sur Discord",
       "discordDescription": "Partagez la beta, signalez des bugs et donnez votre avis sur la suite"
     },
+    "gymCard": {
+      "ownerSubtitle": "La salle de votre crew, à portée de main",
+      "manage": "Gérer",
+      "viewPage": "Voir la page",
+      "andMore": "et {{count}} de plus",
+      "findTitle": "Vous grimpez dans une salle avec des boards ?",
+      "findDescription": "Trouvez-la sur Boardsesh : ouvrez ses boards et notez vos croix avec votre crew.",
+      "findCta": "Trouvez votre salle",
+      "dismiss": "Masquer"
+    },
     "feed": {
       "callout": "Vos potes sont en train de grimper.",
       "cta": "Voir le feed"

--- a/packages/web/app/components/home-gym-card/__tests__/home-gym-card.test.tsx
+++ b/packages/web/app/components/home-gym-card/__tests__/home-gym-card.test.tsx
@@ -123,10 +123,9 @@ describe('HomeGymCard', () => {
     it('renders nothing while the gyms request is still loading', () => {
       mockIsLoading = true;
       mockGyms = [];
-      const { container } = render(<HomeGymCard />);
+      render(<HomeGymCard />);
       expect(screen.queryByTestId('home-gym-card-owner')).toBeNull();
       expect(screen.queryByTestId('home-gym-card-find')).toBeNull();
-      expect(container.querySelector('[data-testid="home-gym-card-owner"]')).toBeNull();
     });
 
     it('renders nothing when the gyms request errored', () => {

--- a/packages/web/app/components/home-gym-card/__tests__/home-gym-card.test.tsx
+++ b/packages/web/app/components/home-gym-card/__tests__/home-gym-card.test.tsx
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import HomeGymCard from '../home-gym-card';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+// --- Controllable mock state ---
+let mockGyms: Array<Record<string, unknown>> = [];
+let mockIsLoading = false;
+let mockError: string | null = null;
+let mockStatus: 'authenticated' | 'unauthenticated' | 'loading' = 'authenticated';
+let mockUserId: string | null = 'user-1';
+let mockKioskFlag = true;
+let mockDismissed = false;
+const mockSetPreference = vi.fn<(key: string, value: unknown) => Promise<void>>(() => Promise.resolve());
+const mockTrack = vi.fn();
+
+vi.mock('@/app/hooks/use-my-gyms', () => ({
+  useMyGyms: () => ({
+    gyms: mockGyms,
+    isLoading: mockIsLoading,
+    isFetchingMore: false,
+    hasMore: false,
+    loadMore: vi.fn(),
+    error: mockError,
+  }),
+}));
+
+vi.mock('@/app/components/providers/feature-flags-provider', () => ({
+  useFeatureFlag: () => mockKioskFlag,
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({
+    status: mockStatus,
+    data: mockUserId ? { user: { id: mockUserId } } : null,
+  }),
+}));
+
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getPreference: () => Promise.resolve(mockDismissed),
+  setPreference: (key: string, value: unknown) => mockSetPreference(key, value),
+}));
+
+vi.mock('@/app/lib/analytics', () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
+vi.mock('@/app/components/i18n/locale-link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children?: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// next/dynamic runs the loader (the mocked drawer module below) asynchronously;
+// findBy* waits for it to resolve and render.
+vi.mock('@/app/components/my-gyms-drawer/my-gyms-drawer', () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="my-gyms-drawer" /> : null),
+}));
+
+vi.mock('@/app/components/search-drawer/unified-search-drawer', () => ({
+  default: ({ open, defaultCategory }: { open: boolean; defaultCategory?: string }) =>
+    open ? <div data-testid="gym-search" data-category={defaultCategory} /> : null,
+}));
+
+function makeGym(overrides?: Record<string, unknown>) {
+  return {
+    uuid: 'gym-uuid-1',
+    slug: 'boulder-project',
+    ownerId: 'user-1',
+    name: 'Boulder Project',
+    address: '123 Crux St',
+    isPublic: true,
+    boardCount: 3,
+    memberCount: 12,
+    followerCount: 8,
+    commentCount: 0,
+    isFollowedByMe: false,
+    isMember: true,
+    myRole: 'admin',
+    canEdit: true,
+    canGrantAccess: true,
+    canClaim: false,
+    createdAt: '2024-01-01',
+    boardTypes: ['kilter'],
+    ...overrides,
+  };
+}
+
+describe('HomeGymCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGyms = [];
+    mockIsLoading = false;
+    mockError = null;
+    mockStatus = 'authenticated';
+    mockUserId = 'user-1';
+    mockKioskFlag = true;
+    mockDismissed = false;
+  });
+
+  describe('variant selection', () => {
+    it('renders nothing for signed-out visitors', () => {
+      mockStatus = 'unauthenticated';
+      mockGyms = [makeGym()];
+      const { container } = render(<HomeGymCard />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing while the gyms request is still loading', () => {
+      mockIsLoading = true;
+      mockGyms = [];
+      const { container } = render(<HomeGymCard />);
+      expect(screen.queryByTestId('home-gym-card-owner')).toBeNull();
+      expect(screen.queryByTestId('home-gym-card-find')).toBeNull();
+      expect(container.querySelector('[data-testid="home-gym-card-owner"]')).toBeNull();
+    });
+
+    it('renders nothing when the gyms request errored', () => {
+      mockError = 'boom';
+      mockGyms = [];
+      render(<HomeGymCard />);
+      expect(screen.queryByTestId('home-gym-card-owner')).toBeNull();
+      expect(screen.queryByTestId('home-gym-card-find')).toBeNull();
+    });
+
+    it('shows the owner variant when the user has a gym', async () => {
+      mockGyms = [makeGym()];
+      render(<HomeGymCard />);
+      const card = await screen.findByTestId('home-gym-card-owner');
+      expect(card).toBeTruthy();
+      expect(screen.getByText('Boulder Project')).toBeTruthy();
+      expect(screen.queryByTestId('home-gym-card-find')).toBeNull();
+    });
+
+    it('shows the non-owner "find your gym" variant when the user has no gyms', async () => {
+      mockGyms = [];
+      render(<HomeGymCard />);
+      const card = await screen.findByTestId('home-gym-card-find');
+      expect(card).toBeTruthy();
+      expect(screen.getByText(/Climb at a gym with boards/i)).toBeTruthy();
+      expect(screen.getByTestId('home-gym-card-find-cta')).toBeTruthy();
+    });
+
+    it('hides the non-owner variant once it has been dismissed', async () => {
+      mockGyms = [];
+      mockDismissed = true;
+      render(<HomeGymCard />);
+      // Give the async getPreference effect a chance to resolve.
+      await waitFor(() => {
+        expect(screen.queryByTestId('home-gym-card-find')).toBeNull();
+      });
+    });
+  });
+
+  describe('owner actions and hrefs', () => {
+    it('links Manage to the manage route and View page to the public gym page', async () => {
+      mockGyms = [makeGym({ slug: 'boulder-project' })];
+      render(<HomeGymCard />);
+      await screen.findByTestId('home-gym-card-owner');
+
+      expect(screen.getByTestId('home-gym-card-manage').getAttribute('href')).toBe('/gym/boulder-project/manage');
+      expect(screen.getByTestId('home-gym-card-view').getAttribute('href')).toBe('/gym/boulder-project');
+    });
+
+    it('falls back to the uuid for the manage route on a slug-less gym and hides View page', async () => {
+      mockGyms = [makeGym({ slug: null, uuid: 'gym-uuid-9' })];
+      render(<HomeGymCard />);
+      await screen.findByTestId('home-gym-card-owner');
+
+      expect(screen.getByTestId('home-gym-card-manage').getAttribute('href')).toBe('/gym/gym-uuid-9/manage');
+      expect(screen.queryByTestId('home-gym-card-view')).toBeNull();
+    });
+
+    it('gates Manage behind the gym-kiosk flag but keeps View page', async () => {
+      mockKioskFlag = false;
+      mockGyms = [makeGym({ slug: 'boulder-project' })];
+      render(<HomeGymCard />);
+      await screen.findByTestId('home-gym-card-owner');
+
+      expect(screen.queryByTestId('home-gym-card-manage')).toBeNull();
+      expect(screen.getByTestId('home-gym-card-view').getAttribute('href')).toBe('/gym/boulder-project');
+    });
+
+    it('gates Manage behind canEdit even when the flag is on', async () => {
+      mockGyms = [makeGym({ slug: 'boulder-project', canEdit: false })];
+      render(<HomeGymCard />);
+      await screen.findByTestId('home-gym-card-owner');
+
+      expect(screen.queryByTestId('home-gym-card-manage')).toBeNull();
+      expect(screen.getByTestId('home-gym-card-view')).toBeTruthy();
+    });
+
+    it('renders nothing when a slug-less gym has no manage access (no actionable owner card)', () => {
+      mockKioskFlag = false;
+      mockGyms = [makeGym({ slug: null, canEdit: false })];
+      render(<HomeGymCard />);
+      expect(screen.queryByTestId('home-gym-card-owner')).toBeNull();
+    });
+
+    it('shows an "and N more" affordance for multiple gyms and opens the My Gyms drawer', async () => {
+      mockGyms = [makeGym({ uuid: 'gym-a' }), makeGym({ uuid: 'gym-b' }), makeGym({ uuid: 'gym-c' })];
+      render(<HomeGymCard />);
+      await screen.findByTestId('home-gym-card-owner');
+
+      const more = screen.getByTestId('home-gym-card-more');
+      expect(more.textContent).toMatch(/and 2 more/i);
+
+      fireEvent.click(more);
+      expect(await screen.findByTestId('my-gyms-drawer')).toBeTruthy();
+      expect(mockTrack).toHaveBeenCalledWith('Homepage Gym Card Click', { action: 'open-my-gyms' });
+    });
+
+    it('does not show "and N more" for a single gym', async () => {
+      mockGyms = [makeGym()];
+      render(<HomeGymCard />);
+      await screen.findByTestId('home-gym-card-owner');
+      expect(screen.queryByTestId('home-gym-card-more')).toBeNull();
+    });
+  });
+
+  describe('non-owner interactions', () => {
+    it('opens the search drawer pre-set to the gyms category', async () => {
+      mockGyms = [];
+      render(<HomeGymCard />);
+      const cta = await screen.findByTestId('home-gym-card-find-cta');
+
+      fireEvent.click(cta);
+      const search = await screen.findByTestId('gym-search');
+      expect(search.getAttribute('data-category')).toBe('gyms');
+      expect(mockTrack).toHaveBeenCalledWith('Homepage Gym Card Click', { action: 'find-gym' });
+    });
+
+    it('persists the dismissal and hides the card when dismissed', async () => {
+      mockGyms = [];
+      render(<HomeGymCard />);
+      const dismiss = await screen.findByTestId('home-gym-card-dismiss');
+
+      fireEvent.click(dismiss);
+      expect(mockSetPreference).toHaveBeenCalledWith('homeGymCard:dismissed', true);
+      await waitFor(() => {
+        expect(screen.queryByTestId('home-gym-card-find')).toBeNull();
+      });
+      expect(mockTrack).toHaveBeenCalledWith('Homepage Gym Card Click', { action: 'dismiss' });
+    });
+  });
+});

--- a/packages/web/app/components/home-gym-card/__tests__/home-gym-card.test.tsx
+++ b/packages/web/app/components/home-gym-card/__tests__/home-gym-card.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { GYM_KIOSK_FLAG } from '@/app/flags';
 import HomeGymCard from '../home-gym-card';
 
 vi.mock('react-i18next', () => ({
@@ -35,7 +36,9 @@ vi.mock('@/app/hooks/use-my-gyms', () => ({
 }));
 
 vi.mock('@/app/components/providers/feature-flags-provider', () => ({
-  useFeatureFlag: () => mockKioskFlag,
+  // Only the gym-kiosk flag is toggled by the card; assert on the exact key so a
+  // second useFeatureFlag call can't silently piggyback on the same mock value.
+  useFeatureFlag: (flag: string) => (flag === GYM_KIOSK_FLAG ? mockKioskFlag : false),
 }));
 
 vi.mock('next-auth/react', () => ({

--- a/packages/web/app/components/home-gym-card/home-gym-card.tsx
+++ b/packages/web/app/components/home-gym-card/home-gym-card.tsx
@@ -129,6 +129,9 @@ function AuthedHomeGymCard({ currentUserId }: { currentUserId: string | null }) 
     track('Homepage Gym Card Click', { action: 'find-gym' });
   }, []);
 
+  const closeMyGyms = useCallback(() => setMyGymsOpen(false), []);
+  const closeSearch = useCallback(() => setSearchOpen(false), []);
+
   const handleDismiss = useCallback(() => {
     setDismissed(true);
     void setPreference(DISMISS_PREFERENCE_KEY, true);
@@ -154,7 +157,7 @@ function AuthedHomeGymCard({ currentUserId }: { currentUserId: string | null }) 
           viewLabel={t('home.gymCard.viewPage')}
           moreLabel={t('home.gymCard.andMore', { count: gyms.length - 1 })}
         />
-        {myGymsRendered && <MyGymsDrawer open={myGymsOpen} onClose={() => setMyGymsOpen(false)} />}
+        {myGymsRendered && <MyGymsDrawer open={myGymsOpen} onClose={closeMyGyms} />}
       </>
     );
   }
@@ -207,7 +210,7 @@ function AuthedHomeGymCard({ currentUserId }: { currentUserId: string | null }) 
       {searchRendered && (
         <UnifiedSearchDrawer
           open={searchOpen}
-          onClose={() => setSearchOpen(false)}
+          onClose={closeSearch}
           defaultCategory="gyms"
           allowedCategories={['gyms']}
           showCloseButton

--- a/packages/web/app/components/home-gym-card/home-gym-card.tsx
+++ b/packages/web/app/components/home-gym-card/home-gym-card.tsx
@@ -19,6 +19,7 @@ import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
 import { GYM_KIOSK_FLAG } from '@/app/flags';
+import type { SearchCategory } from '@/app/components/search-drawer/unified-search-drawer';
 import { useMyGyms } from '@/app/hooks/use-my-gyms';
 import { resolveGymRole, type GymRoleKind } from '@/app/lib/gym-role';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
@@ -32,6 +33,9 @@ const UnifiedSearchDrawer = dynamic(() => import('@/app/components/search-drawer
 });
 
 const DISMISS_PREFERENCE_KEY = 'homeGymCard:dismissed';
+
+// Hoisted so the search drawer gets a stable array reference across renders.
+const GYM_SEARCH_CATEGORIES: SearchCategory[] = ['gyms'];
 
 // Same outlined-card language as the homepage OnboardingCard so the gym card
 // slots into the stack without extra visual weight.
@@ -93,9 +97,16 @@ function AuthedHomeGymCard({ currentUserId }: { currentUserId: string | null }) 
 
   useEffect(() => {
     let cancelled = false;
-    void getPreference<boolean>(DISMISS_PREFERENCE_KEY).then((value) => {
-      if (!cancelled) setDismissed(Boolean(value));
-    });
+    // getPreference already swallows IndexedDB errors and resolves null, but
+    // guard the promise anyway so a rejection can never strand `dismissed` at
+    // null (which would keep the non-owner nudge permanently hidden).
+    void getPreference<boolean>(DISMISS_PREFERENCE_KEY)
+      .then((value) => {
+        if (!cancelled) setDismissed(Boolean(value));
+      })
+      .catch(() => {
+        if (!cancelled) setDismissed(false);
+      });
     return () => {
       cancelled = true;
     };
@@ -212,7 +223,7 @@ function AuthedHomeGymCard({ currentUserId }: { currentUserId: string | null }) 
           open={searchOpen}
           onClose={closeSearch}
           defaultCategory="gyms"
-          allowedCategories={['gyms']}
+          allowedCategories={GYM_SEARCH_CATEGORIES}
           showCloseButton
         />
       )}

--- a/packages/web/app/components/home-gym-card/home-gym-card.tsx
+++ b/packages/web/app/components/home-gym-card/home-gym-card.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { useTranslation } from 'react-i18next';
+import { useSession } from 'next-auth/react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
+import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
+import SettingsOutlined from '@mui/icons-material/SettingsOutlined';
+import VisibilityOutlined from '@mui/icons-material/VisibilityOutlined';
+import SearchOutlined from '@mui/icons-material/SearchOutlined';
+import CloseOutlined from '@mui/icons-material/CloseOutlined';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
+import { GYM_KIOSK_FLAG } from '@/app/flags';
+import { useMyGyms } from '@/app/hooks/use-my-gyms';
+import { resolveGymRole, type GymRoleKind } from '@/app/lib/gym-role';
+import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+import { track } from '@/app/lib/analytics';
+import { themeTokens } from '@/app/theme/theme-config';
+
+const MyGymsDrawer = dynamic(() => import('@/app/components/my-gyms-drawer/my-gyms-drawer'), { ssr: false });
+
+const UnifiedSearchDrawer = dynamic(() => import('@/app/components/search-drawer/unified-search-drawer'), {
+  ssr: false,
+});
+
+const DISMISS_PREFERENCE_KEY = 'homeGymCard:dismissed';
+
+// Same outlined-card language as the homepage OnboardingCard so the gym card
+// slots into the stack without extra visual weight.
+const cardSx = {
+  borderRadius: `${themeTokens.borderRadius.lg}px`,
+  border: '1px solid var(--neutral-200)',
+  transition: themeTokens.transitions.fast,
+  '&:hover': {
+    borderColor: 'var(--neutral-300)',
+    boxShadow: themeTokens.shadows.sm,
+  },
+} as const;
+
+// Low-key violet-slate icon chip (matches the OnboardingCard 'help' accent) —
+// the gym card is a quiet, contextual nudge, not a hero CTA.
+const iconChipSx = {
+  width: 44,
+  height: 44,
+  borderRadius: `${themeTokens.borderRadius.md}px`,
+  backgroundColor: 'rgba(94, 100, 145, 0.12)',
+  color: 'var(--color-info)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+} as const;
+
+/**
+ * Signed-in homepage nudge about gyms. Owners see their gym with Manage / View
+ * actions; signed-in climbers without a gym get a low-key, dismissible "Find
+ * your gym" card. Signed-out visitors see nothing.
+ *
+ * The authenticated body lives in a child component so the `useMyGyms`
+ * GraphQL/React Query hooks never run for signed-out (or still-loading)
+ * sessions — the card just returns null before mounting them.
+ */
+export default function HomeGymCard() {
+  const { data: session, status } = useSession();
+  if (status !== 'authenticated') return null;
+  return <AuthedHomeGymCard currentUserId={session?.user?.id ?? null} />;
+}
+
+function AuthedHomeGymCard({ currentUserId }: { currentUserId: string | null }) {
+  const { t } = useTranslation('marketing');
+  const { t: tCommon } = useTranslation('common');
+  const { gyms, isLoading, error } = useMyGyms(true);
+  // Kill switch for the manage surface — mirrors the My Gyms drawer, which
+  // hides the Manage button until the gym-kiosk feature ships broadly. The
+  // View action stays ungated.
+  const kioskFlag = useFeatureFlag(GYM_KIOSK_FLAG);
+
+  // `null` = not yet resolved from IndexedDB; render nothing until we know so
+  // the non-owner nudge never flashes and then vanishes.
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
+  const [myGymsOpen, setMyGymsOpen] = useState(false);
+  const [myGymsRendered, setMyGymsRendered] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchRendered, setSearchRendered] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getPreference<boolean>(DISMISS_PREFERENCE_KEY).then((value) => {
+      if (!cancelled) setDismissed(Boolean(value));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const roleLabel = useCallback(
+    (role: GymRoleKind): string => {
+      switch (role) {
+        case 'owner':
+          return tCommon('myGyms.roleOwner');
+        case 'admin':
+          return tCommon('myGyms.roleAdmin');
+        case 'editor':
+          return tCommon('myGyms.roleEditor');
+        case 'member':
+          return tCommon('myGyms.roleMember');
+      }
+    },
+    [tCommon],
+  );
+
+  const openMyGyms = useCallback(() => {
+    setMyGymsRendered(true);
+    setMyGymsOpen(true);
+    track('Homepage Gym Card Click', { action: 'open-my-gyms' });
+  }, []);
+
+  const openSearch = useCallback(() => {
+    setSearchRendered(true);
+    setSearchOpen(true);
+    track('Homepage Gym Card Click', { action: 'find-gym' });
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    setDismissed(true);
+    void setPreference(DISMISS_PREFERENCE_KEY, true);
+    track('Homepage Gym Card Click', { action: 'dismiss' });
+  }, []);
+
+  // Wait for the gyms fetch before deciding which variant to show — don't
+  // guess non-owner while the request is still in flight.
+  if (error || (isLoading && gyms.length === 0)) return null;
+
+  if (gyms.length > 0) {
+    return (
+      <>
+        <OwnerGymCard
+          gym={gyms[0]}
+          extraCount={gyms.length - 1}
+          role={resolveGymRole(gyms[0], currentUserId)}
+          roleLabel={roleLabel}
+          kioskFlag={Boolean(kioskFlag)}
+          onOpenMyGyms={openMyGyms}
+          ownerSubtitle={t('home.gymCard.ownerSubtitle')}
+          manageLabel={t('home.gymCard.manage')}
+          viewLabel={t('home.gymCard.viewPage')}
+          moreLabel={t('home.gymCard.andMore', { count: gyms.length - 1 })}
+        />
+        {myGymsRendered && <MyGymsDrawer open={myGymsOpen} onClose={() => setMyGymsOpen(false)} />}
+      </>
+    );
+  }
+
+  // Non-owner: only render once we know the dismissal state and it's not set.
+  if (dismissed !== false) return null;
+
+  return (
+    <>
+      <Card variant="outlined" sx={cardSx} data-testid="home-gym-card-find">
+        <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 2, px: 2.5 }}>
+          <Box sx={iconChipSx}>
+            <FitnessCenterOutlined />
+          </Box>
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Typography
+                variant="body1"
+                fontWeight={themeTokens.typography.fontWeight.semibold}
+                sx={{ color: 'var(--neutral-900)', lineHeight: themeTokens.typography.lineHeight.tight, flex: 1 }}
+              >
+                {t('home.gymCard.findTitle')}
+              </Typography>
+              <IconButton
+                size="small"
+                onClick={handleDismiss}
+                aria-label={t('home.gymCard.dismiss')}
+                data-testid="home-gym-card-dismiss"
+                sx={{ color: 'var(--neutral-400)', flexShrink: 0 }}
+              >
+                <CloseOutlined fontSize="small" />
+              </IconButton>
+            </Box>
+            <Typography variant="body2" sx={{ color: 'var(--neutral-500)', mt: 0.25 }}>
+              {t('home.gymCard.findDescription')}
+            </Typography>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<SearchOutlined />}
+              onClick={openSearch}
+              data-testid="home-gym-card-find-cta"
+              sx={{ textTransform: 'none', mt: 1.25 }}
+            >
+              {t('home.gymCard.findCta')}
+            </Button>
+          </Box>
+        </CardContent>
+      </Card>
+      {searchRendered && (
+        <UnifiedSearchDrawer
+          open={searchOpen}
+          onClose={() => setSearchOpen(false)}
+          defaultCategory="gyms"
+          allowedCategories={['gyms']}
+          showCloseButton
+        />
+      )}
+    </>
+  );
+}
+
+type OwnerGymCardProps = {
+  gym: ReturnType<typeof useMyGyms>['gyms'][number];
+  extraCount: number;
+  role: GymRoleKind | null;
+  roleLabel: (role: GymRoleKind) => string;
+  kioskFlag: boolean;
+  onOpenMyGyms: () => void;
+  ownerSubtitle: string;
+  manageLabel: string;
+  viewLabel: string;
+  moreLabel: string;
+};
+
+function OwnerGymCard({
+  gym,
+  extraCount,
+  role,
+  roleLabel,
+  kioskFlag,
+  onOpenMyGyms,
+  ownerSubtitle,
+  manageLabel,
+  viewLabel,
+  moreLabel,
+}: OwnerGymCardProps) {
+  // The manage route resolves a bare UUID (slug-less legacy gyms); the public
+  // gym page only resolves by slug — so "View page" is offered only with a slug.
+  const showManage = gym.canEdit && kioskFlag;
+  const manageHref = `/gym/${gym.slug ?? gym.uuid}/manage`;
+  const viewHref = gym.slug ? `/gym/${gym.slug}` : null;
+  const showMore = extraCount > 0;
+
+  // Nothing actionable (no manage access, no public page, single gym) — skip the
+  // card entirely rather than show a dead-end owner row.
+  if (!showManage && !viewHref && !showMore) return null;
+
+  return (
+    <Card variant="outlined" sx={cardSx} data-testid="home-gym-card-owner">
+      <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 2, px: 2.5 }}>
+        <Box sx={iconChipSx}>
+          <FitnessCenterOutlined />
+        </Box>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+            <Typography
+              variant="body1"
+              fontWeight={themeTokens.typography.fontWeight.semibold}
+              sx={{ color: 'var(--neutral-900)', lineHeight: themeTokens.typography.lineHeight.tight }}
+            >
+              {gym.name}
+            </Typography>
+            {role && <Chip size="small" label={roleLabel(role)} color="primary" />}
+          </Box>
+          <Typography variant="body2" sx={{ color: 'var(--neutral-500)', mt: 0.25 }}>
+            {ownerSubtitle}
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mt: 1.25 }}>
+            {showManage && (
+              <Button
+                component={LocaleLink}
+                href={manageHref}
+                size="small"
+                variant="outlined"
+                startIcon={<SettingsOutlined />}
+                data-testid="home-gym-card-manage"
+                sx={{ textTransform: 'none' }}
+              >
+                {manageLabel}
+              </Button>
+            )}
+            {viewHref && (
+              <Button
+                component={LocaleLink}
+                href={viewHref}
+                size="small"
+                variant="text"
+                startIcon={<VisibilityOutlined />}
+                data-testid="home-gym-card-view"
+                sx={{ textTransform: 'none' }}
+              >
+                {viewLabel}
+              </Button>
+            )}
+            {showMore && (
+              <Button
+                size="small"
+                variant="text"
+                onClick={onOpenMyGyms}
+                data-testid="home-gym-card-more"
+                sx={{ textTransform: 'none', color: 'var(--neutral-500)' }}
+              >
+                {moreLabel}
+              </Button>
+            )}
+          </Box>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/app/components/home-gym-card/home-gym-card.tsx
+++ b/packages/web/app/components/home-gym-card/home-gym-card.tsx
@@ -123,6 +123,11 @@ function AuthedHomeGymCard({ currentUserId }: { currentUserId: string | null }) 
           return tCommon('myGyms.roleEditor');
         case 'member':
           return tCommon('myGyms.roleMember');
+        default:
+          // Exhaustiveness guard: a new GymRoleKind fails to type-check here
+          // rather than silently rendering a blank chip.
+          role satisfies never;
+          return '';
       }
     },
     [tCommon],

--- a/packages/web/app/components/my-gyms-drawer/my-gyms-drawer.tsx
+++ b/packages/web/app/components/my-gyms-drawer/my-gyms-drawer.tsx
@@ -20,7 +20,7 @@ import { useFeatureFlag } from '@/app/components/providers/feature-flags-provide
 import { GYM_KIOSK_FLAG } from '@/app/flags';
 import { useMyGyms } from '@/app/hooks/use-my-gyms';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
-import type { Gym } from '@boardsesh/shared-schema';
+import { resolveGymRole, type GymRoleKind } from '@/app/lib/gym-role';
 import styles from './my-gyms-drawer.module.css';
 
 type MyGymsDrawerProps = {
@@ -28,8 +28,6 @@ type MyGymsDrawerProps = {
   onClose: () => void;
   onTransitionEnd?: (open: boolean) => void;
 };
-
-type GymRoleKind = 'owner' | 'admin' | 'editor' | 'member';
 
 type ChipColor = 'primary' | 'secondary' | 'default';
 
@@ -39,21 +37,6 @@ const ROLE_CHIP_COLOR: Record<GymRoleKind, ChipColor> = {
   editor: 'default',
   member: 'default',
 };
-
-/**
- * Resolve the viewer's standing at a gym. The owner outranks the `myRole`
- * field (owners are reported as gym admins by the backend), so the owner check
- * comes first. Returns null for a gym the viewer only follows.
- * Admin/editor rows only become reachable once `myGyms` includes gym_members
- * (staff-roles PR); until then every listed gym resolves to `owner`.
- */
-function resolveGymRole(gym: Gym, currentUserId: string | null): GymRoleKind | null {
-  if (currentUserId && gym.ownerId === currentUserId) return 'owner';
-  if (gym.myRole === 'admin') return 'admin';
-  if (gym.myRole === 'editor') return 'editor';
-  if (gym.myRole === 'member') return 'member';
-  return null;
-}
 
 export default function MyGymsDrawer({ open, onClose, onTransitionEnd }: MyGymsDrawerProps) {
   const { t } = useTranslation('common');

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -33,6 +33,7 @@ import type { BoardConfigData } from '@/app/lib/server-board-configs';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import type { RecentBetaLinkRow } from '@/app/lib/server-recent-beta-links';
 import HomeRecentBetaSection from '@/app/components/beta-videos/home-recent-beta-section';
+import HomeGymCard from '@/app/components/home-gym-card/home-gym-card';
 import { track } from '@/app/lib/analytics';
 import { useOnboardingTourOptional } from '@/app/components/onboarding/onboarding-tour-provider';
 import { TOUR_OPEN_START_SESH_EVENT } from '@/app/components/onboarding/onboarding-tour-events';
@@ -511,6 +512,11 @@ export default function HomePageContent({
           </Typography>
 
           <InstallAppCard platform={installPlatform} />
+
+          {/* Signed-in only: owner's gym (Manage / View) or a low-key
+              dismissible "Find your gym" nudge. Self-gates to null for
+              signed-out visitors. */}
+          <HomeGymCard />
 
           <OnboardingCard
             icon={<PlayCircleOutlineOutlined />}

--- a/packages/web/app/lib/__tests__/gym-role.test.ts
+++ b/packages/web/app/lib/__tests__/gym-role.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vite-plus/test';
+import type { Gym } from '@boardsesh/shared-schema';
+import { resolveGymRole } from '../gym-role';
+
+function makeGym(overrides?: Partial<Gym>): Gym {
+  return {
+    uuid: 'gym-1',
+    slug: 'boulder-project',
+    ownerId: 'owner-1',
+    name: 'Boulder Project',
+    isPublic: true,
+    createdAt: '2024-01-01',
+    boardCount: 3,
+    boardTypes: ['kilter'],
+    memberCount: 12,
+    followerCount: 8,
+    commentCount: 0,
+    isFollowedByMe: false,
+    isMember: true,
+    canEdit: true,
+    canGrantAccess: true,
+    canClaim: false,
+    ...overrides,
+  };
+}
+
+describe('resolveGymRole', () => {
+  it('returns owner when the viewer owns the gym, outranking any myRole', () => {
+    // The backend reports owners as gym admins, so owner must be checked first.
+    expect(resolveGymRole(makeGym({ ownerId: 'me', myRole: 'admin' }), 'me')).toBe('owner');
+  });
+
+  it('returns the membership role when the viewer is not the owner', () => {
+    expect(resolveGymRole(makeGym({ ownerId: 'someone-else', myRole: 'admin' }), 'me')).toBe('admin');
+    expect(resolveGymRole(makeGym({ ownerId: 'someone-else', myRole: 'editor' }), 'me')).toBe('editor');
+    expect(resolveGymRole(makeGym({ ownerId: 'someone-else', myRole: 'member' }), 'me')).toBe('member');
+  });
+
+  it('returns null for a gym the viewer only follows', () => {
+    expect(resolveGymRole(makeGym({ ownerId: 'someone-else', myRole: null }), 'me')).toBeNull();
+  });
+
+  it('does not treat a null viewer id as the owner even if ownerId is falsy-ish', () => {
+    expect(resolveGymRole(makeGym({ ownerId: 'owner-1', myRole: null }), null)).toBeNull();
+  });
+});

--- a/packages/web/app/lib/gym-role.ts
+++ b/packages/web/app/lib/gym-role.ts
@@ -1,0 +1,24 @@
+import type { Gym } from '@boardsesh/shared-schema';
+
+/**
+ * The viewer's standing at a gym, in precedence order. `owner` outranks any
+ * `myRole` (owners are reported as gym admins by the backend), so the owner
+ * check comes first.
+ */
+export type GymRoleKind = 'owner' | 'admin' | 'editor' | 'member';
+
+/**
+ * Resolve the viewer's standing at a gym. Returns null for a gym the viewer
+ * only follows. Shared by the My Gyms drawer and the homepage gym card so both
+ * surface the same role.
+ *
+ * Admin/editor rows only become reachable once `myGyms` includes gym_members
+ * (staff-roles PR); until then every listed gym resolves to `owner`.
+ */
+export function resolveGymRole(gym: Gym, currentUserId: string | null): GymRoleKind | null {
+  if (currentUserId && gym.ownerId === currentUserId) return 'owner';
+  if (gym.myRole === 'admin') return 'admin';
+  if (gym.myRole === 'editor') return 'editor';
+  if (gym.myRole === 'member') return 'member';
+  return null;
+}

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -51,6 +51,12 @@ export type UserPreferenceKeyMap = {
   'swipeHint:partyPreviewSeen': boolean;
   tickBarExpanded: boolean;
   'shakeToReport:dismissed': boolean;
+  /**
+   * One-shot dismissal for the signed-in "Find your gym" nudge on the homepage.
+   * Set once a non-owner taps the card's dismiss control so it stays hidden on
+   * future visits. The owner variant of the card is not dismissible.
+   */
+  'homeGymCard:dismissed': boolean;
   esp32Connections: Esp32Connection[];
   lastUsedGrade: number;
 };


### PR DESCRIPTION
## Summary

Nothing on the homepage told a gym owner that Boardsesh can manage their gym. This adds a modest, signed-in-only gym card to the homepage onboarding stack with two variants:

- **Owner** (has ≥1 gym via `useMyGyms`): a "Your gym" card showing the first gym's name and role, with **Manage** → `/gym/{slug ?? uuid}/manage` (gated on `gym.canEdit` + the `gym-kiosk` flag, matching the My Gyms drawer's kill-switch) and **View page** → `/gym/{slug}`. With more than one gym, an "and N more" button opens the existing My Gyms drawer.
- **Non-owner** (signed in, 0 gyms): a low-key, dismissible "Climb at a gym with boards?" card whose **Find your gym** button opens the unified search pre-set to the Gyms category (same as the drawer's empty state). Dismissal persists in IndexedDB; the owner variant is not dismissible.

Signed-out visitors see nothing — the heavy `useMyGyms` / React Query hooks only mount once the session is authenticated.

`resolveGymRole` moved into a shared `app/lib/gym-role.ts` so the drawer and the new card share one source of truth instead of duplicating it.

Part of the coordinated gym-admin wave (builds on the recently merged My Gyms drawer + public `/gym/[slug]` page).

## Release Notes

- Own a gym? Your gym now greets you on the homepage — jump straight to managing its boards or your public page.
- Climb somewhere with boards? Find your gym from the homepage and pull up its boards and crew.

## Test plan

- `vp check` (lint + format) — clean on all changed files.
- `vp run typecheck:web` — passes.
- `vp test run --project web --reporter=agent` — 5288 passing (one pre-existing flaky timeout in `aurora-credentials-section`, passes in isolation); new `home-gym-card.test.tsx` covers variant selection (owner / non-owner / signed-out / loading / error), Manage + View hrefs, the `canEdit` + `gym-kiosk` flag gating, slug-less UUID fallback, "and N more" → My Gyms drawer, search pre-filter to Gyms, and dismissal persistence — 15 tests.
- `vp run check:i18n` + `check:i18n:orphans` — clean; catalog-completeness green (en-US / es / fr parity for the new `marketing.home.gymCard` keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VGxf4ZJGFRanuJGrRMDgY
