### PR TITLE
feat: gym duplicate merge tooling + admin review queue

### DIFF
--- a/packages/backend/src/__tests__/gym-duplicates.test.ts
+++ b/packages/backend/src/__tests__/gym-duplicates.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialGymDuplicateQueries, socialGymDuplicateMutations } from '../graphql/resolvers/social/gym-duplicates';
+
+/**
+ * Real-DB coverage for the /admin/gym-duplicates review queue: the admin gate,
+ * the tiered candidate clustering, dismissal filtering, the orphan audit, and the
+ * mergeGyms mutation (claims unique-pending conflict, kiosk slug-suffix warning,
+ * moved counts, merged_into pointer, audit rows).
+ *
+ * Mirrors gym-write-access-and-claims.test.ts: seeds via raw SQL and calls the
+ * resolvers directly against the per-worker test DB.
+ */
+
+const SYSTEM_OWNER = '00000000-0000-0000-0000-000000000000';
+const ADMIN = 'gd-admin';
+const PLAIN_USER = 'gd-plain';
+const GYM_OWNER = 'gd-gym-owner';
+const CLAIMANT_BOTH = 'gd-claimant-both';
+const CLAIMANT_DUP_ONLY = 'gd-claimant-dup';
+
+const ALL_USERS = [SYSTEM_OWNER, ADMIN, PLAIN_USER, GYM_OWNER, CLAIMANT_BOTH, CLAIMANT_DUP_ONLY];
+
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}`, isAuthenticated: true, userId }) as ConnectionContext;
+
+const anonCtx = (): ConnectionContext => ({ connectionId: 'conn-anon', isAuthenticated: false }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+const insertAdminRole = (userId: string) =>
+  db.execute(sql`
+    INSERT INTO community_roles (user_id, role, board_type, created_at)
+    VALUES (${userId}, 'admin', NULL, now())
+  `);
+
+const insertGym = async (opts: {
+  ownerId: string;
+  name: string;
+  latitude: number;
+  longitude: number;
+  createdAt?: string;
+  uuid?: string;
+}): Promise<{ id: number; uuid: string }> => {
+  const { ownerId, name, latitude, longitude, createdAt = '2026-01-01T00:00:00Z', uuid = uuidv4() } = opts;
+  const result = await db.execute(sql`
+    INSERT INTO gyms (uuid, name, slug, owner_id, latitude, longitude, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${name}, ${uuid}, ${ownerId}, ${latitude}, ${longitude}, true, ${createdAt}, ${createdAt})
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
+};
+
+const insertBoard = async (gymId: number, ownerId: string): Promise<void> => {
+  const uuid = uuidv4();
+  await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, gym_id, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${ownerId}, 'kilter', 1, 10, '1,2', 'Wall', ${gymId}, true, now(), now())
+  `);
+};
+
+const insertSource = (gymId: number, sourceKey: string) =>
+  db.execute(sql`
+    INSERT INTO location_sync_gym_sources (source_key, gym_id, created_at, updated_at)
+    VALUES (${sourceKey}, ${gymId}, now(), now())
+  `);
+
+const insertKiosk = (gymId: number, slug: string, name: string) =>
+  db.execute(sql`
+    INSERT INTO gym_kiosks (uuid, gym_id, slug, name, created_at, updated_at)
+    VALUES (${uuidv4()}, ${gymId}, ${slug}, ${name}, now(), now())
+  `);
+
+const insertClaim = (gymId: number, claimantUserId: string, status = 'pending') =>
+  db.execute(sql`
+    INSERT INTO gym_claims (gym_id, claimant_user_id, method, status, created_at, updated_at)
+    VALUES (${gymId}, ${claimantUserId}, 'admin', ${status}, now(), now())
+  `);
+
+const insertGymMember = (gymId: number, userId: string, role: string) =>
+  db.execute(sql`
+    INSERT INTO gym_members (gym_id, user_id, role, created_at)
+    VALUES (${gymId}, ${userId}, ${role}, now())
+  `);
+
+const gymRow = async (
+  uuid: string,
+): Promise<{ deleted_at: Date | null; merged_into_gym_id: number | null } | undefined> => {
+  const result = await db.execute(sql`
+    SELECT deleted_at, merged_into_gym_id FROM gyms WHERE uuid = ${uuid} LIMIT 1
+  `);
+  return Array.from(result as Iterable<{ deleted_at: Date | null; merged_into_gym_id: number | null }>)[0];
+};
+
+beforeEach(async () => {
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "community_roles", "gym_members", "gym_follows", "gym_claims", "gym_kiosks",
+      "gym_merge_audit", "location_sync_gym_sources", "user_boards", "gyms"
+    RESTART IDENTITY CASCADE
+  `);
+  await Promise.all(ALL_USERS.map(insertUser));
+  await insertAdminRole(ADMIN);
+});
+
+describe('admin gate', () => {
+  it('rejects a non-admin and an anonymous caller on every duplicate resolver', async () => {
+    for (const ctx of [authCtx(PLAIN_USER), anonCtx()]) {
+      await expect(socialGymDuplicateQueries.duplicateGymClusters(null, { input: {} }, ctx)).rejects.toThrow();
+      await expect(socialGymDuplicateQueries.orphanGyms(null, { input: {} }, ctx)).rejects.toThrow();
+      await expect(
+        socialGymDuplicateMutations.mergeGyms(
+          null,
+          { input: { canonicalGymUuid: uuidv4(), duplicateGymUuids: [uuidv4()] } },
+          ctx,
+        ),
+      ).rejects.toThrow();
+      await expect(
+        socialGymDuplicateMutations.dismissGymCluster(
+          null,
+          { input: { gymUuids: [uuidv4(), uuidv4()], canonicalGymUuid: uuidv4() } },
+          ctx,
+        ),
+      ).rejects.toThrow();
+    }
+  });
+});
+
+describe('duplicateGymClusters', () => {
+  it('tiers a tight cluster A and a drifted cluster B, and prefers a user-owned survivor', async () => {
+    // Tier A: two "Alpha Gym" rows ~11 m apart. The system-owned row is more
+    // complete (a board), but the user-owned row must still be pre-selected.
+    const alphaSystem = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Alpha Gym',
+      latitude: 40.0,
+      longitude: -105.0,
+    });
+    await insertBoard(alphaSystem.id, SYSTEM_OWNER);
+    await insertSource(alphaSystem.id, 'kilter:alpha-1');
+    const alphaUser = await insertGym({ ownerId: GYM_OWNER, name: 'Alpha Gym', latitude: 40.0001, longitude: -105.0 });
+
+    // Tier B: two "Beta Gym" rows ~111 m apart.
+    await insertGym({ ownerId: SYSTEM_OWNER, name: 'Beta Gym', latitude: 40.1, longitude: -105.0 });
+    await insertGym({ ownerId: SYSTEM_OWNER, name: 'Beta Gym', latitude: 40.101, longitude: -105.0 });
+
+    const result = await socialGymDuplicateQueries.duplicateGymClusters(null, { input: {} }, authCtx(ADMIN));
+    expect(result.totalCount).toBe(2);
+
+    const alphaCluster = result.clusters.find((c) => c.normalizedName === 'alpha gym')!;
+    const betaCluster = result.clusters.find((c) => c.normalizedName === 'beta gym')!;
+    expect(alphaCluster.tier).toBe('A');
+    expect(betaCluster.tier).toBe('B');
+    // Tier A sorts before tier B.
+    expect(result.clusters[0].normalizedName).toBe('alpha gym');
+
+    // The user-owned Alpha row is the suggested survivor despite being emptier.
+    expect(alphaCluster.suggestedCanonicalGymUuid).toBe(alphaUser.uuid);
+    const suggested = alphaCluster.members.find((m) => m.isSuggestedCanonical)!;
+    expect(suggested.gymUuid).toBe(alphaUser.uuid);
+    expect(suggested.ownerType).toBe('user');
+
+    const systemMember = alphaCluster.members.find((m) => m.gymUuid === alphaSystem.uuid)!;
+    expect(systemMember.ownerType).toBe('system');
+    expect(systemMember.providerOrigins).toEqual(['kilter']);
+    expect(systemMember.boardCount).toBe(1);
+    expect(systemMember.distanceToCanonicalMeters).toBeGreaterThan(0);
+  });
+
+  it('marks a pending-claim member and excludes a dismissed cluster', async () => {
+    const gymA = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Claimed Gym', latitude: 41.0, longitude: -105.0 });
+    const gymB = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Claimed Gym', latitude: 41.0001, longitude: -105.0 });
+    await insertClaim(gymA.id, CLAIMANT_DUP_ONLY, 'pending');
+
+    const before = await socialGymDuplicateQueries.duplicateGymClusters(null, { input: {} }, authCtx(ADMIN));
+    const cluster = before.clusters.find((c) => c.normalizedName === 'claimed gym')!;
+    expect(cluster).toBeDefined();
+    const claimedMember = cluster.members.find((m) => m.gymUuid === gymA.uuid)!;
+    expect(claimedMember.claimStatus).toBe('pending');
+    expect(claimedMember.claimCount).toBe(1);
+    // A pending claim makes gymA the preferred survivor over the plain system row.
+    expect(cluster.suggestedCanonicalGymUuid).toBe(gymA.uuid);
+
+    await socialGymDuplicateMutations.dismissGymCluster(
+      null,
+      { input: { gymUuids: [gymA.uuid, gymB.uuid], canonicalGymUuid: gymA.uuid } },
+      authCtx(ADMIN),
+    );
+
+    const after = await socialGymDuplicateQueries.duplicateGymClusters(null, { input: {} }, authCtx(ADMIN));
+    expect(after.clusters.find((c) => c.normalizedName === 'claimed gym')).toBeUndefined();
+    expect(after.totalCount).toBe(0);
+  });
+});
+
+describe('mergeGyms', () => {
+  it('re-points a duplicate, suffixes a colliding kiosk slug, resolves the claim conflict, and audits it', async () => {
+    const canonical = await insertGym({
+      ownerId: GYM_OWNER,
+      name: 'Merge Gym',
+      latitude: 42.0,
+      longitude: -105.0,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    const duplicate = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Merge Gym',
+      latitude: 42.0001,
+      longitude: -105.0,
+      createdAt: '2026-01-02T00:00:00Z',
+    });
+
+    await insertBoard(duplicate.id, SYSTEM_OWNER);
+    await insertKiosk(canonical.id, 'main-wall', 'Canonical Main');
+    await insertKiosk(duplicate.id, 'main-wall', 'Duplicate Main');
+    // Claimant with a pending claim on BOTH gyms (a mid-flight collision) plus one
+    // claimant with a pending claim only on the duplicate.
+    await insertClaim(canonical.id, CLAIMANT_BOTH, 'pending');
+    await insertClaim(duplicate.id, CLAIMANT_BOTH, 'pending');
+    await insertClaim(duplicate.id, CLAIMANT_DUP_ONLY, 'pending');
+    // Member role precedence: PLAIN_USER is an editor on the canonical but only a
+    // member on the twin (must not be demoted); CLAIMANT_DUP_ONLY is an editor
+    // only on the twin (must arrive as editor).
+    await insertGymMember(canonical.id, PLAIN_USER, 'editor');
+    await insertGymMember(duplicate.id, PLAIN_USER, 'member');
+    await insertGymMember(duplicate.id, CLAIMANT_DUP_ONLY, 'editor');
+
+    const result = await socialGymDuplicateMutations.mergeGyms(
+      null,
+      { input: { canonicalGymUuid: canonical.uuid, duplicateGymUuids: [duplicate.uuid] } },
+      authCtx(ADMIN),
+    );
+
+    expect(result.canonicalGymUuid).toBe(canonical.uuid);
+    expect(result.results).toHaveLength(1);
+    const merged = result.results[0];
+    expect(merged.duplicateGymUuid).toBe(duplicate.uuid);
+    expect(merged.counts.boards).toBe(1);
+    expect(merged.counts.kiosks).toBe(1);
+    // The duplicate's only-there claimant is promoted; the collision is expired.
+    expect(merged.counts.claims).toBe(1);
+
+    // Editor precedence held on both sides — no demotion to member.
+    const roleRows = await db.execute(sql`
+      SELECT user_id, role FROM gym_members WHERE gym_id = ${canonical.id} ORDER BY user_id
+    `);
+    const roleByUser = new Map(
+      Array.from(roleRows as Iterable<{ user_id: string; role: string }>).map((row) => [row.user_id, row.role]),
+    );
+    expect(roleByUser.get(PLAIN_USER)).toBe('editor');
+    expect(roleByUser.get(CLAIMANT_DUP_ONLY)).toBe('editor');
+
+    // The colliding kiosk was re-slugged and reported.
+    expect(merged.warnings).toHaveLength(1);
+    expect(merged.warnings[0]).toMatchObject({ previousSlug: 'main-wall', newSlug: 'main-wall-2' });
+
+    // The duplicate is soft-deleted and points at the survivor.
+    const dupRow = await gymRow(duplicate.uuid);
+    expect(dupRow?.deleted_at).not.toBeNull();
+    expect(Number(dupRow?.merged_into_gym_id)).toBe(canonical.id);
+
+    // Exactly one pending claim per claimant now sits on the canonical.
+    const pending = await db.execute(sql`
+      SELECT claimant_user_id FROM gym_claims WHERE gym_id = ${canonical.id} AND status = 'pending' ORDER BY claimant_user_id
+    `);
+    const pendingClaimants = Array.from(pending as Iterable<{ claimant_user_id: string }>).map(
+      (row) => row.claimant_user_id,
+    );
+    expect(pendingClaimants).toEqual([CLAIMANT_BOTH, CLAIMANT_DUP_ONLY].sort());
+
+    // The board moved onto the canonical.
+    const boardCount = await db.execute(sql`
+      SELECT count(*)::int AS count FROM user_boards WHERE gym_id = ${canonical.id}
+    `);
+    expect(Number(Array.from(boardCount as Iterable<{ count: number }>)[0].count)).toBe(1);
+
+    // One 'merged' audit row was written for the duplicate, carrying the moved-row
+    // ids (not just aggregate counts) so a bad merge can be reversed.
+    const audit = await db.execute(sql`
+      SELECT action, canonical_gym_id, duplicate_gym_id, moved_rows FROM gym_merge_audit WHERE action = 'merged'
+    `);
+    const auditRows = Array.from(
+      audit as Iterable<{
+        action: string;
+        canonical_gym_id: number;
+        duplicate_gym_id: number;
+        moved_rows: { boardIds: number[] } | null;
+      }>,
+    );
+    expect(auditRows).toHaveLength(1);
+    expect(Number(auditRows[0].canonical_gym_id)).toBe(canonical.id);
+    expect(Number(auditRows[0].duplicate_gym_id)).toBe(duplicate.id);
+    expect(auditRows[0].moved_rows?.boardIds).toHaveLength(1);
+  });
+
+  it('rejects a canonical that is also listed as a duplicate', async () => {
+    const gym = await insertGym({ ownerId: GYM_OWNER, name: 'Solo Gym', latitude: 43.0, longitude: -105.0 });
+    await expect(
+      socialGymDuplicateMutations.mergeGyms(
+        null,
+        { input: { canonicalGymUuid: gym.uuid, duplicateGymUuids: [gym.uuid] } },
+        authCtx(ADMIN),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('rejects a SYSTEM canonical over a user-owned duplicate without the override, allows it with', async () => {
+    // Admin inverted the pre-selection: SYSTEM row kept as survivor, user-owned
+    // gym folded into it. Must be refused unless the override is explicit.
+    const systemCanonical = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Invert Gym',
+      latitude: 45.0,
+      longitude: -105.0,
+    });
+    const userDuplicate = await insertGym({
+      ownerId: GYM_OWNER,
+      name: 'Invert Gym',
+      latitude: 45.0001,
+      longitude: -105.0,
+    });
+
+    await expect(
+      socialGymDuplicateMutations.mergeGyms(
+        null,
+        { input: { canonicalGymUuid: systemCanonical.uuid, duplicateGymUuids: [userDuplicate.uuid] } },
+        authCtx(ADMIN),
+      ),
+    ).rejects.toThrow(/override/i);
+
+    // Same call with the explicit override succeeds.
+    const result = await socialGymDuplicateMutations.mergeGyms(
+      null,
+      {
+        input: {
+          canonicalGymUuid: systemCanonical.uuid,
+          duplicateGymUuids: [userDuplicate.uuid],
+          allowSystemCanonicalOverride: true,
+        },
+      },
+      authCtx(ADMIN),
+    );
+    expect(result.results).toHaveLength(1);
+    const dupRow = await gymRow(userDuplicate.uuid);
+    expect(Number(dupRow?.merged_into_gym_id)).toBe(systemCanonical.id);
+  });
+});
+
+describe('orphanGyms', () => {
+  it('lists alias-less system gyms and excludes gyms with a location-sync source', async () => {
+    const orphan = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Orphan Gym', latitude: 44.0, longitude: -105.0 });
+    await insertBoard(orphan.id, SYSTEM_OWNER);
+    const sourced = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Sourced Gym', latitude: 44.1, longitude: -105.0 });
+    await insertSource(sourced.id, 'tension:sourced-1');
+    // A user-owned gym is never an orphan (orphans are system-owned).
+    await insertGym({ ownerId: GYM_OWNER, name: 'User Gym', latitude: 44.2, longitude: -105.0 });
+
+    const result = await socialGymDuplicateQueries.orphanGyms(null, { input: {} }, authCtx(ADMIN));
+    expect(result.totalCount).toBe(1);
+    expect(result.gyms).toHaveLength(1);
+    expect(result.gyms[0].gymUuid).toBe(orphan.uuid);
+    expect(result.gyms[0].boardCount).toBe(1);
+  });
+});

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -301,6 +301,14 @@ export const schemaSQL = `
   EXCEPTION WHEN duplicate_object THEN NULL;
   END $$;
 
+  -- gym_members.role is a real enum in prod. The merge's member-collapse upsert
+  -- builds an enum-typed CASE value (not just a string-equality read), so the
+  -- test schema needs the actual type, not a text column.
+  DO $$ BEGIN
+    CREATE TYPE gym_member_role AS ENUM ('admin', 'editor', 'member');
+  EXCEPTION WHEN duplicate_object THEN NULL;
+  END $$;
+
   DO $$ BEGIN
     CREATE TYPE kilter_table_type AS ENUM ('logs', 'attempts');
   EXCEPTION WHEN duplicate_object THEN NULL;
@@ -588,7 +596,7 @@ export const schemaSQL = `
     "id" bigserial PRIMARY KEY NOT NULL,
     "gym_id" bigint NOT NULL REFERENCES "gyms"("id") ON DELETE CASCADE,
     "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
-    "role" text NOT NULL,
+    "role" gym_member_role NOT NULL,
     "created_at" timestamp DEFAULT now() NOT NULL
   );
   CREATE UNIQUE INDEX IF NOT EXISTS "gym_members_unique_gym_user" ON "gym_members" ("gym_id", "user_id");
@@ -816,17 +824,8 @@ export const schemaSQL = `
   );
   CREATE INDEX IF NOT EXISTS "community_roles_board_type_idx" ON "community_roles" ("board_type");
 
-  -- Gym membership (owner/admin can manage; admin members can edit the gym +
-  -- its boards). viewerCanAdminGym / requireGymOwnerOrAdmin read this.
-  DROP TABLE IF EXISTS "gym_members" CASCADE;
-  CREATE TABLE IF NOT EXISTS "gym_members" (
-    "id" bigserial PRIMARY KEY NOT NULL,
-    "gym_id" bigint NOT NULL REFERENCES "gyms"("id") ON DELETE CASCADE,
-    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
-    "role" text NOT NULL,
-    "created_at" timestamp DEFAULT now() NOT NULL
-  );
-  CREATE UNIQUE INDEX IF NOT EXISTS "gym_members_unique_gym_user" ON "gym_members" ("gym_id", "user_id");
+  -- gym_members is created once, earlier (alongside the follow/member enrichment
+  -- tables). The duplicate DROP+CREATE that used to sit here has been removed.
 
   DROP TABLE IF EXISTS "gym_follows" CASCADE;
   CREATE TABLE IF NOT EXISTS "gym_follows" (
@@ -910,6 +909,39 @@ export const schemaSQL = `
   CREATE INDEX IF NOT EXISTS "app_feedback_board_idx" ON "app_feedback" ("board_name");
   CREATE INDEX IF NOT EXISTS "app_feedback_status_idx" ON "app_feedback" ("status");
   CREATE INDEX IF NOT EXISTS "gym_kiosks_gym_idx" ON "gym_kiosks" ("gym_id") WHERE "deleted_at" IS NULL;
+
+  -- Maps upstream location-provider source keys (kilter:..., tension:...) to the
+  -- canonical gym. The duplicate-review candidate query reads provider prefixes
+  -- from here, the merge re-points aliases, and the orphan audit flags gyms with
+  -- no source row.
+  DROP TABLE IF EXISTS "location_sync_gym_sources" CASCADE;
+  CREATE TABLE IF NOT EXISTS "location_sync_gym_sources" (
+    "source_key" text PRIMARY KEY NOT NULL,
+    "gym_id" bigint NOT NULL REFERENCES "gyms"("id") ON DELETE CASCADE,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS "location_sync_gym_sources_gym_idx" ON "location_sync_gym_sources" ("gym_id");
+
+  -- Audit trail for the /admin/gym-duplicates review queue. entity_type is not
+  -- involved here; action is a plain text column (prod uses a gym_merge_audit_action
+  -- enum) with a CHECK — string-equality is all the queue does with it.
+  DROP TABLE IF EXISTS "gym_merge_audit" CASCADE;
+  CREATE TABLE IF NOT EXISTS "gym_merge_audit" (
+    "id" bigserial PRIMARY KEY NOT NULL,
+    "action" text NOT NULL,
+    "canonical_gym_id" bigint REFERENCES "gyms"("id") ON DELETE SET NULL,
+    "duplicate_gym_id" bigint REFERENCES "gyms"("id") ON DELETE SET NULL,
+    "cluster_signature" text NOT NULL,
+    "moved_counts" jsonb,
+    "moved_rows" jsonb,
+    "warnings" jsonb,
+    "performed_by" text REFERENCES "users"("id") ON DELETE SET NULL,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    CONSTRAINT "gym_merge_audit_action_check" CHECK (action IN ('merged', 'dismissed'))
+  );
+  CREATE INDEX IF NOT EXISTS "gym_merge_audit_signature_action_idx" ON "gym_merge_audit" ("cluster_signature", "action");
+  CREATE INDEX IF NOT EXISTS "gym_merge_audit_canonical_idx" ON "gym_merge_audit" ("canonical_gym_id");
 
   -- Board followers (enrichBoard counts these per board).
   DROP TABLE IF EXISTS "board_follows" CASCADE;

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -41,6 +41,7 @@ import { socialGymMatchQueries } from './social/gym-matching';
 import { socialGymKioskQueries, socialGymKioskMutations } from './social/gym-kiosks';
 import { socialGymInsightsQueries } from './social/gym-insights';
 import { socialGymClaimQueries, socialGymClaimMutations } from './social/gym-claims';
+import { socialGymDuplicateQueries, socialGymDuplicateMutations } from './social/gym-duplicates';
 import {
   socialNotificationQueries,
   socialNotificationMutations,
@@ -90,6 +91,7 @@ export const resolvers = {
     ...socialGymKioskQueries,
     ...socialGymInsightsQueries,
     ...socialGymClaimQueries,
+    ...socialGymDuplicateQueries,
     ...activityFeedQueries,
     ...sessionFeedQueries,
     ...socialNotificationQueries,
@@ -124,6 +126,7 @@ export const resolvers = {
     ...socialGymMutations,
     ...socialGymKioskMutations,
     ...socialGymClaimMutations,
+    ...socialGymDuplicateMutations,
     ...socialNotificationMutations,
     ...socialProposalMutations,
     ...socialRoleMutations,

--- a/packages/backend/src/graphql/resolvers/social/gym-duplicates.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-duplicates.ts
@@ -1,0 +1,662 @@
+import { and, eq, inArray, isNull, sql, type SQLWrapper } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import * as dbSchema from '@boardsesh/db/schema';
+import { executeRows } from '@boardsesh/db/client';
+import {
+  chooseCanonicalGymCandidate,
+  compareCanonicalGymCandidates,
+  computeClusterSignature,
+  distanceMeters,
+  groupPhysicalGymCandidates,
+  mergeGymsIntoCanonical,
+  PHYSICAL_GYM_MATCH_DISTANCE_METERS,
+  type CanonicalGymCandidate,
+  type MergeCounts,
+  type MergeWarning,
+} from '@boardsesh/db/queries';
+import { db } from '../../../db/client';
+import { validateInput, applyRateLimit } from '../shared/helpers';
+import { requireAdmin } from './roles';
+import { SYSTEM_BOARD_OWNER_ID } from '../board-presence/shared';
+import {
+  DuplicateGymClustersInputSchema,
+  OrphanGymsInputSchema,
+  MergeGymsInputSchema,
+  DismissGymClusterInputSchema,
+} from '../../../validation/schemas';
+
+// Members within this band but beyond the tier-A distance are the observed
+// cross-provider coordinate-drift range.
+const TIER_B_DISTANCE_METERS = 150;
+
+type GymOwnerType = 'system' | 'user';
+type GymClusterClaimStatus = 'none' | 'pending' | 'approved';
+
+// Extra per-row signals the duplicate queue shows on top of the shared
+// CanonicalGymCandidate fields (which already carry name/address/coords/counts).
+type MemberExtra = {
+  ownerType: GymOwnerType;
+  claimStatus: GymClusterClaimStatus;
+  providerOrigins: string[];
+  kioskCount: number;
+  claimCount: number;
+};
+
+type DuplicateCandidateRow = {
+  id: number | string;
+  uuid: string;
+  name: string;
+  address: string | null;
+  contactEmail: string | null;
+  contactPhone: string | null;
+  description: string | null;
+  imageUrl: string | null;
+  latitude: number | string;
+  longitude: number | string;
+  createdAt: Date | string;
+  ownerId: string;
+  boardCount: number | string;
+  memberCount: number | string;
+  followerCount: number | string;
+  commentCount: number | string;
+  kioskCount: number | string;
+  claimCount: number | string;
+  hasPendingClaim: boolean | null;
+  hasApprovedClaim: boolean | null;
+  providerOrigins: string[] | null;
+};
+
+function toIsoString(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function toCandidate(row: DuplicateCandidateRow): CanonicalGymCandidate {
+  return {
+    id: Number(row.id),
+    uuid: row.uuid,
+    name: row.name,
+    address: row.address,
+    contactEmail: row.contactEmail,
+    contactPhone: row.contactPhone,
+    description: row.description,
+    imageUrl: row.imageUrl,
+    latitude: Number(row.latitude),
+    longitude: Number(row.longitude),
+    createdAt: row.createdAt,
+    boardCount: Number(row.boardCount),
+    memberCount: Number(row.memberCount),
+    followerCount: Number(row.followerCount),
+    commentCount: Number(row.commentCount),
+  };
+}
+
+function toMemberExtra(row: DuplicateCandidateRow): MemberExtra {
+  const claimStatus: GymClusterClaimStatus = row.hasApprovedClaim
+    ? 'approved'
+    : row.hasPendingClaim
+      ? 'pending'
+      : 'none';
+  return {
+    ownerType: row.ownerId === SYSTEM_BOARD_OWNER_ID ? 'system' : 'user',
+    claimStatus,
+    providerOrigins: row.providerOrigins ?? [],
+    kioskCount: Number(row.kioskCount),
+    claimCount: Number(row.claimCount),
+  };
+}
+
+/**
+ * Load every live gym (with coordinates) whose normalized name is shared by at
+ * least one other live gym, with the FK counts, owner type, claim state, and
+ * provider origins the review queue shows. The normalized-name pre-filter and
+ * the provider/claim aggregates are genuinely awkward in the Drizzle query
+ * builder (regexp_replace name normalization, split_part provider prefixes,
+ * array_agg DISTINCT, HAVING count > 1), so this stays raw SQL — the same
+ * pattern the gym proximity search already uses.
+ */
+async function fetchDuplicateCandidateRows(): Promise<DuplicateCandidateRow[]> {
+  return executeRows<DuplicateCandidateRow>(
+    db,
+    sql`
+    WITH live_gyms AS (
+      SELECT
+        g.id,
+        g.uuid,
+        g.name,
+        g.address,
+        g.contact_email,
+        g.contact_phone,
+        g.description,
+        g.image_url,
+        g.latitude,
+        g.longitude,
+        g.created_at,
+        g.owner_id,
+        lower(regexp_replace(trim(g.name), '[[:space:]]+', ' ', 'g')) AS norm_name
+      FROM gyms g
+      WHERE g.deleted_at IS NULL
+        AND g.latitude IS NOT NULL
+        AND g.longitude IS NOT NULL
+    ),
+    duplicate_names AS (
+      SELECT norm_name FROM live_gyms GROUP BY norm_name HAVING count(*) > 1
+    )
+    SELECT
+      g.id AS "id",
+      g.uuid AS "uuid",
+      g.name AS "name",
+      g.address AS "address",
+      g.contact_email AS "contactEmail",
+      g.contact_phone AS "contactPhone",
+      g.description AS "description",
+      g.image_url AS "imageUrl",
+      g.latitude AS "latitude",
+      g.longitude AS "longitude",
+      g.created_at AS "createdAt",
+      g.owner_id AS "ownerId",
+      COALESCE(board_counts.count, 0)::int AS "boardCount",
+      COALESCE(member_counts.count, 0)::int AS "memberCount",
+      COALESCE(follower_counts.count, 0)::int AS "followerCount",
+      COALESCE(comment_counts.count, 0)::int AS "commentCount",
+      COALESCE(kiosk_counts.count, 0)::int AS "kioskCount",
+      COALESCE(claim_info.claim_count, 0)::int AS "claimCount",
+      COALESCE(claim_info.has_pending, false) AS "hasPendingClaim",
+      COALESCE(claim_info.has_approved, false) AS "hasApprovedClaim",
+      provider_info.providers AS "providerOrigins"
+    FROM live_gyms g
+    INNER JOIN duplicate_names d ON d.norm_name = g.norm_name
+    LEFT JOIN (
+      SELECT gym_id, count(*) AS count FROM user_boards WHERE deleted_at IS NULL GROUP BY gym_id
+    ) board_counts ON board_counts.gym_id = g.id
+    LEFT JOIN (
+      SELECT gym_id, count(*) AS count FROM gym_members GROUP BY gym_id
+    ) member_counts ON member_counts.gym_id = g.id
+    LEFT JOIN (
+      SELECT gym_id, count(*) AS count FROM gym_follows GROUP BY gym_id
+    ) follower_counts ON follower_counts.gym_id = g.id
+    LEFT JOIN (
+      SELECT entity_id, count(*) AS count FROM comments
+      WHERE entity_type = 'gym' AND deleted_at IS NULL GROUP BY entity_id
+    ) comment_counts ON comment_counts.entity_id = g.uuid
+    LEFT JOIN (
+      SELECT gym_id, count(*) AS count FROM gym_kiosks WHERE deleted_at IS NULL GROUP BY gym_id
+    ) kiosk_counts ON kiosk_counts.gym_id = g.id
+    LEFT JOIN (
+      SELECT gym_id,
+             count(*) AS claim_count,
+             bool_or(status = 'pending') AS has_pending,
+             bool_or(status = 'approved') AS has_approved
+      FROM gym_claims GROUP BY gym_id
+    ) claim_info ON claim_info.gym_id = g.id
+    LEFT JOIN (
+      SELECT gym_id, array_agg(DISTINCT split_part(source_key, ':', 1)) AS providers
+      FROM location_sync_gym_sources GROUP BY gym_id
+    ) provider_info ON provider_info.gym_id = g.id
+    ORDER BY lower(g.name), g.id
+  `,
+  );
+}
+
+/**
+ * Pick the survivor the queue pre-selects: a claimed or user-owned row always
+ * wins over a system row regardless of completeness; ties fall back to the shared
+ * ranking (completeness, then oldest).
+ */
+function suggestCanonicalCandidate(
+  candidates: CanonicalGymCandidate[],
+  extraById: Map<number, MemberExtra>,
+): CanonicalGymCandidate {
+  const preferred = candidates.filter((candidate) => {
+    const extra = extraById.get(candidate.id);
+    return extra !== undefined && (extra.ownerType === 'user' || extra.claimStatus !== 'none');
+  });
+  const pool = preferred.length > 0 ? preferred : candidates;
+  const chosen = chooseCanonicalGymCandidate(pool);
+  // pool is always non-empty (a cluster has ≥2 members), so chosen is non-null.
+  return chosen ?? candidates[0];
+}
+
+function maxPairwiseDistance(candidates: CanonicalGymCandidate[]): number {
+  let maxDistance = 0;
+  for (let outer = 0; outer < candidates.length; outer++) {
+    for (let inner = outer + 1; inner < candidates.length; inner++) {
+      const distance = distanceMeters(candidates[outer], candidates[inner]);
+      if (distance > maxDistance) {
+        maxDistance = distance;
+      }
+    }
+  }
+  return maxDistance;
+}
+
+type BuiltCluster = {
+  signature: string;
+  tier: 'A' | 'B';
+  normalizedName: string;
+  suggestedCanonicalGymUuid: string;
+  maxDistanceMeters: number;
+  members: Array<{
+    gymUuid: string;
+    name: string;
+    address: string | null;
+    ownerType: GymOwnerType;
+    claimStatus: GymClusterClaimStatus;
+    providerOrigins: string[];
+    boardCount: number;
+    followerCount: number;
+    memberCount: number;
+    kioskCount: number;
+    claimCount: number;
+    createdAt: string;
+    latitude: number;
+    longitude: number;
+    distanceToCanonicalMeters: number;
+    isSuggestedCanonical: boolean;
+  }>;
+};
+
+function buildClusters(rows: DuplicateCandidateRow[]): BuiltCluster[] {
+  const candidates = rows.map(toCandidate);
+  const extraById = new Map<number, MemberExtra>();
+  for (const row of rows) {
+    extraById.set(Number(row.id), toMemberExtra(row));
+  }
+
+  const clusters = groupPhysicalGymCandidates(candidates, TIER_B_DISTANCE_METERS);
+
+  return clusters.map((cluster) => {
+    const canonical = suggestCanonicalCandidate(cluster.gyms, extraById);
+    const maxDistance = maxPairwiseDistance(cluster.gyms);
+    const signature = computeClusterSignature(cluster.gyms.map((gym) => gym.id));
+
+    const members = [...cluster.gyms].sort(compareCanonicalGymCandidates).map((gym) => {
+      const extra = extraById.get(gym.id);
+      return {
+        gymUuid: gym.uuid,
+        name: gym.name,
+        address: gym.address,
+        ownerType: extra?.ownerType ?? 'system',
+        claimStatus: extra?.claimStatus ?? 'none',
+        providerOrigins: extra?.providerOrigins ?? [],
+        boardCount: gym.boardCount,
+        followerCount: gym.followerCount,
+        memberCount: gym.memberCount,
+        kioskCount: extra?.kioskCount ?? 0,
+        claimCount: extra?.claimCount ?? 0,
+        createdAt: toIsoString(gym.createdAt ?? new Date()),
+        latitude: gym.latitude,
+        longitude: gym.longitude,
+        distanceToCanonicalMeters: distanceMeters(gym, canonical),
+        isSuggestedCanonical: gym.id === canonical.id,
+      };
+    });
+
+    return {
+      signature,
+      tier: maxDistance <= PHYSICAL_GYM_MATCH_DISTANCE_METERS ? ('A' as const) : ('B' as const),
+      normalizedName: cluster.normalizedName,
+      suggestedCanonicalGymUuid: canonical.uuid,
+      maxDistanceMeters: maxDistance,
+      members,
+    };
+  });
+}
+
+/**
+ * Which of the given candidate-cluster signatures have a 'dismissed' audit row.
+ * Bounded to the signatures actually present in this page's candidate clusters
+ * (a handful), so the dismissal history never gets materialized into memory as it
+ * grows — the filter is pushed into SQL via an IN over the current signatures.
+ */
+async function fetchDismissedSignaturesAmong(signatures: string[]): Promise<Set<string>> {
+  if (signatures.length === 0) {
+    return new Set();
+  }
+  const dismissed = await db
+    .select({ signature: dbSchema.gymMergeAudit.clusterSignature })
+    .from(dbSchema.gymMergeAudit)
+    .where(
+      and(eq(dbSchema.gymMergeAudit.action, 'dismissed'), inArray(dbSchema.gymMergeAudit.clusterSignature, signatures)),
+    );
+  return new Set(dismissed.map((row) => row.signature));
+}
+
+export const socialGymDuplicateQueries = {
+  duplicateGymClusters: async (_: unknown, { input }: { input?: unknown }, ctx: ConnectionContext) => {
+    await requireAdmin(ctx);
+    const validatedInput = validateInput(DuplicateGymClustersInputSchema, input || {}, 'input');
+    const { limit, offset } = validatedInput;
+
+    const candidateClusters = buildClusters(await fetchDuplicateCandidateRows());
+    const dismissedSignatures = await fetchDismissedSignaturesAmong(
+      candidateClusters.map((cluster) => cluster.signature),
+    );
+
+    const clusters = candidateClusters
+      .filter((cluster) => !dismissedSignatures.has(cluster.signature))
+      // Tier A (tight, high-confidence) first, then tightest cluster, then name.
+      .sort((first, second) => {
+        if (first.tier !== second.tier) {
+          return first.tier === 'A' ? -1 : 1;
+        }
+        if (first.maxDistanceMeters !== second.maxDistanceMeters) {
+          return first.maxDistanceMeters - second.maxDistanceMeters;
+        }
+        return first.normalizedName.localeCompare(second.normalizedName);
+      });
+
+    const totalCount = clusters.length;
+    const page = clusters.slice(offset, offset + limit);
+
+    return { clusters: page, totalCount, hasMore: offset + page.length < totalCount };
+  },
+
+  orphanGyms: async (_: unknown, { input }: { input?: unknown }, ctx: ConnectionContext) => {
+    await requireAdmin(ctx);
+    const validatedInput = validateInput(OrphanGymsInputSchema, input || {}, 'input');
+    const { limit, offset } = validatedInput;
+
+    // Alias-less, system-owned live gyms: no location-sync source row on file.
+    const orphanFilter = and(
+      eq(dbSchema.gyms.ownerId, SYSTEM_BOARD_OWNER_ID),
+      isNull(dbSchema.gyms.deletedAt),
+      sql`NOT EXISTS (SELECT 1 FROM location_sync_gym_sources s WHERE s.gym_id = ${dbSchema.gyms.id})`,
+    );
+
+    const [countRow] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(dbSchema.gyms)
+      .where(orphanFilter);
+    const totalCount = Number(countRow?.count ?? 0);
+
+    const rows = await executeRows<{
+      gymUuid: string;
+      slug: string | null;
+      name: string;
+      address: string | null;
+      createdAt: Date | string;
+      boardCount: number | string;
+      followerCount: number | string;
+      memberCount: number | string;
+      kioskCount: number | string;
+    }>(
+      db,
+      sql`
+      SELECT
+        g.uuid AS "gymUuid",
+        g.slug AS "slug",
+        g.name AS "name",
+        g.address AS "address",
+        g.created_at AS "createdAt",
+        COALESCE(board_counts.count, 0)::int AS "boardCount",
+        COALESCE(follower_counts.count, 0)::int AS "followerCount",
+        COALESCE(member_counts.count, 0)::int AS "memberCount",
+        COALESCE(kiosk_counts.count, 0)::int AS "kioskCount"
+      FROM gyms g
+      LEFT JOIN (
+        SELECT gym_id, count(*) AS count FROM user_boards WHERE deleted_at IS NULL GROUP BY gym_id
+      ) board_counts ON board_counts.gym_id = g.id
+      LEFT JOIN (
+        SELECT gym_id, count(*) AS count FROM gym_follows GROUP BY gym_id
+      ) follower_counts ON follower_counts.gym_id = g.id
+      LEFT JOIN (
+        SELECT gym_id, count(*) AS count FROM gym_members GROUP BY gym_id
+      ) member_counts ON member_counts.gym_id = g.id
+      LEFT JOIN (
+        SELECT gym_id, count(*) AS count FROM gym_kiosks WHERE deleted_at IS NULL GROUP BY gym_id
+      ) kiosk_counts ON kiosk_counts.gym_id = g.id
+      WHERE g.owner_id = ${SYSTEM_BOARD_OWNER_ID}
+        AND g.deleted_at IS NULL
+        AND NOT EXISTS (SELECT 1 FROM location_sync_gym_sources s WHERE s.gym_id = g.id)
+      ORDER BY lower(g.name), g.id
+      LIMIT ${limit} OFFSET ${offset}
+    `,
+    );
+
+    const gyms = rows.map((row) => ({
+      gymUuid: row.gymUuid,
+      slug: row.slug ?? null,
+      name: row.name,
+      address: row.address ?? null,
+      boardCount: Number(row.boardCount),
+      followerCount: Number(row.followerCount),
+      memberCount: Number(row.memberCount),
+      kioskCount: Number(row.kioskCount),
+      createdAt: toIsoString(row.createdAt),
+    }));
+
+    return { gyms, totalCount, hasMore: offset + gyms.length < totalCount };
+  },
+};
+
+// A live gym loaded (and row-locked) for a merge, as the shared candidate shape
+// plus the id/uuid the resolver keys on.
+type MergeGymRow = {
+  id: number;
+  uuid: string;
+};
+
+// A merge candidate plus the two signals the SYSTEM-override guard needs.
+type LoadedMergeCandidate = {
+  candidate: CanonicalGymCandidate;
+  ownerId: string;
+  hasApprovedClaim: boolean;
+};
+
+async function loadLiveMergeCandidate(
+  tx: { execute(query: SQLWrapper | string): PromiseLike<unknown> },
+  gymUuid: string,
+): Promise<LoadedMergeCandidate | null> {
+  // Lock the gym row in a CTE (FOR UPDATE can't sit over the joined aggregate
+  // subqueries), then attach the counts — the same pattern the CLI dedupe uses.
+  const rows = await executeRows<DuplicateCandidateRow & { hasApprovedClaim: boolean | null }>(
+    tx,
+    sql`
+    WITH locked_gym AS (
+      SELECT g.id, g.uuid, g.name, g.address, g.contact_email, g.contact_phone,
+             g.description, g.image_url, g.latitude, g.longitude, g.created_at, g.owner_id
+      FROM gyms g
+      WHERE g.uuid = ${gymUuid}
+        AND g.deleted_at IS NULL
+        AND g.merged_into_gym_id IS NULL
+        AND g.latitude IS NOT NULL
+        AND g.longitude IS NOT NULL
+      FOR UPDATE
+    )
+    SELECT
+      g.id AS "id",
+      g.uuid AS "uuid",
+      g.name AS "name",
+      g.address AS "address",
+      g.contact_email AS "contactEmail",
+      g.contact_phone AS "contactPhone",
+      g.description AS "description",
+      g.image_url AS "imageUrl",
+      g.latitude AS "latitude",
+      g.longitude AS "longitude",
+      g.created_at AS "createdAt",
+      g.owner_id AS "ownerId",
+      COALESCE(board_counts.count, 0)::int AS "boardCount",
+      COALESCE(member_counts.count, 0)::int AS "memberCount",
+      COALESCE(follower_counts.count, 0)::int AS "followerCount",
+      COALESCE(comment_counts.count, 0)::int AS "commentCount",
+      EXISTS (
+        SELECT 1 FROM gym_claims WHERE gym_id = g.id AND status = 'approved'
+      ) AS "hasApprovedClaim"
+    FROM locked_gym g
+    LEFT JOIN (
+      SELECT gym_id, count(*) AS count FROM user_boards WHERE deleted_at IS NULL GROUP BY gym_id
+    ) board_counts ON board_counts.gym_id = g.id
+    LEFT JOIN (
+      SELECT gym_id, count(*) AS count FROM gym_members GROUP BY gym_id
+    ) member_counts ON member_counts.gym_id = g.id
+    LEFT JOIN (
+      SELECT gym_id, count(*) AS count FROM gym_follows GROUP BY gym_id
+    ) follower_counts ON follower_counts.gym_id = g.id
+    LEFT JOIN (
+      SELECT entity_id, count(*) AS count FROM comments
+      WHERE entity_type = 'gym' AND deleted_at IS NULL GROUP BY entity_id
+    ) comment_counts ON comment_counts.entity_id = g.uuid
+  `,
+  );
+  const row = rows[0];
+  if (!row) {
+    return null;
+  }
+  return { candidate: toCandidate(row), ownerId: row.ownerId, hasApprovedClaim: Boolean(row.hasApprovedClaim) };
+}
+
+function toGymMergeCounts(counts: MergeCounts) {
+  return {
+    boards: counts.boardRowsMoved,
+    follows: counts.followsInserted,
+    members: counts.membersInsertedOrUpdated,
+    claims: counts.claimsMoved,
+    kiosks: counts.kiosksMoved,
+    comments: counts.commentsMoved,
+  };
+}
+
+function toKioskWarnings(warnings: MergeWarning[]) {
+  return warnings.map((warning) => ({
+    kioskUuid: warning.kioskUuid,
+    kioskName: warning.kioskName,
+    previousSlug: warning.previousSlug,
+    newSlug: warning.newSlug,
+  }));
+}
+
+export const socialGymDuplicateMutations = {
+  mergeGyms: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
+    await requireAdmin(ctx);
+    await applyRateLimit(ctx, 30, 'mergeGyms');
+    const validatedInput = validateInput(MergeGymsInputSchema, input, 'input');
+    const adminUserId = ctx.userId!;
+
+    const uniqueDuplicateUuids = [...new Set(validatedInput.duplicateGymUuids)];
+    if (uniqueDuplicateUuids.includes(validatedInput.canonicalGymUuid)) {
+      throw new GraphQLError('The canonical gym cannot also be a duplicate.', {
+        extensions: { code: 'BAD_USER_INPUT' },
+      });
+    }
+
+    const results = await db.transaction(async (tx) => {
+      const canonical = await loadLiveMergeCandidate(tx, validatedInput.canonicalGymUuid);
+      if (!canonical) {
+        throw new GraphQLError('The canonical gym is not a live, un-merged gym.', {
+          extensions: { code: 'NOT_FOUND' },
+        });
+      }
+
+      const duplicates: LoadedMergeCandidate[] = [];
+      for (const duplicateUuid of uniqueDuplicateUuids) {
+        const duplicate = await loadLiveMergeCandidate(tx, duplicateUuid);
+        if (!duplicate) {
+          throw new GraphQLError(`Duplicate gym ${duplicateUuid} is not a live, un-merged gym.`, {
+            extensions: { code: 'NOT_FOUND' },
+          });
+        }
+        duplicates.push(duplicate);
+      }
+
+      // Guard against a silent inversion of the pre-selection rule: keeping a
+      // SYSTEM row as the survivor while folding a user-owned or claim-approved
+      // duplicate INTO it demotes a real owner's gym to a synced listing. The UI
+      // pre-selects correctly; this rejects an inverted pick unless the admin
+      // ticked the explicit override.
+      const canonicalIsSystem = canonical.ownerId === SYSTEM_BOARD_OWNER_ID;
+      const invertsPreselection =
+        canonicalIsSystem &&
+        duplicates.some((duplicate) => duplicate.ownerId !== SYSTEM_BOARD_OWNER_ID || duplicate.hasApprovedClaim);
+      if (invertsPreselection && !validatedInput.allowSystemCanonicalOverride) {
+        throw new GraphQLError(
+          'This keeps a SYSTEM listing as the survivor over a user-owned or claimed gym. Confirm the override to proceed.',
+          { extensions: { code: 'SYSTEM_CANONICAL_OVERRIDE_REQUIRED' } },
+        );
+      }
+
+      // One stable signature for the whole cluster the admin acted on, stored on
+      // every audit row so the merge is auditable as one decision.
+      const clusterSignature = computeClusterSignature([
+        canonical.candidate.id,
+        ...duplicates.map((duplicate) => duplicate.candidate.id),
+      ]);
+
+      const perDuplicate: Array<{
+        duplicateGymUuid: string;
+        counts: ReturnType<typeof toGymMergeCounts>;
+        warnings: ReturnType<typeof toKioskWarnings>;
+      }> = [];
+
+      // Merge one duplicate at a time so each audit row carries that duplicate's
+      // own moved counts, moved-row ids, and warnings.
+      for (const duplicate of duplicates) {
+        const mergeResult = await mergeGymsIntoCanonical(tx, canonical.candidate, [duplicate.candidate]);
+
+        await tx.insert(dbSchema.gymMergeAudit).values({
+          action: 'merged',
+          canonicalGymId: canonical.candidate.id,
+          duplicateGymId: duplicate.candidate.id,
+          clusterSignature,
+          movedCounts: mergeResult.counts,
+          movedRows: mergeResult.movedRows,
+          warnings: mergeResult.warnings,
+          performedBy: adminUserId,
+        });
+
+        perDuplicate.push({
+          duplicateGymUuid: duplicate.candidate.uuid,
+          counts: toGymMergeCounts(mergeResult.counts),
+          warnings: toKioskWarnings(mergeResult.warnings),
+        });
+      }
+
+      return perDuplicate;
+    });
+
+    return { canonicalGymUuid: validatedInput.canonicalGymUuid, results };
+  },
+
+  dismissGymCluster: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
+    await requireAdmin(ctx);
+    await applyRateLimit(ctx, 30, 'dismissGymCluster');
+    const validatedInput = validateInput(DismissGymClusterInputSchema, input, 'input');
+    const adminUserId = ctx.userId!;
+
+    const memberRows = (await db
+      .select({ id: dbSchema.gyms.id, uuid: dbSchema.gyms.uuid })
+      .from(dbSchema.gyms)
+      .where(
+        and(inArray(dbSchema.gyms.uuid, validatedInput.gymUuids), isNull(dbSchema.gyms.deletedAt)),
+      )) as MergeGymRow[];
+
+    if (memberRows.length !== new Set(validatedInput.gymUuids).size) {
+      throw new GraphQLError('Every cluster member must be a live gym.', {
+        extensions: { code: 'NOT_FOUND' },
+      });
+    }
+
+    const canonicalRow = memberRows.find((row) => row.uuid === validatedInput.canonicalGymUuid);
+    if (!canonicalRow) {
+      throw new GraphQLError('The canonical gym must be one of the cluster members.', {
+        extensions: { code: 'BAD_USER_INPUT' },
+      });
+    }
+
+    const clusterSignature = computeClusterSignature(memberRows.map((row) => row.id));
+
+    await db.insert(dbSchema.gymMergeAudit).values({
+      action: 'dismissed',
+      canonicalGymId: canonicalRow.id,
+      duplicateGymId: null,
+      clusterSignature,
+      movedCounts: null,
+      movedRows: null,
+      warnings: null,
+      performedBy: adminUserId,
+    });
+
+    return true;
+  },
+};

--- a/packages/backend/src/validation/schemas/gyms.ts
+++ b/packages/backend/src/validation/schemas/gyms.ts
@@ -224,3 +224,41 @@ export const GymStatsInputSchema = z.object({
   gymUuid: UUIDSchema,
   period: z.enum(['week', 'month']).optional().default('week'),
 });
+
+/**
+ * Duplicate-gym cluster list input validation schema (admin)
+ */
+export const DuplicateGymClustersInputSchema = z.object({
+  limit: z.number().int().min(1).max(50).optional().default(20),
+  offset: z.number().int().min(0).optional().default(0),
+});
+
+/**
+ * Orphan-gym audit list input validation schema (admin)
+ */
+export const OrphanGymsInputSchema = z.object({
+  limit: z.number().int().min(1).max(50).optional().default(20),
+  offset: z.number().int().min(0).optional().default(0),
+});
+
+/**
+ * Merge gyms input validation schema (admin). Fold 1–50 duplicates into one
+ * canonical survivor. The resolver additionally checks every uuid is a live,
+ * un-merged gym and that the canonical is not among the duplicates.
+ */
+export const MergeGymsInputSchema = z.object({
+  canonicalGymUuid: UUIDSchema,
+  duplicateGymUuids: z.array(UUIDSchema).min(1, 'Pick at least one duplicate').max(50),
+  // Explicit acknowledgement required to keep a SYSTEM listing as the survivor
+  // over a user-owned or claim-approved duplicate (an inverted pre-selection).
+  allowSystemCanonicalOverride: z.boolean().optional().default(false),
+});
+
+/**
+ * Dismiss gym cluster input validation schema (admin). The full member set is
+ * needed to compute the stable cluster signature the dismissal is keyed on.
+ */
+export const DismissGymClusterInputSchema = z.object({
+  gymUuids: z.array(UUIDSchema).min(2, 'A cluster has at least two members').max(50),
+  canonicalGymUuid: UUIDSchema,
+});

--- a/packages/db/drizzle/0184_steep_old_lace.sql
+++ b/packages/db/drizzle/0184_steep_old_lace.sql
@@ -1,0 +1,19 @@
+CREATE TYPE "public"."gym_merge_audit_action" AS ENUM('merged', 'dismissed');--> statement-breakpoint
+CREATE TABLE "gym_merge_audit" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"action" "gym_merge_audit_action" NOT NULL,
+	"canonical_gym_id" bigint,
+	"duplicate_gym_id" bigint,
+	"cluster_signature" text NOT NULL,
+	"moved_counts" jsonb,
+	"moved_rows" jsonb,
+	"warnings" jsonb,
+	"performed_by" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "gym_merge_audit" ADD CONSTRAINT "gym_merge_audit_canonical_gym_id_gyms_id_fk" FOREIGN KEY ("canonical_gym_id") REFERENCES "public"."gyms"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "gym_merge_audit" ADD CONSTRAINT "gym_merge_audit_duplicate_gym_id_gyms_id_fk" FOREIGN KEY ("duplicate_gym_id") REFERENCES "public"."gyms"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "gym_merge_audit" ADD CONSTRAINT "gym_merge_audit_performed_by_users_id_fk" FOREIGN KEY ("performed_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "gym_merge_audit_signature_action_idx" ON "gym_merge_audit" USING btree ("cluster_signature","action");--> statement-breakpoint
+CREATE INDEX "gym_merge_audit_canonical_idx" ON "gym_merge_audit" USING btree ("canonical_gym_id");

--- a/packages/db/drizzle/meta/0184_snapshot.json
+++ b/packages/db/drizzle/meta/0184_snapshot.json
@@ -1,0 +1,11920 @@
+{
+  "id": "1412e6eb-c1c5-4fe1-9004-b12b53c5b555",
+  "prevId": "68b63a31-cc12-4010-9035-37bf0ab41764",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.board_attempts": {
+      "name": "board_attempts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_attempts_board_type_id_pk": {
+          "name": "board_attempts_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_beta_links": {
+      "name": "board_beta_links",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tick_uuid": {
+          "name": "tick_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shortcode": {
+          "name": "shortcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_identity": {
+          "name": "video_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_beta_links_shortcode_idx": {
+          "name": "board_beta_links_shortcode_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shortcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"shortcode\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_created_by_idx": {
+          "name": "board_beta_links_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"created_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_video_identity_unique": {
+          "name": "board_beta_links_video_identity_unique",
+          "columns": [
+            {
+              "expression": "video_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_beta_links\".\"video_identity\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_tick_uuid_unique": {
+          "name": "board_beta_links_tick_uuid_unique",
+          "columns": [
+            {
+              "expression": "tick_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_beta_links\".\"tick_uuid\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_board_id_idx": {
+          "name": "board_beta_links_board_id_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"board_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_beta_links_board_type_climb_uuid_link_pk": {
+          "name": "board_beta_links_board_type_climb_uuid_link_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "link"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits": {
+      "name": "board_circuits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_user_fk": {
+          "name": "board_circuits_user_fk",
+          "tableFrom": "board_circuits",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_board_type_uuid_pk": {
+          "name": "board_circuits_board_type_uuid_pk",
+          "columns": [
+            "board_type",
+            "uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits_climbs": {
+      "name": "board_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_climbs_circuit_fk": {
+          "name": "board_circuits_climbs_circuit_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_circuits",
+          "columnsFrom": [
+            "board_type",
+            "circuit_uuid"
+          ],
+          "columnsTo": [
+            "board_type",
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_circuits_climbs_climb_fk": {
+          "name": "board_circuits_climbs_climb_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
+          "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
+          "columns": [
+            "board_type",
+            "circuit_uuid",
+            "climb_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_aliases": {
+      "name": "board_climb_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_uuid": {
+          "name": "alias_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_uuid": {
+          "name": "canonical_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_aliases_canonical_idx": {
+          "name": "board_climb_aliases_canonical_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_aliases_canonical_fk": {
+          "name": "board_climb_aliases_canonical_fk",
+          "tableFrom": "board_climb_aliases",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "canonical_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_aliases_board_type_alias_uuid_pk": {
+          "name": "board_climb_aliases_board_type_alias_uuid_pk",
+          "columns": [
+            "board_type",
+            "alias_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_aliases_uuids_non_empty": {
+          "name": "board_climb_aliases_uuids_non_empty",
+          "value": "\"board_climb_aliases\".\"alias_uuid\" <> '' AND \"board_climb_aliases\".\"canonical_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_holds": {
+      "name": "board_climb_holds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_holds_search_idx": {
+          "name": "board_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_holds_climb_fk": {
+          "name": "board_climb_holds_climb_fk",
+          "tableFrom": "board_climb_holds",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
+          "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "hold_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_ratings": {
+      "name": "board_climb_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_grade_id": {
+          "name": "difficulty_grade_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_ratings_user_climb_angle_idx": {
+          "name": "board_climb_ratings_user_climb_angle_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_kilter_id_unique": {
+          "name": "board_climb_ratings_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_aurora_id_unique": {
+          "name": "board_climb_ratings_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_climb_ratings\".\"aurora_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_user_kilter_idx": {
+          "name": "board_climb_ratings_user_kilter_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_ratings_user_id_users_id_fk": {
+          "name": "board_climb_ratings_user_id_users_id_fk",
+          "tableFrom": "board_climb_ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_ratings_rating_range": {
+          "name": "board_climb_ratings_rating_range",
+          "value": "\"board_climb_ratings\".\"rating\" IS NULL OR (\"board_climb_ratings\".\"rating\" >= 1 AND \"board_climb_ratings\".\"rating\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats": {
+      "name": "board_climb_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_ascensionist_count": {
+          "name": "upstream_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_ascensionist_count": {
+          "name": "boardsesh_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_quality_average": {
+          "name": "upstream_quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_quality_sum": {
+          "name": "boardsesh_quality_sum",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_quality_count": {
+          "name": "boardsesh_quality_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_normalized": {
+          "name": "quality_normalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_synced_at": {
+          "name": "upstream_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_seq": {
+          "name": "sync_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "board_climb_stats_sync_cursor_idx": {
+          "name": "board_climb_stats_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_stats_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats_history": {
+      "name": "board_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_stats_history_lookup_idx": {
+          "name": "board_climb_stats_history_lookup_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climbs": {
+      "name": "board_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_set_ids": {
+          "name": "required_set_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compatible_size_ids": {
+          "name": "compatible_size_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hold_fingerprint": {
+          "name": "hold_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "characteristics": {
+          "name": "characteristics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_seq": {
+          "name": "sync_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "board_climbs_board_type_idx": {
+          "name": "board_climbs_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_sync_cursor_idx": {
+          "name": "board_climbs_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_hold_fingerprint_idx": {
+          "name": "board_climbs_hold_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_search_filter_idx": {
+          "name": "board_climbs_search_filter_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_setter_username_idx": {
+          "name": "board_climbs_setter_username_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_user_id_idx": {
+          "name": "board_climbs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_climbs\".\"user_id\" IS NOT NULL AND \"board_climbs\".\"is_draft\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_name_idx": {
+          "name": "board_climbs_name_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climbs_user_id_users_id_fk": {
+          "name": "board_climbs_user_id_users_id_fk",
+          "tableFrom": "board_climbs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_difficulty_grades": {
+      "name": "board_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_difficulty_grades_board_type_difficulty_pk": {
+          "name": "board_difficulty_grades_board_type_difficulty_pk",
+          "columns": [
+            "board_type",
+            "difficulty"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_holes": {
+      "name": "board_holes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_holes_product_fk": {
+          "name": "board_holes_product_fk",
+          "tableFrom": "board_holes",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_holes_board_type_id_pk": {
+          "name": "board_holes_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_kits": {
+      "name": "board_kits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_autoconnect": {
+          "name": "is_autoconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_kits_board_type_serial_number_pk": {
+          "name": "board_kits_board_type_serial_number_pk",
+          "columns": [
+            "board_type",
+            "serial_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_layout_aliases": {
+      "name": "board_layout_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_uuid": {
+          "name": "layout_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_layout_aliases_layout_idx": {
+          "name": "board_layout_aliases_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_layout_aliases_layout_fk": {
+          "name": "board_layout_aliases_layout_fk",
+          "tableFrom": "board_layout_aliases",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layout_aliases_board_type_layout_uuid_pk": {
+          "name": "board_layout_aliases_board_type_layout_uuid_pk",
+          "columns": [
+            "board_type",
+            "layout_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_layout_aliases_uuid_non_empty": {
+          "name": "board_layout_aliases_uuid_non_empty",
+          "value": "\"board_layout_aliases\".\"layout_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_layouts": {
+      "name": "board_layouts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_layouts_product_fk": {
+          "name": "board_layouts_product_fk",
+          "tableFrom": "board_layouts",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layouts_board_type_id_pk": {
+          "name": "board_layouts_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_leds": {
+      "name": "board_leds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_leds_product_size_fk": {
+          "name": "board_leds_product_size_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_leds_hole_fk": {
+          "name": "board_leds_hole_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_holes",
+          "columnsFrom": [
+            "board_type",
+            "hole_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_leds_board_type_id_pk": {
+          "name": "board_leds_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placement_roles": {
+      "name": "board_placement_roles",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_placement_roles_product_fk": {
+          "name": "board_placement_roles_product_fk",
+          "tableFrom": "board_placement_roles",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placement_roles_board_type_id_pk": {
+          "name": "board_placement_roles_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placements": {
+      "name": "board_placements",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_placements_board_type_layout_id_set_hole_idx": {
+          "name": "board_placements_board_type_layout_id_set_hole_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hole_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_placements_board_type_layout_id_hole_id_idx": {
+          "name": "board_placements_board_type_layout_id_hole_id_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hole_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_placements_layout_fk": {
+          "name": "board_placements_layout_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_hole_fk": {
+          "name": "board_placements_hole_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_holes",
+          "columnsFrom": [
+            "board_type",
+            "hole_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_set_fk": {
+          "name": "board_placements_set_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_sets",
+          "columnsFrom": [
+            "board_type",
+            "set_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_role_fk": {
+          "name": "board_placements_role_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_placement_roles",
+          "columnsFrom": [
+            "board_type",
+            "default_placement_role_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placements_board_type_id_pk": {
+          "name": "board_placements_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes": {
+      "name": "board_product_sizes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_product_sizes_product_fk": {
+          "name": "board_product_sizes_product_fk",
+          "tableFrom": "board_product_sizes",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_board_type_id_pk": {
+          "name": "board_product_sizes_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes_layouts_sets": {
+      "name": "board_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_psls_product_size_fk": {
+          "name": "board_psls_product_size_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_layout_fk": {
+          "name": "board_psls_layout_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_set_fk": {
+          "name": "board_psls_set_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_sets",
+          "columnsFrom": [
+            "board_type",
+            "set_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_layouts_sets_board_type_id_pk": {
+          "name": "board_product_sizes_layouts_sets_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_products": {
+      "name": "board_products",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_products_board_type_id_pk": {
+          "name": "board_products_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sets": {
+      "name": "board_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_sets_board_type_id_pk": {
+          "name": "board_sets_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_shared_syncs": {
+      "name": "board_shared_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_shared_syncs_board_type_table_name_pk": {
+          "name": "board_shared_syncs_board_type_table_name_pk",
+          "columns": [
+            "board_type",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_tags": {
+      "name": "board_tags",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_tags_board_type_entity_uuid_user_id_name_pk": {
+          "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
+          "columns": [
+            "board_type",
+            "entity_uuid",
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_user_syncs": {
+      "name": "board_user_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_user_syncs_user_fk": {
+          "name": "board_user_syncs_user_fk",
+          "tableFrom": "board_user_syncs",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_user_syncs_board_type_user_id_table_name_pk": {
+          "name": "board_user_syncs_board_type_user_id_table_name_pk",
+          "columns": [
+            "board_type",
+            "user_id",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_users": {
+      "name": "board_users",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_users_board_type_id_pk": {
+          "name": "board_users_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_walls": {
+      "name": "board_walls",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_walls_user_fk": {
+          "name": "board_walls_user_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_fk": {
+          "name": "board_walls_product_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_layout_fk": {
+          "name": "board_walls_layout_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_size_fk": {
+          "name": "board_walls_product_size_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_walls_board_type_uuid_pk": {
+          "name": "board_walls_board_type_uuid_pk",
+          "columns": [
+            "board_type",
+            "uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationTokens": {
+      "name": "verificationTokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationTokens_identifier_token_pk": {
+          "name": "verificationTokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credentials": {
+      "name": "user_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aurora_credentials": {
+      "name": "aurora_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_username": {
+          "name": "encrypted_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_user_id": {
+          "name": "aurora_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_token": {
+          "name": "aurora_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_attempt_at": {
+          "name": "last_sync_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_failure_count": {
+          "name": "credential_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_credential_failure_at": {
+          "name": "last_credential_failure_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_credential": {
+          "name": "unique_user_board_credential",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_user_idx": {
+          "name": "aurora_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_sync_priority_idx": {
+          "name": "aurora_credentials_sync_priority_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_sync_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"aurora_credentials\".\"sync_status\" IN ('pending', 'active', 'error')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_sync_attempt_priority_idx": {
+          "name": "aurora_credentials_sync_attempt_priority_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_sync_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"aurora_credentials\".\"sync_status\" IN ('pending', 'active', 'error')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "aurora_credentials_user_id_users_id_fk": {
+          "name": "aurora_credentials_user_id_users_id_fk",
+          "tableFrom": "aurora_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_mappings": {
+      "name": "user_board_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_user_id": {
+          "name": "board_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_user_id_text": {
+          "name": "board_user_id_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_username": {
+          "name": "board_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_mapping": {
+          "name": "unique_user_board_mapping",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_idx": {
+          "name": "board_user_mapping_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_text_idx": {
+          "name": "board_user_mapping_text_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_mappings_user_id_users_id_fk": {
+          "name": "user_board_mappings_user_id_users_id_fk",
+          "tableFrom": "user_board_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mobile_refresh_tokens": {
+      "name": "mobile_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mobile_refresh_tokens_token_hash_idx": {
+          "name": "mobile_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_user_id_idx": {
+          "name": "mobile_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_expires_at_idx": {
+          "name": "mobile_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_revoked_at_partial_idx": {
+          "name": "mobile_refresh_tokens_revoked_at_partial_idx",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"revoked_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mobile_refresh_tokens_user_id_users_id_fk": {
+          "name": "mobile_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "mobile_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credentials": {
+      "name": "integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_name": {
+          "name": "external_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_integration": {
+          "name": "unique_user_integration",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credentials_user_id_users_id_fk": {
+          "name": "integration_credentials_user_id_users_id_fk",
+          "tableFrom": "integration_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_claims": {
+      "name": "gym_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimant_user_id": {
+          "name": "claimant_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "gym_claim_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "gym_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_claims_gym_idx": {
+          "name": "gym_claims_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_claimant_idx": {
+          "name": "gym_claims_claimant_idx",
+          "columns": [
+            {
+              "expression": "claimant_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_status_idx": {
+          "name": "gym_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_token_hash_idx": {
+          "name": "gym_claims_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gym_claims\".\"token_hash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_unique_pending": {
+          "name": "gym_claims_unique_pending",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimant_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gym_claims\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_claims_gym_id_gyms_id_fk": {
+          "name": "gym_claims_gym_id_gyms_id_fk",
+          "tableFrom": "gym_claims",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_claims_claimant_user_id_users_id_fk": {
+          "name": "gym_claims_claimant_user_id_users_id_fk",
+          "tableFrom": "gym_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimant_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_claims_reviewed_by_users_id_fk": {
+          "name": "gym_claims_reviewed_by_users_id_fk",
+          "tableFrom": "gym_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_follows": {
+      "name": "gym_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_follows_unique_gym_user": {
+          "name": "gym_follows_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_follows_gym_id_gyms_id_fk": {
+          "name": "gym_follows_gym_id_gyms_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_follows_user_id_users_id_fk": {
+          "name": "gym_follows_user_id_users_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_members": {
+      "name": "gym_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "gym_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_members_unique_gym_user": {
+          "name": "gym_members_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_members_gym_id_gyms_id_fk": {
+          "name": "gym_members_gym_id_gyms_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_members_user_id_users_id_fk": {
+          "name": "gym_members_user_id_users_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gyms": {
+      "name": "gyms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_primary_color": {
+          "name": "brand_primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_accent_color": {
+          "name": "brand_accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_background_color": {
+          "name": "brand_background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_gym_id": {
+          "name": "merged_into_gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gyms_unique_slug": {
+          "name": "gyms_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_uuid_idx": {
+          "name": "gyms_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_owner_idx": {
+          "name": "gyms_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_public_idx": {
+          "name": "gyms_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_merged_into_idx": {
+          "name": "gyms_merged_into_idx",
+          "columns": [
+            {
+              "expression": "merged_into_gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"merged_into_gym_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gyms_owner_id_users_id_fk": {
+          "name": "gyms_owner_id_users_id_fk",
+          "tableFrom": "gyms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gyms_merged_into_gym_id_gyms_id_fk": {
+          "name": "gyms_merged_into_gym_id_gyms_id_fk",
+          "tableFrom": "gyms",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "merged_into_gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gyms_uuid_unique": {
+          "name": "gyms_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_kiosks": {
+      "name": "gym_kiosks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"version\":1,\"boards\":[],\"leaderboard\":null}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gym_kiosks_unique_gym_slug": {
+          "name": "gym_kiosks_unique_gym_slug",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gym_kiosks\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_kiosks_gym_idx": {
+          "name": "gym_kiosks_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gym_kiosks\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_kiosks_gym_id_gyms_id_fk": {
+          "name": "gym_kiosks_gym_id_gyms_id_fk",
+          "tableFrom": "gym_kiosks",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gym_kiosks_uuid_unique": {
+          "name": "gym_kiosks_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_merge_audit": {
+      "name": "gym_merge_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "gym_merge_audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_gym_id": {
+          "name": "canonical_gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_gym_id": {
+          "name": "duplicate_gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_signature": {
+          "name": "cluster_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moved_counts": {
+          "name": "moved_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moved_rows": {
+          "name": "moved_rows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_merge_audit_signature_action_idx": {
+          "name": "gym_merge_audit_signature_action_idx",
+          "columns": [
+            {
+              "expression": "cluster_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_merge_audit_canonical_idx": {
+          "name": "gym_merge_audit_canonical_idx",
+          "columns": [
+            {
+              "expression": "canonical_gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_merge_audit_canonical_gym_id_gyms_id_fk": {
+          "name": "gym_merge_audit_canonical_gym_id_gyms_id_fk",
+          "tableFrom": "gym_merge_audit",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "canonical_gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gym_merge_audit_duplicate_gym_id_gyms_id_fk": {
+          "name": "gym_merge_audit_duplicate_gym_id_gyms_id_fk",
+          "tableFrom": "gym_merge_audit",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "duplicate_gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gym_merge_audit_performed_by_users_id_fk": {
+          "name": "gym_merge_audit_performed_by_users_id_fk",
+          "tableFrom": "gym_merge_audit",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_follows": {
+      "name": "board_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_follows_unique_user_board": {
+          "name": "board_follows_unique_user_board",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_user_idx": {
+          "name": "board_follows_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_board_uuid_idx": {
+          "name": "board_follows_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_follows_user_id_users_id_fk": {
+          "name": "board_follows_user_id_users_id_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_follows_board_uuid_user_boards_uuid_fk": {
+          "name": "board_follows_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_boards": {
+      "name": "user_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_unlisted": {
+          "name": "is_unlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_location": {
+          "name": "hide_location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_owned": {
+          "name": "is_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "is_angle_adjustable": {
+          "name": "is_angle_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timer_name": {
+          "name": "timer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_boards_gym_idx": {
+          "name": "user_boards_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_owner_config": {
+          "name": "user_boards_unique_owner_config",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL AND \"user_boards\".\"owner_id\" != '00000000-0000-0000-0000-000000000000'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_owner_owned_idx": {
+          "name": "user_boards_owner_owned_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_owned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_public_idx": {
+          "name": "user_boards_public_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_slug": {
+          "name": "user_boards_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_uuid_idx": {
+          "name": "user_boards_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_owner_serial": {
+          "name": "user_boards_unique_owner_serial",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"serial_number\" IS NOT NULL AND \"user_boards\".\"serial_number\" <> '' AND \"user_boards\".\"deleted_at\" IS NULL AND \"user_boards\".\"owner_id\" != '00000000-0000-0000-0000-000000000000'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_serial_idx": {
+          "name": "user_boards_serial_idx",
+          "columns": [
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"serial_number\" IS NOT NULL AND \"user_boards\".\"serial_number\" <> '' AND \"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_boards_owner_id_users_id_fk": {
+          "name": "user_boards_owner_id_users_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_boards_gym_id_gyms_id_fk": {
+          "name": "user_boards_gym_id_gyms_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_boards_uuid_unique": {
+          "name": "user_boards_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_serials": {
+      "name": "user_board_serials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_level": {
+          "name": "api_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_board_serials_unique_user_serial": {
+          "name": "user_board_serials_unique_user_serial",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_serial_idx": {
+          "name": "user_board_serials_serial_idx",
+          "columns": [
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_board_uuid_idx": {
+          "name": "user_board_serials_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_serials_user_id_users_id_fk": {
+          "name": "user_board_serials_user_id_users_id_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_board_serials_board_uuid_user_boards_uuid_fk": {
+          "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_queues": {
+      "name": "board_session_queues",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_climb_queue_item": {
+          "name": "current_climb_queue_item",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_queues_session_id_board_sessions_id_fk": {
+          "name": "board_session_queues_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_queues",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sessions": {
+      "name": "board_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_path": {
+          "name": "board_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_permanent": {
+          "name": "is_permanent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_sessions_location_idx": {
+          "name": "board_sessions_location_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discoverable_idx": {
+          "name": "board_sessions_discoverable_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_user_idx": {
+          "name": "board_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_status_idx": {
+          "name": "board_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_last_activity_idx": {
+          "name": "board_sessions_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discovery_idx": {
+          "name": "board_sessions_discovery_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_sessions_created_by_user_id_users_id_fk": {
+          "name": "board_sessions_created_by_user_id_users_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_sessions_board_id_user_boards_id_fk": {
+          "name": "board_sessions_board_id_user_boards_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_boards": {
+      "name": "session_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_boards_session_board_idx": {
+          "name": "session_boards_session_board_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_session_idx": {
+          "name": "session_boards_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_board_idx": {
+          "name": "session_boards_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_boards_session_id_board_sessions_id_fk": {
+          "name": "session_boards_session_id_board_sessions_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_boards_board_id_user_boards_id_fk": {
+          "name": "session_boards_board_id_user_boards_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_health_kit_workouts": {
+      "name": "session_health_kit_workouts",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_health_kit_workouts_session_idx": {
+          "name": "session_health_kit_workouts_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_health_kit_workouts_user_idx": {
+          "name": "session_health_kit_workouts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_health_kit_workouts_session_id_board_sessions_id_fk": {
+          "name": "session_health_kit_workouts_session_id_board_sessions_id_fk",
+          "tableFrom": "session_health_kit_workouts",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_health_kit_workouts_user_id_users_id_fk": {
+          "name": "session_health_kit_workouts_user_id_users_id_fk",
+          "tableFrom": "session_health_kit_workouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_health_kit_workouts_session_id_user_id_pk": {
+          "name": "session_health_kit_workouts_session_id_user_id_pk",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_favorite": {
+          "name": "unique_user_favorite",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_idx": {
+          "name": "user_favorites_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_climb_idx": {
+          "name": "user_favorites_climb_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_sync_cursor_idx": {
+          "name": "user_favorites_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boardsesh_ticks": {
+      "name": "boardsesh_ticks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "tick_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "status": {
+          "name": "status",
+          "type": "tick_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "aurora_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_sync_error": {
+          "name": "aurora_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "kilter_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_sync_error": {
+          "name": "kilter_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_detached_at": {
+          "name": "kilter_detached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boardsesh_ticks_user_board_idx": {
+          "name": "boardsesh_ticks_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climb_idx": {
+          "name": "boardsesh_ticks_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_aurora_id_unique": {
+          "name": "boardsesh_ticks_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_pending_idx": {
+          "name": "boardsesh_ticks_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_id_unique": {
+          "name": "boardsesh_ticks_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_sync_pending_idx": {
+          "name": "boardsesh_ticks_kilter_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_session_idx": {
+          "name": "boardsesh_ticks_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climbed_at_idx": {
+          "name": "boardsesh_ticks_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climbed_at_idx": {
+          "name": "boardsesh_ticks_user_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_climbed_at_idx": {
+          "name": "boardsesh_ticks_board_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_user_idx": {
+          "name": "boardsesh_ticks_board_user_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climb_lookup_idx": {
+          "name": "boardsesh_ticks_user_climb_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_cursor_idx": {
+          "name": "boardsesh_ticks_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_flash_send_updated_at_idx": {
+          "name": "boardsesh_ticks_flash_send_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"boardsesh_ticks\".\"status\" IN ('flash','send')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boardsesh_ticks_user_id_users_id_fk": {
+          "name": "boardsesh_ticks_user_id_users_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_session_id_board_sessions_id_fk": {
+          "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_board_id_user_boards_id_fk": {
+          "name": "boardsesh_ticks_board_id_user_boards_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boardsesh_ticks_uuid_unique": {
+          "name": "boardsesh_ticks_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "boardsesh_ticks_quality_range": {
+          "name": "boardsesh_ticks_quality_range",
+          "value": "\"boardsesh_ticks\".\"quality\" IS NULL OR (\"boardsesh_ticks\".\"quality\" >= 1 AND \"boardsesh_ticks\".\"quality\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_events": {
+      "name": "board_climb_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter": {
+          "name": "setter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_events_board_confirmed_at_idx": {
+          "name": "board_climb_events_board_confirmed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confirmed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_events_board_seq_unique": {
+          "name": "board_climb_events_board_seq_unique",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_events_session_idx": {
+          "name": "board_climb_events_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_events_board_climb_idx": {
+          "name": "board_climb_events_board_climb_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_events_board_id_user_boards_id_fk": {
+          "name": "board_climb_events_board_id_user_boards_id_fk",
+          "tableFrom": "board_climb_events",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_climb_events_user_id_users_id_fk": {
+          "name": "board_climb_events_user_id_users_id_fk",
+          "tableFrom": "board_climb_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_climb_events_session_id_board_sessions_id_fk": {
+          "name": "board_climb_events_session_id_board_sessions_id_fk",
+          "tableFrom": "board_climb_events",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_climbs": {
+      "name": "playlist_climbs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_climb": {
+          "name": "unique_playlist_climb",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_climb_idx": {
+          "name": "playlist_climbs_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_position_idx": {
+          "name": "playlist_climbs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_sync_cursor_idx": {
+          "name": "playlist_climbs_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_climbs_playlist_id_playlists_id_fk": {
+          "name": "playlist_climbs_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_climbs",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_ownership": {
+      "name": "playlist_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_ownership": {
+          "name": "unique_playlist_ownership",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_ownership_user_idx": {
+          "name": "playlist_ownership_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_ownership_playlist_id_playlists_id_fk": {
+          "name": "playlist_ownership_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_ownership_user_id_users_id_fk": {
+          "name": "playlist_ownership_user_id_users_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_recommendation": {
+          "name": "generated_recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "playlists_board_layout_idx": {
+          "name": "playlists_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_generated_recommendation_idx": {
+          "name": "playlists_generated_recommendation_idx",
+          "columns": [
+            {
+              "expression": "generated_recommendation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_uuid_idx": {
+          "name": "playlists_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_updated_at_idx": {
+          "name": "playlists_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_sync_cursor_idx": {
+          "name": "playlists_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_last_accessed_at_idx": {
+          "name": "playlists_last_accessed_at_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_aurora_id_idx": {
+          "name": "playlists_aurora_id_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_kilter_id_idx": {
+          "name": "playlists_kilter_id_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlists_uuid_unique": {
+          "name": "playlists_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlist_pins": {
+      "name": "user_playlist_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_playlist_pin": {
+          "name": "unique_user_playlist_pin",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_user_idx": {
+          "name": "user_playlist_pins_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_playlist_idx": {
+          "name": "user_playlist_pins_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_playlist_pins_user_id_users_id_fk": {
+          "name": "user_playlist_pins_user_id_users_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_playlist_pins_playlist_id_playlists_id_fk": {
+          "name": "user_playlist_pins_playlist_id_playlists_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hold_classifications": {
+      "name": "user_hold_classifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_type": {
+          "name": "hold_type",
+          "type": "hold_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_rating": {
+          "name": "hand_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foot_rating": {
+          "name": "foot_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_direction": {
+          "name": "pull_direction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hold_classifications_user_board_idx": {
+          "name": "user_hold_classifications_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_unique_idx": {
+          "name": "user_hold_classifications_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_hold_idx": {
+          "name": "user_hold_classifications_hold_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hold_classifications_user_id_users_id_fk": {
+          "name": "user_hold_classifications_user_id_users_id_fk",
+          "tableFrom": "user_hold_classifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esp32_controllers": {
+      "name": "esp32_controllers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "esp32_controllers_user_idx": {
+          "name": "esp32_controllers_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_api_key_idx": {
+          "name": "esp32_controllers_api_key_idx",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_session_idx": {
+          "name": "esp32_controllers_session_idx",
+          "columns": [
+            {
+              "expression": "authorized_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esp32_controllers_user_id_users_id_fk": {
+          "name": "esp32_controllers_user_id_users_id_fk",
+          "tableFrom": "esp32_controllers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "esp32_controllers_api_key_unique": {
+          "name": "esp32_controllers_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_follows": {
+      "name": "playlist_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_uuid": {
+          "name": "playlist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_follow": {
+          "name": "unique_playlist_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_follower_idx": {
+          "name": "playlist_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_playlist_idx": {
+          "name": "playlist_follows_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_sync_cursor_idx": {
+          "name": "playlist_follows_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_follows_follower_id_users_id_fk": {
+          "name": "playlist_follows_follower_id_users_id_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_follows_playlist_uuid_playlists_uuid_fk": {
+          "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setter_follows": {
+      "name": "setter_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_setter_follow": {
+          "name": "unique_setter_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_follower_idx": {
+          "name": "setter_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_setter_idx": {
+          "name": "setter_follows_setter_idx",
+          "columns": [
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_sync_cursor_idx": {
+          "name": "setter_follows_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setter_follows_follower_id_users_id_fk": {
+          "name": "setter_follows_follower_id_users_id_fk",
+          "tableFrom": "setter_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_follow": {
+          "name": "unique_user_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_following_idx": {
+          "name": "user_follows_following_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_sync_cursor_idx": {
+          "name": "user_follows_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_follow": {
+          "name": "no_self_follow",
+          "value": "\"user_follows\".\"follower_id\" != \"user_follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_entity_created_at_idx": {
+          "name": "comments_entity_created_at_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_user_created_at_idx": {
+          "name": "comments_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_parent_comment_idx": {
+          "name": "comments_parent_comment_idx",
+          "columns": [
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comments_uuid_unique": {
+          "name": "comments_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_unique_user_entity": {
+          "name": "votes_unique_user_entity",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_entity_idx": {
+          "name": "votes_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_idx": {
+          "name": "votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vote_value_check": {
+          "name": "vote_value_check",
+          "value": "\"votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_created_at_idx": {
+          "name": "notifications_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_dedup_idx": {
+          "name": "notifications_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_comments_id_fk": {
+          "name": "notifications_comment_id_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_uuid_unique": {
+          "name": "notifications_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "feed_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_recipient_created_at_idx": {
+          "name": "feed_items_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_recipient_board_created_at_idx": {
+          "name": "feed_items_recipient_board_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_actor_created_at_idx": {
+          "name": "feed_items_actor_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_created_at_idx": {
+          "name": "feed_items_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_entity_type_entity_id_idx": {
+          "name": "feed_items_entity_type_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_recipient_id_users_id_fk": {
+          "name": "feed_items_recipient_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feed_items_actor_id_users_id_fk": {
+          "name": "feed_items_actor_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_classic_status": {
+      "name": "climb_classic_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_classic": {
+          "name": "is_classic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_classic_status_unique_idx": {
+          "name": "climb_classic_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_classic_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_classic_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "last_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_community_status": {
+      "name": "climb_community_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_grade": {
+          "name": "community_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_community_status_unique_idx": {
+          "name": "climb_community_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_community_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_community_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "last_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_proposals": {
+      "name": "climb_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "climb_proposals_climb_angle_type_idx": {
+          "name": "climb_proposals_climb_angle_type_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_status_idx": {
+          "name": "climb_proposals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_proposer_idx": {
+          "name": "climb_proposals_proposer_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_board_type_idx": {
+          "name": "climb_proposals_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_created_at_idx": {
+          "name": "climb_proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_proposals_proposer_id_users_id_fk": {
+          "name": "climb_proposals_proposer_id_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "climb_proposals_resolved_by_users_id_fk": {
+          "name": "climb_proposals_resolved_by_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "climb_proposals_uuid_unique": {
+          "name": "climb_proposals_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_roles": {
+      "name": "community_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_roles_board_type_idx": {
+          "name": "community_roles_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_roles_user_id_users_id_fk": {
+          "name": "community_roles_user_id_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_roles_granted_by_users_id_fk": {
+          "name": "community_roles_granted_by_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_roles_user_role_board_idx": {
+          "name": "community_roles_user_role_board_idx",
+          "nullsNotDistinct": true,
+          "columns": [
+            "user_id",
+            "role",
+            "board_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_by": {
+          "name": "set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_settings_scope_key_idx": {
+          "name": "community_settings_scope_key_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_settings_set_by_users_id_fk": {
+          "name": "community_settings_set_by_users_id_fk",
+          "tableFrom": "community_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "set_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_votes_unique_user_proposal": {
+          "name": "proposal_votes_unique_user_proposal",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_proposal_idx": {
+          "name": "proposal_votes_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_climb_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_user_id_users_id_fk": {
+          "name": "proposal_votes_user_id_users_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_vote_value_check": {
+          "name": "proposal_vote_value_check",
+          "value": "\"proposal_votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.new_climb_subscriptions": {
+      "name": "new_climb_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "new_climb_subscriptions_unique_user_board_layout": {
+          "name": "new_climb_subscriptions_unique_user_board_layout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_user_idx": {
+          "name": "new_climb_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_board_layout_idx": {
+          "name": "new_climb_subscriptions_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_climb_subscriptions_user_id_users_id_fk": {
+          "name": "new_climb_subscriptions_user_id_users_id_fk",
+          "tableFrom": "new_climb_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_counts": {
+      "name": "vote_counts",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vote_counts_score_idx": {
+          "name": "vote_counts_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_counts_hot_score_idx": {
+          "name": "vote_counts_hot_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hot_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_counts_entity_type_entity_id_pk": {
+          "name": "vote_counts_entity_type_entity_id_pk",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_participants": {
+      "name": "board_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_session_participants_session_idx": {
+          "name": "board_session_participants_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_session_participants_user_idx": {
+          "name": "board_session_participants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_session_participants_session_id_board_sessions_id_fk": {
+          "name": "board_session_participants_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_session_participants_user_id_users_id_fk": {
+          "name": "board_session_participants_user_id_users_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_session_participants_session_id_user_id_pk": {
+          "name": "board_session_participants_session_id_user_id_pk",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_feedback": {
+      "name": "app_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_consent": {
+          "name": "contact_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "app_feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_number": {
+          "name": "github_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_feedback_created_at_idx": {
+          "name": "app_feedback_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_user_idx": {
+          "name": "app_feedback_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_board_idx": {
+          "name": "app_feedback_board_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_status_idx": {
+          "name": "app_feedback_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_feedback_user_id_users_id_fk": {
+          "name": "app_feedback_user_id_users_id_fk",
+          "tableFrom": "app_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_feedback_resolved_by_users_id_fk": {
+          "name": "app_feedback_resolved_by_users_id_fk",
+          "tableFrom": "app_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_climb_percentiles": {
+      "name": "user_climb_percentiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_distinct_climbs": {
+          "name": "total_distinct_climbs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_climb_percentiles_user_id_users_id_fk": {
+          "name": "user_climb_percentiles_user_id_users_id_fk",
+          "tableFrom": "user_climb_percentiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_push_tokens": {
+      "name": "activity_push_tokens",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_push_tokens_session_idx": {
+          "name": "activity_push_tokens_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_push_tokens_user_idx": {
+          "name": "activity_push_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_push_tokens_updated_at_idx": {
+          "name": "activity_push_tokens_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_push_tokens_session_id_board_sessions_id_fk": {
+          "name": "activity_push_tokens_session_id_board_sessions_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_push_tokens_user_id_users_id_fk": {
+          "name": "activity_push_tokens_user_id_users_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_send_stats": {
+      "name": "board_climb_send_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "send_count_30d": {
+          "name": "send_count_30d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sender_count_30d": {
+          "name": "sender_count_30d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "send_count_90d": {
+          "name": "send_count_90d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_send_stats_trending_idx": {
+          "name": "board_climb_send_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "send_count_30d",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_send_stats_board_type_climb_uuid_pk": {
+          "name": "board_climb_send_stats_board_type_climb_uuid_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_setter_stats": {
+      "name": "board_setter_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_count": {
+          "name": "climb_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_ascents": {
+          "name": "total_ascents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_ascents_per_climb": {
+          "name": "avg_ascents_per_climb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_quality": {
+          "name": "avg_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_score": {
+          "name": "setter_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_setter_stats_score_idx": {
+          "name": "board_setter_stats_score_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_setter_stats_board_type_setter_username_pk": {
+          "name": "board_setter_stats_board_type_setter_username_pk",
+          "columns": [
+            "board_type",
+            "setter_username"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_grades": {
+      "name": "board_climb_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_grade": {
+          "name": "local_grade",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "universal_grade": {
+          "name": "universal_grade",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_low": {
+          "name": "grade_low",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_high": {
+          "name": "grade_high",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "content_prior": {
+          "name": "content_prior",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coeff_version": {
+          "name": "coeff_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_seq": {
+          "name": "sync_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "board_climb_grades_confidence_idx": {
+          "name": "board_climb_grades_confidence_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_grades_sync_cursor_idx": {
+          "name": "board_climb_grades_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_grades_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_grades_board_type_climb_uuid_angle_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_grade_coefficients": {
+      "name": "board_grade_coefficients",
+      "schema": "",
+      "columns": {
+        "coeff_version": {
+          "name": "coeff_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_grade_coefficients_coeff_version_kind_key_pk": {
+          "name": "board_grade_coefficients_coeff_version_kind_key_pk",
+          "columns": [
+            "coeff_version",
+            "kind",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_hold_features": {
+      "name": "board_hold_features",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_id": {
+          "name": "placement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_x": {
+          "name": "norm_x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_y": {
+          "name": "norm_y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_dist": {
+          "name": "edge_dist",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neighbor_dist": {
+          "name": "neighbor_dist",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_kickboard": {
+          "name": "is_kickboard",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hand_difficulty": {
+          "name": "hand_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foot_difficulty": {
+          "name": "foot_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_sample_count": {
+          "name": "hand_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "foot_sample_count": {
+          "name": "foot_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pull_direction": {
+          "name": "pull_direction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coarse_type": {
+          "name": "coarse_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_version": {
+          "name": "feature_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_hold_features_board_layout_idx": {
+          "name": "board_hold_features_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_hold_features_board_type_placement_id_pk": {
+          "name": "board_hold_features_board_type_placement_id_pk",
+          "columns": [
+            "board_type",
+            "placement_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_embeddings": {
+      "name": "board_climb_embeddings",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_prior": {
+          "name": "content_prior",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_sd": {
+          "name": "content_sd",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_seq": {
+          "name": "sync_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "board_climb_embeddings_board_idx": {
+          "name": "board_climb_embeddings_board_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_embeddings_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_embeddings_board_type_climb_uuid_angle_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_similar": {
+      "name": "board_climb_similar",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "neighbor_uuid": {
+          "name": "neighbor_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_similar_lookup_idx": {
+          "name": "board_climb_similar_lookup_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_similar_board_type_climb_uuid_angle_neighbor_uuid_pk": {
+          "name": "board_climb_similar_board_type_climb_uuid_angle_neighbor_uuid_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle",
+            "neighbor_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_exports": {
+      "name": "integration_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_activity_id": {
+          "name": "external_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_integration_export": {
+          "name": "unique_integration_export",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_exports_user_provider_idx": {
+          "name": "integration_exports_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_exports_session_idx": {
+          "name": "integration_exports_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_exports_user_id_users_id_fk": {
+          "name": "integration_exports_user_id_users_id_fk",
+          "tableFrom": "integration_exports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_sync_gym_sources": {
+      "name": "location_sync_gym_sources",
+      "schema": "",
+      "columns": {
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "location_sync_gym_sources_gym_idx": {
+          "name": "location_sync_gym_sources_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_sync_gym_sources_gym_id_gyms_id_fk": {
+          "name": "location_sync_gym_sources_gym_id_gyms_id_fk",
+          "tableFrom": "location_sync_gym_sources",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_deletions": {
+      "name": "sync_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_deletions_user_since_idx": {
+          "name": "sync_deletions_user_since_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_deletions_null_scope_idx": {
+          "name": "sync_deletions_null_scope_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sync_deletions\".\"user_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_deletions_deleted_at_idx": {
+          "name": "sync_deletions_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.gym_claim_method": {
+      "name": "gym_claim_method",
+      "schema": "public",
+      "values": [
+        "domain",
+        "admin"
+      ]
+    },
+    "public.gym_claim_status": {
+      "name": "gym_claim_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied",
+        "expired"
+      ]
+    },
+    "public.gym_member_role": {
+      "name": "gym_member_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "editor",
+        "member"
+      ]
+    },
+    "public.gym_merge_audit_action": {
+      "name": "gym_merge_audit_action",
+      "schema": "public",
+      "values": [
+        "merged",
+        "dismissed"
+      ]
+    },
+    "public.aurora_table_type": {
+      "name": "aurora_table_type",
+      "schema": "public",
+      "values": [
+        "ascents",
+        "bids"
+      ]
+    },
+    "public.kilter_table_type": {
+      "name": "kilter_table_type",
+      "schema": "public",
+      "values": [
+        "logs",
+        "attempts"
+      ]
+    },
+    "public.tick_origin": {
+      "name": "tick_origin",
+      "schema": "public",
+      "values": [
+        "native",
+        "aurora_pull",
+        "kilter_pull",
+        "json_import",
+        "moonboard_import"
+      ]
+    },
+    "public.tick_status": {
+      "name": "tick_status",
+      "schema": "public",
+      "values": [
+        "flash",
+        "send",
+        "attempt"
+      ]
+    },
+    "public.hold_type": {
+      "name": "hold_type",
+      "schema": "public",
+      "values": [
+        "jug",
+        "sloper",
+        "pinch",
+        "crimp",
+        "pocket"
+      ]
+    },
+    "public.social_entity_type": {
+      "name": "social_entity_type",
+      "schema": "public",
+      "values": [
+        "playlist_climb",
+        "climb",
+        "tick",
+        "comment",
+        "proposal",
+        "board",
+        "gym",
+        "session"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "new_follower",
+        "comment_reply",
+        "comment_on_tick",
+        "comment_on_climb",
+        "vote_on_tick",
+        "vote_on_comment",
+        "new_climb",
+        "new_climb_global",
+        "proposal_approved",
+        "proposal_rejected",
+        "proposal_vote",
+        "proposal_created",
+        "new_climbs_synced",
+        "gym_claim_approved"
+      ]
+    },
+    "public.feed_item_type": {
+      "name": "feed_item_type",
+      "schema": "public",
+      "values": [
+        "ascent",
+        "new_climb",
+        "comment",
+        "proposal_approved",
+        "session_summary"
+      ]
+    },
+    "public.community_role_type": {
+      "name": "community_role_type",
+      "schema": "public",
+      "values": [
+        "admin",
+        "community_leader",
+        "tester"
+      ]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "approved",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.proposal_type": {
+      "name": "proposal_type",
+      "schema": "public",
+      "values": [
+        "grade",
+        "classic",
+        "benchmark"
+      ]
+    },
+    "public.app_feedback_status": {
+      "name": "app_feedback_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "in_progress",
+        "resolved",
+        "wont_fix"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1289,6 +1289,13 @@
       "when": 1784236914655,
       "tag": "0183_feedback_status_and_github_link",
       "breakpoints": true
+    },
+    {
+      "idx": 184,
+      "version": "7",
+      "when": 1784531254828,
+      "tag": "0184_steep_old_lace",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/scripts/dedupe-gym-locations-args.test.ts
+++ b/packages/db/scripts/dedupe-gym-locations-args.test.ts
@@ -24,4 +24,22 @@ test('no args is a dry-run (apply stays false)', () => {
   assert.equal(parsed.apply, false);
   assert.equal(parsed.limit, null);
   assert.equal(parsed.onlyName, null);
+  assert.equal(parsed.backfillPointers, false);
+});
+
+test('--backfill-pointers selects the pointer-backfill mode (dry-run by default)', () => {
+  const parsed = parseArgs(['--backfill-pointers']);
+  assert.equal(parsed.backfillPointers, true);
+  assert.equal(parsed.apply, false);
+});
+
+test('--backfill-pointers --apply enables the backfill write path', () => {
+  const parsed = parseArgs(['--backfill-pointers', '--apply']);
+  assert.equal(parsed.backfillPointers, true);
+  assert.equal(parsed.apply, true);
+});
+
+test('backfill defaults to SYSTEM-owned twins unless --include-non-system-twins is passed', () => {
+  assert.equal(parseArgs(['--backfill-pointers']).includeNonSystemTwins, false);
+  assert.equal(parseArgs(['--backfill-pointers', '--include-non-system-twins']).includeNonSystemTwins, true);
 });

--- a/packages/db/scripts/dedupe-gym-locations.integration.test.ts
+++ b/packages/db/scripts/dedupe-gym-locations.integration.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { sql, type SQLWrapper } from 'drizzle-orm';
 import { createScriptDb } from './db-connection.js';
-import { mergeGymCluster } from './dedupe-gym-locations.js';
+import { mergeGymCluster, mergeGymsIntoCanonical } from '../src/queries/gyms/merge-gyms.js';
 import { executeRows } from '../src/client/index.js';
 import type { CanonicalGymCandidate, PhysicalGymCluster } from '../src/queries/gyms/location-dedupe.js';
 
@@ -20,6 +20,7 @@ type GymStateRow = {
   address: string | null;
   isPublic: boolean;
   deletedAt: Date | string | null;
+  mergedIntoGymId: number | string | null;
 };
 
 type VoteRow = {
@@ -279,7 +280,7 @@ void describe('dedupe gym merge apply path', () => {
             ],
           };
 
-          const counts = await mergeGymCluster(transaction, cluster);
+          const { counts, warnings } = await mergeGymCluster(transaction, cluster);
 
           assert.deepEqual(counts, {
             boardRowsMoved: 1,
@@ -288,6 +289,9 @@ void describe('dedupe gym merge apply path', () => {
             followsDeleted: 2,
             membersInsertedOrUpdated: 2,
             membersDeleted: 2,
+            claimsMoved: 0,
+            claimsExpired: 0,
+            kiosksMoved: 0,
             commentsMoved: 1,
             feedItemsMoved: 1,
             notificationsMoved: 1,
@@ -295,6 +299,7 @@ void describe('dedupe gym merge apply path', () => {
             votesDeleted: 2,
             duplicateGymsSoftDeleted: 1,
           });
+          assert.deepEqual(warnings, []);
 
           const [canonicalGymState] = await executeRows<GymStateRow>(
             transaction,
@@ -306,10 +311,12 @@ void describe('dedupe gym merge apply path', () => {
 
           const [duplicateGymState] = await executeRows<GymStateRow>(
             transaction,
-            sql`SELECT address AS "address", is_public AS "isPublic", deleted_at AS "deletedAt" FROM gyms WHERE id = ${duplicateGymId}`,
+            sql`SELECT address AS "address", is_public AS "isPublic", deleted_at AS "deletedAt", merged_into_gym_id AS "mergedIntoGymId" FROM gyms WHERE id = ${duplicateGymId}`,
           );
           assert.equal(duplicateGymState?.isPublic, false);
           assert.notEqual(duplicateGymState?.deletedAt, null);
+          // The soft-deleted twin points at the survivor so its old uuid/slug resolves.
+          assert.equal(Number(duplicateGymState?.mergedIntoGymId), canonicalGymId);
 
           const [movedBoardCount] = await executeRows<CountRow>(
             transaction,
@@ -400,6 +407,183 @@ void describe('dedupe gym merge apply path', () => {
               score: Number(voteCount.score),
             })),
             [{ entityId: canonicalGymUuid, upvotes: 1, downvotes: 1, score: 0 }],
+          );
+
+          throw rollbackMarker;
+        });
+      } catch (error: unknown) {
+        if (error !== rollbackMarker) {
+          throw error;
+        }
+      }
+    } finally {
+      await close();
+    }
+  });
+
+  void it('re-points claims respecting the unique-pending index and suffixes colliding kiosk slugs', async (testContext) => {
+    const databaseUrl = mergeTestDatabaseUrl();
+    if (!databaseUrl) {
+      testContext.skip('set DEDUPE_GYM_LOCATIONS_DB_URL to a migrated writable DB to execute this integration test');
+      return;
+    }
+
+    const { db, close } = createScriptDb(databaseUrl);
+    try {
+      const unavailableReason = await skipReason(db);
+      if (unavailableReason) {
+        testContext.skip(unavailableReason);
+        return;
+      }
+
+      const rollbackMarker = new Error('rollback claims/kiosk fixture');
+      try {
+        await db.transaction(async (transaction) => {
+          const tag = `dedupe-claims-kiosk-${Date.now()}`;
+          const canonicalGymUuid = `${tag}-canonical`;
+          const duplicateGymUuid = `${tag}-duplicate`;
+          const gammaId = `${tag}-gamma`;
+          const deltaId = `${tag}-delta`;
+
+          await transaction.execute(sql`
+            INSERT INTO users (id, email, name)
+            VALUES
+              (${SYSTEM_USER_ID}, 'system@boardsesh.test', 'Boardsesh'),
+              (${gammaId}, ${`${gammaId}@example.test`}, 'Gamma'),
+              (${deltaId}, ${`${deltaId}@example.test`}, 'Delta')
+            ON CONFLICT (id) DO NOTHING
+          `);
+
+          const canonicalGymId = await insertGym(transaction, {
+            uuid: canonicalGymUuid,
+            name: 'Claims Kiosk Gym',
+            address: null,
+            latitude: -33.9,
+            longitude: 151.2,
+            createdAt: '2026-01-01T00:00:00Z',
+          });
+          const duplicateGymId = await insertGym(transaction, {
+            uuid: duplicateGymUuid,
+            name: 'Claims Kiosk Gym',
+            address: null,
+            latitude: -33.90001,
+            longitude: 151.20001,
+            createdAt: '2026-01-02T00:00:00Z',
+          });
+
+          // Gamma has a pending claim on BOTH gyms (a mid-flight collision); Delta
+          // has one only on the duplicate (must be promoted to the survivor).
+          await transaction.execute(sql`
+            INSERT INTO gym_claims (gym_id, claimant_user_id, method, status, created_at, updated_at)
+            VALUES
+              (${canonicalGymId}, ${gammaId}, 'admin', 'pending', now(), now()),
+              (${duplicateGymId}, ${gammaId}, 'admin', 'pending', now(), now()),
+              (${duplicateGymId}, ${deltaId}, 'admin', 'pending', now(), now())
+          `);
+
+          // Member role precedence (admin > editor > member): Gamma is an editor on
+          // the canonical but only a member on the twin — must NOT be demoted to
+          // member on collision. Delta is an editor only on the twin — must arrive
+          // as editor, not member.
+          await transaction.execute(sql`
+            INSERT INTO gym_members (gym_id, user_id, role, created_at)
+            VALUES
+              (${canonicalGymId}, ${gammaId}, 'editor'::gym_member_role, now()),
+              (${duplicateGymId}, ${gammaId}, 'member'::gym_member_role, now()),
+              (${duplicateGymId}, ${deltaId}, 'editor'::gym_member_role, now())
+          `);
+
+          // Canonical owns a 'main-wall' kiosk; the duplicate has a colliding
+          // 'main-wall' plus a distinct 'side-wall'.
+          await transaction.execute(sql`
+            INSERT INTO gym_kiosks (uuid, gym_id, slug, name)
+            VALUES
+              (${`${tag}-k-canon`}, ${canonicalGymId}, 'main-wall', 'Main Wall'),
+              (${`${tag}-k-dup-main`}, ${duplicateGymId}, 'main-wall', 'Dup Main Wall'),
+              (${`${tag}-k-dup-side`}, ${duplicateGymId}, 'side-wall', 'Dup Side Wall')
+          `);
+
+          const canonicalCandidate = candidate({
+            id: canonicalGymId,
+            uuid: canonicalGymUuid,
+            name: 'Claims Kiosk Gym',
+            address: null,
+            latitude: -33.9,
+            longitude: 151.2,
+            createdAt: '2026-01-01T00:00:00Z',
+            boardCount: 0,
+          });
+          const duplicateCandidate = candidate({
+            id: duplicateGymId,
+            uuid: duplicateGymUuid,
+            name: 'Claims Kiosk Gym',
+            address: null,
+            latitude: -33.90001,
+            longitude: 151.20001,
+            createdAt: '2026-01-02T00:00:00Z',
+            boardCount: 0,
+          });
+
+          const { counts, warnings } = await mergeGymsIntoCanonical(transaction, canonicalCandidate, [
+            duplicateCandidate,
+          ]);
+
+          // Delta's pending claim is promoted; Gamma's colliding duplicate claim is
+          // re-pointed to the canonical and expired (never deleted).
+          assert.equal(counts.claimsMoved, 1);
+          assert.equal(counts.claimsExpired, 1);
+          assert.equal(counts.kiosksMoved, 2);
+
+          const pendingClaims = await executeRows<{ claimantUserId: string }>(
+            transaction,
+            sql`SELECT claimant_user_id AS "claimantUserId" FROM gym_claims WHERE gym_id = ${canonicalGymId} AND status = 'pending' ORDER BY claimant_user_id`,
+          );
+          assert.deepEqual(
+            pendingClaims.map((claim) => claim.claimantUserId),
+            [deltaId, gammaId],
+          );
+
+          const [duplicatePending] = await executeRows<CountRow>(
+            transaction,
+            sql`SELECT count(*)::int AS count FROM gym_claims WHERE gym_id = ${duplicateGymId} AND status = 'pending'`,
+          );
+          assert.equal(Number(duplicatePending?.count), 0);
+
+          // Gamma's collided claim was preserved: it now lives on the canonical as
+          // an expired claim rather than being deleted.
+          const [gammaExpired] = await executeRows<CountRow>(
+            transaction,
+            sql`SELECT count(*)::int AS count FROM gym_claims WHERE gym_id = ${canonicalGymId} AND claimant_user_id = ${gammaId} AND status = 'expired'`,
+          );
+          assert.equal(Number(gammaExpired?.count), 1);
+
+          // Editor precedence: neither Gamma (canonical editor + twin member) nor
+          // Delta (twin editor) is demoted to member.
+          const canonicalRoles = await executeRows<{ userId: string; role: string }>(
+            transaction,
+            sql`SELECT user_id AS "userId", role AS "role" FROM gym_members WHERE gym_id = ${canonicalGymId} ORDER BY user_id`,
+          );
+          assert.deepEqual(
+            canonicalRoles.map((member) => ({ userId: member.userId, role: member.role })),
+            [
+              { userId: deltaId, role: 'editor' },
+              { userId: gammaId, role: 'editor' },
+            ],
+          );
+
+          // The colliding kiosk was re-slugged and reported; the QR must be reprinted.
+          assert.equal(warnings.length, 1);
+          assert.equal(warnings[0]?.type, 'kiosk_slug_changed');
+          assert.equal(warnings[0]?.previousSlug, 'main-wall');
+          assert.equal(warnings[0]?.newSlug, 'main-wall-2');
+
+          const canonicalKioskSlugs = await executeRows<{ slug: string }>(
+            transaction,
+            sql`SELECT slug FROM gym_kiosks WHERE gym_id = ${canonicalGymId} AND deleted_at IS NULL ORDER BY slug`,
+          );
+          assert.deepEqual(
+            canonicalKioskSlugs.map((kiosk) => kiosk.slug),
+            ['main-wall', 'main-wall-2', 'side-wall'],
           );
 
           throw rollbackMarker;

--- a/packages/db/scripts/dedupe-gym-locations.ts
+++ b/packages/db/scripts/dedupe-gym-locations.ts
@@ -9,6 +9,14 @@
  *   vp run db:dedupe-gyms --only-name "Sandbox Bouldering"
  *   vp run db:dedupe-gyms --apply --limit 10
  *
+ * Backfill mode (--backfill-pointers): re-cluster ALREADY soft-deleted twins that
+ * predate the merged_into_gym_id pointer (the ~46–60 pre-M1 merged rows) against
+ * live gyms and set each one's missing merged_into_gym_id so its old uuid/slug
+ * resolves to the survivor. Report-only by default; add --apply to write.
+ *
+ *   vp run db:dedupe-gyms --backfill-pointers
+ *   vp run db:dedupe-gyms --backfill-pointers --apply
+ *
  * (A `--` separator before the flags also works — `vp` forwards it to the script
  * verbatim and parseArgs skips it — but it isn't needed.)
  */
@@ -18,25 +26,39 @@ import { pathToFileURL } from 'node:url';
 import { createScriptDb } from './db-connection.js';
 import { executeRows } from '../src/client/index.js';
 import {
-  chooseCanonicalGymCandidate,
-  compareCanonicalGymCandidates,
+  distanceMeters,
   groupPhysicalGymCandidates,
-  hasText,
+  normalizeGymName,
   PHYSICAL_GYM_MATCH_DISTANCE_METERS,
   type CanonicalGymCandidate,
   type PhysicalGymCluster,
 } from '../src/queries/gyms/location-dedupe.js';
+import {
+  addMergeCounts,
+  emptyMergeCounts,
+  mergeGymCluster,
+  selectClusterCandidates,
+  type MergeCounts,
+  type MergeWarning,
+} from '../src/queries/gyms/merge-gyms.js';
 
 const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+// Backfill re-clusters against the observed cross-provider drift band (tier B).
+const BACKFILL_MATCH_DISTANCE_METERS = 150;
 const APPLY_FLAG = '--apply';
 const LIMIT_FLAG = '--limit';
 const ONLY_NAME_FLAG = '--only-name';
+const BACKFILL_POINTERS_FLAG = '--backfill-pointers';
+const INCLUDE_NON_SYSTEM_TWINS_FLAG = '--include-non-system-twins';
 const HELP_FLAG = '--help';
 const ARG_SEPARATOR = '--';
 
 type ExecuteDb = {
   execute(query: SQLWrapper | string): PromiseLike<unknown>;
 };
+
+// The script's Drizzle connection — has both `execute` and `transaction`.
+type ScriptDbInstance = ReturnType<typeof createScriptDb>['db'];
 
 type CandidateDatabaseRow = Omit<
   CanonicalGymCandidate,
@@ -55,26 +77,36 @@ type ScriptArgs = {
   apply: boolean;
   limit: number | null;
   onlyName: string | null;
+  backfillPointers: boolean;
+  includeNonSystemTwins: boolean;
   help: boolean;
-};
-
-type MergeCounts = {
-  boardRowsMoved: number;
-  sourceAliasesMoved: number;
-  followsInserted: number;
-  followsDeleted: number;
-  membersInsertedOrUpdated: number;
-  membersDeleted: number;
-  commentsMoved: number;
-  feedItemsMoved: number;
-  notificationsMoved: number;
-  votesUpserted: number;
-  votesDeleted: number;
-  duplicateGymsSoftDeleted: number;
 };
 
 type CountRow = {
   count: number | string | null;
+};
+
+// A gym reduced to what the pointer backfill needs to match twins to survivors.
+type GymLocationRow = {
+  id: number | string;
+  uuid: string;
+  name: string;
+  latitude: number | string;
+  longitude: number | string;
+};
+
+type GymLocation = {
+  id: number;
+  uuid: string;
+  name: string;
+  latitude: number;
+  longitude: number;
+};
+
+type PointerBackfillMatch = {
+  twin: GymLocation;
+  survivor: GymLocation;
+  distance: number;
 };
 
 function parsePositiveInteger(rawValue: string | undefined, flagName: string): number {
@@ -100,6 +132,8 @@ export function parseArgs(args: string[]): ScriptArgs {
     apply: false,
     limit: null,
     onlyName: null,
+    backfillPointers: false,
+    includeNonSystemTwins: false,
     help: false,
   };
 
@@ -113,6 +147,14 @@ export function parseArgs(args: string[]): ScriptArgs {
     }
     if (currentArg === APPLY_FLAG) {
       parsedArgs.apply = true;
+      continue;
+    }
+    if (currentArg === BACKFILL_POINTERS_FLAG) {
+      parsedArgs.backfillPointers = true;
+      continue;
+    }
+    if (currentArg === INCLUDE_NON_SYSTEM_TWINS_FLAG) {
+      parsedArgs.includeNonSystemTwins = true;
       continue;
     }
     if (currentArg === HELP_FLAG) {
@@ -142,12 +184,20 @@ function printHelp(): void {
   vp run db:dedupe-gyms
   vp run db:dedupe-gyms --only-name "Sandbox Bouldering"
   vp run db:dedupe-gyms --apply --limit 10
+  vp run db:dedupe-gyms --backfill-pointers
+  vp run db:dedupe-gyms --backfill-pointers --apply
 
 Options:
-  --apply              Merge candidates. Omit for dry-run.
-  --limit <n>          Limit the number of duplicate clusters processed.
-  --only-name <name>   Restrict candidates to one normalized gym name.
-  --help               Show this help text.`);
+  --apply               Write changes. Omit for dry-run.
+  --limit <n>           Limit the number of clusters (merge) / twins (backfill) processed.
+  --only-name <name>    Restrict candidates to one normalized gym name.
+  --backfill-pointers   Set missing merged_into_gym_id on pre-pointer soft-deleted
+                        twins by re-clustering them against live gyms. SYSTEM-owned
+                        twins only, and only when exactly one live survivor sits in
+                        the match band (ambiguous twins are reported, never pointed).
+  --include-non-system-twins
+                        Also consider user-owned soft-deleted twins for the backfill.
+  --help                Show this help text.`);
 }
 
 function coerceCandidate(row: CandidateDatabaseRow): CanonicalGymCandidate {
@@ -163,25 +213,18 @@ function coerceCandidate(row: CandidateDatabaseRow): CanonicalGymCandidate {
   };
 }
 
-function pickTextField(
-  candidates: CanonicalGymCandidate[],
-  fieldName: 'address' | 'contactEmail' | 'contactPhone' | 'description' | 'imageUrl',
-): string | null {
-  for (const candidate of candidates) {
-    const candidateValue = candidate[fieldName];
-    if (hasText(candidateValue)) {
-      return candidateValue;
-    }
-  }
-  return null;
+function coerceGymLocation(row: GymLocationRow): GymLocation {
+  return {
+    id: Number(row.id),
+    uuid: row.uuid,
+    name: row.name,
+    latitude: Number(row.latitude),
+    longitude: Number(row.longitude),
+  };
 }
 
 function idsFromCandidates(candidates: CanonicalGymCandidate[]): number[] {
   return candidates.map((candidate) => candidate.id);
-}
-
-function uuidsFromCandidates(candidates: CanonicalGymCandidate[]): string[] {
-  return candidates.map((candidate) => candidate.uuid);
 }
 
 function candidateIdsKey(candidates: CanonicalGymCandidate[]): string {
@@ -195,29 +238,6 @@ function sqlNumberList(values: number[]): SQLWrapper {
     values.map((value) => sql`${value}`),
     sql`, `,
   );
-}
-
-function sqlTextList(values: string[]): SQLWrapper {
-  return sql.join(
-    values.map((value) => sql`${value}`),
-    sql`, `,
-  );
-}
-
-function selectClusterCandidates(cluster: PhysicalGymCluster<CanonicalGymCandidate>): {
-  canonicalGym: CanonicalGymCandidate;
-  duplicateGyms: CanonicalGymCandidate[];
-} {
-  const canonicalGym = chooseCanonicalGymCandidate(cluster.gyms);
-  if (!canonicalGym) {
-    throw new Error(`Duplicate cluster for ${cluster.normalizedName} has no canonical gym candidate.`);
-  }
-
-  const duplicateGyms = cluster.gyms
-    .filter((candidate) => candidate.id !== canonicalGym.id)
-    .sort(compareCanonicalGymCandidates);
-
-  return { canonicalGym, duplicateGyms };
 }
 
 function formatGymLabel(candidate: CanonicalGymCandidate): string {
@@ -427,340 +447,7 @@ async function refetchClusterForApply(
   return matchingCluster;
 }
 
-async function setVoteCountMaintenanceSkipped(commandDb: ExecuteDb, skipped: boolean): Promise<void> {
-  await commandDb.execute(sql`SELECT set_config('boardsesh.skip_vote_counts', ${skipped ? 'on' : 'off'}, true)`);
-}
-
-async function rebuildGymVoteCounts(commandDb: ExecuteDb, gymUuids: string[]): Promise<void> {
-  const gymUuidList = sqlTextList(gymUuids);
-  await commandDb.execute(sql`
-    DELETE FROM vote_counts
-     WHERE entity_type = 'gym'::social_entity_type
-       AND entity_id IN (${gymUuidList})
-  `);
-
-  await commandDb.execute(sql`
-    INSERT INTO vote_counts (entity_type, entity_id, upvotes, downvotes, score, hot_score, created_at)
-    SELECT
-      vote_totals.entity_type,
-      vote_totals.entity_id,
-      vote_totals.upvotes,
-      vote_totals.downvotes,
-      vote_totals.score,
-      SIGN(vote_totals.score) * LN(GREATEST(ABS(vote_totals.score), 1))
-        + EXTRACT(EPOCH FROM COALESCE(feed_created_at.created_at, vote_totals.first_vote_created_at, NOW())) / 45000.0,
-      COALESCE(feed_created_at.created_at, vote_totals.first_vote_created_at, NOW())
-    FROM (
-      SELECT
-        votes.entity_type,
-        votes.entity_id,
-        SUM(CASE WHEN votes.value = 1 THEN 1 ELSE 0 END)::int AS upvotes,
-        SUM(CASE WHEN votes.value = -1 THEN 1 ELSE 0 END)::int AS downvotes,
-        SUM(votes.value)::int AS score,
-        MIN(votes.created_at) AS first_vote_created_at
-      FROM votes
-      WHERE votes.entity_type = 'gym'::social_entity_type
-        AND votes.entity_id IN (${gymUuidList})
-      GROUP BY votes.entity_type, votes.entity_id
-    ) vote_totals
-    LEFT JOIN LATERAL (
-      SELECT feed_items.created_at
-      FROM feed_items
-      WHERE feed_items.entity_type = vote_totals.entity_type
-        AND feed_items.entity_id = vote_totals.entity_id
-      ORDER BY feed_items.created_at ASC, feed_items.id ASC
-      LIMIT 1
-    ) feed_created_at ON true
-    ON CONFLICT (entity_type, entity_id) DO UPDATE SET
-      upvotes = excluded.upvotes,
-      downvotes = excluded.downvotes,
-      score = excluded.score,
-      hot_score = excluded.hot_score,
-      created_at = excluded.created_at
-  `);
-}
-
-export async function mergeGymCluster(
-  commandDb: ExecuteDb,
-  cluster: PhysicalGymCluster<CanonicalGymCandidate>,
-): Promise<MergeCounts> {
-  const { canonicalGym, duplicateGyms } = selectClusterCandidates(cluster);
-  const allCandidatesForMetadata = [canonicalGym, ...duplicateGyms].sort(compareCanonicalGymCandidates);
-  const duplicateGymIds = idsFromCandidates(duplicateGyms);
-  const duplicateGymUuids = uuidsFromCandidates(duplicateGyms);
-  const duplicateGymIdList = sqlNumberList(duplicateGymIds);
-  const duplicateGymUuidList = sqlTextList(duplicateGymUuids);
-  const allGymUuidList = sqlTextList([canonicalGym.uuid, ...duplicateGymUuids]);
-
-  await commandDb.execute(sql`
-    UPDATE gyms
-       SET address = COALESCE(NULLIF(address, ''), ${pickTextField(allCandidatesForMetadata, 'address')}),
-           contact_email = COALESCE(NULLIF(contact_email, ''), ${pickTextField(allCandidatesForMetadata, 'contactEmail')}),
-           contact_phone = COALESCE(NULLIF(contact_phone, ''), ${pickTextField(allCandidatesForMetadata, 'contactPhone')}),
-           description = COALESCE(NULLIF(description, ''), ${pickTextField(allCandidatesForMetadata, 'description')}),
-           image_url = COALESCE(NULLIF(image_url, ''), ${pickTextField(allCandidatesForMetadata, 'imageUrl')}),
-           is_public = true,
-           deleted_at = NULL,
-           updated_at = NOW()
-     WHERE id = ${canonicalGym.id}
-  `);
-
-  const boardRowsMoved = await executeCount(
-    commandDb,
-    sql`
-      WITH moved AS (
-        UPDATE user_boards
-           SET gym_id = ${canonicalGym.id},
-               updated_at = NOW()
-         WHERE gym_id IN (${duplicateGymIdList})
-         RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM moved
-    `,
-  );
-
-  const sourceAliasesMoved = await executeCount(
-    commandDb,
-    sql`
-      WITH moved AS (
-        UPDATE location_sync_gym_sources
-           SET gym_id = ${canonicalGym.id},
-               updated_at = NOW()
-         WHERE gym_id IN (${duplicateGymIdList})
-         RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM moved
-    `,
-  );
-
-  const followsInserted = await executeCount(
-    commandDb,
-    sql`
-      WITH inserted AS (
-        INSERT INTO gym_follows (gym_id, user_id, created_at)
-        SELECT ${canonicalGym.id}, user_id, MIN(created_at)
-          FROM gym_follows
-         WHERE gym_id IN (${duplicateGymIdList})
-         GROUP BY user_id
-        ON CONFLICT (gym_id, user_id) DO NOTHING
-        RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM inserted
-    `,
-  );
-
-  const followsDeleted = await executeCount(
-    commandDb,
-    sql`
-      WITH deleted AS (
-        DELETE FROM gym_follows
-         WHERE gym_id IN (${duplicateGymIdList})
-         RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM deleted
-    `,
-  );
-
-  const membersInsertedOrUpdated = await executeCount(
-    commandDb,
-    sql`
-      WITH upserted AS (
-        INSERT INTO gym_members (gym_id, user_id, role, created_at)
-        SELECT ${canonicalGym.id},
-               user_id,
-               CASE
-                 WHEN bool_or(role = 'admin'::gym_member_role) THEN 'admin'::gym_member_role
-                 ELSE 'member'::gym_member_role
-               END,
-               MIN(created_at)
-          FROM gym_members
-         WHERE gym_id IN (${duplicateGymIdList})
-         GROUP BY user_id
-        ON CONFLICT (gym_id, user_id) DO UPDATE
-          SET role = CASE
-            WHEN gym_members.role = 'admin'::gym_member_role OR excluded.role = 'admin'::gym_member_role
-              THEN 'admin'::gym_member_role
-            ELSE 'member'::gym_member_role
-          END
-        RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM upserted
-    `,
-  );
-
-  const membersDeleted = await executeCount(
-    commandDb,
-    sql`
-      WITH deleted AS (
-        DELETE FROM gym_members
-         WHERE gym_id IN (${duplicateGymIdList})
-         RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM deleted
-    `,
-  );
-
-  const commentsMoved = await executeCount(
-    commandDb,
-    sql`
-      WITH moved AS (
-        UPDATE comments
-           SET entity_id = ${canonicalGym.uuid},
-               updated_at = NOW()
-         WHERE entity_type = 'gym'::social_entity_type
-           AND entity_id IN (${duplicateGymUuidList})
-         RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM moved
-    `,
-  );
-
-  const feedItemsMoved = await executeCount(
-    commandDb,
-    sql`
-      WITH moved AS (
-        UPDATE feed_items
-           SET entity_id = ${canonicalGym.uuid}
-         WHERE entity_type = 'gym'::social_entity_type
-           AND entity_id IN (${duplicateGymUuidList})
-         RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM moved
-    `,
-  );
-
-  const notificationsMoved = await executeCount(
-    commandDb,
-    sql`
-      WITH moved AS (
-        UPDATE notifications
-           SET entity_id = ${canonicalGym.uuid}
-         WHERE entity_type = 'gym'::social_entity_type
-           AND entity_id IN (${duplicateGymUuidList})
-         RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM moved
-    `,
-  );
-
-  let votesUpserted = 0;
-  let votesDeleted = 0;
-  await setVoteCountMaintenanceSkipped(commandDb, true);
-  votesUpserted = await executeCount(
-    commandDb,
-    sql`
-      WITH latest_votes AS (
-        SELECT DISTINCT ON (user_id)
-               user_id,
-               value,
-               created_at
-          FROM votes
-         WHERE entity_type = 'gym'::social_entity_type
-           AND entity_id IN (${allGymUuidList})
-         ORDER BY user_id, created_at DESC, id DESC
-      ),
-      upserted AS (
-        INSERT INTO votes (user_id, entity_type, entity_id, value, created_at)
-        SELECT user_id,
-               'gym'::social_entity_type,
-               ${canonicalGym.uuid},
-               value,
-               created_at
-          FROM latest_votes
-        ON CONFLICT (user_id, entity_type, entity_id) DO UPDATE
-          SET value = excluded.value,
-              created_at = excluded.created_at
-        RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM upserted
-    `,
-  );
-
-  votesDeleted = await executeCount(
-    commandDb,
-    sql`
-      WITH deleted AS (
-        DELETE FROM votes
-         WHERE entity_type = 'gym'::social_entity_type
-           AND entity_id IN (${duplicateGymUuidList})
-         RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM deleted
-    `,
-  );
-  await rebuildGymVoteCounts(commandDb, [canonicalGym.uuid, ...duplicateGymUuids]);
-  await setVoteCountMaintenanceSkipped(commandDb, false);
-
-  // Point each soft-deleted twin at the survivor so the backend's canonical
-  // resolution can follow the pointer — a deduped gym's old uuid/slug (printed
-  // kiosk QRs) then redirects to the canonical gym instead of 404ing.
-  const duplicateGymsSoftDeleted = await executeCount(
-    commandDb,
-    sql`
-      WITH soft_deleted AS (
-        UPDATE gyms
-           SET is_public = false,
-               deleted_at = NOW(),
-               merged_into_gym_id = ${canonicalGym.id},
-               updated_at = NOW()
-         WHERE id IN (${duplicateGymIdList})
-         RETURNING 1
-      )
-      SELECT count(*)::int AS count FROM soft_deleted
-    `,
-  );
-
-  return {
-    boardRowsMoved,
-    sourceAliasesMoved,
-    followsInserted,
-    followsDeleted,
-    membersInsertedOrUpdated,
-    membersDeleted,
-    commentsMoved,
-    feedItemsMoved,
-    notificationsMoved,
-    votesUpserted,
-    votesDeleted,
-    duplicateGymsSoftDeleted,
-  };
-}
-
-function emptyMergeCounts(): MergeCounts {
-  return {
-    boardRowsMoved: 0,
-    sourceAliasesMoved: 0,
-    followsInserted: 0,
-    followsDeleted: 0,
-    membersInsertedOrUpdated: 0,
-    membersDeleted: 0,
-    commentsMoved: 0,
-    feedItemsMoved: 0,
-    notificationsMoved: 0,
-    votesUpserted: 0,
-    votesDeleted: 0,
-    duplicateGymsSoftDeleted: 0,
-  };
-}
-
-function addMergeCounts(firstCounts: MergeCounts, secondCounts: MergeCounts): MergeCounts {
-  return {
-    boardRowsMoved: firstCounts.boardRowsMoved + secondCounts.boardRowsMoved,
-    sourceAliasesMoved: firstCounts.sourceAliasesMoved + secondCounts.sourceAliasesMoved,
-    followsInserted: firstCounts.followsInserted + secondCounts.followsInserted,
-    followsDeleted: firstCounts.followsDeleted + secondCounts.followsDeleted,
-    membersInsertedOrUpdated: firstCounts.membersInsertedOrUpdated + secondCounts.membersInsertedOrUpdated,
-    membersDeleted: firstCounts.membersDeleted + secondCounts.membersDeleted,
-    commentsMoved: firstCounts.commentsMoved + secondCounts.commentsMoved,
-    feedItemsMoved: firstCounts.feedItemsMoved + secondCounts.feedItemsMoved,
-    notificationsMoved: firstCounts.notificationsMoved + secondCounts.notificationsMoved,
-    votesUpserted: firstCounts.votesUpserted + secondCounts.votesUpserted,
-    votesDeleted: firstCounts.votesDeleted + secondCounts.votesDeleted,
-    duplicateGymsSoftDeleted: firstCounts.duplicateGymsSoftDeleted + secondCounts.duplicateGymsSoftDeleted,
-  };
-}
-
-function printMergeCounts(totalCounts: MergeCounts): void {
+function printMergeSummary(totalCounts: MergeCounts, warnings: MergeWarning[]): void {
   console.info('');
   console.info('[dedupe-gyms] Merge complete:');
   console.info(`  board rows moved: ${totalCounts.boardRowsMoved}`);
@@ -769,11 +456,180 @@ function printMergeCounts(totalCounts: MergeCounts): void {
   console.info(
     `  members inserted-or-updated/deleted: ${totalCounts.membersInsertedOrUpdated}/${totalCounts.membersDeleted}`,
   );
+  console.info(`  claims moved/expired: ${totalCounts.claimsMoved}/${totalCounts.claimsExpired}`);
+  console.info(`  kiosks moved: ${totalCounts.kiosksMoved}`);
   console.info(`  comments moved: ${totalCounts.commentsMoved}`);
   console.info(`  feed items moved: ${totalCounts.feedItemsMoved}`);
   console.info(`  notifications moved: ${totalCounts.notificationsMoved}`);
   console.info(`  votes upserted/deleted: ${totalCounts.votesUpserted}/${totalCounts.votesDeleted}`);
   console.info(`  duplicate gyms soft-deleted: ${totalCounts.duplicateGymsSoftDeleted}`);
+
+  if (warnings.length > 0) {
+    console.info('');
+    console.info(`[dedupe-gyms] ${warnings.length} warning(s):`);
+    for (const warning of warnings) {
+      console.info(
+        `  kiosk "${warning.kioskName}" (${warning.kioskUuid}) re-slugged ${warning.previousSlug} -> ${warning.newSlug}; its printed install QR must be reprinted.`,
+      );
+    }
+  }
+}
+
+/**
+ * Load every live gym with coordinates as a potential merge survivor for the
+ * pointer backfill, and every soft-deleted gym that lacks a merged_into pointer
+ * as a candidate twin.
+ */
+async function fetchBackfillGyms(
+  commandDb: ExecuteDb,
+  onlyName: string | null,
+  includeNonSystemTwins: boolean,
+): Promise<{ liveGyms: GymLocation[]; orphanTwins: GymLocation[] }> {
+  const nameClause = onlyName
+    ? sql`AND lower(regexp_replace(trim(name), '[[:space:]]+', ' ', 'g')) = lower(regexp_replace(trim(${onlyName}), '[[:space:]]+', ' ', 'g'))`
+    : sql``;
+  // The pre-M1 dedupe only ever merged SYSTEM-owned listings, so default to those.
+  // A false pointer redirects printed QRs to the wrong gym — worse than a 404.
+  const twinOwnerClause = includeNonSystemTwins ? sql`` : sql`AND owner_id = ${SYSTEM_USER_ID}`;
+
+  const liveRows = await executeRows<GymLocationRow>(
+    commandDb,
+    sql`
+      SELECT id AS "id", uuid AS "uuid", name AS "name", latitude AS "latitude", longitude AS "longitude"
+      FROM gyms
+      WHERE deleted_at IS NULL
+        AND latitude IS NOT NULL
+        AND longitude IS NOT NULL
+        ${nameClause}
+      ORDER BY id
+    `,
+  );
+
+  const orphanRows = await executeRows<GymLocationRow>(
+    commandDb,
+    sql`
+      SELECT id AS "id", uuid AS "uuid", name AS "name", latitude AS "latitude", longitude AS "longitude"
+      FROM gyms
+      WHERE deleted_at IS NOT NULL
+        AND merged_into_gym_id IS NULL
+        AND latitude IS NOT NULL
+        AND longitude IS NOT NULL
+        ${twinOwnerClause}
+        ${nameClause}
+      ORDER BY id
+    `,
+  );
+
+  return {
+    liveGyms: liveRows.map(coerceGymLocation),
+    orphanTwins: orphanRows.map(coerceGymLocation),
+  };
+}
+
+/**
+ * Match each pre-pointer soft-deleted twin to a live survivor sharing its
+ * normalized name within the drift band — but only when the survivor is
+ * UNAMBIGUOUS. If a second live gym also sits in the band, the twin is reported
+ * and left un-pointed: a wrong pointer would redirect printed QRs to the wrong
+ * gym, worse than the current 404.
+ */
+function matchTwinsToSurvivors(
+  liveGyms: GymLocation[],
+  orphanTwins: GymLocation[],
+): { matches: PointerBackfillMatch[]; ambiguousTwins: Array<{ twin: GymLocation; candidateCount: number }> } {
+  const liveByName = new Map<string, GymLocation[]>();
+  for (const liveGym of liveGyms) {
+    const normalizedName = normalizeGymName(liveGym.name);
+    const matches = liveByName.get(normalizedName) ?? [];
+    matches.push(liveGym);
+    liveByName.set(normalizedName, matches);
+  }
+
+  const backfillMatches: PointerBackfillMatch[] = [];
+  const ambiguousTwins: Array<{ twin: GymLocation; candidateCount: number }> = [];
+  for (const twin of orphanTwins) {
+    const candidates = liveByName.get(normalizeGymName(twin.name)) ?? [];
+    const inBand = candidates
+      .map((survivor) => ({ survivor, distance: distanceMeters(twin, survivor) }))
+      .filter((entry) => entry.distance <= BACKFILL_MATCH_DISTANCE_METERS)
+      .sort((first, second) => first.distance - second.distance);
+
+    if (inBand.length === 0) {
+      continue;
+    }
+    if (inBand.length > 1) {
+      ambiguousTwins.push({ twin, candidateCount: inBand.length });
+      continue;
+    }
+    backfillMatches.push({ twin, survivor: inBand[0].survivor, distance: inBand[0].distance });
+  }
+
+  return { matches: backfillMatches, ambiguousTwins };
+}
+
+async function runPointerBackfill(commandDb: ScriptDbInstance, scriptArgs: ScriptArgs): Promise<void> {
+  const { liveGyms, orphanTwins } = await fetchBackfillGyms(
+    commandDb,
+    scriptArgs.onlyName,
+    scriptArgs.includeNonSystemTwins,
+  );
+  const { matches: allMatches, ambiguousTwins } = matchTwinsToSurvivors(liveGyms, orphanTwins);
+  const matches = scriptArgs.limit ? allMatches.slice(0, scriptArgs.limit) : allMatches;
+
+  console.info(
+    `[dedupe-gyms] Pointer backfill: ${orphanTwins.length} soft-deleted ${scriptArgs.includeNonSystemTwins ? '' : 'SYSTEM-owned '}twin(s) without a pointer, ` +
+      `${matches.length} unambiguous survivor match(es) within ${BACKFILL_MATCH_DISTANCE_METERS} m, ${ambiguousTwins.length} skipped as ambiguous.`,
+  );
+
+  for (const match of matches) {
+    const tier = match.distance <= PHYSICAL_GYM_MATCH_DISTANCE_METERS ? 'A' : 'B';
+    console.info(
+      `  twin #${match.twin.id} (${match.twin.uuid}) -> survivor #${match.survivor.id} (${match.survivor.uuid}) ` +
+        `[${match.twin.name}] ${match.distance.toFixed(1)} m, tier ${tier}`,
+    );
+  }
+
+  for (const ambiguous of ambiguousTwins) {
+    console.info(
+      `  SKIP (ambiguous) twin #${ambiguous.twin.id} (${ambiguous.twin.uuid}) [${ambiguous.twin.name}] — ` +
+        `${ambiguous.candidateCount} live gyms within ${BACKFILL_MATCH_DISTANCE_METERS} m; not pointing.`,
+    );
+  }
+
+  if (!scriptArgs.apply || matches.length === 0) {
+    if (!scriptArgs.apply) {
+      console.info('');
+      console.info('[dedupe-gyms] Dry-run only. Re-run with --backfill-pointers --apply to set these pointers.');
+    }
+    return;
+  }
+
+  const pointersSet = await commandDb.transaction(async (transaction) => {
+    let updated = 0;
+    for (const match of matches) {
+      // Only write the pointer when it is still unset (guards against a
+      // concurrent merge having claimed the twin in the meantime).
+      updated += await executeCount(
+        transaction,
+        sql`
+          WITH pointed AS (
+            UPDATE gyms
+               SET merged_into_gym_id = ${match.survivor.id},
+                   updated_at = NOW()
+             WHERE id = ${match.twin.id}
+               AND merged_into_gym_id IS NULL
+               AND deleted_at IS NOT NULL
+             RETURNING 1
+          )
+          SELECT count(*)::int AS count FROM pointed
+        `,
+      );
+    }
+    return updated;
+  });
+
+  console.info('');
+  console.info(`[dedupe-gyms] Pointer backfill complete: ${pointersSet} pointer(s) set.`);
 }
 
 async function main(): Promise<void> {
@@ -786,6 +642,11 @@ async function main(): Promise<void> {
   const { db, close } = createScriptDb();
 
   try {
+    if (scriptArgs.backfillPointers) {
+      await runPointerBackfill(db, scriptArgs);
+      return;
+    }
+
     const candidates = await fetchCandidates(db, scriptArgs.onlyName);
     const allClusters = groupPhysicalGymCandidates(candidates, PHYSICAL_GYM_MATCH_DISTANCE_METERS);
     const selectedClusters = scriptArgs.limit ? allClusters.slice(0, scriptArgs.limit) : allClusters;
@@ -796,19 +657,21 @@ async function main(): Promise<void> {
       return;
     }
 
-    const totalCounts = await db.transaction(async (transaction) => {
+    const { totalCounts, warnings } = await db.transaction(async (transaction) => {
       await transaction.execute(sql`SELECT pg_advisory_xact_lock(hashtext('boardsesh:gym-location-dedupe'))`);
 
       let aggregateCounts = emptyMergeCounts();
+      const aggregateWarnings: MergeWarning[] = [];
       for (const cluster of selectedClusters) {
         const lockedCluster = await refetchClusterForApply(transaction, cluster);
-        const clusterCounts = await mergeGymCluster(transaction, lockedCluster);
-        aggregateCounts = addMergeCounts(aggregateCounts, clusterCounts);
+        const clusterResult = await mergeGymCluster(transaction, lockedCluster);
+        aggregateCounts = addMergeCounts(aggregateCounts, clusterResult.counts);
+        aggregateWarnings.push(...clusterResult.warnings);
       }
-      return aggregateCounts;
+      return { totalCounts: aggregateCounts, warnings: aggregateWarnings };
     });
 
-    printMergeCounts(totalCounts);
+    printMergeSummary(totalCounts, warnings);
   } finally {
     await close();
   }

--- a/packages/db/src/queries/gyms/index.ts
+++ b/packages/db/src/queries/gyms/index.ts
@@ -1,1 +1,2 @@
 export * from './location-dedupe';
+export * from './merge-gyms';

--- a/packages/db/src/queries/gyms/merge-gyms.ts
+++ b/packages/db/src/queries/gyms/merge-gyms.ts
@@ -1,0 +1,787 @@
+import { createHash } from 'node:crypto';
+import { sql, type SQLWrapper } from 'drizzle-orm';
+// Extensionless relative imports, matching the rest of packages/db/src (e.g.
+// queries/gyms/index.ts). merge-gyms is pulled into the web import graph via
+// @boardsesh/db, and Turbopack can't map a `.js` specifier onto the `.ts` source.
+import { executeRows } from '../../client/index';
+import {
+  chooseCanonicalGymCandidate,
+  compareCanonicalGymCandidates,
+  hasText,
+  type CanonicalGymCandidate,
+  type PhysicalGymCluster,
+} from './location-dedupe';
+
+/**
+ * The minimal database surface the merge needs: a single `execute` that runs a
+ * Drizzle `sql` fragment. Both the backend's Drizzle client and a script/backend
+ * transaction satisfy it, so the same merge runs from the CLI dedupe tool and
+ * from the admin GraphQL mutation.
+ */
+export type MergeExecuteDb = {
+  execute(query: SQLWrapper | string): PromiseLike<unknown>;
+};
+
+/**
+ * Counts of what a single canonical merge re-pointed. One object per merged
+ * duplicate (or the sum across a cluster). Written to the merge audit and
+ * surfaced in the admin confirm dialog.
+ */
+export type MergeCounts = {
+  boardRowsMoved: number;
+  sourceAliasesMoved: number;
+  followsInserted: number;
+  followsDeleted: number;
+  membersInsertedOrUpdated: number;
+  membersDeleted: number;
+  claimsMoved: number;
+  // Pending claims the claimant already duplicated on the canonical (or extra
+  // twins of their own): instead of being deleted, they are re-pointed to the
+  // canonical and flipped to `expired` so no content is lost — the claimant's
+  // live canonical claim still stands.
+  claimsExpired: number;
+  kiosksMoved: number;
+  commentsMoved: number;
+  feedItemsMoved: number;
+  notificationsMoved: number;
+  votesUpserted: number;
+  votesDeleted: number;
+  duplicateGymsSoftDeleted: number;
+};
+
+/**
+ * The identifiers of every row a merge re-pointed, per table. Written to the
+ * merge audit (jsonb) so a bad merge can be traced and manually reversed —
+ * aggregate counts alone can't tell you WHICH boards/members/claims moved.
+ */
+export type MergeMovedRows = {
+  boardIds: number[];
+  sourceKeys: string[];
+  followUserIds: string[];
+  memberUserIds: string[];
+  // Claims re-pointed to the canonical keeping their status (pending promotions +
+  // non-pending history).
+  movedClaimIds: number[];
+  // Claims re-pointed to the canonical AND flipped to `expired` (the collided /
+  // extra pending claims that would otherwise trip the unique-pending index).
+  expiredClaimIds: number[];
+  kioskIds: number[];
+  commentIds: number[];
+  feedItemIds: number[];
+  notificationIds: number[];
+  voteUserIds: string[];
+  softDeletedGymIds: number[];
+};
+
+/**
+ * A non-fatal side effect the admin must be told about. Today the only kind is a
+ * kiosk whose slug collided on the canonical gym and had to be suffixed — that
+ * re-slug invalidates the kiosk's printed install QR, so the UI surfaces it.
+ */
+export type MergeWarning = {
+  type: 'kiosk_slug_changed';
+  kioskUuid: string;
+  kioskName: string;
+  previousSlug: string;
+  newSlug: string;
+};
+
+export type MergeResult = {
+  counts: MergeCounts;
+  warnings: MergeWarning[];
+  movedRows: MergeMovedRows;
+};
+
+export function emptyMergeMovedRows(): MergeMovedRows {
+  return {
+    boardIds: [],
+    sourceKeys: [],
+    followUserIds: [],
+    memberUserIds: [],
+    movedClaimIds: [],
+    expiredClaimIds: [],
+    kioskIds: [],
+    commentIds: [],
+    feedItemIds: [],
+    notificationIds: [],
+    voteUserIds: [],
+    softDeletedGymIds: [],
+  };
+}
+
+const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+
+// The social tables' entity_type is a `social_entity_type` enum in prod but a
+// plain text column in the backend test schema. A bare untyped `'gym'` literal
+// coerces to the enum in prod AND string-compares against the text column in
+// tests — an explicit `::social_entity_type` cast would 500 against the test DB.
+
+type CountRow = {
+  count: number | string | null;
+};
+
+type IdRow = {
+  id: number | string;
+};
+
+type UserIdRow = {
+  userId: string;
+};
+
+type SourceKeyRow = {
+  sourceKey: string;
+};
+
+type DuplicateKioskRow = {
+  id: number | string;
+  uuid: string;
+  name: string;
+  slug: string;
+};
+
+type SlugRow = {
+  slug: string;
+};
+
+export function emptyMergeCounts(): MergeCounts {
+  return {
+    boardRowsMoved: 0,
+    sourceAliasesMoved: 0,
+    followsInserted: 0,
+    followsDeleted: 0,
+    membersInsertedOrUpdated: 0,
+    membersDeleted: 0,
+    claimsMoved: 0,
+    claimsExpired: 0,
+    kiosksMoved: 0,
+    commentsMoved: 0,
+    feedItemsMoved: 0,
+    notificationsMoved: 0,
+    votesUpserted: 0,
+    votesDeleted: 0,
+    duplicateGymsSoftDeleted: 0,
+  };
+}
+
+export function addMergeCounts(firstCounts: MergeCounts, secondCounts: MergeCounts): MergeCounts {
+  return {
+    boardRowsMoved: firstCounts.boardRowsMoved + secondCounts.boardRowsMoved,
+    sourceAliasesMoved: firstCounts.sourceAliasesMoved + secondCounts.sourceAliasesMoved,
+    followsInserted: firstCounts.followsInserted + secondCounts.followsInserted,
+    followsDeleted: firstCounts.followsDeleted + secondCounts.followsDeleted,
+    membersInsertedOrUpdated: firstCounts.membersInsertedOrUpdated + secondCounts.membersInsertedOrUpdated,
+    membersDeleted: firstCounts.membersDeleted + secondCounts.membersDeleted,
+    claimsMoved: firstCounts.claimsMoved + secondCounts.claimsMoved,
+    claimsExpired: firstCounts.claimsExpired + secondCounts.claimsExpired,
+    kiosksMoved: firstCounts.kiosksMoved + secondCounts.kiosksMoved,
+    commentsMoved: firstCounts.commentsMoved + secondCounts.commentsMoved,
+    feedItemsMoved: firstCounts.feedItemsMoved + secondCounts.feedItemsMoved,
+    notificationsMoved: firstCounts.notificationsMoved + secondCounts.notificationsMoved,
+    votesUpserted: firstCounts.votesUpserted + secondCounts.votesUpserted,
+    votesDeleted: firstCounts.votesDeleted + secondCounts.votesDeleted,
+    duplicateGymsSoftDeleted: firstCounts.duplicateGymsSoftDeleted + secondCounts.duplicateGymsSoftDeleted,
+  };
+}
+
+/**
+ * A stable identity for a candidate cluster: the sorted member gym ids hashed to
+ * a fixed-length hex string. The queue keys dismissed clusters on this so the
+ * same set of gyms (in any order) is hidden after an admin dismisses it.
+ */
+export function computeClusterSignature(gymIds: number[]): string {
+  const sortedIds = [...gymIds].sort((firstId, secondId) => firstId - secondId).join(',');
+  return createHash('sha256').update(sortedIds).digest('hex');
+}
+
+function pickTextField(
+  candidates: CanonicalGymCandidate[],
+  fieldName: 'address' | 'contactEmail' | 'contactPhone' | 'description' | 'imageUrl',
+): string | null {
+  for (const candidate of candidates) {
+    const candidateValue = candidate[fieldName];
+    if (hasText(candidateValue)) {
+      return candidateValue;
+    }
+  }
+  return null;
+}
+
+function idsFromCandidates(candidates: CanonicalGymCandidate[]): number[] {
+  return candidates.map((candidate) => candidate.id);
+}
+
+function uuidsFromCandidates(candidates: CanonicalGymCandidate[]): string[] {
+  return candidates.map((candidate) => candidate.uuid);
+}
+
+function sqlNumberList(values: number[]): SQLWrapper {
+  return sql.join(
+    values.map((value) => sql`${value}`),
+    sql`, `,
+  );
+}
+
+function sqlTextList(values: string[]): SQLWrapper {
+  return sql.join(
+    values.map((value) => sql`${value}`),
+    sql`, `,
+  );
+}
+
+async function executeCount(commandDb: MergeExecuteDb, query: SQLWrapper): Promise<number> {
+  const [row] = await executeRows<CountRow>(commandDb, query);
+  return Number(row?.count ?? 0);
+}
+
+async function setVoteCountMaintenanceSkipped(commandDb: MergeExecuteDb, skipped: boolean): Promise<void> {
+  await commandDb.execute(sql`SELECT set_config('boardsesh.skip_vote_counts', ${skipped ? 'on' : 'off'}, true)`);
+}
+
+async function rebuildGymVoteCounts(commandDb: MergeExecuteDb, gymUuids: string[]): Promise<void> {
+  const gymUuidList = sqlTextList(gymUuids);
+  await commandDb.execute(sql`
+    DELETE FROM vote_counts
+     WHERE entity_type = 'gym'
+       AND entity_id IN (${gymUuidList})
+  `);
+
+  await commandDb.execute(sql`
+    INSERT INTO vote_counts (entity_type, entity_id, upvotes, downvotes, score, hot_score, created_at)
+    SELECT
+      vote_totals.entity_type,
+      vote_totals.entity_id,
+      vote_totals.upvotes,
+      vote_totals.downvotes,
+      vote_totals.score,
+      SIGN(vote_totals.score) * LN(GREATEST(ABS(vote_totals.score), 1))
+        + EXTRACT(EPOCH FROM COALESCE(feed_created_at.created_at, vote_totals.first_vote_created_at, NOW())) / 45000.0,
+      COALESCE(feed_created_at.created_at, vote_totals.first_vote_created_at, NOW())
+    FROM (
+      SELECT
+        votes.entity_type,
+        votes.entity_id,
+        SUM(CASE WHEN votes.value = 1 THEN 1 ELSE 0 END)::int AS upvotes,
+        SUM(CASE WHEN votes.value = -1 THEN 1 ELSE 0 END)::int AS downvotes,
+        SUM(votes.value)::int AS score,
+        MIN(votes.created_at) AS first_vote_created_at
+      FROM votes
+      WHERE votes.entity_type = 'gym'
+        AND votes.entity_id IN (${gymUuidList})
+      GROUP BY votes.entity_type, votes.entity_id
+    ) vote_totals
+    LEFT JOIN LATERAL (
+      SELECT feed_items.created_at
+      FROM feed_items
+      WHERE feed_items.entity_type = vote_totals.entity_type
+        AND feed_items.entity_id = vote_totals.entity_id
+      ORDER BY feed_items.created_at ASC, feed_items.id ASC
+      LIMIT 1
+    ) feed_created_at ON true
+    ON CONFLICT (entity_type, entity_id) DO UPDATE SET
+      upvotes = excluded.upvotes,
+      downvotes = excluded.downvotes,
+      score = excluded.score,
+      hot_score = excluded.hot_score,
+      created_at = excluded.created_at
+  `);
+}
+
+/**
+ * Re-point every gym claim on a duplicate to the canonical gym, honouring the
+ * `gym_claims_unique_pending` partial index (one pending claim per gym + claimant).
+ *
+ * A claimant mid-flight on a twin must land on the canonical without losing their
+ * place. Because the target may already carry that claimant's pending claim (and
+ * a claimant can even have pending claims on several twins in the same cluster),
+ * a naive `UPDATE ... SET gym_id = canonical` would trip the unique index. So:
+ *  1. Promote at most one duplicate pending claim per claimant who has no pending
+ *     claim on the canonical yet — moved keeping its `pending` status.
+ *  2. Re-point any REMAINING pending claims on the duplicates (they collided with
+ *     an existing canonical claim, or were the claimant's extra twins) to the
+ *     canonical AND flip them to `expired` — never delete. Their full content
+ *     (claimant, method, message, timestamps) is preserved on the survivor for
+ *     audit/reversal; `expired` keeps them clear of the unique-pending index.
+ * Non-pending claims (approved/denied/expired) carry no unique constraint and are
+ * moved wholesale so the ownership history follows the survivor.
+ */
+async function repointClaims(
+  commandDb: MergeExecuteDb,
+  canonicalGymId: number,
+  duplicateGymIdList: SQLWrapper,
+): Promise<{ movedClaimIds: number[]; expiredClaimIds: number[] }> {
+  const promoted = await executeRows<IdRow>(
+    commandDb,
+    sql`
+      WITH promotable AS (
+        SELECT DISTINCT ON (claimant_user_id) id
+          FROM gym_claims
+         WHERE gym_id IN (${duplicateGymIdList})
+           AND status = 'pending'
+           AND claimant_user_id NOT IN (
+             SELECT claimant_user_id
+               FROM gym_claims
+              WHERE gym_id = ${canonicalGymId}
+                AND status = 'pending'
+           )
+         ORDER BY claimant_user_id, created_at DESC, id DESC
+      ),
+      moved AS (
+        UPDATE gym_claims
+           SET gym_id = ${canonicalGymId},
+               updated_at = NOW()
+         WHERE id IN (SELECT id FROM promotable)
+         RETURNING id
+      )
+      SELECT id FROM moved
+    `,
+  );
+
+  const expired = await executeRows<IdRow>(
+    commandDb,
+    sql`
+      WITH expired AS (
+        UPDATE gym_claims
+           SET gym_id = ${canonicalGymId},
+               status = 'expired',
+               updated_at = NOW()
+         WHERE gym_id IN (${duplicateGymIdList})
+           AND status = 'pending'
+         RETURNING id
+      )
+      SELECT id FROM expired
+    `,
+  );
+
+  const history = await executeRows<IdRow>(
+    commandDb,
+    sql`
+      WITH moved AS (
+        UPDATE gym_claims
+           SET gym_id = ${canonicalGymId},
+               updated_at = NOW()
+         WHERE gym_id IN (${duplicateGymIdList})
+           AND status <> 'pending'
+         RETURNING id
+      )
+      SELECT id FROM moved
+    `,
+  );
+
+  return {
+    movedClaimIds: [...promoted.map((row) => Number(row.id)), ...history.map((row) => Number(row.id))],
+    expiredClaimIds: expired.map((row) => Number(row.id)),
+  };
+}
+
+/**
+ * Move a duplicate's live kiosks onto the canonical gym. A kiosk slug is unique
+ * per live gym, so a duplicate kiosk whose slug is already taken on the canonical
+ * (or by an earlier-moved sibling in this same merge) gets a numeric suffix and a
+ * warning — a re-slugged kiosk's printed install QR no longer resolves, and the
+ * gym needs to reprint it. Soft-deleted kiosks stay on the dead twin; they're
+ * already gone and never contend for a slug.
+ */
+async function repointKiosks(
+  commandDb: MergeExecuteDb,
+  canonicalGymId: number,
+  duplicateGymIdList: SQLWrapper,
+): Promise<{ kioskIds: number[]; warnings: MergeWarning[] }> {
+  const duplicateKiosks = await executeRows<DuplicateKioskRow>(
+    commandDb,
+    sql`
+      SELECT id, uuid, name, slug
+        FROM gym_kiosks
+       WHERE gym_id IN (${duplicateGymIdList})
+         AND deleted_at IS NULL
+       ORDER BY id
+    `,
+  );
+
+  if (duplicateKiosks.length === 0) {
+    return { kioskIds: [], warnings: [] };
+  }
+
+  const canonicalSlugs = await executeRows<SlugRow>(
+    commandDb,
+    sql`
+      SELECT slug
+        FROM gym_kiosks
+       WHERE gym_id = ${canonicalGymId}
+         AND deleted_at IS NULL
+    `,
+  );
+  const takenSlugs = new Set(canonicalSlugs.map((row) => row.slug));
+
+  const warnings: MergeWarning[] = [];
+  const kioskIds: number[] = [];
+
+  for (const kiosk of duplicateKiosks) {
+    let nextSlug = kiosk.slug;
+    if (takenSlugs.has(nextSlug)) {
+      let suffix = 2;
+      while (takenSlugs.has(`${kiosk.slug}-${suffix}`)) {
+        suffix += 1;
+      }
+      nextSlug = `${kiosk.slug}-${suffix}`;
+      warnings.push({
+        type: 'kiosk_slug_changed',
+        kioskUuid: kiosk.uuid,
+        kioskName: kiosk.name,
+        previousSlug: kiosk.slug,
+        newSlug: nextSlug,
+      });
+    }
+    takenSlugs.add(nextSlug);
+    await commandDb.execute(sql`
+      UPDATE gym_kiosks
+         SET gym_id = ${canonicalGymId},
+             slug = ${nextSlug},
+             updated_at = NOW()
+       WHERE id = ${Number(kiosk.id)}
+    `);
+    kioskIds.push(Number(kiosk.id));
+  }
+
+  return { kioskIds, warnings };
+}
+
+/**
+ * Fold one or more duplicate gyms into an explicitly chosen canonical survivor.
+ *
+ * Re-points every owned/social/sync row (boards, source aliases, follows,
+ * members, claims, kiosks, comments, feed items, notifications, votes), backfills
+ * any empty canonical metadata from the duplicates, rebuilds the affected gyms'
+ * vote counts, then soft-deletes each duplicate with `merged_into_gym_id` set to
+ * the survivor so old uuids/slugs (printed kiosk QRs) resolve to the canonical.
+ *
+ * The caller supplies the canonical — the admin queue lets a human pick it. Runs
+ * every statement on the passed connection, so wrap it in a transaction (and an
+ * advisory lock for the batch CLI) at the call site.
+ */
+export async function mergeGymsIntoCanonical(
+  commandDb: MergeExecuteDb,
+  canonicalGym: CanonicalGymCandidate,
+  duplicateGyms: CanonicalGymCandidate[],
+): Promise<MergeResult> {
+  if (duplicateGyms.length === 0) {
+    return { counts: emptyMergeCounts(), warnings: [], movedRows: emptyMergeMovedRows() };
+  }
+  if (duplicateGyms.some((duplicate) => duplicate.id === canonicalGym.id)) {
+    throw new Error('mergeGymsIntoCanonical: the canonical gym cannot also be a duplicate.');
+  }
+
+  const allCandidatesForMetadata = [canonicalGym, ...duplicateGyms].sort(compareCanonicalGymCandidates);
+  const duplicateGymIds = idsFromCandidates(duplicateGyms);
+  const duplicateGymUuids = uuidsFromCandidates(duplicateGyms);
+  const duplicateGymIdList = sqlNumberList(duplicateGymIds);
+  const duplicateGymUuidList = sqlTextList(duplicateGymUuids);
+  const allGymUuidList = sqlTextList([canonicalGym.uuid, ...duplicateGymUuids]);
+
+  // Backfill only EMPTY canonical metadata from the duplicates. Critically, the
+  // canonical's own is_public is left untouched — merging into a user-owned
+  // PRIVATE gym must never force-publish it. deleted_at is cleared defensively
+  // (the caller always picks a live survivor, so this is a no-op in practice).
+  await commandDb.execute(sql`
+    UPDATE gyms
+       SET address = COALESCE(NULLIF(address, ''), ${pickTextField(allCandidatesForMetadata, 'address')}),
+           contact_email = COALESCE(NULLIF(contact_email, ''), ${pickTextField(allCandidatesForMetadata, 'contactEmail')}),
+           contact_phone = COALESCE(NULLIF(contact_phone, ''), ${pickTextField(allCandidatesForMetadata, 'contactPhone')}),
+           description = COALESCE(NULLIF(description, ''), ${pickTextField(allCandidatesForMetadata, 'description')}),
+           image_url = COALESCE(NULLIF(image_url, ''), ${pickTextField(allCandidatesForMetadata, 'imageUrl')}),
+           deleted_at = NULL,
+           updated_at = NOW()
+     WHERE id = ${canonicalGym.id}
+  `);
+
+  const boardRows = await executeRows<IdRow>(
+    commandDb,
+    sql`
+      WITH moved AS (
+        UPDATE user_boards
+           SET gym_id = ${canonicalGym.id},
+               updated_at = NOW()
+         WHERE gym_id IN (${duplicateGymIdList})
+         RETURNING id
+      )
+      SELECT id FROM moved
+    `,
+  );
+
+  const sourceRows = await executeRows<SourceKeyRow>(
+    commandDb,
+    sql`
+      WITH moved AS (
+        UPDATE location_sync_gym_sources
+           SET gym_id = ${canonicalGym.id},
+               updated_at = NOW()
+         WHERE gym_id IN (${duplicateGymIdList})
+         RETURNING source_key AS "sourceKey"
+      )
+      SELECT "sourceKey" FROM moved
+    `,
+  );
+
+  const followRows = await executeRows<UserIdRow>(
+    commandDb,
+    sql`
+      WITH inserted AS (
+        INSERT INTO gym_follows (gym_id, user_id, created_at)
+        SELECT ${canonicalGym.id}, user_id, MIN(created_at)
+          FROM gym_follows
+         WHERE gym_id IN (${duplicateGymIdList})
+         GROUP BY user_id
+        ON CONFLICT (gym_id, user_id) DO NOTHING
+        RETURNING user_id AS "userId"
+      )
+      SELECT "userId" FROM inserted
+    `,
+  );
+
+  const followsDeleted = await executeCount(
+    commandDb,
+    sql`
+      WITH deleted AS (
+        DELETE FROM gym_follows
+         WHERE gym_id IN (${duplicateGymIdList})
+         RETURNING 1
+      )
+      SELECT count(*)::int AS count FROM deleted
+    `,
+  );
+
+  // Collapse each user's memberships across the duplicates to their STRONGEST
+  // role, and on conflict keep the STRONGER of the canonical's own role and the
+  // incoming one. Precedence admin > editor > member on both sides — a twin's
+  // editor arrives as editor, and the canonical's existing editor is never
+  // rewritten down to member.
+  const memberRows = await executeRows<UserIdRow>(
+    commandDb,
+    sql`
+      WITH upserted AS (
+        INSERT INTO gym_members (gym_id, user_id, role, created_at)
+        SELECT ${canonicalGym.id},
+               user_id,
+               CASE
+                 WHEN bool_or(role = 'admin'::gym_member_role) THEN 'admin'::gym_member_role
+                 WHEN bool_or(role = 'editor'::gym_member_role) THEN 'editor'::gym_member_role
+                 ELSE 'member'::gym_member_role
+               END,
+               MIN(created_at)
+          FROM gym_members
+         WHERE gym_id IN (${duplicateGymIdList})
+         GROUP BY user_id
+        ON CONFLICT (gym_id, user_id) DO UPDATE
+          SET role = CASE
+            WHEN gym_members.role = 'admin'::gym_member_role OR excluded.role = 'admin'::gym_member_role
+              THEN 'admin'::gym_member_role
+            WHEN gym_members.role = 'editor'::gym_member_role OR excluded.role = 'editor'::gym_member_role
+              THEN 'editor'::gym_member_role
+            ELSE 'member'::gym_member_role
+          END
+        RETURNING user_id AS "userId"
+      )
+      SELECT "userId" FROM upserted
+    `,
+  );
+
+  const membersDeleted = await executeCount(
+    commandDb,
+    sql`
+      WITH deleted AS (
+        DELETE FROM gym_members
+         WHERE gym_id IN (${duplicateGymIdList})
+         RETURNING 1
+      )
+      SELECT count(*)::int AS count FROM deleted
+    `,
+  );
+
+  const { movedClaimIds, expiredClaimIds } = await repointClaims(commandDb, canonicalGym.id, duplicateGymIdList);
+
+  const { kioskIds, warnings } = await repointKiosks(commandDb, canonicalGym.id, duplicateGymIdList);
+
+  const commentRows = await executeRows<IdRow>(
+    commandDb,
+    sql`
+      WITH moved AS (
+        UPDATE comments
+           SET entity_id = ${canonicalGym.uuid},
+               updated_at = NOW()
+         WHERE entity_type = 'gym'
+           AND entity_id IN (${duplicateGymUuidList})
+         RETURNING id
+      )
+      SELECT id FROM moved
+    `,
+  );
+
+  const feedItemRows = await executeRows<IdRow>(
+    commandDb,
+    sql`
+      WITH moved AS (
+        UPDATE feed_items
+           SET entity_id = ${canonicalGym.uuid}
+         WHERE entity_type = 'gym'
+           AND entity_id IN (${duplicateGymUuidList})
+         RETURNING id
+      )
+      SELECT id FROM moved
+    `,
+  );
+
+  const notificationRows = await executeRows<IdRow>(
+    commandDb,
+    sql`
+      WITH moved AS (
+        UPDATE notifications
+           SET entity_id = ${canonicalGym.uuid}
+         WHERE entity_type = 'gym'
+           AND entity_id IN (${duplicateGymUuidList})
+         RETURNING id
+      )
+      SELECT id FROM moved
+    `,
+  );
+
+  await setVoteCountMaintenanceSkipped(commandDb, true);
+  // Vote consolidation is most-recent-wins: when a user voted on both the
+  // canonical and a duplicate, their newest vote (by created_at, then id) is the
+  // one kept on the survivor. This is the intended merge semantic — a person has
+  // one current opinion of the gym, not a sum of stale ones.
+  const voteRows = await executeRows<UserIdRow>(
+    commandDb,
+    sql`
+      WITH latest_votes AS (
+        SELECT DISTINCT ON (user_id)
+               user_id,
+               value,
+               created_at
+          FROM votes
+         WHERE entity_type = 'gym'
+           AND entity_id IN (${allGymUuidList})
+         ORDER BY user_id, created_at DESC, id DESC
+      ),
+      upserted AS (
+        INSERT INTO votes (user_id, entity_type, entity_id, value, created_at)
+        SELECT user_id,
+               'gym',
+               ${canonicalGym.uuid},
+               value,
+               created_at
+          FROM latest_votes
+        ON CONFLICT (user_id, entity_type, entity_id) DO UPDATE
+          SET value = excluded.value,
+              created_at = excluded.created_at
+        RETURNING user_id AS "userId"
+      )
+      SELECT "userId" FROM upserted
+    `,
+  );
+
+  const votesDeleted = await executeCount(
+    commandDb,
+    sql`
+      WITH deleted AS (
+        DELETE FROM votes
+         WHERE entity_type = 'gym'
+           AND entity_id IN (${duplicateGymUuidList})
+         RETURNING 1
+      )
+      SELECT count(*)::int AS count FROM deleted
+    `,
+  );
+  await rebuildGymVoteCounts(commandDb, [canonicalGym.uuid, ...duplicateGymUuids]);
+  await setVoteCountMaintenanceSkipped(commandDb, false);
+
+  // Point each soft-deleted twin at the survivor so the backend's canonical
+  // resolution can follow the pointer — a deduped gym's old uuid/slug (printed
+  // kiosk QRs) then redirects to the canonical gym instead of 404ing.
+  const softDeletedRows = await executeRows<IdRow>(
+    commandDb,
+    sql`
+      WITH soft_deleted AS (
+        UPDATE gyms
+           SET is_public = false,
+               deleted_at = NOW(),
+               merged_into_gym_id = ${canonicalGym.id},
+               updated_at = NOW()
+         WHERE id IN (${duplicateGymIdList})
+         RETURNING id
+      )
+      SELECT id FROM soft_deleted
+    `,
+  );
+
+  const movedRows: MergeMovedRows = {
+    boardIds: boardRows.map((row) => Number(row.id)),
+    sourceKeys: sourceRows.map((row) => row.sourceKey),
+    followUserIds: followRows.map((row) => row.userId),
+    memberUserIds: memberRows.map((row) => row.userId),
+    movedClaimIds,
+    expiredClaimIds,
+    kioskIds,
+    commentIds: commentRows.map((row) => Number(row.id)),
+    feedItemIds: feedItemRows.map((row) => Number(row.id)),
+    notificationIds: notificationRows.map((row) => Number(row.id)),
+    voteUserIds: voteRows.map((row) => row.userId),
+    softDeletedGymIds: softDeletedRows.map((row) => Number(row.id)),
+  };
+
+  return {
+    counts: {
+      boardRowsMoved: movedRows.boardIds.length,
+      sourceAliasesMoved: movedRows.sourceKeys.length,
+      followsInserted: movedRows.followUserIds.length,
+      followsDeleted,
+      membersInsertedOrUpdated: movedRows.memberUserIds.length,
+      membersDeleted,
+      claimsMoved: movedRows.movedClaimIds.length,
+      claimsExpired: movedRows.expiredClaimIds.length,
+      kiosksMoved: movedRows.kioskIds.length,
+      commentsMoved: movedRows.commentIds.length,
+      feedItemsMoved: movedRows.feedItemIds.length,
+      notificationsMoved: movedRows.notificationIds.length,
+      votesUpserted: movedRows.voteUserIds.length,
+      votesDeleted,
+      duplicateGymsSoftDeleted: movedRows.softDeletedGymIds.length,
+    },
+    warnings,
+    movedRows,
+  };
+}
+
+/**
+ * Choose the canonical + duplicate gyms for a cluster using the shared ranking
+ * (completeness, then oldest). Used by the CLI dedupe tool, where no human picks
+ * the survivor.
+ */
+export function selectClusterCandidates(cluster: PhysicalGymCluster<CanonicalGymCandidate>): {
+  canonicalGym: CanonicalGymCandidate;
+  duplicateGyms: CanonicalGymCandidate[];
+} {
+  const canonicalGym = chooseCanonicalGymCandidate(cluster.gyms);
+  if (!canonicalGym) {
+    throw new Error(`Duplicate cluster for ${cluster.normalizedName} has no canonical gym candidate.`);
+  }
+
+  const duplicateGyms = cluster.gyms
+    .filter((candidate) => candidate.id !== canonicalGym.id)
+    .sort(compareCanonicalGymCandidates);
+
+  return { canonicalGym, duplicateGyms };
+}
+
+/**
+ * Rule-based cluster merge for the CLI dedupe tool: pick the canonical with the
+ * shared ranking, then fold the rest in. The admin queue uses
+ * `mergeGymsIntoCanonical` directly with a human-picked survivor.
+ */
+export async function mergeGymCluster(
+  commandDb: MergeExecuteDb,
+  cluster: PhysicalGymCluster<CanonicalGymCandidate>,
+): Promise<MergeResult> {
+  const { canonicalGym, duplicateGyms } = selectClusterCandidates(cluster);
+  return mergeGymsIntoCanonical(commandDb, canonicalGym, duplicateGyms);
+}
+
+export { SYSTEM_USER_ID as MERGE_SYSTEM_USER_ID };

--- a/packages/db/src/schema/app/gym-merge-audit.ts
+++ b/packages/db/src/schema/app/gym-merge-audit.ts
@@ -1,0 +1,64 @@
+import { pgTable, bigserial, bigint, text, jsonb, timestamp, index, pgEnum } from 'drizzle-orm/pg-core';
+import { gyms } from './gyms';
+import { users } from '../auth/users';
+
+/**
+ * A merge either folds a duplicate gym into a canonical survivor ('merged') or
+ * records that an admin looked at a candidate cluster and decided it is NOT a
+ * duplicate ('dismissed'). Dismissals keep the cluster out of the review queue
+ * without touching any gym row.
+ */
+export const gymMergeAuditActionEnum = pgEnum('gym_merge_audit_action', ['merged', 'dismissed']);
+
+/**
+ * Audit trail for the /admin/gym-duplicates review queue.
+ *
+ * One row per admin decision:
+ *  - `merged`: a duplicate gym was folded into the canonical survivor. Both ids
+ *    are set, `moved_counts` records what was re-pointed (boards, follows,
+ *    members, kiosks, claims, ...) and `warnings` any side effects the admin
+ *    should know about (a kiosk whose slug was suffixed, invalidating its
+ *    printed install QR).
+ *  - `dismissed`: the admin decided the cluster is not a duplicate. `duplicate_gym_id`
+ *    is null; the row is keyed by `cluster_signature` (a stable hash of the sorted
+ *    member gym ids) so the queue can hide that exact cluster on the next load.
+ */
+export const gymMergeAudit = pgTable(
+  'gym_merge_audit',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    action: gymMergeAuditActionEnum('action').notNull(),
+    // Always populated on write; nullable at the DB level with ON DELETE SET NULL
+    // so a later hard-delete of a gym never strands an audit row.
+    canonicalGymId: bigint('canonical_gym_id', { mode: 'number' }).references(() => gyms.id, {
+      onDelete: 'set null',
+    }),
+    // Null for dismissals (no gym was merged); set for every 'merged' row.
+    duplicateGymId: bigint('duplicate_gym_id', { mode: 'number' }).references(() => gyms.id, {
+      onDelete: 'set null',
+    }),
+    // Stable hash of the sorted member gym ids — the cluster identity used to hide
+    // dismissed clusters from the queue.
+    clusterSignature: text('cluster_signature').notNull(),
+    // What the merge re-pointed (null for dismissals). Shape mirrors MergeCounts.
+    movedCounts: jsonb('moved_counts'),
+    // The identifiers of every re-pointed row, per table (shape mirrors
+    // MergeMovedRows). Null for dismissals. Aggregate counts can't say WHICH rows
+    // moved, so this is what a manual reversal of a bad merge reads.
+    movedRows: jsonb('moved_rows'),
+    // Non-fatal side effects the admin should see (kiosk slug changes). Array of
+    // MergeWarning; null for dismissals.
+    warnings: jsonb('warnings'),
+    // The admin who performed the action.
+    performedBy: text('performed_by').references(() => users.id, { onDelete: 'set null' }),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    // Serves the queue's "hide dismissed clusters" filter (action = 'dismissed').
+    signatureActionIdx: index('gym_merge_audit_signature_action_idx').on(table.clusterSignature, table.action),
+    canonicalIdx: index('gym_merge_audit_canonical_idx').on(table.canonicalGymId),
+  }),
+);
+
+export type GymMergeAudit = typeof gymMergeAudit.$inferSelect;
+export type NewGymMergeAudit = typeof gymMergeAudit.$inferInsert;

--- a/packages/db/src/schema/app/index.ts
+++ b/packages/db/src/schema/app/index.ts
@@ -1,5 +1,6 @@
 export * from './gyms';
 export * from './gym-kiosks';
+export * from './gym-merge-audit';
 export * from './boards';
 export * from './board-serials';
 export * from './sessions';

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -3142,6 +3142,210 @@ enum GymStatsPeriod {
 }
 
 # ============================================
+# Gym Duplicate Review (admin only)
+# ============================================
+
+"Who owns a gym row in the duplicate queue: the system import user, or a real person. (Distinct from GymOwnerType, which the similar-gyms search uses with SYSTEM/USER casing.)"
+enum DuplicateGymOwnerType {
+  "Owned by the system import user (a synced public listing)."
+  system
+  "Owned by a real Boardsesh user."
+  user
+}
+
+"The strongest ownership-claim state on a gym row."
+enum GymClusterClaimStatus {
+  "No claim on file."
+  none
+  "A claim is awaiting review or verification."
+  pending
+  "A claim was approved (ownership transferred)."
+  approved
+}
+
+"How tightly a candidate duplicate cluster's members sit together."
+enum DuplicateClusterTier {
+  "Every member within 20 m — almost certainly the same wall."
+  A
+  "Members within 150 m — the observed cross-provider coordinate-drift band."
+  B
+}
+
+"One gym row inside a candidate duplicate cluster, with the signals an admin needs to pick the survivor."
+type DuplicateGymMember {
+  "Gym UUID (always a live, canonical row)."
+  gymUuid: ID!
+  "Gym name."
+  name: String!
+  "Physical address (if known)."
+  address: String
+  "Whether the system import user or a real user owns this row."
+  ownerType: DuplicateGymOwnerType!
+  "Strongest ownership-claim state on this row."
+  claimStatus: GymClusterClaimStatus!
+  "Distinct location-sync provider origins (source_key prefixes: kilter, tension, ...)."
+  providerOrigins: [String!]!
+  "Linked, non-deleted boards."
+  boardCount: Int!
+  "Followers."
+  followerCount: Int!
+  "Members."
+  memberCount: Int!
+  "Live kiosks."
+  kioskCount: Int!
+  "Ownership claims on file (any status)."
+  claimCount: Int!
+  "When created."
+  createdAt: String!
+  "GPS latitude."
+  latitude: Float!
+  "GPS longitude."
+  longitude: Float!
+  "Distance in metres from this row to the cluster's suggested canonical survivor."
+  distanceToCanonicalMeters: Float!
+  "Whether the rule pre-selects this row as the canonical survivor (claimed/user-owned over system, then completeness/oldest)."
+  isSuggestedCanonical: Boolean!
+}
+
+"A candidate cluster of live gym rows that look like the same physical location."
+type DuplicateGymCluster {
+  "Stable identity (hash of the sorted member gym ids). Dismissals key on this."
+  signature: String!
+  "How tightly the members sit together."
+  tier: DuplicateClusterTier!
+  "The shared normalized name."
+  normalizedName: String!
+  "The rule's suggested canonical survivor (an admin may override)."
+  suggestedCanonicalGymUuid: ID!
+  "Largest pairwise distance in metres between any two members."
+  maxDistanceMeters: Float!
+  "The cluster's member rows."
+  members: [DuplicateGymMember!]!
+}
+
+"Paginated list of candidate duplicate clusters."
+type DuplicateGymClusterConnection {
+  "The clusters."
+  clusters: [DuplicateGymCluster!]!
+  "Total number of clusters (after dismissals are excluded)."
+  totalCount: Int!
+  "Whether more clusters are available."
+  hasMore: Boolean!
+}
+
+"Input for listing candidate duplicate clusters (admin only)."
+input DuplicateGymClustersInput {
+  "Max clusters to return."
+  limit: Int
+  "Offset for pagination."
+  offset: Int
+}
+
+"An alias-less, system-owned live gym with no location-sync source — an orphan for the audit list."
+type OrphanGym {
+  "Gym UUID."
+  gymUuid: ID!
+  "URL slug (null when unset — link via the uuid instead)."
+  slug: String
+  "Gym name."
+  name: String!
+  "Physical address (if known)."
+  address: String
+  "Linked, non-deleted boards."
+  boardCount: Int!
+  "Followers."
+  followerCount: Int!
+  "Members."
+  memberCount: Int!
+  "Live kiosks."
+  kioskCount: Int!
+  "When created."
+  createdAt: String!
+}
+
+"Paginated list of orphan gyms (list-only, no actions)."
+type OrphanGymConnection {
+  "The orphan gyms."
+  gyms: [OrphanGym!]!
+  "Total number of orphan gyms."
+  totalCount: Int!
+  "Whether more orphan gyms are available."
+  hasMore: Boolean!
+}
+
+"Input for the orphan-gym audit list (admin only)."
+input OrphanGymsInput {
+  "Max gyms to return."
+  limit: Int
+  "Offset for pagination."
+  offset: Int
+}
+
+"Input for merging duplicate gyms into a canonical survivor (admin only)."
+input MergeGymsInput {
+  "The survivor gym UUID."
+  canonicalGymUuid: ID!
+  "The gym UUIDs to fold into the survivor."
+  duplicateGymUuids: [ID!]!
+  "Explicit acknowledgement required to keep a SYSTEM listing as the survivor over a user-owned or claim-approved duplicate. Rejected without it."
+  allowSystemCanonicalOverride: Boolean
+}
+
+"A kiosk whose slug had to change during a merge — its printed install QR must be reprinted."
+type KioskSlugWarning {
+  "Kiosk UUID."
+  kioskUuid: ID!
+  "Kiosk name."
+  kioskName: String!
+  "Slug before the merge."
+  previousSlug: String!
+  "Slug after the merge (suffixed to avoid a collision on the canonical gym)."
+  newSlug: String!
+}
+
+"What one duplicate merge re-pointed onto the canonical gym."
+type GymMergeCounts {
+  "Boards moved."
+  boards: Int!
+  "Follows moved (deduped)."
+  follows: Int!
+  "Members moved (deduped)."
+  members: Int!
+  "Claims moved onto the canonical."
+  claims: Int!
+  "Kiosks moved."
+  kiosks: Int!
+  "Comments moved."
+  comments: Int!
+}
+
+"The result of folding one duplicate into the canonical."
+type GymMergeDuplicateResult {
+  "The duplicate that was merged."
+  duplicateGymUuid: ID!
+  "What moved."
+  counts: GymMergeCounts!
+  "Kiosk slug changes the admin must surface."
+  warnings: [KioskSlugWarning!]!
+}
+
+"The result of a mergeGyms call — one entry per merged duplicate."
+type MergeGymsResult {
+  "The survivor gym UUID."
+  canonicalGymUuid: ID!
+  "Per-duplicate outcomes."
+  results: [GymMergeDuplicateResult!]!
+}
+
+"Input for dismissing a candidate cluster (marks it not-a-duplicate; hides it from the queue)."
+input DismissGymClusterInput {
+  "All member gym UUIDs of the cluster (order-independent; used to compute the signature)."
+  gymUuids: [ID!]!
+  "The suggested canonical member, recorded on the dismissal audit row."
+  canonicalGymUuid: ID!
+}
+
+# ============================================
 # Gym Kiosk Types (smart-TV wall dashboard)
 # ============================================
 
@@ -5179,6 +5383,19 @@ type Query {
   """
   gymStats(input: GymStatsInput!): GymStats!
 
+  """
+  Candidate duplicate-gym clusters for the /admin/gym-duplicates review queue
+  (admin only). Tiered by how tightly members sit together (A: within 20 m,
+  B: within 150 m). Clusters an admin has dismissed are excluded. Paginated.
+  """
+  duplicateGymClusters(input: DuplicateGymClustersInput): DuplicateGymClusterConnection!
+
+  """
+  Alias-less, system-owned live gyms with no location-sync source — the orphan
+  audit list (admin only). List-only; no bulk action.
+  """
+  orphanGyms(input: OrphanGymsInput): OrphanGymConnection!
+
   # ============================================
   # Gym Kiosk Queries
   # ============================================
@@ -5953,6 +6170,21 @@ type Mutation {
   ownership to the claimant.
   """
   reviewGymClaim(input: ReviewGymClaimInput!): Boolean!
+
+  """
+  Fold one or more duplicate gyms into a canonical survivor (admin only). Every
+  duplicate's boards, follows, members, claims, kiosks, comments, feed items,
+  notifications, and votes re-point to the survivor, then each duplicate is
+  soft-deleted with a pointer to it. Returns per-duplicate moved counts and any
+  kiosk-slug-change warnings.
+  """
+  mergeGyms(input: MergeGymsInput!): MergeGymsResult!
+
+  """
+  Dismiss a candidate duplicate cluster (admin only). Records that the cluster is
+  not a duplicate so the review queue hides it. Touches no gym row.
+  """
+  dismissGymCluster(input: DismissGymClusterInput!): Boolean!
 
   # ============================================
   # Gym Kiosk Mutations (require gym edit access)

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1619,6 +1619,14 @@ export type DiscoverableSession = {
   participantCount: Scalars['Int']['output'];
 };
 
+/** Input for dismissing a candidate cluster (marks it not-a-duplicate; hides it from the queue). */
+export type DismissGymClusterInput = {
+  /** The suggested canonical member, recorded on the dismissal audit row. */
+  canonicalGymUuid: Scalars['ID']['input'];
+  /** All member gym UUIDs of the cluster (order-independent; used to compute the signature). */
+  gymUuids: Array<Scalars['ID']['input']>;
+};
+
 /**
  * DEPRECATED. Sessions are always-live; there is no wall driver. This type and its
  * SessionEvent union membership are kept purely so stale clients (cached web bundles,
@@ -1639,6 +1647,93 @@ export type DriverChanged = {
   driverParticipantId?: Maybe<Scalars['ID']['output']>;
   previousDriverParticipantId?: Maybe<Scalars['ID']['output']>;
 };
+
+/** How tightly a candidate duplicate cluster's members sit together. */
+export type DuplicateClusterTier =
+  /** Every member within 20 m — almost certainly the same wall. */
+  | 'A'
+  /** Members within 150 m — the observed cross-provider coordinate-drift band. */
+  | 'B';
+
+/** A candidate cluster of live gym rows that look like the same physical location. */
+export type DuplicateGymCluster = {
+  __typename?: 'DuplicateGymCluster';
+  /** Largest pairwise distance in metres between any two members. */
+  maxDistanceMeters: Scalars['Float']['output'];
+  /** The cluster's member rows. */
+  members: Array<DuplicateGymMember>;
+  /** The shared normalized name. */
+  normalizedName: Scalars['String']['output'];
+  /** Stable identity (hash of the sorted member gym ids). Dismissals key on this. */
+  signature: Scalars['String']['output'];
+  /** The rule's suggested canonical survivor (an admin may override). */
+  suggestedCanonicalGymUuid: Scalars['ID']['output'];
+  /** How tightly the members sit together. */
+  tier: DuplicateClusterTier;
+};
+
+/** Paginated list of candidate duplicate clusters. */
+export type DuplicateGymClusterConnection = {
+  __typename?: 'DuplicateGymClusterConnection';
+  /** The clusters. */
+  clusters: Array<DuplicateGymCluster>;
+  /** Whether more clusters are available. */
+  hasMore: Scalars['Boolean']['output'];
+  /** Total number of clusters (after dismissals are excluded). */
+  totalCount: Scalars['Int']['output'];
+};
+
+/** Input for listing candidate duplicate clusters (admin only). */
+export type DuplicateGymClustersInput = {
+  /** Max clusters to return. */
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  /** Offset for pagination. */
+  offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** One gym row inside a candidate duplicate cluster, with the signals an admin needs to pick the survivor. */
+export type DuplicateGymMember = {
+  __typename?: 'DuplicateGymMember';
+  /** Physical address (if known). */
+  address?: Maybe<Scalars['String']['output']>;
+  /** Linked, non-deleted boards. */
+  boardCount: Scalars['Int']['output'];
+  /** Ownership claims on file (any status). */
+  claimCount: Scalars['Int']['output'];
+  /** Strongest ownership-claim state on this row. */
+  claimStatus: GymClusterClaimStatus;
+  /** When created. */
+  createdAt: Scalars['String']['output'];
+  /** Distance in metres from this row to the cluster's suggested canonical survivor. */
+  distanceToCanonicalMeters: Scalars['Float']['output'];
+  /** Followers. */
+  followerCount: Scalars['Int']['output'];
+  /** Gym UUID (always a live, canonical row). */
+  gymUuid: Scalars['ID']['output'];
+  /** Whether the rule pre-selects this row as the canonical survivor (claimed/user-owned over system, then completeness/oldest). */
+  isSuggestedCanonical: Scalars['Boolean']['output'];
+  /** Live kiosks. */
+  kioskCount: Scalars['Int']['output'];
+  /** GPS latitude. */
+  latitude: Scalars['Float']['output'];
+  /** GPS longitude. */
+  longitude: Scalars['Float']['output'];
+  /** Members. */
+  memberCount: Scalars['Int']['output'];
+  /** Gym name. */
+  name: Scalars['String']['output'];
+  /** Whether the system import user or a real user owns this row. */
+  ownerType: DuplicateGymOwnerType;
+  /** Distinct location-sync provider origins (source_key prefixes: kilter, tension, ...). */
+  providerOrigins: Array<Scalars['String']['output']>;
+};
+
+/** Who owns a gym row in the duplicate queue: the system import user, or a real person. (Distinct from GymOwnerType, which the similar-gyms search uses with SYSTEM/USER casing.) */
+export type DuplicateGymOwnerType =
+  /** Owned by the system import user (a synced public listing). */
+  | 'system'
+  /** Owned by a real Boardsesh user. */
+  | 'user';
 
 /**
  * Response containing events since a given sequence number.
@@ -2266,6 +2361,15 @@ export type GymClaimRequestStatus =
 
 export type GymClaimStatus = 'approved' | 'denied' | 'expired' | 'pending';
 
+/** The strongest ownership-claim state on a gym row. */
+export type GymClusterClaimStatus =
+  /** A claim was approved (ownership transferred). */
+  | 'approved'
+  /** No claim on file. */
+  | 'none'
+  /** A claim is awaiting review or verification. */
+  | 'pending';
+
 /** Paginated list of gyms. */
 export type GymConnection = {
   __typename?: 'GymConnection';
@@ -2411,6 +2515,34 @@ export type GymMembersInput = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** Offset for pagination */
   offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** What one duplicate merge re-pointed onto the canonical gym. */
+export type GymMergeCounts = {
+  __typename?: 'GymMergeCounts';
+  /** Boards moved. */
+  boards: Scalars['Int']['output'];
+  /** Claims moved onto the canonical. */
+  claims: Scalars['Int']['output'];
+  /** Comments moved. */
+  comments: Scalars['Int']['output'];
+  /** Follows moved (deduped). */
+  follows: Scalars['Int']['output'];
+  /** Kiosks moved. */
+  kiosks: Scalars['Int']['output'];
+  /** Members moved (deduped). */
+  members: Scalars['Int']['output'];
+};
+
+/** The result of folding one duplicate into the canonical. */
+export type GymMergeDuplicateResult = {
+  __typename?: 'GymMergeDuplicateResult';
+  /** What moved. */
+  counts: GymMergeCounts;
+  /** The duplicate that was merged. */
+  duplicateGymUuid: Scalars['ID']['output'];
+  /** Kiosk slug changes the admin must surface. */
+  warnings: Array<KioskSlugWarning>;
 };
 
 /** Where a gym came from: an upstream provider sync or a Boardsesh user. */
@@ -2621,6 +2753,19 @@ export type KioskHeartbeatInput = {
   viewportWidth?: InputMaybe<Scalars['Int']['input']>;
 };
 
+/** A kiosk whose slug had to change during a merge — its printed install QR must be reprinted. */
+export type KioskSlugWarning = {
+  __typename?: 'KioskSlugWarning';
+  /** Kiosk name. */
+  kioskName: Scalars['String']['output'];
+  /** Kiosk UUID. */
+  kioskUuid: Scalars['ID']['output'];
+  /** Slug after the merge (suffixed to avoid a collision on the canonical gym). */
+  newSlug: Scalars['String']['output'];
+  /** Slug before the merge. */
+  previousSlug: Scalars['String']['output'];
+};
+
 /** Statistics for a specific board layout. */
 export type LayoutStats = {
   __typename?: 'LayoutStats';
@@ -2690,6 +2835,25 @@ export type LinkBoardToGymInput = {
   boardUuid: Scalars['ID']['input'];
   /** Gym UUID (null to unlink) */
   gymUuid?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Input for merging duplicate gyms into a canonical survivor (admin only). */
+export type MergeGymsInput = {
+  /** Explicit acknowledgement required to keep a SYSTEM listing as the survivor over a user-owned or claim-approved duplicate. Rejected without it. */
+  allowSystemCanonicalOverride?: InputMaybe<Scalars['Boolean']['input']>;
+  /** The survivor gym UUID. */
+  canonicalGymUuid: Scalars['ID']['input'];
+  /** The gym UUIDs to fold into the survivor. */
+  duplicateGymUuids: Array<Scalars['ID']['input']>;
+};
+
+/** The result of a mergeGyms call — one entry per merged duplicate. */
+export type MergeGymsResult = {
+  __typename?: 'MergeGymsResult';
+  /** The survivor gym UUID. */
+  canonicalGymUuid: Scalars['ID']['output'];
+  /** Per-duplicate outcomes. */
+  results: Array<GymMergeDuplicateResult>;
 };
 
 export type MoonBoardClimbDuplicateCandidateInput = {
@@ -2829,6 +2993,11 @@ export type Mutation = {
    */
   disconnectIntegration: Scalars['Boolean']['output'];
   /**
+   * Dismiss a candidate duplicate cluster (admin only). Records that the cluster is
+   * not a duplicate so the review queue hides it. Touches no gym row.
+   */
+  dismissGymCluster: Scalars['Boolean']['output'];
+  /**
    * End a session (active participant only). The optional `notes` is a
    * free-text end-of-session recap persisted on the session and echoed back on
    * the returned SessionSummary.
@@ -2880,6 +3049,14 @@ export type Mutation = {
   markGroupNotificationsRead: Scalars['Int']['output'];
   /** Mark a notification as read. */
   markNotificationRead: Scalars['Boolean']['output'];
+  /**
+   * Fold one or more duplicate gyms into a canonical survivor (admin only). Every
+   * duplicate's boards, follows, members, claims, kiosks, comments, feed items,
+   * notifications, and votes re-point to the survivor, then each duplicate is
+   * soft-deleted with a pointer to it. Returns per-duplicate moved counts and any
+   * kiosk-slug-change warnings.
+   */
+  mergeGyms: MergeGymsResult;
   /** Toggle mirrored display for the current climb. */
   mirrorCurrentClimb?: Maybe<ClimbQueueItem>;
   navigateQueue?: Maybe<ClimbQueueItem>;
@@ -3306,6 +3483,11 @@ export type MutationDisconnectIntegrationArgs = {
 };
 
 /** Root mutation type for all write operations. */
+export type MutationDismissGymClusterArgs = {
+  input: DismissGymClusterInput;
+};
+
+/** Root mutation type for all write operations. */
 export type MutationEndSessionArgs = {
   notes?: InputMaybe<Scalars['String']['input']>;
   sessionId: Scalars['ID']['input'];
@@ -3384,6 +3566,11 @@ export type MutationMarkGroupNotificationsReadArgs = {
 /** Root mutation type for all write operations. */
 export type MutationMarkNotificationReadArgs = {
   notificationUuid: Scalars['ID']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationMergeGymsArgs = {
+  input: MergeGymsInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -3879,6 +4066,48 @@ export type NotificationType =
   | 'vote_on_comment'
   | 'vote_on_tick';
 
+/** An alias-less, system-owned live gym with no location-sync source — an orphan for the audit list. */
+export type OrphanGym = {
+  __typename?: 'OrphanGym';
+  /** Physical address (if known). */
+  address?: Maybe<Scalars['String']['output']>;
+  /** Linked, non-deleted boards. */
+  boardCount: Scalars['Int']['output'];
+  /** When created. */
+  createdAt: Scalars['String']['output'];
+  /** Followers. */
+  followerCount: Scalars['Int']['output'];
+  /** Gym UUID. */
+  gymUuid: Scalars['ID']['output'];
+  /** Live kiosks. */
+  kioskCount: Scalars['Int']['output'];
+  /** Members. */
+  memberCount: Scalars['Int']['output'];
+  /** Gym name. */
+  name: Scalars['String']['output'];
+  /** URL slug (null when unset — link via the uuid instead). */
+  slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** Paginated list of orphan gyms (list-only, no actions). */
+export type OrphanGymConnection = {
+  __typename?: 'OrphanGymConnection';
+  /** The orphan gyms. */
+  gyms: Array<OrphanGym>;
+  /** Whether more orphan gyms are available. */
+  hasMore: Scalars['Boolean']['output'];
+  /** Total number of orphan gyms. */
+  totalCount: Scalars['Int']['output'];
+};
+
+/** Input for the orphan-gym audit list (admin only). */
+export type OrphanGymsInput = {
+  /** Max gyms to return. */
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  /** Offset for pagination. */
+  offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
 /**
  * A live per-PR OTA preview channel. Switching a store/TestFlight build onto one
  * loads that pull request's JS bundle before it ships, with no new build. The
@@ -4366,6 +4595,12 @@ export type Query = {
   /** Discover public playlists with at least 1 climb. */
   discoverPlaylists: DiscoverPlaylistsResult;
   /**
+   * Candidate duplicate-gym clusters for the /admin/gym-duplicates review queue
+   * (admin only). Tiered by how tightly members sit together (A: within 20 m,
+   * B: within 150 m). Clusters an admin has dismissed are excluded. Paginated.
+   */
+  duplicateGymClusters: DuplicateGymClusterConnection;
+  /**
    * Get buffered events since a sequence number for delta sync.
    * Used to catch up after reconnection without full state transfer.
    */
@@ -4526,6 +4761,11 @@ export type Query = {
   newClimbFeed: NewClimbFeedResult;
   /** Get notifications for the current user. */
   notifications: NotificationConnection;
+  /**
+   * Alias-less, system-owned live gyms with no location-sync source — the orphan
+   * audit list (admin only). List-only; no bulk action.
+   */
+  orphanGyms: OrphanGymConnection;
   /**
    * Live per-PR OTA preview channels a user can switch a store/TestFlight build
    * onto to try a pull request before it ships. Public — no authentication.
@@ -4925,6 +5165,11 @@ export type QueryDiscoverPlaylistsArgs = {
 };
 
 /** Root query type for all read operations. */
+export type QueryDuplicateGymClustersArgs = {
+  input?: InputMaybe<DuplicateGymClustersInput>;
+};
+
+/** Root query type for all read operations. */
 export type QueryEventsReplayArgs = {
   sessionId: Scalars['ID']['input'];
   sinceSequence: Scalars['Int']['input'];
@@ -5066,6 +5311,11 @@ export type QueryNotificationsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   unreadOnly?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Root query type for all read operations. */
+export type QueryOrphanGymsArgs = {
+  input?: InputMaybe<OrphanGymsInput>;
 };
 
 /** Root query type for all read operations. */
@@ -7545,7 +7795,14 @@ export type ResolversTypes = ResolversObject<{
   DiscoverPlaylistsResult: ResolverTypeWrapper<DiscoverPlaylistsResult>;
   DiscoverablePlaylist: ResolverTypeWrapper<DiscoverablePlaylist>;
   DiscoverableSession: ResolverTypeWrapper<DiscoverableSession>;
+  DismissGymClusterInput: DismissGymClusterInput;
   DriverChanged: ResolverTypeWrapper<DriverChanged>;
+  DuplicateClusterTier: DuplicateClusterTier;
+  DuplicateGymCluster: ResolverTypeWrapper<DuplicateGymCluster>;
+  DuplicateGymClusterConnection: ResolverTypeWrapper<DuplicateGymClusterConnection>;
+  DuplicateGymClustersInput: DuplicateGymClustersInput;
+  DuplicateGymMember: ResolverTypeWrapper<DuplicateGymMember>;
+  DuplicateGymOwnerType: DuplicateGymOwnerType;
   EventsReplayResponse: ResolverTypeWrapper<
     Omit<EventsReplayResponse, 'events'> & { events: Array<ResolversTypes['QueueEvent']> }
   >;
@@ -7595,6 +7852,7 @@ export type ResolversTypes = ResolversObject<{
   GymClaimMethod: GymClaimMethod;
   GymClaimRequestStatus: GymClaimRequestStatus;
   GymClaimStatus: GymClaimStatus;
+  GymClusterClaimStatus: GymClusterClaimStatus;
   GymConnection: ResolverTypeWrapper<GymConnection>;
   GymDayActivity: ResolverTypeWrapper<GymDayActivity>;
   GymKiosk: ResolverTypeWrapper<GymKiosk>;
@@ -7603,6 +7861,8 @@ export type ResolversTypes = ResolversObject<{
   GymMemberConnection: ResolverTypeWrapper<GymMemberConnection>;
   GymMemberRole: GymMemberRole;
   GymMembersInput: GymMembersInput;
+  GymMergeCounts: ResolverTypeWrapper<GymMergeCounts>;
+  GymMergeDuplicateResult: ResolverTypeWrapper<GymMergeDuplicateResult>;
   GymOwnerType: GymOwnerType;
   GymStats: ResolverTypeWrapper<GymStats>;
   GymStatsInput: GymStatsInput;
@@ -7623,12 +7883,15 @@ export type ResolversTypes = ResolversObject<{
   IntegrationStatus: ResolverTypeWrapper<IntegrationStatus>;
   JSON: ResolverTypeWrapper<Scalars['JSON']['output']>;
   KioskHeartbeatInput: KioskHeartbeatInput;
+  KioskSlugWarning: ResolverTypeWrapper<KioskSlugWarning>;
   LayoutStats: ResolverTypeWrapper<LayoutStats>;
   LeaderChanged: ResolverTypeWrapper<LeaderChanged>;
   LedCommand: ResolverTypeWrapper<LedCommand>;
   LedCommandInput: LedCommandInput;
   LedUpdate: ResolverTypeWrapper<LedUpdate>;
   LinkBoardToGymInput: LinkBoardToGymInput;
+  MergeGymsInput: MergeGymsInput;
+  MergeGymsResult: ResolverTypeWrapper<MergeGymsResult>;
   MoonBoardClimbDuplicateCandidateInput: MoonBoardClimbDuplicateCandidateInput;
   MoonBoardClimbDuplicateMatch: ResolverTypeWrapper<MoonBoardClimbDuplicateMatch>;
   MoonBoardHoldsInput: MoonBoardHoldsInput;
@@ -7646,6 +7909,9 @@ export type ResolversTypes = ResolversObject<{
   NotificationConnection: ResolverTypeWrapper<NotificationConnection>;
   NotificationEvent: ResolverTypeWrapper<NotificationEvent>;
   NotificationType: NotificationType;
+  OrphanGym: ResolverTypeWrapper<OrphanGym>;
+  OrphanGymConnection: ResolverTypeWrapper<OrphanGymConnection>;
+  OrphanGymsInput: OrphanGymsInput;
   OtaPreviewChannel: ResolverTypeWrapper<OtaPreviewChannel>;
   OutlierAnalysis: ResolverTypeWrapper<OutlierAnalysis>;
   PendingGymClaimsInput: PendingGymClaimsInput;
@@ -7883,7 +8149,12 @@ export type ResolversParentTypes = ResolversObject<{
   DiscoverPlaylistsResult: DiscoverPlaylistsResult;
   DiscoverablePlaylist: DiscoverablePlaylist;
   DiscoverableSession: DiscoverableSession;
+  DismissGymClusterInput: DismissGymClusterInput;
   DriverChanged: DriverChanged;
+  DuplicateGymCluster: DuplicateGymCluster;
+  DuplicateGymClusterConnection: DuplicateGymClusterConnection;
+  DuplicateGymClustersInput: DuplicateGymClustersInput;
+  DuplicateGymMember: DuplicateGymMember;
   EventsReplayResponse: Omit<EventsReplayResponse, 'events'> & { events: Array<ResolversParentTypes['QueueEvent']> };
   FavoritesCount: FavoritesCount;
   FeedbackContextInput: FeedbackContextInput;
@@ -7934,6 +8205,8 @@ export type ResolversParentTypes = ResolversObject<{
   GymMember: GymMember;
   GymMemberConnection: GymMemberConnection;
   GymMembersInput: GymMembersInput;
+  GymMergeCounts: GymMergeCounts;
+  GymMergeDuplicateResult: GymMergeDuplicateResult;
   GymStats: GymStats;
   GymStatsInput: GymStatsInput;
   GymStatsWindow: GymStatsWindow;
@@ -7951,12 +8224,15 @@ export type ResolversParentTypes = ResolversObject<{
   IntegrationStatus: IntegrationStatus;
   JSON: Scalars['JSON']['output'];
   KioskHeartbeatInput: KioskHeartbeatInput;
+  KioskSlugWarning: KioskSlugWarning;
   LayoutStats: LayoutStats;
   LeaderChanged: LeaderChanged;
   LedCommand: LedCommand;
   LedCommandInput: LedCommandInput;
   LedUpdate: LedUpdate;
   LinkBoardToGymInput: LinkBoardToGymInput;
+  MergeGymsInput: MergeGymsInput;
+  MergeGymsResult: MergeGymsResult;
   MoonBoardClimbDuplicateCandidateInput: MoonBoardClimbDuplicateCandidateInput;
   MoonBoardClimbDuplicateMatch: MoonBoardClimbDuplicateMatch;
   MoonBoardHoldsInput: MoonBoardHoldsInput;
@@ -7972,6 +8248,9 @@ export type ResolversParentTypes = ResolversObject<{
   Notification: Notification;
   NotificationConnection: NotificationConnection;
   NotificationEvent: NotificationEvent;
+  OrphanGym: OrphanGym;
+  OrphanGymConnection: OrphanGymConnection;
+  OrphanGymsInput: OrphanGymsInput;
   OtaPreviewChannel: OtaPreviewChannel;
   OutlierAnalysis: OutlierAnalysis;
   PendingGymClaimsInput: PendingGymClaimsInput;
@@ -8953,6 +9232,53 @@ export type DriverChangedResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type DuplicateGymClusterResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['DuplicateGymCluster'] = ResolversParentTypes['DuplicateGymCluster'],
+> = ResolversObject<{
+  maxDistanceMeters?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  members?: Resolver<Array<ResolversTypes['DuplicateGymMember']>, ParentType, ContextType>;
+  normalizedName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  suggestedCanonicalGymUuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  tier?: Resolver<ResolversTypes['DuplicateClusterTier'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type DuplicateGymClusterConnectionResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['DuplicateGymClusterConnection'] =
+    ResolversParentTypes['DuplicateGymClusterConnection'],
+> = ResolversObject<{
+  clusters?: Resolver<Array<ResolversTypes['DuplicateGymCluster']>, ParentType, ContextType>;
+  hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  totalCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type DuplicateGymMemberResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['DuplicateGymMember'] = ResolversParentTypes['DuplicateGymMember'],
+> = ResolversObject<{
+  address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  boardCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  claimCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  claimStatus?: Resolver<ResolversTypes['GymClusterClaimStatus'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  distanceToCanonicalMeters?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  followerCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  gymUuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  isSuggestedCanonical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  kioskCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  latitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  longitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  memberCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  ownerType?: Resolver<ResolversTypes['DuplicateGymOwnerType'], ParentType, ContextType>;
+  providerOrigins?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type EventsReplayResponseResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['EventsReplayResponse'] = ResolversParentTypes['EventsReplayResponse'],
@@ -9279,6 +9605,29 @@ export type GymMemberConnectionResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GymMergeCountsResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['GymMergeCounts'] = ResolversParentTypes['GymMergeCounts'],
+> = ResolversObject<{
+  boards?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  claims?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  comments?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  follows?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  kiosks?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  members?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GymMergeDuplicateResultResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['GymMergeDuplicateResult'] = ResolversParentTypes['GymMergeDuplicateResult'],
+> = ResolversObject<{
+  counts?: Resolver<ResolversTypes['GymMergeCounts'], ParentType, ContextType>;
+  duplicateGymUuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  warnings?: Resolver<Array<ResolversTypes['KioskSlugWarning']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type GymStatsResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['GymStats'] = ResolversParentTypes['GymStats'],
@@ -9406,6 +9755,17 @@ export interface JsonScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes
   name: 'JSON';
 }
 
+export type KioskSlugWarningResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['KioskSlugWarning'] = ResolversParentTypes['KioskSlugWarning'],
+> = ResolversObject<{
+  kioskName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  kioskUuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  newSlug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  previousSlug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type LayoutStatsResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['LayoutStats'] = ResolversParentTypes['LayoutStats'],
@@ -9453,6 +9813,15 @@ export type LedUpdateResolvers<
   gradeColor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   navigation?: Resolver<Maybe<ResolversTypes['QueueNavigationContext']>, ParentType, ContextType>;
   queueItemUuid?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type MergeGymsResultResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['MergeGymsResult'] = ResolversParentTypes['MergeGymsResult'],
+> = ResolversObject<{
+  canonicalGymUuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  results?: Resolver<Array<ResolversTypes['GymMergeDuplicateResult']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -9641,6 +10010,12 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationDisconnectIntegrationArgs, 'provider'>
   >;
+  dismissGymCluster?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDismissGymClusterArgs, 'input'>
+  >;
   endSession?: Resolver<
     Maybe<ResolversTypes['SessionSummary']>,
     ParentType,
@@ -9726,6 +10101,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationMarkNotificationReadArgs, 'notificationUuid'>
+  >;
+  mergeGyms?: Resolver<
+    ResolversTypes['MergeGymsResult'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationMergeGymsArgs, 'input'>
   >;
   mirrorCurrentClimb?: Resolver<
     Maybe<ResolversTypes['ClimbQueueItem']>,
@@ -10196,6 +10577,32 @@ export type NotificationEventResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type OrphanGymResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['OrphanGym'] = ResolversParentTypes['OrphanGym'],
+> = ResolversObject<{
+  address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  boardCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  followerCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  gymUuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  kioskCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  memberCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OrphanGymConnectionResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['OrphanGymConnection'] = ResolversParentTypes['OrphanGymConnection'],
+> = ResolversObject<{
+  gyms?: Resolver<Array<ResolversTypes['OrphanGym']>, ParentType, ContextType>;
+  hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  totalCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type OtaPreviewChannelResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['OtaPreviewChannel'] = ResolversParentTypes['OtaPreviewChannel'],
@@ -10600,6 +11007,12 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QueryDiscoverPlaylistsArgs, 'input'>
   >;
+  duplicateGymClusters?: Resolver<
+    ResolversTypes['DuplicateGymClusterConnection'],
+    ParentType,
+    ContextType,
+    Partial<QueryDuplicateGymClustersArgs>
+  >;
   eventsReplay?: Resolver<
     ResolversTypes['EventsReplayResponse'],
     ParentType,
@@ -10748,6 +11161,7 @@ export type QueryResolvers<
     ContextType,
     Partial<QueryNotificationsArgs>
   >;
+  orphanGyms?: Resolver<ResolversTypes['OrphanGymConnection'], ParentType, ContextType, Partial<QueryOrphanGymsArgs>>;
   otaPreviewChannels?: Resolver<Array<ResolversTypes['OtaPreviewChannel']>, ParentType, ContextType>;
   pendingGymClaims?: Resolver<
     ResolversTypes['GymClaimConnection'],
@@ -12129,6 +12543,9 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   DiscoverablePlaylist?: DiscoverablePlaylistResolvers<ContextType>;
   DiscoverableSession?: DiscoverableSessionResolvers<ContextType>;
   DriverChanged?: DriverChangedResolvers<ContextType>;
+  DuplicateGymCluster?: DuplicateGymClusterResolvers<ContextType>;
+  DuplicateGymClusterConnection?: DuplicateGymClusterConnectionResolvers<ContextType>;
+  DuplicateGymMember?: DuplicateGymMemberResolvers<ContextType>;
   EventsReplayResponse?: EventsReplayResponseResolvers<ContextType>;
   FavoritesCount?: FavoritesCountResolvers<ContextType>;
   FollowConnection?: FollowConnectionResolvers<ContextType>;
@@ -12152,6 +12569,8 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   GymKioskBoard?: GymKioskBoardResolvers<ContextType>;
   GymMember?: GymMemberResolvers<ContextType>;
   GymMemberConnection?: GymMemberConnectionResolvers<ContextType>;
+  GymMergeCounts?: GymMergeCountsResolvers<ContextType>;
+  GymMergeDuplicateResult?: GymMergeDuplicateResultResolvers<ContextType>;
   GymStats?: GymStatsResolvers<ContextType>;
   GymStatsWindow?: GymStatsWindowResolvers<ContextType>;
   GymTopClimb?: GymTopClimbResolvers<ContextType>;
@@ -12163,10 +12582,12 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   IntegrationExportResult?: IntegrationExportResultResolvers<ContextType>;
   IntegrationStatus?: IntegrationStatusResolvers<ContextType>;
   JSON?: GraphQLScalarType;
+  KioskSlugWarning?: KioskSlugWarningResolvers<ContextType>;
   LayoutStats?: LayoutStatsResolvers<ContextType>;
   LeaderChanged?: LeaderChangedResolvers<ContextType>;
   LedCommand?: LedCommandResolvers<ContextType>;
   LedUpdate?: LedUpdateResolvers<ContextType>;
+  MergeGymsResult?: MergeGymsResultResolvers<ContextType>;
   MoonBoardClimbDuplicateMatch?: MoonBoardClimbDuplicateMatchResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   NewClimbCreatedEvent?: NewClimbCreatedEventResolvers<ContextType>;
@@ -12176,6 +12597,8 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   Notification?: NotificationResolvers<ContextType>;
   NotificationConnection?: NotificationConnectionResolvers<ContextType>;
   NotificationEvent?: NotificationEventResolvers<ContextType>;
+  OrphanGym?: OrphanGymResolvers<ContextType>;
+  OrphanGymConnection?: OrphanGymConnectionResolvers<ContextType>;
   OtaPreviewChannel?: OtaPreviewChannelResolvers<ContextType>;
   OutlierAnalysis?: OutlierAnalysisResolvers<ContextType>;
   PlaybackStateChanged?: PlaybackStateChangedResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -555,4 +555,208 @@ export const gymsTypeDefs = /* GraphQL */ `
     "Rolling last 30 days."
     month
   }
+
+  # ============================================
+  # Gym Duplicate Review (admin only)
+  # ============================================
+
+  "Who owns a gym row in the duplicate queue: the system import user, or a real person. (Distinct from GymOwnerType, which the similar-gyms search uses with SYSTEM/USER casing.)"
+  enum DuplicateGymOwnerType {
+    "Owned by the system import user (a synced public listing)."
+    system
+    "Owned by a real Boardsesh user."
+    user
+  }
+
+  "The strongest ownership-claim state on a gym row."
+  enum GymClusterClaimStatus {
+    "No claim on file."
+    none
+    "A claim is awaiting review or verification."
+    pending
+    "A claim was approved (ownership transferred)."
+    approved
+  }
+
+  "How tightly a candidate duplicate cluster's members sit together."
+  enum DuplicateClusterTier {
+    "Every member within 20 m — almost certainly the same wall."
+    A
+    "Members within 150 m — the observed cross-provider coordinate-drift band."
+    B
+  }
+
+  "One gym row inside a candidate duplicate cluster, with the signals an admin needs to pick the survivor."
+  type DuplicateGymMember {
+    "Gym UUID (always a live, canonical row)."
+    gymUuid: ID!
+    "Gym name."
+    name: String!
+    "Physical address (if known)."
+    address: String
+    "Whether the system import user or a real user owns this row."
+    ownerType: DuplicateGymOwnerType!
+    "Strongest ownership-claim state on this row."
+    claimStatus: GymClusterClaimStatus!
+    "Distinct location-sync provider origins (source_key prefixes: kilter, tension, ...)."
+    providerOrigins: [String!]!
+    "Linked, non-deleted boards."
+    boardCount: Int!
+    "Followers."
+    followerCount: Int!
+    "Members."
+    memberCount: Int!
+    "Live kiosks."
+    kioskCount: Int!
+    "Ownership claims on file (any status)."
+    claimCount: Int!
+    "When created."
+    createdAt: String!
+    "GPS latitude."
+    latitude: Float!
+    "GPS longitude."
+    longitude: Float!
+    "Distance in metres from this row to the cluster's suggested canonical survivor."
+    distanceToCanonicalMeters: Float!
+    "Whether the rule pre-selects this row as the canonical survivor (claimed/user-owned over system, then completeness/oldest)."
+    isSuggestedCanonical: Boolean!
+  }
+
+  "A candidate cluster of live gym rows that look like the same physical location."
+  type DuplicateGymCluster {
+    "Stable identity (hash of the sorted member gym ids). Dismissals key on this."
+    signature: String!
+    "How tightly the members sit together."
+    tier: DuplicateClusterTier!
+    "The shared normalized name."
+    normalizedName: String!
+    "The rule's suggested canonical survivor (an admin may override)."
+    suggestedCanonicalGymUuid: ID!
+    "Largest pairwise distance in metres between any two members."
+    maxDistanceMeters: Float!
+    "The cluster's member rows."
+    members: [DuplicateGymMember!]!
+  }
+
+  "Paginated list of candidate duplicate clusters."
+  type DuplicateGymClusterConnection {
+    "The clusters."
+    clusters: [DuplicateGymCluster!]!
+    "Total number of clusters (after dismissals are excluded)."
+    totalCount: Int!
+    "Whether more clusters are available."
+    hasMore: Boolean!
+  }
+
+  "Input for listing candidate duplicate clusters (admin only)."
+  input DuplicateGymClustersInput {
+    "Max clusters to return."
+    limit: Int
+    "Offset for pagination."
+    offset: Int
+  }
+
+  "An alias-less, system-owned live gym with no location-sync source — an orphan for the audit list."
+  type OrphanGym {
+    "Gym UUID."
+    gymUuid: ID!
+    "URL slug (null when unset — link via the uuid instead)."
+    slug: String
+    "Gym name."
+    name: String!
+    "Physical address (if known)."
+    address: String
+    "Linked, non-deleted boards."
+    boardCount: Int!
+    "Followers."
+    followerCount: Int!
+    "Members."
+    memberCount: Int!
+    "Live kiosks."
+    kioskCount: Int!
+    "When created."
+    createdAt: String!
+  }
+
+  "Paginated list of orphan gyms (list-only, no actions)."
+  type OrphanGymConnection {
+    "The orphan gyms."
+    gyms: [OrphanGym!]!
+    "Total number of orphan gyms."
+    totalCount: Int!
+    "Whether more orphan gyms are available."
+    hasMore: Boolean!
+  }
+
+  "Input for the orphan-gym audit list (admin only)."
+  input OrphanGymsInput {
+    "Max gyms to return."
+    limit: Int
+    "Offset for pagination."
+    offset: Int
+  }
+
+  "Input for merging duplicate gyms into a canonical survivor (admin only)."
+  input MergeGymsInput {
+    "The survivor gym UUID."
+    canonicalGymUuid: ID!
+    "The gym UUIDs to fold into the survivor."
+    duplicateGymUuids: [ID!]!
+    "Explicit acknowledgement required to keep a SYSTEM listing as the survivor over a user-owned or claim-approved duplicate. Rejected without it."
+    allowSystemCanonicalOverride: Boolean
+  }
+
+  "A kiosk whose slug had to change during a merge — its printed install QR must be reprinted."
+  type KioskSlugWarning {
+    "Kiosk UUID."
+    kioskUuid: ID!
+    "Kiosk name."
+    kioskName: String!
+    "Slug before the merge."
+    previousSlug: String!
+    "Slug after the merge (suffixed to avoid a collision on the canonical gym)."
+    newSlug: String!
+  }
+
+  "What one duplicate merge re-pointed onto the canonical gym."
+  type GymMergeCounts {
+    "Boards moved."
+    boards: Int!
+    "Follows moved (deduped)."
+    follows: Int!
+    "Members moved (deduped)."
+    members: Int!
+    "Claims moved onto the canonical."
+    claims: Int!
+    "Kiosks moved."
+    kiosks: Int!
+    "Comments moved."
+    comments: Int!
+  }
+
+  "The result of folding one duplicate into the canonical."
+  type GymMergeDuplicateResult {
+    "The duplicate that was merged."
+    duplicateGymUuid: ID!
+    "What moved."
+    counts: GymMergeCounts!
+    "Kiosk slug changes the admin must surface."
+    warnings: [KioskSlugWarning!]!
+  }
+
+  "The result of a mergeGyms call — one entry per merged duplicate."
+  type MergeGymsResult {
+    "The survivor gym UUID."
+    canonicalGymUuid: ID!
+    "Per-duplicate outcomes."
+    results: [GymMergeDuplicateResult!]!
+  }
+
+  "Input for dismissing a candidate cluster (marks it not-a-duplicate; hides it from the queue)."
+  input DismissGymClusterInput {
+    "All member gym UUIDs of the cluster (order-independent; used to compute the signature)."
+    gymUuids: [ID!]!
+    "The suggested canonical member, recorded on the dismissal audit row."
+    canonicalGymUuid: ID!
+  }
 `;

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -536,6 +536,21 @@ export const mutationsTypeDefs = /* GraphQL */ `
     """
     reviewGymClaim(input: ReviewGymClaimInput!): Boolean!
 
+    """
+    Fold one or more duplicate gyms into a canonical survivor (admin only). Every
+    duplicate's boards, follows, members, claims, kiosks, comments, feed items,
+    notifications, and votes re-point to the survivor, then each duplicate is
+    soft-deleted with a pointer to it. Returns per-duplicate moved counts and any
+    kiosk-slug-change warnings.
+    """
+    mergeGyms(input: MergeGymsInput!): MergeGymsResult!
+
+    """
+    Dismiss a candidate duplicate cluster (admin only). Records that the cluster is
+    not a duplicate so the review queue hides it. Touches no gym row.
+    """
+    dismissGymCluster(input: DismissGymClusterInput!): Boolean!
+
     # ============================================
     # Gym Kiosk Mutations (require gym edit access)
     # ============================================

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -619,6 +619,19 @@ export const queriesTypeDefs = /* GraphQL */ `
     """
     gymStats(input: GymStatsInput!): GymStats!
 
+    """
+    Candidate duplicate-gym clusters for the /admin/gym-duplicates review queue
+    (admin only). Tiered by how tightly members sit together (A: within 20 m,
+    B: within 150 m). Clusters an admin has dismissed are excluded. Paginated.
+    """
+    duplicateGymClusters(input: DuplicateGymClustersInput): DuplicateGymClusterConnection!
+
+    """
+    Alias-less, system-owned live gyms with no location-sync source — the orphan
+    audit list (admin only). List-only; no bulk action.
+    """
+    orphanGyms(input: OrphanGymsInput): OrphanGymConnection!
+
     # ============================================
     # Gym Kiosk Queries
     # ============================================

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -262,3 +262,115 @@ export type GymStatsInput = {
   gymUuid: string;
   period?: GymStatsPeriod;
 };
+
+// ============================================
+// Gym duplicate review (admin)
+// ============================================
+
+// Distinct from the similar-gyms search's GymOwnerType ('SYSTEM' | 'USER').
+export type DuplicateGymOwnerType = 'system' | 'user';
+
+export type GymClusterClaimStatus = 'none' | 'pending' | 'approved';
+
+export type DuplicateClusterTier = 'A' | 'B';
+
+export type DuplicateGymMember = {
+  gymUuid: string;
+  name: string;
+  address?: string | null;
+  ownerType: DuplicateGymOwnerType;
+  claimStatus: GymClusterClaimStatus;
+  providerOrigins: string[];
+  boardCount: number;
+  followerCount: number;
+  memberCount: number;
+  kioskCount: number;
+  claimCount: number;
+  createdAt: string;
+  latitude: number;
+  longitude: number;
+  distanceToCanonicalMeters: number;
+  isSuggestedCanonical: boolean;
+};
+
+export type DuplicateGymCluster = {
+  signature: string;
+  tier: DuplicateClusterTier;
+  normalizedName: string;
+  suggestedCanonicalGymUuid: string;
+  maxDistanceMeters: number;
+  members: DuplicateGymMember[];
+};
+
+export type DuplicateGymClusterConnection = {
+  clusters: DuplicateGymCluster[];
+  totalCount: number;
+  hasMore: boolean;
+};
+
+export type DuplicateGymClustersInput = {
+  limit?: number;
+  offset?: number;
+};
+
+export type OrphanGym = {
+  gymUuid: string;
+  slug?: string | null;
+  name: string;
+  address?: string | null;
+  boardCount: number;
+  followerCount: number;
+  memberCount: number;
+  kioskCount: number;
+  createdAt: string;
+};
+
+export type OrphanGymConnection = {
+  gyms: OrphanGym[];
+  totalCount: number;
+  hasMore: boolean;
+};
+
+export type OrphanGymsInput = {
+  limit?: number;
+  offset?: number;
+};
+
+export type MergeGymsInput = {
+  canonicalGymUuid: string;
+  duplicateGymUuids: string[];
+  /** Explicit acknowledgement to keep a SYSTEM listing as the survivor over a user-owned/claim-approved duplicate. */
+  allowSystemCanonicalOverride?: boolean;
+};
+
+export type KioskSlugWarning = {
+  kioskUuid: string;
+  kioskName: string;
+  previousSlug: string;
+  newSlug: string;
+};
+
+export type GymMergeCounts = {
+  boards: number;
+  follows: number;
+  members: number;
+  claims: number;
+  kiosks: number;
+  comments: number;
+};
+
+export type GymMergeDuplicateResult = {
+  duplicateGymUuid: string;
+  counts: GymMergeCounts;
+  warnings: KioskSlugWarning[];
+};
+
+export type MergeGymsResult = {
+  canonicalGymUuid: string;
+  results: GymMergeDuplicateResult[];
+};
+
+export type DismissGymClusterInput = {
+  gymUuids: string[];
+  canonicalGymUuid: string;
+};

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1616,6 +1616,14 @@ export type DiscoverableSession = {
   participantCount: Scalars['Int']['output'];
 };
 
+/** Input for dismissing a candidate cluster (marks it not-a-duplicate; hides it from the queue). */
+export type DismissGymClusterInput = {
+  /** The suggested canonical member, recorded on the dismissal audit row. */
+  canonicalGymUuid: Scalars['ID']['input'];
+  /** All member gym UUIDs of the cluster (order-independent; used to compute the signature). */
+  gymUuids: Array<Scalars['ID']['input']>;
+};
+
 /**
  * DEPRECATED. Sessions are always-live; there is no wall driver. This type and its
  * SessionEvent union membership are kept purely so stale clients (cached web bundles,
@@ -1636,6 +1644,93 @@ export type DriverChanged = {
   driverParticipantId?: Maybe<Scalars['ID']['output']>;
   previousDriverParticipantId?: Maybe<Scalars['ID']['output']>;
 };
+
+/** How tightly a candidate duplicate cluster's members sit together. */
+export type DuplicateClusterTier =
+  /** Every member within 20 m — almost certainly the same wall. */
+  | 'A'
+  /** Members within 150 m — the observed cross-provider coordinate-drift band. */
+  | 'B';
+
+/** A candidate cluster of live gym rows that look like the same physical location. */
+export type DuplicateGymCluster = {
+  __typename?: 'DuplicateGymCluster';
+  /** Largest pairwise distance in metres between any two members. */
+  maxDistanceMeters: Scalars['Float']['output'];
+  /** The cluster's member rows. */
+  members: Array<DuplicateGymMember>;
+  /** The shared normalized name. */
+  normalizedName: Scalars['String']['output'];
+  /** Stable identity (hash of the sorted member gym ids). Dismissals key on this. */
+  signature: Scalars['String']['output'];
+  /** The rule's suggested canonical survivor (an admin may override). */
+  suggestedCanonicalGymUuid: Scalars['ID']['output'];
+  /** How tightly the members sit together. */
+  tier: DuplicateClusterTier;
+};
+
+/** Paginated list of candidate duplicate clusters. */
+export type DuplicateGymClusterConnection = {
+  __typename?: 'DuplicateGymClusterConnection';
+  /** The clusters. */
+  clusters: Array<DuplicateGymCluster>;
+  /** Whether more clusters are available. */
+  hasMore: Scalars['Boolean']['output'];
+  /** Total number of clusters (after dismissals are excluded). */
+  totalCount: Scalars['Int']['output'];
+};
+
+/** Input for listing candidate duplicate clusters (admin only). */
+export type DuplicateGymClustersInput = {
+  /** Max clusters to return. */
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  /** Offset for pagination. */
+  offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** One gym row inside a candidate duplicate cluster, with the signals an admin needs to pick the survivor. */
+export type DuplicateGymMember = {
+  __typename?: 'DuplicateGymMember';
+  /** Physical address (if known). */
+  address?: Maybe<Scalars['String']['output']>;
+  /** Linked, non-deleted boards. */
+  boardCount: Scalars['Int']['output'];
+  /** Ownership claims on file (any status). */
+  claimCount: Scalars['Int']['output'];
+  /** Strongest ownership-claim state on this row. */
+  claimStatus: GymClusterClaimStatus;
+  /** When created. */
+  createdAt: Scalars['String']['output'];
+  /** Distance in metres from this row to the cluster's suggested canonical survivor. */
+  distanceToCanonicalMeters: Scalars['Float']['output'];
+  /** Followers. */
+  followerCount: Scalars['Int']['output'];
+  /** Gym UUID (always a live, canonical row). */
+  gymUuid: Scalars['ID']['output'];
+  /** Whether the rule pre-selects this row as the canonical survivor (claimed/user-owned over system, then completeness/oldest). */
+  isSuggestedCanonical: Scalars['Boolean']['output'];
+  /** Live kiosks. */
+  kioskCount: Scalars['Int']['output'];
+  /** GPS latitude. */
+  latitude: Scalars['Float']['output'];
+  /** GPS longitude. */
+  longitude: Scalars['Float']['output'];
+  /** Members. */
+  memberCount: Scalars['Int']['output'];
+  /** Gym name. */
+  name: Scalars['String']['output'];
+  /** Whether the system import user or a real user owns this row. */
+  ownerType: DuplicateGymOwnerType;
+  /** Distinct location-sync provider origins (source_key prefixes: kilter, tension, ...). */
+  providerOrigins: Array<Scalars['String']['output']>;
+};
+
+/** Who owns a gym row in the duplicate queue: the system import user, or a real person. (Distinct from GymOwnerType, which the similar-gyms search uses with SYSTEM/USER casing.) */
+export type DuplicateGymOwnerType =
+  /** Owned by the system import user (a synced public listing). */
+  | 'system'
+  /** Owned by a real Boardsesh user. */
+  | 'user';
 
 /**
  * Response containing events since a given sequence number.
@@ -2263,6 +2358,15 @@ export type GymClaimRequestStatus =
 
 export type GymClaimStatus = 'approved' | 'denied' | 'expired' | 'pending';
 
+/** The strongest ownership-claim state on a gym row. */
+export type GymClusterClaimStatus =
+  /** A claim was approved (ownership transferred). */
+  | 'approved'
+  /** No claim on file. */
+  | 'none'
+  /** A claim is awaiting review or verification. */
+  | 'pending';
+
 /** Paginated list of gyms. */
 export type GymConnection = {
   __typename?: 'GymConnection';
@@ -2408,6 +2512,34 @@ export type GymMembersInput = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** Offset for pagination */
   offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** What one duplicate merge re-pointed onto the canonical gym. */
+export type GymMergeCounts = {
+  __typename?: 'GymMergeCounts';
+  /** Boards moved. */
+  boards: Scalars['Int']['output'];
+  /** Claims moved onto the canonical. */
+  claims: Scalars['Int']['output'];
+  /** Comments moved. */
+  comments: Scalars['Int']['output'];
+  /** Follows moved (deduped). */
+  follows: Scalars['Int']['output'];
+  /** Kiosks moved. */
+  kiosks: Scalars['Int']['output'];
+  /** Members moved (deduped). */
+  members: Scalars['Int']['output'];
+};
+
+/** The result of folding one duplicate into the canonical. */
+export type GymMergeDuplicateResult = {
+  __typename?: 'GymMergeDuplicateResult';
+  /** What moved. */
+  counts: GymMergeCounts;
+  /** The duplicate that was merged. */
+  duplicateGymUuid: Scalars['ID']['output'];
+  /** Kiosk slug changes the admin must surface. */
+  warnings: Array<KioskSlugWarning>;
 };
 
 /** Where a gym came from: an upstream provider sync or a Boardsesh user. */
@@ -2618,6 +2750,19 @@ export type KioskHeartbeatInput = {
   viewportWidth?: InputMaybe<Scalars['Int']['input']>;
 };
 
+/** A kiosk whose slug had to change during a merge — its printed install QR must be reprinted. */
+export type KioskSlugWarning = {
+  __typename?: 'KioskSlugWarning';
+  /** Kiosk name. */
+  kioskName: Scalars['String']['output'];
+  /** Kiosk UUID. */
+  kioskUuid: Scalars['ID']['output'];
+  /** Slug after the merge (suffixed to avoid a collision on the canonical gym). */
+  newSlug: Scalars['String']['output'];
+  /** Slug before the merge. */
+  previousSlug: Scalars['String']['output'];
+};
+
 /** Statistics for a specific board layout. */
 export type LayoutStats = {
   __typename?: 'LayoutStats';
@@ -2687,6 +2832,25 @@ export type LinkBoardToGymInput = {
   boardUuid: Scalars['ID']['input'];
   /** Gym UUID (null to unlink) */
   gymUuid?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Input for merging duplicate gyms into a canonical survivor (admin only). */
+export type MergeGymsInput = {
+  /** Explicit acknowledgement required to keep a SYSTEM listing as the survivor over a user-owned or claim-approved duplicate. Rejected without it. */
+  allowSystemCanonicalOverride?: InputMaybe<Scalars['Boolean']['input']>;
+  /** The survivor gym UUID. */
+  canonicalGymUuid: Scalars['ID']['input'];
+  /** The gym UUIDs to fold into the survivor. */
+  duplicateGymUuids: Array<Scalars['ID']['input']>;
+};
+
+/** The result of a mergeGyms call — one entry per merged duplicate. */
+export type MergeGymsResult = {
+  __typename?: 'MergeGymsResult';
+  /** The survivor gym UUID. */
+  canonicalGymUuid: Scalars['ID']['output'];
+  /** Per-duplicate outcomes. */
+  results: Array<GymMergeDuplicateResult>;
 };
 
 export type MoonBoardClimbDuplicateCandidateInput = {
@@ -2826,6 +2990,11 @@ export type Mutation = {
    */
   disconnectIntegration: Scalars['Boolean']['output'];
   /**
+   * Dismiss a candidate duplicate cluster (admin only). Records that the cluster is
+   * not a duplicate so the review queue hides it. Touches no gym row.
+   */
+  dismissGymCluster: Scalars['Boolean']['output'];
+  /**
    * End a session (active participant only). The optional `notes` is a
    * free-text end-of-session recap persisted on the session and echoed back on
    * the returned SessionSummary.
@@ -2877,6 +3046,14 @@ export type Mutation = {
   markGroupNotificationsRead: Scalars['Int']['output'];
   /** Mark a notification as read. */
   markNotificationRead: Scalars['Boolean']['output'];
+  /**
+   * Fold one or more duplicate gyms into a canonical survivor (admin only). Every
+   * duplicate's boards, follows, members, claims, kiosks, comments, feed items,
+   * notifications, and votes re-point to the survivor, then each duplicate is
+   * soft-deleted with a pointer to it. Returns per-duplicate moved counts and any
+   * kiosk-slug-change warnings.
+   */
+  mergeGyms: MergeGymsResult;
   /** Toggle mirrored display for the current climb. */
   mirrorCurrentClimb?: Maybe<ClimbQueueItem>;
   navigateQueue?: Maybe<ClimbQueueItem>;
@@ -3303,6 +3480,11 @@ export type MutationDisconnectIntegrationArgs = {
 };
 
 /** Root mutation type for all write operations. */
+export type MutationDismissGymClusterArgs = {
+  input: DismissGymClusterInput;
+};
+
+/** Root mutation type for all write operations. */
 export type MutationEndSessionArgs = {
   notes?: InputMaybe<Scalars['String']['input']>;
   sessionId: Scalars['ID']['input'];
@@ -3381,6 +3563,11 @@ export type MutationMarkGroupNotificationsReadArgs = {
 /** Root mutation type for all write operations. */
 export type MutationMarkNotificationReadArgs = {
   notificationUuid: Scalars['ID']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationMergeGymsArgs = {
+  input: MergeGymsInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -3876,6 +4063,48 @@ export type NotificationType =
   | 'vote_on_comment'
   | 'vote_on_tick';
 
+/** An alias-less, system-owned live gym with no location-sync source — an orphan for the audit list. */
+export type OrphanGym = {
+  __typename?: 'OrphanGym';
+  /** Physical address (if known). */
+  address?: Maybe<Scalars['String']['output']>;
+  /** Linked, non-deleted boards. */
+  boardCount: Scalars['Int']['output'];
+  /** When created. */
+  createdAt: Scalars['String']['output'];
+  /** Followers. */
+  followerCount: Scalars['Int']['output'];
+  /** Gym UUID. */
+  gymUuid: Scalars['ID']['output'];
+  /** Live kiosks. */
+  kioskCount: Scalars['Int']['output'];
+  /** Members. */
+  memberCount: Scalars['Int']['output'];
+  /** Gym name. */
+  name: Scalars['String']['output'];
+  /** URL slug (null when unset — link via the uuid instead). */
+  slug?: Maybe<Scalars['String']['output']>;
+};
+
+/** Paginated list of orphan gyms (list-only, no actions). */
+export type OrphanGymConnection = {
+  __typename?: 'OrphanGymConnection';
+  /** The orphan gyms. */
+  gyms: Array<OrphanGym>;
+  /** Whether more orphan gyms are available. */
+  hasMore: Scalars['Boolean']['output'];
+  /** Total number of orphan gyms. */
+  totalCount: Scalars['Int']['output'];
+};
+
+/** Input for the orphan-gym audit list (admin only). */
+export type OrphanGymsInput = {
+  /** Max gyms to return. */
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  /** Offset for pagination. */
+  offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
 /**
  * A live per-PR OTA preview channel. Switching a store/TestFlight build onto one
  * loads that pull request's JS bundle before it ships, with no new build. The
@@ -4363,6 +4592,12 @@ export type Query = {
   /** Discover public playlists with at least 1 climb. */
   discoverPlaylists: DiscoverPlaylistsResult;
   /**
+   * Candidate duplicate-gym clusters for the /admin/gym-duplicates review queue
+   * (admin only). Tiered by how tightly members sit together (A: within 20 m,
+   * B: within 150 m). Clusters an admin has dismissed are excluded. Paginated.
+   */
+  duplicateGymClusters: DuplicateGymClusterConnection;
+  /**
    * Get buffered events since a sequence number for delta sync.
    * Used to catch up after reconnection without full state transfer.
    */
@@ -4523,6 +4758,11 @@ export type Query = {
   newClimbFeed: NewClimbFeedResult;
   /** Get notifications for the current user. */
   notifications: NotificationConnection;
+  /**
+   * Alias-less, system-owned live gyms with no location-sync source — the orphan
+   * audit list (admin only). List-only; no bulk action.
+   */
+  orphanGyms: OrphanGymConnection;
   /**
    * Live per-PR OTA preview channels a user can switch a store/TestFlight build
    * onto to try a pull request before it ships. Public — no authentication.
@@ -4922,6 +5162,11 @@ export type QueryDiscoverPlaylistsArgs = {
 };
 
 /** Root query type for all read operations. */
+export type QueryDuplicateGymClustersArgs = {
+  input?: InputMaybe<DuplicateGymClustersInput>;
+};
+
+/** Root query type for all read operations. */
 export type QueryEventsReplayArgs = {
   sessionId: Scalars['ID']['input'];
   sinceSequence: Scalars['Int']['input'];
@@ -5063,6 +5308,11 @@ export type QueryNotificationsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   unreadOnly?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Root query type for all read operations. */
+export type QueryOrphanGymsArgs = {
+  input?: InputMaybe<OrphanGymsInput>;
 };
 
 /** Root query type for all read operations. */

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -24,6 +24,13 @@ import type {
   UserBoard,
   GymStats,
   GymStatsInput,
+  DuplicateGymClustersInput,
+  DuplicateGymClusterConnection,
+  OrphanGymsInput,
+  OrphanGymConnection,
+  MergeGymsInput,
+  MergeGymsResult,
+  DismissGymClusterInput,
 } from '@boardsesh/shared-schema';
 
 // ============================================
@@ -312,6 +319,99 @@ export const PENDING_GYM_CLAIMS = gql`
 `;
 
 // ============================================
+// Gym Duplicate Review Admin Queue
+// ============================================
+
+const DUPLICATE_GYM_CLUSTER_FIELDS = `
+  signature
+  tier
+  normalizedName
+  suggestedCanonicalGymUuid
+  maxDistanceMeters
+  members {
+    gymUuid
+    name
+    address
+    ownerType
+    claimStatus
+    providerOrigins
+    boardCount
+    followerCount
+    memberCount
+    kioskCount
+    claimCount
+    createdAt
+    latitude
+    longitude
+    distanceToCanonicalMeters
+    isSuggestedCanonical
+  }
+`;
+
+export const DUPLICATE_GYM_CLUSTERS = gql`
+  query DuplicateGymClusters($input: DuplicateGymClustersInput) {
+    duplicateGymClusters(input: $input) {
+      clusters {
+        ${DUPLICATE_GYM_CLUSTER_FIELDS}
+      }
+      totalCount
+      hasMore
+    }
+  }
+`;
+
+export const ORPHAN_GYMS = gql`
+  query OrphanGyms($input: OrphanGymsInput) {
+    orphanGyms(input: $input) {
+      gyms {
+        gymUuid
+        slug
+        name
+        address
+        boardCount
+        followerCount
+        memberCount
+        kioskCount
+        createdAt
+      }
+      totalCount
+      hasMore
+    }
+  }
+`;
+
+export const MERGE_GYMS = gql`
+  mutation MergeGyms($input: MergeGymsInput!) {
+    mergeGyms(input: $input) {
+      canonicalGymUuid
+      results {
+        duplicateGymUuid
+        counts {
+          boards
+          follows
+          members
+          claims
+          kiosks
+          comments
+        }
+        warnings {
+          kioskUuid
+          kioskName
+          previousSlug
+          newSlug
+        }
+      }
+    }
+  }
+`;
+
+export const DISMISS_GYM_CLUSTER = gql`
+  mutation DismissGymCluster($input: DismissGymClusterInput!) {
+    dismissGymCluster(input: $input)
+  }
+`;
+
+// ============================================
 // Query/Mutation Variable Types
 // ============================================
 
@@ -481,4 +581,36 @@ export type PendingGymClaimsQueryVariables = {
 
 export type PendingGymClaimsQueryResponse = {
   pendingGymClaims: GymClaimConnection;
+};
+
+export type DuplicateGymClustersQueryVariables = {
+  input?: DuplicateGymClustersInput;
+};
+
+export type DuplicateGymClustersQueryResponse = {
+  duplicateGymClusters: DuplicateGymClusterConnection;
+};
+
+export type OrphanGymsQueryVariables = {
+  input?: OrphanGymsInput;
+};
+
+export type OrphanGymsQueryResponse = {
+  orphanGyms: OrphanGymConnection;
+};
+
+export type MergeGymsMutationVariables = {
+  input: MergeGymsInput;
+};
+
+export type MergeGymsMutationResponse = {
+  mergeGyms: MergeGymsResult;
+};
+
+export type DismissGymClusterMutationVariables = {
+  input: DismissGymClusterInput;
+};
+
+export type DismissGymClusterMutationResponse = {
+  dismissGymCluster: boolean;
 };

--- a/packages/shared/i18n/locales/en-US/admin.json
+++ b/packages/shared/i18n/locales/en-US/admin.json
@@ -21,9 +21,9 @@
   "nav": {
     "retention": "Retention dashboard",
     "gymClaims": "Gym claims",
-    "feedback": "Bug reports"
+    "feedback": "Bug reports",
+    "gymDuplicates": "Duplicate gyms"
   },
-
   "feedback": {
     "title": "Bug reports & feedback",
     "subtitle": "Bug reports and ratings from the app. Filter, find the reporter's email, and mark them done.",
@@ -244,5 +244,58 @@
       "actions": "Actions"
     },
     "loadMore": "Load more"
+  },
+  "gymDuplicates": {
+    "title": "Duplicate gyms",
+    "backToAdmin": "Back to admin",
+    "heading": "Duplicate review queue",
+    "tabs": {
+      "duplicates": "Duplicates",
+      "orphans": "Orphan audit"
+    },
+    "tier": {
+      "a": "Exact match",
+      "b": "Close match"
+    },
+    "maxDistance": "Up to {{meters}} m apart",
+    "owner": {
+      "system": "System",
+      "user": "User-owned"
+    },
+    "claim": {
+      "pending": "Claim pending",
+      "approved": "Claim approved"
+    },
+    "counts": "{{boards}} boards · {{follows}} follows · {{members}} members · {{kiosks}} kiosks · {{claims}} claims",
+    "orphanCounts": "{{boards}} boards · {{follows}} follows · {{members}} members · {{kiosks}} kiosks",
+    "distance": "{{meters}} m from survivor",
+    "merge": "Merge",
+    "dismiss": "Not a duplicate",
+    "confirm": {
+      "title": "Merge these gyms?",
+      "body": "This folds {{count}} duplicate gyms into {{canonical}} and moves {{boards}} boards, {{follows}} follows, {{members}} members, {{kiosks}} kiosks, and {{claims}} claims onto it. This can't be undone.",
+      "cancel": "Cancel",
+      "confirm": "Merge",
+      "overrideWarning": "Heads up: you're keeping a system listing as the survivor over a gym someone owns or has claimed. Their gym gets folded into the system one. Only do this if the system row is genuinely the right home.",
+      "confirmOverride": "Merge anyway"
+    },
+    "kioskWarning": "Kiosk \"{{name}}\" moved from /{{previous}} to /{{next}}",
+    "snackbar": {
+      "merged": "Gyms merged",
+      "mergeFailed": "Couldn't merge the gyms",
+      "dismissed": "Marked as not a duplicate",
+      "dismissFailed": "Couldn't dismiss the group"
+    },
+    "empty": "No duplicates to review",
+    "error": "Couldn't load duplicates. Try again.",
+    "retry": "Retry",
+    "loadMore": "Load more",
+    "orphans": {
+      "summary": "{{count}} system-owned gyms with no location-sync source",
+      "empty": "No orphan gyms",
+      "name": "Gym",
+      "address": "Address",
+      "counts": "Counts"
+    }
   }
 }

--- a/packages/shared/i18n/locales/es/admin.json
+++ b/packages/shared/i18n/locales/es/admin.json
@@ -120,9 +120,9 @@
   "nav": {
     "retention": "Panel de retención",
     "gymClaims": "Reclamaciones de gimnasios",
-    "feedback": "Reportes de errores"
+    "feedback": "Reportes de errores",
+    "gymDuplicates": "Gimnasios duplicados"
   },
-
   "feedback": {
     "title": "Errores y comentarios",
     "subtitle": "Errores y valoraciones desde la app. Filtra, encuentra el correo de quien lo reportó y márcalos como resueltos.",
@@ -244,5 +244,58 @@
       "actions": "Acciones"
     },
     "loadMore": "Cargar más"
+  },
+  "gymDuplicates": {
+    "title": "Gimnasios duplicados",
+    "backToAdmin": "Volver al panel",
+    "heading": "Cola de revisión de duplicados",
+    "tabs": {
+      "duplicates": "Duplicados",
+      "orphans": "Auditoría de huérfanos"
+    },
+    "tier": {
+      "a": "Coincidencia exacta",
+      "b": "Coincidencia aproximada"
+    },
+    "maxDistance": "Hasta {{meters}} m de distancia",
+    "owner": {
+      "system": "Sistema",
+      "user": "De un usuario"
+    },
+    "claim": {
+      "pending": "Reclamación pendiente",
+      "approved": "Reclamación aprobada"
+    },
+    "counts": "{{boards}} plafones · {{follows}} seguidores · {{members}} miembros · {{kiosks}} kioscos · {{claims}} reclamaciones",
+    "orphanCounts": "{{boards}} plafones · {{follows}} seguidores · {{members}} miembros · {{kiosks}} kioscos",
+    "distance": "a {{meters}} m del superviviente",
+    "merge": "Fusionar",
+    "dismiss": "No es un duplicado",
+    "confirm": {
+      "title": "¿Fusionar estos gimnasios?",
+      "body": "Esto une {{count}} gimnasios duplicados en {{canonical}} y le mueve {{boards}} plafones, {{follows}} seguidores, {{members}} miembros, {{kiosks}} kioscos y {{claims}} reclamaciones. No se puede deshacer.",
+      "cancel": "Cancelar",
+      "confirm": "Fusionar",
+      "overrideWarning": "Atención: vas a conservar una ficha del sistema como superviviente frente a un gimnasio que alguien posee o ha reclamado. Su gimnasio se fusionará con el del sistema. Hazlo solo si la ficha del sistema es realmente la correcta.",
+      "confirmOverride": "Fusionar de todos modos"
+    },
+    "kioskWarning": "El kiosco «{{name}}» pasó de /{{previous}} a /{{next}}",
+    "snackbar": {
+      "merged": "Gimnasios fusionados",
+      "mergeFailed": "No se pudieron fusionar los gimnasios",
+      "dismissed": "Marcado como no duplicado",
+      "dismissFailed": "No se pudo descartar el grupo"
+    },
+    "empty": "No hay duplicados para revisar",
+    "error": "No se pudieron cargar los duplicados. Inténtalo de nuevo.",
+    "retry": "Reintentar",
+    "loadMore": "Cargar más",
+    "orphans": {
+      "summary": "{{count}} gimnasios del sistema sin fuente de sincronización de ubicación",
+      "empty": "No hay gimnasios huérfanos",
+      "name": "Gimnasio",
+      "address": "Dirección",
+      "counts": "Totales"
+    }
   }
 }

--- a/packages/shared/i18n/locales/fr/admin.json
+++ b/packages/shared/i18n/locales/fr/admin.json
@@ -21,9 +21,9 @@
   "nav": {
     "retention": "Tableau de rétention",
     "gymClaims": "Revendications de salles",
-    "feedback": "Rapports de bugs"
+    "feedback": "Rapports de bugs",
+    "gymDuplicates": "Salles en double"
   },
-
   "feedback": {
     "title": "Bugs et retours",
     "subtitle": "Bugs et évaluations depuis l'app. Filtrez, trouvez l'e-mail de l'auteur et marquez-les comme résolus.",
@@ -244,5 +244,58 @@
       "actions": "Actions"
     },
     "loadMore": "Charger plus"
+  },
+  "gymDuplicates": {
+    "title": "Salles en double",
+    "backToAdmin": "Retour à l’administration",
+    "heading": "File de révision des doublons",
+    "tabs": {
+      "duplicates": "Doublons",
+      "orphans": "Audit des orphelines"
+    },
+    "tier": {
+      "a": "Correspondance exacte",
+      "b": "Correspondance proche"
+    },
+    "maxDistance": "Jusqu’à {{meters}} m d’écart",
+    "owner": {
+      "system": "Système",
+      "user": "D’un utilisateur"
+    },
+    "claim": {
+      "pending": "Revendication en attente",
+      "approved": "Revendication approuvée"
+    },
+    "counts": "{{boards}} boards · {{follows}} abonnés · {{members}} membres · {{kiosks}} kiosques · {{claims}} revendications",
+    "orphanCounts": "{{boards}} boards · {{follows}} abonnés · {{members}} membres · {{kiosks}} kiosques",
+    "distance": "à {{meters}} m de la salle conservée",
+    "merge": "Fusionner",
+    "dismiss": "Pas un doublon",
+    "confirm": {
+      "title": "Fusionner ces salles ?",
+      "body": "Cela regroupe {{count}} salles en double dans {{canonical}} et lui rattache {{boards}} boards, {{follows}} abonnés, {{members}} membres, {{kiosks}} kiosques et {{claims}} revendications. Action irréversible.",
+      "cancel": "Annuler",
+      "confirm": "Fusionner",
+      "overrideWarning": "Attention : vous gardez une fiche système comme survivante face à une salle détenue ou revendiquée par quelqu'un. Sa salle sera fusionnée dans celle du système. Ne le faites que si la fiche système est vraiment la bonne.",
+      "confirmOverride": "Fusionner quand même"
+    },
+    "kioskWarning": "Le kiosque « {{name}} » est passé de /{{previous}} à /{{next}}",
+    "snackbar": {
+      "merged": "Salles fusionnées",
+      "mergeFailed": "Impossible de fusionner les salles",
+      "dismissed": "Marqué comme non-doublon",
+      "dismissFailed": "Impossible d’écarter le groupe"
+    },
+    "empty": "Aucun doublon à réviser",
+    "error": "Impossible de charger les doublons. Réessaie.",
+    "retry": "Réessayer",
+    "loadMore": "Charger plus",
+    "orphans": {
+      "summary": "{{count}} salles gérées par le système sans source de synchronisation de localisation",
+      "empty": "Aucune salle orpheline",
+      "name": "Salle",
+      "address": "Adresse",
+      "counts": "Totaux"
+    }
   }
 }

--- a/packages/web/app/admin/gym-duplicates/page.tsx
+++ b/packages/web/app/admin/gym-duplicates/page.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import MuiLink from '@mui/material/Link';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import { checkAdmin } from '@/app/lib/admin/check-admin';
+import { themeTokens } from '@/app/theme/theme-config';
+import GymDuplicatesPanel from '@/app/components/admin/gym-duplicates-panel';
+import LocaleLink from '@/app/components/i18n/locale-link';
+
+// Server-rendered so admin access is enforced before any markup ships — matching
+// /admin/gym-claims. The GraphQL queries and mutations are already admin-gated on
+// the backend, so this is defense-in-depth, but it keeps the /admin subtree consistent.
+export const dynamic = 'force-dynamic';
+
+export default async function AdminGymDuplicatesPage() {
+  const access = await checkAdmin();
+  const locale = await getLocale();
+  const { t } = await getServerTranslation('admin');
+
+  if (!access.authenticated) {
+    return (
+      <I18nProvider locale={locale} namespaces={['common', 'admin']}>
+        <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+          <Alert severity="warning">{t('auth.signInRequired')}</Alert>
+        </Container>
+      </I18nProvider>
+    );
+  }
+
+  if (!access.isAdmin) {
+    return (
+      <I18nProvider locale={locale} namespaces={['common', 'admin']}>
+        <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+          <Alert severity="error">{t('auth.noAccess')}</Alert>
+        </Container>
+      </I18nProvider>
+    );
+  }
+
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'admin']}>
+      <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+        <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, color: themeTokens.neutral[800] }}>
+          {t('gymDuplicates.title')}
+        </Typography>
+        <Box sx={{ mb: 3 }}>
+          <MuiLink component={LocaleLink} href="/admin" underline="hover" sx={{ color: themeTokens.colors.primary }}>
+            {t('gymDuplicates.backToAdmin')}
+          </MuiLink>
+        </Box>
+        <GymDuplicatesPanel />
+      </Container>
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/admin/page.tsx
+++ b/packages/web/app/admin/page.tsx
@@ -88,6 +88,14 @@ export default function AdminPage() {
         <MuiLink component={LocaleLink} href="/admin/feedback" underline="hover" sx={{ color: 'var(--color-primary)' }}>
           {t('nav.feedback')}
         </MuiLink>
+        <MuiLink
+          component={LocaleLink}
+          href="/admin/gym-duplicates"
+          underline="hover"
+          sx={{ color: themeTokens.colors.primary }}
+        >
+          {t('nav.gymDuplicates')}
+        </MuiLink>
       </Box>
 
       <Box sx={{ borderBottom: 1, borderColor: themeTokens.neutral[200], mb: 3 }}>

--- a/packages/web/app/components/admin/gym-duplicates-panel.tsx
+++ b/packages/web/app/components/admin/gym-duplicates-panel.tsx
@@ -1,0 +1,573 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import Paper from '@mui/material/Paper';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Divider from '@mui/material/Divider';
+import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import CircularProgress from '@mui/material/CircularProgress';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import MuiLink from '@mui/material/Link';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { themeTokens } from '@/app/theme/theme-config';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  DUPLICATE_GYM_CLUSTERS,
+  ORPHAN_GYMS,
+  MERGE_GYMS,
+  DISMISS_GYM_CLUSTER,
+  type DuplicateGymClustersQueryResponse,
+  type DuplicateGymClustersQueryVariables,
+  type OrphanGymsQueryResponse,
+  type OrphanGymsQueryVariables,
+  type MergeGymsMutationResponse,
+  type MergeGymsMutationVariables,
+  type DismissGymClusterMutationResponse,
+  type DismissGymClusterMutationVariables,
+} from '@boardsesh/graphql/operations';
+import type { DuplicateGymCluster, DuplicateGymMember, OrphanGym, KioskSlugWarning } from '@boardsesh/shared-schema';
+
+const PAGE_SIZE = 20;
+
+// Sum the FK counts an admin is about to move off the duplicates onto the survivor.
+function sumDuplicateCounts(duplicates: DuplicateGymMember[]) {
+  return duplicates.reduce(
+    (totals, member) => ({
+      boards: totals.boards + member.boardCount,
+      follows: totals.follows + member.followerCount,
+      members: totals.members + member.memberCount,
+      kiosks: totals.kiosks + member.kioskCount,
+      claims: totals.claims + member.claimCount,
+    }),
+    { boards: 0, follows: 0, members: 0, kiosks: 0, claims: 0 },
+  );
+}
+
+function DuplicatesQueue() {
+  const { t } = useTranslation('admin');
+  const { token } = useWsAuthToken();
+  const [clusters, setClusters] = useState<DuplicateGymCluster[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(false);
+  // `null` = no error; otherwise the offset to retry. Wrapped in an object so a
+  // 0 offset is never mistaken for "no error" by a truthiness check.
+  const [error, setError] = useState<{ offset: number } | null>(null);
+  const [snackbar, setSnackbar] = useState('');
+  // Per-cluster canonical survivor selection, keyed by cluster signature.
+  const [selection, setSelection] = useState<Record<string, string>>({});
+  // The cluster awaiting a merge confirmation, or null when the dialog is closed.
+  const [mergeTarget, setMergeTarget] = useState<DuplicateGymCluster | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [pendingSignature, setPendingSignature] = useState<string | null>(null);
+  // Kiosk slug moves surfaced from the most recent merge — kept until dismissed.
+  const [kioskWarnings, setKioskWarnings] = useState<KioskSlugWarning[]>([]);
+
+  const fetchClusters = useCallback(
+    async (offset = 0) => {
+      if (!token) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const client = createGraphQLHttpClient(token);
+        const result = await client.request<DuplicateGymClustersQueryResponse, DuplicateGymClustersQueryVariables>(
+          DUPLICATE_GYM_CLUSTERS,
+          { input: { limit: PAGE_SIZE, offset } },
+        );
+        const incoming = result.duplicateGymClusters.clusters;
+        setClusters((prev) => (offset === 0 ? incoming : [...prev, ...incoming]));
+        setSelection((prev) => {
+          const next = { ...prev };
+          for (const cluster of incoming) {
+            if (next[cluster.signature] === undefined) {
+              next[cluster.signature] = cluster.suggestedCanonicalGymUuid;
+            }
+          }
+          return next;
+        });
+        setHasMore(result.duplicateGymClusters.hasMore);
+      } catch (err) {
+        console.error('[GymDuplicatesPanel] Failed to fetch duplicate clusters:', err);
+        setError({ offset });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [token],
+  );
+
+  useEffect(() => {
+    void fetchClusters();
+  }, [fetchClusters]);
+
+  const selectCanonical = useCallback((signature: string, gymUuid: string) => {
+    setSelection((prev) => ({ ...prev, [signature]: gymUuid }));
+  }, []);
+
+  const confirmMerge = useCallback(async () => {
+    if (!token || !mergeTarget) return;
+    const canonicalGymUuid = selection[mergeTarget.signature] ?? mergeTarget.suggestedCanonicalGymUuid;
+    const duplicates = mergeTarget.members.filter((member) => member.gymUuid !== canonicalGymUuid);
+    const duplicateGymUuids = duplicates.map((member) => member.gymUuid);
+    // Keeping a SYSTEM listing as the survivor over a user-owned / claim-approved
+    // duplicate inverts the pre-selection; the backend rejects it without this flag.
+    const canonicalMember = mergeTarget.members.find((member) => member.gymUuid === canonicalGymUuid);
+    const allowSystemCanonicalOverride =
+      canonicalMember?.ownerType === 'system' &&
+      duplicates.some((member) => member.ownerType === 'user' || member.claimStatus === 'approved');
+    setSubmitting(true);
+    try {
+      const client = createGraphQLHttpClient(token);
+      const result = await client.request<MergeGymsMutationResponse, MergeGymsMutationVariables>(MERGE_GYMS, {
+        input: { canonicalGymUuid, duplicateGymUuids, allowSystemCanonicalOverride },
+      });
+      const warnings = result.mergeGyms.results.flatMap((duplicate) => duplicate.warnings);
+      if (warnings.length > 0) setKioskWarnings((prev) => [...prev, ...warnings]);
+      setClusters((prev) => prev.filter((cluster) => cluster.signature !== mergeTarget.signature));
+      setSnackbar(t('gymDuplicates.snackbar.merged'));
+      setMergeTarget(null);
+    } catch {
+      setSnackbar(t('gymDuplicates.snackbar.mergeFailed'));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [token, mergeTarget, selection, t]);
+
+  const dismissCluster = useCallback(
+    async (cluster: DuplicateGymCluster) => {
+      if (!token) return;
+      const canonicalGymUuid = selection[cluster.signature] ?? cluster.suggestedCanonicalGymUuid;
+      setPendingSignature(cluster.signature);
+      try {
+        const client = createGraphQLHttpClient(token);
+        await client.request<DismissGymClusterMutationResponse, DismissGymClusterMutationVariables>(
+          DISMISS_GYM_CLUSTER,
+          { input: { gymUuids: cluster.members.map((member) => member.gymUuid), canonicalGymUuid } },
+        );
+        setClusters((prev) => prev.filter((entry) => entry.signature !== cluster.signature));
+        setSnackbar(t('gymDuplicates.snackbar.dismissed'));
+      } catch {
+        setSnackbar(t('gymDuplicates.snackbar.dismissFailed'));
+      } finally {
+        setPendingSignature(null);
+      }
+    },
+    [token, selection, t],
+  );
+
+  const mergeCanonicalUuid = mergeTarget
+    ? (selection[mergeTarget.signature] ?? mergeTarget.suggestedCanonicalGymUuid)
+    : null;
+  const mergeDuplicates = mergeTarget
+    ? mergeTarget.members.filter((member) => member.gymUuid !== mergeCanonicalUuid)
+    : [];
+  const mergeCanonicalMember = mergeTarget
+    ? mergeTarget.members.find((member) => member.gymUuid === mergeCanonicalUuid)
+    : undefined;
+  const mergeTotals = sumDuplicateCounts(mergeDuplicates);
+  // The admin has inverted the pre-selection: a SYSTEM listing survives over a
+  // user-owned or claim-approved duplicate. Warn and require confirmation.
+  const mergeOverrideRequired =
+    mergeCanonicalMember?.ownerType === 'system' &&
+    mergeDuplicates.some((member) => member.ownerType === 'user' || member.claimStatus === 'approved');
+
+  return (
+    <Box>
+      {kioskWarnings.length > 0 && (
+        <Alert severity="warning" sx={{ mb: 2 }} onClose={() => setKioskWarnings([])}>
+          <Stack spacing={0.5}>
+            {kioskWarnings.map((warning) => (
+              <Typography key={warning.kioskUuid} variant="body2">
+                {t('gymDuplicates.kioskWarning', {
+                  name: warning.kioskName,
+                  previous: warning.previousSlug,
+                  next: warning.newSlug,
+                })}
+              </Typography>
+            ))}
+          </Stack>
+        </Alert>
+      )}
+
+      {error !== null && (
+        <Alert
+          severity="error"
+          sx={{ mb: 2 }}
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => error !== null && fetchClusters(error.offset)}
+              sx={{ textTransform: 'none' }}
+            >
+              {t('gymDuplicates.retry')}
+            </Button>
+          }
+        >
+          {t('gymDuplicates.error')}
+        </Alert>
+      )}
+
+      <Stack spacing={2}>
+        {clusters.map((cluster) => {
+          const selected = selection[cluster.signature] ?? cluster.suggestedCanonicalGymUuid;
+          return (
+            <Card key={cluster.signature} variant="outlined">
+              <CardContent>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 2 }}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                    {cluster.normalizedName}
+                  </Typography>
+                  <Chip
+                    label={cluster.tier === 'A' ? t('gymDuplicates.tier.a') : t('gymDuplicates.tier.b')}
+                    size="small"
+                    color={cluster.tier === 'A' ? 'success' : 'warning'}
+                    variant="outlined"
+                    sx={{ fontSize: 11 }}
+                  />
+                  <Typography variant="caption" sx={{ color: themeTokens.neutral[500] }}>
+                    {t('gymDuplicates.maxDistance', { meters: Math.round(cluster.maxDistanceMeters) })}
+                  </Typography>
+                </Box>
+
+                <RadioGroup
+                  value={selected}
+                  onChange={(event) => selectCanonical(cluster.signature, event.target.value)}
+                >
+                  <Stack divider={<Divider flexItem />} spacing={1}>
+                    {cluster.members.map((member) => (
+                      <FormControlLabel
+                        key={member.gymUuid}
+                        value={member.gymUuid}
+                        control={<Radio size="small" />}
+                        sx={{ alignItems: 'flex-start', m: 0 }}
+                        slotProps={{ typography: { sx: { width: '100%' } } }}
+                        label={
+                          <Box sx={{ pt: 0.5 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                {member.name}
+                              </Typography>
+                              <Chip
+                                label={
+                                  member.ownerType === 'system'
+                                    ? t('gymDuplicates.owner.system')
+                                    : t('gymDuplicates.owner.user')
+                                }
+                                size="small"
+                                color={member.ownerType === 'system' ? 'default' : 'success'}
+                                variant="outlined"
+                                sx={{ fontSize: 10 }}
+                              />
+                              {member.claimStatus !== 'none' && (
+                                <Chip
+                                  label={
+                                    member.claimStatus === 'approved'
+                                      ? t('gymDuplicates.claim.approved')
+                                      : t('gymDuplicates.claim.pending')
+                                  }
+                                  size="small"
+                                  color="primary"
+                                  variant="outlined"
+                                  sx={{ fontSize: 10 }}
+                                />
+                              )}
+                              {member.providerOrigins.map((provider) => (
+                                <Chip key={provider} label={provider} size="small" sx={{ fontSize: 10 }} />
+                              ))}
+                            </Box>
+                            <Typography variant="caption" sx={{ display: 'block', color: themeTokens.neutral[500] }}>
+                              {member.address || '—'}
+                            </Typography>
+                            <Typography variant="caption" sx={{ display: 'block', color: themeTokens.neutral[500] }}>
+                              {t('gymDuplicates.counts', {
+                                boards: member.boardCount,
+                                follows: member.followerCount,
+                                members: member.memberCount,
+                                kiosks: member.kioskCount,
+                                claims: member.claimCount,
+                              })}
+                              {' · '}
+                              {t('gymDuplicates.distance', {
+                                meters: Math.round(member.distanceToCanonicalMeters),
+                              })}
+                            </Typography>
+                          </Box>
+                        }
+                      />
+                    ))}
+                  </Stack>
+                </RadioGroup>
+
+                <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end', mt: 2 }}>
+                  <Button
+                    color="error"
+                    onClick={() => dismissCluster(cluster)}
+                    disabled={pendingSignature === cluster.signature}
+                    sx={{ textTransform: 'none' }}
+                  >
+                    {t('gymDuplicates.dismiss')}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    onClick={() => setMergeTarget(cluster)}
+                    disabled={pendingSignature === cluster.signature}
+                    sx={{ textTransform: 'none' }}
+                  >
+                    {t('gymDuplicates.merge')}
+                  </Button>
+                </Box>
+              </CardContent>
+            </Card>
+          );
+        })}
+
+        {clusters.length === 0 && !loading && error === null && (
+          <Typography variant="body2" sx={{ color: themeTokens.neutral[400], py: 2, textAlign: 'center' }}>
+            {t('gymDuplicates.empty')}
+          </Typography>
+        )}
+
+        {loading && (
+          <Box sx={{ textAlign: 'center', py: 2 }}>
+            <CircularProgress size={20} />
+          </Box>
+        )}
+      </Stack>
+
+      {hasMore && (
+        <Box sx={{ mt: 2, textAlign: 'center' }}>
+          <Button
+            variant="outlined"
+            onClick={() => fetchClusters(clusters.length)}
+            disabled={loading}
+            sx={{ textTransform: 'none' }}
+          >
+            {t('gymDuplicates.loadMore')}
+          </Button>
+        </Box>
+      )}
+
+      <Dialog open={mergeTarget !== null} onClose={() => (submitting ? undefined : setMergeTarget(null))}>
+        <DialogTitle>{t('gymDuplicates.confirm.title')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {t('gymDuplicates.confirm.body', {
+              count: mergeDuplicates.length,
+              canonical: mergeCanonicalMember?.name ?? '',
+              boards: mergeTotals.boards,
+              follows: mergeTotals.follows,
+              members: mergeTotals.members,
+              kiosks: mergeTotals.kiosks,
+              claims: mergeTotals.claims,
+            })}
+          </DialogContentText>
+          {mergeOverrideRequired && (
+            <Alert severity="warning" sx={{ mt: 2 }}>
+              {t('gymDuplicates.confirm.overrideWarning')}
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setMergeTarget(null)} disabled={submitting} sx={{ textTransform: 'none' }}>
+            {t('gymDuplicates.confirm.cancel')}
+          </Button>
+          <Button
+            variant="contained"
+            color={mergeOverrideRequired ? 'warning' : 'primary'}
+            onClick={confirmMerge}
+            disabled={submitting}
+            sx={{ textTransform: 'none' }}
+          >
+            {mergeOverrideRequired ? t('gymDuplicates.confirm.confirmOverride') : t('gymDuplicates.confirm.confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar open={!!snackbar} autoHideDuration={3000} onClose={() => setSnackbar('')} message={snackbar} />
+    </Box>
+  );
+}
+
+function OrphanAudit() {
+  const { t } = useTranslation('admin');
+  const { token } = useWsAuthToken();
+  const [orphans, setOrphans] = useState<OrphanGym[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(false);
+  // `null` = no error; otherwise the offset to retry (wrapped so offset 0 isn't
+  // mistaken for "no error").
+  const [error, setError] = useState<{ offset: number } | null>(null);
+
+  const fetchOrphans = useCallback(
+    async (offset = 0) => {
+      if (!token) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const client = createGraphQLHttpClient(token);
+        const result = await client.request<OrphanGymsQueryResponse, OrphanGymsQueryVariables>(ORPHAN_GYMS, {
+          input: { limit: PAGE_SIZE, offset },
+        });
+        setOrphans((prev) => (offset === 0 ? result.orphanGyms.gyms : [...prev, ...result.orphanGyms.gyms]));
+        setTotalCount(result.orphanGyms.totalCount);
+        setHasMore(result.orphanGyms.hasMore);
+      } catch (err) {
+        console.error('[GymDuplicatesPanel] Failed to fetch orphan gyms:', err);
+        setError({ offset });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [token],
+  );
+
+  useEffect(() => {
+    void fetchOrphans();
+  }, [fetchOrphans]);
+
+  return (
+    <Box>
+      {error !== null && (
+        <Alert
+          severity="error"
+          sx={{ mb: 2 }}
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => error !== null && fetchOrphans(error.offset)}
+              sx={{ textTransform: 'none' }}
+            >
+              {t('gymDuplicates.retry')}
+            </Button>
+          }
+        >
+          {t('gymDuplicates.error')}
+        </Alert>
+      )}
+
+      <Typography variant="body2" sx={{ mb: 2, color: themeTokens.neutral[600] }}>
+        {t('gymDuplicates.orphans.summary', { count: totalCount })}
+      </Typography>
+
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>{t('gymDuplicates.orphans.name')}</TableCell>
+              <TableCell>{t('gymDuplicates.orphans.address')}</TableCell>
+              <TableCell>{t('gymDuplicates.orphans.counts')}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {orphans.map((orphan) => (
+              <TableRow key={orphan.gymUuid}>
+                <TableCell>
+                  <MuiLink
+                    component={LocaleLink}
+                    href={`/gym/${orphan.slug ?? orphan.gymUuid}`}
+                    underline="hover"
+                    variant="body2"
+                    sx={{ color: themeTokens.colors.primary }}
+                  >
+                    {orphan.name}
+                  </MuiLink>
+                </TableCell>
+                <TableCell sx={{ color: themeTokens.neutral[500] }}>{orphan.address || '—'}</TableCell>
+                <TableCell sx={{ color: themeTokens.neutral[500] }}>
+                  {t('gymDuplicates.orphanCounts', {
+                    boards: orphan.boardCount,
+                    follows: orphan.followerCount,
+                    members: orphan.memberCount,
+                    kiosks: orphan.kioskCount,
+                  })}
+                </TableCell>
+              </TableRow>
+            ))}
+            {orphans.length === 0 && !loading && error === null && (
+              <TableRow>
+                <TableCell colSpan={3} align="center">
+                  <Typography variant="body2" sx={{ color: themeTokens.neutral[400], py: 2 }}>
+                    {t('gymDuplicates.orphans.empty')}
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+            {loading && (
+              <TableRow>
+                <TableCell colSpan={3} align="center">
+                  <CircularProgress size={20} sx={{ my: 2 }} />
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {hasMore && (
+        <Box sx={{ mt: 2, textAlign: 'center' }}>
+          <Button
+            variant="outlined"
+            onClick={() => fetchOrphans(orphans.length)}
+            disabled={loading}
+            sx={{ textTransform: 'none' }}
+          >
+            {t('gymDuplicates.loadMore')}
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export default function GymDuplicatesPanel() {
+  const { t } = useTranslation('admin');
+  const [tab, setTab] = useState(0);
+
+  return (
+    <Box>
+      <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+        {t('gymDuplicates.heading')}
+      </Typography>
+
+      <Box sx={{ borderBottom: 1, borderColor: themeTokens.neutral[200], mb: 3 }}>
+        <Tabs value={tab} onChange={(_, value) => setTab(value)}>
+          <Tab label={t('gymDuplicates.tabs.duplicates')} sx={{ textTransform: 'none' }} />
+          <Tab label={t('gymDuplicates.tabs.orphans')} sx={{ textTransform: 'none' }} />
+        </Tabs>
+      </Box>
+
+      {/* Keep the duplicates queue mounted so merge selections survive a tab switch;
+          the orphan audit mounts lazily on first open. */}
+      <Box sx={{ display: tab === 0 ? 'block' : 'none' }}>
+        <DuplicatesQueue />
+      </Box>
+      {tab === 1 && <OrphanAudit />}
+    </Box>
+  );
+}


### PR DESCRIPTION
> Builds on M1 (#3669, now merged into `main`): `merged_into_gym_id` + canonical resolution. This PR targets `main` directly; its migration `0183_bouncy_azazel` chains from M1's `0182_magical_thor`.

## What this does

Prod has ~46–60 physical duplicate gym rows (same normalized name within ~100 m, most 40–90 m apart from cross-provider coordinate drift) plus ~1,485 alias-less SYSTEM-owned gyms. The call: humans merge duplicates through an easy admin page — no bulk auto-apply.

**Merge library** (`packages/db/src/queries/gyms/merge-gyms.ts`): the cluster-merge internals moved out of the dedupe CLI so the backend can import them (the script is now a thin wrapper). Re-points boards, source aliases, follows, members, comments, feed items, notifications, votes onto the survivor — plus the two verified gaps:

- **gym_claims** — honours the unique-pending index. A claimant mid-flight on a twin lands on the canonical; if they already have a pending claim there, that one stands and the duplicate's is dropped (ON CONFLICT DO NOTHING semantics). Nobody loses their place.
- **gym_kiosks** — a live kiosk slug that collides on the canonical is suffixed (`main-wall` → `main-wall-2`) and returned as a **warning**. A re-slugged kiosk's printed install QR no longer resolves, so the merge surfaces it for reprinting.

**Audit table** (`gym_merge_audit`, migration `0183_bouncy_azazel`): one row per admin decision — `merged` (canonical + duplicate ids, moved counts, warnings) or `dismissed` (keyed by a stable hash of the sorted member gym ids so the queue hides that exact cluster).

**Backend admin GraphQL** (admin-gated via `requireAdmin`, mirroring the gym-claims review flow):

- `duplicateGymClusters` — tiered candidate clusters over LIVE gyms. Tier A: same normalized name within 20 m; tier B: within 150 m (the observed drift band). Each member marked with ownerType (system/user), claimStatus (none/pending/approved), provider origins, FK counts (boards/follows/members/kiosks/claims), coords + distance-to-canonical. Dismissed clusters excluded. Paginated.
- `orphanGyms` — alias-less SYSTEM-owned live gyms with no location-sync source. List-only, count summary + page (no bulk action).
- `mergeGyms` — validates every uuid is live + un-merged and that the canonical is not among the duplicates; runs the library merge per duplicate in one transaction; writes audit rows; returns per-duplicate moved counts + kiosk-slug warnings.
- `dismissGymCluster` — writes the dismissal audit row.

**Web `/admin/gym-duplicates`** (cloned from `/admin/gym-claims`, same `checkAdmin` gate): cluster cards with member rows (owner/claim badges, provider chips, FK counts, distance); canonical pre-selected by rule — a claimed or user-owned row always wins over SYSTEM regardless of completeness, ties fall back to completeness-then-oldest — with an admin radio override; a merge confirm dialog listing exactly what moves (board/follow/member/kiosk/claim counts) plus any kiosk-slug warning after; a dismiss button; and a second tab for the orphan audit. Linked from the `/admin` index. i18n across en-US/es/fr.

**CLI `--backfill-pointers`** (M1's deferred follow-up): re-clusters pre-pointer SOFT-DELETED twins (the ~46–60 pre-M1 merged rows) against live gyms by name + distance (same tiers) and sets their missing `merged_into_gym_id`, so old uuids/slugs (printed kiosk QRs) resolve to the survivor. Report-only by default; `--apply` writes, under human review.

- `vp run db:dedupe-gyms --backfill-pointers` — dry-run report
- `vp run db:dedupe-gyms --backfill-pointers --apply` — set the pointers

## Kiosk-slug warning example

Merging a twin whose kiosk slug `main-wall` collides with the canonical's `main-wall` returns:

```json
{ "type": "kiosk_slug_changed", "kioskUuid": "…", "kioskName": "Main Wall",
  "previousSlug": "main-wall", "newSlug": "main-wall-2" }
```

The UI shows this in a persistent warning banner so the gym reprints that wall's install QR.

## Tests

- **db** (`dedupe-gym-locations.integration.test.ts`): moved-counts accuracy, `merged_into` set on the twin, claims unique-pending conflict path, kiosk slug-suffix warning; `--backfill-pointers` arg parsing.
- **backend** (`gym-duplicates.test.ts`): admin gate denies non-admin + anonymous on every resolver, tier A vs B classification, user-owned/claimed canonical preference, dismissal filtering, orphan listing, and mergeGyms end-to-end (boards/members/kiosks/claims re-point, merged_into pointer, audit rows).

## Notes

- The merge SQL now uses bare `'gym'` literals instead of `'gym'::social_entity_type` casts — the untyped literal coerces to the enum in prod and string-compares against the backend test schema's text column, so the same code is portable across both.
- `gym_member_role` was added to the backend test schema (`schema-sql.ts`) because the member-collapse upsert builds an enum-typed value there.

## Review fixes (Fable pass)

- **Member role precedence** — the member-collapse upsert now preserves `admin > editor > member` on both the SELECT and the ON CONFLICT sides, so a twin's editor arrives as editor and the canonical's own editor is never demoted to member. Covered by a new editor-role test (db + backend).
- **`is_public` no longer forced** — merging into a user-owned private gym keeps the survivor's own `is_public`; the metadata backfill only fills empty fields.
- **SYSTEM-canonical override guard** — `mergeGyms` rejects an inverted pre-selection (a SYSTEM row kept as survivor over a user-owned or claim-approved duplicate) unless the input carries `allowSystemCanonicalOverride: true`. The panel detects the inversion, shows a warning in the confirm dialog, and only then sends the flag.
- **Audit reversibility** — (a) every merge audit row now stores per-table moved-row ids (`moved_rows` jsonb: board/source/follow/member/claim/kiosk/comment/feed/notification/vote ids + soft-deleted gym id), not just aggregate counts, so a bad merge can be traced and manually reversed. (b) **Chosen approach for the collided pending claims: re-point to the canonical and flip to `expired`** (an existing `gym_claim_status` value — no new enum, no migration), instead of deleting them. The claimant's full claim content is preserved on the survivor and their live canonical claim still stands.
- **Backfill ambiguity guard** — `--backfill-pointers` now skips a twin when a second live candidate sits within the match band (reported, never pointed — a wrong pointer redirects printed QRs to the wrong gym), and restricts to SYSTEM-owned twins by default (`--include-non-system-twins` to opt in).
- **Orphan copy fixed** — `orphans.summary` now says "system-owned gyms with no location-sync source" (what the query returns) in all three locales, not the old "no boards, members, or followers".

**Discretionary items deferred (noted, not blocking):** metadata backfill for website/logo/brand colours (finding 7), a lock-ordering comment, audit-count-noise cleanups (live-only board counts, self-upsert votes), i18next plural forms in the panel counts, RadioGroup aria-labels, and double-merge-idempotency / signature-resurface tests.

## Release Notes

One gym, one page — we're merging duplicate gym listings, and your follows, boards, and kiosks ride along to the surviving page. If a merge shifts a kiosk's address, we flag it so the gym can reprint that wall's install QR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VGxf4ZJGFRanuJGrRMDgY

