### PR TITLE
perf(web): fix homepage LCP for cold-load mobile minority (#3123)

### DIFF
--- a/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
@@ -29,9 +29,23 @@ type BoardseshBetaCardProps = {
    * can measure CTR per placement.
    */
   source?: BoardseshBetaCardSource;
+  /**
+   * When true, this card's thumbnail is the Largest Contentful Paint element
+   * (the first card of the above-the-fold home rail). Load it eagerly at high
+   * priority instead of the default lazy — a lazy above-the-fold image is a
+   * well-known LCP anti-pattern (the browser discovers it late and
+   * deprioritizes the fetch). Only the first home-rail card sets this.
+   */
+  priority?: boolean;
 };
 
-const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link, climbName, climbHref, source = 'drawer' }) => {
+const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({
+  link,
+  climbName,
+  climbHref,
+  source = 'drawer',
+  priority = false,
+}) => {
   const [thumbnailFailed, setThumbnailFailed] = useState(false);
   const thumbnailSrc = !thumbnailFailed ? link.thumbnail : null;
   const isTikTok = isTikTokUrl(link.link);
@@ -75,7 +89,8 @@ const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link, climbName, 
               src={thumbnailSrc}
               alt={`Beta by ${link.foreign_username || 'unknown'}`}
               className={styles.thumbnail}
-              loading="lazy"
+              loading={priority ? 'eager' : 'lazy'}
+              fetchPriority={priority ? 'high' : undefined}
               referrerPolicy="no-referrer"
               onError={() => setThumbnailFailed(true)}
             />

--- a/packages/web/app/components/beta-videos/boardsesh-beta-list.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-list.tsx
@@ -24,6 +24,13 @@ type BoardseshBetaListProps = {
    */
   getClimbHref?: (link: BetaLink) => string | null | undefined;
   source?: BoardseshBetaListSource;
+  /**
+   * When true, the first card's thumbnail loads eagerly at high priority
+   * because it's the above-the-fold LCP element. Only the home rail (which
+   * renders directly under the hero) sets this; the drawer and profile lists
+   * open behind an interaction and are never the page's LCP.
+   */
+  priorityFirstCard?: boolean;
 };
 
 const BoardseshBetaList: React.FC<BoardseshBetaListProps> = ({
@@ -32,6 +39,7 @@ const BoardseshBetaList: React.FC<BoardseshBetaListProps> = ({
   getClimbName,
   getClimbHref,
   source = 'drawer',
+  priorityFirstCard = false,
 }) => {
   const { t } = useTranslation('common');
   return (
@@ -47,13 +55,14 @@ const BoardseshBetaList: React.FC<BoardseshBetaListProps> = ({
           ))
         ) : (
           <>
-            {links.map((link) => (
+            {links.map((link, index) => (
               <BoardseshBetaCard
                 key={link.link}
                 link={link}
                 climbName={getClimbName?.(link) ?? null}
                 climbHref={getClimbHref?.(link) ?? null}
                 source={source}
+                priority={priorityFirstCard && index === 0}
               />
             ))}
             {links.length === 0 && <span className={styles.emptyText}>{t('betaVideos.empty')}</span>}

--- a/packages/web/app/components/beta-videos/home-recent-beta-section.tsx
+++ b/packages/web/app/components/beta-videos/home-recent-beta-section.tsx
@@ -84,6 +84,7 @@ export default function HomeRecentBetaSection({ initialRecentBeta }: HomeRecentB
         links={links}
         isLoading={false}
         source="home"
+        priorityFirstCard
         getClimbName={(link) => climbNameByLink.get(link.link)}
         getClimbHref={(link) => climbHrefByLink.get(link.link)}
       />

--- a/packages/web/app/lib/__tests__/beta-video-url.test.ts
+++ b/packages/web/app/lib/__tests__/beta-video-url.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 
 describe('mapBetaLinksResponse — thumbnail absolutization', () => {
   const originalEnv = process.env;
+  const originalWindow = global.window;
 
   beforeEach(() => {
     vi.resetModules();
@@ -10,6 +11,7 @@ describe('mapBetaLinksResponse — thumbnail absolutization', () => {
 
   afterEach(() => {
     process.env = originalEnv;
+    Object.defineProperty(global, 'window', { configurable: true, value: originalWindow });
   });
 
   function commonRow(thumbnail: string | null) {
@@ -69,16 +71,32 @@ describe('mapBetaLinksResponse — thumbnail absolutization', () => {
   });
 
   it('does not produce double slashes if the backend URL ever ends with a slash', async () => {
-    // getBackendHttpUrl strips trailing slashes today, but absolutize is
+    // getPublicBackendHttpUrl strips trailing slashes today, but absolutize is
     // defensive against a future change to that contract — a doubled slash
     // would 404 against the static handler and silently break thumbnails.
     process.env.NEXT_PUBLIC_WS_URL = 'wss://ws.boardsesh.com/graphql';
     const backendUrl = await import('../backend-url');
-    vi.spyOn(backendUrl, 'getBackendHttpUrl').mockReturnValue('https://ws.boardsesh.com/');
+    vi.spyOn(backendUrl, 'getPublicBackendHttpUrl').mockReturnValue('https://ws.boardsesh.com/');
     const { mapBetaLinksResponse } = await import('../beta-video-url');
 
     const [link] = mapBetaLinksResponse([commonRow('/static/beta-link-thumbnails/instagram/ABC.jpg')]);
 
     expect(link.thumbnail).toBe('https://ws.boardsesh.com/static/beta-link-thumbnails/instagram/ABC.jpg?size=280');
+  });
+
+  it('server-side: resolves the browser-reachable public origin, not the Docker-internal one', async () => {
+    // The home page server-renders beta <img src> above the fold (the LCP
+    // element on mobile). Absolutization must use the PUBLIC origin so the
+    // SSR'd URL is browser-fetchable — otherwise the LCP image can't paint
+    // until hydration re-resolves it. Emulate SSR by removing `window`.
+    Object.defineProperty(global, 'window', { configurable: true, value: undefined });
+    process.env.BACKEND_INTERNAL_URL = 'ws://backend:8080/graphql';
+    process.env.NEXT_PUBLIC_WS_URL = 'wss://ws.boardsesh.com/graphql';
+    const { mapBetaLinksResponse } = await import('../beta-video-url');
+
+    const [link] = mapBetaLinksResponse([commonRow('/static/beta-link-thumbnails/instagram/ABC.jpg')]);
+
+    expect(link.thumbnail).toBe('https://ws.boardsesh.com/static/beta-link-thumbnails/instagram/ABC.jpg?size=280');
+    expect(link.thumbnail).not.toContain('backend:8080');
   });
 });

--- a/packages/web/app/lib/__tests__/popular-lcp-preload.test.ts
+++ b/packages/web/app/lib/__tests__/popular-lcp-preload.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/app/components/board-renderer/util', () => ({
   getImageUrl: (...args: unknown[]) => getImageUrlMock(...args),
 }));
 
-import { buildPopularLcpImageUrl } from '../popular-lcp-preload';
+import { buildPopularLcpImageUrl, selectHomeLcpHints } from '../popular-lcp-preload';
 
 function makeConfig(overrides: Partial<PopularBoardConfig> = {}): PopularBoardConfig {
   return {
@@ -90,5 +90,59 @@ describe('buildPopularLcpImageUrl', () => {
       throw new Error('Unknown layout');
     });
     expect(buildPopularLcpImageUrl([makeConfig({ layoutId: 99999 })])).toBeNull();
+  });
+});
+
+describe('selectHomeLcpHints', () => {
+  it('preconnects to the backend and does NOT preload the board thumbnail when the beta rail renders', () => {
+    // The first beta thumbnail is the LCP element in this case; preloading the
+    // board thumbnail too would steal high-priority bandwidth from it.
+    const hints = selectHomeLcpHints({
+      recentBetaCount: 5,
+      popularConfigs: [makeConfig()],
+      backendOrigin: 'https://ws.boardsesh.com',
+    });
+
+    expect(hints).toEqual({ preconnectOrigin: 'https://ws.boardsesh.com', boardPreloadUrl: null });
+    // The board-thumbnail lookup must be skipped entirely — no wasted work and,
+    // more importantly, no second high-priority image hint.
+    expect(getBoardDetailsForBoardMock).not.toHaveBeenCalled();
+  });
+
+  it('passes a null backend origin through (no preconnect emitted)', () => {
+    const hints = selectHomeLcpHints({
+      recentBetaCount: 3,
+      popularConfigs: [makeConfig()],
+      backendOrigin: null,
+    });
+
+    expect(hints).toEqual({ preconnectOrigin: null, boardPreloadUrl: null });
+  });
+
+  it('preloads the board thumbnail (no preconnect) when the beta rail is empty', () => {
+    getBoardDetailsForBoardMock.mockReturnValue(stubBoardDetails);
+    getImageUrlMock.mockReturnValue('/images/kilter/thumbs/screen-1.webp');
+
+    const hints = selectHomeLcpHints({
+      recentBetaCount: 0,
+      popularConfigs: [makeConfig()],
+      backendOrigin: 'https://ws.boardsesh.com',
+    });
+
+    // Board thumbnail is now the LCP: preload it, and don't preconnect a host
+    // whose image won't render.
+    expect(hints).toEqual({ preconnectOrigin: null, boardPreloadUrl: '/images/kilter/thumbs/screen-1.webp' });
+    expect(getBoardDetailsForBoardMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('yields no image hint at all when the beta rail is empty and there are no popular configs', () => {
+    const hints = selectHomeLcpHints({
+      recentBetaCount: 0,
+      popularConfigs: [],
+      backendOrigin: 'https://ws.boardsesh.com',
+    });
+
+    expect(hints).toEqual({ preconnectOrigin: null, boardPreloadUrl: null });
+    expect(getBoardDetailsForBoardMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/lib/beta-video-url.ts
+++ b/packages/web/app/lib/beta-video-url.ts
@@ -11,7 +11,7 @@ import {
   type BetaLink,
   type BetaLinksGqlRow,
 } from '@boardsesh/shared-schema';
-import { getBackendHttpUrl } from '@/app/lib/backend-url';
+import { getPublicBackendHttpUrl } from '@/app/lib/backend-url';
 
 export {
   BETA_VIDEO_URL_VALIDATION_MESSAGE,
@@ -28,8 +28,8 @@ export type { BetaLink, BetaLinksGqlRow };
  * handler, which streams the cached image from S3. The GraphQL resolver
  * persists and returns the path as a backend-relative URL so the same value
  * works in same-origin deploys; in split-domain deploys (web + backend on
- * different hosts, see `getBackendHttpUrl`) we need to prepend the backend
- * origin so the browser actually hits the backend instead of 404-ing
+ * different hosts, see `getPublicBackendHttpUrl`) we need to prepend the
+ * backend origin so the browser actually hits the backend instead of 404-ing
  * against the frontend host.
  */
 function withThumbnailSize(url: string): string {
@@ -39,13 +39,22 @@ function withThumbnailSize(url: string): string {
 
 function absolutizeThumbnail(thumbnail: string | null): string | null {
   if (!thumbnail || !thumbnail.startsWith('/')) return thumbnail;
-  const backendBase = getBackendHttpUrl();
+  // Use the *browser-reachable* backend origin, not `getBackendHttpUrl`. The
+  // home page server-renders these <img src> values (the recent-beta rail is
+  // above the fold and is the LCP element on mobile), so the SSR'd URL must be
+  // one the browser can fetch. `getBackendHttpUrl` prefers BACKEND_INTERNAL_URL
+  // on the server — a Docker-internal origin the browser can't reach — which
+  // would leave the LCP image un-paintable until hydration re-resolved it
+  // client-side. `getPublicBackendHttpUrl` resolves from NEXT_PUBLIC_WS_URL on
+  // the server and is identical to `getBackendHttpUrl` on the client, so this
+  // is behaviour-preserving in the browser and only fixes the SSR value.
+  const backendBase = getPublicBackendHttpUrl();
   // Same-origin deploys keep the backend-relative path; split-domain deploys
   // prepend the backend origin. Either way request a sized variant via
   // `?size=` so the browser fetches a small thumbnail, not the full-res
   // social image.
-  // Defensive: getBackendHttpUrl strips a trailing slash today, but normalize
-  // here too so a future change to its return shape can't produce
+  // Defensive: getPublicBackendHttpUrl strips a trailing slash today, but
+  // normalize here too so a future change to its return shape can't produce
   // `https://host//static/...` which would 404.
   const base = backendBase ? `${backendBase.replace(/\/+$/, '')}${thumbnail}` : thumbnail;
   return withThumbnailSize(base);

--- a/packages/web/app/lib/popular-lcp-preload.ts
+++ b/packages/web/app/lib/popular-lcp-preload.ts
@@ -4,15 +4,15 @@ import { getImageUrl } from '@/app/components/board-renderer/util';
 import type { BoardName } from './types';
 
 /**
- * Build the preload URL for the unauthenticated home page's LCP image.
+ * Build the preload URL for the first board-discovery card thumbnail.
  *
- * The LCP element on the home page is the first popular board card
- * thumbnail rendered by `BoardDiscoveryScroll`. That thumbnail is an
- * inline SVG `<image>` element — and the Fetch Priority API spec does NOT
- * cover SVG images (only HTML `<img>`/`<link>`/`<script>`/`<iframe>`),
- * so attribute-based hints get silently ignored. Emitting
- * `<link rel="preload" as="image" fetchpriority="high">` from the
- * server-rendered head is the cross-browser way to escalate the priority:
+ * When the board thumbnail is the home page's LCP element (i.e. the
+ * recent-beta rail above it is empty — see `selectHomeLcpHints`), that
+ * thumbnail is an inline SVG `<image>` element. The Fetch Priority API spec
+ * does NOT cover SVG images (only HTML `<img>`/`<link>`/`<script>`/`<iframe>`),
+ * so attribute-based hints get silently ignored and the preload scanner can't
+ * see it. Emitting `<link rel="preload" as="image" fetchpriority="high">` from
+ * the server-rendered head is the cross-browser way to escalate the priority:
  * the browser starts the request before any JS has parsed.
  *
  * Returns null when the popular configs list is empty (backend
@@ -34,4 +34,51 @@ export function buildPopularLcpImageUrl(popularConfigs: PopularBoardConfig[]): s
   } catch {
     return null;
   }
+}
+
+export type HomeLcpHints = {
+  /**
+   * Cross-origin backend host to warm with `<link rel="preconnect">`, or null
+   * when the beta rail is empty / no backend origin is resolvable.
+   */
+  preconnectOrigin: string | null;
+  /**
+   * Board thumbnail to escalate with `<link rel="preload" as="image"
+   * fetchpriority="high">`, or null when it isn't the LCP element.
+   */
+  boardPreloadUrl: string | null;
+};
+
+/**
+ * Pick the single high-priority resource hint for the home page's LCP element.
+ *
+ * The above-the-fold order is hero → recent-beta rail → board discovery. When
+ * the beta rail renders, its first (portrait) thumbnail is the largest visible
+ * image and therefore the LCP element. That thumbnail is a cross-origin backend
+ * `<img>`, so we warm its origin with a preconnect and let the eager
+ * `fetchpriority="high"` `<img>` (see `BoardseshBetaCard`) drive the fetch —
+ * we deliberately do NOT also preload the board thumbnail, which is below the
+ * fold in this case and whose high-priority preload would only steal bandwidth
+ * from the real LCP on the slow connections that dominate the poor cohort.
+ *
+ * When the beta rail is empty, the first board thumbnail is the LCP; it's an
+ * inline SVG `<image>` the preload scanner can't see, so keep the explicit
+ * high-priority image preload.
+ *
+ * Only one image hint is ever high-priority, and it always matches the element
+ * the browser will actually paint as the LCP.
+ */
+export function selectHomeLcpHints({
+  recentBetaCount,
+  popularConfigs,
+  backendOrigin,
+}: {
+  recentBetaCount: number;
+  popularConfigs: PopularBoardConfig[];
+  backendOrigin: string | null;
+}): HomeLcpHints {
+  if (recentBetaCount > 0) {
+    return { preconnectOrigin: backendOrigin, boardPreloadUrl: null };
+  }
+  return { preconnectOrigin: null, boardPreloadUrl: buildPopularLcpImageUrl(popularConfigs) };
 }

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -6,7 +6,8 @@ import I18nProvider from '@/app/components/providers/i18n-provider';
 import { getAllBoardConfigs } from './lib/server-board-configs';
 import { getPopularBoardConfigs } from './lib/server-popular-configs';
 import { getRecentBetaLinks } from './lib/server-recent-beta-links';
-import { buildPopularLcpImageUrl } from './lib/popular-lcp-preload';
+import { selectHomeLcpHints } from './lib/popular-lcp-preload';
+import { getPublicBackendHttpUrl } from './lib/backend-url';
 import HomePageContent from './home-page-content';
 
 export async function generateMetadata() {
@@ -27,11 +28,24 @@ export default async function Home() {
     getRecentBetaLinks(),
     getLocale(),
   ]);
-  const lcpPreloadUrl = buildPopularLcpImageUrl(popularConfigs);
+  // Point the single high-priority image hint at whatever the browser will
+  // actually paint as the LCP element: the first (cross-origin) beta thumbnail
+  // when the recent-beta rail renders, otherwise the first board thumbnail.
+  // `getPublicBackendHttpUrl()` resolves to a browser-reachable origin on the
+  // server (unlike `getBackendHttpUrl`, which can return a Docker-internal one).
+  const { preconnectOrigin, boardPreloadUrl } = selectHomeLcpHints({
+    recentBetaCount: recentBeta.length,
+    popularConfigs,
+    backendOrigin: getPublicBackendHttpUrl(),
+  });
 
   return (
     <I18nProvider locale={locale} namespaces={['marketing', 'boards', 'climbs', 'profile', 'feed']}>
-      {lcpPreloadUrl && <link rel="preload" as="image" href={lcpPreloadUrl} fetchPriority="high" />}
+      {/* Warm the cross-origin backend host that serves the beta-rail LCP image.
+          No crossOrigin: the beta <img> is a credentialed no-cors request, so a
+          plain preconnect opens the connection it can reuse. */}
+      {preconnectOrigin && <link rel="preconnect" href={preconnectOrigin} />}
+      {boardPreloadUrl && <link rel="preload" as="image" href={boardPreloadUrl} fetchPriority="high" />}
       <HomePageContent
         boardConfigs={boardConfigs}
         initialPopularConfigs={popularConfigs}


### PR DESCRIPTION
Fixes #3123.

## What & why

Homepage LCP p75 sits at ~7.7s for a steady ~6% minority (PostHog `$web_vitals`, `$pathname='/'`). That cohort is almost entirely **cold first-loads** (103/112 poor samples are `navigation_type=navigate`), low-end **Android over-indexed** (49% vs 31% in the good cohort), median screen width ~393px.

The Velvet Send redesign (#3678, merged the same day as this analysis) moved the community **beta rail directly under the hero, above the board-discovery scroll**. A fresh look at the current page shows the LCP element shifted with it: the first beta thumbnail (portrait `143×254 ≈ 36k px²`) is now the largest fully-visible above-the-fold image on mobile — larger than the board card square (`182×182 ≈ 33k px²`) and the hero mark (`130×130`). That beta thumbnail carried three LCP anti-patterns, and the existing preload no longer pointed at it:

1. **Lazy above-the-fold image.** `BoardseshBetaCard`'s `<img>` was `loading="lazy"` for every card — including the first, above-the-fold one. Lazy on the LCP image is a classic late-discovery / deprioritized fetch.
2. **Cross-origin with no preconnect.** Beta thumbnails come from the backend static host (`ws.boardsesh.com` ≠ `boardsesh.com`), so each cold load paid extra DNS+TLS round-trips.
3. **SSR'd with a possibly-unreachable URL.** `absolutizeThumbnail` built the URL with `getBackendHttpUrl()`, which is `window`-dependent; on the server it can resolve to `BACKEND_INTERNAL_URL` (a Docker-internal origin the browser can't reach). When that happens, the server-rendered LCP `<img>` can't paint until hydration re-resolves it client-side — literally "LCP waits on hydration." The repo already has `getPublicBackendHttpUrl()` built for exactly this ("URLs that end up in server-rendered HTML for the browser to fetch"; used by the gym + kiosk pages) — the beta path just wasn't using it.
4. **Mis-targeted preload.** `page.tsx` still emitted `<link rel="preload" as="image" fetchpriority="high">` for the first *board* thumbnail, which is now below the fold when the beta rail renders. A mis-aimed high-priority preload steals bandwidth from the real LCP image on exactly the slow connections that define the poor cohort.

## Changes (Fixes 1–3; scoped, no reorder)

- **Fix 1 — SSR-reachable beta thumbnail URLs.** `absolutizeThumbnail` now uses `getPublicBackendHttpUrl()`. Client behaviour is unchanged (both helpers are identical in the browser); only the SSR'd value changes, so the LCP image is browser-fetchable from the initial HTML with no hydration re-resolve. Matches the existing gym/kiosk precedent.
- **Fix 2 — First beta card loads eager + high priority.** Threaded a `priorityFirstCard` flag `HomeRecentBetaSection → BoardseshBetaList → BoardseshBetaCard`; the first home-rail card renders `<img loading="eager" fetchpriority="high">`. All other cards (and the drawer/profile lists, which are never the LCP) stay `loading="lazy"`.
- **Fix 3 — Retarget the resource hints at the real LCP.** New pure helper `selectHomeLcpHints()`: when the beta rail renders, emit a `<link rel="preconnect">` to the backend origin and **drop** the board-thumbnail preload; when the beta rail is empty, keep the board-thumbnail preload (it's an inline SVG `<image>` the preload scanner can't see). Exactly one high-priority image hint, always matching the element the browser paints.

## Validation

- `vp run typecheck:web`, `vp check` — green.
- `vp test run --project web` — new/updated unit tests pass:
  - `beta-video-url.test.ts`: SSR branch resolves the public origin, never the Docker-internal `backend:8080`.
  - `popular-lcp-preload.test.ts`: `selectHomeLcpHints` preconnects (no board preload) when beta present; preloads the board thumbnail (no preconnect) when beta absent.
- No production build / dev server run: another session held a dev server in a sibling worktree, and the win is justified by DOM geometry + the removed anti-patterns. **The real verdict is post-merge RUM** (see below).

## Post-merge measurement plan

The 30-day PostHog window used for the diagnosis predates the redesign, so this is a forward-looking fix. After deploy, confirm with `$web_vitals` on `$pathname='/'`, **filtered to `$web_vitals_LCP_navigation_type = 'navigate'`** (the cold-load cohort that owns the regression), localhost excluded:
- p75 / avg LCP for the poor cohort trending down from the ~7.2–7.7s baseline;
- poor-bucket share trending below ~6%;
- optionally break down by `$os` (Android was over-indexed) to confirm the low-end-mobile tail improves.

Give it ~1–2 weeks of cold-load volume before judging.

## For @marcodejongh

- [ ] **Product question (not changed here):** the beta rail sitting *above* the board-discovery scroll is what created this new LCP surface (a cross-origin video thumbnail). Fixes 1–3 make that element fast, but if you'd rather the same-origin board thumbnail be the LCP, moving the beta rail below the board scroll would do it. Intentional to keep the community rail first? Not reordering in this PR — flagging only.
- [ ] **Deploy config:** is `BACKEND_INTERNAL_URL` set for the web server in prod? If yes, Fix 1 is a direct hydration-wait fix; if no, it's hardening (SSR was already reachable) and Fixes 2–3 carry the win. **Fix 1 is safe either way** — in the browser both helpers resolve identically.

## Follow-up (split out, not in this PR)

- **Fix 4 — trim first-load JS competing with the LCP image.** `board-discovery-scroll.tsx` statically imports `BoardSearchDrawer` (pulls the board-search map bundle into the above-the-fold client island). Making it `dynamic(..., { ssr: false })` would cut JS that contends with the LCP image on slow links. Deferred to keep this PR focused; will track separately.

## Release Notes

The home screen's community beta clips and boards show up faster on phones and patchy signal — the first thumbnail loads right away instead of waiting on the rest of the page to wake up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va
