### PR TITLE
test(mobile): pin accessory-bar route gate off create/edit-board (#3298)

### DIFF
--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -195,6 +195,18 @@ describe('PersistentQueueBar', () => {
     expect(container.querySelector('[data-tick]')).toBeNull();
   });
 
+  it('renders nothing on the create-board / edit-board screens (regression test for #3298)', () => {
+    // `boards` is a root push, not a top-level tab page — a leftover queued climb
+    // must not float the bar over BoardForm's pinned submit button. Before #3253's
+    // allow-list rewrite the route gate was a deny-list (auth/gyms/player only)
+    // that let this fall through and cover the create-board CTA (#3298).
+    cfg.onTopLevelTab = false;
+    cfg.onAccessorySurface = false;
+    const { container } = render(<PersistentQueueBar />);
+    expect(container.querySelector('[data-capsule]')).toBeNull();
+    expect(container.querySelector('[data-tick]')).toBeNull();
+  });
+
   it('renders nothing on the full-screen player route', () => {
     // The /play player owns the whole surface. The native accessory host stays
     // mounted (occluded) under the transparent player, so `onAccessorySurface` is

--- a/packages/mobile/src/lib/__tests__/route-segments.test.ts
+++ b/packages/mobile/src/lib/__tests__/route-segments.test.ts
@@ -50,6 +50,16 @@ describe('isTopLevelTabRoute', () => {
     expect(isTopLevelTabRoute(['auth', 'login'])).toBe(false);
     expect(isTopLevelTabRoute([])).toBe(false);
   });
+
+  it('is false on the create-board / edit-board screens (regression test for #3298)', () => {
+    // `boards` is a root Stack.Screen (app/_layout.tsx), not nested under `(tabs)`,
+    // so its create/edit screens must never be treated as a top-level tab page.
+    // Before #3253's allow-list rewrite, the accessory bar's route gate was a
+    // deny-list (auth/gyms/player only) that let it fall through and show here,
+    // overlapping BoardForm's pinned submit button (#3298).
+    expect(isTopLevelTabRoute(['boards', 'create'])).toBe(false);
+    expect(isTopLevelTabRoute(['boards', 'edit'])).toBe(false);
+  });
 });
 
 describe('isAccessorySurfaceRoute', () => {
@@ -66,5 +76,12 @@ describe('isAccessorySurfaceRoute', () => {
     expect(isAccessorySurfaceRoute(['gyms'])).toBe(false);
     expect(isAccessorySurfaceRoute(['auth', 'login'])).toBe(false);
     expect(isAccessorySurfaceRoute([])).toBe(false);
+  });
+
+  it('is false on the create-board / edit-board screens (regression test for #3298)', () => {
+    // Pins the JS PersistentQueueBar's mount gate off the create/edit board
+    // screens — see the isTopLevelTabRoute case above for the full context.
+    expect(isAccessorySurfaceRoute(['boards', 'create'])).toBe(false);
+    expect(isAccessorySurfaceRoute(['boards', 'edit'])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3298 — "Bottom 'now playing' accessory blocks the create-board buttons (Android)".

**The runtime bug is already fixed on `main`, no production code change here.**

- Root cause: `PersistentQueueBar` (the JS bottom "now playing" bar used on
  Android, since the native accessory is iOS-only) is mounted as an absolute
  overlay at the app root. Before PR #3253 it was gated by a **deny-list**
  (`isAuthRoute` / `isGymDiscoveryRoute` / `isPlayerRoute`), so any other root
  push — including `/boards/create` and `/boards/edit` — fell through and let
  the bar float over `BoardForm`'s pinned submit button.
- PR #3253 ("show the climb accessory bar only on top-level tab pages"),
  merged **2026-06-28** — one day before this issue was filed — replaced that
  deny-list with an **allow-list** (`isTopLevelTabRoute`): the bar now shows
  only on a tab's own index page or under the player route. `/boards/create`
  and `/boards/edit` are root `Stack.Screen`s (`app/_layout.tsx`), not nested
  under `(tabs)`, so they no longer match and the bar correctly stays hidden.
  Confirmed by reading the code path end-to-end and by the existing (already
  green) test suite on unmodified `main`.
- The change is JS-only, so it rides OTA automatically — no native build
  needed for it to reach users on a matching binary.

**What this PR adds:** the fix landed as a side effect of unrelated,
more general route-gate work, so nothing pinned the exact `boards/create` /
`boards/edit` scenario named in the bug report. This PR adds that explicit
regression coverage at two levels so a future "just add one more exception"
deny-list-style change can't silently reopen the bug:

- `packages/mobile/src/lib/__tests__/route-segments.test.ts` — asserts
  `isTopLevelTabRoute` / `isAccessorySurfaceRoute` are `false` for
  `['boards', 'create']` and `['boards', 'edit']`.
- `packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx`
  — a named test asserting `PersistentQueueBar` renders nothing on that
  surface even with a current climb queued.

## Test plan

- [x] `vp run typecheck:mobile`
- [x] `vp run test:mobile` (full suite, 3871/3871 passing)
- [x] `vp check:mobile-bundle` (Android bundle exports OK)
- [x] `vp check` (lint + format)

No visual verification run (no production code changes — the tests are the
evidence).

## Release Notes

- [x] No release note needed (internal / technical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va