### PR TITLE
fix(web): guard setter filter against non-array API responses

### DIFF
--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -88,7 +88,8 @@
       "gyms": "Search gyms...",
       "users": "Search climbers...",
       "playlists": "Search playlists...",
-      "climbs": "Search climbs..."
+      "climbs": "Search climbs...",
+      "setters": "Search setters..."
     },
     "fields": {
       "climbName": "Climb Name",
@@ -116,7 +117,9 @@
       "somewhatAccurate": "Somewhat Accurate (<0.2)",
       "veryAccurate": "Very Accurate (<0.1)",
       "extremelyAccurate": "Extremely Accurate (<0.05)",
-      "classicsOnly": "Classics Only"
+      "classicsOnly": "Classics Only",
+      "setterPromptOpen": "Open dropdown to see setters",
+      "setterNoResults": "No setters found"
     },
     "panels": {
       "quality": "Quality",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -88,7 +88,8 @@
       "gyms": "Busca rocódromos...",
       "users": "Busca escaladores...",
       "playlists": "Busca listas...",
-      "climbs": "Busca bloques..."
+      "climbs": "Busca bloques...",
+      "setters": "Busca setters..."
     },
     "fields": {
       "climbName": "Nombre del bloque",
@@ -116,7 +117,9 @@
       "classicsOnly": "Solo clásicos",
       "minAscentsOption": "{{value}}+",
       "minRatingOption_one": "{{count}} estrella o más",
-      "minRatingOption_other": "{{count}} estrellas o más"
+      "minRatingOption_other": "{{count}} estrellas o más",
+      "setterPromptOpen": "Abre la lista para ver los setters",
+      "setterNoResults": "No se encontraron setters"
     },
     "panels": {
       "quality": "Calidad",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -88,7 +88,8 @@
       "gyms": "Rechercher des salles...",
       "users": "Rechercher des grimpeurs...",
       "playlists": "Rechercher des playlists...",
-      "climbs": "Rechercher des blocs..."
+      "climbs": "Rechercher des blocs...",
+      "setters": "Rechercher des ouvreurs..."
     },
     "fields": {
       "climbName": "Nom du bloc",
@@ -116,7 +117,9 @@
       "somewhatAccurate": "Plutôt précise (<0.2)",
       "veryAccurate": "Très précise (<0.1)",
       "extremelyAccurate": "Extrêmement précise (<0.05)",
-      "classicsOnly": "Classiques uniquement"
+      "classicsOnly": "Classiques uniquement",
+      "setterPromptOpen": "Ouvrez la liste pour voir les ouvreurs",
+      "setterNoResults": "Aucun ouvreur trouvé"
     },
     "panels": {
       "quality": "Qualité",

--- a/packages/web/app/components/search-drawer/__tests__/setter-name-select.test.tsx
+++ b/packages/web/app/components/search-drawer/__tests__/setter-name-select.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { SearchRequestPagination } from '@/app/lib/types';
+import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
+import SetterNameSelect from '../setter-name-select';
+
+// Issue #2068 / Sentry BOARDSESH-7C: `f.map is not a function` in the
+// setter-username filter builder. Root cause was `fetcher` in
+// setter-name-select.tsx resolving a non-2xx response's error body
+// (`{ error: "..." }`, truthy but not an array) as if it were the setter
+// list, which then crashed `setterStats.map(...)`. These tests pin the fix:
+// a failed fetch must degrade to an empty, non-crashing dropdown instead.
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+const mockUpdateFilters = vi.fn();
+let mockUISearchParams: SearchRequestPagination = { ...DEFAULT_SEARCH_PARAMS };
+
+vi.mock('../../queue-control/ui-searchparams-provider', () => ({
+  useUISearchParams: () => ({
+    uiSearchParams: mockUISearchParams,
+    updateFilters: mockUpdateFilters,
+  }),
+}));
+
+vi.mock('../../graphql-queue', () => ({
+  useSearchData: () => ({
+    parsedParams: { board_name: 'kilter', layout_id: 1, size_id: 1, set_ids: [1], angle: 40 },
+  }),
+}));
+
+function renderWithQueryClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SetterNameSelect />
+    </QueryClientProvider>,
+  );
+}
+
+describe('SetterNameSelect', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockUISearchParams = { ...DEFAULT_SEARCH_PARAMS };
+    mockUpdateFilters.mockReset();
+    mockFetch = vi.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  it('does not crash and shows the empty state when the setters API returns a 500 error body', async () => {
+    // The route handler's catch block returns `{ error: '...' }` (an object,
+    // not an array) with a 500 status — exactly the shape that used to reach
+    // `.map` unguarded.
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: 'Failed to fetch setter stats' }),
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderWithQueryClient();
+
+    const combobox = screen.getByRole('combobox');
+    fireEvent.mouseDown(combobox);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('No setters found')).toBeTruthy();
+      },
+      { timeout: 8000 },
+    );
+
+    vi.restoreAllMocks();
+  }, 15000);
+
+  it('renders setter options from a successful array response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([{ setter_username: 'abc', climb_count: 5 }]),
+    });
+
+    renderWithQueryClient();
+
+    const combobox = screen.getByRole('combobox');
+    fireEvent.mouseDown(combobox);
+
+    await waitFor(
+      () => {
+        const listbox = screen.getByRole('listbox');
+        expect(within(listbox).getByText('abc (5)')).toBeTruthy();
+      },
+      { timeout: 8000 },
+    );
+  }, 15000);
+
+  it('does not crash when a 2xx response body is not an array (defense-in-depth guard)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    renderWithQueryClient();
+
+    const combobox = screen.getByRole('combobox');
+    fireEvent.mouseDown(combobox);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('No setters found')).toBeTruthy();
+      },
+      { timeout: 8000 },
+    );
+  }, 15000);
+});

--- a/packages/web/app/components/search-drawer/setter-name-select.tsx
+++ b/packages/web/app/components/search-drawer/setter-name-select.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import CircularProgress from '@mui/material/CircularProgress';
+import { useTranslation } from 'react-i18next';
 import { useUISearchParams } from '../queue-control/ui-searchparams-provider';
 import { useSearchData } from '../graphql-queue';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
@@ -20,11 +21,24 @@ type SetterOption = {
   count: number;
 };
 
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
+// Throws on a non-2xx response instead of silently resolving the error body
+// (e.g. `{ error: "..." }` from the setters API route) as if it were data.
+// Without this, a transient API failure hands the query an object where an
+// array was expected, which crashed `.map` downstream (issue #2068 /
+// Sentry BOARDSESH-7C). This message is never rendered — it only surfaces
+// via React Query's `error` state / console — so it doesn't need i18n.
+const fetcher = (url: string) =>
+  fetch(url).then((res) => {
+    if (!res.ok) {
+      throw new Error('Failed to fetch setter stats');
+    }
+    return res.json();
+  });
 
 const MIN_SEARCH_LENGTH = 2; // Only search when user has typed at least 2 characters
 
 const SetterNameSelect = () => {
+  const { t } = useTranslation('climbs');
   const { uiSearchParams, updateFilters } = useUISearchParams();
   const { parsedParams } = useSearchData();
   const [searchValue, setSearchValue] = useState('');
@@ -46,9 +60,11 @@ const SetterNameSelect = () => {
     placeholderData: keepPreviousData,
   });
 
-  // Map setter stats to Autocomplete options
+  // Map setter stats to Autocomplete options. Guards against any non-array
+  // shape reaching here (e.g. a future API response drift), not just the
+  // undefined-while-loading case — see the fetcher comment above.
   const options: SetterOption[] = React.useMemo(() => {
-    if (!setterStats) return [];
+    if (!Array.isArray(setterStats)) return [];
 
     return setterStats.map((stat) => ({
       value: stat.setter_username,
@@ -67,11 +83,11 @@ const SetterNameSelect = () => {
 
   let noOptionsText: string;
   if (isLoading) {
-    noOptionsText = 'Loading...';
+    noOptionsText = t('common:actions.loading');
   } else if (!isOpen && searchValue.length === 0) {
-    noOptionsText = 'Open dropdown to see setters';
+    noOptionsText = t('search.fields.setterPromptOpen');
   } else {
-    noOptionsText = 'No setters found';
+    noOptionsText = t('search.fields.setterNoResults');
   }
 
   return (
@@ -100,7 +116,7 @@ const SetterNameSelect = () => {
       renderInput={(params) => (
         <TextField
           {...params}
-          placeholder={selectedOptions.length === 0 ? 'Search setters...' : ''}
+          placeholder={selectedOptions.length === 0 ? t('search.placeholders.setters') : ''}
           slotProps={{
             input: {
               ...params.InputProps,


### PR DESCRIPTION
## Summary

Fixes #2068.

- The setter-username filter's `fetcher` resolved *any* fetch response — including a non-2xx `{ error: "..." }` body from the setters API route (`/api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/setters`) — as if it were the array of setter stats. A transient API failure therefore handed React Query a truthy, non-array object, which slipped past the `if (!setterStats)` guard and crashed `setterStats.map(...)`. That's Sentry `BOARDSESH-7C`, `f.map is not a function` on the board list (12 events / 4 users, ongoing as of 2026-06-24).
- `fetcher` now checks `res.ok` and throws on failure, matching the sibling `use-heatmap.tsx` convention already used elsewhere in the same search drawer — React Query now surfaces a failed fetch as an error state instead of treating the error body as data.
- The `options` memo now guards with `Array.isArray(setterStats)` instead of a bare truthiness check, so any future non-array response shape (not just this specific error envelope) degrades to an empty dropdown instead of crashing.
- While touching this block, replaced its hardcoded loading/empty/placeholder copy with i18n catalog keys (`climbs:search.placeholders.setters`, `climbs:search.fields.setterPromptOpen`/`setterNoResults`, plus the existing shared `common:actions.loading`) across `en-US`/`es`/`fr`, per the repo's "never hardcode user-facing strings" rule. The Spanish strings keep "setter(s)" in English per `docs/i18n-spanish-glossary.md`. The thrown `Error` message is not rendered anywhere (only surfaces via React Query's `error` state / console), so it doesn't need translation.

**Staleness note:** the original May report (`BOARDSESH-2X`, `A.map is not a function` in `AngleSelector`'s climb-stats fetch, `.map(e => [e.angle, e])`) was already fixed by `c3540c3d64aa372dc73b812b61351d7dbf57e89a` ("fix(web): move climb-stats off the uncached REST route to GraphQL", merged 2026-06-20), which moved that query off the same unguarded-fetch pattern onto a GraphQL client that throws on error rather than resolving to a non-array object. This PR addresses the reopened, higher-volume June stack trace (`BOARDSESH-7C`) — same failure class (an API error response silently treated as success data), different component.

## Test plan

- [x] New regression test `packages/web/app/components/search-drawer/__tests__/setter-name-select.test.tsx`:
  - a 500 response with an `{ error }` body no longer crashes the component and falls back to the "No setters found" empty state
  - a successful array response still renders options normally (`abc (5)`)
  - a 2xx response with a non-array body (defense-in-depth for the `Array.isArray` guard) also degrades gracefully instead of crashing
- [x] `vp run typecheck`
- [x] `vp test run --project web setter-name-select --reporter=agent` (3/3 passing, verified stable across repeated runs)
- [x] `vp check` — no lint/format issues in touched files
- [x] `vp run check:i18n` / `vp run check:i18n:orphans` — no hardcoded strings, no orphaned keys, new keys resolve correctly

## Release Notes

Fixed a bug where the setter filter on the climb list could crash the page if search results failed to load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va