### PR TITLE
fix(mobile): guard GraphQL client against empty/malformed 2xx bodies

### DIFF
--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -134,6 +134,17 @@ describe('reportHandledError', () => {
     });
   });
 
+  it('downgrades a GraphQLEmptyResponseError (2xx with an empty/truncated body) to a warning tagged network (#3190)', () => {
+    const emptyBody = Object.assign(new Error('GraphQL response body was empty or not valid JSON (HTTP 200)'), {
+      name: 'GraphQLEmptyResponseError',
+    });
+    reportHandledError(emptyBody, { tags: { source: 'react-query', kind: 'query' } });
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(emptyBody, {
+      level: 'warning',
+      tags: { source: 'react-query', kind: 'query', network: true },
+    });
+  });
+
   it('forces warning for a network error even if the caller asked for a higher level', () => {
     const offline = new TypeError('Network request failed');
     reportHandledError(offline, { level: 'fatal', tags: { source: 'x' } });

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -36,10 +36,15 @@ function isCancellation(error: unknown): boolean {
  * networks, so we keep it filterable as a low-severity breadcrumb rather than a
  * full `error` that drowns real bugs. RN's fetch rejects offline requests with
  * `TypeError: Network request failed`; graphql-request wraps a fetch failure in
- * a ClientError that carries no HTTP `response.status`.
+ * a ClientError that carries no HTTP `response.status`; our GraphQL client
+ * throws a typed `GraphQLEmptyResponseError` (see `./graphql/client.ts`) when a
+ * nominally-2xx response body arrives empty or truncated — the same offline
+ * blip signature, just caught a layer up (#3190).
  */
 function isNetworkError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
+  const name = (error as { name?: unknown }).name;
+  if (name === 'GraphQLEmptyResponseError') return true;
   const response = (error as { response?: { status?: unknown } }).response;
   // A ClientError with a `response` but no numeric `status` is a transport
   // failure; one with a status is a real server error (4xx/5xx) we want to see.

--- a/packages/mobile/src/lib/graphql/__tests__/client.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/client.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// The guard wraps authenticatedFetch — mock it directly so we can hand back
+// whatever Response shape the test wants without touching auth/token plumbing
+// (that's covered by auth-interceptor.test.ts).
+vi.mock('../../auth-interceptor', () => ({
+  authenticatedFetch: vi.fn(),
+}));
+
+import { authenticatedFetch } from '../../auth-interceptor';
+import { graphqlFetchWithEmptyBodyGuard, GraphQLEmptyResponseError } from '../client';
+
+const mockAuthenticatedFetch = authenticatedFetch as Mock;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('graphqlFetchWithEmptyBodyGuard', () => {
+  it('throws GraphQLEmptyResponseError for a 200 with an empty body (#3190 — connection dropped mid-response)', async () => {
+    mockAuthenticatedFetch.mockResolvedValue(new Response('', { status: 200 }));
+
+    await expect(graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql')).rejects.toThrow(
+      GraphQLEmptyResponseError,
+    );
+  });
+
+  it('throws GraphQLEmptyResponseError for a 200 with a whitespace-only body', async () => {
+    mockAuthenticatedFetch.mockResolvedValue(new Response('   \n', { status: 200 }));
+
+    await expect(graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql')).rejects.toThrow(
+      GraphQLEmptyResponseError,
+    );
+  });
+
+  it('throws GraphQLEmptyResponseError for a 200 with a non-JSON body (e.g. an HTML captive-portal page)', async () => {
+    mockAuthenticatedFetch.mockResolvedValue(new Response('<html>not json</html>', { status: 200 }));
+
+    await expect(graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql')).rejects.toThrow(
+      GraphQLEmptyResponseError,
+    );
+  });
+
+  it('throws GraphQLEmptyResponseError for a 200 whose body is valid JSON but not an object/array', async () => {
+    mockAuthenticatedFetch.mockResolvedValue(new Response('"just a string"', { status: 200 }));
+
+    await expect(graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql')).rejects.toThrow(
+      GraphQLEmptyResponseError,
+    );
+  });
+
+  it('names the thrown error GraphQLEmptyResponseError and includes the HTTP status', async () => {
+    mockAuthenticatedFetch.mockResolvedValue(new Response('', { status: 200 }));
+
+    await expect(graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql')).rejects.toMatchObject({
+      name: 'GraphQLEmptyResponseError',
+      message: expect.stringContaining('200'),
+    });
+  });
+
+  it('passes a valid JSON object body straight through untouched', async () => {
+    const body = JSON.stringify({ data: { climbStatsHistory: [] } });
+    mockAuthenticatedFetch.mockResolvedValue(new Response(body, { status: 200 }));
+
+    const response = await graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql');
+
+    expect(response.ok).toBe(true);
+    await expect(response.text()).resolves.toBe(body);
+  });
+
+  it('passes a valid JSON array body straight through untouched (batched requests)', async () => {
+    const body = JSON.stringify([{ data: { climbStatsHistory: [] } }]);
+    mockAuthenticatedFetch.mockResolvedValue(new Response(body, { status: 200 }));
+
+    const response = await graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql');
+
+    expect(response.ok).toBe(true);
+    await expect(response.text()).resolves.toBe(body);
+  });
+
+  it('does not intercept a non-2xx response even with an empty body — graphql-request already handles that as a ClientError', async () => {
+    mockAuthenticatedFetch.mockResolvedValue(new Response('', { status: 500 }));
+
+    const response = await graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql');
+
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(500);
+  });
+
+  it('does not intercept a non-2xx response with a non-JSON body', async () => {
+    mockAuthenticatedFetch.mockResolvedValue(new Response('Bad Gateway', { status: 502 }));
+
+    const response = await graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql');
+
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(502);
+  });
+
+  it('forwards url and options to authenticatedFetch unchanged', async () => {
+    mockAuthenticatedFetch.mockResolvedValue(new Response(JSON.stringify({ data: {} }), { status: 200 }));
+    const options = { method: 'POST', body: '{"query":"{ __typename }"}' };
+
+    await graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql', options);
+
+    expect(mockAuthenticatedFetch).toHaveBeenCalledWith('https://api.example.com/graphql', options);
+  });
+});

--- a/packages/mobile/src/lib/graphql/client.ts
+++ b/packages/mobile/src/lib/graphql/client.ts
@@ -6,9 +6,66 @@ export function getGraphQLHttpUrl(): string {
   return `${BACKEND_URL}/graphql`;
 }
 
+/**
+ * A 2xx GraphQL response whose body is empty or not a JSON object/array — the
+ * signature of a connection dropped mid-response (headers/status already
+ * committed, body truncated) rather than a real GraphQL answer. Common on
+ * flaky mobile networks going offline mid-request (#3190).
+ *
+ * `name` is checked by `isNetworkError` in `../error-reporting.ts` so this
+ * gets the same "warning, tagged network" Sentry treatment as other
+ * transport failures instead of showing up as a raw crash.
+ */
+export class GraphQLEmptyResponseError extends Error {
+  constructor(status: number) {
+    super(`GraphQL response body was empty or not valid JSON (HTTP ${status})`);
+    this.name = 'GraphQLEmptyResponseError';
+  }
+}
+
+/**
+ * Wraps `authenticatedFetch` to guard against graphql-request's unguarded
+ * `JSON.parse` on the response body. graphql-request's `runRequest` only
+ * wraps parse failures into a `ClientError` for non-2xx responses; for a 2xx
+ * response it re-throws the raw parse error (a `SyntaxError` for an empty
+ * body, or an "Invalid execution result" `Error` for a non-object/array body)
+ * — see `parseResultFromText` / `runRequest` in graphql-request's
+ * `legacy/helpers/runRequest.ts`. That raw throw is exactly the crash in
+ * #3190: an Android device going offline mid-request can get back a `200`
+ * whose body never arrived.
+ *
+ * We peek the body via `response.clone().text()` (so graphql-request can
+ * still read the original stream) and, for an `ok` response only, replace an
+ * empty/malformed body with a typed `GraphQLEmptyResponseError` before
+ * graphql-request ever sees it. Non-2xx responses are left untouched —
+ * graphql-request already turns those into a `ClientError` without throwing.
+ */
+export async function graphqlFetchWithEmptyBodyGuard(
+  url: string | URL | Request,
+  options: RequestInit = {},
+): Promise<Response> {
+  const response = await authenticatedFetch(url, options);
+  if (!response.ok) return response;
+
+  const text = await response.clone().text();
+  const trimmed = text.trim();
+  let parsesToObjectOrArray = false;
+  if (trimmed.length > 0) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      parsesToObjectOrArray = typeof parsed === 'object' && parsed !== null;
+    } catch {
+      parsesToObjectOrArray = false;
+    }
+  }
+  if (!parsesToObjectOrArray) throw new GraphQLEmptyResponseError(response.status);
+
+  return response;
+}
+
 export function createGraphQLHttpClient(): GraphQLClient {
   return new GraphQLClient(getGraphQLHttpUrl(), {
-    fetch: authenticatedFetch,
+    fetch: graphqlFetchWithEmptyBodyGuard,
   });
 }
 


### PR DESCRIPTION
## Summary

- `climbStatsHistory` (and every other query that goes through `getHttpClient().request`) could crash with a raw, uncatchable-looking `SyntaxError: JSON Parse error: Unexpected end of input` when a flaky Android connection resolves a GraphQL fetch as HTTP 200 with an empty/truncated body (connection dropped mid-response, after headers were already committed). `graphql-request@7.4.0`'s `runRequest` only wraps parse failures into a `ClientError` for non-2xx responses — for a 2xx it re-throws the raw parse error, by design.
- Added a `graphqlFetchWithEmptyBodyGuard` wrapper around `authenticatedFetch` in `packages/mobile/src/lib/graphql/client.ts`: for `ok` (2xx) responses it peeks the body, and if it's empty, non-JSON, or JSON that isn't an object/array, throws a typed `GraphQLEmptyResponseError` before graphql-request ever runs its own `JSON.parse`. Non-2xx responses are untouched — graphql-request already handles those gracefully.
- `error-reporting.ts`'s `isNetworkError` now recognizes `GraphQLEmptyResponseError` by name, so it gets the same "downgrade to `warning`, tag `network`" treatment as other transport failures (`TypeError: Network request failed`, status-less `ClientError`) instead of reporting at full `error` severity — this is what actually filed Sentry issue BOARDSESH-7R / #3190.
- **Why a typed error instead of a null/empty result**: the queryFn still throws, it just throws something typed and classifiable. Faking a `null`/empty result instead would get cached by React Query (`staleTime: 5 min` on this query) and misrepresent "the connection dropped" as "this climb has no stats" for up to 5 minutes even after connectivity returns — a cache-poisoning failure mode worse than the crash it replaces. Throwing keeps the existing retry (`failureCount < 2`) and `networkMode: 'offlineFirst'` behavior intact.
- Scoped to mobile only: web's `graphql-request` usage runs over a normal browser `fetch`, which rejects with a `TypeError` on a dropped connection rather than resolving 200-with-empty-body — that resolve-with-empty-body behavior is an RN/OkHttp-specific quirk, which is what Sentry actually caught (Android, Pixel 7).

### Follow-up (not in this PR)

`CLIMB_STATS_HISTORY` is not registered in `packages/mobile/src/lib/graphql/offline-request.ts`'s `OFFLINE_OPERATIONS`, so it always hits the network regardless of the `offline-board-downloads` flag — no local-first read, no offline fallback. That's a feature gap, not this bug; left out of scope here to keep the fix minimal and targeted.

Fixes #3190

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- New `packages/mobile/src/lib/graphql/__tests__/client.test.ts`: empty body, whitespace-only body, non-JSON body, valid-JSON-non-object body all throw `GraphQLEmptyResponseError` on a 2xx response; valid object/array JSON bodies pass through untouched; non-2xx responses (500, 502) are never intercepted even with an empty/non-JSON body; url/options are forwarded to `authenticatedFetch` unchanged.
- Extended `packages/mobile/src/lib/__tests__/error-reporting.test.ts`: a `GraphQLEmptyResponseError` is downgraded to `warning` and tagged `network`, matching the existing offline-error test cases.
- This is a network-race-condition fix (connection drop mid-response) with no UI surface to drive manually — verified via `vp run typecheck:mobile`, `vp test run --project mobile --reporter=agent`, `vp check`, `vp run check:mobile-bundle`.
