### PR TITLE
test(shared): cover dual-grade weekly volume chart labels (#3302)

### DIFF
--- a/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
+++ b/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
+import { getGradeColor } from '@boardsesh/board-constants/grade-colors';
 import {
   filterLogbookByTimeframe,
   buildAggregatedStackedBars,
@@ -233,6 +234,57 @@ describe('buildWeeklyBars', () => {
     expect(keys).toContain(
       `${dayjs('2024-10-15T12:00:00Z').isoWeekYear()}-W${dayjs('2024-10-15T12:00:00Z').isoWeek()}`,
     );
+  });
+});
+
+// Regression coverage for #3302: the week-by-week volume chart rendered every
+// bar grey with an unreadable x-axis when the app's grade display is set to
+// "both" (font + V). The axis-width fix lives in mobile's YouCharts.tsx and
+// the color fix lives in mobile's gradeChartColor (now routed through
+// @boardsesh/board-constants' getGradeColor instead of an exact-string
+// lookup) — both landed in commits bcf45eb55 / fdfc061a4. This suite locks in
+// the renderer-agnostic half of the contract those fixes depend on:
+// buildWeeklyBars('both') must keep emitting combined "V<n>[+] / <font>[+]"
+// labels that a real color lookup can actually extract a V-grade from, so a
+// future change to the 'both' label template can't silently reintroduce grey
+// bars on either platform.
+describe("buildWeeklyBars with dual grade format ('both')", () => {
+  it('emits combined V + Font grade labels that a real color lookup resolves', () => {
+    const logbook = [
+      makeEntry({ climbed_at: '2024-01-08T12:00:00Z', difficulty: 16 }), // 6a/V3
+      makeEntry({ climbed_at: '2024-01-08T12:00:00Z', difficulty: 17 }), // 6a+/V3 (needs "+" disambiguation)
+      makeEntry({ climbed_at: '2024-01-08T12:00:00Z', difficulty: 22 }), // 7a/V6
+    ];
+    const result = buildWeeklyBars(logbook, undefined, undefined, 'both');
+    expect(result).not.toBeNull();
+
+    const segments = result!.flatMap((bar) => bar.segments);
+    expect(segments.length).toBeGreaterThan(0);
+
+    for (const segment of segments) {
+      // Combined label shape: "V<n>[+] / <FONT>[+]" — the key a color
+      // resolver keys off of is the same string as the display label.
+      expect(segment.label).toMatch(/^V\d+\+? \/ \S+$/);
+      expect(segment.key).toBe(segment.label);
+      // The exact regression: every combined label must resolve to a real
+      // color, not fall through to the grey "unknown grade" fallback.
+      expect(getGradeColor(segment.label)).toBeDefined();
+    }
+  });
+
+  it('keeps font sub-grades distinguishable (6a vs 6a+ both map to V3, but stay separate bars)', () => {
+    const logbook = [
+      makeEntry({ climbed_at: '2024-01-08T12:00:00Z', difficulty: 16 }), // 6a/V3
+      makeEntry({ climbed_at: '2024-01-08T12:00:00Z', difficulty: 17 }), // 6a+/V3
+    ];
+    const result = buildWeeklyBars(logbook, undefined, undefined, 'both')!;
+    const labels = result.flatMap((bar) => bar.segments.map((segment) => segment.label));
+
+    expect(labels).toContain('V3 / 6A');
+    expect(labels).toContain('V3+ / 6A+');
+    // Distinct font sub-grades resolve to the same underlying V-grade color —
+    // by design, the badge differentiates by V-grade family, not sub-grade.
+    expect(getGradeColor('V3 / 6A')).toBe(getGradeColor('V3+ / 6A+'));
   });
 });
 


### PR DESCRIPTION
## Summary

Investigated #3302 (week-by-week volume chart renders grey with an unreadable
X axis when the app's grade display is set to "both" / font+V) end-to-end and
traced the exact code path: `ProgressTab.tsx` → `buildWeeklyBars()` in
`@boardsesh/profile-stats` → `StackedBarChart` → `gradeChartColor()` →
`getGradeColor()`.

**Both symptoms are already fixed on `main`, and were fixed *before this
issue was even filed*:**

- "all grey" — fixed by `bcf45eb55` ("Fix combined grade chart colors",
  2026-06-17). Mobile's `gradeChartColor` used to do an exact-string lookup
  (`V_GRADE_COLORS[normalized] ?? FONT_GRADE_COLORS[...]`) that failed on
  combined labels like `"V3+ / 6A+"`, falling through to the grey fallback.
  It now routes through `@boardsesh/board-constants`' `getGradeColor()`,
  which regex-extracts the V-grade token from the combined string.
- "unreadable X axis" — fixed by `fdfc061a4` ("Profile charts: device-QA
  feedback — … readable axes …", 2026-06-17), which gives every kept x-axis
  label the full downsample-step width instead of clipping to the ~1-bar
  default box.

Timeline: the in-app bug report is dated 2026-06-16. Both fixes landed
2026-06-17 (one day later). The GitHub issue was filed 2026-06-29 — 12 days
*after* the fix — by the automated PostHog-triage pipeline, which doesn't
check whether a fix already shipped before filing from a stale report.

I confirmed this by reading the current code (not just trusting commit
messages): `gradeChartColor()` and `getGradeColor()` both correctly resolve
combined grade strings today, and existing tests already assert this
(`profile-chart-colors.test.ts`, `grade-colors.test.ts`). I ran the full
existing `chart-builders` suite (36/36 green) and the mobile
`profile-chart-colors` suite (11/11 green) with no changes — confirming
current behavior is already correct.

**The one real gap**: `@boardsesh/profile-stats`'s own test suite had zero
coverage of `buildWeeklyBars(..., 'both')` — the shared, renderer-agnostic
layer that both web and mobile build their charts from. This PR closes that
gap so a future change to the `'both'` label template (e.g. reordering
`formatGrade`'s V/Font parts, or dropping the `V<n>` prefix) can't silently
reintroduce grey bars on either platform without a test failing first.

This PR is **test-only** — no production code changes, because none are
needed.

### Follow-up (not implemented here)

While tracing this, I noticed the weekly volume chart (`ProgressTab.tsx`,
`colorBy="grade"`) is the only stacked chart on the Progress tab with no
`legend` prop — the grade-distribution chart right below it does pass one.
Users currently can't decode which color maps to which grade on the weekly
chart. Distinct from what #3302 describes (colors resolve fine, they're just
undecoded), so leaving this out of scope here. @marcodejongh — worth a
follow-up issue if you'd like a grade legend added under the weekly chart.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Added two tests to `packages/shared/profile-stats/src/__tests__/chart-builders.test.ts`:
  - `buildWeeklyBars(..., 'both')` emits combined `"V<n>[+] / <font>[+]"`
    labels, and every label resolves to a real color via the actual
    `@boardsesh/board-constants` `getGradeColor()` (the exact regression
    guard for the "all grey" symptom).
  - Font sub-grades that collapse to the same V-grade (6a vs 6a+, both V3)
    stay as distinct bars but resolve to the same underlying color, by
    design.
- `vp test run --project profile-stats --reporter=agent` — 38/38 passed
  (36 pre-existing + 2 new).
- `vp run typecheck:profile-stats` — clean.
- `vp check packages/shared/profile-stats/src/__tests__/chart-builders.test.ts` — clean (format + lint).

Fixes #3302
