### PR TITLE
fix(mobile): let horizontal shelves scroll inside the play drawer on Android

### DIFF
--- a/packages/mobile/src/components/play-drawer/BetaVideosSection.tsx
+++ b/packages/mobile/src/components/play-drawer/BetaVideosSection.tsx
@@ -1,5 +1,11 @@
 import { memo, useCallback } from 'react';
-import { ScrollView, View, Pressable, StyleSheet } from 'react-native';
+import { View, Pressable, StyleSheet } from 'react-native';
+// The play drawer's outer scroll is a react-native-gesture-handler ScrollView, so
+// a nested horizontal shelf must also be RNGH's ScrollView — otherwise on Android
+// the outer scroll's native gesture handler swallows the horizontal pans and this
+// strip never scrolls (a plain RN ScrollView isn't in RNGH's gesture tree). Same
+// pattern as WorkoutTypeShelf inside PreSessionView's RNGH scroll.
+import { ScrollView } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 import * as Haptics from 'expo-haptics';
 import { betaLinkIdentity } from '@boardsesh/shared-schema';
@@ -88,6 +94,7 @@ export const BetaVideosSection = memo(function BetaVideosSection({ climbUuid, bo
       ) : (
         <ScrollView
           horizontal
+          nestedScrollEnabled
           showsHorizontalScrollIndicator={false}
           contentContainerStyle={styles.scrollContent}
           snapToInterval={BETA_CARD_WIDTH + CARD_GAP}

--- a/packages/mobile/src/components/play-drawer/SimilarClimbsSection.tsx
+++ b/packages/mobile/src/components/play-drawer/SimilarClimbsSection.tsx
@@ -1,5 +1,10 @@
 import { memo, useCallback, useMemo } from 'react';
-import { ScrollView, View, Pressable, StyleSheet } from 'react-native';
+import { View, Pressable, StyleSheet } from 'react-native';
+// RNGH ScrollView (not react-native's): the play drawer's outer scroll is an RNGH
+// ScrollView, so this nested horizontal strip must join the same gesture tree or
+// Android's outer scroll swallows its horizontal pans and it never scrolls. Same
+// pattern as WorkoutTypeShelf / BetaVideosSection.
+import { ScrollView } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 import type { Climb, BoardName, SimilarClimb } from '@boardsesh/shared-schema';
 import * as Haptics from 'expo-haptics';
@@ -59,7 +64,12 @@ export const SimilarClimbsSection = memo(function SimilarClimbsSection({
 
   if (isLoading) {
     return (
-      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.scroller}>
+      <ScrollView
+        horizontal
+        nestedScrollEnabled
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scroller}
+      >
         {Array.from({ length: SKELETON_COUNT }, (_, index) => (
           <View key={index} style={[styles.card, styles.skeletonCard]} />
         ))}
@@ -95,7 +105,12 @@ export const SimilarClimbsSection = memo(function SimilarClimbsSection({
   }
 
   return (
-    <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.scroller}>
+    <ScrollView
+      horizontal
+      nestedScrollEnabled
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.scroller}
+    >
       {ranked.map(({ climb: similar, compatible }) => {
         // SimilarClimb carries no Boardsesh grade today, so `resolveGrade` falls
         // back to the legacy label + colour — lights up once the backend stamps them.

--- a/packages/mobile/src/components/play-drawer/__tests__/beta-videos-section-scroll.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/beta-videos-section-scroll.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BetaLink } from '@boardsesh/shared-schema';
+
+// Regression guard for the Android nested-scroll fix (issue #3506): the play
+// drawer's outer scroll is a react-native-gesture-handler ScrollView, so the
+// horizontal beta strip must scroll with RNGH's ScrollView too — a plain
+// react-native ScrollView isn't in RNGH's gesture tree and Android's outer scroll
+// swallows its horizontal pans. Two distinct stubs let us assert which module the
+// strip came from, so a refactor back to the RN ScrollView fails here.
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-testid': 'rn-scroll' }, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('react-native-gesture-handler', () => ({
+  ScrollView: ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-testid': 'rngh-scroll' }, children),
+}));
+
+const betaLinks = vi.hoisted(() => ({
+  data: undefined as BetaLink[] | undefined,
+  isLoading: false,
+  isError: false,
+  isRefetching: false,
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('expo-haptics', () => ({ selectionAsync: vi.fn() }));
+vi.mock('@boardsesh/shared-schema', () => ({ betaLinkIdentity: (url: string) => url }));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => null }));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useBetaLinks: () => ({
+    data: betaLinks.data,
+    isLoading: betaLinks.isLoading,
+    isError: betaLinks.isError,
+    isRefetching: betaLinks.isRefetching,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ brandColors: { primary: '#000' } }) }));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#888', systemRed: '#f00' } }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12 }, borderRadius: { md: 8, full: 999 } }));
+vi.mock('../BetaVideoCard', () => ({
+  BETA_CARD_WIDTH: 108,
+  BETA_CARD_HEIGHT: 192,
+  BetaVideoCard: ({ link }: { link: BetaLink }) =>
+    createElement('div', { 'data-testid': 'beta-card', 'data-link': link.link }),
+}));
+
+import { BetaVideosSection } from '../BetaVideosSection';
+
+function betaLink(url: string): BetaLink {
+  return {
+    climb_uuid: 'climb-1',
+    link: url,
+    foreign_username: null,
+    angle: 40,
+    thumbnail: null,
+    is_listed: true,
+    created_at: '2026-06-12T00:00:00.000Z',
+    tick_uuid: null,
+    board_id: null,
+  };
+}
+
+beforeEach(() => {
+  betaLinks.data = undefined;
+  betaLinks.isLoading = false;
+  betaLinks.isError = false;
+  betaLinks.isRefetching = false;
+});
+
+describe('BetaVideosSection', () => {
+  it('scrolls the loaded beta strip with the gesture-handler ScrollView (Android nested-scroll fix)', () => {
+    betaLinks.data = [betaLink('https://www.instagram.com/reel/aaa/'), betaLink('https://www.tiktok.com/@u/video/1')];
+
+    const { getByTestId, queryByTestId, getAllByTestId } = render(
+      createElement(BetaVideosSection, { climbUuid: 'climb-1', boardName: 'kilter' }),
+    );
+
+    expect(getByTestId('rngh-scroll')).toBeTruthy();
+    expect(queryByTestId('rn-scroll')).toBeNull();
+    expect(getAllByTestId('beta-card')).toHaveLength(2);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/similar-climbs-section-scroll.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/similar-climbs-section-scroll.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression guard for the Android nested-scroll fix (issue #3506): like the beta
+// strip, the Similar Climbs strip lives inside the play drawer's RNGH ScrollView,
+// so it must scroll with react-native-gesture-handler's ScrollView — a plain
+// react-native ScrollView can't scroll there on Android. Distinct stubs let us
+// assert the strip's scroller came from the gesture-handler module.
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-testid': 'rn-scroll' }, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('react-native-gesture-handler', () => ({
+  ScrollView: ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-testid': 'rngh-scroll' }, children),
+}));
+
+const similar = vi.hoisted(() => ({
+  data: undefined as unknown,
+  isLoading: false,
+  isError: false,
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('expo-haptics', () => ({ selectionAsync: vi.fn() }));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => null }));
+vi.mock('../../ClimbListThumbnail', () => ({ ClimbListThumbnail: () => null }));
+vi.mock('../similar-climbs-utils', () => ({
+  rankBySizeCompatibility: () => [
+    {
+      climb: { uuid: 'sc-1', name: 'Test Similar', difficultyName: 'V4', frames: '', layoutId: 1 },
+      compatible: true,
+    },
+  ],
+  buildClimbStub: () => ({ uuid: 'sc-1' }),
+  formatByline: () => '',
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useSimilarClimbs: () => ({
+    data: similar.data,
+    isLoading: similar.isLoading,
+    isError: similar.isError,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock('../../../hooks/use-display-grade', () => ({
+  useDisplayGrade: () => ({ resolveGrade: () => ({ label: 'V4', color: '#333' }) }),
+}));
+vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ brandColors: { primary: '#000' } }) }));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#888', white: '#fff' } }));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 16: 64 },
+  borderRadius: { md: 8, full: 999 },
+}));
+
+import { SimilarClimbsSection } from '../SimilarClimbsSection';
+
+beforeEach(() => {
+  similar.data = [{ uuid: 'sc-1' }];
+  similar.isLoading = false;
+  similar.isError = false;
+});
+
+describe('SimilarClimbsSection', () => {
+  it('scrolls the loaded strip with the gesture-handler ScrollView (Android nested-scroll fix)', () => {
+    const { getByTestId, queryByTestId } = render(
+      createElement(SimilarClimbsSection, {
+        climbUuid: 'climb-1',
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1',
+        angle: 40,
+        onClimbPress: vi.fn(),
+      }),
+    );
+
+    expect(getByTestId('rngh-scroll')).toBeTruthy();
+    expect(queryByTestId('rn-scroll')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3506 — on Android the play drawer's **Beta Videos** strip wouldn't scroll horizontally ("the beta slider doesn't let me slide; the one on home is fine").

**Root cause.** The beta strip was a plain `react-native` `ScrollView` nested inside the play drawer's `react-native-gesture-handler` (RNGH) `ScrollView`.

- Play drawer outer scroll is RNGH: `PlayDrawer.tsx:21` (`import { ScrollView, GestureDetector } from 'react-native-gesture-handler'`) and `:795`. (The drawer is no longer gorhom — that was removed in #3167.)
- Beta strip was a plain RN scroller: `BetaVideosSection.tsx:2` imported `ScrollView` from `react-native`; the horizontal scroller was that plain RN `ScrollView` at `:89`.

On Android the outer RNGH scroll's native gesture handler claims the touch stream, and a plain RN child scroller isn't part of RNGH's gesture tree, so RNGH never arbitrates the cross-axis pan down to it — the strip renders but can't scroll. iOS handles nested `UIScrollView`s at the UIKit level regardless of RNGH, so it only broke on Android.

**Why Home worked.** The Home beta shelf is a different component (`RecentBetaShelf`, a `FlatList horizontal` inside the Home `FlashList`'s header) whose surrounding scroll is a vanilla RN scroller — no RNGH pan competing for the gesture — so the nested horizontal list scrolls natively on Android.

**Same-drawer sibling bug.** `SimilarClimbsSection` (also in `DeferredSections`, same drawer) had the identical plain-RN-`ScrollView`-inside-RNGH pattern and the same Android failure, so it's fixed in the same PR.

**Checked and left untouched:** `SessionBetaCarousel` (session detail) and `ProfileBetaShelf` / `HorizontalScrollSection` (You/profile) use the same `BetaVideoCard` but are **not** nested inside an RNGH `ScrollView` — their screens scroll with vanilla RN scrollers, so Android nested scrolling works and there's nothing to fix there.

**The fix.** Scroll both drawer strips with RNGH's `ScrollView` (+ `nestedScrollEnabled`), so RNGH arbitrates the horizontal pans on Android. This mirrors the codebase's own proven pattern: `WorkoutTypeShelf.tsx:3,33` is a horizontal shelf using RNGH's `ScrollView` nested inside `PreSessionView`'s RNGH scroll (`renderScrollComponent={GestureScrollView}`, `PreSessionView.tsx:366`). Cross-platform safe — iOS keeps working — so no `.android.tsx` split.

Ruled out (repo priors): no width-measures-0 issue (strips use hardcoded card widths, no `onLayout`/`useSharedValue` width), and the dismiss `Pan` isn't the culprit (`failOffsetX` + `activeOffsetY` yield on horizontal).

## Release Notes

- Beta videos and similar climbs now swipe sideways in the climb drawer on Android — flick through the whole strip, not just the first couple.

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 4009 tests pass (494 files), including two new regression tests (`beta-videos-section-scroll`, `similar-climbs-section-scroll`) that assert each strip's horizontal scroller comes from `react-native-gesture-handler`, not `react-native`, so a refactor back to the plain RN scroller fails CI.
- `vp run check:mobile-bundle` — Android bundle OK (14.1 MB)
- `vp check` — 0 errors

**Not headlessly testable:** the actual Android gesture arbitration (does the finger drag move the strip) needs a real device — the tests can only lock in the module-origin structural fix. No Metro/dev-server run from this session (another session owns 8081), so no on-device QA here.

### Device QA for @marcodejongh (Android)

- [ ] Beta Videos strip in the play drawer slides horizontally
- [ ] Similar Climbs strip in the play drawer slides horizontally
- [ ] Drawer still scrolls vertically and the pull-down dismiss still works
- [ ] Home beta shelf still slides (regression check)
- [ ] iOS spot-check: both drawer strips still slide (no regression)

## Delivery

JS-only (import swap + one prop, no native deps, no `app.config.ts` / fingerprint change) — ships via OTA. Auto-publishes to the `production` channel on merge to `main`; for on-device testing before merge it can go to the `pr-<number>` channel (More → Development → OTA Channel Switcher) on Marco's existing store/TestFlight binary, no new native build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnaSWURC1whr82cja4o3va
