### PR TITLE
fix(mobile): send only +1/-1 on the vote mutation, never 0

### DIFF
--- a/packages/backend/src/__tests__/social-validation.test.ts
+++ b/packages/backend/src/__tests__/social-validation.test.ts
@@ -9,6 +9,7 @@ import {
   SetterClimbsInputSchema,
   SetterClimbsFullInputSchema,
   BulkVoteSummaryInputSchema,
+  VoteInputSchema,
 } from '../validation/schemas';
 
 describe('Social Validation Schemas', () => {
@@ -333,6 +334,53 @@ describe('Social Validation Schemas', () => {
         entityIds: Array.from({ length: 101 }, (_unused, index) => `id-${index}`),
       });
       expect(result.success).toBe(false);
+    });
+  });
+
+  // Regression coverage for issue #3189: the mobile client sent `value: 0` on
+  // un-vote, which this schema rejects — but nothing exercised it directly,
+  // so the gap shipped. Pins the exact domain (+1/-1 only) at the boundary
+  // that produced the Sentry error ("Vote value must be +1 or -1").
+  describe('VoteInputSchema', () => {
+    it('should accept a value of +1', () => {
+      const result = VoteInputSchema.safeParse({ entityType: 'session', entityId: 'session-1', value: 1 });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept a value of -1', () => {
+      const result = VoteInputSchema.safeParse({ entityType: 'session', entityId: 'session-1', value: -1 });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject a value of 0 (the un-vote bug from #3189)', () => {
+      const result = VoteInputSchema.safeParse({ entityType: 'session', entityId: 'session-1', value: 0 });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Vote value must be +1 or -1');
+      }
+    });
+
+    it('should reject values other than +1/-1 (2, -2, non-integer)', () => {
+      expect(VoteInputSchema.safeParse({ entityType: 'session', entityId: 'session-1', value: 2 }).success).toBe(false);
+      expect(VoteInputSchema.safeParse({ entityType: 'session', entityId: 'session-1', value: -2 }).success).toBe(
+        false,
+      );
+      expect(VoteInputSchema.safeParse({ entityType: 'session', entityId: 'session-1', value: 0.5 }).success).toBe(
+        false,
+      );
+    });
+
+    it('should reject a missing value', () => {
+      const result = VoteInputSchema.safeParse({ entityType: 'session', entityId: 'session-1' });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject an empty entityId', () => {
+      const result = VoteInputSchema.safeParse({ entityType: 'session', entityId: '', value: 1 });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('cannot be empty');
+      }
     });
   });
 });

--- a/packages/mobile/src/components/you/__tests__/use-optimistic-vote.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/use-optimistic-vote.test.tsx
@@ -41,6 +41,44 @@ describe('useOptimisticVote', () => {
     expect(mutate.mock.calls[0][0]).toEqual({ entityType: 'session', entityId: 's1', value: 1 });
   });
 
+  it('sends value: 1 — never 0 — when un-voting (regression for #3189)', () => {
+    // Already upvoted server-side. Tapping again removes the vote: the backend
+    // only accepts +1/-1 (no 0/null "clear vote"), and toggles off when the
+    // SAME value is resent — so the un-vote tap must also send `value: 1`.
+    const { result } = renderHook(() => useOptimisticVote('s1', 5, 1));
+    expect(result.current.voted).toBe(true);
+
+    act(() => result.current.toggle());
+
+    expect(result.current.voted).toBe(false);
+    expect(result.current.count).toBe(4);
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate.mock.calls[0][0]).toEqual({ entityType: 'session', entityId: 's1', value: 1 });
+  });
+
+  it('pins every wire value across a full none -> voted -> none -> voted transition sequence', () => {
+    const { result } = renderHook(() => useOptimisticVote('s1', 5, null));
+
+    // none -> voted
+    act(() => result.current.toggle());
+    expect(result.current.voted).toBe(true);
+    act(() => (mutate.mock.calls[0][1] as VoteOpts).onSuccess({ upvotes: 6, userVote: 1 }));
+
+    // voted -> none (the un-vote path this bug broke)
+    act(() => result.current.toggle());
+    expect(result.current.voted).toBe(false);
+    act(() => (mutate.mock.calls[1][1] as VoteOpts).onSuccess({ upvotes: 5, userVote: 0 }));
+
+    // none -> voted again
+    act(() => result.current.toggle());
+    expect(result.current.voted).toBe(true);
+
+    expect(mutate).toHaveBeenCalledTimes(3);
+    for (const call of mutate.mock.calls) {
+      expect(call[0]).toEqual({ entityType: 'session', entityId: 's1', value: 1 });
+    }
+  });
+
   it('reconciles to the server summary on success', () => {
     const { result } = renderHook(() => useOptimisticVote('s1', 5, null));
     act(() => result.current.toggle());

--- a/packages/mobile/src/components/you/use-optimistic-vote.ts
+++ b/packages/mobile/src/components/you/use-optimistic-vote.ts
@@ -46,8 +46,13 @@ export function useOptimisticVote(
     if (voteIsPending) return; // guard double-tap
     const nextVoted = !voted;
     setOptimistic({ count: count + (nextVoted ? 1 : -1), voted: nextVoted });
+    // The backend's vote mutation only accepts +1/-1 (no 0/null "clear vote"
+    // value) — un-voting is done by resending the SAME value already on
+    // record, which the resolver detects and deletes. Mobile only ever
+    // represents an upvote, so the wire value is always 1; `nextVoted` still
+    // drives the local optimistic voted/count flip above.
     voteMutate(
-      { entityType, entityId, value: nextVoted ? 1 : 0 },
+      { entityType, entityId, value: 1 },
       {
         onSuccess: (summary) => setOptimistic({ count: summary.upvotes, voted: summary.userVote === 1 }),
         onError: () => setOptimistic(null),

--- a/packages/shared/graphql/src/operations/comments-votes.ts
+++ b/packages/shared/graphql/src/operations/comments-votes.ts
@@ -254,7 +254,10 @@ export type VoteMutationVariables = {
   input: {
     entityType: SocialEntityType;
     entityId: string;
-    value: number;
+    // The backend rejects anything but +1/-1 (see VoteInputSchema in
+    // packages/backend) — narrowed to a literal union so a stray 0/undefined
+    // can never type-check onto the wire.
+    value: 1 | -1;
   };
 };
 

--- a/packages/web/app/components/social/__tests__/vote-button.test.tsx
+++ b/packages/web/app/components/social/__tests__/vote-button.test.tsx
@@ -220,6 +220,71 @@ describe('VoteButton', () => {
     });
   });
 
+  describe('wire payload: value is always +1/-1, never 0 (pins every UI transition)', () => {
+    // The backend rejects any `value` that isn't +1 or -1 — un-voting is done
+    // by resending the same value already on record, which the resolver
+    // detects and deletes. `0` only ever exists as local "not voted" UI state
+    // (see `newUserVote = 0` in vote-button.tsx) and must never reach the wire.
+    // These tests exercise the full upvote -> un-vote -> downvote -> un-vote
+    // sequence and assert every outgoing VOTE payload.
+    function mockVoteResponse(summary: { upvotes: number; downvotes: number; voteScore: number; userVote: number }) {
+      mockRequest.mockResolvedValueOnce({
+        vote: { entityType: 'climb', entityId: 'climb-1', ...summary },
+      });
+    }
+
+    it('sends value: 1 on first upvote, then value: 1 again to un-vote (never 0)', async () => {
+      renderVoteButton({ initialUserVote: 0, initialUpvotes: 0, initialDownvotes: 0 });
+
+      mockVoteResponse({ upvotes: 1, downvotes: 0, voteScore: 1, userVote: 1 });
+      fireEvent.click(screen.getByLabelText('Upvote'));
+      await waitFor(() =>
+        expect(mockRequest).toHaveBeenCalledWith('VOTE', {
+          input: { entityType: 'climb', entityId: 'climb-1', value: 1 },
+        }),
+      );
+
+      mockVoteResponse({ upvotes: 0, downvotes: 0, voteScore: 0, userVote: 0 });
+      fireEvent.click(screen.getByLabelText('Upvote'));
+      await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+      expect(mockRequest).toHaveBeenLastCalledWith('VOTE', {
+        input: { entityType: 'climb', entityId: 'climb-1', value: 1 },
+      });
+    });
+
+    it('sends value: -1 on downvote, then value: -1 again to un-vote (never 0)', async () => {
+      renderVoteButton({ initialUserVote: 0, initialUpvotes: 0, initialDownvotes: 0 });
+
+      mockVoteResponse({ upvotes: 0, downvotes: 1, voteScore: -1, userVote: -1 });
+      fireEvent.click(screen.getByLabelText('Downvote'));
+      await waitFor(() =>
+        expect(mockRequest).toHaveBeenCalledWith('VOTE', {
+          input: { entityType: 'climb', entityId: 'climb-1', value: -1 },
+        }),
+      );
+
+      mockVoteResponse({ upvotes: 0, downvotes: 0, voteScore: 0, userVote: 0 });
+      fireEvent.click(screen.getByLabelText('Downvote'));
+      await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+      expect(mockRequest).toHaveBeenLastCalledWith('VOTE', {
+        input: { entityType: 'climb', entityId: 'climb-1', value: -1 },
+      });
+    });
+
+    it('switching from upvote to downvote sends the new literal value, not a delta', async () => {
+      renderVoteButton({ initialUserVote: 1, initialUpvotes: 1, initialDownvotes: 0 });
+
+      mockVoteResponse({ upvotes: 0, downvotes: 1, voteScore: -1, userVote: -1 });
+      fireEvent.click(screen.getByLabelText('Downvote'));
+
+      await waitFor(() =>
+        expect(mockRequest).toHaveBeenCalledWith('VOTE', {
+          input: { entityType: 'climb', entityId: 'climb-1', value: -1 },
+        }),
+      );
+    });
+  });
+
   describe('likeOnly mode', () => {
     it('shows Unlike aria-label when userVote is 1 (filled heart)', () => {
       renderVoteButton({ likeOnly: true, initialUserVote: 1, initialUpvotes: 3 });


### PR DESCRIPTION
## Summary

Fixes #3189. The mobile vote toggle (`useOptimisticVote`, backing the like/vote button on session and tick feed cards) sent `value: 0` to the backend when a user tapped to remove their vote. The backend's Zod validator only ever accepts `+1`/`-1` — there is no `0`/`null` "clear vote" value in the schema. Un-voting is done by resending the *same* value already on record, which the resolver detects and deletes (`existing.value === value` → delete row). Web's `VoteButton` already implements this correctly; mobile's hook conflated the local "not voted" UI sentinel (`0`) with the wire payload.

- `packages/mobile/src/components/you/use-optimistic-vote.ts`: always send `value: 1` (mobile only ever represents an upvote) and let the server's existing toggle-off semantics do the rest.
- `packages/shared/graphql/src/operations/comments-votes.ts`: narrow `VoteMutationVariables.input.value` from `number` to `1 | -1` so a stray `0`/`undefined` can no longer type-check onto the wire.
- Tests added at all three layers to pin the wire payload across the full upvote → un-vote → downvote → un-vote transition sequence (mobile hook, web `VoteButton`, backend `VoteInputSchema`).

## Release Notes

- Removing a vote or like on a session now works every time — it used to get silently rejected.

## Test plan

- `vp run typecheck:mobile` / `typecheck:web` / `typecheck:backend` / `typecheck:graphql` — all pass.
- `vp test run --project mobile src/components/you/__tests__/use-optimistic-vote.test.tsx` — 8 passed (2 new: pins `value: 1` on un-vote, and across a full none → voted → none → voted sequence).
- `vp test run --project web app/components/social/__tests__/vote-button.test.tsx` — 13 passed (3 new: upvote/un-vote, downvote/un-vote, and switch-vote all assert the literal wire value, never `0`).
- `SKIP_TEST_INFRA=1 vp test run --project backend src/__tests__/social-validation.test.ts` — 42 passed (6 new for `VoteInputSchema`: accepts `±1`, rejects `0` — reproducing the exact Sentry message "Vote value must be +1 or -1" — rejects `±2`/non-integer/missing).
- `vp check` — 0 errors.

No native/Expo changes — pure JS/TS, ships via existing OTA channels (no new preview build needed).