### PR TITLE
fix(mobile): never mount Android GoogleMaps without a build key

### DIFF
--- a/.github/workflows/android-apk-dev-client.yml
+++ b/.github/workflows/android-apk-dev-client.yml
@@ -60,6 +60,17 @@ jobs:
       EXPO_PUBLIC_USE_RN_FETCH: '1'
       # Switches app.config.ts to the "Boardsesh Dev" identity + reddish icons.
       BOARDSESH_APP_VARIANT: dev
+      # Android Google Maps key, read directly by app.config.ts (not inlined into
+      # the JS bundle, so it does NOT go in the .env heredoc below — see the
+      # production workflow's identical convention). Without it, app.config.ts
+      # omits the com.google.android.geo.API_KEY manifest meta-data and mounting
+      # the native GoogleMaps view is a FATAL crash on attach, not just a blank
+      # map (issue #3187). GymMap.tsx also gates the view on this at runtime, but
+      # setting it here is what makes the dev-client map actually render instead
+      # of degrading to list-only. Repo-level secret (see
+      # scripts/mobile-ota-setup.ts) — no `environment:` scoping needed, unlike
+      # the signing secrets this job doesn't use.
+      GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
     steps:
       - name: Checkout repository

--- a/docs/android-sideload-build.md
+++ b/docs/android-sideload-build.md
@@ -44,14 +44,14 @@ serve the right APKs for its supported device set.
 The release APK is signed with the **shared Android release keystore** (the same
 key the Capacitor app used), via the existing repo secrets — no new secrets:
 
-| Secret                              | Used for                                         |
-| ----------------------------------- | ------------------------------------------------ |
-| `ANDROID_KEYSTORE_BASE64`           | base64 of the `.keystore`, decoded at build time |
-| `ANDROID_KEYSTORE_PASSWORD`         | store password                                   |
-| `ANDROID_KEY_ALIAS`                 | key alias                                        |
-| `ANDROID_KEY_PASSWORD`              | key password                                     |
-| `GOOGLE_MAPS_API_KEY` (optional)    | Android map tiles; map is blank without it       |
-| `DISCORD_DEPLOY_WEBHOOK` (optional) | best-effort release notification                 |
+| Secret                              | Used for                                                                                                                                                                  |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ANDROID_KEYSTORE_BASE64`           | base64 of the `.keystore`, decoded at build time                                                                                                                          |
+| `ANDROID_KEYSTORE_PASSWORD`         | store password                                                                                                                                                            |
+| `ANDROID_KEY_ALIAS`                 | key alias                                                                                                                                                                 |
+| `ANDROID_KEY_PASSWORD`              | key password                                                                                                                                                              |
+| `GOOGLE_MAPS_API_KEY` (optional)    | Android Google Maps meta-data; the /gyms map degrades to list-only without it (GymMap.tsx never mounts the native view — a fatal native crash otherwise, see issue #3187) |
+| `DISCORD_DEPLOY_WEBHOOK` (optional) | best-effort release notification                                                                                                                                          |
 
 Signing is injected by the `with-android-release-signing` config plugin
 (`packages/mobile/plugins/`), which rewrites the prebuild-generated
@@ -268,6 +268,11 @@ It installs **side-by-side** with the production app. `app.config.ts` reads
 
 `scheme`, the iOS bundle id, and the iOS entitlement/App-Group block stay on the
 production values — the variant is Android-identity + icons only.
+
+The job also sets `GOOGLE_MAPS_API_KEY` (same repo-level secret as the
+production build) so the dev-client APK's manifest carries the Google Maps
+meta-data too — otherwise the /gyms map would degrade to list-only on every
+dev-client install (see the table above and issue #3187).
 
 The reddish icons are generated from the production brand PNGs by
 `scripts/mobile-make-dev-icons.ts` (a hue rotation via `sharp`, not new art).

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -391,8 +391,11 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
       blockedPermissions: ['android.permission.BLUETOOTH_ADVERTISE'],
       // expo-maps on Android renders Google Maps, which needs an API key. iOS
       // uses Apple Maps and needs none. Supplied via env so iOS works out of the
-      // box; the Android map stays blank until GOOGLE_MAPS_API_KEY is set + a
-      // rebuild. Only emit the block when the key exists to keep config clean.
+      // box; the Android GoogleMaps view is UNSAFE to mount at all without this
+      // (fatal native "API key not found" crash on attach, not just a blank map —
+      // see issue #3187 / GymMap.tsx). Only emit the block when the key exists to
+      // keep config clean; googleMapsApiKeyConfigured below (in `extra`) is how
+      // JS learns whether it's safe to mount the native view.
       ...(process.env.GOOGLE_MAPS_API_KEY
         ? { config: { googleMaps: { apiKey: process.env.GOOGLE_MAPS_API_KEY } } }
         : {}),
@@ -595,6 +598,11 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
           }
         : {}),
       ...(tailscaleHosts.length > 0 ? { tailscaleHosts } : {}),
+      // Read at runtime by GymMap.tsx to decide whether the native Android
+      // GoogleMaps view is safe to mount (see the comment on `android.config`
+      // above and issue #3187). A boolean, not the key itself — the key never
+      // needs to reach JS, only whether the manifest meta-data is present.
+      googleMapsApiKeyConfigured: Boolean(process.env.GOOGLE_MAPS_API_KEY),
     },
   };
 };

--- a/packages/mobile/src/components/gym-directory/GymMap.tsx
+++ b/packages/mobile/src/components/gym-directory/GymMap.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from 'react';
 import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import Constants from 'expo-constants';
 
 export type GymMapMarker = {
   id: string;
@@ -65,6 +66,45 @@ try {
   Maps = null;
 }
 
+// Reads app.config.ts's `extra.googleMapsApiKeyConfigured` flag (whether
+// GOOGLE_MAPS_API_KEY was baked into this build's AndroidManifest as the
+// com.google.android.geo.API_KEY meta-data). Pulled out as a pure function
+// (rather than inlined at the `Constants.expoConfig?.extra` call site) so it's
+// unit-testable without mocking expo-constants or expo-maps — see
+// __tests__/gym-map.test.tsx. Exported for that reason only.
+export function readGoogleMapsApiKeyConfigured(extra: unknown): boolean {
+  if (!extra || typeof extra !== 'object') return false;
+  return (extra as { googleMapsApiKeyConfigured?: unknown }).googleMapsApiKeyConfigured === true;
+}
+
+// Decides which native map view (if any) is safe to mount. Without the
+// AndroidManifest's Google Maps meta-data, mounting the native GoogleMaps.View
+// throws a FATAL native IllegalStateException ("API key not found") the
+// instant the view attaches to the window — issue #3187. That throw happens in
+// Android's View.dispatchAttachedToWindow, entirely outside React's
+// render/commit cycle, so MapErrorBoundary below (a JS componentDidCatch)
+// CANNOT catch it: the only safe fix is to never construct the native view
+// when the key is absent. `maps` is `null` when the expo-maps module itself
+// isn't linked (a build that predates it); `undefined` returned here is
+// treated identically to that case by the caller (degrades to list-only).
+// Pure + exported so the branch selection is unit-testable without rendering
+// through the real (native-only) expo-maps module — see
+// __tests__/gym-map.test.tsx.
+export function resolveMapView(
+  platformOS: string,
+  maps: typeof import('expo-maps') | null,
+  androidGoogleMapsKeyConfigured: boolean,
+) {
+  if (!maps) return undefined;
+  if (platformOS === 'ios') return maps.AppleMaps?.View;
+  return androidGoogleMapsKeyConfigured ? maps.GoogleMaps?.View : undefined;
+}
+
+// Read once at module scope — both the flag and Platform.OS are fixed for the
+// life of the binary (baked at build time / set by the OS), so there's nothing
+// to react to on re-render.
+const isAndroidGoogleMapsKeyConfigured = readGoogleMapsApiKeyConfigured(Constants.expoConfig?.extra);
+
 /**
  * Catches a render/mount throw from the native map (e.g. the expo-maps native
  * view isn't linked in this build) so it degrades to no-map instead of taking
@@ -113,11 +153,16 @@ const NativeGymMap = forwardRef<GymMapHandle, GymMapProps>(function NativeGymMap
     nativeRef.current = (instance as NativeMapHandle | null) ?? null;
   }, []);
 
-  const MapView = Platform.OS === 'ios' ? Maps?.AppleMaps?.View : Maps?.GoogleMaps?.View;
+  // On Android, only resolve the native GoogleMaps view when the build has the
+  // API key baked in (see resolveMapView above) — an undefined MapView here
+  // falls through to the same "unavailable" branch as a missing expo-maps
+  // module, degrading to the list-only layout instead of crashing on mount.
+  const MapView = resolveMapView(Platform.OS, Maps, isAndroidGoogleMapsKeyConfigured);
 
   // Report a missing native map exactly once (the module or platform view is
-  // absent — e.g. a build without expo-maps). Read through a ref so the effect
-  // stays mount-only and isn't torn down by a changing callback identity.
+  // absent — e.g. a build without expo-maps, or Android without the Google Maps
+  // key). Read through a ref so the effect stays mount-only and isn't torn down
+  // by a changing callback identity.
   const onMapUnavailableRef = useRef(onMapUnavailable);
   onMapUnavailableRef.current = onMapUnavailable;
   useEffect(() => {
@@ -178,13 +223,15 @@ const NativeGymMap = forwardRef<GymMapHandle, GymMapProps>(function NativeGymMap
 
 /**
  * Renders nearby gyms as pins on the platform map (Apple Maps on iOS, Google
- * Maps on Android — the latter needs GOOGLE_MAPS_API_KEY + a native build, else
- * blank). Marker taps drive `onMarkerPress` (a map→list convenience); selection
- * itself lives in the gym list so the flow works identically whether or not the
- * map renders, and a missing/broken native map never crashes the screen (it
- * reports `onMapUnavailable` so the screen lays out list-only). Panning the map
- * fires `onRegionChange`; a place search drives the camera via the
- * {@link GymMapHandle} ref. Both no-op when the native map is unavailable.
+ * Maps on Android — the latter needs GOOGLE_MAPS_API_KEY baked in at build time,
+ * else the native view is never mounted rather than crashing, see
+ * isAndroidGoogleMapsKeyConfigured above / issue #3187). Marker taps drive
+ * `onMarkerPress` (a map→list convenience); selection itself lives in the gym
+ * list so the flow works identically whether or not the map renders, and a
+ * missing/broken native map never crashes the screen (it reports
+ * `onMapUnavailable` so the screen lays out list-only). Panning the map fires
+ * `onRegionChange`; a place search drives the camera via the {@link GymMapHandle}
+ * ref. Both no-op when the native map is unavailable.
  */
 export const GymMap = memo(
   forwardRef<GymMapHandle, GymMapProps>(function GymMap(

--- a/packages/mobile/src/components/gym-directory/__tests__/gym-map.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/gym-map.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Issue #3187: mounting the native Android GoogleMaps view without
+// GOOGLE_MAPS_API_KEY baked into the build is a FATAL native crash the instant
+// the view attaches to the window (thrown outside React's render/commit cycle,
+// so the component's MapErrorBoundary can't catch it). GymMap.tsx guards this
+// with two pure decision functions, tested directly here — the actual
+// expo-maps package is native-only and can't be exercised through a render in
+// this Node/jsdom test environment (`require('expo-maps')` isn't interceptable
+// by `vi.mock` the way a static `import` is, and the real package throws
+// outside a React Native runtime), so a full-render test would only ever
+// exercise the "module missing" branch regardless of the key flag. Testing the
+// pure functions directly covers the actual bug fix without that limitation.
+//
+// react-native / expo-maps / expo-constants are mocked only so importing
+// GymMap.tsx (for its exported pure functions) doesn't touch native/Flow
+// source under vitest's node env; nothing below depends on the mocked values
+// beyond `readGoogleMapsApiKeyConfigured` and `resolveMapView`'s own args.
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android' },
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+vi.mock('expo-maps', () => ({}));
+vi.mock('expo-constants', () => ({ default: { expoConfig: { extra: {} } } }));
+
+const { readGoogleMapsApiKeyConfigured, resolveMapView } = await import('../GymMap');
+
+describe('readGoogleMapsApiKeyConfigured', () => {
+  it('is true only when extra.googleMapsApiKeyConfigured is exactly true', () => {
+    expect(readGoogleMapsApiKeyConfigured({ googleMapsApiKeyConfigured: true })).toBe(true);
+  });
+
+  it('is false when the flag is absent, false, or the wrong type (dev-client build, or a build predating this fix)', () => {
+    expect(readGoogleMapsApiKeyConfigured({ googleMapsApiKeyConfigured: false })).toBe(false);
+    expect(readGoogleMapsApiKeyConfigured({})).toBe(false);
+    expect(readGoogleMapsApiKeyConfigured(undefined)).toBe(false);
+    expect(readGoogleMapsApiKeyConfigured(null)).toBe(false);
+    expect(readGoogleMapsApiKeyConfigured('unexpected')).toBe(false);
+    expect(readGoogleMapsApiKeyConfigured({ googleMapsApiKeyConfigured: 'true' })).toBe(false);
+  });
+});
+
+describe('resolveMapView', () => {
+  const AppleView = () => null;
+  const GoogleView = () => null;
+  const maps = {
+    AppleMaps: { View: AppleView },
+    GoogleMaps: { View: GoogleView },
+  } as unknown as typeof import('expo-maps');
+
+  it('never resolves GoogleMaps.View on Android when the build key is missing (the crash this issue fixes)', () => {
+    expect(resolveMapView('android', maps, false)).toBeUndefined();
+  });
+
+  it('resolves GoogleMaps.View on Android when the build key is present', () => {
+    expect(resolveMapView('android', maps, true)).toBe(GoogleView);
+  });
+
+  it('resolves AppleMaps.View on iOS regardless of the Android key flag (iOS never needs the key)', () => {
+    expect(resolveMapView('ios', maps, false)).toBe(AppleView);
+    expect(resolveMapView('ios', maps, true)).toBe(AppleView);
+  });
+
+  it('resolves undefined on any platform when the expo-maps module itself is unavailable', () => {
+    expect(resolveMapView('android', null, true)).toBeUndefined();
+    expect(resolveMapView('ios', null, true)).toBeUndefined();
+  });
+});

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -46,6 +46,14 @@ const OTA_PREVIEW = 'mobile-ota-preview.yml';
 // native builds too, or the assertion diverges from the value the shipped binary
 // actually embeds.
 const OTA_BACKPORT = 'mobile-ota-backport.yml';
+// The debug/dev-client APK (android-apk-dev-client.yml) loads JS from Metro at
+// runtime and never receives an OTA, so it's deliberately EXCLUDED from the
+// `workflows` fingerprint-parity array below — its env has no fingerprint to
+// keep in lockstep. But it still needs GOOGLE_MAPS_API_KEY set (job-level, not
+// workflow-level, hence the separate helper) or `expo prebuild` omits the
+// Android manifest's Google Maps meta-data and the native GoogleMaps view is a
+// fatal crash the instant it mounts (issue #3187) — checked on its own below.
+const DEV_CLIENT_ANDROID = 'android-apk-dev-client.yml';
 
 // Workflow-level env keys that feed the resolved config (fingerprint) and/or the
 // inlined JS bundle (runtime correctness). Every one must be declared identically
@@ -201,6 +209,19 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
     // merely names it is fine — match a YAML/shell key, not the bare word).
     expect(ios).not.toMatch(/^\s*GOOGLE_MAPS_API_KEY:/m);
     expect(android).toMatch(/^\s*GOOGLE_MAPS_API_KEY:\s*\$\{\{\s*secrets\.GOOGLE_MAPS_API_KEY\s*\}\}/m);
+  });
+
+  it('sets GOOGLE_MAPS_API_KEY on the debug/dev-client Android build too (issue #3187)', () => {
+    // Not a fingerprint-parity concern (this workflow is excluded from the
+    // `workflows` array above — see DEV_CLIENT_ANDROID) but the same repo-level
+    // secret as the production build must still reach `expo prebuild`, or every
+    // com.boardsesh.app.dev install crashes the instant a Google Map mounts
+    // (GymMap.tsx's runtime gate covers already-shipped binaries; this closes
+    // the gap for future dev-client builds). Any indentation matches — the job's
+    // `env:` block sits one level deeper than the workflow-level blocks the
+    // other assertions check.
+    const devClient = readWorkflow(DEV_CLIENT_ANDROID);
+    expect(devClient).toMatch(/^\s*GOOGLE_MAPS_API_KEY:\s*\$\{\{\s*secrets\.GOOGLE_MAPS_API_KEY\s*\}\}\s*$/m);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #3187 — a fatal Android crash ("API key not found") the instant a Google Map view mounts, seen on `com.boardsesh.app.dev@2.0.0+1` (Sentry BOARDSESH-6X, 10 events / 3 users).

**Root cause, two compounding bugs:**

1. `packages/mobile/app.config.ts` only writes the `com.google.android.geo.API_KEY` AndroidManifest meta-data when `GOOGLE_MAPS_API_KEY` is set at build time. `.github/workflows/android-apk-dev-client.yml` — the workflow that builds `com.boardsesh.app.dev`, exactly the package in the Sentry report — never set it, unlike every other Android build path (production, OTA preview, OTA backport).
2. The existing `MapErrorBoundary` in `GymMap.tsx` (added in a prior fix for a *different* failure mode) can't catch this crash at all. The Sentry stack trace shows the throw happening in `GoogleMapKt$GoogleMap$5...onViewAttachedToWindow` → `MapView.onCreate` — a native Kotlin/Java exception thrown when Android's View system attaches the underlying view to the window, entirely outside React's render/commit cycle. A JS `componentDidCatch` cannot intercept that. The only real fix is to never construct the native view when the key is missing.

**Delivery-relevant split (why both changes matter, not just one):**

- The **JS-level mount gate** (`GymMap.tsx` + a new `extra.googleMapsApiKeyConfigured` build-time flag in `app.config.ts`) ships via OTA and stops the crash on **every already-installed binary**, keyed or not — this is the part that actually protects users today.
- The **CI key injection** (`android-apk-dev-client.yml`) only fixes *future* dev-client builds; it can't reach binaries already in the wild (`GOOGLE_MAPS_API_KEY` perturbs the Android fingerprint, so this is a native-build change).

**Fix:**

- `packages/mobile/src/components/gym-directory/GymMap.tsx` — never resolves `GoogleMaps.View` on Android unless the build-time flag is true; falls through to the existing list-only fallback (same path as "expo-maps module missing"). Decision logic pulled into two pure, exported functions (`readGoogleMapsApiKeyConfigured`, `resolveMapView`) since the real `expo-maps` package is native-only and can't be exercised through a render under Vitest (`require('expo-maps')` isn't interceptable by `vi.mock` the way a static `import` is, and the real package throws outside a React Native runtime).
- `packages/mobile/app.config.ts` — adds `extra.googleMapsApiKeyConfigured: Boolean(process.env.GOOGLE_MAPS_API_KEY)`, read by `GymMap.tsx` via `expo-constants`.
- `.github/workflows/android-apk-dev-client.yml` — now sets `GOOGLE_MAPS_API_KEY` from the same repo-level secret every other Android workflow uses (confirmed repo-level, not `Production`-environment-scoped, per `scripts/mobile-ota-setup.ts`).
- `scripts/mobile-ci-env-parity.test.ts` — new assertion that the dev-client workflow sets the key (standalone check; this workflow is deliberately excluded from the fingerprint-parity array since dev-client never receives an OTA).
- `docs/android-sideload-build.md` — corrects the stale "map is blank without it" claim (it's a fatal crash, not a blank map) and documents the dev-client key.

**Open items handled:**

- Sentry's "first seen 2026-06-04" predates `GymMap.tsx`'s introduction (2026-06-13) — read as a Sentry grouping/date artifact, not a second map surface. Confirmed only one `expo-maps` consumer exists in the codebase.
- The dev-client debug keystore's SHA-1 fingerprint differs from the production release keystore's. If the Google Cloud Console API-key restriction is scoped by package + SHA-1, the dev-client map may still show a "for development purposes only" watermark or fail to load tiles until that pairing is allow-listed — that's a Cloud Console change outside this repo, tracked below as a follow-up. It does not affect the crash fix: the manifest meta-data being present is what stops the fatal exception regardless of tile-serving restrictions.

## Follow-up (not blocking this PR)

- [ ] @marcodejongh: confirm/add `com.boardsesh.app.dev` + the Expo template debug keystore's SHA-1 to the Google Cloud Console API key's allowed Android apps, so dev-client map tiles render cleanly (not just crash-free).

## Release Notes

- [ ] No release note needed (internal / technical change)

Fixed a crash on Android when opening the gym/board map — a build missing the Google Maps configuration now shows the gym list instead of closing the app.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp test run --project mobile` — full suite green, including new `gym-map.test.tsx` (6 cases covering the flag-read and view-resolution pure functions across Android-with-key / Android-without-key / iOS / module-missing).
- `vp test run --project scripts` (scoped to `mobile-ci-env-parity.test.ts`) — 25/25 green, including the new dev-client assertion.
- `vp check` — lint + format clean.
- `vp run check:mobile-bundle` — Metro bundle check (Linux-safe).
