### PR TITLE
fix: silently clear session on NOT_SESSION_MEMBER subscription denial

### DIFF
--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -17,6 +17,7 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { parseBoardPath, parseNamedBoardPath } from '@boardsesh/board-config';
 import type { SessionUser, SubscriptionQueueEvent, UserBoard } from '@boardsesh/shared-schema';
 import { emitWallConfirm } from '@boardsesh/play-view';
+import { isNotSessionMemberError } from '@boardsesh/graphql-client';
 import { getWsClient } from '../../lib/graphql/ws-client';
 import {
   QUEUE_UPDATES_SUBSCRIPTION,
@@ -369,7 +370,20 @@ export function useSessionRealtime({
                 break;
             }
           },
-          error: () => {
+          error: (subscriptionError) => {
+            // The server denied our queue subscription because this connection
+            // isn't a member of the session (NOT_SESSION_MEMBER). Post-#3695 an
+            // authenticated member reconnecting is re-authorized instantly, so
+            // reaching here means the session is genuinely gone for us
+            // (ended / emptied / a stale pointer) — clear the local session
+            // silently. A "Queue sync error" toast for a session that no longer
+            // exists is just noise. (#2385 follow-up.) Guarded on the still-
+            // active session so a late error from a superseded A→B switch can't
+            // clear the new session.
+            if (sessionIdRef.current === sessionId && isNotSessionMemberError(subscriptionError)) {
+              void clearSessionRef.current();
+              return;
+            }
             // i18n-keep session:mobile.queue.syncError — called through `tRef.current`,
             // which the orphan checker can't trace back to the session-bound `t`.
             showToastRef.current(tRef.current('mobile.queue.syncError'), 'error');

--- a/packages/shared/graphql-client/src/__tests__/errors.test.ts
+++ b/packages/shared/graphql-client/src/__tests__/errors.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { GraphQLOperationError, parseRateLimitError, isRateLimitedError } from '../errors';
+import {
+  GraphQLOperationError,
+  parseRateLimitError,
+  isRateLimitedError,
+  isNotSessionMemberExtension,
+  isNotSessionMemberError,
+} from '../errors';
 
 describe('parseRateLimitError', () => {
   it('reads retryAfterSeconds from the structured RATE_LIMITED extension', () => {
@@ -45,5 +51,77 @@ describe('parseRateLimitError', () => {
     expect(parseRateLimitError(new Error('network down'))).toBeNull();
     expect(parseRateLimitError('rate limit exceeded. try again in 1 seconds.')).toBeNull();
     expect(parseRateLimitError(null)).toBeNull();
+  });
+});
+
+describe('isNotSessionMemberExtension', () => {
+  it('matches the NOT_SESSION_MEMBER code and narrows the reason', () => {
+    const extensions = { code: 'NOT_SESSION_MEMBER', reason: 'no-session-id' };
+    expect(isNotSessionMemberExtension(extensions)).toBe(true);
+    if (isNotSessionMemberExtension(extensions)) {
+      // Type narrowing: `reason` is accessible without a cast.
+      expect(extensions.reason).toBe('no-session-id');
+    }
+  });
+
+  it('does not match other codes, null, or undefined', () => {
+    expect(isNotSessionMemberExtension({ code: 'RATE_LIMITED' })).toBe(false);
+    expect(isNotSessionMemberExtension({ code: 'SESSION_ENDED' })).toBe(false);
+    expect(isNotSessionMemberExtension(null)).toBe(false);
+    expect(isNotSessionMemberExtension(undefined)).toBe(false);
+  });
+});
+
+describe('isNotSessionMemberError', () => {
+  it('is true for a GraphQLOperationError carrying NOT_SESSION_MEMBER', () => {
+    const error = new GraphQLOperationError([
+      {
+        message: 'Unauthorized: not in any session',
+        extensions: { code: 'NOT_SESSION_MEMBER', reason: 'no-session-id' },
+      },
+    ]);
+    expect(isNotSessionMemberError(error)).toBe(true);
+  });
+
+  it('finds NOT_SESSION_MEMBER even when a DIFFERENTLY-coded error comes first', () => {
+    // The harder case: `GraphQLOperationError.extensions` resolves to the first
+    // *coded* error (here SESSION_ENDED), so the guard must iterate every error
+    // rather than trust that convenience field.
+    const error = new GraphQLOperationError([
+      { message: 'This session has ended', extensions: { code: 'SESSION_ENDED' } },
+      {
+        message: 'Unauthorized: session mismatch',
+        extensions: { code: 'NOT_SESSION_MEMBER', reason: 'session-mismatch' },
+      },
+    ]);
+    expect(isNotSessionMemberError(error)).toBe(true);
+  });
+
+  it('is true for a raw graphql-ws GraphQLError[] payload (mobile client.subscribe sink)', () => {
+    // graphql-ws hands a `client.subscribe` sink's `error` callback the raw
+    // error array — mobile session subscriptions never box it into a
+    // GraphQLOperationError, so the guard must recognise this shape too.
+    const rawPayload = [
+      {
+        message: 'Unauthorized: not in any session',
+        extensions: { code: 'NOT_SESSION_MEMBER', reason: 'no-session-id' },
+      },
+    ];
+    expect(isNotSessionMemberError(rawPayload)).toBe(true);
+  });
+
+  it('is false for a raw payload carrying a different code, or malformed entries', () => {
+    expect(isNotSessionMemberError([{ message: 'x', extensions: { code: 'RATE_LIMITED' } }])).toBe(false);
+    expect(isNotSessionMemberError([{ message: 'no extensions' }])).toBe(false);
+    expect(isNotSessionMemberError([null, 'nope'])).toBe(false);
+    expect(isNotSessionMemberError([])).toBe(false);
+  });
+
+  it('is false for other GraphQL errors, plain errors, and non-errors', () => {
+    expect(
+      isNotSessionMemberError(new GraphQLOperationError([{ message: 'x', extensions: { code: 'SESSION_ENDED' } }])),
+    ).toBe(false);
+    expect(isNotSessionMemberError(new Error('Unauthorized: not in any session'))).toBe(false);
+    expect(isNotSessionMemberError(null)).toBe(false);
   });
 });

--- a/packages/shared/graphql-client/src/errors.ts
+++ b/packages/shared/graphql-client/src/errors.ts
@@ -44,6 +44,52 @@ export function isRateLimitedExtension(
 }
 
 /**
+ * Type guard for the NOT_SESSION_MEMBER extension shape. The backend's
+ * subscription-auth gate (`requireSessionMember`) rejects a caller who isn't a
+ * member of the session (issues #2355 / #2385). Since #3695 an authenticated
+ * member reconnecting is re-authorized instantly, so this code reaching a
+ * client means the session is genuinely gone for it (ended / emptied / a stale
+ * pointer) — the caller should clear the local session silently rather than
+ * surface a generic sync-error toast. `reason` (`no-session-id` |
+ * `session-mismatch`) is carried for observability.
+ */
+export function isNotSessionMemberExtension(
+  extensions: GraphQLErrorExtensions | null | undefined,
+): extensions is GraphQLErrorExtensions & { code: 'NOT_SESSION_MEMBER'; reason?: string } {
+  return extensions?.code === 'NOT_SESSION_MEMBER';
+}
+
+/** Convenience: does this error carry the NOT_SESSION_MEMBER code? Narrows
+ *  `unknown` for call-sites that only hold the thrown/callback value.
+ *
+ *  Handles both shapes a client can see:
+ *   - a `GraphQLOperationError` — from `execute()` or the `subscribe()` wrapper
+ *     (web's session subscriptions, board-presence);
+ *   - a raw `GraphQLError[]` payload — delivered straight to a graphql-ws
+ *     `client.subscribe` sink's `error` callback (mobile's session
+ *     subscriptions call the ws client directly, so they never pass through the
+ *     `subscribe()` wrapper that would box the array into a
+ *     `GraphQLOperationError`). */
+export function isNotSessionMemberError(error: unknown): boolean {
+  if (error instanceof GraphQLOperationError) {
+    // Iterate every error, not just `error.extensions` — that convenience field
+    // resolves to the FIRST *coded* error, so a NOT_SESSION_MEMBER that trails
+    // another coded error would be missed. Mirrors `parseRateLimitError`'s
+    // graphqlErrors fallback.
+    return error.graphqlErrors.some((graphqlError) => isNotSessionMemberExtension(graphqlError.extensions));
+  }
+  if (Array.isArray(error)) {
+    return error.some(
+      (item): boolean =>
+        typeof item === 'object' &&
+        item !== null &&
+        (item as { extensions?: { code?: unknown } }).extensions?.code === 'NOT_SESSION_MEMBER',
+    );
+  }
+  return false;
+}
+
+/**
  * Error subclass that preserves GraphQL error extensions. Callers can inspect
  * `extensions.code` (or any other extension keys) to branch on a typed error
  * — e.g. CLIMB_IS_DUPLICATE — without resorting to message-string matching.

--- a/packages/shared/graphql-client/src/index.ts
+++ b/packages/shared/graphql-client/src/index.ts
@@ -19,6 +19,8 @@ export {
   GraphQLOperationError,
   isClimbDuplicateExtension,
   isRateLimitedExtension,
+  isNotSessionMemberExtension,
+  isNotSessionMemberError,
   parseRateLimitError,
   isRateLimitedError,
 } from './errors';

--- a/packages/web/app/components/persistent-session/__tests__/session-connection-ports-not-member.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/session-connection-ports-not-member.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { MutableRefObject } from 'react';
+import { GraphQLOperationError } from '@boardsesh/graphql-client';
+import { createQueueSyncGate } from '@boardsesh/queue-runtime';
+import type { ActiveSessionInfo } from '../types';
+import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
+
+// The onError NOT_SESSION_MEMBER branch clears the persisted session id via
+// removePreference — mock it so the test can assert the clear without IndexedDB.
+const removePreferenceMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+vi.mock('@/app/lib/user-preferences-db', () => ({ removePreference: removePreferenceMock }));
+
+import { createWebSessionConnectionDeps } from '../hooks/session-connection-ports';
+
+function buildArgs() {
+  const setActiveSession = vi.fn();
+  const setError = vi.fn();
+  const setIsConnecting = vi.fn();
+  const args = {
+    activeSession: {
+      sessionId: 's1',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: { board_name: 'kilter' } as unknown as ActiveSessionInfo['boardDetails'],
+      parsedParams: { board_name: 'kilter' } as unknown as ActiveSessionInfo['parsedParams'],
+    } as ActiveSessionInfo,
+    backendUrl: 'ws://localhost:8080/graphql',
+    syncGate: createQueueSyncGate(),
+    refs: {
+      wsAuthTokenRef: { current: null } as MutableRefObject<string | null>,
+      usernameRef: { current: undefined } as MutableRefObject<string | undefined>,
+      avatarUrlRef: { current: undefined } as MutableRefObject<string | undefined>,
+      queueRef: { current: [] } as MutableRefObject<LocalClimbQueueItem[]>,
+      currentClimbQueueItemRef: { current: null } as MutableRefObject<LocalClimbQueueItem | null>,
+    },
+    pendingInitialQueueRef: { current: null },
+    handleQueueEvent: vi.fn(),
+    handleSessionEvent: vi.fn(),
+    setActiveSession,
+    setClient: vi.fn(),
+    setSession: vi.fn(),
+    setIsConnecting,
+    setError,
+    setHasConnected: vi.fn(),
+  };
+  return { args, setActiveSession, setError, setIsConnecting };
+}
+
+describe('createWebSessionConnectionDeps — onError NOT_SESSION_MEMBER handling (#2385 follow-up)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('force-clears the persisted + active session on a NOT_SESSION_MEMBER error, without the generic error path', () => {
+    const { args, setActiveSession, setError, setIsConnecting } = buildArgs();
+    const deps = createWebSessionConnectionDeps(args);
+
+    deps.onError(
+      new GraphQLOperationError([
+        {
+          message: 'Unauthorized: not in any session',
+          extensions: { code: 'NOT_SESSION_MEMBER', reason: 'no-session-id' },
+        },
+      ]),
+    );
+
+    expect(removePreferenceMock).toHaveBeenCalledTimes(1);
+    expect(setActiveSession).toHaveBeenCalledWith(null);
+    // The generic error path (which would keep the session and surface an error)
+    // must not run.
+    expect(setError).not.toHaveBeenCalled();
+    expect(setIsConnecting).not.toHaveBeenCalled();
+  });
+
+  it('routes a generic connection error to setError and does not clear the session', () => {
+    const { args, setActiveSession, setError, setIsConnecting } = buildArgs();
+    const deps = createWebSessionConnectionDeps(args);
+
+    const genericError = new Error('WebSocket closed');
+    deps.onError(genericError);
+
+    expect(setActiveSession).not.toHaveBeenCalled();
+    expect(removePreferenceMock).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenCalledWith(genericError);
+    expect(setIsConnecting).toHaveBeenCalledWith(false);
+  });
+
+  it('does not clear on a different coded error (e.g. RATE_LIMITED)', () => {
+    const { args, setActiveSession, setError } = buildArgs();
+    const deps = createWebSessionConnectionDeps(args);
+
+    deps.onError(
+      new GraphQLOperationError([{ message: 'slow down', extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 5 } }]),
+    );
+
+    expect(setActiveSession).not.toHaveBeenCalled();
+    expect(removePreferenceMock).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/app/components/persistent-session/hooks/session-connection-ports.ts
+++ b/packages/web/app/components/persistent-session/hooks/session-connection-ports.ts
@@ -11,6 +11,11 @@ import {
   MAX_RETRY_DELAY_MS,
   BACKOFF_MULTIPLIER,
   MAX_TRANSIENT_RETRIES,
+  // Imported from the shared package directly (not the web re-export) so the
+  // many web tests that vi.mock('../../graphql-queue/graphql-client') don't
+  // each need to add this export to their factory — @boardsesh/graphql-client
+  // is never mocked in web tests.
+  isNotSessionMemberError,
 } from '@boardsesh/graphql-client';
 import {
   JOIN_SESSION,
@@ -383,6 +388,20 @@ export function createWebSessionConnectionDeps({
     },
 
     onError: (err) => {
+      // The queue subscription was denied because we're not a member of this
+      // session (NOT_SESSION_MEMBER). Post-#3695 an authenticated member is
+      // re-authorized instantly on reconnect, so reaching here means the
+      // session is genuinely gone for us — force-clear it now instead of
+      // burning MAX_TRANSIENT_RETRIES subscription-recovery strikes before
+      // `onFatal` does the same. Mirrors the SESSION_ENDED join-path branch.
+      // (#2385 follow-up.) setActiveSession(null) pre-empts the controller's
+      // scheduled retry via the React re-render, exactly like SESSION_ENDED.
+      if (isNotSessionMemberError(err)) {
+        if (DEBUG) console.info('[PersistentSession] Not a session member; clearing stored session');
+        removePreference(ACTIVE_SESSION_KEY).catch(() => {});
+        setActiveSession(null);
+        return;
+      }
       console.error('[PersistentSession] Connection error:', err);
       setError(err instanceof Error ? err : new Error(String(err)));
       setIsConnecting(false);


### PR DESCRIPTION
## Summary

Follow-up to #3695 (part of #2385) — the client half.

The backend now rejects a non-member's queue/session subscription with a typed `NOT_SESSION_MEMBER` extension (#3695), and the shared `subscribe()` wrapper forwards subscription-error extensions to callers (#3690). This PR wires the clients to that code: when a subscription is denied because the caller isn't a member of the session, the session is genuinely gone for it (ended / emptied / a stale pointer) — so clear the local session **silently** instead of surfacing a generic "Queue sync error".

- **Shared (`@boardsesh/graphql-client`)** — add `isNotSessionMemberExtension` + `isNotSessionMemberError` guards (mirroring `isRateLimitedExtension` / `isRateLimitedError`). `isNotSessionMemberError` classifies **both** shapes a client can see:
  - a `GraphQLOperationError` — web / board-presence, via the `subscribe()` wrapper;
  - a raw `GraphQLError[]` payload — mobile's session subscriptions call the graphql-ws client's `.subscribe` directly, so their error callback never passes through the wrapper that would box the array. Handling both is why the guard lives in the shared package rather than inline in each client.
- **Mobile (`use-session-realtime`)** — the `queueUpdates` error callback clears the local session silently on `NOT_SESSION_MEMBER` (no `mobile.queue.syncError` toast). Guarded on the still-active session so a late error from a superseded A→B switch can't clear the new one. The generic transport-error toast is untouched for every other error.
- **Web (`session-connection-ports`)** — `onError` force-clears the persisted + active session on `NOT_SESSION_MEMBER` instead of burning `MAX_TRANSIENT_RETRIES` subscription-recovery strikes before `onFatal` clears it anyway. Mirrors the existing `SESSION_ENDED` join-path branch; `setActiveSession(null)` pre-empts the controller's scheduled retry via the React re-render.

### Why now

Post-#3695 an authenticated member reconnecting is re-authorized instantly (durable-membership fast-path), so a `NOT_SESSION_MEMBER` reaching a client is no longer a transient reconnect race — it's authoritative "you're not in this session". Acting on it is safe and removes the last user-visible noise from the original bug.

## Release Notes

- No more spurious "Queue sync error" when a party session you were in has ended or moved on — the app quietly drops the stale session instead.

## Test plan

- **Shared** (`@boardsesh/graphql-client`, `errors.test.ts`) — `isNotSessionMemberExtension` matches the code and narrows `reason`; `isNotSessionMemberError` is true for a `GraphQLOperationError`, for the code appearing anywhere in the array, and for a raw graphql-ws `GraphQLError[]` payload; false for other codes, plain errors, malformed/empty arrays, and non-errors. (37/37 in the graphql-client project.)
- **Web** (new `session-connection-ports-not-member.test.ts`) — `createWebSessionConnectionDeps(...).onError`: a `NOT_SESSION_MEMBER` error clears the persisted + active session and skips the generic error path; a generic error routes to `setError` and does not clear; a different coded error (`RATE_LIMITED`) does not clear.
- **Mobile** — the branch is thin wiring over the shared-tested guard + the existing `clearSession` path (no bespoke mobile hook test). `vp run test:mobile` (3915 pass), `vp run typecheck:mobile`, `vp run check:mobile-bundle` (OK) all green.
- Full `vp run typecheck` (exit 0), `vp check` (0 errors), web persistent-session suite (146 pass — one pre-existing unrelated unhandled-rejection artifact in `join-ended-session.test.tsx`, reproduces on its own and is untouched here).
