### PR TITLE
feat: suggest existing gyms before creating a duplicate

### DIFF
--- a/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
+++ b/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialGymMatchQueries } from '../graphql/resolvers/social/gym-matching';
+import {
+  findExactNameMatchesWithin,
+  decideAutoGymAttachment,
+  type SimilarGymResult,
+} from '../graphql/resolvers/social/gym-matching';
+import { socialBoardMutations } from '../graphql/resolvers/social/boards';
+import { resetAllRateLimits } from '../utils/rate-limiter';
+
+/**
+ * Real-DB coverage for the gym-creation dedup surface:
+ *   - findSimilarGyms matching tiers (exact-name ≤5 km, any-name ≤150 m,
+ *     substring ≤1 km), ordering, exclusions, enrichment (ownerType, provider
+ *     origins, isClaimable), the no-coordinates path, the private-gym visibility
+ *     gate, auth, and rate limiting.
+ *   - the shared findExactNameMatchesWithin physical matcher + the pure
+ *     decideAutoGymAttachment branch (incl. the generic-name guard).
+ *   - the createBoard MUTATION end-to-end through the auto-gym guard: attach to a
+ *     SYSTEM gym vs. refuse a generic-named match.
+ *
+ * Seeds via raw SQL and calls the resolvers directly against the per-worker test
+ * DB (plain postgres — no PostGIS), mirroring gym-branding-and-boards.test.ts.
+ */
+
+const SYSTEM_OWNER = '00000000-0000-0000-0000-000000000000';
+const QUERIER = 'fsg-querier';
+const OTHER = 'fsg-other';
+const ALL_USERS = [SYSTEM_OWNER, QUERIER, OTHER];
+
+// Base point + latitude offsets (111_320 m per degree lat, longitude-independent).
+const BASE = { latitude: 47.0, longitude: 8.0 };
+const LAT_60M = 47.0 + 0.00054; // ~60 m north
+const LAT_120M = 47.0 + 0.00108; // ~120 m (still within 150 m)
+const LAT_300M = 47.0 + 0.0027; // ~301 m
+const LAT_2KM = 47.0 + 0.018; // ~2 km
+const LAT_8KM = 47.0 + 0.072; // ~8 km
+
+let connectionCounter = 0;
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}-${connectionCounter++}`, isAuthenticated: true, userId }) as ConnectionContext;
+const anonCtx = (): ConnectionContext =>
+  ({ connectionId: `conn-anon-${connectionCounter++}`, isAuthenticated: false }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+const insertGym = async (opts: {
+  ownerId: string;
+  name: string;
+  latitude?: number | null;
+  longitude?: number | null;
+  deleted?: boolean;
+  isPublic?: boolean;
+}): Promise<{ id: number; uuid: string }> => {
+  const { ownerId, name, latitude = null, longitude = null, deleted = false, isPublic = true } = opts;
+  const uuid = uuidv4();
+  const result = await db.execute(sql`
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, latitude, longitude, deleted_at, created_at, updated_at)
+    VALUES (${uuid}, ${name}, ${uuid}, ${ownerId}, ${isPublic}, ${latitude}, ${longitude}, ${deleted ? sql`now()` : null}, now(), now())
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
+};
+
+const insertSource = (gymId: number, sourceKey: string) =>
+  db.execute(sql`
+    INSERT INTO location_sync_gym_sources (source_key, gym_id, created_at, updated_at)
+    VALUES (${sourceKey}, ${gymId}, now(), now())
+  `);
+
+const countGyms = async (): Promise<number> => {
+  const result = await db.execute(sql`SELECT count(*)::int AS count FROM gyms`);
+  return Number(Array.from(result as Iterable<{ count: number }>)[0].count);
+};
+
+const findSimilarGyms = (input: unknown, ctx: ConnectionContext) =>
+  socialGymMatchQueries.findSimilarGyms(null, { input }, ctx) as Promise<SimilarGymResult[]>;
+
+// A distinct size_id per board so createBoard's (owner, type, layout, size,
+// set_ids) unique constraint never trips across the several boards in this suite.
+let boardConfigCounter = 0;
+const createBoard = (input: Record<string, unknown>, ctx: ConnectionContext) =>
+  socialBoardMutations.createBoard(
+    null,
+    { input: { boardType: 'kilter', layoutId: 1, sizeId: 900 + boardConfigCounter++, setIds: '1,2', ...input } },
+    ctx,
+  ) as Promise<{ gymId: number | null; gymUuid: string | null }>;
+
+beforeEach(async () => {
+  resetAllRateLimits();
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "community_roles", "gym_members", "gym_follows", "location_sync_gym_sources", "user_boards", "gyms"
+    RESTART IDENTITY CASCADE
+  `);
+  await Promise.all(ALL_USERS.map(insertUser));
+});
+
+describe('findSimilarGyms — matching tiers', () => {
+  it('matches exact-name ≤5 km, any-name ≤150 m, and substring ≤1 km; excludes far & deleted; nearest first', async () => {
+    // (a) exact name, 2 km away — SYSTEM-synced from Kilter.
+    const exactFar = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Bahnhof Bloc',
+      latitude: LAT_2KM,
+      longitude: BASE.longitude,
+    });
+    await insertSource(exactFar.id, 'kilter:100');
+    // (b) different name, 60 m away.
+    const proximity = await insertGym({
+      ownerId: OTHER,
+      name: 'Random Wall',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+    // (c) substring name, 300 m away.
+    const substring = await insertGym({
+      ownerId: OTHER,
+      name: 'Bahnhof Bloc Annex',
+      latitude: LAT_300M,
+      longitude: BASE.longitude,
+    });
+    // exact name but 8 km away — excluded (beyond 5 km).
+    await insertGym({ ownerId: OTHER, name: 'Bahnhof Bloc', latitude: LAT_8KM, longitude: BASE.longitude });
+    // unrelated name at 300 m — excluded (not within 150 m, no name similarity).
+    await insertGym({ ownerId: OTHER, name: 'Totally Different', latitude: LAT_300M, longitude: BASE.longitude });
+    // deleted exact-name at 60 m — excluded.
+    await insertGym({
+      ownerId: OTHER,
+      name: 'Bahnhof Bloc',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+      deleted: true,
+    });
+
+    const results = await findSimilarGyms(
+      { name: 'Bahnhof Bloc', latitude: BASE.latitude, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+
+    // Ordered nearest-first: proximity (60 m), substring (300 m), exactFar (2 km).
+    expect(results.map((gym) => gym.uuid)).toEqual([proximity.uuid, substring.uuid, exactFar.uuid]);
+    expect(results[0].distanceMeters).toBeLessThan(150);
+    expect(results[2].distanceMeters).toBeGreaterThan(1000);
+    expect(results[2].distanceMeters).toBeLessThan(5000);
+  });
+
+  it('enriches ownerType, providerOrigins, and isClaimable', async () => {
+    const systemGym = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Boulder Bar',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+    await insertSource(systemGym.id, 'kilter:1');
+    await insertSource(systemGym.id, 'tension:2');
+    const ownGym = await insertGym({
+      ownerId: QUERIER,
+      name: 'Boulder Bar',
+      latitude: LAT_120M,
+      longitude: BASE.longitude,
+    });
+
+    const results = await findSimilarGyms(
+      { name: 'Boulder Bar', latitude: BASE.latitude, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+
+    const byUuid = new Map(results.map((gym) => [gym.uuid, gym]));
+    const system = byUuid.get(systemGym.uuid)!;
+    expect(system.ownerType).toBe('SYSTEM');
+    expect(system.providerOrigins).toEqual(['kilter', 'tension']);
+    // A non-owner/non-member can claim the SYSTEM gym.
+    expect(system.isClaimable).toBe(true);
+
+    const own = byUuid.get(ownGym.uuid)!;
+    expect(own.ownerType).toBe('USER');
+    expect(own.providerOrigins).toEqual([]);
+    // The querier owns this gym, so they cannot claim it.
+    expect(own.isClaimable).toBe(false);
+  });
+
+  it("never enumerates another user's private gym, but includes the viewer's own private gym", async () => {
+    // Another user's PRIVATE gym 60 m away — must NOT leak (name/address/distance).
+    await insertGym({
+      ownerId: OTHER,
+      name: 'Secret Home Board',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+      isPublic: false,
+    });
+    // The viewer's OWN private gym 120 m away — a legitimate suggestion.
+    const ownPrivate = await insertGym({
+      ownerId: QUERIER,
+      name: 'My Basement',
+      latitude: LAT_120M,
+      longitude: BASE.longitude,
+      isPublic: false,
+    });
+
+    // Name-agnostic 150 m proximity tier: without the visibility gate this would
+    // return BOTH private gyms to any authenticated caller.
+    const results = await findSimilarGyms(
+      { name: 'Anything At All', latitude: BASE.latitude, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+
+    expect(results.map((gym) => gym.uuid)).toEqual([ownPrivate.uuid]);
+  });
+
+  it('falls back to name-only matching when no coordinates are given', async () => {
+    const named = await insertGym({
+      ownerId: OTHER,
+      name: 'Far Away Gym',
+      latitude: LAT_8KM,
+      longitude: BASE.longitude,
+    });
+    await insertGym({ ownerId: OTHER, name: 'Unrelated Place', latitude: LAT_60M, longitude: BASE.longitude });
+
+    const results = await findSimilarGyms({ name: 'Far Away Gym' }, authCtx(QUERIER));
+
+    expect(results.map((gym) => gym.uuid)).toEqual([named.uuid]);
+    expect(results[0].distanceMeters).toBeNull();
+  });
+});
+
+describe('findSimilarGyms — auth & rate limit', () => {
+  it('requires authentication', async () => {
+    await expect(findSimilarGyms({ name: 'Anywhere' }, anonCtx())).rejects.toThrow(/Authentication required/);
+  });
+
+  it('rate limits repeated calls with a RATE_LIMITED code', async () => {
+    const rateLimitUser = `fsg-ratelimit-${uuidv4()}`;
+    await insertUser(rateLimitUser);
+    const ctx = authCtx(rateLimitUser);
+
+    // The first call is allowed (rate limiting doesn't block legitimate use).
+    await expect(findSimilarGyms({ name: 'No Match Here' }, ctx)).resolves.toEqual([]);
+
+    // Hammering the resolver eventually trips the limiter (bound is generous so
+    // this holds whether Redis is connected or the in-memory fallback is active).
+    let code: string | undefined;
+    for (let i = 0; i < 300 && !code; i++) {
+      try {
+        await findSimilarGyms({ name: 'No Match Here' }, ctx);
+      } catch (error) {
+        code = (error as { extensions?: { code?: string } }).extensions?.code;
+      }
+    }
+    expect(code).toBe('RATE_LIMITED');
+  });
+});
+
+describe('findExactNameMatchesWithin (auto-gym physical matcher)', () => {
+  it('matches an exact-name gym of ANY owner within the radius and excludes those beyond it', async () => {
+    const near = await insertGym({
+      ownerId: OTHER,
+      name: 'Depot Climbing',
+      latitude: LAT_120M,
+      longitude: BASE.longitude,
+    });
+    await insertGym({ ownerId: OTHER, name: 'Depot Climbing', latitude: LAT_300M, longitude: BASE.longitude });
+
+    const matches = await findExactNameMatchesWithin({
+      name: 'depot climbing',
+      latitude: BASE.latitude,
+      longitude: BASE.longitude,
+      radiusMeters: 150,
+    });
+
+    expect(matches.map((gym) => gym.uuid)).toEqual([near.uuid]);
+    expect(matches[0].distanceMeters).toBeLessThan(150);
+  });
+
+  it('does not match a different name at the same spot', async () => {
+    await insertGym({ ownerId: OTHER, name: 'Other Name', latitude: LAT_60M, longitude: BASE.longitude });
+
+    const matches = await findExactNameMatchesWithin({
+      name: 'Depot Climbing',
+      latitude: BASE.latitude,
+      longitude: BASE.longitude,
+      radiusMeters: 150,
+    });
+
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe('decideAutoGymAttachment (auto-gym branch)', () => {
+  it('attaches to a SYSTEM-owned, specifically-named match', () => {
+    expect(decideAutoGymAttachment({ id: 7, ownerId: SYSTEM_OWNER, name: 'Boulder Central' }, QUERIER)).toEqual({
+      action: 'attach',
+      gymId: 7,
+    });
+  });
+
+  it('attaches to a specifically-named match the requesting user already owns', () => {
+    expect(decideAutoGymAttachment({ id: 9, ownerId: QUERIER, name: 'The Depot' }, QUERIER)).toEqual({
+      action: 'attach',
+      gymId: 9,
+    });
+  });
+
+  it('mints a fresh gym when the match belongs to another user', () => {
+    expect(decideAutoGymAttachment({ id: 11, ownerId: OTHER, name: 'Boulder Central' }, QUERIER)).toEqual({
+      action: 'mint',
+    });
+  });
+
+  it('never auto-attaches a generic name, even to a SYSTEM/own match', () => {
+    // A claimable SYSTEM "home wall" pin must not silently capture a neighbour's board.
+    expect(decideAutoGymAttachment({ id: 13, ownerId: SYSTEM_OWNER, name: 'Home Wall' }, QUERIER)).toEqual({
+      action: 'mint',
+    });
+    expect(decideAutoGymAttachment({ id: 14, ownerId: QUERIER, name: 'garage' }, QUERIER)).toEqual({ action: 'mint' });
+    expect(decideAutoGymAttachment({ id: 15, ownerId: SYSTEM_OWNER, name: 'Kilter Board' }, QUERIER)).toEqual({
+      action: 'mint',
+    });
+  });
+
+  it('mints a fresh gym when there is no match', () => {
+    expect(decideAutoGymAttachment(undefined, QUERIER)).toEqual({ action: 'mint' });
+  });
+});
+
+describe('createBoard auto-gym guard (end-to-end mutation)', () => {
+  it('attaches a first board to a SYSTEM gym at the same coords + specific name (no duplicate gym minted)', async () => {
+    const systemGym = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Boulder Central',
+      latitude: BASE.latitude,
+      longitude: BASE.longitude,
+    });
+    const gymCountBefore = await countGyms();
+
+    const board = await createBoard(
+      {
+        name: 'My Kilter',
+        locationName: 'Boulder Central',
+        latitude: LAT_60M,
+        longitude: BASE.longitude,
+      },
+      authCtx(QUERIER),
+    );
+
+    // Board attached to the existing SYSTEM gym; no new gym row minted.
+    expect(board.gymId).toBe(systemGym.id);
+    expect(board.gymUuid).toBe(systemGym.uuid);
+    expect(await countGyms()).toBe(gymCountBefore);
+  });
+
+  it('does NOT attach a first board to a generic-named SYSTEM gym (a stranger could claim it)', async () => {
+    const systemGeneric = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Home Wall',
+      latitude: BASE.latitude,
+      longitude: BASE.longitude,
+    });
+
+    const board = await createBoard(
+      {
+        name: 'My Home Kilter',
+        locationName: 'Home Wall',
+        latitude: LAT_60M,
+        longitude: BASE.longitude,
+      },
+      authCtx(QUERIER),
+    );
+
+    // The board must NOT be linked to the stranger's claimable "Home Wall" pin.
+    expect(board.gymId).not.toBe(systemGeneric.id);
+  });
+});

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -594,6 +594,16 @@ export const schemaSQL = `
   );
   CREATE UNIQUE INDEX IF NOT EXISTS "gym_follows_unique_gym_user" ON "gym_follows" ("gym_id", "user_id");
 
+  -- Maps upstream provider source keys (e.g. "kilter:123") to the canonical gym.
+  -- findSimilarGyms reads the source-key prefixes to surface provider origins.
+  DROP TABLE IF EXISTS "location_sync_gym_sources" CASCADE;
+  CREATE TABLE IF NOT EXISTS "location_sync_gym_sources" (
+    "source_key" text PRIMARY KEY NOT NULL,
+    "gym_id" bigint NOT NULL REFERENCES "gyms"("id") ON DELETE CASCADE,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+  );
+
   DROP TABLE IF EXISTS "board_follows" CASCADE;
   CREATE TABLE IF NOT EXISTS "board_follows" (
     "id" bigserial PRIMARY KEY NOT NULL,

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -37,6 +37,7 @@ import { socialCommentQueries, socialCommentMutations } from './social/comments'
 import { socialVoteQueries, socialVoteMutations } from './social/votes';
 import { socialBoardQueries, socialBoardMutations } from './social/boards';
 import { socialGymQueries, socialGymMutations } from './social/gyms';
+import { socialGymMatchQueries } from './social/gym-matching';
 import { socialGymKioskQueries, socialGymKioskMutations } from './social/gym-kiosks';
 import { socialGymInsightsQueries } from './social/gym-insights';
 import { socialGymClaimQueries, socialGymClaimMutations } from './social/gym-claims';
@@ -84,6 +85,7 @@ export const resolvers = {
     ...socialVoteQueries,
     ...socialBoardQueries,
     ...socialGymQueries,
+    ...socialGymMatchQueries,
     ...socialGymKioskQueries,
     ...socialGymInsightsQueries,
     ...socialGymClaimQueries,

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -21,6 +21,8 @@ import {
   UUIDSchema,
 } from '../../../validation/schemas';
 import { generateUniqueGymSlug, userCanEditGym } from './gyms';
+import { findExactNameMatchesWithin, decideAutoGymAttachment, AUTO_GYM_MATCH_RADIUS_METERS } from './gym-matching';
+import { isGenericGymName } from '@boardsesh/db/queries';
 import { getUserCommunityRoles, hasAdminOrLeader, rolesGrantAdminOrLeader } from './roles';
 import { SYSTEM_BOARD_OWNER_ID, requireAnonReadableBoard } from '../board-presence/shared';
 import { logger } from '../../../utils/logger';
@@ -1635,6 +1637,44 @@ export const socialBoardMutations = {
         .limit(1);
 
       if (!existingGym) {
+        const gymName = validatedInput.locationName || validatedInput.name;
+
+        // Dedup guard: before minting a fresh gym for the user's first board,
+        // look for a live gym of ANY owner at these exact coordinates + name
+        // (mirrors findSimilarGyms's physical-proximity tier). A SYSTEM-synced
+        // gym or one the user already owns is attached instead of duplicated —
+        // UNLESS the name is generic (home wall / garage / bare board brands),
+        // which collides across unrelated walls. Another user's gym, or a generic
+        // match, is left alone (mint a fresh gym as before) but logged so the
+        // admin dedup queue gets a signal.
+        if (validatedInput.latitude != null && validatedInput.longitude != null) {
+          const physicalMatches = await findExactNameMatchesWithin({
+            name: gymName,
+            latitude: validatedInput.latitude,
+            longitude: validatedInput.longitude,
+            radiusMeters: AUTO_GYM_MATCH_RADIUS_METERS,
+          });
+          const nearest = physicalMatches[0];
+          const decision = decideAutoGymAttachment(nearest, userId);
+          if (decision.action === 'attach') {
+            // Fall through to the normal board insert below, which links `gymId`.
+            gymId = decision.gymId;
+          } else if (nearest) {
+            logger.warn('createBoard auto-gym: nearby name match not auto-attached; minting a separate gym', {
+              userId,
+              gymName,
+              matchedGymId: nearest.id,
+              matchedGymUuid: nearest.uuid,
+              matchedOwnerId: nearest.ownerId,
+              matchedOwnerIsSystem: nearest.ownerId === SYSTEM_BOARD_OWNER_ID,
+              genericName: isGenericGymName(nearest.name),
+              distanceMeters: Math.round(nearest.distanceMeters ?? 0),
+            });
+          }
+        }
+      }
+
+      if (!existingGym && gymId === null) {
         // Auto-create a gym for the user. If this fails, fall through
         // and create the board without a gym link rather than failing entirely.
         try {
@@ -1741,11 +1781,22 @@ export const socialBoardMutations = {
       throw error;
     }
 
-    // Populate PostGIS location column if lat/lon provided
+    // Populate the PostGIS location column if lat/lon provided. This is a
+    // denormalization used by proximity search — a failure here (e.g. PostGIS not
+    // installed) must not fail an otherwise-created board; log and continue, the
+    // column can be backfilled. Mirrors the auto-gym mint path, which already
+    // tolerates a location-write failure by falling through.
     if (validatedInput.latitude != null && validatedInput.longitude != null) {
-      await db.execute(
-        sql`UPDATE user_boards SET location = ST_MakePoint(${validatedInput.longitude}, ${validatedInput.latitude})::geography WHERE id = ${board.id}`,
-      );
+      try {
+        await db.execute(
+          sql`UPDATE user_boards SET location = ST_MakePoint(${validatedInput.longitude}, ${validatedInput.latitude})::geography WHERE id = ${board.id}`,
+        );
+      } catch (error) {
+        logger.warn('createBoard: failed to set board location geography; leaving it null', {
+          boardId: board.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     return enrichBoard(board, userId);

--- a/packages/backend/src/graphql/resolvers/social/gym-matching.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-matching.ts
@@ -1,0 +1,394 @@
+import { and, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { distanceMeters, isGenericGymName, normalizeGymName } from '@boardsesh/db/queries';
+import { db } from '../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
+import { FindSimilarGymsInputSchema } from '../../../validation/schemas';
+import { SYSTEM_BOARD_OWNER_ID } from '../board-presence/shared';
+import { getUserCommunityRoles, rolesGrantAdminOrLeader } from './roles';
+
+// ============================================
+// Shared gym-dedup matching helpers
+// ============================================
+//
+// Both the createBoard auto-gym guard and the findSimilarGyms read resolver need
+// to answer "is there already a live gym at these coordinates with (roughly) this
+// name?". The production `gyms` table carries a PostGIS `location` geography, but
+// the backend test DB is plain postgres (no PostGIS / pg_trgm), so everything
+// here stays portable: a cheap lat/lng bounding-box prefilter in SQL, then an
+// exact Haversine refine in JS (`distanceMeters` from @boardsesh/db/queries). The
+// bounding box is padded (BOUNDING_BOX_SAFETY_FACTOR) so it stays a superset of
+// the true circle even where a metre-per-degree of latitude runs short of the
+// 111_320 average (~0.7% at the equator) — otherwise the prefilter could drop a
+// gym sitting just inside the circle near a box corner. Name similarity uses
+// plain LIKE over the normalized name — no extension required — instead of pg_trgm.
+
+/** Per-tier distance ceilings (metres) for findSimilarGyms. */
+export const EXACT_NAME_MATCH_RADIUS_METERS = 5_000;
+export const PROXIMITY_MATCH_RADIUS_METERS = 150;
+export const SIMILAR_NAME_MATCH_RADIUS_METERS = 1_000;
+
+/** Physical-match radius for the createBoard auto-gym guard. */
+export const AUTO_GYM_MATCH_RADIUS_METERS = 150;
+
+const MAX_SIMILAR_GYMS = 5;
+
+// Pads the lat/lng bounding box so it fully contains the target circle despite
+// metres-per-degree varying with latitude (111_320 is only an average; a degree
+// of latitude is ~0.7% shorter at the equator). The JS Haversine still does the
+// exact circle test — this just guarantees the SQL prefilter never drops a match.
+const BOUNDING_BOX_SAFETY_FACTOR = 1.02;
+
+export type GymNameMatch = {
+  id: number;
+  uuid: string;
+  slug: string | null;
+  name: string;
+  address: string | null;
+  website: string | null;
+  ownerId: string;
+  latitude: number | null;
+  longitude: number | null;
+  /** Metres from the supplied coordinates, or null when no coordinates were given. */
+  distanceMeters: number | null;
+};
+
+const gymColumns = {
+  id: dbSchema.gyms.id,
+  uuid: dbSchema.gyms.uuid,
+  slug: dbSchema.gyms.slug,
+  name: dbSchema.gyms.name,
+  address: dbSchema.gyms.address,
+  website: dbSchema.gyms.website,
+  ownerId: dbSchema.gyms.ownerId,
+  latitude: dbSchema.gyms.latitude,
+  longitude: dbSchema.gyms.longitude,
+};
+
+/**
+ * SQL for the normalized gym name: trim, collapse internal whitespace, lowercase.
+ * Mirrors `normalizeGymName` so DB-side matching agrees with the JS refine. Uses
+ * the same expression the location-sync physical matcher uses (upsert.ts).
+ */
+const normalizedNameExpr: SQL = sql`lower(regexp_replace(trim(${dbSchema.gyms.name}), '[[:space:]]+', ' ', 'g'))`;
+
+/** Escape LIKE metacharacters (default backslash escape) in an already-normalized string. */
+function escapeLike(value: string): string {
+  return value.replace(/[%_\\]/g, '\\$&');
+}
+
+/** A lat/lng bounding box wide enough to contain the `radiusMeters` circle. Portable (no PostGIS). */
+function withinBoundingBox(latitude: number, longitude: number, radiusMeters: number): SQL {
+  const paddedRadius = radiusMeters * BOUNDING_BOX_SAFETY_FACTOR;
+  const latDelta = paddedRadius / 111_320;
+  const cosLat = Math.max(Math.cos((latitude * Math.PI) / 180), 1e-6);
+  const lngDelta = paddedRadius / (111_320 * cosLat);
+  return sql`${dbSchema.gyms.latitude} IS NOT NULL AND ${dbSchema.gyms.longitude} IS NOT NULL AND ${dbSchema.gyms.latitude} BETWEEN ${latitude - latDelta} AND ${latitude + latDelta} AND ${dbSchema.gyms.longitude} BETWEEN ${longitude - lngDelta} AND ${longitude + lngDelta}`;
+}
+
+/** Whether the candidate's normalized name is a substring of the query or vice-versa. */
+function nameSimilarInJs(candidateName: string, normalizedQuery: string): boolean {
+  const candidate = normalizeGymName(candidateName);
+  if (candidate.length === 0 || normalizedQuery.length === 0) return false;
+  return candidate.includes(normalizedQuery) || (candidate.length >= 3 && normalizedQuery.includes(candidate));
+}
+
+function haversineTo(
+  center: { latitude: number; longitude: number },
+  row: { latitude: number; longitude: number },
+): number {
+  return distanceMeters(center, { latitude: row.latitude, longitude: row.longitude });
+}
+
+/**
+ * Live gyms of ANY owner whose normalized name exactly equals `name` and that sit
+ * within `radiusMeters` of the given coordinates. Ordered nearest-first. Shared by
+ * the createBoard auto-gym guard (radius 150 m) and findSimilarGyms's exact-name
+ * tier. Portable: bounding-box prefilter + JS Haversine refine.
+ */
+export async function findExactNameMatchesWithin(opts: {
+  name: string;
+  latitude: number;
+  longitude: number;
+  radiusMeters: number;
+}): Promise<GymNameMatch[]> {
+  const { name, latitude, longitude, radiusMeters } = opts;
+  const normalized = normalizeGymName(name);
+
+  const rows = await db
+    .select(gymColumns)
+    .from(dbSchema.gyms)
+    .where(
+      and(
+        isNull(dbSchema.gyms.deletedAt),
+        sql`${normalizedNameExpr} = ${normalized}`,
+        withinBoundingBox(latitude, longitude, radiusMeters),
+      ),
+    );
+
+  return rows
+    .filter(
+      (row): row is typeof row & { latitude: number; longitude: number } =>
+        row.latitude != null && row.longitude != null,
+    )
+    .map((row) => ({ ...row, distanceMeters: haversineTo({ latitude, longitude }, row) }))
+    .filter((row) => row.distanceMeters <= radiusMeters)
+    .sort((first, second) => first.distanceMeters - second.distanceMeters);
+}
+
+export type AutoGymDecision = { action: 'attach'; gymId: number } | { action: 'mint' };
+
+/**
+ * Given the nearest physical-name match for a board's location, decide whether to
+ * attach the board to that existing gym or mint a fresh one. A SYSTEM-owned match
+ * (upstream catalog) or one already owned by the requesting user is safe to reuse.
+ * Any other owner's gym is left alone — no cross-user auto-attach — and the board
+ * mints its own gym (the caller logs a warning so the admin dedup queue improves).
+ *
+ * A generic matched name (`isGenericGymName`) is NEVER auto-attached, even to a
+ * SYSTEM/own gym: "home wall" / "garage" pins collide across unrelated residential
+ * walls, and a false attach to a claimable SYSTEM pin would hand board-edit rights
+ * to whoever later claims it. Generic names still get suggested (suggest path is
+ * unaffected) — they just don't silently link.
+ */
+export function decideAutoGymAttachment(
+  nearestMatch: Pick<GymNameMatch, 'id' | 'ownerId' | 'name'> | undefined,
+  requestingUserId: string,
+): AutoGymDecision {
+  if (!nearestMatch) return { action: 'mint' };
+  if (isGenericGymName(nearestMatch.name)) return { action: 'mint' };
+  if (nearestMatch.ownerId === SYSTEM_BOARD_OWNER_ID || nearestMatch.ownerId === requestingUserId) {
+    return { action: 'attach', gymId: nearestMatch.id };
+  }
+  return { action: 'mint' };
+}
+
+/**
+ * Candidate gyms that resemble one the user is about to create. Matching tiers:
+ *   (a) exact normalized name within 5 km,
+ *   (b) any name within 150 m (name-agnostic close-proximity),
+ *   (c) substring name similarity within 1 km.
+ * When no coordinates are supplied, only name-based tiers (a exact / c substring)
+ * apply, with no distance. Nearest-first, capped at five.
+ */
+export async function findSimilarGymCandidates(opts: {
+  name: string;
+  latitude?: number | null;
+  longitude?: number | null;
+  viewerUserId: string;
+}): Promise<GymNameMatch[]> {
+  const { name, latitude, longitude, viewerUserId } = opts;
+  const normalized = normalizeGymName(name);
+  const hasCoords = latitude != null && longitude != null;
+
+  // Never enumerate other users' PRIVATE gyms — otherwise the name-agnostic 150 m
+  // tier leaks private home walls (name + address + metre-precise distance) to any
+  // authenticated caller. Public gyms and the viewer's own private gyms are fair
+  // game. Mirrors the visibility gate on searchGyms / gymBoards.
+  const visibleCond: SQL = or(eq(dbSchema.gyms.isPublic, true), eq(dbSchema.gyms.ownerId, viewerUserId))!;
+
+  const exactNameCond: SQL = sql`${normalizedNameExpr} = ${normalized}`;
+  const similarNameCond: SQL | undefined =
+    normalized.length >= 2
+      ? sql`(${normalizedNameExpr} LIKE ${`%${escapeLike(normalized)}%`} OR ${normalized} LIKE '%' || ${normalizedNameExpr} || '%')`
+      : undefined;
+
+  if (hasCoords) {
+    const tierExact = and(exactNameCond, withinBoundingBox(latitude, longitude, EXACT_NAME_MATCH_RADIUS_METERS));
+    const tierProximity = withinBoundingBox(latitude, longitude, PROXIMITY_MATCH_RADIUS_METERS);
+    const tierSimilar = similarNameCond
+      ? and(similarNameCond, withinBoundingBox(latitude, longitude, SIMILAR_NAME_MATCH_RADIUS_METERS))
+      : undefined;
+    const tiers = [tierExact, tierProximity, tierSimilar].filter((clause): clause is SQL => clause != null);
+
+    const rows = await db
+      .select(gymColumns)
+      .from(dbSchema.gyms)
+      .where(and(isNull(dbSchema.gyms.deletedAt), visibleCond, or(...tiers)!));
+
+    const center = { latitude, longitude };
+    return rows
+      .filter(
+        (row): row is typeof row & { latitude: number; longitude: number } =>
+          row.latitude != null && row.longitude != null,
+      )
+      .map((row) => ({ ...row, distanceMeters: haversineTo(center, row) }))
+      .filter((row) => {
+        const isExactName = normalizeGymName(row.name) === normalized;
+        const isSimilarName = nameSimilarInJs(row.name, normalized);
+        return (
+          (isExactName && row.distanceMeters <= EXACT_NAME_MATCH_RADIUS_METERS) ||
+          row.distanceMeters <= PROXIMITY_MATCH_RADIUS_METERS ||
+          (isSimilarName && row.distanceMeters <= SIMILAR_NAME_MATCH_RADIUS_METERS)
+        );
+      })
+      .sort((first, second) => first.distanceMeters - second.distanceMeters)
+      .slice(0, MAX_SIMILAR_GYMS);
+  }
+
+  // No coordinates: name-only matching (exact + substring), no distance to sort by.
+  const nameCond = similarNameCond ? or(exactNameCond, similarNameCond)! : exactNameCond;
+  const rows = await db
+    .select(gymColumns)
+    .from(dbSchema.gyms)
+    .where(and(isNull(dbSchema.gyms.deletedAt), visibleCond, nameCond))
+    .limit(50);
+
+  return (
+    rows
+      .map((row) => ({ ...row, distanceMeters: null as number | null }))
+      // JS refine (mirrors the coords path): the SQL LIKE prefilter treats a gym
+      // name's own %/_ as wildcards, so re-check with plain string semantics.
+      .filter((row) => normalizeGymName(row.name) === normalized || nameSimilarInJs(row.name, normalized))
+      .sort((first, second) => {
+        const firstExact = normalizeGymName(first.name) === normalized ? 0 : 1;
+        const secondExact = normalizeGymName(second.name) === normalized ? 0 : 1;
+        if (firstExact !== secondExact) return firstExact - secondExact;
+        return first.name.localeCompare(second.name);
+      })
+      .slice(0, MAX_SIMILAR_GYMS)
+  );
+}
+
+/**
+ * Distinct upstream provider origins (source-key prefixes, e.g. "kilter",
+ * "tension") for each of the given gym ids, from the location-sync alias table.
+ * User-created gyms have no aliases and map to an empty list. Batched into a
+ * single query.
+ */
+async function providerOriginsByGymId(gymIds: number[]): Promise<Map<number, string[]>> {
+  const result = new Map<number, string[]>();
+  if (gymIds.length === 0) return result;
+
+  const rows = await db
+    .select({ gymId: dbSchema.locationSyncGymSources.gymId, sourceKey: dbSchema.locationSyncGymSources.sourceKey })
+    .from(dbSchema.locationSyncGymSources)
+    .where(inArray(dbSchema.locationSyncGymSources.gymId, gymIds));
+
+  const originsByGym = new Map<number, Set<string>>();
+  for (const row of rows) {
+    const prefix = row.sourceKey.split(':')[0]?.trim();
+    if (!prefix) continue;
+    const origins = originsByGym.get(row.gymId) ?? new Set<string>();
+    origins.add(prefix);
+    originsByGym.set(row.gymId, origins);
+  }
+
+  for (const [gymId, origins] of originsByGym) {
+    result.set(gymId, [...origins].sort());
+  }
+  return result;
+}
+
+/**
+ * `isClaimable` per candidate for an authenticated viewer, batched: one
+ * community-roles read + one member-roles read + one board-types read for ALL
+ * candidates, instead of an N+1 `userCanEditGym` per card. Mirrors enrichGym's
+ * `canClaim` — a viewer who cannot already edit a gym is the one who may claim it.
+ */
+async function computeClaimableFlags(
+  candidates: Array<Pick<GymNameMatch, 'id' | 'ownerId'>>,
+  viewerUserId: string,
+): Promise<Map<number, boolean>> {
+  const result = new Map<number, boolean>();
+  if (candidates.length === 0) return result;
+
+  const gymIds = candidates.map((candidate) => candidate.id);
+  const communityRoles = await getUserCommunityRoles(viewerUserId);
+
+  // A global community admin/leader can edit every gym → nothing is claimable.
+  if (rolesGrantAdminOrLeader(communityRoles, null)) {
+    for (const candidate of candidates) result.set(candidate.id, false);
+    return result;
+  }
+
+  const [memberRows, boardTypeRows] = await Promise.all([
+    db
+      .select({ gymId: dbSchema.gymMembers.gymId, role: dbSchema.gymMembers.role })
+      .from(dbSchema.gymMembers)
+      .where(and(eq(dbSchema.gymMembers.userId, viewerUserId), inArray(dbSchema.gymMembers.gymId, gymIds))),
+    db
+      .selectDistinct({ gymId: dbSchema.userBoards.gymId, boardType: dbSchema.userBoards.boardType })
+      .from(dbSchema.userBoards)
+      .where(and(inArray(dbSchema.userBoards.gymId, gymIds), isNull(dbSchema.userBoards.deletedAt))),
+  ]);
+
+  const roleByGym = new Map<number, string>();
+  for (const row of memberRows) roleByGym.set(row.gymId, row.role);
+
+  const boardTypesByGym = new Map<number, string[]>();
+  for (const row of boardTypeRows) {
+    if (row.gymId == null) continue;
+    const list = boardTypesByGym.get(row.gymId) ?? [];
+    list.push(row.boardType);
+    boardTypesByGym.set(row.gymId, list);
+  }
+
+  for (const candidate of candidates) {
+    const isOwner = candidate.ownerId === viewerUserId;
+    const memberRole = roleByGym.get(candidate.id);
+    const canEditAsMember = memberRole === 'admin' || memberRole === 'editor';
+    const boardTypes = boardTypesByGym.get(candidate.id) ?? [];
+    const hasCommunityAccess = boardTypes.some((boardType) => rolesGrantAdminOrLeader(communityRoles, boardType));
+    result.set(candidate.id, !(isOwner || canEditAsMember || hasCommunityAccess));
+  }
+  return result;
+}
+
+// ============================================
+// Query resolver
+// ============================================
+
+/** The `SimilarGym` GraphQL payload shape returned by findSimilarGyms. */
+export type SimilarGymResult = {
+  uuid: string;
+  slug: string | null;
+  name: string;
+  address: string | null;
+  website: string | null;
+  distanceMeters: number | null;
+  ownerType: 'SYSTEM' | 'USER';
+  isClaimable: boolean;
+  providerOrigins: string[];
+};
+
+export const socialGymMatchQueries = {
+  findSimilarGyms: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext,
+  ): Promise<SimilarGymResult[]> => {
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, 120, 'findSimilarGyms');
+
+    const validatedInput = validateInput(FindSimilarGymsInputSchema, input, 'input');
+    const userId = ctx.userId!;
+
+    const candidates = await findSimilarGymCandidates({
+      name: validatedInput.name,
+      latitude: validatedInput.latitude,
+      longitude: validatedInput.longitude,
+      viewerUserId: userId,
+    });
+
+    if (candidates.length === 0) return [];
+
+    const [originsByGym, claimableByGym] = await Promise.all([
+      providerOriginsByGymId(candidates.map((candidate) => candidate.id)),
+      computeClaimableFlags(candidates, userId),
+    ]);
+
+    return candidates.map((candidate) => ({
+      uuid: candidate.uuid,
+      slug: candidate.slug,
+      name: candidate.name,
+      address: candidate.address,
+      website: candidate.website,
+      distanceMeters: candidate.distanceMeters,
+      ownerType: candidate.ownerId === SYSTEM_BOARD_OWNER_ID ? 'SYSTEM' : 'USER',
+      isClaimable: claimableByGym.get(candidate.id) ?? false,
+      providerOrigins: originsByGym.get(candidate.id) ?? [],
+    }));
+  },
+};

--- a/packages/backend/src/validation/schemas/gyms.ts
+++ b/packages/backend/src/validation/schemas/gyms.ts
@@ -187,6 +187,18 @@ export const SearchGymsInputSchema = z.object({
 });
 
 /**
+ * Find similar gyms input validation schema. Powers the "is this gym already on
+ * Boardsesh?" dedup suggestions surfaced during gym creation. Coordinates are
+ * optional — with them the resolver adds proximity tiers, without them it falls
+ * back to name-only matching.
+ */
+export const FindSimilarGymsInputSchema = z.object({
+  name: z.string().min(1, 'Gym name cannot be empty').max(100, 'Gym name too long'),
+  latitude: LatitudeSchema.optional(),
+  longitude: LongitudeSchema.optional(),
+});
+
+/**
  * Gym members input validation schema
  */
 export const GymMembersInputSchema = z.object({

--- a/packages/db/src/queries/gyms/location-dedupe.ts
+++ b/packages/db/src/queries/gyms/location-dedupe.ts
@@ -30,6 +30,37 @@ export function normalizeGymName(name: string): string {
   return name.trim().toLowerCase().replace(/\s+/g, ' ');
 }
 
+/**
+ * Normalized gym names too generic to be a reliable physical identity. These are
+ * prod's biggest name-collision classes — home-wall / garage pins and bare board
+ * brands the location sync mints at residential coordinates. A first board named
+ * one of these must NOT auto-attach to a stranger's nearby gym (a claimable SYSTEM
+ * pin), since a false attach ultimately hands board-edit control to whoever claims
+ * that gym. The suggest surface is unaffected (suggest-never-block).
+ *
+ * Compare with `isGenericGymName` (normalized) rather than raw membership.
+ */
+export const GENERIC_GYM_NAMES: ReadonlySet<string> = new Set([
+  'home wall',
+  'homewall',
+  'home',
+  'garage',
+  'cellar',
+  'basement',
+  'kilter',
+  'kilter board',
+  'tension',
+  'tension board',
+  'moonboard',
+  'moon',
+  'moon board',
+]);
+
+/** Whether a gym name is too generic to anchor an auto-attach (normalized comparison). */
+export function isGenericGymName(name: string): boolean {
+  return GENERIC_GYM_NAMES.has(normalizeGymName(name));
+}
+
 export function hasText(value: string | null): boolean {
   return value !== null && value.trim().length > 0;
 }

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2699,6 +2699,39 @@ type GymConnection {
   hasMore: Boolean!
 }
 
+"Where a gym came from: an upstream provider sync or a Boardsesh user."
+enum GymOwnerType {
+  "System-synced from an upstream board provider (Boardsesh catalog)."
+  SYSTEM
+  "Created by a Boardsesh user."
+  USER
+}
+
+"""
+A live gym that resembles one the user is about to create — surfaced so they
+can view or claim it instead of making a duplicate.
+"""
+type SimilarGym {
+  "Unique identifier"
+  uuid: ID!
+  "URL slug for this gym"
+  slug: String
+  "Gym name"
+  name: String!
+  "Physical address"
+  address: String
+  "Website URL (used for domain-verified ownership claims)"
+  website: String
+  "Distance in metres from the supplied coordinates; null when no coordinates were given."
+  distanceMeters: Float
+  "Whether this gym came from an upstream provider sync (SYSTEM) or a user (USER)."
+  ownerType: GymOwnerType!
+  "Whether the current viewer can start an ownership claim for this gym."
+  isClaimable: Boolean!
+  "Upstream provider origins for a synced gym (e.g. \"kilter\", \"tension\"), from source-key prefixes. Empty for user-created gyms."
+  providerOrigins: [String!]!
+}
+
 """
 A member of a gym.
 """
@@ -2859,6 +2892,20 @@ input SearchGymsInput {
   limit: Int
   "Offset for pagination"
   offset: Int
+}
+
+"""
+Input for finding gyms that resemble one the user is about to create (dedup
+suggestions). Coordinates are optional — with them the match adds proximity
+tiers; without them it falls back to name-only matching.
+"""
+input FindSimilarGymsInput {
+  "Proposed gym name to match against existing gyms."
+  name: String!
+  "Optional latitude for proximity matching."
+  latitude: Float
+  "Optional longitude for proximity matching."
+  longitude: Float
 }
 
 """
@@ -5050,6 +5097,15 @@ type Query {
   Search public gyms.
   """
   searchGyms(input: SearchGymsInput!): GymConnection!
+
+  """
+  Live gyms that resemble one the user is about to create, so they can view or
+  claim an existing gym instead of making a duplicate. Authenticated + rate
+  limited. Matches by exact normalized name within 5 km, any name within 150 m,
+  or substring name similarity within 1 km; coordinates optional. Nearest first,
+  capped at five.
+  """
+  findSimilarGyms(input: FindSimilarGymsInput!): [SimilarGym!]!
 
   """
   Get members of a gym.

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1582,6 +1582,20 @@ export type FeedbackContextInput = {
   userAgent?: InputMaybe<Scalars['String']['input']>;
 };
 
+/**
+ * Input for finding gyms that resemble one the user is about to create (dedup
+ * suggestions). Coordinates are optional — with them the match adds proximity
+ * tiers; without them it falls back to name-only matching.
+ */
+export type FindSimilarGymsInput = {
+  /** Optional latitude for proximity matching. */
+  latitude?: InputMaybe<Scalars['Float']['input']>;
+  /** Optional longitude for proximity matching. */
+  longitude?: InputMaybe<Scalars['Float']['input']>;
+  /** Proposed gym name to match against existing gyms. */
+  name: Scalars['String']['input'];
+};
+
 /** Input for following/unfollowing a board. */
 export type FollowBoardInput = {
   /** Board UUID */
@@ -2290,6 +2304,13 @@ export type GymMembersInput = {
   /** Offset for pagination */
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
+
+/** Where a gym came from: an upstream provider sync or a Boardsesh user. */
+export type GymOwnerType =
+  /** System-synced from an upstream board provider (Boardsesh catalog). */
+  | 'SYSTEM'
+  /** Created by a Boardsesh user. */
+  | 'USER';
 
 /**
  * A gym owner's activity snapshot for the current window and the window
@@ -4197,6 +4218,14 @@ export type Query = {
    * Returns array of favorited climb UUIDs.
    */
   favorites: Array<Scalars['String']['output']>;
+  /**
+   * Live gyms that resemble one the user is about to create, so they can view or
+   * claim an existing gym instead of making a duplicate. Authenticated + rate
+   * limited. Matches by exact normalized name within 5 km, any name within 150 m,
+   * or substring name similarity within 1 km; coordinates optional. Nearest first,
+   * capped at five.
+   */
+  findSimilarGyms: Array<SimilarGym>;
   /** Get followers of a user. */
   followers: FollowConnection;
   /** Get users that a user is following. */
@@ -4744,6 +4773,11 @@ export type QueryFavoritesArgs = {
   angle: Scalars['Int']['input'];
   boardName: Scalars['String']['input'];
   climbUuids: Array<Scalars['String']['input']>;
+};
+
+/** Root query type for all read operations. */
+export type QueryFindSimilarGymsArgs = {
+  input: FindSimilarGymsInput;
 };
 
 /** Root query type for all read operations. */
@@ -6287,6 +6321,32 @@ export type SimilarClimbsInput = {
   threshold?: InputMaybe<Scalars['Float']['input']>;
 };
 
+/**
+ * A live gym that resembles one the user is about to create — surfaced so they
+ * can view or claim it instead of making a duplicate.
+ */
+export type SimilarGym = {
+  __typename?: 'SimilarGym';
+  /** Physical address */
+  address?: Maybe<Scalars['String']['output']>;
+  /** Distance in metres from the supplied coordinates; null when no coordinates were given. */
+  distanceMeters?: Maybe<Scalars['Float']['output']>;
+  /** Whether the current viewer can start an ownership claim for this gym. */
+  isClaimable: Scalars['Boolean']['output'];
+  /** Gym name */
+  name: Scalars['String']['output'];
+  /** Whether this gym came from an upstream provider sync (SYSTEM) or a user (USER). */
+  ownerType: GymOwnerType;
+  /** Upstream provider origins for a synced gym (e.g. "kilter", "tension"), from source-key prefixes. Empty for user-created gyms. */
+  providerOrigins: Array<Scalars['String']['output']>;
+  /** URL slug for this gym */
+  slug?: Maybe<Scalars['String']['output']>;
+  /** Unique identifier */
+  uuid: Scalars['ID']['output'];
+  /** Website URL (used for domain-verified ownership claims) */
+  website?: Maybe<Scalars['String']['output']>;
+};
+
 /** Climb count for a single smart playlist type (used to render library cards). */
 export type SmartPlaylistCount = {
   __typename?: 'SmartPlaylistCount';
@@ -7312,6 +7372,7 @@ export type ResolversTypes = ResolversObject<{
   >;
   FavoritesCount: ResolverTypeWrapper<FavoritesCount>;
   FeedbackContextInput: FeedbackContextInput;
+  FindSimilarGymsInput: FindSimilarGymsInput;
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   FollowBoardInput: FollowBoardInput;
   FollowConnection: ResolverTypeWrapper<FollowConnection>;
@@ -7363,6 +7424,7 @@ export type ResolversTypes = ResolversObject<{
   GymMemberConnection: ResolverTypeWrapper<GymMemberConnection>;
   GymMemberRole: GymMemberRole;
   GymMembersInput: GymMembersInput;
+  GymOwnerType: GymOwnerType;
   GymStats: ResolverTypeWrapper<GymStats>;
   GymStatsInput: GymStatsInput;
   GymStatsPeriod: GymStatsPeriod;
@@ -7498,6 +7560,7 @@ export type ResolversTypes = ResolversObject<{
   SetterStatsInput: SetterStatsInput;
   SimilarClimb: ResolverTypeWrapper<SimilarClimb>;
   SimilarClimbsInput: SimilarClimbsInput;
+  SimilarGym: ResolverTypeWrapper<SimilarGym>;
   SmartPlaylistCount: ResolverTypeWrapper<SmartPlaylistCount>;
   SmartPlaylistMeta: ResolverTypeWrapper<SmartPlaylistMeta>;
   SmartPlaylistResult: ResolverTypeWrapper<SmartPlaylistResult>;
@@ -7637,6 +7700,7 @@ export type ResolversParentTypes = ResolversObject<{
   EventsReplayResponse: Omit<EventsReplayResponse, 'events'> & { events: Array<ResolversParentTypes['QueueEvent']> };
   FavoritesCount: FavoritesCount;
   FeedbackContextInput: FeedbackContextInput;
+  FindSimilarGymsInput: FindSimilarGymsInput;
   Float: Scalars['Float']['output'];
   FollowBoardInput: FollowBoardInput;
   FollowConnection: FollowConnection;
@@ -7810,6 +7874,7 @@ export type ResolversParentTypes = ResolversObject<{
   SetterStatsInput: SetterStatsInput;
   SimilarClimb: SimilarClimb;
   SimilarClimbsInput: SimilarClimbsInput;
+  SimilarGym: SimilarGym;
   SmartPlaylistCount: SmartPlaylistCount;
   SmartPlaylistMeta: SmartPlaylistMeta;
   SmartPlaylistResult: SmartPlaylistResult;
@@ -10269,6 +10334,12 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QueryFavoritesArgs, 'angle' | 'boardName' | 'climbUuids'>
   >;
+  findSimilarGyms?: Resolver<
+    Array<ResolversTypes['SimilarGym']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryFindSimilarGymsArgs, 'input'>
+  >;
   followers?: Resolver<
     ResolversTypes['FollowConnection'],
     ParentType,
@@ -11329,6 +11400,22 @@ export type SimilarClimbResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type SimilarGymResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['SimilarGym'] = ResolversParentTypes['SimilarGym'],
+> = ResolversObject<{
+  address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  distanceMeters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  isClaimable?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  ownerType?: Resolver<ResolversTypes['GymOwnerType'], ParentType, ContextType>;
+  providerOrigins?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  website?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type SmartPlaylistCountResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['SmartPlaylistCount'] = ResolversParentTypes['SmartPlaylistCount'],
@@ -11864,6 +11951,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   SetterSearchResult?: SetterSearchResultResolvers<ContextType>;
   SetterStat?: SetterStatResolvers<ContextType>;
   SimilarClimb?: SimilarClimbResolvers<ContextType>;
+  SimilarGym?: SimilarGymResolvers<ContextType>;
   SmartPlaylistCount?: SmartPlaylistCountResolvers<ContextType>;
   SmartPlaylistMeta?: SmartPlaylistMetaResolvers<ContextType>;
   SmartPlaylistResult?: SmartPlaylistResultResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -114,6 +114,39 @@ export const gymsTypeDefs = /* GraphQL */ `
     hasMore: Boolean!
   }
 
+  "Where a gym came from: an upstream provider sync or a Boardsesh user."
+  enum GymOwnerType {
+    "System-synced from an upstream board provider (Boardsesh catalog)."
+    SYSTEM
+    "Created by a Boardsesh user."
+    USER
+  }
+
+  """
+  A live gym that resembles one the user is about to create — surfaced so they
+  can view or claim it instead of making a duplicate.
+  """
+  type SimilarGym {
+    "Unique identifier"
+    uuid: ID!
+    "URL slug for this gym"
+    slug: String
+    "Gym name"
+    name: String!
+    "Physical address"
+    address: String
+    "Website URL (used for domain-verified ownership claims)"
+    website: String
+    "Distance in metres from the supplied coordinates; null when no coordinates were given."
+    distanceMeters: Float
+    "Whether this gym came from an upstream provider sync (SYSTEM) or a user (USER)."
+    ownerType: GymOwnerType!
+    "Whether the current viewer can start an ownership claim for this gym."
+    isClaimable: Boolean!
+    "Upstream provider origins for a synced gym (e.g. \\"kilter\\", \\"tension\\"), from source-key prefixes. Empty for user-created gyms."
+    providerOrigins: [String!]!
+  }
+
   """
   A member of a gym.
   """
@@ -274,6 +307,20 @@ export const gymsTypeDefs = /* GraphQL */ `
     limit: Int
     "Offset for pagination"
     offset: Int
+  }
+
+  """
+  Input for finding gyms that resemble one the user is about to create (dedup
+  suggestions). Coordinates are optional — with them the match adds proximity
+  tiers; without them it falls back to name-only matching.
+  """
+  input FindSimilarGymsInput {
+    "Proposed gym name to match against existing gyms."
+    name: String!
+    "Optional latitude for proximity matching."
+    latitude: Float
+    "Optional longitude for proximity matching."
+    longitude: Float
   }
 
   """

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -571,6 +571,15 @@ export const queriesTypeDefs = /* GraphQL */ `
     searchGyms(input: SearchGymsInput!): GymConnection!
 
     """
+    Live gyms that resemble one the user is about to create, so they can view or
+    claim an existing gym instead of making a duplicate. Authenticated + rate
+    limited. Matches by exact normalized name within 5 km, any name within 150 m,
+    or substring name similarity within 1 km; coordinates optional. Nearest first,
+    capped at five.
+    """
+    findSimilarGyms(input: FindSimilarGymsInput!): [SimilarGym!]!
+
+    """
     Get members of a gym.
     """
     gymMembers(input: GymMembersInput!): GymMemberConnection!

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -71,6 +71,28 @@ export type GymMemberConnection = {
   hasMore: boolean;
 };
 
+export type GymOwnerType = 'SYSTEM' | 'USER';
+
+export type SimilarGym = {
+  uuid: string;
+  slug?: string | null;
+  name: string;
+  address?: string | null;
+  website?: string | null;
+  /** Distance in metres from the supplied coordinates; null when no coordinates were given. */
+  distanceMeters?: number | null;
+  ownerType: GymOwnerType;
+  isClaimable: boolean;
+  /** Upstream provider origins for a synced gym (e.g. "kilter"); empty for user-created gyms. */
+  providerOrigins: string[];
+};
+
+export type FindSimilarGymsInput = {
+  name: string;
+  latitude?: number;
+  longitude?: number;
+};
+
 export type CreateGymInput = {
   name: string;
   description?: string;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1579,6 +1579,20 @@ export type FeedbackContextInput = {
   userAgent?: InputMaybe<Scalars['String']['input']>;
 };
 
+/**
+ * Input for finding gyms that resemble one the user is about to create (dedup
+ * suggestions). Coordinates are optional — with them the match adds proximity
+ * tiers; without them it falls back to name-only matching.
+ */
+export type FindSimilarGymsInput = {
+  /** Optional latitude for proximity matching. */
+  latitude?: InputMaybe<Scalars['Float']['input']>;
+  /** Optional longitude for proximity matching. */
+  longitude?: InputMaybe<Scalars['Float']['input']>;
+  /** Proposed gym name to match against existing gyms. */
+  name: Scalars['String']['input'];
+};
+
 /** Input for following/unfollowing a board. */
 export type FollowBoardInput = {
   /** Board UUID */
@@ -2287,6 +2301,13 @@ export type GymMembersInput = {
   /** Offset for pagination */
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
+
+/** Where a gym came from: an upstream provider sync or a Boardsesh user. */
+export type GymOwnerType =
+  /** System-synced from an upstream board provider (Boardsesh catalog). */
+  | 'SYSTEM'
+  /** Created by a Boardsesh user. */
+  | 'USER';
 
 /**
  * A gym owner's activity snapshot for the current window and the window
@@ -4194,6 +4215,14 @@ export type Query = {
    * Returns array of favorited climb UUIDs.
    */
   favorites: Array<Scalars['String']['output']>;
+  /**
+   * Live gyms that resemble one the user is about to create, so they can view or
+   * claim an existing gym instead of making a duplicate. Authenticated + rate
+   * limited. Matches by exact normalized name within 5 km, any name within 150 m,
+   * or substring name similarity within 1 km; coordinates optional. Nearest first,
+   * capped at five.
+   */
+  findSimilarGyms: Array<SimilarGym>;
   /** Get followers of a user. */
   followers: FollowConnection;
   /** Get users that a user is following. */
@@ -4741,6 +4770,11 @@ export type QueryFavoritesArgs = {
   angle: Scalars['Int']['input'];
   boardName: Scalars['String']['input'];
   climbUuids: Array<Scalars['String']['input']>;
+};
+
+/** Root query type for all read operations. */
+export type QueryFindSimilarGymsArgs = {
+  input: FindSimilarGymsInput;
 };
 
 /** Root query type for all read operations. */
@@ -6282,6 +6316,32 @@ export type SimilarClimbsInput = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** Jaccard threshold (0..1). Returns climbs at or above this similarity. */
   threshold?: InputMaybe<Scalars['Float']['input']>;
+};
+
+/**
+ * A live gym that resembles one the user is about to create — surfaced so they
+ * can view or claim it instead of making a duplicate.
+ */
+export type SimilarGym = {
+  __typename?: 'SimilarGym';
+  /** Physical address */
+  address?: Maybe<Scalars['String']['output']>;
+  /** Distance in metres from the supplied coordinates; null when no coordinates were given. */
+  distanceMeters?: Maybe<Scalars['Float']['output']>;
+  /** Whether the current viewer can start an ownership claim for this gym. */
+  isClaimable: Scalars['Boolean']['output'];
+  /** Gym name */
+  name: Scalars['String']['output'];
+  /** Whether this gym came from an upstream provider sync (SYSTEM) or a user (USER). */
+  ownerType: GymOwnerType;
+  /** Upstream provider origins for a synced gym (e.g. "kilter", "tension"), from source-key prefixes. Empty for user-created gyms. */
+  providerOrigins: Array<Scalars['String']['output']>;
+  /** URL slug for this gym */
+  slug?: Maybe<Scalars['String']['output']>;
+  /** Unique identifier */
+  uuid: Scalars['ID']['output'];
+  /** Website URL (used for domain-verified ownership claims) */
+  website?: Maybe<Scalars['String']['output']>;
 };
 
 /** Climb count for a single smart playlist type (used to render library cards). */

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -19,6 +19,8 @@ import type {
   ReviewGymClaimInput,
   PendingGymClaimsInput,
   GymClaimConnection,
+  FindSimilarGymsInput,
+  SimilarGym,
   UserBoard,
   GymStats,
   GymStatsInput,
@@ -98,6 +100,22 @@ export const SEARCH_GYMS = gql`
       }
       totalCount
       hasMore
+    }
+  }
+`;
+
+export const FIND_SIMILAR_GYMS = gql`
+  query FindSimilarGyms($input: FindSimilarGymsInput!) {
+    findSimilarGyms(input: $input) {
+      uuid
+      slug
+      name
+      address
+      website
+      distanceMeters
+      ownerType
+      isClaimable
+      providerOrigins
     }
   }
 `;
@@ -327,6 +345,14 @@ export type SearchGymsQueryVariables = {
 
 export type SearchGymsQueryResponse = {
   searchGyms: GymConnection;
+};
+
+export type FindSimilarGymsQueryVariables = {
+  input: FindSimilarGymsInput;
+};
+
+export type FindSimilarGymsQueryResponse = {
+  findSimilarGyms: SimilarGym[];
 };
 
 export type GetGymMembersQueryVariables = {

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -478,6 +478,16 @@
     "noGym": "No gym",
     "createNew": "Create new"
   },
+  "similarGyms": {
+    "heading": "Looks like your gym might already be here",
+    "subtitle": "Claim yours to manage it, or add a new one below.",
+    "distanceMeters": "{{meters}} m away",
+    "distanceKm": "{{km}} km away",
+    "providerBadge": "From {{provider}}",
+    "viewGym": "See the gym",
+    "claim": "This is my gym — claim it",
+    "createAnyway": "None of these? Add your gym with the button below."
+  },
   "selectorDrawer": {
     "customTitle": "Custom Board",
     "createTitle": "Create Board",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -478,6 +478,16 @@
     "noGym": "Sin gimnasio",
     "createNew": "Crear nuevo"
   },
+  "similarGyms": {
+    "heading": "Parece que tu gimnasio ya está aquí",
+    "subtitle": "Reclama el tuyo para gestionarlo, o añade uno nuevo abajo.",
+    "distanceMeters": "a {{meters}} m",
+    "distanceKm": "a {{km}} km",
+    "providerBadge": "Desde {{provider}}",
+    "viewGym": "Ver el gimnasio",
+    "claim": "Este es mi gimnasio: reclamarlo",
+    "createAnyway": "¿Ninguno es el tuyo? Añade tu gimnasio con el botón de abajo."
+  },
   "selectorDrawer": {
     "customTitle": "Plafón personalizado",
     "createTitle": "Crear plafón",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -478,6 +478,16 @@
     "noGym": "Aucune salle",
     "createNew": "Créer"
   },
+  "similarGyms": {
+    "heading": "On dirait que votre salle est déjà là",
+    "subtitle": "Revendiquez la vôtre pour la gérer, ou ajoutez-en une nouvelle ci-dessous.",
+    "distanceMeters": "à {{meters}} m",
+    "distanceKm": "à {{km}} km",
+    "providerBadge": "Depuis {{provider}}",
+    "viewGym": "Voir la salle",
+    "claim": "C'est ma salle — la revendiquer",
+    "createAnyway": "Aucune ne correspond ? Ajoutez votre salle avec le bouton ci-dessous."
+  },
   "selectorDrawer": {
     "customTitle": "Board personnalisée",
     "createTitle": "Créer une board",

--- a/packages/web/app/components/gym-entity/__tests__/gym-form-create-anyway.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/gym-form-create-anyway.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { GymFormFieldValues } from '../gym-form';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+// Stub the map picker so the form test doesn't pull in Leaflet.
+vi.mock('@/app/components/board-entity/map-location-picker', () => ({
+  default: () => <div data-testid="map-picker" />,
+}));
+
+import GymForm from '../gym-form';
+
+const initialValues: GymFormFieldValues = {
+  name: '',
+  description: '',
+  address: '',
+  website: '',
+  contactEmail: '',
+  contactPhone: '',
+  isPublic: true,
+  latitude: null,
+  longitude: null,
+};
+
+describe('GymForm — create-anyway path', () => {
+  it('submits unchanged while dedup suggestions are shown, and never disables submit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <GymForm
+        title="Create Gym"
+        submitLabel="Create Gym"
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        renderSuggestions={({ name }) => <div>{`suggestions for ${name}`}</div>}
+      />,
+    );
+
+    // Name drives both the suggestions slot and the submit button's enabled state.
+    const nameInput = screen.getByRole('textbox', { name: 'gymForm.fields.name' });
+    fireEvent.change(nameInput, { target: { value: 'Bahnhof Bloc' } });
+
+    // Suggestions are visible...
+    expect(screen.getByText('suggestions for Bahnhof Bloc')).toBeTruthy();
+
+    // ...but the submit button is still enabled ("create anyway").
+    const submitButton = screen.getByRole('button', { name: 'Create Gym' });
+    expect((submitButton as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({ name: 'Bahnhof Bloc' });
+  });
+});

--- a/packages/web/app/components/gym-entity/__tests__/similar-gym-suggestions.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/similar-gym-suggestions.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import type { SimilarGym } from '@boardsesh/shared-schema';
+
+// Minimal i18n: echo the key with {{var}} interpolation so assertions can target
+// the interpolated distance strings.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (!vars) return key;
+      return Object.entries(vars).reduce((out, [name, value]) => out.replace(`{{${name}}}`, String(value)), key);
+    },
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token' }),
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@boardsesh/graphql/operations', () => ({
+  FIND_SIMILAR_GYMS: 'FIND_SIMILAR_GYMS',
+}));
+
+// Stub the claim dialog so we can assert it opens without pulling in its own
+// graphql/token wiring.
+vi.mock('../claim-gym-dialog', () => ({
+  default: ({ open, gymName }: { open: boolean; gymName: string }) =>
+    open ? <div data-testid="claim-dialog">{`claiming ${gymName}`}</div> : null,
+}));
+
+import SimilarGymSuggestions from '../similar-gym-suggestions';
+
+const gymFixture = (overrides: Partial<SimilarGym> = {}): SimilarGym => ({
+  uuid: 'gym-1',
+  slug: 'bahnhof-bloc',
+  name: 'Bahnhof Bloc',
+  address: 'Zurich',
+  website: null,
+  distanceMeters: 60,
+  ownerType: 'SYSTEM',
+  isClaimable: true,
+  providerOrigins: ['kilter'],
+  ...overrides,
+});
+
+function renderSuggestions(name = 'Bahnhof Bloc') {
+  return render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <SimilarGymSuggestions name={name} latitude={47.0} longitude={8.0} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('SimilarGymSuggestions', () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it('renders suggestion cards with distance, provider badge, and view/claim actions', async () => {
+    mockRequest.mockResolvedValueOnce({
+      findSimilarGyms: [gymFixture(), gymFixture({ uuid: 'gym-2', name: 'Bahnhof Bloc Annex', distanceMeters: 1200 })],
+    });
+
+    renderSuggestions();
+
+    // Heading + both cards appear after the debounce + query resolve.
+    await waitFor(() => expect(screen.getByText('similarGyms.heading')).toBeTruthy(), { timeout: 3000 });
+    expect(screen.getByText('Bahnhof Bloc')).toBeTruthy();
+    expect(screen.getByText('Bahnhof Bloc Annex')).toBeTruthy();
+
+    // Distance formatting: metres under 1 km, km above.
+    expect(screen.getByText('similarGyms.distanceMeters')).toBeTruthy();
+    expect(screen.getByText('similarGyms.distanceKm')).toBeTruthy();
+
+    // Provider origin badge + view link + claim action + the "create anyway" caption.
+    expect(screen.getAllByText('similarGyms.providerBadge').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('similarGyms.viewGym').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('similarGyms.claim').length).toBeGreaterThan(0);
+    expect(screen.getByText('similarGyms.createAnyway')).toBeTruthy();
+  });
+
+  it('opens the claim dialog when "this is my gym" is pressed', async () => {
+    mockRequest.mockResolvedValueOnce({ findSimilarGyms: [gymFixture()] });
+
+    renderSuggestions();
+
+    await waitFor(() => expect(screen.getByText('similarGyms.claim')).toBeTruthy(), { timeout: 3000 });
+    fireEvent.click(screen.getByText('similarGyms.claim'));
+
+    expect(screen.getByTestId('claim-dialog').textContent).toBe('claiming Bahnhof Bloc');
+  });
+
+  it('renders nothing while the name is too short to query', () => {
+    const { container } = renderSuggestions('ab');
+    expect(container.firstChild).toBeNull();
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/gym-entity/create-gym-form.tsx
+++ b/packages/web/app/components/gym-entity/create-gym-form.tsx
@@ -11,6 +11,7 @@ import {
 } from '@boardsesh/graphql/operations';
 import type { Gym } from '@boardsesh/shared-schema';
 import GymForm, { type GymFormFieldValues } from './gym-form';
+import SimilarGymSuggestions from './similar-gym-suggestions';
 
 type CreateGymFormProps = {
   boardUuid?: string;
@@ -42,6 +43,8 @@ export default function CreateGymForm({ boardUuid, onSuccess, onCancel }: Create
           website: values.website || undefined,
           contactEmail: values.contactEmail || undefined,
           contactPhone: values.contactPhone || undefined,
+          latitude: values.latitude ?? undefined,
+          longitude: values.longitude ?? undefined,
           isPublic: values.isPublic,
           boardUuid,
         },
@@ -67,9 +70,14 @@ export default function CreateGymForm({ boardUuid, onSuccess, onCancel }: Create
         contactEmail: '',
         contactPhone: '',
         isPublic: true,
+        latitude: null,
+        longitude: null,
       }}
       onSubmit={handleSubmit}
       onCancel={onCancel}
+      renderSuggestions={({ name, latitude, longitude }) => (
+        <SimilarGymSuggestions name={name} latitude={latitude} longitude={longitude} />
+      )}
     />
   );
 }

--- a/packages/web/app/components/gym-entity/edit-gym-form.tsx
+++ b/packages/web/app/components/gym-entity/edit-gym-form.tsx
@@ -44,6 +44,8 @@ export default function EditGymForm({ gym, onSuccess, onCancel }: EditGymFormPro
           website: values.website || null,
           contactEmail: values.contactEmail || undefined,
           contactPhone: values.contactPhone || undefined,
+          latitude: values.latitude,
+          longitude: values.longitude,
           isPublic: values.isPublic,
         },
       });
@@ -68,6 +70,8 @@ export default function EditGymForm({ gym, onSuccess, onCancel }: EditGymFormPro
         contactEmail: gym.contactEmail ?? '',
         contactPhone: gym.contactPhone ?? '',
         isPublic: gym.isPublic,
+        latitude: gym.latitude ?? null,
+        longitude: gym.longitude ?? null,
       }}
       showSlugField
       onSubmit={handleSubmit}

--- a/packages/web/app/components/gym-entity/gym-form.tsx
+++ b/packages/web/app/components/gym-entity/gym-form.tsx
@@ -9,6 +9,7 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import MuiButton from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import MuiTypography from '@mui/material/Typography';
+import MapLocationPicker from '@/app/components/board-entity/map-location-picker';
 
 export type GymFormFieldValues = {
   name: string;
@@ -19,6 +20,14 @@ export type GymFormFieldValues = {
   contactEmail: string;
   contactPhone: string;
   isPublic: boolean;
+  latitude: number | null;
+  longitude: number | null;
+};
+
+export type GymFormLocationValues = {
+  name: string;
+  latitude: number | null;
+  longitude: number | null;
 };
 
 type GymFormProps = {
@@ -28,6 +37,12 @@ type GymFormProps = {
   showSlugField?: boolean;
   onSubmit: (values: GymFormFieldValues) => Promise<void>;
   onCancel?: () => void;
+  /**
+   * Optional slot rendered just above the action buttons, fed the live name +
+   * coordinates. The create flow uses it to surface "this gym might already
+   * exist" dedup suggestions.
+   */
+  renderSuggestions?: (values: GymFormLocationValues) => React.ReactNode;
 };
 
 export default function GymForm({
@@ -37,6 +52,7 @@ export default function GymForm({
   showSlugField = false,
   onSubmit,
   onCancel,
+  renderSuggestions,
 }: GymFormProps) {
   const { t } = useTranslation('boards');
   const [name, setName] = useState(initialValues.name);
@@ -47,6 +63,8 @@ export default function GymForm({
   const [contactEmail, setContactEmail] = useState(initialValues.contactEmail);
   const [contactPhone, setContactPhone] = useState(initialValues.contactPhone);
   const [isPublic, setIsPublic] = useState(initialValues.isPublic);
+  const [latitude, setLatitude] = useState<number | null>(initialValues.latitude);
+  const [longitude, setLongitude] = useState<number | null>(initialValues.longitude);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -63,6 +81,8 @@ export default function GymForm({
         contactEmail: contactEmail.trim(),
         contactPhone: contactPhone.trim(),
         isPublic,
+        latitude,
+        longitude,
       });
     } finally {
       setIsSubmitting(false);
@@ -116,6 +136,15 @@ export default function GymForm({
         placeholder={t('gymForm.placeholders.address')}
       />
 
+      <MapLocationPicker
+        latitude={latitude}
+        longitude={longitude}
+        onChange={(lat, lng) => {
+          setLatitude(lat);
+          setLongitude(lng);
+        }}
+      />
+
       <TextField
         label={t('gymForm.fields.website')}
         value={website}
@@ -151,6 +180,8 @@ export default function GymForm({
         control={<Switch checked={isPublic} onChange={(e) => setIsPublic(e.target.checked)} />}
         label={t('gymForm.fields.isPublic')}
       />
+
+      {renderSuggestions?.({ name: name.trim(), latitude, longitude })}
 
       <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end', mt: 1 }}>
         {onCancel && (

--- a/packages/web/app/components/gym-entity/similar-gym-suggestions.tsx
+++ b/packages/web/app/components/gym-entity/similar-gym-suggestions.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import MuiButton from '@mui/material/Button';
+import MuiTypography from '@mui/material/Typography';
+import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
+import OpenInNewOutlined from '@mui/icons-material/OpenInNewOutlined';
+import VerifiedOutlined from '@mui/icons-material/VerifiedOutlined';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { useDebouncedValue } from '@/app/hooks/use-debounced-value';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import {
+  FIND_SIMILAR_GYMS,
+  type FindSimilarGymsQueryResponse,
+  type FindSimilarGymsQueryVariables,
+} from '@boardsesh/graphql/operations';
+import type { SimilarGym } from '@boardsesh/shared-schema';
+import { themeTokens } from '@/app/theme/theme-config';
+import ClaimGymDialog from './claim-gym-dialog';
+
+type SimilarGymSuggestionsProps = {
+  name: string;
+  latitude: number | null;
+  longitude: number | null;
+};
+
+const MIN_NAME_LENGTH = 3;
+
+function capitalize(value: string): string {
+  return value.length > 0 ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+}
+
+export default function SimilarGymSuggestions({ name, latitude, longitude }: SimilarGymSuggestionsProps) {
+  const { t } = useTranslation('boards');
+  const { token } = useWsAuthToken();
+  const [claimTarget, setClaimTarget] = useState<SimilarGym | null>(null);
+
+  // Debounce the whole lookup input so typing a name (and nudging the map) fires
+  // at most one request per pause instead of one per keystroke.
+  const debounced = useDebouncedValue(
+    useMemo(() => ({ name: name.trim(), latitude, longitude }), [name, latitude, longitude]),
+    400,
+  );
+
+  const enabled = Boolean(token) && debounced.name.length >= MIN_NAME_LENGTH;
+
+  const { data } = useQuery<SimilarGym[]>({
+    queryKey: ['findSimilarGyms', debounced.name, debounced.latitude, debounced.longitude],
+    enabled,
+    staleTime: 30_000,
+    // Don't re-hammer a rate-limited (or otherwise failing) lookup — it's an
+    // as-you-type convenience, not a critical fetch.
+    retry: false,
+    queryFn: async () => {
+      const client = createGraphQLHttpClient(token);
+      const response = await client.request<FindSimilarGymsQueryResponse, FindSimilarGymsQueryVariables>(
+        FIND_SIMILAR_GYMS,
+        {
+          input: {
+            name: debounced.name,
+            latitude: debounced.latitude ?? undefined,
+            longitude: debounced.longitude ?? undefined,
+          },
+        },
+      );
+      return response.findSimilarGyms;
+    },
+  });
+
+  const suggestions = data ?? [];
+  if (suggestions.length === 0) return null;
+
+  const formatDistance = (distanceMeters: number | null | undefined): string | null => {
+    if (distanceMeters == null) return null;
+    if (distanceMeters < 1000) {
+      return t('similarGyms.distanceMeters', { meters: Math.round(distanceMeters) });
+    }
+    return t('similarGyms.distanceKm', { km: (distanceMeters / 1000).toFixed(1) });
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1.5,
+        p: 2,
+        borderRadius: `${themeTokens.borderRadius.lg}px`,
+        backgroundColor: 'var(--neutral-50)',
+        border: '1px solid var(--neutral-200)',
+      }}
+    >
+      <Box>
+        <MuiTypography variant="subtitle2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+          {t('similarGyms.heading')}
+        </MuiTypography>
+        <MuiTypography variant="body2" color="text.secondary">
+          {t('similarGyms.subtitle')}
+        </MuiTypography>
+      </Box>
+
+      <Stack spacing={1}>
+        {suggestions.map((gym) => {
+          const distanceLabel = formatDistance(gym.distanceMeters);
+          // /gym/[slug] resolves via gymBySlug, which can't resolve a uuid — so
+          // only offer the link when there's a real slug.
+          const gymHref = gym.slug ? `/gym/${gym.slug}` : null;
+          return (
+            <Card key={gym.uuid} variant="outlined" sx={{ borderRadius: `${themeTokens.borderRadius.md}px` }}>
+              <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
+                <MuiTypography
+                  variant="subtitle2"
+                  sx={{
+                    fontWeight: themeTokens.typography.fontWeight.semibold,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {gym.name}
+                </MuiTypography>
+
+                {gym.address && (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
+                    <LocationOnOutlined sx={{ fontSize: 14, color: 'var(--neutral-400)' }} />
+                    <MuiTypography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    >
+                      {gym.address}
+                    </MuiTypography>
+                  </Box>
+                )}
+
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 0.75, mt: 1 }}>
+                  {distanceLabel && <Chip size="small" variant="outlined" label={distanceLabel} />}
+                  {gym.providerOrigins.map((origin) => (
+                    <Chip
+                      key={origin}
+                      size="small"
+                      color="primary"
+                      variant="outlined"
+                      icon={<VerifiedOutlined sx={{ fontSize: 14 }} />}
+                      label={t('similarGyms.providerBadge', { provider: capitalize(origin) })}
+                    />
+                  ))}
+                </Box>
+
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1.5 }}>
+                  {gymHref && (
+                    <MuiButton
+                      component={LocaleLink}
+                      href={gymHref}
+                      size="small"
+                      variant="text"
+                      startIcon={<OpenInNewOutlined />}
+                      sx={{ textTransform: 'none' }}
+                    >
+                      {t('similarGyms.viewGym')}
+                    </MuiButton>
+                  )}
+                  {gym.isClaimable && (
+                    <MuiButton
+                      size="small"
+                      variant="contained"
+                      onClick={() => setClaimTarget(gym)}
+                      sx={{ textTransform: 'none' }}
+                    >
+                      {t('similarGyms.claim')}
+                    </MuiButton>
+                  )}
+                </Box>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </Stack>
+
+      <MuiTypography variant="caption" color="text.secondary">
+        {t('similarGyms.createAnyway')}
+      </MuiTypography>
+
+      {claimTarget && (
+        <ClaimGymDialog
+          gymUuid={claimTarget.uuid}
+          gymName={claimTarget.name}
+          website={claimTarget.website}
+          open={claimTarget !== null}
+          onClose={() => setClaimTarget(null)}
+        />
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

Prod keeps growing duplicate gyms because the two user-facing creation paths had **zero** dedup: `createGym` inserted unconditionally, and the `createBoard` auto-gym branch minted a gym for a user's first board without checking anything. (Verified example: a user re-created "bahnhof blo" 62 m from the SYSTEM-synced row.)

This adds a **suggest, never block** dedup layer — users can always proceed.

**Backend**
- New `findSimilarGyms` query (authenticated + rate-limited). Matches live gyms by: exact normalized name within 5 km, **any** name within 150 m (name-agnostic close-proximity), or substring name similarity within 1 km. Coordinates optional (name-only fallback). Returns per gym: uuid, slug, name, address, distance, `ownerType` (SYSTEM vs USER), `isClaimable`, and provider origins (source-key prefixes, e.g. `kilter`, `tension`).
- Shared matcher in a new `social/gym-matching.ts`, reused by the resolver and the board guard. It's **portable** — a lat/lng bounding-box prefilter (padded so it stays a superset of the target circle at all latitudes) + Haversine refine, and `LIKE` over the normalized name — so it runs identically on the PostGIS prod DB and the plain-postgres test DB (no PostGIS / `pg_trgm` dependency).
- `createBoard` auto-gym guard: before minting a gym for a user's first board, it physical-matches (exact name + 150 m, any owner). A SYSTEM-synced or self-owned match is **attached** instead of duplicated; another user's gym is left alone (a fresh gym is minted, as before) and a structured warning is logged.

**Web**
- The Create-gym form now has a map/location picker (address search, "use my location", draggable pin) so gyms are created **with** coordinates — which both powers the dedup lookup and fixes the fact that form-created gyms never had coords to dedup against later.
- As you type a name (debounced), a **"Looks like your gym might already be here"** panel shows up to five suggestion cards: distance chip ("60 m away"), provider badge, **See the gym**, and **This is my gym — claim it** (opens the existing claim dialog). Submit is never disabled — a subdued "None of these? Add your gym with the button below." keeps the create-anyway path one click away.

i18n for all three locales (en-US, es: *gimnasio*, fr: *salle*).

## Security & safety

- **`findSimilarGyms` never enumerates other users' private gyms.** Both candidate queries gate on `isPublic = true OR ownerId = viewer` (mirroring `searchGyms` / `gymBoards`), so the name-agnostic 150 m tier can't leak private home walls (name + address + metre-precise distance), and coordinate-sweeping can't map them.
- **Auto-attach refuses generic names.** A shared `GENERIC_GYM_NAMES` denylist (`home wall`, `garage`, bare board brands, …) blocks silent attachment to a claimable SYSTEM pin at residential coords — otherwise a neighbour's first "Home Wall" board could hand board-edit control to whoever later claims the pin. Generic names still get *suggested*.
- The board-location denormalization write is now fault-tolerant (a geography-write failure logs instead of failing an otherwise-created board).

## Release Notes

- Adding your gym? We'll show you if it's already on Boardsesh so you can claim it instead of starting from scratch.
- The gym form now has a map — drop a pin or search an address so your crew can find the wall.

## Test plan

- `VITEST_POOL_ID=solo-m4 vp test run --project backend` — `find-similar-gyms-and-auto-gym.test.ts` covers the matching tiers, ordering/exclusions, the **private-gym visibility gate**, ownerType/provider-origins/isClaimable enrichment, no-coordinates path, auth, rate limiting; the shared `findExactNameMatchesWithin` matcher; the `decideAutoGymAttachment` branches incl. the **generic-name guard**; and the **createBoard mutation end-to-end** (attach to a SYSTEM gym vs. refuse a generic match, no duplicate minted). Blast-radius suite green (352/352).
- `vp test run --project web` — `similar-gym-suggestions.tsx` (cards render, claim dialog opens, short names don't query) + `gym-form-create-anyway.tsx` (submit never disabled). Full web suite green (5326/5326).
- `vp check` (0 errors), `vp run typecheck` (backend/db/shared/web all clean), codegen (no drift).
- No DB migration in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VGxf4ZJGFRanuJGrRMDgY
