### PR TITLE
fix(web): restore embed i18n metadata and document Insights UTC-day bucketing

### DIFF
--- a/packages/backend/src/__tests__/gym-insights.test.ts
+++ b/packages/backend/src/__tests__/gym-insights.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { describe, it, expect, beforeEach, afterAll } from 'vite-plus/test';
 import { v4 as uuidv4 } from 'uuid';
 import { sql } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
@@ -28,6 +28,12 @@ const ALL_USERS = [OWNER, ADMIN, EDITOR, MEMBER, RANDOM];
 
 const CLIMB_PREFIX = 'gym-insights-test-climb-';
 const BOARD_TYPE = 'kilter';
+
+// A synthetic grade id well outside the real (kilter, 1..~40) catalog range, so
+// seeding/clearing our consensus-grade row can never touch a difficulty another
+// test in the same worker DB reads. display 99.2 → ROUND → 99 joins this row.
+const SYNTHETIC_GRADE_ID = 99;
+const SYNTHETIC_DISPLAY_DIFFICULTY = 99.2;
 
 let connectionCounter = 0;
 const authCtx = (userId: string): ConnectionContext =>
@@ -137,7 +143,9 @@ beforeEach(async () => {
   `);
   await db.execute(sql`DELETE FROM board_climb_stats WHERE climb_uuid LIKE ${CLIMB_PREFIX + '%'}`);
   await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${CLIMB_PREFIX + '%'}`);
-  await db.execute(sql`DELETE FROM board_difficulty_grades WHERE board_type = ${BOARD_TYPE} AND difficulty = 13`);
+  await db.execute(
+    sql`DELETE FROM board_difficulty_grades WHERE board_type = ${BOARD_TYPE} AND difficulty = ${SYNTHETIC_GRADE_ID}`,
+  );
 
   await Promise.all(ALL_USERS.map(insertUser));
 
@@ -151,11 +159,11 @@ beforeEach(async () => {
   const otherGym = await insertGym({ ownerId: RANDOM, name: 'Other Gym', slug: 'other-gym' });
   otherGymBoard = await insertBoard({ gymId: otherGym.id, ownerId: RANDOM, name: 'Elsewhere Wall' });
 
-  // Catalog: two climbs; CLIMB_X carries a consensus grade (display 13.2 → 13 → "V4").
+  // Catalog: two climbs; CLIMB_X carries a consensus grade (display 99.2 → 99 → "V4").
   await insertClimb(CLIMB_X, 'Crimpy Traverse');
   await insertClimb(CLIMB_Y, 'Sloper Heaven');
-  await insertClimbStats(CLIMB_X, 40, 13.2);
-  await insertGrade(13, 'V4');
+  await insertClimbStats(CLIMB_X, 40, SYNTHETIC_DISPLAY_DIFFICULTY);
+  await insertGrade(SYNTHETIC_GRADE_ID, 'V4');
 
   // Current window (last 7 days): 3 ascents, 3 distinct climbers, CLIMB_X twice.
   await insertTick({ userId: OWNER, boardId: boardA.id, climbUuid: CLIMB_X, climbedAt: daysAgoIso(1) });
@@ -182,6 +190,14 @@ beforeEach(async () => {
     status: 'attempt',
   });
   await insertTick({ userId: RANDOM, boardId: otherGymBoard.id, climbUuid: CLIMB_X, climbedAt: daysAgoIso(1) });
+});
+
+// Leave the shared worker DB as we found it: drop the synthetic grade row the
+// last test left behind (beforeEach clears it between tests, not after the last).
+afterAll(async () => {
+  await db.execute(
+    sql`DELETE FROM board_difficulty_grades WHERE board_type = ${BOARD_TYPE} AND difficulty = ${SYNTHETIC_GRADE_ID}`,
+  );
 });
 
 describe('gymStats access guard', () => {

--- a/packages/backend/src/graphql/resolvers/social/gym-insights.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-insights.ts
@@ -85,6 +85,11 @@ export const socialGymInsightsQueries = {
     const outerStart = sql`NOW() - make_interval(days => ${windowDays * 2}::int)`;
 
     const inGymBoards = inArray(dbSchema.boardseshTicks.boardId, boardIds);
+    // Day-of-week bucket is UTC: climbed_at is a naive (no-tz) timestamp and
+    // EXTRACT(DOW) reads it verbatim, so there's no per-gym local-time shift — a
+    // gym west of UTC sees a Friday-evening send land in Saturday's bucket. This
+    // is the accepted v1 (no gym-timezone column exists yet); gym-local bucketing
+    // is a possible follow-up. 0 = Sunday … 6 = Saturday.
     const dayOfWeekExpr = sql<number>`EXTRACT(DOW FROM ${dbSchema.boardseshTicks.climbedAt})::int`;
 
     const [countsRows, topClimbRows, busiestDayRows] = await Promise.all([

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -3024,9 +3024,15 @@ type GymTopClimb {
 Ascents bucketed by day of week for the current window. `dayOfWeek` follows
 Postgres EXTRACT(DOW): 0 = Sunday … 6 = Saturday. Only days with at least one
 ascent appear; the UI fills the missing days with zero.
+
+Bucketing is by UTC day: `climbed_at` is a naive (no-timezone) timestamp and
+EXTRACT(DOW) reads it as-is, so a gym has no local-time correction. For a gym
+west of UTC a Friday-evening send can land in Saturday's bucket. This is the
+accepted v1 behaviour — there is no per-gym timezone yet; gym-local bucketing
+is a possible follow-up once a timezone is stored.
 """
 type GymDayActivity {
-  "Day of week, 0 = Sunday … 6 = Saturday."
+  "Day of week (UTC), 0 = Sunday … 6 = Saturday."
   dayOfWeek: Int!
   "Ascents (flash + send) on that weekday in the current window."
   ascentCount: Int!

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2173,12 +2173,18 @@ export type GymConnection = {
  * Ascents bucketed by day of week for the current window. `dayOfWeek` follows
  * Postgres EXTRACT(DOW): 0 = Sunday … 6 = Saturday. Only days with at least one
  * ascent appear; the UI fills the missing days with zero.
+ *
+ * Bucketing is by UTC day: `climbed_at` is a naive (no-timezone) timestamp and
+ * EXTRACT(DOW) reads it as-is, so a gym has no local-time correction. For a gym
+ * west of UTC a Friday-evening send can land in Saturday's bucket. This is the
+ * accepted v1 behaviour — there is no per-gym timezone yet; gym-local bucketing
+ * is a possible follow-up once a timezone is stored.
  */
 export type GymDayActivity = {
   __typename?: 'GymDayActivity';
   /** Ascents (flash + send) on that weekday in the current window. */
   ascentCount: Scalars['Int']['output'];
-  /** Day of week, 0 = Sunday … 6 = Saturday. */
+  /** Day of week (UTC), 0 = Sunday … 6 = Saturday. */
   dayOfWeek: Scalars['Int']['output'];
 };
 

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -439,9 +439,15 @@ export const gymsTypeDefs = /* GraphQL */ `
   Ascents bucketed by day of week for the current window. \`dayOfWeek\` follows
   Postgres EXTRACT(DOW): 0 = Sunday … 6 = Saturday. Only days with at least one
   ascent appear; the UI fills the missing days with zero.
+
+  Bucketing is by UTC day: \`climbed_at\` is a naive (no-timezone) timestamp and
+  EXTRACT(DOW) reads it as-is, so a gym has no local-time correction. For a gym
+  west of UTC a Friday-evening send can land in Saturday's bucket. This is the
+  accepted v1 behaviour — there is no per-gym timezone yet; gym-local bucketing
+  is a possible follow-up once a timezone is stored.
   """
   type GymDayActivity {
-    "Day of week, 0 = Sunday … 6 = Saturday."
+    "Day of week (UTC), 0 = Sunday … 6 = Saturday."
     dayOfWeek: Int!
     "Ascents (flash + send) on that weekday in the current window."
     ascentCount: Int!

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2170,12 +2170,18 @@ export type GymConnection = {
  * Ascents bucketed by day of week for the current window. `dayOfWeek` follows
  * Postgres EXTRACT(DOW): 0 = Sunday … 6 = Saturday. Only days with at least one
  * ascent appear; the UI fills the missing days with zero.
+ *
+ * Bucketing is by UTC day: `climbed_at` is a naive (no-timezone) timestamp and
+ * EXTRACT(DOW) reads it as-is, so a gym has no local-time correction. For a gym
+ * west of UTC a Friday-evening send can land in Saturday's bucket. This is the
+ * accepted v1 behaviour — there is no per-gym timezone yet; gym-local bucketing
+ * is a possible follow-up once a timezone is stored.
  */
 export type GymDayActivity = {
   __typename?: 'GymDayActivity';
   /** Ascents (flash + send) on that weekday in the current window. */
   ascentCount: Scalars['Int']['output'];
-  /** Day of week, 0 = Sunday … 6 = Saturday. */
+  /** Day of week (UTC), 0 = Sunday … 6 = Saturday. */
   dayOfWeek: Scalars['Int']['output'];
 };
 

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -45,6 +45,20 @@
     "poweredBy": "Powered by"
   },
   "embed": {
+    "metadata": {
+      "boardTitle": "{{boardName}} — live board view",
+      "boardDescription": "See what's lit on {{boardName}} right now. Powered by Boardsesh.",
+      "boardFallbackTitle": "Live board view",
+      "boardFallbackDescription": "Live climbing board widget. Powered by Boardsesh.",
+      "leaderboardTitle": "{{gymName}} — leaderboard",
+      "leaderboardDescription": "Who's sending at {{gymName}}. Powered by Boardsesh.",
+      "leaderboardFallbackTitle": "Gym leaderboard",
+      "leaderboardFallbackDescription": "Gym leaderboard widget. Powered by Boardsesh."
+    },
+    "leaderboard": {
+      "errorTitle": "Leaderboard unavailable",
+      "errorBody": "Couldn't load the latest sends. It'll retry on its own."
+    },
     "boardButton": "Embed this board",
     "railButton": "Embed leaderboard",
     "boardDialogTitle": "Embed {{name}}",

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -45,6 +45,20 @@
     "poweredBy": "Con la tecnología de"
   },
   "embed": {
+    "metadata": {
+      "boardTitle": "{{boardName}} — vista del plafón en directo",
+      "boardDescription": "Mira qué está encendido en {{boardName}} ahora mismo. Con la tecnología de Boardsesh.",
+      "boardFallbackTitle": "Vista del plafón en directo",
+      "boardFallbackDescription": "Widget del plafón en directo. Con la tecnología de Boardsesh.",
+      "leaderboardTitle": "{{gymName}} — clasificación",
+      "leaderboardDescription": "Quién está encadenando en {{gymName}}. Con la tecnología de Boardsesh.",
+      "leaderboardFallbackTitle": "Clasificación del rocódromo",
+      "leaderboardFallbackDescription": "Widget de clasificación del rocódromo. Con la tecnología de Boardsesh."
+    },
+    "leaderboard": {
+      "errorTitle": "Clasificación no disponible",
+      "errorBody": "No se han podido cargar los últimos encadenes. Se reintentará automáticamente."
+    },
     "boardButton": "Insertar este plafón",
     "railButton": "Insertar la clasificación",
     "boardDialogTitle": "Insertar {{name}}",

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -45,6 +45,20 @@
     "poweredBy": "Propulsé par"
   },
   "embed": {
+    "metadata": {
+      "boardTitle": "{{boardName}} — vue de la board en direct",
+      "boardDescription": "Ce qui est allumé sur {{boardName}} en ce moment. Propulsé par Boardsesh.",
+      "boardFallbackTitle": "Vue de la board en direct",
+      "boardFallbackDescription": "Widget de board en direct. Propulsé par Boardsesh.",
+      "leaderboardTitle": "{{gymName}} — classement",
+      "leaderboardDescription": "Qui enchaîne à {{gymName}}. Propulsé par Boardsesh.",
+      "leaderboardFallbackTitle": "Classement de la salle",
+      "leaderboardFallbackDescription": "Widget de classement de salle. Propulsé par Boardsesh."
+    },
+    "leaderboard": {
+      "errorTitle": "Classement indisponible",
+      "errorBody": "Impossible de charger les dernières croix. Le widget réessaie tout seul."
+    },
     "boardButton": "Intégrer cette board",
     "railButton": "Intégrer le classement",
     "boardDialogTitle": "Intégrer {{name}}",

--- a/packages/web/app/components/gym-entity/manage/insights-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/insights-tab.tsx
@@ -41,9 +41,9 @@ const INSIGHTS_STALE_MS = 5 * 60_000;
 
 // 2024-01-07 is a Sunday, so +dow lands on the matching weekday. Labels come from
 // Intl so they follow the viewer's locale without seven hand-kept i18n keys.
-function weekdayLabel(dayOfWeek: number, locale: string, style: 'short' | 'long'): string {
+function weekdayLabel(dayOfWeek: number, locale: string): string {
   const date = new Date(Date.UTC(2024, 0, 7 + dayOfWeek));
-  return new Intl.DateTimeFormat(locale, { weekday: style, timeZone: 'UTC' }).format(date);
+  return new Intl.DateTimeFormat(locale, { weekday: 'short', timeZone: 'UTC' }).format(date);
 }
 
 export type WowDelta = {
@@ -192,7 +192,7 @@ export default function InsightsTab({ gym }: GymManageTabProps) {
     const countByDow = new Map(stats.busiestDays.map((day) => [day.dayOfWeek, day.ascentCount]));
     return WEEK_ORDER.map((dow) => ({
       key: String(dow),
-      label: weekdayLabel(dow, locale, 'short'),
+      label: weekdayLabel(dow, locale),
       segments: [
         { value: countByDow.get(dow) ?? 0, color: themeTokens.colors.primary, label: t('manage.insights.ascents') },
       ],
@@ -256,7 +256,7 @@ export default function InsightsTab({ gym }: GymManageTabProps) {
           deltaTestId="insights-delta-ascents"
         />
         <StatCard
-          value={busiestDow === null ? '—' : weekdayLabel(busiestDow, locale, 'short')}
+          value={busiestDow === null ? '—' : weekdayLabel(busiestDow, locale)}
           label={t('manage.insights.busiestDay')}
         />
       </Box>


### PR DESCRIPTION
## Summary

Follow-up to the merged owner Insights tab (#3681), addressing Fable review feedback.

**Fixes #3698 — embed pages rendered raw i18n key names.** `kiosk.json` carried a duplicate top-level `embed` block; JSON last-wins already shadowed the first block's `embed.metadata.*` and `embed.leaderboard.errorTitle/errorBody` at runtime (tracked as #3698), and the Insights i18n edit in #3681 resolved the duplicate by dropping them entirely. The embed board page, gym-leaderboard page, and the embed leaderboard rail reference those keys, so they rendered the bare key strings. This merges the `metadata` + `leaderboard` sub-blocks back into the surviving `embed` object in all three locales (existing glossary-correct copy: *plafón/rocódromo/encadenes*, *board/salle/croix*), so every reference resolves. `check:i18n:orphans` confirms all 4113 keys now have a live reference.

**UTC-day bucketing documented.** `busiestDays` buckets by `EXTRACT(DOW)` over the naive (no-timezone) `climbed_at`, so a gym west of UTC sees a Friday-evening send land in Saturday's bucket. UTC is the accepted v1 (there's no per-gym timezone column yet); gym-local bucketing is a possible follow-up. Now stated in the `GymDayActivity` SDL doc and a resolver comment.

**Test hygiene.** `gym-insights.test.ts` seeded/cleared the shared `board_difficulty_grades (kilter, 13)` row, which could poison other tests sharing the worker DB. Switched to a synthetic out-of-range grade id (99) no other test reads, with an `afterAll` cleanup.

Also removed the dead `'long'` branch of the weekday-label helper (house rule).

## Release Notes

- Embed widgets now show proper titles and descriptions again — the live board and gym-leaderboard embeds were briefly rendering placeholder text instead of real metadata.

## Test plan

- `vp check` — 0 errors · `vp run typecheck` — pass
- `vp run check:i18n` — OK · `vp run check:i18n:orphans` — OK (all keys referenced) · catalog-completeness — 60/60 (en/es/fr parity)
- Backend `gym-insights.test.ts` (isolated pool) — 9/9 · web `insights-tab.test.tsx` — 6/6
- Full web suite — 5322/5322