### PR TITLE
feat(web): gym console Overview tab + profile editing in the console

### DIFF
--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -86,7 +86,21 @@
     "exploreFeed": "See what climbers are sending",
     "claimTitle": "Is this your gym?",
     "claimBody": "Claim it to run the boards, the branding, and what shows up on the wall.",
-    "claimCta": "Claim this gym"
+    "claimCta": "Claim this gym",
+    "owner": {
+      "linkBoards": {
+        "title": "Link your boards",
+        "body": "Climbers can't see any walls here yet."
+      },
+      "putOnTv": {
+        "title": "Put this wall on a TV",
+        "body": "Turn a screen in your gym into a live board display."
+      },
+      "addBranding": {
+        "title": "Add your branding",
+        "body": "Add your logo and colors so your page looks like you."
+      }
+    }
   },
   "manage": {
     "welcome": {
@@ -122,7 +136,9 @@
       "branding": "Branding",
       "boards": "Boards",
       "members": "Members",
-      "insights": "Insights"
+      "insights": "Insights",
+      "overview": "Overview",
+      "profile": "Profile"
     },
     "insights": {
       "subtitle": "How your boards did this week compared with last.",
@@ -303,6 +319,47 @@
       "discardBody": "Your layout edits aren't saved yet.",
       "keepEditing": "Keep editing",
       "discard": "Discard"
+    },
+    "overview": {
+      "quickLinksHeading": "Run your gym",
+      "viewPublicPage": "View public page",
+      "embedAction": "Embed on your website",
+      "stats": {
+        "boards": "boards",
+        "members": "members",
+        "followers": "followers",
+        "kiosks": "kiosks"
+      },
+      "quickLinks": {
+        "kiosks": {
+          "title": "Put it on the TV",
+          "body": "Build a wall display for your gym"
+        },
+        "branding": {
+          "title": "Set your colors",
+          "body": "Add your logo and brand colors"
+        },
+        "boards": {
+          "title": "Link your boards",
+          "body": "Connect the walls in your gym"
+        },
+        "members": {
+          "title": "Invite your crew",
+          "body": "Add the staff and setters who run it"
+        },
+        "insights": {
+          "title": "See this week's activity",
+          "body": "Who's climbing and what's getting sent"
+        },
+        "profile": {
+          "title": "Edit your profile",
+          "body": "Name, address, website, and visibility"
+        }
+      }
+    },
+    "profile": {
+      "heading": "Gym profile",
+      "description": "Your gym's name, address, and what climbers see on the public page."
     }
   },
   "branding": {

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -86,7 +86,21 @@
     "exploreFeed": "Mira qué están encadenando otros escaladores",
     "claimTitle": "¿Es tuyo este rocódromo?",
     "claimBody": "Reclámalo para gestionar los plafones, la marca y lo que se ve en el muro.",
-    "claimCta": "Reclamar este rocódromo"
+    "claimCta": "Reclamar este rocódromo",
+    "owner": {
+      "linkBoards": {
+        "title": "Vincula tus plafones",
+        "body": "Los escaladores todavía no ven ningún muro aquí."
+      },
+      "putOnTv": {
+        "title": "Pon este muro en una tele",
+        "body": "Convierte una pantalla de tu rocódromo en un muro en directo."
+      },
+      "addBranding": {
+        "title": "Añade tu marca",
+        "body": "Añade tu logo y tus colores para que la página sea tuya."
+      }
+    }
   },
   "manage": {
     "welcome": {
@@ -122,7 +136,9 @@
       "branding": "Marca",
       "boards": "Plafones",
       "members": "Miembros",
-      "insights": "Estadísticas"
+      "insights": "Estadísticas",
+      "overview": "Resumen",
+      "profile": "Perfil"
     },
     "insights": {
       "subtitle": "Cómo fueron tus plafones esta semana frente a la anterior.",
@@ -303,6 +319,47 @@
       "discardBody": "Tus cambios de diseño aún no están guardados.",
       "keepEditing": "Seguir editando",
       "discard": "Descartar"
+    },
+    "overview": {
+      "quickLinksHeading": "Gestiona tu rocódromo",
+      "viewPublicPage": "Ver la página pública",
+      "embedAction": "Insertar en tu sitio web",
+      "stats": {
+        "boards": "plafones",
+        "members": "miembros",
+        "followers": "seguidores",
+        "kiosks": "kioscos"
+      },
+      "quickLinks": {
+        "kiosks": {
+          "title": "Ponlo en la tele",
+          "body": "Crea una pantalla para el muro de tu rocódromo"
+        },
+        "branding": {
+          "title": "Elige tus colores",
+          "body": "Añade tu logo y los colores de tu marca"
+        },
+        "boards": {
+          "title": "Vincula tus plafones",
+          "body": "Conecta los muros de tu rocódromo"
+        },
+        "members": {
+          "title": "Invita a tu equipo",
+          "body": "Añade al personal y a los aperturistas que lo llevan"
+        },
+        "insights": {
+          "title": "Mira la actividad de esta semana",
+          "body": "Quién escala y qué se está encadenando"
+        },
+        "profile": {
+          "title": "Edita tu perfil",
+          "body": "Nombre, dirección, sitio web y visibilidad"
+        }
+      }
+    },
+    "profile": {
+      "heading": "Perfil del rocódromo",
+      "description": "El nombre, la dirección y lo que ven los escaladores en la página pública."
     }
   },
   "branding": {

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -86,7 +86,21 @@
     "exploreFeed": "Voir ce que les grimpeurs enchaînent",
     "claimTitle": "C'est ta salle ?",
     "claimBody": "Revendique-la pour gérer les boards, l'identité visuelle et ce qui s'affiche sur le mur.",
-    "claimCta": "Revendiquer cette salle"
+    "claimCta": "Revendiquer cette salle",
+    "owner": {
+      "linkBoards": {
+        "title": "Relie tes boards",
+        "body": "Les grimpeurs ne voient encore aucun mur ici."
+      },
+      "putOnTv": {
+        "title": "Mets ce mur sur une TV",
+        "body": "Transforme un écran de ta salle en mur en direct."
+      },
+      "addBranding": {
+        "title": "Ajoute ton identité",
+        "body": "Ajoute ton logo et tes couleurs pour que la page te ressemble."
+      }
+    }
   },
   "manage": {
     "welcome": {
@@ -122,7 +136,9 @@
       "branding": "Identité",
       "boards": "Boards",
       "members": "Membres",
-      "insights": "Statistiques"
+      "insights": "Statistiques",
+      "overview": "Aperçu",
+      "profile": "Profil"
     },
     "insights": {
       "subtitle": "Comment tes boards ont tourné cette semaine par rapport à la dernière.",
@@ -303,6 +319,47 @@
       "discardBody": "Tes changements de disposition ne sont pas encore enregistrés.",
       "keepEditing": "Continuer à modifier",
       "discard": "Abandonner"
+    },
+    "overview": {
+      "quickLinksHeading": "Gère ta salle",
+      "viewPublicPage": "Voir la page publique",
+      "embedAction": "Intégrer à ton site web",
+      "stats": {
+        "boards": "boards",
+        "members": "membres",
+        "followers": "abonnés",
+        "kiosks": "bornes"
+      },
+      "quickLinks": {
+        "kiosks": {
+          "title": "Affiche-la sur la TV",
+          "body": "Crée un écran pour le mur de ta salle"
+        },
+        "branding": {
+          "title": "Choisis tes couleurs",
+          "body": "Ajoute ton logo et tes couleurs"
+        },
+        "boards": {
+          "title": "Relie tes boards",
+          "body": "Connecte les murs de ta salle"
+        },
+        "members": {
+          "title": "Invite ton crew",
+          "body": "Ajoute le staff et les ouvreurs qui la font tourner"
+        },
+        "insights": {
+          "title": "Vois l'activité de la semaine",
+          "body": "Qui grimpe et ce qui s'enchaîne"
+        },
+        "profile": {
+          "title": "Modifie ton profil",
+          "body": "Nom, adresse, site web et visibilité"
+        }
+      }
+    },
+    "profile": {
+      "heading": "Profil de la salle",
+      "description": "Le nom, l'adresse et ce que les grimpeurs voient sur la page publique."
     }
   },
   "branding": {

--- a/packages/web/app/components/gym-entity/edit-gym-form.tsx
+++ b/packages/web/app/components/gym-entity/edit-gym-form.tsx
@@ -16,9 +16,11 @@ type EditGymFormProps = {
   gym: Gym;
   onSuccess?: (gym: Gym) => void;
   onCancel?: () => void;
+  /** Bubbles the form's unsaved-edit state (used by the console's dirty guard). */
+  onDirtyChange?: (isDirty: boolean) => void;
 };
 
-export default function EditGymForm({ gym, onSuccess, onCancel }: EditGymFormProps) {
+export default function EditGymForm({ gym, onSuccess, onCancel, onDirtyChange }: EditGymFormProps) {
   const { t } = useTranslation('boards');
   const { showMessage } = useSnackbar();
 
@@ -76,6 +78,7 @@ export default function EditGymForm({ gym, onSuccess, onCancel }: EditGymFormPro
       showSlugField
       onSubmit={handleSubmit}
       onCancel={onCancel}
+      onDirtyChange={onDirtyChange}
     />
   );
 }

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -261,7 +261,19 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
                 onFollowChange={() => fetchGym()}
               />
             )}
-            {gym.canEdit && (
+            {gym.canEdit && kioskFlag && (
+              <MuiButton
+                component={LocaleLink}
+                href={`/gym/${gym.slug ?? gym.uuid}/manage?tab=profile`}
+                variant="outlined"
+                size="small"
+                startIcon={<EditOutlined />}
+                sx={{ textTransform: 'none' }}
+              >
+                {t('gymEntity.actions.edit')}
+              </MuiButton>
+            )}
+            {gym.canEdit && !kioskFlag && (
               <MuiButton
                 variant="outlined"
                 size="small"

--- a/packages/web/app/components/gym-entity/gym-form.tsx
+++ b/packages/web/app/components/gym-entity/gym-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
@@ -43,6 +43,8 @@ type GymFormProps = {
    * exist" dedup suggestions.
    */
   renderSuggestions?: (values: GymFormLocationValues) => React.ReactNode;
+  /** Reports whether any field diverges from its initial value. */
+  onDirtyChange?: (isDirty: boolean) => void;
 };
 
 export default function GymForm({
@@ -53,6 +55,7 @@ export default function GymForm({
   onSubmit,
   onCancel,
   renderSuggestions,
+  onDirtyChange,
 }: GymFormProps) {
   const { t } = useTranslation('boards');
   const [name, setName] = useState(initialValues.name);
@@ -66,6 +69,26 @@ export default function GymForm({
   const [latitude, setLatitude] = useState<number | null>(initialValues.latitude);
   const [longitude, setLongitude] = useState<number | null>(initialValues.longitude);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Report unsaved edits so a host (the manage console's Profile tab) can guard
+  // tab switches behind a discard confirmation. Report clean on unmount so a
+  // confirmed navigation doesn't leave a stale dirty flag.
+  const isDirty =
+    name !== initialValues.name ||
+    slug !== (initialValues.slug ?? '') ||
+    description !== initialValues.description ||
+    address !== initialValues.address ||
+    website !== initialValues.website ||
+    contactEmail !== initialValues.contactEmail ||
+    contactPhone !== initialValues.contactPhone ||
+    isPublic !== initialValues.isPublic ||
+    latitude !== initialValues.latitude ||
+    longitude !== initialValues.longitude;
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+    return () => onDirtyChange?.(false);
+  }, [isDirty, onDirtyChange]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/packages/web/app/components/gym-entity/gym-stat-chip.tsx
+++ b/packages/web/app/components/gym-entity/gym-stat-chip.tsx
@@ -5,7 +5,8 @@ import { themeTokens } from '@/app/theme/theme-config';
 
 type GymStatChipProps = {
   icon: React.ReactNode;
-  value: number;
+  /** A count, or a placeholder (em-dash / skeleton) while it resolves. */
+  value: React.ReactNode;
   label: string;
 };
 

--- a/packages/web/app/components/gym-entity/manage/__tests__/overview-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/overview-tab.test.tsx
@@ -103,6 +103,15 @@ describe('OverviewTab', () => {
     expect(screen.getByText('kiosks')).toBeTruthy();
   });
 
+  it('shows a placeholder for the kiosk count until the query resolves, not a hard 0', () => {
+    mockRequest.mockReset();
+    mockRequest.mockReturnValue(new Promise(() => {})); // never resolves
+    renderTab(makeGym());
+    // Em-dash placeholder while pending; the server-passed counts still render.
+    expect(screen.getByText('—')).toBeTruthy();
+    expect(screen.getByText('7')).toBeTruthy();
+  });
+
   it('mounts the relocated welcome checklist at the top of the surface', () => {
     renderTab(makeGym());
     expect(screen.getByTestId('welcome-card')).toBeTruthy();

--- a/packages/web/app/components/gym-entity/manage/__tests__/overview-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/overview-tab.test.tsx
@@ -103,13 +103,22 @@ describe('OverviewTab', () => {
     expect(screen.getByText('kiosks')).toBeTruthy();
   });
 
-  it('shows a placeholder for the kiosk count until the query resolves, not a hard 0', () => {
+  it('shows a loading skeleton for the kiosk count while the query is in flight, not a hard 0', () => {
     mockRequest.mockReset();
     mockRequest.mockReturnValue(new Promise(() => {})); // never resolves
-    renderTab(makeGym());
-    // Em-dash placeholder while pending; the server-passed counts still render.
-    expect(screen.getByText('—')).toBeTruthy();
+    const { container } = renderTab(makeGym());
+    // Skeleton while pending; the server-passed counts still render; no hard 0.
+    expect(container.querySelector('.MuiSkeleton-root')).toBeTruthy();
     expect(screen.getByText('7')).toBeTruthy();
+  });
+
+  it('falls back to an em-dash for the kiosk count when the query fails', async () => {
+    mockRequest.mockReset();
+    mockRequest.mockRejectedValue(new Error('boom'));
+    const { container } = renderTab(makeGym());
+    // Settled error state: an em-dash, not an endless skeleton.
+    expect(await screen.findByText('—')).toBeTruthy();
+    expect(container.querySelector('.MuiSkeleton-root')).toBeNull();
   });
 
   it('mounts the relocated welcome checklist at the top of the surface', () => {

--- a/packages/web/app/components/gym-entity/manage/__tests__/overview-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/overview-tab.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { Gym } from '@boardsesh/shared-schema';
+import OverviewTab from '../overview-tab';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'user-owner' } }, status: 'authenticated' }),
+}));
+
+// The welcome checklist has its own IndexedDB + query machinery; stub it so this
+// test can prove the checklist was relocated INTO the Overview surface without
+// dragging in that machinery.
+vi.mock('../gym-welcome-card', () => ({ default: () => <div data-testid="welcome-card" /> }));
+
+// EmbedCodeDialog's Copy button uses the snackbar; stub the provider so opening
+// the dialog doesn't need a real one.
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+function makeGym(overrides: Partial<Gym> = {}): Gym {
+  return {
+    uuid: 'gym-uuid-1',
+    slug: 'test-gym',
+    ownerId: 'user-owner',
+    name: 'Test Gym',
+    boardCount: 3,
+    memberCount: 4,
+    followerCount: 7,
+    commentCount: 0,
+    isPublic: true,
+    ...overrides,
+  } as unknown as Gym;
+}
+
+function renderTab(gym: Gym) {
+  return render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <OverviewTab gym={gym} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockRequest.mockReset();
+  mockRequest.mockResolvedValue({ gymKiosks: [{ uuid: 'k1' }, { uuid: 'k2' }] });
+});
+
+describe('OverviewTab', () => {
+  it('deep-links each quick link to its manage tab', async () => {
+    renderTab(makeGym());
+
+    const cases: Record<string, string> = {
+      'Put it on the TV': '/gym/test-gym/manage?tab=kiosks',
+      'Set your colors': '/gym/test-gym/manage?tab=branding',
+      'Link your boards': '/gym/test-gym/manage?tab=boards',
+      'Invite your crew': '/gym/test-gym/manage?tab=members',
+      "See this week's activity": '/gym/test-gym/manage?tab=insights',
+      'Edit your profile': '/gym/test-gym/manage?tab=profile',
+    };
+    for (const [label, href] of Object.entries(cases)) {
+      const link = await screen.findByRole('link', { name: new RegExp(label, 'i') });
+      expect(link.getAttribute('href')).toBe(href);
+    }
+  });
+
+  it('links to the public gym page', async () => {
+    renderTab(makeGym());
+    const link = await screen.findByRole('link', { name: /view public page/i });
+    expect(link.getAttribute('href')).toBe('/gym/test-gym');
+  });
+
+  it('shows the follower/member/board counts from the gym and the kiosk count from the query', async () => {
+    renderTab(makeGym());
+
+    // Kiosk count comes from the mocked GET_GYM_KIOSKS response (2 kiosks).
+    expect(await screen.findByText('2')).toBeTruthy();
+    // Counts already on the gym.
+    expect(screen.getByText('7')).toBeTruthy();
+    expect(screen.getByText('4')).toBeTruthy();
+    expect(screen.getByText('3')).toBeTruthy();
+    expect(screen.getByText('kiosks')).toBeTruthy();
+  });
+
+  it('mounts the relocated welcome checklist at the top of the surface', () => {
+    renderTab(makeGym());
+    expect(screen.getByTestId('welcome-card')).toBeTruthy();
+  });
+
+  it('opens the embed dialog with the gym leaderboard snippet', async () => {
+    renderTab(makeGym());
+
+    fireEvent.click(await screen.findByRole('button', { name: /embed on your website/i }));
+
+    await waitFor(() => {
+      const field = screen.getByDisplayValue(/\/embed\/gym\/gym-uuid-1\/leaderboard/);
+      expect(field).toBeTruthy();
+    });
+  });
+
+  it('hides the public-page link for a slug-less gym', async () => {
+    renderTab(makeGym({ slug: null }));
+    // Quick links fall back to the UUID; the public-page button is slug-only.
+    await screen.findByRole('link', { name: /put it on the tv/i });
+    expect(screen.queryByRole('button', { name: /view public page/i })).toBeNull();
+  });
+});

--- a/packages/web/app/components/gym-entity/manage/__tests__/profile-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/profile-tab.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { Gym } from '@boardsesh/shared-schema';
+import ProfileTab from '../profile-tab';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+
+// The console profile form must save through the SAME mutation the sheet used
+// (UPDATE_GYM via useEntityMutation). Capture the execute call at the hook seam.
+const mockExecute = vi.fn();
+vi.mock('@/app/hooks/use-entity-mutation', () => ({
+  useEntityMutation: () => ({ execute: mockExecute, token: 'test-token' }),
+}));
+
+function makeGym(overrides: Partial<Gym> = {}): Gym {
+  return {
+    uuid: 'gym-uuid-1',
+    slug: 'test-gym',
+    ownerId: 'user-owner',
+    name: 'Test Gym',
+    description: 'A gym',
+    address: '1 Crux St',
+    website: 'https://example.com',
+    isPublic: true,
+    ...overrides,
+  } as unknown as Gym;
+}
+
+beforeEach(() => {
+  mockExecute.mockReset();
+});
+
+describe('ProfileTab', () => {
+  it('mounts the shared gym profile form in the console', () => {
+    render(<ProfileTab gym={makeGym()} onGymChange={vi.fn()} />);
+
+    expect(screen.getByText('Gym profile')).toBeTruthy();
+    // The shared EditGymForm's name field, prefilled from the gym.
+    expect(screen.getByDisplayValue('Test Gym')).toBeTruthy();
+  });
+
+  it('saves through the same mutation and pushes the result to the shell', async () => {
+    const updatedGym = makeGym({ name: 'Test Gym' });
+    mockExecute.mockResolvedValue({ updateGym: updatedGym });
+    const onGymChange = vi.fn();
+
+    render(<ProfileTab gym={makeGym()} onGymChange={onGymChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+    const variables = mockExecute.mock.calls[0][0];
+    expect(variables.input.gymUuid).toBe('gym-uuid-1');
+    expect(variables.input.name).toBe('Test Gym');
+
+    await waitFor(() => {
+      expect(onGymChange).toHaveBeenCalledWith(updatedGym);
+    });
+  });
+});

--- a/packages/web/app/components/gym-entity/manage/__tests__/profile-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/profile-tab.test.tsx
@@ -17,6 +17,12 @@ vi.mock('@/app/components/providers/snackbar-provider', () => ({
   useSnackbar: () => ({ showMessage: vi.fn() }),
 }));
 
+// The shared form embeds a Leaflet-backed location picker; stub it so this test
+// stays focused on the profile fields.
+vi.mock('@/app/components/board-entity/map-location-picker', () => ({
+  default: () => <div data-testid="map-picker" />,
+}));
+
 // The console profile form must save through the SAME mutation the sheet used
 // (UPDATE_GYM via useEntityMutation). Capture the execute call at the hook seam.
 const mockExecute = vi.fn();
@@ -69,6 +75,22 @@ describe('ProfileTab', () => {
 
     await waitFor(() => {
       expect(onGymChange).toHaveBeenCalledWith(updatedGym);
+    });
+  });
+
+  it('bubbles the form dirty state so the shell can guard tab switches', async () => {
+    const onDirtyChange = vi.fn();
+    render(<ProfileTab gym={makeGym()} onGymChange={vi.fn()} onDirtyChange={onDirtyChange} />);
+
+    // Clean on mount.
+    await waitFor(() => {
+      expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+    });
+
+    // Editing a field flips it to dirty.
+    fireEvent.change(screen.getByDisplayValue('Test Gym'), { target: { value: 'Test Gym 2' } });
+    await waitFor(() => {
+      expect(onDirtyChange).toHaveBeenLastCalledWith(true);
     });
   });
 });

--- a/packages/web/app/components/gym-entity/manage/gym-welcome-card.tsx
+++ b/packages/web/app/components/gym-entity/manage/gym-welcome-card.tsx
@@ -138,9 +138,10 @@ export default function GymWelcomeCard({ gym }: { gym: Gym }) {
   // Deep-link base: prefer the slug, fall back to the UUID (the manage route resolves both).
   const gymRef = gym.slug || gym.uuid;
   const tabHref = (key: GymChecklistStepKey): string => {
+    // Overview is the default tab now, so every checklist step links explicitly
+    // to its own tab (none of the steps target Overview).
     const tab = CHECKLIST_STEP_TAB[key];
-    // Kiosks is the default tab (no query param in the canonical URL).
-    return tab === 'kiosks' ? `/gym/${gymRef}/manage` : `/gym/${gymRef}/manage?tab=${tab}`;
+    return `/gym/${gymRef}/manage?tab=${tab}`;
   };
 
   const handleDismiss = () => {

--- a/packages/web/app/components/gym-entity/manage/overview-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/overview-tab.tsx
@@ -65,7 +65,10 @@ export default function OverviewTab({ gym }: { gym: Gym }) {
     },
     enabled: !!token,
   });
-  const kioskCount = (kiosks ?? []).length;
+  // The other three counts are server-passed and stable; the kiosk count is the
+  // one async value. Hold a placeholder until it resolves rather than flashing a
+  // hard 0 (a gym with kiosks would briefly read as having none).
+  const kioskCountDisplay: React.ReactNode = kiosks === undefined ? '—' : kiosks.length;
 
   const logoDisplayUrl = resolveGymLogoDisplayUrl(gym.logoUrl ?? null, getBackendHttpUrl());
 
@@ -149,7 +152,7 @@ export default function OverviewTab({ gym }: { gym: Gym }) {
         />
         <GymStatChip
           icon={<TvOutlined sx={{ fontSize: 18 }} />}
-          value={kioskCount}
+          value={kioskCountDisplay}
           label={t('manage.overview.stats.kiosks')}
         />
       </Box>

--- a/packages/web/app/components/gym-entity/manage/overview-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/overview-tab.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+// Overview tab: the manage-console landing surface. It reuses data the page
+// already holds (the enriched gym's counts) plus one lightweight kiosk-count
+// query (shared cache key with the welcome card, so no extra round-trip) to show
+// an at-a-glance summary, deep links into every other tab, a link to the public
+// page, and a first-class "embed the leaderboard" action reusing the kiosk
+// editor's dialog. The welcome checklist lives at the top of this surface.
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Card from '@mui/material/Card';
+import Button from '@mui/material/Button';
+import MuiLink from '@mui/material/Link';
+import TvOutlined from '@mui/icons-material/TvOutlined';
+import PaletteOutlined from '@mui/icons-material/PaletteOutlined';
+import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
+import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
+import PersonOutlined from '@mui/icons-material/PersonOutlined';
+import InsightsOutlined from '@mui/icons-material/InsightsOutlined';
+import BadgeOutlined from '@mui/icons-material/BadgeOutlined';
+import ArrowForwardOutlined from '@mui/icons-material/ArrowForwardOutlined';
+import LaunchOutlined from '@mui/icons-material/LaunchOutlined';
+import CodeOutlined from '@mui/icons-material/CodeOutlined';
+import type { Gym } from '@boardsesh/shared-schema';
+import {
+  GET_GYM_KIOSKS,
+  type GetGymKiosksQueryResponse,
+  type GetGymKiosksQueryVariables,
+} from '@boardsesh/graphql/operations';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { getBackendHttpUrl } from '@/app/lib/backend-url';
+import { resolveGymLogoDisplayUrl } from '@/app/lib/gym-logo-display-url';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import GymStatChip from '@/app/components/gym-entity/gym-stat-chip';
+import { themeTokens } from '@/app/theme/theme-config';
+import GymWelcomeCard from './gym-welcome-card';
+import EmbedCodeDialog, { type EmbedCodeDialogState } from './embed-code-dialog';
+import { buildLeaderboardEmbedSnippet } from './embed-snippets';
+
+type QuickLinkTab = 'kiosks' | 'branding' | 'boards' | 'members' | 'insights' | 'profile';
+
+export default function OverviewTab({ gym }: { gym: Gym }) {
+  const { t } = useTranslation('kiosk');
+  const { token } = useWsAuthToken();
+  const { data: session } = useSession();
+  const viewerUserId = session?.user?.id ?? 'anonymous';
+  const [embedDialog, setEmbedDialog] = useState<EmbedCodeDialogState | null>(null);
+
+  // Kiosk count: the one summary number not already on the gym. Same query key
+  // the welcome card uses, so the two share a single fetch.
+  const { data: kiosks } = useQuery({
+    queryKey: ['gymKiosks', gym.uuid, viewerUserId],
+    queryFn: async () => {
+      const client = createGraphQLHttpClient(token);
+      const response = await client.request<GetGymKiosksQueryResponse, GetGymKiosksQueryVariables>(GET_GYM_KIOSKS, {
+        gymUuid: gym.uuid,
+      });
+      return response.gymKiosks;
+    },
+    enabled: !!token,
+  });
+  const kioskCount = (kiosks ?? []).length;
+
+  const logoDisplayUrl = resolveGymLogoDisplayUrl(gym.logoUrl ?? null, getBackendHttpUrl());
+
+  // Deep-link base: prefer the slug, fall back to the UUID (the manage route
+  // resolves both). Overview is the default tab, so every link is explicit.
+  const gymRef = gym.slug || gym.uuid;
+  const tabHref = (tab: QuickLinkTab): string => `/gym/${gymRef}/manage?tab=${tab}`;
+
+  const quickLinks: { tab: QuickLinkTab; icon: React.ReactNode; title: string; body: string }[] = [
+    {
+      tab: 'kiosks',
+      icon: <TvOutlined />,
+      title: t('manage.overview.quickLinks.kiosks.title'),
+      body: t('manage.overview.quickLinks.kiosks.body'),
+    },
+    {
+      tab: 'branding',
+      icon: <PaletteOutlined />,
+      title: t('manage.overview.quickLinks.branding.title'),
+      body: t('manage.overview.quickLinks.branding.body'),
+    },
+    {
+      tab: 'boards',
+      icon: <FitnessCenterOutlined />,
+      title: t('manage.overview.quickLinks.boards.title'),
+      body: t('manage.overview.quickLinks.boards.body'),
+    },
+    {
+      tab: 'members',
+      icon: <PeopleOutlined />,
+      title: t('manage.overview.quickLinks.members.title'),
+      body: t('manage.overview.quickLinks.members.body'),
+    },
+    {
+      tab: 'insights',
+      icon: <InsightsOutlined />,
+      title: t('manage.overview.quickLinks.insights.title'),
+      body: t('manage.overview.quickLinks.insights.body'),
+    },
+    {
+      tab: 'profile',
+      icon: <BadgeOutlined />,
+      title: t('manage.overview.quickLinks.profile.title'),
+      body: t('manage.overview.quickLinks.profile.body'),
+    },
+  ];
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <GymWelcomeCard gym={gym} />
+
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        {logoDisplayUrl && (
+          <Box
+            component="img"
+            src={logoDisplayUrl}
+            alt={gym.name}
+            sx={{ width: 56, height: 56, borderRadius: 2, objectFit: 'contain', flexShrink: 0 }}
+          />
+        )}
+        <Typography variant="h5" sx={{ fontWeight: themeTokens.typography.fontWeight.bold, minWidth: 0 }}>
+          {gym.name}
+        </Typography>
+      </Box>
+
+      <Box sx={{ display: 'flex', gap: 2.5, flexWrap: 'wrap' }}>
+        <GymStatChip
+          icon={<PeopleOutlined sx={{ fontSize: 18 }} />}
+          value={gym.followerCount}
+          label={t('manage.overview.stats.followers')}
+        />
+        <GymStatChip
+          icon={<PersonOutlined sx={{ fontSize: 18 }} />}
+          value={gym.memberCount}
+          label={t('manage.overview.stats.members')}
+        />
+        <GymStatChip
+          icon={<FitnessCenterOutlined sx={{ fontSize: 18 }} />}
+          value={gym.boardCount}
+          label={t('manage.overview.stats.boards')}
+        />
+        <GymStatChip
+          icon={<TvOutlined sx={{ fontSize: 18 }} />}
+          value={kioskCount}
+          label={t('manage.overview.stats.kiosks')}
+        />
+      </Box>
+
+      <Box>
+        <Typography variant="subtitle2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold, mb: 1.5 }}>
+          {t('manage.overview.quickLinksHeading')}
+        </Typography>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+            gap: 1.5,
+          }}
+        >
+          {quickLinks.map((link) => (
+            <Card
+              key={link.tab}
+              variant="outlined"
+              sx={{ borderRadius: themeTokens.borderRadius.md, borderColor: 'divider' }}
+            >
+              <MuiLink
+                component={LocaleLink}
+                href={tabHref(link.tab)}
+                underline="none"
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.5,
+                  p: 2,
+                  color: 'text.primary',
+                  '&:hover': { backgroundColor: 'var(--neutral-100)' },
+                }}
+              >
+                <Box sx={{ color: 'var(--color-primary)', display: 'flex' }}>{link.icon}</Box>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="body2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+                    {link.title}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {link.body}
+                  </Typography>
+                </Box>
+                <ArrowForwardOutlined sx={{ fontSize: 18, color: 'var(--color-primary)' }} />
+              </MuiLink>
+            </Card>
+          ))}
+        </Box>
+      </Box>
+
+      <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap' }}>
+        {gym.slug && (
+          <Button
+            component={LocaleLink}
+            href={`/gym/${gym.slug}`}
+            variant="outlined"
+            size="small"
+            startIcon={<LaunchOutlined />}
+            sx={{ textTransform: 'none' }}
+          >
+            {t('manage.overview.viewPublicPage')}
+          </Button>
+        )}
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<CodeOutlined />}
+          onClick={() =>
+            setEmbedDialog({
+              title: t('embed.railDialogTitle', { name: gym.name }),
+              snippet: buildLeaderboardEmbedSnippet({ gymUuid: gym.uuid, gymName: gym.name }),
+              showPeriodNote: true,
+            })
+          }
+          sx={{ textTransform: 'none' }}
+        >
+          {t('manage.overview.embedAction')}
+        </Button>
+      </Box>
+
+      <EmbedCodeDialog state={embedDialog} onClose={() => setEmbedDialog(null)} />
+    </Box>
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/overview-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/overview-tab.tsx
@@ -16,6 +16,7 @@ import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
 import Button from '@mui/material/Button';
 import MuiLink from '@mui/material/Link';
+import Skeleton from '@mui/material/Skeleton';
 import TvOutlined from '@mui/icons-material/TvOutlined';
 import PaletteOutlined from '@mui/icons-material/PaletteOutlined';
 import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
@@ -54,7 +55,7 @@ export default function OverviewTab({ gym }: { gym: Gym }) {
 
   // Kiosk count: the one summary number not already on the gym. Same query key
   // the welcome card uses, so the two share a single fetch.
-  const { data: kiosks } = useQuery({
+  const { data: kiosks, isError: kiosksError } = useQuery({
     queryKey: ['gymKiosks', gym.uuid, viewerUserId],
     queryFn: async () => {
       const client = createGraphQLHttpClient(token);
@@ -66,9 +67,17 @@ export default function OverviewTab({ gym }: { gym: Gym }) {
     enabled: !!token,
   });
   // The other three counts are server-passed and stable; the kiosk count is the
-  // one async value. Hold a placeholder until it resolves rather than flashing a
-  // hard 0 (a gym with kiosks would briefly read as having none).
-  const kioskCountDisplay: React.ReactNode = kiosks === undefined ? '—' : kiosks.length;
+  // one async value. Show the count once resolved; while the fetch is in flight a
+  // skeleton, and on failure an em-dash — never a misleading hard 0 and never a
+  // stuck spinner (a failed fetch would otherwise sit on the placeholder forever).
+  let kioskCountDisplay: React.ReactNode;
+  if (kiosks !== undefined) {
+    kioskCountDisplay = kiosks.length;
+  } else if (kiosksError) {
+    kioskCountDisplay = '—';
+  } else {
+    kioskCountDisplay = <Skeleton variant="text" width={14} sx={{ display: 'inline-block' }} />;
+  }
 
   const logoDisplayUrl = resolveGymLogoDisplayUrl(gym.logoUrl ?? null, getBackendHttpUrl());
 
@@ -184,10 +193,10 @@ export default function OverviewTab({ gym }: { gym: Gym }) {
                   gap: 1.5,
                   p: 2,
                   color: 'text.primary',
-                  '&:hover': { backgroundColor: 'var(--neutral-100)' },
+                  '&:hover': { bgcolor: 'action.hover' },
                 }}
               >
-                <Box sx={{ color: 'var(--color-primary)', display: 'flex' }}>{link.icon}</Box>
+                <Box sx={{ color: 'primary.main', display: 'flex' }}>{link.icon}</Box>
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Typography variant="body2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
                     {link.title}
@@ -196,7 +205,7 @@ export default function OverviewTab({ gym }: { gym: Gym }) {
                     {link.body}
                   </Typography>
                 </Box>
-                <ArrowForwardOutlined sx={{ fontSize: 18, color: 'var(--color-primary)' }} />
+                <ArrowForwardOutlined sx={{ fontSize: 18, color: 'primary.main' }} />
               </MuiLink>
             </Card>
           ))}

--- a/packages/web/app/components/gym-entity/manage/profile-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/profile-tab.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+// Profile tab: the gym's core identity (name, address, website, description,
+// public/private). It mounts the SAME EditGymForm the GymDetail sheet used —
+// single-source, no duplicate form — and pushes saves back to the shell via
+// onGymChange so sibling tabs and the Overview see the update.
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import EditGymForm from '@/app/components/gym-entity/edit-gym-form';
+import { themeTokens } from '@/app/theme/theme-config';
+import type { GymManageTabProps } from './tab-props';
+
+export default function ProfileTab({ gym, onGymChange }: GymManageTabProps) {
+  const { t } = useTranslation('kiosk');
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box>
+        <Typography variant="h6" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+          {t('manage.profile.heading')}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {t('manage.profile.description')}
+        </Typography>
+      </Box>
+      <EditGymForm gym={gym} onSuccess={onGymChange} />
+    </Box>
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/profile-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/profile-tab.tsx
@@ -3,7 +3,9 @@
 // Profile tab: the gym's core identity (name, address, website, description,
 // public/private). It mounts the SAME EditGymForm the GymDetail sheet used —
 // single-source, no duplicate form — and pushes saves back to the shell via
-// onGymChange so sibling tabs and the Overview see the update.
+// onGymChange so sibling tabs and the Overview see the update. onDirtyChange
+// bubbles the form's unsaved-edit state so the shell routes tab switches
+// through the discard confirmation (parity with Kiosks/Branding).
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,7 +15,7 @@ import EditGymForm from '@/app/components/gym-entity/edit-gym-form';
 import { themeTokens } from '@/app/theme/theme-config';
 import type { GymManageTabProps } from './tab-props';
 
-export default function ProfileTab({ gym, onGymChange }: GymManageTabProps) {
+export default function ProfileTab({ gym, onGymChange, onDirtyChange }: GymManageTabProps) {
   const { t } = useTranslation('kiosk');
 
   return (
@@ -26,7 +28,7 @@ export default function ProfileTab({ gym, onGymChange }: GymManageTabProps) {
           {t('manage.profile.description')}
         </Typography>
       </Box>
-      <EditGymForm gym={gym} onSuccess={onGymChange} />
+      <EditGymForm gym={gym} onSuccess={onGymChange} onDirtyChange={onDirtyChange} />
     </Box>
   );
 }

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-owner-prompts-logic.test.ts
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-owner-prompts-logic.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { ownerPromptsToShow } from '../gym-owner-prompts-logic';
+
+describe('ownerPromptsToShow', () => {
+  it('shows nothing to a non-editor, regardless of content', () => {
+    expect(ownerPromptsToShow({ canEdit: false, hasBoards: false, hasKiosk: false, hasBranding: false })).toEqual([]);
+    expect(ownerPromptsToShow({ canEdit: false, hasBoards: true, hasKiosk: true, hasBranding: true })).toEqual([]);
+  });
+
+  it('shows every prompt to an editor whose gym has no boards, kiosk, or branding', () => {
+    expect(ownerPromptsToShow({ canEdit: true, hasBoards: false, hasKiosk: false, hasBranding: false })).toEqual([
+      'boards',
+      'kiosk',
+      'branding',
+    ]);
+  });
+
+  it('shows nothing to an editor whose gym is fully set up', () => {
+    expect(ownerPromptsToShow({ canEdit: true, hasBoards: true, hasKiosk: true, hasBranding: true })).toEqual([]);
+  });
+
+  it('shows only the prompts for the missing pieces', () => {
+    expect(ownerPromptsToShow({ canEdit: true, hasBoards: true, hasKiosk: false, hasBranding: true })).toEqual([
+      'kiosk',
+    ]);
+    expect(ownerPromptsToShow({ canEdit: true, hasBoards: false, hasKiosk: true, hasBranding: false })).toEqual([
+      'boards',
+      'branding',
+    ]);
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-owner-prompts.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-owner-prompts.test.tsx
@@ -57,4 +57,11 @@ describe('GymOwnerPrompts', () => {
     );
     expect(container.firstChild).toBeNull();
   });
+
+  it('self-gates a non-editor to nothing (the public page renders it unconditionally)', () => {
+    const { container } = render(
+      <GymOwnerPrompts gymSlug="test-gym" canEdit={false} hasBoards={false} hasKiosk={false} hasBranding={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
 });

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-owner-prompts.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-owner-prompts.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import GymOwnerPrompts from '../gym-owner-prompts';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const mockFlag = vi.fn();
+vi.mock('@/app/components/providers/feature-flags-provider', () => ({
+  useFeatureFlag: () => mockFlag(),
+}));
+
+beforeEach(() => {
+  mockFlag.mockReset();
+  mockFlag.mockReturnValue(true);
+});
+
+describe('GymOwnerPrompts', () => {
+  it('renders a deep-linked card for each missing piece', () => {
+    render(<GymOwnerPrompts gymSlug="test-gym" canEdit hasBoards={false} hasKiosk={false} hasBranding={false} />);
+
+    expect(screen.getByRole('link', { name: /link your boards/i }).getAttribute('href')).toBe(
+      '/gym/test-gym/manage?tab=boards',
+    );
+    expect(screen.getByRole('link', { name: /put this wall on a tv/i }).getAttribute('href')).toBe(
+      '/gym/test-gym/manage?tab=kiosks',
+    );
+    expect(screen.getByRole('link', { name: /add your branding/i }).getAttribute('href')).toBe(
+      '/gym/test-gym/manage?tab=branding',
+    );
+  });
+
+  it('renders only the prompt for the missing piece', () => {
+    render(<GymOwnerPrompts gymSlug="test-gym" canEdit hasBoards hasKiosk={false} hasBranding />);
+
+    expect(screen.getByRole('link', { name: /put this wall on a tv/i })).toBeTruthy();
+    expect(screen.queryByRole('link', { name: /link your boards/i })).toBeNull();
+    expect(screen.queryByRole('link', { name: /add your branding/i })).toBeNull();
+  });
+
+  it('renders nothing when the gym is fully set up', () => {
+    const { container } = render(<GymOwnerPrompts gymSlug="test-gym" canEdit hasBoards hasKiosk hasBranding />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing while the kiosk flag is off', () => {
+    mockFlag.mockReturnValue(false);
+    const { container } = render(
+      <GymOwnerPrompts gymSlug="test-gym" canEdit hasBoards={false} hasKiosk={false} hasBranding={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/gym-owner-prompts-logic.ts
+++ b/packages/web/app/gym/[gym_slug]/gym-owner-prompts-logic.ts
@@ -1,0 +1,40 @@
+// Pure selection of which owner-facing setup prompts the public gym page shows.
+// Framework-free so the gating matrix (canEdit × content present/absent) is
+// unit-testable without rendering. Each prompt maps to a missing piece of the
+// gym's public page and deep-links into the matching manage-console tab.
+
+export type OwnerPromptKey = 'boards' | 'kiosk' | 'branding';
+
+/** Which manage-console tab each owner prompt deep-links to. */
+export const OWNER_PROMPT_TAB: Record<OwnerPromptKey, 'boards' | 'kiosks' | 'branding'> = {
+  boards: 'boards',
+  kiosk: 'kiosks',
+  branding: 'branding',
+};
+
+export type OwnerPromptsInput = {
+  /** Only editors get setup prompts — a non-owner viewer sees none. */
+  canEdit: boolean;
+  /** At least one board is linked to the gym. */
+  hasBoards: boolean;
+  /** A default kiosk exists for the gym. */
+  hasKiosk: boolean;
+  /** A logo or any brand colour is set. */
+  hasBranding: boolean;
+};
+
+/**
+ * The prompts to show, in display order: link boards, put a wall on a TV, add
+ * branding. A prompt appears only when its content is missing; a non-editor
+ * gets none.
+ */
+export function ownerPromptsToShow(input: OwnerPromptsInput): OwnerPromptKey[] {
+  if (!input.canEdit) {
+    return [];
+  }
+  const prompts: OwnerPromptKey[] = [];
+  if (!input.hasBoards) prompts.push('boards');
+  if (!input.hasKiosk) prompts.push('kiosk');
+  if (!input.hasBranding) prompts.push('branding');
+  return prompts;
+}

--- a/packages/web/app/gym/[gym_slug]/gym-owner-prompts.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-owner-prompts.tsx
@@ -94,10 +94,10 @@ export default function GymOwnerPrompts({ gymSlug, canEdit, hasBoards, hasKiosk,
               gap: 1.5,
               p: 2,
               color: 'text.primary',
-              '&:hover': { backgroundColor: 'var(--neutral-100)' },
+              '&:hover': { bgcolor: 'action.hover' },
             }}
           >
-            <Box sx={{ color: 'var(--color-primary)', display: 'flex' }}>{promptIcon(key)}</Box>
+            <Box sx={{ color: 'primary.main', display: 'flex' }}>{promptIcon(key)}</Box>
             <Box sx={{ flex: 1, minWidth: 0 }}>
               <Typography variant="subtitle2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
                 {promptTitle(t, key)}
@@ -106,7 +106,7 @@ export default function GymOwnerPrompts({ gymSlug, canEdit, hasBoards, hasKiosk,
                 {promptBody(t, key)}
               </Typography>
             </Box>
-            <ArrowForwardOutlined sx={{ fontSize: 18, color: 'var(--color-primary)' }} />
+            <ArrowForwardOutlined sx={{ fontSize: 18, color: 'primary.main' }} />
           </MuiLink>
         </Card>
       ))}

--- a/packages/web/app/gym/[gym_slug]/gym-owner-prompts.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-owner-prompts.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+// Client island: low-key owner CTAs on the public gym page. The server renders
+// this only for editors and passes the content-absence booleans it already
+// computed from the enriched gym, so the gating is decided server-side; the
+// island adds the kiosk-flag check (the manage console it links into is
+// flag-gated) and renders one small outlined card per missing piece.
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import Typography from '@mui/material/Typography';
+import MuiLink from '@mui/material/Link';
+import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
+import TvOutlined from '@mui/icons-material/TvOutlined';
+import PaletteOutlined from '@mui/icons-material/PaletteOutlined';
+import ArrowForwardOutlined from '@mui/icons-material/ArrowForwardOutlined';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
+import { GYM_KIOSK_FLAG } from '@/app/flags';
+import { themeTokens } from '@/app/theme/theme-config';
+import { ownerPromptsToShow, OWNER_PROMPT_TAB, type OwnerPromptKey } from './gym-owner-prompts-logic';
+
+type GymOwnerPromptsProps = {
+  gymSlug: string;
+  canEdit: boolean;
+  hasBoards: boolean;
+  hasKiosk: boolean;
+  hasBranding: boolean;
+};
+
+// Static-literal lookups: the i18n linter forbids t(variable)/t(template).
+function promptTitle(t: TFunction, key: OwnerPromptKey): string {
+  switch (key) {
+    case 'boards':
+      return t('gymPage.owner.linkBoards.title');
+    case 'kiosk':
+      return t('gymPage.owner.putOnTv.title');
+    case 'branding':
+      return t('gymPage.owner.addBranding.title');
+  }
+}
+
+function promptBody(t: TFunction, key: OwnerPromptKey): string {
+  switch (key) {
+    case 'boards':
+      return t('gymPage.owner.linkBoards.body');
+    case 'kiosk':
+      return t('gymPage.owner.putOnTv.body');
+    case 'branding':
+      return t('gymPage.owner.addBranding.body');
+  }
+}
+
+function promptIcon(key: OwnerPromptKey): React.ReactNode {
+  switch (key) {
+    case 'boards':
+      return <FitnessCenterOutlined sx={{ fontSize: 18 }} />;
+    case 'kiosk':
+      return <TvOutlined sx={{ fontSize: 18 }} />;
+    case 'branding':
+      return <PaletteOutlined sx={{ fontSize: 18 }} />;
+  }
+}
+
+export default function GymOwnerPrompts({ gymSlug, canEdit, hasBoards, hasKiosk, hasBranding }: GymOwnerPromptsProps) {
+  const { t } = useTranslation('kiosk');
+  const kioskFlag = useFeatureFlag(GYM_KIOSK_FLAG);
+
+  // The prompts link into the manage console, which is gated until the feature
+  // ships broadly — hide them entirely while the flag is off.
+  if (!kioskFlag) {
+    return null;
+  }
+
+  const prompts = ownerPromptsToShow({ canEdit, hasBoards, hasKiosk, hasBranding });
+  if (prompts.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mb: 3 }}>
+      {prompts.map((key) => (
+        <Card key={key} variant="outlined" sx={{ borderRadius: themeTokens.borderRadius.md, borderColor: 'divider' }}>
+          <MuiLink
+            component={LocaleLink}
+            href={`/gym/${gymSlug}/manage?tab=${OWNER_PROMPT_TAB[key]}`}
+            underline="none"
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              p: 2,
+              color: 'text.primary',
+              '&:hover': { backgroundColor: 'var(--neutral-100)' },
+            }}
+          >
+            <Box sx={{ color: 'var(--color-primary)', display: 'flex' }}>{promptIcon(key)}</Box>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography variant="subtitle2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+                {promptTitle(t, key)}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {promptBody(t, key)}
+              </Typography>
+            </Box>
+            <ArrowForwardOutlined sx={{ fontSize: 18, color: 'var(--color-primary)' }} />
+          </MuiLink>
+        </Card>
+      ))}
+    </Box>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/manage/__tests__/manage-gym-content.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/__tests__/manage-gym-content.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { Gym } from '@boardsesh/shared-schema';
+import ManageGymContent from '../manage-gym-content';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+// The shell reads the active tab from the URL; pin it to Profile for these tests.
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams('tab=profile'),
+}));
+
+const pushSpy = vi.fn();
+const replaceSpy = vi.fn();
+vi.mock('@/app/lib/i18n/use-locale-router', () => ({
+  useLocaleRouter: () => ({ push: pushSpy, replace: replaceSpy, prefetch: vi.fn() }),
+  usePathnameWithoutLocale: () => '/gym/old-slug/manage',
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'user-owner' } }, status: 'authenticated' }),
+}));
+
+// Sibling tabs have their own hooks/subscriptions — stub them so the shell test
+// stays focused on the profile-save routing and the dirty guard.
+vi.mock('@/app/components/gym-entity/manage/overview-tab', () => ({ default: () => <div data-testid="overview" /> }));
+vi.mock('@/app/components/gym-entity/manage/kiosks-tab', () => ({ default: () => <div data-testid="kiosks" /> }));
+vi.mock('@/app/components/gym-entity/manage/insights-tab', () => ({ default: () => <div data-testid="insights" /> }));
+vi.mock('@/app/components/gym-entity/manage/branding-tab', () => ({ default: () => <div data-testid="branding" /> }));
+vi.mock('@/app/components/gym-entity/manage/gym-boards-tab', () => ({ default: () => <div data-testid="boards" /> }));
+vi.mock('@/app/components/gym-entity/gym-member-management', () => ({ default: () => <div data-testid="members" /> }));
+
+// Controllable Profile-tab stub: buttons that fire the same callbacks the real
+// tab wires to the shared form.
+vi.mock('@/app/components/gym-entity/manage/profile-tab', () => ({
+  default: ({
+    gym,
+    onGymChange,
+    onDirtyChange,
+  }: {
+    gym: Gym;
+    onGymChange: (gym: Gym) => void;
+    onDirtyChange?: (dirty: boolean) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onGymChange({ ...gym, slug: 'new-slug' })}>
+        save-renamed
+      </button>
+      <button type="button" onClick={() => onGymChange({ ...gym, slug: gym.slug })}>
+        save-same
+      </button>
+      <button type="button" onClick={() => onDirtyChange?.(true)}>
+        make-dirty
+      </button>
+    </div>
+  ),
+}));
+
+function makeGym(overrides: Partial<Gym> = {}): Gym {
+  return {
+    uuid: 'gym-uuid-1',
+    slug: 'old-slug',
+    ownerId: 'user-owner',
+    name: 'Test Gym',
+    boardCount: 1,
+    memberCount: 1,
+    followerCount: 1,
+    commentCount: 0,
+    isPublic: true,
+    canEdit: true,
+    canGrantAccess: true,
+    ...overrides,
+  } as unknown as Gym;
+}
+
+beforeEach(() => {
+  pushSpy.mockReset();
+  replaceSpy.mockReset();
+});
+
+describe('ManageGymContent profile save routing', () => {
+  it('moves onto the new slug URL when a profile save renames the slug', () => {
+    render(<ManageGymContent initialGym={makeGym()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'save-renamed' }));
+
+    // Active tab is Profile, so the tab param is carried onto the new slug.
+    expect(replaceSpy).toHaveBeenCalledWith('/gym/new-slug/manage?tab=profile', { scroll: false });
+  });
+
+  it('does not redirect when a profile save keeps the same slug', () => {
+    render(<ManageGymContent initialGym={makeGym()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'save-same' }));
+
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('ManageGymContent dirty guard on the Profile tab', () => {
+  it('holds a tab switch behind the discard confirmation once the profile form is dirty', async () => {
+    render(<ManageGymContent initialGym={makeGym()} />);
+
+    // Clean switch: no confirmation.
+    fireEvent.click(screen.getByRole('tab', { name: 'Overview' }));
+    expect(screen.queryByText('Discard unsaved changes?')).toBeNull();
+    expect(pushSpy).toHaveBeenCalled();
+    pushSpy.mockReset();
+
+    // Mark the profile form dirty, then attempt a tab switch.
+    fireEvent.click(screen.getByRole('button', { name: 'make-dirty' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Boards' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Discard unsaved changes?')).toBeTruthy();
+    });
+    // Navigation is held until the user confirms.
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/manage/__tests__/manage-gym-content.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/__tests__/manage-gym-content.test.tsx
@@ -13,9 +13,12 @@ vi.mock('react-i18next', () => ({
   Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
 }));
 
-// The shell reads the active tab from the URL; pin it to Profile for these tests.
+// The shell reads the active tab from the URL. Most tests pin it to Profile; the
+// default-tab test clears it. A hoisted holder lets a test flip the value before
+// render.
+const searchState = vi.hoisted(() => ({ params: 'tab=profile' }));
 vi.mock('next/navigation', () => ({
-  useSearchParams: () => new URLSearchParams('tab=profile'),
+  useSearchParams: () => new URLSearchParams(searchState.params),
 }));
 
 const pushSpy = vi.fn();
@@ -84,6 +87,18 @@ function makeGym(overrides: Partial<Gym> = {}): Gym {
 beforeEach(() => {
   pushSpy.mockReset();
   replaceSpy.mockReset();
+  searchState.params = 'tab=profile';
+});
+
+describe('ManageGymContent default tab', () => {
+  it('renders the Overview tab when no ?tab= param is present', () => {
+    searchState.params = '';
+    render(<ManageGymContent initialGym={makeGym()} />);
+
+    // Overview is the default landing surface; the Profile stub must not mount.
+    expect(screen.getByTestId('overview')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'make-dirty' })).toBeNull();
+  });
 });
 
 describe('ManageGymContent profile save routing', () => {

--- a/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
@@ -92,6 +92,18 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
     router.replace(`/gym/${updatedGym.slug}/manage${query}`, { scroll: false });
   };
 
+  // The Profile tab's form can rename the slug. When it does, the shell's
+  // basePath still points at the old slug, so the next tab switch would push
+  // `${oldSlug}?tab=X` and 404 (a renamed slug resolves to nothing). Reuse the
+  // slug-guard's replace to move onto the new slug; otherwise just sync state.
+  const handleProfileSaved = (updatedGym: Gym) => {
+    if (updatedGym.slug && updatedGym.slug !== gym.slug) {
+      handleSlugSet(updatedGym);
+    } else {
+      setGym(updatedGym);
+    }
+  };
+
   return (
     <Container
       maxWidth="md"
@@ -149,7 +161,9 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
       {activeTab === 'kiosks' && <KiosksTab gym={gym} onGymChange={setGym} onDirtyChange={setIsActiveTabDirty} />}
       {activeTab === 'insights' && <InsightsTab gym={gym} onGymChange={setGym} />}
       {activeTab === 'branding' && <BrandingTab gym={gym} onGymChange={setGym} onDirtyChange={setIsActiveTabDirty} />}
-      {activeTab === 'profile' && <ProfileTab gym={gym} onGymChange={setGym} />}
+      {activeTab === 'profile' && (
+        <ProfileTab gym={gym} onGymChange={handleProfileSaved} onDirtyChange={setIsActiveTabDirty} />
+      )}
       {activeTab === 'boards' && <GymBoardsTab gym={gym} onGymChange={setGym} />}
       {activeTab === 'members' && (
         <GymMemberManagement

--- a/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
@@ -21,14 +21,15 @@ import GymBoardsTab from '@/app/components/gym-entity/manage/gym-boards-tab';
 import KiosksTab from '@/app/components/gym-entity/manage/kiosks-tab';
 import InsightsTab from '@/app/components/gym-entity/manage/insights-tab';
 import BrandingTab from '@/app/components/gym-entity/manage/branding-tab';
+import OverviewTab from '@/app/components/gym-entity/manage/overview-tab';
+import ProfileTab from '@/app/components/gym-entity/manage/profile-tab';
 import GymSlugGuard from '@/app/components/gym-entity/manage/gym-slug-guard';
-import GymWelcomeCard from '@/app/components/gym-entity/manage/gym-welcome-card';
 import ConfirmDialog from '@/app/components/gym-entity/manage/confirm-dialog';
 import { decideManageNavigation, type ManageNavigation } from '@/app/components/gym-entity/manage/manage-nav-guard';
 
-type ManageTab = 'kiosks' | 'insights' | 'branding' | 'boards' | 'members';
-const VALID_TABS: ManageTab[] = ['kiosks', 'insights', 'branding', 'boards', 'members'];
-const DEFAULT_TAB: ManageTab = 'kiosks';
+type ManageTab = 'overview' | 'kiosks' | 'insights' | 'branding' | 'profile' | 'boards' | 'members';
+const VALID_TABS: ManageTab[] = ['overview', 'kiosks', 'insights', 'branding', 'profile', 'boards', 'members'];
+const DEFAULT_TAB: ManageTab = 'overview';
 
 export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
   const { t } = useTranslation('kiosk');
@@ -128,8 +129,6 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
 
       {!gym.slug && <GymSlugGuard gym={gym} onSlugSet={handleSlugSet} />}
 
-      <GymWelcomeCard gym={gym} />
-
       <Tabs
         value={activeTab}
         onChange={handleTabChange}
@@ -137,16 +136,20 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
         scrollButtons="auto"
         sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}
       >
+        <Tab value="overview" label={t('manage.tabs.overview')} sx={{ textTransform: 'none' }} />
         <Tab value="kiosks" label={t('manage.tabs.kiosks')} sx={{ textTransform: 'none' }} />
         <Tab value="insights" label={t('manage.tabs.insights')} sx={{ textTransform: 'none' }} />
         <Tab value="branding" label={t('manage.tabs.branding')} sx={{ textTransform: 'none' }} />
+        <Tab value="profile" label={t('manage.tabs.profile')} sx={{ textTransform: 'none' }} />
         <Tab value="boards" label={t('manage.tabs.boards')} sx={{ textTransform: 'none' }} />
         <Tab value="members" label={t('manage.tabs.members')} sx={{ textTransform: 'none' }} />
       </Tabs>
 
+      {activeTab === 'overview' && <OverviewTab gym={gym} />}
       {activeTab === 'kiosks' && <KiosksTab gym={gym} onGymChange={setGym} onDirtyChange={setIsActiveTabDirty} />}
       {activeTab === 'insights' && <InsightsTab gym={gym} onGymChange={setGym} />}
       {activeTab === 'branding' && <BrandingTab gym={gym} onGymChange={setGym} onDirtyChange={setIsActiveTabDirty} />}
+      {activeTab === 'profile' && <ProfileTab gym={gym} onGymChange={setGym} />}
       {activeTab === 'boards' && <GymBoardsTab gym={gym} onGymChange={setGym} />}
       {activeTab === 'members' && (
         <GymMemberManagement

--- a/packages/web/app/gym/[gym_slug]/manage/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/page.tsx
@@ -24,6 +24,7 @@ export const dynamic = 'force-dynamic';
 
 type ManageGymRouteProps = {
   params: Promise<{ gym_slug: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 /**
@@ -76,6 +77,7 @@ export async function generateMetadata(props: ManageGymRouteProps): Promise<Meta
 
 export default async function ManageGymPage(props: ManageGymRouteProps) {
   const { gym_slug } = await props.params;
+  const { tab } = await props.searchParams;
   const token = await getServerAuthToken();
 
   if (!token) {
@@ -93,9 +95,11 @@ export default async function ManageGymPage(props: ManageGymRouteProps) {
   // A merged twin's slug resolved to the canonical gym under a different slug:
   // redirect the manage URL onto the canonical slug. Skip when the URL segment is
   // a UUID — that's the deliberate slug-less-gym-by-uuid addressing path, not a
-  // stale twin slug.
+  // stale twin slug. Carry the ?tab= param so a tab-carrying deep-link (e.g. a
+  // stale ?tab=members link) lands on the right tab after the redirect.
   if (gym.slug && gym.slug !== gym_slug && !looksLikeGymUuid(gym_slug)) {
-    permanentRedirect(`/gym/${gym.slug}/manage`);
+    const tabQuery = typeof tab === 'string' && tab ? `?tab=${encodeURIComponent(tab)}` : '';
+    permanentRedirect(`/gym/${gym.slug}/manage${tabQuery}`);
   }
 
   const locale = await getLocale();

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -39,6 +39,7 @@ import CommentSection from '@/app/components/social/comment-section';
 import GymPageManageButton from './gym-page-manage-button';
 import GymFollowButton from './gym-follow-button';
 import GymClaimCta from './gym-claim-cta';
+import GymOwnerPrompts from './gym-owner-prompts';
 import { getPublicBackendHttpUrl } from '@/app/lib/backend-url';
 import { resolveGymLogoDisplayUrl } from '@/app/lib/gym-logo-display-url';
 
@@ -243,6 +244,18 @@ export default async function GymPage(props: GymRouteProps) {
           )}
           {gym.canEdit && <GymPageManageButton gymSlug={gym_slug} />}
         </Box>
+
+        {gym.canEdit && (
+          <GymOwnerPrompts
+            gymSlug={gym_slug}
+            canEdit={gym.canEdit}
+            hasBoards={boards.length > 0}
+            hasKiosk={kiosk !== null}
+            hasBranding={Boolean(
+              gym.logoUrl || gym.brandPrimaryColor || gym.brandAccentColor || gym.brandBackgroundColor,
+            )}
+          />
+        )}
 
         {gym.canClaim && <GymClaimCta gymUuid={gym.uuid} gymName={gym.name} website={gym.website} />}
 

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -245,17 +245,18 @@ export default async function GymPage(props: GymRouteProps) {
           {gym.canEdit && <GymPageManageButton gymSlug={gym_slug} />}
         </Box>
 
-        {gym.canEdit && (
-          <GymOwnerPrompts
-            gymSlug={gym_slug}
-            canEdit={gym.canEdit}
-            hasBoards={boards.length > 0}
-            hasKiosk={kiosk !== null}
-            hasBranding={Boolean(
-              gym.logoUrl || gym.brandPrimaryColor || gym.brandAccentColor || gym.brandBackgroundColor,
-            )}
-          />
-        )}
+        {/* Self-gating: GymOwnerPrompts renders nothing for a non-editor (or a
+            fully set-up gym), so the canEdit prop stays honest instead of being
+            shadowed by an always-true outer guard. */}
+        <GymOwnerPrompts
+          gymSlug={gym_slug}
+          canEdit={gym.canEdit}
+          hasBoards={boards.length > 0}
+          hasKiosk={kiosk !== null}
+          hasBranding={Boolean(
+            gym.logoUrl || gym.brandPrimaryColor || gym.brandAccentColor || gym.brandBackgroundColor,
+          )}
+        />
 
         {gym.canClaim && <GymClaimCta gymUuid={gym.uuid} gymName={gym.name} website={gym.website} />}
 


### PR DESCRIPTION
## Summary

The gym manage console now opens on an **Overview** tab, and gym owners can finally edit their profile without leaving the console.

**Overview tab (first tab, default landing).** An at-a-glance summary built entirely from data the page already loads — the enriched gym's follower / member / board counts plus one lightweight kiosk-count query (shared cache key with the welcome checklist, so no extra round-trip). It carries:
- gym logo + name and the four counts,
- one deep-linked quick-link card per tab ("Put it on the TV" → Kiosks, "Set your colors" → Branding, "Link your boards" → Boards, "Invite your crew" → Members, "See this week's activity" → Insights, "Edit your profile" → Profile),
- a "View public page" link,
- a first-class "Embed on your website" action that reuses the kiosk editor's existing `EmbedCodeDialog` with the gym leaderboard snippet.

The first-run welcome checklist (`gym-welcome-card`) moved from above the tabs into the top of the Overview surface — the landing surface it always belonged on. Overview does **not** show kiosk liveness (that heartbeat work is a separate PR; nothing here depends on it).

**Profile editing in the console.** New **Profile** tab that mounts the *same* `edit-gym-form.tsx` the GymDetail sheet used — imported, not duplicated, so the form stays single-source. The sheet's Edit action becomes a deep link to `/gym/<slug>/manage?tab=profile` when the console is available, keeping the inline sheet form as the flag-off fallback.

**Why a dedicated Profile tab rather than folding into Branding?** Two reasons. First, the deep-link contract is `?tab=profile` — a dedicated `profile` tab keeps that URL honest instead of aliasing it onto `branding`. Second, the two concerns are genuinely distinct: Profile is identity (name, address, website, description, visibility); Branding is the visual kit (logo, colors). Folding them would make one long, mixed-purpose tab. The tab strip is already `variant="scrollable"`, so the extra tab costs nothing.

**Public-page owner CTAs.** On `/gym/<slug>`, editors now get low-key outlined cards where content is missing — "Link your boards", "Put this wall on a TV", "Add your branding" — each deep-linking to the matching console tab. The gating (canEdit × content present/absent) is computed server-side from the already-enriched gym via a pure helper (`gym-owner-prompts-logic.ts`); the client island only adds the kiosk-flag check, consistent with how the existing "Manage gym" entry point is gated.

`manage-gym-content.tsx` stays a minimal structural diff: the tab list gains Overview + Profile, the default tab flips to Overview, and the welcome-card mount relocates into Overview. `kiosks-tab.tsx` is untouched (per the in-flight heartbeat PR). `gym-welcome-card.tsx`'s deep-link builder is updated so it no longer assumes Kiosks is the default tab.

## Release Notes

- Your gym console now opens on an Overview — every setup step, your public page, and a paste-anywhere embed are one tap away.
- Edit your gym's profile (name, address, website, visibility) right in the console instead of hunting for the sheet.
- On your public gym page, quick prompts point you straight to whatever's still missing — boards, a TV wall, or your branding.

## Test plan

- `vp run typecheck:web` — green
- `vp run typecheck` (full monorepo) — green
- `vp test run --project web` — new suites pass (Overview quick-link hrefs + kiosk count + checklist relocation + embed dialog; Profile form mounts and saves via the shared `UPDATE_GYM` mutation; owner-CTA gating matrix canEdit × content); full web suite green apart from one unrelated fake-timer flake in `error-boundary.test.tsx` (passes in isolation)
- `vp check` — new/changed files lint + format clean
- `vp run check:i18n` + `check:i18n:orphans` — clean; catalog-completeness parity green across en-US / es / fr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VGxf4ZJGFRanuJGrRMDgY
