### PR TITLE
fix(mobile): default bug report contact consent to opt-out

### DIFF
--- a/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
+++ b/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
@@ -43,7 +43,7 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
   const [selectedRating, setSelectedRating] = useState<number | null>(null);
   const [comment, setComment] = useState('');
   const [captureBleDiag, setCaptureBleDiag] = useState(false);
-  const [contactConsent, setContactConsent] = useState(false);
+  const [contactConsent, setContactConsent] = useState(true);
 
   const isBugReport = mode === 'bug';
   const trimmedComment = comment.trim();
@@ -57,7 +57,7 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
     setSelectedRating(null);
     setComment('');
     setCaptureBleDiag(false);
-    setContactConsent(false);
+    setContactConsent(true);
     reset();
   }, [mode, reset]);
 
@@ -92,7 +92,7 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
       showToast(isBugReport ? t('feedbackDialog.successBug') : t('feedbackDialog.successRating'), 'success');
       setSelectedRating(null);
       setComment('');
-      setContactConsent(false);
+      setContactConsent(true);
     } catch {
       showToast(t('feedbackDialog.errorRating'), 'error');
     }

--- a/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
@@ -44,6 +44,14 @@ vi.mock('../../settings/SessionRecordingSwitchRow', () => ({
   SessionRecordingSwitchRow: () => createElement('div', { 'data-testid': 'session-recording-switch' }),
 }));
 
+// Real tokens.ts pulls in ios-colors.ts, which reads Platform.OS at module load —
+// stub the constants FeedbackSheet actually consumes instead of widening the
+// react-native mock to support that transitive chain.
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24 },
+  borderRadius: { lg: 12 },
+}));
+
 type SwitchRowMockProps = { label: string; value: boolean; onValueChange: (next: boolean) => void };
 vi.mock('../../SwitchRow', () => ({
   SwitchRow: ({ label, value, onValueChange }: SwitchRowMockProps) =>

--- a/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
@@ -136,9 +136,7 @@ describe('FeedbackSheet bug report contact consent', () => {
     });
     fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);
     await vi.waitFor(() => expect(feedbackMutation.mutateAsync).toHaveBeenCalledTimes(1));
-    expect(feedbackMutation.mutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ contactConsent: true }),
-    );
+    expect(feedbackMutation.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ contactConsent: true }));
   });
 
   it('respects an explicit opt-out when the reporter flips the switch off', async () => {
@@ -152,8 +150,6 @@ describe('FeedbackSheet bug report contact consent', () => {
     });
     fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);
     await vi.waitFor(() => expect(feedbackMutation.mutateAsync).toHaveBeenCalledTimes(1));
-    expect(feedbackMutation.mutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ contactConsent: false }),
-    );
+    expect(feedbackMutation.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ contactConsent: false }));
   });
 });

--- a/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
@@ -160,4 +160,18 @@ describe('FeedbackSheet bug report contact consent', () => {
     await vi.waitFor(() => expect(feedbackMutation.mutateAsync).toHaveBeenCalledTimes(1));
     expect(feedbackMutation.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ contactConsent: false }));
   });
+
+  it('resets the switch back to on after a successful submit, even from an opt-out', async () => {
+    const sheetRef = createRef<BottomSheetModal>();
+    const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    fireEvent.click(switchRow(container)!);
+    expect(switchRow(container)?.getAttribute('data-value')).toBe('false');
+
+    fireEvent.change(getByPlaceholderText('feedbackForm.bugPlaceholder'), {
+      target: { value: 'the board disconnects on start' },
+    });
+    fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);
+    await vi.waitFor(() => expect(feedbackMutation.mutateAsync).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(switchRow(container)?.getAttribute('data-value')).toBe('true'));
+  });
 });

--- a/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, createRef, type ReactNode } from 'react';
+import type { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
+
+type ViewMockProps = { children?: ReactNode };
+vi.mock('react-native', () => ({
+  View: ({ children }: ViewMockProps) => createElement('div', {}, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+type ModalSheetMockProps = { children?: ReactNode };
+vi.mock('../../ModalSheet', () => ({
+  ModalSheet: ({ children }: ModalSheetMockProps) => createElement('div', { 'data-modal-sheet': 'true' }, children),
+}));
+
+type TextMockProps = { children?: ReactNode };
+vi.mock('../../Text', () => ({
+  Text: ({ children }: TextMockProps) => createElement('span', {}, children),
+}));
+
+vi.mock('../../Icon', () => ({
+  Icon: () => createElement('span', { 'data-icon': 'true' }),
+}));
+
+type ButtonMockProps = { title: string; onPress?: () => void; disabled?: boolean; loading?: boolean };
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress, disabled }: ButtonMockProps) =>
+    createElement('button', { onClick: onPress, disabled, 'data-button': title }),
+}));
+
+type PressableMockProps = { children?: ReactNode; onPress?: () => void; accessibilityLabel?: string };
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({ children, onPress, accessibilityLabel }: PressableMockProps) =>
+    createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+}));
+
+vi.mock('../../settings/SessionRecordingSwitchRow', () => ({
+  SessionRecordingSwitchRow: () => createElement('div', { 'data-testid': 'session-recording-switch' }),
+}));
+
+type SwitchRowMockProps = { label: string; value: boolean; onValueChange: (next: boolean) => void };
+vi.mock('../../SwitchRow', () => ({
+  SwitchRow: ({ label, value, onValueChange }: SwitchRowMockProps) =>
+    createElement('button', {
+      'data-switch': label,
+      'data-value': String(value),
+      onClick: () => onValueChange(!value),
+    }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { secondaryLabel: '#888', fill: '#eee', separator: '#ccc', label: '#000', tertiaryLabel: '#aaa' },
+    brandColors: { warning: '#f90', primary: '#60f' },
+  }),
+}));
+
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+const auth = vi.hoisted(() => ({ isAuthenticated: true }));
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: auth.isAuthenticated }),
+}));
+
+const feedbackMutation = vi.hoisted(() => ({
+  mutateAsync: vi.fn().mockResolvedValue(true),
+  isPending: false,
+  reset: vi.fn(),
+}));
+vi.mock('../../../lib/feedback/use-submit-app-feedback', () => ({
+  useSubmitMobileAppFeedback: () => feedbackMutation,
+}));
+
+vi.mock('../../../lib/ble/advertisement-recon', () => ({
+  runBleAdvertisementRecon: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../lib/discord', () => ({
+  openDiscordInvite: vi.fn(),
+}));
+
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  BottomSheetTextInput: ({
+    value,
+    onChangeText,
+    placeholder,
+  }: {
+    value?: string;
+    onChangeText?: (text: string) => void;
+    placeholder?: string;
+  }) =>
+    createElement('input', {
+      value: value ?? '',
+      placeholder,
+      onChange: (event: { target: { value: string } }) => onChangeText?.(event.target.value),
+    }),
+}));
+
+import { FeedbackSheet } from '../FeedbackSheet';
+
+describe('FeedbackSheet bug report contact consent', () => {
+  beforeEach(() => {
+    auth.isAuthenticated = true;
+    feedbackMutation.mutateAsync.mockClear();
+  });
+
+  const switchRow = (root: HTMLElement) =>
+    root.querySelector('[data-switch="feedbackForm.contactConsentLabel"]') as HTMLButtonElement | null;
+
+  it('defaults contact consent to on (opt-out) for an authenticated bug report', () => {
+    const sheetRef = createRef<BottomSheetModal>();
+    const { container } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    expect(switchRow(container)?.getAttribute('data-value')).toBe('true');
+  });
+
+  it('does not render the consent switch when unauthenticated', () => {
+    auth.isAuthenticated = false;
+    const sheetRef = createRef<BottomSheetModal>();
+    const { container } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    expect(switchRow(container)).toBeNull();
+  });
+
+  it('submits contactConsent true by default without the user touching the switch', async () => {
+    const sheetRef = createRef<BottomSheetModal>();
+    const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    fireEvent.change(getByPlaceholderText('feedbackForm.bugPlaceholder'), {
+      target: { value: 'the board disconnects on start' },
+    });
+    fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);
+    await vi.waitFor(() => expect(feedbackMutation.mutateAsync).toHaveBeenCalledTimes(1));
+    expect(feedbackMutation.mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ contactConsent: true }),
+    );
+  });
+
+  it('respects an explicit opt-out when the reporter flips the switch off', async () => {
+    const sheetRef = createRef<BottomSheetModal>();
+    const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    fireEvent.click(switchRow(container)!);
+    expect(switchRow(container)?.getAttribute('data-value')).toBe('false');
+
+    fireEvent.change(getByPlaceholderText('feedbackForm.bugPlaceholder'), {
+      target: { value: 'the board disconnects on start' },
+    });
+    fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);
+    await vi.waitFor(() => expect(feedbackMutation.mutateAsync).toHaveBeenCalledTimes(1));
+    expect(feedbackMutation.mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ contactConsent: false }),
+    );
+  });
+});

--- a/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
@@ -174,4 +174,15 @@ describe('FeedbackSheet bug report contact consent', () => {
     await vi.waitFor(() => expect(feedbackMutation.mutateAsync).toHaveBeenCalledTimes(1));
     await vi.waitFor(() => expect(switchRow(container)?.getAttribute('data-value')).toBe('true'));
   });
+
+  it('resets the switch back to on when the sheet mode changes away and back', () => {
+    const sheetRef = createRef<BottomSheetModal>();
+    const { container, rerender } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    fireEvent.click(switchRow(container)!);
+    expect(switchRow(container)?.getAttribute('data-value')).toBe('false');
+
+    rerender(<FeedbackSheet sheetRef={sheetRef} mode="rating" />);
+    rerender(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    expect(switchRow(container)?.getAttribute('data-value')).toBe('true');
+  });
 });


### PR DESCRIPTION
## Summary

The "Can we contact you about this?" switch in the mobile bug report sheet (`packages/mobile/src/components/user-drawer/FeedbackSheet.tsx`) started unchecked (`contactConsent = false`), requiring reporters to actively opt in before we could follow up on a bug report. This flips the default to checked (`true`) so contact is opt-out instead of opt-in, across initial state, the mode-change reset effect, and the post-submit reset.

Web's bug report form has no contact-consent toggle at all yet (`packages/web/app/components/feedback/feedback-form.tsx` / `feedback-dialog.tsx`), so this change is scoped to mobile, the only surface with the switch today.

## Release Notes

- Bug reports now default to letting us follow up with you — flip the switch off if you'd rather we didn't.

## Test plan

- [ ] `vp run typecheck:mobile` (not runnable in this sandbox — no `node_modules`/`vp` installed)
- Manual: open the bug report sheet while signed in and confirm the "Can we contact you about this?" switch starts on.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N65fkTHFy2eAU389Wdq4WQ)_