### PR TITLE
fix(mobile): recover Android Google DEVELOPER_ERROR/INTERNAL_ERROR via browser fallback

### DIFF
--- a/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
@@ -300,7 +300,7 @@ describe('useNativeOAuthSignIn — Apple web fallback (iOS)', () => {
   });
 });
 
-describe('useNativeOAuthSignIn — Android has no web fallback', () => {
+describe('useNativeOAuthSignIn — Android Google config-class fallback (#3100)', () => {
   beforeEach(() => {
     platform.OS = 'android';
     trackMock.mockReset();
@@ -311,22 +311,70 @@ describe('useNativeOAuthSignIn — Android has no web fallback', () => {
     signInWithAppleWebMock.mockReset();
   });
 
-  it('surfaces the native error (no fallback) when Google throws — the SHA-1/DEVELOPER_ERROR case', async () => {
+  it('falls back to the browser when native Google throws DEVELOPER_ERROR (string code) and signs in', async () => {
+    // The SHA-1 / OAuth-client dead-end (#3100): the fallback runs a full NextAuth
+    // flow with no native SDK, so it recovers login while the signing cert is fixed.
     signInWithGoogleMock.mockRejectedValue(Object.assign(new Error('developer error'), { code: 'DEVELOPER_ERROR' }));
+    signInWithGoogleWebMock.mockResolvedValue({ success: true });
+
+    const setError = await runSignIn('google');
+
+    expect(signInWithGoogleWebMock).toHaveBeenCalledTimes(1);
+    // The fallback owns the outcome, so the handled native throw no longer reports.
+    expect(reportErrorMock).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenLastCalledWith(null);
+    const events = trackedEvents();
+    // The native throw is now recoverable on Android too, so the failure metric excludes it.
+    expect(events).toContainEqual({ event: 'Login Failed', flow: 'native', reason: 'exception', recoverable: true });
+    expect(events).toContainEqual({
+      event: 'Login Succeeded',
+      flow: 'web_fallback',
+      reason: undefined,
+      recoverable: undefined,
+      mechanism: 'browser_deeplink',
+    });
+  });
+
+  it('falls back when native Google throws INTERNAL_ERROR as a numeric code (8)', async () => {
+    signInWithGoogleMock.mockRejectedValue(Object.assign(new Error('internal'), { code: 8 }));
+    signInWithGoogleWebMock.mockResolvedValue({ success: true });
+
+    await runSignIn('google');
+
+    expect(signInWithGoogleWebMock).toHaveBeenCalledTimes(1);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back when DEVELOPER_ERROR arrives only in the message (no usable code)', async () => {
+    // Some builds throw with no `.code`, the name only in the message — must still recover.
+    signInWithGoogleMock.mockRejectedValue(
+      new Error('DEVELOPER_ERROR: Follow troubleshooting instructions at https://.../troubleshooting'),
+    );
+    signInWithGoogleWebMock.mockResolvedValue({ success: true });
+
+    await runSignIn('google');
+
+    expect(signInWithGoogleWebMock).toHaveBeenCalledTimes(1);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the native error (no fallback) for a non-config Google throw — NETWORK_ERROR (7)', async () => {
+    // Strict scope: only DEVELOPER_ERROR / INTERNAL_ERROR recover. A transient
+    // NETWORK_ERROR keeps surfacing its native error rather than bouncing to a browser.
+    signInWithGoogleMock.mockRejectedValue(Object.assign(new Error('network error'), { code: 7 }));
 
     const setError = await runSignIn('google');
 
     expect(signInWithGoogleWebMock).not.toHaveBeenCalled();
-    // Reported once, tagged with the native code so PostHog records DEVELOPER_ERROR.
     expect(reportErrorMock).toHaveBeenCalledTimes(1);
     expect(reportErrorMock).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({
-        tags: expect.objectContaining({ provider: 'google', flow: 'native', native_error_code: 'DEVELOPER_ERROR' }),
+        tags: expect.objectContaining({ provider: 'google', flow: 'native', native_error_code: '7' }),
       }),
     );
     expect(setError).toHaveBeenLastCalledWith('nativeStart.oauthError');
-    // No fallback on Android, so the native throw is terminal, not recoverable.
+    // Not recoverable, so it counts toward the terminal failure metric.
     expect(trackedEvents()).toContainEqual({
       event: 'Login Failed',
       flow: 'native',
@@ -335,7 +383,9 @@ describe('useNativeOAuthSignIn — Android has no web fallback', () => {
     });
   });
 
-  it('surfaces the native error (no fallback) when Google returns a non-cancel failure', async () => {
+  it('does not fall back when native Google RETURNS a non-cancel failure (result path stays iOS-only)', async () => {
+    // Config errors are throws, not returns; a returned backend failure on Android
+    // isn't a native-SDK dead-end, so the result path keeps surfacing it.
     signInWithGoogleMock.mockResolvedValue({ success: false, status: 401, error: 'invalid' });
 
     const setError = await runSignIn('google');
@@ -362,10 +412,10 @@ describe('useNativeOAuthSignIn — Android has no web fallback', () => {
     expect(events).not.toContainEqual(expect.objectContaining({ event: 'Login Failed' }));
   });
 
-  it('does not run the Apple web fallback on Android (the iOS gate holds)', async () => {
-    // Apple sign-in isn't offered on Android, but guard the gate anyway: a native
-    // throw must surface the real error, not silently open a browser fallback.
-    signInWithAppleMock.mockRejectedValue(Object.assign(new Error('unknown'), { code: 1000 }));
+  it('does not run the Apple web fallback on Android even for a config-class-looking throw', async () => {
+    // The gate is provider === 'google': Apple isn't offered on Android, so a
+    // native Apple throw must surface the real error, never open a browser fallback.
+    signInWithAppleMock.mockRejectedValue(Object.assign(new Error('unknown'), { code: 'DEVELOPER_ERROR' }));
 
     const setError = await runSignIn('apple');
 

--- a/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
+++ b/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
@@ -4,7 +4,11 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { useAuth } from '../providers/auth-provider';
 import { track } from '../lib/analytics';
 import { reportError } from '../lib/error-reporting';
-import { classifyNativeAuthFailureReason, nativeSignInErrorCode } from '../lib/native-auth-analytics';
+import {
+  classifyNativeAuthFailureReason,
+  isRecoverableAndroidGoogleSignInError,
+  nativeSignInErrorCode,
+} from '../lib/native-auth-analytics';
 import type { OAuthSignInResult } from '../lib/auth';
 import { useTranslation } from 'react-i18next';
 
@@ -185,26 +189,27 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
         // signing/client-id mismatch, …). Prefer the native `.code` for
         // failure_detail — far more actionable than the opaque message.
         const nativeErrorCode = nativeSignInErrorCode(oauthError);
-        // On iOS the browser fallback runs next (recoverable); on Android the
-        // native throw dead-ends and is terminal.
+        // Recover in the browser when the native throw is recoverable there:
+        // every iOS throw (the fallback owns the outcome), plus — now that the
+        // fallback uses the reliable openBrowserAsync + deep-link race instead of
+        // the openAuthSessionAsync that didn't return on Android (#3083) — the
+        // config-class Android Google throws (DEVELOPER_ERROR / INTERNAL_ERROR)
+        // that otherwise dead-end login while the signing-cert SHA-1 is fixed
+        // (see #3100). Other Android throws (NETWORK_ERROR, PLAY_SERVICES_*, and
+        // Apple, which isn't offered on Android) still surface their native error.
+        const willFallBack =
+          Platform.OS === 'ios' ||
+          (Platform.OS === 'android' && provider === 'google' && isRecoverableAndroidGoogleSignInError(oauthError));
         track(SHARED_EVENTS.LoginFailed, {
           auth_method: provider,
           flow: 'native',
           failure_reason: 'exception',
           failure_detail: nativeErrorCode ?? (oauthError instanceof Error ? oauthError.message : undefined),
-          recoverable: Platform.OS === 'ios',
+          recoverable: willFallBack,
           duration_ms: Date.now() - attemptStartedAt,
           ...registrationProps,
         });
-        // Native throws land here — on iOS, recover via the browser flow instead
-        // of reporting and dead-ending the user. Google's is the iOS 26.5.1
-        // "Unable to open Safari" GIDSignIn throw; Apple's is
-        // ASAuthorizationError.unknown (code 1000). On Android a Google throw is
-        // almost always an unregistered signing-cert SHA-1 (DEVELOPER_ERROR) and
-        // Apple isn't offered, so fall through and let reportError tag it with
-        // native_error_code for PostHog rather than hide it behind a fallback that
-        // can't complete.
-        if (Platform.OS === 'ios') {
+        if (willFallBack) {
           await runWebFallback();
           return;
         }

--- a/packages/mobile/src/lib/__tests__/auth.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { classifyNativeAuthFailureReason, nativeSignInErrorCode } from '../native-auth-analytics';
+import {
+  classifyNativeAuthFailureReason,
+  isRecoverableAndroidGoogleSignInError,
+  nativeSignInErrorCode,
+} from '../native-auth-analytics';
 
 describe('classifyNativeAuthFailureReason', () => {
   it('maps native credential and OAuth failures to low-cardinality analytics reasons', () => {
@@ -84,5 +88,40 @@ describe('nativeSignInErrorCode', () => {
     expect(nativeSignInErrorCode(undefined)).toBeUndefined();
     expect(nativeSignInErrorCode(null)).toBeUndefined();
     expect(nativeSignInErrorCode('DEVELOPER_ERROR')).toBeUndefined();
+  });
+});
+
+describe('isRecoverableAndroidGoogleSignInError', () => {
+  // GMS surfaces DEVELOPER_ERROR / INTERNAL_ERROR inconsistently across builds:
+  // a numeric `.code`, a string `.code`, or no code with the name only in the
+  // message. All three must recover (the browser fallback bypasses the native SDK).
+  it('recovers the config-class codes in every representation GMS throws', () => {
+    expect(isRecoverableAndroidGoogleSignInError(Object.assign(new Error('x'), { code: 'DEVELOPER_ERROR' }))).toBe(
+      true,
+    );
+    expect(isRecoverableAndroidGoogleSignInError(Object.assign(new Error('x'), { code: 'INTERNAL_ERROR' }))).toBe(true);
+    expect(isRecoverableAndroidGoogleSignInError(Object.assign(new Error('x'), { code: 10 }))).toBe(true);
+    expect(isRecoverableAndroidGoogleSignInError(Object.assign(new Error('x'), { code: 8 }))).toBe(true);
+    // No usable code — the name is only in the message (observed on builds 350+).
+    expect(
+      isRecoverableAndroidGoogleSignInError(new Error('DEVELOPER_ERROR: Follow troubleshooting instructions at ...')),
+    ).toBe(true);
+    expect(isRecoverableAndroidGoogleSignInError(new Error('INTERNAL_ERROR'))).toBe(true);
+  });
+
+  // Strict scope: everything else surfaces its native error rather than bouncing
+  // into a browser — transient network, Play Services gaps, cancels, unknown.
+  it('does not recover non-config failures', () => {
+    expect(isRecoverableAndroidGoogleSignInError(Object.assign(new Error('network'), { code: 7 }))).toBe(false);
+    expect(isRecoverableAndroidGoogleSignInError(Object.assign(new Error('no play services'), { code: 2 }))).toBe(
+      false,
+    );
+    expect(
+      isRecoverableAndroidGoogleSignInError(Object.assign(new Error('cancelled'), { code: 'SIGN_IN_CANCELLED' })),
+    ).toBe(false);
+    expect(isRecoverableAndroidGoogleSignInError(new Error('some other failure'))).toBe(false);
+    expect(isRecoverableAndroidGoogleSignInError(undefined)).toBe(false);
+    expect(isRecoverableAndroidGoogleSignInError(null)).toBe(false);
+    expect(isRecoverableAndroidGoogleSignInError('DEVELOPER_ERROR')).toBe(false);
   });
 });

--- a/packages/mobile/src/lib/native-auth-analytics.ts
+++ b/packages/mobile/src/lib/native-auth-analytics.ts
@@ -54,3 +54,30 @@ export function nativeSignInErrorCode(error: unknown): string | undefined {
   const code = (error as { code?: unknown }).code;
   return typeof code === 'string' || typeof code === 'number' ? String(code) : undefined;
 }
+
+// The two GMS Google-Sign-In failure codes that dead-end Android login and are
+// recoverable via the browser fallback (a full NextAuth flow with no native SDK,
+// so it's immune to the SHA-1 / OAuth-client misconfig behind them). DEVELOPER_ERROR
+// is the classic unregistered-signing-cert SHA-1; INTERNAL_ERROR (8) is frequently
+// the same mismatch (or transient Play Services). Deliberately narrow — NETWORK_ERROR
+// (7), PLAY_SERVICES_NOT_AVAILABLE and friends are left to surface the real native
+// error instead of bouncing into a browser. `com.google.android.gms.common.api.ApiException`
+// surfaces these inconsistently across builds: a numeric `.code` (8 / 10), a string
+// `.code` ('INTERNAL_ERROR'), or no usable `.code` at all with the name only in the
+// message ("DEVELOPER_ERROR: Follow troubleshooting…"). Match all three forms.
+const RECOVERABLE_ANDROID_GOOGLE_CODES = new Set(['8', '10', 'DEVELOPER_ERROR', 'INTERNAL_ERROR']);
+
+/**
+ * Whether a thrown Android Google-Sign-In error is a config-class failure
+ * (DEVELOPER_ERROR / INTERNAL_ERROR) that the browser fallback can recover, vs a
+ * failure that should surface its native error. Checks the `.code` (numeric or
+ * string form) first, then falls back to the error message for the builds that
+ * throw these with no usable code. The caller gates this on Platform.OS ===
+ * 'android' && provider === 'google'.
+ */
+export function isRecoverableAndroidGoogleSignInError(error: unknown): boolean {
+  const code = nativeSignInErrorCode(error);
+  if (code !== undefined && RECOVERABLE_ANDROID_GOOGLE_CODES.has(code)) return true;
+  const message = error instanceof Error ? error.message : '';
+  return message.includes('DEVELOPER_ERROR') || message.includes('INTERNAL_ERROR');
+}


### PR DESCRIPTION
## Summary

Android Google Sign-In hard-fails for affected users and can't recover. Two compounding problems (see #3100): a native config error, and #3083 having removed the only recovery path.

**This PR is the code half.** It restores an Android recovery path for the config-class Google failures — reusing the reliable `raceBrowserSignIn` fallback shipped in #3120 — so an affected user can still sign in with Google while the config fix rolls out. The config fix itself is an admin action (below).

## The config fix (NOT code — @marcodejongh, do this too)

`DEVELOPER_ERROR (10)` and most `INTERNAL_ERROR (8)` on Android Google Sign-In mean the **signing-cert SHA-1 + package name for the shipped build isn't registered against the Google Cloud OAuth client**. The recovery path below unblocks users, but the real fix is registering the cert. Runbook:

1. **Play App Signing SHA-1 (the one that actually ships).** Play Console → your app → **Test and release → App integrity → App signing** → copy the **SHA-1 of the "App signing key certificate"** (Google's re-signing key). This is the cert production installs run under — **not** the upload key. This is the SHA-1 that halted the June rollout.
2. **Any sideload / internal-distribution keystore SHA-1.** If internal builds (2000350–2000363) are signed with a separate keystore, get its SHA-1 too: `apksigner verify --print-certs <apk>` (or `keytool -list -v -keystore <ks>`). See `docs/android-sideload-build.md`.
3. In **Google Cloud Console → APIs & Services → Credentials**, for the **Android OAuth client** with package `com.boardsesh.app`, register **both** SHA-1s (Play App Signing + any sideload keystore). Confirm the package name matches and the web client ID (the idToken audience) is the one the app configures.
4. Re-test native Google sign-in on a build signed with each cert — a correctly-registered SHA-1 stops throwing `DEVELOPER_ERROR`/`INTERNAL_ERROR`.

## What changed (code)

Reinstate the Android Google web-OAuth fallback, **strictly** for the two config-class native throws that dead-end login — reversing the iOS-only gate from #3083 (`d35247c47`).

- `native-auth-analytics.ts` — new pure, tested `isRecoverableAndroidGoogleSignInError(error)`. PostHog (120d, `Login Failed` / `$os=Android` / `google`) shows GMS surfaces these **three ways** across builds, so the matcher covers all: numeric `.code` (`8`=58 events, `10`=13), string `.code` (`INTERNAL_ERROR`), and — on builds 350+ — **no usable `.code`, the name only in the message** (`DEVELOPER_ERROR: Follow troubleshooting…`, 6 events). `NETWORK_ERROR (7)` and friends are deliberately excluded.
- `use-native-oauth-sign-in.ts` — **catch path only.** `willFallBack = iOS || (android && google && isRecoverableAndroidGoogleSignInError(error))`; drives both the fallback gate and the `recoverable` analytics tag. The native-result-failure path stays iOS-only (config errors are throws, never returns). Recovery reuses `runWebFallback` → `signInWithGoogleWeb` → `raceBrowserSignIn`, so Android fallback events are already tagged `flow=web_fallback fallback_mechanism=browser_deeplink`.

## Why this reverses #3083 safely

#3083 gated the fallback to iOS because the **old** fallback (`WebBrowser.openAuthSessionAsync`) didn't reliably return `com.boardsesh.app://auth/callback` on Android — a silent "never logs in." #3120 replaced that primitive with `raceBrowserSignIn` (openBrowserAsync + a `Linking` url-listener), the standard reliable Android custom-scheme deep-link path (and what the legacy Capacitor app used), and #3120's `+native-intent.ts` guard already returns `''` for `auth/callback` on all platforms. So the original blocker is gone. The trade-off #3083 chose — surface native errors vs recover — flips because telemetry now distinguishes the mechanism (`fallback_mechanism`), and the config errors it wanted to surface (DEVELOPER_ERROR/INTERNAL_ERROR) also reach Sentry via the native `Login Failed`/`recoverable:true` event and this PR's admin runbook, so we keep visibility while un-dead-ending users.

## Scope notes

- **Strict:** only `DEVELOPER_ERROR`/`INTERNAL_ERROR` (+ numeric `10`/`8`). `PLAY_SERVICES_NOT_AVAILABLE`, `NETWORK_ERROR`, cancels, and unknowns keep surfacing their native error.
- **#3088 hygiene:** the query showed **no** `google/cancel` landing as an exception — google cancels are already classified correctly — so no cancel-code change was needed here. (The "user canceled" events that *do* land as exceptions are all **Apple on iOS**, 82 in 120d — that's #3088's actual content, out of scope for this Android-Google PR.)

## OTA note

JS-only (a pure helper + hook gate + tests), no native dep/config change → **no fingerprint change** → ships to the already-shipped Android 2.0 binary (affected builds 2000350–2000363) via production OTA. The value: the SHA-1 fix needs a store rebuild, but this recovery path reaches affected users over the air now.

## Device-test checklist for @marcodejongh (Android)

- [ ] On a build whose SHA-1 is **not** registered (repro `DEVELOPER_ERROR`/`INTERNAL_ERROR`): tap Google → native fails → **browser fallback presents** → complete → land signed in.
- [ ] The `com.boardsesh.app://auth/callback` deep link returns to the app (the one thing CI can't prove) — no `+not-found` flash, no stuck Custom Tab blocking sign-in.
- [ ] Real cancel: dismiss the Google sheet → no browser fallback, no error toast, logged `Login Cancelled` (not `Login Failed`).
- [ ] A non-config failure (e.g. airplane mode → `NETWORK_ERROR`) still surfaces the native error, no browser.
- [ ] After the SHA-1 registration lands: native Google succeeds directly, fallback never runs.
- [ ] Post-OTA PostHog: `$os=Android` `flow=web_fallback` `fallback_mechanism=browser_deeplink` shows real `Login Succeeded`.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 3920 tests pass, incl. new `isRecoverableAndroidGoogleSignInError` unit cases (all three GMS representations + strict-exclusion set) and rewritten Android hook cases (DEVELOPER_ERROR string / INTERNAL_ERROR numeric / message-only DEVELOPER_ERROR all recover; NETWORK_ERROR + returned-failure + cancel + Apple-on-Android do not).
- `vp run check:mobile-bundle` — Metro bundle OK.
- `vp check` — 0 errors.

## Release Notes

- Google sign-in on Android now recovers through the browser instead of dead-ending when the native sign-in hits a configuration error.

Fixes #3100
