### PR TITLE
fix(web): resolve My Gyms before choosing a homepage card variant

### DIFF
--- a/packages/web/app/components/home-gym-card/__tests__/home-gym-card.test.tsx
+++ b/packages/web/app/components/home-gym-card/__tests__/home-gym-card.test.tsx
@@ -17,6 +17,10 @@ vi.mock('react-i18next', () => ({
 let mockGyms: Array<Record<string, unknown>> = [];
 let mockIsLoading = false;
 let mockError: string | null = null;
+// Mirrors the real hook's `hasResolved` (React Query `isFetched`): false while
+// the ws-auth token is still in flight, true once the fetch has settled
+// (success or error). Defaults true so most tests don't need to think about it.
+let mockHasResolved = true;
 let mockStatus: 'authenticated' | 'unauthenticated' | 'loading' = 'authenticated';
 let mockUserId: string | null = 'user-1';
 let mockKioskFlag = true;
@@ -32,6 +36,7 @@ vi.mock('@/app/hooks/use-my-gyms', () => ({
     hasMore: false,
     loadMore: vi.fn(),
     error: mockError,
+    hasResolved: mockHasResolved,
   }),
 }));
 
@@ -106,6 +111,7 @@ describe('HomeGymCard', () => {
     mockGyms = [];
     mockIsLoading = false;
     mockError = null;
+    mockHasResolved = true;
     mockStatus = 'authenticated';
     mockUserId = 'user-1';
     mockKioskFlag = true;
@@ -122,6 +128,20 @@ describe('HomeGymCard', () => {
 
     it('renders nothing while the gyms request is still loading', () => {
       mockIsLoading = true;
+      mockHasResolved = false;
+      mockGyms = [];
+      render(<HomeGymCard />);
+      expect(screen.queryByTestId('home-gym-card-owner')).toBeNull();
+      expect(screen.queryByTestId('home-gym-card-find')).toBeNull();
+    });
+
+    it('renders nothing while the ws-auth token is still in flight (pre-token, not yet resolved)', () => {
+      // The bug this pins: the hook used to report isLoading=false AND gyms=[]
+      // while idle pre-token, which the old gate misread as "loaded with zero
+      // gyms" and flashed the non-owner nudge. hasResolved=false is the
+      // definitive "we don't know yet" signal regardless of isLoading.
+      mockIsLoading = false;
+      mockHasResolved = false;
       mockGyms = [];
       render(<HomeGymCard />);
       expect(screen.queryByTestId('home-gym-card-owner')).toBeNull();
@@ -162,6 +182,19 @@ describe('HomeGymCard', () => {
       await waitFor(() => {
         expect(screen.queryByTestId('home-gym-card-find')).toBeNull();
       });
+    });
+
+    it('still shows the owner card when dismissed=true and the user has a gym (owner branch precedes the dismissal gate)', async () => {
+      // Dismissal only ever applies to the non-owner "find your gym" nudge. An
+      // owner who dismissed the nudge before joining/creating a gym must still
+      // see their owner card — the owner check has to run before the
+      // dismissal gate is ever consulted.
+      mockGyms = [makeGym()];
+      mockDismissed = true;
+      render(<HomeGymCard />);
+      const card = await screen.findByTestId('home-gym-card-owner');
+      expect(card).toBeTruthy();
+      expect(screen.queryByTestId('home-gym-card-find')).toBeNull();
     });
   });
 

--- a/packages/web/app/components/home-gym-card/home-gym-card.tsx
+++ b/packages/web/app/components/home-gym-card/home-gym-card.tsx
@@ -55,7 +55,7 @@ const iconChipSx = {
   width: 44,
   height: 44,
   borderRadius: `${themeTokens.borderRadius.md}px`,
-  backgroundColor: 'rgba(94, 100, 145, 0.12)',
+  backgroundColor: themeTokens.colors.infoTint,
   color: 'var(--color-info)',
   display: 'flex',
   alignItems: 'center',
@@ -81,7 +81,7 @@ export default function HomeGymCard() {
 function AuthedHomeGymCard({ currentUserId }: { currentUserId: string | null }) {
   const { t } = useTranslation('marketing');
   const { t: tCommon } = useTranslation('common');
-  const { gyms, isLoading, error } = useMyGyms(true);
+  const { gyms, error, hasResolved } = useMyGyms(true);
   // Kill switch for the manage surface — mirrors the My Gyms drawer, which
   // hides the Manage button until the gym-kiosk feature ships broadly. The
   // View action stays ungated.
@@ -154,9 +154,12 @@ function AuthedHomeGymCard({ currentUserId }: { currentUserId: string | null }) 
     track('Homepage Gym Card Click', { action: 'dismiss' });
   }, []);
 
-  // Wait for the gyms fetch before deciding which variant to show — don't
-  // guess non-owner while the request is still in flight.
-  if (error || (isLoading && gyms.length === 0)) return null;
+  // Wait for the gyms fetch to definitively resolve before deciding which
+  // variant to show. `hasResolved` stays false while the ws-auth token is
+  // still in flight, so this never misreads "idle, pre-token" as "loaded with
+  // zero gyms" and flashes the non-owner nudge before swapping to the owner
+  // card (see use-my-gyms.ts).
+  if (error || !hasResolved) return null;
 
   if (gyms.length > 0) {
     return (

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -77,7 +77,7 @@ type OnboardingCardProps = {
 const accentSurface: Record<OnboardingCardAccent, string> = {
   action: 'var(--semantic-selected-light)', // existing rose tint
   social: 'rgba(156, 39, 176, 0.10)', // V11 purple
-  help: 'rgba(94, 100, 145, 0.12)', // violet-slate (Velvet info) — same family as the rest
+  help: themeTokens.colors.infoTint, // violet-slate (Velvet info) — same family as the rest
   v11: 'rgba(156, 39, 176, 0.10)', // V11 #9C27B0
   v12: 'rgba(123, 31, 162, 0.10)', // V12 #7B1FA2
   v13: 'rgba(106, 27, 154, 0.10)', // V13 #6A1B9A

--- a/packages/web/app/hooks/__tests__/use-my-gyms.test.ts
+++ b/packages/web/app/hooks/__tests__/use-my-gyms.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '@/app/test-utils/test-providers';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { useMyGyms } from '../use-my-gyms';
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: vi.fn(),
+}));
+
+let mockUserId: string | null = 'user-1';
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: mockUserId ? { user: { id: mockUserId } } : null }),
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@boardsesh/graphql/operations', () => ({
+  GET_MY_GYMS: 'GET_MY_GYMS_QUERY',
+}));
+
+const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
+
+const mockGyms = [
+  { uuid: 'gym-1', name: 'Boulder Project', slug: 'boulder-project', ownerId: 'user-1' },
+  { uuid: 'gym-2', name: 'Send Town', slug: 'send-town', ownerId: 'user-1' },
+];
+
+describe('useMyGyms', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserId = 'user-1';
+    mockUseWsAuthToken.mockReturnValue({
+      token: 'test-token',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('does not fetch when disabled', () => {
+    const { result } = renderHook(() => useMyGyms(false), { wrapper: createQueryWrapper() });
+
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(result.current.gyms).toEqual([]);
+    // hasResolved is the definitive "we know the answer" signal — a disabled
+    // query has never fetched, so it must report unresolved, not empty-success.
+    expect(result.current.hasResolved).toBe(false);
+  });
+
+  it('does not fetch when not authenticated', () => {
+    mockUseWsAuthToken.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useMyGyms(true), { wrapper: createQueryWrapper() });
+
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(result.current.gyms).toEqual([]);
+    expect(result.current.hasResolved).toBe(false);
+  });
+
+  it('reports isLoading=true and hasResolved=false while the ws-auth token is still in flight', () => {
+    // This is the exact pre-token state that caused the homepage gym card to
+    // flash the non-owner nudge: enabled=true, isAuthenticated=true, but no
+    // token yet. The query stays disabled until the token resolves, so it
+    // must never look like a settled "0 gyms" result.
+    mockUseWsAuthToken.mockReturnValue({
+      token: null,
+      isAuthenticated: true,
+      isLoading: true,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useMyGyms(true), { wrapper: createQueryWrapper() });
+
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(result.current.gyms).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.hasResolved).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fetches gyms when enabled and authenticated, and resolves hasResolved=true', async () => {
+    mockRequest.mockResolvedValueOnce({ myGyms: { gyms: mockGyms, totalCount: 2, hasMore: false } });
+
+    const { result } = renderHook(() => useMyGyms(true), { wrapper: createQueryWrapper() });
+
+    expect(result.current.hasResolved).toBe(false);
+
+    await waitFor(() => {
+      expect(result.current.hasResolved).toBe(true);
+    });
+
+    expect(result.current.gyms).toEqual(mockGyms);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(mockRequest).toHaveBeenCalledWith('GET_MY_GYMS_QUERY', { input: { limit: 50, offset: 0 } });
+  });
+
+  it('sets error and hasResolved=true on fetch failure', async () => {
+    mockRequest.mockRejectedValueOnce(new Error('network error'));
+
+    const { result } = renderHook(() => useMyGyms(true), { wrapper: createQueryWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.hasResolved).toBe(true);
+    });
+
+    expect(result.current.error).toBe('Failed to load your gyms');
+    expect(result.current.gyms).toEqual([]);
+  });
+
+  it('passes a custom limit to the query', async () => {
+    mockRequest.mockResolvedValueOnce({ myGyms: { gyms: [], totalCount: 0, hasMore: false } });
+
+    renderHook(() => useMyGyms(true, 20), { wrapper: createQueryWrapper() });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith('GET_MY_GYMS_QUERY', { input: { limit: 20, offset: 0 } });
+    });
+  });
+
+  it('exposes hasMore and paginates via loadMore', async () => {
+    mockRequest.mockResolvedValueOnce({
+      myGyms: { gyms: [mockGyms[0]], totalCount: 2, hasMore: true },
+    });
+
+    const { result } = renderHook(() => useMyGyms(true, 1), { wrapper: createQueryWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.gyms).toHaveLength(1);
+    });
+    expect(result.current.hasMore).toBe(true);
+
+    mockRequest.mockResolvedValueOnce({
+      myGyms: { gyms: [mockGyms[1]], totalCount: 2, hasMore: false },
+    });
+
+    result.current.loadMore();
+
+    await waitFor(() => {
+      expect(result.current.gyms).toHaveLength(2);
+    });
+    expect(result.current.hasMore).toBe(false);
+    expect(mockRequest).toHaveBeenLastCalledWith('GET_MY_GYMS_QUERY', { input: { limit: 1, offset: 1 } });
+  });
+
+  it('scopes the cached result to the viewer so a different signed-in user does not see stale gyms', async () => {
+    mockRequest.mockResolvedValueOnce({ myGyms: { gyms: mockGyms, totalCount: 2, hasMore: false } });
+
+    const { result, rerender } = renderHook(() => useMyGyms(true), { wrapper: createQueryWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.gyms).toHaveLength(2);
+    });
+
+    mockUserId = 'user-2';
+    mockRequest.mockResolvedValueOnce({ myGyms: { gyms: [], totalCount: 0, hasMore: false } });
+    rerender();
+
+    // A new viewer has no cached entry under their own query key, so the hook
+    // goes back to unresolved rather than briefly showing user-1's gyms.
+    expect(result.current.hasResolved).toBe(false);
+
+    await waitFor(() => {
+      expect(result.current.hasResolved).toBe(true);
+    });
+    expect(result.current.gyms).toEqual([]);
+  });
+});

--- a/packages/web/app/hooks/use-my-gyms.ts
+++ b/packages/web/app/hooks/use-my-gyms.ts
@@ -53,16 +53,15 @@ export function useMyGyms(enabled: boolean, limit = 50) {
   >({
     queryKey: ['myGyms', viewerUserId, limit] as const,
     queryFn: async ({ pageParam }) => {
+      // `enabled` guards `token` being non-null whenever this actually runs;
+      // narrow explicitly so a future `createGraphQLHttpClient` signature
+      // change can't silently accept a null token.
+      if (!token) throw new Error('useMyGyms: queryFn ran without a token');
       const client = createGraphQLHttpClient(token);
-      try {
-        const response = await client.request<GetMyGymsQueryResponse, GetMyGymsQueryVariables>(GET_MY_GYMS, {
-          input: { limit, offset: pageParam },
-        });
-        return response.myGyms;
-      } catch (requestError) {
-        console.error('Failed to fetch gyms:', requestError);
-        throw requestError;
-      }
+      const response = await client.request<GetMyGymsQueryResponse, GetMyGymsQueryVariables>(GET_MY_GYMS, {
+        input: { limit, offset: pageParam },
+      });
+      return response.myGyms;
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {

--- a/packages/web/app/hooks/use-my-gyms.ts
+++ b/packages/web/app/hooks/use-my-gyms.ts
@@ -1,8 +1,12 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+'use client';
+
+import { useInfiniteQuery, type InfiniteData } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useSession } from 'next-auth/react';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { GET_MY_GYMS, type GetMyGymsQueryResponse, type GetMyGymsQueryVariables } from '@boardsesh/graphql/operations';
-import type { Gym } from '@boardsesh/shared-schema';
+import type { Gym, GymConnection } from '@boardsesh/shared-schema';
 
 /**
  * Fetches the gyms the current user owns via GraphQL. Membership-based listing
@@ -12,79 +16,65 @@ import type { Gym } from '@boardsesh/shared-schema';
  * includes gym_members.
  * Gyms are fetched when `enabled` becomes true and the user is authenticated.
  *
- * Call `loadMore` to fetch the next page; `hasMore` indicates whether more pages exist.
- * Mirrors {@link import('./use-my-boards').useMyBoards} so the My Gyms drawer follows
- * the same load/paginate/error shape as My Boards.
+ * Built on `useInfiniteQuery` so the homepage card and the My Gyms drawer share a
+ * single cache entry per viewer — opening the drawer after the homepage has
+ * already resolved reuses the cached first page instead of refetching.
+ *
+ * Call `loadMore` to fetch the next page; `hasMore` indicates whether more pages
+ * exist. Mirrors {@link import('./use-my-boards').useMyBoards}'s shape so the My
+ * Gyms drawer follows the same load/paginate/error contract as My Boards.
+ *
+ * `hasResolved` is the definitive "we know the answer" signal: it stays false
+ * while the ws-auth token is still in flight (the query is `enabled: false`
+ * with no cached data), so callers can gate a variant decision on it instead of
+ * misreading "not loading yet" as "loaded with zero gyms" — see home-gym-card.tsx.
  */
 export function useMyGyms(enabled: boolean, limit = 50) {
   const { token, isAuthenticated } = useWsAuthToken();
-  const [gyms, setGyms] = useState<Gym[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isFetchingMore, setIsFetchingMore] = useState(false);
-  const [hasMore, setHasMore] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { data: session } = useSession();
+  // Scope the cache entry to the viewer so an in-session login/logout can't
+  // serve the previous user's gyms from the query cache.
+  const viewerUserId = session?.user?.id ?? 'anonymous';
 
-  const offsetRef = useRef(0);
-  // Synchronous guard prevents double-fires from the IntersectionObserver
-  const isFetchingMoreRef = useRef(false);
-  const hasDataRef = useRef(false);
-
-  useEffect(() => {
-    if (!enabled || !isAuthenticated || !token) return;
-
-    let cancelled = false;
-    if (!hasDataRef.current) {
-      setIsLoading(true);
-    }
-    setError(null);
-    offsetRef.current = 0;
-
-    const client = createGraphQLHttpClient(token);
-    client
-      .request<GetMyGymsQueryResponse, GetMyGymsQueryVariables>(GET_MY_GYMS, { input: { limit, offset: 0 } })
-      .then((response) => {
-        if (!cancelled) {
-          setGyms(response.myGyms.gyms);
-          setHasMore(response.myGyms.hasMore);
-          offsetRef.current = response.myGyms.gyms.length;
-          hasDataRef.current = true;
-        }
-      })
-      .catch((requestError) => {
-        console.error('Failed to fetch gyms:', requestError);
-        if (!cancelled) setError('Failed to load your gyms');
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoading(false);
+  const query = useInfiniteQuery<
+    GymConnection,
+    Error,
+    InfiniteData<GymConnection>,
+    readonly ['myGyms', string, number],
+    number
+  >({
+    queryKey: ['myGyms', viewerUserId, limit] as const,
+    queryFn: async ({ pageParam }) => {
+      const client = createGraphQLHttpClient(token);
+      const response = await client.request<GetMyGymsQueryResponse, GetMyGymsQueryVariables>(GET_MY_GYMS, {
+        input: { limit, offset: pageParam },
       });
+      return response.myGyms;
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+      if (!lastPage.hasMore) return undefined;
+      return lastPageParam + lastPage.gyms.length;
+    },
+    enabled: enabled && isAuthenticated && !!token,
+    staleTime: 60 * 1000,
+  });
 
-    return () => {
-      cancelled = true;
-    };
-  }, [enabled, isAuthenticated, token, limit]);
+  const gyms: Gym[] = useMemo(() => query.data?.pages.flatMap((page) => page.gyms) ?? [], [query.data]);
 
-  const loadMore = useCallback(() => {
-    if (!hasMore || isFetchingMoreRef.current || !token || !isAuthenticated) return;
+  const loadMore = () => {
+    void query.fetchNextPage();
+  };
 
-    isFetchingMoreRef.current = true;
-    setIsFetchingMore(true);
-    const offset = offsetRef.current;
-    const client = createGraphQLHttpClient(token);
-    client
-      .request<GetMyGymsQueryResponse, GetMyGymsQueryVariables>(GET_MY_GYMS, { input: { limit, offset } })
-      .then((response) => {
-        setGyms((prev) => [...prev, ...response.myGyms.gyms]);
-        setHasMore(response.myGyms.hasMore);
-        offsetRef.current = offset + response.myGyms.gyms.length;
-      })
-      .catch((requestError) => {
-        console.error('Failed to load more gyms:', requestError);
-      })
-      .finally(() => {
-        isFetchingMoreRef.current = false;
-        setIsFetchingMore(false);
-      });
-  }, [hasMore, token, isAuthenticated, limit]);
-
-  return { gyms, isLoading, isFetchingMore, hasMore, loadMore, error };
+  return {
+    gyms,
+    isLoading: query.isPending,
+    isFetchingMore: query.isFetchingNextPage,
+    hasMore: query.hasNextPage ?? false,
+    loadMore,
+    error: query.isError ? 'Failed to load your gyms' : null,
+    // True once the first fetch attempt has settled (success or error) — false
+    // while disabled (no token yet) or genuinely in flight for the first time.
+    hasResolved: query.isFetched,
+  };
 }

--- a/packages/web/app/hooks/use-my-gyms.ts
+++ b/packages/web/app/hooks/use-my-gyms.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useInfiniteQuery, type InfiniteData } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSession } from 'next-auth/react';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -36,6 +36,14 @@ export function useMyGyms(enabled: boolean, limit = 50) {
   // serve the previous user's gyms from the query cache.
   const viewerUserId = session?.user?.id ?? 'anonymous';
 
+  // The query key is deliberately NOT keyed on `token`: the ws-auth JWT is
+  // re-minted on its own ~5min revalidation cycle (see use-ws-auth-token.ts)
+  // even when the signed-in user hasn't changed, and gyms data has no reason
+  // to change alongside it — keying on it would re-fetch the whole gyms list
+  // on every silent token refresh. Same convention as
+  // useGroupedNotifications/useUnreadNotificationCount/InsightsTab's gymStats
+  // query. `queryFn` still closes over the latest `token` on every actual
+  // fetch, so a genuine token rotation is never used stale.
   const query = useInfiniteQuery<
     GymConnection,
     Error,
@@ -46,10 +54,15 @@ export function useMyGyms(enabled: boolean, limit = 50) {
     queryKey: ['myGyms', viewerUserId, limit] as const,
     queryFn: async ({ pageParam }) => {
       const client = createGraphQLHttpClient(token);
-      const response = await client.request<GetMyGymsQueryResponse, GetMyGymsQueryVariables>(GET_MY_GYMS, {
-        input: { limit, offset: pageParam },
-      });
-      return response.myGyms;
+      try {
+        const response = await client.request<GetMyGymsQueryResponse, GetMyGymsQueryVariables>(GET_MY_GYMS, {
+          input: { limit, offset: pageParam },
+        });
+        return response.myGyms;
+      } catch (requestError) {
+        console.error('Failed to fetch gyms:', requestError);
+        throw requestError;
+      }
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
@@ -62,9 +75,10 @@ export function useMyGyms(enabled: boolean, limit = 50) {
 
   const gyms: Gym[] = useMemo(() => query.data?.pages.flatMap((page) => page.gyms) ?? [], [query.data]);
 
-  const loadMore = () => {
-    void query.fetchNextPage();
-  };
+  const { fetchNextPage } = query;
+  const loadMore = useCallback(() => {
+    void fetchNextPage();
+  }, [fetchNextPage]);
 
   return {
     gyms,

--- a/packages/web/app/theme/theme-config.ts
+++ b/packages/web/app/theme/theme-config.ts
@@ -36,6 +36,7 @@ export const themeTokens = {
     live: brandColors.live, // #B45309 — "now on the wall / physically lit" status hue (own role, not warning)
     secondary: '#5B5563', // violet-grey for info/secondary
     info: '#5E6491', // Violet-slate — help/guide accent, re-pulled into the violet family
+    infoTint: 'rgba(94, 100, 145, 0.12)', // 12%-alpha `info` — shared low-key icon-chip bg (OnboardingCard 'help', homepage gym card)
     success: brandColors.success, // #047857
     successHover: '#036B4D',
     successBg: '#E7F4EE',


### PR DESCRIPTION
## Summary

- Post-merge follow-up on #3697's homepage gym card: on a cold load, a signed-in gym owner could briefly see the non-owner "Find your gym" nudge before it blanked and swapped to the owner card.
- Root cause: `useMyGyms` was a raw `useState`/`useEffect` hook whose fetch effect bailed out early while the ws-auth token was still in flight, *without* setting `isLoading` — so the card's gate `if (error || (isLoading && gyms.length === 0)) return null` read "idle, pre-token" as "loaded with zero gyms."
- Ported `useMyGyms` to `useInfiniteQuery` (TanStack Query), matching the pattern already used by `useGroupedNotifications`/`useUnreadNotificationCount`/`InsightsTab`. It now exposes a definitive `hasResolved` signal (`query.isFetched`) that stays false while the query is disabled pre-token, and caches per-viewer so the homepage card and the My Gyms drawer share one cache entry.
- `home-gym-card.tsx` now gates the variant decision on `hasResolved` instead of guessing from `isLoading`/`gyms.length` — it renders nothing until the fetch has genuinely settled (or errored). The owner-branch-before-dismissal-gate ordering is unchanged (pinned by a new test).
- Extracted the duplicated `rgba(94, 100, 145, 0.12)` icon-chip tint (`home-gym-card.tsx` + `home-page-content.tsx`'s OnboardingCard `help` accent) into `themeTokens.colors.infoTint`.

## Release Notes

- [ ] No release note needed (internal / technical change)

The homepage gym card no longer flickers between states while it figures out whose gym is whose.

## Test plan

- `vp check` — 0 errors (pre-existing unrelated warnings only, all outside this diff)
- `vp run typecheck:web` — clean
- `vp test run --project web --reporter=agent` — 418 files / 5384 tests, all pass
- `vp run check:i18n` — no hardcoded strings
- Added `packages/web/app/hooks/__tests__/use-my-gyms.test.ts`: pre-token "not resolved" state (the exact bug scenario), successful/error resolution, pagination via `loadMore`, and per-viewer cache scoping.
- Added a `home-gym-card.test.tsx` case pinning that dismissed=true + non-empty gyms still renders the owner card (owner branch precedes the dismissal gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VGxf4ZJGFRanuJGrRMDgY