### PR TITLE
fix(web): consolidate cron-route auth into a shared timing-safe helper

### DIFF
--- a/packages/web/app/api/internal/cleanup/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/cleanup/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+const mockLimit = vi.fn();
+const mockWhere = vi.fn(() => ({ limit: mockLimit }));
+const mockFrom = vi.fn(() => ({ where: mockWhere }));
+const mockSelect = vi.fn(() => ({ from: mockFrom }));
+const mockDeleteWhere = vi.fn();
+const mockDelete = vi.fn(() => ({ where: mockDeleteWhere }));
+
+vi.mock('@/app/lib/db/db', () => ({
+  dbz: {
+    select: mockSelect,
+    delete: mockDelete,
+  },
+}));
+
+vi.mock('@boardsesh/db/schema', () => ({
+  feedItems: { id: 'feed_items.id', createdAt: 'feed_items.created_at' },
+  notifications: { id: 'notifications.id', createdAt: 'notifications.created_at' },
+}));
+
+const routeModule = await import('../route');
+
+describe('GET /api/internal/cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLimit.mockResolvedValue([]);
+    mockDeleteWhere.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns 401 when the cron secret is missing or invalid', async () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+
+    const response = await routeModule.GET(new Request('http://localhost/api/internal/cleanup'));
+
+    expect(response.status).toBe(401);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it('runs the batched cleanup when the cron secret matches', async () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+
+    const response = await routeModule.GET(
+      new Request('http://localhost/api/internal/cleanup', {
+        headers: { authorization: 'Bearer test-secret' },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ feedItemsDeleted: 0, notificationsDeleted: 0 });
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/internal/cleanup/route.ts
+++ b/packages/web/app/api/internal/cleanup/route.ts
@@ -2,20 +2,20 @@ import { NextResponse } from 'next/server';
 import { lt, inArray, sql } from 'drizzle-orm';
 import { dbz as db } from '@/app/lib/db/db';
 import { feedItems, notifications } from '@boardsesh/db/schema';
+import { requireCronAuth } from '@/app/lib/auth/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
-const CRON_SECRET = process.env.CRON_SECRET;
 const BATCH_SIZE = 5000;
 
 // Leave 10s buffer before timeout
 const DEADLINE_MS = (maxDuration - 10) * 1000;
 
 export async function GET(request: Request) {
-  const authHeader = request.headers.get('authorization');
-  if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const authError = requireCronAuth(request);
+  if (authError) {
+    return authError;
   }
 
   try {

--- a/packages/web/app/api/internal/prewarm-heatmap/[board_name]/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/prewarm-heatmap/[board_name]/__tests__/route.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+const mockExecuteRows = vi.fn();
+vi.mock('@/app/lib/db/db', () => ({
+  executeRows: (...args: unknown[]) => mockExecuteRows(...args),
+  dbzRead: {},
+}));
+
+const mockGetBoardSelectorOptions = vi.fn();
+vi.mock('@/app/lib/board-constants', () => ({
+  AURORA_BOARD_NAMES: ['kilter', 'tension', 'decoy', 'touchstone', 'grasshopper'],
+  isAuroraBoardName: (boardName: string) =>
+    ['kilter', 'tension', 'decoy', 'touchstone', 'grasshopper'].includes(boardName),
+  getBoardSelectorOptions: () => mockGetBoardSelectorOptions(),
+}));
+
+const mockCachedGetHoldHeatmapData = vi.fn();
+vi.mock('@/app/lib/db/queries/climbs/holds-heatmap-cache', () => ({
+  cachedGetHoldHeatmapData: (...args: unknown[]) => mockCachedGetHoldHeatmapData(...args),
+}));
+
+vi.mock('@/app/lib/url-utils', () => ({
+  DEFAULT_SEARCH_PARAMS: {},
+}));
+
+const routeModule = await import('../route');
+
+function buildRequest(headers?: Record<string, string>) {
+  return new Request('http://localhost/api/internal/prewarm-heatmap/kilter', { headers });
+}
+
+describe('GET /api/internal/prewarm-heatmap/[board_name]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // No layouts for this board — buildTargetsForBoard returns [] and the
+    // handler completes without touching the heatmap-warming path.
+    mockGetBoardSelectorOptions.mockReturnValue({ layouts: {}, sizes: {}, sets: {} });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns 401 when the cron secret is missing or invalid', async () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+
+    const response = await routeModule.GET(buildRequest(), {
+      params: Promise.resolve({ board_name: 'kilter' }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(mockCachedGetHoldHeatmapData).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an unknown board name once authorized', async () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+
+    const response = await routeModule.GET(buildRequest({ authorization: 'Bearer test-secret' }), {
+      params: Promise.resolve({ board_name: 'not-a-board' }),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('warms the requested board when the cron secret matches', async () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+
+    const response = await routeModule.GET(buildRequest({ authorization: 'Bearer test-secret' }), {
+      params: Promise.resolve({ board_name: 'kilter' }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({ board: 'kilter', total: 0, warmed: 0, failed: 0 });
+  });
+});

--- a/packages/web/app/api/internal/prewarm-heatmap/[board_name]/route.ts
+++ b/packages/web/app/api/internal/prewarm-heatmap/[board_name]/route.ts
@@ -7,11 +7,10 @@ import { dbzRead as db } from '@/app/lib/db/db';
 import { cachedGetHoldHeatmapData } from '@/app/lib/db/queries/climbs/holds-heatmap-cache';
 import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 import type { ParsedBoardRouteParameters } from '@/app/lib/types';
+import { requireCronAuth } from '@/app/lib/auth/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
-
-const CRON_SECRET = process.env.CRON_SECRET;
 
 // Max concurrent warm-up queries per run. Keeps DB load reasonable while still
 // finishing well inside maxDuration for the largest boards.
@@ -129,9 +128,9 @@ export async function GET(request: Request, props: { params: Promise<PrewarmRout
   const { board_name: boardNameParam } = params;
 
   // Auth check — always require valid CRON_SECRET.
-  const authHeader = request.headers.get('authorization');
-  if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const authError = requireCronAuth(request);
+  if (authError) {
+    return authError;
   }
 
   if (!isAuroraBoardName(boardNameParam)) {

--- a/packages/web/app/api/internal/profile-percentiles/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/profile-percentiles/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 vi.mock('server-only', () => ({}));
 
@@ -26,9 +26,6 @@ vi.mock('@boardsesh/db/schema', () => ({
   userClimbPercentiles: {},
 }));
 
-const originalCronSecret = process.env.CRON_SECRET;
-process.env.CRON_SECRET = 'test-secret';
-
 const routeModule = await import('../route');
 
 describe('GET /api/internal/profile-percentiles', () => {
@@ -39,7 +36,13 @@ describe('GET /api/internal/profile-percentiles', () => {
     mockExecute.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('returns 401 when the cron secret is missing or invalid', async () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+
     const response = await routeModule.GET(new Request('http://localhost/api/internal/profile-percentiles'));
 
     expect(response.status).toBe(401);
@@ -47,6 +50,8 @@ describe('GET /api/internal/profile-percentiles', () => {
   });
 
   it('refreshes the snapshot and invalidates the shared percentile cache tag', async () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+
     const response = await routeModule.GET(
       new Request('http://localhost/api/internal/profile-percentiles', {
         headers: {
@@ -63,9 +68,3 @@ describe('GET /api/internal/profile-percentiles', () => {
     expect(body.refreshedUsers).toBe(3);
   });
 });
-
-if (originalCronSecret === undefined) {
-  delete process.env.CRON_SECRET;
-} else {
-  process.env.CRON_SECRET = originalCronSecret;
-}

--- a/packages/web/app/api/internal/profile-percentiles/route.ts
+++ b/packages/web/app/api/internal/profile-percentiles/route.ts
@@ -4,16 +4,15 @@ import { sql } from 'drizzle-orm';
 import { getDb } from '@/app/lib/db/db';
 import { USER_CLIMB_PERCENTILE_CACHE_TAG } from '@/app/lib/graphql/server-cached-client';
 import { userClimbPercentiles } from '@boardsesh/db/schema';
+import { requireCronAuth } from '@/app/lib/auth/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
 
-const CRON_SECRET = process.env.CRON_SECRET;
-
 export async function GET(request: Request) {
-  const authHeader = request.headers.get('authorization');
-  if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const authError = requireCronAuth(request);
+  if (authError) {
+    return authError;
   }
 
   try {

--- a/packages/web/app/lib/auth/__tests__/cron-auth.test.ts
+++ b/packages/web/app/lib/auth/__tests__/cron-auth.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, afterEach, vi } from 'vite-plus/test';
+import { requireCronAuth } from '../cron-auth';
+
+describe('requireCronAuth', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns 401 when CRON_SECRET is not configured', () => {
+    vi.stubEnv('CRON_SECRET', '');
+
+    const response = requireCronAuth(
+      new Request('http://localhost/api/internal/cleanup', {
+        headers: { authorization: 'Bearer anything' },
+      }),
+    );
+
+    expect(response?.status).toBe(401);
+  });
+
+  it('returns 401 when the authorization header is missing', () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+
+    const response = requireCronAuth(new Request('http://localhost/api/internal/cleanup'));
+
+    expect(response?.status).toBe(401);
+  });
+
+  it('returns 401 when the token is wrong but the same length as the expected header', () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+
+    const response = requireCronAuth(
+      new Request('http://localhost/api/internal/cleanup', {
+        // Same length as "Bearer test-secret" so this exercises the
+        // timingSafeEqual comparison branch, not the length-mismatch branch.
+        headers: { authorization: 'Bearer wrong-secre' },
+      }),
+    );
+
+    expect(response?.status).toBe(401);
+  });
+
+  it('returns 401 when the token has a different length than expected', () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+
+    const response = requireCronAuth(
+      new Request('http://localhost/api/internal/cleanup', {
+        headers: { authorization: 'Bearer short' },
+      }),
+    );
+
+    expect(response?.status).toBe(401);
+  });
+
+  it('returns null for a valid bearer token', () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+
+    const response = requireCronAuth(
+      new Request('http://localhost/api/internal/cleanup', {
+        headers: { authorization: 'Bearer test-secret' },
+      }),
+    );
+
+    expect(response).toBeNull();
+  });
+});

--- a/packages/web/app/lib/auth/cron-auth.ts
+++ b/packages/web/app/lib/auth/cron-auth.ts
@@ -1,0 +1,43 @@
+import crypto from 'crypto';
+import { NextResponse } from 'next/server';
+
+/**
+ * Shared auth guard for the handful of `/api/internal/*` routes that Vercel
+ * invokes on a schedule (see `packages/web/vercel.json`'s `crons` array).
+ *
+ * The env var MUST be named `CRON_SECRET` — Vercel auto-injects
+ * `Authorization: Bearer <CRON_SECRET>` on every cron invocation only when
+ * the project env var has this exact name
+ * (https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs).
+ * Renaming it (e.g. to `CRON_TOKEN`) would silently break that auto-injection
+ * and 401 every cron run.
+ *
+ * Comparison is constant-time to avoid leaking the secret's value through
+ * response-timing side channels, mirroring the pattern used for the native
+ * OAuth transfer token in `native-oauth-transfer.ts`.
+ */
+export function requireCronAuth(request: Request): NextResponse | null {
+  const cronSecret = process.env.CRON_SECRET;
+  const authHeader = request.headers.get('authorization');
+
+  if (!cronSecret || !authHeader) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const expected = Buffer.from(`Bearer ${cronSecret}`);
+  const actual = Buffer.from(authHeader);
+
+  if (expected.length !== actual.length) {
+    // No-op timingSafeEqual so this branch takes the same time as the
+    // valid-length comparison below — the length itself isn't secret, but
+    // this keeps the two branches trivially indistinguishable.
+    crypto.timingSafeEqual(expected, expected);
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!crypto.timingSafeEqual(actual, expected)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Fixes #1888.

**Staleness finding first, since it changes the shape of this fix:** the issue's premise — a `packages/scheduler` service calling `/api/internal/*-cron` routes with a `CRON_TOKEN` secret — never happened. `packages/scheduler` (issue #1874) was never built. It was part of epic #1859 ("Mobile app distribution plan v9.0" — Railway/arctic/TanStack Start migration), which was **closed `NOT_PLANNED` on 2026-06-12**. #1860/#1861/#1874 were left open as dangling children of that closed epic.

Separately, and *before* #1888 was even filed (2026-05-04), the actual security gap had already been closed: commits from 2026-04-11/12/16 added an inline `Bearer ${CRON_SECRET}` check to all 3 routes Vercel actually invokes on a schedule (`packages/web/vercel.json`'s `crons` array — `cleanup`, `profile-percentiles`, `prewarm-heatmap/[board_name]`). No route was left unauthenticated. Older cron-triggered routes (`user-sync-cron`, `migrate-users-cron`, `kilter-sync-cron`, aurora `sync-cron`) were fully decommissioned in favor of long-lived daemons that don't front an HTTP endpoint at all (see `docs/kilter-sync.md`, `docs/branch-deploys.md`).

**So this PR is a consolidation, not a gap closure:**
- Extracted the 3x-duplicated inline auth check into `packages/web/app/lib/auth/cron-auth.ts` (`requireCronAuth`), using `crypto.timingSafeEqual` (mirroring the existing pattern in `native-oauth-transfer.ts`) instead of a plain `!==` string compare.
- Applied it to all 3 routes: `cleanup`, `profile-percentiles`, `prewarm-heatmap/[board_name]`.
- Added test coverage — `cleanup` and `prewarm-heatmap` had **zero tests** before this PR (not even auth tests).

**Kept the env var name `CRON_SECRET`**, diverging from the issue's literal title (`CRON_TOKEN`). Confirmed against Vercel's docs: Vercel only auto-injects the `Authorization: Bearer <value>` header on cron invocations when the project env var is named exactly `CRON_SECRET` (https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs). Renaming it would silently break all 3 crons (they'd 401 forever, since Vercel would never send a token under the new name).

No caller changes needed — `vercel.json` is unchanged, and no GitHub Actions workflow or script calls these routes (grepped `.github/workflows` and `scripts/` for `api/internal`, zero hits). Vercel Cron is the only caller and already sends the right header under the right name.

**⚠️ Flag for @marcodejongh:** please confirm `CRON_SECRET` is actually set in the Vercel **Production** environment. I can't check the Vercel dashboard from here. `requireCronAuth` fails closed exactly like the code it replaces — if the var is unset, all 3 crons 401 every invocation rather than running unauthenticated, which is safe, but if it's been unset since these routes shipped in April, `cleanup`/`profile-percentiles`/`prewarm-heatmap` have silently never run. Worth a positive check either way.

Issue hygiene (#1860/#1861/#1874 — children of the closed epic) is left to you; not touching those here.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `packages/web/app/lib/auth/__tests__/cron-auth.test.ts` (new): missing secret, missing header, wrong token (same length — exercises the `timingSafeEqual` branch), wrong token (different length), valid token.
- `packages/web/app/api/internal/cleanup/__tests__/route.test.ts` (new): 401 without token, 200 + batched-cleanup runs with a valid token.
- `packages/web/app/api/internal/prewarm-heatmap/[board_name]/__tests__/route.test.ts` (new): 401 without token, 400 for an unknown board name once authorized, 200 + warm run with a valid token.
- `packages/web/app/api/internal/profile-percentiles/__tests__/route.test.ts` (updated): same auth cases, simplified from manual `process.env` save/restore to `vi.stubEnv`/`vi.unstubAllEnvs` now that `requireCronAuth` reads the env at call time instead of module-load time.
- Commands run: `tsc --noEmit` (packages/web, 0 errors), `vp test run --project web` scoped to the 4 files above (4 files / 12 tests, all passed), `vp staged --diff HEAD~1` (the actual pre-commit hook's scoped lint/format/i18n check against this commit's files — all completed clean).