### PR TITLE
fix(web): catch BLE errors in the light drawer + cover long-press and party loop

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -850,7 +850,15 @@ export function useBoardBluetooth({
         connectionDurationSec,
       });
     }
-    await adapter?.disconnect();
+    // The native BLE teardown can reject (e.g. the peripheral is already gone).
+    // Every caller fires this and moves on without awaiting — the light drawer's
+    // handleDisconnect, the tab bar via registerBluetoothConnection, the
+    // board-switch guard — so an unhandled rejection here would surface as a
+    // console error / unhandledrejection with no owner. The UI state above is
+    // already updated, so swallow it after logging.
+    await adapter?.disconnect().catch((error) => {
+      console.error('Error tearing down Bluetooth connection:', error);
+    });
   }, [onConnectionChange]);
 
   // Clean up on unmount — reject any pending picker promise so the adapter's

--- a/packages/web/app/components/board-page/__tests__/light-control-drawer.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/light-control-drawer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
-import { render, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 
 // Echo i18n keys so assertions can match on the key directly.
 vi.mock('react-i18next', () => ({
@@ -22,17 +22,21 @@ vi.mock('@/app/lib/led-color-overrides-db', () => ({
   CUSTOMISABLE_LED_ROLES: ['HAND', 'FOOT', 'FINISH'],
 }));
 
-const mockSendFramesToBoard = vi.fn<(frames: string) => Promise<boolean | undefined>>();
+const mockSendFramesToBoard =
+  vi.fn<(frames: string, mirrored?: boolean, signal?: unknown, ctx?: unknown) => Promise<boolean | undefined>>();
 const mockSetPartyMode = vi.fn();
-const mockClearBoard = vi.fn(() => Promise.resolve(true));
+const mockClearBoard = vi.fn<() => Promise<boolean | undefined>>();
+const mockDisconnect = vi.fn();
 
 let mockBtContext: Record<string, unknown>;
 vi.mock('../../board-bluetooth-control/bluetooth-context', () => ({
   useBluetoothContext: () => mockBtContext,
 }));
 
+// Mutable so disco tests can supply a climb with frames; null by default.
+let mockCurrentClimbQueueItem: unknown = null;
 vi.mock('../../graphql-queue', () => ({
-  useCurrentClimb: () => ({ currentClimbQueueItem: null }),
+  useCurrentClimb: () => ({ currentClimbQueueItem: mockCurrentClimbQueueItem }),
 }));
 
 import { LightControlDrawer } from '../light-control-drawer';
@@ -40,6 +44,9 @@ import type { BoardDetails } from '@/app/lib/types';
 
 const boardDetails = {
   board_name: 'kilter',
+  layout_id: 1,
+  size_id: 1,
+  set_ids: [1],
   holdsData: [],
   edge_left: 0,
   edge_right: 100,
@@ -47,21 +54,60 @@ const boardDetails = {
   edge_bottom: 0,
 } as unknown as BoardDetails;
 
+const moonboardDetails = {
+  board_name: 'moonboard',
+  layout_id: 1,
+  size_id: 1,
+  set_ids: [1],
+  holdsData: [],
+  edge_left: 0,
+  edge_right: 100,
+  edge_top: 100,
+  edge_bottom: 0,
+} as unknown as BoardDetails;
+
+// STARTING(42) + HAND(43) + FINISH(44) for kilter — the HAND segment is what
+// the disco effect re-rolls, so a frames string needs at least one HAND hold
+// or the effect bails before sending anything.
+const discoClimbQueueItem = {
+  climb: {
+    uuid: 'climb-1',
+    frames: 'p1000r42p1001r43p1002r44',
+    mirrored: false,
+    boardType: 'kilter',
+    layoutId: 1,
+  },
+};
+
+function baseContext(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    isConnected: true,
+    sendFramesToBoard: mockSendFramesToBoard,
+    clearBoard: mockClearBoard,
+    disconnect: mockDisconnect,
+    // boardDetails now comes in as a prop, not from the BLE context.
+    partyMode: 'off',
+    setPartyMode: mockSetPartyMode,
+    ledColorOverrides: {},
+    setLedColorOverrides: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSendFramesToBoard.mockReset();
+  mockSendFramesToBoard.mockResolvedValue(true);
+  mockClearBoard.mockReset();
+  mockClearBoard.mockResolvedValue(true);
+  mockCurrentClimbQueueItem = null;
+  mockBtContext = baseContext();
+});
+
 describe('LightControlDrawer light-show failure guard', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.useFakeTimers();
-    mockBtContext = {
-      isConnected: true,
-      sendFramesToBoard: mockSendFramesToBoard,
-      clearBoard: mockClearBoard,
-      disconnect: vi.fn(),
-      // boardDetails now comes in as a prop, not from the BLE context.
-      partyMode: 'glyphs',
-      setPartyMode: mockSetPartyMode,
-      ledColorOverrides: {},
-      setLedColorOverrides: vi.fn(),
-    };
+    mockBtContext = baseContext({ partyMode: 'glyphs' });
   });
 
   afterEach(() => {
@@ -96,5 +142,167 @@ describe('LightControlDrawer light-show failure guard', () => {
     expect(mockShowMessage).not.toHaveBeenCalledWith('lightControl.lightShowFailed', 'error');
     // It did keep sending frames each tick.
     expect(mockSendFramesToBoard.mock.calls.length).toBeGreaterThan(1);
+  });
+});
+
+describe('LightControlDrawer party-loop lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sends a frame immediately when the glyph show activates', () => {
+    mockBtContext = baseContext({ partyMode: 'glyphs' });
+    mockSendFramesToBoard.mockResolvedValue(true);
+
+    render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
+
+    // The mount-time `void sendCurrentLetter()` fires one write before any
+    // interval tick — no timer advance needed.
+    expect(mockSendFramesToBoard).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run the glyph show on a MoonBoard', async () => {
+    mockBtContext = baseContext({ partyMode: 'glyphs' });
+
+    render(<LightControlDrawer open onClose={() => {}} boardDetails={moonboardDetails} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1400);
+    });
+
+    expect(mockSendFramesToBoard).not.toHaveBeenCalled();
+  });
+
+  it('does not run the glyph show while disconnected', async () => {
+    mockBtContext = baseContext({ partyMode: 'glyphs', isConnected: false });
+
+    render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1400);
+    });
+
+    expect(mockSendFramesToBoard).not.toHaveBeenCalled();
+  });
+
+  it('clears the wall once when the show stops', async () => {
+    mockBtContext = baseContext({ partyMode: 'glyphs' });
+    mockSendFramesToBoard.mockResolvedValue(true);
+
+    const { rerender } = render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
+
+    // Flip the show off — the one-shot clear effect should fire a single
+    // clearBoard() as partyMode transitions glyphs → off.
+    mockBtContext = baseContext({ partyMode: 'off' });
+    await act(async () => {
+      rerender(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
+    });
+
+    expect(mockClearBoard).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops sending after unmount', async () => {
+    mockBtContext = baseContext({ partyMode: 'glyphs' });
+    mockSendFramesToBoard.mockResolvedValue(true);
+
+    const { unmount } = render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1400);
+    });
+    const callsBeforeUnmount = mockSendFramesToBoard.mock.calls.length;
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(mockSendFramesToBoard.mock.calls.length).toBe(callsBeforeUnmount);
+  });
+
+  it('stops the disco show and warns after repeated failed writes', async () => {
+    mockBtContext = baseContext({ partyMode: 'disco' });
+    mockCurrentClimbQueueItem = discoClimbQueueItem;
+    mockSendFramesToBoard.mockResolvedValue(false);
+
+    render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
+
+    // Mount tick (failure 1) + one interval tick (failure 2) trips the guard.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(mockSetPartyMode).toHaveBeenCalledWith('off');
+    expect(mockShowMessage).toHaveBeenCalledWith('lightControl.lightShowFailed', 'error');
+  });
+});
+
+describe('LightControlDrawer handleClearAll', () => {
+  // Real timers: these assertions ride on the clearBoard() promise resolving,
+  // not on an interval, so waitFor is the reliable drain.
+  const clickTurnOffAll = () => fireEvent.click(screen.getByText('lightControl.turnOffAll'));
+
+  it('does not warn when the clear succeeds', async () => {
+    mockClearBoard.mockResolvedValue(true);
+    render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
+
+    await act(async () => {
+      clickTurnOffAll();
+    });
+
+    expect(mockClearBoard).toHaveBeenCalledTimes(1);
+    expect(mockShowMessage).not.toHaveBeenCalledWith('lightControl.clearFailed', 'error');
+  });
+
+  it('warns when the clear returns false', async () => {
+    mockClearBoard.mockResolvedValue(false);
+    render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
+
+    clickTurnOffAll();
+
+    await waitFor(() => expect(mockShowMessage).toHaveBeenCalledWith('lightControl.clearFailed', 'error'));
+  });
+
+  it('warns when the clear returns undefined (adapter momentarily gone)', async () => {
+    // clearBoard() returns undefined when the adapter is null under a still-true
+    // isConnected — the `!success` guard now surfaces that instead of === false
+    // swallowing it.
+    mockClearBoard.mockResolvedValue(undefined);
+    render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
+
+    clickTurnOffAll();
+
+    await waitFor(() => expect(mockShowMessage).toHaveBeenCalledWith('lightControl.clearFailed', 'error'));
+  });
+
+  it('warns and logs when the clear rejects mid-write', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockClearBoard.mockRejectedValue(new Error('GATT disconnected mid-write'));
+    render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
+
+    clickTurnOffAll();
+
+    await waitFor(() => expect(mockShowMessage).toHaveBeenCalledWith('lightControl.clearFailed', 'error'));
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('stops the light show instead of double-clearing while a show is running', async () => {
+    mockBtContext = baseContext({ partyMode: 'glyphs' });
+    render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
+
+    await act(async () => {
+      clickTurnOffAll();
+    });
+
+    // The stop effect owns the clearBoard() when partyMode flips off — tapping
+    // "turn off all" during a show must not issue its own clear.
+    expect(mockSetPartyMode).toHaveBeenCalledWith('off');
+    expect(mockClearBoard).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/components/board-page/light-control-drawer.tsx
+++ b/packages/web/app/components/board-page/light-control-drawer.tsx
@@ -282,8 +282,20 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
       setPartyMode('off');
       return;
     }
-    const result = await clearBoard();
-    if (result === false) {
+    try {
+      const success = await clearBoard();
+      // Treat null/undefined as failure — only an explicit `true` means the
+      // wall was cleared. clearBoard() returns undefined when the adapter is
+      // momentarily gone (a drop the `isConnected` state hasn't caught up to
+      // yet), which `=== false` used to swallow silently.
+      if (!success) {
+        showMessage(t('lightControl.clearFailed'), 'error');
+      }
+    } catch (error) {
+      // clearBoard's underlying BLE write usually has its own try/catch and
+      // returns false on failure, but a disconnect mid-write can still surface
+      // here as a rejected promise instead of a `false` return.
+      console.error('Failed to clear board lights:', error);
       showMessage(t('lightControl.clearFailed'), 'error');
     }
   };

--- a/packages/web/app/lib/hooks/__tests__/use-long-press.test.ts
+++ b/packages/web/app/lib/hooks/__tests__/use-long-press.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { renderHook, act } from '@testing-library/react';
+import { useLongPress } from '../use-long-press';
+
+/**
+ * jsdom doesn't implement the PointerEvent constructor, so synthesize a
+ * plain Event and tack on the pointer-specific properties the hook reads.
+ */
+function createPointerEvent(
+  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel' | 'pointerleave',
+  { clientX = 0, clientY = 0, button = 0 }: { clientX?: number; clientY?: number; button?: number } = {},
+): Event {
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperty(event, 'clientX', { value: clientX });
+  Object.defineProperty(event, 'clientY', { value: clientY });
+  Object.defineProperty(event, 'button', { value: button });
+  return event;
+}
+
+describe('useLongPress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires the callback after the press threshold elapses', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(callback).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the timer when the pointer is released before the threshold', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+      element.dispatchEvent(createPointerEvent('pointerup'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('cancels on pointercancel', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+    });
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointercancel'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('cancels on pointerleave', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+    });
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerleave'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('does not cancel when movement is exactly at the threshold (boundary)', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500, moveThresholdPx: 10 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown', { clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      // hypot(8, 6) === 10 — the hook uses strict `>`, so exactly at the
+      // threshold should NOT cancel.
+      element.dispatchEvent(createPointerEvent('pointermove', { clientX: 108, clientY: 106 }));
+      vi.advanceTimersByTime(500);
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels when the pointer drags past the movement threshold', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500, moveThresholdPx: 10 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown', { clientX: 100, clientY: 100 }));
+    });
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointermove', { clientX: 120, clientY: 100 }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-primary mouse buttons', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown', { button: 2 }));
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('consumeLongPress returns true exactly once after a long-press fires', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.consumeLongPress()).toBe(true);
+    expect(result.current.consumeLongPress()).toBe(false);
+  });
+
+  it('consumeLongPress returns false when no long-press has fired', () => {
+    const { result } = renderHook(() => useLongPress(vi.fn(), { thresholdMs: 500 }));
+
+    expect(result.current.consumeLongPress()).toBe(false);
+  });
+
+  it('preventDefault is called on contextmenu to suppress the iOS callout', () => {
+    const { result } = renderHook(() => useLongPress(vi.fn(), { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    const contextMenuEvent = new Event('contextmenu', { bubbles: true, cancelable: true });
+    element.dispatchEvent(contextMenuEvent);
+    expect(contextMenuEvent.defaultPrevented).toBe(true);
+  });
+
+  it('detaches listeners from the previous element when the ref node changes', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const first = document.createElement('button');
+    const second = document.createElement('button');
+
+    act(() => {
+      result.current.ref(first);
+    });
+    act(() => {
+      result.current.ref(second);
+    });
+
+    // The old element no longer fires the callback.
+    act(() => {
+      first.dispatchEvent(createPointerEvent('pointerdown'));
+      vi.advanceTimersByTime(500);
+    });
+    expect(callback).not.toHaveBeenCalled();
+
+    // The new element does.
+    act(() => {
+      second.dispatchEvent(createPointerEvent('pointerdown'));
+      vi.advanceTimersByTime(500);
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears any pending timer when the hook unmounts mid-press', () => {
+    const callback = vi.fn();
+    const { result, unmount } = renderHook(() => useLongPress(callback, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    act(() => {
+      element.dispatchEvent(createPointerEvent('pointerdown'));
+    });
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('handles undefined callback without throwing when the timer fires', () => {
+    const { result } = renderHook(() => useLongPress(undefined, { thresholdMs: 500 }));
+
+    const element = document.createElement('button');
+    act(() => {
+      result.current.ref(element);
+    });
+
+    expect(() => {
+      act(() => {
+        element.dispatchEvent(createPointerEvent('pointerdown'));
+        vi.advanceTimersByTime(500);
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Revives #1815 against the reworked light-drawer code on `main`. Closes #2646.

- **`handleClearAll` now catches BLE errors.** Wraps `clearBoard()` in try/catch and treats `null`/`undefined` returns as failure (`!success` instead of `=== false`). A mid-write GATT disconnect can surface as a rejected promise, and `clearBoard()` returns `undefined` when the adapter is momentarily gone under a still-true `isConnected` — both used to swallow the failure silently instead of showing the "Couldn't clear the board" snackbar.
- **`disconnect()` in `use-board-bluetooth.ts` now catches the native teardown rejection.** Every caller fires it without awaiting (the drawer's `handleDisconnect`, the tab bar via `registerBluetoothConnection`, the board-switch guard), so a reject from `adapter.disconnect()` was an unowned unhandled rejection. This goes **beyond #1815's literal scope** (which was `handleClearAll`-only) but is squarely within this issue's "catch BLE errors" spirit and fixes every fire-and-forget caller at once — the UI state is already updated synchronously before the teardown, so we log and swallow.
- **`useLongPress` is now under test** (13 tests). The hook is unchanged on `main`, so the file lands as-is from the preserved `claude/light-drawer-followups` branch: threshold fire, early release, `pointercancel`/`pointerleave`, at-threshold boundary (no cancel), drag-past cancel, non-primary buttons, `consumeLongPress` once-true/false, `contextmenu` suppression, ref re-attach, unmount cleanup, undefined-callback safety.
- **`LightControlDrawer` party-loop + `handleClearAll` are now under test**, written against `main`'s real `partyMode`/`setPartyMode` API (the original PR's tests targeted a non-existent `partyActive` API — the reason a mechanical rebase was impossible). Covers `handleClearAll`'s branches (success, `false`, `undefined`, thrown-rejection, party-running early-return) plus party-loop lifecycle (immediate send on activation, MoonBoard and disconnect guards, one-shot clear on stop, unmount cleanup) and the disco failure guard. Merged with `main`'s existing failure-guard tests, no duplication.

## Release Notes

- Tapping "Turn off all lights" now tells you when the board dropped mid-clear instead of going quiet.

## Test plan

- `vp test run --project web` — the two test files pass (26/26: 13 long-press + 13 drawer).
- `vp run typecheck:web` — clean.
- `vp check` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va