### PR TITLE
fix(mobile): attribute iOS BLE connect_failed sub-reasons (#3676)

### DIFF
--- a/packages/mobile/ios-tests/BoardBleConnectFailureReasonTests.swift
+++ b/packages/mobile/ios-tests/BoardBleConnectFailureReasonTests.swift
@@ -1,0 +1,93 @@
+import CoreBluetooth
+import XCTest
+
+/// Unit tests for the connect-failure sub-reason attribution that backs
+/// `getLastConnectFailureReason` (#3676): the pure `BoardBleConnectFailureReason`
+/// enum (construction from a CoreBluetooth NSError + the bridge dictionary shape)
+/// and the manager's clear-on-read stash contract. Mirrors the pure-decision
+/// approach of BoardBleServiceDiscoveryTests so it runs without a real
+/// `CBCentralManager`.
+@available(iOS 17.0, *)
+final class BoardBleConnectFailureReasonTests: XCTestCase {
+    private var scheduler: FakeBleTimerScheduler!
+    private var manager: BoardBleManager!
+
+    override func setUp() {
+        super.setUp()
+        scheduler = FakeBleTimerScheduler()
+        manager = BoardBleManager(timerScheduler: scheduler, createCentralManagerEagerly: false)
+    }
+
+    override func tearDown() {
+        manager = nil
+        scheduler = nil
+        super.tearDown()
+    }
+
+    // MARK: - Pure enum construction from a didFailToConnect NSError
+
+    func testFromNilErrorHasNoCodeOrDomain() {
+        XCTAssertEqual(
+            BoardBleConnectFailureReason.from(didFailToConnectError: nil),
+            .didFailToConnect(code: nil, domain: nil)
+        )
+    }
+
+    func testFromCoreBluetoothErrorCarriesCodeAndDomain() {
+        let error = NSError(domain: CBErrorDomain, code: 7, userInfo: nil)
+        XCTAssertEqual(
+            BoardBleConnectFailureReason.from(didFailToConnectError: error),
+            .didFailToConnect(code: 7, domain: CBErrorDomain)
+        )
+    }
+
+    // MARK: - Bridge dictionary shape
+
+    func testWatchdogTimeoutDictionaryIsReasonOnly() {
+        let dictionary = BoardBleConnectFailureReason.watchdogTimeout.analyticsDictionary
+        XCTAssertEqual(dictionary["reason"] as? String, "watchdog_timeout")
+        XCTAssertNil(dictionary["cbErrorCode"])
+        XCTAssertNil(dictionary["cbErrorDomain"])
+    }
+
+    func testDiscoveryTimeoutDictionaryIsReasonOnly() {
+        let dictionary = BoardBleConnectFailureReason.discoveryTimeout.analyticsDictionary
+        XCTAssertEqual(dictionary["reason"] as? String, "discovery_timeout")
+        XCTAssertNil(dictionary["cbErrorCode"])
+        XCTAssertNil(dictionary["cbErrorDomain"])
+    }
+
+    func testDidFailToConnectDictionaryCarriesCbError() {
+        let dictionary = BoardBleConnectFailureReason
+            .didFailToConnect(code: 3, domain: CBErrorDomain)
+            .analyticsDictionary
+        XCTAssertEqual(dictionary["reason"] as? String, "did_fail_to_connect")
+        XCTAssertEqual(dictionary["cbErrorCode"] as? Int, 3)
+        XCTAssertEqual(dictionary["cbErrorDomain"] as? String, CBErrorDomain)
+    }
+
+    func testDidFailToConnectDictionaryOmitsMissingCbError() {
+        let dictionary = BoardBleConnectFailureReason
+            .didFailToConnect(code: nil, domain: nil)
+            .analyticsDictionary
+        XCTAssertEqual(dictionary["reason"] as? String, "did_fail_to_connect")
+        XCTAssertNil(dictionary["cbErrorCode"])
+        XCTAssertNil(dictionary["cbErrorDomain"])
+    }
+
+    // MARK: - Clear-on-read stash contract
+
+    func testTakeReturnsNilWithNoStashedReason() {
+        XCTAssertNil(manager.takeConnectFailureReasonAnalytics())
+    }
+
+    func testTakeReturnsStashedReasonThenClears() {
+        manager.testHooks.setConnectFailureReason(.watchdogTimeout)
+
+        let first = manager.takeConnectFailureReasonAnalytics()
+        XCTAssertEqual(first?["reason"] as? String, "watchdog_timeout")
+
+        // Clear-on-read: a single failure is attributed to a single event.
+        XCTAssertNil(manager.takeConnectFailureReasonAnalytics())
+    }
+}

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -168,6 +168,60 @@ enum BoardBleError: LocalizedError {
     }
 }
 
+/// Sub-reason a connect attempt failed (#3676), stashed so JS can attach it to
+/// the `BluetoothConnectionFailed` event. On iOS a `connect_failed` event
+/// otherwise carries no cause — the native error string alone can't tell our 8 s
+/// watchdog firing apart from a CoreBluetooth `didFailToConnect` or a
+/// reconnect-scan discovery timeout. Mirrors the write-side telemetry (#3230)
+/// and connect-diagnostics (#3480) clear-on-read stashes. The `analyticsDictionary`
+/// shape is what crosses the JS bridge (see `getLastConnectFailureReason`).
+enum BoardBleConnectFailureReason: Equatable {
+    /// Our 8 s `connectTimeout` watchdog fired: `centralManager.connect` never
+    /// called back `didConnect`/`didFailToConnect`.
+    case watchdogTimeout
+    /// CoreBluetooth's `didFailToConnect` delegate settled the attempt. Carries
+    /// the underlying `CBError` code/domain (nil when iOS supplied no NSError).
+    case didFailToConnect(code: Int?, domain: String?)
+    /// The widget-lightbulb reconnect-by-last-known scan timed out before the
+    /// stored board advertised.
+    case discoveryTimeout
+
+    var reason: String {
+        switch self {
+        case .watchdogTimeout:
+            return "watchdog_timeout"
+        case .didFailToConnect:
+            return "did_fail_to_connect"
+        case .discoveryTimeout:
+            return "discovery_timeout"
+        }
+    }
+
+    /// Build the `didFailToConnect` case from CoreBluetooth's optional NSError,
+    /// reading its `CBError` code + domain. Pure so it's unit-testable without a
+    /// real `CBCentralManager` (#3676).
+    static func from(didFailToConnectError error: Error?) -> BoardBleConnectFailureReason {
+        let nsError = error as NSError?
+        return .didFailToConnect(code: nsError?.code, domain: nsError?.domain)
+    }
+
+    /// The bridge payload. Only the `didFailToConnect` case adds `cbErrorCode` /
+    /// `cbErrorDomain`, and only when iOS actually supplied them, so older JS /
+    /// PostHog sees no empty fields.
+    var analyticsDictionary: [String: Any] {
+        var dictionary: [String: Any] = ["reason": reason]
+        if case let .didFailToConnect(code, domain) = self {
+            if let code {
+                dictionary["cbErrorCode"] = code
+            }
+            if let domain {
+                dictionary["cbErrorDomain"] = domain
+            }
+        }
+        return dictionary
+    }
+}
+
 final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     static let shared = BoardBleManager()
 
@@ -273,6 +327,14 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // decoy peripheral) or an unknown third controller generation. Clear-on-read
     // via takeLastConnectFailureDiagnostics(). See #3480.
     private var lastConnectFailureDiscoveredServices: [String]?
+    // Sub-reason the most recent connect attempt failed (#3676): our 8 s watchdog,
+    // a CoreBluetooth didFailToConnect (+CBError), or a reconnect-scan discovery
+    // timeout. Stashed at each failure site so JS can attach it to
+    // `BluetoothConnectionFailed` (an Expo reject can't carry structured data).
+    // Clear-on-read via takeConnectFailureReasonAnalytics(), and cleared at the
+    // start of every fresh connectOnBleQueue so a discovery_timeout the widget
+    // reconnect scan left unread can't be misattributed to a later JS connect.
+    private var lastConnectFailureReason: BoardBleConnectFailureReason?
     private var writeQueue: [WriteRequest] = []
     private var writeGeneration: UInt64 = 0
     private var isWriting = false
@@ -450,6 +512,18 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
     }
 
+    /// The bridge payload for the most recent failed connect's sub-reason, or nil
+    /// when there's no failure to report. Clear-on-read so a single failure is
+    /// attributed to a single analytics event. Exposed to JS as
+    /// `getLastConnectFailureReason` (read right after a `connect` rejection). See
+    /// #3676.
+    func takeConnectFailureReasonAnalytics() -> [String: Any]? {
+        runOnBleQueueSync {
+            defer { lastConnectFailureReason = nil }
+            return lastConnectFailureReason?.analyticsDictionary
+        }
+    }
+
     func setEventHandlers(
         onScanResult: ((BoardBleScanResult) -> Void)?,
         onDisconnect: ((String, [String: Any]?) -> Void)?,
@@ -622,6 +696,14 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     private func connectOnBleQueue(deviceId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        // Fresh attempt: drop any stale connect-failure sub-reason (#3676). A
+        // discovery_timeout the widget reconnect scan stashed is never consumed by
+        // JS (its completion is the native ReconnectBoardIntent, not the JS
+        // `connect`), so without this it would survive and be taken by the NEXT JS
+        // connect failure — misattributing a watchdog/didFailToConnect as
+        // discovery_timeout. All JS connects route through here, so one clear
+        // covers the class.
+        lastConnectFailureReason = nil
         // Supersede any in-flight reconnect-by-last-known scan: this is a no-op
         // when called from the reconnect path itself (which already nils the scan
         // state first), but settles a stranded scan immediately when an unrelated
@@ -687,6 +769,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 self.writeCharacteristic = nil
             }
             self.centralManager.cancelPeripheralConnection(peripheral)
+            // Attribute this connect_failed to our watchdog before settling, so
+            // JS can distinguish it from a CoreBluetooth didFailToConnect (#3676).
+            self.lastConnectFailureReason = .watchdogTimeout
             self.completePendingConnect(.failure(BoardBleError.connectTimedOut))
         }
         connectTimeoutWorkItem = timeoutWorkItem
@@ -736,6 +821,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         reconnectScanCompletion = completion
 
         let timeout = DispatchWorkItem { [weak self] in
+            // The stored board never advertised in time. Attribute it as a
+            // discovery timeout, distinct from the direct-connect watchdog (#3676).
+            // The work item is cancelled the moment the scan settles any other
+            // way, so if it fires the scan is genuinely still pending.
+            self?.lastConnectFailureReason = .discoveryTimeout
             self?.failReconnectScan(BoardBleError.connectTimedOut)
         }
         reconnectScanTimeoutWorkItem = timeout
@@ -1162,6 +1252,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             connectedPeripheral = nil
             writeCharacteristic = nil
         }
+        // Attribute this connect_failed to CoreBluetooth, carrying its CBError
+        // code/domain, before settling — so JS can tell it apart from our own
+        // watchdog timeout (#3676).
+        lastConnectFailureReason = .from(didFailToConnectError: error)
         completePendingConnect(.failure(error ?? BoardBleError.notConnected))
     }
 
@@ -2350,6 +2444,12 @@ extension BoardBleManager {
         /// The Nordic UART and RedBearLab write-service UUIDs, in probe order,
         /// so tests can assert the decision without hardcoding them.
         var writeServiceUuidsForTesting: [CBUUID] { manager.writeServiceUuids() }
+
+        /// Seed the connect-failure sub-reason stash so a test can exercise the
+        /// clear-on-read `takeConnectFailureReasonAnalytics()` contract (#3676).
+        func setConnectFailureReason(_ reason: BoardBleConnectFailureReason?) {
+            manager.runOnBleQueueSync { manager.lastConnectFailureReason = reason }
+        }
 
         var hasPendingWriteResume: Bool { manager.pendingWriteResume != nil }
         var capturedPendingWriteResume: (() -> Void)? { manager.pendingWriteResume }

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -188,6 +188,15 @@ public class BoardBleModule: Module {
             return ["discoveredServices": discoveredServices]
         }
 
+        // Sub-reason for the most recent failed JS connect (#3676): watchdog_timeout
+        // | did_fail_to_connect (+CBError code/domain) | discovery_timeout. Read
+        // right after a `connect` rejection so `BluetoothConnectionFailed` can carry
+        // it. Clear-on-read (the manager clears its stash), mirroring
+        // getLastConnectDiagnostics.
+        AsyncFunction("getLastConnectFailureReason") { () -> [String: Any]? in
+            BoardBleManager.shared.takeConnectFailureReasonAnalytics()
+        }
+
         AsyncFunction("cancelWrites") { () -> Void in
             BoardBleManager.shared.cancelWrites()
         }

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -109,6 +109,21 @@ export type NativeBleConnectDiagnostics = {
   discoveredServices: string[];
 };
 
+/**
+ * Sub-reason a connect attempt failed (#3676), fetched via
+ * `getLastConnectFailureReason` right after a rejected `connect`. On iOS a
+ * `connect_failed` event otherwise carries no cause — the native error string
+ * can't tell our 8 s watchdog firing apart from a CoreBluetooth
+ * `didFailToConnect` or a reconnect-scan discovery timeout.
+ */
+export type NativeBleConnectFailureReason = {
+  reason: 'watchdog_timeout' | 'did_fail_to_connect' | 'discovery_timeout';
+  /** CoreBluetooth CBError code — present only for `did_fail_to_connect`. */
+  cbErrorCode?: number;
+  /** CoreBluetooth error domain (e.g. `CBErrorDomain`) — `did_fail_to_connect` only. */
+  cbErrorDomain?: string;
+};
+
 export type NativeBleConfigureBoardOptions = {
   boardName: string;
   layoutId: number;
@@ -162,6 +177,15 @@ type BoardBleNativeModule = {
    * run against an older binary). See #3480.
    */
   getLastConnectDiagnostics?(): Promise<NativeBleConnectDiagnostics | null>;
+  /**
+   * Sub-reason for the most recent failed JS connect, for tagging
+   * `BluetoothConnectionFailed` so the iOS `connect_failed` cohort splits into
+   * watchdog / didFailToConnect / discovery-timeout buckets (a rejected promise
+   * can't carry it). Only present on newer binaries — gate on
+   * `typeof getLastConnectFailureReason === 'function'` (an OTA JS update can run
+   * against an older binary). See #3676.
+   */
+  getLastConnectFailureReason?(): Promise<NativeBleConnectFailureReason | null>;
   addListener(event: 'scanResult', listener: (payload: NativeBleScanEvent) => void): EventSubscription;
   addListener(event: 'disconnected', listener: (payload: NativeBleDisconnectEvent) => void): EventSubscription;
   addListener(event: 'connected', listener: (payload: NativeBleConnectedEvent) => void): EventSubscription;

--- a/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
@@ -669,3 +669,90 @@ describe('NativeIosBleAdapter connect diagnostics (#3480)', () => {
     await expect(adapter.getLastConnectDiagnostics()).resolves.toBeNull();
   });
 });
+
+describe('NativeIosBleAdapter connect failure reason (#3676)', () => {
+  afterEach(() => {
+    delete (nativeMock as Record<string, unknown>).getLastConnectFailureReason;
+  });
+
+  // Drive requestAndConnect to the point native.connect is invoked by
+  // auto-selecting a device advertising the target serial.
+  const driveConnect = (adapter: NativeIosBleAdapter, serial: string): Promise<unknown> => {
+    const promise = adapter.requestAndConnect(serial).catch((error: Error) => error);
+    void Promise.resolve().then(() => {
+      scanListeners[0]?.({
+        device: { deviceId: 'dev-1', name: `Kilter Board#${serial}@3` },
+        localName: `Kilter Board#${serial}@3`,
+        rssi: -55,
+      });
+    });
+    return promise;
+  };
+
+  it('fetches the native sub-reason and rethrows when a connect rejects on a newer binary', async () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    const connectError = new Error('Bluetooth connection timed out');
+    nativeMock.connect.mockRejectedValueOnce(connectError);
+    const getReason = vi.fn().mockResolvedValue({ reason: 'watchdog_timeout' });
+    (nativeMock as Record<string, unknown>).getLastConnectFailureReason = getReason;
+
+    const connectPromise = driveConnect(adapter, 'A1B2C3');
+    await vi.runAllTimersAsync();
+
+    expect(await connectPromise).toBe(connectError);
+    expect(getReason).toHaveBeenCalledOnce();
+    await expect(adapter.getLastConnectFailureReason()).resolves.toEqual({ reason: 'watchdog_timeout' });
+  });
+
+  it('carries the CBError code/domain on a didFailToConnect sub-reason', async () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    nativeMock.connect.mockRejectedValueOnce(new Error('Bluetooth connection timed out'));
+    (nativeMock as Record<string, unknown>).getLastConnectFailureReason = vi
+      .fn()
+      .mockResolvedValue({ reason: 'did_fail_to_connect', cbErrorCode: 7, cbErrorDomain: 'CBErrorDomain' });
+
+    const connectPromise = driveConnect(adapter, 'A1B2C3');
+    await vi.runAllTimersAsync();
+    await connectPromise;
+
+    await expect(adapter.getLastConnectFailureReason()).resolves.toEqual({
+      reason: 'did_fail_to_connect',
+      cbErrorCode: 7,
+      cbErrorDomain: 'CBErrorDomain',
+    });
+  });
+
+  it('rethrows without a sub-reason fetch when a connect rejects on an old binary', async () => {
+    // Default native mock has no getLastConnectFailureReason — the old-binary
+    // case where the reject path must not attempt (or throw from) a fetch.
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    const connectError = new Error('Bluetooth connection timed out');
+    nativeMock.connect.mockRejectedValueOnce(connectError);
+
+    const connectPromise = driveConnect(adapter, 'A1B2C3');
+    await vi.runAllTimersAsync();
+
+    expect(await connectPromise).toBe(connectError);
+    await expect(adapter.getLastConnectFailureReason()).resolves.toBeNull();
+  });
+
+  it('clears a stale sub-reason on a subsequent successful connect', async () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    (nativeMock as Record<string, unknown>).getLastConnectFailureReason = vi
+      .fn()
+      .mockResolvedValue({ reason: 'discovery_timeout' });
+
+    // First attempt fails and stashes a sub-reason.
+    nativeMock.connect.mockRejectedValueOnce(new Error('Bluetooth connection timed out'));
+    const firstAttempt = driveConnect(adapter, 'A1B2C3');
+    await vi.runAllTimersAsync();
+    await firstAttempt;
+    await expect(adapter.getLastConnectFailureReason()).resolves.toEqual({ reason: 'discovery_timeout' });
+
+    // Second attempt succeeds — the stale sub-reason must be dropped.
+    const secondAttempt = driveConnect(adapter, 'A1B2C3');
+    await vi.runAllTimersAsync();
+    await secondAttempt;
+    await expect(adapter.getLastConnectFailureReason()).resolves.toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -361,6 +361,99 @@ describe('useBoardBluetooth', () => {
     );
   });
 
+  it('splits a connect_failed with the native sub-reason (#3676)', async () => {
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockRejectedValue(new Error('Bluetooth connection timed out')),
+    });
+    // Newer binary: the adapter reports which connect path failed.
+    (fakeAdapter as Record<string, unknown>).getLastConnectFailureReason = vi
+      .fn()
+      .mockResolvedValue({ reason: 'watchdog_timeout' });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    // Sentry (warning-level for connect_failed) carries the sub-reason tag.
+    expect(reportHandledError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          failure_category: 'connect_failed',
+          ble_connect_failure_reason: 'watchdog_timeout',
+        }),
+      }),
+    );
+    // The BluetoothConnectionFailed event carries it too.
+    const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed');
+    expect(failureCall?.[1]).toMatchObject({
+      failureReason: 'connect_failed',
+      bleConnectFailureReason: 'watchdog_timeout',
+    });
+  });
+
+  it('carries the CBError code on a didFailToConnect connect_failed (#3676)', async () => {
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockRejectedValue(new Error('Bluetooth connection timed out')),
+    });
+    (fakeAdapter as Record<string, unknown>).getLastConnectFailureReason = vi
+      .fn()
+      .mockResolvedValue({ reason: 'did_fail_to_connect', cbErrorCode: 7, cbErrorDomain: 'CBErrorDomain' });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(reportHandledError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          ble_connect_failure_reason: 'did_fail_to_connect',
+          ble_cb_error_code: 7,
+        }),
+      }),
+    );
+    const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed');
+    expect(failureCall?.[1]).toMatchObject({
+      bleConnectFailureReason: 'did_fail_to_connect',
+      bleCbErrorCode: 7,
+      bleCbErrorDomain: 'CBErrorDomain',
+    });
+  });
+
+  it('omits the connect-failure sub-reason on an old binary without the accessor (#3676)', async () => {
+    // No getLastConnectFailureReason on the adapter → no tag/prop, but still reports.
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockRejectedValue(new Error('Bluetooth connection timed out')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    const reportCall = vi
+      .mocked(reportHandledError)
+      .mock.calls.find(([, context]) => context?.tags?.failure_category === 'connect_failed');
+    expect(reportCall?.[1]?.tags).not.toHaveProperty('ble_connect_failure_reason');
+    const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed');
+    expect(failureCall?.[1]?.bleConnectFailureReason).toBeUndefined();
+  });
+
   it('serialises overlapping sendFramesToBoard calls so chunks never interleave', async () => {
     const writeEvents: string[] = [];
     let releaseFirstWrite!: () => void;

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -14,6 +14,7 @@ import type {
   BluetoothAdapter,
   BleConnection,
   BleConnectDiagnostics,
+  BleConnectFailureReason,
   BleDisconnectInfo,
   BleWriteDiagnostics,
   BoardScanFamily,
@@ -78,6 +79,11 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
   // connect attempt so both the failure analytics event and the Sentry report
   // can read it.
   private lastConnectDiagnostics: BleConnectDiagnostics | null = null;
+  // Sub-reason of the most recent failed connect (#3676): watchdog / didFailToConnect
+  // / discovery-timeout, fetched from the native stash after a rejected connect.
+  // Held until the next connect attempt so both the failure analytics event and
+  // the Sentry report can read it.
+  private lastConnectFailureReason: BleConnectFailureReason | null = null;
 
   constructor(
     private readonly devicePicker: DevicePickerFn,
@@ -239,9 +245,10 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       }
     }
 
-    // Fresh attempt: drop any stale connect diagnostics so a later read can't
-    // re-attribute a previous failure to this connect.
+    // Fresh attempt: drop any stale connect diagnostics/sub-reason so a later
+    // read can't re-attribute a previous failure to this connect.
     this.lastConnectDiagnostics = null;
+    this.lastConnectFailureReason = null;
     try {
       await native.connect(selectedDeviceId);
     } catch (error) {
@@ -251,6 +258,12 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       // outrun the native build) — then there's simply nothing to fetch.
       if (typeof native.getLastConnectDiagnostics === 'function') {
         this.lastConnectDiagnostics = await native.getLastConnectDiagnostics().catch(() => null);
+      }
+      // Likewise fetch the connect-failure sub-reason (watchdog / didFailToConnect
+      // / discovery-timeout) for the connect_failed split (#3676). Also absent on
+      // older binaries.
+      if (typeof native.getLastConnectFailureReason === 'function') {
+        this.lastConnectFailureReason = await native.getLastConnectFailureReason().catch(() => null);
       }
       throw error;
     }
@@ -374,6 +387,12 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
   // Sentry report) without a read consuming it.
   async getLastConnectDiagnostics(): Promise<BleConnectDiagnostics | null> {
     return this.lastConnectDiagnostics;
+  }
+
+  // Sub-reason of the most recent failed connect (#3676), held until the next
+  // connect attempt like the diagnostics above so a read doesn't consume it.
+  async getLastConnectFailureReason(): Promise<BleConnectFailureReason | null> {
+    return this.lastConnectFailureReason;
   }
 
   onDisconnect(callback: (info?: BleDisconnectInfo) => void): () => void {

--- a/packages/mobile/src/lib/ble/types.ts
+++ b/packages/mobile/src/lib/ble/types.ts
@@ -99,6 +99,18 @@ export type BleConnectDiagnostics = {
   discoveredServices: string[];
 };
 
+// Sub-reason a connect failed (#3676), for splitting the iOS `connect_failed`
+// cohort. Populated only by native iOS; a rejected connect promise can't carry
+// it, so the adapter stashes it and the hook reads it right after the failure.
+export type BleConnectFailureReason = {
+  // watchdog_timeout: our 8 s connect watchdog fired. did_fail_to_connect: a
+  // CoreBluetooth didFailToConnect (cbErrorCode/cbErrorDomain carry the CBError).
+  // discovery_timeout: the reconnect-by-last-known scan never saw the board.
+  reason: 'watchdog_timeout' | 'did_fail_to_connect' | 'discovery_timeout';
+  cbErrorCode?: number;
+  cbErrorDomain?: string;
+};
+
 export type BluetoothAdapter = {
   isAvailable(): Promise<boolean>;
   requestAndConnect(targetSerial?: string): Promise<BleConnection>;
@@ -112,4 +124,7 @@ export type BluetoothAdapter = {
   // Diagnostics of the adapter's most recent failed connect, for tagging a
   // service_missing report. Optional: only native iOS reports it.
   getLastConnectDiagnostics?(): Promise<BleConnectDiagnostics | null>;
+  // Sub-reason of the adapter's most recent failed connect, for splitting the
+  // connect_failed cohort on BluetoothConnectionFailed. Optional: only native iOS.
+  getLastConnectFailureReason?(): Promise<BleConnectFailureReason | null>;
 };

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -33,6 +33,7 @@ import {
 import { requestBleRuntimePermissions } from './use-ble-permissions';
 import { manufacturerCompanyId } from './advertisement';
 import type {
+  BleConnectFailureReason,
   BleDisconnectInfo,
   BleWriteDiagnostics,
   BluetoothAdapter,
@@ -926,6 +927,16 @@ export function useBoardBluetooth({
         // faults (unavailable / service_missing / unknown) stay at error level.
         const failureCategory = classifyBleFailure(error);
         const reportLevel = bleConnectReportLevel(failureCategory);
+        // For connect_failed, pull the native sub-reason (our 8 s watchdog vs a
+        // CoreBluetooth didFailToConnect vs a discovery timeout) so the iOS
+        // connect_failed cohort — BOARDSESH-80, 32 users — finally splits by cause
+        // (#3676). Fetched once up front so both the Sentry report and the
+        // BluetoothConnectionFailed event carry it. Null on Android / web / older
+        // binaries (the accessor is native-iOS-only and feature-gated).
+        let connectFailureReason: BleConnectFailureReason | null = null;
+        if (failureCategory === 'connect_failed') {
+          connectFailureReason = (await connectAdapter?.getLastConnectFailureReason?.().catch(() => null)) ?? null;
+        }
         if (reportLevel === null) {
           console.warn('Bluetooth device selection cancelled by user');
         } else {
@@ -948,6 +959,12 @@ export function useBoardBluetooth({
               source: 'ble-connect',
               failure_category: failureCategory,
               ...(discoveredServicesTag ? { ble_discovered_services: discoveredServicesTag } : {}),
+              // Sub-reason for the connect_failed cohort (#3676). cbErrorCode is
+              // present only for the didFailToConnect bucket.
+              ...(connectFailureReason ? { ble_connect_failure_reason: connectFailureReason.reason } : {}),
+              ...(connectFailureReason?.cbErrorCode !== undefined
+                ? { ble_cb_error_code: connectFailureReason.cbErrorCode }
+                : {}),
             },
           });
         }
@@ -994,6 +1011,13 @@ export function useBoardBluetooth({
           layoutId,
           sizeId,
           failureReason: failureCategory === 'unknown' ? classifyBleFailureReason(error) : failureCategory,
+          // Native iOS connect_failed sub-reason (#3676): watchdog_timeout |
+          // did_fail_to_connect | discovery_timeout, with the CBError code/domain
+          // on the didFailToConnect bucket. Undefined on Android / web / older
+          // binaries, so the props drop out cleanly.
+          bleConnectFailureReason: connectFailureReason?.reason,
+          bleCbErrorCode: connectFailureReason?.cbErrorCode,
+          bleCbErrorDomain: connectFailureReason?.cbErrorDomain,
           // Raw ble-plx codes (Android) so the real connect-failure cause and the
           // low-level GATT status are visible for re-measurement (#3608). Empty on
           // web / native iOS.

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -25,6 +25,10 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/BoardBleServiceDiscoveryTests.swift',
   },
   {
+    sourcePath: '../ios-tests/BoardBleConnectFailureReasonTests.swift',
+    projectPath: 'BoardseshTests/BoardBleConnectFailureReasonTests.swift',
+  },
+  {
     sourcePath: '../modules/live-activity/ios/BoardBleManager.swift',
     projectPath: 'BoardseshTests/LiveActivitySources/BoardBleManager.swift',
   },


### PR DESCRIPTION
## Summary

Fixes #3676.

On iOS a `connect_failed` (Sentry BOARDSESH-80 — "Bluetooth connection timed out", 32 users) carries **no cause**: the native error string alone can't tell our 8 s connect watchdog firing apart from a CoreBluetooth `didFailToConnect` or a reconnect-scan discovery timeout, and `blePlxErrorCodes` is Android-only. Without a sub-reason we can't diagnose the ~2.3% iOS connect-failure baseline (#3608's iOS mirror) that #3365's write-stall fix does not and cannot touch.

This is **instrumentation, not a behaviour change** — no `connectTimeout` bump, no auto-retry (the two-phone ping-pong risk the issue calls out).

**Native attribution**, mirroring the write telemetry (#3230) and connect-diagnostics (#3480) clear-on-read stashes:
- `BoardBleManager` records a `BoardBleConnectFailureReason` at each failure site — `watchdog_timeout` | `did_fail_to_connect` (+ CBError code/domain) | `discovery_timeout` — and exposes it to JS through a new bridged `getLastConnectFailureReason` (clear-on-read).
- The stash is cleared at the start of every `connectOnBleQueue`, so a `discovery_timeout` the widget `ReconnectBoardIntent` scan leaves unread can't be misattributed to a later JS connect.
- `NativeIosBleAdapter` fetches the sub-reason after a rejected connect (feature-gated); `useBoardBluetooth` tags the Sentry report (`ble_connect_failure_reason`, `ble_cb_error_code`) and the `BluetoothConnectionFailed` event (`bleConnectFailureReason`, `bleCbErrorCode`, `bleCbErrorDomain`) for the `connect_failed` cohort.

**Ships in the next binary.** The `getLastConnectFailureReason` bridge is native, so the sub-reason only starts flowing once a new store/TestFlight build reaches users. The JS reader is feature-gated (`typeof getLastConnectFailureReason === 'function'`), so the OTA JS is a safe no-op on older binaries.

**Cohort caveat / follow-up:** `discovery_timeout` is stashed for completeness but does not yet reach `BluetoothConnectionFailed` — the reconnect-by-last-known scan is driven by the native `ReconnectBoardIntent`, not the JS `connect`. So the initial BOARDSESH-80 cohort splits **watchdog_timeout vs did_fail_to_connect**. JS surfacing of the reconnect-intent path is a follow-up.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — passes (0 errors).
- `vp test run --project mobile native-ios-adapter.test use-board-bluetooth.test` — 95 passed. New: adapter fetch/clear-on-read for the sub-reason; hook tagging of Sentry + `BluetoothConnectionFailed` (incl. CBError code, old-binary omission).
- `vp check` on the changed files — formatted, no lint/type warnings.
- `vp run check:mobile-bundle` — iOS + Android bundles OK.
- Swift unit tests (`BoardBleConnectFailureReasonTests`, run by iOS CI on macOS): pure reason enum (NSError → reason, bridge dict shape) + the clear-on-read `takeConnectFailureReasonAnalytics` contract. Registered in `scripts/prepare-rn-ios-tests.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va