### PR TITLE
fix(mobile): pin history stats to climbed-at angle on angle change

### DIFF
--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -284,6 +284,14 @@ function QueueItemRowComponent({
   const showTick = isHistoryItem && !isEditMode && !!onTickHistory;
   const showDragHandle = !!dragHandleGesture && !isEditMode;
 
+  // History rows pin the grade for the angle the climb was CLIMBED at, which can
+  // differ from the live board angle (e.g. the session moved on after the send).
+  // Surface the climbed-at angle only when it differs — no chip on the common
+  // case where history and the wall share an angle.
+  const climbedAtAngle = item.climb?.angle;
+  const showSentAtAngle =
+    isHistoryItem && !isEditMode && typeof climbedAtAngle === 'number' && climbedAtAngle !== board.angle;
+
   const rowContent = (
     <AnimatedPressable
       onPress={handlePress}
@@ -318,6 +326,18 @@ function QueueItemRowComponent({
         setIds={board.setIds}
         angle={board.angle}
       />
+
+      {/* Sent-at-angle chip: history climbed at an angle other than the wall's */}
+      {showSentAtAngle && (
+        <Text
+          variant="caption1"
+          color={iosSystemColors.systemGray}
+          style={styles.sentAtAngle}
+          accessibilityLabel={t('mobile.queue.sentAtAngle', { angle: climbedAtAngle })}
+        >
+          {t('mobile.queue.sentAtAngle', { angle: climbedAtAngle })}
+        </Text>
+      )}
 
       {/* Trailing action: tick (history) or drag handle (upcoming) */}
       {showTick ? (
@@ -411,6 +431,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
+  },
+  sentAtAngle: {
+    flexShrink: 0,
+    fontVariant: ['tabular-nums'],
   },
   deleteAction: {
     position: 'absolute',

--- a/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
@@ -103,6 +103,7 @@ type Snapshot = {
   state: ReturnType<typeof useQueue>['state'];
   playlistSuggestionSource: PlaylistSuggestionSource | null;
   setCurrentClimb: ReturnType<typeof useQueue>['setCurrentClimb'];
+  setQueue: ReturnType<typeof useQueue>['setQueue'];
 };
 
 function makeClimb(uuid: string, angle: number, difficulty: string): Climb {
@@ -129,8 +130,13 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
   const queue = useQueue();
   const playlistSuggestionSource = usePlaylistSuggestionSource();
   useEffect(() => {
-    onSnapshot({ state: queue.state, playlistSuggestionSource, setCurrentClimb: queue.setCurrentClimb });
-  }, [queue.state, playlistSuggestionSource, queue.setCurrentClimb, onSnapshot]);
+    onSnapshot({
+      state: queue.state,
+      playlistSuggestionSource,
+      setCurrentClimb: queue.setCurrentClimb,
+      setQueue: queue.setQueue,
+    });
+  }, [queue.state, playlistSuggestionSource, queue.setCurrentClimb, queue.setQueue, onSnapshot]);
   return null;
 }
 
@@ -191,5 +197,54 @@ describe('QueueProvider angle-change re-grade of the playlist suggestion peek', 
     const fetchedUuids = http.request.mock.calls.map((call) => (call[1] as { climbUuid: string }).climbUuid);
     expect(fetchedUuids).toContain('climb-next');
     expect(fetchedUuids).not.toContain('climb-current');
+  });
+
+  it('re-grades upcoming items but never re-fetches history on angle change', async () => {
+    // Live board angle is 25. Queue laid out as [history, current, upcoming]:
+    //   - history climb baked at 40 (already sent — keeps its climbed-at angle)
+    //   - current climb already at the live angle 25 (nothing to fetch)
+    //   - upcoming climb baked at 40 (stale — must be re-graded to 25)
+    // Only the upcoming climb should be fetched; history must be left alone.
+    const historyClimb = makeClimb('climb-history', 40, 'V7');
+    const currentClimb = makeClimb('climb-current', 25, 'V3');
+    const upcomingClimb = makeClimb('climb-upcoming', 40, 'V6');
+
+    http.request.mockImplementation(async (_query: string, variables: { climbUuid: string; angle: number }) => {
+      if (variables.climbUuid === 'climb-upcoming' && variables.angle === 25) {
+        return { climb: makeClimb('climb-upcoming', 25, 'V4') };
+      }
+      return { climb: null };
+    });
+
+    const snapshots: Snapshot[] = [];
+    render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (snap) => snapshots.push(snap) })));
+
+    await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+    // Seed the exact history/current/upcoming arrangement. The current item is
+    // in the queue so the history/upcoming split is positional (currentIndex 1).
+    await act(async () => {
+      snapshots
+        .at(-1)
+        ?.setQueue([makeItem(historyClimb), makeItem(currentClimb), makeItem(upcomingClimb)], makeItem(currentClimb));
+    });
+
+    // The upcoming climb is re-graded to the live angle.
+    await waitFor(() => {
+      const patched = snapshots.at(-1)?.state.queue.find((item) => item.climb.uuid === 'climb-upcoming');
+      expect(patched?.climb.angle).toBe(25);
+      expect(patched?.climb.difficulty).toBe('V4');
+    });
+
+    const fetchedUuids = http.request.mock.calls.map((call) => (call[1] as { climbUuid: string }).climbUuid);
+    expect(fetchedUuids).toContain('climb-upcoming');
+    // History is never fetched, and the already-live current item isn't either.
+    expect(fetchedUuids).not.toContain('climb-history');
+    expect(fetchedUuids).not.toContain('climb-current');
+
+    // History keeps the grade for the angle it was climbed at.
+    const history = snapshots.at(-1)?.state.queue.find((item) => item.climb.uuid === 'climb-history');
+    expect(history?.climb.angle).toBe(40);
+    expect(history?.climb.difficulty).toBe('V7');
   });
 });

--- a/packages/mobile/src/providers/queue/use-queue-regrade.ts
+++ b/packages/mobile/src/providers/queue/use-queue-regrade.ts
@@ -58,7 +58,18 @@ export function useQueueRegrade({
         uuids.add(item.climb.uuid);
       }
     };
-    queue.forEach(consider);
+    // Only the current climb + upcoming items follow the live angle. History
+    // items (everything before the current climb — the same split
+    // buildQueueListModel uses) keep the grade for the angle they were CLIMBED
+    // at, so we skip fetching for them. REGRADE_CLIMBS also guards this, but
+    // skipping the fetch here avoids wasted GET_CLIMB round-trips for the past.
+    const currentIndex = currentClimbQueueItem
+      ? queue.findIndex((item) => item.uuid === currentClimbQueueItem.uuid)
+      : -1;
+    queue.forEach((item, index) => {
+      if (index < currentIndex) return;
+      consider(item);
+    });
     consider(currentClimbQueueItem);
     // Also re-grade the single displayed playlist peek (the next-up suggestion
     // shown at the queue tail). It lives in playlistSuggestionSource.climbs —

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -401,6 +401,7 @@
       "logAscent": "Log ascent",
       "alreadyLogged": "Logged",
       "dragHandleAria": "Drag to reorder {{name}}",
+      "sentAtAngle": "Sent at {{angle}}°",
       "endSessionCommentPlaceholder": "Add a recap — how did it go?",
       "endSessionCommentAria": "Session recap",
       "endSessionCancel": "Keep climbing"

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -401,6 +401,7 @@
       "logAscent": "Registrar ascenso",
       "alreadyLogged": "Registrado",
       "dragHandleAria": "Arrastra para reordenar {{name}}",
+      "sentAtAngle": "Encadenado a {{angle}}°",
       "endSessionCommentPlaceholder": "Añade un resumen: ¿qué tal ha ido?",
       "endSessionCommentAria": "Resumen de la sesión",
       "endSessionCancel": "Sigue escalando"

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -401,6 +401,7 @@
       "logAscent": "Enregistrer l'ascension",
       "alreadyLogged": "Enregistré",
       "dragHandleAria": "Glisser pour réorganiser {{name}}",
+      "sentAtAngle": "Enchaîné à {{angle}}°",
       "endSessionCommentPlaceholder": "Ajoute un récap — ça a donné quoi ?",
       "endSessionCommentAria": "Récap de la session",
       "endSessionCancel": "Continue à grimper"

--- a/packages/shared/queue/src/__tests__/reducer.test.ts
+++ b/packages/shared/queue/src/__tests__/reducer.test.ts
@@ -635,4 +635,110 @@ describe('REGRADE_CLIMBS', () => {
 
     expect(result).toBe(state);
   });
+
+  it('re-grades the current climb and upcoming items but NOT history', () => {
+    // Queue laid out as [history, current, upcoming] with the current item
+    // sitting inside the queue (real usage — SET_CURRENT_CLIMB inserts it).
+    const history = makeClimbQueueItem({ uuid: 'h1', climb: { uuid: 'climb-h', angle: 40, difficulty: '7a/V6' } });
+    const current = makeClimbQueueItem({ uuid: 'c1', climb: { uuid: 'climb-c', angle: 40, difficulty: '6b/V4' } });
+    const upcoming = makeClimbQueueItem({ uuid: 'u1', climb: { uuid: 'climb-u', angle: 40, difficulty: '6a/V3' } });
+    const state = makeState({ queue: [history, current, upcoming], currentClimbQueueItem: current });
+
+    const gradeAt25 = (difficulty: string) => ({
+      angle: 25,
+      difficulty,
+      quality_average: '3.0',
+      ascensionist_count: 5,
+      benchmark_difficulty: null,
+    });
+
+    const result = queueReducer(state, {
+      type: 'REGRADE_CLIMBS',
+      payload: {
+        grades: {
+          'climb-h': gradeAt25('5+/V1'),
+          'climb-c': gradeAt25('6a/V3'),
+          'climb-u': gradeAt25('5c/V2'),
+        },
+      },
+    });
+
+    // History keeps the angle it was CLIMBED at — same reference, untouched.
+    expect(result.queue[0]).toBe(history);
+    expect(result.queue[0].climb.angle).toBe(40);
+    expect(result.queue[0].climb.difficulty).toBe('7a/V6');
+
+    // Current + upcoming follow the live angle.
+    expect(result.queue[1].climb.angle).toBe(25);
+    expect(result.queue[1].climb.difficulty).toBe('6a/V3');
+    expect(result.currentClimbQueueItem?.climb.angle).toBe(25);
+    expect(result.queue[2].climb.angle).toBe(25);
+    expect(result.queue[2].climb.difficulty).toBe('5c/V2');
+  });
+
+  it('does not re-grade a history occurrence that shares a climb uuid with an upcoming item', () => {
+    // The SAME climb sits in history (climbed at 40°) and upcoming (re-added).
+    // The grade is keyed by climb.uuid, but only the upcoming occurrence must
+    // follow the new angle; the history occurrence pins its climbed-at angle.
+    const historyDup = makeClimbQueueItem({ uuid: 'h1', climb: { uuid: 'dup', angle: 40, difficulty: '7a/V6' } });
+    const current = makeClimbQueueItem({ uuid: 'c1', climb: { uuid: 'climb-c', angle: 40, difficulty: '6b/V4' } });
+    const upcomingDup = makeClimbQueueItem({ uuid: 'u1', climb: { uuid: 'dup', angle: 40, difficulty: '7a/V6' } });
+    const state = makeState({ queue: [historyDup, current, upcomingDup], currentClimbQueueItem: current });
+
+    const result = queueReducer(state, {
+      type: 'REGRADE_CLIMBS',
+      payload: {
+        grades: {
+          dup: {
+            angle: 25,
+            difficulty: '5+/V1',
+            quality_average: '3.0',
+            ascensionist_count: 5,
+            benchmark_difficulty: null,
+          },
+        },
+      },
+    });
+
+    // History occurrence: pinned (same reference, original grade).
+    expect(result.queue[0]).toBe(historyDup);
+    expect(result.queue[0].climb.difficulty).toBe('7a/V6');
+    expect(result.queue[0].climb.angle).toBe(40);
+    // Upcoming occurrence: re-graded to the live angle.
+    expect(result.queue[2].climb.difficulty).toBe('5+/V1');
+    expect(result.queue[2].climb.angle).toBe(25);
+  });
+
+  it('re-grades the whole queue when there is no current item', () => {
+    // No current climb → the entire queue is "upcoming" (buildQueueListModel),
+    // so every item follows the live angle.
+    const first = makeClimbQueueItem({ uuid: 'q1', climb: { uuid: 'climb-a', angle: 40, difficulty: '6a/V3' } });
+    const second = makeClimbQueueItem({ uuid: 'q2', climb: { uuid: 'climb-b', angle: 40, difficulty: '6b/V4' } });
+    const state = makeState({ queue: [first, second], currentClimbQueueItem: null });
+
+    const result = queueReducer(state, {
+      type: 'REGRADE_CLIMBS',
+      payload: {
+        grades: {
+          'climb-a': {
+            angle: 25,
+            difficulty: '5+/V1',
+            quality_average: '3.0',
+            ascensionist_count: 5,
+            benchmark_difficulty: null,
+          },
+          'climb-b': {
+            angle: 25,
+            difficulty: '5c/V2',
+            quality_average: '3.0',
+            ascensionist_count: 5,
+            benchmark_difficulty: null,
+          },
+        },
+      },
+    });
+
+    expect(result.queue[0].climb.angle).toBe(25);
+    expect(result.queue[1].climb.angle).toBe(25);
+  });
 });

--- a/packages/shared/queue/src/reducer.ts
+++ b/packages/shared/queue/src/reducer.ts
@@ -374,12 +374,20 @@ export function queueReducer<TSearchParams extends QueueSearchParams>(
     }
 
     case 'REGRADE_CLIMBS': {
-      // Patch the per-angle grade fields onto climbs already in the queue /
-      // current item when the board angle changes. Keyed by climb.uuid (the
-      // SAME climb can appear multiple times — e.g. re-added after a tick — so
-      // every occurrence is patched). Local-only: the caller re-fetches each
+      // Patch the per-angle grade fields onto the CURRENT + UPCOMING climbs when
+      // the board angle changes. Keyed by climb.uuid (the SAME climb can appear
+      // multiple times — e.g. re-added after a tick — so every occurrence in the
+      // regraded range is patched). Local-only: the caller re-fetches each
       // climb's grade for the new angle and dispatches this; nothing is sent to
       // peers (each client follows the angle and re-grades its own queue).
+      //
+      // History items (everything before the current climb — the same split
+      // buildQueueListModel uses) are deliberately NOT re-graded: they keep the
+      // grade for the angle they were CLIMBED at. A V6 send at 40° must not turn
+      // into a V8 when the rest of the session moves to 35°. Because current +
+      // upcoming continuously track the live angle, a climb's angle is already
+      // the live angle at the moment it advances into history, so freezing it
+      // there pins the climbed-at angle for free — no separate `sentAtAngle`.
       const { grades } = action.payload;
       let changed = false;
       const regrade = (item: ClimbQueueItem): ClimbQueueItem => {
@@ -391,7 +399,16 @@ export function queueReducer<TSearchParams extends QueueSearchParams>(
         return { ...item, climb: { ...item.climb, ...patch } };
       };
 
-      const newQueue = state.queue.map(regrade);
+      // Index of the current climb in the flat queue. When there's no current
+      // item (-1) the whole queue is "upcoming" per buildQueueListModel, so the
+      // `index < currentIndex` guard is never true and everything is re-graded.
+      const currentIndex = state.currentClimbQueueItem
+        ? state.queue.findIndex(({ uuid }) => uuid === state.currentClimbQueueItem?.uuid)
+        : -1;
+
+      // History items (index < currentIndex) are returned by reference, so the
+      // reference-equality / no-churn guarantees hold for them too.
+      const newQueue = state.queue.map((item, index) => (index < currentIndex ? item : regrade(item)));
       const newCurrent = state.currentClimbQueueItem ? regrade(state.currentClimbQueueItem) : null;
 
       // Preserve the original state reference when nothing matched, so the


### PR DESCRIPTION
## Summary

Queue climbs carry per-angle stats — grade, quality, send count — baked in for the angle they were fetched at. Since the session angle became shared, the mobile re-grade engine refreshed the **whole** queue on an angle change, so already-sent history climbs lost the angle they were actually climbed at. A V6 send at 40° turned into a V8 the moment the session moved to 35°.

**The fix is to skip history on re-grade, not to add a new per-item field.** `REGRADE_CLIMBS` now re-grades only the current climb + upcoming items (`index >= currentIndex` — the same history/current/upcoming split `buildQueueListModel` already uses). Because current + upcoming continuously track the live angle, a climb's angle already equals the live angle the instant it advances into history — so freezing it there pins the *climbed-at* angle for free, satisfying all three acceptance criteria (current/upcoming refresh, history not refreshed, history = climbed angle) with **no** new `sentAtAngle` state to sync/persist/replay.

What changed:

- **`packages/shared/queue/src/reducer.ts`** — `REGRADE_CLIMBS` computes `currentIndex` and returns history items (before the current climb) by reference; only current + upcoming get patched. No current item → the whole queue is "upcoming" and all re-grade (matches `buildQueueListModel`). Reference-equality / no-churn guarantees preserved.
- **`packages/mobile/src/providers/queue/use-queue-regrade.ts`** — skips history in the fetch pass too, so we don't burn `GET_CLIMB` round-trips re-grading the past.
- **`packages/mobile/src/components/QueueItemRow.tsx`** — a small "Sent at N°" chip on a history row, shown **only** when its climbed-at angle differs from the live board angle (no chip on the common case where they match). New i18n key `session > mobile.queue.sentAtAngle` in `en-US` / `es` / `fr` (glossary-correct: ES "Encadenado a {{angle}}°", FR "Enchaîné à {{angle}}°").
- Tests: shared reducer pins (a) current/upcoming re-grade, (b) history not re-graded (incl. the same-climb-uuid-in-both-history-and-upcoming case), (c) climbed-at angle, and the no-current fallback; a mobile provider test pins that history is never re-fetched on angle change.

**Known limitation:** if the wall advances into history in the same tick as an angle change, before the async `GET_CLIMB` resolves, a history item can freeze at the pre-change angle. Inherent async race, rare in practice.

**Follow-up (not this PR):** web has no re-grade driver at all, so web current/upcoming stats still don't refresh on angle change. Wiring `REGRADE_CLIMBS` into the web queue surface is a separate, larger change — tracked as a follow-up.

Closes #2242

## Release Notes

- Change your board angle mid-session and the queue keeps up: the climb you're on and everything coming up show grades, stars, and sends for the angle the wall is actually set to.
- Climbs you've already sent stay pinned to the angle you climbed them at, with a "Sent at N°" tag when that differs from the wall's current angle.

## Test plan

- `vp test run --project queue --reporter=agent` — shared queue reducer (109 pass, incl. new history-skip cases)
- `vp run test:mobile` — full mobile suite (3972 pass, incl. new regrade history test)
- `vp test run --project i18n` — catalog parity (60 pass; new key present in all three locales)
- `vp run typecheck` — clean (exit 0)
- `vp check` — 0 errors
- `vp run check:mobile-bundle` — OK (14.1 MB)
