### PR TITLE
fix(web): widen wall-confirm window and reconcile late board acks

### DIFF
--- a/packages/shared/play-view/src/__tests__/wall-confirm-fallback.test.ts
+++ b/packages/shared/play-view/src/__tests__/wall-confirm-fallback.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createWallConfirmFallbackController,
+  WALL_CONFIRM_RECONCILE_MS,
   WALL_CONFIRM_TIMEOUT_MS,
   type WallConfirmControllerCallbacks,
   type WallConfirmControllerDeps,
@@ -57,8 +58,10 @@ function createCallbacks(): Required<WallConfirmControllerCallbacks> {
   return {
     onConfirmed: vi.fn(),
     onTimeout: vi.fn(),
+    onReconciled: vi.fn(),
     onTrackConfirmed: vi.fn(),
     onTrackTimeout: vi.fn(),
+    onTrackReconciled: vi.fn(),
   };
 }
 
@@ -208,6 +211,11 @@ describe('createWallConfirmFallbackController', () => {
 
     expect(deps.bluetoothConnect).toHaveBeenCalledOnce();
     expect(callbacks.onTimeout).toHaveBeenCalledWith({ climbUuid: 'climb-2' });
+    // climb-2 is now in the reconcile phase, so its subscription is still live
+    // (the cancelled climb-1 subscription is gone — exactly one listener).
+    expect(wallConfirmBus.listenerCount()).toBe(1);
+    // Draining the reconcile backstop tears the last one down cleanly.
+    vi.advanceTimersByTime(WALL_CONFIRM_RECONCILE_MS);
     expect(wallConfirmBus.listenerCount()).toBe(0);
   });
 
@@ -308,5 +316,127 @@ describe('createWallConfirmFallbackController', () => {
       fallback: 'already_connected',
       boardLayout: 'Original',
     });
+  });
+
+  it('lands a slow-but-valid confirm inside the widened window as a clean confirm', () => {
+    // 2500ms would have been clipped by the old 2000ms cap. It now confirms.
+    const wallConfirmBus = createLocalWallConfirmBus();
+    const callbacks = createCallbacks();
+    const deps = createDeps(wallConfirmBus);
+    const controller = createWallConfirmFallbackController(deps, callbacks);
+
+    controller.armWatcher(baseClimb);
+    vi.advanceTimersByTime(2500);
+    wallConfirmBus.emit('climb-1');
+
+    expect(callbacks.onConfirmed).toHaveBeenCalledWith({
+      climbUuid: 'climb-1',
+      latencyMs: 2500,
+      confirmedByRole: 'other',
+    });
+    expect(callbacks.onTimeout).not.toHaveBeenCalled();
+    expect(callbacks.onTrackTimeout).not.toHaveBeenCalled();
+    expect(callbacks.onReconciled).not.toHaveBeenCalled();
+    expect(deps.bluetoothConnect).not.toHaveBeenCalled();
+    expect(wallConfirmBus.listenerCount()).toBe(0);
+  });
+
+  it('reconciles a late confirm that lands after the deadline but inside the backstop', () => {
+    const wallConfirmBus = createLocalWallConfirmBus();
+    const callbacks = createCallbacks();
+    const deps = createDeps(wallConfirmBus);
+    const controller = createWallConfirmFallbackController(deps, callbacks);
+
+    controller.armWatcher({ ...baseClimb, pulseOnly: true });
+    // Deadline fires — pulse_only timeout recorded.
+    vi.advanceTimersByTime(WALL_CONFIRM_TIMEOUT_MS);
+    expect(callbacks.onTimeout).toHaveBeenCalledWith({ climbUuid: 'climb-1' });
+    expect(callbacks.onTrackTimeout).toHaveBeenCalledWith({
+      mode: 'solo',
+      fallback: 'pulse_only',
+      boardLayout: 'Original',
+    });
+    // Subscription stays live through the reconcile backstop.
+    expect(wallConfirmBus.listenerCount()).toBe(1);
+
+    // A genuine ack arrives 2s after the deadline (5s total) — still inside the
+    // 10s backstop. It reconciles instead of being dropped.
+    vi.advanceTimersByTime(2000);
+    wallConfirmBus.emit('climb-1');
+
+    expect(callbacks.onReconciled).toHaveBeenCalledWith({
+      climbUuid: 'climb-1',
+      latencyMs: WALL_CONFIRM_TIMEOUT_MS + 2000,
+      confirmedByRole: 'other',
+    });
+    expect(callbacks.onTrackReconciled).toHaveBeenCalledWith({
+      climbUuid: 'climb-1',
+      latencyMs: WALL_CONFIRM_TIMEOUT_MS + 2000,
+      confirmedByRole: 'other',
+      mode: 'solo',
+      boardLayout: 'Original',
+      previousFallback: 'pulse_only',
+    });
+    // A reconcile is not a fresh confirm — the confirm path stays untouched.
+    expect(callbacks.onConfirmed).not.toHaveBeenCalled();
+    expect(callbacks.onTrackConfirmed).not.toHaveBeenCalled();
+    expect(wallConfirmBus.listenerCount()).toBe(0);
+  });
+
+  it('carries the recorded fallback classification into the reconcile telemetry', () => {
+    // A disconnected, supported, no-serial client times out to the picker; a
+    // late confirm reports previousFallback: 'picker'.
+    const wallConfirmBus = createLocalWallConfirmBus();
+    const callbacks = createCallbacks();
+    const deps = createDeps(wallConfirmBus);
+    const controller = createWallConfirmFallbackController(deps, callbacks);
+
+    controller.armWatcher(baseClimb);
+    vi.advanceTimersByTime(WALL_CONFIRM_TIMEOUT_MS);
+    expect(callbacks.onTrackTimeout).toHaveBeenCalledWith(expect.objectContaining({ fallback: 'picker' }));
+
+    vi.advanceTimersByTime(1000);
+    wallConfirmBus.emit('climb-1');
+
+    expect(callbacks.onTrackReconciled).toHaveBeenCalledWith(
+      expect.objectContaining({ previousFallback: 'picker', latencyMs: WALL_CONFIRM_TIMEOUT_MS + 1000 }),
+    );
+  });
+
+  it('drops a confirm that only arrives after the reconcile backstop elapses', () => {
+    const wallConfirmBus = createLocalWallConfirmBus();
+    const callbacks = createCallbacks();
+    const deps = createDeps(wallConfirmBus);
+    const controller = createWallConfirmFallbackController(deps, callbacks);
+
+    controller.armWatcher({ ...baseClimb, pulseOnly: true });
+    // Past the deadline and past the full backstop — the watcher has given up.
+    vi.advanceTimersByTime(WALL_CONFIRM_RECONCILE_MS + 100);
+    expect(wallConfirmBus.listenerCount()).toBe(0);
+
+    wallConfirmBus.emit('climb-1');
+
+    expect(callbacks.onReconciled).not.toHaveBeenCalled();
+    expect(callbacks.onTrackReconciled).not.toHaveBeenCalled();
+    expect(callbacks.onConfirmed).not.toHaveBeenCalled();
+  });
+
+  it('re-arming during the reconcile phase tears down the stale subscription', () => {
+    const wallConfirmBus = createLocalWallConfirmBus();
+    const callbacks = createCallbacks();
+    const deps = createDeps(wallConfirmBus);
+    const controller = createWallConfirmFallbackController(deps, callbacks);
+
+    controller.armWatcher({ ...baseClimb, pulseOnly: true });
+    vi.advanceTimersByTime(WALL_CONFIRM_TIMEOUT_MS); // climb-1 now reconciling
+    controller.armWatcher({ ...baseClimb, climbUuid: 'climb-2', pulseOnly: true });
+
+    // Exactly one live listener — climb-1's reconcile subscription was removed.
+    expect(wallConfirmBus.listenerCount()).toBe(1);
+
+    // A stale climb-1 ack no longer reconciles anything.
+    wallConfirmBus.emit('climb-1');
+    expect(callbacks.onReconciled).not.toHaveBeenCalled();
+    expect(callbacks.onTrackReconciled).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/play-view/src/wall-confirm-fallback.ts
+++ b/packages/shared/play-view/src/wall-confirm-fallback.ts
@@ -9,7 +9,34 @@
  * or open the board picker so web and mobile do not each carry their own
  * timer/listener/fallback implementation.
  */
-export const WALL_CONFIRM_TIMEOUT_MS = 2000;
+/**
+ * How long the pulse waits for the board to confirm the climb lit up before it
+ * renders a verdict (clears the pulse / runs the connect fallback). This is the
+ * user-facing feedback deadline.
+ *
+ * Successful confirm latency (PostHog, un-truncated) runs p95 ~1.5s / p99 ~1.9s;
+ * the previous 2000ms cap sat right on top of that tail and *truncated* it, so
+ * legitimately-confirmed-but-slow sends were logged as timeouts. 3000ms clears
+ * the observed tail with headroom; anything slower still lands via the reconcile
+ * window below rather than being dropped.
+ */
+export const WALL_CONFIRM_TIMEOUT_MS = 3000;
+
+/**
+ * Total window (from arm) during which a late `WallConfirmedClimb` still
+ * reconciles the earlier timeout into an honest confirm instead of being
+ * dropped. After WALL_CONFIRM_TIMEOUT_MS the pulse/fallback verdict has already
+ * landed (so the user waits no longer for feedback); the watcher then keeps
+ * listening quietly until this backstop so a slow board ack — or a cold connect
+ * that only lands after the deadline — is recorded truthfully.
+ *
+ * Kept in step with the BLE reconnect grace: a reconnect-by-serial keeps
+ * scanning for `SERIAL_RECONNECT_GRACE_MS` (`@boardsesh/ble-protocol/scan-constants`,
+ * currently 10_000ms) before it surfaces the picker, so a cold-connect confirm
+ * can legitimately land that late. If that grace changes, revisit this backstop —
+ * the two are intentionally the same value.
+ */
+export const WALL_CONFIRM_RECONCILE_MS = 10_000;
 
 export type WallConfirmMode = 'party' | 'solo';
 export type WallConfirmFallback = 'already_connected' | 'unsupported' | 'auto_connect' | 'picker' | 'pulse_only';
@@ -49,6 +76,13 @@ export type WallConfirmControllerDeps = {
 export type WallConfirmControllerCallbacks = {
   onConfirmed?: (info: { climbUuid: string; latencyMs: number; confirmedByRole: 'self' | 'other' }) => void;
   onTimeout?: (info: { climbUuid: string }) => void;
+  /**
+   * Fired when a `WallConfirmedClimb` arrives *after* the timeout verdict has
+   * already run but still inside WALL_CONFIRM_RECONCILE_MS. The wall did light —
+   * just slowly — so the earlier timeout was a false negative. `latencyMs` is the
+   * true elapsed time from arm.
+   */
+  onReconciled?: (info: { climbUuid: string; latencyMs: number; confirmedByRole: 'self' | 'other' }) => void;
   onTrackConfirmed?: (info: {
     climbUuid: string;
     latencyMs: number;
@@ -57,9 +91,24 @@ export type WallConfirmControllerCallbacks = {
     boardLayout: string;
   }) => void;
   onTrackTimeout?: (info: { mode: WallConfirmMode; fallback: WallConfirmFallback; boardLayout: string }) => void;
+  /**
+   * Telemetry hook for a reconciled confirm. `previousFallback` is the timeout
+   * classification that was recorded at the deadline, so a consumer can net the
+   * two out (a reconciled confirm means the paired timeout was not a real
+   * board-ack failure).
+   */
+  onTrackReconciled?: (info: {
+    climbUuid: string;
+    latencyMs: number;
+    confirmedByRole: 'self' | 'other';
+    mode: WallConfirmMode;
+    boardLayout: string;
+    previousFallback: WallConfirmFallback;
+  }) => void;
 };
 
-type Watcher = { timeoutId: WallConfirmTimeoutId; unsubscribe: () => void };
+type WatcherPhase = 'pending' | 'reconciling';
+type Watcher = { token: object; phase: WatcherPhase; timeoutId: WallConfirmTimeoutId; unsubscribe: () => void };
 
 export type WallConfirmFallbackController = {
   armWatcher: (args: WallConfirmArmArgs) => void;
@@ -95,53 +144,79 @@ export function createWallConfirmFallbackController(
     cancelWatcher();
 
     const armedAt = getNow();
-    let capturedTimeoutId: WallConfirmTimeoutId | null = null;
+    // Per-arm identity: survives the pending → reconciling transition (same
+    // token) but distinguishes this arm from any later one, so a stale timer or
+    // bus callback that slips through no-ops.
+    const token: object = {};
+    // Classification recorded at the deadline; reported back if a late confirm
+    // reconciles it.
+    let recordedFallback: WallConfirmFallback = 'pulse_only';
+
+    const runReconcileBackstop = () => {
+      if (watcher?.token !== token) return;
+      // No late confirm arrived within the backstop — the timeout stands.
+      cancelWatcher();
+    };
 
     const runFallback = () => {
-      if (watcher?.timeoutId !== capturedTimeoutId) return;
+      if (watcher?.token !== token) return;
 
-      cancelWatcher();
       callbacks.onTimeout?.({ climbUuid });
 
       // The caller already kicked off its own connect — never start another one
       // (the second scan is what breaks iOS pairing). Just record the timeout.
       if (pulseOnly) {
-        callbacks.onTrackTimeout?.({ mode, fallback: 'pulse_only', boardLayout });
-        return;
+        recordedFallback = 'pulse_only';
+      } else if (deps.isBluetoothConnected()) {
+        recordedFallback = 'already_connected';
+      } else if (!deps.isBluetoothSupported()) {
+        recordedFallback = 'unsupported';
+      } else {
+        const serial = deps.lastConnectedBoardSerial();
+        if (serial && deps.isNativeApp()) {
+          recordedFallback = 'auto_connect';
+          void deps.bluetoothConnect(undefined, undefined, serial);
+        } else {
+          recordedFallback = 'picker';
+          void deps.bluetoothConnect();
+        }
       }
+      callbacks.onTrackTimeout?.({ mode, fallback: recordedFallback, boardLayout });
 
-      if (deps.isBluetoothConnected()) {
-        callbacks.onTrackTimeout?.({ mode, fallback: 'already_connected', boardLayout });
-        return;
-      }
-      if (!deps.isBluetoothSupported()) {
-        callbacks.onTrackTimeout?.({ mode, fallback: 'unsupported', boardLayout });
-        return;
-      }
-
-      const serial = deps.lastConnectedBoardSerial();
-      if (serial && deps.isNativeApp()) {
-        callbacks.onTrackTimeout?.({ mode, fallback: 'auto_connect', boardLayout });
-        void deps.bluetoothConnect(undefined, undefined, serial);
-        return;
-      }
-
-      callbacks.onTrackTimeout?.({ mode, fallback: 'picker', boardLayout });
-      void deps.bluetoothConnect();
+      // Keep listening: a slow-but-valid ack that lands after the deadline
+      // reconciles this timeout instead of being dropped. The pending timer has
+      // already fired, so we only re-point the watcher at the reconcile backstop
+      // and keep the same bus subscription alive.
+      const reconcileDelayMs = Math.max(0, WALL_CONFIRM_RECONCILE_MS - WALL_CONFIRM_TIMEOUT_MS);
+      const reconcileTimeoutId = scheduleTimeout(runReconcileBackstop, reconcileDelayMs);
+      watcher = { token, phase: 'reconciling', timeoutId: reconcileTimeoutId, unsubscribe };
     };
 
     const unsubscribe = deps.subscribeToWallConfirm((confirmedUuid) => {
-      if (watcher?.timeoutId !== capturedTimeoutId) return;
+      if (watcher?.token !== token) return;
       if (confirmedUuid !== climbUuid) return;
       const latencyMs = getNow() - armedAt;
       const confirmedByRole: 'self' | 'other' = deps.isBluetoothConnected() ? 'self' : 'other';
+      const wasReconciling = watcher.phase === 'reconciling';
       cancelWatcher();
+      if (wasReconciling) {
+        callbacks.onReconciled?.({ climbUuid, latencyMs, confirmedByRole });
+        callbacks.onTrackReconciled?.({
+          climbUuid,
+          latencyMs,
+          confirmedByRole,
+          mode,
+          boardLayout,
+          previousFallback: recordedFallback,
+        });
+        return;
+      }
       callbacks.onConfirmed?.({ climbUuid, latencyMs, confirmedByRole });
       callbacks.onTrackConfirmed?.({ climbUuid, latencyMs, confirmedByRole, mode, boardLayout });
     });
 
-    capturedTimeoutId = scheduleTimeout(runFallback, WALL_CONFIRM_TIMEOUT_MS);
-    watcher = { timeoutId: capturedTimeoutId, unsubscribe };
+    const capturedTimeoutId = scheduleTimeout(runFallback, WALL_CONFIRM_TIMEOUT_MS);
+    watcher = { token, phase: 'pending', timeoutId: capturedTimeoutId, unsubscribe };
   };
 
   return { armWatcher, cancelWatcher, handleSessionActiveChange };

--- a/packages/web/app/components/play-view/__tests__/use-wall-confirm-fallback.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/use-wall-confirm-fallback.test.tsx
@@ -2,7 +2,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { renderHook, act } from '@testing-library/react';
-import { useWallConfirmFallback, WALL_CONFIRM_TIMEOUT_MS } from '../use-wall-confirm-fallback';
+import {
+  useWallConfirmFallback,
+  WALL_CONFIRM_RECONCILE_MS,
+  WALL_CONFIRM_TIMEOUT_MS,
+} from '../use-wall-confirm-fallback';
 import { emitWallConfirm } from '@boardsesh/play-view';
 
 const mockTrack = vi.fn();
@@ -345,15 +349,41 @@ describe('useWallConfirmFallback', () => {
     );
   });
 
-  it('is a no-op when a WallConfirmedClimb arrives after the timeout already ran', () => {
+  it('lands a slow confirm inside the widened window as a clean Wall Confirmed', () => {
+    // 2500ms was clipped by the old 2000ms cap; it now confirms cleanly.
     const deps = makeDeps();
-    const { result } = renderHook(() => useWallConfirmFallback(deps));
+    const onConfirmed = vi.fn();
+    const { result } = renderHook(() => useWallConfirmFallback(deps, { onConfirmed } satisfies Callbacks));
+
+    act(() => {
+      result.current.armWatcher(baseClimb);
+    });
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+    act(() => {
+      emitWallConfirm('climb-1');
+    });
+
+    expect(deps.bluetoothConnect).not.toHaveBeenCalled();
+    expect(onConfirmed).toHaveBeenCalledOnce();
+    expect(mockTrack).toHaveBeenCalledOnce();
+    expect(mockTrack).toHaveBeenCalledWith(
+      'Wall Confirmed',
+      expect.objectContaining({ climbUuid: 'climb-1', latencyMs: 2500 }),
+    );
+  });
+
+  it('reconciles a late WallConfirmedClimb into an honest Wall Confirmed after the timeout ran', () => {
+    const deps = makeDeps();
+    const onReconciled = vi.fn();
+    const { result } = renderHook(() => useWallConfirmFallback(deps, { onReconciled } satisfies Callbacks));
 
     act(() => {
       result.current.armWatcher(baseClimb);
     });
 
-    // Timeout fires — fallback runs.
+    // Timeout fires — fallback runs, timeout recorded.
     act(() => {
       vi.advanceTimersByTime(WALL_CONFIRM_TIMEOUT_MS);
     });
@@ -361,14 +391,50 @@ describe('useWallConfirmFallback', () => {
     expect(mockTrack).toHaveBeenCalledOnce();
     expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Timeout', expect.objectContaining({ fallback: 'picker' }));
 
-    // A late confirm for the same climb arrives — must not double-fire or
-    // tear anything down (the watcher is already gone).
+    // A genuine ack lands 2s after the deadline — still inside the backstop.
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
     act(() => {
       emitWallConfirm('climb-1');
     });
 
+    // No second connect; the confirm is recorded honestly (flagged so it can be
+    // netted against the paired timeout) and the drawer settle callback fires.
     expect(deps.bluetoothConnect).toHaveBeenCalledOnce();
+    expect(onReconciled).toHaveBeenCalledOnce();
+    expect(mockTrack).toHaveBeenCalledTimes(2);
+    expect(mockTrack).toHaveBeenLastCalledWith('Wall Confirmed', {
+      climbUuid: 'climb-1',
+      latencyMs: WALL_CONFIRM_TIMEOUT_MS + 2000,
+      confirmedByRole: 'other',
+      mode: 'solo',
+      boardLayout: 'Original',
+      reconciledAfterTimeout: true,
+      previousFallback: 'picker',
+    });
+  });
+
+  it('drops a confirm that only arrives after the reconcile backstop elapses', () => {
+    const deps = makeDeps();
+    const onReconciled = vi.fn();
+    const { result } = renderHook(() => useWallConfirmFallback(deps, { onReconciled } satisfies Callbacks));
+
+    act(() => {
+      result.current.armWatcher(baseClimb);
+    });
+    act(() => {
+      vi.advanceTimersByTime(WALL_CONFIRM_RECONCILE_MS + 100);
+    });
+
+    // The watcher has fully given up; a much-later ack changes nothing.
+    act(() => {
+      emitWallConfirm('climb-1');
+    });
+
+    expect(onReconciled).not.toHaveBeenCalled();
     expect(mockTrack).toHaveBeenCalledOnce();
+    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Timeout', expect.objectContaining({ fallback: 'picker' }));
   });
 
   it('coalesces repeated emits for the same climbUuid (two-phones racing)', () => {

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -381,12 +381,15 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     navigate('previous', 'playViewDrawer');
   }, [navigate]);
   // Wall-confirm watcher: armed by handleLightbulbClick, dismissed by the
-  // local wall-confirm bus or fires a connect fallback after 2 s. Owns its
-  // own unmount cleanup so the drawer doesn't need to thread that wiring.
+  // local wall-confirm bus or fires a connect fallback after the confirm
+  // deadline. Owns its own unmount cleanup so the drawer doesn't need to thread
+  // that wiring.
   //
   // `onConfirmed` / `onTimeout` clear the lightbulb's pending pulse state so
   // the UI accurately reflects the round-trip — pulse during the window,
-  // solid lit on confirm, picker (or no-op) on timeout.
+  // solid lit on confirm, picker (or no-op) on timeout. `onReconciled` handles
+  // a slow ack that lands after the deadline: the pulse already cleared, so this
+  // is an idempotent settle (the honest analytics event fires in the hook).
   const handleWallConfirmed = useCallback((info: { climbUuid: string }) => {
     setPendingClimbUuid((current) => (current === info.climbUuid ? null : current));
   }, []);
@@ -401,7 +404,11 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
       isPersistentSessionActive,
       bluetoothConnect,
     },
-    { onConfirmed: handleWallConfirmed, onTimeout: handleWallConfirmTimeout },
+    {
+      onConfirmed: handleWallConfirmed,
+      onTimeout: handleWallConfirmTimeout,
+      onReconciled: handleWallConfirmed,
+    },
   );
 
   // Session-swap during pending: if the watcher hook cancels because the

--- a/packages/web/app/components/play-view/use-wall-confirm-fallback.ts
+++ b/packages/web/app/components/play-view/use-wall-confirm-fallback.ts
@@ -4,13 +4,14 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import {
   createWallConfirmFallbackController,
   subscribeToWallConfirm,
+  WALL_CONFIRM_RECONCILE_MS,
   WALL_CONFIRM_TIMEOUT_MS,
   type WallConfirmArmArgs,
 } from '@boardsesh/play-view';
 import { track } from '@/app/lib/analytics';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 
-export { WALL_CONFIRM_TIMEOUT_MS };
+export { WALL_CONFIRM_RECONCILE_MS, WALL_CONFIRM_TIMEOUT_MS };
 
 type Deps = {
   /** Current local BLE connection state. */
@@ -33,14 +34,19 @@ type Deps = {
 
 type Callbacks = {
   /** Fired when a `WallConfirmedClimb` matching the armed `climbUuid` arrives
-   *  inside the 2-second window. Receives the elapsed `latencyMs` and a
+   *  inside the confirm window. Receives the elapsed `latencyMs` and a
    *  `confirmedByRole` hint derived from the local BLE state at confirm time
    *  (`'self'` when the local phone is currently BLE-paired — most likely the
    *  AutoSender that just wrote; `'other'` otherwise). The drawer uses this
    *  to fire the `Wall Confirmed` analytics event and clear pending UI. */
   onConfirmed?: (info: { climbUuid: string; latencyMs: number; confirmedByRole: 'self' | 'other' }) => void;
-  /** Fired when the 2-second window expires and a fallback ran. */
+  /** Fired when the confirm window expires and a fallback ran. */
   onTimeout?: (info: { climbUuid: string }) => void;
+  /** Fired when the wall confirmed *after* the timeout verdict but still inside
+   *  the reconcile backstop — a slow-but-valid ack. The drawer settles any
+   *  lingering pulse; the honest `Wall Confirmed` analytics event is emitted
+   *  here (flagged `reconciledAfterTimeout`). */
+  onReconciled?: (info: { climbUuid: string; latencyMs: number; confirmedByRole: 'self' | 'other' }) => void;
 };
 
 /**
@@ -74,11 +80,27 @@ export function useWallConfirmFallback(deps: Deps, callbacks: Callbacks = {}) {
         {
           onConfirmed: (info) => callbacksRef.current.onConfirmed?.(info),
           onTimeout: (info) => callbacksRef.current.onTimeout?.(info),
+          onReconciled: (info) => callbacksRef.current.onReconciled?.(info),
           onTrackConfirmed: ({ climbUuid, latencyMs, confirmedByRole, mode, boardLayout }) => {
             track('Wall Confirmed', { climbUuid, latencyMs, confirmedByRole, mode, boardLayout });
           },
           onTrackTimeout: ({ mode, fallback, boardLayout }) => {
             track('Wall Confirm Timeout', { mode, fallback, boardLayout });
+          },
+          onTrackReconciled: ({ climbUuid, latencyMs, confirmedByRole, mode, boardLayout, previousFallback }) => {
+            // The wall did light, just after the deadline. Record it as a real
+            // confirm (so the confirm count is honest) but flag it so the
+            // clipped-latency distribution and the paired `Wall Confirm Timeout`
+            // can be netted out.
+            track('Wall Confirmed', {
+              climbUuid,
+              latencyMs,
+              confirmedByRole,
+              mode,
+              boardLayout,
+              reconciledAfterTimeout: true,
+              previousFallback,
+            });
           },
         },
       ),


### PR DESCRIPTION
## Summary

Fixes #3121.

After a send, the play-drawer lightbulb pulses while it waits for the board to confirm the climb lit up. That wait was a flat **2s** timer that rendered a terminal verdict — confirm or "timeout". Real confirm latency (PostHog project 412845) runs **p95 ~1.5s / p99 ~1.9s / max 1,986ms**, pinned right under the 2,000ms cap because the cap *truncated* the distribution. Roughly 5% of legitimately-confirmed sends landed just after 2s and were logged as `Wall Confirm Timeout`, with the pulse stopping early.

This widens the window and, more importantly, stops dropping a slow-but-valid ack.

### What changed (`@boardsesh/play-view` + web wrapper)

- **Wider deadline.** `WALL_CONFIRM_TIMEOUT_MS` 2000 → **3000ms**, clearing the observed tail. The drawer path is `pulseOnly` (no picker re-pop), so the only cost is the reassuring pulse lasting a beat longer before a negative verdict — time-to-feedback isn't regressed.
- **Reconcile instead of drop.** After the deadline fires, the wall-confirm subscription stays alive for a **10s reconcile backstop** (`WALL_CONFIRM_RECONCILE_MS`). A `WallConfirmedClimb` that arrives late now reconciles the earlier timeout into an honest `Wall Confirmed` — flagged `reconciledAfterTimeout: true` and carrying the `previousFallback` it corrected, so the confirm count becomes truthful and the paired timeout nets out. The user's feedback still lands at the deadline; the reconcile is a background correction.
- The backstop is intentionally the same value as `SERIAL_RECONNECT_GRACE_MS` (bumped to 10s in #3687): a cold-connect ack can legitimately land that late, and a comment flags the coupling so a future grace change revisits it.

The native RN app doesn't use this controller (it only *produces* `emitWallConfirm`), so this is web/shared only — it ships over the web deploy, no native build.

### Overlaps PR #3129

@marcodejongh's #3129 (`fix/3121-wall-confirm-convergent`, currently BLOCKED) tackles the same issue with a larger refactor — converging the pulse onto the seq'd board-presence state and splitting the timeout taxonomy (a new `Wall Confirm Connecting` event). **This PR is a narrow, independent subset**: the deadline widen + reconcile + honest telemetry, with no taxonomy change (only a `reconciledAfterTimeout` flag on `Wall Confirmed`). It lands the tunable fix now; the convergence and taxonomy call stays with @marcodejongh. If #3129 continues, it will need a rebase on top of this — both touch `wall-confirm-fallback.ts`, the web hook, and the drawer.

## Release Notes

- Send a climb and the board takes an extra second to light up? The bulb keeps waiting instead of flashing a false miss — a slow-but-good confirm now shows as lit.

## Test plan

- `vp test run --project play-view` — 155 passed. New cases: a 2.5s confirm landing as a clean confirm (widened window), a late ack reconciling inside the backstop, `previousFallback` carried into the reconcile telemetry, a confirm dropped after the backstop elapses, and re-arm during the reconcile phase tearing down the stale subscription.
- `vp test run --project web` (`use-wall-confirm-fallback`) — passed. Rewrote the old "no-op after timeout" case into a reconciliation assertion; added widened-window and drop-after-backstop cases.
- `vp run typecheck:web`, `vp run typecheck:play-view`, `vp check` — clean.
- Manual QA to exercise: send on a connected board and confirm a >2s ack lands solid-lit (not a phantom timeout); navigate off the pending climb mid-pulse; cold-connect via the drawer lightbulb and confirm no duplicate picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va
