### PR TITLE
fix(web): refresh session.user.name from userProfiles on every read

### DIFF
--- a/packages/web/app/lib/auth/__tests__/auth-options.test.ts
+++ b/packages/web/app/lib/auth/__tests__/auth-options.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import type { Session } from 'next-auth';
 import { authOptions } from '../auth-options';
 
 // Mock server-only before any imports
@@ -274,6 +275,87 @@ describe('authOptions.callbacks.signIn', () => {
 
       expect(result).toBe(true);
     });
+  });
+});
+
+// =============================================================================
+// session callback — issue #3304: display name must not stay stuck at the
+// sign-in-time JWT value after a Settings edit
+// =============================================================================
+
+type SessionParams = Parameters<NonNullable<NonNullable<typeof authOptions.callbacks>['session']>>[0];
+type SessionResult = Session;
+
+async function callSession(params: Partial<SessionParams>): Promise<SessionResult> {
+  const cb = authOptions.callbacks?.session;
+  if (!cb) throw new Error('session callback not defined');
+  return (await cb(params as SessionParams)) as SessionResult;
+}
+
+describe('authOptions.callbacks.session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default DB chain: select().from().where().limit() resolves to empty
+    mockDbSelect.mockReturnValue({ from: mockDbFrom });
+    mockDbFrom.mockReturnValue({ where: mockDbWhere });
+    mockDbWhere.mockReturnValue({ limit: mockDbLimit });
+    mockDbLimit.mockResolvedValue([]);
+  });
+
+  it('overrides session.user.name with userProfiles.displayName when present', async () => {
+    mockDbLimit.mockResolvedValue([{ avatarUrl: null, displayName: 'jojo' }]);
+
+    const result = await callSession({
+      session: { user: { id: 'user-1', name: 'speedywalker8392', email: 'user@example.com' }, expires: '2099-01-01' },
+      token: { sub: 'user-1' },
+    });
+
+    expect(result.user?.name).toBe('jojo');
+  });
+
+  it('leaves session.user.name unchanged when no userProfiles row exists', async () => {
+    mockDbLimit.mockResolvedValue([]);
+
+    const result = await callSession({
+      session: { user: { id: 'user-1', name: 'speedywalker8392' }, expires: '2099-01-01' },
+      token: { sub: 'user-1' },
+    });
+
+    expect(result.user?.name).toBe('speedywalker8392');
+  });
+
+  it('leaves session.user.name unchanged when the profile row has a null displayName', async () => {
+    mockDbLimit.mockResolvedValue([{ avatarUrl: 'https://cdn.example.com/avatar.jpg', displayName: null }]);
+
+    const result = await callSession({
+      session: { user: { id: 'user-1', name: 'speedywalker8392' }, expires: '2099-01-01' },
+      token: { sub: 'user-1' },
+    });
+
+    expect(result.user?.name).toBe('speedywalker8392');
+  });
+
+  it('still overrides session.user.image with userProfiles.avatarUrl when present (regression guard)', async () => {
+    mockDbLimit.mockResolvedValue([{ avatarUrl: 'https://cdn.example.com/avatar.jpg', displayName: null }]);
+
+    const result = await callSession({
+      session: { user: { id: 'user-1', name: 'speedywalker8392', image: 'old.png' }, expires: '2099-01-01' },
+      token: { sub: 'user-1' },
+    });
+
+    expect(result.user?.image).toBe('https://cdn.example.com/avatar.jpg');
+  });
+
+  it('sets session.user.id from token.sub', async () => {
+    mockDbLimit.mockResolvedValue([]);
+
+    const result = await callSession({
+      session: { user: { id: 'user-99', name: 'speedywalker8392' }, expires: '2099-01-01' },
+      token: { sub: 'user-42' },
+    });
+
+    expect(result.user?.id).toBe('user-42');
   });
 });
 

--- a/packages/web/app/lib/auth/__tests__/auth-options.test.ts
+++ b/packages/web/app/lib/auth/__tests__/auth-options.test.ts
@@ -336,6 +336,17 @@ describe('authOptions.callbacks.session', () => {
     expect(result.user?.name).toBe('speedywalker8392');
   });
 
+  it('leaves session.user.name unchanged when the profile row has an empty-string displayName (known gap: clearing the field does not live-revert to the auto-generated handle)', async () => {
+    mockDbLimit.mockResolvedValue([{ avatarUrl: null, displayName: '' }]);
+
+    const result = await callSession({
+      session: { user: { id: 'user-1', name: 'speedywalker8392' }, expires: '2099-01-01' },
+      token: { sub: 'user-1' },
+    });
+
+    expect(result.user?.name).toBe('speedywalker8392');
+  });
+
   it('still overrides session.user.image with userProfiles.avatarUrl when present (regression guard)', async () => {
     mockDbLimit.mockResolvedValue([{ avatarUrl: 'https://cdn.example.com/avatar.jpg', displayName: null }]);
 

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -244,15 +244,20 @@ export const authOptions: NextAuthOptions = {
       if (session?.user && token?.sub) {
         session.user.id = token.sub;
 
-        // Fetch custom avatar from userProfiles so the drawer/header show the current avatar
+        // Fetch custom avatar/display name from userProfiles on every session read so the
+        // drawer/header reflect the latest Settings edit instead of whatever was baked into
+        // the JWT at sign-in (the JWT's name/image claims are never refreshed otherwise).
         const db = getDb();
         const profiles = await db
-          .select({ avatarUrl: schema.userProfiles.avatarUrl })
+          .select({ avatarUrl: schema.userProfiles.avatarUrl, displayName: schema.userProfiles.displayName })
           .from(schema.userProfiles)
           .where(eq(schema.userProfiles.userId, token.sub))
           .limit(1);
         if (profiles[0]?.avatarUrl) {
           session.user.image = profiles[0].avatarUrl;
+        }
+        if (profiles[0]?.displayName) {
+          session.user.name = profiles[0].displayName;
         }
       }
       return session;

--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -320,9 +320,7 @@ export default function SettingsPageContent() {
       // Refresh profile locally and in context (so queue items show updated avatar)
       await fetchProfile();
       await refreshPartyProfile();
-      // Force NextAuth to re-run the session callback now, so the header/drawer (which read
-      // session.user.name) reflect the new display name immediately instead of waiting for
-      // the next window-focus session refetch.
+      // Refresh the NextAuth session now so the header/drawer show the new name immediately.
       await updateSession();
     } catch (error) {
       console.error('Failed to save settings:', error);

--- a/packages/web/app/settings/settings-page-content.tsx
+++ b/packages/web/app/settings/settings-page-content.tsx
@@ -118,7 +118,7 @@ type UserProfile = {
 };
 
 export default function SettingsPageContent() {
-  const { data: session, status } = useSession();
+  const { data: session, status, update: updateSession } = useSession();
   const router = useLocaleRouter();
   const { t, i18n } = useTranslation('settings');
   const activeLocale: Locale = isSupportedLocale(i18n.language) ? i18n.language : DEFAULT_LOCALE;
@@ -320,6 +320,10 @@ export default function SettingsPageContent() {
       // Refresh profile locally and in context (so queue items show updated avatar)
       await fetchProfile();
       await refreshPartyProfile();
+      // Force NextAuth to re-run the session callback now, so the header/drawer (which read
+      // session.user.name) reflect the new display name immediately instead of waiting for
+      // the next window-focus session refetch.
+      await updateSession();
     } catch (error) {
       console.error('Failed to save settings:', error);
       showMessage(error instanceof Error ? error.message : t('profile.saveError'), 'error');


### PR DESCRIPTION
## Summary
- Settings display-name edits were saved to the DB correctly, but the NextAuth JWT session's `name` claim was baked in once at sign-in and never refreshed — so the hamburger menu, share text, and a couple of other spots kept showing the auto-generated handle (e.g. `speedywalker8392`) instead of the saved name (e.g. `jojo`).
- `session` callback in `auth-options.ts` already refreshed `avatarUrl` from `userProfiles` on every session read (there's even a comment saying so); it just never did the same for `displayName`. Extended it to do both.
- Added `updateSession()` (NextAuth's `update()`) after a successful Settings save so the header/drawer refresh immediately instead of waiting for the next window-focus session refetch.
- Mobile (2.x native) was not affected — it reads through a React Query cache (`['profile']`) that's correctly invalidated on save, not a JWT session.

## Root cause
- Write path (`PUT /api/internal/profile`) was always correct: updates both `user_profiles.display_name` and `users.name`.
- Read path bug: `packages/web/app/components/user-drawer/user-drawer.tsx` (and a few other places) reads `session.user.name` from `useSession()`. NextAuth bakes `name` into the JWT once at sign-in; nothing in the repo ever called `session.update()` or handled `trigger === 'update'` in the `jwt` callback, so that value never changed for the life of the session cookie.

## Changes
- `packages/web/app/lib/auth/auth-options.ts` — `session` callback now also selects `userProfiles.displayName` and overrides `session.user.name` with it when present, mirroring the existing `avatarUrl` → `session.user.image` refresh.
- `packages/web/app/settings/settings-page-content.tsx` — calls `updateSession()` (destructured from `useSession()`) after a successful save for an instant refresh.
- `packages/web/app/lib/auth/__tests__/auth-options.test.ts` — 5 new tests for the `session` callback: overrides name when `displayName` present, leaves it unchanged with no profile row, leaves it unchanged when `displayName` is null, regression guard on the existing `avatarUrl` override, and `session.user.id` still set from `token.sub`.

## Out of scope / follow-ups
- **Clearing the display name entirely** (saving it back to empty) doesn't currently make the header/drawer revert live to the auto-generated handle — the session only overrides `name` when `userProfiles.displayName` is non-empty, same as the pre-existing `avatarUrl` behavior. This is existing behavior, not something this PR changes; filed as a known gap, not fixed here.
- **FYI for whoever next touches `updateProfile`**: the GraphQL resolver (`packages/backend/src/graphql/resolvers/users/mutations.ts`, mobile's write path, recently refactored in #3603/#3679) updates `userProfiles.displayName` but never syncs `users.name` the way the web REST route (`/api/internal/profile`) does. It doesn't cause a visible symptom today — every read path prefers `userProfiles.displayName` over `users.name` — but it's a divergence between the two write paths worth aligning at some point. Not touched in this PR, deliberately, to avoid conflicting with #3603's just-merged changes to that same file.

## Release Notes
Fixed: your Settings display name now shows everywhere right away — no more getting stuck with your auto-generated handle in the menu after you change it.

## Test plan
- [x] `vp run typecheck:web`
- [x] `vp test run --project web --reporter=agent` (targeted: `auth-options.test.ts`)
- [x] `vp check`
- [ ] Manual: sign in, change display name in Settings, confirm hamburger menu updates immediately without reload (see `.boardsesh/qa-notes.md`)

Fixes #3304
