### PR TITLE
fix: address follow-up review on kiosk heartbeat

### DIFF
--- a/packages/backend/src/__tests__/kiosk-heartbeat.test.ts
+++ b/packages/backend/src/__tests__/kiosk-heartbeat.test.ts
@@ -202,7 +202,10 @@ describe('kioskHeartbeat rate limiting', () => {
 
   it('trips the per-client rate limit past the ceiling', async () => {
     // A single fixed connection so the in-memory bucket accumulates. The
-    // heartbeat ceiling is 60/min; the 61st call must be throttled.
+    // heartbeat ceiling is 60/min; the 61st call must be throttled. `connectionId`
+    // is unique to this test (no other test reuses 'kh-rate-limit-conn'), so the
+    // in-memory bucket starting non-empty on a re-run isn't a real hazard —
+    // beforeEach only resets the DB, not the rate limiter, on purpose.
     const ctx: ConnectionContext = {
       connectionId: 'kh-rate-limit-conn',
       isAuthenticated: false,
@@ -215,5 +218,30 @@ describe('kioskHeartbeat rate limiting', () => {
     await expect(
       socialGymKioskMutations.kioskHeartbeat(null, { input: { kioskUuid: kioskA.uuid, gymUuid: gym.uuid } }, ctx),
     ).rejects.toThrow(/Rate limit exceeded/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input validation (Redis-independent — rejected before any store lookup)
+// ---------------------------------------------------------------------------
+
+describe('kioskHeartbeat viewport validation', () => {
+  beforeEach(async () => {
+    await resetAndSeed();
+  });
+
+  it.each([
+    ['zero width', { viewportWidth: 0, viewportHeight: 1080 }],
+    ['negative height', { viewportWidth: 1920, viewportHeight: -1 }],
+    ['width over the 20000 ceiling', { viewportWidth: 20001, viewportHeight: 1080 }],
+    ['height over the 20000 ceiling', { viewportWidth: 1920, viewportHeight: 20001 }],
+  ])('rejects a %s viewport dimension', async (_description, viewport) => {
+    await expect(
+      socialGymKioskMutations.kioskHeartbeat(
+        null,
+        { input: { kioskUuid: kioskA.uuid, gymUuid: gym.uuid, ...viewport } },
+        anonCtx(),
+      ),
+    ).rejects.toThrow(/Invalid input/);
   });
 });

--- a/packages/backend/src/services/kiosk-heartbeat.ts
+++ b/packages/backend/src/services/kiosk-heartbeat.ts
@@ -51,7 +51,9 @@ type HeartbeatValue = { lastSeenAt: number; viewport?: string };
 
 // Test seam: the roundtrip suite injects a real Redis client here (mirrors how
 // distributed-state.test.ts drives real Redis) so the resolver path can be
-// exercised without booting the whole redisClientManager singleton.
+// exercised without booting the whole redisClientManager singleton. Module-level
+// mutable state is fine for today's serial test execution; it would race if the
+// suite ever ran multiple Vitest workers sharing this module.
 let clientOverrideForTests: Redis | null = null;
 
 /** @internal test-only — inject/clear the Redis client the heartbeat store uses. */

--- a/packages/web/app/components/gym-entity/manage/__tests__/kiosk-liveness-chip.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/kiosk-liveness-chip.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import KioskLivenessChip from '../kiosk-liveness-chip';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+// Swap the real MUI Tooltip for a thin marker so we can assert on whether a
+// tooltip renders at all and what title it was given, without simulating
+// hover/focus timing (MUI lazy-mounts the popper only on interaction).
+vi.mock('@mui/material/Tooltip', () => ({
+  default: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div data-testid="tooltip" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
+
+describe('KioskLivenessChip', () => {
+  it('renders "No signal yet" with no tooltip for an unparseable lastSeenAt (regression: previously rendered an Invalid Date tooltip)', () => {
+    render(<KioskLivenessChip lastSeenAt="not-a-date" kioskName="Front Desk TV" tvPath="/gym/front-desk" />);
+
+    expect(screen.getByText('No signal yet')).toBeTruthy();
+    expect(screen.queryByTestId('tooltip')).toBeNull();
+  });
+
+  it('renders "No signal yet" with no tooltip for a null lastSeenAt', () => {
+    render(<KioskLivenessChip lastSeenAt={null} kioskName="Front Desk TV" tvPath="/gym/front-desk" />);
+
+    expect(screen.getByText('No signal yet')).toBeTruthy();
+    expect(screen.queryByTestId('tooltip')).toBeNull();
+  });
+
+  it('wraps the chip in a tooltip with a formatted timestamp for a parseable lastSeenAt', () => {
+    const lastSeenAt = new Date(Date.now() - 1000).toISOString();
+
+    render(<KioskLivenessChip lastSeenAt={lastSeenAt} kioskName="Front Desk TV" tvPath="/gym/front-desk" />);
+
+    expect(screen.getByText('Live')).toBeTruthy();
+    const tooltip = screen.getByTestId('tooltip');
+    expect(tooltip.dataset.title).toBe(new Date(lastSeenAt).toLocaleString());
+    expect(tooltip.dataset.title).not.toBe('Invalid Date');
+  });
+});

--- a/packages/web/app/components/gym-entity/manage/kiosk-liveness-chip.tsx
+++ b/packages/web/app/components/gym-entity/manage/kiosk-liveness-chip.tsx
@@ -74,7 +74,9 @@ export default function KioskLivenessChip({ lastSeenAt, kioskName, tvPath }: Kio
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-      {lastSeenAt === null ? chip : <Tooltip title={new Date(lastSeenAt).toLocaleString()}>{chip}</Tooltip>}
+      {/* liveness.status === 'never' covers both null and unparseable lastSeenAt
+          (see bucketKioskLiveness), so the tooltip never formats an invalid date. */}
+      {liveness.status === 'never' ? chip : <Tooltip title={new Date(lastSeenAt!).toLocaleString()}>{chip}</Tooltip>}
       {liveness.status === 'stale' && (
         <>
           <Button


### PR DESCRIPTION
## Summary

Follow-up on the merged kiosk heartbeat feature (#3685), addressing a round of review feedback:

- **`kiosk-liveness-chip.tsx`**: the Tooltip wrapper checked `lastSeenAt === null` to decide whether to format a date. A non-null but unparseable `lastSeenAt` slipped past that check and rendered "Invalid Date" in the tooltip. Now reuses `bucketKioskLiveness`'s already-computed `'never'` status (which already treats null/unparseable identically), so the same bucketing decides both the label and whether a date gets formatted.
- **`kiosk-heartbeat.test.ts`**: added coverage for the viewport-clamping rejection path — `KioskHeartbeatInputSchema` rejects `viewportWidth`/`viewportHeight` outside `[1, 20000]`, but nothing exercised that before.
- **`kiosk-heartbeat.test.ts`**: documented the rate-limit test's implicit assumption (fixed `connectionId`, no explicit bucket reset in `beforeEach`) for future readers.
- **`kiosk-heartbeat.ts`**: noted that `clientOverrideForTests` is module-level mutable state that's fine under today's serial test execution but would race under concurrent Vitest workers.

Other findings from the review (per-process rate limiting, the 1-hour existence-cache TTL, the manage tab's 60s poll interval, and a minor hand-written-vs-generated type divergence for `lastSeenAt`) were already explicitly called out as acceptable trade-offs in code comments or have no runtime impact, so no code change was made for those.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:web` — passed
- `vp test run --project backend` (full suite, real Postgres + Redis) — 2484 tests passed, including the new viewport-clamping cases
- `vp test run --project web` (full suite) — 5390 tests passed
- `vp check` — no new lint/format issues (the one pre-existing error is in an unrelated file, `packages/db/src/queries/__tests__/tick-offset-inference.test.ts`, untouched by this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_017DxND2AFXabGztRChvejvn)_