### PR TITLE
perf(mobile): cache Intl formatters for logbook rows and You stats

### DIFF
--- a/packages/mobile/src/components/play-drawer/LogbookEntryRow.tsx
+++ b/packages/mobile/src/components/play-drawer/LogbookEntryRow.tsx
@@ -8,6 +8,7 @@ import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { normalizeAscentStatus, type AscentStatusValue } from '../../lib/ascent-status-utils';
 import { useGradeFormat } from '../../hooks/use-grade-format';
+import { getCachedDateTimeFormat } from '../../lib/intl-formatter-cache';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 
@@ -18,16 +19,20 @@ type LogbookEntryRowProps = {
   showAngleChip?: boolean;
 };
 
+// Hoisted so every row shares one cache lookup key instead of allocating a
+// fresh options object per call (#3155).
+const CLIMBED_AT_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+};
+
 function formatClimbedAt(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
-  return new Intl.DateTimeFormat(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  }).format(date);
+  return getCachedDateTimeFormat(undefined, CLIMBED_AT_FORMAT_OPTIONS).format(date);
 }
 
 // Canonical difficulty_id → "6a/V3" name, which always carries both scales so
@@ -84,12 +89,14 @@ export const LogbookEntryRow = memo(function LogbookEntryRow({
     ));
   }, [isSuccess, entry.effectiveQuality, entry.quality]);
 
+  const climbedAtLabel = useMemo(() => formatClimbedAt(entry.climbed_at), [entry.climbed_at]);
+
   return (
     <View style={styles.container}>
       <View style={styles.headerRow}>
         <Icon name={statusIcon.name} size={16} color={statusIcon.color} />
         <Text variant="subheadline" style={styles.date} numberOfLines={1}>
-          {formatClimbedAt(entry.climbed_at)}
+          {climbedAtLabel}
         </Text>
         {showAngleChip ? (
           <View style={styles.angleChip}>

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -16,6 +16,7 @@ import { layoutChartColor, flashRedpointColor } from './profile-chart-colors';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { OnboardingTipBanner } from '../onboarding/OnboardingTipBanner';
 import { hasSeenTip, markTipSeen } from '../../lib/onboarding/onboarding-storage';
+import { getCachedNumberFormat } from '../../lib/intl-formatter-cache';
 import { ONBOARDING_TIP_RECORD_KEY } from '@boardsesh/key-value-storage';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
@@ -196,7 +197,9 @@ export const ProgressTab = memo(function ProgressTab({ data, topInset, userId }:
               <SectionHeader title={t('stats.vPoints')} />
               <Card style={styles.chartCard}>
                 <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.vpTotal}>
-                  {t('stats.vPointsTotal', { value: data.vPointsTimeline.totalPoints.toLocaleString() })}
+                  {t('stats.vPointsTotal', {
+                    value: getCachedNumberFormat(undefined).format(data.vPointsTimeline.totalPoints),
+                  })}
                 </Text>
                 <TotalAreaChart timeline={data.vPointsTimeline} color={brandColors.primary} emptyLabel={noAscentData} />
               </Card>

--- a/packages/mobile/src/components/you/SocialTab.tsx
+++ b/packages/mobile/src/components/you/SocialTab.tsx
@@ -31,6 +31,7 @@ import {
   useToggleUserFollow,
 } from '../../lib/graphql/hooks';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { getCachedNumberFormat } from '../../lib/intl-formatter-cache';
 import { borderRadius, spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 
@@ -259,7 +260,7 @@ function SocialStatCard({
     >
       <Icon name={icon} size={20} color={color} />
       <Text variant="title3" style={styles.statValue}>
-        {value.toLocaleString()}
+        {getCachedNumberFormat(undefined).format(value)}
       </Text>
       <Text variant="footnote" color={systemColors.secondaryLabel}>
         {label}

--- a/packages/mobile/src/lib/__tests__/intl-formatter-cache.test.ts
+++ b/packages/mobile/src/lib/__tests__/intl-formatter-cache.test.ts
@@ -1,0 +1,69 @@
+// Every expectation pins an explicit locale (never `undefined`): Node has full
+// ICU, but the host locale isn't deterministic across CI boxes — see the same
+// convention in format-bytes.test.ts.
+
+import { describe, it, expect } from 'vitest';
+import { getCachedDateTimeFormat, getCachedNumberFormat } from '../intl-formatter-cache';
+
+describe('getCachedDateTimeFormat', () => {
+  it('reuses the same formatter instance for an identical locale + options', () => {
+    const options: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', year: 'numeric' };
+    const first = getCachedDateTimeFormat('en-US', options);
+    const second = getCachedDateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    expect(second).toBe(first);
+  });
+
+  it('does not serve a stale formatter after a locale switch', () => {
+    const options: Intl.DateTimeFormatOptions = { month: 'short' };
+    const date = new Date('2026-01-15T00:00:00.000Z');
+
+    const enUS = getCachedDateTimeFormat('en-US', options);
+    const es = getCachedDateTimeFormat('es', options);
+
+    expect(enUS).not.toBe(es);
+    expect(enUS.format(date)).toBe('Jan');
+    expect(es.format(date)).toBe('ene');
+
+    // Re-requesting the first locale still returns its own cached formatter,
+    // not the one built for the second locale in between.
+    expect(getCachedDateTimeFormat('en-US', options)).toBe(enUS);
+  });
+
+  it('caches distinct options for the same locale separately', () => {
+    const short = getCachedDateTimeFormat('en-US', { month: 'short' });
+    const long = getCachedDateTimeFormat('en-US', { month: 'long' });
+    const date = new Date('2026-01-15T00:00:00.000Z');
+
+    expect(short).not.toBe(long);
+    expect(short.format(date)).toBe('Jan');
+    expect(long.format(date)).toBe('January');
+  });
+});
+
+describe('getCachedNumberFormat', () => {
+  it('reuses the same formatter instance for an identical locale + options', () => {
+    const first = getCachedNumberFormat('en-US');
+    const second = getCachedNumberFormat('en-US');
+    expect(second).toBe(first);
+  });
+
+  it('does not serve a stale formatter after a locale switch', () => {
+    const enUS = getCachedNumberFormat('en-US');
+    const deDE = getCachedNumberFormat('de-DE');
+
+    expect(enUS).not.toBe(deDE);
+    expect(enUS.format(1234)).toBe('1,234');
+    expect(deDE.format(1234)).toBe('1.234');
+
+    expect(getCachedNumberFormat('en-US')).toBe(enUS);
+  });
+
+  it('caches distinct options for the same locale separately', () => {
+    const plain = getCachedNumberFormat('en-US');
+    const percent = getCachedNumberFormat('en-US', { style: 'percent' });
+
+    expect(plain).not.toBe(percent);
+    expect(plain.format(0.5)).toBe('0.5');
+    expect(percent.format(0.5)).toBe('50%');
+  });
+});

--- a/packages/mobile/src/lib/intl-formatter-cache.ts
+++ b/packages/mobile/src/lib/intl-formatter-cache.ts
@@ -1,0 +1,49 @@
+/**
+ * Module-scope cache for `Intl.DateTimeFormat` / `Intl.NumberFormat` instances,
+ * keyed by locale + options (#3155).
+ *
+ * On Hermes-with-ICU, constructing an `Intl` formatter calls
+ * `Intl.getCanonicalLocales` internally, which showed up as ~95–118ms self-time
+ * when the You/Profile tab mounted (Pixel 8 Pro profiling session). The worst
+ * offender was a fresh `Intl.DateTimeFormat` built **per logbook row** on every
+ * render; the You-page stat cards paid the same cost via `toLocaleString()`,
+ * which is sugar for `new Intl.NumberFormat(locale).format(value)`.
+ *
+ * `Intl.DateTimeFormat` / `Intl.NumberFormat` are safe to use on Hermes (unlike
+ * `Intl.RelativeTimeFormat` / `Intl.ListFormat`, which are lint-blocked
+ * repo-wide for `packages/mobile` — see the `no-restricted-properties` block in
+ * the root `vite.config.ts`).
+ */
+
+const dateTimeFormatCache = new Map<string, Intl.DateTimeFormat>();
+const numberFormatCache = new Map<string, Intl.NumberFormat>();
+
+function cacheKey(locale: string | string[] | undefined, options: object | undefined): string {
+  return JSON.stringify([locale ?? null, options ?? {}]);
+}
+
+/** Cached `Intl.DateTimeFormat` for the given locale + options. */
+export function getCachedDateTimeFormat(
+  locale: string | string[] | undefined,
+  options?: Intl.DateTimeFormatOptions,
+): Intl.DateTimeFormat {
+  const key = cacheKey(locale, options);
+  const cached = dateTimeFormatCache.get(key);
+  if (cached) return cached;
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  dateTimeFormatCache.set(key, formatter);
+  return formatter;
+}
+
+/** Cached `Intl.NumberFormat` for the given locale + options. */
+export function getCachedNumberFormat(
+  locale: string | string[] | undefined,
+  options?: Intl.NumberFormatOptions,
+): Intl.NumberFormat {
+  const key = cacheKey(locale, options);
+  const cached = numberFormatCache.get(key);
+  if (cached) return cached;
+  const formatter = new Intl.NumberFormat(locale, options);
+  numberFormatCache.set(key, formatter);
+  return formatter;
+}


### PR DESCRIPTION
## Summary

Fixes #3155 — a few mobile render paths were constructing a **fresh `Intl` formatter on every call** instead of reusing a module-scope one. On Hermes-with-ICU each construction calls `Intl.getCanonicalLocales`, which showed up as ~95–118ms self-time when the You/Profile tab mounted in a Pixel 8 Pro profiling session. The worst offender was **per logbook row**.

- `LogbookEntryRow.tsx` — `formatClimbedAt` built `new Intl.DateTimeFormat(undefined, {...})` in render, per row, per render.
- `SocialTab.tsx` — `value.toLocaleString()` per stat card (followers/following).
- `ProgressTab.tsx` — `totalPoints.toLocaleString()` (v-points total, minor).

`toLocaleString()` with no args is sugar for `new Intl.NumberFormat(locale).format(value)`, so it pays the same uncached constructor cost.

### Fix

New `packages/mobile/src/lib/intl-formatter-cache.ts` — a module-scope `Map`-backed cache for `Intl.DateTimeFormat` / `Intl.NumberFormat`, keyed by locale + options (`getCachedDateTimeFormat` / `getCachedNumberFormat`). All three call sites now go through it instead of constructing a formatter inline. `LogbookEntryRow` also wraps the formatted label in a `useMemo` keyed on `entry.climbed_at`, matching the sibling `gradeLabel`/`gradeColor`/`stars` memoization already in that component, so an unrelated re-render doesn't re-run the format call either.

`Intl.DateTimeFormat`/`Intl.NumberFormat` are safe on Hermes — this repo already lint-blocks `Intl.RelativeTimeFormat`/`Intl.ListFormat` (missing on-device, crash release builds), which don't apply here.

Locale stays `undefined` (device locale) at all three sites — this PR is a pure perf fix, not a behavior change.

### Follow-up (not in this PR)

`packages/mobile/src/lib/format-bytes.ts` documents a house convention that user-facing numbers interpolated into translated copy should use the **app's** i18n locale, not the device's, so digit grouping matches the surrounding language (e.g. Spanish UI should show Spanish grouping even on an English phone). The three sites touched here don't follow that convention today (pre-existing behavior, `undefined` locale). Worth a separate pass to align them — left out of scope here to keep this a narrow, low-risk perf fix.

## Release Notes

- Smoother scrolling through your logbook and a snappier You tab

## Test plan

- New `packages/mobile/src/lib/__tests__/intl-formatter-cache.test.ts`: cache-hit identity (same locale+options returns the same instance), locale-switch correctness (switching locale returns a distinct, correctly-formatted instance instead of a stale one — e.g. `'en-US'` vs `'es'` month names, `'en-US'` vs `'de-DE'` digit grouping), and distinct-options-same-locale caching, for both `getCachedDateTimeFormat` and `getCachedNumberFormat`.
- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 481 files / 3930 tests passing (includes the new suite + regression run of `logbook-entry-row-grade.test.tsx` and `social-tab.test.tsx`, both unaffected).
- `vp check` — 0 errors (260 pre-existing warnings elsewhere in the repo, none touching the changed files).
- `vp run check:mobile-bundle` — Android bundle exports clean (14.1 MB).

No native deps or config touched — pure JS/TS, rides the existing OTA channels (PR preview channel now, production OTA on merge).
