### PR TITLE
fix(web): harden climb-list header against browser-translator DOM crashes

### DIFF
--- a/packages/web/app/components/board-page/__tests__/angle-selector.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/angle-selector.test.tsx
@@ -163,4 +163,23 @@ describe('AngleSelector', () => {
     expect(mockPush).toHaveBeenCalled();
     expect(mockSetSessionBoardPath).not.toHaveBeenCalled();
   });
+
+  // -------------------------------------------------------------------
+  // #3604: the trigger button re-renders on nearly every climb selection
+  // (angleSelectorElement is memoized on currentClimb). A bare `{currentAngle}°`
+  // compiles to two sibling text nodes; if a browser translator wraps one in
+  // a <font> tag before React updates it, the reconciler's removeChild can
+  // target a node that's no longer where it expects. Wrapping in a single
+  // <span> gives the translator one element to mutate instead.
+  // -------------------------------------------------------------------
+  it('renders the trigger angle as a single element, not bare sibling text nodes', () => {
+    render(<AngleSelector boardName="kilter" boardDetails={boardDetails} currentAngle={40} currentClimb={null} />);
+
+    const trigger = screen.getByRole('button', { name: /40/ });
+    // The angle + degree symbol must live inside one child element (a span),
+    // not as direct bare text children of the button.
+    expect(trigger.children).toHaveLength(1);
+    expect(trigger.children[0].tagName).toBe('SPAN');
+    expect(trigger.children[0].textContent).toBe('40°');
+  });
 });

--- a/packages/web/app/components/board-page/__tests__/climbs-list-translator-resilience.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-translator-resilience.test.tsx
@@ -1,0 +1,294 @@
+// @vitest-environment jsdom
+//
+// Regression coverage for issue #3604: browser translators (Chrome/Safari
+// auto-translate) mutate React-owned DOM text nodes, and when React later
+// tries to remove/insert a node that's been reparented, it throws
+// `NotFoundError: Failed to execute 'removeChild'/'insertBefore' on 'Node'`.
+// The list rows already carried `translate="no"` + a recoverable
+// ErrorBoundary (April 2026, PR #1163) — this file covers the header row
+// (search pills + angle selector), which didn't have either and could crash
+// straight past the local boundary into the root `app/error.tsx` handler.
+//
+// This file intentionally does NOT mock `../../error-boundary` (unlike
+// climbs-list-virtualization.test.tsx) so the real recoverable behavior runs.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { render, screen, act } from '@testing-library/react';
+import React from 'react';
+import type { Climb, BoardDetails } from '@/app/lib/types';
+import ClimbsList from '../climbs-list';
+
+// --- Mocks (mirrors climbs-list-virtualization.test.tsx, minus error-boundary) ---
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/kilter/original/12x12/default/40/list',
+}));
+
+vi.mock('@/app/hooks/use-is-dark-mode', () => ({
+  useIsDarkMode: () => false,
+}));
+
+vi.mock('@/app/lib/analytics', () => ({
+  track: vi.fn(),
+}));
+
+vi.mock('next/dynamic', () => ({
+  default: () => () => null,
+}));
+
+vi.mock('../../climb-card/climb-list-item', () => ({
+  default: ({ climb }: { climb: Climb }) => (
+    <div data-testid="climb-list-item" data-uuid={climb.uuid}>
+      {climb.name}
+    </div>
+  ),
+}));
+
+vi.mock('../../climb-card/climb-card', () => ({
+  default: ({ climb }: { climb: Climb }) => (
+    <div data-testid="climb-card" data-uuid={climb.uuid}>
+      {climb.name}
+    </div>
+  ),
+}));
+
+vi.mock('../../climb-card/drawer-climb-header', () => ({
+  default: () => <div data-testid="drawer-climb-header" />,
+}));
+
+vi.mock('../../climb-actions', () => ({
+  ClimbActions: () => <div data-testid="climb-actions" />,
+}));
+
+vi.mock('../../climb-actions/playlist-selection-content', () => ({
+  default: () => <div data-testid="playlist-selection-content" />,
+}));
+
+vi.mock('../board-page-skeleton', () => ({
+  ClimbCardSkeleton: () => <div data-testid="climb-card-skeleton" />,
+  ClimbListItemSkeleton: () => <div data-testid="climb-list-item-skeleton" />,
+}));
+
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getPreference: vi.fn(() => Promise.resolve('list')),
+  setPreference: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@/app/hooks/use-infinite-scroll', () => ({
+  useInfiniteScroll: () => ({ sentinelRef: { current: null } }),
+}));
+
+vi.mock('@/app/lib/rendering-metrics', () => ({
+  trackRenderError: vi.fn(),
+}));
+
+vi.mock('../climb-list-utils', () => ({
+  classifyClimbListChange: () => 'replace',
+}));
+
+vi.mock('@/app/lib/climb-action-utils', () => ({
+  getExcludedClimbActions: () => [],
+}));
+
+vi.mock('../selected-climb-store', () => ({
+  SelectionStoreContext: React.createContext(null),
+  useSelectionStore: () => ({
+    getSnapshot: () => null,
+    subscribe: () => () => {},
+    setUuid: vi.fn(),
+  }),
+  useIsClimbSelected: () => false,
+}));
+
+vi.mock('../climbs-list.module.css', () => ({
+  default: { gridItem: 'gridItem', listItem: 'listItem' },
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: {
+    spacing: { 0: 0, 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 16: 64 },
+    colors: { error: '#B8524C', primary: '#8C4A52', success: '#6B9080' },
+    neutral: { 200: '#E5E7EB', 400: '#9CA3AF', 500: '#6B7280', 600: '#4B5563' },
+    typography: {
+      fontSize: { xs: 12, sm: 14, base: 16, xl: 20, '2xl': 24 },
+      fontWeight: { normal: 400, semibold: 600, bold: 700 },
+    },
+    layout: { bottomNavSpacer: 80 },
+  },
+}));
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useWindowVirtualizer: (opts: {
+    count: number;
+    estimateSize: () => number;
+    getItemKey: (i: number) => string | number;
+  }) => {
+    const estimatedSize = opts.estimateSize();
+    const items = Array.from({ length: opts.count }, (_, i) => ({
+      index: i,
+      key: opts.getItemKey ? opts.getItemKey(i) : `item-${i}`,
+      start: i * estimatedSize,
+      size: estimatedSize,
+      end: (i + 1) * estimatedSize,
+      lane: 0,
+    }));
+    return {
+      getVirtualItems: () => items,
+      getTotalSize: () => opts.count * estimatedSize,
+      measureElement: vi.fn(),
+      scrollToIndex: vi.fn(),
+      scrollOffset: 0,
+      range: opts.count > 0 ? { startIndex: 0, endIndex: opts.count - 1 } : null,
+    };
+  },
+}));
+
+// --- Helpers ---
+
+function makeClimb(index: number): Climb {
+  return {
+    uuid: `climb-${index}`,
+    name: `Test Boulder ${index}`,
+    setter_username: 'setter',
+    description: '',
+    frames: `p${index}r14`,
+    angle: 40,
+    ascensionist_count: 5,
+    difficulty: 'V4',
+    quality_average: '3.0',
+    stars: 0,
+    difficulty_error: '0.5',
+    benchmark_difficulty: null,
+  };
+}
+
+function makeBoardDetails(): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: [1],
+    images_to_holds: {},
+    holdsData: [],
+    edge_left: 0,
+    edge_right: 100,
+    edge_bottom: 0,
+    edge_top: 100,
+    boardHeight: 100,
+    boardWidth: 100,
+  } as BoardDetails;
+}
+
+const threeClimbs = Array.from({ length: 3 }, (_, i) => makeClimb(i));
+
+describe('ClimbsList translator-DOM resilience (#3604)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('marks the whole list surface translate="no" so browser translators skip it', () => {
+    const { container } = render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={threeClimbs}
+        isFetching={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+
+    // The outermost rendered element is the wrapper Box — SelectionStoreContext.Provider
+    // is a transparent React context provider with no DOM node of its own.
+    expect(container.firstElementChild?.getAttribute('translate')).toBe('no');
+  });
+
+  it('recovers a header crash (removeChild NotFoundError) without unmounting the climb rows below', async () => {
+    // A persistent flag (not a "throw once" counter) — React 19 retries a
+    // render-phase throw once, synchronously, before handing off to the
+    // nearest error boundary. A component that throws only on its first
+    // invocation gets silently rescued by that internal retry and never
+    // reaches componentDidCatch at all, which would defeat this test. Real
+    // translator-DOM errors happen in the commit phase (an actual DOM
+    // removeChild call failing), which isn't eligible for that render-phase
+    // retry — so this mirrors error-boundary.test.tsx's proven pattern to
+    // reliably exercise the boundary's own rAF-driven recovery instead.
+    let shouldThrow = true;
+    function FlakyHeader() {
+      if (shouldThrow) {
+        // Same error shape browser-translator DOM mutation produces (see
+        // isTranslatorDomError in app/error.tsx).
+        throw new Error(
+          "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+        );
+      }
+      return <div data-testid="flaky-header">header ok</div>;
+    }
+
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={threeClimbs}
+        isFetching={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+        headerInline={<FlakyHeader />}
+      />,
+    );
+
+    // The header threw and its ErrorBoundary caught it — but the climb rows
+    // are in a separate ErrorBoundary and were never touched.
+    expect(screen.getAllByTestId('climb-list-item')).toHaveLength(3);
+    expect(screen.queryByTestId('flaky-header')).toBeNull();
+
+    // Fix the underlying condition, then flush the requestAnimationFrame the
+    // recoverable boundary scheduled from componentDidCatch.
+    shouldThrow = false;
+    await act(async () => {
+      vi.advanceTimersByTime(16);
+    });
+
+    // Header remounted and rendered successfully; climb rows are unaffected.
+    expect(screen.getByTestId('flaky-header')).toBeTruthy();
+    expect(screen.getAllByTestId('climb-list-item')).toHaveLength(3);
+  });
+
+  it('contains a persistently-crashing header to its own boundary — climb rows keep rendering', async () => {
+    // Arrow-function const (not a `function` declaration) — matches the
+    // working pattern in error-boundary.test.tsx. A `function` declaration
+    // that only throws infers a `void` return type here, which TS rejects
+    // as a JSX element type; the arrow form infers `never`, which is fine.
+    const AlwaysThrow = () => {
+      throw new Error(
+        "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+      );
+    };
+
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={threeClimbs}
+        isFetching={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+        headerInline={<AlwaysThrow />}
+      />,
+    );
+
+    // Exhaust the header boundary's retry budget (3 attempts).
+    for (let i = 0; i < 4; i++) {
+      await act(async () => {
+        vi.advanceTimersByTime(16);
+      });
+    }
+
+    // The header gave up and shows nothing (no fallback prop passed), but
+    // the climb list below is completely unaffected — no white screen.
+    expect(screen.getAllByTestId('climb-list-item')).toHaveLength(3);
+  });
+});

--- a/packages/web/app/components/board-page/angle-selector.tsx
+++ b/packages/web/app/components/board-page/angle-selector.tsx
@@ -235,7 +235,13 @@ export default function AngleSelector({
           color: isDark ? '#ffffff' : 'primary.main',
         }}
       >
-        {currentAngle}°
+        {/*
+         * Wrapped in a span (rather than two bare sibling text nodes) so a
+         * browser translator replaces one element instead of orphaning
+         * React's text node — same pattern as logbook-feed-item.tsx. This
+         * button re-renders on nearly every climb selection. See #3604.
+         */}
+        <span>{currentAngle}°</span>
       </MuiButton>
 
       <SwipeableDrawer

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -585,37 +585,55 @@ const ClimbsList = ({
 
   return (
     <SelectionStoreContext.Provider value={selectionStore}>
-      <Box>
+      {/*
+       * translate="no" on the whole list surface tells well-behaved browser
+       * translators (Chrome/Safari auto-translate) to leave this subtree's
+       * DOM alone. The climb rows below already carried their own
+       * translate="no" (kept, now redundant but harmless) — this closes the
+       * gap for the header row and sentinel/skeleton area, which re-render
+       * at least as often as the rows (angle/search-pill state changes on
+       * nearly every climb tap) but weren't previously covered. See
+       * issue #3604.
+       */}
+      <Box translate="no">
         {header}
         {/* Header: Search pills (left, scrollable) | View toggle + Angle selector (right) */}
-        <Box sx={headerContainerSx}>
-          {/* Left: Search pills (scrollable) */}
-          <Box sx={searchPillsContainerSx}>{headerInline}</Box>
-          {/* Right: View toggle + Angle selector */}
-          <Box sx={rightControlsSx}>
-            <Box sx={viewModeToggleBoxSx}>
-              <IconButton
-                id="onboarding-view-mode-list"
-                onClick={handleListView}
-                aria-label={t('list.viewMode.list')}
-                size="small"
-                sx={listButtonSx}
-              >
-                <FormatListBulletedOutlined fontSize="small" />
-              </IconButton>
-              <IconButton
-                id="onboarding-view-mode-grid"
-                onClick={handleGridView}
-                aria-label={t('list.viewMode.grid')}
-                size="small"
-                sx={gridButtonSx}
-              >
-                <AppsOutlined fontSize="small" />
-              </IconButton>
+        {/*
+         * Separate recoverable ErrorBoundary from the climb-rows one below —
+         * defense-in-depth for translator extensions that ignore
+         * translate="no". Kept isolated so a recovery-remount here doesn't
+         * reset AngleSelector's/RecentSearchPills' unrelated local state.
+         */}
+        <ErrorBoundary recoverable>
+          <Box sx={headerContainerSx}>
+            {/* Left: Search pills (scrollable) */}
+            <Box sx={searchPillsContainerSx}>{headerInline}</Box>
+            {/* Right: View toggle + Angle selector */}
+            <Box sx={rightControlsSx}>
+              <Box sx={viewModeToggleBoxSx}>
+                <IconButton
+                  id="onboarding-view-mode-list"
+                  onClick={handleListView}
+                  aria-label={t('list.viewMode.list')}
+                  size="small"
+                  sx={listButtonSx}
+                >
+                  <FormatListBulletedOutlined fontSize="small" />
+                </IconButton>
+                <IconButton
+                  id="onboarding-view-mode-grid"
+                  onClick={handleGridView}
+                  aria-label={t('list.viewMode.grid')}
+                  size="small"
+                  sx={gridButtonSx}
+                >
+                  <AppsOutlined fontSize="small" />
+                </IconButton>
+              </Box>
+              {angleSelector}
             </Box>
-            {angleSelector}
           </Box>
-        </Box>
+        </ErrorBoundary>
 
         <ErrorBoundary recoverable>
           {viewMode === 'grid' ? (


### PR DESCRIPTION
## Summary

Sentry BOARDSESH-79: `NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.` was crashing the climb-list route (`/:board_name/:layout_id/:size_id/:set_ids/:angle/list`) for 5 users / 22 events — the classic browser-translator-vs-React conflict (Chrome/Safari auto-translate rewrites text nodes into `<font>` wrappers, then React's reconciler trips trying to remove/insert a node that's no longer where it expects).

This exact class of bug was already fixed once, for `/`, `/you/logbook`, `/settings` (#2064 → PR #2086) and, separately, for this route's climb rows specifically (PR #1163, April 2026): the grid/list containers in `climbs-list.tsx` already carry `translate="no"` plus a recoverable `ErrorBoundary` that auto-remounts on the next frame.

What neither fix covered: the **header row** (search pills + angle selector + view-mode toggle) inside `ClimbsList`. `RecentSearchPills` is only ever rendered on this route family, and the angle-selector trigger button's `angleSelectorElement` is memoized on `currentClimb` — meaning it re-renders on nearly every climb tap, far more often than the page navigates. Because that region sat outside both the `translate="no"` zone and the local `ErrorBoundary`, a translator-mutated node there threw straight past the local recovery into the root `app/error.tsx` boundary (the only one that reports to Sentry), which lines up with BOARDSESH-79 staying open.

## Changes

`packages/web/app/components/board-page/climbs-list.tsx`
- `translate="no"` on the whole `ClimbsList` surface (previously scoped only to the grid/list containers) — now also covers the header row and the sentinel/skeleton/"no more climbs" area.
- A second, separate recoverable `ErrorBoundary` around the header row, kept isolated from the climb-rows boundary so a recovery-remount there doesn't reset unrelated local state (`AngleSelector`'s drawer-open state, `RecentSearchPills`' loaded-searches state).

`packages/web/app/components/board-page/angle-selector.tsx`
- Wrapped the trigger button's `{currentAngle}°` in a `<span>` — two bare sibling text nodes otherwise, the same shape PR #2086 already fixed in `logbook-feed-item.tsx`.

## Follow-ups (explicitly out of scope for this PR)

- `SharedDrawers` / `Snackbar` (climb actions, playlist selector, drawer climb header with the dynamic climb name) render through MUI's default `Portal` to `document.body`, so they sit outside this fix's `translate="no"` reach. Left out to keep this change surgical — worth revisiting if BOARDSESH-79 volume doesn't fully drop.
- `app/error.tsx`'s `MAX_AUTO_RESETS` is a global, **per-tab-session** budget (1 silent auto-reset total), not per-route. 5 users / 22 events (~4.4 events/user) suggests some users exhaust that single budget elsewhere in the session and then hit the visible "Something broke" fallback here. Worth a separate follow-up, not bundled into this fix.

## Caveat

Root-causing here was static code analysis (diffing against exactly what the prior fixes already covered) — there's no Sentry access in this environment, so the header-row hypothesis wasn't verified against BOARDSESH-79's actual stack trace/breadcrumbs. Worth a quick sanity check against Sentry, and re-checking BOARDSESH-79's event volume a week or two post-merge.

## Release Notes

- [ ] No release note needed (internal / technical change)

Fixed a rare crash on the climb list when a browser translate extension (like Chrome's auto-translate) was switched on.

## Test plan

- New test file `packages/web/app/components/board-page/__tests__/climbs-list-translator-resilience.test.tsx` (real `ErrorBoundary`, not mocked, unlike the existing virtualization test file): asserts the whole list surface carries `translate="no"`, that a header crash (`removeChild` NotFoundError) recovers via the boundary's rAF retry without ever unmounting the climb rows below, and that a persistently-crashing header stays contained to its own boundary while climb rows keep rendering.
- New test in `angle-selector.test.tsx`: the trigger button's angle text renders as a single `<span>` element, not bare sibling text nodes.
- `vp run typecheck:web` — pass
- `vp test run --project web --reporter=agent` (scoped to the 4 touched/related test files, and once against the full web suite modulo unrelated timeout flakes from shared-machine CPU contention, confirmed unrelated to this diff) — pass
- `vp check` — pass (0 errors; pre-existing warnings elsewhere untouched by this diff)
- `vp run check:i18n` — pass (no new user-facing strings)
