### PR TITLE
fix(db): canonicalize MoonBoard catalog aliases

### DIFF
--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -9,9 +9,11 @@ import { blendedQualityAverageSql } from '../src/queries/climb-stats/quality-ble
 import { fingerprintFromHolds } from './moonboard-2024-helpers.js';
 import {
   HOLDSETUP_TO_LAYOUT,
+  buildExistingCatalogMatchIndex,
   catalogAliasRows,
   catalogProblemToClimbs,
   isBetterCatalogClimb,
+  resolveCatalogClimbUuid,
   type MoonBoardCatalogFile,
   type MappedCatalogClimb,
 } from './moonboard-catalog-helpers.js';
@@ -48,8 +50,6 @@ const DEFAULT_DIR = path.join(__dirname, '../data/moonboard/app-catalog');
 // (widest is board_climbs at ~24 cols) while cutting round-trips ~4× vs 500.
 const BATCH_SIZE = 2000;
 
-type ExistingClimb = { uuid: string; name: string | null };
-
 /**
  * Build the in-memory match index for the non-destructive merge:
  * `${layoutId}|${angle}|${fingerprint}` → existing climbs with those holds.
@@ -60,7 +60,7 @@ type ExistingClimb = { uuid: string; name: string | null };
 async function buildExistingIndex(
   client: postgres.Sql,
   db: ReturnType<typeof drizzle>,
-): Promise<Map<string, ExistingClimb[]>> {
+): Promise<ReturnType<typeof buildExistingCatalogMatchIndex>> {
   console.info('   Building match index from existing MoonBoard climbs...');
   const fingerprintByUuid = new Map<string, string>();
   let currentUuid: string | null = null;
@@ -92,42 +92,20 @@ async function buildExistingIndex(
       layoutId: boardClimbs.layoutId,
       angle: boardClimbs.angle,
       name: boardClimbs.name,
+      isListed: boardClimbs.isListed,
     })
     .from(boardClimbs)
     .where(eq(boardClimbs.boardType, 'moonboard'));
 
-  const index = new Map<string, ExistingClimb[]>();
-  for (const row of climbRows) {
-    const fingerprint = fingerprintByUuid.get(row.uuid);
-    if (!fingerprint) continue;
-    const key = `${row.layoutId}|${row.angle}|${fingerprint}`;
-    const bucket = index.get(key);
-    if (bucket) bucket.push({ uuid: row.uuid, name: row.name });
-    else index.set(key, [{ uuid: row.uuid, name: row.name }]);
-  }
+  const aliasRows = await db
+    .select({ aliasUuid: boardClimbAliases.aliasUuid, canonicalUuid: boardClimbAliases.canonicalUuid })
+    .from(boardClimbAliases)
+    .where(eq(boardClimbAliases.boardType, 'moonboard'));
+  const canonicalByAlias = new Map(aliasRows.map((row) => [row.aliasUuid, row.canonicalUuid]));
+  const index = buildExistingCatalogMatchIndex(climbRows, fingerprintByUuid, canonicalByAlias);
   fingerprintByUuid.clear();
   console.info(`   Indexed ${climbRows.length} existing climbs (${index.size} hold groups)`);
   return index;
-}
-
-/**
- * Resolve the UUID an incoming climb should use: an existing match (update in
- * place) or its own minted id-based UUID (insert). Tie-break a fingerprint that
- * maps to several climbs by case-insensitive name; if none matches, mint new
- * rather than risk overwriting the wrong climb. `matched` reports whether an
- * existing row was found — note a re-import matches its own id-based rows, whose
- * UUID equals the minted one, so we can't infer `matched` from UUID equality.
- */
-function resolveUuid(
-  mapped: MappedCatalogClimb,
-  index: Map<string, ExistingClimb[]>,
-): { uuid: string; matched: boolean } {
-  const candidates = index.get(`${mapped.layoutId}|${mapped.angle}|${mapped.holdFingerprint}`);
-  if (!candidates || candidates.length === 0) return { uuid: mapped.uuid, matched: false };
-  if (candidates.length === 1) return { uuid: candidates[0].uuid, matched: true };
-  const target = mapped.name.trim().toLowerCase();
-  const named = candidates.find((candidate) => (candidate.name ?? '').trim().toLowerCase() === target);
-  return named ? { uuid: named.uuid, matched: true } : { uuid: mapped.uuid, matched: false };
 }
 
 function parseFlag(name: string): string | undefined {
@@ -202,7 +180,7 @@ async function importMoonBoardCatalog() {
           continue;
         }
         for (const mapped of climbs) {
-          const { uuid, matched: matchedExisting } = resolveUuid(mapped, existingIndex);
+          const { uuid, matched: matchedExisting } = resolveCatalogClimbUuid(mapped, existingIndex);
 
           // Record the aliases before the dedupe below: when two problems collapse
           // onto one climb (same holds+angle) we drop the weaker climb row, but we
@@ -374,7 +352,7 @@ async function importMoonBoardCatalog() {
             .values(aliasRecords.slice(i, i + BATCH_SIZE))
             .onConflictDoUpdate({
               target: [boardClimbAliases.boardType, boardClimbAliases.aliasUuid],
-              set: { lastSeenAt: sql`now()` },
+              set: { canonicalUuid: sql`excluded.canonical_uuid`, lastSeenAt: sql`now()` },
             });
         }
       });

--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -10,6 +10,7 @@ import { fingerprintFromHolds } from './moonboard-2024-helpers.js';
 import {
   HOLDSETUP_TO_LAYOUT,
   buildExistingCatalogMatchIndex,
+  catalogAliasConflictUpdate,
   catalogAliasRows,
   catalogProblemToClimbs,
   isBetterCatalogClimb,
@@ -352,7 +353,7 @@ async function importMoonBoardCatalog() {
             .values(aliasRecords.slice(i, i + BATCH_SIZE))
             .onConflictDoUpdate({
               target: [boardClimbAliases.boardType, boardClimbAliases.aliasUuid],
-              set: { canonicalUuid: sql`excluded.canonical_uuid`, lastSeenAt: sql`now()` },
+              set: catalogAliasConflictUpdate(),
             });
         }
       });

--- a/packages/db/scripts/moonboard-catalog-helpers.test.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.test.ts
@@ -2,10 +2,12 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { uuidv5, MOONBOARD_UUID_NAMESPACE } from './moonboard-helpers.js';
 import { fingerprintFromHolds } from './moonboard-2024-helpers.js';
+import { sqlText } from '../src/test-utils/sql-text.js';
 import {
   HOLDSETUP_TO_LAYOUT,
   angleFromConfiguration,
   buildExistingCatalogMatchIndex,
+  catalogAliasConflictUpdate,
   roleLetterToHoldState,
   parseMovesString,
   resolveCatalogClimbUuid,
@@ -203,6 +205,31 @@ void test('catalog matching ignores cyclic aliases instead of writing another br
   );
 
   assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: mapped.uuid, matched: false });
+});
+
+void test('catalog matching ignores a listed alias chain whose terminal climb is delisted', () => {
+  const mapped = mapCatalogConfig(PORRIDGE, PORRIDGE.configurations![1], { layoutId: 3, angle: 40 });
+  const listedUuid = 'moonboard-listed-alias';
+  const delistedUuid = 'moonboard-delisted-terminal';
+  const index = buildExistingCatalogMatchIndex(
+    [
+      { uuid: listedUuid, layoutId: 3, angle: 40, name: mapped.name, isListed: true },
+      { uuid: delistedUuid, layoutId: 3, angle: 40, name: mapped.name, isListed: false },
+    ],
+    new Map([[listedUuid, mapped.holdFingerprint]]),
+    new Map([
+      [listedUuid, delistedUuid],
+      [delistedUuid, delistedUuid],
+    ]),
+  );
+
+  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: mapped.uuid, matched: false });
+});
+
+void test('catalog alias conflicts repair the canonical target and refresh last seen', () => {
+  const update = catalogAliasConflictUpdate();
+  assert.equal(sqlText(update.canonicalUuid), 'excluded.canonical_uuid');
+  assert.equal(sqlText(update.lastSeenAt), 'now()');
 });
 
 void test('isImportableProblem rejects deleted / inactive / holdless / config-less problems', () => {

--- a/packages/db/scripts/moonboard-catalog-helpers.test.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.test.ts
@@ -5,8 +5,10 @@ import { fingerprintFromHolds } from './moonboard-2024-helpers.js';
 import {
   HOLDSETUP_TO_LAYOUT,
   angleFromConfiguration,
+  buildExistingCatalogMatchIndex,
   roleLetterToHoldState,
   parseMovesString,
+  resolveCatalogClimbUuid,
   holdsToFrames,
   catalogClimbUuid,
   catalogAliasRows,
@@ -123,6 +125,84 @@ void test('catalogAliasRows aliases the problem-id UUID onto a reused legacy UUI
     { aliasUuid: legacy, canonicalUuid: legacy },
     { aliasUuid: idBased, canonicalUuid: legacy },
   ]);
+});
+
+void test('catalog matching excludes delisted rows even when they have stale self-aliases', () => {
+  const mapped = mapCatalogConfig(PORRIDGE, PORRIDGE.configurations![1], { layoutId: 3, angle: 40 });
+  const delistedUuid = 'moonboard-delisted-duplicate';
+  const canonicalUuid = 'moonboard-listed-canonical';
+  const index = buildExistingCatalogMatchIndex(
+    [
+      {
+        uuid: delistedUuid,
+        layoutId: mapped.layoutId,
+        angle: mapped.angle,
+        name: mapped.name,
+        isListed: false,
+      },
+      {
+        uuid: canonicalUuid,
+        layoutId: mapped.layoutId,
+        angle: mapped.angle,
+        name: mapped.name,
+        isListed: true,
+      },
+    ],
+    new Map([
+      [delistedUuid, mapped.holdFingerprint],
+      [canonicalUuid, mapped.holdFingerprint],
+    ]),
+    new Map([
+      [delistedUuid, delistedUuid],
+      [canonicalUuid, canonicalUuid],
+    ]),
+  );
+
+  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: canonicalUuid, matched: true });
+  assert.deepEqual(catalogAliasRows(mapped.uuid, canonicalUuid), [
+    { aliasUuid: canonicalUuid, canonicalUuid },
+    { aliasUuid: mapped.uuid, canonicalUuid },
+  ]);
+});
+
+void test('catalog matching follows alias chains and collapses candidates at the same canonical UUID', () => {
+  const mapped = mapCatalogConfig(PORRIDGE, PORRIDGE.configurations![1], { layoutId: 3, angle: 40 });
+  const firstUuid = 'moonboard-first-listed-alias';
+  const secondUuid = 'moonboard-intermediate-alias';
+  const canonicalUuid = 'moonboard-terminal-canonical';
+  const index = buildExistingCatalogMatchIndex(
+    [
+      { uuid: firstUuid, layoutId: 3, angle: 40, name: 'old name', isListed: true },
+      { uuid: canonicalUuid, layoutId: 3, angle: 40, name: 'canonical name', isListed: true },
+    ],
+    new Map([
+      [firstUuid, mapped.holdFingerprint],
+      [canonicalUuid, mapped.holdFingerprint],
+    ]),
+    new Map([
+      [firstUuid, secondUuid],
+      [secondUuid, canonicalUuid],
+      [canonicalUuid, canonicalUuid],
+    ]),
+  );
+
+  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: canonicalUuid, matched: true });
+});
+
+void test('catalog matching ignores cyclic aliases instead of writing another broken redirect', () => {
+  const mapped = mapCatalogConfig(PORRIDGE, PORRIDGE.configurations![1], { layoutId: 3, angle: 40 });
+  const firstUuid = 'moonboard-cycle-a';
+  const secondUuid = 'moonboard-cycle-b';
+  const index = buildExistingCatalogMatchIndex(
+    [{ uuid: firstUuid, layoutId: 3, angle: 40, name: mapped.name, isListed: true }],
+    new Map([[firstUuid, mapped.holdFingerprint]]),
+    new Map([
+      [firstUuid, secondUuid],
+      [secondUuid, firstUuid],
+    ]),
+  );
+
+  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: mapped.uuid, matched: false });
 });
 
 void test('isImportableProblem rejects deleted / inactive / holdless / config-less problems', () => {

--- a/packages/db/scripts/moonboard-catalog-helpers.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.ts
@@ -7,6 +7,7 @@ import {
 } from './moonboard-helpers.js';
 import { fingerprintFromHolds, methodDescription } from './moonboard-2024-helpers.js';
 import { moonBoardMethodToCharacteristic } from '@boardsesh/shared-schema/characteristics';
+import { sql } from 'drizzle-orm';
 
 // =============================================================================
 // MoonBoard catalog dataset
@@ -122,12 +123,14 @@ export function buildExistingCatalogMatchIndex(
   canonicalByAlias: ReadonlyMap<string, string>,
 ): Map<string, ExistingCatalogClimb[]> {
   const index = new Map<string, ExistingCatalogClimb[]>();
+  // `null` is not affirmative catalog visibility, so it is treated as unlisted.
+  const listedUuids = new Set(climbRows.filter((row) => row.isListed === true).map((row) => row.uuid));
   for (const row of climbRows) {
-    if (!row.isListed) continue;
+    if (row.isListed !== true) continue;
     const fingerprint = fingerprintByUuid.get(row.uuid);
     if (!fingerprint) continue;
     const canonicalUuid = terminalCanonicalUuid(row.uuid, canonicalByAlias);
-    if (!canonicalUuid) continue;
+    if (!canonicalUuid || !listedUuids.has(canonicalUuid)) continue;
     const key = `${row.layoutId}|${row.angle}|${fingerprint}`;
     const candidate = { uuid: canonicalUuid, name: row.name };
     const bucket = index.get(key);
@@ -135,6 +138,11 @@ export function buildExistingCatalogMatchIndex(
     else index.set(key, [candidate]);
   }
   return index;
+}
+
+/** Update fields used when a catalog rerun repairs an existing alias target. */
+export function catalogAliasConflictUpdate() {
+  return { canonicalUuid: sql`excluded.canonical_uuid`, lastSeenAt: sql`now()` };
 }
 
 /** Resolve an incoming catalog climb to an existing merge candidate, if any. */

--- a/packages/db/scripts/moonboard-catalog-helpers.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.ts
@@ -95,6 +95,62 @@ export type MappedCatalogClimb = {
   description: string;
 };
 
+export type ExistingCatalogClimb = { uuid: string; name: string | null };
+
+type ExistingCatalogClimbRow = ExistingCatalogClimb & {
+  layoutId: number;
+  angle: number | null;
+  isListed: boolean | null;
+};
+
+function terminalCanonicalUuid(uuid: string, canonicalByAlias: ReadonlyMap<string, string>): string | undefined {
+  const visited = new Set<string>();
+  let currentUuid = uuid;
+  while (!visited.has(currentUuid)) {
+    visited.add(currentUuid);
+    const nextUuid = canonicalByAlias.get(currentUuid);
+    if (!nextUuid || nextUuid === currentUuid) return currentUuid;
+    currentUuid = nextUuid;
+  }
+  return undefined;
+}
+
+/** Build the merge index, resolving redirects to their terminal canonical UUID. */
+export function buildExistingCatalogMatchIndex(
+  climbRows: ExistingCatalogClimbRow[],
+  fingerprintByUuid: ReadonlyMap<string, string>,
+  canonicalByAlias: ReadonlyMap<string, string>,
+): Map<string, ExistingCatalogClimb[]> {
+  const index = new Map<string, ExistingCatalogClimb[]>();
+  for (const row of climbRows) {
+    if (!row.isListed) continue;
+    const fingerprint = fingerprintByUuid.get(row.uuid);
+    if (!fingerprint) continue;
+    const canonicalUuid = terminalCanonicalUuid(row.uuid, canonicalByAlias);
+    if (!canonicalUuid) continue;
+    const key = `${row.layoutId}|${row.angle}|${fingerprint}`;
+    const candidate = { uuid: canonicalUuid, name: row.name };
+    const bucket = index.get(key);
+    if (bucket) bucket.push(candidate);
+    else index.set(key, [candidate]);
+  }
+  return index;
+}
+
+/** Resolve an incoming catalog climb to an existing merge candidate, if any. */
+export function resolveCatalogClimbUuid(
+  mapped: MappedCatalogClimb,
+  index: Map<string, ExistingCatalogClimb[]>,
+): { uuid: string; matched: boolean } {
+  const candidates = index.get(`${mapped.layoutId}|${mapped.angle}|${mapped.holdFingerprint}`);
+  if (!candidates || candidates.length === 0) return { uuid: mapped.uuid, matched: false };
+  const candidateUuids = new Set(candidates.map((candidate) => candidate.uuid));
+  if (candidateUuids.size === 1) return { uuid: candidates[0].uuid, matched: true };
+  const target = mapped.name.trim().toLowerCase();
+  const named = candidates.find((candidate) => (candidate.name ?? '').trim().toLowerCase() === target);
+  return named ? { uuid: named.uuid, matched: true } : { uuid: mapped.uuid, matched: false };
+}
+
 const STATE_TO_ROLE: Record<string, number> = {
   STARTING: HOLD_STATE_CODES.start,
   HAND: HOLD_STATE_CODES.hand,

--- a/packages/db/src/schema/boards/unified.ts
+++ b/packages/db/src/schema/boards/unified.ts
@@ -416,9 +416,9 @@ export const boardClimbs = pgTable(
 //     UUIDs — the alias_uuid is precisely the UUID we did NOT promote to
 //     board_climbs. A FK would block every non-canonical insert.
 //
-// last_seen_at is refreshed on every ingest via ON CONFLICT DO UPDATE
-// (`source` and `last_seen_at` are the only mutable columns); first_seen_at
-// is stamped on insert and never touched again.
+// last_seen_at is refreshed on every ingest via ON CONFLICT DO UPDATE.
+// Importers may also repair canonical_uuid when a later dedup pass identifies
+// the true survivor; first_seen_at is stamped on insert and never touched again.
 //
 // Resolving a UUID to its canonical: see resolveCanonicalClimbUuid() in
 // packages/db/src/queries/aliases.ts.


### PR DESCRIPTION
## What changed

- Exclude delisted MoonBoard climbs from the catalog merge index, including rows with stale self-aliases.
- Follow existing redirects to their terminal canonical UUID with cycle protection.
- Treat multiple candidates that converge on one canonical UUID as one match.
- Repair `canonical_uuid` when a catalog alias already exists with a stale target.

## Why

PR #3749 added problem-ID aliases for MoonBoard catalog matches, but a post-merge P1 review found that the importer could select a delisted duplicate. The logbook resolver follows one alias hop, so writing a problem-ID alias to that duplicate could still leave MoonBoard imports unresolved or attached to an unlisted row.

Production preflight also found delisted MoonBoard 2024 duplicates with stale self-aliases, so following one stored alias was not sufficient by itself.

## Verification

- `vp check` on the four changed files
- `vp run typecheck:db`
- `vp run typecheck:backend`
- Database suite: all three new catalog-alias regression tests pass. The suite's three existing `create-climb-filters` SQL-string assertions still fail locally because of float rendering and SQL keyword casing; no changed file is involved.
- Independent review covered delisted self-aliases, redirect chains, cycles, converging candidates, and repair-on-rerun.
- Local dev-stack QA notes were detected, but the stack could not become healthy because local Redis/Postgres services were unavailable.

## Release Notes

- Your MoonBoard 2024 logbook imports now stay attached to the listed climb, even when older duplicate rows exist.
