### PR TITLE
test(mobile): regression guard for board-art 403 fix (#3191)

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -29,6 +29,8 @@ const mocks = vi.hoisted(() => ({
   getRecentFilters: vi.fn(),
   getLogbook: vi.fn(),
   track: vi.fn(),
+  ensureBackgroundsCached: vi.fn(),
+  imagePrefetch: vi.fn(),
 }));
 
 type FlashListProps<Item> = {
@@ -45,6 +47,10 @@ vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
   RefreshControl: () => createElement('div', { 'data-refresh-control': 'true' }),
   Keyboard: { dismiss: mocks.dismissKeyboard },
+  // No `Image.prefetch` should ever fire for board art (#3191 — the native
+  // Android image loader gets a 403 from the CDN/WAF for direct board-art
+  // fetches). Exposed here so the pre-warm test can assert it stays unused.
+  Image: { prefetch: mocks.imagePrefetch },
   // Run deferred work synchronously in tests; the prewarm + background-cache
   // effects schedule through InteractionManager.runAfterInteractions in the screen.
   InteractionManager: {
@@ -291,7 +297,9 @@ vi.mock('../../../../src/lib/graphql/use-active-board', () => ({
 }));
 
 vi.mock('../../../../src/providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
-vi.mock('../../../../src/lib/background-image-cache', () => ({ ensureBackgroundsCached: vi.fn() }));
+vi.mock('../../../../src/lib/background-image-cache', () => ({
+  ensureBackgroundsCached: mocks.ensureBackgroundsCached,
+}));
 
 vi.mock('../../../../src/lib/recent-filter-store', () => ({
   getRecentFilters: mocks.getRecentFilters,
@@ -336,6 +344,8 @@ beforeEach(() => {
   mocks.saveLastSearch.mockResolvedValue(undefined);
   mocks.getRecentFilters.mockResolvedValue([]);
   mocks.track.mockClear();
+  mocks.ensureBackgroundsCached.mockClear();
+  mocks.imagePrefetch.mockClear();
   mocks.searchClimbs = [mocks.climb, mocks.secondClimb];
   mocks.searchState = { filters: {}, boardFilters: {}, name: '' };
 });
@@ -417,5 +427,28 @@ describe('ClimbList zero-result filter snapshot', () => {
     expect(properties).toMatchObject({ resultCount: 1 });
     expect(properties).not.toHaveProperty('zeroResultOnlyTallClimbs');
     expect(properties).not.toHaveProperty('zeroResultStatus');
+  });
+});
+
+// Regression guard for #3191: the native Android image loader was getting a
+// hard 403 from the CDN/WAF fetching board-art PNGs directly (fixed by
+// #2633, which replaced an `Image.prefetch(url)` pre-warm with the bundled
+// `ensureBackgroundsCached` asset lookup — see the effect's comment in
+// ../index.tsx). This locks that behaviour in so a future edit to the
+// pre-warm effect can't silently reintroduce a network board-art fetch.
+describe('ClimbList board-art pre-warm (#3191 regression guard)', () => {
+  it('pre-warms the bundled board background for the active board and never calls Image.prefetch', async () => {
+    render(<ClimbList />);
+
+    await waitFor(() =>
+      expect(mocks.ensureBackgroundsCached).toHaveBeenCalledWith({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: [1],
+      }),
+    );
+
+    expect(mocks.imagePrefetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/__tests__/background-image-cache.test.ts
+++ b/packages/mobile/src/lib/__tests__/background-image-cache.test.ts
@@ -28,6 +28,11 @@ vi.mock('../board-backgrounds-manifest', () => ({
     // thumb-variant fallback-to-full path is exercised below.
     'kilter/product_sizes_layouts_sets/thumbs/36-1.webp': 300,
     'tension/product_sizes_layouts_sets/12.webp': 200,
+    // Dedicated key for the asset-resolution-failure regression test below —
+    // module 999 is never touched by any other test, so the module-scoped
+    // `resolvedPaths` cache in background-image-cache.ts can't short-circuit
+    // it with a stale success from an earlier test in this file.
+    'kilter/product_sizes_layouts_sets/999-failure-test.webp': 999,
   },
 }));
 
@@ -167,6 +172,52 @@ describe('ensureBackgroundsCached', () => {
     // placeholder for the missing one. Previously this returned just
     // ['/bundled/100.webp'] and the consumer never knew a layer was lost.
     expect(result).toEqual({ paths: ['/bundled/100.webp'], missingCount: 1 });
+  });
+
+  // Regression guard for #3191: the Sentry crash was an *unhandled promise
+  // rejection* from a network board-art fetch that 403'd. That call site was
+  // removed (see index.tsx), but ensureBackgroundsCached itself must stay
+  // reject-proof for any asset-resolution failure — a failed layer degrades
+  // to a missing-count gap the caller renders visibly, never an uncaught
+  // rejection that crashes the surrounding effect.
+  it('resolves with a missing layer instead of rejecting when native asset resolution fails', async () => {
+    vi.mocked(getBoardRenderData).mockReturnValue({
+      boardWidth: 100,
+      boardHeight: 100,
+      edgeLeft: 0,
+      edgeRight: 11,
+      edgeBottom: 0,
+      edgeTop: 18,
+      holdsData: [],
+      // Dedicated manifest key (module 999) — see the manifest mock comment —
+      // so this test's fromModule() call can't be served by another test's
+      // already-cached success.
+      backgroundImageKeys: ['kilter/product_sizes_layouts_sets/999-failure-test.webp'],
+    } as ReturnType<typeof getBoardRenderData>);
+
+    // Simulate the dev-mode / not-yet-materialized case (localUri unset), so
+    // resolution falls through to downloadAsync() — then make that reject,
+    // standing in for any native asset-resolution failure.
+    const fromModuleSpy = vi.spyOn(MockAsset, 'fromModule').mockImplementationOnce((moduleId: number) => {
+      const asset = new MockAsset(moduleId);
+      asset.localUri = null;
+      return asset;
+    });
+    downloadAsyncMock.mockRejectedValueOnce(new Error('simulated asset resolution failure'));
+
+    const result = await ensureBackgroundsCached({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: [24],
+    });
+
+    // If this ever regressed to an uncaught rejection, `await` above would
+    // throw and fail the test — resolving here proves the catch-and-degrade
+    // contract holds.
+    expect(result).toEqual({ paths: [], missingCount: 1 });
+
+    fromModuleSpy.mockRestore();
   });
 });
 

--- a/packages/mobile/src/lib/__tests__/background-image-cache.test.ts
+++ b/packages/mobile/src/lib/__tests__/background-image-cache.test.ts
@@ -205,19 +205,24 @@ describe('ensureBackgroundsCached', () => {
     });
     downloadAsyncMock.mockRejectedValueOnce(new Error('simulated asset resolution failure'));
 
-    const result = await ensureBackgroundsCached({
-      boardName: 'kilter',
-      layoutId: 1,
-      sizeId: 10,
-      setIds: [24],
-    });
+    try {
+      const result = await ensureBackgroundsCached({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: [24],
+      });
 
-    // If this ever regressed to an uncaught rejection, `await` above would
-    // throw and fail the test — resolving here proves the catch-and-degrade
-    // contract holds.
-    expect(result).toEqual({ paths: [], missingCount: 1 });
-
-    fromModuleSpy.mockRestore();
+      // If this ever regressed to an uncaught rejection, `await` above would
+      // throw and fail the test — resolving here proves the catch-and-degrade
+      // contract holds.
+      expect(result).toEqual({ paths: [], missingCount: 1 });
+    } finally {
+      // try/finally so a failed assertion above still restores the spy —
+      // otherwise a failure here would leak a mocked fromModule() into
+      // every later test in this file.
+      fromModuleSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- #3191 reports the native Android image loader getting a hard **403** from the CDN fetching board-art PNGs directly (`java.io.IOException: ... code=403 ... url=https://www.boardsesh.com/images/kilter/product_sizes_layouts_sets/original-16x12-bolt-ons-v2.png`), surfaced as an unhandled promise rejection. Sentry BOARDSESH-70, 14 events / 1 user, last seen 2026-06-06.
- This was already fixed by #2633 (`fix(mobile): stop fetching board art over HTTP on climbs screen`, merged 2026-06-08 — two days after the only Sentry burst this issue is based on). That PR replaced the climbs-screen `Image.prefetch(url)` pre-warm with `ensureBackgroundsCached()`, which only resolves **bundled `file://` webp assets** — board art is never fetched over the network on mobile (see the comment on the pre-warm effect in `packages/mobile/app/(tabs)/climbs/index.tsx`).
- I re-audited `packages/mobile` end to end for this PR (grepped for `Image.prefetch`, `imageUrls`, raw `boardsesh.com/images` URL construction, and any network `source={{ uri: ... }}` touching board art) and found nothing left that fetches board art over HTTP. Every consumer (native climb renderer, Live Activity widget, playlist backdrop, climb thumbnails) goes through the bundled-asset lookup.
- So no functional app code change is needed here. This PR adds two regression tests that lock the #2633 fix in place, so a future edit to the pre-warm effect or the asset-cache catch-and-degrade contract can't silently reintroduce the crash:
  1. `packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx` — asserts the board pre-warm effect calls `ensureBackgroundsCached` with the active board config and never calls `Image.prefetch`.
  2. `packages/mobile/src/lib/__tests__/background-image-cache.test.ts` — asserts `ensureBackgroundsCached` resolves with a missing-layer count instead of rejecting when native asset resolution fails (the original crash's `mechanism: onunhandledrejection`, now proven unreachable).

Fixes #3191

### @marcodejongh — two things I couldn't verify from this environment

- [ ] **Confirm BOARDSESH-70 has zero events since 2026-06-08.** I have no Sentry access here; the issue's own volume stat (14 events / 1 user, all attributed to 2026-06-06) plus the #2633 fix timeline strongly suggest it's already resolved, but a Sentry check would make that certain before closing.
- [ ] **Unverified WAF hypothesis, optional defense-in-depth:** I couldn't inspect the actual Vercel Firewall config (no valid local token). My working theory is Vercel's bot-management/Attack Challenge Mode 403s OkHttp-style native requests (no browser TLS/JA3 fingerprint, no `Sec-Fetch-*`, rapid sequential requests) rather than anything in-repo — I found no header/rewrite/middleware rule in `packages/web` that would 403 `/images/*`. If you want to harden against any *future* code path re-fetching board art directly, consider excluding `/images/*` (public, non-sensitive static assets) from that WAF tier. Not blocking — the actual fix here is app-side and already shipped.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project mobile "packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx" "packages/mobile/src/lib/__tests__/background-image-cache.test.ts"` — both files pass (20 tests).
- `vp run test:mobile` — full mobile suite: 485 files / 3956 tests, all passing.
- `vp run typecheck:mobile` — clean.
- `vp check` — clean (format + lint).
- `vp run check:mobile-bundle` — Metro bundle check, Linux-safe.
