### PR TITLE
feat(web): the form kit — one label pattern, pilot on board form + log ascent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Vitest via `vp test`. Backend tests auto-start postgres+redis via `packages/back
 - **Web uses MUI.** Always MUI components and props. Avoid the `style` prop. Always use design tokens from `packages/web/app/theme/theme-config.ts` for colours/spacing — no hardcoded values.
 - Use CSS media queries for responsive design. Avoid JS breakpoint detection (`Grid.useBreakpoint()`).
 - Remove dead code as you go.
-- **Dark mode uses white input fields.** Intentional for contrast (`darkTokens.semantic.inputSurface`). Do not change.
+- **Dark mode inputs use the elevated dark surface** (`darkTokens.semantic.inputSurface`, #2F234A) with a violet `#A78BFA` focus ring — don't force white fields (`--input-*` vars in index.css are the source of truth).
 - **Never hardcode user-facing strings** in `packages/web/app/**/*.tsx` — all visible text via i18n catalogs. CI runs `vp run check:i18n` and `vp run check:i18n:orphans`. Mark unresolvable dynamic lookups with `// i18n-keep namespace.dotted.key`.
 - **Variable names describe contents.** No single-letter aliases (`r`, `x`, `s`) or vague placeholders (`data`, `info`, `temp`, `value`) outside tight loops. Destructure at the use site instead of generic aliases.
 - **Drizzle ORM over raw SQL.** Use `db.select/insert/update/delete()`. Raw `sql` from `drizzle-orm` only when the query genuinely can't be expressed otherwise. Importing `sql` from `@/app/lib/db/db` (raw Neon HTTP client) is lint-blocked.

--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -538,6 +538,11 @@ The web app renders Velvet Send in light and dark. Wiring notes specific to web:
 - **Scheme-awareness.** A direct `themeTokens.colors.{primary,success,error,warning,info}` read renders
   the _light_ value in dark mode — use the scheme-aware CSS vars instead: `var(--color-primary)`
   (foreground), `var(--color-primary-fill)` (fills), `var(--color-success|error|warning|info)` (status).
+- **Input fields.** The `--input-*` family in `index.css` (bg / bg-hover / text / placeholder / border /
+  border-hover, both scheme blocks) is the source of truth for form fields; the MUI theme and the
+  `.module.css` files both read it. Light fields are white; dark fields ride the elevated violet
+  (`darkTokens.semantic.inputSurface`, `#2F234A`) with a 2px foreground-violet focus outline — never
+  force white fields in dark. All pairings are contrast-guarded in the parity test.
 
 **Shared across web and mobile:** the brand palette + colour helpers (`@boardsesh/velvet-tokens`) and the
 climbing **grade colours** (`@boardsesh/board-constants`). Both are platform-agnostic and stay shared.

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -345,7 +345,8 @@
     },
     "placeholders": {
       "description": "Optional description",
-      "serialNumber": "e.g. ABC-12345"
+      "serialNumber": "e.g. ABC-12345",
+      "select": "Select…"
     },
     "helperText": {
       "unlisted": "Hidden from search results but accessible via direct link",
@@ -353,6 +354,11 @@
     },
     "alerts": {
       "configEditable": "You can change the layout, size, and hold sets. Climbs already logged stay put."
+    },
+    "sections": {
+      "details": "Board details",
+      "setup": "Setup",
+      "visibility": "Visibility"
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -331,7 +331,7 @@
       "name": "Board Name",
       "slug": "URL Slug",
       "description": "Description",
-      "location": "Location",
+      "location": "Location name",
       "serialNumber": "Controller Serial Number",
       "defaultAngle": "Default Angle",
       "angleAdjustable": "Angle is adjustable",
@@ -357,6 +357,7 @@
     },
     "sections": {
       "details": "Board details",
+      "location": "Location",
       "setup": "Setup",
       "visibility": "Visibility"
     }

--- a/packages/shared/i18n/locales/en-US/profile.json
+++ b/packages/shared/i18n/locales/en-US/profile.json
@@ -129,7 +129,17 @@
       "cancel": "Cancel",
       "wallMoved": "Wall moved to {{wallClimb}}. Still logging {{loggingClimb}}?",
       "switchClimb": "Switch to {{climbName}}",
-      "switchDirtyConfirm": "You'll lose what you typed. Switch anyway?"
+      "switchDirtyConfirm": "You'll lose what you typed. Switch anyway?",
+      "logType": "Log type",
+      "saveFailed": "Couldn't save your tick. Try again.",
+      "sections": {
+        "details": "Details",
+        "howItFelt": "How it felt"
+      },
+      "validation": {
+        "flashOneAttempt": "Flash requires exactly 1 attempt",
+        "sendMoreAttempts": "Send requires more than 1 attempt"
+      }
     },
     "feed": {
       "deleteSwipeLabel": "Delete",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -331,7 +331,7 @@
       "name": "Nombre del plafón",
       "slug": "URL personalizada",
       "description": "Descripción",
-      "location": "Ubicación",
+      "location": "Nombre de la ubicación",
       "serialNumber": "Número de serie del controlador",
       "defaultAngle": "Ángulo por defecto",
       "angleAdjustable": "Ángulo ajustable",
@@ -357,6 +357,7 @@
     },
     "sections": {
       "details": "Detalles del plafón",
+      "location": "Ubicación",
       "setup": "Configuración",
       "visibility": "Visibilidad"
     }

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -345,7 +345,8 @@
     },
     "placeholders": {
       "description": "Descripción opcional",
-      "serialNumber": "p. ej. ABC-12345"
+      "serialNumber": "p. ej. ABC-12345",
+      "select": "Selecciona…"
     },
     "helperText": {
       "unlisted": "Oculto de los resultados de búsqueda pero accesible por enlace directo",
@@ -353,6 +354,11 @@
     },
     "alerts": {
       "configEditable": "Puedes cambiar la disposición, el tamaño y los conjuntos de presas. Los bloques ya registrados se mantienen igual."
+    },
+    "sections": {
+      "details": "Detalles del plafón",
+      "setup": "Configuración",
+      "visibility": "Visibilidad"
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/es/profile.json
+++ b/packages/shared/i18n/locales/es/profile.json
@@ -129,7 +129,17 @@
       "cancel": "Cancelar",
       "wallMoved": "El muro pasó a {{wallClimb}}. ¿Sigues registrando {{loggingClimb}}?",
       "switchClimb": "Cambiar a {{climbName}}",
-      "switchDirtyConfirm": "Perderás lo que escribiste. ¿Cambiar igual?"
+      "switchDirtyConfirm": "Perderás lo que escribiste. ¿Cambiar igual?",
+      "logType": "Tipo de registro",
+      "saveFailed": "No se pudo guardar tu registro. Inténtalo de nuevo.",
+      "sections": {
+        "details": "Detalles",
+        "howItFelt": "Cómo fue"
+      },
+      "validation": {
+        "flashOneAttempt": "El flash requiere exactamente 1 intento",
+        "sendMoreAttempts": "El encadene requiere más de 1 intento"
+      }
     },
     "feed": {
       "deleteSwipeLabel": "Eliminar",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -345,7 +345,8 @@
     },
     "placeholders": {
       "description": "Description facultative",
-      "serialNumber": "ex. ABC-12345"
+      "serialNumber": "ex. ABC-12345",
+      "select": "Sélectionner…"
     },
     "helperText": {
       "unlisted": "Masqué des résultats de recherche, mais accessible par lien direct",
@@ -353,6 +354,11 @@
     },
     "alerts": {
       "configEditable": "Vous pouvez modifier le layout, la taille et les jeux de prises. Les blocs déjà enregistrés restent intacts."
+    },
+    "sections": {
+      "details": "Détails de la board",
+      "setup": "Configuration",
+      "visibility": "Visibilité"
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -331,7 +331,7 @@
       "name": "Nom de la board",
       "slug": "Slug d'URL",
       "description": "Description",
-      "location": "Emplacement",
+      "location": "Nom du lieu",
       "serialNumber": "Numéro de série du contrôleur",
       "defaultAngle": "Inclinaison par défaut",
       "angleAdjustable": "Inclinaison réglable",
@@ -357,6 +357,7 @@
     },
     "sections": {
       "details": "Détails de la board",
+      "location": "Emplacement",
       "setup": "Configuration",
       "visibility": "Visibilité"
     }

--- a/packages/shared/i18n/locales/fr/profile.json
+++ b/packages/shared/i18n/locales/fr/profile.json
@@ -129,7 +129,17 @@
       "cancel": "Annuler",
       "wallMoved": "Le mur est passé à {{wallClimb}}. Tu logges toujours {{loggingClimb}} ?",
       "switchClimb": "Passer à {{climbName}}",
-      "switchDirtyConfirm": "Tu vas perdre ce que tu as tapé. Changer quand même ?"
+      "switchDirtyConfirm": "Tu vas perdre ce que tu as tapé. Changer quand même ?",
+      "logType": "Type de log",
+      "saveFailed": "Impossible d'enregistrer ta croix. Réessaie.",
+      "sections": {
+        "details": "Détails",
+        "howItFelt": "Ton ressenti"
+      },
+      "validation": {
+        "flashOneAttempt": "Le flash demande exactement 1 essai",
+        "sendMoreAttempts": "L'enchaînement demande plus d'un essai"
+      }
     },
     "feed": {
       "deleteSwipeLabel": "Supprimer",

--- a/packages/web/app/components/board-entity/__tests__/board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/board-form.test.tsx
@@ -55,7 +55,7 @@ describe('BoardForm', () => {
 
     expect(screen.getByLabelText('Board Name *')).toBeDefined();
     expect(screen.getByLabelText('Description')).toBeDefined();
-    expect(screen.getByLabelText('Location')).toBeDefined();
+    expect(screen.getByLabelText('Location name')).toBeDefined();
     expect(screen.getByLabelText('Controller Serial Number')).toBeDefined();
     expect(screen.getByText('Edit Board')).toBeDefined();
     expect(screen.getByText('Save')).toBeDefined();

--- a/packages/web/app/components/board-entity/board-detail.tsx
+++ b/packages/web/app/components/board-entity/board-detail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useId, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Avatar from '@mui/material/Avatar';
@@ -47,11 +47,25 @@ import AddOutlined from '@mui/icons-material/AddOutlined';
 import FollowButton from '@/app/components/ui/follow-button';
 import BoardLeaderboard from './board-leaderboard';
 import EditBoardForm from './edit-board-form';
+import type { BoardFormSubmitState } from './board-form';
 import CommentSection from '@/app/components/social/comment-section';
 import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
 import GymDetail from '@/app/components/gym-entity/gym-detail';
 import GymSelector from '@/app/components/gym-entity/gym-selector';
 import { boardTypeLabel } from '@boardsesh/board-constants';
+
+/**
+ * Reported up by BoardDetailContent while the board is being edited, so a
+ * titled host drawer can move the edit title + Save action into its header
+ * (the bottom-drawer ruling — the iOS keyboard buries a footer). `null` while
+ * not editing.
+ */
+export type BoardDetailEditHost = {
+  formId: string;
+  title: string;
+  submit: BoardFormSubmitState;
+  onCancel: () => void;
+};
 
 export type BoardDetailContentProps = {
   boardUuid: string;
@@ -60,6 +74,14 @@ export type BoardDetailContentProps = {
   onDeleted?: () => void;
   /** Called when follow state changes, so parent can update caches. */
   onFollowChange?: (boardUuid: string, isFollowing: boolean) => void;
+  /**
+   * When provided (a titled drawer host), the edit form's title and Save action
+   * are hosted by the drawer chrome instead of rendered inline. Called with the
+   * edit host descriptor while editing, `null` otherwise. Omit for hosts with
+   * no header (e.g. the search-result BoardDetail drawer), where the inline
+   * title + action bar are kept.
+   */
+  onEditHostChange?: (host: BoardDetailEditHost | null) => void;
 };
 
 export function BoardDetailContent({
@@ -67,12 +89,23 @@ export function BoardDetailContent({
   initialIsFollowing,
   onDeleted,
   onFollowChange,
+  onEditHostChange,
 }: BoardDetailContentProps) {
   const { t } = useTranslation('boards');
   const [board, setBoard] = useState<UserBoard | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [activeTab, setActiveTab] = useState(0);
   const [isEditing, setIsEditing] = useState(false);
+  // Edit-form action hosting: when the host asks for it (onEditHostChange), the
+  // drawer header carries the title + Save button and the form submits by id.
+  const hostsEditExternally = onEditHostChange != null;
+  const editFormId = useId();
+  const [editSubmitState, setEditSubmitState] = useState<BoardFormSubmitState>({
+    submitLabel: t('editBoard.submitLabel'),
+    submitting: false,
+    canSubmit: false,
+  });
+  const handleEditCancel = useCallback(() => setIsEditing(false), []);
   const [isDeleting, setIsDeleting] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showGymDetail, setShowGymDetail] = useState(false);
@@ -107,6 +140,22 @@ export function BoardDetailContent({
     setIsEditing(false);
     setActiveTab(0);
   }, [fetchBoard]);
+
+  // Report the edit-host descriptor to a titled drawer so it can title the
+  // surface + host the Save action. Kept in a ref so the unmount cleanup below
+  // can clear a stale header action bar without re-subscribing on identity
+  // change.
+  const onEditHostChangeRef = useRef(onEditHostChange);
+  onEditHostChangeRef.current = onEditHostChange;
+  const editTitle = t('editBoard.title');
+  useEffect(() => {
+    const report = onEditHostChangeRef.current;
+    if (!report) return;
+    report(
+      isEditing ? { formId: editFormId, title: editTitle, submit: editSubmitState, onCancel: handleEditCancel } : null,
+    );
+  }, [isEditing, editFormId, editTitle, editSubmitState, handleEditCancel]);
+  useEffect(() => () => onEditHostChangeRef.current?.(null), []);
 
   const isOwner = !!currentUserId && board?.ownerId === currentUserId;
 
@@ -183,7 +232,13 @@ export function BoardDetailContent({
   if (isEditing) {
     return (
       <Box sx={{ px: 2, pb: 2, overflow: 'auto', flex: 1 }}>
-        <EditBoardForm board={board} onSuccess={handleEditSuccess} onCancel={() => setIsEditing(false)} />
+        <EditBoardForm
+          board={board}
+          onSuccess={handleEditSuccess}
+          onCancel={handleEditCancel}
+          formId={hostsEditExternally ? editFormId : undefined}
+          onSubmitStateChange={hostsEditExternally ? setEditSubmitState : undefined}
+        />
       </Box>
     );
   }

--- a/packages/web/app/components/board-entity/board-form.tsx
+++ b/packages/web/app/components/board-entity/board-form.tsx
@@ -2,21 +2,14 @@
 
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
-import Switch from '@mui/material/Switch';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import MuiButton from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
 import MuiTypography from '@mui/material/Typography';
 import MenuItem from '@mui/material/MenuItem';
 import Alert from '@mui/material/Alert';
 import ListItemText from '@mui/material/ListItemText';
 import Check from '@mui/icons-material/Check';
 import MuiSelect, { type SelectChangeEvent } from '@mui/material/Select';
-import FormControl from '@mui/material/FormControl';
-import FormHelperText from '@mui/material/FormHelperText';
-import InputLabel from '@mui/material/InputLabel';
+import { FormShell, FormSection, FormField, FormActions, FormSwitchRow } from '@/app/components/form';
 import MapLocationPicker from './map-location-picker';
 
 type BoardFormFieldValues = {
@@ -39,7 +32,7 @@ type BoardFormFieldValues = {
 };
 
 type BoardFormProps = {
-  /** Form title displayed at the top */
+  /** Surface title. Pass an empty string when the host chrome already titles the surface. */
   title: string;
   /** Submit button label */
   submitLabel: string;
@@ -69,6 +62,10 @@ type BoardFormProps = {
   /** Optional cancel handler */
   onCancel?: () => void;
 };
+
+const NAME_MAX_LENGTH = 100;
+const DESCRIPTION_MAX_LENGTH = 500;
+const SERIAL_MAX_LENGTH = 100;
 
 /**
  * Shared form component for creating and editing boards.
@@ -119,8 +116,8 @@ export default function BoardForm({
       ? (configEditable.sets[`${configEditable.boardType}-${layoutId}-${sizeId}`] ?? [])
       : [];
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
     setIsSubmitting(true);
 
     try {
@@ -152,212 +149,265 @@ export default function BoardForm({
   };
 
   return (
-    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      {title && <MuiTypography variant="h6">{title}</MuiTypography>}
+    <FormShell onSubmit={handleSubmit} maxWidth={640}>
+      {title ? (
+        <MuiTypography variant="h6" component="h2">
+          {title}
+        </MuiTypography>
+      ) : null}
 
-      {configEditable && (
-        <>
-          <Alert severity="info" sx={{ fontSize: '0.8rem' }}>
-            {t('boardForm.alerts.configEditable')}
-          </Alert>
-
-          <FormControl size="small" fullWidth>
-            <InputLabel>{t('boardForm.fields.layout')}</InputLabel>
-            <MuiSelect
-              value={layoutId ?? ''}
-              label={t('boardForm.fields.layout')}
-              onChange={(e: SelectChangeEvent<number | string>) => {
-                const newLayout = e.target.value as number;
-                setLayoutId(newLayout);
-                // Reset dependent fields
-                const newSizes = configEditable.sizes[`${configEditable.boardType}-${newLayout}`] ?? [];
-                setSizeId(newSizes.length > 0 ? newSizes[0].id : undefined);
-                setSelectedSets([]);
-              }}
-            >
-              {configEditable.layouts.map(({ id, name: layoutName }) => (
-                <MenuItem key={id} value={id}>
-                  {layoutName}
-                </MenuItem>
-              ))}
-            </MuiSelect>
-          </FormControl>
-
-          {availableSizes.length > 0 && (
-            <FormControl size="small" fullWidth>
-              <InputLabel>{t('boardForm.fields.size')}</InputLabel>
-              <MuiSelect
-                value={sizeId ?? ''}
-                label={t('boardForm.fields.size')}
-                onChange={(e: SelectChangeEvent<number | string>) => {
-                  setSizeId(e.target.value as number);
-                  setSelectedSets([]);
-                }}
-              >
-                {availableSizes.map(({ id, name: sizeName, description: sizeDesc }) => (
-                  <MenuItem key={id} value={id}>{`${sizeName} ${sizeDesc}`}</MenuItem>
-                ))}
-              </MuiSelect>
-            </FormControl>
+      <FormSection title={t('boardForm.sections.details')}>
+        <FormField label={t('boardForm.fields.name')} required counter={{ value: name.length, max: NAME_MAX_LENGTH }}>
+          {(field) => (
+            <TextField
+              id={field.id}
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              required
+              fullWidth
+              size="small"
+              placeholder={namePlaceholder}
+              error={Boolean(field.error)}
+              slotProps={{ htmlInput: { maxLength: NAME_MAX_LENGTH, 'aria-describedby': field.describedBy } }}
+            />
           )}
+        </FormField>
 
-          {availableSets.length > 0 && (
-            <FormControl size="small" fullWidth>
-              <InputLabel>{t('boardForm.fields.holdSets')}</InputLabel>
+        {showSlugField && (
+          <FormField label={t('boardForm.fields.slug')} helper={`${slugHelperPrefix}${slug || '...'}`}>
+            {(field) => (
+              <TextField
+                id={field.id}
+                value={slug}
+                onChange={(event) => setSlug(event.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                fullWidth
+                size="small"
+                slotProps={{ htmlInput: { 'aria-describedby': field.describedBy } }}
+              />
+            )}
+          </FormField>
+        )}
+
+        <FormField
+          label={t('boardForm.fields.description')}
+          counter={{ value: description.length, max: DESCRIPTION_MAX_LENGTH }}
+        >
+          {(field) => (
+            <TextField
+              id={field.id}
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              fullWidth
+              size="small"
+              multiline
+              minRows={2}
+              maxRows={4}
+              placeholder={resolvedDescriptionPlaceholder}
+              slotProps={{ htmlInput: { maxLength: DESCRIPTION_MAX_LENGTH, 'aria-describedby': field.describedBy } }}
+            />
+          )}
+        </FormField>
+      </FormSection>
+
+      <FormSection title={t('boardForm.fields.location')}>
+        <FormField label={t('boardForm.fields.location')}>
+          {(field) => (
+            <TextField
+              id={field.id}
+              value={locationName}
+              onChange={(event) => setLocationName(event.target.value)}
+              fullWidth
+              size="small"
+              placeholder={locationPlaceholder}
+              slotProps={{ htmlInput: { 'aria-describedby': field.describedBy } }}
+            />
+          )}
+        </FormField>
+
+        <MapLocationPicker
+          latitude={latitude}
+          longitude={longitude}
+          onChange={(lat, lng) => {
+            setLatitude(lat);
+            setLongitude(lng);
+          }}
+        />
+      </FormSection>
+
+      <FormSection title={t('boardForm.sections.setup')}>
+        {configEditable && (
+          <>
+            <Alert severity="info" sx={{ fontSize: '0.8rem' }}>
+              {t('boardForm.alerts.configEditable')}
+            </Alert>
+
+            <FormField label={t('boardForm.fields.layout')}>
+              {(field) => (
+                <MuiSelect
+                  labelId={field.labelId}
+                  id={field.id}
+                  value={layoutId ?? ''}
+                  displayEmpty
+                  fullWidth
+                  size="small"
+                  error={Boolean(field.error)}
+                  onChange={(event: SelectChangeEvent<number | string>) => {
+                    const newLayout = event.target.value as number;
+                    setLayoutId(newLayout);
+                    // Reset dependent fields
+                    const newSizes = configEditable.sizes[`${configEditable.boardType}-${newLayout}`] ?? [];
+                    setSizeId(newSizes.length > 0 ? newSizes[0].id : undefined);
+                    setSelectedSets([]);
+                  }}
+                >
+                  <MenuItem value="" disabled>
+                    {t('boardForm.placeholders.select')}
+                  </MenuItem>
+                  {configEditable.layouts.map(({ id, name: layoutName }) => (
+                    <MenuItem key={id} value={id}>
+                      {layoutName}
+                    </MenuItem>
+                  ))}
+                </MuiSelect>
+              )}
+            </FormField>
+
+            {availableSizes.length > 0 && (
+              <FormField label={t('boardForm.fields.size')}>
+                {(field) => (
+                  <MuiSelect
+                    labelId={field.labelId}
+                    id={field.id}
+                    value={sizeId ?? ''}
+                    displayEmpty
+                    fullWidth
+                    size="small"
+                    error={Boolean(field.error)}
+                    onChange={(event: SelectChangeEvent<number | string>) => {
+                      setSizeId(event.target.value as number);
+                      setSelectedSets([]);
+                    }}
+                  >
+                    <MenuItem value="" disabled>
+                      {t('boardForm.placeholders.select')}
+                    </MenuItem>
+                    {availableSizes.map(({ id, name: sizeName, description: sizeDesc }) => (
+                      <MenuItem key={id} value={id}>{`${sizeName} ${sizeDesc}`}</MenuItem>
+                    ))}
+                  </MuiSelect>
+                )}
+              </FormField>
+            )}
+
+            {availableSets.length > 0 && (
+              <FormField label={t('boardForm.fields.holdSets')}>
+                {(field) => (
+                  <MuiSelect
+                    labelId={field.labelId}
+                    id={field.id}
+                    multiple
+                    value={selectedSets}
+                    fullWidth
+                    size="small"
+                    error={Boolean(field.error)}
+                    onChange={(event) => {
+                      const selected = event.target.value as unknown as number[];
+                      setSelectedSets(selected);
+                    }}
+                    renderValue={() =>
+                      availableSets
+                        .filter((set) => selectedSets.includes(set.id))
+                        .map((set) => set.name)
+                        .join(', ')
+                    }
+                  >
+                    {availableSets.map(({ id, name: setName }) => (
+                      <MenuItem key={id} value={id} sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                        <ListItemText
+                          primary={setName}
+                          primaryTypographyProps={{
+                            color: selectedSets.includes(id) ? 'text.primary' : 'text.secondary',
+                          }}
+                        />
+                        {selectedSets.includes(id) && (
+                          <Check fontSize="small" sx={{ color: 'primary.main', flexShrink: 0 }} />
+                        )}
+                      </MenuItem>
+                    ))}
+                  </MuiSelect>
+                )}
+              </FormField>
+            )}
+          </>
+        )}
+
+        <FormField label={t('boardForm.fields.serialNumber')}>
+          {(field) => (
+            <TextField
+              id={field.id}
+              value={serialNumber}
+              onChange={(event) => setSerialNumber(event.target.value)}
+              fullWidth
+              size="small"
+              placeholder={t('boardForm.placeholders.serialNumber')}
+              slotProps={{ htmlInput: { maxLength: SERIAL_MAX_LENGTH, 'aria-describedby': field.describedBy } }}
+            />
+          )}
+        </FormField>
+
+        {availableAngles && availableAngles.length > 0 && (
+          <FormField label={t('boardForm.fields.defaultAngle')}>
+            {(field) => (
               <MuiSelect
-                multiple
-                value={selectedSets}
-                label={t('boardForm.fields.holdSets')}
-                onChange={(e) => {
-                  const val = e.target.value as unknown as number[];
-                  setSelectedSets(val);
-                }}
-                renderValue={() =>
-                  availableSets
-                    .filter((s) => selectedSets.includes(s.id))
-                    .map((s) => s.name)
-                    .join(', ')
-                }
+                labelId={field.labelId}
+                id={field.id}
+                value={angle}
+                fullWidth
+                size="small"
+                error={Boolean(field.error)}
+                onChange={(event: SelectChangeEvent<number | string>) => setAngle(Number(event.target.value))}
               >
-                {availableSets.map(({ id, name: setName }) => (
-                  <MenuItem key={id} value={id} sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-                    <ListItemText
-                      primary={setName}
-                      primaryTypographyProps={{
-                        color: selectedSets.includes(id) ? 'text.primary' : 'text.secondary',
-                      }}
-                    />
-                    {selectedSets.includes(id) && (
-                      <Check fontSize="small" sx={{ color: 'primary.main', flexShrink: 0 }} />
-                    )}
+                {availableAngles.map((availableAngle) => (
+                  <MenuItem key={availableAngle} value={availableAngle}>
+                    {availableAngle}°
                   </MenuItem>
                 ))}
               </MuiSelect>
-            </FormControl>
-          )}
-        </>
-      )}
-
-      <TextField
-        label={t('boardForm.fields.name')}
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        required
-        fullWidth
-        size="small"
-        placeholder={namePlaceholder}
-        inputProps={{ maxLength: 100 }}
-      />
-
-      {showSlugField && (
-        <TextField
-          label={t('boardForm.fields.slug')}
-          value={slug}
-          onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
-          fullWidth
-          size="small"
-          helperText={`${slugHelperPrefix}${slug || '...'}`}
-        />
-      )}
-
-      <TextField
-        label={t('boardForm.fields.description')}
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        fullWidth
-        size="small"
-        multiline
-        minRows={2}
-        maxRows={4}
-        placeholder={resolvedDescriptionPlaceholder}
-      />
-
-      <TextField
-        label={t('boardForm.fields.location')}
-        value={locationName}
-        onChange={(e) => setLocationName(e.target.value)}
-        fullWidth
-        size="small"
-        placeholder={locationPlaceholder}
-      />
-
-      <MapLocationPicker
-        latitude={latitude}
-        longitude={longitude}
-        onChange={(lat, lng) => {
-          setLatitude(lat);
-          setLongitude(lng);
-        }}
-      />
-
-      <TextField
-        label={t('boardForm.fields.serialNumber')}
-        value={serialNumber}
-        onChange={(e) => setSerialNumber(e.target.value)}
-        fullWidth
-        size="small"
-        placeholder={t('boardForm.placeholders.serialNumber')}
-        inputProps={{ maxLength: 100 }}
-      />
-
-      {availableAngles && availableAngles.length > 0 && (
-        <TextField
-          label={t('boardForm.fields.defaultAngle')}
-          value={angle}
-          onChange={(e) => setAngle(Number(e.target.value))}
-          select
-          fullWidth
-          size="small"
-        >
-          {availableAngles.map((a) => (
-            <MenuItem key={a} value={a}>
-              {a}°
-            </MenuItem>
-          ))}
-        </TextField>
-      )}
-
-      <FormControlLabel
-        control={<Switch checked={isAngleAdjustable} onChange={(e) => setIsAngleAdjustable(e.target.checked)} />}
-        label={t('boardForm.fields.angleAdjustable')}
-      />
-
-      <FormControlLabel
-        control={<Switch checked={isPublic} onChange={(e) => setIsPublic(e.target.checked)} />}
-        label={t('boardForm.fields.isPublic')}
-      />
-
-      <Box>
-        <FormControlLabel
-          control={<Switch checked={isUnlisted} onChange={(e) => setIsUnlisted(e.target.checked)} />}
-          label={t('boardForm.fields.unlisted')}
-        />
-        <FormHelperText sx={{ mt: -0.5, ml: 7 }}>{t('boardForm.helperText.unlisted')}</FormHelperText>
-      </Box>
-
-      <Box>
-        <FormControlLabel
-          control={<Switch checked={hideLocation} onChange={(e) => setHideLocation(e.target.checked)} />}
-          label={t('boardForm.fields.hideLocation')}
-        />
-        <FormHelperText sx={{ mt: -0.5, ml: 7 }}>{t('boardForm.helperText.hideLocation')}</FormHelperText>
-      </Box>
-
-      <FormControlLabel
-        control={<Switch checked={isOwned} onChange={(e) => setIsOwned(e.target.checked)} />}
-        label={t('boardForm.fields.isOwned')}
-      />
-
-      <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end', mt: 1 }}>
-        {onCancel && (
-          <MuiButton variant="text" onClick={onCancel} disabled={isSubmitting}>
-            {t('common:actions.cancel')}
-          </MuiButton>
+            )}
+          </FormField>
         )}
-        <MuiButton type="submit" variant="contained" disabled={isSubmitting || !name.trim()}>
-          {isSubmitting ? <CircularProgress size={20} color="inherit" /> : submitLabel}
-        </MuiButton>
-      </Box>
-    </Box>
+
+        <FormSwitchRow
+          label={t('boardForm.fields.angleAdjustable')}
+          checked={isAngleAdjustable}
+          onChange={setIsAngleAdjustable}
+        />
+      </FormSection>
+
+      <FormSection title={t('boardForm.sections.visibility')}>
+        <FormSwitchRow label={t('boardForm.fields.isPublic')} checked={isPublic} onChange={setIsPublic} />
+        <FormSwitchRow
+          label={t('boardForm.fields.unlisted')}
+          description={t('boardForm.helperText.unlisted')}
+          checked={isUnlisted}
+          onChange={setIsUnlisted}
+        />
+        <FormSwitchRow
+          label={t('boardForm.fields.hideLocation')}
+          description={t('boardForm.helperText.hideLocation')}
+          checked={hideLocation}
+          onChange={setHideLocation}
+        />
+        <FormSwitchRow label={t('boardForm.fields.isOwned')} checked={isOwned} onChange={setIsOwned} />
+      </FormSection>
+
+      <FormActions
+        submitLabel={submitLabel}
+        submitting={isSubmitting}
+        disabled={!name.trim()}
+        onCancel={onCancel}
+        layout="inline"
+      />
+    </FormShell>
   );
 }

--- a/packages/web/app/components/board-entity/board-form.tsx
+++ b/packages/web/app/components/board-entity/board-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import TextField from '@mui/material/TextField';
 import MuiTypography from '@mui/material/Typography';
@@ -11,6 +11,13 @@ import Check from '@mui/icons-material/Check';
 import MuiSelect, { type SelectChangeEvent } from '@mui/material/Select';
 import { FormShell, FormSection, FormField, FormActions, FormSwitchRow } from '@/app/components/form';
 import MapLocationPicker from './map-location-picker';
+
+/** Submit-affordance state the form reports up so a drawer header can host the action. */
+export type BoardFormSubmitState = {
+  submitLabel: React.ReactNode;
+  submitting: boolean;
+  canSubmit: boolean;
+};
 
 type BoardFormFieldValues = {
   name: string;
@@ -61,6 +68,18 @@ type BoardFormProps = {
   onSubmit: (values: BoardFormFieldValues) => Promise<void>;
   /** Optional cancel handler */
   onCancel?: () => void;
+  /**
+   * When hosted in a drawer, the id wired onto the `<form>` so a header-hosted
+   * submit button can target it via `form={formId}`.
+   */
+  formId?: string;
+  /**
+   * When provided, the form reports its submit affordance here (for a header
+   * action bar) instead of rendering the inline submit/cancel buttons. Bottom
+   * drawers carry actions in the header because the iOS keyboard buries a
+   * footer — see docs/mobile-sheets-vs-routes.md.
+   */
+  onSubmitStateChange?: (state: BoardFormSubmitState) => void;
 };
 
 const NAME_MAX_LENGTH = 100;
@@ -84,6 +103,8 @@ export default function BoardForm({
   configEditable,
   onSubmit,
   onCancel,
+  formId,
+  onSubmitStateChange,
 }: BoardFormProps) {
   const { t } = useTranslation('boards');
   const resolvedDescriptionPlaceholder = descriptionPlaceholder ?? t('boardForm.placeholders.description');
@@ -115,6 +136,16 @@ export default function BoardForm({
     configEditable && layoutId && sizeId
       ? (configEditable.sets[`${configEditable.boardType}-${layoutId}-${sizeId}`] ?? [])
       : [];
+
+  const canSubmit = Boolean(name.trim());
+  const hostsActionsExternally = onSubmitStateChange != null;
+
+  // Report the submit affordance to a header-hosted action bar. Fires only when
+  // the label / saving / enabled state actually changes.
+  useEffect(() => {
+    if (!onSubmitStateChange) return;
+    onSubmitStateChange({ submitLabel, submitting: isSubmitting, canSubmit });
+  }, [onSubmitStateChange, submitLabel, isSubmitting, canSubmit]);
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -149,7 +180,7 @@ export default function BoardForm({
   };
 
   return (
-    <FormShell onSubmit={handleSubmit} maxWidth={640}>
+    <FormShell id={formId} onSubmit={handleSubmit} maxWidth={640}>
       {title ? (
         <MuiTypography variant="h6" component="h2">
           {title}
@@ -209,7 +240,7 @@ export default function BoardForm({
         </FormField>
       </FormSection>
 
-      <FormSection title={t('boardForm.fields.location')}>
+      <FormSection title={t('boardForm.sections.location')}>
         <FormField label={t('boardForm.fields.location')}>
           {(field) => (
             <TextField
@@ -401,13 +432,15 @@ export default function BoardForm({
         <FormSwitchRow label={t('boardForm.fields.isOwned')} checked={isOwned} onChange={setIsOwned} />
       </FormSection>
 
-      <FormActions
-        submitLabel={submitLabel}
-        submitting={isSubmitting}
-        disabled={!name.trim()}
-        onCancel={onCancel}
-        layout="inline"
-      />
+      {!hostsActionsExternally && (
+        <FormActions
+          submitLabel={submitLabel}
+          submitting={isSubmitting}
+          disabled={!canSubmit}
+          onCancel={onCancel}
+          layout="inline"
+        />
+      )}
     </FormShell>
   );
 }

--- a/packages/web/app/components/board-entity/board-form.tsx
+++ b/packages/web/app/components/board-entity/board-form.tsx
@@ -78,6 +78,9 @@ type BoardFormProps = {
    * action bar) instead of rendering the inline submit/cancel buttons. Bottom
    * drawers carry actions in the header because the iOS keyboard buries a
    * footer — see docs/mobile-sheets-vs-routes.md.
+   *
+   * Must be referentially stable (a setState or `useCallback`) — it sits in the
+   * report effect's deps, so a per-render identity re-fires the effect every render.
    */
   onSubmitStateChange?: (state: BoardFormSubmitState) => void;
 };
@@ -268,9 +271,7 @@ export default function BoardForm({
       <FormSection title={t('boardForm.sections.setup')}>
         {configEditable && (
           <>
-            <Alert severity="info" sx={{ fontSize: '0.8rem' }}>
-              {t('boardForm.alerts.configEditable')}
-            </Alert>
+            <Alert severity="info">{t('boardForm.alerts.configEditable')}</Alert>
 
             <FormField label={t('boardForm.fields.layout')}>
               {(field) => (

--- a/packages/web/app/components/board-entity/create-board-form.tsx
+++ b/packages/web/app/components/board-entity/create-board-form.tsx
@@ -18,7 +18,7 @@ import { constructBoardSlugListUrl } from '@/app/lib/url-utils';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { BoardName } from '@/app/lib/types';
 import { ANGLES } from '@/app/lib/board-data';
-import BoardForm from './board-form';
+import BoardForm, { type BoardFormSubmitState } from './board-form';
 
 type BoardConfig = { boardType: string; layoutId: number; sizeId: number; setIds: string };
 
@@ -59,6 +59,10 @@ type CreateBoardFormProps = {
   defaultAngle: number;
   onSuccess?: (board: UserBoard) => void;
   onCancel?: () => void;
+  /** When hosted in a drawer, the id wired onto the form for a header-hosted submit. */
+  formId?: string;
+  /** When provided, the form reports its submit affordance here so the drawer header hosts the action. */
+  onSubmitStateChange?: (state: BoardFormSubmitState) => void;
 };
 
 export default function CreateBoardForm({
@@ -69,6 +73,8 @@ export default function CreateBoardForm({
   defaultAngle,
   onSuccess,
   onCancel,
+  formId,
+  onSubmitStateChange,
 }: CreateBoardFormProps) {
   const { t } = useTranslation('boards');
   const { showMessage } = useSnackbar();
@@ -174,6 +180,8 @@ export default function CreateBoardForm({
       availableAngles={availableAngles}
       onSubmit={handleSubmit}
       onCancel={onCancel}
+      formId={formId}
+      onSubmitStateChange={onSubmitStateChange}
     />
   );
 }

--- a/packages/web/app/components/board-entity/edit-board-form.tsx
+++ b/packages/web/app/components/board-entity/edit-board-form.tsx
@@ -13,15 +13,23 @@ import type { UserBoard } from '@boardsesh/shared-schema';
 import type { BoardName } from '@/app/lib/types';
 import { ANGLES } from '@/app/lib/board-data';
 import { getBoardSelectorOptions } from '@/app/lib/board-constants';
-import BoardForm from './board-form';
+import BoardForm, { type BoardFormSubmitState } from './board-form';
 
 type EditBoardFormProps = {
   board: UserBoard;
   onSuccess?: (board: UserBoard) => void;
   onCancel?: () => void;
+  /** When hosted in a drawer, the id wired onto the form for a header-hosted submit. */
+  formId?: string;
+  /**
+   * When provided, the form reports its submit affordance here and the host
+   * titles the surface + owns the action bar (so the drawer header, not the
+   * form, shows the "Edit Board" title and Save button).
+   */
+  onSubmitStateChange?: (state: BoardFormSubmitState) => void;
 };
 
-export default function EditBoardForm({ board, onSuccess, onCancel }: EditBoardFormProps) {
+export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSubmitStateChange }: EditBoardFormProps) {
   const { t } = useTranslation('boards');
   const { showMessage } = useSnackbar();
 
@@ -100,7 +108,9 @@ export default function EditBoardForm({ board, onSuccess, onCancel }: EditBoardF
 
   return (
     <BoardForm
-      title={t('editBoard.title')}
+      // The host drawer titles the surface + hosts the action bar when it asks
+      // for submit-state reporting; drop the in-form title so it isn't doubled.
+      title={onSubmitStateChange ? '' : t('editBoard.title')}
       submitLabel={t('editBoard.submitLabel')}
       initialValues={{
         name: board.name,
@@ -125,6 +135,8 @@ export default function EditBoardForm({ board, onSuccess, onCancel }: EditBoardF
       configEditable={configEditable}
       onSubmit={handleSubmit}
       onCancel={onCancel}
+      formId={formId}
+      onSubmitStateChange={onSubmitStateChange}
     />
   );
 }

--- a/packages/web/app/components/board-entity/map-location-picker.tsx
+++ b/packages/web/app/components/board-entity/map-location-picker.tsx
@@ -224,7 +224,7 @@ export default function MapLocationPicker({ latitude, longitude, onChange }: Map
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <MapOutlined fontSize="small" color="action" />
-          <MuiTypography sx={{ fontSize: 14, fontWeight: 500 }}>
+          <MuiTypography variant="body2" sx={{ fontWeight: themeTokens.typography.fontWeight.medium }}>
             {hasLocation
               ? t('mapLocationPicker.locationDisplay', {
                   lat: latitude.toFixed(4),

--- a/packages/web/app/components/board-entity/map-location-picker.tsx
+++ b/packages/web/app/components/board-entity/map-location-picker.tsx
@@ -18,6 +18,7 @@ import SearchOutlined from '@mui/icons-material/SearchOutlined';
 import type { Map as LeafletMap, Marker as LeafletMarker } from 'leaflet';
 import type * as LeafletNamespace from 'leaflet';
 import { useGeolocation } from '@/app/hooks/use-geolocation';
+import { themeTokens } from '@/app/theme/theme-config';
 
 type NominatimResult = {
   lat: string;
@@ -57,7 +58,9 @@ export default function MapLocationPicker({ latitude, longitude, onChange }: Map
     } else {
       const icon = L.divIcon({
         className: '',
-        html: '<div style="width:16px;height:16px;background:#6d28d9;border:3px solid #fff;border-radius:50%;box-shadow:0 1px 4px rgba(0,0,0,0.4);"></div>',
+        // The marker renders inside the document, so the CSS custom property
+        // resolves against the app theme instead of a hardcoded brand hex.
+        html: '<div style="width:16px;height:16px;background:var(--color-primary-fill);border:3px solid #fff;border-radius:50%;box-shadow:0 1px 4px rgba(0,0,0,0.4);"></div>',
         iconSize: [16, 16],
         iconAnchor: [8, 8],
       });
@@ -205,12 +208,23 @@ export default function MapLocationPicker({ latitude, longitude, onChange }: Map
       onChange={handleAccordionChange}
       variant="outlined"
       disableGutters
-      sx={{ '&:before': { display: 'none' }, borderRadius: 1 }}
+      // Card-level disclosure — one surface step above the form background, not
+      // an input field. Rounded to the `lg` card radius and clipped so the map
+      // corners follow it.
+      sx={{
+        '&:before': { display: 'none' },
+        borderRadius: `${themeTokens.borderRadius.lg}px`,
+        backgroundColor: 'var(--semantic-surface)',
+        overflow: 'hidden',
+      }}
     >
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        sx={{ minHeight: 44, '& .MuiAccordionSummary-content': { my: 0 } }}
+      >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <MapOutlined fontSize="small" color="action" />
-          <MuiTypography variant="body2">
+          <MuiTypography sx={{ fontSize: 14, fontWeight: 500 }}>
             {hasLocation
               ? t('mapLocationPicker.locationDisplay', {
                   lat: latitude.toFixed(4),

--- a/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
+++ b/packages/web/app/components/board-selector-drawer/board-selector-drawer.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import React, { useState, useEffect, useMemo, useCallback, lazy, Suspense } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useId, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import { FormActions } from '@/app/components/form';
+import type { BoardFormSubmitState } from '../board-entity/board-form';
 import CollapsibleSection, {
   type CollapsibleSectionConfig,
 } from '@/app/components/collapsible-section/collapsible-section';
@@ -44,6 +46,15 @@ export default function BoardSelectorDrawer({
   const router = useLocaleRouter();
   const guardBoardSwitch = useBoardSwitchGuard();
   const [showCreateBoardForm, setShowCreateBoardForm] = useState(false);
+  // The create form's Save action lives in the create drawer's header (bottom-
+  // drawer ruling — the iOS keyboard buries a footer). The form reports its
+  // label / saving / enabled state here and the header button submits by id.
+  const createFormId = useId();
+  const [createSubmitState, setCreateSubmitState] = useState<BoardFormSubmitState>({
+    submitLabel: t('boardForm.create.submit'),
+    submitting: false,
+    canSubmit: false,
+  });
 
   // Board config form state
   const [selectedBoard, setSelectedBoard] = useState<BoardName | undefined>(undefined);
@@ -263,6 +274,16 @@ export default function BoardSelectorDrawer({
           open={showCreateBoardForm}
           onClose={() => setShowCreateBoardForm(false)}
           height="85dvh"
+          extra={
+            <FormActions
+              formId={createFormId}
+              submitLabel={createSubmitState.submitLabel}
+              submitting={createSubmitState.submitting}
+              disabled={!createSubmitState.canSubmit}
+              onCancel={() => setShowCreateBoardForm(false)}
+              layout="row"
+            />
+          }
         >
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
             <CollapsibleSection
@@ -318,6 +339,8 @@ export default function BoardSelectorDrawer({
                 sizeId={selectedSize}
                 setIds={selectedSets.join(',')}
                 defaultAngle={selectedAngle}
+                formId={createFormId}
+                onSubmitStateChange={setCreateSubmitState}
                 onSuccess={(board: UserBoard) => {
                   setShowCreateBoardForm(false);
                   const url = constructBoardSlugListUrl(board.slug, board.angle);

--- a/packages/web/app/components/form/__tests__/form-actions.test.tsx
+++ b/packages/web/app/components/form/__tests__/form-actions.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { FormActions } from '../form-actions';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+describe('FormActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the submit label, shows a spinner, and disables while submitting', () => {
+    render(<FormActions submitLabel="Save changes" submitting />);
+    const submit = screen.getByRole('button', { name: /Save changes/i }) as HTMLButtonElement;
+    expect(screen.getByText('Save changes')).toBeTruthy();
+    expect(submit.disabled).toBe(true);
+    expect(document.querySelector('.MuiCircularProgress-root')).toBeTruthy();
+  });
+
+  it('renders the submit button with the error colour when destructive', () => {
+    render(<FormActions submitLabel="Delete" destructive />);
+    const submit = screen.getByRole('button', { name: 'Delete' });
+    expect(submit.className).toMatch(/Error/);
+  });
+
+  it('renders the primary colour and no spinner by default', () => {
+    render(<FormActions submitLabel="Save" />);
+    const submit = screen.getByRole('button', { name: 'Save' });
+    expect(submit.className).not.toMatch(/Error/);
+    expect(document.querySelector('.MuiCircularProgress-root')).toBeNull();
+  });
+
+  it('fires onCancel when the cancel button is clicked', () => {
+    const onCancel = vi.fn();
+    render(<FormActions submitLabel="Save" onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('lands formId on the submit button form attribute', () => {
+    render(<FormActions submitLabel="Save" formId="my-form" />);
+    const submit = screen.getByRole('button', { name: 'Save' });
+    expect(submit.getAttribute('form')).toBe('my-form');
+  });
+
+  it('renders a secondary action', () => {
+    render(<FormActions submitLabel="Save" secondaryAction={<button type="button">Save draft</button>} />);
+    expect(screen.getByRole('button', { name: 'Save draft' })).toBeTruthy();
+  });
+});

--- a/packages/web/app/components/form/__tests__/form-actions.test.tsx
+++ b/packages/web/app/components/form/__tests__/form-actions.test.tsx
@@ -51,6 +51,22 @@ describe('FormActions', () => {
     expect(submit.getAttribute('form')).toBe('my-form');
   });
 
+  it('submits a form it sits outside of via formId (header-hosted action path)', () => {
+    // This is how drawer headers submit: the FormShell carries the id, the
+    // header's FormActions lives outside the <form> and targets it by id.
+    const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+    render(
+      <>
+        <form id="external-form" onSubmit={onSubmit}>
+          <input name="field" defaultValue="value" />
+        </form>
+        <FormActions submitLabel="Save" formId="external-form" />
+      </>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
   it('renders a secondary action', () => {
     render(<FormActions submitLabel="Save" secondaryAction={<button type="button">Save draft</button>} />);
     expect(screen.getByRole('button', { name: 'Save draft' })).toBeTruthy();

--- a/packages/web/app/components/form/__tests__/form-date-time-picker.test.tsx
+++ b/packages/web/app/components/form/__tests__/form-date-time-picker.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vite-plus/test';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import dayjs from 'dayjs';
+import { FormDateTimePicker } from '../form-date-time-picker';
+
+function renderPicker(element: React.ReactElement) {
+  return render(<LocalizationProvider dateAdapter={AdapterDayjs}>{element}</LocalizationProvider>);
+}
+
+// MUI X v8's accessible field DOM splits the wiring: `id` lands on the hidden
+// <input>, while aria-* / placeholder land on the sectioned field element. The
+// assertions below query by attribute rather than assuming one host element.
+const hiddenInput = (container: HTMLElement) => container.querySelector('input') as HTMLInputElement;
+
+describe('FormDateTimePicker', () => {
+  it('forwards id, error, and describedBy onto the picker field', () => {
+    const { container } = renderPicker(
+      <FormDateTimePicker id="climbed-at" error describedBy="climbed-at-helper" value={dayjs('2026-07-16')} />,
+    );
+    expect(hiddenInput(container).id).toBe('climbed-at');
+    expect(container.querySelector('[aria-describedby="climbed-at-helper"]')).toBeTruthy();
+    expect(container.querySelector('[aria-invalid="true"]')).toBeTruthy();
+  });
+
+  it('merges an object textField slot, with injected wiring winning on conflicts', () => {
+    const { container } = renderPicker(
+      <FormDateTimePicker
+        id="injected-id"
+        value={dayjs('2026-07-16')}
+        slotProps={{ textField: { id: 'caller-id', placeholder: 'caller placeholder', size: 'small' } }}
+      />,
+    );
+    // Injected id wins over the caller's; the caller's other props survive.
+    expect(hiddenInput(container).id).toBe('injected-id');
+    expect(container.querySelector('[placeholder="caller placeholder"]')).toBeTruthy();
+    expect(container.querySelector('.MuiPickersInputBase-root')).toBeTruthy();
+  });
+
+  it('merges a function textField slot the same way', () => {
+    const { container } = renderPicker(
+      <FormDateTimePicker
+        id="injected-id"
+        describedBy="helper-id"
+        value={dayjs('2026-07-16')}
+        slotProps={{ textField: () => ({ id: 'caller-id', placeholder: 'from function' }) }}
+      />,
+    );
+    expect(hiddenInput(container).id).toBe('injected-id');
+    expect(container.querySelector('[placeholder="from function"]')).toBeTruthy();
+    expect(container.querySelector('[aria-describedby="helper-id"]')).toBeTruthy();
+  });
+
+  it('leaves caller-supplied wiring untouched when nothing is injected', () => {
+    const { container } = renderPicker(
+      <FormDateTimePicker value={dayjs('2026-07-16')} slotProps={{ textField: { id: 'caller-id' } }} />,
+    );
+    expect(hiddenInput(container).id).toBe('caller-id');
+  });
+});

--- a/packages/web/app/components/form/__tests__/form-field.test.tsx
+++ b/packages/web/app/components/form/__tests__/form-field.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vite-plus/test';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TextField from '@mui/material/TextField';
+import { FormField } from '../form-field';
+
+describe('FormField', () => {
+  describe('render-prop path (TextField)', () => {
+    it('associates the label with the input via htmlFor / id', () => {
+      render(
+        <FormField label="Display name">
+          {(field) => <TextField id={field.id} inputProps={{ 'aria-describedby': field.describedBy }} />}
+        </FormField>,
+      );
+      // getByLabelText resolves the input through the FormLabel's htmlFor -> input id link.
+      expect(screen.getByLabelText('Display name')).toBeTruthy();
+    });
+
+    it('replaces the helper with the error string and wires aria-describedby + aria-invalid', () => {
+      render(
+        <FormField label="Email" helper="We never share it" error="Enter a valid email">
+          {(field) => (
+            <TextField
+              id={field.id}
+              error={Boolean(field.error)}
+              inputProps={{ 'aria-describedby': field.describedBy }}
+            />
+          )}
+        </FormField>,
+      );
+
+      // Helper copy is replaced by the error message.
+      expect(screen.queryByText('We never share it')).toBeNull();
+      expect(screen.getByText('Enter a valid email')).toBeTruthy();
+
+      const input = screen.getByLabelText('Email');
+      expect(input.getAttribute('aria-invalid')).toBe('true');
+
+      const describedById = input.getAttribute('aria-describedby');
+      expect(describedById).toBeTruthy();
+      const helperEl = document.getElementById(describedById as string);
+      expect(helperEl?.textContent).toBe('Enter a valid email');
+    });
+
+    it('renders the counter and emphasizes it once value reaches 80% of max', () => {
+      const { rerender } = render(
+        <FormField label="Bio" counter={{ value: 40, max: 100 }}>
+          {(field) => <TextField id={field.id} />}
+        </FormField>,
+      );
+      const belowThreshold = screen.getByText('40 / 100');
+      expect(belowThreshold).toBeTruthy();
+      expect(belowThreshold.getAttribute('data-emphasized')).toBe('false');
+
+      rerender(
+        <FormField label="Bio" counter={{ value: 80, max: 100 }}>
+          {(field) => <TextField id={field.id} />}
+        </FormField>,
+      );
+      expect(screen.getByText('80 / 100').getAttribute('data-emphasized')).toBe('true');
+    });
+
+    it('renders a required asterisk that is hidden from the accessibility tree', () => {
+      const { container } = render(
+        <FormField label="Name" required>
+          {(field) => <TextField id={field.id} />}
+        </FormField>,
+      );
+      const asterisk = container.querySelector('.MuiFormLabel-asterisk');
+      expect(asterisk).toBeTruthy();
+      expect(asterisk?.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('renders labelAccessory content', () => {
+      render(
+        <FormField label="Password" labelAccessory={<span>Forgot?</span>}>
+          {(field) => <TextField id={field.id} />}
+        </FormField>,
+      );
+      expect(screen.getByText('Forgot?')).toBeTruthy();
+    });
+
+    it('omits the helper row entirely when there is no helper, error, or counter', () => {
+      const { container } = render(<FormField label="Nickname">{(field) => <TextField id={field.id} />}</FormField>);
+      expect(container.querySelector('.MuiFormHelperText-root')).toBeNull();
+    });
+  });
+
+  describe('plain-element path (custom control)', () => {
+    it('wraps a plain element in role="group" labelled by the field label', () => {
+      render(
+        <FormField label="Colour">
+          <div data-testid="custom-control">custom</div>
+        </FormField>,
+      );
+      const group = screen.getByRole('group');
+      const labelledBy = group.getAttribute('aria-labelledby');
+      expect(labelledBy).toBeTruthy();
+      const labelEl = document.getElementById(labelledBy as string);
+      expect(labelEl?.textContent).toContain('Colour');
+      expect(screen.getByTestId('custom-control')).toBeTruthy();
+    });
+  });
+});

--- a/packages/web/app/components/form/__tests__/form-field.test.tsx
+++ b/packages/web/app/components/form/__tests__/form-field.test.tsx
@@ -60,6 +60,32 @@ describe('FormField', () => {
       expect(screen.getByText('80 / 100').getAttribute('data-emphasized')).toBe('true');
     });
 
+    it('announces a counter-only field via aria-describedby', () => {
+      render(
+        <FormField label="Bio" counter={{ value: 40, max: 100 }}>
+          {(field) => <TextField id={field.id} inputProps={{ 'aria-describedby': field.describedBy }} />}
+        </FormField>,
+      );
+      const input = screen.getByLabelText('Bio');
+      const describedBy = input.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy as string)?.textContent).toBe('40 / 100');
+    });
+
+    it('lists both the helper id and the counter id in aria-describedby when both are present', () => {
+      render(
+        <FormField label="Bio" helper="Tell the crew about yourself" counter={{ value: 40, max: 100 }}>
+          {(field) => <TextField id={field.id} inputProps={{ 'aria-describedby': field.describedBy }} />}
+        </FormField>,
+      );
+      const input = screen.getByLabelText('Bio');
+      const describedByIds = (input.getAttribute('aria-describedby') ?? '').split(' ');
+      expect(describedByIds).toHaveLength(2);
+      const referencedText = describedByIds.map((referencedId) => document.getElementById(referencedId)?.textContent);
+      expect(referencedText).toContain('Tell the crew about yourself');
+      expect(referencedText).toContain('40 / 100');
+    });
+
     it('renders a required asterisk that is hidden from the accessibility tree', () => {
       const { container } = render(
         <FormField label="Name" required>

--- a/packages/web/app/components/form/__tests__/form-row.test.tsx
+++ b/packages/web/app/components/form/__tests__/form-row.test.tsx
@@ -32,6 +32,32 @@ describe('FormRow', () => {
     expect(styleText).toMatch(/repeat\(2,\s*1fr\)/);
   });
 
+  it('ignores conditionally-omitted (null) children when sizing the grid', () => {
+    // A `{condition && <Field/>}` slot that resolves to null must not leave a
+    // ghost column — the remaining child should get the full row.
+    render(
+      <FormRow>
+        {null}
+        <div>Only child</div>
+      </FormRow>,
+    );
+    // Scope to this container's own emotion class — the shared jsdom style
+    // registry still holds rules from other tests in this file.
+    const gridClass = screen
+      .getByText('Only child')
+      .parentElement?.className.split(' ')
+      .find((cls) => cls.startsWith('css-'));
+    expect(gridClass).toBeTruthy();
+    const ruleText = Array.from(document.querySelectorAll('style'))
+      .map((styleEl) => styleEl.textContent ?? '')
+      .join('')
+      .split(`.${gridClass}`)
+      .slice(1)
+      .join(' ');
+    expect(ruleText).toMatch(/repeat\(1,\s*1fr\)/);
+    expect(ruleText).not.toMatch(/repeat\(2,\s*1fr\)/);
+  });
+
   it('puts the children in a grid container with an sx-generated class', () => {
     render(
       <FormRow>

--- a/packages/web/app/components/form/__tests__/form-row.test.tsx
+++ b/packages/web/app/components/form/__tests__/form-row.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vite-plus/test';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FormRow } from '../form-row';
+
+describe('FormRow', () => {
+  it('renders each child', () => {
+    render(
+      <FormRow>
+        <div data-testid="first">A</div>
+        <div data-testid="second">B</div>
+      </FormRow>,
+    );
+    expect(screen.getByTestId('first')).toBeTruthy();
+    expect(screen.getByTestId('second')).toBeTruthy();
+  });
+
+  it('applies the grid sx (single column base + N-column container query)', () => {
+    // Container queries don't evaluate in JSDOM, so assert the emitted CSS instead: a
+    // single-column base with a container-query bump to one column per child.
+    render(
+      <FormRow>
+        <div>A</div>
+        <div>B</div>
+      </FormRow>,
+    );
+    const styleText = Array.from(document.querySelectorAll('style'))
+      .map((styleEl) => styleEl.textContent ?? '')
+      .join('');
+    expect(styleText).toMatch(/grid-template-columns:\s*1fr/);
+    expect(styleText).toMatch(/@container[^{]*min-width:\s*440px/);
+    expect(styleText).toMatch(/repeat\(2,\s*1fr\)/);
+  });
+
+  it('puts the children in a grid container with an sx-generated class', () => {
+    render(
+      <FormRow>
+        <div data-testid="cell">A</div>
+      </FormRow>,
+    );
+    const gridContainer = screen.getByTestId('cell').parentElement;
+    expect(gridContainer?.className).toBeTruthy();
+  });
+});

--- a/packages/web/app/components/form/__tests__/form-section.test.tsx
+++ b/packages/web/app/components/form/__tests__/form-section.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vite-plus/test';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FormSection } from '../form-section';
+
+describe('FormSection', () => {
+  it('renders the title and description above the fields', () => {
+    render(
+      <FormSection title="Location" description="Where the board lives">
+        <div>field</div>
+      </FormSection>,
+    );
+    expect(screen.getByText('Location')).toBeTruthy();
+    expect(screen.getByText('Where the board lives')).toBeTruthy();
+    expect(screen.getByText('field')).toBeTruthy();
+  });
+
+  it('renders a title without a description (and vice versa)', () => {
+    const { rerender } = render(
+      <FormSection title="Setup">
+        <div>field</div>
+      </FormSection>,
+    );
+    expect(screen.getByText('Setup')).toBeTruthy();
+
+    rerender(
+      <FormSection description="Only supporting copy">
+        <div>field</div>
+      </FormSection>,
+    );
+    expect(screen.queryByText('Setup')).toBeNull();
+    expect(screen.getByText('Only supporting copy')).toBeTruthy();
+  });
+
+  it('omits the header block entirely when neither title nor description is given', () => {
+    const { container } = render(
+      <FormSection>
+        <div>only field</div>
+      </FormSection>,
+    );
+    // Root box should contain exactly one child: the fields column (no empty
+    // header box reserving its 12px gap).
+    const rootBox = container.firstElementChild as HTMLElement;
+    expect(rootBox.children.length).toBe(1);
+    expect(screen.getByText('only field')).toBeTruthy();
+  });
+
+  it('stacks children inside a single fields column', () => {
+    const { container } = render(
+      <FormSection title="Details">
+        <div>first</div>
+        <div>second</div>
+      </FormSection>,
+    );
+    const rootBox = container.firstElementChild as HTMLElement;
+    // Header block + fields column.
+    expect(rootBox.children.length).toBe(2);
+    const fieldsColumn = rootBox.children[1] as HTMLElement;
+    expect(fieldsColumn.children.length).toBe(2);
+  });
+});

--- a/packages/web/app/components/form/__tests__/form-shell.test.tsx
+++ b/packages/web/app/components/form/__tests__/form-shell.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FormShell, focusFirstInvalid } from '../form-shell';
+
+describe('FormShell', () => {
+  it('renders the error banner as an alert', () => {
+    render(
+      <FormShell onSubmit={vi.fn()} error="Something went wrong">
+        <div />
+      </FormShell>,
+    );
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('Something went wrong');
+  });
+
+  it('renders no alert when there is no error', () => {
+    render(
+      <FormShell onSubmit={vi.fn()}>
+        <div />
+      </FormShell>,
+    );
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('caps content width at 640px by default', () => {
+    render(
+      <FormShell onSubmit={vi.fn()}>
+        <div />
+      </FormShell>,
+    );
+    const styleText = Array.from(document.querySelectorAll('style'))
+      .map((styleEl) => styleEl.textContent ?? '')
+      .join('');
+    expect(styleText).toMatch(/max-width:\s*640px/);
+  });
+
+  describe('focusFirstInvalid', () => {
+    it('focuses the first control marked aria-invalid', () => {
+      render(
+        <FormShell onSubmit={vi.fn()} id="focus-form">
+          <input aria-invalid="false" data-testid="ok" />
+          <input aria-invalid="true" data-testid="bad" />
+          <input aria-invalid="true" data-testid="bad-two" />
+        </FormShell>,
+      );
+      const form = document.getElementById('focus-form');
+      const focused = focusFirstInvalid(form);
+      expect(focused).toBe(screen.getByTestId('bad'));
+      expect(document.activeElement).toBe(screen.getByTestId('bad'));
+    });
+
+    it('returns null when nothing is invalid', () => {
+      render(
+        <FormShell onSubmit={vi.fn()} id="clean-form">
+          <input aria-invalid="false" />
+        </FormShell>,
+      );
+      expect(focusFirstInvalid(document.getElementById('clean-form'))).toBeNull();
+    });
+
+    it('returns null for a missing form element', () => {
+      expect(focusFirstInvalid(null)).toBeNull();
+    });
+  });
+});

--- a/packages/web/app/components/form/__tests__/form-switch-row.test.tsx
+++ b/packages/web/app/components/form/__tests__/form-switch-row.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { FormSwitchRow } from '../form-switch-row';
+
+describe('FormSwitchRow', () => {
+  it('toggles when the row (label text) is clicked', () => {
+    const onChange = vi.fn();
+    render(<FormSwitchRow label="Make public" checked={false} onChange={onChange} />);
+    // Clicking the label text bubbles to the wrapping <label>, activating the switch.
+    fireEvent.click(screen.getByText('Make public'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('wires the description to the switch via aria-describedby', () => {
+    const { container } = render(
+      <FormSwitchRow label="Make public" description="Anyone can view this board" checked={false} onChange={vi.fn()} />,
+    );
+    const input = container.querySelector('input[type="checkbox"]');
+    const describedBy = input?.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const descriptionEl = document.getElementById(describedBy as string);
+    expect(descriptionEl?.textContent).toContain('Anyone can view this board');
+  });
+
+  it('reflects the checked state on the input', () => {
+    const { container } = render(<FormSwitchRow label="On" checked onChange={vi.fn()} />);
+    const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(input.checked).toBe(true);
+  });
+});

--- a/packages/web/app/components/form/form-actions.tsx
+++ b/packages/web/app/components/form/form-actions.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+export type FormActionsLayout = 'inline' | 'stacked' | 'row';
+
+export type FormActionsProps = {
+  submitLabel: React.ReactNode;
+  submitting?: boolean;
+  disabled?: boolean;
+  /** Renders the submit button with the error colour (destructive confirmations). */
+  destructive?: boolean;
+  onCancel?: () => void;
+  /** Cancel button label. Defaults to the shared `common:actions.cancel` string. */
+  cancelLabel?: React.ReactNode;
+  /** Left-aligned content, e.g. a "Delete" or "Save draft" secondary control. */
+  secondaryAction?: React.ReactNode;
+  /**
+   * - `inline` (default): right-aligned row on >=sm, full-width column-reverse on <sm.
+   * - `stacked`: always a full-width column.
+   * - `row`: always a right-aligned row.
+   */
+  layout?: FormActionsLayout;
+  /** Associate the submit button with a form by id (submit from outside the `<form>`). */
+  formId?: string;
+};
+
+/**
+ * FormActions renders the cancel / submit button pair (plus an optional left-aligned
+ * secondary action). The submit button keeps its label while submitting and shows a
+ * `startIcon` spinner, so its width never jumps.
+ */
+export function FormActions({
+  submitLabel,
+  submitting = false,
+  disabled = false,
+  destructive = false,
+  onCancel,
+  cancelLabel,
+  secondaryAction,
+  layout = 'inline',
+  formId,
+}: FormActionsProps) {
+  const { t } = useTranslation('common');
+  const resolvedCancelLabel = cancelLabel ?? t('actions.cancel');
+
+  const containerSx: SxProps<Theme> =
+    layout === 'stacked'
+      ? { display: 'flex', flexDirection: 'column', gap: 1.5 }
+      : layout === 'row'
+        ? { display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'flex-end', gap: 1.5 }
+        : {
+            display: 'flex',
+            flexDirection: { xs: 'column-reverse', sm: 'row' },
+            alignItems: { xs: 'stretch', sm: 'center' },
+            justifyContent: { sm: 'flex-end' },
+            gap: 1.5,
+          };
+
+  const buttonWidthSx: SxProps<Theme> =
+    layout === 'stacked' ? { width: '100%' } : layout === 'inline' ? { width: { xs: '100%', sm: 'auto' } } : {};
+
+  const secondaryWrapperSx: SxProps<Theme> =
+    layout === 'stacked' ? { width: '100%' } : { mr: { sm: 'auto' }, display: 'flex' };
+
+  return (
+    <Box sx={containerSx}>
+      {secondaryAction != null ? <Box sx={secondaryWrapperSx}>{secondaryAction}</Box> : null}
+      {onCancel ? (
+        <Button variant="text" onClick={onCancel} disabled={submitting} sx={buttonWidthSx}>
+          {resolvedCancelLabel}
+        </Button>
+      ) : null}
+      <Button
+        type="submit"
+        variant="contained"
+        color={destructive ? 'error' : 'primary'}
+        form={formId}
+        disabled={submitting || disabled}
+        startIcon={submitting ? <CircularProgress size={16} color="inherit" /> : undefined}
+        sx={buttonWidthSx}
+      >
+        {submitLabel}
+      </Button>
+    </Box>
+  );
+}

--- a/packages/web/app/components/form/form-date-time-picker.tsx
+++ b/packages/web/app/components/form/form-date-time-picker.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import * as React from 'react';
+import { DateTimePicker, type DateTimePickerProps } from '@mui/x-date-pickers/DateTimePicker';
+
+export type FormDateTimePickerProps = DateTimePickerProps & {
+  /** Control id, forwarded to the picker's text field. */
+  id?: string;
+  /** Error styling flag, forwarded to the picker's text field. */
+  error?: boolean;
+  /** id of the field's helper/error text, forwarded as `aria-describedby`. */
+  describedBy?: string;
+};
+
+/**
+ * FormDateTimePicker is a thin wrapper over the x-date-pickers `DateTimePicker` that maps
+ * FormField's wiring (`id`, `error`, `describedBy`) into the `textField` slot, merging
+ * with any caller-supplied `slotProps` so its own text-field overrides still apply.
+ * The injected values win only when provided, so a caller can still set them itself.
+ */
+export function FormDateTimePicker({ id, error, describedBy, slotProps, ...rest }: FormDateTimePickerProps) {
+  const injectedTextField = {
+    ...(id !== undefined ? { id } : {}),
+    ...(error !== undefined ? { error } : {}),
+    ...(describedBy !== undefined ? { 'aria-describedby': describedBy } : {}),
+  };
+  const callerTextField = slotProps?.textField;
+
+  return (
+    <DateTimePicker
+      {...rest}
+      slotProps={{
+        ...slotProps,
+        textField:
+          typeof callerTextField === 'function'
+            ? (ownerState) => ({ ...callerTextField(ownerState), ...injectedTextField })
+            : { ...callerTextField, ...injectedTextField },
+      }}
+    />
+  );
+}

--- a/packages/web/app/components/form/form-field.tsx
+++ b/packages/web/app/components/form/form-field.tsx
@@ -148,7 +148,8 @@ export function FormField({
           sx={{
             display: 'flex',
             alignItems: 'flex-start',
-            justifyContent: 'space-between',
+            // Counter-only rows right-align without a placeholder element.
+            justifyContent: helperContent != null ? 'space-between' : 'flex-end',
             gap: 1,
             mt: '4px',
           }}
@@ -157,9 +158,7 @@ export function FormField({
             <FormHelperText id={describedById} error={hasError} sx={{ m: 0 }}>
               {helperContent}
             </FormHelperText>
-          ) : (
-            <span />
-          )}
+          ) : null}
           {counter != null ? (
             <Typography
               variant="caption"

--- a/packages/web/app/components/form/form-field.tsx
+++ b/packages/web/app/components/form/form-field.tsx
@@ -7,6 +7,7 @@ import FormLabel from '@mui/material/FormLabel';
 import FormHelperText from '@mui/material/FormHelperText';
 import Typography from '@mui/material/Typography';
 import type { SxProps, Theme } from '@mui/material/styles';
+import { themeTokens } from '@/app/theme/theme-config';
 
 /** Counter is emphasised once the value reaches 80% of its max. */
 const COUNTER_EMPHASIS_RATIO = 0.8;
@@ -165,7 +166,13 @@ export function FormField({
               component="span"
               data-emphasized={nearMax ? 'true' : 'false'}
               color={nearMax ? 'text.primary' : 'text.secondary'}
-              sx={{ flexShrink: 0, fontWeight: nearMax ? 600 : 400, whiteSpace: 'nowrap' }}
+              sx={{
+                flexShrink: 0,
+                fontWeight: nearMax
+                  ? themeTokens.typography.fontWeight.semibold
+                  : themeTokens.typography.fontWeight.normal,
+                whiteSpace: 'nowrap',
+              }}
             >
               {counter.value} / {counter.max}
             </Typography>

--- a/packages/web/app/components/form/form-field.tsx
+++ b/packages/web/app/components/form/form-field.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import * as React from 'react';
+import { useId } from 'react';
+import Box from '@mui/material/Box';
+import FormLabel from '@mui/material/FormLabel';
+import FormHelperText from '@mui/material/FormHelperText';
+import Typography from '@mui/material/Typography';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+/** Counter is emphasised once the value reaches 80% of its max. */
+const COUNTER_EMPHASIS_RATIO = 0.8;
+
+/**
+ * The wiring object handed to a FormField render-prop child. Spread the relevant bits
+ * onto the control:
+ *  - TextField:  `id={field.id}` + `error={Boolean(field.error)}` +
+ *                `inputProps={{ 'aria-describedby': field.describedBy }}`
+ *  - Select:     `labelId={field.labelId}` + `id={field.id}` + `error={Boolean(field.error)}`
+ *  - pickers:    map `id` / `error` / `describedBy` into the picker's textField slot
+ *                (see `FormDateTimePicker`)
+ */
+export type FormFieldRenderState = {
+  /** id for the control; set as `id` on a TextField / picker text field. */
+  id: string;
+  /** id of the helper/error text; pass to the control's `aria-describedby`. Undefined when there is no helper/error. */
+  describedBy: string | undefined;
+  /** Current error — a string message, a truthy element, or a boolean flag (ReactNode covers booleans). `false` when clean. */
+  error: React.ReactNode;
+  /** Whether the field is required. */
+  required: boolean;
+  /** id of the visible label. MUI `Select` needs this as its `labelId` to be announced. */
+  labelId: string;
+};
+
+export type FormFieldProps = {
+  label: React.ReactNode;
+  required?: boolean;
+  helper?: React.ReactNode;
+  /** Error message (string, replaces the helper) or a boolean flag (error styling only; ReactNode covers booleans). */
+  error?: React.ReactNode;
+  /** Character counter, right-aligned in the helper row. Emphasised at >= 80% of max. */
+  counter?: { value: number; max: number };
+  /** Right-aligned content next to the label (e.g. an "optional" chip or a help link). */
+  labelAccessory?: React.ReactNode;
+  /** Explicit control id. When omitted a stable id is generated with `useId`. */
+  htmlFor?: string;
+  /**
+   * Either a render-prop `(field) => ReactNode` (preferred for TextField / Select /
+   * pickers, which bring their own FormControl) or a plain element (a custom / non-MUI
+   * control, wrapped in `role="group"` + `aria-labelledby`).
+   */
+  children: React.ReactNode | ((field: FormFieldRenderState) => React.ReactNode);
+  sx?: SxProps<Theme>;
+};
+
+/**
+ * Build the trio of ids (`id`, `labelId`, `describedById`) a field needs, honouring an
+ * explicit id when supplied. Exposed for consumers composing controls outside FormField.
+ */
+export function useFormFieldIds(providedId?: string): { id: string; labelId: string; describedById: string } {
+  const generatedId = useId();
+  const id = providedId ?? generatedId;
+  return { id, labelId: `${id}-label`, describedById: `${id}-helper` };
+}
+
+/**
+ * FormField renders the label row, the control, and the helper/counter row for a single
+ * field. It deliberately does NOT wrap the control in its own `FormControl`: MUI's
+ * TextField (and Select-via-TextField) ship their own FormControl, and nesting them
+ * fights over context. Instead:
+ *
+ *  - Render-prop children receive an explicit wiring object (`id`, `describedBy`,
+ *    `error`, `required`, `labelId`) to spread onto the control. This is the path for
+ *    MUI inputs and date/time pickers.
+ *  - Plain-element children (custom / non-MUI controls) are wrapped in a
+ *    `role="group"` + `aria-labelledby` container so the visible label still names them.
+ *
+ * The helper row only renders when a helper, an error, or a counter is present
+ * (conditional reservation — no empty gap under clean fields). When `error` is a string
+ * it replaces the helper text.
+ */
+export function FormField({
+  label,
+  required = false,
+  helper,
+  error,
+  counter,
+  labelAccessory,
+  htmlFor,
+  children,
+  sx,
+}: FormFieldProps) {
+  const { id: inputId, labelId, describedById } = useFormFieldIds(htmlFor);
+
+  const isRenderProp = typeof children === 'function';
+  const errorText = typeof error === 'string' ? error : null;
+  const hasError = Boolean(error);
+  const helperContent = errorText ?? helper;
+  const hasHelperRow = helperContent != null || counter != null;
+  const describedBy = helperContent != null ? describedById : undefined;
+
+  const nearMax = counter != null && counter.max > 0 && counter.value >= counter.max * COUNTER_EMPHASIS_RATIO;
+
+  return (
+    <Box sx={[{ display: 'flex', flexDirection: 'column' }, ...(Array.isArray(sx) ? sx : [sx])]}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 1,
+          mb: '4px',
+          minHeight: 20,
+        }}
+      >
+        <FormLabel
+          id={labelId}
+          htmlFor={isRenderProp ? inputId : undefined}
+          required={required}
+          error={hasError}
+          sx={{ m: 0 }}
+        >
+          {label}
+        </FormLabel>
+        {labelAccessory != null ? (
+          <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>{labelAccessory}</Box>
+        ) : null}
+      </Box>
+
+      {isRenderProp ? (
+        (children as (field: FormFieldRenderState) => React.ReactNode)({
+          id: inputId,
+          describedBy,
+          error: error ?? false,
+          required,
+          labelId,
+        })
+      ) : (
+        <Box role="group" aria-labelledby={labelId} aria-describedby={describedBy}>
+          {children}
+        </Box>
+      )}
+
+      {hasHelperRow ? (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: 1,
+            mt: '4px',
+          }}
+        >
+          {helperContent != null ? (
+            <FormHelperText id={describedById} error={hasError} sx={{ m: 0 }}>
+              {helperContent}
+            </FormHelperText>
+          ) : (
+            <span />
+          )}
+          {counter != null ? (
+            <Typography
+              variant="caption"
+              component="span"
+              data-emphasized={nearMax ? 'true' : 'false'}
+              color={nearMax ? 'text.primary' : 'text.secondary'}
+              sx={{ flexShrink: 0, fontWeight: nearMax ? 600 : 400, whiteSpace: 'nowrap' }}
+            >
+              {counter.value} / {counter.max}
+            </Typography>
+          ) : null}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/web/app/components/form/form-field.tsx
+++ b/packages/web/app/components/form/form-field.tsx
@@ -99,7 +99,11 @@ export function FormField({
   const hasError = Boolean(error);
   const helperContent = errorText ?? helper;
   const hasHelperRow = helperContent != null || counter != null;
-  const describedBy = helperContent != null ? describedById : undefined;
+  // The counter joins aria-describedby so screen readers announce the limit,
+  // not just sighted users.
+  const counterId = counter != null ? `${inputId}-counter` : undefined;
+  const describedBy =
+    [helperContent != null ? describedById : undefined, counterId].filter(Boolean).join(' ') || undefined;
 
   const nearMax = counter != null && counter.max > 0 && counter.value >= counter.max * COUNTER_EMPHASIS_RATIO;
 
@@ -161,6 +165,7 @@ export function FormField({
           ) : null}
           {counter != null ? (
             <Typography
+              id={counterId}
               variant="caption"
               component="span"
               data-emphasized={nearMax ? 'true' : 'false'}

--- a/packages/web/app/components/form/form-row.tsx
+++ b/packages/web/app/components/form/form-row.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+export type FormRowProps = {
+  children: React.ReactNode;
+  sx?: SxProps<Theme>;
+};
+
+/**
+ * FormRow lays its children out side by side once there's room.
+ *
+ * It's a single-column grid by default; at a container width of 440px (the form's own
+ * width via `FormShell`'s `containerType: 'inline-size'`, not the viewport) it becomes an
+ * N-column grid where N is the child count. Container queries — rather than viewport
+ * breakpoints — keep rows sensible inside narrow surfaces like dialogs and drawers.
+ */
+export function FormRow({ children, sx }: FormRowProps) {
+  const columnCount = React.Children.count(children);
+  return (
+    <Box
+      sx={[
+        {
+          display: 'grid',
+          gridTemplateColumns: '1fr',
+          gap: 2,
+          alignItems: 'flex-start',
+          '@container (min-width: 440px)': {
+            gridTemplateColumns: `repeat(${columnCount}, 1fr)`,
+          },
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/packages/web/app/components/form/form-row.tsx
+++ b/packages/web/app/components/form/form-row.tsx
@@ -18,7 +18,9 @@ export type FormRowProps = {
  * breakpoints — keep rows sensible inside narrow surfaces like dialogs and drawers.
  */
 export function FormRow({ children, sx }: FormRowProps) {
-  const columnCount = React.Children.count(children);
+  // toArray (not Children.count) so conditionally-omitted children — null /
+  // undefined / false slots — don't leave a ghost column in the grid.
+  const columnCount = React.Children.toArray(children).length;
   return (
     <Box
       sx={[

--- a/packages/web/app/components/form/form-section.tsx
+++ b/packages/web/app/components/form/form-section.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+export type FormSectionProps = {
+  /** Section heading (subtitle2 · secondary). */
+  title?: React.ReactNode;
+  /** Supporting copy under the title (body2 · secondary). */
+  description?: React.ReactNode;
+  children: React.ReactNode;
+  sx?: SxProps<Theme>;
+};
+
+/**
+ * FormSection groups related fields under an optional heading.
+ *
+ * Header block spacing: 4px between title and description, 12px between the header block
+ * and the fields. Fields stack in a 20px column. When neither title nor description is
+ * provided the header (and its 12px gap) is omitted entirely.
+ */
+export function FormSection({ title, description, children, sx }: FormSectionProps) {
+  const hasHeader = title != null || description != null;
+  return (
+    <Box sx={[{ display: 'flex', flexDirection: 'column' }, ...(Array.isArray(sx) ? sx : [sx])]}>
+      {hasHeader ? (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px', mb: '12px' }}>
+          {title != null ? (
+            <Typography
+              variant="subtitle2"
+              color="text.secondary"
+              sx={{ fontSize: 14, fontWeight: 600, lineHeight: '20px' }}
+            >
+              {title}
+            </Typography>
+          ) : null}
+          {description != null ? (
+            <Typography variant="body2" color="text.secondary">
+              {description}
+            </Typography>
+          ) : null}
+        </Box>
+      ) : null}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>{children}</Box>
+    </Box>
+  );
+}

--- a/packages/web/app/components/form/form-section.tsx
+++ b/packages/web/app/components/form/form-section.tsx
@@ -28,11 +28,7 @@ export function FormSection({ title, description, children, sx }: FormSectionPro
       {hasHeader ? (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px', mb: '12px' }}>
           {title != null ? (
-            <Typography
-              variant="subtitle2"
-              color="text.secondary"
-              sx={{ fontSize: 14, fontWeight: 600, lineHeight: '20px' }}
-            >
+            <Typography variant="subtitle2" color="text.secondary">
               {title}
             </Typography>
           ) : null}

--- a/packages/web/app/components/form/form-shell.tsx
+++ b/packages/web/app/components/form/form-shell.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Alert from '@mui/material/Alert';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+export type FormShellProps = {
+  /** Submit handler wired to the underlying `<form>` element. */
+  onSubmit: React.FormEventHandler<HTMLFormElement>;
+  /** Error banner shown above the fields. Any truthy ReactNode renders an alert. */
+  error?: React.ReactNode;
+  /**
+   * Content width cap. Defaults to 640px. Pass `false` to disable capping in dense /
+   * dialog contexts where the surrounding container already controls width.
+   */
+  maxWidth?: number | false;
+  children: React.ReactNode;
+  sx?: SxProps<Theme>;
+  id?: string;
+};
+
+/**
+ * FormShell is the outer `<form>` primitive of the Velvet form kit.
+ *
+ * It renders `<Box component="form" noValidate>` (validation is the caller's job — see
+ * `focusFirstInvalid`), stacks children in a 24px column, caps content width, and sets
+ * `containerType: 'inline-size'` so nested `FormRow`s can use container queries to go
+ * multi-column based on the form's own width rather than the viewport.
+ */
+export function FormShell({ onSubmit, error, maxWidth = 640, children, sx, id }: FormShellProps) {
+  return (
+    <Box
+      component="form"
+      noValidate
+      onSubmit={onSubmit}
+      id={id}
+      sx={[
+        {
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 3,
+          width: '100%',
+          maxWidth: maxWidth === false ? 'none' : maxWidth,
+          mx: 'auto',
+          containerType: 'inline-size',
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+    >
+      {error ? (
+        <Alert severity="error" role="alert">
+          {error}
+        </Alert>
+      ) : null}
+      {children}
+    </Box>
+  );
+}
+
+/**
+ * Focus (and centre-scroll) the first control the browser marked invalid.
+ *
+ * The kit's convention is that the caller validates on submit and flags each bad field
+ * with `error` (which MUI maps to `aria-invalid="true"` on the input). After a failed
+ * submit, call this with the form element to send keyboard focus to the first offender.
+ *
+ * Returns the focused element, or `null` if nothing was invalid.
+ */
+export function focusFirstInvalid(formEl: HTMLElement | null | undefined): HTMLElement | null {
+  if (!formEl) return null;
+  const invalid = formEl.querySelector<HTMLElement>('[aria-invalid="true"]');
+  if (!invalid) return null;
+  invalid.focus();
+  if (typeof invalid.scrollIntoView === 'function') {
+    invalid.scrollIntoView({ block: 'center' });
+  }
+  return invalid;
+}

--- a/packages/web/app/components/form/form-switch-row.tsx
+++ b/packages/web/app/components/form/form-switch-row.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import * as React from 'react';
+import { useId } from 'react';
+import Box from '@mui/material/Box';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
+
+export type FormSwitchRowProps = {
+  label: React.ReactNode;
+  /** Supporting copy under the label. Wired to the switch via `aria-describedby`. */
+  description?: React.ReactNode;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+};
+
+/**
+ * FormSwitchRow is a full-width, 44px-min tappable row (>=64px with a description): the
+ * text block sits left, the switch right. The whole row is a `<label>` that wraps the
+ * switch, so a tap anywhere on the row toggles it; the switch also carries `htmlFor` for
+ * an explicit association, and the description is linked with `aria-describedby`.
+ */
+export function FormSwitchRow({ label, description, checked, onChange, disabled = false }: FormSwitchRowProps) {
+  const switchId = useId();
+  const descriptionId = `${switchId}-description`;
+  return (
+    <Box
+      component="label"
+      htmlFor={switchId}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 2,
+        width: '100%',
+        minHeight: description != null ? 64 : 44,
+        cursor: disabled ? 'default' : 'pointer',
+      }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2px', minWidth: 0 }}>
+        <Typography variant="body1" component="span" color={disabled ? 'text.disabled' : 'text.primary'}>
+          {label}
+        </Typography>
+        {description != null ? (
+          <Typography id={descriptionId} variant="caption" component="span" color="text.secondary">
+            {description}
+          </Typography>
+        ) : null}
+      </Box>
+      <Switch
+        id={switchId}
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        disabled={disabled}
+        slotProps={{ input: { 'aria-describedby': description != null ? descriptionId : undefined } }}
+      />
+    </Box>
+  );
+}

--- a/packages/web/app/components/form/index.ts
+++ b/packages/web/app/components/form/index.ts
@@ -1,0 +1,7 @@
+export { FormShell, focusFirstInvalid, type FormShellProps } from './form-shell';
+export { FormSection, type FormSectionProps } from './form-section';
+export { FormField, useFormFieldIds, type FormFieldProps, type FormFieldRenderState } from './form-field';
+export { FormRow, type FormRowProps } from './form-row';
+export { FormActions, type FormActionsProps, type FormActionsLayout } from './form-actions';
+export { FormSwitchRow, type FormSwitchRowProps } from './form-switch-row';
+export { FormDateTimePicker, type FormDateTimePickerProps } from './form-date-time-picker';

--- a/packages/web/app/components/global-header/global-header.module.css
+++ b/packages/web/app/components/global-header/global-header.module.css
@@ -35,7 +35,9 @@
 }
 
 .searchInput input {
-  font-size: 14px;
+  /* 16px so iOS Safari never zooms the viewport on focus (matches the theme-level input
+     size; the old max-width:768px !important guard used to force this on mobile). */
+  font-size: 16px;
   padding: 6px 0;
 }
 
@@ -84,15 +86,5 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-:global(html[data-theme='dark']) .searchInput :global(.MuiOutlinedInput-root) {
-  background: #ffffff;
-  color: #000000;
-}
-
-:global(html[data-theme='dark']) .searchInput :global(.MuiOutlinedInput-root) fieldset {
-  border-color: #ffffff;
-}
-
-:global(html[data-theme='dark']) .searchInput :global(.MuiSvgIcon-root) {
-  color: #6b7280;
-}
+/* The header search input rides the shared --input-* tokens (elevated violet field,
+   violet focus ring) via the MUI theme — no dark-mode white-field override needed. */

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -53,8 +53,8 @@
   /* Darkened from Velvet #c81e1e so error TEXT clears AA (4.96:1) on the #E8DDF6 page. */
   --color-error: #b91c1c;
   --color-error-bg: #fbe9e9;
-  --color-error-muted: rgba(200, 30, 30, 0.18);
-  --color-error-muted-hover: rgba(200, 30, 30, 0.28);
+  --color-error-muted: rgba(185, 28, 28, 0.18);
+  --color-error-muted-hover: rgba(185, 28, 28, 0.28);
   --color-warning: #a04a08;
   --color-warning-bg: #fbf0e3;
 

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -422,9 +422,12 @@ input:-webkit-autofill:focus {
   caret-color: var(--input-text);
 }
 
+/* Firefox path — the -webkit-* properties above are inert there; standard
+   properties carry the same repaint. WebKit matches this too, harmlessly. */
 input:autofill {
-  -webkit-box-shadow: 0 0 0 1000px var(--input-bg) inset;
-  -webkit-text-fill-color: var(--input-text);
+  box-shadow: 0 0 0 1000px var(--input-bg) inset;
+  background-color: var(--input-bg);
+  color: var(--input-text);
   caret-color: var(--input-text);
 }
 

--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -50,7 +50,8 @@
   --color-success: #047857;
   --color-success-hover: #036b4d;
   --color-success-bg: #e7f4ee;
-  --color-error: #c81e1e;
+  /* Darkened from Velvet #c81e1e so error TEXT clears AA (4.96:1) on the #E8DDF6 page. */
+  --color-error: #b91c1c;
   --color-error-bg: #fbe9e9;
   --color-error-muted: rgba(200, 30, 30, 0.18);
   --color-error-muted-hover: rgba(200, 30, 30, 0.28);
@@ -108,12 +109,18 @@
   --border-radius-xl: 16px;
   --border-radius-full: 9999px;
 
-  /* Input field backgrounds */
+  /* Input field tokens — the source of truth for input surface/text/border in BOTH
+     schemes. The MUI theme (mui-theme.ts) and ~150 module.css files read these. */
   --input-bg: #ffffff;
   --input-bg-hover: #f1eef7;
   --input-bg-focused: #ffffff;
-  /* Placeholder text on the (always light) input surface — fixed dark grey ≥4.5:1. */
+  /* Dark-on-white body text inside the field. */
+  --input-text: #26222d;
+  /* Placeholder — fixed dark grey ≥4.5:1 on the white field. */
   --input-placeholder: #6b6577;
+  /* Resting outline (≥3:1 on white and on the #E8DDF6 page); one neutral step darker on hover. */
+  --input-border: #7b7591;
+  --input-border-hover: #595464;
 
   /* Safe-area insets, exposed as CSS vars so consumers resolve through
      a single indirection (and so future per-platform or per-view overrides
@@ -224,12 +231,17 @@ html[data-theme='dark'] {
   --color-error-muted-hover: rgba(248, 113, 113, 0.3);
   --color-warning-bg: rgba(251, 191, 36, 0.14);
 
-  /* Input field backgrounds (white in dark mode) */
-  --input-bg: #ffffff;
-  --input-bg-hover: #f1eef7;
-  --input-bg-focused: #ffffff;
-  /* Input text stays dark in dark mode because inputs have white backgrounds */
-  --input-text: #26222d;
+  /* Input field tokens — elevated violet field (#2F234A). The surface is unchanged on
+     hover/focus; the BORDER carries the hover state, the violet ring carries focus. */
+  --input-bg: #2f234a;
+  --input-bg-hover: #2f234a;
+  --input-bg-focused: #2f234a;
+  /* Light-on-violet body text + placeholder (both ≥4.5:1 on the field). */
+  --input-text: #e7e2f0;
+  --input-placeholder: #a9a2b6;
+  /* Translucent resting outline; brighter on hover (both composite to ≥3:1 on the field). */
+  --input-border: rgba(195, 188, 211, 0.5);
+  --input-border-hover: rgba(195, 188, 211, 0.7);
 
   /* Shadows (stronger for dark backgrounds) */
   --shadow-xs: 0 1px 2px 0 rgba(0, 0, 0, 0.2);
@@ -319,17 +331,13 @@ button,
 
 /* Firefox scrollbar properties are set in the html rule above */
 
-/* Focus styles for accessibility. The foreground violet clears 3:1 on the page in
-   both schemes, but in dark mode the focus ring can wrap the intentionally-white
-   inputs, where #A78BFA is only 2.72:1 — so dark uses the fill violet (#7C3AED,
-   5.70:1 on white, 3.99:1 on the page). Outline is not transitioned (stays instant). */
+/* Focus styles for accessibility. The foreground violet (`--color-primary`) clears the
+   3:1 UI floor on the page in both schemes — and now on the elevated dark input surface
+   (#2F234A) too — so a single rule covers both. Outline is not transitioned (stays
+   instant). MUI ButtonBase re-emits the same outline at the component layer. */
 :focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
-}
-
-html[data-theme='dark'] :focus-visible {
-  outline-color: var(--color-primary-fill);
 }
 
 /* Remove default focus outline when using mouse */
@@ -402,51 +410,22 @@ html[data-theme='dark'] :focus-visible {
   }
 }
 
-/* Dark-mode input overrides — MUI theme darkComponents handles most
-   input styling, but color-scheme:dark can override native input
-   backgrounds. These CSS rules ensure inputs stay white in dark mode
-   using the tokenized custom properties. */
-html[data-theme='dark'] .MuiOutlinedInput-root,
-html[data-theme='dark'] .MuiFilledInput-root {
-  background-color: var(--input-bg);
-  color: var(--input-text);
+/* Autofill + caret. Browsers repaint autofilled fields with their own yellow/blue
+   background and text colour; force the field's own surface + text back so an
+   autofilled input matches an empty one in both schemes. --input-bg / --input-text
+   auto-flip per scheme. */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0 1000px var(--input-bg) inset;
+  -webkit-text-fill-color: var(--input-text);
+  caret-color: var(--input-text);
 }
 
-html[data-theme='dark'] .MuiOutlinedInput-root:hover {
-  background-color: var(--input-bg-hover);
-}
-
-html[data-theme='dark'] .MuiOutlinedInput-root.Mui-focused {
-  background-color: var(--input-bg-focused);
-}
-
-html[data-theme='dark'] .MuiSelect-icon {
-  color: var(--neutral-500);
-}
-
-html[data-theme='dark'] .MuiOutlinedInput-input::placeholder {
-  color: var(--input-placeholder);
-  opacity: 1;
-}
-
-html[data-theme='dark'] .MuiOutlinedInput-root .MuiSvgIcon-root,
-html[data-theme='dark'] .MuiOutlinedInput-root .MuiInputAdornment-root,
-html[data-theme='dark'] .MuiFilledInput-root .MuiSvgIcon-root,
-html[data-theme='dark'] .MuiFilledInput-root .MuiInputAdornment-root {
-  color: var(--neutral-500);
-}
-
-/* Ensure all interactive elements have minimum 16px font to prevent iOS auto-zoom on focus */
-@media (max-width: 768px) {
-  input,
-  textarea,
-  select,
-  button,
-  .MuiOutlinedInput-input,
-  .MuiSelect-select,
-  .MuiButton-root {
-    font-size: 16px !important;
-  }
+input:autofill {
+  -webkit-box-shadow: 0 0 0 1000px var(--input-bg) inset;
+  -webkit-text-fill-color: var(--input-text);
+  caret-color: var(--input-text);
 }
 
 /* Override Atlaskit drag-and-drop indicator color to match theme

--- a/packages/web/app/components/logbook/__tests__/logascent-form-error-banner.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logascent-form-error-banner.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * The form-level error banner exists because failed saves used to be silent
+ * (console.error + dropped tick). These tests pin its lifecycle: a failed
+ * save surfaces it and keeps the form open, a re-submit clears it, and
+ * switching log type clears it (ascent-only validation doesn't apply to
+ * attempts, so a stale banner would contradict the visible form).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import type { BoardDetails, BoardName, Climb } from '@/app/lib/types';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const mockSaveTick = vi.fn();
+
+vi.mock('../../board-provider/board-provider-context', () => ({
+  useBoardProvider: () => ({
+    saveTick: mockSaveTick,
+    logbook: [],
+    boardName: 'kilter' as BoardName,
+    isAuthenticated: true,
+    isLoading: false,
+    error: null,
+    isInitialized: true,
+    getLogbook: vi.fn(),
+    saveClimb: vi.fn(),
+  }),
+}));
+
+vi.mock('../../board-presence/board-presence-context', () => ({
+  useBoardPresenceControls: () => ({
+    enabled: false,
+    boardId: null,
+    resolveAndBindBoard: vi.fn(),
+  }),
+}));
+
+vi.mock('@/app/lib/analytics', () => ({
+  track: vi.fn(),
+}));
+
+vi.mock('@/app/hooks/use-effective-angle', () => ({
+  useEffectiveAngle: () => 40,
+}));
+
+// Keep the wall-drift banner out of the picture — these tests assert on the
+// form-level error Alert and nothing else.
+vi.mock('../../graphql-queue/QueueContext', () => ({
+  useOptionalCurrentClimb: () => null,
+}));
+
+const { LogAscentForm } = await import('../logascent-form');
+
+const SAVE_FAILED_COPY = /Couldn't save your tick/i;
+
+function makeClimb(): Climb {
+  return {
+    uuid: 'climb-1',
+    name: 'Banner Check',
+    difficulty: 'V5',
+    frames: 'p1r42',
+    quality_average: '3.5',
+    angle: 40,
+    ascensionist_count: 10,
+    display_difficulty: 5,
+    difficulty_average: 12.5,
+    setter_username: 'setter',
+  } as unknown as Climb;
+}
+
+function makeBoardDetails(): BoardDetails {
+  return {
+    board_name: 'kilter' as BoardName,
+    layout_id: 1,
+    size_id: 10,
+    set_ids: [1, 2],
+    layout_name: 'Original',
+    size_name: '12x12',
+    size_description: 'Full',
+    set_names: ['Standard'],
+    supportsMirroring: false,
+    images_to_holds: {},
+    holdsData: {},
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+    boardHeight: 100,
+    boardWidth: 100,
+  } as BoardDetails;
+}
+
+function renderForm(onClose = vi.fn()) {
+  render(
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <LogAscentForm currentClimb={makeClimb()} boardDetails={makeBoardDetails()} onClose={onClose} />
+    </LocalizationProvider>,
+  );
+  return onClose;
+}
+
+const submitButton = () => screen.getByRole('button', { name: /Log at 40°/i });
+
+describe('LogAscentForm — error banner lifecycle', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The save-failure path console.errors by design — keep test output clean.
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('surfaces the banner on a failed save and keeps the form open', async () => {
+    mockSaveTick.mockRejectedValueOnce(new Error('network down'));
+    const onClose = renderForm();
+
+    fireEvent.click(submitButton());
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(SAVE_FAILED_COPY);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('clears the banner when a re-submit succeeds', async () => {
+    mockSaveTick.mockRejectedValueOnce(new Error('network down')).mockResolvedValueOnce(undefined);
+    const onClose = renderForm();
+
+    fireEvent.click(submitButton());
+    await screen.findByRole('alert');
+
+    fireEvent.click(submitButton());
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('clears the banner when the log type is switched', async () => {
+    mockSaveTick.mockRejectedValueOnce(new Error('network down'));
+    renderForm();
+
+    fireEvent.click(submitButton());
+    await screen.findByRole('alert');
+
+    fireEvent.click(screen.getByRole('button', { name: /Attempt/i }));
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull());
+  });
+});

--- a/packages/web/app/components/logbook/log-ascent-drawer.tsx
+++ b/packages/web/app/components/logbook/log-ascent-drawer.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { LogAscentForm } from './logascent-form';
+import { LogAscentForm, type LogAscentSubmitState } from './logascent-form';
+import { FormActions } from '@/app/components/form';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 
 type LogAscentDrawerProps = {
@@ -15,6 +16,18 @@ type LogAscentDrawerProps = {
 
 export const LogAscentDrawer: React.FC<LogAscentDrawerProps> = ({ open, onClose, currentClimb, boardDetails }) => {
   const { t } = useTranslation('climbs');
+  const { t: tProfile } = useTranslation('profile');
+
+  // The form's submit button lives in the drawer HEADER, not a footer: the iOS
+  // keyboard buries a bottom action bar (see docs/mobile-sheets-vs-routes.md).
+  // The form reports its label / saving / enabled state here and the header
+  // button submits the form by id.
+  const formId = useId();
+  const [submitState, setSubmitState] = useState<LogAscentSubmitState>({
+    submitLabel: tProfile('logbook.form.submit'),
+    submitting: false,
+    canSubmit: false,
+  });
 
   // Pin the climb the user opened the form on. A remote queue advance
   // (driver moves the wall on to the next climb while User A is mid-log)
@@ -45,6 +58,17 @@ export const LogAscentDrawer: React.FC<LogAscentDrawerProps> = ({ open, onClose,
       open={open}
       fullHeight
       styles={{ wrapper: { height: '100%' } }}
+      extra={
+        lockedClimb ? (
+          <FormActions
+            formId={formId}
+            submitLabel={submitState.submitLabel}
+            submitting={submitState.submitting}
+            disabled={!submitState.canSubmit}
+            layout="row"
+          />
+        ) : undefined
+      }
     >
       {lockedClimb && (
         <LogAscentForm
@@ -53,6 +77,8 @@ export const LogAscentDrawer: React.FC<LogAscentDrawerProps> = ({ open, onClose,
           onSwitchClimb={setLockedClimb}
           boardDetails={boardDetails}
           onClose={onClose}
+          formId={formId}
+          onSubmitStateChange={setSubmitState}
         />
       )}
     </SwipeableDrawer>

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -87,6 +87,9 @@ type LogAscentFormProps = {
    * action bar) instead of rendering inline submit/cancel buttons. Bottom
    * drawers carry actions in the header because the iOS keyboard buries a
    * footer — see docs/mobile-sheets-vs-routes.md.
+   *
+   * Must be referentially stable (a setState or `useCallback`) — it sits in the
+   * report effect's deps, so a per-render identity re-fires the effect every render.
    */
   onSubmitStateChange?: (state: LogAscentSubmitState) => void;
 };
@@ -312,7 +315,13 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({
             exclusive
             fullWidth
             value={logType}
-            onChange={(_, val) => val && setLogType(val as LogType)}
+            onChange={(_, val) => {
+              if (!val) return;
+              setLogType(val as LogType);
+              // Ascent-only validation errors (the flash/send attempts guard)
+              // don't apply across modes — clear the banner so it can't go stale.
+              setFormError(null);
+            }}
           >
             <ToggleButton value="ascent">{tProfile('logbook.form.ascent')}</ToggleButton>
             <ToggleButton value="attempt">{tProfile('logbook.form.attempt')}</ToggleButton>

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -1,24 +1,19 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import MuiRating from '@mui/material/Rating';
 import Chip from '@mui/material/Chip';
 import MuiTooltip from '@mui/material/Tooltip';
-import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-import CircularProgress from '@mui/material/CircularProgress';
 import Stack from '@mui/material/Stack';
 import Box from '@mui/material/Box';
 import MuiAlert from '@mui/material/Alert';
 import MuiSelect from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
-import FormControl from '@mui/material/FormControl';
-import FormHelperText from '@mui/material/FormHelperText';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import ToggleButton from '@mui/material/ToggleButton';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import { track } from '@/app/lib/analytics';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -30,6 +25,7 @@ import { getGradesForBoard, ANGLES } from '@/app/lib/board-data';
 import { isBetaVideoUrl, BETA_VIDEO_URL_VALIDATION_MESSAGE } from '@/app/lib/beta-video-url';
 import { useEffectiveAngle } from '@/app/hooks/use-effective-angle';
 import { useOptionalCurrentClimb } from '../graphql-queue/QueueContext';
+import { FormShell, FormSection, FormField, FormRow, FormActions, FormDateTimePicker } from '@/app/components/form';
 
 import dayjs from 'dayjs';
 
@@ -49,6 +45,13 @@ type LogAscentFormValues = {
   difficulty: number | undefined;
   notes?: string;
   videoUrl?: string;
+};
+
+/** Submit-affordance state the form reports up so a drawer header can host the action. */
+export type LogAscentSubmitState = {
+  submitLabel: string;
+  submitting: boolean;
+  canSubmit: boolean;
 };
 
 // Helper to determine tick status from attempt count (for ascents)
@@ -74,9 +77,28 @@ type LogAscentFormProps = {
    * form, which remounts with the new climb's initial values.
    */
   onSwitchClimb?: (climb: Climb) => void;
+  /**
+   * When hosted in a drawer, the id wired onto the form so a header-hosted
+   * submit button can target it via `form={formId}`.
+   */
+  formId?: string;
+  /**
+   * When provided, the form reports its submit affordance here (for a header
+   * action bar) instead of rendering inline submit/cancel buttons. Bottom
+   * drawers carry actions in the header because the iOS keyboard buries a
+   * footer — see docs/mobile-sheets-vs-routes.md.
+   */
+  onSubmitStateChange?: (state: LogAscentSubmitState) => void;
 };
 
-export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boardDetails, onClose, onSwitchClimb }) => {
+export const LogAscentForm: React.FC<LogAscentFormProps> = ({
+  currentClimb,
+  boardDetails,
+  onClose,
+  onSwitchClimb,
+  formId,
+  onSubmitStateChange,
+}) => {
   const { t } = useTranslation('climbs');
   const { t: tProfile } = useTranslation('profile');
   const { saveTick, isAuthenticated } = useBoardProvider();
@@ -85,7 +107,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
   const angleOptions = ANGLES[boardDetails.board_name];
   // Resolve the wall's current angle (route → party session → climb record).
   // Never `|| 0` here — group-session feedback fix. If nothing resolves the
-  // submit button is disabled until the user picks one in the angle Select.
+  // submit action stays disabled until the user picks one in the angle Select.
   const effectiveAngle = useEffectiveAngle(currentClimb);
 
   const getInitialValues = (): LogAscentFormValues => ({
@@ -101,6 +123,9 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
   const [isSaving, setIsSaving] = useState(false);
   const [logType, setLogType] = useState<LogType>('ascent');
   const [bannerDismissed, setBannerDismissed] = useState(false);
+  // Surfaced above the fields via FormShell. Covers backend/save failures and
+  // the flash/send guard so a failed submit is never silent.
+  const [formError, setFormError] = useState<string | null>(null);
 
   // TODO: Tension spray doesnt support mirroring
   const showMirrorTag = boardDetails.supportsMirroring;
@@ -140,7 +165,8 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
       ? BETA_VIDEO_URL_VALIDATION_MESSAGE
       : null;
 
-  // Validation function matching backend rules
+  // Validation function matching backend rules. Returns a translated,
+  // user-facing message (surfaced in the form-level Alert) or null.
   const validateTickInput = (values: LogAscentFormValues): string | null => {
     // Attempts don't need flash/send validation
     if (logType === 'attempt') {
@@ -151,16 +177,12 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
 
     // Flash requires attemptCount === 1
     if (status === 'flash' && values.attempts !== 1) {
-      return 'Flash requires exactly 1 attempt';
+      return tProfile('logbook.form.validation.flashOneAttempt');
     }
 
     // Send requires attemptCount > 1
     if (status === 'send' && values.attempts <= 1) {
-      return 'Send requires more than 1 attempt';
-    }
-
-    if (values.videoUrl && !isBetaVideoUrl(values.videoUrl)) {
-      return BETA_VIDEO_URL_VALIDATION_MESSAGE;
+      return tProfile('logbook.form.validation.sendMoreAttempts');
     }
 
     return null; // Valid
@@ -170,18 +192,20 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
     if (!currentClimb?.uuid || !isAuthenticated) {
       return;
     }
-    // Guard against a programmatic submit slipping past the disabled
-    // button — never send `angle: null` (would coerce to 0° on the wire
-    // and silently miscredit the climb).
+    setFormError(null);
+
+    // Guard against a submit slipping past the disabled action — never send
+    // `angle: null` (would coerce to 0° on the wire and silently miscredit the
+    // climb). The angle FormField already shows an inline error whenever the
+    // angle is unset, so returning here surfaces the reason without a toast.
     if (values.angle == null) {
-      console.error('Validation error: angle is required before logging');
       return;
     }
 
     // Client-side validation
     const validationError = validateTickInput(values);
     if (validationError) {
-      console.error('Validation error:', validationError);
+      setFormError(validationError);
       return;
     }
 
@@ -223,7 +247,10 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
       setLogType('ascent');
       onClose();
     } catch (error) {
+      // Keep the drawer open and tell the user — a failed save must never be
+      // silent (previously this only console.error'd and dropped the tick).
       console.error('Failed to save tick:', error);
+      setFormError(tProfile('logbook.form.saveFailed'));
       track('Tick Save Failed', {
         boardLayout: boardDetails.layout_name || '',
       });
@@ -232,11 +259,27 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
     }
   };
 
+  const submitDisabled = isSaving || !!videoUrlError || formValues.angle == null;
+  const submitLabel =
+    formValues.angle != null
+      ? tProfile('logbook.form.submitAtAngle', { angle: formValues.angle })
+      : tProfile('logbook.form.submit');
+  const hostsActionsExternally = onSubmitStateChange != null;
+
+  // Report the submit affordance to a header-hosted action bar. Fires only when
+  // the label / saving / enabled state actually changes.
+  useEffect(() => {
+    if (!onSubmitStateChange) return;
+    onSubmitStateChange({ submitLabel, submitting: isSaving, canSubmit: !submitDisabled });
+  }, [onSubmitStateChange, submitLabel, isSaving, submitDisabled]);
+
   return (
-    <Box
-      component="form"
-      onSubmit={(e: React.FormEvent) => {
-        e.preventDefault();
+    <FormShell
+      id={formId}
+      error={formError}
+      maxWidth={640}
+      onSubmit={(event: React.FormEvent) => {
+        event.preventDefault();
         void handleSubmit(formValues);
       }}
     >
@@ -246,7 +289,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
         // long climb names (Aurora's "Tortured Soul on Sloping Crystal"
         // shape) don't wrap awkwardly inside MuiAlert's right-aligned
         // action slot on narrow phones (UI review E).
-        <MuiAlert severity="warning" sx={{ mb: 2 }} onClose={() => setBannerDismissed(true)}>
+        <MuiAlert severity="warning" onClose={() => setBannerDismissed(true)}>
           <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 1 }}>
             <Box component="span">
               {tProfile('logbook.form.wallMoved', {
@@ -263,20 +306,24 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
         </MuiAlert>
       )}
 
-      <Box sx={{ mb: 2 }}>
-        <ToggleButtonGroup exclusive fullWidth value={logType} onChange={(_, val) => val && setLogType(val as LogType)}>
-          <ToggleButton value="ascent">{tProfile('logbook.form.ascent')}</ToggleButton>
-          <ToggleButton value="attempt">{tProfile('logbook.form.attempt')}</ToggleButton>
-        </ToggleButtonGroup>
-      </Box>
+      <FormSection title={tProfile('logbook.form.sections.details')}>
+        <FormField label={tProfile('logbook.form.logType')}>
+          <ToggleButtonGroup
+            exclusive
+            fullWidth
+            value={logType}
+            onChange={(_, val) => val && setLogType(val as LogType)}
+          >
+            <ToggleButton value="ascent">{tProfile('logbook.form.ascent')}</ToggleButton>
+            <ToggleButton value="attempt">{tProfile('logbook.form.attempt')}</ToggleButton>
+          </ToggleButtonGroup>
+        </FormField>
 
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-        <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.boulder')}</Typography>
-        <Box sx={{ flex: 1 }}>
-          <Stack direction="row" spacing={1}>
+        <FormField label={tProfile('logbook.form.boulder')}>
+          <Stack direction="row" spacing={1} alignItems="center">
             <strong>{currentClimb?.name || 'N/A'}</strong>
             {showMirrorTag && (
-              <Stack direction="row" spacing={0.5}>
+              <Stack direction="row" spacing={0.5} alignItems="center">
                 <Chip
                   label={tProfile('logbook.form.mirrored')}
                   size="small"
@@ -290,160 +337,158 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
               </Stack>
             )}
           </Stack>
-        </Box>
-      </Box>
+        </FormField>
 
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-        <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.dateAndTime')}</Typography>
-        <Box sx={{ flex: 1 }}>
-          <DateTimePicker
-            value={formValues.date}
-            onChange={(val) => setFormValues((prev) => ({ ...prev, date: val || dayjs() }))}
-            views={['year', 'month', 'day', 'hours', 'minutes']}
-            slotProps={{ textField: { size: 'small' } }}
-          />
-        </Box>
-      </Box>
+        <FormField label={tProfile('logbook.form.dateAndTime')}>
+          {(field) => (
+            <FormDateTimePicker
+              id={field.id}
+              describedBy={field.describedBy}
+              value={formValues.date}
+              onChange={(val) => setFormValues((prev) => ({ ...prev, date: val || dayjs() }))}
+              views={['year', 'month', 'day', 'hours', 'minutes']}
+              slotProps={{ textField: { size: 'small', fullWidth: true } }}
+            />
+          )}
+        </FormField>
 
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 1.5 }}>
-        <Typography sx={{ width: 120, flexShrink: 0, pt: 1 }}>{tProfile('logbook.form.angle')}</Typography>
-        <Box sx={{ flex: 1 }}>
-          {/* FormControl + FormHelperText so screen readers hear *why* the
-              Select is in an error state ("Pick an angle") rather than only
-              "field is invalid" (UI review C). */}
-          <FormControl error={formValues.angle == null} size="small">
-            <MuiSelect
-              // `?? ''` not `|| ''` — 0° is a real selectable angle on
-              // vertical boards. Truthy fallthrough here would have rendered
-              // the "Pick an angle" placeholder over a valid 0° selection.
-              value={formValues.angle ?? ''}
-              onChange={(e) => setFormValues((prev) => ({ ...prev, angle: Number(e.target.value) }))}
-              sx={{ width: 100 }}
-              displayEmpty
-            >
-              <MenuItem value="" disabled>
-                <em>{tProfile('logbook.form.pickAngle')}</em>
-              </MenuItem>
-              {angleOptions.map((angle) => (
-                <MenuItem key={angle} value={angle}>
-                  {angle}°
+        <FormRow>
+          <FormField
+            label={tProfile('logbook.form.angle')}
+            error={formValues.angle == null ? tProfile('logbook.form.pickAngle') : undefined}
+          >
+            {(field) => (
+              <MuiSelect
+                labelId={field.labelId}
+                id={field.id}
+                // `?? ''` not `|| ''` — 0° is a real selectable angle on
+                // vertical boards. Truthy fallthrough here would have rendered
+                // the "Pick an angle" placeholder over a valid 0° selection.
+                value={formValues.angle ?? ''}
+                onChange={(event) => setFormValues((prev) => ({ ...prev, angle: Number(event.target.value) }))}
+                error={Boolean(field.error)}
+                displayEmpty
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="" disabled>
+                  <em>{tProfile('logbook.form.pickAngle')}</em>
                 </MenuItem>
-              ))}
-            </MuiSelect>
-            {formValues.angle == null && <FormHelperText>{tProfile('logbook.form.pickAngle')}</FormHelperText>}
-          </FormControl>
-        </Box>
-      </Box>
+                {angleOptions.map((angleOption) => (
+                  <MenuItem key={angleOption} value={angleOption}>
+                    {angleOption}°
+                  </MenuItem>
+                ))}
+              </MuiSelect>
+            )}
+          </FormField>
 
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-        <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.attempts')}</Typography>
-        <Box sx={{ flex: 1 }}>
-          <TextField
-            type="number"
-            value={formValues.attempts}
-            onChange={(e) => setFormValues((prev) => ({ ...prev, attempts: Number(e.target.value) }))}
-            slotProps={{ htmlInput: { min: 1, max: 999 } }}
-            size="small"
-            sx={{ width: 80 }}
-          />
-        </Box>
-      </Box>
+          <FormField label={tProfile('logbook.form.attempts')}>
+            {(field) => (
+              <TextField
+                id={field.id}
+                type="number"
+                value={formValues.attempts}
+                onChange={(event) => setFormValues((prev) => ({ ...prev, attempts: Number(event.target.value) }))}
+                size="small"
+                fullWidth
+                slotProps={{ htmlInput: { min: 1, max: 999, 'aria-describedby': field.describedBy } }}
+              />
+            )}
+          </FormField>
+        </FormRow>
+      </FormSection>
 
-      {logType === 'ascent' && (
-        <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-          <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.quality')}</Typography>
-          <Box sx={{ flex: 1 }}>
+      <FormSection title={tProfile('logbook.form.sections.howItFelt')}>
+        {logType === 'ascent' && (
+          <FormField label={tProfile('logbook.form.quality')}>
             <MuiRating
               value={formValues.quality}
               onChange={(_, val) => setFormValues((prev) => ({ ...prev, quality: val ?? 0 }))}
               max={5}
             />
-          </Box>
-        </Box>
-      )}
+          </FormField>
+        )}
 
-      {logType === 'ascent' && (
-        <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-          <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.difficulty')}</Typography>
-          <Box sx={{ flex: 1 }}>
-            <MuiSelect<number | ''>
-              value={formValues.difficulty ?? ''}
-              onChange={(e) =>
-                setFormValues((prev) => ({
-                  ...prev,
-                  difficulty: e.target.value === '' ? undefined : Number(e.target.value),
-                }))
-              }
-              size="small"
-              sx={{ width: 120 }}
-              displayEmpty
-            >
-              <MenuItem value="">
-                <em>{tProfile('logbook.form.difficultyNoOverride')}</em>
-              </MenuItem>
-              {grades.map((grade) => (
-                <MenuItem key={grade.difficulty_id} value={grade.difficulty_id}>
-                  {grade.difficulty_name}
+        {logType === 'ascent' && (
+          <FormField label={tProfile('logbook.form.difficulty')}>
+            {(field) => (
+              <MuiSelect<number | ''>
+                labelId={field.labelId}
+                id={field.id}
+                value={formValues.difficulty ?? ''}
+                onChange={(event) =>
+                  setFormValues((prev) => ({
+                    ...prev,
+                    difficulty: event.target.value === '' ? undefined : Number(event.target.value),
+                  }))
+                }
+                size="small"
+                fullWidth
+                displayEmpty
+              >
+                <MenuItem value="">
+                  <em>{tProfile('logbook.form.difficultyNoOverride')}</em>
                 </MenuItem>
-              ))}
-            </MuiSelect>
-          </Box>
-        </Box>
-      )}
+                {grades.map((grade) => (
+                  <MenuItem key={grade.difficulty_id} value={grade.difficulty_id}>
+                    {grade.difficulty_name}
+                  </MenuItem>
+                ))}
+              </MuiSelect>
+            )}
+          </FormField>
+        )}
 
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-        <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.notes')}</Typography>
-        <Box sx={{ flex: 1 }}>
-          <TextField
-            multiline
-            rows={3}
-            variant="outlined"
-            size="small"
-            fullWidth
-            value={formValues.notes || ''}
-            onChange={(e) => setFormValues((prev) => ({ ...prev, notes: e.target.value }))}
-          />
-        </Box>
-      </Box>
-
-      {logType === 'ascent' && (
-        <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 1.5 }}>
-          <Typography sx={{ width: 120, flexShrink: 0, pt: 1 }}>{tProfile('logbook.form.video')}</Typography>
-          <Box sx={{ flex: 1 }}>
+        <FormField label={tProfile('logbook.form.notes')}>
+          {(field) => (
             <TextField
-              placeholder={tProfile('logbook.form.videoPlaceholder')}
+              id={field.id}
+              multiline
+              rows={3}
               variant="outlined"
               size="small"
               fullWidth
-              value={formValues.videoUrl || ''}
-              onChange={(e) => setFormValues((prev) => ({ ...prev, videoUrl: e.target.value }))}
-              error={!!videoUrlError}
-              helperText={videoUrlError ?? tProfile('logbook.form.videoHelper')}
+              value={formValues.notes || ''}
+              onChange={(event) => setFormValues((prev) => ({ ...prev, notes: event.target.value }))}
+              slotProps={{ htmlInput: { 'aria-describedby': field.describedBy } }}
             />
-          </Box>
-        </Box>
+          )}
+        </FormField>
+
+        {logType === 'ascent' && (
+          <FormField
+            label={tProfile('logbook.form.video')}
+            error={videoUrlError ?? undefined}
+            helper={tProfile('logbook.form.videoHelper')}
+          >
+            {(field) => (
+              <TextField
+                id={field.id}
+                placeholder={tProfile('logbook.form.videoPlaceholder')}
+                variant="outlined"
+                size="small"
+                fullWidth
+                value={formValues.videoUrl || ''}
+                onChange={(event) => setFormValues((prev) => ({ ...prev, videoUrl: event.target.value }))}
+                error={Boolean(field.error)}
+                slotProps={{ htmlInput: { 'aria-describedby': field.describedBy } }}
+              />
+            )}
+          </FormField>
+        )}
+      </FormSection>
+
+      {!hostsActionsExternally && (
+        <FormActions
+          submitLabel={submitLabel}
+          submitting={isSaving}
+          disabled={submitDisabled}
+          onCancel={onClose}
+          cancelLabel={tProfile('logbook.form.cancel')}
+          layout="stacked"
+        />
       )}
-
-      <Box sx={{ mb: 1 }}>
-        <Button
-          variant="contained"
-          type="submit"
-          disabled={isSaving || !!videoUrlError || formValues.angle == null}
-          startIcon={isSaving ? <CircularProgress size={16} /> : undefined}
-          fullWidth
-          size="large"
-        >
-          {formValues.angle != null
-            ? tProfile('logbook.form.submitAtAngle', { angle: formValues.angle })
-            : tProfile('logbook.form.submit')}
-        </Button>
-      </Box>
-
-      <Box>
-        <Button variant="outlined" fullWidth size="large" onClick={onClose} disabled={isSaving}>
-          {tProfile('logbook.form.cancel')}
-        </Button>
-      </Box>
-    </Box>
+    </FormShell>
   );
 };

--- a/packages/web/app/components/my-boards-drawer/my-boards-drawer.tsx
+++ b/packages/web/app/components/my-boards-drawer/my-boards-drawer.tsx
@@ -14,8 +14,9 @@ import AddOutlined from '@mui/icons-material/AddOutlined';
 import SearchOutlined from '@mui/icons-material/SearchOutlined';
 import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
-import { BoardDetailContent } from '../board-entity/board-detail';
+import { BoardDetailContent, type BoardDetailEditHost } from '../board-entity/board-detail';
 import BoardSearchResults from '../social/board-search-results';
+import { FormActions } from '@/app/components/form';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
@@ -42,6 +43,10 @@ export default function MyBoardsDrawer({ open, onClose, onCreateBoard, onTransit
   const { token } = useWsAuthToken();
   const [view, setView] = useState<DrawerView>({ type: 'list' });
   const [searchQuery, setSearchQuery] = useState('');
+  // Set while the board-detail view is in edit mode: the drawer header hosts
+  // the "Edit Board" title + Save/Cancel actions (bottom-drawer ruling), and
+  // the board-detail form drops its own title so it isn't doubled.
+  const [editHost, setEditHost] = useState<BoardDetailEditHost | null>(null);
 
   const handleBack = useCallback(() => {
     if (view.type === 'board-detail') {
@@ -88,31 +93,44 @@ export default function MyBoardsDrawer({ open, onClose, onCreateBoard, onTransit
     return parts.join(' \u00B7 ');
   };
 
-  const drawerTitle =
-    view.type === 'list' ? (
-      t('myBoards.title')
-    ) : (
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-        <IconButton size="small" onClick={handleBack} edge="start" aria-label={t('ariaLabels.back')}>
-          <ArrowBackOutlined fontSize="small" />
-        </IconButton>
-        {view.type === 'search' ? t('myBoards.findBoard') : t('myBoards.boardDetail')}
-      </Box>
-    );
+  // Only honour the edit host while the board-detail view is actually mounted —
+  // guards against a stale descriptor if BoardDetailContent hasn't cleared yet.
+  const activeEditHost = view.type === 'board-detail' ? editHost : null;
 
-  const headerExtra =
-    view.type === 'list' ? (
-      <>
-        <IconButton size="small" onClick={() => setView({ type: 'search' })} aria-label={t('myBoards.ariaFindBoard')}>
-          <SearchOutlined fontSize="small" />
+  const drawerTitle = activeEditHost ? (
+    activeEditHost.title
+  ) : view.type === 'list' ? (
+    t('myBoards.title')
+  ) : (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <IconButton size="small" onClick={handleBack} edge="start" aria-label={t('ariaLabels.back')}>
+        <ArrowBackOutlined fontSize="small" />
+      </IconButton>
+      {view.type === 'search' ? t('myBoards.findBoard') : t('myBoards.boardDetail')}
+    </Box>
+  );
+
+  const headerExtra = activeEditHost ? (
+    <FormActions
+      formId={activeEditHost.formId}
+      submitLabel={activeEditHost.submit.submitLabel}
+      submitting={activeEditHost.submit.submitting}
+      disabled={!activeEditHost.submit.canSubmit}
+      onCancel={activeEditHost.onCancel}
+      layout="row"
+    />
+  ) : view.type === 'list' ? (
+    <>
+      <IconButton size="small" onClick={() => setView({ type: 'search' })} aria-label={t('myBoards.ariaFindBoard')}>
+        <SearchOutlined fontSize="small" />
+      </IconButton>
+      {onCreateBoard && (
+        <IconButton size="small" onClick={onCreateBoard} aria-label={t('myBoards.ariaCreateBoard')}>
+          <AddOutlined fontSize="small" />
         </IconButton>
-        {onCreateBoard && (
-          <IconButton size="small" onClick={onCreateBoard} aria-label={t('myBoards.ariaCreateBoard')}>
-            <AddOutlined fontSize="small" />
-          </IconButton>
-        )}
-      </>
-    ) : null;
+      )}
+    </>
+  ) : null;
 
   const renderListContent = () => {
     if (error && boards.length === 0) {
@@ -219,6 +237,7 @@ export default function MyBoardsDrawer({ open, onClose, onCreateBoard, onTransit
           boardUuid={view.boardUuid}
           initialIsFollowing={view.isFollowedByMe}
           onDeleted={handleBoardDeleted}
+          onEditHostChange={setEditHost}
         />
       )}
     </SwipeableDrawer>

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -183,6 +183,19 @@ function RootSeshSettingsDrawer() {
 /** Pages where the bottom tab bar is hidden unless there's an active queue */
 const HIDE_TAB_BAR_PAGES = ['/aurora-migration'];
 
+/**
+ * Routes where the persistent queue control bar is suppressed (user directive):
+ * gym landing/detail and admin surfaces are management contexts, not a place to
+ * drive the wall, so the always-on queue bar shouldn't leak onto them. The tab
+ * bar stays. Boundary-aware match so a distinct sibling like /gym-claim is not
+ * affected (`/gym` and `/gym/…` match, `/gym-claim` does not).
+ */
+const HIDE_QUEUE_BAR_PREFIXES = ['/gym', '/admin'];
+
+function isQueueBarHiddenPath(pathname: string): boolean {
+  return HIDE_QUEUE_BAR_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
 export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData }) {
   const { boardDetails, angle, hasActiveQueue } = useQueueBridgeBoardInfo();
   const pathname = usePathnameWithoutLocale();
@@ -193,6 +206,8 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
   const isDevelopmentRoute = pathname.startsWith('/development');
   const hideTabBar =
     isDevelopmentRoute || (HIDE_TAB_BAR_PAGES.some((prefix) => pathname.startsWith(prefix)) && !hasActiveQueue);
+  // Gym + admin surfaces never host the queue control bar, even mid-session.
+  const hideQueueBar = isQueueBarHiddenPath(pathname);
   const shouldShowQueueShell = !isDevelopmentRoute && isBoardRoutePath(pathname) && !hasActiveQueue && !boardDetails;
 
   // Measure the bottom bar's visual occlusion and publish it into the
@@ -259,7 +274,7 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
     >
       <FeedbackPromptBanner />
       <CapacitorUpdateBanner />
-      {!isDevelopmentRoute && hasActiveQueue && boardDetails && (
+      {!isDevelopmentRoute && !hideQueueBar && hasActiveQueue && boardDetails && (
         <ErrorBoundary>
           <BoardProvider boardName={boardDetails.board_name}>
             <ConnectionSettingsProvider>

--- a/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
+++ b/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
@@ -252,6 +252,21 @@ describe('Velvet dark input surface is defined, legible, and free of the elevati
   it('primary text clears AA on the elevated popup paper (autocomplete/menu) in dark', () => {
     expect(contrast(darkTokens.neutral[800], darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(4.5);
   });
+
+  // The input slot sets `color` DIRECTLY on the <input>, which beats colour inherited
+  // from the disabled wrapper — the disabled tier must be restated on the input itself
+  // (both engines: color + WebkitTextFillColor) or disabled text renders full-opacity.
+  it.each([
+    ['light', lightTheme],
+    ['dark', darkTheme],
+  ] as const)('disabled input text dims to text.disabled on the input slot itself (%s)', (_scheme, theme) => {
+    const inputOverride = theme.components?.MuiInputBase?.styleOverrides?.input;
+    expect(typeof inputOverride).toBe('function');
+    const resolved = (inputOverride as (props: { theme: typeof theme }) => Record<string, unknown>)({ theme });
+    const disabled = resolved['&.Mui-disabled'] as { color?: string; WebkitTextFillColor?: string };
+    expect(disabled?.color).toBe(theme.palette.text.disabled);
+    expect(disabled?.WebkitTextFillColor).toBe(theme.palette.text.disabled);
+  });
 });
 
 describe('web surface ladder deliberately diverges from the shared velvet-tokens anchors', () => {

--- a/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
+++ b/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
@@ -149,6 +149,42 @@ describe('MUI theme wires the foreground/fill split correctly', () => {
   });
 });
 
+describe('Velvet typography ramp is pinned in px (the 16/14 coefficient does not inflate it)', () => {
+  // Unpinned, MUI's coefficient (fontSize 16 / htmlFontSize 14) inflates every heading —
+  // an unpinned h6 renders 22.86px. These assert the pinned px values survive theme build.
+  it('heading font sizes are pinned to the intended px in both schemes', () => {
+    for (const theme of [lightTheme, darkTheme]) {
+      expect(theme.typography.h3.fontSize).toBe(24);
+      expect(theme.typography.h4.fontSize).toBe(20);
+      expect(theme.typography.h5.fontSize).toBe(18);
+      expect(theme.typography.h6.fontSize).toBe(16);
+    }
+  });
+
+  it('heading font weights match the ramp', () => {
+    expect(lightTheme.typography.h3.fontWeight).toBe(700);
+    expect(lightTheme.typography.h4.fontWeight).toBe(600);
+    expect(lightTheme.typography.h5.fontWeight).toBe(600);
+    expect(lightTheme.typography.h6.fontWeight).toBe(600);
+  });
+
+  it('h3 carries the 32/24 line height', () => {
+    expect(lightTheme.typography.h3.lineHeight).toBe(32 / 24);
+  });
+
+  it('button is 16/500 and keeps its casing (textTransform: none)', () => {
+    expect(lightTheme.typography.button.fontSize).toBe(16);
+    expect(lightTheme.typography.button.fontWeight).toBe(500);
+    expect(lightTheme.typography.button.textTransform).toBe('none');
+  });
+
+  it('caption is 12/400 with a 16/12 line height', () => {
+    expect(lightTheme.typography.caption.fontSize).toBe(12);
+    expect(lightTheme.typography.caption.fontWeight).toBe(400);
+    expect(lightTheme.typography.caption.lineHeight).toBe(16 / 12);
+  });
+});
+
 describe('Velvet palette clears WCAG AA at its load-bearing pairings', () => {
   it('white text on the primary fill ≥ 4.5:1 (both schemes)', () => {
     expect(contrast('#ffffff', themeTokens.colors.primaryFill)).toBeGreaterThanOrEqual(4.5);

--- a/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
+++ b/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
@@ -79,6 +79,9 @@ describe('index.css ↔ theme-config parity', () => {
     ['--semantic-surface', themeTokens.semantic.surface, darkTokens.semantic.surface],
     ['--semantic-selected-border', themeTokens.semantic.selectedBorder, darkTokens.semantic.selectedBorder],
     ['--separator', themeTokens.semantic.separator, darkTokens.semantic.separator],
+    // Input surface: light white field, dark elevated violet. Rest of the --input-*
+    // family (no theme-config counterpart) is pinned in its own block below.
+    ['--input-bg', themeTokens.semantic.inputSurface, darkTokens.semantic.inputSurface],
     ['--neutral-50', themeTokens.neutral[50], darkTokens.neutral[50]],
     ['--neutral-500', themeTokens.neutral[500], darkTokens.neutral[500]],
     ['--neutral-900', themeTokens.neutral[900], darkTokens.neutral[900]],
@@ -109,6 +112,22 @@ function contrast(a: string, b: string): number {
   const la = luminance(a);
   const lb = luminance(b);
   return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+// Composite a translucent `rgba()` colour over an opaque hex background → the opaque
+// colour the eye actually sees. Needed to contrast-check the semi-transparent input
+// border (rgba(195,188,211,0.x)) against the field it sits on.
+function blendOpaque(rgba: string, bgHex: string): string {
+  const match = rgba.match(/rgba?\(([^)]+)\)/);
+  if (!match) throw new Error(`not an rgba() colour: ${rgba}`);
+  const parts = match[1].split(',').map((part) => part.trim());
+  const alpha = parts[3] === undefined ? 1 : parseFloat(parts[3]);
+  const foreground = parts.slice(0, 3).map((channel) => parseInt(channel, 10));
+  const cleanBg = bgHex.replace('#', '');
+  const fullBg = cleanBg.length === 3 ? cleanBg.replace(/(.)/g, '$1$1') : cleanBg;
+  const background = [0, 2, 4].map((i) => parseInt(fullBg.slice(i, i + 2), 16));
+  const blended = foreground.map((channel, i) => Math.round(channel * alpha + background[i] * (1 - alpha)));
+  return `#${blended.map((channel) => channel.toString(16).padStart(2, '0')).join('')}`;
 }
 
 describe('MUI theme wires the foreground/fill split correctly', () => {
@@ -148,13 +167,69 @@ describe('Velvet palette clears WCAG AA at its load-bearing pairings', () => {
     expect(contrast(darkTokens.colors.primary, darkTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
   });
 
-  it('the dark focus ring (fill violet) clears the 3:1 UI floor on the white dark-mode input', () => {
-    expect(contrast(darkTokens.colors.primaryFill, '#ffffff')).toBeGreaterThanOrEqual(3);
+  it('the dark focus ring (foreground violet #A78BFA) clears the 3:1 UI floor on the field, card, and page', () => {
+    // Inputs are no longer white in dark mode, so the focus ring is the FOREGROUND violet
+    // everywhere (index.css dropped the fill-violet override). It must clear 3:1 on the
+    // elevated input field, the card, and the page.
+    expect(contrast(darkTokens.colors.primary, darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(3);
+    expect(contrast(darkTokens.colors.primary, darkTokens.semantic.surface)).toBeGreaterThanOrEqual(3);
+    expect(contrast(darkTokens.colors.primary, darkTokens.semantic.background)).toBeGreaterThanOrEqual(3);
   });
 
   it('secondary text clears AA on its surface (both schemes)', () => {
     expect(contrast(themeTokens.neutral[500], themeTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
     expect(contrast(darkTokens.neutral[500], darkTokens.semantic.surface)).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe('Velvet dark input surface is defined, legible, and free of the elevation overlay', () => {
+  // The rest of the --input-* family has no theme-config counterpart (only --input-bg
+  // maps to semantic.inputSurface, asserted in the parity block). Pin the literal values
+  // in both schemes so a silent drift in either scheme fails.
+  const inputRows: Array<[string, string, string]> = [
+    ['--input-bg-hover', '#f1eef7', '#2f234a'],
+    ['--input-bg-focused', '#ffffff', '#2f234a'],
+    ['--input-text', '#26222d', '#e7e2f0'],
+    ['--input-placeholder', '#6b6577', '#a9a2b6'],
+    ['--input-border', '#7b7591', 'rgba(195,188,211,0.5)'],
+    ['--input-border-hover', '#595464', 'rgba(195,188,211,0.7)'],
+  ];
+  it.each(inputRows)('%s is set in both schemes', (cssVar, lightValue, darkValue) => {
+    expect(lightVars[cssVar], `${cssVar} missing from :root`).toBeDefined();
+    expect(darkVars[cssVar], `${cssVar} missing from dark block`).toBeDefined();
+    expect(norm(lightVars[cssVar])).toBe(norm(lightValue));
+    expect(norm(darkVars[cssVar])).toBe(norm(darkValue));
+  });
+
+  it('dark input text (#E7E2F0) clears AA on the field (#2F234A)', () => {
+    expect(contrast(darkVars['--input-text'], darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('dark placeholder (#A9A2B6) clears AA on the field (#2F234A)', () => {
+    expect(contrast(darkVars['--input-placeholder'], darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('the dark resting border, composited over the field, clears 3:1 vs the field and vs the page', () => {
+    const composited = blendOpaque(darkVars['--input-border'], darkTokens.semantic.surfaceElevated);
+    expect(contrast(composited, darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(3);
+    expect(contrast(composited, darkTokens.semantic.background)).toBeGreaterThanOrEqual(3);
+  });
+
+  it('the light resting border (#7B7591) clears 3:1 on the white field and on the page', () => {
+    expect(contrast(lightVars['--input-border'], themeTokens.semantic.inputSurface)).toBeGreaterThanOrEqual(3);
+    expect(contrast(lightVars['--input-border'], themeTokens.semantic.background)).toBeGreaterThanOrEqual(3);
+  });
+
+  it('error text clears AA on the input field and the page in both schemes (light is now #B91C1C)', () => {
+    expect(contrast(themeTokens.colors.error, themeTokens.semantic.inputSurface)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(themeTokens.colors.error, themeTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(darkTokens.colors.error, darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(darkTokens.colors.error, darkTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('the dark theme disables the MUI v7 Paper elevation overlay (backgroundImage: none)', () => {
+    const paperRoot = darkTheme.components?.MuiPaper?.styleOverrides?.root as { backgroundImage?: string } | undefined;
+    expect(paperRoot?.backgroundImage).toBe('none');
   });
 });
 

--- a/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
+++ b/packages/web/app/theme/__tests__/velvet-tokens-parity.test.ts
@@ -231,6 +231,27 @@ describe('Velvet dark input surface is defined, legible, and free of the elevati
     const paperRoot = darkTheme.components?.MuiPaper?.styleOverrides?.root as { backgroundImage?: string } | undefined;
     expect(paperRoot?.backgroundImage).toBe('none');
   });
+
+  // Legacy floating labels (theme text.secondary) survive until the FormField waves:
+  // the SHRUNK label floats over the page or a card, not the field — assert those
+  // pairings so removing the old dual-tone MuiInputLabel hack can't regress contrast.
+  it('floating-label text (text.secondary) clears AA over the page and the card in both schemes', () => {
+    expect(contrast(themeTokens.neutral[500], themeTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(themeTokens.neutral[500], themeTokens.semantic.surface)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(darkTokens.neutral[500], darkTokens.semantic.background)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(darkTokens.neutral[500], darkTokens.semantic.surface)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  // Filled-variant inputs and Autocomplete ride the same --input-* family; the popup
+  // paper is pinned to the elevated surface — assert its text pairing too.
+  it('input text clears AA on the field in both schemes (covers filled + autocomplete inputs)', () => {
+    expect(contrast(lightVars['--input-text'], themeTokens.semantic.inputSurface)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(darkVars['--input-text'], darkTokens.semantic.inputSurface)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('primary text clears AA on the elevated popup paper (autocomplete/menu) in dark', () => {
+    expect(contrast(darkTokens.neutral[800], darkTokens.semantic.surfaceElevated)).toBeGreaterThanOrEqual(4.5);
+  });
 });
 
 describe('web surface ladder deliberately diverges from the shared velvet-tokens anchors', () => {

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -156,6 +156,9 @@ const sharedComponents: Components<Theme> = {
     styleOverrides: {
       input: {
         fontSize: 16,
+        // Single source of truth for field text — the same var the autofill guard uses,
+        // so palette drift can't desync typed vs autofilled text.
+        color: 'var(--input-text)',
         '&::placeholder': {
           color: 'var(--input-placeholder)',
           opacity: 1,

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -391,6 +391,35 @@ const sharedComponents: Components<Theme> = {
       },
     },
   },
+  // Form kit label: 14/500, primary text colour (labels read as content, not muted
+  // captions). The required asterisk carries the error hue; focus is signalled by the
+  // input's ring, so the label deliberately does NOT flash violet on focus.
+  MuiFormLabel: {
+    styleOverrides: {
+      root: ({ theme }) => ({
+        fontSize: 14,
+        fontWeight: themeTokens.typography.fontWeight.medium,
+        lineHeight: 20 / 14,
+        color: theme.palette.text.primary,
+        '& .MuiFormLabel-asterisk': {
+          color: theme.palette.error.main,
+        },
+        '&.Mui-focused': {
+          color: 'inherit',
+        },
+      }),
+    },
+  },
+  // Helper text sits flush-left under the field with a 4px gap; 12px caption size.
+  MuiFormHelperText: {
+    styleOverrides: {
+      root: {
+        marginLeft: 0,
+        marginTop: '4px',
+        fontSize: 12,
+      },
+    },
+  },
 };
 
 // Velvet motion: Glass-leaning. M3 'standard' easing on utility transitions; MUI's
@@ -405,10 +434,17 @@ const sharedOptions: Partial<ThemeOptions> = {
     fontSize: themeTokens.typography.fontSize.base,
     h1: { fontWeight: themeTokens.typography.fontWeight.bold },
     h2: { fontWeight: themeTokens.typography.fontWeight.bold },
-    h3: { fontWeight: themeTokens.typography.fontWeight.semibold },
-    h4: { fontWeight: themeTokens.typography.fontWeight.semibold },
-    h5: { fontWeight: themeTokens.typography.fontWeight.semibold },
-    h6: { fontWeight: themeTokens.typography.fontWeight.medium },
+    // Pin the heading ramp in px. MUI derives unpinned variants from a 16/14 coefficient
+    // (htmlFontSize / fontSize), which inflates them — an unpinned h6 renders 22.86px
+    // instead of the intended 16. Pinning fontSize side-steps the coefficient.
+    h3: {
+      fontSize: themeTokens.typography.fontSize['2xl'],
+      fontWeight: themeTokens.typography.fontWeight.bold,
+      lineHeight: 32 / 24,
+    },
+    h4: { fontSize: themeTokens.typography.fontSize.xl, fontWeight: themeTokens.typography.fontWeight.semibold },
+    h5: { fontSize: themeTokens.typography.fontSize.lg, fontWeight: themeTokens.typography.fontWeight.semibold },
+    h6: { fontSize: themeTokens.typography.fontSize.base, fontWeight: themeTokens.typography.fontWeight.semibold },
     body1: {
       fontSize: themeTokens.typography.fontSize.base,
       lineHeight: themeTokens.typography.lineHeight.normal,
@@ -416,6 +452,16 @@ const sharedOptions: Partial<ThemeOptions> = {
     body2: {
       fontSize: themeTokens.typography.fontSize.sm,
       lineHeight: themeTokens.typography.lineHeight.normal,
+    },
+    button: {
+      fontSize: themeTokens.typography.fontSize.base,
+      fontWeight: themeTokens.typography.fontWeight.medium,
+      textTransform: 'none' as const,
+    },
+    caption: {
+      fontSize: themeTokens.typography.fontSize.xs,
+      fontWeight: themeTokens.typography.fontWeight.normal,
+      lineHeight: 16 / 12,
     },
   },
   shape: {

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -154,16 +154,22 @@ const sharedComponents: Components<Theme> = {
   // iPads and any wider input). Applies to all input variants via the shared base.
   MuiInputBase: {
     styleOverrides: {
-      input: {
+      input: ({ theme }) => ({
         fontSize: 16,
         // Single source of truth for field text — the same var the autofill guard uses,
         // so palette drift can't desync typed vs autofilled text.
         color: 'var(--input-text)',
+        // A direct rule on the input beats colour inherited from the disabled wrapper,
+        // so the disabled tier must be restated here (WebKit needs text-fill-color too).
+        '&.Mui-disabled': {
+          color: theme.palette.text.disabled,
+          WebkitTextFillColor: theme.palette.text.disabled,
+        },
         '&::placeholder': {
           color: 'var(--input-placeholder)',
           opacity: 1,
         },
-      },
+      }),
     },
   },
   // Input surface + borders ride the scheme-aware `--input-*` CSS vars (light: white field,

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -233,6 +233,12 @@ const sharedComponents: Components<Theme> = {
         '&.Mui-focused': {
           backgroundColor: 'var(--input-bg-focused)',
         },
+        '&.Mui-disabled': {
+          backgroundColor: 'var(--input-bg-hover)',
+          '@supports (background-color: color-mix(in srgb, red 50%, transparent))': {
+            backgroundColor: 'color-mix(in srgb, var(--input-bg) 50%, transparent)',
+          },
+        },
       },
     },
   },

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -183,12 +183,48 @@ const sharedComponents: Components<Theme> = {
           borderWidth: 2,
         },
         '&.Mui-disabled': {
-          // Field surface at reduced alpha + the disabled text tier (#7B7591 light,
-          // #6F6882 dark), never a light-scale grey stranded on the dark field.
-          backgroundColor: 'color-mix(in srgb, var(--input-bg) 50%, transparent)',
+          // Field surface dimmed + the disabled text tier (#7B7591 light, #6F6882 dark),
+          // never a light-scale grey stranded on the dark field. The hover surface is the
+          // opaque fallback for browsers without color-mix() (Safari < 16.2).
+          backgroundColor: 'var(--input-bg-hover)',
+          '@supports (background-color: color-mix(in srgb, red 50%, transparent))': {
+            backgroundColor: 'color-mix(in srgb, var(--input-bg) 50%, transparent)',
+          },
           color: theme.palette.text.disabled,
         },
       }),
+    },
+  },
+  // Legacy floating labels (unmigrated forms, until the FormField waves land): the
+  // resting label sits INSIDE the field, the shrunk label floats over the page/card —
+  // text.secondary clears AA on both in both schemes (guard-tested). Focus keeps the
+  // label quiet; the 2px violet outline carries focus.
+  MuiInputLabel: {
+    styleOverrides: {
+      root: ({ theme }) => ({
+        color: theme.palette.text.secondary,
+        '&.Mui-focused': {
+          color: theme.palette.text.secondary,
+        },
+        '&.Mui-error': {
+          color: theme.palette.error.main,
+        },
+      }),
+    },
+  },
+  // Filled-variant inputs (climbs list, bulk import, snackbar) ride the same field
+  // surface family as outlined ones.
+  MuiFilledInput: {
+    styleOverrides: {
+      root: {
+        backgroundColor: 'var(--input-bg)',
+        '&:hover': {
+          backgroundColor: 'var(--input-bg-hover)',
+        },
+        '&.Mui-focused': {
+          backgroundColor: 'var(--input-bg-focused)',
+        },
+      },
     },
   },
   MuiSelect: {
@@ -453,6 +489,16 @@ const darkComponents: Components<Theme> = {
     },
   },
   MuiPopover: {
+    styleOverrides: {
+      paper: {
+        borderRadius: themeTokens.borderRadius.md,
+        ...darkElevatedPaper,
+      },
+    },
+  },
+  // Autocomplete popups render through a Popper (not Menu/Popover), so the elevated
+  // paper needs its own pin.
+  MuiAutocomplete: {
     styleOverrides: {
       paper: {
         borderRadius: themeTokens.borderRadius.md,

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -445,6 +445,12 @@ const sharedOptions: Partial<ThemeOptions> = {
     h4: { fontSize: themeTokens.typography.fontSize.xl, fontWeight: themeTokens.typography.fontWeight.semibold },
     h5: { fontSize: themeTokens.typography.fontSize.lg, fontWeight: themeTokens.typography.fontWeight.semibold },
     h6: { fontSize: themeTokens.typography.fontSize.base, fontWeight: themeTokens.typography.fontWeight.semibold },
+    // Section-heading variant (FormSection titles and friends): 14/600/20.
+    subtitle2: {
+      fontSize: themeTokens.typography.fontSize.sm,
+      fontWeight: themeTokens.typography.fontWeight.semibold,
+      lineHeight: 20 / 14,
+    },
     body1: {
       fontSize: themeTokens.typography.fontSize.base,
       lineHeight: themeTokens.typography.lineHeight.normal,

--- a/packages/web/app/theme/mui-theme.ts
+++ b/packages/web/app/theme/mui-theme.ts
@@ -149,11 +149,46 @@ const sharedComponents: Components<Theme> = {
       size: 'small',
     },
   },
+  // Every MUI input renders at 16px so iOS Safari never zooms the viewport on focus.
+  // Replaces the old max-width:768px `!important` media guard in index.css (which missed
+  // iPads and any wider input). Applies to all input variants via the shared base.
+  MuiInputBase: {
+    styleOverrides: {
+      input: {
+        fontSize: 16,
+        '&::placeholder': {
+          color: 'var(--input-placeholder)',
+          opacity: 1,
+        },
+      },
+    },
+  },
+  // Input surface + borders ride the scheme-aware `--input-*` CSS vars (light: white field,
+  // #7B7591 border; dark: elevated violet #2F234A, translucent border). The focused outline
+  // uses the FOREGROUND violet `palette.primary.main` (#6D28D9 light, #A78BFA dark) at 2px;
+  // the field surface itself never changes on hover/focus — hover is carried by the border.
   MuiOutlinedInput: {
     styleOverrides: {
-      root: {
+      root: ({ theme }) => ({
         borderRadius: themeTokens.borderRadius.button,
-      },
+        backgroundColor: 'var(--input-bg)',
+        '& .MuiOutlinedInput-notchedOutline': {
+          borderColor: 'var(--input-border)',
+        },
+        '&:hover .MuiOutlinedInput-notchedOutline': {
+          borderColor: 'var(--input-border-hover)',
+        },
+        '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+          borderColor: theme.palette.primary.main,
+          borderWidth: 2,
+        },
+        '&.Mui-disabled': {
+          // Field surface at reduced alpha + the disabled text tier (#7B7591 light,
+          // #6F6882 dark), never a light-scale grey stranded on the dark field.
+          backgroundColor: 'color-mix(in srgb, var(--input-bg) 50%, transparent)',
+          color: theme.palette.text.disabled,
+        },
+      }),
     },
   },
   MuiSelect: {
@@ -161,6 +196,9 @@ const sharedComponents: Components<Theme> = {
       root: {
         borderRadius: themeTokens.borderRadius.button,
       },
+      icon: ({ theme }) => ({
+        color: theme.palette.text.secondary,
+      }),
     },
   },
   MuiDrawer: {
@@ -364,124 +402,62 @@ const lightShadows = [
   ...Array(16).fill(themeTokens.shadows.xl),
 ] as unknown as typeof createTheme extends (o: { shadows?: infer S }) => unknown ? S : never;
 
-// Dark mode component overrides — extends shared overrides with white input fields.
+// Dark mode component overrides. Input fields now ride the shared `--input-*` CSS vars
+// (elevated violet #2F234A, violet focus ring) — no dark-only input block remains. Two
+// dark-only concerns stay:
+// (1) MUI v7 composites a white elevation overlay onto every Paper in dark mode via
+//     `backgroundImage`. Kill it, or dialog paper drifts to ~#49415B where secondary
+//     text fails AA.
+// (2) Pin the floating surfaces (dialog/drawer/menu/popover) to the elevated dark
+//     surface (#2F234A) with a hairline separator border, so they read as one
+//     deliberate Velvet layer instead of an elevation-tinted grey.
+const darkElevatedPaper = {
+  backgroundColor: darkTokens.semantic.surfaceElevated,
+  border: '1px solid var(--separator)',
+} as const;
+
 const darkComponents: Components<Theme> = {
   ...sharedComponents,
-  MuiInputBase: {
+  MuiPaper: {
     styleOverrides: {
       root: {
-        backgroundColor: darkTokens.semantic.inputSurface,
-        color: themeTokens.neutral[800],
-        '&.Mui-disabled': {
-          backgroundColor: themeTokens.neutral[200],
-        },
-      },
-      input: {
-        '&::placeholder': {
-          // Inputs are white in dark mode, so the placeholder must be a dark grey
-          // that clears AA on white — the LIGHT neutral scale, not the inverted one.
-          color: themeTokens.neutral[500],
-          opacity: 1,
-        },
+        backgroundImage: 'none',
       },
     },
   },
-  MuiOutlinedInput: {
-    ...sharedComponents.MuiOutlinedInput,
+  MuiDialog: {
     styleOverrides: {
-      root: ({ theme }) => ({
-        borderRadius: themeTokens.borderRadius.button,
-        backgroundColor: darkTokens.semantic.inputSurface,
-        color: themeTokens.neutral[800],
-        '& .MuiOutlinedInput-notchedOutline': {
-          borderColor: themeTokens.neutral[300],
-        },
-        '&:hover .MuiOutlinedInput-notchedOutline': {
-          borderColor: themeTokens.neutral[400],
-        },
-        // Focus border uses the FILL violet (#7C3AED, 5.70:1 on the white input), not
-        // the lifted foreground #A78BFA (2.72:1 on white — fails).
-        '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-          borderColor: theme.palette.primaryFill.main,
-        },
-        '&.Mui-disabled': {
-          backgroundColor: themeTokens.neutral[200],
-        },
-      }),
-    },
-  },
-  MuiFilledInput: {
-    styleOverrides: {
-      root: {
-        backgroundColor: darkTokens.semantic.inputSurface,
-        color: themeTokens.neutral[800],
-        '&:hover': {
-          backgroundColor: themeTokens.neutral[100],
-        },
-        '&.Mui-focused': {
-          backgroundColor: darkTokens.semantic.inputSurface,
-        },
-        '&.Mui-disabled': {
-          backgroundColor: themeTokens.neutral[200],
-        },
+      paper: {
+        borderRadius: themeTokens.borderRadius.lg,
+        ...darkElevatedPaper,
       },
     },
   },
-  MuiSelect: {
-    ...sharedComponents.MuiSelect,
+  MuiDrawer: {
     styleOverrides: {
-      root: {
-        borderRadius: themeTokens.borderRadius.button,
-        backgroundColor: darkTokens.semantic.inputSurface,
-        color: themeTokens.neutral[800],
-      },
-      icon: {
-        color: themeTokens.neutral[500],
+      // Preserve the shared anchor-specific radius/padding slots; only the base `paper`
+      // slot gains the elevated surface + border.
+      ...sharedComponents.MuiDrawer?.styleOverrides,
+      paper: {
+        borderRadius: themeTokens.borderRadius.lg,
+        ...darkElevatedPaper,
       },
     },
   },
-  MuiAutocomplete: {
+  MuiMenu: {
     styleOverrides: {
-      inputRoot: {
-        backgroundColor: darkTokens.semantic.inputSurface,
-        color: themeTokens.neutral[800],
+      paper: {
+        borderRadius: themeTokens.borderRadius.md,
+        ...darkElevatedPaper,
       },
     },
   },
-  MuiInputLabel: {
+  MuiPopover: {
     styleOverrides: {
-      root: ({ theme }) => ({
-        // Resting label sits inside the white input — needs dark text.
-        color: themeTokens.neutral[700],
-        // Shrunk label floats over the dark page bg — needs light text.
-        '&.MuiInputLabel-shrink': {
-          color: darkTokens.neutral[700],
-        },
-        '&.Mui-focused': {
-          color: theme.palette.primary.main,
-        },
-      }),
-    },
-  },
-  MuiTextField: {
-    ...sharedComponents.MuiTextField,
-    styleOverrides: {
-      root: ({ theme }) => ({
-        '& .MuiOutlinedInput-root': {
-          borderRadius: themeTokens.borderRadius.button,
-          backgroundColor: darkTokens.semantic.inputSurface,
-          color: themeTokens.neutral[800],
-        },
-        '& .MuiInputLabel-root': {
-          color: themeTokens.neutral[700],
-        },
-        '& .MuiInputLabel-root.MuiInputLabel-shrink': {
-          color: darkTokens.neutral[700],
-        },
-        '& .MuiInputLabel-root.Mui-focused': {
-          color: theme.palette.primary.main,
-        },
-      }),
+      paper: {
+        borderRadius: themeTokens.borderRadius.md,
+        ...darkElevatedPaper,
+      },
     },
   },
 };

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -43,8 +43,8 @@ export const themeTokens = {
     warningBg: '#FBF0E3',
     error: '#B91C1C', // Darkened from Velvet #C81E1E so error TEXT clears AA (4.96:1) on the #E8DDF6 page (#C81E1E was 4.40)
     errorBg: '#FBE9E9',
-    errorMuted: 'rgba(200, 30, 30, 0.18)', // Translucent error for non-destructive action buttons
-    errorMutedHover: 'rgba(200, 30, 30, 0.28)',
+    errorMuted: 'rgba(185, 28, 28, 0.18)', // Translucent error for non-destructive action buttons
+    errorMutedHover: 'rgba(185, 28, 28, 0.28)',
     purple: '#9C27B0', // V11 brand purple — Mirror button + chart palette accent (grade token)
     purpleHover: '#7B1FA2', // V12 — Mirror button hover
     amber: '#FBBF24', // Flash/benchmark badges + star ratings (data yellow, distinct from brand accent)

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -41,7 +41,7 @@ export const themeTokens = {
     successBg: '#E7F4EE',
     warning: '#A04A08', // Nudged up from Velvet #B45309 so warning text clears AA on the tinted bg
     warningBg: '#FBF0E3',
-    error: brandColors.error, // #C81E1E
+    error: '#B91C1C', // Darkened from Velvet #C81E1E so error TEXT clears AA (4.96:1) on the #E8DDF6 page (#C81E1E was 4.40)
     errorBg: '#FBE9E9',
     errorMuted: 'rgba(200, 30, 30, 0.18)', // Translucent error for non-destructive action buttons
     errorMutedHover: 'rgba(200, 30, 30, 0.28)',
@@ -91,6 +91,7 @@ export const themeTokens = {
     background: '#E8DDF6', // violet-tinted page base (richer than the shared surface)
     surface: '#FAF6FE', // cards/sheets — faintly violet, not stark white
     surfaceElevated: '#FFFFFF', // elevated layers pop one step brighter than the card
+    inputSurface: '#FFFFFF', // input fields on light (matches elevated) — dark diverges to the elevated violet
     surfaceOverlay: 'rgba(250, 246, 254, 0.95)', // Semi-transparent overlay (matches surface)
     overlayLight: 'rgba(0, 0, 0, 0.3)', // Light dark overlay for hover states
     overlayDark: 'rgba(0, 0, 0, 0.6)', // Dark overlay for text backgrounds
@@ -265,7 +266,7 @@ export const darkTokens = {
     background: '#110A20', // deeper violet near-black (richer than a generic dark theme)
     surface: '#251B3A', // cards/sheets — richer violet
     surfaceElevated: '#2F234A',
-    inputSurface: '#FFFFFF', // Intentional white inputs in dark mode (contrast) — do not change
+    inputSurface: '#2F234A', // input fields ride the elevated dark surface (violet focus ring, not white)
     surfaceOverlay: 'rgba(37, 27, 58, 0.95)',
     overlayLight: 'rgba(0, 0, 0, 0.4)',
     overlayDark: 'rgba(0, 0, 0, 0.7)',


### PR DESCRIPTION
## Summary

Phase 3 of the Velvet Send web epic (stacks on #3700): the form design system that fixes the class of problems in the original bug report (clipped floating labels, inconsistent multiline fields, full-bleed iPad layouts, four competing label patterns).

**The kit** (`app/components/form/`): `FormShell` (640px measure, form-level alert, `focusFirstInvalid`), `FormSection` (one vertical rhythm), `FormField` (static label OUTSIDE the field — render-prop ARIA contract for MUI inputs, labelled-group path for custom controls, counters, conditional helper row), container-query `FormRow` (viewport breakpoints misfire inside dialog paper), `FormActions` (spinner keeps the label; bottom drawers carry actions in the header per the design-panel ruling), `FormSwitchRow` (44px, kills the ml:7 helper hack), `FormDateTimePicker`. The MUI type ramp is pinned (the 16/14 coefficient inflated every unpinned variant) and guard-tested.

**Pilots**: the Edit Board form (the original screenshot offender) rebuilt as Board details / Location / Setup / Visibility with counters and a card-style map disclosure; the log-ascent form loses its 120px label column, gains Details / How-it-felt sections, and its silent failures now speak (inline angle error, form-level alerts for validation + save failures).

165 pre-existing tests pass unchanged (label queries resolve through FormField's wiring); 80 kit + theme guard tests; new strings in en/es/fr.

**Resolved review nit**: the My Boards drawer double-title (drawer's "Board" header over the form's "Edit Board" heading) is fixed — `BoardDetailContent` reports an edit-host descriptor (`onEditHostChange`) so the drawer chrome claims the title and Save action while editing, and the form renders no in-body heading. The headerless search-result drawer keeps the inline title by design.

Screenshots (both themes, phone + iPad) attached in comments. Live QA: https://vibetunnel-dev-1.tailedd9d5.ts.net:3001

## Release Notes

- Forms got a full redesign: clear labels that never clip, sensible widths on tablets, grouped sections, and character counters where they help.
- Logging an ascent now tells you when something goes wrong instead of failing silently.

## Test plan

- `vp run typecheck:web` green; kit + theme guards 80/80; board-entity + logbook + form suites 222/222; `vp run check:i18n` + orphans green.
- Manual QA on the dev server in both themes and viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHy7Edddxsv5oztCTmGP4s
