### PR TITLE
fix(web): stop the climb list reflowing as it loads

### DIFF
--- a/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import ClimbsList from '../climbs-list';
+import { LIST_ROW_HEIGHT } from '../constants';
 
 // --- Mocks ---
 
@@ -120,7 +121,7 @@ vi.mock('@/app/theme/theme-config', () => ({
 }));
 
 // Track calls to useWindowVirtualizer
-let lastVirtualizerOpts: { count: number; overscan: number } | null = null;
+let lastVirtualizerOpts: { count: number; overscan: number; estimateSize: () => number } | null = null;
 
 vi.mock('@tanstack/react-virtual', () => ({
   useWindowVirtualizer: (opts: {
@@ -256,11 +257,47 @@ describe('ClimbsList virtualization', () => {
       />,
     );
 
-    // With estimateSize=107, overscan=10 is ~1070px headroom — enough for
-    // smooth fast scrolling without bloating the first-paint mount count.
-    // Production traces tied a 25→10 cut directly to a render-delay drop.
+    // With estimateSize=LIST_ROW_HEIGHT, overscan=10 is ~1070px headroom —
+    // enough for smooth fast scrolling without bloating the first-paint mount
+    // count. Production traces tied a 25→10 cut directly to a render-delay drop.
     expect(lastVirtualizerOpts).not.toBeNull();
     expect(lastVirtualizerOpts!.overscan).toBe(10);
+  });
+
+  it('estimates each row at the fixed LIST_ROW_HEIGHT', () => {
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs}
+        isFetching={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+
+    // The estimate must equal the row wrapper's minHeight below so a mounted
+    // row measures to exactly the estimate — no post-mount reflow / CLS.
+    expect(lastVirtualizerOpts).not.toBeNull();
+    expect(lastVirtualizerOpts!.estimateSize()).toBe(LIST_ROW_HEIGHT);
+  });
+
+  it('floors each virtualized row wrapper at LIST_ROW_HEIGHT (no measure reflow)', () => {
+    const { container } = render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs}
+        isFetching={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+
+    // The measured wrapper (the element carrying ref={measureElement}) must
+    // pin minHeight to the same constant, so a plain row measures to exactly
+    // the estimate. renderItemExtra rows still grow past this floor.
+    const firstRow = container.querySelector<HTMLElement>('[data-index="0"]');
+    expect(firstRow).not.toBeNull();
+    expect(firstRow!.style.minHeight).toBe(`${LIST_ROW_HEIGHT}px`);
   });
 
   it('renders skeleton when fetching with no climbs', () => {

--- a/packages/web/app/components/board-page/board-page-skeleton.tsx
+++ b/packages/web/app/components/board-page/board-page-skeleton.tsx
@@ -12,6 +12,7 @@ import CallSplitOutlined from '@mui/icons-material/CallSplitOutlined';
 import FavoriteBorderOutlined from '@mui/icons-material/FavoriteBorderOutlined';
 import AddCircleOutlined from '@mui/icons-material/AddCircleOutlined';
 import { themeTokens } from '@/app/theme/theme-config';
+import { LIST_ROW_HEIGHT } from './constants';
 import styles from './board-page-skeleton.module.css';
 
 type BoardPageSkeletonProps = {
@@ -72,22 +73,30 @@ const ClimbCardSkeleton = ({ aspectRatio }: { aspectRatio?: number }) => (
 );
 
 /**
- * Skeleton that mimics the ClimbListItem layout (~60px rows with thumbnail, text, and grade).
+ * Skeleton that mimics the ClimbListItem layout.
+ *
+ * Height is pinned to LIST_ROW_HEIGHT (the real row height) so the
+ * skeleton→content swap on /view and empty /list doesn't grow each row as
+ * placeholders resolve — the loading-time CLS this list was flagged for
+ * (issue #3086).
  */
 const ClimbListItemSkeleton = () => (
   <div
     style={{
       display: 'flex',
       alignItems: 'center',
+      minHeight: LIST_ROW_HEIGHT,
+      boxSizing: 'border-box',
       padding: `${themeTokens.spacing[2]}px ${themeTokens.spacing[3]}px`,
       gap: themeTokens.spacing[3],
       backgroundColor: 'var(--semantic-surface)',
       borderBottom: `1px solid var(--border-subtle)`,
     }}
   >
-    {/* Thumbnail placeholder - matches ClimbListItem width of themeTokens.spacing[16] (64px) */}
+    {/* Thumbnail placeholder — matches the real ClimbThumbnail box: spacing[16]
+        (64px) wide at aspect-ratio 5 / 7 (~90px tall). */}
     <div style={{ width: themeTokens.spacing[16], flexShrink: 0 }}>
-      <MuiSkeleton variant="rounded" width={48} height={48} animation="wave" />
+      <MuiSkeleton variant="rounded" animation="wave" sx={{ width: '100%', aspectRatio: '5 / 7' }} />
     </div>
 
     {/* Center: Name and setter lines */}

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -21,6 +21,7 @@ import { ClimbCardSkeleton, ClimbListItemSkeleton } from './board-page-skeleton'
 import { themeTokens } from '@/app/theme/theme-config';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
+import { LIST_ROW_HEIGHT } from './constants';
 import { classifyClimbListChange } from './climb-list-utils';
 import SwipeHintOrchestrator from './swipe-hint-orchestrator';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
@@ -556,14 +557,19 @@ const ClimbsList = ({
   const selectionStore = useSelectionStore(selectedClimbUuid ?? null);
 
   // --- List virtualization ---
-  // Overscan of 10 items (~1070px at the 107px estimate) is enough headroom for
-  // fast scrolling while keeping the LCP-time mount count low. Production traces
-  // showed the previous overscan=25 was mounting ~50 items on first paint, with
-  // each item attaching virtualizer.measureElement (a ResizeObserver) — this
-  // dominated the render delay (76% of LCP / 2.2s of forced reflow) on /list.
+  // Overscan of 10 items (~1070px at the LIST_ROW_HEIGHT estimate) is enough
+  // headroom for fast scrolling while keeping the LCP-time mount count low.
+  // Production traces showed the previous overscan=25 was mounting ~50 items on
+  // first paint, with each item attaching virtualizer.measureElement (a
+  // ResizeObserver) — this dominated the render delay (76% of LCP / 2.2s of
+  // forced reflow) on /list.
+  //
+  // The estimate matches the row wrapper's fixed minHeight below, so a row
+  // measures to exactly the estimate on mount: no reflow shifting every row
+  // beneath it (the loading-time CLS this list was flagged for, issue #3086).
   const virtualizer = useWindowVirtualizer({
     count: visibleClimbs.length,
-    estimateSize: () => 107,
+    estimateSize: () => LIST_ROW_HEIGHT,
     overscan: 10,
     getItemKey: (index) => visibleClimbs[index]?.uuid ?? index,
     // Provide a fake viewport so the virtualizer renders items during SSR.
@@ -687,6 +693,13 @@ const ClimbsList = ({
                           top: 0,
                           left: 0,
                           width: '100%',
+                          // Floor at the estimated row height so a plain climb row
+                          // measures to exactly the estimate (no post-mount reflow
+                          // / CLS). Rows with extra content below the item
+                          // (renderItemExtra) still grow past this via
+                          // measureElement.
+                          minHeight: LIST_ROW_HEIGHT,
+                          boxSizing: 'border-box',
                           transform: `translateY(${virtualItem.start}px)`,
                           contain: 'layout style paint',
                         }}

--- a/packages/web/app/components/board-page/constants.ts
+++ b/packages/web/app/components/board-page/constants.ts
@@ -31,3 +31,26 @@ export function resolveSsrInitialPageSize(requestedPage: number, requestedPageSi
 // When suggestedClimbs falls below this, we fetch more automatically
 // Set to 10 to keep a healthy buffer of suggestions available
 export const SUGGESTIONS_THRESHOLD = 10;
+
+/**
+ * Fixed height (px) of a single virtualized climb row in list mode.
+ *
+ * Derived deterministically from the row's CSS: it is thumbnail-dominated —
+ * ClimbThumbnail renders a `spacing[16]` (64px) wide box at `aspect-ratio:
+ * 5 / 7` ≈ 89.6px tall, plus the row's vertical padding (2 × `spacing[2]` =
+ * 16px) and a 1px bottom border ≈ 106.6px, which rounds to the pre-existing
+ * 107px estimate. (An in-browser getBoundingClientRect check was intentionally
+ * skipped — see the PR — so if this ever visibly clips or gaps a row, measure a
+ * real `[data-index]` wrapper and set this to that value.)
+ *
+ * This is the single source of truth shared by:
+ *  - the virtualizer `estimateSize` AND the measured row wrapper's `minHeight`
+ *    in `climbs-list.tsx`, so a freshly rendered row measures to exactly the
+ *    estimate — no post-mount reflow that shifts every row below it (CLS), and
+ *    SSR layout matches the client. Rows that render extra content below the
+ *    item (session-detail tick details via `renderItemExtra`) still grow past
+ *    this floor via `measureElement`.
+ *  - `ClimbListItemSkeleton`, so the skeleton→content swap on /view and empty
+ *    /list doesn't grow each row (~43px) as placeholders resolve.
+ */
+export const LIST_ROW_HEIGHT = 107;


### PR DESCRIPTION
## Summary

The virtualized climb list — shared by `/list`, `/view`, and the named-board `/b/[slug]` routes via `board-page-climbs-list.tsx → climbs-list.tsx` — sized every row from a single `estimateSize: () => 107` while also measuring each mounted row with a ResizeObserver (`virtualizer.measureElement`). Any delta between the estimate and the measured height re-flowed every row below it and grew the container as thumbnails, grades, and skeletons settled in — the loading-time layout shift PostHog flagged (p75 CLS **0.274** on `/list`, **0.215** on `/view`; ~45% of `/list` loads degraded).

This gives the list a **deterministic row height** so a plain row measures to exactly its estimate — no post-mount reflow, and SSR layout matches the client.

- New shared `LIST_ROW_HEIGHT` (107px) in `board-page/constants.ts`, derived from the row CSS (a 64px-wide `5 / 7` thumbnail ≈ 89.6px + 16px padding + 1px border ≈ 106.6px → the pre-existing 107 estimate). Used by **both** the virtualizer `estimateSize` **and** the measured row wrapper's `minHeight`.
- `measureElement` is intentionally **kept**, so session-detail rows that render extra content below the item (`renderItemExtra`) still grow past the floor — only plain climb rows are pinned.
- `ClimbListItemSkeleton` is pinned to the same height with the real 64px `5 / 7` thumbnail box (was a 48×48 → ~64px row), so the skeleton→content swap on `/view` and empty `/list` no longer grows each row (~43px) as placeholders resolve.

Board art already reserved its box via `aspect-ratio` (with `<img width/height>` hints), so images were never the cause — confirmed while investigating. `overscan` and `INITIAL_BATCH` are left untouched (they defend the earlier LCP win).

Closes #3086.

## Release Notes

- The climb list holds still while it loads — no more rows jumping around as thumbnails and grades settle in.

## Test plan

- `vp run typecheck:web` — clean.
- `vp check` (lint + format) — clean.
- `vp test run --project web climbs-list-virtualization` — 16/16. Added two assertions: `estimateSize()` returns `LIST_ROW_HEIGHT`, and the measured `[data-index]` wrapper carries `min-height: 107px`. Updated the stale "107" comments.
- `vp test run --project web board-page-climbs-list session-detail-content` — 43/43 (guards the `renderItemExtra` / variable-height session rows).

### Verification notes

- **In-browser (`vp run dev`) confirmation was intentionally skipped** — this ran on a shared machine. `LIST_ROW_HEIGHT` is locked to the deterministic CSS derivation (≈106.6 → 107, the value the list already estimated), so no row is inflated or clipped versus today. jsdom can't compute real pixel heights, so the test assertions are structural (inline-style / opts), per the existing suite's conventions.
- **The real verdict is post-merge PostHog CLS.** Query to re-check `$web_vitals` on these routes after this ships:
  ```sql
  SELECT
    quantile(0.75)(toFloat(properties.$web_vitals_CLS_value)) AS p75_cls,
    quantile(0.90)(toFloat(properties.$web_vitals_CLS_value)) AS p90_cls,
    count() AS samples
  FROM events
  WHERE event = '$web_vitals'
    AND properties.$web_vitals_CLS_value IS NOT NULL
    AND match(properties.$pathname, '/(list|view)(/|$)')
    AND timestamp > now() - INTERVAL 30 DAY
  ```
- If a real-browser number is wanted before merge, @marcodejongh can drop this in the devtools console on `/kilter/original/12x12-square/screw_bolt/40/list` — expected ≈107; if it differs by >~2px, bump the single `LIST_ROW_HEIGHT` constant:
  ```js
  document.querySelector('[data-index="0"]').getBoundingClientRect().height
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va