### PR TITLE
fix(web): reserve bottom-chrome space on gym, manage & claim pages

### DIFF
--- a/packages/web/app/admin/gym-claims/page.tsx
+++ b/packages/web/app/admin/gym-claims/page.tsx
@@ -25,7 +25,10 @@ export default async function AdminGymClaimsPage() {
   if (!access.authenticated) {
     return (
       <I18nProvider locale={locale} namespaces={['common', 'admin']}>
-        <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+        <Container
+          maxWidth="md"
+          sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)', pb: 'var(--bottom-bar-height)' }}
+        >
           <Alert severity="warning">{t('auth.signInRequired')}</Alert>
         </Container>
       </I18nProvider>
@@ -35,7 +38,10 @@ export default async function AdminGymClaimsPage() {
   if (!access.isAdmin) {
     return (
       <I18nProvider locale={locale} namespaces={['common', 'admin']}>
-        <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+        <Container
+          maxWidth="md"
+          sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)', pb: 'var(--bottom-bar-height)' }}
+        >
           <Alert severity="error">{t('auth.noAccess')}</Alert>
         </Container>
       </I18nProvider>
@@ -44,7 +50,10 @@ export default async function AdminGymClaimsPage() {
 
   return (
     <I18nProvider locale={locale} namespaces={['common', 'admin']}>
-      <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+      <Container
+        maxWidth="md"
+        sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)', pb: 'var(--bottom-bar-height)' }}
+      >
         <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, color: themeTokens.neutral[800] }}>
           {t('gymClaims.title')}
         </Typography>

--- a/packages/web/app/gym-claim/success/page.tsx
+++ b/packages/web/app/gym-claim/success/page.tsx
@@ -36,7 +36,15 @@ export default async function GymClaimSuccessPage({ searchParams }: { searchPara
 
   return (
     <I18nProvider locale={locale} namespaces={['common', 'boards']}>
-      <Container maxWidth="sm" sx={{ py: 8, pt: 'calc(var(--global-header-height) + 48px)', textAlign: 'center' }}>
+      <Container
+        maxWidth="sm"
+        sx={{
+          py: 8,
+          pt: 'calc(var(--global-header-height) + 48px)',
+          pb: 'var(--bottom-bar-height)',
+          textAlign: 'center',
+        }}
+      >
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
           <CheckCircleOutlined color="success" sx={{ fontSize: 56 }} />
           <Typography variant="h5" sx={{ fontWeight: 700 }}>

--- a/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
@@ -92,7 +92,10 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
   };
 
   return (
-    <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+    <Container
+      maxWidth="md"
+      sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)', pb: 'var(--bottom-bar-height)' }}
+    >
       {gym.slug && (
         <Box sx={{ mb: 1.5 }}>
           <MuiLink

--- a/packages/web/app/gym/[gym_slug]/manage/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/page.tsx
@@ -97,7 +97,10 @@ export default async function ManageGymPage(props: ManageGymRouteProps) {
     const { t } = await getServerTranslation('kiosk');
     return (
       <I18nProvider locale={locale} namespaces={['common', 'boards', 'kiosk']}>
-        <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+        <Container
+          maxWidth="md"
+          sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)', pb: 'var(--bottom-bar-height)' }}
+        >
           <Alert severity="error">{t('manage.accessDenied')}</Alert>
         </Container>
       </I18nProvider>

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -146,7 +146,10 @@ export default async function GymPage(props: GymRouteProps) {
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
         />
       )}
-      <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+      <Container
+        maxWidth="md"
+        sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)', pb: 'var(--bottom-bar-height)' }}
+      >
         <Box sx={{ mb: 2 }}>
           <MuiLink component={LocaleLink} href="/" underline="hover" sx={{ color: 'var(--color-primary)' }}>
             {t('gymPage.breadcrumbHome')}


### PR DESCRIPTION
## Summary

The gym surfaces expanded this week (stats, follow, claim CTA, comments, the manage console tabs), but their page containers still only reserved `py: 4` (32px) of bottom padding. The app's fixed bottom chrome — queue control bar + tab bar + iOS safe-area inset — is ~48px (tab bar only) up to ~156px (with an active session's queue dock), so it sat **on top of** the last rows: the comment box and "See what climbers are sending" link on the gym page, and the bottom of every manage tab.

Every other long page in the app already solves this by consuming the shared `var(--bottom-bar-height)` custom property (feed, home, playlists, discover, notifications, settings). This PR extends that same convention to the gym containers — one mechanism, no per-page magic numbers.

`--bottom-bar-height` (defined in `components/index.css`) is `max(145px default, ResizeObserver-measured wrapper height)`, published by `persistent-session-wrapper.tsx`. Because the observer measures the whole bottom-bar wrapper, the value tracks the queue dock when a session is active and already folds in `env(safe-area-inset-bottom)`.

**Surfaces fixed** (container/padding only — no manage-tab internals touched):
- `/gym/[slug]`
- `/gym/[slug]/manage` (all five tabs share one container)
- `/admin/gym-claims` (all three states)
- `/gym-claim/success`

## Release Notes

- Gym pages no longer hide their last few rows behind the queue or tab bar — the comments, links, and manage settings all clear the bottom.

## Test plan

Reproduced and verified in the running app (Playwright, seeded gym `send-central-boulders`, test user, iPhone 390×844 + desktop 1280×900), scrolled to the bottom of each page. Overlap = lowest content pixel minus the fixed bar's top edge (positive = occluded).

| Surface | Viewport | Before | After |
|---|---|---|---|
| Gym page | mobile | **+12px occluded** | −101px clear |
| Gym page | desktop | **+30px occluded** | −83px clear |
| Manage · Kiosks | mobile | **+7px** | −106px |
| Manage · Kiosks | desktop | **+25px** | −88px |
| Manage · Boards | mobile | **+16px** | −97px |
| Manage · Branding | mobile | **+3px** | −110px |
| Manage · Members | mobile | 0px (touching) | −113px |
| Manage · Insights | mobile | −16px | −129px |

Container `padding-bottom` went from `32px` to `var(--bottom-bar-height)` (145px at rest) on every surface.

**Queue dock coverage:** with an active session the dock docks above the tab bar and the wrapper measures **156px** (desktop). `--bottom-bar-height` correctly resolves to `max(145px, 156px) = 156px` via the ResizeObserver, so the same `padding-bottom` reserves the taller chrome — the one variable handles both the tab bar and the queue dock.

**Validation:**
- `vp check` — pass
- `vp run typecheck:web` — pass (`tsc --noEmit` clean)
- Relevant tests pass in isolation (`gym-boards-tab`, `persistent-session-wrapper`, + samples): 42/42. The full `--project web` run showed 71 unrelated timeouts across ~28 files (board-form, feedback, logbook, playlist, settings…) from concurrent test suites saturating the shared box; each passes in isolation.