### PR TITLE
fix(db): make merged MoonBoard climbs addressable by problem id (2024 logbook import)

### DIFF
--- a/packages/backend/src/__tests__/moonboard-import-service.test.ts
+++ b/packages/backend/src/__tests__/moonboard-import-service.test.ts
@@ -74,6 +74,17 @@ async function insertMoonBoardAlias(problemId: number, canonicalUuid: string): P
   `);
 }
 
+// The 2024-board fix: the catalog importer merges each problem onto its
+// pre-existing legacy (name-based) climb and records an alias keyed off the
+// stable problem-id UUID `moonboard:{id}:40` (the resolver's angle-suffixed
+// candidate), so the climb is addressable by problem id.
+async function insertMoonBoardAngleAlias(problemId: number, canonicalUuid: string): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO board_climb_aliases (board_type, alias_uuid, canonical_uuid, source)
+    VALUES ('moonboard', ${uuidv5(`moonboard:${problemId}:40`, UUID_NAMESPACE)}, ${canonicalUuid}, 'moonboard-catalog-import')
+  `);
+}
+
 async function importedTicks(): Promise<ImportedTickRow[]> {
   return (await db.execute(sql`
     SELECT
@@ -186,6 +197,29 @@ describeWithDatabase('importMoonBoardExportData', () => {
     expect(result.ticks).toEqual({ imported: 1, skipped: 0, failed: 1 });
     expect(result.ascents).toEqual({ imported: 1, skipped: 0, failed: 1 });
     expect(result.unresolvedClimbs).toEqual(['104']);
+    expect(await importedTicks()).toEqual([
+      { climb_uuid: canonicalUuid, status: 'flash', attempt_count: 1, climbed_on: '2026-02-13' },
+    ]);
+  });
+
+  it('resolves a legacy (name-based) 2024 climb via its moonboard:{id}:40 alias', async () => {
+    // A MoonBoard 2024 climb whose canonical UUID has no problem id in it (seeded
+    // under the name+setter+frames scheme). Before the importer wrote the
+    // angle-suffixed alias, neither `moonboard:{id}` nor `moonboard:{id}:40`
+    // reached it, so every 2024 tick dropped as "unknown problem".
+    const canonicalUuid = 'moonboard-2024-legacy-name-based-uuid';
+    await insertMoonBoardClimb({ problemId: 509834, canonicalUuid });
+    await insertMoonBoardAngleAlias(509834, canonicalUuid);
+
+    const result = await importMoonBoardExportData(
+      db,
+      TEST_USER_ID,
+      moonBoardImportData([moonBoardLogRow({ lineNumber: 1, problemId: 509834, tries: 'Flashed' })]),
+      () => {},
+    );
+
+    expect(result.ticks).toEqual({ imported: 1, skipped: 0, failed: 0 });
+    expect(result.unresolvedClimbs).toEqual([]);
     expect(await importedTicks()).toEqual([
       { climb_uuid: canonicalUuid, status: 'flash', attempt_count: 1, climbed_on: '2026-02-13' },
     ]);

--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -9,6 +9,7 @@ import { blendedQualityAverageSql } from '../src/queries/climb-stats/quality-ble
 import { fingerprintFromHolds } from './moonboard-2024-helpers.js';
 import {
   HOLDSETUP_TO_LAYOUT,
+  catalogAliasRows,
   catalogProblemToClimbs,
   isBetterCatalogClimb,
   type MoonBoardCatalogFile,
@@ -202,6 +203,22 @@ async function importMoonBoardCatalog() {
         }
         for (const mapped of climbs) {
           const { uuid, matched: matchedExisting } = resolveUuid(mapped, existingIndex);
+
+          // Record the aliases before the dedupe below: when two problems collapse
+          // onto one climb (same holds+angle) we drop the weaker climb row, but we
+          // still want BOTH problem ids to resolve to the survivor. The self-alias
+          // lets resolveCanonicalClimbUuid hit; the id-based alias (only added when
+          // the merge reused a legacy UUID) makes the climb addressable by its
+          // MoonBoard problem id — the fix for 2024 logbook imports.
+          for (const aliasRow of catalogAliasRows(mapped.uuid, uuid)) {
+            aliasByUuid.set(aliasRow.aliasUuid, {
+              boardType: 'moonboard',
+              aliasUuid: aliasRow.aliasUuid,
+              canonicalUuid: aliasRow.canonicalUuid,
+              source: 'moonboard-catalog-import',
+            });
+          }
+
           const incumbent = bestByUuid.get(uuid);
           if (incumbent) {
             // Same holds+angle as an already-seen problem — keep the stronger one.
@@ -273,13 +290,6 @@ async function importMoonBoardCatalog() {
               holdState: hold.holdState,
             });
           }
-
-          aliasByUuid.set(uuid, {
-            boardType: 'moonboard',
-            aliasUuid: uuid,
-            canonicalUuid: uuid,
-            source: 'moonboard-catalog-import',
-          });
         }
       }
 
@@ -355,7 +365,9 @@ async function importMoonBoardCatalog() {
             .onConflictDoNothing();
         }
 
-        // Self-aliases so resolveCanonicalClimbUuid always hits.
+        // Self-aliases so resolveCanonicalClimbUuid always hits, plus id-based
+        // aliases (moonboard:{id}:{angle} → canonical) so problem-id lookups from
+        // the logbook importer resolve merged/legacy climbs.
         for (let i = 0; i < aliasRecords.length; i += BATCH_SIZE) {
           await tx
             .insert(boardClimbAliases)

--- a/packages/db/scripts/moonboard-catalog-helpers.test.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   parseMovesString,
   holdsToFrames,
   catalogClimbUuid,
+  catalogAliasRows,
   isImportableProblem,
   isImportableConfig,
   mapCatalogConfig,
@@ -105,6 +106,23 @@ void test('catalogClimbUuid is deterministic, id+angle keyed, distinct per angle
   assert.equal(uuid, uuidv5('moonboard:541453:40', MOONBOARD_UUID_NAMESPACE));
   assert.match(uuid, /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
   assert.notEqual(uuid, catalogClimbUuid({ id: 541453, angle: 25 }));
+});
+
+void test('catalogAliasRows aliases the problem-id UUID onto a reused legacy UUID', () => {
+  const idBased = catalogClimbUuid({ id: 509834, angle: 40 });
+
+  // New climb (no merge): the id-based UUID *is* the canonical, so only a
+  // self-alias — no redundant second row.
+  assert.deepEqual(catalogAliasRows(idBased, idBased), [{ aliasUuid: idBased, canonicalUuid: idBased }]);
+
+  // Merged onto a legacy (name-based) UUID — as every MoonBoard 2024 climb was.
+  // We must alias the stable problem-id UUID to the canonical, otherwise the
+  // logbook importer's `moonboard:{id}:{angle}` lookup never finds the climb.
+  const legacy = 'moonboard-legacy-name-based-uuid';
+  assert.deepEqual(catalogAliasRows(idBased, legacy), [
+    { aliasUuid: legacy, canonicalUuid: legacy },
+    { aliasUuid: idBased, canonicalUuid: legacy },
+  ]);
 });
 
 void test('isImportableProblem rejects deleted / inactive / holdless / config-less problems', () => {

--- a/packages/db/scripts/moonboard-catalog-helpers.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.ts
@@ -151,6 +151,29 @@ export function catalogClimbUuid(args: { id: number; angle: number }): string {
   return uuidv5(`moonboard:${args.id}:${args.angle}`, MOONBOARD_UUID_NAMESPACE);
 }
 
+/**
+ * The alias rows to persist for a resolved catalog climb.
+ *
+ * Always a self-alias on the canonical UUID so `resolveCanonicalClimbUuid` hits.
+ * When the non-destructive merge reused an existing (legacy) UUID, the climb's
+ * stable problem-id UUID (`moonboard:{id}:{angle}`) differs from the canonical —
+ * so alias that too, pointing at the canonical. Without it a logbook import that
+ * looks a tick up by problem id (`uuidv5("moonboard:{id}:{angle}")`) resolves to
+ * nothing: MoonBoard 2024 problems were first seeded under name-based UUIDs, then
+ * merged in place, so their canonical UUID has no problem id in it and every 2024
+ * tick drops as "unknown problem". Idempotent — a re-run yields the same rows.
+ */
+export function catalogAliasRows(
+  idBasedUuid: string,
+  canonicalUuid: string,
+): { aliasUuid: string; canonicalUuid: string }[] {
+  const rows = [{ aliasUuid: canonicalUuid, canonicalUuid }];
+  if (idBasedUuid !== canonicalUuid) {
+    rows.push({ aliasUuid: idBasedUuid, canonicalUuid });
+  }
+  return rows;
+}
+
 /** A problem is importable if it isn't soft-deleted and has holds + configs. */
 export function isImportableProblem(problem: MoonBoardCatalogProblem): boolean {
   if (problem.dateDeleted) return false;


### PR DESCRIPTION
## What's wrong

Importing a MoonBoard logbook is a key lookup:

```
your tick: "I climbed problem 509834"  →  compute a climb UUID  →  find that row in board_climbs
```

Boardsesh keys climbs by UUID, not by problem id, so the importer computes the UUID from the id:

```js
uuidv5("moonboard:509834:40")
```

That only finds the row if the row was stored under a UUID built from the same string. For **2016** it mostly is, so 2016 imports. For **2024** it isn't — the computed key hits nothing, and every 2024 tick drops as "unknown problem".

## Why 2024 is stored under a different key

The 2024 climbs were loaded twice, from two sources with different identifiers:

1. An **older** importer's source had no problem id, so it built the UUID from name + setter + holds → `7fc49fa0-…`
2. The **current** catalog importer *does* have the problem id, but when it found the same climb already present (matched by holds) it **reused the old UUID** instead of inserting a duplicate — deliberately, to keep existing ticks, share URLs and favourites pointing at the same climb.

Result: the climb lives under `7fc49fa0-…`, and nothing is stored under `uuidv5("moonboard:509834:40")`. The importer's computed key points nowhere.

Example: `birthday cake trail mix` (id 509834) → its 40° row is `7fc49fa0-…` = `uuidv5("moonboard:3:40:BIRTHDAY CAKE TRAIL MIX|Dana Rader|<holds>")`, not `uuidv5("moonboard:509834:40")`.

## The fix

Boardsesh already has a redirect table — `board_climb_aliases` (`alias_uuid → canonical_uuid`) — and the tick resolver already follows it. The importer just never wrote the redirect for the reused-UUID case (only a useless self-redirect). This PR writes it:

```js
// inside the importer's existing dedup step
if (idBasedUuid !== reusedUuid) {
  aliases.insert({ alias_uuid: idBasedUuid, canonical_uuid: reusedUuid });
}
```

- **No re-keying** — existing UUIDs, ticks and links stay put.
- **No resolver change** — it already follows aliases.
- **No schema change.**
- **Idempotent**, and written inside the existing dedup step, so it's self-healing on every future import.

## Verification (production board snapshot)

Simulated the real resolver over a complete 260-tick MoonBoard logbook (181 on 2016, 79 on 2024) against the live `board-snapshots` dataset:

| board | before | after |
|---|---|---|
| 2016 (181) | 181/181 | 181/181 |
| 2024 (79) | **0/79** | **79/79** |
| total | 181/260 | **260/260** |

## Rollout / backfill

The fix only helps once the redirects exist in prod. The redirect for a 2024 climb can't be reconstructed from the DB alone (no problem id is stored on those rows), so it's filled by re-running the importer against the current catalog — it replays the same dedup and inserts every missing redirect (idempotent):

```
DB_URL=<prod> vp run db:import-moonboard-catalog /path/to/app-catalog
```

## Release Notes

- Your MoonBoard 2024 logbook now imports — sends on the 2024 board match up instead of getting dropped as unknown problems.

## Test plan

- `vp run typecheck:db`, `vp run typecheck:backend` — clean
- `packages/db/scripts/moonboard-catalog-helpers.test.ts` (new `catalogAliasRows` case) — 15/15 pass locally
- New backend DB test `resolves a legacy (name-based) 2024 climb via its moonboard:{id}:40 alias` — mirrors the existing alias-resolution test; runs in CI (Docker Postgres unavailable in my local env)
