### PR TITLE
fix(backend): order-aware setQueue no-op detection (#2387)

### DIFF
--- a/packages/backend/src/__tests__/queue-sync-fixes.test.ts
+++ b/packages/backend/src/__tests__/queue-sync-fixes.test.ts
@@ -9,6 +9,7 @@ import { roomManager, VersionConflictError } from '../services/room-manager';
 import type { ClimbQueueItem } from '@boardsesh/shared-schema';
 import { queueMutations } from '../graphql/resolvers/queue/mutations';
 import { pubsub } from '../pubsub/index';
+import { logger } from '../utils/logger';
 import { createMockRedis, type MockRedis } from './helpers/mock-redis';
 
 const createTestClimb = (uuid?: string): ClimbQueueItem => ({
@@ -641,6 +642,70 @@ describe('order-sensitive dual-hash (stateHashOrdered)', () => {
         }),
       }),
     );
+  });
+});
+
+// Issue #2387 — the setQueue "redundant resync" warning must be order-aware.
+// A pure reorder (same members, different order) is a legitimate state change
+// that leaves the order-insensitive v1 hash unchanged; comparing v1 alone
+// misreported it as a no-op and blamed "hash-drift on the publisher". The check
+// now requires BOTH v1 and v2 to match, so a reorder passes silently while a
+// genuinely redundant setQueue (nothing changed at all) still warns.
+describe('setQueue - order-aware no-op resync warning (issue #2387)', () => {
+  let mockRedis: MockRedis;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  const NOOP_MESSAGE = 'Redundant full-queue resync';
+
+  beforeEach(async () => {
+    mockRedis = createMockRedis();
+    roomManager.reset();
+    await roomManager.initialize(mockRedis);
+    vi.spyOn(pubsub, 'publishQueueEvent').mockImplementation(() => {});
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation((() => logger) as unknown as typeof logger.warn);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const ctxFor = (sessionId: string) => ({
+    connectionId: 'client-1',
+    sessionId,
+    rateLimitTokens: 60,
+    rateLimitLastReset: Date.now(),
+  });
+
+  it('does NOT warn when a setQueue only reorders the queue (v1 equal, v2 moved)', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+
+    const climb1 = createTestClimb();
+    const climb2 = createTestClimb();
+
+    // Seed the queue (previous = empty, so this first call legitimately differs).
+    await queueMutations.setQueue({}, { queue: [climb1, climb2] }, ctxFor(sessionId));
+    warnSpy.mockClear();
+
+    // Same members, reversed order — a real reorder, not a no-op.
+    await queueMutations.setQueue({}, { queue: [climb2, climb1] }, ctxFor(sessionId));
+
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining(NOOP_MESSAGE));
+  });
+
+  it('warns when a setQueue re-pushes an identical queue (v1 and v2 both equal)', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+
+    const climb1 = createTestClimb();
+    const climb2 = createTestClimb();
+
+    await queueMutations.setQueue({}, { queue: [climb1, climb2] }, ctxFor(sessionId));
+    warnSpy.mockClear();
+
+    // Identical membership AND order AND current climb — a genuine no-op.
+    await queueMutations.setQueue({}, { queue: [climb1, climb2] }, ctxFor(sessionId));
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(NOOP_MESSAGE));
   });
 });
 

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -398,24 +398,34 @@ export const queueMutations = {
       validateInput(ClimbQueueItemSchema, currentClimbQueueItem, 'currentClimbQueueItem');
     }
 
-    // updateQueueState returns `previousStateHash` from the same Redis
+    // updateQueueState returns the prior state hashes from the same Redis
     // read it already does internally, so this no-op check costs nothing
-    // extra. The client's 60s state-hash watchdog (see
-    // packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts)
-    // triggers setQueue when it thinks local and server state have
-    // diverged. If the resulting hash matches what the server already
-    // had, the client was wrong about the drift — usually a bug in the
-    // local hash computation or event processor — and the loop will fire
-    // again next minute. The warn surfaces those loops.
-    const { sequence, stateHash, stateHashOrdered, previousStateHash } = await roomManager.updateQueueState(
-      sessionId,
-      queue,
-      currentClimbQueueItem || null,
-    );
+    // extra. It surfaces a genuinely redundant full-queue resync: a setQueue
+    // whose incoming queue matched what the server already had in membership,
+    // order, AND current climb — nothing changed, so the FullSync below was
+    // pointless work. Look at the *caller* that re-pushed unchanged state, not
+    // the state hash.
+    //
+    // We require BOTH hashes to match. Comparing only the order-insensitive v1
+    // hash misreported a legitimate reorder (same members, different order) as
+    // a no-op, because v1 is blind to reordering — the whole reason the
+    // order-sensitive v2 hash exists. Web's queue-edit reorder pushes a full
+    // setQueue (not the reorderQueueItem delta), so a v1-only check fired this
+    // warning on every drag-to-reorder and blamed the publisher's hash for a
+    // drift that wasn't there (issue #2387). v2 moves on a reorder, so gating
+    // on both hashes lets a real reorder through silently while still catching
+    // a true no-op.
+    const { sequence, stateHash, stateHashOrdered, previousStateHash, previousStateHashOrdered } =
+      await roomManager.updateQueueState(sessionId, queue, currentClimbQueueItem || null);
 
-    if (previousStateHash !== null && previousStateHash === stateHash) {
+    if (
+      previousStateHash !== null &&
+      previousStateHash === stateHash &&
+      previousStateHashOrdered !== null &&
+      previousStateHashOrdered === stateHashOrdered
+    ) {
       logger.warn(
-        `[setQueue] No-op resync for session ${sessionId} (hash=${stateHash}, queueSize=${queue.length}). Client state already matched server — investigate hash-drift on the publisher.`,
+        `[setQueue] Redundant full-queue resync for session ${sessionId} (hash=${stateHash}, queueSize=${queue.length}). Incoming queue matched server state in membership, order, and current climb — a wasted setQueue; check the caller re-pushing unchanged state.`,
       );
     }
 

--- a/packages/backend/src/services/room-manager/queue-state.ts
+++ b/packages/backend/src/services/room-manager/queue-state.ts
@@ -22,13 +22,21 @@ export async function updateQueueState(
   stateHash: string;
   stateHashOrdered: string;
   previousStateHash: string | null;
+  previousStateHashOrdered: string | null;
 }> {
   const { redisStore, writeScheduler, distributedState } = deps;
 
   // Get current version, sequence, and prior state hash from Redis if
-  // available, otherwise from Postgres. The prior hash is returned so
+  // available, otherwise from Postgres. The prior hashes are returned so
   // callers (currently setQueue) can detect no-op resyncs without a
   // second round-trip.
+  //
+  // We return BOTH the prior order-insensitive (v1) and order-sensitive (v2)
+  // hashes. Redis persists only v1, so the prior v2 is recomputed from the
+  // same snapshot Redis/Postgres just returned (mirrors getQueueState's
+  // read-time derivation). setQueue's no-op check needs both: a pure reorder
+  // leaves v1 unchanged but moves v2, so comparing v1 alone misreports a
+  // legitimate reorder as a no-op (issue #2387).
   //
   // We coerce empty-string hashes to null. Legacy session rows in Redis
   // or Postgres can have `stateHash = ''` (the hash field was added
@@ -44,6 +52,17 @@ export async function updateQueueState(
   let currentVersion = expectedVersion;
   let currentSequence = 0;
   let previousStateHash: string | null = null;
+  let previousStateHashOrdered: string | null = null;
+
+  // Derive the prior order-sensitive (v2) hash from a Redis snapshot's stored
+  // queue — Redis persists only v1, so v2 is recomputed on read (same pattern
+  // as getQueueState). `null` when there's no snapshot to derive from.
+  const orderedHashFromRedisSession = (
+    redisSession: { queue: ClimbQueueItem[]; currentClimbQueueItem: ClimbQueueItem | null } | null | undefined,
+  ): string | null =>
+    redisSession
+      ? computeQueueStateHashOrdered(redisSession.queue, redisSession.currentClimbQueueItem?.uuid || null)
+      : null;
 
   if (currentVersion === undefined) {
     if (redisStore) {
@@ -51,24 +70,28 @@ export async function updateQueueState(
       currentVersion = redisSession?.version ?? 0;
       currentSequence = redisSession?.sequence ?? 0;
       previousStateHash = normalizeHash(redisSession?.stateHash);
+      previousStateHashOrdered = orderedHashFromRedisSession(redisSession);
     }
     if (currentVersion === undefined || currentVersion === 0) {
       const pgState = await getQueueState(sessionId, redisStore);
       currentVersion = pgState.version;
       currentSequence = pgState.sequence;
       previousStateHash ??= normalizeHash(pgState.stateHash);
+      previousStateHashOrdered ??= normalizeHash(pgState.stateHashOrdered);
     }
   } else {
-    // If version is provided, get sequence and prior hash from Redis or Postgres
+    // If version is provided, get sequence and prior hashes from Redis or Postgres
     if (redisStore) {
       const redisSession = await redisStore.getSession(sessionId);
       currentSequence = redisSession?.sequence ?? 0;
       previousStateHash = normalizeHash(redisSession?.stateHash);
+      previousStateHashOrdered = orderedHashFromRedisSession(redisSession);
     }
     if (currentSequence === 0) {
       const pgState = await getQueueState(sessionId, redisStore);
       currentSequence = pgState.sequence;
       previousStateHash ??= normalizeHash(pgState.stateHash);
+      previousStateHashOrdered ??= normalizeHash(pgState.stateHashOrdered);
     }
   }
 
@@ -101,7 +124,14 @@ export async function updateQueueState(
     );
   }
 
-  return { version: newVersion, sequence: newSequence, stateHash, stateHashOrdered, previousStateHash };
+  return {
+    version: newVersion,
+    sequence: newSequence,
+    stateHash,
+    stateHashOrdered,
+    previousStateHash,
+    previousStateHashOrdered,
+  };
 }
 
 /**

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -562,6 +562,7 @@ class RoomManager {
     stateHash: string;
     stateHashOrdered: string;
     previousStateHash: string | null;
+    previousStateHashOrdered: string | null;
   }> {
     return updateQueueStateFn(this.deps(), sessionId, queue, currentClimbQueueItem, expectedVersion);
   }

--- a/packages/shared/queue/src/__tests__/state-hash.test.ts
+++ b/packages/shared/queue/src/__tests__/state-hash.test.ts
@@ -126,6 +126,57 @@ describe('state-hash', () => {
         expect(() => computeQueueStateHash([null, { uuid: 'climb-a' }], 'climb-a')).not.toThrow();
       });
     });
+
+    // Issue #2387 — the hash must be invariant to the SHAPE of a queue item, so
+    // the server's full ClimbQueueItem (climb metadata, addedBy, angle, …) and a
+    // client's slim `{ uuid }` item hash identically for equivalent state. The
+    // hash consumes only `uuid`, so extra fields, differing key order, and
+    // null-vs-undefined-vs-absent on non-uuid fields can never drift the two
+    // sides. These lock that invariant in so a future refactor can't reintroduce
+    // the cross-side drift the no-op-resync warning was blamed on.
+    describe('issue #2387 — server-shaped vs client-shaped item equivalence', () => {
+      // A rich "server-shaped" item as the backend stores/broadcasts it.
+      const serverShaped = [
+        {
+          uuid: 'q-1',
+          climb: { uuid: 'climb-1', name: 'Crimp Ladder', angle: 40, boardType: 'kilter', layoutId: 1 },
+          addedBy: 'conn-abc',
+          addedByUser: { id: 'user-9', username: 'marco' },
+          suggested: false,
+          tickedBy: null,
+        },
+        {
+          uuid: 'q-2',
+          climb: { uuid: 'climb-2', name: 'Sloper Traverse', angle: 40, boardType: 'kilter', layoutId: 1 },
+          addedBy: undefined,
+          suggested: true,
+        },
+      ] as unknown as Array<{ uuid: string }>;
+
+      // The same queue as a client's slim `{ uuid }` shape.
+      const clientShaped = [{ uuid: 'q-1' }, { uuid: 'q-2' }];
+
+      it('hashes identically for v1 regardless of item shape', () => {
+        expect(computeQueueStateHash(serverShaped, 'q-1')).toBe(computeQueueStateHash(clientShaped, 'q-1'));
+      });
+
+      it('hashes identically for v2 regardless of item shape', () => {
+        expect(computeQueueStateHashOrdered(serverShaped, 'q-1')).toBe(
+          computeQueueStateHashOrdered(clientShaped, 'q-1'),
+        );
+      });
+
+      it('is invariant to key order and null-vs-undefined on non-uuid fields', () => {
+        const reorderedKeys = [
+          { addedBy: null, climb: { name: 'x' }, suggested: true, uuid: 'q-1' },
+          { suggested: undefined, uuid: 'q-2', climb: undefined },
+        ] as unknown as Array<{ uuid: string }>;
+        expect(computeQueueStateHash(reorderedKeys, 'q-1')).toBe(computeQueueStateHash(clientShaped, 'q-1'));
+        expect(computeQueueStateHashOrdered(reorderedKeys, 'q-1')).toBe(
+          computeQueueStateHashOrdered(clientShaped, 'q-1'),
+        );
+      });
+    });
   });
 
   describe('computeQueueStateHashOrdered (v2, order-sensitive)', () => {


### PR DESCRIPTION
## Summary

Fixes #2387.

The backend logs `[setQueue] No-op resync ... investigate hash-drift on the publisher` at `warn` (24x over the triage window). The check that fires it compared **only the order-insensitive v1 state hash**:

```ts
if (previousStateHash !== null && previousStateHash === stateHash) { logger.warn(...) }
```

A `setQueue` that changes **only queue order** (same members, same current climb) leaves the v1 hash unchanged — v1 sorts UUIDs before hashing, so it is blind to reordering. That is a legitimate state change (new sequence, new v2 hash, `FullSync` broadcast), but the v1-only check misreported it as a no-op and pointed on-call at a hash "drift" that wasn't there.

Confirmed trigger: web's queue-edit drag-to-reorder pushes a full `setQueue` (`queue-list.tsx` -> `queue-actions-core.ts` `party.mutations.setQueue`), **not** the dedicated `reorderQueueItem` delta. So every drag fired the warning.

### The fix

- `updateQueueState` now also returns `previousStateHashOrdered` (the prior **order-sensitive v2** hash). Redis persists only v1, so v2 is recomputed from the same Redis/Postgres snapshot the function already reads — no extra round-trip, matching the existing "costs nothing extra" design.
- The `setQueue` no-op check requires **both** hashes to match before warning. v2 moves on a reorder, so a real reorder passes silently; a genuinely redundant `setQueue` (identical membership, order, and current climb) still warns.
- The warning text now names the real cause — a redundant `setQueue` re-pushing unchanged state — instead of blaming publisher hash-drift. The stale comment claiming the client watchdog pushes `setQueue` was refreshed (the watchdog does a pull-based reconnect now, not a push).

### Staleness note (why the "hash-drift" framing was already obsolete)

The issue was bulk-filed 2026-05-30 from a backward-looking log export, and its hypothesized root cause — *client and server compute different hashes for equivalent state* — was **killed the same day by #2359**, which unified web and backend onto one shared hash (`packages/shared/queue/src/state-hash.ts`) that consumes **only** queue-item UUIDs. Field order, climb metadata, and null-vs-undefined can no longer drift the two sides. What remained was this order-blind no-op **diagnostic**, which the later order-sensitive v2 hash (added 2026-07-03) finally makes fixable: v2 is what distinguishes a real reorder from a true no-op. This PR closes that residual false positive. Added shared-hash tests lock in the cross-side equivalence #2359 established.

### Follow-up (not in this PR)

Web queue-edit reorders route through full-queue `setQueue` rather than the lighter `reorderQueueItem` delta mutation (which preserves the current climb and emits a `QueueReordered` delta instead of a full `FullSync`). Switching web reorders to `reorderQueueItem` would be cleaner semantically and lighter on the wire, but it changes current-climb handling and touches the web queue path — deferred as a separate change.

## Release Notes

- [x] No release note needed (internal / technical change)

Backend log-diagnostic correctness only; no user-facing behavior change.

## Test plan

- `vp test run --reporter=agent packages/shared/queue/src/__tests__/state-hash.test.ts` — 30 passed, incl. new **server-shaped vs client-shaped** item-equivalence tests (full `ClimbQueueItem` with metadata/`addedBy`/angle vs slim `{ uuid }` hash identically for v1 and v2; invariant to key order and null-vs-undefined on non-uuid fields).
- `vp test run --project backend --reporter=agent queue-sync-fixes` — 25 passed, incl. new tests: a reorder-only `setQueue` does **not** warn; a redundant `setQueue` **does** warn.
- `vp run typecheck:backend` — clean.
- `vp check` — 0 errors (pre-existing warnings only, none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va
