### PR TITLE
fix(mobile): reset saved climb + preview uuid when the create working angle changes

### DIFF
--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Guards the working-angle change effect in useCreateClimbScreen: because the
+// screen key excludes `angle`, the hook stays mounted across an angle change, so
+// the effect must detach the saved-climb row + mint a fresh preview uuid so
+// Set Active / Save operate on the new angle as a fresh authoring context —
+// except in edit mode, where the identity is the edited climb (not the angle).
+
+// randomUUID returns a distinct value per call so we can tell a freshly minted
+// preview uuid from the stale one (and from a saved server uuid).
+const cryptoMock = vi.hoisted(() => {
+  let counter = 0;
+  return { randomUUID: vi.fn(() => `uuid-${++counter}`) };
+});
+
+const board = vi.hoisted(() => ({
+  isAuthenticated: true,
+  saveClimb: vi.fn(),
+  updateClimb: vi.fn(),
+  isDuplicateClimbError: vi.fn((_err: unknown) => false),
+}));
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+const queue = vi.hoisted(() => ({ setCurrentClimb: vi.fn() }));
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+// Edit mode seeds a savedClimb from `useClimb`.
+const editClimb = vi.hoisted(() => ({ data: undefined as unknown }));
+
+const createClimb = vi.hoisted(() => ({
+  litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
+  setHoldState: vi.fn(),
+  generateFramesString: vi.fn(() => 'p1r12p2r13p3r14'),
+  startingCount: 1,
+  finishCount: 1,
+  isValid: true,
+  resetHolds: vi.fn(),
+  loadHolds: vi.fn(),
+  undo: vi.fn(),
+  redo: vi.fn(),
+  canUndo: false,
+  canRedo: false,
+}));
+
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: () => ({ remove: () => {} }) },
+}));
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('expo-crypto', () => ({ randomUUID: cryptoMock.randomUUID }));
+vi.mock('expo-router', () => ({ useRouter: () => router }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+vi.mock('@boardsesh/shared-schema', () => ({
+  isNoMatchClimb: () => false,
+  withNoMatch: (description: string) => description,
+}));
+vi.mock('@boardsesh/create-climb-react', () => ({
+  useCreateClimb: () => createClimb,
+  computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
+  computeEditLocked: () => false,
+  buildInitialHoldsMap: () => ({}),
+}));
+vi.mock('@boardsesh/board-react', () => ({
+  useBoardActions: () => ({
+    isAuthenticated: board.isAuthenticated,
+    saveClimb: board.saveClimb,
+    updateClimb: board.updateClimb,
+  }),
+  isDuplicateClimbError: (err: unknown) => board.isDuplicateClimbError(err),
+}));
+vi.mock('@boardsesh/graphql-client', () => ({
+  GraphQLOperationError: class GraphQLOperationError extends Error {},
+}));
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ refreshAuthState: vi.fn() }),
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: { displayName: 'Tester' } }),
+  useClimb: () => ({ data: editClimb.data }),
+}));
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueueActions: () => ({ setCurrentClimb: queue.setCurrentClimb }),
+}));
+vi.mock('../../../providers/bluetooth-provider', () => ({
+  useOptionalBluetoothContext: () => null,
+}));
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: toast.showToast }),
+}));
+// Pass the provisional climb straight through so the test can read its uuid +
+// angle off the queue item handed to setCurrentClimb.
+vi.mock('../../../lib/climb-to-queue-item', () => ({
+  climbToQueueItem: (climb: unknown) => climb,
+}));
+vi.mock('../../../lib/create-climb-draft-store', () => ({
+  loadDraft: vi.fn(async () => null),
+  saveDraft: vi.fn(async () => {}),
+  clearDraft: vi.fn(async () => {}),
+  createClimbDraftKey: () => 'draft-key',
+}));
+vi.mock('../brush-roles', () => ({
+  getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],
+}));
+
+import { useCreateClimbScreen } from '../use-create-climb-screen';
+
+type ProvisionalQueueItem = { uuid: string; angle: number };
+
+function boardAt(angle: number) {
+  return { boardName: 'kilter' as const, layoutId: 1, sizeId: 10, setIds: '1,2', angle };
+}
+
+/** The uuid + angle of the last queue item pushed via handleSetActive. */
+function lastSetActive(): ProvisionalQueueItem {
+  const calls = queue.setCurrentClimb.mock.calls;
+  return calls[calls.length - 1]?.[0] as ProvisionalQueueItem;
+}
+
+beforeEach(() => {
+  toast.showToast.mockClear();
+  queue.setCurrentClimb.mockClear();
+  router.push.mockClear();
+  cryptoMock.randomUUID.mockClear();
+  board.isAuthenticated = true;
+  board.isDuplicateClimbError.mockReturnValue(false);
+  board.saveClimb.mockReset();
+  board.updateClimb.mockReset();
+  editClimb.data = undefined;
+});
+
+describe('useCreateClimbScreen working-angle change', () => {
+  it('detaches the saved climb + mints a fresh preview uuid so Set Active tracks the new angle', async () => {
+    board.saveClimb.mockResolvedValue({ uuid: 'saved-25', createdAt: null, publishedAt: null, isDraft: true });
+
+    const { result, rerender } = renderHook(
+      (props: { board: ReturnType<typeof boardAt> }) => useCreateClimbScreen(props),
+      {
+        initialProps: { board: boardAt(25) },
+      },
+    );
+
+    // Before any save, Set Active uses the WIP preview uuid stamped at 25°.
+    act(() => result.current.handleSetActive());
+    const initialPreview = lastSetActive();
+    expect(initialPreview.angle).toBe(25);
+
+    // Save at 25° → Set Active now rides the saved server row.
+    act(() => result.current.setName('Slab Project'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+    act(() => result.current.handleSetActive());
+    expect(lastSetActive().uuid).toBe('saved-25');
+
+    // Switch the working angle to 40°.
+    rerender({ board: boardAt(40) });
+
+    // Set Active must no longer masquerade as the 25° server climb: fresh uuid
+    // (neither the saved row nor the stale pre-save preview) and the new angle.
+    act(() => result.current.handleSetActive());
+    const afterChange = lastSetActive();
+    expect(afterChange.uuid).not.toBe('saved-25');
+    expect(afterChange.uuid).not.toBe(initialPreview.uuid);
+    expect(afterChange.angle).toBe(40);
+    // A save after the angle change creates a NEW climb (no update of the 25° row).
+    board.saveClimb.mockResolvedValue({ uuid: 'saved-40', createdAt: null, publishedAt: null, isDraft: true });
+    await act(async () => {
+      await result.current.handleSave();
+    });
+    expect(board.saveClimb).toHaveBeenCalledTimes(2);
+    expect(board.updateClimb).not.toHaveBeenCalled();
+  });
+
+  it('clears a stale duplicate banner when the angle changes', async () => {
+    board.isDuplicateClimbError.mockReturnValue(true);
+    board.saveClimb.mockRejectedValue(new Error('duplicate'));
+
+    const { result, rerender } = renderHook(
+      (props: { board: ReturnType<typeof boardAt> }) => useCreateClimbScreen(props),
+      {
+        initialProps: { board: boardAt(25) },
+      },
+    );
+
+    act(() => result.current.setName('Dup Problem'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+    await waitFor(() => expect(result.current.publishDuplicateError).not.toBeNull());
+
+    rerender({ board: boardAt(40) });
+
+    expect(result.current.publishDuplicateError).toBeNull();
+  });
+
+  it('does NOT detach the saved climb in edit mode when the angle changes', async () => {
+    editClimb.data = {
+      uuid: 'edit-uuid',
+      name: 'Existing',
+      description: '',
+      frames: 'p1r12',
+      is_draft: true,
+      created_at: '2026-01-01T00:00:00.000Z',
+      published_at: null,
+    };
+
+    const { result, rerender } = renderHook(
+      (props: { board: ReturnType<typeof boardAt>; editClimbUuid?: string }) => useCreateClimbScreen(props),
+      { initialProps: { board: boardAt(25), editClimbUuid: 'edit-uuid' } },
+    );
+
+    // Wait for the edit-mode seed effect to set savedClimb.
+    await waitFor(() => expect(result.current.name).toBe('Existing'));
+    act(() => result.current.handleSetActive());
+    expect(lastSetActive().uuid).toBe('edit-uuid');
+
+    // Changing the angle in edit mode keeps editing the same row.
+    rerender({ board: boardAt(40), editClimbUuid: 'edit-uuid' });
+
+    act(() => result.current.handleSetActive());
+    expect(lastSetActive().uuid).toBe('edit-uuid');
+  });
+});

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -174,6 +174,31 @@ export function useCreateClimbScreen({
     [],
   );
 
+  // ---- Detach the saved-climb row + queue identity when the working angle
+  // changes. ----
+  // The screen key (createClimbScreenKey) deliberately excludes `angle`, so a
+  // working-angle change keeps this hook mounted (and its in-progress paint —
+  // hold geometry is angle-independent). But `savedClimb` was saved *at* the
+  // old angle, and `handleSetActive` / `handleSave` stamp the live `board.angle`
+  // — so leaving the old row attached would pair the old climb's uuid with the
+  // new angle (Set Active shows the wrong angle; a re-Save would updateClimb the
+  // old row to the new angle). Web has no such bug: its angle is a URL segment,
+  // so an angle change remounts the form and resets `savedClimb` to null. This
+  // mirrors that reset without wiping the paint. Skipped in edit mode, whose
+  // identity is `editClimbUuid` (you're editing one row across any angle).
+  const lastAngleRef = useRef(board.angle);
+  useEffect(() => {
+    if (lastAngleRef.current === board.angle) return;
+    lastAngleRef.current = board.angle;
+    if (isEditing) return;
+    // Fresh authoring context at the new angle: drop the saved-row link so the
+    // next Save creates a new climb, clear any stale duplicate banner, and mint
+    // a new preview uuid so Set Active pushes an independent queue item.
+    setSavedClimb(null);
+    setPublishDuplicateError(null);
+    previewUuidRef.current = randomUUID();
+  }, [board.angle, isEditing]);
+
   // ---- Edit mode: fetch the climb and seed the editor once. ----
   const editVariables = useMemo(
     () =>


### PR DESCRIPTION
## Summary

Fixes #2654 (revive of #2520, concern #1).

The mobile create-climb screen key (`createClimbScreenKey`) deliberately **excludes `angle`**, so a working-angle change keeps the hook mounted and preserves the in-progress paint (hold geometry is angle-independent). But nothing reset the angle-dependent state on that change:

- `savedClimb` was saved *at* the old angle, while `handleSetActive` / `handleSave` stamp the **live** `board.angle`.
- Net effect: save at 25° → switch to 40° → **Set Active** pairs the 25° climb's uuid with a 40° angle (card shows the wrong angle), and a re-**Save** would `updateClimb` the 25° row to 40°.

**Fix:** one effect in `use-create-climb-screen.ts` that, on a working-angle change (skipped in edit mode, whose identity is `editClimbUuid`), detaches `savedClimb`, clears any stale duplicate banner, and mints a fresh `previewUuidRef`. This mirrors web's behavior — on web the angle is a URL segment, so an angle change **remounts** the form and resets `savedClimb` to null — without wiping the mobile paint.

Deliberately does **not** clear the previous angle's persisted autosave slot: the draft store is keyed per `board+angle` **by design** for independent per-angle drafts, and clearing the old slot on an in-place change would risk clobbering a genuine separate draft (and is unnecessary — the preserved paint auto-saves into the new angle's slot once `savedClimb` clears).

### ⚠️ Decision needed — @marcodejongh: this fix is currently **latent, not live**

The bug as described is **not reachable through any current entry point**, and I want that on the record before merge:

- All six navigations to `/(tabs)/climbs/create` (FAB, fork, edit ×2, `handleLoadDraft`) pass an explicit `angle` param.
- `create.tsx` pins `board.angle = params.angle ? Number(params.angle) : activeBoard?.angle` — **params win** — so the mounted screen ignores live `activeBoard.angle` updates.
- The session-sync path (`queue-provider.tsx` `SessionBoardPathChanged → setActiveBoard`) updates `activeBoard.angle`, but that never reaches the frozen create screen.

So today `board.angle` cannot change while create is mounted. This PR is a **defensive correctness guard** that matches the deliberate `createClimbScreenKey` design (whose own comment anticipates in-place angle changes) and becomes live the moment create reads the live angle.

**The real decision — do you also want create to track the live session/active-board angle?** (e.g. prefer `activeBoard.angle` when the active board matches the create config). That would make Set Active push a climb at the angle the crew is actually on, and would make this fix *live* rather than latent. It's a real UX/behavior change beyond #2654's scope, so I've left it out and am surfacing it here for you to call. If you'd rather the create angle stay frozen at open-time, this guard is the right stopping point.

## Release Notes

- [x] No release note needed (internal / technical change)

Defensive correctness guard for a path users can't currently reach (see decision note above). No user-visible behavior change to describe today. If we later make create track the live session angle, that becomes user-facing and warrants a real note.

## Test plan

New controller test `use-create-climb-screen-angle.test.tsx` (3 cases):
- Non-edit: save at 25° → change angle → Set Active uses a fresh preview uuid (not the saved row, not the stale pre-save preview) at the new angle, and a subsequent Save creates a new climb (no `updateClimb`).
- Duplicate banner is cleared on angle change.
- Edit-mode guard: with `editClimbUuid`, an angle change does **not** detach the saved climb.

Validation (vp only, all green):
- `vp run typecheck:mobile`
- `vp run test:mobile` (create-climb suite: 14 pass, incl. the 3 new)
- `vp check` (0 errors)
- `vp run check:mobile-bundle` (Android bundle OK)

OTA: JS-only change (one effect + a test) — rides OTA, fingerprint unchanged, no fresh build needed.
