### PR TITLE
fix: replace dead board_products_angles query with static ANGLES

### DIFF
--- a/packages/backend/src/__tests__/rest-parity.test.ts
+++ b/packages/backend/src/__tests__/rest-parity.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { ANGLES } from '@boardsesh/board-config';
 import { startServer } from '../server';
 
 const BACKEND_PORT = 8083; // Use different port to avoid conflicts with other tests
@@ -94,24 +95,29 @@ describe('REST vs GraphQL Parity Tests', () => {
       }
     });
 
-    it.skip('angles should match between REST and GraphQL for kilter layout 1', async () => {
-      // Skipped: REST API at www.boardsesh.com/api/v1/angles returns 500
-      // TODO: Re-enable when REST API is fixed
-      const layoutId = 1;
+    it('angles should return the static per-board angle range in ascending order (#2379)', async () => {
+      // `board_products_angles` (GraphQL resolver) and `kilter_products_angles`
+      // (REST) never existed / were dropped from the DB — Aurora deliberately
+      // doesn't sync a per-layout angle table (see
+      // packages/aurora-sync/src/sync/shared-sync.ts). Both endpoints now read
+      // the shared static ANGLES source
+      // (packages/shared/board-config/src/board-data.ts) instead. We assert
+      // against that source directly rather than calling the live production
+      // REST API (like the grades parity tests above do): the REST fix in
+      // this same PR isn't deployed yet, so hitting production here would be
+      // a chicken-and-egg problem — this test could only pass after a
+      // separate deploy step, defeating pre-merge CI.
+      for (const boardName of ['kilter', 'tension', 'moonboard'] as const) {
+        const gqlResult = await fetchGraphQL<{
+          angles: Array<{ angle: number }>;
+        }>(`query { angles(boardName: "${boardName}", layoutId: 1) { angle } }`);
 
-      // REST API call
-      const restResult = await fetchRest<Array<{ angle: number }>>(`/api/v1/angles/kilter/${layoutId}`);
+        const expectedAngles = ANGLES[boardName];
+        expect(gqlResult.angles).toEqual(expectedAngles.map((angle) => ({ angle })));
 
-      // GraphQL API call
-      const gqlResult = await fetchGraphQL<{
-        angles: Array<{ angle: number }>;
-      }>(`query { angles(boardName: "kilter", layoutId: ${layoutId}) { angle } }`);
-
-      // Compare lengths
-      expect(gqlResult.angles.length).toBe(restResult.length);
-
-      // Compare values
-      expect(gqlResult.angles).toEqual(restResult);
+        const angleValues = gqlResult.angles.map((entry) => entry.angle);
+        expect(angleValues).toEqual([...angleValues].sort((a, b) => a - b));
+      }
     });
   });
 

--- a/packages/backend/src/graphql/resolvers/board/queries.ts
+++ b/packages/backend/src/graphql/resolvers/board/queries.ts
@@ -1,6 +1,6 @@
-import { eq, asc, and, sql } from 'drizzle-orm';
+import { eq, asc, and } from 'drizzle-orm';
 import type { QueryResolvers } from '@boardsesh/shared-schema/generated';
-import { executeRows } from '@boardsesh/db/client';
+import { ANGLES } from '@boardsesh/board-config';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { validateInput } from '../shared/helpers';
@@ -27,21 +27,14 @@ export const boardQueries: Pick<QueryResolvers, 'grades' | 'angles'> = {
     }));
   },
 
-  angles: async (_, { boardName, layoutId }) => {
-    validateInput(BoardNameSchema, boardName, 'boardName');
+  angles: async (_, { boardName }) => {
+    const validatedBoardName = validateInput(BoardNameSchema, boardName, 'boardName');
 
-    const result = await executeRows<{ angle: number }>(
-      db,
-      sql`
-      SELECT DISTINCT pa.angle
-      FROM board_products_angles pa
-      JOIN board_layouts l
-        ON l.board_type = pa.board_type AND l.product_id = pa.product_id
-      WHERE l.board_type = ${boardName} AND l.id = ${layoutId}
-      ORDER BY pa.angle ASC
-    `,
-    );
-
-    return result.map((r) => ({ angle: r.angle }));
+    // Aurora doesn't sync a per-layout angle table (deliberately excluded —
+    // see packages/aurora-sync/src/sync/shared-sync.ts). Every layout for a
+    // given board type supports the same fixed angle range, hardcoded in
+    // ANGLES (packages/shared/board-config/src/board-data.ts). The `layoutId`
+    // argument is kept for API compatibility but doesn't affect the result.
+    return ANGLES[validatedBoardName].map((angle) => ({ angle }));
   },
 };

--- a/packages/web/app/api/internal/prewarm-heatmap/[board_name]/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/prewarm-heatmap/[board_name]/__tests__/route.test.ts
@@ -2,12 +2,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
 
 vi.mock('server-only', () => ({}));
 
-const mockExecuteRows = vi.fn();
-vi.mock('@/app/lib/db/db', () => ({
-  executeRows: (...args: unknown[]) => mockExecuteRows(...args),
-  dbzRead: {},
-}));
-
 const mockGetBoardSelectorOptions = vi.fn();
 vi.mock('@/app/lib/board-constants', () => ({
   AURORA_BOARD_NAMES: ['kilter', 'tension', 'decoy', 'touchstone', 'grasshopper'],
@@ -34,8 +28,9 @@ function buildRequest(headers?: Record<string, string>) {
 describe('GET /api/internal/prewarm-heatmap/[board_name]', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // No layouts for this board — buildTargetsForBoard returns [] and the
-    // handler completes without touching the heatmap-warming path.
+    mockCachedGetHoldHeatmapData.mockResolvedValue(undefined);
+    // No layouts for this board by default — buildTargetsForBoard returns []
+    // and the handler completes without touching the heatmap-warming path.
     mockGetBoardSelectorOptions.mockReturnValue({ layouts: {}, sizes: {}, sets: {} });
   });
 
@@ -64,7 +59,7 @@ describe('GET /api/internal/prewarm-heatmap/[board_name]', () => {
     expect(response.status).toBe(400);
   });
 
-  it('warms the requested board when the cron secret matches', async () => {
+  it('warms nothing when the board has no configured layouts', async () => {
     vi.stubEnv('CRON_SECRET', 'test-secret');
 
     const response = await routeModule.GET(buildRequest({ authorization: 'Bearer test-secret' }), {
@@ -74,5 +69,33 @@ describe('GET /api/internal/prewarm-heatmap/[board_name]', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body).toMatchObject({ board: 'kilter', total: 0, warmed: 0, failed: 0 });
+  });
+
+  // Regression test for issue #2379: the old `board_products_angles` query
+  // threw for every layout, was caught, and silently fell back to an empty
+  // angle list — so `buildTargetsForBoard` skipped every layout and the cron
+  // warmed exactly zero cache entries, every week, while still returning a
+  // 200 "success" response. Angles now come from the static ANGLES source
+  // (@boardsesh/board-config — no DB round trip at all), so a board with
+  // real layouts/sizes/sets now builds and warms real targets.
+  it('builds and warms a non-empty set of targets when the board has layouts', async () => {
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+    mockGetBoardSelectorOptions.mockReturnValue({
+      layouts: { kilter: [{ id: 8, name: 'Original Layout' }] },
+      sizes: { 'kilter-8': [{ id: 25, name: '8x12' }] },
+      sets: { 'kilter-8-25': [{ id: 26, name: 'Screw-Ons' }] },
+    });
+
+    const response = await routeModule.GET(buildRequest({ authorization: 'Bearer test-secret' }), {
+      params: Promise.resolve({ board_name: 'kilter' }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { total: number; warmed: number; failed: number };
+
+    expect(body.total).toBeGreaterThan(0);
+    expect(body.warmed).toBe(body.total);
+    expect(body.failed).toBe(0);
+    expect(mockCachedGetHoldHeatmapData).toHaveBeenCalledTimes(body.total);
   });
 });

--- a/packages/web/app/api/internal/prewarm-heatmap/[board_name]/route.ts
+++ b/packages/web/app/api/internal/prewarm-heatmap/[board_name]/route.ts
@@ -1,9 +1,7 @@
 import { NextResponse } from 'next/server';
-import { sql } from 'drizzle-orm';
-import { executeRows } from '@/app/lib/db/db';
 import { AURORA_BOARD_NAMES, getBoardSelectorOptions, isAuroraBoardName } from '@/app/lib/board-constants';
 import type { AuroraBoardName } from '@boardsesh/shared-schema';
-import { dbzRead as db } from '@/app/lib/db/db';
+import { ANGLES } from '@/app/lib/board-data';
 import { cachedGetHoldHeatmapData } from '@/app/lib/db/queries/climbs/holds-heatmap-cache';
 import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 import type { ParsedBoardRouteParameters } from '@/app/lib/types';
@@ -27,20 +25,12 @@ type WarmTarget = {
   angle: number;
 };
 
-async function getAnglesForLayout(boardName: AuroraBoardName, layoutId: number): Promise<number[]> {
-  // Same query used by packages/backend/src/graphql/resolvers/board/queries.ts:44-50
-  const result = await executeRows<{ angle: number }>(
-    db,
-    sql`
-    SELECT DISTINCT pa.angle
-    FROM board_products_angles pa
-    JOIN board_layouts l
-      ON l.board_type = pa.board_type AND l.product_id = pa.product_id
-    WHERE l.board_type = ${boardName} AND l.id = ${layoutId}
-    ORDER BY pa.angle ASC
-  `,
-  );
-  return result.map((row) => Number(row.angle));
+function getAnglesForBoard(boardName: AuroraBoardName): number[] {
+  // Aurora doesn't sync a per-layout angle table (deliberately excluded —
+  // see packages/aurora-sync/src/sync/shared-sync.ts). Every layout for a
+  // given board type supports the same fixed angle range, hardcoded in
+  // ANGLES. Mirrors packages/backend/src/graphql/resolvers/board/queries.ts.
+  return ANGLES[boardName];
 }
 
 function buildTargetsForBoard(boardName: AuroraBoardName, anglesByLayout: Map<number, number[]>): WarmTarget[] {
@@ -149,19 +139,9 @@ export async function GET(request: Request, props: { params: Promise<PrewarmRout
     const selectorOptions = getBoardSelectorOptions();
     const layouts = selectorOptions.layouts[boardName] ?? [];
 
-    // Fetch angles per layout once (they're the same across all sizes/sets).
-    const anglesByLayout = new Map<number, number[]>();
-    await Promise.all(
-      layouts.map(async (layout) => {
-        try {
-          const angles = await getAnglesForLayout(boardName, layout.id);
-          anglesByLayout.set(layout.id, angles);
-        } catch (error) {
-          console.error(`[prewarm-heatmap] failed to load angles for ${boardName} layout ${layout.id}:`, error);
-          anglesByLayout.set(layout.id, []);
-        }
-      }),
-    );
+    // Angles are the same across all layouts/sizes/sets for a given board type.
+    const angles = getAnglesForBoard(boardName);
+    const anglesByLayout = new Map<number, number[]>(layouts.map((layout) => [layout.id, angles]));
 
     const targets = buildTargetsForBoard(boardName, anglesByLayout);
     console.info(`[prewarm-heatmap] ${boardName}: ${targets.length} combinations to warm`);

--- a/packages/web/app/api/v1/angles/[board_name]/[layout_id]/__tests__/route.test.ts
+++ b/packages/web/app/api/v1/angles/[board_name]/[layout_id]/__tests__/route.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { ANGLES } from '@boardsesh/board-config';
+import { GET } from '../route';
+
+function callGet(boardName: string, layoutId: string) {
+  const req = new Request(`http://localhost/api/v1/angles/${boardName}/${layoutId}`);
+  return GET(req, { params: Promise.resolve({ board_name: boardName, layout_id: layoutId }) });
+}
+
+describe('GET /api/v1/angles/[board_name]/[layout_id]', () => {
+  // Regression test for issue #2379: this route used to query
+  // `kilter_products_angles` joined to a nonexistent `layouts` table (and
+  // ignored the board_name param entirely) — always 500ing. Angles are now
+  // read from the static ANGLES source shared with the GraphQL resolver.
+  it('returns the static angle range for a valid Aurora board, ignoring layout_id', async () => {
+    const res = await callGet('kilter', '1');
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ angle: number }>;
+    expect(body).toEqual(ANGLES.kilter.map((angle) => ({ angle })));
+  });
+
+  it('parameterizes correctly on board_name instead of always returning kilter angles', async () => {
+    const res = await callGet('tension', '9');
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ angle: number }>;
+    expect(body).toEqual(ANGLES.tension.map((angle) => ({ angle })));
+  });
+
+  it('returns 400 for an unknown board name', async () => {
+    const res = await callGet('not-a-board', '1');
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('Invalid board name');
+  });
+});

--- a/packages/web/app/api/v1/angles/[board_name]/[layout_id]/route.ts
+++ b/packages/web/app/api/v1/angles/[board_name]/[layout_id]/route.ts
@@ -1,23 +1,22 @@
-// oxlint-disable-next-line no-restricted-imports -- raw postgres-js sql usage; migrate to drizzle
-import { rowsFromResult, sql } from '@/app/lib/db/db';
 import { NextResponse } from 'next/server';
+import { isAuroraBoardName, AURORA_BOARD_NAMES } from '@/app/lib/board-constants';
+import { ANGLES } from '@/app/lib/board-data';
 
 export async function GET(req: Request, props: { params: Promise<{ board_name: string; layout_id: string }> }) {
   const params = await props.params;
-  const { /*board_name,*/ layout_id } = params;
+  const { board_name } = params;
 
-  try {
-    const angles = rowsFromResult<{ angle: number }>(
-      await sql`
-      SELECT angle
-      FROM kilter_products_angles
-      JOIN layouts ON layouts.product_id = products_angles.product_id
-      WHERE layouts.id = ${layout_id}
-      ORDER BY angle ASC
-    `,
+  if (!isAuroraBoardName(board_name)) {
+    return NextResponse.json(
+      { error: `Invalid board name: ${board_name}. Expected one of: ${AURORA_BOARD_NAMES.join(', ')}` },
+      { status: 400 },
     );
-    return NextResponse.json(angles);
-  } catch {
-    return NextResponse.json({ error: 'Failed to fetch angles' }, { status: 500 });
   }
+
+  // Aurora doesn't sync a per-layout angle table (deliberately excluded —
+  // see packages/aurora-sync/src/sync/shared-sync.ts). Every layout for a
+  // given board type supports the same fixed angle range, hardcoded in
+  // ANGLES. Mirrors packages/backend/src/graphql/resolvers/board/queries.ts.
+  const angles = ANGLES[board_name].map((angle) => ({ angle }));
+  return NextResponse.json(angles);
 }

--- a/packages/web/app/lib/api-docs/openapi-routes.ts
+++ b/packages/web/app/lib/api-docs/openapi-routes.ts
@@ -105,7 +105,7 @@ registry.registerPath({
   path: '/api/v1/angles/{board_name}/{layout_id}',
   summary: 'Get available angles',
   description:
-    'Returns all available board angles for a specific layout. Angles are typically between 0-70 degrees depending on the board configuration.',
+    'Returns all available angles for a board (the same range applies to every layout). Angles are typically between 0-70 degrees depending on the board configuration.',
   tags: ['Board Configuration'],
   request: {
     params: z.object({


### PR DESCRIPTION
## Summary

`board_products_angles` never existed in the unified schema. It's the mechanically-renamed remnant of `kilter_products_angles`/`tension_products_angles`, which were deliberately dropped in `74e8d2a0` ("Remove unused database tables to clean up schema", Jul 2025) because Aurora doesn't sync a per-layout angle table — see `packages/aurora-sync/src/sync/shared-sync.ts:57`: *"`products_angles`: angles are hardcoded in the `ANGLES` constant in board-data.ts."*

**Root-cause chain:**
1. `74e8d2a0` (Jul 2025) drops the real `kilter_products_angles`/`tension_products_angles` tables as unused — angles are, and always were, a static per-board-type range (`ANGLES` in `packages/shared/board-config/src/board-data.ts`), never something that varies by layout.
2. Nobody updated the `angles` resolver, which kept querying the now-gone tables.
3. The Jan 2026 schema-unification refactor mechanically renamed the leftover dead SQL text (`kilter_products_angles` → `board_products_angles`, `layouts` → `board_layouts`) without noticing the table itself had been gone for months — preserving the bug through the rewrite.
4. The web heatmap-prewarm cron (Apr 2026) copy-pasted the already-broken query from the backend resolver.

**Real-world impact:** two live call sites hit this query.
- The backend GraphQL `angles` resolver — the exact stack trace reported in #2379 (11× over 6 days).
- `packages/web/app/api/internal/prewarm-heatmap/[board_name]/route.ts`, a weekly Vercel cron for 5 boards. It caught the DB error per layout and fell back to an empty angle list, so `buildTargetsForBoard` skipped every layout — **the heatmap-prewarm cron has been silently warming zero cache entries every week since it shipped**, while still returning a 200 "success" response. This is now fixed as a side effect: angles come from a static lookup, so real (layout, size, angle) combinations get built and warmed again.

Also fixed the same defect family in the legacy `/api/v1/angles/{board_name}/{layout_id}` REST route: it queried an even older table (`kilter_products_angles` joined to a nonexistent `layouts` table) and ignored the `board_name` param entirely, always assuming Kilter. It's now parameterized correctly and un-skips the `rest-parity.test.ts` test that had a standing `TODO: Re-enable when REST API is fixed`.

All three call sites now read `ANGLES` (`@boardsesh/board-config`), the same static source web's actual angle-picker UI already uses — so this also removes three now-unnecessary DB round trips.

Closes #2379.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Added a regression test in `packages/backend/src/__tests__/rest-parity.test.ts` (previously `it.skip`'d with a stale TODO) asserting the GraphQL `angles` resolver returns the correct static, ascending angle list for kilter/tension/moonboard — no more live-production dependency, since that would create a chicken-and-egg problem for pre-merge CI (this PR's REST fix isn't deployed yet).
- Added `packages/web/app/api/v1/angles/[board_name]/[layout_id]/__tests__/route.test.ts`: valid Aurora board returns the static angle list ignoring `layout_id`, board-name parameterization works (tension ≠ kilter), unknown board name returns 400.
- Added `packages/web/app/api/internal/prewarm-heatmap/[board_name]/__tests__/route.test.ts`: 401 without cron secret, 400 for a non-Aurora board, and — the direct regression check for the silent no-op — a real Aurora board now builds and warms a non-empty target set (`warmed === total`, `failed === 0`), where it previously warmed zero.
- `vp check` — clean.
- `vp run typecheck:backend` / `vp run typecheck:web` — clean.
- `vp test run --project backend --reporter=agent` — 170/178 files passed, 2336/2399 tests passed; the 8 failing files are pre-existing local Postgres worker-DB provisioning flakes (`[setup] Cannot initialise worker database`) unrelated to any file this PR touches — `rest-parity.test.ts` itself passed. CI provisions Postgres/Redis fresh per job so this should be clean there.
- `vp test run --project web` (scoped to `prewarm-heatmap`/`angles`) — 2 files, 6 tests, all passed.