### PR TITLE
fix(mobile): resolve partially-synced queue items instead of "Unknown Climb"

### DIFF
--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '../providers/theme-provider';
 import { Icon } from './Icon';
 import { ClimbAttributeIcons } from './ClimbAttributeIcons';
 import { ClimbPlaylistChips } from './ClimbPlaylistChips';
+import { isClimbResolved } from '../lib/queue-climb-resolution';
 import type { IconName } from './icon-map';
 import type { AscentStatusValue } from '../lib/ascent-status-utils';
 
@@ -62,7 +63,13 @@ export type ClimbListItemClimb = {
 };
 
 type ClimbListItemContentProps = {
-  climb: ClimbListItemClimb;
+  // Nullable/thin-tolerant: the search list always supplies a resolved climb, but
+  // a partially-synced peer queue item can reach the queue row with a missing or
+  // unresolved climb (`ClimbQueueItem.climb` is typed non-null, yet the wire
+  // boundary is untyped). When it isn't resolved we render an "Unknown Climb"
+  // placeholder rather than crashing on `climb.frames`; useQueueResolveClimbs
+  // then re-fetches and hydrates it in place (#2527).
+  climb: ClimbListItemClimb | null | undefined;
   boardName: BoardName;
   layoutId: number;
   sizeId: number;
@@ -164,20 +171,18 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   showPlaylistChips = false,
 }: ClimbListItemContentProps) {
   const { t } = useTranslation('climbs');
+  const { t: tSession } = useTranslation('session');
   const { resolveGrade } = useDisplayGrade();
   const { systemColors } = useTheme();
 
-  // One O(1) resolve per row: the Boardsesh grade (label + colour) when the "Show
-  // Boardsesh grades" toggle is on and a trusted one exists, else the legacy
-  // Aurora grade. `resolveGrade` is the stable callback from `useDisplayGrade`
-  // (called once above), so it never re-derives per render beyond this call.
-  const { label: formattedGrade, color: gradeColor } = resolveGrade(climb);
-
   // Subtitle parts: sends · quality★ · setter (each dropped when absent). A
   // caller-supplied override wins outright — a string replaces the line, null
-  // hides it — so session rows can show the sender instead.
+  // hides it — so session rows can show the sender instead. Tolerates a nullish
+  // climb (partially-synced peer item) — the placeholder branch below renders
+  // before this value is read in that case.
   const subtitleText = useMemo(() => {
     if (primarySubtitleOverride !== undefined) return primarySubtitleOverride;
+    if (!climb) return null;
     const parts: string[] = [];
     if (climb.is_draft) {
       parts.push(t('createClimbForm.draftBadge'));
@@ -195,10 +200,10 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
     return parts.length > 0 ? parts.join(' · ') : t('mobile.climbRow.projectFallback');
   }, [
     primarySubtitleOverride,
-    climb.is_draft,
-    climb.ascensionist_count,
-    climb.quality_average,
-    climb.setter_username,
+    climb?.is_draft,
+    climb?.ascensionist_count,
+    climb?.quality_average,
+    climb?.setter_username,
     t,
   ]);
 
@@ -206,6 +211,33 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
     const parts = subtitleDetailParts?.filter((part) => part.length > 0) ?? [];
     return parts.length > 0 ? parts.join(' · ') : null;
   }, [subtitleDetailParts]);
+
+  // Partially-synced peer item whose climb isn't resolved yet (#2527): render an
+  // "Unknown Climb" placeholder that keeps the three-block layout so the row
+  // doesn't crash and its gutter/separator still line up with resolved rows.
+  // useQueueResolveClimbs re-fetches the climb by uuid and swaps in the real one,
+  // so this is transient for any item that carries a fetchable uuid.
+  // `!climb ||` is redundant with isClimbResolved at runtime but lets TypeScript
+  // narrow `climb` to non-null for the resolved render below.
+  if (!climb || !isClimbResolved(climb)) {
+    return (
+      <>
+        <View style={styles.thumbnailContainer} />
+        <View style={styles.centerColumn}>
+          <Text variant="body" numberOfLines={1} style={styles.climbName}>
+            {tSession('mobile.queue.unknownClimb')}
+          </Text>
+        </View>
+        <View style={styles.rightSection} />
+      </>
+    );
+  }
+
+  // One O(1) resolve per row: the Boardsesh grade (label + colour) when the "Show
+  // Boardsesh grades" toggle is on and a trusted one exists, else the legacy
+  // Aurora grade. `resolveGrade` is the stable callback from `useDisplayGrade`
+  // (called once above), so it never re-derives per render beyond this call.
+  const { label: formattedGrade, color: gradeColor } = resolveGrade(climb);
 
   return (
     <>

--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -279,7 +279,9 @@ function QueueItemRowComponent({
     [isDraggable, drag],
   );
 
-  const climbName = item.climb?.name ?? t('mobile.queue.unknownClimb');
+  // `||` (not `??`) so a partially-synced item with an empty-string name also
+  // falls back to the placeholder label instead of an empty accessibility string.
+  const climbName = item.climb?.name || t('mobile.queue.unknownClimb');
 
   const showTick = isHistoryItem && !isEditMode && !!onTickHistory;
   const showDragHandle = !!dragHandleGesture && !isEditMode;

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -2,6 +2,10 @@ import { randomUUID } from 'expo-crypto';
 import type { Climb, ClimbInput } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 
+// `isClimbResolved` lives in ./queue-climb-resolution (no expo-crypto import) so
+// the shared visual can pull the predicate without this module's native deps.
+export { isClimbResolved } from './queue-climb-resolution';
+
 /**
  * Map a `Climb` to the GraphQL `ClimbInput` for queue mutations. `ClimbInput` is
  * a strict subset of `Climb` — sending extra fields (notably `created_at`, which

--- a/packages/mobile/src/lib/queue-climb-resolution.ts
+++ b/packages/mobile/src/lib/queue-climb-resolution.ts
@@ -1,0 +1,21 @@
+// Pure predicate for a queue climb's resolution state — no expo/native imports,
+// so it's safe to pull into the shared visual (`ClimbListItemContent`) whose
+// tests don't mock expo-crypto. Lives apart from `climb-to-queue-item.ts` for
+// exactly that reason (that module imports `randomUUID` from expo-crypto).
+
+// The minimum a queue climb needs to render (name, thumbnail) AND to be a valid
+// `ClimbInput` for a peer broadcast (`name`/`frames` are `String!` server-side).
+type ResolvableClimb = { uuid?: string | null; name?: string | null; frames?: string | null } | null | undefined;
+
+/**
+ * Whether a queue item's climb is fully resolved: it carries the uuid, name, and
+ * frames the row/thumbnail render and a `ClimbInput` requires. A party peer can
+ * broadcast a queue item whose climb arrived partially synced (missing details,
+ * or only an item shell), and the wire boundary is untyped despite
+ * `ClimbQueueItem.climb` being declared non-null — so guard with this before
+ * rendering or re-broadcasting. An unresolved-but-uuid'd climb is re-fetched by
+ * `useQueueResolveClimbs`; a uuid-less one is genuinely unresolvable (#2527).
+ */
+export function isClimbResolved(climb: ResolvableClimb): boolean {
+  return !!climb && !!climb.uuid && !!climb.name && !!climb.frames;
+}

--- a/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
@@ -1,0 +1,283 @@
+// @vitest-environment jsdom
+import { act, render, waitFor } from '@testing-library/react';
+import { createElement, useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+// Self-contained QueueProvider harness (mirrors queue-provider-regrade.test.tsx)
+// scoped to the self-healing resolve of partially-synced queue climbs (#2527).
+
+const ws = vi.hoisted(() => ({
+  client: {
+    on: vi.fn(() => vi.fn()),
+    subscribe: vi.fn(() => vi.fn()),
+  },
+}));
+
+const graph = vi.hoisted(() => ({ execute: vi.fn() }));
+const http = vi.hoisted(() => ({ request: vi.fn() }));
+
+const activeBoard = vi.hoisted(() => ({
+  stored: {
+    uuid: 'board-1',
+    slug: 'board-1',
+    ownerId: 'owner-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '1,2',
+    name: 'Test board',
+    isPublic: true,
+    isUnlisted: false,
+    hideLocation: false,
+    isOwned: true,
+    angle: 25,
+    isAngleAdjustable: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    totalAscents: 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+    canEdit: false,
+  } satisfies UserBoard,
+  getStoredActiveBoard: vi.fn(),
+}));
+
+const queueMutations = vi.hoisted(() => ({
+  addQueueItem: vi.fn(async () => {}),
+  removeQueueItem: vi.fn(async () => {}),
+  reorderQueueItem: vi.fn(async () => {}),
+  setCurrentClimb: vi.fn(async () => {}),
+  mirrorCurrentClimb: vi.fn(async () => {}),
+  publishPlaybackState: vi.fn(async () => {}),
+  setQueue: vi.fn(async () => {}),
+  replaceQueueItem: vi.fn(async () => {}),
+  reportWallDisconnect: vi.fn(async () => {}),
+  confirmClimbOnWall: vi.fn(async () => {}),
+  setSessionBoardSerial: vi.fn(async () => {}),
+  setSessionBoardPath: vi.fn(async () => {}),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
+  AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
+}));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-correlation-id' }));
+vi.mock('@boardsesh/graphql-client', () => ({ execute: graph.execute }));
+vi.mock('@boardsesh/queue-react', () => ({ useQueueMutations: () => queueMutations }));
+vi.mock('@boardsesh/play-view', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/play-view')>()),
+  emitWallConfirm: vi.fn(),
+}));
+vi.mock('../../lib/graphql/ws-client', () => ({ getWsClient: () => ws.client }));
+// Solo (no session) keeps the resolve path isolated from join/subscription noise.
+vi.mock('../../lib/session-store', () => ({
+  getStoredSessionId: vi.fn(async () => null),
+  setStoredSessionId: vi.fn(async () => {}),
+  clearStoredSessionId: vi.fn(async () => {}),
+}));
+vi.mock('../../lib/queue-snapshot-store', () => ({
+  getStoredQueueSnapshot: vi.fn(async () => null),
+  setStoredQueueSnapshot: vi.fn(async () => {}),
+  clearStoredQueueSnapshot: vi.fn(async () => {}),
+}));
+vi.mock('../../lib/active-board-store', () => ({ getStoredActiveBoard: activeBoard.getStoredActiveBoard }));
+vi.mock('../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: activeBoard.stored }),
+  useSetActiveBoard: () => vi.fn(async () => {}),
+}));
+vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: http.request }) }));
+vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+vi.mock('../party-profile-provider', () => ({
+  usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
+}));
+
+import { QueueProvider, useQueue } from '../queue-provider';
+
+type QueueApi = ReturnType<typeof useQueue>;
+type Snapshot = {
+  state: QueueApi['state'];
+  dispatch: QueueApi['dispatch'];
+  setQueue: QueueApi['setQueue'];
+  setCurrentClimb: QueueApi['setCurrentClimb'];
+};
+
+// A fully-resolved climb (uuid + name + frames): renderable and syncable.
+function makeClimb(uuid: string, angle: number, difficulty: string): Climb {
+  return {
+    uuid,
+    name: `Climb ${uuid}`,
+    frames: 'p1r12',
+    setter_username: 'setter',
+    angle,
+    ascensionist_count: 0,
+    difficulty,
+    quality_average: '3.0',
+    stars: 3,
+    difficulty_error: '0.3',
+    benchmark_difficulty: null,
+  };
+}
+
+// A partially-synced climb: carries a fetchable uuid but no name/frames, so it
+// renders as an "Unknown Climb" placeholder until resolved.
+function makeThinClimb(uuid: string): Climb {
+  return {
+    uuid,
+    name: '',
+    frames: '',
+    setter_username: '',
+    angle: 25,
+    ascensionist_count: 0,
+    difficulty: '',
+    quality_average: '0',
+    stars: 0,
+    difficulty_error: '',
+    benchmark_difficulty: null,
+  };
+}
+
+function makeItem(queueUuid: string, climb: Climb): ClimbQueueItem {
+  return { uuid: queueUuid, climb, suggested: false };
+}
+
+function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
+  const queue = useQueue();
+  useEffect(() => {
+    onSnapshot({
+      state: queue.state,
+      dispatch: queue.dispatch,
+      setQueue: queue.setQueue,
+      setCurrentClimb: queue.setCurrentClimb,
+    });
+  }, [queue.state, queue.dispatch, queue.setQueue, queue.setCurrentClimb, onSnapshot]);
+  return null;
+}
+
+function renderProvider() {
+  const snapshots: Snapshot[] = [];
+  render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (snap) => snapshots.push(snap) })));
+  return snapshots;
+}
+
+describe('QueueProvider self-healing resolve of partially-synced climbs (#2527)', () => {
+  beforeEach(() => {
+    ws.client.on.mockClear();
+    ws.client.subscribe.mockClear();
+    activeBoard.getStoredActiveBoard.mockReset();
+    activeBoard.getStoredActiveBoard.mockResolvedValue(activeBoard.stored);
+    for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
+      mutation.mockReset();
+      mutation.mockResolvedValue(undefined);
+    }
+    graph.execute.mockReset();
+    http.request.mockReset();
+  });
+
+  it('re-fetches an unresolved queue climb by uuid and hydrates it in place', async () => {
+    http.request.mockImplementation(async (_query: string, variables: { climbUuid: string; angle: number }) => {
+      if (variables.climbUuid === 'climb-thin' && variables.angle === 25) {
+        return { climb: makeClimb('climb-thin', 25, 'V5') };
+      }
+      return { climb: null };
+    });
+
+    const snapshots = renderProvider();
+    await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+    // A partially-synced item lands in the queue (as if from a peer FullSync).
+    await act(async () => {
+      snapshots.at(-1)?.dispatch({
+        type: 'UPDATE_QUEUE',
+        payload: { queue: [makeItem('q1', makeThinClimb('climb-thin'))] },
+      });
+    });
+
+    // The resolve effect fetches the climb at the live angle and patches it in.
+    await waitFor(() => {
+      const resolved = snapshots.at(-1)?.state.queue.find((item) => item.uuid === 'q1');
+      expect(resolved?.climb.name).toBe('Climb climb-thin');
+      expect(resolved?.climb.frames).toBe('p1r12');
+      expect(resolved?.climb.difficulty).toBe('V5');
+    });
+
+    const fetchedUuids = http.request.mock.calls.map((call) => (call[1] as { climbUuid: string }).climbUuid);
+    expect(fetchedUuids).toContain('climb-thin');
+  });
+
+  it('leaves the placeholder in place and does not crash when resolution fails (offline)', async () => {
+    // Simulate offline: the wrapped request rejects. offlineAwareRequest degrades
+    // to plain HTTP with the offline engine off, so a network failure surfaces here.
+    http.request.mockRejectedValue(new Error('offline'));
+
+    const snapshots = renderProvider();
+    await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+    await act(async () => {
+      snapshots.at(-1)?.dispatch({
+        type: 'UPDATE_QUEUE',
+        payload: { queue: [makeItem('q1', makeThinClimb('climb-thin'))] },
+      });
+    });
+
+    // It attempted a fetch...
+    await waitFor(() => expect(http.request).toHaveBeenCalled());
+    // ...but the item stays unresolved (no throw, no hydration).
+    const stillThin = snapshots.at(-1)?.state.queue.find((item) => item.uuid === 'q1');
+    expect(stillThin?.climb.name).toBe('');
+  });
+
+  it('never broadcasts an unresolved climb via setQueue (skips it from the wire payload)', async () => {
+    // Keep resolution from succeeding so the thin item stays unresolved.
+    http.request.mockResolvedValue({ climb: null });
+
+    const snapshots = renderProvider();
+    await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+    const resolvedItem = makeItem('q-ok', makeClimb('climb-ok', 25, 'V4'));
+    const thinItem = makeItem('q-thin', makeThinClimb('climb-thin'));
+
+    await act(async () => {
+      snapshots.at(-1)?.setQueue([resolvedItem, thinItem], thinItem);
+    });
+
+    await waitFor(() => expect(queueMutations.setQueue).toHaveBeenCalled());
+    // The mock is untyped (vi.fn with no declared params) but records the real
+    // args; bridge through `unknown` to read them as the mutation's tuple shape.
+    const [syncedQueue, syncedCurrent] = queueMutations.setQueue.mock.calls.at(-1) as unknown as [
+      ClimbQueueItem[],
+      ClimbQueueItem | undefined,
+    ];
+    // Only the resolved item reaches the wire; the thin item (and thin current) is dropped.
+    expect(syncedQueue.map((item) => item.uuid)).toEqual(['q-ok']);
+    expect(syncedCurrent).toBeUndefined();
+
+    // The local reducer still holds BOTH items — the drop is wire-only.
+    expect(
+      snapshots
+        .at(-1)
+        ?.state.queue.map((item) => item.uuid)
+        .sort(),
+    ).toEqual(['q-ok', 'q-thin']);
+  });
+
+  it('never broadcasts an unresolved climb via setCurrentClimb', async () => {
+    http.request.mockResolvedValue({ climb: null });
+
+    const snapshots = renderProvider();
+    await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+    await act(async () => {
+      snapshots.at(-1)?.setCurrentClimb(makeItem('q-thin', makeThinClimb('climb-thin')));
+    });
+
+    // Local reducer applied it (so the UI can show/resolve it) but nothing was sent.
+    await waitFor(() => expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('q-thin'));
+    expect(queueMutations.setCurrentClimb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -32,7 +32,7 @@ import { getStoredActiveBoard } from '../lib/active-board-store';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
 import { findPreviousQueueItem, findNextQueueItemWithSuggestions } from '@boardsesh/play-view';
 import { toClimbQueueItem } from '../lib/queue-conversion';
-import { climbToQueueItem, toClimbInput } from '../lib/climb-to-queue-item';
+import { climbToQueueItem, toClimbInput, isClimbResolved } from '../lib/climb-to-queue-item';
 import { track } from '../lib/analytics';
 import { reportHandledError } from '../lib/error-reporting';
 import { useToast } from './toast-provider';
@@ -60,6 +60,7 @@ import {
   type QueuePlaylistSuggestionContextValue,
 } from './queue/queue-contexts';
 import { useQueueRegrade } from './queue/use-queue-regrade';
+import { useQueueResolveClimbs } from './queue/use-queue-resolve-climbs';
 import { useQueuePersistence } from './queue/use-queue-persistence';
 import { useSessionCommands } from './queue/use-session-commands';
 import {
@@ -600,6 +601,13 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     setPlaylistSuggestionSourceState,
   });
 
+  // Self-healing resolve: a partially-synced peer item (or a snapshot restored
+  // before its climb data loaded) can land in the queue with an unresolved climb.
+  // Re-fetch it by uuid at the live angle and patch it in place so the row shows
+  // the real name/grade/thumbnail instead of an "Unknown Climb" placeholder. See
+  // useQueueResolveClimbs (#2527).
+  useQueueResolveClimbs({ activeBoard, queue: state.queue, dispatch });
+
   // The reducer raises `needsResync` when it filters corrupted (null) items out
   // of a server FullSync/UPDATE_QUEUE — the local queue is now known-stale.
   // Mirror web (use-queue-event-subscription): in a party session, clear the
@@ -628,6 +636,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         addedFromTab: 'mobile',
         currentQueueLength: stateRef.current.queue.length + 1,
       });
+      // No unresolved-climb guard here: addToQueue is only ever called with a
+      // fully-resolved climb from search / detail / playlist (a real user tap),
+      // never a peer placeholder. The re-broadcast vectors that need guarding are
+      // setCurrentClimb (next/previousClimb can land on an unhydrated peer item)
+      // and setQueue (whole-queue replace) — see #2527.
       mutations.addQueueItem(item).catch((error) => {
         if (__DEV__) console.warn('[queue] addQueueItem sync failed', error);
         // In a party session the add never reached peers — reconcile against the
@@ -716,7 +729,15 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const setQueue = useCallback(
     (queue: ClimbQueueItem[], currentClimbQueueItem?: ClimbQueueItem | null) => {
       dispatch({ type: 'UPDATE_QUEUE', payload: { queue, currentClimbQueueItem: currentClimbQueueItem ?? null } });
-      mutations.setQueue(queue, currentClimbQueueItem ?? undefined).catch((error) => {
+      // Keep the full queue locally, but never broadcast a placeholder/thin item
+      // to peers (#2527): drop unresolved items from the wire payload (they can't
+      // form a valid ClimbInput and peers can't render them). useQueueResolveClimbs
+      // hydrates any resolvable item in place; a later mutation re-syncs the real
+      // one. An unresolved current climb is likewise not sent as current.
+      const syncableQueue = queue.filter((item) => isClimbResolved(item.climb));
+      const syncableCurrent =
+        currentClimbQueueItem && isClimbResolved(currentClimbQueueItem.climb) ? currentClimbQueueItem : undefined;
+      mutations.setQueue(syncableQueue, syncableCurrent).catch((error) => {
         if (__DEV__) console.warn('[queue] setQueue sync failed', error);
         void resyncQueueAfterMutationFailure();
       });
@@ -760,6 +781,16 @@ export function QueueProvider({ children }: { children: ReactNode }) {
           insertAfterCurrent,
         },
       });
+      // Skip the broadcast for an unresolved climb (#2527) — a placeholder
+      // ClimbInput can't be sent (its uuid may be empty and name/frames are
+      // required server-side), and next/previousClimb can navigate onto a
+      // not-yet-hydrated peer item. The local reducer already applied the change,
+      // and useQueueResolveClimbs hydrates the item within a tick. No pending
+      // correlation is tracked since no server echo will arrive.
+      if (!isClimbResolved(item.climb)) {
+        if (__DEV__) console.warn('[queue] skipping setCurrentClimb sync for an unresolved climb. See #2527.');
+        return;
+      }
       coordinator.trackPendingMutation(correlationId);
       mutations.setCurrentClimb(item, shouldAddToQueue, correlationId).catch(() => {
         // In a party session the current-climb change never reached peers —

--- a/packages/mobile/src/providers/queue/use-queue-resolve-climbs.ts
+++ b/packages/mobile/src/providers/queue/use-queue-resolve-climbs.ts
@@ -1,0 +1,119 @@
+import { useEffect, useRef } from 'react';
+import type { ClimbQueueItem, QueueAction } from '@boardsesh/queue';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { offlineAwareRequest } from '../../lib/graphql/offline-request';
+import { GET_CLIMB, type GetClimbQueryResponse } from '../../lib/graphql/operations';
+import { climbToQueueItem, isClimbResolved } from '../../lib/climb-to-queue-item';
+
+type UseQueueResolveClimbsParams = {
+  /** The active board (climb-scope + angle source of truth). Undefined until the React Query cache hydrates. */
+  activeBoard: UserBoard | null | undefined;
+  queue: ClimbQueueItem[];
+  dispatch: React.Dispatch<QueueAction>;
+};
+
+/**
+ * Self-healing climb resolution (#2527): a party peer can broadcast a queue item
+ * whose climb arrived partially synced — missing name/frames/grade — or a local
+ * snapshot can restore before the climb data hydrates. `ClimbQueueItem.climb` is
+ * typed non-null, but the wire boundary is untyped, so such items slip into the
+ * queue and render as an "Unknown Climb" placeholder. When the climb still
+ * carries a fetchable uuid, re-fetch it (by uuid, at the live board angle) and
+ * patch the resolved climb back into the item in place — the same shape as the
+ * angle re-grade path (`useQueueRegrade`).
+ *
+ * Local only: each client resolves its own queue; nothing is sent to peers.
+ * Fails gracefully offline — `offlineAwareRequest` returns `{ climb: null }`
+ * (or the wrapped HTTP request throws), which is caught and skipped, leaving the
+ * placeholder until data is available. Idempotent + loop-safe: a `DELTA_REPLACE`
+ * only fires for a result that is itself resolved, so a null/still-thin response
+ * never churns state and re-triggers the effect.
+ *
+ * We scan the queue only. `DELTA_REPLACE_QUEUE_ITEM` updates the current climb
+ * when its uuid is in the queue (the common case); a bare current-climb-only item
+ * can't be patched this way, but the current climb always arrives fully populated
+ * over the wire (schema-enforced `Climb!`), so that edge doesn't occur in
+ * practice.
+ */
+export function useQueueResolveClimbs({ activeBoard, queue, dispatch }: UseQueueResolveClimbsParams): void {
+  // climb uuid -> the angle a resolve fetch is currently in flight for. Keyed by
+  // angle (not a plain Set) so a fetch already running for a STALE angle doesn't
+  // block a fresh fetch when the angle changes again mid-flight.
+  const resolveInFlightRef = useRef<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    if (!activeBoard) return undefined;
+    const { boardType, layoutId, sizeId, setIds, angle } = activeBoard;
+
+    // Unresolved queue items that still carry a fetchable climb uuid. A uuid-less
+    // placeholder is genuinely unresolvable (no key to fetch by) — it stays a
+    // transient "Unknown Climb" row and is skipped, never re-broadcast.
+    const uuids = new Set<string>();
+    for (const item of queue) {
+      const climbUuid = item.climb?.uuid;
+      if (!climbUuid || isClimbResolved(item.climb)) continue;
+      if (resolveInFlightRef.current.get(climbUuid) === angle) continue;
+      uuids.add(climbUuid);
+    }
+    if (uuids.size === 0) return undefined;
+
+    const targetUuids = [...uuids];
+    targetUuids.forEach((climbUuid) => resolveInFlightRef.current.set(climbUuid, angle));
+
+    let cancelled = false;
+    void (async () => {
+      const resolved = await Promise.all(
+        targetUuids.map(async (climbUuid) => {
+          try {
+            const response = await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, {
+              boardName: boardType,
+              layoutId,
+              sizeId,
+              setIds,
+              angle,
+              climbUuid,
+            });
+            const climb = response.climb;
+            // Only accept a result that is actually resolved — a null (offline /
+            // not-yet-synced) or still-thin climb must NOT be dispatched, or the
+            // replaced item would stay unresolved and re-trigger this effect.
+            if (!isClimbResolved(climb)) return null;
+            return [climbUuid, climb] as const;
+          } catch {
+            return null;
+          } finally {
+            // Only clear our own marker — a newer run may have re-targeted this
+            // uuid to a different angle and must keep its in-flight claim. Clearing
+            // it lets a still-thin item retry on the next queue/board churn.
+            if (resolveInFlightRef.current.get(climbUuid) === angle) {
+              resolveInFlightRef.current.delete(climbUuid);
+            }
+          }
+        }),
+      );
+      if (cancelled) return;
+
+      const byUuid = new Map(resolved.filter((entry): entry is NonNullable<typeof entry> => entry !== null));
+      if (byUuid.size === 0) return;
+
+      // Patch every occurrence of a resolved climb back into its queue item(s),
+      // preserving the queue-slot uuid and item metadata (addedBy / tickedBy).
+      // The same climb can appear multiple times (e.g. re-added after a tick).
+      for (const item of queue) {
+        const climbUuid = item.climb?.uuid;
+        if (!climbUuid) continue;
+        const climb = byUuid.get(climbUuid);
+        if (!climb) continue;
+        const resolvedClimb = climbToQueueItem(climb, { uuid: item.uuid, suggested: item.suggested }).climb;
+        dispatch({
+          type: 'DELTA_REPLACE_QUEUE_ITEM',
+          payload: { uuid: item.uuid, item: { ...item, climb: resolvedClimb } },
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [queue, activeBoard, dispatch]);
+}


### PR DESCRIPTION
## Summary

Fixes #2527. A party peer can broadcast a queue item whose climb arrived **partially synced** (missing name/frames/grade), or a local snapshot can restore before the climb data hydrates. `ClimbQueueItem.climb` is typed non-null, but the wire boundary is untyped, so such items slipped into the queue and rendered as a **permanent "Unknown Climb" placeholder** rather than being resolved.

This is the follow-up the issue tracked. The earlier band-aids (null-tolerant `toClimbInput` placeholder + placeholder row) were already removed during the mobile queue refactor; this replaces them with a proper resolve path.

**What changed**

- **`isClimbResolved`** (`packages/mobile/src/lib/queue-climb-resolution.ts`) — one predicate: a climb is resolved when it carries the `uuid` + `name` + `frames` the row/thumbnail render and a `ClimbInput` requires. Kept in its own expo-crypto-free module so the shared visual can import it without pulling native deps into component tests.
- **`useQueueResolveClimbs`** (new self-healing hook, mirrors `useQueueRegrade`) — for each queue item that's unresolved but carries a fetchable `uuid`, re-fetch the climb by uuid at the live board angle via `offlineAwareRequest` and patch it in place with `DELTA_REPLACE_QUEUE_ITEM`. Local-only (nothing sent to peers), loop-safe (only a *resolved* result is dispatched, so a null/still-thin response never churns state), and fails gracefully offline (null result is skipped; the placeholder stays transiently).
- **No placeholder `ClimbInput` reaches peers** — `setCurrentClimb` (next/previousClimb can land on a not-yet-hydrated peer item) skips the broadcast for an unresolved climb, and `setQueue` filters unresolved items out of the wire payload. The local reducer keeps the full queue either way. `addToQueue` is intentionally not guarded — it only ever receives a fully-resolved climb from search/detail/playlist.
- **`ClimbListItemContent`** tolerates an unresolved climb and renders an "Unknown Climb" placeholder that preserves the three-block row layout instead of crashing on `climb.frames`.

**Acceptance criteria**

- Partially-synced peer items resolve to their real climb (thumbnail, name, grade) once data is available. ✅
- No placeholder `ClimbInput` is broadcast to peers. ✅
- "Unknown Climb" only appears transiently (or not at all) for genuinely unresolvable (uuid-less) climbs. ✅

**Scope notes / limitations**

- **Queue-only scan.** `DELTA_REPLACE_QUEUE_ITEM` updates the current climb when its uuid is in the queue (the common case). A bare current-climb-only item can't be patched this way, but the current climb always arrives fully populated over the wire (schema-enforced `Climb!`), so this edge doesn't occur in practice.
- **Retry cadence.** Matches `useQueueRegrade`: an unresolved item re-attempts on the next queue/board change rather than via an explicit connectivity subscription. Thin items arrive during party sessions where queue churn is constant, so retries happen naturally. Edge case: a static queue that stays put after a reconnect could hold a thin item until the next churn — a possible `onlineManager`-triggered retry follow-up if we ever see it in the wild.

**OTA:** JS/TS-only, no native deps, no migrations, no backend changes — rides OTA; no new store/preview build required.

## Release Notes

- Queue climbs your crew adds now fill in their name, grade, and thumbnail on your phone instead of getting stuck on "Unknown Climb" — even when the climb wasn't already cached on your device.

## Test plan

- New `packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx` (4 cases): an unresolved queue item is re-fetched by uuid and hydrated in place; a failed fetch (offline) leaves the placeholder without crashing; `setQueue` drops the unresolved item (and unresolved current) from the wire payload while the local reducer keeps both; `setCurrentClimb` on an unresolved item applies locally but is never broadcast.
- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 488 files / 3975 tests pass
- `vp check` — 0 errors
- `vp run check:mobile-bundle` — Android bundle OK (14.1 MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va
