### PR TITLE
perf(mobile): stop the home crew feed re-rendering every card on vote/page updates

### DIFF
--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -31,6 +31,7 @@ import { useDrawerHost } from '../../../src/providers/drawer-host-provider';
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
 import { dedupeSessionsById } from '../../../src/lib/feed-time-buckets';
 import { deriveFeedScopeInput, type FeedMode } from '../../../src/lib/feed/feed-scope';
+import { buildVoteSummaryMap, voteSummaryKey, type VoteSummary } from '../../../src/lib/feed/vote-summary-map';
 import { openClimbInPlayDrawer } from '../../../src/lib/open-climb-in-play-drawer';
 import { openValidatedUrl } from '../../../src/lib/open-external-link';
 import { hapticLight } from '../../../src/lib/haptics';
@@ -50,10 +51,9 @@ type CommentTarget = {
   entityType: SocialEntityType;
 };
 
-type VoteSummary = {
-  upvotes: number;
-  userVote: number | null;
-};
+// Hoisted so the FlashList `keyExtractor` prop keeps a stable identity across
+// renders (perf playbook rule 3) instead of a fresh inline arrow each pass.
+const keyExtractor = (item: SessionFeedItem) => item.sessionId;
 
 function detectPlatform(url: string): { name: 'instagram' | 'tiktok'; icon: IconName } | null {
   if (isInstagramUrl(url)) return { name: 'instagram', icon: 'instagram' };
@@ -134,16 +134,34 @@ export default function HomeTab() {
     isAuthenticated && sessionEntityIds.length > 0,
   );
   const tickVoteSummaries = useBulkVoteSummaries('tick', tickEntityIds, isAuthenticated && tickEntityIds.length > 0);
-  const summaryMap = useMemo(() => {
-    const map = new Map<string, VoteSummary>();
-    for (const summary of sessionVoteSummaries.data ?? []) {
-      map.set(`session:${summary.entityId}`, { upvotes: summary.upvotes, userVote: summary.userVote });
-    }
-    for (const summary of tickVoteSummaries.data ?? []) {
-      map.set(`tick:${summary.entityId}`, { upvotes: summary.upvotes, userVote: summary.userVote });
-    }
-    return map;
-  }, [sessionVoteSummaries.data, tickVoteSummaries.data]);
+  // Rebuild the vote map on each summary change, but reuse the prior value object
+  // for any unchanged entity (see buildVoteSummaryMap). The `Map` reference still
+  // changes each rebuild — that's what drives FlashList `extraData` — while the
+  // stable inner objects let each `React.memo`'d card bail unless its vote moved.
+  // `summaryMapRef` holds the last committed map so the rebuild can diff against
+  // it; `renderItem` also reads it so it never has to depend on `summaryMap`.
+  const summaryMapRef = useRef<Map<string, VoteSummary>>(new Map());
+  const summaryMap = useMemo(
+    () =>
+      buildVoteSummaryMap(summaryMapRef.current, [
+        ...(sessionVoteSummaries.data ?? []).map((summary) => ({
+          entityType: 'session' as const,
+          entityId: summary.entityId,
+          upvotes: summary.upvotes,
+          userVote: summary.userVote,
+        })),
+        ...(tickVoteSummaries.data ?? []).map((summary) => ({
+          entityType: 'tick' as const,
+          entityId: summary.entityId,
+          upvotes: summary.upvotes,
+          userVote: summary.userVote,
+        })),
+      ]),
+    [sessionVoteSummaries.data, tickVoteSummaries.data],
+  );
+  // Point the ref at the freshly-built map before `renderItem` reads it below, so
+  // the stable `renderItem` always closes over the current vote data.
+  summaryMapRef.current = summaryMap;
 
   const handleOpenComments = useCallback((entityId: string, entityType: SocialEntityType) => {
     setCommentTarget({ entityId, entityType });
@@ -201,17 +219,21 @@ export default function HomeTab() {
     setMode('gym');
   }, []);
 
+  // Read the map through `summaryMapRef` (not `summaryMap`) so this stays
+  // referentially stable across vote/page updates — `extraData={summaryMap}` is
+  // the single signal that re-invokes it. A churning `renderItem` would force
+  // FlashList to re-render regardless of `extraData` (perf playbook rule 3).
   const renderItem = useCallback(
     ({ item }: { item: SessionFeedItem }) => (
       <SessionFeedCard
         session={item}
-        voteSummary={summaryMap.get(`${item.socialEntityType}:${item.socialEntityId}`)}
+        voteSummary={summaryMapRef.current.get(voteSummaryKey(item.socialEntityType, item.socialEntityId))}
         onOpenComments={handleOpenComments}
         onPress={handleSessionPress}
         onOpenClimb={handleOpenClimb}
       />
     ),
-    [handleOpenComments, handleSessionPress, handleOpenClimb, summaryMap],
+    [handleOpenComments, handleSessionPress, handleOpenClimb],
   );
 
   // The scope menu: "My crew" (default), the home gym/board, any other owned
@@ -353,7 +375,7 @@ export default function HomeTab() {
         data={sessions}
         extraData={summaryMap}
         renderItem={renderItem}
-        keyExtractor={(item) => item.sessionId}
+        keyExtractor={keyExtractor}
         // The floating glass header owns the top inset on every platform (the
         // iOS-only `automatic` behaviour left an Android gap), so pad manually.
         contentInsetAdjustmentBehavior="never"

--- a/packages/mobile/src/components/you/__tests__/session-feed-card-memo.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/session-feed-card-memo.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { SessionFeedItem } from '@boardsesh/shared-schema';
+
+// Count how many times SessionFeedCard's body actually runs. The body renders a
+// `Card` exactly once, so a counter in the Card mock is a faithful proxy: if
+// React.memo bails an identical-props re-render, this must NOT bump.
+const renderCounter = vi.hoisted(() => ({ count: 0 }));
+
+vi.mock('react-native', () => {
+  const passthrough =
+    (tag: string) =>
+    ({ children }: { children?: ReactNode }) =>
+      createElement(tag, null, children);
+  return {
+    Platform: { OS: 'ios' },
+    PlatformColor: (name: string) => name,
+    View: passthrough('div'),
+    StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  };
+});
+
+vi.mock('expo-image', () => ({
+  Image: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@boardsesh/profile-stats', () => ({
+  formatTickRelativeTime: () => '2h ago',
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { secondaryLabel: '#666', tertiaryLabel: '#999', separator: '#ccc', fill: '#eee' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (grade: string) => grade }),
+}));
+
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+vi.mock('../../../providers/drawer-host-provider', () => ({
+  useDrawerHost: () => ({ openClimbActions: vi.fn() }),
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn(), hapticMedium: vi.fn() }));
+
+vi.mock('../../../lib/beta-video-url', () => ({ mapBetaLink: () => null }));
+vi.mock('../../../lib/open-external-link', () => ({ openValidatedUrl: vi.fn() }));
+vi.mock('../../../lib/playlists/board-details-for-playlist', () => ({ getBoardConfigForPlaylist: () => null }));
+vi.mock('../../../lib/tick-to-climb', () => ({ tickToClimb: () => null }));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('span', { 'data-icon': 'true' }) }));
+vi.mock('../../Card', () => ({
+  Card: ({ children }: { children?: ReactNode }) => {
+    renderCounter.count += 1;
+    return createElement('div', { 'data-card': 'true' }, children);
+  },
+}));
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../ClimbListThumbnail', () => ({
+  ClimbListThumbnail: () => createElement('div', { 'data-thumb': 'true' }),
+}));
+vi.mock('../AvatarGroup', () => ({ AvatarGroup: () => createElement('div', { 'data-avatars': 'true' }) }));
+vi.mock('../FeedSocialRow', () => ({ FeedSocialRow: () => createElement('div', { 'data-social': 'true' }) }));
+vi.mock('../SessionGradeStrip', () => ({ SessionGradeStrip: () => null }));
+vi.mock('../profile-chart-colors', () => ({ gradeBadgeColor: () => '#000' }));
+
+import { SessionFeedCard } from '../SessionFeedCard';
+
+function makeSession(overrides: Partial<SessionFeedItem> = {}): SessionFeedItem {
+  return {
+    sessionId: 's1',
+    sessionType: 'party',
+    participants: [{ userId: 'u1', displayName: 'Alex', avatarUrl: null }],
+    totalSends: 4,
+    totalFlashes: 1,
+    totalAttempts: 6,
+    tickCount: 5,
+    gradeDistribution: [],
+    boardTypes: ['Kilter'],
+    hardestGrade: null,
+    hardestSend: null,
+    featuredBeta: null,
+    socialEntityType: 'session',
+    socialEntityId: 'entity-1',
+    firstTickAt: '2026-01-01T10:00:00',
+    lastTickAt: '2026-01-01T12:00:00',
+    durationMinutes: 90,
+    goal: null,
+    upvotes: 3,
+    downvotes: 0,
+    voteScore: 3,
+    commentCount: 2,
+    ...overrides,
+  } as SessionFeedItem;
+}
+
+// Stable handlers — the home screen passes useCallback-stable ones.
+const onOpenComments = vi.fn();
+const onPress = vi.fn();
+const onOpenClimb = vi.fn();
+
+describe('SessionFeedCard React.memo', () => {
+  beforeEach(() => {
+    renderCounter.count = 0;
+    vi.clearAllMocks();
+  });
+
+  it('skips re-render when props (incl. the same voteSummary object) are referentially equal', () => {
+    const session = makeSession();
+    const voteSummary = { upvotes: 3, userVote: 1 };
+    const element = (
+      <SessionFeedCard
+        session={session}
+        voteSummary={voteSummary}
+        onOpenComments={onOpenComments}
+        onPress={onPress}
+        onOpenClimb={onOpenClimb}
+      />
+    );
+
+    const { rerender } = render(element);
+    expect(renderCounter.count).toBe(1);
+
+    // Same element identity → identical props. A working memo skips the body.
+    rerender(element);
+    expect(renderCounter.count).toBe(1);
+  });
+
+  it('bails when a fresh render passes the SAME voteSummary object (identity-preserving map case)', () => {
+    const session = makeSession();
+    // This is exactly what buildVoteSummaryMap yields for an unchanged entity:
+    // a brand-new SessionFeedCard element, but the same voteSummary reference.
+    const voteSummary = { upvotes: 3, userVote: 1 };
+    const props = { session, onOpenComments, onPress, onOpenClimb };
+
+    const { rerender } = render(<SessionFeedCard {...props} voteSummary={voteSummary} />);
+    expect(renderCounter.count).toBe(1);
+
+    rerender(<SessionFeedCard {...props} voteSummary={voteSummary} />);
+    expect(renderCounter.count).toBe(1);
+  });
+
+  it('re-renders when the voteSummary object changes (a vote landed for this row)', () => {
+    const session = makeSession();
+    const props = { session, onOpenComments, onPress, onOpenClimb };
+
+    const { rerender } = render(<SessionFeedCard {...props} voteSummary={{ upvotes: 3, userVote: 1 }} />);
+    expect(renderCounter.count).toBe(1);
+
+    // A new object (buildVoteSummaryMap mints one only when the vote actually moved).
+    rerender(<SessionFeedCard {...props} voteSummary={{ upvotes: 4, userVote: 1 }} />);
+    expect(renderCounter.count).toBe(2);
+  });
+});

--- a/packages/mobile/src/lib/feed/__tests__/vote-summary-map.test.ts
+++ b/packages/mobile/src/lib/feed/__tests__/vote-summary-map.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { buildVoteSummaryMap, voteSummaryKey, type VoteSummaryEntry } from '../vote-summary-map';
+
+function entry(
+  entityType: VoteSummaryEntry['entityType'],
+  entityId: string,
+  upvotes: number,
+  userVote: number | null,
+): VoteSummaryEntry {
+  return { entityType, entityId, upvotes, userVote };
+}
+
+describe('buildVoteSummaryMap', () => {
+  it('keys entries by `entityType:entityId`', () => {
+    const map = buildVoteSummaryMap(null, [entry('session', 's1', 3, 1), entry('tick', 't1', 0, null)]);
+    expect(map.get(voteSummaryKey('session', 's1'))).toEqual({ upvotes: 3, userVote: 1 });
+    expect(map.get(voteSummaryKey('tick', 't1'))).toEqual({ upvotes: 0, userVote: null });
+    // Distinct namespaces: a session and a tick with the same id don't collide.
+    const collide = buildVoteSummaryMap(null, [entry('session', 'x', 1, null), entry('tick', 'x', 9, 1)]);
+    expect(collide.get('session:x')).toEqual({ upvotes: 1, userVote: null });
+    expect(collide.get('tick:x')).toEqual({ upvotes: 9, userVote: 1 });
+  });
+
+  it('returns a fresh Map reference every rebuild (so FlashList extraData fires)', () => {
+    const previous = buildVoteSummaryMap(null, [entry('session', 's1', 3, 1)]);
+    const next = buildVoteSummaryMap(previous, [entry('session', 's1', 3, 1)]);
+    expect(next).not.toBe(previous);
+  });
+
+  it('reuses the prior value object for an entity whose vote is unchanged', () => {
+    const previous = buildVoteSummaryMap(null, [entry('session', 's1', 3, 1)]);
+    const priorObject = previous.get('session:s1');
+    const next = buildVoteSummaryMap(previous, [entry('session', 's1', 3, 1)]);
+    // Same values → the exact same object reference, so React.memo can bail the row.
+    expect(next.get('session:s1')).toBe(priorObject);
+  });
+
+  it('mints a new value object when upvotes change', () => {
+    const previous = buildVoteSummaryMap(null, [entry('session', 's1', 3, 1)]);
+    const priorObject = previous.get('session:s1');
+    const next = buildVoteSummaryMap(previous, [entry('session', 's1', 4, 1)]);
+    expect(next.get('session:s1')).not.toBe(priorObject);
+    expect(next.get('session:s1')).toEqual({ upvotes: 4, userVote: 1 });
+  });
+
+  it('mints a new value object when userVote changes', () => {
+    const previous = buildVoteSummaryMap(null, [entry('session', 's1', 3, 1)]);
+    const priorObject = previous.get('session:s1');
+    const next = buildVoteSummaryMap(previous, [entry('session', 's1', 3, null)]);
+    expect(next.get('session:s1')).not.toBe(priorObject);
+    expect(next.get('session:s1')).toEqual({ upvotes: 3, userVote: null });
+  });
+
+  it('preserves identity for untouched entities while a sibling changes (page-load / single-vote case)', () => {
+    const previous = buildVoteSummaryMap(null, [
+      entry('session', 's1', 3, 1),
+      entry('session', 's2', 5, null),
+      entry('tick', 't1', 2, 1),
+    ]);
+    const s1 = previous.get('session:s1');
+    const t1 = previous.get('tick:t1');
+    // s2's vote moved; s1 and t1 are untouched.
+    const next = buildVoteSummaryMap(previous, [
+      entry('session', 's1', 3, 1),
+      entry('session', 's2', 6, 1),
+      entry('tick', 't1', 2, 1),
+    ]);
+    expect(next.get('session:s1')).toBe(s1);
+    expect(next.get('tick:t1')).toBe(t1);
+    expect(next.get('session:s2')).toEqual({ upvotes: 6, userVote: 1 });
+  });
+
+  it('adds new entities and drops entities no longer present', () => {
+    const previous = buildVoteSummaryMap(null, [entry('session', 's1', 3, 1)]);
+    const next = buildVoteSummaryMap(previous, [entry('session', 's2', 1, null)]);
+    expect(next.has('session:s1')).toBe(false);
+    expect(next.get('session:s2')).toEqual({ upvotes: 1, userVote: null });
+  });
+
+  it('handles an empty entry list', () => {
+    expect(buildVoteSummaryMap(null, []).size).toBe(0);
+  });
+});

--- a/packages/mobile/src/lib/feed/vote-summary-map.ts
+++ b/packages/mobile/src/lib/feed/vote-summary-map.ts
@@ -1,0 +1,56 @@
+import type { SocialEntityType } from '@boardsesh/shared-schema';
+
+/** Per-viewer vote state for one feed entity (a session or a tick). */
+export type VoteSummary = {
+  upvotes: number;
+  userVote: number | null;
+};
+
+/** A single bulk-vote-summary row, keyed by the entity it belongs to. */
+export type VoteSummaryEntry = {
+  entityType: SocialEntityType;
+  entityId: string;
+  upvotes: number;
+  userVote: number | null;
+};
+
+/** The composite key a feed row reads its summary by: `session:<id>` / `tick:<id>`. */
+export function voteSummaryKey(entityType: SocialEntityType, entityId: string): string {
+  return `${entityType}:${entityId}`;
+}
+
+/**
+ * Build the `key -> VoteSummary` map the home feed hands each card as
+ * `voteSummary`, **preserving the previous value object** for any entity whose
+ * `upvotes` + `userVote` are unchanged.
+ *
+ * Why identity matters: the feed passes the rebuilt map as FlashList
+ * `extraData`, so every rebuild (a new page fetched mid-fling, a vote refetch,
+ * the initial load) re-invokes `renderItem` for every mounted row. `SessionFeedCard`
+ * is `React.memo`'d, so a row only re-renders its subtree when a prop identity
+ * changes. If we minted a fresh `{ upvotes, userVote }` for every entity on
+ * every rebuild, `voteSummary` would churn on all rows and defeat the memo —
+ * the whole visible window would re-render each time. Reusing the prior object
+ * for unchanged entities lets memo bail those rows, so only genuinely-changed
+ * votes re-render.
+ *
+ * The returned `Map` reference is always new, which is intentional: `extraData`
+ * relies on the reference changing to know a rebuild happened.
+ */
+export function buildVoteSummaryMap(
+  previous: Map<string, VoteSummary> | null,
+  entries: readonly VoteSummaryEntry[],
+): Map<string, VoteSummary> {
+  const next = new Map<string, VoteSummary>();
+  for (const entry of entries) {
+    const key = voteSummaryKey(entry.entityType, entry.entityId);
+    const prior = previous?.get(key);
+    next.set(
+      key,
+      prior && prior.upvotes === entry.upvotes && prior.userVote === entry.userVote
+        ? prior
+        : { upvotes: entry.upvotes, userVote: entry.userVote },
+    );
+  }
+  return next;
+}


### PR DESCRIPTION
## Summary

Fixes #3154 — the Home crew feed was the jankiest scroll surface measured on a Pixel 8 (18.3% legacy-janky frames vs 9.75% for the climbs list).

**On current `main`, the issue's contributor #1 is already resolved.** #3152 (BoardProvider context split) and #3688 (Android tab-residency) have both landed. No feed component subscribes to the board/logbook context anymore (`SessionFeedCard` and its children read theme / i18n / grade-format / toast / drawer-host, never `useBoardProvider` / `useBoardLogbook` / `useAscentStatus`), so a logbook merge can no longer re-render feed cards — the named `propagateParentContextChanges` cascade is defused. This PR handles the remaining contributor (#2), the `summaryMap` churn.

### The issue's proposed fix, corrected

The issue suggested "drop `summaryMap` from the `renderItem` dep array — rely on `extraData` for vote-summary updates." Tracing it through, **that change alone is a no-op for re-render count**: `extraData={summaryMap}` already forces FlashList to re-invoke `renderItem` for every mounted row on each rebuild, whether or not `renderItem`'s identity also churned. The two signals are redundant, but removing one doesn't reduce the work.

The real cost is one level down: the old `summaryMap` minted a **fresh `{ upvotes, userVote }` object for every entity on every rebuild**. `SessionFeedCard` is `React.memo`'d, but a brand-new `voteSummary` object on every row defeats the memo, so the entire visible window re-rendered on each rebuild — and rebuilds happen exactly when you're scrolling (a new page fetched mid-fling), plus after every vote (`useVote`'s `onSuccess` rewrites the `bulkVoteSummaries` cache). That's the "heavy Fabric mounting during fling" in the profile.

Session object identity is already stable across rebuilds (`dedupeSessionsById` returns the originals; React Query keeps fetched-page references), and the handler props are `useCallback`-stable — so `voteSummary` was the *only* prop defeating the memo.

### The fix

- **`buildVoteSummaryMap` (new, `packages/mobile/src/lib/feed/vote-summary-map.ts`)** — rebuilds the map (new `Map` ref each time, so `extraData` still fires) but **reuses the previous value object** for any entity whose `upvotes` + `userVote` are unchanged. A page-load or single vote now mints a new object only for genuinely-changed entities, so `React.memo` bails every unchanged card. This is the load-bearing change.
- **`renderItem` reads the map through a ref** (`summaryMapRef.current`) and **drops `summaryMap` from its deps**, so it stays referentially stable across vote/page updates (perf playbook rule 3). `extraData={summaryMap}` remains the single re-render trigger.
- **Hoisted `keyExtractor`** to module scope (was an inline arrow — perf playbook rule 3).

### Tests

- `vote-summary-map.test.ts` — asserts the mechanism: unchanged entity keeps `===` identity across rebuilds, changed `upvotes`/`userVote` mints a new object, sibling-unchanged entities keep identity when one vote moves (the page-load / single-vote case), the `Map` reference is always new, add/remove handled.
- `session-feed-card-memo.test.tsx` — render-count guard modeled on `queue-item-row-memo.test.tsx`: the card skips its body on referentially-equal props (incl. the same `voteSummary` object) and re-renders when the `voteSummary` object changes.

### Follow-ups (not in this PR)

- **Row weight.** `SessionFeedCard` is inherently rich (avatar group, grade strip, hero media, vote row). Trimming or lazy-loading secondary content is a UX trade-off, not a clean win.
- **Residual per-card context reads.** Each card still reads ~5 contexts; the leftover `propagateParentContextChanges` during a fling is React pushing those into newly-mounted rows. Reducing that is a larger refactor.

### Re-profile ask

@marcodejongh — the acceptance criteria (legacy-janky frames materially down; `propagateParentContextChanges` no longer prominent) need a **release-build re-profile on the Pixel 8**; the dev-build timings in the issue are inflated and I can't reproduce Hermes CPU sampling / gfxinfo here.

## Release Notes

- The Home feed scrolls smoother — flinging through your crew's sessions drops fewer frames, especially on Android.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — full suite green (incl. the two new tests)
- `vp check` — format + lint clean
- `vp run check:mobile-bundle` — Metro bundle OK
- JS/TS-only change, no native deps touched → OTA-eligible (fingerprint unchanged).
