### PR TITLE
fix(mobile): stop re-arming the FGS start deadline on session-notification updates

### DIFF
--- a/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceController.kt
+++ b/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceController.kt
@@ -32,13 +32,29 @@ internal class SessionForegroundServiceStartException(cause: Throwable) :
  * SessionPresenceModule is the thin adapter that constructs this from appContext
  * and routes the async-function calls here.
  *
- * `startForegroundService` is injectable so a test can drive the
- * ForegroundServiceStartNotAllowedException path without a live service.
+ * Two delivery seams, both injectable so a test can drive the
+ * ForegroundServiceStartNotAllowedException / BackgroundServiceStartNotAllowedException
+ * paths without a live service:
+ *  - `startForegroundService` — the initial START promotion and the ACTION_STOP
+ *    teardown. These genuinely (re)arm the service's foreground state.
+ *  - `startService` — every subsequent UPDATE. The service is already promoted by
+ *    startSession(), so a plain startService delivers the new state WITHOUT arming
+ *    a fresh startForeground() deadline. Each startForegroundService() call sets
+ *    fgRequired/fgWaiting on the ServiceRecord and schedules the foreground-start
+ *    timeout — even when the service is already foreground — so routing the
+ *    high-frequency update path through startForegroundService made every
+ *    climb/queue change race a congested or backgrounding main thread and could
+ *    trip ForegroundServiceDidNotStartInTimeException (#3188). startService never
+ *    schedules that timeout, so it can't. A running FGS keeps the process
+ *    foreground-exempt, so startService is also allowed from the background.
  */
 internal class SessionPresenceController(
     private val context: Context,
     private val startForegroundService: (Context, Intent) -> Unit = { ctx, intent ->
         ContextCompat.startForegroundService(ctx, intent)
+    },
+    private val startService: (Context, Intent) -> Unit = { ctx, intent ->
+        ctx.startService(intent)
     },
 ) {
     // Whether a session is logically active (startSession called, endSession not
@@ -75,14 +91,15 @@ internal class SessionPresenceController(
             options?.holderDisplayName?.let { putExtra(BoardSessionService.EXTRA_HOLDER_NAME, it) }
         }
         // Startup path: a failed initial promotion means the service never
-        // started, so clear sessionActive to stop futile update retries.
-        launchService(intent, clearSessionOnFailure = true)
+        // started, so clear sessionActive to stop futile update retries and
+        // reject startSession so JS resets its active ref and can retry later.
+        launchForegroundService(intent)
     }
 
     fun updateActivity(options: SessionUpdateOptions) {
-        // Only update inside an active session window. startSession() owns
-        // promotion; a stray update would issue startForegroundService() just to
-        // refresh, risking ForegroundServiceDidNotStartInTimeException.
+        // Only update inside an active session window. startSession() owns the
+        // foreground promotion; a stray update on a never-started service would
+        // deliver to nothing.
         if (!sessionActive) return
         val subtitle = buildString {
             append(options.climbDifficulty)
@@ -111,12 +128,20 @@ internal class SessionPresenceController(
                 )
             }
         }
-        // Update path: the service is already running. A failed re-delivery while
-        // the app briefly backgrounds (ForegroundServiceStartNotAllowedException)
-        // is non-fatal — keep sessionActive so the next update, once foregrounded,
+        // Update path: the service is already promoted, so deliver via
+        // startService — NOT startForegroundService, which would re-arm a
+        // startForeground() deadline on every climb/queue change (see the class
+        // doc). A failed re-delivery (BackgroundServiceStartNotAllowedException —
+        // service already gone and the process no longer foreground-exempt) is
+        // non-fatal: keep sessionActive so the next update, once foregrounded,
         // refreshes the notification. Clearing it here would permanently freeze
         // the notification mid-session.
-        launchService(intent, clearSessionOnFailure = false)
+        try {
+            startService(context, intent)
+        } catch (error: Exception) {
+            val errorName = error.javaClass.simpleName.ifBlank { error.javaClass.name }
+            Log.w(TAG, "updateActivity startService failed ($errorName): ${error.message}")
+        }
     }
 
     fun endSession() {
@@ -150,20 +175,18 @@ internal class SessionPresenceController(
         }
     }
 
-    // startForegroundService() throws ForegroundServiceStartNotAllowedException on
-    // API 31+ when the app is backgrounded. clearSessionOnFailure distinguishes the
-    // startup path (failure is terminal — clear the flag) from the update path
-    // (failure is transient — the service is already running, keep the flag).
-    private fun launchService(intent: Intent, clearSessionOnFailure: Boolean) {
+    // The initial START promotion. startForegroundService() throws
+    // ForegroundServiceStartNotAllowedException on API 31+ when the app is
+    // backgrounded; a failure here is terminal (the service never started), so
+    // clear the flag and reject startSession so JS resets its active ref.
+    private fun launchForegroundService(intent: Intent) {
         try {
             startForegroundService(context, intent)
         } catch (error: Exception) {
             val errorName = error.javaClass.simpleName.ifBlank { error.javaClass.name }
             Log.w(TAG, "startForegroundService failed ($errorName): ${error.message}", error)
-            if (clearSessionOnFailure) {
-                sessionActive = false
-                throw SessionForegroundServiceStartException(error)
-            }
+            sessionActive = false
+            throw SessionForegroundServiceStartException(error)
         }
     }
 

--- a/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/SessionPresenceControllerTest.kt
+++ b/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/SessionPresenceControllerTest.kt
@@ -2,6 +2,7 @@ package com.boardsesh.liveactivity
 
 import android.Manifest
 import android.app.Application
+import android.content.Context
 import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
@@ -18,8 +19,9 @@ import org.robolectric.annotation.Config
 /**
  * Lifecycle of the logical `sessionActive` flag — the source of the
  * "notification freezes mid-session" and "JS thinks the session started when it
- * didn't" bugs. The controller takes an injectable startForegroundService seam so
- * the ForegroundServiceStartNotAllowedException path is drivable without a live
+ * didn't" bugs. The controller takes injectable startForegroundService /
+ * startService seams so the ForegroundServiceStartNotAllowedException and
+ * BackgroundServiceStartNotAllowedException paths are drivable without a live
  * service.
  */
 @RunWith(RobolectricTestRunner::class)
@@ -27,15 +29,28 @@ class SessionPresenceControllerTest {
 
     private val application: Application = ApplicationProvider.getApplicationContext()
 
+    // Records both delivery seams into one ordered list so intent-content
+    // assertions don't care which seam carried a given action. Tests that assert
+    // the delivery MECHANISM (START/STOP via startForegroundService, UPDATE via
+    // startService) inject the seams separately instead.
     private fun recordingController(): Pair<SessionPresenceController, MutableList<Intent>> {
         val launchedIntents = mutableListOf<Intent>()
-        val controller = SessionPresenceController(application) { _, intent -> launchedIntents.add(intent) }
+        val record: (Context, Intent) -> Unit = { _, intent -> launchedIntents.add(intent) }
+        val controller = SessionPresenceController(
+            application,
+            startForegroundService = record,
+            startService = record,
+        )
         return controller to launchedIntents
     }
 
-    // Stands in for ForegroundServiceStartNotAllowedException (API 31+); launchService
-    // catches plain Exception, so the type doesn't matter for the flag logic.
+    // Stands in for ForegroundServiceStartNotAllowedException (API 31+); the catch
+    // handles plain Exception, so the type doesn't matter for the flag logic.
     private fun fgsNotAllowed(): Exception = IllegalStateException("ForegroundServiceStartNotAllowedException")
+
+    // Stands in for BackgroundServiceStartNotAllowedException (API 31+), thrown by
+    // startService when the process is no longer foreground-exempt.
+    private fun bgServiceNotAllowed(): Exception = IllegalStateException("BackgroundServiceStartNotAllowedException")
 
     private fun updateOptions(): SessionUpdateOptions = SessionUpdateOptions().apply {
         climbName = "Test Climb"
@@ -85,7 +100,10 @@ class SessionPresenceControllerTest {
     @Config(sdk = [31])
     fun `startup-path launch failure clears sessionActive and rejects startSession`() {
         val startupFailure = fgsNotAllowed()
-        val controller = SessionPresenceController(application) { _, _ -> throw startupFailure }
+        val controller = SessionPresenceController(
+            application,
+            startForegroundService = { _, _ -> throw startupFailure },
+        )
 
         val thrown = assertThrows(SessionForegroundServiceStartException::class.java) {
             controller.startSession(null)
@@ -100,28 +118,54 @@ class SessionPresenceControllerTest {
 
     @Test
     @Config(sdk = [31])
-    fun `update-path launch failure keeps sessionActive`() {
-        var failNextLaunch = false
-        val launchedIntents = mutableListOf<Intent>()
-        val controller = SessionPresenceController(application) { _, intent ->
-            if (failNextLaunch) throw fgsNotAllowed()
-            launchedIntents.add(intent)
-        }
+    fun `updateActivity delivers via startService, never startForegroundService`() {
+        val fgsIntents = mutableListOf<Intent>()
+        val serviceIntents = mutableListOf<Intent>()
+        val controller = SessionPresenceController(
+            application,
+            startForegroundService = { _, intent -> fgsIntents.add(intent) },
+            startService = { _, intent -> serviceIntents.add(intent) },
+        )
+
+        controller.startSession(null)
+        controller.updateActivity(updateOptions())
+
+        // START promotes via startForegroundService (the one legitimate FGS
+        // start). The UPDATE must go through startService so it never re-arms a
+        // startForeground() deadline — the accumulation of those per-update
+        // deadlines was the ForegroundServiceDidNotStartInTimeException in #3188.
+        assertEquals(listOf(BoardSessionService.ACTION_START), fgsIntents.map { it.action })
+        assertEquals(listOf(BoardSessionService.ACTION_UPDATE), serviceIntents.map { it.action })
+    }
+
+    @Test
+    @Config(sdk = [31])
+    fun `update-path startService failure keeps sessionActive`() {
+        var failNextUpdate = false
+        val updateIntents = mutableListOf<Intent>()
+        val controller = SessionPresenceController(
+            application,
+            startForegroundService = { _, _ -> },
+            startService = { _, intent ->
+                if (failNextUpdate) throw bgServiceNotAllowed()
+                updateIntents.add(intent)
+            },
+        )
 
         controller.startSession(null)
         assertTrue(controller.sessionActive)
 
-        // App briefly backgrounds: the UPDATE re-delivery throws, but the service
-        // is already running — the session must stay active (the regression this
-        // PR fixes; clearing here permanently froze the notification).
-        failNextLaunch = true
+        // Process no longer foreground-exempt: the UPDATE startService throws, but
+        // the service was already promoted — the session must stay active (the
+        // regression this guards; clearing here permanently froze the notification).
+        failNextUpdate = true
         controller.updateActivity(updateOptions())
         assertTrue(controller.sessionActive)
 
         // Back in the foreground, a later update refreshes the notification.
-        failNextLaunch = false
+        failNextUpdate = false
         controller.updateActivity(updateOptions())
-        assertEquals(BoardSessionService.ACTION_UPDATE, launchedIntents.last().action)
+        assertEquals(BoardSessionService.ACTION_UPDATE, updateIntents.last().action)
     }
 
     @Test
@@ -228,9 +272,12 @@ class SessionPresenceControllerTest {
     @Config(sdk = [31])
     fun `endSession falls back to stopService when ACTION_STOP delivery throws`() {
         var failNextLaunch = false
-        val controller = SessionPresenceController(application) { _, _ ->
-            if (failNextLaunch) throw fgsNotAllowed()
-        }
+        val controller = SessionPresenceController(
+            application,
+            startForegroundService = { _, _ ->
+                if (failNextLaunch) throw fgsNotAllowed()
+            },
+        )
         controller.startSession(null)
 
         // Service already gone and app backgrounded: the ACTION_STOP delivery


### PR DESCRIPTION
Fixes #3188.

## What was happening

The Android Live-Activity foreground service (`BoardSessionService`) crashed with `RemoteServiceException$ForegroundServiceDidNotStartInTimeException` — `Context.startForegroundService()` was accepted, but `Service.startForeground()` didn't land inside Android's ~5–10s window, so the OS killed the app (fatal, Android 12+). Sentry BOARDSESH-6W: ~7 events / 3 users, Android 15 / Galaxy S21 Ultra.

## Root cause

Most of what the issue asks for already shipped in #2722 — startForeground-first in `onStartCommand`, channel-before-start, `ForegroundServiceStartNotAllowedException` handling, and the `ACTION_STOP` promote-then-stop teardown that fixed the dangling-token crash. The crashed build (`2.0.0+2000031`, first seen 2026-06-04) predates that merge (2026-06-10). This PR closes the one residual gap those fixes didn't cover.

`SessionPresenceController.updateActivity()` delivered **every** climb/queue change through `startForegroundService(ACTION_UPDATE)` — and via `useLiveActivity` that fires many times per session. The load-bearing detail: **each `startForegroundService()` call sets `fgRequired`/`fgWaiting` on the `ServiceRecord` and schedules the foreground-start timeout — even when the service is already foreground.** So the high-frequency update path kept re-arming a fresh `startForeground()` deadline, and any one of those deadlines racing a congested or backgrounding main thread (slow `onStartCommand` dispatch) tripped `ForegroundServiceDidNotStartInTime`. With one START vs. many UPDATEs per session, UPDATE was by far the largest exposure. The existing catch only helps when the start is *rejected synchronously*; it does nothing for the accept-then-timeout race.

## The fix

The service is already promoted by `startSession()`, so route updates through a plain `context.startService()` instead of `startForegroundService()`:

- `startService()` delivers the new state **without** scheduling the foreground-start timeout, so the update path can no longer cause `ForegroundServiceDidNotStartInTime`.
- A running FGS keeps the process foreground-exempt, so `startService()` is still allowed from the background. **Bonus:** updates that used to be rejected with `ForegroundServiceStartNotAllowedException` while backgrounded now actually land, so the ongoing notification stays current for its own Previous/Next taps.
- `startForegroundService()` stays for the one legitimate START promotion and the `ACTION_STOP` teardown (which must still satisfy a possibly-pending START token).
- Failed update delivery stays non-fatal — `sessionActive` is kept so the next foreground update refreshes the notification.

Added a second injectable `startService` seam mirroring the existing `startForegroundService` one, plus tests asserting UPDATE goes through `startService` (never `startForegroundService`) while START/STOP keep the FGS start, and that a failed `startService` update keeps the session active.

## Delivery

Native Kotlin change — it moves the `fingerprint` runtimeVersion, so it **ships with the next store / TestFlight / Play build, not via OTA**. Kotlin unit tests run in the `android-pr-rn` CI job (no local Kotlin runner in `vp`).

## Release Notes

Fixed a rare Android crash that could close the app during a climbing session while the ongoing session notification updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va
