### PR TITLE
feat(web): dark inputs on the Velvet elevated surface — white-input rule retired

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Vitest via `vp test`. Backend tests auto-start postgres+redis via `packages/back
 - **Web uses MUI.** Always MUI components and props. Avoid the `style` prop. Always use design tokens from `packages/web/app/theme/theme-config.ts` for colours/spacing — no hardcoded values.
 - Use CSS media queries for responsive design. Avoid JS breakpoint detection (`Grid.useBreakpoint()`).
 - Remove dead code as you go.
-- **Dark mode uses white input fields.** Intentional for contrast (`darkTokens.semantic.inputSurface`). Do not change.
+- **Dark mode inputs use the elevated dark surface** (`darkTokens.semantic.inputSurface`, #2F234A) with a violet `#A78BFA` focus ring — don't force white fields (`--input-*` vars in index.css are the source of truth).
 - **Never hardcode user-facing strings** in `packages/web/app/**/*.tsx` — all visible text via i18n catalogs. CI runs `vp run check:i18n` and `vp run check:i18n:orphans`. Mark unresolvable dynamic lookups with `// i18n-keep namespace.dotted.key`.
 - **Variable names describe contents.** No single-letter aliases (`r`, `x`, `s`) or vague placeholders (`data`, `info`, `temp`, `value`) outside tight loops. Destructure at the use site instead of generic aliases.
 - **Drizzle ORM over raw SQL.** Use `db.select/insert/update/delete()`. Raw `sql` from `drizzle-orm` only when the query genuinely can't be expressed otherwise. Importing `sql` from `@/app/lib/db/db` (raw Neon HTTP client) is lint-blocked.

--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -538,6 +538,11 @@ The web app renders Velvet Send in light and dark. Wiring notes specific to web:
 - **Scheme-awareness.** A direct `themeTokens.colors.{primary,success,error,warning,info}` read renders
   the _light_ value in dark mode — use the scheme-aware CSS vars instead: `var(--color-primary)`
   (foreground), `var(--color-primary-fill)` (fills), `var(--color-success|error|warning|info)` (status).
+- **Input fields.** The `--input-*` family in `index.css` (bg / bg-hover / text / placeholder / border /
+  border-hover, both scheme blocks) is the source of truth for form fields; the MUI theme and the
+  `.module.css` files both read it. Light fields are white; dark fields ride the elevated violet
+  (`darkTokens.semantic.inputSurface`, `#2F234A`) with a 2px foreground-violet focus outline — never
+  force white fields in dark. All pairings are contrast-guarded in the parity test.
 
 **Shared across web and mobile:** the brand palette + colour helpers (`@boardsesh/velvet-tokens`) and the
 climbing **grade colours** (`@boardsesh/board-constants`). Both are platform-agnostic and stay shared.

--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -35,7 +35,9 @@
 }
 
 .searchInput input {
-  font-size: 14px;
+  /* 16px so iOS Safari never zooms the viewport on focus (matches the theme-level input
+     size; the old max-width:768px !important guard used to force this on mobile). */
+  font-size: 16px;
   padding: 6px 0;
 }
 
@@ -84,15 +86,5 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-:global(html[data-theme='dark']) .searchInput :global(.MuiOutlinedInput-root) {
-  background: #ffffff;
-  color: #000000;
-}
-
-:global(html[data-theme='dark']) .searchInput :global(.MuiOutlinedInput-root) fieldset {
-  border-color: #ffffff;
-}
-
-:global(html[data-theme='dark']) .searchInput :global(.MuiSvgIcon-root) {
-  color: #6b7280;
-}
+/* The header search input rides the shared --input-* tokens (elevated violet field,
+   violet focus ring) via the MUI theme — no dark-mode white-field override needed. */

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -53,8 +53,8 @@
   /* Darkened from Velvet #c81e1e so error TEXT clears AA (4.96:1) on the #E8DDF6 page. */
   --color-error: #b91c1c;
   --color-error-bg: #fbe9e9;
-  --color-error-muted: rgba(200, 30, 30, 0.18);
-  --color-error-muted-hover: rgba(200, 30, 30, 0.28);
+  --color-error-muted: rgba(185, 28, 28, 0.18);
+  --color-error-muted-hover: rgba(185, 28, 28, 0.28);
   --color-warning: #a04a08;
   --color-warning-bg: #fbf0e3;
 

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -422,9 +422,12 @@ input:-webkit-autofill:focus {
   caret-color: var(--input-text);
 }
 
+/* Firefox path — the -webkit-* properties above are inert there; standard
+   properties carry the same repaint. WebKit matches this too, harmlessly. */
 input:autofill {
-  -webkit-box-shadow: 0 0 0 1000px var(--input-bg) inset;
-  -webkit-text-fill-color: var(--input-text);
+  box-shadow: 0 0 0 1000px var(--input-bg) inset;
+  background-color: var(--input-bg);
+  color: var(--input-text);
   caret-color: var(--input-text);
 }
 

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -50,7 +50,8 @@
   --color-success: #047857;
   --color-success-hover: #036b4d;
   --color-success-bg: #e7f4ee;
-  --color-error: #c81e1e;
+  /* Darkened from Velvet #c81e1e so error TEXT clears AA (4.96:1) on the #E8DDF6 page. */
+  --color-error: #b91c1c;
   --color-error-bg: #fbe9e9;
   --color-error-muted: rgba(200, 30, 30, 0.18);
   --color-error-muted-hover: rgba(200, 30, 30, 0.28);
@@ -108,12 +109,18 @@
   --border-radius-xl: 16px;
   --border-radius-full: 9999px;
 
-  /* Input field backgrounds */
+  /* Input field tokens — the source of truth for input surface/text/border in BOTH
+     schemes. The MUI theme (mui-theme.ts) and ~150 module.css files read these. */
   --input-bg: #ffffff;
   --input-bg-hover: #f1eef7;
   --input-bg-focused: #ffffff;
-  /* Placeholder text on the (always light) input surface — fixed dark grey ≥4.5:1. */
+  /* Dark-on-white body text inside the field. */
+  --input-text: #26222d;
+  /* Placeholder — fixed dark grey ≥4.5:1 on the white field. */
   --input-placeholder: #6b6577;
+  /* Resting outline (≥3:1 on white and on the #E8DDF6 page); one neutral step darker on hover. */
+  --input-border: #7b7591;
+  --input-border-hover: #595464;
 
   /* Safe-area insets, exposed as CSS vars so consumers resolve through
      a single indirection (and so future per-platform or per-view overrides
@@ -224,12 +231,17 @@ html[data-theme='dark'] {
   --color-error-muted-hover: rgba(248, 113, 113, 0.3);
   --color-warning-bg: rgba(251, 191, 36, 0.14);
 
-  /* Input field backgrounds (white in dark mode) */
-  --input-bg: #ffffff;
-  --input-bg-hover: #f1eef7;
-  --input-bg-focused: #ffffff;
-  /* Input text stays dark in dark mode because inputs have white backgrounds */
-  --input-text: #26222d;
+  /* Input field tokens — elevated violet field (#2F234A). The surface is unchanged on
+     hover/focus; the BORDER carries the hover state, the violet ring carries focus. */
+  --input-bg: #2f234a;
+  --input-bg-hover: #2f234a;
+  --input-bg-focused: #2f234a;
+  /* Light-on-violet body text + placeholder (both ≥4.5:1 on the field). */
+  --input-text: #e7e2f0;
+  --input-placeholder: #a9a2b6;
+  /* Translucent resting outline; brighter on hover (both composite to ≥3:1 on the field). */
+  --input-border: rgba(195, 188, 211, 0.5);
+  --input-border-hover: rgba(195, 188, 211, 0.7);
 
   /* Shadows (stronger for dark backgrounds) */
   --shadow-xs: 0 1px 2px 0 rgba(0, 0, 0, 0.2);
@@ -319,17 +331,13 @@ button,
 
 /* Firefox scrollbar properties are set in the html rule above */
 
-/* Focus styles for accessibility. The foreground violet clears 3:1 on the page in
-   both schemes, but in dark mode the focus ring can wrap the intentionally-white
-   inputs, where #A78BFA is only 2.72:1 — so dark uses the fill violet (#7C3AED,
-   5.70:1 on white, 3.99:1 on the page). Outline is not transitioned (stays instant). */
+/* Focus styles for accessibility. The foreground violet (`--color-primary`) clears the
+   3:1 UI floor on the page in both schemes — and now on the elevated dark input surface
+   (#2F234A) too — so a single rule covers both. Outline is not transitioned (stays
+   instant). MUI ButtonBase re-emits the same outline at the component layer. */
 :focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
-}
-
-html[data-theme='dark'] :focus-visible {
-  outline-color: var(--color-primary-fill);
 }
 
 /* Remove default focus outline when using mouse */
@@ -402,51 +410,22 @@ html[data-theme='dark'] :focus-visible {
   }
 }
 
-/* Dark-mode input overrides — MUI theme darkComponents handles most
-   input styling, but color-scheme:dark can override native input
-   backgrounds. These CSS rules ensure inputs stay white in dark mode
-   using the tokenized custom properties. */
-html[data-theme='dark'] .MuiOutlinedInput-root,
-html[data-theme='dark'] .MuiFilledInput-root {
-  background-color: var(--input-bg);
-  color: var(--input-text);
+/* Autofill + caret. Browsers repaint autofilled fields with their own yellow/blue
+   background and text colour; force the field's own surface + text back so an
+   autofilled input matches an empty one in both schemes. --input-bg / --input-text
+   auto-flip per scheme. */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0 1000px var(--input-bg) inset;
+  -webkit-text-fill-color: var(--input-text);
+  caret-color: var(--input-text);
 }
 
-html[data-theme='dark'] .MuiOutlinedInput-root:hover {
-  background-color: var(--input-bg-hover);
-}
-
-html[data-theme='dark'] .MuiOutlinedInput-root.Mui-focused {
-  background-color: var(--input-bg-focused);
-}
-
-html[data-theme='dark'] .MuiSelect-icon {
-  color: var(--neutral-500);
-}
-
-html[data-theme='dark'] .MuiOutlinedInput-input::placeholder {
-  color: var(--input-placeholder);
-  opacity: 1;
-}
-
-html[data-theme='dark'] .MuiOutlinedInput-root .MuiSvgIcon-root,
-html[data-theme='dark'] .MuiOutlinedInput-root .MuiInputAdornment-root,
-html[data-theme='dark'] .MuiFilledInput-root .MuiSvgIcon-root,
-html[data-theme='dark'] .MuiFilledInput-root .MuiInputAdornment-root {
-  color: var(--neutral-500);
-}
-
-/* Ensure all interactive elements have minimum 16px font to prevent iOS auto-zoom on focus */
-@media (max-width: 768px) {
-  input,
-  textarea,
-  select,
-  button,
-  .MuiOutlinedInput-input,
-  .MuiSelect-select,
-  .MuiButton-root {
-    font-size: 16px !important;
-  }
+input:autofill {
+  -webkit-box-shadow: 0 0 0 1000px var(--input-bg) inset;
+  -webkit-text-fill-color: var(--input-text);
+  caret-color: var(--input-text);
 }
 
 /* Override Atlaskit drag-and-drop indicator color to match theme

--- a/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
+++ b/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
@@ -252,6 +252,21 @@ describe('Velvet dark input surface is defined, legible, and free of the elevati
   it('primary text clears AA on the elevated popup paper (autocomplete/menu) in dark', () => {
     expect(contrast(darkTokens.neutral[800], darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(4.5);
   });
+
+  // The input slot sets `color` DIRECTLY on the <input>, which beats colour inherited
+  // from the disabled wrapper — the disabled tier must be restated on the input itself
+  // (both engines: color + WebkitTextFillColor) or disabled text renders full-opacity.
+  it.each([
+    ['light', lightTheme],
+    ['dark', darkTheme],
+  ] as const)('disabled input text dims to text.disabled on the input slot itself (%s)', (_scheme, theme) => {
+    const inputOverride = theme.components?.MuiInputBase?.styleOverrides?.input;
+    expect(typeof inputOverride).toBe('function');
+    const resolved = (inputOverride as (props: { theme: typeof theme }) => Record<string, unknown>)({ theme });
+    const disabled = resolved['&.Mui-disabled'] as { color?: string; WebkitTextFillColor?: string };
+    expect(disabled?.color).toBe(theme.palette.text.disabled);
+    expect(disabled?.WebkitTextFillColor).toBe(theme.palette.text.disabled);
+  });
 });
 
 describe('web surface ladder deliberately diverges from the shared velvet-tokens anchors', () => {

--- a/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
+++ b/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
@@ -79,6 +79,9 @@ describe('index.css ↔ theme-config parity', () => {
     ['--semantic-surface', themeTokens.semantic.surface, darkTokens.semantic.surface],
     ['--semantic-selected-border', themeTokens.semantic.selectedBorder, darkTokens.semantic.selectedBorder],
     ['--separator', themeTokens.semantic.separator, darkTokens.semantic.separator],
+    // Input surface: light white field, dark elevated violet. Rest of the --input-*
+    // family (no theme-config counterpart) is pinned in its own block below.
+    ['--input-bg', themeTokens.semantic.inputSurface, darkTokens.semantic.inputSurface],
     ['--neutral-50', themeTokens.neutral[50], darkTokens.neutral[50]],
     ['--neutral-500', themeTokens.neutral[500], darkTokens.neutral[500]],
     ['--neutral-900', themeTokens.neutral[900], darkTokens.neutral[900]],
@@ -109,6 +112,22 @@ function contrast(a: string, b: string): number {
   const la = luminance(a);
   const lb = luminance(b);
   return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+// Composite a translucent `rgba()` colour over an opaque hex background → the opaque
+// colour the eye actually sees. Needed to contrast-check the semi-transparent input
+// border (rgba(195,188,211,0.x)) against the field it sits on.
+function blendOpaque(rgba: string, bgHex: string): string {
+  const match = rgba.match(/rgba?\(([^)]+)\)/);
+  if (!match) throw new Error(`not an rgba() colour: ${rgba}`);
+  const parts = match[1].split(',').map((part) => part.trim());
+  const alpha = parts[3] === undefined ? 1 : parseFloat(parts[3]);
+  const foreground = parts.slice(0, 3).map((channel) => parseInt(channel, 10));
+  const cleanBg = bgHex.replace('#', '');
+  const fullBg = cleanBg.length === 3 ? cleanBg.replace(/(.)/g, '$1$1') : cleanBg;
+  const background = [0, 2, 4].map((i) => parseInt(fullBg.slice(i, i + 2), 16));
+  const blended = foreground.map((channel, i) => Math.round(channel * alpha + background[i] * (1 - alpha)));
+  return `#${blended.map((channel) => channel.toString(16).padStart(2, '0')).join('')}`;
 }
 
 describe('MUI theme wires the foreground/fill split correctly', () => {
@@ -148,13 +167,69 @@ describe('Velvet palette clears WCAG AA at its load-bearing pairings', () => {
     expect(contrast(darkTokens.colors.primary, darkTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
   });
 
-  it('the dark focus ring (fill violet) clears the 3:1 UI floor on the white dark-mode input', () => {
-    expect(contrast(darkTokens.colors.primaryFill, '#ffffff')).toBeGreaterThanOrEqual(3);
+  it('the dark focus ring (foreground violet #A78BFA) clears the 3:1 UI floor on the field, card, and page', () => {
+    // Inputs are no longer white in dark mode, so the focus ring is the FOREGROUND violet
+    // everywhere (index.css dropped the fill-violet override). It must clear 3:1 on the
+    // elevated input field, the card, and the page.
+    expect(contrast(darkTokens.colors.primary, darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(3);
+    expect(contrast(darkTokens.colors.primary, darkTokens.semantic.surface)).toBeGreaterThanOrEqual(3);
+    expect(contrast(darkTokens.colors.primary, darkTokens.semantic.background)).toBeGreaterThanOrEqual(3);
   });
 
   it('secondary text clears AA on its surface (both schemes)', () => {
     expect(contrast(themeTokens.neutral[500], themeTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
     expect(contrast(darkTokens.neutral[500], darkTokens.semantic.surface)).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe('Velvet dark input surface is defined, legible, and free of the elevation overlay', () => {
+  // The rest of the --input-* family has no theme-config counterpart (only --input-bg
+  // maps to semantic.inputSurface, asserted in the parity block). Pin the literal values
+  // in both schemes so a silent drift in either scheme fails.
+  const inputRows: Array<[string, string, string]> = [
+    ['--input-bg-hover', '#f1eef7', '#2f234a'],
+    ['--input-bg-focused', '#ffffff', '#2f234a'],
+    ['--input-text', '#26222d', '#e7e2f0'],
+    ['--input-placeholder', '#6b6577', '#a9a2b6'],
+    ['--input-border', '#7b7591', 'rgba(195,188,211,0.5)'],
+    ['--input-border-hover', '#595464', 'rgba(195,188,211,0.7)'],
+  ];
+  it.each(inputRows)('%s is set in both schemes', (cssVar, lightValue, darkValue) => {
+    expect(lightVars[cssVar], `${cssVar} missing from :root`).toBeDefined();
+    expect(darkVars[cssVar], `${cssVar} missing from dark block`).toBeDefined();
+    expect(norm(lightVars[cssVar])).toBe(norm(lightValue));
+    expect(norm(darkVars[cssVar])).toBe(norm(darkValue));
+  });
+
+  it('dark input text (#E7E2F0) clears AA on the field (#2F234A)', () => {
+    expect(contrast(darkVars['--input-text'], darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('dark placeholder (#A9A2B6) clears AA on the field (#2F234A)', () => {
+    expect(contrast(darkVars['--input-placeholder'], darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('the dark resting border, composited over the field, clears 3:1 vs the field and vs the page', () => {
+    const composited = blendOpaque(darkVars['--input-border'], darkTokens.semantic.surfaceElevated);
+    expect(contrast(composited, darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(3);
+    expect(contrast(composited, darkTokens.semantic.background)).toBeGreaterThanOrEqual(3);
+  });
+
+  it('the light resting border (#7B7591) clears 3:1 on the white field and on the page', () => {
+    expect(contrast(lightVars['--input-border'], themeTokens.semantic.inputSurface)).toBeGreaterThanOrEqual(3);
+    expect(contrast(lightVars['--input-border'], themeTokens.semantic.background)).toBeGreaterThanOrEqual(3);
+  });
+
+  it('error text clears AA on the input field and the page in both schemes (light is now #B91C1C)', () => {
+    expect(contrast(themeTokens.colors.error, themeTokens.semantic.inputSurface)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(themeTokens.colors.error, themeTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(darkTokens.colors.error, darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(darkTokens.colors.error, darkTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('the dark theme disables the MUI v7 Paper elevation overlay (backgroundImage: none)', () => {
+    const paperRoot = darkTheme.components?.MuiPaper?.styleOverrides?.root as { backgroundImage?: string } | undefined;
+    expect(paperRoot?.backgroundImage).toBe('none');
   });
 });
 

--- a/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
+++ b/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
@@ -231,6 +231,27 @@ describe('Velvet dark input surface is defined, legible, and free of the elevati
     const paperRoot = darkTheme.components?.MuiPaper?.styleOverrides?.root as { backgroundImage?: string } | undefined;
     expect(paperRoot?.backgroundImage).toBe('none');
   });
+
+  // Legacy floating labels (theme text.secondary) survive until the FormField waves:
+  // the SHRUNK label floats over the page or a card, not the field — assert those
+  // pairings so removing the old dual-tone MuiInputLabel hack can't regress contrast.
+  it('floating-label text (text.secondary) clears AA over the page and the card in both schemes', () => {
+    expect(contrast(themeTokens.neutral[500], themeTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(themeTokens.neutral[500], themeTokens.semantic.surface)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(darkTokens.neutral[500], darkTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(darkTokens.neutral[500], darkTokens.semantic.surface)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  // Filled-variant inputs and Autocomplete ride the same --input-* family; the popup
+  // paper is pinned to the elevated surface — assert its text pairing too.
+  it('input text clears AA on the field in both schemes (covers filled + autocomplete inputs)', () => {
+    expect(contrast(lightVars['--input-text'], themeTokens.semantic.inputSurface)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(darkVars['--input-text'], darkTokens.semantic.inputSurface)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('primary text clears AA on the elevated popup paper (autocomplete/menu) in dark', () => {
+    expect(contrast(darkTokens.neutral[800], darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(4.5);
+  });
 });
 
 describe('web surface ladder deliberately diverges from the shared velvet-tokens anchors', () => {

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -156,6 +156,9 @@ const sharedComponents: Components<Theme> = {
     styleOverrides: {
       input: {
         fontSize: 16,
+        // Single source of truth for field text — the same var the autofill guard uses,
+        // so palette drift can't desync typed vs autofilled text.
+        color: 'var(--input-text)',
         '&::placeholder': {
           color: 'var(--input-placeholder)',
           opacity: 1,

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -154,16 +154,22 @@ const sharedComponents: Components<Theme> = {
   // iPads and any wider input). Applies to all input variants via the shared base.
   MuiInputBase: {
     styleOverrides: {
-      input: {
+      input: ({ theme }) => ({
         fontSize: 16,
         // Single source of truth for field text — the same var the autofill guard uses,
         // so palette drift can't desync typed vs autofilled text.
         color: 'var(--input-text)',
+        // A direct rule on the input beats colour inherited from the disabled wrapper,
+        // so the disabled tier must be restated here (WebKit needs text-fill-color too).
+        '&.Mui-disabled': {
+          color: theme.palette.text.disabled,
+          WebkitTextFillColor: theme.palette.text.disabled,
+        },
         '&::placeholder': {
           color: 'var(--input-placeholder)',
           opacity: 1,
         },
-      },
+      }),
     },
   },
   // Input surface + borders ride the scheme-aware `--input-*` CSS vars (light: white field,

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -233,6 +233,12 @@ const sharedComponents: Components<Theme> = {
         '&.Mui-focused': {
           backgroundColor: 'var(--input-bg-focused)',
         },
+        '&.Mui-disabled': {
+          backgroundColor: 'var(--input-bg-hover)',
+          '@supports (background-color: color-mix(in srgb, red 50%, transparent))': {
+            backgroundColor: 'color-mix(in srgb, var(--input-bg) 50%, transparent)',
+          },
+        },
       },
     },
   },

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -183,12 +183,48 @@ const sharedComponents: Components<Theme> = {
           borderWidth: 2,
         },
         '&.Mui-disabled': {
-          // Field surface at reduced alpha + the disabled text tier (#7B7591 light,
-          // #6F6882 dark), never a light-scale grey stranded on the dark field.
-          backgroundColor: 'color-mix(in srgb, var(--input-bg) 50%, transparent)',
+          // Field surface dimmed + the disabled text tier (#7B7591 light, #6F6882 dark),
+          // never a light-scale grey stranded on the dark field. The hover surface is the
+          // opaque fallback for browsers without color-mix() (Safari < 16.2).
+          backgroundColor: 'var(--input-bg-hover)',
+          '@supports (background-color: color-mix(in srgb, red 50%, transparent))': {
+            backgroundColor: 'color-mix(in srgb, var(--input-bg) 50%, transparent)',
+          },
           color: theme.palette.text.disabled,
         },
       }),
+    },
+  },
+  // Legacy floating labels (unmigrated forms, until the FormField waves land): the
+  // resting label sits INSIDE the field, the shrunk label floats over the page/card —
+  // text.secondary clears AA on both in both schemes (guard-tested). Focus keeps the
+  // label quiet; the 2px violet outline carries focus.
+  MuiInputLabel: {
+    styleOverrides: {
+      root: ({ theme }) => ({
+        color: theme.palette.text.secondary,
+        '&.Mui-focused': {
+          color: theme.palette.text.secondary,
+        },
+        '&.Mui-error': {
+          color: theme.palette.error.main,
+        },
+      }),
+    },
+  },
+  // Filled-variant inputs (climbs list, bulk import, snackbar) ride the same field
+  // surface family as outlined ones.
+  MuiFilledInput: {
+    styleOverrides: {
+      root: {
+        backgroundColor: 'var(--input-bg)',
+        '&:hover': {
+          backgroundColor: 'var(--input-bg-hover)',
+        },
+        '&.Mui-focused': {
+          backgroundColor: 'var(--input-bg-focused)',
+        },
+      },
     },
   },
   MuiSelect: {
@@ -453,6 +489,16 @@ const darkComponents: Components<Theme> = {
     },
   },
   MuiPopover: {
+    styleOverrides: {
+      paper: {
+        borderRadius: themeTokens.borderRadius.md,
+        ...darkElevatedPaper,
+      },
+    },
+  },
+  // Autocomplete popups render through a Popper (not Menu/Popover), so the elevated
+  // paper needs its own pin.
+  MuiAutocomplete: {
     styleOverrides: {
       paper: {
         borderRadius: themeTokens.borderRadius.md,

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -149,11 +149,46 @@ const sharedComponents: Components<Theme> = {
       size: 'small',
     },
   },
+  // Every MUI input renders at 16px so iOS Safari never zooms the viewport on focus.
+  // Replaces the old max-width:768px `!important` media guard in index.css (which missed
+  // iPads and any wider input). Applies to all input variants via the shared base.
+  MuiInputBase: {
+    styleOverrides: {
+      input: {
+        fontSize: 16,
+        '&::placeholder': {
+          color: 'var(--input-placeholder)',
+          opacity: 1,
+        },
+      },
+    },
+  },
+  // Input surface + borders ride the scheme-aware `--input-*` CSS vars (light: white field,
+  // #7B7591 border; dark: elevated violet #2F234A, translucent border). The focused outline
+  // uses the FOREGROUND violet `palette.primary.main` (#6D28D9 light, #A78BFA dark) at 2px;
+  // the field surface itself never changes on hover/focus — hover is carried by the border.
   MuiOutlinedInput: {
     styleOverrides: {
-      root: {
+      root: ({ theme }) => ({
         borderRadius: themeTokens.borderRadius.button,
-      },
+        backgroundColor: 'var(--input-bg)',
+        '& .MuiOutlinedInput-notchedOutline': {
+          borderColor: 'var(--input-border)',
+        },
+        '&:hover .MuiOutlinedInput-notchedOutline': {
+          borderColor: 'var(--input-border-hover)',
+        },
+        '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+          borderColor: theme.palette.primary.main,
+          borderWidth: 2,
+        },
+        '&.Mui-disabled': {
+          // Field surface at reduced alpha + the disabled text tier (#7B7591 light,
+          // #6F6882 dark), never a light-scale grey stranded on the dark field.
+          backgroundColor: 'color-mix(in srgb, var(--input-bg) 50%, transparent)',
+          color: theme.palette.text.disabled,
+        },
+      }),
     },
   },
   MuiSelect: {
@@ -161,6 +196,9 @@ const sharedComponents: Components<Theme> = {
       root: {
         borderRadius: themeTokens.borderRadius.button,
       },
+      icon: ({ theme }) => ({
+        color: theme.palette.text.secondary,
+      }),
     },
   },
   MuiDrawer: {
@@ -364,124 +402,62 @@ const lightShadows = [
   ...Array(16).fill(themeTokens.shadows.xl),
 ] as unknown as typeof createTheme extends (o: { shadows?: infer S }) => unknown ? S : never;
 
-// Dark mode component overrides — extends shared overrides with white input fields.
+// Dark mode component overrides. Input fields now ride the shared `--input-*` CSS vars
+// (elevated violet #2F234A, violet focus ring) — no dark-only input block remains. Two
+// dark-only concerns stay:
+// (1) MUI v7 composites a white elevation overlay onto every Paper in dark mode via
+//     `backgroundImage`. Kill it, or dialog paper drifts to ~#49415B where secondary
+//     text fails AA.
+// (2) Pin the floating surfaces (dialog/drawer/menu/popover) to the elevated dark
+//     surface (#2F234A) with a hairline separator border, so they read as one
+//     deliberate Velvet layer instead of an elevation-tinted grey.
+const darkElevatedPaper = {
+  backgroundColor: darkTokens.semantic.surfaceElevated,
+  border: '1px solid var(--separator)',
+} as const;
+
 const darkComponents: Components<Theme> = {
   ...sharedComponents,
-  MuiInputBase: {
+  MuiPaper: {
     styleOverrides: {
       root: {
-        backgroundColor: darkTokens.semantic.inputSurface,
-        color: themeTokens.neutral[800],
-        '&.Mui-disabled': {
-          backgroundColor: themeTokens.neutral[200],
-        },
-      },
-      input: {
-        '&::placeholder': {
-          // Inputs are white in dark mode, so the placeholder must be a dark grey
-          // that clears AA on white — the LIGHT neutral scale, not the inverted one.
-          color: themeTokens.neutral[500],
-          opacity: 1,
-        },
+        backgroundImage: 'none',
       },
     },
   },
-  MuiOutlinedInput: {
-    ...sharedComponents.MuiOutlinedInput,
+  MuiDialog: {
     styleOverrides: {
-      root: ({ theme }) => ({
-        borderRadius: themeTokens.borderRadius.button,
-        backgroundColor: darkTokens.semantic.inputSurface,
-        color: themeTokens.neutral[800],
-        '& .MuiOutlinedInput-notchedOutline': {
-          borderColor: themeTokens.neutral[300],
-        },
-        '&:hover .MuiOutlinedInput-notchedOutline': {
-          borderColor: themeTokens.neutral[400],
-        },
-        // Focus border uses the FILL violet (#7C3AED, 5.70:1 on the white input), not
-        // the lifted foreground #A78BFA (2.72:1 on white — fails).
-        '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-          borderColor: theme.palette.primaryFill.main,
-        },
-        '&.Mui-disabled': {
-          backgroundColor: themeTokens.neutral[200],
-        },
-      }),
-    },
-  },
-  MuiFilledInput: {
-    styleOverrides: {
-      root: {
-        backgroundColor: darkTokens.semantic.inputSurface,
-        color: themeTokens.neutral[800],
-        '&:hover': {
-          backgroundColor: themeTokens.neutral[100],
-        },
-        '&.Mui-focused': {
-          backgroundColor: darkTokens.semantic.inputSurface,
-        },
-        '&.Mui-disabled': {
-          backgroundColor: themeTokens.neutral[200],
-        },
+      paper: {
+        borderRadius: themeTokens.borderRadius.lg,
+        ...darkElevatedPaper,
       },
     },
   },
-  MuiSelect: {
-    ...sharedComponents.MuiSelect,
+  MuiDrawer: {
     styleOverrides: {
-      root: {
-        borderRadius: themeTokens.borderRadius.button,
-        backgroundColor: darkTokens.semantic.inputSurface,
-        color: themeTokens.neutral[800],
-      },
-      icon: {
-        color: themeTokens.neutral[500],
+      // Preserve the shared anchor-specific radius/padding slots; only the base `paper`
+      // slot gains the elevated surface + border.
+      ...sharedComponents.MuiDrawer?.styleOverrides,
+      paper: {
+        borderRadius: themeTokens.borderRadius.lg,
+        ...darkElevatedPaper,
       },
     },
   },
-  MuiAutocomplete: {
+  MuiMenu: {
     styleOverrides: {
-      inputRoot: {
-        backgroundColor: darkTokens.semantic.inputSurface,
-        color: themeTokens.neutral[800],
+      paper: {
+        borderRadius: themeTokens.borderRadius.md,
+        ...darkElevatedPaper,
       },
     },
   },
-  MuiInputLabel: {
+  MuiPopover: {
     styleOverrides: {
-      root: ({ theme }) => ({
-        // Resting label sits inside the white input — needs dark text.
-        color: themeTokens.neutral[700],
-        // Shrunk label floats over the dark page bg — needs light text.
-        '&.MuiInputLabel-shrink': {
-          color: darkTokens.neutral[700],
-        },
-        '&.Mui-focused': {
-          color: theme.palette.primary.main,
-        },
-      }),
-    },
-  },
-  MuiTextField: {
-    ...sharedComponents.MuiTextField,
-    styleOverrides: {
-      root: ({ theme }) => ({
-        '& .MuiOutlinedInput-root': {
-          borderRadius: themeTokens.borderRadius.button,
-          backgroundColor: darkTokens.semantic.inputSurface,
-          color: themeTokens.neutral[800],
-        },
-        '& .MuiInputLabel-root': {
-          color: themeTokens.neutral[700],
-        },
-        '& .MuiInputLabel-root.MuiInputLabel-shrink': {
-          color: darkTokens.neutral[700],
-        },
-        '& .MuiInputLabel-root.Mui-focused': {
-          color: theme.palette.primary.main,
-        },
-      }),
+      paper: {
+        borderRadius: themeTokens.borderRadius.md,
+        ...darkElevatedPaper,
+      },
     },
   },
 };

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -43,8 +43,8 @@ export const themeTokens = {
     warningBg: '#FBF0E3',
     error: '#B91C1C', // Darkened from Velvet #C81E1E so error TEXT clears AA (4.96:1) on the #E8DDF6 page (#C81E1E was 4.40)
     errorBg: '#FBE9E9',
-    errorMuted: 'rgba(200, 30, 30, 0.18)', // Translucent error for non-destructive action buttons
-    errorMutedHover: 'rgba(200, 30, 30, 0.28)',
+    errorMuted: 'rgba(185, 28, 28, 0.18)', // Translucent error for non-destructive action buttons
+    errorMutedHover: 'rgba(185, 28, 28, 0.28)',
     purple: '#9C27B0', // V11 brand purple — Mirror button + chart palette accent (grade token)
     purpleHover: '#7B1FA2', // V12 — Mirror button hover
     amber: '#FBBF24', // Flash/benchmark badges + star ratings (data yellow, distinct from brand accent)

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -41,7 +41,7 @@ export const themeTokens = {
     successBg: '#E7F4EE',
     warning: '#A04A08', // Nudged up from Velvet #B45309 so warning text clears AA on the tinted bg
     warningBg: '#FBF0E3',
-    error: brandColors.error, // #C81E1E
+    error: '#B91C1C', // Darkened from Velvet #C81E1E so error TEXT clears AA (4.96:1) on the #E8DDF6 page (#C81E1E was 4.40)
     errorBg: '#FBE9E9',
     errorMuted: 'rgba(200, 30, 30, 0.18)', // Translucent error for non-destructive action buttons
     errorMutedHover: 'rgba(200, 30, 30, 0.28)',
@@ -91,6 +91,7 @@ export const themeTokens = {
     background: '#E8DDF6', // violet-tinted page base (richer than the shared surface)
     surface: '#FAF6FE', // cards/sheets — faintly violet, not stark white
     surfaceElevated: '#FFFFFF', // elevated layers pop one step brighter than the card
+    inputSurface: '#FFFFFF', // input fields on light (matches elevated) — dark diverges to the elevated violet
     surfaceOverlay: 'rgba(250, 246, 254, 0.95)', // Semi-transparent overlay (matches surface)
     overlayLight: 'rgba(0, 0, 0, 0.3)', // Light dark overlay for hover states
     overlayDark: 'rgba(0, 0, 0, 0.6)', // Dark overlay for text backgrounds
@@ -265,7 +266,7 @@ export const darkTokens = {
     background: '#110A20', // deeper violet near-black (richer than a generic dark theme)
     surface: '#251B3A', // cards/sheets — richer violet
     surfaceElevated: '#2F234A',
-    inputSurface: '#FFFFFF', // Intentional white inputs in dark mode (contrast) — do not change
+    inputSurface: '#2F234A', // input fields ride the elevated dark surface (violet focus ring, not white)
     surfaceOverlay: 'rgba(37, 27, 58, 0.95)',
     overlayLight: 'rgba(0, 0, 0, 0.4)',
     overlayDark: 'rgba(0, 0, 0, 0.7)',


### PR DESCRIPTION
## Summary

Phase 2 of the Velvet Send web epic (#3678 follow-on): dark mode stops forcing white input fields. All values were contrast-verified by the design panel before implementation:

- **Dark fields** ride the elevated violet surface `#2F234A` with a `rgba(195,188,211,0.5)` resting border (≥3:1 composited against field, card, and page); hover brightens the **border**, not the surface; text `#E7E2F0` (~9:1), placeholder `#A9A2B6` (AA).
- **MUI v7's dark Paper elevation overlay is disabled** and dialog/drawer/menu paper pinned to the token surface — the overlay was washing dark dialogs to ~`#49415B`, where secondary text silently fell below AA (invisible to token-based tests; now guarded).
- **Focus flips to the foreground violet `#A78BFA`** (the fill `#7C3AED` only cleared 3:1 against white fields — 2.5:1 on the new dark ones). The seven dark white-input overrides die, including the dual-tone `MuiInputLabel` hack that caused the clipped-label bug that kicked off this whole epic.
- **Autofill guard**: Chrome/Safari autofill can no longer flash a white fill over dark fields; caret colour rides the input text token.
- **Light error text darkens to `#B91C1C`** (was 4.40:1 at helper size on the tinted page — AA fail).
- **16px inputs unconditionally** and the `max-width: 768px` iOS zoom-guard block dies — it missed iPads entirely (the original bug screenshot device zoomed on focus).
- Guard suite: `--input-*` parity rows, ~10 new WCAG assertions, and a Paper-overlay-disabled tripwire. The CLAUDE.md white-input rule is rewritten.

QA: dev server on the branch at https://vibetunnel-dev-1.tailedd9d5.ts.net:3001 — exercise auth, search drawer, log-ascent, board edit, and any dialog in dark + light.

## Release Notes

- Dark mode forms finally look like they belong: input fields sit on the same violet surfaces as the rest of the app, with a clear violet focus ring — no more glaring white boxes.
- Autofill no longer flashes your login fields white in dark mode, and iPads stop zooming when you tap a field.

## Test plan

- `vp run typecheck:web`, `vp run build:web` — green.
- Theme guard suite: 47 tests green (parity rows for every `--input-*` var; ≥3:1 / ≥4.5:1 assertions for border, text, placeholder, focus, and error on every surface they sit on; Paper-overlay tripwire).
- Manual QA in both schemes on the dev server (see link above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHy7Edddxsv5oztCTmGP4s