### PR TITLE
feat: location-sync guarded 150 m match tier + user-owned gym aliasing

### DIFF
--- a/packages/aurora-sync/src/sync/locations-sync.ts
+++ b/packages/aurora-sync/src/sync/locations-sync.ts
@@ -2,6 +2,7 @@ import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import {
   formatLocationBoardName,
   resolveDefaultAuroraLocationConfig,
+  toLocationSyncLogger,
   upsertPublicBoardLocations,
   type LocationSyncSummary,
   type PublicBoardLocationInput,
@@ -59,7 +60,9 @@ export async function syncAuroraBoardLocations(args: {
 }): Promise<LocationSyncSummary> {
   const pins = await fetchAuroraPins(args.board);
   const { records, skipped } = buildAuroraLocationRecords(args.board, pins.gyms);
-  const summary = await upsertPublicBoardLocations(args.db, records);
+  const summary = await upsertPublicBoardLocations(args.db, records, {
+    logger: toLocationSyncLogger(args.log),
+  });
   const mergedSummary = {
     ...summary,
     boardsSkipped: summary.boardsSkipped + skipped.length,

--- a/packages/db/src/queries/gyms/__tests__/location-dedupe.test.ts
+++ b/packages/db/src/queries/gyms/__tests__/location-dedupe.test.ts
@@ -65,12 +65,15 @@ void describe('guarded second match tier', () => {
     assert.equal(isGenericGymName('Board House'), false);
   });
 
-  void it('exposes an all-normalized denylist', () => {
+  void it('exposes an all-normalized denylist set', () => {
     for (const name of GENERIC_GYM_NAMES) {
       assert.equal(normalizeGymName(name), name);
     }
-    assert.ok(GENERIC_GYM_NAMES.includes('home wall'));
-    assert.ok(GENERIC_GYM_NAMES.includes('kilter board'));
+    assert.ok(GENERIC_GYM_NAMES.has('home wall'));
+    assert.ok(GENERIC_GYM_NAMES.has('kilter board'));
+    assert.ok(GENERIC_GYM_NAMES.has('tension board'));
+    assert.ok(GENERIC_GYM_NAMES.has('moon board'));
+    assert.ok(GENERIC_GYM_NAMES.has('touchstone'));
   });
 });
 

--- a/packages/db/src/queries/gyms/__tests__/location-dedupe.test.ts
+++ b/packages/db/src/queries/gyms/__tests__/location-dedupe.test.ts
@@ -3,9 +3,13 @@ import assert from 'node:assert/strict';
 import {
   chooseCanonicalGymCandidate,
   distanceMeters,
+  GENERIC_GYM_NAMES,
   groupPhysicalGymCandidates,
+  GYM_MATCH_GUARDED_DISTANCE_METERS,
   gymCompletenessScore,
+  isGenericGymName,
   normalizeGymName,
+  PHYSICAL_GYM_MATCH_DISTANCE_METERS,
   type CanonicalGymCandidate,
 } from '../location-dedupe';
 
@@ -39,6 +43,34 @@ void describe('normalizeGymName', () => {
 void describe('distanceMeters', () => {
   void it('returns small distances for near-identical coordinates', () => {
     assert.ok(distanceMeters(candidate({}), candidate({ latitude: -33.83542, longitude: 151.0531 })) < 2);
+  });
+});
+
+void describe('guarded second match tier', () => {
+  void it('sits above the unconditional 20 m tier', () => {
+    assert.equal(GYM_MATCH_GUARDED_DISTANCE_METERS, 150);
+    assert.ok(GYM_MATCH_GUARDED_DISTANCE_METERS > PHYSICAL_GYM_MATCH_DISTANCE_METERS);
+  });
+
+  void it('flags generic names case- and whitespace-insensitively', () => {
+    assert.equal(isGenericGymName('Home Wall'), true);
+    assert.equal(isGenericGymName('  HOME   WALL '), true);
+    assert.equal(isGenericGymName('garage'), true);
+    assert.equal(isGenericGymName('Kilter Board'), true);
+    assert.equal(isGenericGymName('MoonBoard'), true);
+  });
+
+  void it('does not flag a real gym name', () => {
+    assert.equal(isGenericGymName('Sandbox Bouldering'), false);
+    assert.equal(isGenericGymName('Board House'), false);
+  });
+
+  void it('exposes an all-normalized denylist', () => {
+    for (const name of GENERIC_GYM_NAMES) {
+      assert.equal(normalizeGymName(name), name);
+    }
+    assert.ok(GENERIC_GYM_NAMES.includes('home wall'));
+    assert.ok(GENERIC_GYM_NAMES.includes('kilter board'));
   });
 });
 

--- a/packages/db/src/queries/gyms/__tests__/location-dedupe.test.ts
+++ b/packages/db/src/queries/gyms/__tests__/location-dedupe.test.ts
@@ -65,6 +65,13 @@ void describe('guarded second match tier', () => {
     assert.equal(isGenericGymName('Board House'), false);
   });
 
+  void it('never denylists a real gym-chain name', () => {
+    // Touchstone is a real chain whose provider pins drift 40-90 m: it MUST be
+    // allowed to auto-merge at the guarded tier, so it stays out of the set.
+    assert.equal(isGenericGymName('Touchstone'), false);
+    assert.equal(GENERIC_GYM_NAMES.has('touchstone'), false);
+  });
+
   void it('exposes an all-normalized denylist set', () => {
     for (const name of GENERIC_GYM_NAMES) {
       assert.equal(normalizeGymName(name), name);
@@ -73,7 +80,7 @@ void describe('guarded second match tier', () => {
     assert.ok(GENERIC_GYM_NAMES.has('kilter board'));
     assert.ok(GENERIC_GYM_NAMES.has('tension board'));
     assert.ok(GENERIC_GYM_NAMES.has('moon board'));
-    assert.ok(GENERIC_GYM_NAMES.has('touchstone'));
+    assert.ok(GENERIC_GYM_NAMES.has('soill'));
   });
 });
 

--- a/packages/db/src/queries/gyms/location-dedupe.ts
+++ b/packages/db/src/queries/gyms/location-dedupe.ts
@@ -1,5 +1,16 @@
 export const PHYSICAL_GYM_MATCH_DISTANCE_METERS = 20;
 
+/**
+ * Guarded second match tier for the location-sync importer.
+ *
+ * The unconditional 20 m tier only catches cross-provider pins that land almost
+ * on top of each other. Prod data shows the same physical gym drifts 40–90 m
+ * between providers, so a wider tier is needed to stop every new provider
+ * minting a twin. To avoid false merges in dense urban areas the wider tier only
+ * fires for a specific, non-generic name (see {@link GENERIC_GYM_NAMES}).
+ */
+export const GYM_MATCH_GUARDED_DISTANCE_METERS = 150;
+
 const EARTH_RADIUS_METERS = 6_371_000;
 const MISSING_CREATED_AT = Number.POSITIVE_INFINITY;
 
@@ -31,16 +42,22 @@ export function normalizeGymName(name: string): string {
 }
 
 /**
- * Normalized gym names too generic to be a reliable physical identity. These are
- * prod's biggest name-collision classes — home-wall / garage pins and bare board
- * brands the location sync mints at residential coordinates. A first board named
- * one of these must NOT auto-attach to a stranger's nearby gym (a claimable SYSTEM
- * pin), since a false attach ultimately hands board-edit control to whoever claims
- * that gym. The suggest surface is unaffected (suggest-never-block).
+ * Normalized names too generic to safely match at the guarded (150 m) tier.
+ * Built from prod reality: home walls, garages, cellars, and bare board-brand
+ * names show up on unrelated gyms all over a city. Entries are already
+ * normalized (lowercase, single-spaced) and matched EXACTLY on the whole name
+ * (see {@link isGenericGymName}) — never as a substring, so `Kilter Kingpin` or
+ * `Tension Climbing Co` are NOT generic and still dedupe at 150 m.
  *
- * Compare with `isGenericGymName` (normalized) rather than raw membership.
+ * Trade-off: a commercial gym named exactly `Tension` or `Moon` won't auto-merge
+ * across providers at the guarded tier; it still merges at the 20 m tier, and
+ * the admin dedup queue catches the rest. A standalone board-brand name collides
+ * across unrelated home setups far more often than it names a real gym.
+ *
+ * NOTE (cross-PR): #3701 declares this same `GENERIC_GYM_NAMES` set here too.
+ * Whoever merges second reconciles the two to the union of both lists.
  */
-export const GENERIC_GYM_NAMES: ReadonlySet<string> = new Set([
+export const GENERIC_GYM_NAMES: ReadonlySet<string> = new Set<string>([
   'home wall',
   'homewall',
   'home',
@@ -52,11 +69,18 @@ export const GENERIC_GYM_NAMES: ReadonlySet<string> = new Set([
   'tension',
   'tension board',
   'moonboard',
-  'moon',
   'moon board',
+  'moon',
+  'grasshopper',
+  'decoy',
+  'soill',
+  'touchstone',
 ]);
 
-/** Whether a gym name is too generic to anchor an auto-attach (normalized comparison). */
+/**
+ * True when a gym name is too generic to match at the guarded (150 m) tier.
+ * Normalizes first, so casing and repeated whitespace never matter.
+ */
 export function isGenericGymName(name: string): boolean {
   return GENERIC_GYM_NAMES.has(normalizeGymName(name));
 }
@@ -179,60 +203,4 @@ export function groupPhysicalGymCandidates<T extends CanonicalGymCandidate>(
   return clusters.sort((firstCluster, secondCluster) =>
     firstCluster.normalizedName.localeCompare(secondCluster.normalizedName),
   );
-}
-
-/**
- * Guarded second match tier for the location-sync importer.
- *
- * The unconditional tier (`PHYSICAL_GYM_MATCH_DISTANCE_METERS`, 20 m) only
- * catches cross-provider pins that land almost on top of each other. Prod data
- * shows the same physical gym drifts 40–90 m between providers, so a wider tier
- * is needed to stop every new provider minting a twin. To avoid false merges in
- * dense urban areas, the wider tier only fires for a specific, non-generic
- * normalized name — generic names (`home wall`, `garage`, bare board brands, …)
- * are far too likely to collide across genuinely distinct walls, so they only
- * ever match at the 20 m tier.
- */
-export const GYM_MATCH_GUARDED_DISTANCE_METERS = 150;
-
-/**
- * Normalized names that are too generic to safely match at the guarded (150 m)
- * tier. Built from prod reality: home walls, garages, cellars, and bare board
- * brand names show up on unrelated gyms all over a city. Compared
- * case-insensitively against the already-normalized gym name (see
- * `isGenericGymName`), so entries here are lowercase and single-spaced.
- *
- * Kept as an append-only exported constant so it can be shared with the gym
- * dedup admin tooling without a rebase conflict.
- *
- * Matching is exact on the whole normalized name, never a substring — so
- * `Kilter Kingpin` or `Tension Climbing Co` are NOT generic and still dedupe at
- * 150 m. The trade-off is that a commercial gym named exactly `Tension` or
- * `Moon` won't auto-merge across providers at the guarded tier; it still merges
- * at the 20 m tier, and the admin dedup queue catches the rest. Board-brand
- * names used as a standalone gym name collide across unrelated home setups far
- * more often than they name a real gym, so this is the safe default.
- */
-export const GENERIC_GYM_NAMES: readonly string[] = [
-  'home wall',
-  'homewall',
-  'home',
-  'garage',
-  'cellar',
-  'basement',
-  'kilter',
-  'kilter board',
-  'tension',
-  'moonboard',
-  'moon',
-];
-
-const GENERIC_GYM_NAME_SET = new Set<string>(GENERIC_GYM_NAMES);
-
-/**
- * True when a gym name is too generic to match at the guarded (150 m) tier.
- * Normalizes first, so casing and repeated whitespace never matter.
- */
-export function isGenericGymName(name: string): boolean {
-  return GENERIC_GYM_NAME_SET.has(normalizeGymName(name));
 }

--- a/packages/db/src/queries/gyms/location-dedupe.ts
+++ b/packages/db/src/queries/gyms/location-dedupe.ts
@@ -43,19 +43,29 @@ export function normalizeGymName(name: string): string {
 
 /**
  * Normalized names too generic to safely match at the guarded (150 m) tier.
- * Built from prod reality: home walls, garages, cellars, and bare board-brand
- * names show up on unrelated gyms all over a city. Entries are already
- * normalized (lowercase, single-spaced) and matched EXACTLY on the whole name
- * (see {@link isGenericGymName}) — never as a substring, so `Kilter Kingpin` or
- * `Tension Climbing Co` are NOT generic and still dedupe at 150 m.
+ * Entries are already normalized (lowercase, single-spaced) and matched EXACTLY
+ * on the whole name (see {@link isGenericGymName}) — never as a substring, so
+ * `Kilter Kingpin` or `Tension Climbing Co` are NOT generic and still dedupe at
+ * 150 m.
+ *
+ * INCLUSION CRITERION — board-brand names and homewall genericisms, NOT
+ * gym-chain names. A home wall gets named after the board on it (`kilter`,
+ * `moonboard`, `moon board`, `grasshopper`, `decoy`, `soill`) or after where it
+ * lives (`garage`, `cellar`, `home wall`), so those collide across unrelated
+ * setups all over a city — denylisting them is safe. A real gym CHAIN
+ * (Touchstone, etc.) is the opposite case: its provider pins DO drift 40–90 m
+ * and MUST auto-merge, so a chain name must never go in this set even though it
+ * "looks brand-y". When adding an entry, ask: is this a board brand / homewall
+ * word, or the name of a real gym business? Only the former belongs here.
  *
  * Trade-off: a commercial gym named exactly `Tension` or `Moon` won't auto-merge
  * across providers at the guarded tier; it still merges at the 20 m tier, and
- * the admin dedup queue catches the rest. A standalone board-brand name collides
- * across unrelated home setups far more often than it names a real gym.
+ * the admin dedup queue catches the rest.
  *
  * NOTE (cross-PR): #3701 declares this same `GENERIC_GYM_NAMES` set here too.
- * Whoever merges second reconciles the two to the union of both lists.
+ * Whoever merges second reconciles the two to the union of both lists — but the
+ * union must still exclude gym-chain names (e.g. `touchstone`) per the criterion
+ * above.
  */
 export const GENERIC_GYM_NAMES: ReadonlySet<string> = new Set<string>([
   'home wall',
@@ -74,7 +84,6 @@ export const GENERIC_GYM_NAMES: ReadonlySet<string> = new Set<string>([
   'grasshopper',
   'decoy',
   'soill',
-  'touchstone',
 ]);
 
 /**

--- a/packages/db/src/queries/gyms/location-dedupe.ts
+++ b/packages/db/src/queries/gyms/location-dedupe.ts
@@ -180,3 +180,51 @@ export function groupPhysicalGymCandidates<T extends CanonicalGymCandidate>(
     firstCluster.normalizedName.localeCompare(secondCluster.normalizedName),
   );
 }
+
+/**
+ * Guarded second match tier for the location-sync importer.
+ *
+ * The unconditional tier (`PHYSICAL_GYM_MATCH_DISTANCE_METERS`, 20 m) only
+ * catches cross-provider pins that land almost on top of each other. Prod data
+ * shows the same physical gym drifts 40–90 m between providers, so a wider tier
+ * is needed to stop every new provider minting a twin. To avoid false merges in
+ * dense urban areas, the wider tier only fires for a specific, non-generic
+ * normalized name — generic names (`home wall`, `garage`, bare board brands, …)
+ * are far too likely to collide across genuinely distinct walls, so they only
+ * ever match at the 20 m tier.
+ */
+export const GYM_MATCH_GUARDED_DISTANCE_METERS = 150;
+
+/**
+ * Normalized names that are too generic to safely match at the guarded (150 m)
+ * tier. Built from prod reality: home walls, garages, cellars, and bare board
+ * brand names show up on unrelated gyms all over a city. Compared
+ * case-insensitively against the already-normalized gym name (see
+ * `isGenericGymName`), so entries here are lowercase and single-spaced.
+ *
+ * Kept as an append-only exported constant so it can be shared with the gym
+ * dedup admin tooling without a rebase conflict.
+ */
+export const GENERIC_GYM_NAMES: readonly string[] = [
+  'home wall',
+  'homewall',
+  'home',
+  'garage',
+  'cellar',
+  'basement',
+  'kilter',
+  'kilter board',
+  'tension',
+  'moonboard',
+  'moon',
+];
+
+const GENERIC_GYM_NAME_SET = new Set<string>(GENERIC_GYM_NAMES);
+
+/**
+ * True when a gym name is too generic to match at the guarded (150 m) tier.
+ * Normalizes first, so casing and repeated whitespace never matter.
+ */
+export function isGenericGymName(name: string): boolean {
+  return GENERIC_GYM_NAME_SET.has(normalizeGymName(name));
+}

--- a/packages/db/src/queries/gyms/location-dedupe.ts
+++ b/packages/db/src/queries/gyms/location-dedupe.ts
@@ -204,6 +204,14 @@ export const GYM_MATCH_GUARDED_DISTANCE_METERS = 150;
  *
  * Kept as an append-only exported constant so it can be shared with the gym
  * dedup admin tooling without a rebase conflict.
+ *
+ * Matching is exact on the whole normalized name, never a substring — so
+ * `Kilter Kingpin` or `Tension Climbing Co` are NOT generic and still dedupe at
+ * 150 m. The trade-off is that a commercial gym named exactly `Tension` or
+ * `Moon` won't auto-merge across providers at the guarded tier; it still merges
+ * at the 20 m tier, and the admin dedup queue catches the rest. Board-brand
+ * names used as a standalone gym name collide across unrelated home setups far
+ * more often than they name a real gym, so this is the safe default.
  */
 export const GENERIC_GYM_NAMES: readonly string[] = [
   'home wall',

--- a/packages/kilter-sync/src/sync/locations-sync.ts
+++ b/packages/kilter-sync/src/sync/locations-sync.ts
@@ -1,6 +1,7 @@
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import {
   resolveKilterInstallConfig,
+  toLocationSyncLogger,
   type LocationSyncSummary,
   type PublicBoardLocationInput,
   type SizeEdgesInput,
@@ -167,7 +168,9 @@ export async function syncKilterLocations(args: {
   log?: (message: string) => void;
 }): Promise<LocationSyncSummary> {
   const { records, skipped } = buildKilterLocationRecords(args.reference, args.resolver);
-  const summary = await upsertPublicBoardLocations(args.db, records);
+  const summary = await upsertPublicBoardLocations(args.db, records, {
+    logger: toLocationSyncLogger(args.log),
+  });
   // Merge the upsert-side skips (e.g. invalid coordinates) with the kilter-side
   // skips (unlisted / unmapped / unsupported) and dedupe — boardsSkipped tracks
   // the deduped length so the count and the array stay in step.

--- a/packages/location-sync/src/index.ts
+++ b/packages/location-sync/src/index.ts
@@ -2,5 +2,6 @@ export * from './config';
 export * from './coords';
 export * from './dedupe';
 export * from './ids';
+export * from './logger';
 export * from './types';
 export * from './upsert';

--- a/packages/location-sync/src/logger.test.ts
+++ b/packages/location-sync/src/logger.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { noopLocationSyncLogger, toLocationSyncLogger } from './logger';
+
+describe('toLocationSyncLogger', () => {
+  it('returns the shared no-op logger when no sink is given', () => {
+    expect(toLocationSyncLogger(undefined)).toBe(noopLocationSyncLogger);
+    // No-op must not throw for either level.
+    expect(() => noopLocationSyncLogger.info('x', { a: 1 })).not.toThrow();
+    expect(() => noopLocationSyncLogger.warn('y')).not.toThrow();
+  });
+
+  it('prefixes the level and appends fields as a JSON suffix', () => {
+    const sink = vi.fn();
+    const logger = toLocationSyncLogger(sink);
+
+    logger.info('matched gym', { gymId: 7, tier: 2 });
+    logger.warn('rejected', { reason: 'generic' });
+
+    expect(sink).toHaveBeenNthCalledWith(1, '[location-sync] [info] matched gym {"gymId":7,"tier":2}');
+    expect(sink).toHaveBeenNthCalledWith(2, '[location-sync] [warn] rejected {"reason":"generic"}');
+  });
+
+  it('omits the JSON suffix when fields are absent or empty', () => {
+    const sink = vi.fn();
+    const logger = toLocationSyncLogger(sink);
+
+    logger.info('no fields');
+    logger.info('empty fields', {});
+
+    expect(sink).toHaveBeenNthCalledWith(1, '[location-sync] [info] no fields');
+    expect(sink).toHaveBeenNthCalledWith(2, '[location-sync] [info] empty fields');
+  });
+});

--- a/packages/location-sync/src/logger.test.ts
+++ b/packages/location-sync/src/logger.test.ts
@@ -4,7 +4,8 @@ import { noopLocationSyncLogger, toLocationSyncLogger } from './logger';
 describe('toLocationSyncLogger', () => {
   it('returns the shared no-op logger when no sink is given', () => {
     expect(toLocationSyncLogger(undefined)).toBe(noopLocationSyncLogger);
-    // No-op must not throw for either level.
+    // No-op must not throw for any level.
+    expect(() => noopLocationSyncLogger.debug('d', { a: 1 })).not.toThrow();
     expect(() => noopLocationSyncLogger.info('x', { a: 1 })).not.toThrow();
     expect(() => noopLocationSyncLogger.warn('y')).not.toThrow();
   });
@@ -13,11 +14,13 @@ describe('toLocationSyncLogger', () => {
     const sink = vi.fn();
     const logger = toLocationSyncLogger(sink);
 
+    logger.debug('resolved alias', { gymId: 3 });
     logger.info('matched gym', { gymId: 7, tier: 2 });
     logger.warn('rejected', { reason: 'generic' });
 
-    expect(sink).toHaveBeenNthCalledWith(1, '[location-sync] [info] matched gym {"gymId":7,"tier":2}');
-    expect(sink).toHaveBeenNthCalledWith(2, '[location-sync] [warn] rejected {"reason":"generic"}');
+    expect(sink).toHaveBeenNthCalledWith(1, '[location-sync] [debug] resolved alias {"gymId":3}');
+    expect(sink).toHaveBeenNthCalledWith(2, '[location-sync] [info] matched gym {"gymId":7,"tier":2}');
+    expect(sink).toHaveBeenNthCalledWith(3, '[location-sync] [warn] rejected {"reason":"generic"}');
   });
 
   it('omits the JSON suffix when fields are absent or empty', () => {

--- a/packages/location-sync/src/logger.ts
+++ b/packages/location-sync/src/logger.ts
@@ -1,0 +1,44 @@
+/**
+ * Structured logging seam for the location-sync importer.
+ *
+ * `location-sync` is a shared package, so it can't import the backend's winston
+ * singleton directly (shared packages never depend on `backend`). Instead the
+ * caller injects a structural logger. The shape matches winston's
+ * `info(message, meta)` / `warn(message, meta)` signature, so the backend can
+ * pass its winston logger straight through (per docs/logging.md) while other
+ * hosts pass a string-callback adapter or the no-op below.
+ */
+export type LocationSyncLogFields = Record<string, unknown>;
+
+export type LocationSyncLogger = {
+  info(message: string, fields?: LocationSyncLogFields): void;
+  warn(message: string, fields?: LocationSyncLogFields): void;
+};
+
+/** Swallows every log line — the default when no logger is injected. */
+export const noopLocationSyncLogger: LocationSyncLogger = {
+  info() {},
+  warn() {},
+};
+
+/**
+ * Adapts the importer's existing `log?: (message: string) => void` callback into
+ * a {@link LocationSyncLogger}. Fields are appended as a JSON suffix so the
+ * report lines stay greppable in plain string sinks; a winston-backed caller
+ * should pass its logger directly instead of going through this adapter.
+ */
+export function toLocationSyncLogger(log?: (message: string) => void): LocationSyncLogger {
+  if (!log) {
+    return noopLocationSyncLogger;
+  }
+
+  const emit = (level: 'info' | 'warn', message: string, fields?: LocationSyncLogFields): void => {
+    const suffix = fields && Object.keys(fields).length > 0 ? ` ${JSON.stringify(fields)}` : '';
+    log(`[location-sync] [${level}] ${message}${suffix}`);
+  };
+
+  return {
+    info: (message, fields) => emit('info', message, fields),
+    warn: (message, fields) => emit('warn', message, fields),
+  };
+}

--- a/packages/location-sync/src/logger.ts
+++ b/packages/location-sync/src/logger.ts
@@ -10,13 +10,17 @@
  */
 export type LocationSyncLogFields = Record<string, unknown>;
 
+export type LocationSyncLogLevel = 'debug' | 'info' | 'warn';
+
 export type LocationSyncLogger = {
+  debug(message: string, fields?: LocationSyncLogFields): void;
   info(message: string, fields?: LocationSyncLogFields): void;
   warn(message: string, fields?: LocationSyncLogFields): void;
 };
 
 /** Swallows every log line — the default when no logger is injected. */
 export const noopLocationSyncLogger: LocationSyncLogger = {
+  debug() {},
   info() {},
   warn() {},
 };
@@ -32,12 +36,13 @@ export function toLocationSyncLogger(log?: (message: string) => void): LocationS
     return noopLocationSyncLogger;
   }
 
-  const emit = (level: 'info' | 'warn', message: string, fields?: LocationSyncLogFields): void => {
+  const emit = (level: LocationSyncLogLevel, message: string, fields?: LocationSyncLogFields): void => {
     const suffix = fields && Object.keys(fields).length > 0 ? ` ${JSON.stringify(fields)}` : '';
     log(`[location-sync] [${level}] ${message}${suffix}`);
   };
 
   return {
+    debug: (message, fields) => emit('debug', message, fields),
     info: (message, fields) => emit('info', message, fields),
     warn: (message, fields) => emit('warn', message, fields),
   };

--- a/packages/location-sync/src/upsert.test.ts
+++ b/packages/location-sync/src/upsert.test.ts
@@ -644,6 +644,37 @@ describe('guarded second-tier gym matching', () => {
     );
   });
 
+  it('aliases into a user-owned gym at tier-1 (<=20 m) without touching its metadata', async () => {
+    const { logger, infoCalls } = createFakeLogger();
+    const fakeDb = new FakeLocationSyncDb({
+      physicalCandidates: [candidate({ id: 98, uuid: 'user-owned-close', ownerId: USER_OWNER_ID, distanceMeters: 12 })],
+    });
+
+    const summary = await upsertPublicBoardLocations(
+      fakeDb as unknown as UpsertDb,
+      [
+        locationRecord({
+          sourceKey: 'kilter:board-user-close',
+          gymSourceKey: 'kilter:gym-user-close',
+          gymName: 'Board House',
+        }),
+      ],
+      { logger },
+    );
+
+    expect(summary.gymsUpserted).toBe(1);
+    expect(fakeDb.createdGymWrites).toEqual([]);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-user-close', gymId: 98 }]);
+    // Owner-curated at any tier: alias written, NO metadata write.
+    expect(fakeDb.gymMetadataWrites).toEqual([]);
+    expect(infoCalls).toContainEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('user-owned gym'),
+        fields: expect.objectContaining({ gymId: 98, ownerId: USER_OWNER_ID, tier: 1 }),
+      }),
+    );
+  });
+
   it('treats a SYSTEM gym with an approved claim as owner-curated (alias, no refresh)', async () => {
     const fakeDb = new FakeLocationSyncDb({
       physicalCandidates: [candidate({ id: 95, uuid: 'claimed-gym', hasApprovedClaim: true, distanceMeters: 10 })],
@@ -704,10 +735,12 @@ describe('guarded second-tier gym matching', () => {
 
     const matchQueryText = fakeDb.executeSqlTexts.find((queryText) => queryText.includes('WITH candidate_gyms'));
     expect(matchQueryText).toBeDefined();
-    // The old owner_id = SYSTEM filter is gone; owner + distance are selected.
+    // The old `owner_id = SYSTEM` filter is gone (user-owned gyms now participate)
+    // and distance is computed for the tier split. The approved-claim and
+    // alias-source-key columns are covered behaviorally by the owner-curated and
+    // same-provider tests above, so this only asserts the two shape changes that
+    // aren't otherwise observable from behavior.
     expect(matchQueryText).not.toMatch(/g\.owner_id = /);
     expect(matchQueryText).toContain('ST_Distance');
-    expect(matchQueryText).toContain('hasApprovedClaim');
-    expect(matchQueryText).toContain('aliasSourceKeys');
   });
 });

--- a/packages/location-sync/src/upsert.test.ts
+++ b/packages/location-sync/src/upsert.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { gyms, locationSyncGymSources, userBoards, users } from '@boardsesh/db/schema';
 import type { CanonicalGymCandidate } from '@boardsesh/db/queries';
 import type { PublicBoardLocationInput } from './types';
+import { SYSTEM_USER_ID } from './ids';
+import type { LocationSyncLogger, LocationSyncLogFields } from './logger';
 import {
   buildBoardWriteIdentifiers,
   buildGymWriteIdentifiers,
@@ -12,6 +14,45 @@ import {
 } from './upsert';
 
 type UpsertDb = Parameters<typeof upsertPublicBoardLocations>[0];
+
+const USER_OWNER_ID = '11111111-1111-1111-1111-111111111111';
+
+/**
+ * A physical-match candidate row as {@link upsertPublicBoardLocations} reads it
+ * back from the match query: the canonical fields plus the guarded-tier / alias
+ * facts (distance, owner, approved-claim, existing provider aliases).
+ */
+type MatchCandidateRow = CanonicalGymCandidate & {
+  ownerId: string;
+  distanceMeters: number;
+  hasApprovedClaim: boolean;
+  aliasSourceKeys: string[];
+};
+
+type AliasedGymRow = {
+  id: number;
+  ownerId: string;
+  hasApprovedClaim: boolean;
+};
+
+type CapturedLog = { message: string; fields?: LocationSyncLogFields };
+
+function createFakeLogger(): {
+  logger: LocationSyncLogger;
+  infoCalls: CapturedLog[];
+  warnCalls: CapturedLog[];
+} {
+  const infoCalls: CapturedLog[] = [];
+  const warnCalls: CapturedLog[] = [];
+  return {
+    logger: {
+      info: (message, fields) => infoCalls.push({ message, fields }),
+      warn: (message, fields) => warnCalls.push({ message, fields }),
+    },
+    infoCalls,
+    warnCalls,
+  };
+}
 
 const baseLocationRecord: PublicBoardLocationInput = {
   boardType: 'tension',
@@ -87,11 +128,12 @@ function rowValues(row: unknown): Record<string, unknown> {
   return row as Record<string, unknown>;
 }
 
-function candidate(overrides: Partial<CanonicalGymCandidate>): CanonicalGymCandidate {
+function candidate(overrides: Partial<MatchCandidateRow>): MatchCandidateRow {
   return {
     id: 500,
     uuid: 'physical-gym',
     name: 'Board House',
+    ownerId: SYSTEM_USER_ID,
     address: null,
     contactEmail: null,
     contactPhone: null,
@@ -100,6 +142,10 @@ function candidate(overrides: Partial<CanonicalGymCandidate>): CanonicalGymCandi
     latitude: -33.86,
     longitude: 151.2,
     createdAt: '2026-01-01T00:00:00Z',
+    // Default to a dead-on tier-1 candidate; guarded-tier tests override.
+    distanceMeters: 0,
+    hasApprovedClaim: false,
+    aliasSourceKeys: [],
     boardCount: 0,
     memberCount: 0,
     followerCount: 0,
@@ -190,8 +236,8 @@ class FakeSelectBuilder {
     return this;
   }
 
-  limit(_limit: number): Array<{ id: number }> {
-    return this.fakeDb.aliasedGymId === null ? [] : [{ id: this.fakeDb.aliasedGymId }];
+  limit(_limit: number): AliasedGymRow[] {
+    return this.fakeDb.aliasedGym === null ? [] : [this.fakeDb.aliasedGym];
   }
 }
 
@@ -203,18 +249,18 @@ class FakeLocationSyncDb {
   readonly boardWrites: Array<Record<string, unknown>> = [];
   readonly executeSqlTexts: string[] = [];
 
-  readonly aliasedGymId: number | null;
-  readonly physicalCandidates: CanonicalGymCandidate[];
+  readonly aliasedGym: AliasedGymRow | null;
+  readonly physicalCandidates: MatchCandidateRow[];
   readonly createdGymId: number;
   readonly createdBoardId: number;
 
   constructor(options: {
-    aliasedGymId?: number | null;
-    physicalCandidates?: CanonicalGymCandidate[];
+    aliasedGym?: AliasedGymRow | null;
+    physicalCandidates?: MatchCandidateRow[];
     createdGymId?: number;
     createdBoardId?: number;
   }) {
-    this.aliasedGymId = options.aliasedGymId ?? null;
+    this.aliasedGym = options.aliasedGym ?? null;
     this.physicalCandidates = options.physicalCandidates ?? [];
     this.createdGymId = options.createdGymId ?? 900;
     this.createdBoardId = options.createdBoardId ?? 901;
@@ -325,8 +371,10 @@ describe('location upsert planning', () => {
 });
 
 describe('public board location upsert gym resolution', () => {
-  it('refreshes an existing source alias before physical matching or source upsert', async () => {
-    const fakeDb = new FakeLocationSyncDb({ aliasedGymId: 42 });
+  it('refreshes an existing SYSTEM-owned source alias before physical matching or source upsert', async () => {
+    const fakeDb = new FakeLocationSyncDb({
+      aliasedGym: { id: 42, ownerId: SYSTEM_USER_ID, hasApprovedClaim: false },
+    });
 
     const summary = await upsertPublicBoardLocations(fakeDb as unknown as UpsertDb, [
       locationRecord({
@@ -400,5 +448,266 @@ describe('public board location upsert gym resolution', () => {
     expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'tension:gym-new', gymId: 123 }]);
     expect(fakeDb.gymMetadataWrites).toEqual([]);
     expect(fakeDb.boardWrites[0]?.gymId).toBe(123);
+  });
+});
+
+describe('guarded second-tier gym matching', () => {
+  it('prefers a tier-1 (<=20 m) candidate over a farther tier-2 candidate without a tier-2 log', async () => {
+    const { logger, infoCalls, warnCalls } = createFakeLogger();
+    const fakeDb = new FakeLocationSyncDb({
+      physicalCandidates: [
+        candidate({ id: 71, uuid: 'tier-two-gym', distanceMeters: 120, boardCount: 9 }),
+        candidate({ id: 70, uuid: 'tier-one-gym', distanceMeters: 15, boardCount: 1 }),
+      ],
+    });
+
+    const summary = await upsertPublicBoardLocations(
+      fakeDb as unknown as UpsertDb,
+      [locationRecord({ sourceKey: 'tension:board-t1', gymSourceKey: 'tension:gym-t1' })],
+      { logger },
+    );
+
+    expect(summary.gymsUpserted).toBe(1);
+    // Tier-1 wins even though the tier-2 candidate is more complete (higher board count).
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'tension:gym-t1', gymId: 70 }]);
+    expect(fakeDb.gymMetadataWrites).toHaveLength(1);
+    expect(fakeDb.createdGymWrites).toEqual([]);
+    // Tier-1 matches stay quiet (today's behavior); only tier-2 events are logged.
+    expect(infoCalls).toEqual([]);
+    expect(warnCalls).toEqual([]);
+  });
+
+  it('matches an exact-name SYSTEM candidate at the 150 m tier and refreshes it', async () => {
+    const { logger, infoCalls } = createFakeLogger();
+    const fakeDb = new FakeLocationSyncDb({
+      physicalCandidates: [candidate({ id: 88, uuid: 'guarded-gym', distanceMeters: 140 })],
+    });
+
+    const summary = await upsertPublicBoardLocations(
+      fakeDb as unknown as UpsertDb,
+      [
+        locationRecord({
+          sourceKey: 'kilter:board-guarded',
+          gymSourceKey: 'kilter:gym-guarded',
+          gymName: 'Board House',
+        }),
+      ],
+      { logger },
+    );
+
+    expect(summary.gymsUpserted).toBe(1);
+    expect(fakeDb.createdGymWrites).toEqual([]);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-guarded', gymId: 88 }]);
+    // SYSTEM-owned match still refreshes metadata.
+    expect(fakeDb.gymMetadataWrites).toHaveLength(1);
+    expect(fakeDb.boardWrites[0]?.gymId).toBe(88);
+    expect(infoCalls).toContainEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('guarded-tier'),
+        fields: expect.objectContaining({ gymId: 88, distanceMeters: 140 }),
+      }),
+    );
+  });
+
+  it('does NOT match a generic-named candidate at 150 m and logs the rejection', async () => {
+    const { logger, infoCalls } = createFakeLogger();
+    const fakeDb = new FakeLocationSyncDb({
+      createdGymId: 321,
+      physicalCandidates: [candidate({ id: 90, uuid: 'generic-gym', name: 'Home Wall', distanceMeters: 130 })],
+    });
+
+    const summary = await upsertPublicBoardLocations(
+      fakeDb as unknown as UpsertDb,
+      [
+        locationRecord({
+          sourceKey: 'kilter:board-generic',
+          gymSourceKey: 'kilter:gym-generic',
+          gymName: 'Home Wall',
+        }),
+      ],
+      { logger },
+    );
+
+    expect(summary.gymsUpserted).toBe(1);
+    // Falls through to a fresh gym; the generic candidate is never aliased.
+    expect(fakeDb.createdGymWrites).toMatchObject([{ name: 'Home Wall' }]);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-generic', gymId: 321 }]);
+    expect(fakeDb.boardWrites[0]?.gymId).toBe(321);
+    expect(infoCalls).toContainEqual(expect.objectContaining({ message: expect.stringContaining('generic gym name') }));
+  });
+
+  it('still matches a generic name at tier-1 (<=20 m)', async () => {
+    const fakeDb = new FakeLocationSyncDb({
+      physicalCandidates: [candidate({ id: 91, uuid: 'generic-close', name: 'Garage', distanceMeters: 12 })],
+    });
+
+    const summary = await upsertPublicBoardLocations(fakeDb as unknown as UpsertDb, [
+      locationRecord({ sourceKey: 'kilter:board-garage', gymSourceKey: 'kilter:gym-garage', gymName: 'Garage' }),
+    ]);
+
+    expect(summary.gymsUpserted).toBe(1);
+    expect(fakeDb.createdGymWrites).toEqual([]);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-garage', gymId: 91 }]);
+  });
+
+  it('does NOT match at 150 m when a same-provider source is already aliased, and logs the rejection', async () => {
+    const { logger, warnCalls } = createFakeLogger();
+    const fakeDb = new FakeLocationSyncDb({
+      createdGymId: 654,
+      physicalCandidates: [
+        candidate({
+          id: 92,
+          uuid: 'same-provider-gym',
+          distanceMeters: 145,
+          aliasSourceKeys: ['tension:gym-existing'],
+        }),
+      ],
+    });
+
+    const summary = await upsertPublicBoardLocations(
+      fakeDb as unknown as UpsertDb,
+      [
+        locationRecord({
+          sourceKey: 'tension:board-conflict',
+          gymSourceKey: 'tension:gym-conflict',
+          gymName: 'Board House',
+        }),
+      ],
+      { logger },
+    );
+
+    expect(summary.gymsUpserted).toBe(1);
+    // Same-provider twin 150 m away is treated as distinct: a new gym is minted.
+    expect(fakeDb.createdGymWrites).toMatchObject([{ name: 'Board House' }]);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'tension:gym-conflict', gymId: 654 }]);
+    expect(warnCalls).toContainEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('same-provider'),
+        fields: expect.objectContaining({
+          candidateGymId: 92,
+          conflictingSourceKeys: ['tension:gym-existing'],
+        }),
+      }),
+    );
+  });
+
+  it('still matches at 150 m when the only alias is the same source key (no conflict)', async () => {
+    const fakeDb = new FakeLocationSyncDb({
+      physicalCandidates: [
+        candidate({ id: 93, uuid: 'resync-gym', distanceMeters: 140, aliasSourceKeys: ['tension:gym-resync'] }),
+      ],
+    });
+
+    const summary = await upsertPublicBoardLocations(fakeDb as unknown as UpsertDb, [
+      locationRecord({
+        sourceKey: 'tension:board-resync',
+        gymSourceKey: 'tension:gym-resync',
+        gymName: 'Board House',
+      }),
+    ]);
+
+    expect(summary.gymsUpserted).toBe(1);
+    expect(fakeDb.createdGymWrites).toEqual([]);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'tension:gym-resync', gymId: 93 }]);
+  });
+
+  it('aliases into a user-owned gym without touching its metadata', async () => {
+    const { logger, infoCalls } = createFakeLogger();
+    const fakeDb = new FakeLocationSyncDb({
+      physicalCandidates: [candidate({ id: 94, uuid: 'user-owned-gym', ownerId: USER_OWNER_ID, distanceMeters: 60 })],
+    });
+
+    const summary = await upsertPublicBoardLocations(
+      fakeDb as unknown as UpsertDb,
+      [
+        locationRecord({
+          sourceKey: 'kilter:board-user',
+          gymSourceKey: 'kilter:gym-user',
+          gymName: 'Board House',
+          gymAddress: '9 Sync Street',
+        }),
+      ],
+      { logger },
+    );
+
+    expect(summary.gymsUpserted).toBe(1);
+    expect(fakeDb.createdGymWrites).toEqual([]);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-user', gymId: 94 }]);
+    // Owner-curated fields are sacrosanct: alias written, NO metadata write.
+    expect(fakeDb.gymMetadataWrites).toEqual([]);
+    expect(fakeDb.boardWrites[0]?.gymId).toBe(94);
+    expect(infoCalls).toContainEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('user-owned gym'),
+        fields: expect.objectContaining({ gymId: 94, ownerId: USER_OWNER_ID }),
+      }),
+    );
+  });
+
+  it('treats a SYSTEM gym with an approved claim as owner-curated (alias, no refresh)', async () => {
+    const fakeDb = new FakeLocationSyncDb({
+      physicalCandidates: [candidate({ id: 95, uuid: 'claimed-gym', hasApprovedClaim: true, distanceMeters: 10 })],
+    });
+
+    const summary = await upsertPublicBoardLocations(fakeDb as unknown as UpsertDb, [
+      locationRecord({ sourceKey: 'kilter:board-claimed', gymSourceKey: 'kilter:gym-claimed', gymName: 'Board House' }),
+    ]);
+
+    expect(summary.gymsUpserted).toBe(1);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-claimed', gymId: 95 }]);
+    expect(fakeDb.gymMetadataWrites).toEqual([]);
+  });
+
+  it('never refreshes metadata when an existing alias points at a user-owned gym (squat protection)', async () => {
+    const fakeDb = new FakeLocationSyncDb({
+      aliasedGym: { id: 96, ownerId: USER_OWNER_ID, hasApprovedClaim: false },
+    });
+
+    const summary = await upsertPublicBoardLocations(fakeDb as unknown as UpsertDb, [
+      locationRecord({
+        sourceKey: 'kilter:board-aliased-user',
+        gymSourceKey: 'kilter:gym-aliased-user',
+        gymName: 'Renamed By Owner',
+      }),
+    ]);
+
+    expect(summary.gymsUpserted).toBe(1);
+    // The alias resolves to the user's gym but the owner's fields are left alone.
+    expect(fakeDb.gymMetadataWrites).toEqual([]);
+    expect(fakeDb.createdGymWrites).toEqual([]);
+    expect(fakeDb.boardWrites[0]?.gymId).toBe(96);
+  });
+
+  it('does NOT match a candidate just past the 150 m boundary (151 m)', async () => {
+    const fakeDb = new FakeLocationSyncDb({
+      createdGymId: 777,
+      physicalCandidates: [candidate({ id: 97, uuid: 'too-far-gym', distanceMeters: 151 })],
+    });
+
+    const summary = await upsertPublicBoardLocations(fakeDb as unknown as UpsertDb, [
+      locationRecord({ sourceKey: 'kilter:board-far', gymSourceKey: 'kilter:gym-far', gymName: 'Board House' }),
+    ]);
+
+    expect(summary.gymsUpserted).toBe(1);
+    // Beyond the guarded radius: a fresh gym is minted, the far candidate untouched.
+    expect(fakeDb.createdGymWrites).toMatchObject([{ name: 'Board House' }]);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-far', gymId: 777 }]);
+    expect(fakeDb.boardWrites[0]?.gymId).toBe(777);
+  });
+
+  it('widens the match query to include user-owned gyms and select owner + distance', async () => {
+    const fakeDb = new FakeLocationSyncDb({ createdGymId: 555 });
+
+    await upsertPublicBoardLocations(fakeDb as unknown as UpsertDb, [
+      locationRecord({ sourceKey: 'kilter:board-q', gymSourceKey: 'kilter:gym-q', gymName: 'Board House' }),
+    ]);
+
+    const matchQueryText = fakeDb.executeSqlTexts.find((queryText) => queryText.includes('WITH candidate_gyms'));
+    expect(matchQueryText).toBeDefined();
+    // The old owner_id = SYSTEM filter is gone; owner + distance are selected.
+    expect(matchQueryText).not.toMatch(/g\.owner_id = /);
+    expect(matchQueryText).toContain('ST_Distance');
+    expect(matchQueryText).toContain('hasApprovedClaim');
+    expect(matchQueryText).toContain('aliasSourceKeys');
   });
 });

--- a/packages/location-sync/src/upsert.test.ts
+++ b/packages/location-sync/src/upsert.test.ts
@@ -39,16 +39,20 @@ type CapturedLog = { message: string; fields?: LocationSyncLogFields };
 
 function createFakeLogger(): {
   logger: LocationSyncLogger;
+  debugCalls: CapturedLog[];
   infoCalls: CapturedLog[];
   warnCalls: CapturedLog[];
 } {
+  const debugCalls: CapturedLog[] = [];
   const infoCalls: CapturedLog[] = [];
   const warnCalls: CapturedLog[] = [];
   return {
     logger: {
+      debug: (message, fields) => debugCalls.push({ message, fields }),
       info: (message, fields) => infoCalls.push({ message, fields }),
       warn: (message, fields) => warnCalls.push({ message, fields }),
     },
+    debugCalls,
     infoCalls,
     warnCalls,
   };
@@ -611,10 +615,18 @@ describe('guarded second-tier gym matching', () => {
     expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'tension:gym-resync', gymId: 93 }]);
   });
 
-  it('aliases into a user-owned gym without touching its metadata', async () => {
-    const { logger, infoCalls } = createFakeLogger();
+  it('binds into an approved-claim user-owned gym at the 150 m tier without touching its metadata', async () => {
+    const { logger, warnCalls } = createFakeLogger();
     const fakeDb = new FakeLocationSyncDb({
-      physicalCandidates: [candidate({ id: 94, uuid: 'user-owned-gym', ownerId: USER_OWNER_ID, distanceMeters: 60 })],
+      physicalCandidates: [
+        candidate({
+          id: 94,
+          uuid: 'claimed-user-gym',
+          ownerId: USER_OWNER_ID,
+          hasApprovedClaim: true,
+          distanceMeters: 60,
+        }),
+      ],
     });
 
     const summary = await upsertPublicBoardLocations(
@@ -636,16 +648,57 @@ describe('guarded second-tier gym matching', () => {
     // Owner-curated fields are sacrosanct: alias written, NO metadata write.
     expect(fakeDb.gymMetadataWrites).toEqual([]);
     expect(fakeDb.boardWrites[0]?.gymId).toBe(94);
-    expect(infoCalls).toContainEqual(
+    // The initial bind into an owner-controlled gym is a security-relevant warn.
+    expect(warnCalls).toContainEqual(
       expect.objectContaining({
-        message: expect.stringContaining('user-owned gym'),
-        fields: expect.objectContaining({ gymId: 94, ownerId: USER_OWNER_ID }),
+        message: expect.stringContaining('owner-curated gym'),
+        fields: expect.objectContaining({ gymId: 94, ownerId: USER_OWNER_ID, tier: 2 }),
       }),
     );
   });
 
-  it('aliases into a user-owned gym at tier-1 (<=20 m) without touching its metadata', async () => {
+  it('skips an UNCLAIMED user-owned candidate at the 150 m tier and mints a fresh gym', async () => {
     const { logger, infoCalls } = createFakeLogger();
+    const fakeDb = new FakeLocationSyncDb({
+      createdGymId: 940,
+      physicalCandidates: [
+        candidate({
+          id: 94,
+          uuid: 'unclaimed-user-gym',
+          ownerId: USER_OWNER_ID,
+          hasApprovedClaim: false,
+          distanceMeters: 60,
+        }),
+      ],
+    });
+
+    const summary = await upsertPublicBoardLocations(
+      fakeDb as unknown as UpsertDb,
+      [
+        locationRecord({
+          sourceKey: 'kilter:board-unclaimed',
+          gymSourceKey: 'kilter:gym-unclaimed',
+          gymName: 'Board House',
+        }),
+      ],
+      { logger },
+    );
+
+    expect(summary.gymsUpserted).toBe(1);
+    // Never auto-captured: no alias into the user's gym, a fresh gym is minted.
+    expect(fakeDb.createdGymWrites).toMatchObject([{ name: 'Board House' }]);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-unclaimed', gymId: 940 }]);
+    expect(fakeDb.boardWrites[0]?.gymId).toBe(940);
+    expect(infoCalls).toContainEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('unclaimed user-owned gym'),
+        fields: expect.objectContaining({ candidateGymId: 94, ownerId: USER_OWNER_ID, distanceMeters: 60 }),
+      }),
+    );
+  });
+
+  it('binds into a user-owned gym at tier-1 (<=20 m) without touching its metadata', async () => {
+    const { logger, warnCalls } = createFakeLogger();
     const fakeDb = new FakeLocationSyncDb({
       physicalCandidates: [candidate({ id: 98, uuid: 'user-owned-close', ownerId: USER_OWNER_ID, distanceMeters: 12 })],
     });
@@ -665,14 +718,39 @@ describe('guarded second-tier gym matching', () => {
     expect(summary.gymsUpserted).toBe(1);
     expect(fakeDb.createdGymWrites).toEqual([]);
     expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-user-close', gymId: 98 }]);
-    // Owner-curated at any tier: alias written, NO metadata write.
+    // Owner-curated at any tier: alias written, NO metadata write. Tier-1
+    // user-owned matching needs no claim (the pin is essentially on the gym).
     expect(fakeDb.gymMetadataWrites).toEqual([]);
-    expect(infoCalls).toContainEqual(
+    expect(warnCalls).toContainEqual(
       expect.objectContaining({
-        message: expect.stringContaining('user-owned gym'),
+        message: expect.stringContaining('owner-curated gym'),
         fields: expect.objectContaining({ gymId: 98, ownerId: USER_OWNER_ID, tier: 1 }),
       }),
     );
+  });
+
+  it('does NOT let a generic-named user-owned gym capture a stranger pin at tier-1', async () => {
+    const { logger, infoCalls, warnCalls } = createFakeLogger();
+    const fakeDb = new FakeLocationSyncDb({
+      createdGymId: 981,
+      physicalCandidates: [
+        candidate({ id: 99, uuid: 'user-home-wall', ownerId: USER_OWNER_ID, name: 'Home Wall', distanceMeters: 15 }),
+      ],
+    });
+
+    const summary = await upsertPublicBoardLocations(
+      fakeDb as unknown as UpsertDb,
+      [locationRecord({ sourceKey: 'kilter:board-hw', gymSourceKey: 'kilter:gym-hw', gymName: 'Home Wall' })],
+      { logger },
+    );
+
+    expect(summary.gymsUpserted).toBe(1);
+    // A public "Home Wall" 15 m away is NOT captured; a fresh gym is minted.
+    expect(fakeDb.createdGymWrites).toMatchObject([{ name: 'Home Wall' }]);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-hw', gymId: 981 }]);
+    // Distance is inside tier-1, so it never reaches the tier-2 generic-block log.
+    expect(infoCalls).toEqual([]);
+    expect(warnCalls).toEqual([]);
   });
 
   it('treats a SYSTEM gym with an approved claim as owner-curated (alias, no refresh)', async () => {
@@ -724,6 +802,40 @@ describe('guarded second-tier gym matching', () => {
     expect(fakeDb.createdGymWrites).toMatchObject([{ name: 'Board House' }]);
     expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-far', gymId: 777 }]);
     expect(fakeDb.boardWrites[0]?.gymId).toBe(777);
+  });
+
+  it('does NOT auto-match when two candidates sit in the 21-150 m band (ambiguous), and logs a warn', async () => {
+    const { logger, warnCalls } = createFakeLogger();
+    const fakeDb = new FakeLocationSyncDb({
+      createdGymId: 606,
+      physicalCandidates: [
+        candidate({ id: 60, uuid: 'ambig-a', distanceMeters: 40, boardCount: 2 }),
+        candidate({ id: 61, uuid: 'ambig-b', distanceMeters: 90, boardCount: 9 }),
+      ],
+    });
+
+    const summary = await upsertPublicBoardLocations(
+      fakeDb as unknown as UpsertDb,
+      [locationRecord({ sourceKey: 'kilter:board-ambig', gymSourceKey: 'kilter:gym-ambig', gymName: 'Board House' })],
+      { logger },
+    );
+
+    expect(summary.gymsUpserted).toBe(1);
+    // Two same-name gyms inside one 150 m circle: refuse to guess, mint fresh.
+    expect(fakeDb.createdGymWrites).toMatchObject([{ name: 'Board House' }]);
+    expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-ambig', gymId: 606 }]);
+    expect(fakeDb.boardWrites[0]?.gymId).toBe(606);
+    expect(warnCalls).toContainEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('multiple candidates'),
+        fields: expect.objectContaining({
+          candidates: expect.arrayContaining([
+            expect.objectContaining({ gymId: 60, distanceMeters: 40 }),
+            expect.objectContaining({ gymId: 61, distanceMeters: 90 }),
+          ]),
+        }),
+      }),
+    );
   });
 
   it('widens the match query to include user-owned gyms and select owner + distance', async () => {

--- a/packages/location-sync/src/upsert.test.ts
+++ b/packages/location-sync/src/upsert.test.ts
@@ -729,7 +729,7 @@ describe('guarded second-tier gym matching', () => {
     );
   });
 
-  it('does NOT let a generic-named user-owned gym capture a stranger pin at tier-1', async () => {
+  it('does NOT let a generic-named user-owned gym capture a stranger pin at tier-1, and logs the near-miss', async () => {
     const { logger, infoCalls, warnCalls } = createFakeLogger();
     const fakeDb = new FakeLocationSyncDb({
       createdGymId: 981,
@@ -748,8 +748,13 @@ describe('guarded second-tier gym matching', () => {
     // A public "Home Wall" 15 m away is NOT captured; a fresh gym is minted.
     expect(fakeDb.createdGymWrites).toMatchObject([{ name: 'Home Wall' }]);
     expect(fakeDb.sourceAliasWrites).toMatchObject([{ sourceKey: 'kilter:gym-hw', gymId: 981 }]);
-    // Distance is inside tier-1, so it never reaches the tier-2 generic-block log.
-    expect(infoCalls).toEqual([]);
+    // The dead-zone near-miss surfaces to humans instead of vanishing silently.
+    expect(infoCalls).toContainEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('generic-named user-owned gym'),
+        fields: expect.objectContaining({ candidateGymId: 99, ownerId: USER_OWNER_ID, distanceMeters: 15 }),
+      }),
+    );
     expect(warnCalls).toEqual([]);
   });
 

--- a/packages/location-sync/src/upsert.ts
+++ b/packages/location-sync/src/upsert.ts
@@ -360,7 +360,10 @@ function classifyGymMatch(
   }
 
   // No tier-1 candidate. The DB query already caps distance at the guarded
-  // radius, but re-filter defensively so the tier boundary is enforced here too.
+  // radius, so this filter is a no-op in production — but it keeps the tier
+  // boundary owned here (not split across the query and the classifier) and lets
+  // this function be unit-tested against raw candidate lists without a DB to
+  // enforce the cap.
   const guardedCandidates = candidates.filter(
     (candidate) => candidate.distanceMeters <= GYM_MATCH_GUARDED_DISTANCE_METERS,
   );

--- a/packages/location-sync/src/upsert.ts
+++ b/packages/location-sync/src/upsert.ts
@@ -203,6 +203,13 @@ async function findAliasedGym(db: DrizzleDb, sourceKey: string): Promise<Aliased
  * re-minting gyms that owners already curate. Each row carries its distance,
  * owner, approved-claim flag, and the provider source keys already aliased to it;
  * {@link classifyGymMatch} turns that into a tier-1 / tier-2 / reject decision.
+ *
+ * This is a hand-written raw SQL block (PostGIS `ST_Distance`/`ST_DWithin`,
+ * multi-CTE aggregation) that literal-names every table — `gyms`, `user_boards`,
+ * `gym_claims`, `location_sync_gym_sources`, … — matching the importer's existing
+ * match-query convention. The lighter `findAliasedGym` below is a Drizzle builder
+ * query, so it uses the `${gymClaims}` table reference; the two intentionally
+ * differ because one is raw SQL and the other is a query builder.
  */
 async function findGymMatchCandidates(db: DrizzleDb, record: ValidBoardLocation): Promise<GymMatchCandidate[]> {
   const result = await db.execute(sql`

--- a/packages/location-sync/src/upsert.ts
+++ b/packages/location-sync/src/upsert.ts
@@ -300,100 +300,182 @@ async function findGymMatchCandidates(db: DrizzleDb, record: ValidBoardLocation)
     LEFT JOIN alias_source_keys ON alias_source_keys.gym_id = g.id
   `);
 
-  return rowsFromResult<GymMatchCandidate>(result).map((candidate) => ({
-    ...candidate,
-    id: Number(candidate.id),
-    latitude: Number(candidate.latitude),
-    longitude: Number(candidate.longitude),
-    distanceMeters: Number(candidate.distanceMeters),
-    hasApprovedClaim: Boolean(candidate.hasApprovedClaim),
-    aliasSourceKeys: Array.isArray(candidate.aliasSourceKeys) ? candidate.aliasSourceKeys : [],
-    boardCount: Number(candidate.boardCount),
-    memberCount: Number(candidate.memberCount),
-    followerCount: Number(candidate.followerCount),
-    commentCount: Number(candidate.commentCount),
-  }));
+  return rowsFromResult<GymMatchCandidate>(result).map((candidate) => {
+    if (!Array.isArray(candidate.aliasSourceKeys)) {
+      // Fail loud: a silent `[]` would disable the same-provider false-merge
+      // guard for this candidate and let a twin auto-merge. The COALESCE in the
+      // query guarantees a text[]; a non-array here means the driver/query
+      // contract broke, so stop rather than mask it.
+      throw new TypeError(
+        `location-sync: expected aliasSourceKeys to be an array for gym ${String(candidate.id)}, got ${typeof candidate.aliasSourceKeys}`,
+      );
+    }
+    return {
+      ...candidate,
+      id: Number(candidate.id),
+      latitude: Number(candidate.latitude),
+      longitude: Number(candidate.longitude),
+      distanceMeters: Number(candidate.distanceMeters),
+      hasApprovedClaim: Boolean(candidate.hasApprovedClaim),
+      aliasSourceKeys: candidate.aliasSourceKeys,
+      boardCount: Number(candidate.boardCount),
+      memberCount: Number(candidate.memberCount),
+      followerCount: Number(candidate.followerCount),
+      commentCount: Number(candidate.commentCount),
+    };
+  });
 }
 
 type GymMatchTier = 1 | 2;
 
-/** A tier-2 candidate rejected because a same-provider alias already exists. */
+/** A guarded-tier candidate rejected because a same-provider alias already exists. */
 type SameProviderConflict = {
   candidateGymId: number;
   conflictingSourceKeys: string[];
 };
 
+/** A guarded-tier candidate captured for a structured skip / ambiguity log. */
+type CandidateReference = {
+  gymId: number;
+  ownerId: string;
+  distanceMeters: number;
+};
+
 type GymMatchClassification = {
   match: { candidate: GymMatchCandidate; tier: GymMatchTier } | null;
-  // A generic name blocked the guarded tier (there were 150 m candidates that a
-  // non-generic name would have matched).
+  // A generic name blocked the whole guarded tier (there were 21–150 m
+  // candidates that a non-generic name would have considered).
   genericNameBlocked: boolean;
   // Guarded-tier candidates rejected because a same-provider source already
   // points at them (likely genuinely distinct walls 150 m apart).
   sameProviderConflicts: SameProviderConflict[];
+  // Guarded-tier candidates that are user-owned WITHOUT an approved claim: never
+  // auto-captured — a human resolves them in the admin duplicates queue.
+  unclaimedUserOwnedSkips: CandidateReference[];
+  // More than one candidate cleared the guarded tier: ambiguous, so we refuse to
+  // auto-match (two same-name gyms inside one 150 m circle is itself a signal the
+  // name is generic-ish).
+  ambiguousCandidates: CandidateReference[];
 };
+
+function isUserOwned(gym: { ownerId: string }): boolean {
+  return gym.ownerId !== SYSTEM_USER_ID;
+}
+
+function toCandidateReference(candidate: GymMatchCandidate): CandidateReference {
+  return { gymId: candidate.id, ownerId: candidate.ownerId, distanceMeters: candidate.distanceMeters };
+}
 
 /**
  * Turns the raw candidate list into a match decision.
  *
- * - Tier 1 (<= 20 m) always wins, even for generic names — an exact-name pin
- *   almost on top of a gym is the same gym.
- * - Tier 2 (<= 150 m) only fires for a non-generic name AND only for candidates
- *   that don't already carry a same-provider alias. Same-provider twins 150 m
- *   apart are reported, not merged.
+ * - Tier 1 (<= 20 m): a pin almost on top of a gym is the same gym. SYSTEM-owned
+ *   candidates always match here; a user-owned candidate only matches when the
+ *   name is NOT generic (a public "Home Wall" 15 m from a stranger's pin must
+ *   not capture it). Multiple tier-1 candidates pick the canonical one.
+ * - Tier 2 (20 m < d <= 150 m): only for a non-generic name, only for candidates
+ *   with no same-provider alias, and only into SYSTEM-owned gyms or user-owned
+ *   gyms that carry an approved claim. Unclaimed user-owned candidates skip to
+ *   the admin queue. If more than one candidate qualifies, it's ambiguous — no
+ *   auto-match.
  */
 function classifyGymMatch(
   sourceKey: string,
   record: ValidBoardLocation,
   candidates: GymMatchCandidate[],
 ): GymMatchClassification {
-  const tierOneCandidates = candidates.filter(
-    (candidate) => candidate.distanceMeters <= PHYSICAL_GYM_MATCH_DISTANCE_METERS,
+  const nameIsGeneric = isGenericGymName(record.gymName);
+
+  const tierOneEligible = candidates.filter(
+    (candidate) =>
+      candidate.distanceMeters <= PHYSICAL_GYM_MATCH_DISTANCE_METERS && (!isUserOwned(candidate) || !nameIsGeneric),
   );
-  if (tierOneCandidates.length > 0) {
-    const winner = chooseCanonicalGymCandidate(tierOneCandidates);
+  if (tierOneEligible.length > 0) {
+    const winner = chooseCanonicalGymCandidate(tierOneEligible);
     return {
       match: winner ? { candidate: winner, tier: 1 } : null,
       genericNameBlocked: false,
       sameProviderConflicts: [],
+      unclaimedUserOwnedSkips: [],
+      ambiguousCandidates: [],
     };
   }
 
-  // No tier-1 candidate. The DB query already caps distance at the guarded
-  // radius, so this filter is a no-op in production — but it keeps the tier
-  // boundary owned here (not split across the query and the classifier) and lets
-  // this function be unit-tested against raw candidate lists without a DB to
-  // enforce the cap.
+  // Tier 2. Distances are strictly in the 21–150 m band; the DB query already
+  // caps at the guarded radius, but re-deriving the band here keeps the tier
+  // boundary owned in one place and lets this function be unit-tested against raw
+  // candidate lists without a DB to enforce the cap.
   const guardedCandidates = candidates.filter(
-    (candidate) => candidate.distanceMeters <= GYM_MATCH_GUARDED_DISTANCE_METERS,
+    (candidate) =>
+      candidate.distanceMeters > PHYSICAL_GYM_MATCH_DISTANCE_METERS &&
+      candidate.distanceMeters <= GYM_MATCH_GUARDED_DISTANCE_METERS,
   );
   if (guardedCandidates.length === 0) {
-    return { match: null, genericNameBlocked: false, sameProviderConflicts: [] };
+    return {
+      match: null,
+      genericNameBlocked: false,
+      sameProviderConflicts: [],
+      unclaimedUserOwnedSkips: [],
+      ambiguousCandidates: [],
+    };
   }
-
-  if (isGenericGymName(record.gymName)) {
-    return { match: null, genericNameBlocked: true, sameProviderConflicts: [] };
+  if (nameIsGeneric) {
+    return {
+      match: null,
+      genericNameBlocked: true,
+      sameProviderConflicts: [],
+      unclaimedUserOwnedSkips: [],
+      ambiguousCandidates: [],
+    };
   }
 
   const providerPrefix = providerPrefixOf(sourceKey);
   const sameProviderConflicts: SameProviderConflict[] = [];
+  const unclaimedUserOwnedSkips: CandidateReference[] = [];
   const eligibleCandidates: GymMatchCandidate[] = [];
   for (const candidate of guardedCandidates) {
+    // NOTE: moonboard embeds the pin's coordinates in its source key
+    // (`moonboard:<name>:<lat>:<lng>`), so a pin that moves > 20 m mints a new
+    // source key. The same-provider guard then sees that key as a different
+    // moonboard source on the old gym and refuses to re-merge — the moved pin
+    // warns here, then mints a permanent twin. Tracked for a key-scheme redesign
+    // (follow-up issue); see docs and the same-provider log below.
     const conflictingSourceKeys = candidate.aliasSourceKeys.filter(
       (aliasSourceKey) => aliasSourceKey !== sourceKey && providerPrefixOf(aliasSourceKey) === providerPrefix,
     );
     if (conflictingSourceKeys.length > 0) {
       sameProviderConflicts.push({ candidateGymId: candidate.id, conflictingSourceKeys });
-    } else {
-      eligibleCandidates.push(candidate);
+      continue;
     }
+    // Squat protection: at the guarded tier we only ever bind into a user-owned
+    // gym that carries an approved claim. An unclaimed user-owned candidate is
+    // never auto-captured — it surfaces for a human in the admin queue.
+    if (isUserOwned(candidate) && !candidate.hasApprovedClaim) {
+      unclaimedUserOwnedSkips.push(toCandidateReference(candidate));
+      continue;
+    }
+    eligibleCandidates.push(candidate);
   }
 
-  const winner = chooseCanonicalGymCandidate(eligibleCandidates);
+  // Ambiguity policy: more than one eligible candidate inside the 150 m circle
+  // means we can't tell which is the real gym — refuse to auto-match.
+  if (eligibleCandidates.length > 1) {
+    return {
+      match: null,
+      genericNameBlocked: false,
+      sameProviderConflicts,
+      unclaimedUserOwnedSkips,
+      ambiguousCandidates: eligibleCandidates.map(toCandidateReference),
+    };
+  }
+
+  const [soleEligible] = eligibleCandidates;
   return {
-    match: winner ? { candidate: winner, tier: 2 } : null,
+    match: soleEligible ? { candidate: soleEligible, tier: 2 } : null,
     genericNameBlocked: false,
     sameProviderConflicts,
+    unclaimedUserOwnedSkips,
+    ambiguousCandidates: [],
   };
 }
 
@@ -449,7 +531,11 @@ async function resolveGymIdForSource(
     // an owner-curated gym. Only SYSTEM-owned, unclaimed gyms keep today's
     // refresh-on-every-sync behavior.
     if (isOwnerCurated(aliasedGym)) {
-      logger.info('location-sync alias resolved into owner-curated gym; metadata left untouched', {
+      // debug, not info: this fires every sync cycle (~48×/day) for every gym the
+      // importer has ever aliased into an owner-curated row — it would drown the
+      // tier-2 signal. The security-relevant event is the INITIAL alias write
+      // below (logged at warn), not the steady-state resolution.
+      logger.debug('location-sync alias resolved into owner-curated gym; metadata left untouched', {
         sourceKey,
         gymId: aliasedGym.id,
         ownerId: aliasedGym.ownerId,
@@ -480,6 +566,26 @@ async function resolveGymIdForSource(
       guardedDistanceMeters: GYM_MATCH_GUARDED_DISTANCE_METERS,
     });
   }
+  for (const skipped of classification.unclaimedUserOwnedSkips) {
+    logger.info(
+      'location-sync guarded-tier match skipped: unclaimed user-owned gym (surfaces in admin duplicates queue)',
+      {
+        sourceKey,
+        gymName: record.gymName,
+        candidateGymId: skipped.gymId,
+        ownerId: skipped.ownerId,
+        distanceMeters: skipped.distanceMeters,
+      },
+    );
+  }
+  if (classification.ambiguousCandidates.length > 0) {
+    logger.warn('location-sync guarded-tier match skipped: multiple candidates within the guarded radius', {
+      sourceKey,
+      gymName: record.gymName,
+      guardedDistanceMeters: GYM_MATCH_GUARDED_DISTANCE_METERS,
+      candidates: classification.ambiguousCandidates,
+    });
+  }
 
   const { match } = classification;
   if (match) {
@@ -488,8 +594,10 @@ async function resolveGymIdForSource(
 
     if (isOwnerCurated(candidate)) {
       // Alias-and-leave-alone: bind the source so future syncs resolve here, but
-      // never overwrite the owner's curated name / coords / metadata.
-      logger.info('location-sync aliased source into user-owned gym; metadata left untouched', {
+      // never overwrite the owner's curated name / coords / metadata. warn, not
+      // info: this initial write binds a provider source into a gym a human
+      // controls — a security-relevant event worth surfacing on the first sync.
+      logger.warn('location-sync bound source into owner-curated gym; metadata left untouched', {
         sourceKey,
         gymId: candidate.id,
         ownerId: candidate.ownerId,

--- a/packages/location-sync/src/upsert.ts
+++ b/packages/location-sync/src/upsert.ts
@@ -352,6 +352,10 @@ type GymMatchClassification = {
   // Guarded-tier candidates that are user-owned WITHOUT an approved claim: never
   // auto-captured — a human resolves them in the admin duplicates queue.
   unclaimedUserOwnedSkips: CandidateReference[];
+  // Tier-1 (<= 20 m) user-owned candidates dropped by the generic-name guard.
+  // They can't reach tier 2 (distance too small), so without surfacing them the
+  // near-miss would vanish silently before a fresh gym is minted.
+  tierOneGenericUserOwnedSkips: CandidateReference[];
   // More than one candidate cleared the guarded tier: ambiguous, so we refuse to
   // auto-match (two same-name gyms inside one 150 m circle is itself a signal the
   // name is generic-ish).
@@ -397,9 +401,21 @@ function classifyGymMatch(
       genericNameBlocked: false,
       sameProviderConflicts: [],
       unclaimedUserOwnedSkips: [],
+      tierOneGenericUserOwnedSkips: [],
       ambiguousCandidates: [],
     };
   }
+
+  // Tier 1 produced no eligible match. Capture the user-owned generic candidates
+  // the guard dropped at <= 20 m: they can't reach tier 2 (distance too small)
+  // and would otherwise fall through to a fresh gym with no signal at all. The
+  // caller logs these so a human can review the near-miss / possible squat.
+  const tierOneGenericUserOwnedSkips = candidates
+    .filter(
+      (candidate) =>
+        candidate.distanceMeters <= PHYSICAL_GYM_MATCH_DISTANCE_METERS && isUserOwned(candidate) && nameIsGeneric,
+    )
+    .map(toCandidateReference);
 
   // Tier 2. Distances are strictly in the 21–150 m band; the DB query already
   // caps at the guarded radius, but re-deriving the band here keeps the tier
@@ -416,6 +432,7 @@ function classifyGymMatch(
       genericNameBlocked: false,
       sameProviderConflicts: [],
       unclaimedUserOwnedSkips: [],
+      tierOneGenericUserOwnedSkips,
       ambiguousCandidates: [],
     };
   }
@@ -425,6 +442,7 @@ function classifyGymMatch(
       genericNameBlocked: true,
       sameProviderConflicts: [],
       unclaimedUserOwnedSkips: [],
+      tierOneGenericUserOwnedSkips,
       ambiguousCandidates: [],
     };
   }
@@ -465,6 +483,8 @@ function classifyGymMatch(
       genericNameBlocked: false,
       sameProviderConflicts,
       unclaimedUserOwnedSkips,
+      // Empty here: this branch is only reached for a non-generic name.
+      tierOneGenericUserOwnedSkips,
       ambiguousCandidates: eligibleCandidates.map(toCandidateReference),
     };
   }
@@ -475,6 +495,8 @@ function classifyGymMatch(
     genericNameBlocked: false,
     sameProviderConflicts,
     unclaimedUserOwnedSkips,
+    // Empty here: this branch is only reached for a non-generic name.
+    tierOneGenericUserOwnedSkips,
     ambiguousCandidates: [],
   };
 }
@@ -569,6 +591,21 @@ async function resolveGymIdForSource(
   for (const skipped of classification.unclaimedUserOwnedSkips) {
     logger.info(
       'location-sync guarded-tier match skipped: unclaimed user-owned gym (surfaces in admin duplicates queue)',
+      {
+        sourceKey,
+        gymName: record.gymName,
+        candidateGymId: skipped.gymId,
+        ownerId: skipped.ownerId,
+        distanceMeters: skipped.distanceMeters,
+      },
+    );
+  }
+  for (const skipped of classification.tierOneGenericUserOwnedSkips) {
+    // A generic-named user-owned gym sat within 20 m of the pin but the guard
+    // refused to let it capture the pin. Surface it (same admin-queue signal as
+    // the unclaimed tier-2 skip) so the near-miss / possible squat isn't silent.
+    logger.info(
+      'location-sync tier-1 match skipped: generic-named user-owned gym (surfaces in admin duplicates queue)',
       {
         sourceKey,
         gymName: record.gymName,

--- a/packages/location-sync/src/upsert.ts
+++ b/packages/location-sync/src/upsert.ts
@@ -1,7 +1,7 @@
 import { and, eq, sql } from 'drizzle-orm';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import { rowsFromResult } from '@boardsesh/db/client';
-import { gyms, locationSyncGymSources, userBoards, users } from '@boardsesh/db/schema';
+import { gymClaims, gyms, locationSyncGymSources, userBoards, users } from '@boardsesh/db/schema';
 import {
   boardUuidForSource,
   gymUuidForSource,
@@ -12,13 +12,51 @@ import {
 } from './ids';
 import { isValidCoordinate } from './coords';
 import type { LocationSyncSummary, PublicBoardLocationInput, SkippedLocationRecord } from './types';
+import { noopLocationSyncLogger, type LocationSyncLogger } from './logger';
 import {
   chooseCanonicalGymCandidate,
+  GYM_MATCH_GUARDED_DISTANCE_METERS,
+  isGenericGymName,
   PHYSICAL_GYM_MATCH_DISTANCE_METERS,
   type CanonicalGymCandidate,
 } from '@boardsesh/db/queries';
 
 type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
+
+/**
+ * A physical-match candidate enriched with the fields the guarded (150 m) tier
+ * and the alias-and-leave-alone rule need: how far the pin is, who owns the gym,
+ * whether an approved claim exists, and which provider source keys already point
+ * at it (used to reject same-provider twins from auto-matching at 150 m).
+ */
+type GymMatchCandidate = CanonicalGymCandidate & {
+  ownerId: string;
+  distanceMeters: number;
+  hasApprovedClaim: boolean;
+  aliasSourceKeys: string[];
+};
+
+/** A resolved alias row plus the ownership facts that gate a metadata refresh. */
+type AliasedGym = {
+  id: number;
+  ownerId: string;
+  hasApprovedClaim: boolean;
+};
+
+/**
+ * A gym is "owner-curated" when a real user owns it or an approved claim exists.
+ * The importer may bind a provider source to such a gym (aliasing), but must
+ * never overwrite its name, coords, or metadata — those belong to the owner.
+ */
+function isOwnerCurated(gym: { ownerId: string; hasApprovedClaim: boolean }): boolean {
+  return gym.ownerId !== SYSTEM_USER_ID || gym.hasApprovedClaim;
+}
+
+/** Provider prefix of a source key, e.g. `tension:gym-1` -> `tension`. */
+function providerPrefixOf(sourceKey: string): string {
+  const separatorIndex = sourceKey.indexOf(':');
+  return separatorIndex === -1 ? sourceKey : sourceKey.slice(0, separatorIndex);
+}
 
 export type ValidBoardLocation = PublicBoardLocationInput & {
   latitude: number;
@@ -129,24 +167,51 @@ async function refreshSyncedGymMetadata(db: DrizzleDb, gymId: number, record: Va
     .where(eq(gyms.id, gymId));
 }
 
-async function findAliasedGymId(db: DrizzleDb, sourceKey: string): Promise<number | null> {
+async function findAliasedGym(db: DrizzleDb, sourceKey: string): Promise<AliasedGym | null> {
   const [aliasedGym] = await db
-    .select({ id: gyms.id })
+    .select({
+      id: gyms.id,
+      ownerId: gyms.ownerId,
+      // Squat protection: a user-owned (or approved-claim) gym that the importer
+      // aliased earlier must keep its owner-curated fields. The alias-resolution
+      // path reads this so it never refreshes metadata into such a gym.
+      hasApprovedClaim: sql<boolean>`EXISTS (
+        SELECT 1 FROM ${gymClaims} claim
+        WHERE claim.gym_id = ${gyms.id} AND claim.status = 'approved'
+      )`,
+    })
     .from(locationSyncGymSources)
     .innerJoin(gyms, eq(locationSyncGymSources.gymId, gyms.id))
     .where(and(eq(locationSyncGymSources.sourceKey, sourceKey), sql`${gyms.deletedAt} IS NULL`))
     .limit(1);
 
-  return aliasedGym?.id ?? null;
+  if (!aliasedGym) {
+    return null;
+  }
+
+  return {
+    id: Number(aliasedGym.id),
+    ownerId: aliasedGym.ownerId,
+    hasApprovedClaim: Boolean(aliasedGym.hasApprovedClaim),
+  };
 }
 
-async function findPhysicalGymMatch(db: DrizzleDb, record: ValidBoardLocation): Promise<CanonicalGymCandidate | null> {
+/**
+ * Fetches every public, live gym that shares the record's exact normalized name
+ * and sits within the guarded (150 m) radius. Unlike the old physical match this
+ * intentionally spans BOTH SYSTEM-owned and user-owned gyms so the importer stops
+ * re-minting gyms that owners already curate. Each row carries its distance,
+ * owner, approved-claim flag, and the provider source keys already aliased to it;
+ * {@link classifyGymMatch} turns that into a tier-1 / tier-2 / reject decision.
+ */
+async function findGymMatchCandidates(db: DrizzleDb, record: ValidBoardLocation): Promise<GymMatchCandidate[]> {
   const result = await db.execute(sql`
     WITH candidate_gyms AS (
       SELECT
         g.id,
         g.uuid,
         g.name,
+        g.owner_id,
         g.address,
         g.contact_email,
         g.contact_phone,
@@ -154,10 +219,13 @@ async function findPhysicalGymMatch(db: DrizzleDb, record: ValidBoardLocation): 
         g.image_url,
         g.latitude,
         g.longitude,
-        g.created_at
+        g.created_at,
+        ST_Distance(
+          g.location,
+          ST_MakePoint(${record.longitude}, ${record.latitude})::geography
+        ) AS distance_meters
       FROM gyms g
-      WHERE g.owner_id = ${SYSTEM_USER_ID}
-        AND g.is_public = true
+      WHERE g.is_public = true
         AND g.deleted_at IS NULL
         AND g.location IS NOT NULL
         AND lower(regexp_replace(trim(g.name), '[[:space:]]+', ' ', 'g')) =
@@ -165,7 +233,7 @@ async function findPhysicalGymMatch(db: DrizzleDb, record: ValidBoardLocation): 
         AND ST_DWithin(
           g.location,
           ST_MakePoint(${record.longitude}, ${record.latitude})::geography,
-          ${PHYSICAL_GYM_MATCH_DISTANCE_METERS}
+          ${GYM_MATCH_GUARDED_DISTANCE_METERS}
         )
     ),
     board_counts AS (
@@ -194,11 +262,18 @@ async function findPhysicalGymMatch(db: DrizzleDb, record: ValidBoardLocation): 
       WHERE gym_comment.entity_type = 'gym'
         AND gym_comment.deleted_at IS NULL
       GROUP BY gym_comment.entity_id
+    ),
+    alias_source_keys AS (
+      SELECT alias.gym_id, array_agg(alias.source_key) AS source_keys
+      FROM location_sync_gym_sources alias
+      INNER JOIN candidate_gyms candidate_gym ON candidate_gym.id = alias.gym_id
+      GROUP BY alias.gym_id
     )
     SELECT
       g.id AS "id",
       g.uuid AS "uuid",
       g.name AS "name",
+      g.owner_id AS "ownerId",
       g.address AS "address",
       g.contact_email AS "contactEmail",
       g.contact_phone AS "contactPhone",
@@ -207,6 +282,12 @@ async function findPhysicalGymMatch(db: DrizzleDb, record: ValidBoardLocation): 
       g.latitude AS "latitude",
       g.longitude AS "longitude",
       g.created_at AS "createdAt",
+      g.distance_meters AS "distanceMeters",
+      EXISTS (
+        SELECT 1 FROM gym_claims claim
+        WHERE claim.gym_id = g.id AND claim.status = 'approved'
+      ) AS "hasApprovedClaim",
+      COALESCE(alias_source_keys.source_keys, ARRAY[]::text[]) AS "aliasSourceKeys",
       COALESCE(board_counts.count, 0)::int AS "boardCount",
       COALESCE(member_counts.count, 0)::int AS "memberCount",
       COALESCE(follower_counts.count, 0)::int AS "followerCount",
@@ -216,20 +297,101 @@ async function findPhysicalGymMatch(db: DrizzleDb, record: ValidBoardLocation): 
     LEFT JOIN member_counts ON member_counts.gym_id = g.id
     LEFT JOIN follower_counts ON follower_counts.gym_id = g.id
     LEFT JOIN comment_counts ON comment_counts.entity_id = g.uuid
+    LEFT JOIN alias_source_keys ON alias_source_keys.gym_id = g.id
   `);
 
-  const candidates = rowsFromResult<CanonicalGymCandidate>(result).map((candidate) => ({
+  return rowsFromResult<GymMatchCandidate>(result).map((candidate) => ({
     ...candidate,
     id: Number(candidate.id),
     latitude: Number(candidate.latitude),
     longitude: Number(candidate.longitude),
+    distanceMeters: Number(candidate.distanceMeters),
+    hasApprovedClaim: Boolean(candidate.hasApprovedClaim),
+    aliasSourceKeys: Array.isArray(candidate.aliasSourceKeys) ? candidate.aliasSourceKeys : [],
     boardCount: Number(candidate.boardCount),
     memberCount: Number(candidate.memberCount),
     followerCount: Number(candidate.followerCount),
     commentCount: Number(candidate.commentCount),
   }));
+}
 
-  return chooseCanonicalGymCandidate(candidates);
+type GymMatchTier = 1 | 2;
+
+/** A tier-2 candidate rejected because a same-provider alias already exists. */
+type SameProviderConflict = {
+  candidateGymId: number;
+  conflictingSourceKeys: string[];
+};
+
+type GymMatchClassification = {
+  match: { candidate: GymMatchCandidate; tier: GymMatchTier } | null;
+  // A generic name blocked the guarded tier (there were 150 m candidates that a
+  // non-generic name would have matched).
+  genericNameBlocked: boolean;
+  // Guarded-tier candidates rejected because a same-provider source already
+  // points at them (likely genuinely distinct walls 150 m apart).
+  sameProviderConflicts: SameProviderConflict[];
+};
+
+/**
+ * Turns the raw candidate list into a match decision.
+ *
+ * - Tier 1 (<= 20 m) always wins, even for generic names — an exact-name pin
+ *   almost on top of a gym is the same gym.
+ * - Tier 2 (<= 150 m) only fires for a non-generic name AND only for candidates
+ *   that don't already carry a same-provider alias. Same-provider twins 150 m
+ *   apart are reported, not merged.
+ */
+function classifyGymMatch(
+  sourceKey: string,
+  record: ValidBoardLocation,
+  candidates: GymMatchCandidate[],
+): GymMatchClassification {
+  const tierOneCandidates = candidates.filter(
+    (candidate) => candidate.distanceMeters <= PHYSICAL_GYM_MATCH_DISTANCE_METERS,
+  );
+  if (tierOneCandidates.length > 0) {
+    const winner = chooseCanonicalGymCandidate(tierOneCandidates);
+    return {
+      match: winner ? { candidate: winner, tier: 1 } : null,
+      genericNameBlocked: false,
+      sameProviderConflicts: [],
+    };
+  }
+
+  // No tier-1 candidate. The DB query already caps distance at the guarded
+  // radius, but re-filter defensively so the tier boundary is enforced here too.
+  const guardedCandidates = candidates.filter(
+    (candidate) => candidate.distanceMeters <= GYM_MATCH_GUARDED_DISTANCE_METERS,
+  );
+  if (guardedCandidates.length === 0) {
+    return { match: null, genericNameBlocked: false, sameProviderConflicts: [] };
+  }
+
+  if (isGenericGymName(record.gymName)) {
+    return { match: null, genericNameBlocked: true, sameProviderConflicts: [] };
+  }
+
+  const providerPrefix = providerPrefixOf(sourceKey);
+  const sameProviderConflicts: SameProviderConflict[] = [];
+  const eligibleCandidates: GymMatchCandidate[] = [];
+  for (const candidate of guardedCandidates) {
+    const conflictingSourceKeys = candidate.aliasSourceKeys.filter(
+      (aliasSourceKey) => aliasSourceKey !== sourceKey && providerPrefixOf(aliasSourceKey) === providerPrefix,
+    );
+    if (conflictingSourceKeys.length > 0) {
+      sameProviderConflicts.push({ candidateGymId: candidate.id, conflictingSourceKeys });
+    } else {
+      eligibleCandidates.push(candidate);
+    }
+  }
+
+  const winner = chooseCanonicalGymCandidate(eligibleCandidates);
+  return {
+    match: winner ? { candidate: winner, tier: 2 } : null,
+    genericNameBlocked: false,
+    sameProviderConflicts,
+  };
 }
 
 async function createOrUpdateSourceGym(
@@ -276,18 +438,74 @@ async function resolveGymIdForSource(
   db: DrizzleDb,
   sourceKey: string,
   record: ValidBoardLocation,
+  logger: LocationSyncLogger,
 ): Promise<number | null> {
-  const aliasedGymId = await findAliasedGymId(db, sourceKey);
-  if (aliasedGymId !== null) {
-    await refreshSyncedGymMetadata(db, aliasedGymId, record);
-    return aliasedGymId;
+  const aliasedGym = await findAliasedGym(db, sourceKey);
+  if (aliasedGym !== null) {
+    // Squat protection: an existing alias never licenses a metadata refresh into
+    // an owner-curated gym. Only SYSTEM-owned, unclaimed gyms keep today's
+    // refresh-on-every-sync behavior.
+    if (isOwnerCurated(aliasedGym)) {
+      logger.info('location-sync alias resolved into owner-curated gym; metadata left untouched', {
+        sourceKey,
+        gymId: aliasedGym.id,
+        ownerId: aliasedGym.ownerId,
+        hasApprovedClaim: aliasedGym.hasApprovedClaim,
+      });
+    } else {
+      await refreshSyncedGymMetadata(db, aliasedGym.id, record);
+    }
+    return aliasedGym.id;
   }
 
-  const physicalGymMatch = await findPhysicalGymMatch(db, record);
-  if (physicalGymMatch) {
-    await upsertSourceAlias(db, sourceKey, physicalGymMatch.id);
-    await refreshSyncedGymMetadata(db, physicalGymMatch.id, record);
-    return physicalGymMatch.id;
+  const candidates = await findGymMatchCandidates(db, record);
+  const classification = classifyGymMatch(sourceKey, record, candidates);
+
+  for (const conflict of classification.sameProviderConflicts) {
+    logger.warn('location-sync guarded-tier match rejected: same-provider source already aliased', {
+      sourceKey,
+      gymName: record.gymName,
+      candidateGymId: conflict.candidateGymId,
+      conflictingSourceKeys: conflict.conflictingSourceKeys,
+      guardedDistanceMeters: GYM_MATCH_GUARDED_DISTANCE_METERS,
+    });
+  }
+  if (classification.genericNameBlocked) {
+    logger.info('location-sync guarded-tier match rejected: generic gym name', {
+      sourceKey,
+      gymName: record.gymName,
+      guardedDistanceMeters: GYM_MATCH_GUARDED_DISTANCE_METERS,
+    });
+  }
+
+  const { match } = classification;
+  if (match) {
+    const { candidate, tier } = match;
+    await upsertSourceAlias(db, sourceKey, candidate.id);
+
+    if (isOwnerCurated(candidate)) {
+      // Alias-and-leave-alone: bind the source so future syncs resolve here, but
+      // never overwrite the owner's curated name / coords / metadata.
+      logger.info('location-sync aliased source into user-owned gym; metadata left untouched', {
+        sourceKey,
+        gymId: candidate.id,
+        ownerId: candidate.ownerId,
+        hasApprovedClaim: candidate.hasApprovedClaim,
+        tier,
+        distanceMeters: candidate.distanceMeters,
+      });
+    } else {
+      if (tier === 2) {
+        logger.info('location-sync guarded-tier (150 m) match', {
+          sourceKey,
+          gymId: candidate.id,
+          gymName: record.gymName,
+          distanceMeters: candidate.distanceMeters,
+        });
+      }
+      await refreshSyncedGymMetadata(db, candidate.id, record);
+    }
+    return candidate.id;
   }
 
   return createOrUpdateSourceGym(db, sourceKey, record);
@@ -297,6 +515,7 @@ async function resolveGymIdForSourceWithLock(
   db: DrizzleDb,
   sourceKey: string,
   record: ValidBoardLocation,
+  logger: LocationSyncLogger,
 ): Promise<number | null> {
   return db.transaction(async (transaction) => {
     const transactionDb = transaction as unknown as DrizzleDb;
@@ -306,7 +525,7 @@ async function resolveGymIdForSourceWithLock(
         hashtext(lower(regexp_replace(trim(${record.gymName}), '[[:space:]]+', ' ', 'g')))
       )
     `);
-    return resolveGymIdForSource(transactionDb, sourceKey, record);
+    return resolveGymIdForSource(transactionDb, sourceKey, record, logger);
   });
 }
 
@@ -324,14 +543,16 @@ async function resolveGymIdForSourceWithLock(
 export async function upsertPublicBoardLocations(
   db: DrizzleDb,
   records: PublicBoardLocationInput[],
+  options: { logger?: LocationSyncLogger } = {},
 ): Promise<LocationSyncSummary> {
+  const logger = options.logger ?? noopLocationSyncLogger;
   await ensureSystemUser(db);
 
   const { validRecords, skipped, gymsBySource } = buildLocationUpsertPlan(records);
 
   const gymIdBySource = new Map<string, number>();
   for (const [sourceKey, record] of gymsBySource) {
-    const gymId = await resolveGymIdForSourceWithLock(db, sourceKey, record);
+    const gymId = await resolveGymIdForSourceWithLock(db, sourceKey, record, logger);
     if (gymId !== null) {
       // The PostGIS `location` geography is derived from lat/lng by the
       // gyms_set_location trigger (migration 0127), so resolving the gym row

--- a/packages/moonboard-sync/src/sync/locations-sync.ts
+++ b/packages/moonboard-sync/src/sync/locations-sync.ts
@@ -1,6 +1,7 @@
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import {
   getMoonBoardLocationConfigs,
+  toLocationSyncLogger,
   upsertPublicBoardLocations,
   type LocationSyncSummary,
   type PublicBoardLocationInput,
@@ -76,7 +77,9 @@ export async function syncMoonBoardLocations(args: {
   await client.authenticate(args.username, args.password);
   const markers = await client.getMapMarkers();
   const records = buildMoonBoardLocationRecords(markers);
-  const summary = await upsertPublicBoardLocations(args.db, records);
+  const summary = await upsertPublicBoardLocations(args.db, records, {
+    logger: toLocationSyncLogger(args.log),
+  });
   args.log?.(
     `[moonboard-locations] upserted ${summary.boardsUpserted}/${summary.boardsSeen} board(s), ${summary.gymsUpserted} gym(s), skipped ${summary.boardsSkipped}`,
   );


### PR DESCRIPTION
## Summary

The location-sync importer (`packages/location-sync`) is the biggest active generator of duplicate gym listings. Its only physical-match tier required `owner_id = SYSTEM` **and** exact normalized name **and** `ST_DWithin` 20 m. Verified prod data shows cross-provider pins for the *same* gym drift 40–90 m (24 of 46 dup pairs span two providers), so every new provider minted a twin. User-owned/claimed gyms were invisible to the match (hard owner filter), so the importer re-created gyms owners already curate.

This adds a **guarded second match tier** and makes **user-owned gyms matchable, alias-and-leave-alone** — with squat protection and an ambiguity guard. Net user-visible effect over time: fewer duplicate gym listings appearing as new providers sync.

## Release Notes

- [x] No release note needed (internal / technical change)

## Match tiers (`classifyGymMatch` / `resolveGymIdForSource`)

- **Tier 1 (≤ 20 m)** — a pin almost on top of a gym is the same gym. SYSTEM-owned candidates always match here; a **user-owned candidate only matches when the name is NOT generic** (a public "Home Wall" 15 m from a stranger's pin must not capture it). Multiple tier-1 candidates pick the canonical one.
- **Tier 2 (20 m < d ≤ 150 m)** — only for a non-generic name, gated by three guards:
  - **Same-provider guard:** a candidate that already carries an alias for the incoming provider prefix pointing at a *different* source key is refused (same-provider twins 150 m apart are likely distinct walls) → structured `warn`.
  - **Squat protection:** tier-2 only binds into a user-owned gym when it carries an **approved claim**. An unclaimed user-owned candidate is never auto-captured — it skips to the `/admin/gym-duplicates` queue where a human merges (the merge re-points the alias) → structured `info`.
  - **Ambiguity guard:** if more than one candidate clears the tier, refuse to auto-match (two same-name gyms in one 150 m circle is itself evidence the name is generic-ish) → structured `warn`.
- **Tier-1 dead-zone log:** a ≤ 20 m user-owned candidate dropped by the tier-1 generic-name guard can't reach tier 2, so it's surfaced with the same admin-queue `info` signal as the unclaimed tier-2 skip instead of vanishing silently before a fresh gym is minted.

## User-owned gyms: alias-and-leave-alone

- The match query now spans non-SYSTEM public live gyms too.
- A match into an owner-curated gym (user-owned, or SYSTEM with an approved claim) writes the source alias but **never** refreshes its name/coords/metadata. The initial bind is logged at **`warn`** (security-relevant); the steady-state per-cycle alias resolution is **`debug`** (it fires ~48×/day/gym and would drown the tier-2 signal).
- **Squat protection at the alias path:** `findAliasedGym` reads owner + approved-claim, so an existing alias never licenses a metadata refresh into an owner-curated gym. Audited every consumer of the alias table (`upsert.ts`, `dedupe-gym-locations.ts`) — nothing else treats "has alias" as "SYSTEM-owned".
- The candidate mapping **throws** on a non-array `aliasSourceKeys` — a silent `[]` would disable the same-provider guard.

## Denylist (`GENERIC_GYM_NAMES`)

`ReadonlySet<string>` declared right after `normalizeGymName`, matched **exactly** on the whole normalized name (never a substring): home wall, homewall, home, garage, cellar, basement, kilter, kilter board, tension, tension board, moonboard, moon board, moon, grasshopper, decoy, soill.

**Inclusion criterion:** board-brand names and homewall genericisms — **not gym-chain names**. A home wall gets named after its board or where it lives, so those collide across unrelated setups; a real gym chain's pins *do* drift 40–90 m and must auto-merge. `touchstone` was intentionally **removed** (Touchstone is a real CA chain) — capping it at 20 m would foreclose the exact drift-merges this PR fixes.

**Cross-PR (resolved):** #3701 merged first and declared its own `GENERIC_GYM_NAMES` in the same spot. This branch is **rebased onto merged `main`** and the conflict is resolved to a **single declaration** — the union of both lists **minus `touchstone`** (#3701's 13 entries + `grasshopper`/`decoy`/`soill`). #3701's consumers (`gym-matching.ts`, `boards.ts`) compile against it (typecheck green).

**Raw-SQL convention:** `findGymMatchCandidates` is a hand-written raw SQL block that literal-names every table (`gyms`, `gym_claims`, `location_sync_gym_sources`, …), matching the importer's existing match-query style; the lighter `findAliasedGym` is a Drizzle builder query using the `${gymClaims}` reference. The two differ by query style, not oversight — documented in a code comment.

## Known limitation (follow-up)

moonboard source keys embed the pin coordinates (`moonboard:<name>:<lat>:<lng>`), so a pin that moves > 20 m mints a new source key; the same-provider guard then warns and mints a permanent twin. Left a code comment at the guard; a key-scheme redesign is a separate follow-up issue.

## Structured logging

`LocationSyncLogger` seam (winston-compatible `debug`/`info`/`warn`), injected into `upsertPublicBoardLocations` and wired into the aurora/kilter/moonboard callers via `toLocationSyncLogger(args.log)`. Logs every tier-2 match, every rejection/skip (generic, same-provider, unclaimed-user-owned, ambiguous), and the initial owner-curated bind.

## Test plan
- `packages/location-sync/src/upsert.test.ts` (31 tests): tier-1 wins at 20 m; tier-2 exact-name match at 150 m; generic blocked at 150 m but matches at 20 m for SYSTEM; generic user-owned does NOT capture a stranger pin at tier-1; same-provider skip + log; unclaimed user-owned tier-2 skip + log; approved-claim user-owned tier-2 bind + no refresh + warn; tier-1 user-owned bind + no refresh + warn; ambiguous two-candidate skip + warn; existing alias into user-owned gym never refreshes; 151 m does not match; query widening.
- `packages/location-sync/src/logger.test.ts`: level prefixes (debug/info/warn), JSON suffix, empty-fields, no-op path.
- `packages/db/src/queries/gyms/__tests__/location-dedupe.test.ts`: guarded distance, generic-name matching, denylist set contents.
- Validation: `vp check`; `vp run typecheck`; `vp test run --project location-sync`; `VITEST_POOL_ID=solo-m3 vp test run --project backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VGxf4ZJGFRanuJGrRMDgY
