### PR TITLE
feat(web): migrate the auth form family onto the form kit (Wave 2)

### DIFF
--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -95,6 +95,9 @@
     "title": "Check your email",
     "description": "We sent you a verification link. Click the link in your email to verify your account.",
     "resendPlaceholder": "Enter your email to resend",
+    "fields": {
+      "email": "Email"
+    },
     "resend": "Resend Verification Email",
     "back": "Back to Login",
     "messages": {

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -69,7 +69,9 @@
     },
     "a11y": {
       "showPassword": "Show password",
-      "hidePassword": "Hide password"
+      "hidePassword": "Hide password",
+      "showConfirmPassword": "Show password confirmation",
+      "hideConfirmPassword": "Hide password confirmation"
     }
   },
   "error": {

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -258,6 +258,12 @@
         "descriptionPlaceholder": "Optional description...",
         "colorLabel": "Color (optional)",
         "submit": "Create"
+      },
+      "row": {
+        "removeAria": "Remove from playlist {{name}}",
+        "addAria": "Add to playlist {{name}}",
+        "climbCount_one": "{{count}} climb",
+        "climbCount_other": "{{count}} climbs"
       }
     },
     "sendToBoard": {

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -69,7 +69,9 @@
     },
     "a11y": {
       "showPassword": "Mostrar contraseña",
-      "hidePassword": "Ocultar contraseña"
+      "hidePassword": "Ocultar contraseña",
+      "showConfirmPassword": "Mostrar la confirmación de contraseña",
+      "hideConfirmPassword": "Ocultar la confirmación de contraseña"
     }
   },
   "error": {

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -95,6 +95,9 @@
     "title": "Revisa tu correo",
     "description": "Te enviamos un enlace de verificación. Haz clic en el enlace para verificar tu cuenta.",
     "resendPlaceholder": "Escribe tu correo para reenviar",
+    "fields": {
+      "email": "Correo electrónico"
+    },
     "resend": "Reenviar correo de verificación",
     "back": "Volver a iniciar sesión",
     "messages": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -258,6 +258,12 @@
         "descriptionPlaceholder": "Descripción opcional...",
         "colorLabel": "Color (opcional)",
         "submit": "Crear"
+      },
+      "row": {
+        "removeAria": "Quitar de la playlist {{name}}",
+        "addAria": "Añadir a la playlist {{name}}",
+        "climbCount_one": "{{count}} bloque",
+        "climbCount_other": "{{count}} bloques"
       }
     },
     "tick": {

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -69,7 +69,9 @@
     },
     "a11y": {
       "showPassword": "Afficher le mot de passe",
-      "hidePassword": "Masquer le mot de passe"
+      "hidePassword": "Masquer le mot de passe",
+      "showConfirmPassword": "Afficher la confirmation du mot de passe",
+      "hideConfirmPassword": "Masquer la confirmation du mot de passe"
     }
   },
   "error": {

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -95,6 +95,9 @@
     "title": "Consultez votre boîte mail",
     "description": "Nous vous avons envoyé un lien de vérification. Cliquez sur ce lien pour vérifier votre compte.",
     "resendPlaceholder": "Saisissez votre e-mail pour le recevoir à nouveau",
+    "fields": {
+      "email": "E-mail"
+    },
     "resend": "Renvoyer l'e-mail de vérification",
     "back": "Retour à la connexion",
     "messages": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -258,6 +258,12 @@
         "descriptionPlaceholder": "Description optionnelle...",
         "colorLabel": "Couleur (optionnelle)",
         "submit": "Créer"
+      },
+      "row": {
+        "removeAria": "Retirer de la playlist {{name}}",
+        "addAria": "Ajouter à la playlist {{name}}",
+        "climbCount_one": "{{count}} bloc",
+        "climbCount_other": "{{count}} blocs"
       }
     },
     "sendToBoard": {

--- a/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
+++ b/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
@@ -92,4 +92,13 @@ describe('ForgotPasswordContent', () => {
     expect(await screen.findByText('Too many requests')).toBeTruthy();
     expect(mockShowMessage).not.toHaveBeenCalled();
   });
+
+  it('shows a form-level error when the request throws (network down)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network down'));
+    const { container } = render(<ForgotPasswordContent />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'test@example.com' } });
+    submitForm(container);
+    expect(await screen.findByText('Failed to request password reset')).toBeTruthy();
+    expect(mockShowMessage).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
+++ b/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
@@ -81,7 +81,7 @@ describe('ForgotPasswordContent', () => {
     expect(screen.getByText(/if an account exists/i)).toBeTruthy();
   });
 
-  it('shows error toast when API returns failure', async () => {
+  it('shows a form-level error when the API returns failure (never a toast while the form is visible)', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       json: async () => ({ error: 'Too many requests' }),
@@ -89,6 +89,7 @@ describe('ForgotPasswordContent', () => {
     const { container } = render(<ForgotPasswordContent />);
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'test@example.com' } });
     submitForm(container);
-    await waitFor(() => expect(mockShowMessage).toHaveBeenCalledWith('Too many requests', 'error'));
+    expect(await screen.findByText('Too many requests')).toBeTruthy();
+    expect(mockShowMessage).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/auth/forgot-password/forgot-password-content.tsx
+++ b/packages/web/app/auth/forgot-password/forgot-password-content.tsx
@@ -5,29 +5,28 @@ import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
 import MailOutlined from '@mui/icons-material/MailOutlined';
 import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
 import LocaleLink from '@/app/components/i18n/locale-link';
-import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
 import { EMAIL_REGEX } from '@/app/components/auth/validate-fields';
+import { FormShell, FormField, FormActions } from '@/app/components/form';
 
 export default function ForgotPasswordContent() {
   const { t } = useTranslation('auth');
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-  const { showMessage } = useSnackbar();
 
   const handleSubmit = async () => {
+    setFormError(null);
     const trimmedEmail = email.trim();
     if (!trimmedEmail) {
       setEmailError(t('forgotPassword.validation.emailRequired'));
@@ -49,14 +48,14 @@ export default function ForgotPasswordContent() {
       const data = await response.json();
 
       if (!response.ok) {
-        showMessage(data.error || t('forgotPassword.toasts.failed'), 'error');
+        setFormError(data.error || t('forgotPassword.toasts.failed'));
         return;
       }
 
       setSubmitted(true);
     } catch (error) {
       console.error('Forgot password error:', error);
-      showMessage(t('forgotPassword.toasts.failed'), 'error');
+      setFormError(t('forgotPassword.toasts.failed'));
     } finally {
       setLoading(false);
     }
@@ -86,68 +85,64 @@ export default function ForgotPasswordContent() {
       <Box component="main" sx={{ padding: '24px', display: 'flex', justifyContent: 'center', paddingTop: '48px' }}>
         <Card sx={{ width: '100%', maxWidth: 400 }}>
           <CardContent>
-            <Stack
-              spacing={2}
-              component="form"
-              onSubmit={(e) => {
-                e.preventDefault();
-                void handleSubmit();
-              }}
-              noValidate
-            >
-              {submitted ? (
-                <>
-                  <Typography variant="body1" component="p">
-                    {t('forgotPassword.success')}
-                  </Typography>
-                  <Button component={LocaleLink} variant="text" href="/auth/login">
-                    {t('forgotPassword.back')}
-                  </Button>
-                </>
-              ) : (
-                <>
-                  <Typography variant="body1" component="p" color="text.secondary">
-                    {t('forgotPassword.description')}
-                  </Typography>
+            {submitted ? (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <Typography variant="body1" component="p">
+                  {t('forgotPassword.success')}
+                </Typography>
+                <Button component={LocaleLink} variant="text" href="/auth/login">
+                  {t('forgotPassword.back')}
+                </Button>
+              </Box>
+            ) : (
+              <FormShell
+                maxWidth={false}
+                error={formError}
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void handleSubmit();
+                }}
+              >
+                <Typography variant="body1" component="p" color="text.secondary">
+                  {t('forgotPassword.description')}
+                </Typography>
 
-                  <TextField
-                    label={t('forgotPassword.fields.email')}
-                    type="email"
-                    placeholder={t('login.placeholders.email')}
-                    value={email}
-                    onChange={(e) => {
-                      setEmail(e.target.value);
-                      if (emailError) setEmailError(null);
-                    }}
-                    error={!!emailError}
-                    helperText={emailError}
-                    required
-                    slotProps={{
-                      input: {
-                        startAdornment: (
-                          <InputAdornment position="start">
-                            <MailOutlined />
-                          </InputAdornment>
-                        ),
-                      },
-                    }}
-                  />
+                <FormField label={t('forgotPassword.fields.email')} required error={emailError}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      type="email"
+                      autoComplete="email"
+                      placeholder={t('login.placeholders.email')}
+                      value={email}
+                      onChange={(e) => {
+                        setEmail(e.target.value);
+                        if (emailError) setEmailError(null);
+                      }}
+                      required
+                      fullWidth
+                      error={Boolean(field.error)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <MailOutlined />
+                            </InputAdornment>
+                          ),
+                        },
+                        htmlInput: { 'aria-describedby': field.describedBy },
+                      }}
+                    />
+                  )}
+                </FormField>
 
-                  <Button
-                    type="submit"
-                    variant="contained"
-                    disabled={loading}
-                    startIcon={loading ? <CircularProgress size={16} color="inherit" /> : undefined}
-                  >
-                    {t('forgotPassword.submit')}
-                  </Button>
+                <FormActions submitLabel={t('forgotPassword.submit')} submitting={loading} layout="stacked" />
 
-                  <Button component={LocaleLink} variant="text" href="/auth/login">
-                    {t('forgotPassword.back')}
-                  </Button>
-                </>
-              )}
-            </Stack>
+                <Button component={LocaleLink} variant="text" href="/auth/login">
+                  {t('forgotPassword.back')}
+                </Button>
+              </FormShell>
+            )}
           </CardContent>
         </Card>
       </Box>

--- a/packages/web/app/auth/forgot-password/forgot-password-content.tsx
+++ b/packages/web/app/auth/forgot-password/forgot-password-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
@@ -15,7 +15,7 @@ import BackButton from '@/app/components/back-button';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { themeTokens } from '@/app/theme/theme-config';
 import { EMAIL_REGEX } from '@/app/components/auth/validate-fields';
-import { FormShell, FormField, FormActions } from '@/app/components/form';
+import { FormShell, FormField, FormActions, focusFirstInvalidAfterRender } from '@/app/components/form';
 
 export default function ForgotPasswordContent() {
   const { t } = useTranslation('auth');
@@ -24,16 +24,19 @@ export default function ForgotPasswordContent() {
   const [formError, setFormError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const formId = useId();
 
   const handleSubmit = async () => {
     setFormError(null);
     const trimmedEmail = email.trim();
     if (!trimmedEmail) {
       setEmailError(t('forgotPassword.validation.emailRequired'));
+      focusFirstInvalidAfterRender(formId);
       return;
     }
     if (!EMAIL_REGEX.test(trimmedEmail)) {
       setEmailError(t('forgotPassword.validation.emailInvalid'));
+      focusFirstInvalidAfterRender(formId);
       return;
     }
 
@@ -96,6 +99,7 @@ export default function ForgotPasswordContent() {
               </Box>
             ) : (
               <FormShell
+                id={formId}
                 maxWidth={false}
                 error={formError}
                 onSubmit={(event) => {

--- a/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
+++ b/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
@@ -73,6 +73,8 @@ describe('AuthPageContent — login server errors', () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    // Failed assertions must not leak a fetch stub into later tests.
+    vi.unstubAllGlobals();
   });
 
   it('shows the invalid-credentials alert when signIn reports an auth error', async () => {
@@ -108,7 +110,6 @@ describe('AuthPageContent — login server errors', () => {
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Email already registered/i);
-    vi.unstubAllGlobals();
   });
 
   it('surfaces a thrown register fetch (network down) in the register form alert', async () => {
@@ -119,7 +120,6 @@ describe('AuthPageContent — login server errors', () => {
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Registration failed\. Please try again/i);
-    vi.unstubAllGlobals();
   });
 
   it('does not resurface a stale register error after a tab round-trip', async () => {
@@ -132,7 +132,6 @@ describe('AuthPageContent — login server errors', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Login' }));
     fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));
     expect(screen.queryByRole('alert')).toBeNull();
-    vi.unstubAllGlobals();
   });
 
   it('moves focus to the first invalid field after a failed-validation submit', async () => {

--- a/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
+++ b/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
@@ -53,6 +53,14 @@ async function submitLogin() {
   fireEvent.click(screen.getByRole('button', { name: 'Login' }));
 }
 
+async function submitRegister() {
+  fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));
+  fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'climber@example.com' } });
+  fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'hunter2222' } });
+  fireEvent.change(screen.getByLabelText('Confirm Password'), { target: { value: 'hunter2222' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+}
+
 describe('AuthPageContent — login server errors', () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
@@ -86,6 +94,44 @@ describe('AuthPageContent — login server errors', () => {
     expect(alert.textContent).toMatch(/Authentication failed/i);
     // The form must stay interactive — no frozen state.
     expect((screen.getByRole('button', { name: 'Login' }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('surfaces a register API error in the register form alert', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({ ok: false, json: () => Promise.resolve({ error: 'Email already registered' }) }),
+    );
+    render(<AuthPageContent />);
+
+    await submitRegister();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Email already registered/i);
+    vi.unstubAllGlobals();
+  });
+
+  it('surfaces a thrown register fetch (network down) in the register form alert', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('network down')));
+    render(<AuthPageContent />);
+
+    await submitRegister();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Registration failed\. Please try again/i);
+    vi.unstubAllGlobals();
+  });
+
+  it('does not resurface a stale register error after a tab round-trip', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('network down')));
+    render(<AuthPageContent />);
+
+    await submitRegister();
+    await screen.findByRole('alert');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Login' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));
+    expect(screen.queryByRole('alert')).toBeNull();
+    vi.unstubAllGlobals();
   });
 
   it('moves focus to the first invalid field after a failed-validation submit', async () => {

--- a/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
+++ b/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Server-error paths for the standalone login page: auth failures and thrown
+ * signIn calls (network down) must surface in the form-level alert, and a
+ * stale error must not resurface after a tab round-trip.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const mockSignIn = vi.fn();
+vi.mock('next-auth/react', () => ({
+  signIn: (...args: unknown[]) => mockSignIn(...args),
+  useSession: () => ({ status: 'unauthenticated', data: null }),
+}));
+
+const mockSearchParams = new URLSearchParams();
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock('@/app/lib/i18n/use-locale-router', () => ({
+  useLocaleRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathnameWithoutLocale: () => '/auth/login',
+}));
+
+vi.mock('@/app/components/auth/social-login-buttons', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+
+vi.mock('@/app/lib/analytics', () => ({
+  track: vi.fn(),
+  setPersonProperties: vi.fn(),
+}));
+
+const { default: AuthPageContent } = await import('../auth-page-content');
+
+async function submitLogin() {
+  fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'climber@example.com' } });
+  fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'hunter22' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Login' }));
+}
+
+describe('AuthPageContent — login server errors', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The network-failure path console.errors by design.
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('shows the invalid-credentials alert when signIn reports an auth error', async () => {
+    mockSignIn.mockResolvedValueOnce({ error: 'CredentialsSignin', ok: false });
+    render(<AuthPageContent />);
+
+    await submitLogin();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Invalid email or password/i);
+  });
+
+  it('shows the generic auth-failed alert when signIn throws (network down)', async () => {
+    mockSignIn.mockRejectedValueOnce(new Error('fetch failed'));
+    render(<AuthPageContent />);
+
+    await submitLogin();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Authentication failed/i);
+    // The form must stay interactive — no frozen state.
+    expect((screen.getByRole('button', { name: 'Login' }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('does not resurface a stale login error after a tab round-trip', async () => {
+    mockSignIn.mockRejectedValueOnce(new Error('fetch failed'));
+    render(<AuthPageContent />);
+
+    await submitLogin();
+    await screen.findByRole('alert');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Login' }));
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
+++ b/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 
 vi.mock('react-i18next', () => ({
@@ -86,6 +86,18 @@ describe('AuthPageContent — login server errors', () => {
     expect(alert.textContent).toMatch(/Authentication failed/i);
     // The form must stay interactive — no frozen state.
     expect((screen.getByRole('button', { name: 'Login' }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('moves focus to the first invalid field after a failed-validation submit', async () => {
+    render(<AuthPageContent />);
+
+    // Submit with both fields empty — validation fails, no signIn call.
+    fireEvent.click(screen.getByRole('button', { name: 'Login' }));
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByLabelText('Email'));
+    });
+    expect(mockSignIn).not.toHaveBeenCalled();
   });
 
   it('does not resurface a stale login error after a tab round-trip', async () => {

--- a/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
+++ b/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
@@ -55,6 +55,7 @@ async function submitLogin() {
 
 async function submitRegister() {
   fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Crusher' } });
   fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'climber@example.com' } });
   fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'hunter2222' } });
   fireEvent.change(screen.getByLabelText('Confirm Password'), { target: { value: 'hunter2222' } });

--- a/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
+++ b/packages/web/app/auth/login/__tests__/auth-page-server-errors.test.tsx
@@ -47,13 +47,13 @@ vi.mock('@/app/lib/analytics', () => ({
 
 const { default: AuthPageContent } = await import('../auth-page-content');
 
-async function submitLogin() {
+function submitLogin() {
   fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'climber@example.com' } });
   fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'hunter22' } });
   fireEvent.click(screen.getByRole('button', { name: 'Login' }));
 }
 
-async function submitRegister() {
+function submitRegister() {
   fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));
   fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Crusher' } });
   fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'climber@example.com' } });
@@ -81,7 +81,7 @@ describe('AuthPageContent — login server errors', () => {
     mockSignIn.mockResolvedValueOnce({ error: 'CredentialsSignin', ok: false });
     render(<AuthPageContent />);
 
-    await submitLogin();
+    submitLogin();
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Invalid email or password/i);
@@ -91,7 +91,7 @@ describe('AuthPageContent — login server errors', () => {
     mockSignIn.mockRejectedValueOnce(new Error('fetch failed'));
     render(<AuthPageContent />);
 
-    await submitLogin();
+    submitLogin();
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Authentication failed/i);
@@ -106,7 +106,7 @@ describe('AuthPageContent — login server errors', () => {
     );
     render(<AuthPageContent />);
 
-    await submitRegister();
+    submitRegister();
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Email already registered/i);
@@ -116,7 +116,7 @@ describe('AuthPageContent — login server errors', () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('network down')));
     render(<AuthPageContent />);
 
-    await submitRegister();
+    submitRegister();
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Registration failed\. Please try again/i);
@@ -126,7 +126,7 @@ describe('AuthPageContent — login server errors', () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('network down')));
     render(<AuthPageContent />);
 
-    await submitRegister();
+    submitRegister();
     await screen.findByRole('alert');
 
     fireEvent.click(screen.getByRole('tab', { name: 'Login' }));
@@ -150,7 +150,7 @@ describe('AuthPageContent — login server errors', () => {
     mockSignIn.mockRejectedValueOnce(new Error('fetch failed'));
     render(<AuthPageContent />);
 
-    await submitLogin();
+    submitLogin();
     await screen.findByRole('alert');
 
     fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useId } from 'react';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Typography from '@mui/material/Typography';
@@ -22,7 +22,7 @@ import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-lo
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
 import SocialLoginButtons from '@/app/components/auth/social-login-buttons';
-import { FormShell, FormSection, FormField, FormActions } from '@/app/components/form';
+import { FormShell, FormSection, FormField, FormActions, focusFirstInvalidAfterRender } from '@/app/components/form';
 import {
   initialLoginValues,
   initialRegisterValues,
@@ -48,6 +48,8 @@ export default function AuthPageContent() {
   const callbackUrl = searchParams.get('callbackUrl') || '/';
   const error = searchParams.get('error');
   const { showMessage } = useSnackbar();
+  const loginFormId = useId();
+  const registerFormId = useId();
 
   const [loginValues, setLoginValues] = useState(initialLoginValues);
   const [loginErrors, setLoginErrors] = useState<LoginErrors>({});
@@ -106,7 +108,10 @@ export default function AuthPageContent() {
     setLoginServerError(null);
     const errors = validateLoginFields(loginValues, t);
     setLoginErrors(errors);
-    if (Object.keys(errors).length > 0) return;
+    if (Object.keys(errors).length > 0) {
+      focusFirstInvalidAfterRender(loginFormId);
+      return;
+    }
 
     try {
       setLoginLoading(true);
@@ -143,7 +148,10 @@ export default function AuthPageContent() {
     setRegisterServerError(null);
     const errors = validateRegisterFields(registerValues, t);
     setRegisterErrors(errors);
-    if (Object.keys(errors).length > 0) return;
+    if (Object.keys(errors).length > 0) {
+      focusFirstInvalidAfterRender(registerFormId);
+      return;
+    }
 
     try {
       setRegisterLoading(true);
@@ -289,6 +297,7 @@ export default function AuthPageContent() {
 
             <TabPanel value={activeTab} index="login">
               <FormShell
+                id={loginFormId}
                 onSubmit={(e) => {
                   e.preventDefault();
                   void handleLogin();
@@ -370,6 +379,7 @@ export default function AuthPageContent() {
 
             <TabPanel value={activeTab} index="register">
               <FormShell
+                id={registerFormId}
                 onSubmit={(e) => {
                   e.preventDefault();
                   void handleRegister();

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -284,10 +284,12 @@ export default function AuthPageContent() {
               value={activeTab}
               onChange={(_, selectedTab) => {
                 setActiveTab(selectedTab);
-                // A server error belongs to the submit that produced it — don't
-                // resurface a stale one after a tab round-trip.
+                // Errors belong to the submit that produced them — don't
+                // resurface stale ones after a tab round-trip.
                 setLoginServerError(null);
                 setRegisterServerError(null);
+                setLoginErrors({});
+                setRegisterErrors({});
               }}
               centered
             >

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -130,7 +130,10 @@ export default function AuthPageContent() {
         router.push(callbackUrl);
       }
     } catch (error) {
+      // A thrown signIn (network down, server unreachable) must not leave the
+      // form frozen with no feedback — surface it like the auth-error path.
       console.error('Login error:', error);
+      setLoginServerError(t('login.toasts.authFailed'));
     } finally {
       setLoginLoading(false);
     }

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -272,7 +272,17 @@ export default function AuthPageContent() {
               </Typography>
             </Stack>
 
-            <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} centered>
+            <Tabs
+              value={activeTab}
+              onChange={(_, selectedTab) => {
+                setActiveTab(selectedTab);
+                // A server error belongs to the submit that produced it — don't
+                // resurface a stale one after a tab round-trip.
+                setLoginServerError(null);
+                setRegisterServerError(null);
+              }}
+              centered
+            >
               <Tab label={t('login.tabs.signIn')} value="login" />
               <Tab label={t('login.tabs.signUp')} value="register" />
             </Tabs>

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -1,15 +1,14 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
-import CircularProgress from '@mui/material/CircularProgress';
+import MuiLink from '@mui/material/Link';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import MuiDivider from '@mui/material/Divider';
@@ -23,6 +22,7 @@ import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-lo
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
 import SocialLoginButtons from '@/app/components/auth/social-login-buttons';
+import { FormShell, FormSection, FormField, FormActions } from '@/app/components/form';
 import {
   initialLoginValues,
   initialRegisterValues,
@@ -51,21 +51,25 @@ export default function AuthPageContent() {
 
   const [loginValues, setLoginValues] = useState(initialLoginValues);
   const [loginErrors, setLoginErrors] = useState<LoginErrors>({});
+  const [loginServerError, setLoginServerError] = useState<string | null>(null);
   const [registerValues, setRegisterValues] = useState(initialRegisterValues);
   const [registerErrors, setRegisterErrors] = useState<RegisterErrors>({});
+  const [registerServerError, setRegisterServerError] = useState<string | null>(null);
   const [loginLoading, setLoginLoading] = useState(false);
   const [registerLoading, setRegisterLoading] = useState(false);
   const [activeTab, setActiveTab] = useState('login');
 
   const verified = searchParams.get('verified');
 
-  // Show error message from NextAuth
+  // Surface NextAuth redirect errors (failed OAuth round-trip or credentials
+  // redirect) as the login form's inline alert rather than a transient toast —
+  // the form is on screen, so the error belongs with it.
   useEffect(() => {
     if (error) {
       if (error === 'CredentialsSignin') {
-        showMessage(t('login.toasts.invalidCredentials'), 'error');
+        setLoginServerError(t('login.toasts.invalidCredentials'));
       } else {
-        showMessage(t('login.toasts.authFailed'), 'error');
+        setLoginServerError(t('login.toasts.authFailed'));
       }
       // NextAuth redirects back to /auth/login?error=... after either a failed
       // OAuth round-trip or — under some flows — a credentials redirect path.
@@ -82,7 +86,7 @@ export default function AuthPageContent() {
       const queryString = cleanParams.toString();
       router.replace(queryString ? `${pathnameWithoutLocale}?${queryString}` : pathnameWithoutLocale);
     }
-  }, [error, showMessage, t, router, pathnameWithoutLocale, searchParams]);
+  }, [error, t, router, pathnameWithoutLocale, searchParams]);
 
   // Show success message when email is verified
   useEffect(() => {
@@ -99,6 +103,7 @@ export default function AuthPageContent() {
   }, [status, router, callbackUrl]);
 
   const handleLogin = async () => {
+    setLoginServerError(null);
     const errors = validateLoginFields(loginValues, t);
     setLoginErrors(errors);
     if (Object.keys(errors).length > 0) return;
@@ -114,7 +119,7 @@ export default function AuthPageContent() {
       });
 
       if (result?.error) {
-        showMessage(t('login.toasts.invalidCredentials'), 'error');
+        setLoginServerError(t('login.toasts.invalidCredentials'));
         track('Login Failed', {
           auth_method: 'credentials',
           failure_reason: safeAuthError(result.error),
@@ -132,6 +137,7 @@ export default function AuthPageContent() {
   };
 
   const handleRegister = async () => {
+    setRegisterServerError(null);
     const errors = validateRegisterFields(registerValues, t);
     setRegisterErrors(errors);
     if (Object.keys(errors).length > 0) return;
@@ -155,7 +161,7 @@ export default function AuthPageContent() {
       const data = await response.json();
 
       if (!response.ok) {
-        showMessage(data.error || t('login.toasts.registrationFailed'), 'error');
+        setRegisterServerError(data.error || t('login.toasts.registrationFailed'));
         return;
       }
 
@@ -209,7 +215,7 @@ export default function AuthPageContent() {
       }
     } catch (error) {
       console.error('Registration error:', error);
-      showMessage(t('login.toasts.registrationFailedRetry'), 'error');
+      setRegisterServerError(t('login.toasts.registrationFailedRetry'));
     } finally {
       setRegisterLoading(false);
     }
@@ -269,199 +275,215 @@ export default function AuthPageContent() {
             </Tabs>
 
             <TabPanel value={activeTab} index="login">
-              <Box
-                component="form"
-                onSubmit={(e: React.FormEvent) => {
+              <FormShell
+                onSubmit={(e) => {
                   e.preventDefault();
                   void handleLogin();
                 }}
-                sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+                error={loginServerError}
+                maxWidth={false}
               >
-                <TextField
-                  label={t('login.fields.email')}
-                  placeholder={t('login.placeholders.email')}
-                  variant="outlined"
-                  size="medium"
-                  fullWidth
-                  value={loginValues.email}
-                  onChange={(e) => {
-                    setLoginValues((prev) => ({ ...prev, email: e.target.value }));
-                    if (loginErrors.email) setLoginErrors((prev) => ({ ...prev, email: undefined }));
-                  }}
-                  error={!!loginErrors.email}
-                  helperText={loginErrors.email}
-                  slotProps={{
-                    input: {
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <MailOutlined />
-                        </InputAdornment>
-                      ),
-                    },
-                  }}
-                />
+                <FormSection>
+                  <FormField label={t('login.fields.email')} error={loginErrors.email}>
+                    {(field) => (
+                      <TextField
+                        id={field.id}
+                        type="email"
+                        autoComplete="username"
+                        placeholder={t('login.placeholders.email')}
+                        fullWidth
+                        value={loginValues.email}
+                        onChange={(e) => {
+                          setLoginValues((prev) => ({ ...prev, email: e.target.value }));
+                          if (loginErrors.email) setLoginErrors((prev) => ({ ...prev, email: undefined }));
+                          if (loginServerError) setLoginServerError(null);
+                        }}
+                        error={Boolean(field.error)}
+                        slotProps={{
+                          input: {
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <MailOutlined />
+                              </InputAdornment>
+                            ),
+                          },
+                          htmlInput: { autoCapitalize: 'none', 'aria-describedby': field.describedBy },
+                        }}
+                      />
+                    )}
+                  </FormField>
 
-                <TextField
-                  label={t('login.fields.password')}
-                  type="password"
-                  placeholder={t('login.placeholders.password')}
-                  variant="outlined"
-                  size="medium"
-                  fullWidth
-                  value={loginValues.password}
-                  onChange={(e) => {
-                    setLoginValues((prev) => ({ ...prev, password: e.target.value }));
-                    if (loginErrors.password) setLoginErrors((prev) => ({ ...prev, password: undefined }));
-                  }}
-                  error={!!loginErrors.password}
-                  helperText={loginErrors.password}
-                  slotProps={{
-                    input: {
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <LockOutlined />
-                        </InputAdornment>
-                      ),
-                    },
-                  }}
-                />
+                  <FormField
+                    label={t('login.fields.password')}
+                    error={loginErrors.password}
+                    labelAccessory={
+                      <MuiLink component={LocaleLink} href="/auth/forgot-password" variant="body2">
+                        {t('login.links.forgotPassword')}
+                      </MuiLink>
+                    }
+                  >
+                    {(field) => (
+                      <TextField
+                        id={field.id}
+                        type="password"
+                        autoComplete="current-password"
+                        placeholder={t('login.placeholders.password')}
+                        fullWidth
+                        value={loginValues.password}
+                        onChange={(e) => {
+                          setLoginValues((prev) => ({ ...prev, password: e.target.value }));
+                          if (loginErrors.password) setLoginErrors((prev) => ({ ...prev, password: undefined }));
+                          if (loginServerError) setLoginServerError(null);
+                        }}
+                        error={Boolean(field.error)}
+                        slotProps={{
+                          input: {
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <LockOutlined />
+                              </InputAdornment>
+                            ),
+                          },
+                          htmlInput: { 'aria-describedby': field.describedBy },
+                        }}
+                      />
+                    )}
+                  </FormField>
+                </FormSection>
 
-                <Button
-                  variant="contained"
-                  type="submit"
-                  disabled={loginLoading}
-                  startIcon={loginLoading ? <CircularProgress size={16} /> : undefined}
-                  fullWidth
-                  size="large"
-                >
-                  {t('login.submit.signIn')}
-                </Button>
-
-                <Button component={LocaleLink} variant="text" href="/auth/forgot-password">
-                  {t('login.links.forgotPassword')}
-                </Button>
-              </Box>
+                <FormActions submitLabel={t('login.submit.signIn')} submitting={loginLoading} layout="stacked" />
+              </FormShell>
             </TabPanel>
 
             <TabPanel value={activeTab} index="register">
-              <Box
-                component="form"
-                onSubmit={(e: React.FormEvent) => {
+              <FormShell
+                onSubmit={(e) => {
                   e.preventDefault();
                   void handleRegister();
                 }}
-                sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+                error={registerServerError}
+                maxWidth={false}
               >
-                <TextField
-                  label={t('login.fields.name')}
-                  placeholder={t('login.placeholders.name')}
-                  variant="outlined"
-                  size="medium"
-                  fullWidth
-                  value={registerValues.name}
-                  onChange={(e) => {
-                    setRegisterValues((prev) => ({ ...prev, name: e.target.value }));
-                    if (registerErrors.name) setRegisterErrors((prev) => ({ ...prev, name: undefined }));
-                  }}
-                  error={!!registerErrors.name}
-                  helperText={registerErrors.name}
-                  slotProps={{
-                    input: {
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <PersonOutlined />
-                        </InputAdornment>
-                      ),
-                    },
-                  }}
-                />
+                <FormSection>
+                  <FormField label={t('login.fields.name')} error={registerErrors.name}>
+                    {(field) => (
+                      <TextField
+                        id={field.id}
+                        autoComplete="name"
+                        placeholder={t('login.placeholders.name')}
+                        fullWidth
+                        value={registerValues.name}
+                        onChange={(e) => {
+                          setRegisterValues((prev) => ({ ...prev, name: e.target.value }));
+                          if (registerErrors.name) setRegisterErrors((prev) => ({ ...prev, name: undefined }));
+                          if (registerServerError) setRegisterServerError(null);
+                        }}
+                        error={Boolean(field.error)}
+                        slotProps={{
+                          input: {
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <PersonOutlined />
+                              </InputAdornment>
+                            ),
+                          },
+                          htmlInput: { 'aria-describedby': field.describedBy },
+                        }}
+                      />
+                    )}
+                  </FormField>
 
-                <TextField
-                  label={t('login.fields.email')}
-                  placeholder={t('login.placeholders.email')}
-                  variant="outlined"
-                  size="medium"
-                  fullWidth
-                  value={registerValues.email}
-                  onChange={(e) => {
-                    setRegisterValues((prev) => ({ ...prev, email: e.target.value }));
-                    if (registerErrors.email) setRegisterErrors((prev) => ({ ...prev, email: undefined }));
-                  }}
-                  error={!!registerErrors.email}
-                  helperText={registerErrors.email}
-                  slotProps={{
-                    input: {
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <MailOutlined />
-                        </InputAdornment>
-                      ),
-                    },
-                  }}
-                />
+                  <FormField label={t('login.fields.email')} error={registerErrors.email}>
+                    {(field) => (
+                      <TextField
+                        id={field.id}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={t('login.placeholders.email')}
+                        fullWidth
+                        value={registerValues.email}
+                        onChange={(e) => {
+                          setRegisterValues((prev) => ({ ...prev, email: e.target.value }));
+                          if (registerErrors.email) setRegisterErrors((prev) => ({ ...prev, email: undefined }));
+                          if (registerServerError) setRegisterServerError(null);
+                        }}
+                        error={Boolean(field.error)}
+                        slotProps={{
+                          input: {
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <MailOutlined />
+                              </InputAdornment>
+                            ),
+                          },
+                          htmlInput: { autoCapitalize: 'none', 'aria-describedby': field.describedBy },
+                        }}
+                      />
+                    )}
+                  </FormField>
 
-                <TextField
-                  label={t('login.fields.password')}
-                  type="password"
-                  placeholder={t('login.placeholders.passwordWithMin')}
-                  variant="outlined"
-                  size="medium"
-                  fullWidth
-                  value={registerValues.password}
-                  onChange={(e) => {
-                    setRegisterValues((prev) => ({ ...prev, password: e.target.value }));
-                    if (registerErrors.password) setRegisterErrors((prev) => ({ ...prev, password: undefined }));
-                  }}
-                  error={!!registerErrors.password}
-                  helperText={registerErrors.password}
-                  slotProps={{
-                    input: {
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <LockOutlined />
-                        </InputAdornment>
-                      ),
-                    },
-                  }}
-                />
+                  <FormField label={t('login.fields.password')} error={registerErrors.password}>
+                    {(field) => (
+                      <TextField
+                        id={field.id}
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={t('login.placeholders.passwordWithMin')}
+                        fullWidth
+                        value={registerValues.password}
+                        onChange={(e) => {
+                          setRegisterValues((prev) => ({ ...prev, password: e.target.value }));
+                          if (registerErrors.password) setRegisterErrors((prev) => ({ ...prev, password: undefined }));
+                          if (registerServerError) setRegisterServerError(null);
+                        }}
+                        error={Boolean(field.error)}
+                        slotProps={{
+                          input: {
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <LockOutlined />
+                              </InputAdornment>
+                            ),
+                          },
+                          htmlInput: { 'aria-describedby': field.describedBy },
+                        }}
+                      />
+                    )}
+                  </FormField>
 
-                <TextField
-                  label={t('login.fields.confirmPassword')}
-                  type="password"
-                  placeholder={t('login.placeholders.confirmPassword')}
-                  variant="outlined"
-                  size="medium"
-                  fullWidth
-                  value={registerValues.confirmPassword}
-                  onChange={(e) => {
-                    setRegisterValues((prev) => ({ ...prev, confirmPassword: e.target.value }));
-                    if (registerErrors.confirmPassword)
-                      setRegisterErrors((prev) => ({ ...prev, confirmPassword: undefined }));
-                  }}
-                  error={!!registerErrors.confirmPassword}
-                  helperText={registerErrors.confirmPassword}
-                  slotProps={{
-                    input: {
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <LockOutlined />
-                        </InputAdornment>
-                      ),
-                    },
-                  }}
-                />
+                  <FormField label={t('login.fields.confirmPassword')} error={registerErrors.confirmPassword}>
+                    {(field) => (
+                      <TextField
+                        id={field.id}
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={t('login.placeholders.confirmPassword')}
+                        fullWidth
+                        value={registerValues.confirmPassword}
+                        onChange={(e) => {
+                          setRegisterValues((prev) => ({ ...prev, confirmPassword: e.target.value }));
+                          if (registerErrors.confirmPassword)
+                            setRegisterErrors((prev) => ({ ...prev, confirmPassword: undefined }));
+                          if (registerServerError) setRegisterServerError(null);
+                        }}
+                        error={Boolean(field.error)}
+                        slotProps={{
+                          input: {
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <LockOutlined />
+                              </InputAdornment>
+                            ),
+                          },
+                          htmlInput: { 'aria-describedby': field.describedBy },
+                        }}
+                      />
+                    )}
+                  </FormField>
+                </FormSection>
 
-                <Button
-                  variant="contained"
-                  type="submit"
-                  disabled={registerLoading}
-                  startIcon={registerLoading ? <CircularProgress size={16} /> : undefined}
-                  fullWidth
-                  size="large"
-                >
-                  {t('login.submit.signUp')}
-                </Button>
-              </Box>
+                <FormActions submitLabel={t('login.submit.signUp')} submitting={registerLoading} layout="stacked" />
+              </FormShell>
             </TabPanel>
 
             <MuiDivider>

--- a/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
+++ b/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
@@ -124,7 +124,7 @@ describe('ResetPasswordContent', () => {
     await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith('/auth/login'));
   });
 
-  it('shows error toast when API returns failure', async () => {
+  it('shows a form-level error when the API returns failure (never a toast while the form is visible)', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       json: async () => ({ error: 'Invalid or expired reset link' }),
@@ -133,7 +133,8 @@ describe('ResetPasswordContent', () => {
     fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: 'SecurePass1!' } });
     fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: 'SecurePass1!' } });
     submitForm();
-    await waitFor(() => expect(mockShowMessage).toHaveBeenCalledWith('Invalid or expired reset link', 'error'));
+    expect(await screen.findByText('Invalid or expired reset link')).toBeTruthy();
+    expect(mockShowMessage).not.toHaveBeenCalled();
     expect(mockRouterReplace).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
+++ b/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
@@ -137,4 +137,15 @@ describe('ResetPasswordContent', () => {
     expect(mockShowMessage).not.toHaveBeenCalled();
     expect(mockRouterReplace).not.toHaveBeenCalled();
   });
+
+  it('shows a form-level error when the request throws (network down)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network down'));
+    renderWithParams('abc-token', 'user@example.com');
+    fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: 'SecurePass1!' } });
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: 'SecurePass1!' } });
+    submitForm();
+    expect(await screen.findByText('Failed to reset password')).toBeTruthy();
+    expect(mockShowMessage).not.toHaveBeenCalled();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/app/auth/reset-password/reset-password-content.tsx
+++ b/packages/web/app/auth/reset-password/reset-password-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useId } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
@@ -17,7 +17,7 @@ import LocaleLink from '@/app/components/i18n/locale-link';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH } from '@/app/components/auth/validate-fields';
 import { themeTokens } from '@/app/theme/theme-config';
-import { FormShell, FormField, FormActions } from '@/app/components/form';
+import { FormShell, FormField, FormActions, focusFirstInvalidAfterRender } from '@/app/components/form';
 
 export default function ResetPasswordContent() {
   const { t } = useTranslation('auth');
@@ -36,27 +36,33 @@ export default function ResetPasswordContent() {
   const [loading, setLoading] = useState(false);
 
   const isLinkInvalid = !token || !email;
+  const formId = useId();
 
   const handleSubmit = async () => {
     setFormError(null);
     if (!password) {
       setPasswordError(t('resetPassword.validation.passwordRequired'));
+      focusFirstInvalidAfterRender(formId);
       return;
     }
     if (password.length < PASSWORD_MIN_LENGTH) {
       setPasswordError(t('resetPassword.validation.passwordTooShort'));
+      focusFirstInvalidAfterRender(formId);
       return;
     }
     if (password.length > PASSWORD_MAX_LENGTH) {
       setPasswordError(t('resetPassword.validation.passwordTooLong'));
+      focusFirstInvalidAfterRender(formId);
       return;
     }
     if (!confirmPassword) {
       setConfirmPasswordError(t('resetPassword.validation.confirmPasswordRequired'));
+      focusFirstInvalidAfterRender(formId);
       return;
     }
     if (password !== confirmPassword) {
       setConfirmPasswordError(t('resetPassword.validation.passwordsMismatch'));
+      focusFirstInvalidAfterRender(formId);
       return;
     }
 
@@ -119,6 +125,7 @@ export default function ResetPasswordContent() {
               </Box>
             ) : (
               <FormShell
+                id={formId}
                 maxWidth={false}
                 error={formError}
                 onSubmit={(event) => {

--- a/packages/web/app/auth/reset-password/reset-password-content.tsx
+++ b/packages/web/app/auth/reset-password/reset-password-content.tsx
@@ -6,19 +6,18 @@ import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
 import LockOutlined from '@mui/icons-material/LockOutlined';
 import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH } from '@/app/components/auth/validate-fields';
 import { themeTokens } from '@/app/theme/theme-config';
+import { FormShell, FormField, FormActions } from '@/app/components/form';
 
 export default function ResetPasswordContent() {
   const { t } = useTranslation('auth');
@@ -33,11 +32,13 @@ export default function ResetPasswordContent() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [passwordError, setPasswordError] = useState<string | null>(null);
   const [confirmPasswordError, setConfirmPasswordError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   const isLinkInvalid = !token || !email;
 
   const handleSubmit = async () => {
+    setFormError(null);
     if (!password) {
       setPasswordError(t('resetPassword.validation.passwordRequired'));
       return;
@@ -69,7 +70,7 @@ export default function ResetPasswordContent() {
 
       const data = await response.json();
       if (!response.ok) {
-        showMessage(data.error || t('resetPassword.toasts.failed'), 'error');
+        setFormError(data.error || t('resetPassword.toasts.failed'));
         return;
       }
 
@@ -77,7 +78,7 @@ export default function ResetPasswordContent() {
       router.replace('/auth/login');
     } catch (error) {
       console.error('Reset password error:', error);
-      showMessage(t('resetPassword.toasts.failed'), 'error');
+      setFormError(t('resetPassword.toasts.failed'));
     } finally {
       setLoading(false);
     }
@@ -107,82 +108,89 @@ export default function ResetPasswordContent() {
       <Box component="main" sx={{ padding: '24px', display: 'flex', justifyContent: 'center', paddingTop: '48px' }}>
         <Card sx={{ width: '100%', maxWidth: 400 }}>
           <CardContent>
-            <Stack
-              spacing={2}
-              component="form"
-              onSubmit={(e) => {
-                e.preventDefault();
-                void handleSubmit();
-              }}
-              noValidate
-            >
-              {isLinkInvalid ? (
+            {isLinkInvalid ? (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                 <Typography variant="body1" color="error">
                   {t('resetPassword.invalidLink')}
                 </Typography>
-              ) : (
-                <>
-                  <Typography variant="body1" component="p" color="text.secondary">
-                    {t('resetPassword.description', { email })}
-                  </Typography>
+                <Button component={LocaleLink} variant="text" href="/auth/login">
+                  {t('resetPassword.back')}
+                </Button>
+              </Box>
+            ) : (
+              <FormShell
+                maxWidth={false}
+                error={formError}
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void handleSubmit();
+                }}
+              >
+                <Typography variant="body1" component="p" color="text.secondary">
+                  {t('resetPassword.description', { email })}
+                </Typography>
 
-                  <TextField
-                    label={t('resetPassword.fields.newPassword')}
-                    type="password"
-                    value={password}
-                    onChange={(e) => {
-                      setPassword(e.target.value);
-                      if (passwordError) setPasswordError(null);
-                    }}
-                    error={!!passwordError}
-                    helperText={passwordError}
-                    slotProps={{
-                      input: {
-                        startAdornment: (
-                          <InputAdornment position="start">
-                            <LockOutlined />
-                          </InputAdornment>
-                        ),
-                      },
-                    }}
-                  />
+                <FormField label={t('resetPassword.fields.newPassword')} error={passwordError}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      type="password"
+                      autoComplete="new-password"
+                      value={password}
+                      onChange={(e) => {
+                        setPassword(e.target.value);
+                        if (passwordError) setPasswordError(null);
+                      }}
+                      fullWidth
+                      error={Boolean(field.error)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <LockOutlined />
+                            </InputAdornment>
+                          ),
+                        },
+                        htmlInput: { 'aria-describedby': field.describedBy },
+                      }}
+                    />
+                  )}
+                </FormField>
 
-                  <TextField
-                    label={t('resetPassword.fields.confirmPassword')}
-                    type="password"
-                    value={confirmPassword}
-                    onChange={(e) => {
-                      setConfirmPassword(e.target.value);
-                      if (confirmPasswordError) setConfirmPasswordError(null);
-                    }}
-                    error={!!confirmPasswordError}
-                    helperText={confirmPasswordError}
-                    slotProps={{
-                      input: {
-                        startAdornment: (
-                          <InputAdornment position="start">
-                            <LockOutlined />
-                          </InputAdornment>
-                        ),
-                      },
-                    }}
-                  />
+                <FormField label={t('resetPassword.fields.confirmPassword')} error={confirmPasswordError}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      type="password"
+                      autoComplete="new-password"
+                      value={confirmPassword}
+                      onChange={(e) => {
+                        setConfirmPassword(e.target.value);
+                        if (confirmPasswordError) setConfirmPasswordError(null);
+                      }}
+                      fullWidth
+                      error={Boolean(field.error)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <LockOutlined />
+                            </InputAdornment>
+                          ),
+                        },
+                        htmlInput: { 'aria-describedby': field.describedBy },
+                      }}
+                    />
+                  )}
+                </FormField>
 
-                  <Button
-                    type="submit"
-                    variant="contained"
-                    disabled={loading}
-                    startIcon={loading ? <CircularProgress size={16} color="inherit" /> : undefined}
-                  >
-                    {t('resetPassword.submit')}
-                  </Button>
-                </>
-              )}
+                <FormActions submitLabel={t('resetPassword.submit')} submitting={loading} layout="stacked" />
 
-              <Button component={LocaleLink} variant="text" href="/auth/login">
-                {t('resetPassword.back')}
-              </Button>
-            </Stack>
+                <Button component={LocaleLink} variant="text" href="/auth/login">
+                  {t('resetPassword.back')}
+                </Button>
+              </FormShell>
+            )}
           </CardContent>
         </Card>
       </Box>

--- a/packages/web/app/auth/verify-request/__tests__/verify-request-inline-errors.test.tsx
+++ b/packages/web/app/auth/verify-request/__tests__/verify-request-inline-errors.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * The resend form's failure paths used to be swallowed (or toasted) — they now
+ * surface in the FormShell alert. These tests pin that behaviour for both the
+ * API-error response and a thrown fetch.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const mockSearchParams = new URLSearchParams();
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock('@/app/lib/i18n/use-locale-router', () => ({
+  useLocaleRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+
+const { default: VerifyRequestContent } = await import('../verify-request-content');
+
+async function submitResend() {
+  fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'climber@example.com' } });
+  fireEvent.click(screen.getByRole('button', { name: /resend/i }));
+}
+
+describe('VerifyRequestContent — inline resend errors', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('surfaces an API error response in the form alert', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: 'Too many attempts. Try later.' }),
+    });
+    render(<VerifyRequestContent />);
+
+    await submitResend();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Too many attempts/i);
+  });
+
+  it('surfaces a thrown fetch (network down) instead of swallowing it', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    render(<VerifyRequestContent />);
+
+    await submitResend();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Failed to send verification email/i);
+    expect((screen.getByRole('button', { name: /resend/i }) as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/packages/web/app/auth/verify-request/verify-request-content.tsx
+++ b/packages/web/app/auth/verify-request/verify-request-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import MuiAlert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -8,7 +8,6 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
-import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import MailOutlined from '@mui/icons-material/MailOutlined';
@@ -20,6 +19,7 @@ import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
+import { FormShell, FormField, FormActions } from '@/app/components/form';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -44,6 +44,7 @@ export default function VerifyRequestContent() {
   const [resendLoading, setResendLoading] = useState(false);
   const [email, setEmail] = useState('');
   const [errors, setErrors] = useState<EmailErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
   const { showMessage } = useSnackbar();
 
   const getErrorMessage = () => {
@@ -54,6 +55,7 @@ export default function VerifyRequestContent() {
   };
 
   const handleResend = async () => {
+    setFormError(null);
     const validationErrors = validateEmail(email, t);
     setErrors(validationErrors);
     if (Object.keys(validationErrors).length > 0) return;
@@ -72,10 +74,11 @@ export default function VerifyRequestContent() {
       if (response.ok) {
         showMessage(t('verifyRequest.toasts.sent'), 'success');
       } else {
-        showMessage(data.error || t('verifyRequest.toasts.failed'), 'error');
+        setFormError(data.error || t('verifyRequest.toasts.failed'));
       }
     } catch (err) {
       console.error('Resend error:', err);
+      setFormError(t('verifyRequest.toasts.failed'));
     } finally {
       setResendLoading(false);
     }
@@ -132,48 +135,44 @@ export default function VerifyRequestContent() {
                 </>
               )}
 
-              <Box
-                component="form"
-                onSubmit={(e: React.FormEvent) => {
-                  e.preventDefault();
+              <FormShell
+                maxWidth={false}
+                error={formError}
+                onSubmit={(event) => {
+                  event.preventDefault();
                   void handleResend();
                 }}
-                sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
               >
-                <TextField
-                  placeholder={t('verifyRequest.resendPlaceholder')}
-                  variant="outlined"
-                  size="medium"
-                  fullWidth
-                  value={email}
-                  onChange={(e) => {
-                    setEmail(e.target.value);
-                    if (errors.email) setErrors({});
-                  }}
-                  error={!!errors.email}
-                  helperText={errors.email}
-                  slotProps={{
-                    input: {
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <MailOutlined />
-                        </InputAdornment>
-                      ),
-                    },
-                  }}
-                />
+                <FormField label={t('verifyRequest.fields.email')} error={errors.email}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      type="email"
+                      autoComplete="email"
+                      placeholder={t('verifyRequest.resendPlaceholder')}
+                      fullWidth
+                      value={email}
+                      onChange={(e) => {
+                        setEmail(e.target.value);
+                        if (errors.email) setErrors({});
+                      }}
+                      error={Boolean(field.error)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <MailOutlined />
+                            </InputAdornment>
+                          ),
+                        },
+                        htmlInput: { autoCapitalize: 'none', 'aria-describedby': field.describedBy },
+                      }}
+                    />
+                  )}
+                </FormField>
 
-                <Button
-                  variant="contained"
-                  type="submit"
-                  disabled={resendLoading}
-                  startIcon={resendLoading ? <CircularProgress size={16} /> : undefined}
-                  fullWidth
-                  size="large"
-                >
-                  {t('verifyRequest.resend')}
-                </Button>
-              </Box>
+                <FormActions submitLabel={t('verifyRequest.resend')} submitting={resendLoading} layout="stacked" />
+              </FormShell>
 
               <Button variant="text" href="/auth/login">
                 {t('verifyRequest.back')}

--- a/packages/web/app/auth/verify-request/verify-request-content.tsx
+++ b/packages/web/app/auth/verify-request/verify-request-content.tsx
@@ -17,11 +17,11 @@ import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
+import LocaleLink from '@/app/components/i18n/locale-link';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { EMAIL_REGEX } from '@/app/components/auth/validate-fields';
 import { themeTokens } from '@/app/theme/theme-config';
 import { FormShell, FormField, FormActions } from '@/app/components/form';
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const KNOWN_VERIFY_ERROR_CODES = new Set(['EmailNotVerified', 'InvalidToken', 'TokenExpired', 'TooManyAttempts']);
 
@@ -174,7 +174,7 @@ export default function VerifyRequestContent() {
                 <FormActions submitLabel={t('verifyRequest.resend')} submitting={resendLoading} layout="stacked" />
               </FormShell>
 
-              <Button variant="text" href="/auth/login">
+              <Button component={LocaleLink} variant="text" href="/auth/login">
                 {t('verifyRequest.back')}
               </Button>
             </Stack>

--- a/packages/web/app/auth/verify-request/verify-request-content.tsx
+++ b/packages/web/app/auth/verify-request/verify-request-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useId } from 'react';
 import MuiAlert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -21,7 +21,7 @@ import LocaleLink from '@/app/components/i18n/locale-link';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { EMAIL_REGEX } from '@/app/components/auth/validate-fields';
 import { themeTokens } from '@/app/theme/theme-config';
-import { FormShell, FormField, FormActions } from '@/app/components/form';
+import { FormShell, FormField, FormActions, focusFirstInvalidAfterRender } from '@/app/components/form';
 
 const KNOWN_VERIFY_ERROR_CODES = new Set(['EmailNotVerified', 'InvalidToken', 'TokenExpired', 'TooManyAttempts']);
 
@@ -41,6 +41,7 @@ export default function VerifyRequestContent() {
   const { t } = useTranslation('auth');
   const searchParams = useSearchParams();
   const error = searchParams.get('error');
+  const formId = useId();
   const [resendLoading, setResendLoading] = useState(false);
   const [email, setEmail] = useState('');
   const [errors, setErrors] = useState<EmailErrors>({});
@@ -58,7 +59,10 @@ export default function VerifyRequestContent() {
     setFormError(null);
     const validationErrors = validateEmail(email, t);
     setErrors(validationErrors);
-    if (Object.keys(validationErrors).length > 0) return;
+    if (Object.keys(validationErrors).length > 0) {
+      focusFirstInvalidAfterRender(formId);
+      return;
+    }
 
     try {
       setResendLoading(true);
@@ -136,6 +140,7 @@ export default function VerifyRequestContent() {
               )}
 
               <FormShell
+                id={formId}
                 maxWidth={false}
                 error={formError}
                 onSubmit={(event) => {

--- a/packages/web/app/components/auth/__tests__/auth-modal-server-errors.test.tsx
+++ b/packages/web/app/components/auth/__tests__/auth-modal-server-errors.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Server-error paths for the modal login form: auth failures and thrown
+ * signIn calls (network down) must surface in the form-level alert — a
+ * swallowed catch previously left the form frozen with no feedback.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const mockSignIn = vi.fn();
+vi.mock('next-auth/react', () => ({
+  signIn: (...args: unknown[]) => mockSignIn(...args),
+}));
+
+vi.mock('../social-login-buttons', () => ({
+  default: () => null,
+}));
+
+const mockShowMessage = vi.fn();
+vi.mock('../../providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+const { default: AuthModal } = await import('../auth-modal');
+
+async function submitLogin() {
+  fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'climber@example.com' } });
+  fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'hunter22' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Login' }));
+}
+
+describe('AuthModal — login server errors', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The network-failure path console.errors by design.
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('shows the invalid-credentials alert when signIn reports an auth error', async () => {
+    mockSignIn.mockResolvedValueOnce({ error: 'CredentialsSignin', ok: false });
+    const onClose = vi.fn();
+    render(<AuthModal open onClose={onClose} />);
+
+    await submitLogin();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Invalid email or password/i);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('shows the generic auth-failed alert when signIn throws (network down)', async () => {
+    mockSignIn.mockRejectedValueOnce(new Error('fetch failed'));
+    const onClose = vi.fn();
+    render(<AuthModal open onClose={onClose} />);
+
+    await submitLogin();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Authentication failed/i);
+    // The form must stay open and interactive — no frozen state.
+    expect(onClose).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect((screen.getByRole('button', { name: 'Login' }) as HTMLButtonElement).disabled).toBe(false);
+    });
+  });
+
+  it('clears the alert on a successful retry', async () => {
+    mockSignIn.mockRejectedValueOnce(new Error('fetch failed')).mockResolvedValueOnce({ ok: true, error: null });
+    const onClose = vi.fn();
+    render(<AuthModal open onClose={onClose} />);
+
+    await submitLogin();
+    await screen.findByRole('alert');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Login' }));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/packages/web/app/components/auth/__tests__/auth-modal-server-errors.test.tsx
+++ b/packages/web/app/components/auth/__tests__/auth-modal-server-errors.test.tsx
@@ -58,6 +58,8 @@ describe('AuthModal — login server errors', () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    // Failed assertions must not leak a fetch stub into later tests.
+    vi.unstubAllGlobals();
   });
 
   it('shows the invalid-credentials alert when signIn reports an auth error', async () => {
@@ -99,7 +101,6 @@ describe('AuthModal — login server errors', () => {
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Email already registered/i);
-    vi.unstubAllGlobals();
   });
 
   it('surfaces a thrown register fetch (network down) in the register form alert', async () => {
@@ -110,7 +111,6 @@ describe('AuthModal — login server errors', () => {
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Registration failed\. Please try again/i);
-    vi.unstubAllGlobals();
   });
 
   it('does not resurface a stale register error after a tab round-trip', async () => {
@@ -123,7 +123,6 @@ describe('AuthModal — login server errors', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Login' }));
     fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));
     expect(screen.queryByRole('alert')).toBeNull();
-    vi.unstubAllGlobals();
   });
 
   it('clears the alert on a successful retry', async () => {

--- a/packages/web/app/components/auth/__tests__/auth-modal-server-errors.test.tsx
+++ b/packages/web/app/components/auth/__tests__/auth-modal-server-errors.test.tsx
@@ -32,13 +32,13 @@ vi.mock('../../providers/snackbar-provider', () => ({
 
 const { default: AuthModal } = await import('../auth-modal');
 
-async function submitLogin() {
+function submitLogin() {
   fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'climber@example.com' } });
   fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'hunter22' } });
   fireEvent.click(screen.getByRole('button', { name: 'Login' }));
 }
 
-async function submitRegister() {
+function submitRegister() {
   fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));
   fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Crusher' } });
   fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'climber@example.com' } });
@@ -67,7 +67,7 @@ describe('AuthModal — login server errors', () => {
     const onClose = vi.fn();
     render(<AuthModal open onClose={onClose} />);
 
-    await submitLogin();
+    submitLogin();
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Invalid email or password/i);
@@ -79,7 +79,7 @@ describe('AuthModal — login server errors', () => {
     const onClose = vi.fn();
     render(<AuthModal open onClose={onClose} />);
 
-    await submitLogin();
+    submitLogin();
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Authentication failed/i);
@@ -97,7 +97,7 @@ describe('AuthModal — login server errors', () => {
     );
     render(<AuthModal open onClose={vi.fn()} />);
 
-    await submitRegister();
+    submitRegister();
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Email already registered/i);
@@ -107,7 +107,7 @@ describe('AuthModal — login server errors', () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('network down')));
     render(<AuthModal open onClose={vi.fn()} />);
 
-    await submitRegister();
+    submitRegister();
 
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/Registration failed\. Please try again/i);
@@ -117,7 +117,7 @@ describe('AuthModal — login server errors', () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('network down')));
     render(<AuthModal open onClose={vi.fn()} />);
 
-    await submitRegister();
+    submitRegister();
     await screen.findByRole('alert');
 
     fireEvent.click(screen.getByRole('tab', { name: 'Login' }));
@@ -130,7 +130,7 @@ describe('AuthModal — login server errors', () => {
     const onClose = vi.fn();
     render(<AuthModal open onClose={onClose} />);
 
-    await submitLogin();
+    submitLogin();
     await screen.findByRole('alert');
 
     fireEvent.click(screen.getByRole('button', { name: 'Login' }));

--- a/packages/web/app/components/auth/__tests__/auth-modal-server-errors.test.tsx
+++ b/packages/web/app/components/auth/__tests__/auth-modal-server-errors.test.tsx
@@ -40,6 +40,7 @@ async function submitLogin() {
 
 async function submitRegister() {
   fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Crusher' } });
   fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'climber@example.com' } });
   fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'hunter2222' } });
   fireEvent.change(screen.getByLabelText('Confirm Password'), { target: { value: 'hunter2222' } });

--- a/packages/web/app/components/auth/__tests__/auth-modal-server-errors.test.tsx
+++ b/packages/web/app/components/auth/__tests__/auth-modal-server-errors.test.tsx
@@ -38,6 +38,14 @@ async function submitLogin() {
   fireEvent.click(screen.getByRole('button', { name: 'Login' }));
 }
 
+async function submitRegister() {
+  fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));
+  fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'climber@example.com' } });
+  fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'hunter2222' } });
+  fireEvent.change(screen.getByLabelText('Confirm Password'), { target: { value: 'hunter2222' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+}
+
 describe('AuthModal — login server errors', () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
@@ -77,6 +85,44 @@ describe('AuthModal — login server errors', () => {
     await waitFor(() => {
       expect((screen.getByRole('button', { name: 'Login' }) as HTMLButtonElement).disabled).toBe(false);
     });
+  });
+
+  it('surfaces a register API error in the register form alert', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({ ok: false, json: () => Promise.resolve({ error: 'Email already registered' }) }),
+    );
+    render(<AuthModal open onClose={vi.fn()} />);
+
+    await submitRegister();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Email already registered/i);
+    vi.unstubAllGlobals();
+  });
+
+  it('surfaces a thrown register fetch (network down) in the register form alert', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('network down')));
+    render(<AuthModal open onClose={vi.fn()} />);
+
+    await submitRegister();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Registration failed\. Please try again/i);
+    vi.unstubAllGlobals();
+  });
+
+  it('does not resurface a stale register error after a tab round-trip', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('network down')));
+    render(<AuthModal open onClose={vi.fn()} />);
+
+    await submitRegister();
+    await screen.findByRole('alert');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Login' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Create Account' }));
+    expect(screen.queryByRole('alert')).toBeNull();
+    vi.unstubAllGlobals();
   });
 
   it('clears the alert on a successful retry', async () => {

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -197,10 +197,12 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
             value={activeTab}
             onChange={(_, selectedTab) => {
               setActiveTab(selectedTab);
-              // A server error belongs to the submit that produced it — don't
-              // resurface a stale one after a tab round-trip.
+              // Errors belong to the submit that produced them — don't
+              // resurface stale ones after a tab round-trip.
               setLoginServerError(null);
               setRegisterServerError(null);
+              setLoginErrors({});
+              setRegisterErrors({});
             }}
             centered
           >

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useId } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import Tabs from '@mui/material/Tabs';
@@ -20,7 +20,7 @@ import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { signIn } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
 import SocialLoginButtons from '@/app/components/auth/social-login-buttons';
-import { FormShell, FormSection, FormField, FormActions } from '@/app/components/form';
+import { FormShell, FormSection, FormField, FormActions, focusFirstInvalidAfterRender } from '@/app/components/form';
 import {
   initialLoginValues,
   initialRegisterValues,
@@ -58,12 +58,17 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
   const [showRegisterPassword, setShowRegisterPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const { showMessage } = useSnackbar();
+  const loginFormId = useId();
+  const registerFormId = useId();
 
   const handleLogin = async () => {
     setLoginServerError(null);
     const errors = validateLoginFields(loginValues, t);
     setLoginErrors(errors);
-    if (Object.keys(errors).length > 0) return;
+    if (Object.keys(errors).length > 0) {
+      focusFirstInvalidAfterRender(loginFormId);
+      return;
+    }
 
     try {
       setLoginLoading(true);
@@ -97,7 +102,10 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
     setRegisterServerError(null);
     const errors = validateRegisterFields(registerValues, t);
     setRegisterErrors(errors);
-    if (Object.keys(errors).length > 0) return;
+    if (Object.keys(errors).length > 0) {
+      focusFirstInvalidAfterRender(registerFormId);
+      return;
+    }
 
     try {
       setRegisterLoading(true);
@@ -202,6 +210,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
 
           <TabPanel value={activeTab} index="login">
             <FormShell
+              id={loginFormId}
               onSubmit={(e) => {
                 e.preventDefault();
                 void handleLogin();
@@ -291,6 +300,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
 
           <TabPanel value={activeTab} index="register">
             <FormShell
+              id={registerFormId}
               onSubmit={(e) => {
                 e.preventDefault();
                 void handleRegister();

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -368,7 +368,11 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
                   )}
                 </FormField>
 
-                <FormField label={t('login.fields.password')} htmlFor="register_password" error={registerErrors.password}>
+                <FormField
+                  label={t('login.fields.password')}
+                  htmlFor="register_password"
+                  error={registerErrors.password}
+                >
                   {(field) => (
                     <TextField
                       id={field.id}
@@ -413,7 +417,11 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
                   )}
                 </FormField>
 
-                <FormField label={t('login.fields.confirmPassword')} htmlFor="register_confirm_password" error={registerErrors.confirmPassword}>
+                <FormField
+                  label={t('login.fields.confirmPassword')}
+                  htmlFor="register_confirm_password"
+                  error={registerErrors.confirmPassword}
+                >
                   {(field) => (
                     <TextField
                       id={field.id}

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -311,7 +311,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
               maxWidth={false}
             >
               <FormSection>
-                <FormField label={t('login.fields.name')} error={registerErrors.name}>
+                <FormField label={t('login.fields.name')} htmlFor="register_name" error={registerErrors.name}>
                   {(field) => (
                     <TextField
                       id={field.id}
@@ -339,7 +339,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
                   )}
                 </FormField>
 
-                <FormField label={t('login.fields.email')} error={registerErrors.email}>
+                <FormField label={t('login.fields.email')} htmlFor="register_email" error={registerErrors.email}>
                   {(field) => (
                     <TextField
                       id={field.id}
@@ -368,7 +368,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
                   )}
                 </FormField>
 
-                <FormField label={t('login.fields.password')} error={registerErrors.password}>
+                <FormField label={t('login.fields.password')} htmlFor="register_password" error={registerErrors.password}>
                   {(field) => (
                     <TextField
                       id={field.id}
@@ -413,7 +413,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
                   )}
                 </FormField>
 
-                <FormField label={t('login.fields.confirmPassword')} error={registerErrors.confirmPassword}>
+                <FormField label={t('login.fields.confirmPassword')} htmlFor="register_confirm_password" error={registerErrors.confirmPassword}>
                   {(field) => (
                     <TextField
                       id={field.id}

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -1,16 +1,13 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
-import CircularProgress from '@mui/material/CircularProgress';
-import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import MuiDivider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
@@ -23,6 +20,7 @@ import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { signIn } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
 import SocialLoginButtons from '@/app/components/auth/social-login-buttons';
+import { FormShell, FormSection, FormField, FormActions } from '@/app/components/form';
 import {
   initialLoginValues,
   initialRegisterValues,
@@ -49,8 +47,10 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
   const resolvedDescription = description ?? t('modal.description');
   const [loginValues, setLoginValues] = useState(initialLoginValues);
   const [loginErrors, setLoginErrors] = useState<LoginErrors>({});
+  const [loginServerError, setLoginServerError] = useState<string | null>(null);
   const [registerValues, setRegisterValues] = useState(initialRegisterValues);
   const [registerErrors, setRegisterErrors] = useState<RegisterErrors>({});
+  const [registerServerError, setRegisterServerError] = useState<string | null>(null);
   const [loginLoading, setLoginLoading] = useState(false);
   const [registerLoading, setRegisterLoading] = useState(false);
   const [activeTab, setActiveTab] = useState('login');
@@ -60,6 +60,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
   const { showMessage } = useSnackbar();
 
   const handleLogin = async () => {
+    setLoginServerError(null);
     const errors = validateLoginFields(loginValues, t);
     setLoginErrors(errors);
     if (Object.keys(errors).length > 0) return;
@@ -74,7 +75,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
       });
 
       if (result?.error) {
-        showMessage(t('login.toasts.invalidCredentials'), 'error');
+        setLoginServerError(t('login.toasts.invalidCredentials'));
       } else if (result?.ok) {
         showMessage(t('login.toasts.loggedIn'), 'success');
         setLoginValues(initialLoginValues);
@@ -90,6 +91,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
   };
 
   const handleRegister = async () => {
+    setRegisterServerError(null);
     const errors = validateRegisterFields(registerValues, t);
     setRegisterErrors(errors);
     if (Object.keys(errors).length > 0) return;
@@ -115,7 +117,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
       const data = await response.json();
 
       if (!response.ok) {
-        showMessage(data.error || t('login.toasts.registrationFailed'), 'error');
+        setRegisterServerError(data.error || t('login.toasts.registrationFailed'));
         return;
       }
 
@@ -150,7 +152,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
       }
     } catch (error) {
       console.error('Registration error:', error);
-      showMessage(t('login.toasts.registrationFailedRetry'), 'error');
+      setRegisterServerError(t('login.toasts.registrationFailedRetry'));
     } finally {
       setRegisterLoading(false);
     }
@@ -159,8 +161,10 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
   const handleCancel = () => {
     setLoginValues(initialLoginValues);
     setLoginErrors({});
+    setLoginServerError(null);
     setRegisterValues(initialRegisterValues);
     setRegisterErrors({});
+    setRegisterServerError(null);
     onClose();
   };
 
@@ -184,234 +188,255 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
           </Tabs>
 
           <TabPanel value={activeTab} index="login">
-            <Box
-              component="form"
-              onSubmit={(e: React.FormEvent) => {
+            <FormShell
+              onSubmit={(e) => {
                 e.preventDefault();
                 void handleLogin();
               }}
-              sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+              error={loginServerError}
+              maxWidth={false}
             >
-              <TextField
-                id="login_email"
-                placeholder={t('login.placeholders.email')}
-                variant="outlined"
-                size="medium"
-                fullWidth
-                value={loginValues.email}
-                onChange={(e) => {
-                  setLoginValues((prev) => ({ ...prev, email: e.target.value }));
-                  if (loginErrors.email) setLoginErrors((prev) => ({ ...prev, email: undefined }));
-                }}
-                error={!!loginErrors.email}
-                helperText={loginErrors.email}
-                slotProps={{
-                  input: {
-                    type: 'email',
-                    autoCapitalize: 'none',
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <MailOutlined />
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-              />
+              <FormSection>
+                <FormField label={t('login.fields.email')} htmlFor="login_email" error={loginErrors.email}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      type="email"
+                      autoComplete="username"
+                      placeholder={t('login.placeholders.email')}
+                      fullWidth
+                      value={loginValues.email}
+                      onChange={(e) => {
+                        setLoginValues((prev) => ({ ...prev, email: e.target.value }));
+                        if (loginErrors.email) setLoginErrors((prev) => ({ ...prev, email: undefined }));
+                        if (loginServerError) setLoginServerError(null);
+                      }}
+                      error={Boolean(field.error)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <MailOutlined />
+                            </InputAdornment>
+                          ),
+                        },
+                        htmlInput: { autoCapitalize: 'none', 'aria-describedby': field.describedBy },
+                      }}
+                    />
+                  )}
+                </FormField>
 
-              <TextField
-                id="login_password"
-                type={showLoginPassword ? 'text' : 'password'}
-                placeholder={t('login.placeholders.password')}
-                variant="outlined"
-                size="medium"
-                fullWidth
-                value={loginValues.password}
-                onChange={(e) => {
-                  setLoginValues((prev) => ({ ...prev, password: e.target.value }));
-                  if (loginErrors.password) setLoginErrors((prev) => ({ ...prev, password: undefined }));
-                }}
-                error={!!loginErrors.password}
-                helperText={loginErrors.password}
-                slotProps={{
-                  input: {
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <LockOutlined />
-                      </InputAdornment>
-                    ),
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        <IconButton
-                          onClick={() => setShowLoginPassword(!showLoginPassword)}
-                          onMouseDown={(e) => e.preventDefault()}
-                          edge="end"
-                          size="small"
-                          tabIndex={-1}
-                        >
-                          {showLoginPassword ? <VisibilityOff /> : <Visibility />}
-                        </IconButton>
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-              />
+                <FormField label={t('login.fields.password')} htmlFor="login_password" error={loginErrors.password}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      type={showLoginPassword ? 'text' : 'password'}
+                      autoComplete="current-password"
+                      placeholder={t('login.placeholders.password')}
+                      fullWidth
+                      value={loginValues.password}
+                      onChange={(e) => {
+                        setLoginValues((prev) => ({ ...prev, password: e.target.value }));
+                        if (loginErrors.password) setLoginErrors((prev) => ({ ...prev, password: undefined }));
+                        if (loginServerError) setLoginServerError(null);
+                      }}
+                      error={Boolean(field.error)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <LockOutlined />
+                            </InputAdornment>
+                          ),
+                          endAdornment: (
+                            <InputAdornment position="end">
+                              <IconButton
+                                aria-label={
+                                  showLoginPassword ? t('login.a11y.hidePassword') : t('login.a11y.showPassword')
+                                }
+                                onClick={() => setShowLoginPassword(!showLoginPassword)}
+                                onMouseDown={(e) => e.preventDefault()}
+                                edge="end"
+                                size="small"
+                                tabIndex={-1}
+                              >
+                                {showLoginPassword ? <VisibilityOff /> : <Visibility />}
+                              </IconButton>
+                            </InputAdornment>
+                          ),
+                        },
+                        htmlInput: { 'aria-describedby': field.describedBy },
+                      }}
+                    />
+                  )}
+                </FormField>
+              </FormSection>
 
-              <Button
-                variant="contained"
-                type="submit"
-                disabled={loginLoading}
-                startIcon={loginLoading ? <CircularProgress size={16} /> : undefined}
-                fullWidth
-                size="large"
-              >
-                {t('login.submit.signIn')}
-              </Button>
-            </Box>
+              <FormActions submitLabel={t('login.submit.signIn')} submitting={loginLoading} layout="stacked" />
+            </FormShell>
           </TabPanel>
 
           <TabPanel value={activeTab} index="register">
-            <Box
-              component="form"
-              onSubmit={(e: React.FormEvent) => {
+            <FormShell
+              onSubmit={(e) => {
                 e.preventDefault();
                 void handleRegister();
               }}
-              sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+              error={registerServerError}
+              maxWidth={false}
             >
-              <TextField
-                placeholder={t('login.placeholders.name')}
-                variant="outlined"
-                size="medium"
-                fullWidth
-                value={registerValues.name}
-                onChange={(e) => {
-                  setRegisterValues((prev) => ({ ...prev, name: e.target.value }));
-                  if (registerErrors.name) setRegisterErrors((prev) => ({ ...prev, name: undefined }));
-                }}
-                error={!!registerErrors.name}
-                helperText={registerErrors.name}
-                slotProps={{
-                  input: {
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <PersonOutlined />
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-              />
+              <FormSection>
+                <FormField label={t('login.fields.name')} error={registerErrors.name}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      autoComplete="name"
+                      placeholder={t('login.placeholders.name')}
+                      fullWidth
+                      value={registerValues.name}
+                      onChange={(e) => {
+                        setRegisterValues((prev) => ({ ...prev, name: e.target.value }));
+                        if (registerErrors.name) setRegisterErrors((prev) => ({ ...prev, name: undefined }));
+                        if (registerServerError) setRegisterServerError(null);
+                      }}
+                      error={Boolean(field.error)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <PersonOutlined />
+                            </InputAdornment>
+                          ),
+                        },
+                        htmlInput: { 'aria-describedby': field.describedBy },
+                      }}
+                    />
+                  )}
+                </FormField>
 
-              <TextField
-                placeholder={t('login.placeholders.email')}
-                variant="outlined"
-                size="medium"
-                fullWidth
-                value={registerValues.email}
-                onChange={(e) => {
-                  setRegisterValues((prev) => ({ ...prev, email: e.target.value }));
-                  if (registerErrors.email) setRegisterErrors((prev) => ({ ...prev, email: undefined }));
-                }}
-                error={!!registerErrors.email}
-                helperText={registerErrors.email}
-                slotProps={{
-                  input: {
-                    type: 'email',
-                    autoCapitalize: 'none',
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <MailOutlined />
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-              />
+                <FormField label={t('login.fields.email')} error={registerErrors.email}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      type="email"
+                      autoComplete="email"
+                      placeholder={t('login.placeholders.email')}
+                      fullWidth
+                      value={registerValues.email}
+                      onChange={(e) => {
+                        setRegisterValues((prev) => ({ ...prev, email: e.target.value }));
+                        if (registerErrors.email) setRegisterErrors((prev) => ({ ...prev, email: undefined }));
+                        if (registerServerError) setRegisterServerError(null);
+                      }}
+                      error={Boolean(field.error)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <MailOutlined />
+                            </InputAdornment>
+                          ),
+                        },
+                        htmlInput: { autoCapitalize: 'none', 'aria-describedby': field.describedBy },
+                      }}
+                    />
+                  )}
+                </FormField>
 
-              <TextField
-                type={showRegisterPassword ? 'text' : 'password'}
-                placeholder={t('login.placeholders.passwordWithMin')}
-                variant="outlined"
-                size="medium"
-                fullWidth
-                value={registerValues.password}
-                onChange={(e) => {
-                  setRegisterValues((prev) => ({ ...prev, password: e.target.value }));
-                  if (registerErrors.password) setRegisterErrors((prev) => ({ ...prev, password: undefined }));
-                }}
-                error={!!registerErrors.password}
-                helperText={registerErrors.password}
-                slotProps={{
-                  input: {
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <LockOutlined />
-                      </InputAdornment>
-                    ),
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        <IconButton
-                          onClick={() => setShowRegisterPassword(!showRegisterPassword)}
-                          onMouseDown={(e) => e.preventDefault()}
-                          edge="end"
-                          size="small"
-                          tabIndex={-1}
-                        >
-                          {showRegisterPassword ? <VisibilityOff /> : <Visibility />}
-                        </IconButton>
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-              />
+                <FormField label={t('login.fields.password')} error={registerErrors.password}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      type={showRegisterPassword ? 'text' : 'password'}
+                      autoComplete="new-password"
+                      placeholder={t('login.placeholders.passwordWithMin')}
+                      fullWidth
+                      value={registerValues.password}
+                      onChange={(e) => {
+                        setRegisterValues((prev) => ({ ...prev, password: e.target.value }));
+                        if (registerErrors.password) setRegisterErrors((prev) => ({ ...prev, password: undefined }));
+                        if (registerServerError) setRegisterServerError(null);
+                      }}
+                      error={Boolean(field.error)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <LockOutlined />
+                            </InputAdornment>
+                          ),
+                          endAdornment: (
+                            <InputAdornment position="end">
+                              <IconButton
+                                aria-label={
+                                  showRegisterPassword ? t('login.a11y.hidePassword') : t('login.a11y.showPassword')
+                                }
+                                onClick={() => setShowRegisterPassword(!showRegisterPassword)}
+                                onMouseDown={(e) => e.preventDefault()}
+                                edge="end"
+                                size="small"
+                                tabIndex={-1}
+                              >
+                                {showRegisterPassword ? <VisibilityOff /> : <Visibility />}
+                              </IconButton>
+                            </InputAdornment>
+                          ),
+                        },
+                        htmlInput: { 'aria-describedby': field.describedBy },
+                      }}
+                    />
+                  )}
+                </FormField>
 
-              <TextField
-                type={showConfirmPassword ? 'text' : 'password'}
-                placeholder={t('login.placeholders.confirmPassword')}
-                variant="outlined"
-                size="medium"
-                fullWidth
-                value={registerValues.confirmPassword}
-                onChange={(e) => {
-                  setRegisterValues((prev) => ({ ...prev, confirmPassword: e.target.value }));
-                  if (registerErrors.confirmPassword)
-                    setRegisterErrors((prev) => ({ ...prev, confirmPassword: undefined }));
-                }}
-                error={!!registerErrors.confirmPassword}
-                helperText={registerErrors.confirmPassword}
-                slotProps={{
-                  input: {
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <LockOutlined />
-                      </InputAdornment>
-                    ),
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        <IconButton
-                          onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                          onMouseDown={(e) => e.preventDefault()}
-                          edge="end"
-                          size="small"
-                          tabIndex={-1}
-                        >
-                          {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
-                        </IconButton>
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-              />
+                <FormField label={t('login.fields.confirmPassword')} error={registerErrors.confirmPassword}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      type={showConfirmPassword ? 'text' : 'password'}
+                      autoComplete="new-password"
+                      placeholder={t('login.placeholders.confirmPassword')}
+                      fullWidth
+                      value={registerValues.confirmPassword}
+                      onChange={(e) => {
+                        setRegisterValues((prev) => ({ ...prev, confirmPassword: e.target.value }));
+                        if (registerErrors.confirmPassword)
+                          setRegisterErrors((prev) => ({ ...prev, confirmPassword: undefined }));
+                        if (registerServerError) setRegisterServerError(null);
+                      }}
+                      error={Boolean(field.error)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <LockOutlined />
+                            </InputAdornment>
+                          ),
+                          endAdornment: (
+                            <InputAdornment position="end">
+                              <IconButton
+                                aria-label={
+                                  showConfirmPassword ? t('login.a11y.hidePassword') : t('login.a11y.showPassword')
+                                }
+                                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                                onMouseDown={(e) => e.preventDefault()}
+                                edge="end"
+                                size="small"
+                                tabIndex={-1}
+                              >
+                                {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                              </IconButton>
+                            </InputAdornment>
+                          ),
+                        },
+                        htmlInput: { 'aria-describedby': field.describedBy },
+                      }}
+                    />
+                  )}
+                </FormField>
+              </FormSection>
 
-              <Button
-                variant="contained"
-                type="submit"
-                disabled={registerLoading}
-                startIcon={registerLoading ? <CircularProgress size={16} /> : undefined}
-                fullWidth
-                size="large"
-              >
-                {t('login.submit.signUp')}
-              </Button>
-            </Box>
+              <FormActions submitLabel={t('login.submit.signUp')} submitting={registerLoading} layout="stacked" />
+            </FormShell>
           </TabPanel>
 
           <MuiDivider sx={{ margin: '8px 0' }}>

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -185,7 +185,17 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
             </Typography>
           </Stack>
 
-          <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} centered>
+          <Tabs
+            value={activeTab}
+            onChange={(_, selectedTab) => {
+              setActiveTab(selectedTab);
+              // A server error belongs to the submit that produced it — don't
+              // resurface a stale one after a tab round-trip.
+              setLoginServerError(null);
+              setRegisterServerError(null);
+            }}
+            centered
+          >
             <Tab label={t('login.tabs.signIn')} value="login" />
             <Tab label={t('login.tabs.signUp')} value="register" />
           </Tabs>

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -84,7 +84,10 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
         onSuccess?.();
       }
     } catch (error) {
+      // A thrown signIn (network down, server unreachable) must not leave the
+      // form frozen with no feedback — surface it like the auth-error path.
       console.error('Login error:', error);
+      setLoginServerError(t('login.toasts.authFailed'));
     } finally {
       setLoginLoading(false);
     }

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -440,7 +440,9 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
                             <InputAdornment position="end">
                               <IconButton
                                 aria-label={
-                                  showConfirmPassword ? t('login.a11y.hidePassword') : t('login.a11y.showPassword')
+                                  showConfirmPassword
+                                    ? t('login.a11y.hideConfirmPassword')
+                                    : t('login.a11y.showConfirmPassword')
                                 }
                                 onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                                 onMouseDown={(e) => e.preventDefault()}

--- a/packages/web/app/components/climb-actions/playlist-selection-content.tsx
+++ b/packages/web/app/components/climb-actions/playlist-selection-content.tsx
@@ -12,6 +12,7 @@ import Stack from '@mui/material/Stack';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
 import { track } from '@/app/lib/analytics';
+import { FormField } from '@/app/components/form';
 import { usePlaylists } from './use-playlists';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import type { Playlist } from './playlists-batch-context';
@@ -255,7 +256,6 @@ export default function PlaylistSelectionContent({
                 startIcon={<AddOutlined />}
                 onClick={() => setShowCreateForm(true)}
                 fullWidth
-                size="medium"
                 sx={{ marginTop: `${themeTokens.spacing[2]}px` }}
               >
                 {t('actions.playlist.popover.createNew')}
@@ -266,47 +266,45 @@ export default function PlaylistSelectionContent({
           {showCreateForm && (
             <div>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                <Box>
-                  <MuiTypography variant="body2" fontWeight={600} sx={{ mb: 0.5, fontSize: 12 }}>
-                    {t('actions.playlist.create.nameLabel')}
-                  </MuiTypography>
-                  <TextField
-                    placeholder={t('actions.playlist.create.namePlaceholder')}
-                    autoFocus
-                    fullWidth
-                    size="small"
-                    value={createFormValues.name}
-                    onChange={(e) => setCreateFormValues((prev) => ({ ...prev, name: e.target.value }))}
-                    slotProps={{ htmlInput: { maxLength: 100 } }}
-                  />
-                </Box>
-                <Box>
-                  <MuiTypography variant="body2" fontWeight={600} sx={{ mb: 0.5, fontSize: 12 }}>
-                    {t('actions.playlist.create.descriptionLabel')}
-                  </MuiTypography>
-                  <TextField
-                    placeholder={t('actions.playlist.create.descriptionPlaceholder')}
-                    multiline
-                    rows={2}
-                    fullWidth
-                    size="small"
-                    value={createFormValues.description}
-                    onChange={(e) => setCreateFormValues((prev) => ({ ...prev, description: e.target.value }))}
-                    slotProps={{ htmlInput: { maxLength: 500 } }}
-                  />
-                </Box>
-                <Box>
-                  <MuiTypography variant="body2" fontWeight={600} sx={{ mb: 0.5, fontSize: 12 }}>
-                    {t('actions.playlist.create.colorLabel')}
-                  </MuiTypography>
-                  <TextField
-                    type="color"
-                    value={createFormValues.color || '#000000'}
-                    onChange={(e) => setCreateFormValues((prev) => ({ ...prev, color: e.target.value }))}
-                    size="small"
-                    sx={{ width: 60 }}
-                  />
-                </Box>
+                <FormField label={t('actions.playlist.create.nameLabel')}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      placeholder={t('actions.playlist.create.namePlaceholder')}
+                      autoFocus
+                      fullWidth
+                      value={createFormValues.name}
+                      onChange={(e) => setCreateFormValues((prev) => ({ ...prev, name: e.target.value }))}
+                      slotProps={{ htmlInput: { maxLength: 100, 'aria-describedby': field.describedBy } }}
+                    />
+                  )}
+                </FormField>
+                <FormField label={t('actions.playlist.create.descriptionLabel')}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      placeholder={t('actions.playlist.create.descriptionPlaceholder')}
+                      multiline
+                      rows={2}
+                      fullWidth
+                      value={createFormValues.description}
+                      onChange={(e) => setCreateFormValues((prev) => ({ ...prev, description: e.target.value }))}
+                      slotProps={{ htmlInput: { maxLength: 500, 'aria-describedby': field.describedBy } }}
+                    />
+                  )}
+                </FormField>
+                <FormField label={t('actions.playlist.create.colorLabel')}>
+                  {(field) => (
+                    <TextField
+                      id={field.id}
+                      type="color"
+                      value={createFormValues.color || '#000000'}
+                      onChange={(e) => setCreateFormValues((prev) => ({ ...prev, color: e.target.value }))}
+                      sx={{ width: 60 }}
+                      slotProps={{ htmlInput: { 'aria-describedby': field.describedBy } }}
+                    />
+                  )}
+                </FormField>
               </Box>
               <Stack
                 direction="row"

--- a/packages/web/app/components/climb-actions/playlist-selection-content.tsx
+++ b/packages/web/app/components/climb-actions/playlist-selection-content.tsx
@@ -217,7 +217,11 @@ export default function PlaylistSelectionContent({
                         role="button"
                         tabIndex={0}
                         aria-pressed={isInPlaylist}
-                        aria-label={`${isInPlaylist ? 'Remove from' : 'Add to'} playlist ${playlist.name}`}
+                        aria-label={
+                          isInPlaylist
+                            ? t('actions.playlist.row.removeAria', { name: playlist.name })
+                            : t('actions.playlist.row.addAria', { name: playlist.name })
+                        }
                         sx={{
                           padding: `${themeTokens.spacing[2]}px ${themeTokens.spacing[2]}px`,
                           cursor: 'pointer',
@@ -241,7 +245,7 @@ export default function PlaylistSelectionContent({
                               color="text.secondary"
                               sx={{ fontSize: themeTokens.typography.fontSize.sm }}
                             >
-                              {playlist.climbCount} {playlist.climbCount === 1 ? 'climb' : 'climbs'}
+                              {t('actions.playlist.row.climbCount', { count: playlist.climbCount })}
                             </MuiTypography>
                           </Stack>
                           {isInPlaylist && <CheckOutlined sx={{ color: 'var(--color-success)', fontSize: 18 }} />}

--- a/packages/web/app/components/form/form-shell.tsx
+++ b/packages/web/app/components/form/form-shell.tsx
@@ -84,6 +84,11 @@ export function focusFirstInvalid(formEl: HTMLElement | null | undefined): HTMLE
  * Call this from a submit handler's early-return branch, passing the FormShell's `id`.
  * The deferral matters: inside the handler the fields haven't re-rendered with
  * `aria-invalid="true"` yet, so a synchronous call would find nothing.
+ *
+ * Constraint: one rAF is enough only when the error-state update commits before the
+ * next paint (true for plain setState in a submit handler). If a caller ever sets the
+ * error state inside `startTransition`, the callback can fire before `aria-invalid`
+ * lands — don't wrap validation errors in a transition.
  */
 export function focusFirstInvalidAfterRender(formId: string): void {
   if (typeof window === 'undefined') return;

--- a/packages/web/app/components/form/form-shell.tsx
+++ b/packages/web/app/components/form/form-shell.tsx
@@ -77,3 +77,15 @@ export function focusFirstInvalid(formEl: HTMLElement | null | undefined): HTMLE
   }
   return invalid;
 }
+
+/**
+ * Schedule `focusFirstInvalid` for after React commits the failed-validation render.
+ *
+ * Call this from a submit handler's early-return branch, passing the FormShell's `id`.
+ * The deferral matters: inside the handler the fields haven't re-rendered with
+ * `aria-invalid="true"` yet, so a synchronous call would find nothing.
+ */
+export function focusFirstInvalidAfterRender(formId: string): void {
+  if (typeof window === 'undefined') return;
+  requestAnimationFrame(() => focusFirstInvalid(document.getElementById(formId)));
+}

--- a/packages/web/app/components/form/index.ts
+++ b/packages/web/app/components/form/index.ts
@@ -1,4 +1,4 @@
-export { FormShell, focusFirstInvalid, type FormShellProps } from './form-shell';
+export { FormShell, focusFirstInvalid, focusFirstInvalidAfterRender, type FormShellProps } from './form-shell';
 export { FormSection, type FormSectionProps } from './form-section';
 export { FormField, useFormFieldIds, type FormFieldProps, type FormFieldRenderState } from './form-field';
 export { FormRow, type FormRowProps } from './form-row';


### PR DESCRIPTION
## Summary

Wave 2 of the Velvet Send form migration — and per the expo-web decision, the **final** migration wave. The whole auth family moves onto the form kit from #3703 (this PR stacks on that branch and retargets `main` when it merges):

- **Sign-in / sign-up page + auth modal**: FormShell → FormSection → FormField (render-prop wiring) → stacked FormActions. One static-label pattern on the existing i18n keys; the tab structure, social buttons, and divider are untouched. "Forgot password?" becomes a `labelAccessory` link on the password field.
- **Forgot / reset / verify-request**: same conversion. The verify-request resend email input finally gets an accessible name (new `verifyRequest.fields.email` key in en/es/fr — it was placeholder-only, a WCAG 4.1.2 failure).
- **Server errors surface in the form**, not as toasts, while the form is visible (invalid credentials, NextAuth `?error=` redirects, registration and resend failures — the resend catch previously swallowed the error entirely). Success toasts on navigate-away paths stay.
- **Autofill actually works now**: the auth inputs never had `autoComplete` — login gets `username`/`current-password`, register gets `name`/`email`/`new-password`, email fields get `type="email"` + no autocapitalize. Password show/hide toggles get aria-labels.
- **Playlist-selection mini-form** (create playlist name/description/colour) joins the kit; the popover stays compact (no FormShell width cap).
- No `size` props anywhere — theme defaults only.

Built by an Opus implement lane + Sonnet mechanical lane, adversarially reviewed by Opus, findings fixed (the verify-request half-touch and email autoComplete parity).

## Release Notes

- Signing in is smoother: your password manager can finally autofill Boardsesh, and login errors show up right in the form instead of a vanishing popup.

## Test plan

- [x] `vp test run` — auth + form suites: 72/72 after rebasing onto the latest form-kit branch
- [x] `vp run typecheck:web`, `vp check`, `vp run check:i18n` — clean
- [x] Catalog parity (en/es/fr) maintained — new key added to all three locales
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHy7Edddxsv5oztCTmGP4s