### PR TITLE
[on hold] feat(mobile): add Projects progress filter, split benchmarks from progress

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -127,6 +127,9 @@ vi.mock('@boardsesh/climb-filters', () => ({
   hasActiveBoardFilters: () => false,
   // Consumed by filter-chip-menus (imported via index.tsx for the chip row).
   SORT_OPTIONS: ['ascents', 'quality', 'difficulty', 'name', 'popular', 'creation'],
+  // "Your progress" selector wiring for the persistent chip row.
+  flagsToProgress: () => 'all',
+  progressToFlags: () => ({}),
 }));
 
 vi.mock('@boardsesh/board-react', () => ({

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -13,10 +13,13 @@ import {
   countActiveFilters,
   hasActiveBoardFilters,
   describeGradeFilter,
+  flagsToProgress,
+  progressToFlags,
   DEFAULT_CLIMB_FILTER_STATE,
   DEFAULT_CLIMB_BOARD_FILTER_STATE,
   type ClimbBoardFilterState,
   type GradeTapMeta,
+  type ProgressFilter,
 } from '@boardsesh/climb-filters';
 import { getTallWideScope } from '@boardsesh/board-constants';
 import { ClimbListRow } from '../../../src/components/ClimbListRow';
@@ -101,7 +104,7 @@ const PREWARM_BOARD_HOLDS_DELAY_MS = 1200;
 // excluded from the removable token row so an active filter is never worded
 // twice — the chip shows/changes it, the token row is the receipt for the
 // long-tail (sheet-only) filters that have no chip.
-const CHIP_BACKED_TOKEN_KEYS = new Set<string>(['grade', 'minAscents', 'minRating', 'hideCompleted', 'benchmark']);
+const CHIP_BACKED_TOKEN_KEYS = new Set<string>(['grade', 'minAscents', 'minRating', 'progress', 'benchmark']);
 
 type NativeSearchBarRef = {
   focus: () => void;
@@ -1042,8 +1045,10 @@ function ClimbListInner() {
     (bucket: number | undefined) => patchFilters(applyPopularityBucket(filters, bucket)),
     [patchFilters, filters],
   );
-  const handleToggleHideCompleted = useCallback(
-    (next: boolean) => patchFilters({ hideCompleted: next || undefined }),
+  // "Your progress" writes a full four-flag patch (progressToFlags clears stale
+  // flags), so switching between values never leaves a contradictory flag behind.
+  const handleChangeProgress = useCallback(
+    (value: ProgressFilter) => patchFilters(progressToFlags(value)),
     [patchFilters],
   );
   const handleToggleBenchmarks = useCallback(
@@ -1154,11 +1159,11 @@ function ClimbListInner() {
           onChangePopularity={handleChangePopularity}
           minRating={filters.minRating}
           onChangeRating={handleChangeRating}
-          hideCompleted={!!filters.hideCompleted}
-          onToggleHideCompleted={handleToggleHideCompleted}
+          progress={flagsToProgress(filters)}
+          onChangeProgress={handleChangeProgress}
+          canFilterProgress={isAuthenticated}
           onlyBenchmarks={!!boardFilters.onlyBenchmarks}
           onToggleBenchmarks={handleToggleBenchmarks}
-          canHideCompleted={isAuthenticated}
         />
         <FilterTokenRow tokens={sheetOnlyFilterTokens} />
       </>
@@ -1179,7 +1184,7 @@ function ClimbListInner() {
     dimensionChips,
     handleChangePopularity,
     handleChangeRating,
-    handleToggleHideCompleted,
+    handleChangeProgress,
     handleToggleBenchmarks,
     boardFilters.onlyBenchmarks,
     isAuthenticated,

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -29,8 +29,12 @@ import {
   type ClimbBoardFilterState,
   SORT_OPTIONS,
   GRADE_ACCURACY_VALUES,
+  PROGRESS_FILTER_VALUES,
+  flagsToProgress,
+  progressToFlags,
   newSortSeed,
   type BoardSearchConfig,
+  type ProgressFilter,
 } from '@boardsesh/climb-filters';
 import { Text } from './Text';
 import { Button } from './Button';
@@ -46,7 +50,7 @@ import { androidSafeSnapPoints } from './sheet-snap-points';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useGrades, useSearchClimbsCount } from '../lib/graphql/hooks';
 import type { BoardName, HoldsFilter } from '@boardsesh/shared-schema';
-import { buildFilterLabels, formatSettersLabel } from '../lib/filter-labels';
+import { buildFilterLabels, formatSettersLabel, progressFilterLabel } from '../lib/filter-labels';
 import { parseSetIdsParam, prewarmCreateBoardHolds } from '../lib/create-board-holds';
 import { subscribeToHoldsFilterSelection } from '../lib/hold-filter-handoff';
 import { subscribeToZoneFilterSelection, type ZoneFilterSelection } from '../lib/zone-filter-handoff';
@@ -277,6 +281,18 @@ export function ClimbFilterSheet({
       established: t('mobile.filter.status.established'),
       projects: t('mobile.filter.status.projects'),
     }),
+    [t],
+  );
+
+  const progressLabels = useMemo<Record<ProgressFilter, string>>(
+    () =>
+      PROGRESS_FILTER_VALUES.reduce(
+        (labels, value) => {
+          labels[value] = progressFilterLabel(value, t);
+          return labels;
+        },
+        {} as Record<ProgressFilter, string>,
+      ),
     [t],
   );
 
@@ -644,12 +660,11 @@ export function ClimbFilterSheet({
     return parts.join(' · ') || null;
   }, [localFilters, accuracyLabels, holdFilterCount, zoneActive, formatSetterSelection, t]);
 
+  // Progress moved to the always-visible PRIMARY section, so it no longer feeds
+  // the Advanced collapsed summary — only Status, beta videos, and sort remain.
   const advancedSummary = useMemo(() => {
     const parts: string[] = [];
     if (localFilters.status !== 'any') parts.push(statusLabels[localFilters.status]);
-    if (localFilters.hideAttempted) parts.push(t('mobile.filter.progress.hideAttempted'));
-    if (localFilters.showOnlyAttempted) parts.push(t('mobile.filter.progress.onlyAttempted'));
-    if (localFilters.showOnlyCompleted) parts.push(t('mobile.filter.progress.onlyCompleted'));
     if (localFilters.onlyWithBetaVideos) parts.push(t('mobile.filter.betaVideosShort'));
     if (localFilters.sortBy !== DEFAULT_FILTERS.sortBy || localFilters.sortOrder !== DEFAULT_FILTERS.sortOrder) {
       parts.push(sortLabels[localFilters.sortBy]);
@@ -657,9 +672,6 @@ export function ClimbFilterSheet({
     return parts.join(' · ') || null;
   }, [
     localFilters.status,
-    localFilters.hideAttempted,
-    localFilters.showOnlyAttempted,
-    localFilters.showOnlyCompleted,
     localFilters.onlyWithBetaVideos,
     localFilters.sortBy,
     localFilters.sortOrder,
@@ -725,20 +737,32 @@ export function ClimbFilterSheet({
               style={styles.inlineGradeRail}
             />
 
-            {/* Quality toggles, grouped as one iOS inset card. */}
+            {/* Your progress — a single-select over the four per-user tick flags
+              (auth-gated, exactly like the old hide-sent switch). "Projects" =
+              attempted-but-not-sent; "Unsent" = the old "hide climbs I've sent". */}
+            {isAuthenticated ? (
+              <>
+                <View style={styles.subsectionGap} />
+                <Text variant="footnote" style={styles.subsectionLabel}>
+                  {t('mobile.filter.progress.label')}
+                </Text>
+                <View style={styles.chipRow}>
+                  {PROGRESS_FILTER_VALUES.map((value) => (
+                    <Chip
+                      key={value}
+                      label={progressLabels[value]}
+                      selected={flagsToProgress(localFilters) === value}
+                      onPress={() => setFiltersPatch(progressToFlags(value))}
+                    />
+                  ))}
+                </View>
+              </>
+            ) : null}
+
+            {/* Benchmarks — its own inset card; a top-tier lever, not part of
+              progress. */}
             <View style={styles.subsectionGap} />
             <View style={styles.groupedCard}>
-              {isAuthenticated ? (
-                <>
-                  <SwitchRow
-                    label={t('mobile.filter.hideSent')}
-                    description={t('mobile.filter.hideSentDescription')}
-                    value={!!localFilters.hideCompleted}
-                    onValueChange={(value) => setFiltersPatch({ hideCompleted: value || undefined })}
-                  />
-                  <View style={[styles.groupDivider, { backgroundColor: systemColors.separator }]} />
-                </>
-              ) : null}
               <SwitchRow
                 label={t('mobile.filter.benchmark')}
                 description={t('mobile.filter.benchmarkDescription')}
@@ -917,27 +941,6 @@ export function ClimbFilterSheet({
                 </Text>
               ) : null}
 
-              {isAuthenticated ? (
-                <>
-                  <View style={styles.subsectionGap} />
-                  <SwitchRow
-                    label={t('mobile.filter.progress.hideAttempted')}
-                    value={!!localFilters.hideAttempted}
-                    onValueChange={(value) => setFiltersPatch({ hideAttempted: value || undefined })}
-                  />
-                  <SwitchRow
-                    label={t('mobile.filter.progress.onlyAttempted')}
-                    value={!!localFilters.showOnlyAttempted}
-                    onValueChange={(value) => setFiltersPatch({ showOnlyAttempted: value || undefined })}
-                  />
-                  <SwitchRow
-                    label={t('mobile.filter.progress.onlyCompleted')}
-                    value={!!localFilters.showOnlyCompleted}
-                    onValueChange={(value) => setFiltersPatch({ showOnlyCompleted: value || undefined })}
-                  />
-                </>
-              ) : null}
-
               <View style={styles.subsectionGap} />
               <SwitchRow
                 label={t('mobile.filter.betaVideos')}
@@ -1063,10 +1066,6 @@ const styles = StyleSheet.create({
     borderRadius: borderRadius.lg,
     backgroundColor: `${iosSystemColors.systemGray}14`,
     overflow: 'hidden',
-  },
-  groupDivider: {
-    height: StyleSheet.hairlineWidth,
-    marginLeft: spacing[4],
   },
   ratingRow: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
@@ -218,6 +218,21 @@ vi.mock('@boardsesh/climb-filters', () => ({
   mergeBoardFilters: (input: unknown) => input,
   formatMinAscentsFilterCount: (count: number) => String(count),
   countFilteredHolds: (holdsFilter?: Record<string, unknown>) => Object.keys(holdsFilter ?? {}).length,
+  // "Your progress" selector (PRIMARY card single-select).
+  PROGRESS_FILTER_VALUES: ['all', 'untried', 'projects', 'sent', 'unsent'],
+  flagsToProgress: (flags?: Record<string, unknown>) => {
+    if (flags?.showOnlyCompleted) return 'sent';
+    if (flags?.showOnlyAttempted) return 'projects';
+    if (flags?.hideAttempted && flags?.hideCompleted) return 'untried';
+    if (flags?.hideCompleted) return 'unsent';
+    return 'all';
+  },
+  progressToFlags: () => ({
+    hideAttempted: undefined,
+    hideCompleted: undefined,
+    showOnlyAttempted: undefined,
+    showOnlyCompleted: undefined,
+  }),
 }));
 
 vi.mock('../../lib/graphql/hooks', () => ({

--- a/packages/mobile/src/components/search/FilterChipRow.android.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.android.tsx
@@ -9,9 +9,9 @@
 //   • DropdownMenu is CONTROLLED — each menu-bearing chip is its own small stateful
 //     sub-component owning `expanded` (cf. MoreForm.android.tsx's SelectRow). The
 //     chip's onClick opens it; an explicit close() in an item dismisses it.
-//   • The "Show" menu stays open while toggling simply by NOT closing the controlled
-//     menu on a toggle item's click — Compose has no menuActionDismissBehavior and
-//     doesn't auto-dismiss on click, so this is the natural equivalent.
+//   • Single-select menus (Your progress, Popularity, Rating) close on pick by
+//     calling the renderItems `close()`; a keep-open menu would simply not call it
+//     (Compose has no menuActionDismissBehavior and doesn't auto-dismiss on click).
 //   • Dimension chips DIVERGE from iOS here (tap-toggle + long-press-lock). iOS uses a
 //     Menu+onPrimaryAction so a tap toggles and a long-press opens lock/unlock. On
 //     Compose that's unreachable: the FilterChip always wires its own internal onClick,
@@ -42,6 +42,7 @@ import {
   HorizontalDivider,
 } from '@expo/ui/jetpack-compose';
 import { fillMaxWidth, horizontalScroll, padding } from '@expo/ui/jetpack-compose/modifiers';
+import { PROGRESS_FILTER_VALUES } from '@boardsesh/climb-filters';
 import { getFilterKey } from '../../lib/recent-filter-store';
 import { POPULARITY_BUCKETS, RATING_BUCKETS } from '../../lib/filter-chip-menus';
 import { useTheme } from '../../providers/theme-provider';
@@ -49,7 +50,7 @@ import { spacing } from '../../theme/tokens';
 import { filterChipBrandColors } from '../../theme/expo-ui-modifiers';
 import { useMaterialAngleControl } from '../chrome/use-material-angle-control';
 import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
-import { popularityChipLabel, ratingChipLabel } from './FilterChipRow.logic';
+import { popularityChipLabel, ratingChipLabel, progressFilterLabel } from './FilterChipRow.logic';
 import type { DimensionChip, FilterChipRowProps } from './FilterChipRow.types';
 
 // Semantic icon → Material XML vector drawable. White-filled (#FFFFFFFF) so the
@@ -244,11 +245,11 @@ function FilterChipRowComponent({
   onChangePopularity,
   minRating,
   onChangeRating,
-  hideCompleted,
-  onToggleHideCompleted,
+  progress,
+  onChangeProgress,
+  canFilterProgress,
   onlyBenchmarks,
   onToggleBenchmarks,
-  canHideCompleted,
 }: FilterChipRowProps) {
   const { t } = useTranslation('climbs');
   const { brandColors, colorScheme } = useTheme();
@@ -346,28 +347,38 @@ function FilterChipRowComponent({
             onPress={gradeRailOpen ? onCloseGrade : onOpenGrade}
           />
 
-          {/* Show ▾ — hide-sent (auth-gated) + benchmarks. The controlled menu stays
-            OPEN while toggling (these items don't call close()). */}
-          <MenuChip
-            label={t('mobile.search.chips.show')}
-            selected={hideCompleted || onlyBenchmarks}
+          {/* Your progress ▾ — single-select over the four tick flags (auth-gated,
+            the chip hides when signed out). Each item commits its value and closes. */}
+          {canFilterProgress ? (
+            <MenuChip
+              label={progress === 'all' ? t('mobile.filter.progress.label') : progressFilterLabel(progress, t)}
+              selected={progress !== 'all'}
+              colors={chipColors}
+              renderItems={(close) => (
+                <>
+                  {PROGRESS_FILTER_VALUES.map((value) => (
+                    <MenuItem
+                      key={value}
+                      label={progressFilterLabel(value, t)}
+                      checked={value === progress}
+                      onClick={() => {
+                        onChangeProgress(value);
+                        close();
+                      }}
+                    />
+                  ))}
+                </>
+              )}
+            />
+          ) : null}
+
+          {/* Benchmarks — its own toggle chip (a tap flips it), no longer folded in
+            with progress. */}
+          <ActionChip
+            label={t('mobile.filter.benchmark')}
+            selected={onlyBenchmarks}
             colors={chipColors}
-            renderItems={() => (
-              <>
-                {canHideCompleted ? (
-                  <MenuItem
-                    label={t('mobile.filter.hideSent')}
-                    checked={hideCompleted}
-                    onClick={() => onToggleHideCompleted(!hideCompleted)}
-                  />
-                ) : null}
-                <MenuItem
-                  label={t('mobile.filter.benchmark')}
-                  checked={onlyBenchmarks}
-                  onClick={() => onToggleBenchmarks(!onlyBenchmarks)}
-                />
-              </>
-            )}
+            onPress={() => onToggleBenchmarks(!onlyBenchmarks)}
           />
 
           {/* Tall / Wide — board-shape chips for the current Kilter homewall size

--- a/packages/mobile/src/components/search/FilterChipRow.ios.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.ios.tsx
@@ -6,7 +6,7 @@
 //
 // The always-visible facet chips follow the filter sheet's data-driven PRIMARY
 // importance order (the sheet's own comment: "the levers the analytics say carry
-// the product"): Grade → hide-sent/benchmarks → popularity → min-rating. Sort
+// the product"): Grade → progress/benchmarks → popularity → min-rating. Sort
 // lives in the sheet's ADVANCED ("sub-2% long tail") and is intentionally NOT a
 // chip — it surfaces as a removable token when non-default.
 //
@@ -14,7 +14,8 @@
 //   Filters · N → opens the long-tail sheet (Button, no menu)
 //   Recent ▾    → native Menu of saved filters + Clear (hidden when none)
 //   Grade       → opens the GradeRangeRail overlay (Button, no menu)   [PRIMARY #1]
-//   Show ▾      → native Menu of Toggles (hide-sent, benchmarks) — stays open [#2/#3]
+//   Your progress ▾ → native Menu + Picker (single-select, auth-gated) [PRIMARY #2]
+//   Benchmarks  → toggle chip (Button, tap flips it)                   [PRIMARY #3]
 //   Popularity ▾→ native Menu + Picker (min-ascents buckets)           [PRIMARY #4]
 //   Min rating ▾→ native Menu + Picker (star buckets)                  [PRIMARY #5]
 //
@@ -25,8 +26,9 @@
 import { memo, useCallback } from 'react';
 import { StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { Host, HStack, ScrollView, Menu, Picker, Toggle, Button, Text, Divider } from '@expo/ui/swift-ui';
-import { buttonStyle, controlSize, tint, tag, padding, menuActionDismissBehavior } from '@expo/ui/swift-ui/modifiers';
+import { Host, HStack, ScrollView, Menu, Picker, Button, Text, Divider } from '@expo/ui/swift-ui';
+import { buttonStyle, controlSize, tint, tag, padding } from '@expo/ui/swift-ui/modifiers';
+import { PROGRESS_FILTER_VALUES } from '@boardsesh/climb-filters';
 import { getFilterKey } from '../../lib/recent-filter-store';
 import {
   POPULARITY_BUCKETS,
@@ -38,7 +40,7 @@ import {
 } from '../../lib/filter-chip-menus';
 import { useTheme } from '../../providers/theme-provider';
 import { spacing } from '../../theme/tokens';
-import { popularityChipLabel, ratingChipLabel } from './FilterChipRow.logic';
+import { popularityChipLabel, ratingChipLabel, progressFilterLabel, isProgressFilter } from './FilterChipRow.logic';
 import type { FilterChipRowProps } from './FilterChipRow.types';
 
 function FilterChipRowComponent({
@@ -59,11 +61,11 @@ function FilterChipRowComponent({
   onChangePopularity,
   minRating,
   onChangeRating,
-  hideCompleted,
-  onToggleHideCompleted,
+  progress,
+  onChangeProgress,
+  canFilterProgress,
   onlyBenchmarks,
   onToggleBenchmarks,
-  canHideCompleted,
 }: FilterChipRowProps) {
   const { t } = useTranslation('climbs');
   const { brandColors } = useTheme();
@@ -136,17 +138,39 @@ function FilterChipRowComponent({
             modifiers={chipModifiers(gradeActive)}
           />
 
-          {/* Show ▾ — hide-sent + benchmarks; menuActionDismissBehavior keeps it
-              open. [PRIMARY #2 + #3] — kept directly after Grade. */}
-          <Menu
-            label={t('mobile.search.chips.show')}
-            modifiers={[...chipModifiers(hideCompleted || onlyBenchmarks), menuActionDismissBehavior('disabled')]}
-          >
-            {canHideCompleted ? (
-              <Toggle label={t('mobile.filter.hideSent')} isOn={hideCompleted} onIsOnChange={onToggleHideCompleted} />
-            ) : null}
-            <Toggle label={t('mobile.filter.benchmark')} isOn={onlyBenchmarks} onIsOnChange={onToggleBenchmarks} />
-          </Menu>
+          {/* Your progress ▾ — single-select over the four tick flags (auth-gated,
+              the chip hides when signed out). [PRIMARY #2] — kept directly after
+              Grade. Resting label is the dimension name; active shows the pick. */}
+          {canFilterProgress ? (
+            <Menu
+              label={progress === 'all' ? t('mobile.filter.progress.label') : progressFilterLabel(progress, t)}
+              modifiers={chipModifiers(progress !== 'all')}
+            >
+              <Picker
+                selection={progress}
+                onSelectionChange={(value) => {
+                  // The Picker hands back its selection as an untyped tag string;
+                  // guard it to a real ProgressFilter before committing.
+                  if (typeof value !== 'string' || !isProgressFilter(value)) return;
+                  onChangeProgress(value);
+                }}
+              >
+                {PROGRESS_FILTER_VALUES.map((value) => (
+                  <Text key={value} modifiers={[tag(value)]}>
+                    {progressFilterLabel(value, t)}
+                  </Text>
+                ))}
+              </Picker>
+            </Menu>
+          ) : null}
+
+          {/* Benchmarks — its own toggle chip (a tap flips it), no longer folded in
+              with progress. [PRIMARY #3] */}
+          <Button
+            label={t('mobile.filter.benchmark')}
+            onPress={() => onToggleBenchmarks(!onlyBenchmarks)}
+            modifiers={chipModifiers(onlyBenchmarks)}
+          />
 
           {/* Tall / Wide — board-shape chips, present only on the Kilter homewall
               sizes where they apply (Wide on 10x10, Tall on 8x12, both on 10x12).

--- a/packages/mobile/src/components/search/FilterChipRow.logic.ts
+++ b/packages/mobile/src/components/search/FilterChipRow.logic.ts
@@ -11,7 +11,18 @@
 // `filter-chip-menus.ts` at the call sites so the chip and the sheet never diverge.
 
 import type { TFunction } from 'i18next';
-import { formatMinAscentsFilterCount } from '@boardsesh/climb-filters';
+import { formatMinAscentsFilterCount, PROGRESS_FILTER_VALUES, type ProgressFilter } from '@boardsesh/climb-filters';
+
+export { progressFilterLabel } from '../../lib/filter-labels';
+
+/**
+ * Narrows a raw native-picker tag to a {@link ProgressFilter}. The iOS Picker
+ * hands back its selection as an untyped tag string, so the menu guards it here
+ * before calling `onChangeProgress` — a stray value is ignored rather than cast.
+ */
+export function isProgressFilter(value: string): value is ProgressFilter {
+  return (PROGRESS_FILTER_VALUES as readonly string[]).includes(value);
+}
 
 /**
  * Label for a popularity (min-ascents) bucket: "Any ascents" for the undefined

--- a/packages/mobile/src/components/search/FilterChipRow.types.ts
+++ b/packages/mobile/src/components/search/FilterChipRow.types.ts
@@ -5,6 +5,7 @@
 // jetpack-compose) — whose components resolve native views at module load — off the
 // other platform's bundle path.
 
+import type { ProgressFilter } from '@boardsesh/climb-filters';
 import type { RecentFilter } from '../../lib/recent-filter-store';
 import type { ClimbFilters } from '../ClimbFilterSheet';
 
@@ -52,10 +53,11 @@ export type FilterChipRowProps = {
   minRating: number | undefined;
   onChangeRating: (minRating: number | undefined) => void;
 
-  hideCompleted: boolean;
-  onToggleHideCompleted: (next: boolean) => void;
+  /** The current "Your progress" selection, read from the four tick flags. */
+  progress: ProgressFilter;
+  onChangeProgress: (value: ProgressFilter) => void;
+  /** The progress selector is auth-gated (its chip hides), matching the sheet. */
+  canFilterProgress: boolean;
   onlyBenchmarks: boolean;
   onToggleBenchmarks: (next: boolean) => void;
-  /** Hide-sent is auth-gated, matching the filter sheet. */
-  canHideCompleted: boolean;
 };

--- a/packages/mobile/src/components/search/__tests__/FilterChipRow.logic.test.ts
+++ b/packages/mobile/src/components/search/__tests__/FilterChipRow.logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { TFunction } from 'i18next';
-import { popularityChipLabel, ratingChipLabel } from '../FilterChipRow.logic';
+import { PROGRESS_FILTER_VALUES, progressToFlags } from '@boardsesh/climb-filters';
+import { popularityChipLabel, ratingChipLabel, progressFilterLabel, isProgressFilter } from '../FilterChipRow.logic';
 import { POPULARITY_BUCKETS, RATING_BUCKETS } from '../../../lib/filter-chip-menus';
 
 // Mirrors filter-labels.test.ts: the mock t returns the key (with interpolated
@@ -47,5 +48,56 @@ describe('ratingChipLabel', () => {
     for (const bucket of RATING_BUCKETS) {
       expect(ratingChipLabel(bucket, mockT).length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('progressFilterLabel', () => {
+  it('maps every progress value to its literal i18n key', () => {
+    expect(progressFilterLabel('all', mockT)).toBe('mobile.filter.progress.all');
+    expect(progressFilterLabel('untried', mockT)).toBe('mobile.filter.progress.untried');
+    expect(progressFilterLabel('projects', mockT)).toBe('mobile.filter.progress.projects');
+    expect(progressFilterLabel('sent', mockT)).toBe('mobile.filter.progress.sent');
+    expect(progressFilterLabel('unsent', mockT)).toBe('mobile.filter.progress.unsent');
+  });
+
+  it('produces a non-empty label for every shared PROGRESS_FILTER_VALUE', () => {
+    for (const value of PROGRESS_FILTER_VALUES) {
+      expect(progressFilterLabel(value, mockT).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('isProgressFilter', () => {
+  it('accepts every real progress value', () => {
+    for (const value of PROGRESS_FILTER_VALUES) {
+      expect(isProgressFilter(value)).toBe(true);
+    }
+  });
+
+  it('rejects a stray tag string', () => {
+    expect(isProgressFilter('nonsense')).toBe(false);
+    expect(isProgressFilter('')).toBe(false);
+  });
+});
+
+// Guards the chip↔flag round trip the menu relies on: picking "Projects" must set
+// exactly showOnlyAttempted + hideCompleted (the flags create-climb-filters reads).
+describe('progressToFlags (chip commit)', () => {
+  it('maps "projects" to attempted-but-not-sent flags', () => {
+    expect(progressToFlags('projects')).toEqual({
+      hideAttempted: undefined,
+      hideCompleted: true,
+      showOnlyAttempted: true,
+      showOnlyCompleted: undefined,
+    });
+  });
+
+  it('clears every flag for "all"', () => {
+    expect(progressToFlags('all')).toEqual({
+      hideAttempted: undefined,
+      hideCompleted: undefined,
+      showOnlyAttempted: undefined,
+      showOnlyCompleted: undefined,
+    });
   });
 });

--- a/packages/mobile/src/lib/__tests__/filter-labels.test.ts
+++ b/packages/mobile/src/lib/__tests__/filter-labels.test.ts
@@ -94,24 +94,16 @@ describe('buildFilterLabels', () => {
     expect(labels.status('projects')).toBe('mobile.filter.status.projects');
   });
 
-  it('hideAttempted uses mobile.filter.progress.hideAttempted', () => {
-    expect(labels.hideAttempted()).toBe('mobile.filter.progress.hideAttempted');
-  });
-
-  it('hideCompleted uses mobile.filter.progress.hideCompleted', () => {
-    expect(labels.hideCompleted()).toBe('mobile.filter.progress.hideCompleted');
-  });
-
-  it('showOnlyAttempted uses mobile.filter.progress.onlyAttempted', () => {
-    expect(labels.showOnlyAttempted()).toBe('mobile.filter.progress.onlyAttempted');
-  });
-
-  it('showOnlyCompleted uses mobile.filter.progress.onlyCompleted', () => {
-    expect(labels.showOnlyCompleted()).toBe('mobile.filter.progress.onlyCompleted');
+  it('progress collapses the four tick flags into one value label', () => {
+    expect(labels.progress('untried')).toBe('mobile.filter.progress.untried');
+    expect(labels.progress('projects')).toBe('mobile.filter.progress.projects');
+    expect(labels.progress('sent')).toBe('mobile.filter.progress.sent');
+    expect(labels.progress('unsent')).toBe('mobile.filter.progress.unsent');
   });
 
   it('returns all required keys (no missing fields)', () => {
-    // Ensures Required<FilterSummaryLabels> is fully populated.
+    // Ensures every label the token/summary builders index is populated (the four
+    // per-flag progress labels collapsed into one `progress` label).
     const keys: Array<keyof ReturnType<typeof buildFilterLabels>> = [
       'gradeRange',
       'gradeMin',
@@ -125,10 +117,7 @@ describe('buildFilterLabels', () => {
       'wideOnly',
       'betaOnly',
       'status',
-      'hideAttempted',
-      'hideCompleted',
-      'showOnlyAttempted',
-      'showOnlyCompleted',
+      'progress',
     ];
     for (const key of keys) {
       expect(typeof labels[key]).toBe('function');

--- a/packages/mobile/src/lib/filter-labels.ts
+++ b/packages/mobile/src/lib/filter-labels.ts
@@ -3,14 +3,46 @@
 // the active-filter token chips never word a filter differently.
 
 import type { TFunction } from 'i18next';
-import { gradeAccuracyBucket, type FilterSummaryLabels, type SortOption } from '@boardsesh/climb-filters';
+import {
+  gradeAccuracyBucket,
+  type FilterSummaryLabels,
+  type ProgressFilter,
+  type SortOption,
+} from '@boardsesh/climb-filters';
 
-// `FilterSummaryLabels` marks several fields optional for shared callers that
-// emit a partial summary, but this builder always populates every one — so the
-// return type is `Required` here. That lets the token builder index the labels
-// without `&& labels.x` guards that would silently drop a token if a field were
-// ever forgotten (a real bug) rather than absent by design.
-export function buildFilterLabels(t: TFunction<'climbs'>): Required<FilterSummaryLabels> {
+// The four per-user tick flags collapse into one "Your progress" value, so the
+// summary/token labels expose a single `progress` label instead of one label per
+// flag. This builder always populates every field except those four, so the
+// return type omits them from the otherwise-`Required` shape — the token builder
+// can then index the labels without `&& labels.x` guards that would silently
+// drop a token if a field were ever forgotten (a real bug) rather than absent by
+// design.
+type ClimbFilterLabels = Omit<
+  Required<FilterSummaryLabels>,
+  'hideAttempted' | 'hideCompleted' | 'showOnlyAttempted' | 'showOnlyCompleted'
+>;
+
+/**
+ * Label for a "Your progress" value. Literal `t` keys (the i18n linter forbids
+ * `t(variable)`), sourced once here so the sheet chips, the persistent chip row,
+ * and the filter summary / tokens never word the selector differently.
+ */
+export function progressFilterLabel(value: ProgressFilter, t: TFunction<'climbs'>): string {
+  switch (value) {
+    case 'all':
+      return t('mobile.filter.progress.all');
+    case 'untried':
+      return t('mobile.filter.progress.untried');
+    case 'projects':
+      return t('mobile.filter.progress.projects');
+    case 'sent':
+      return t('mobile.filter.progress.sent');
+    case 'unsent':
+      return t('mobile.filter.progress.unsent');
+  }
+}
+
+export function buildFilterLabels(t: TFunction<'climbs'>): ClimbFilterLabels {
   return {
     gradeRange: (min, max) => t('mobile.search.gradeRange', { min, max }),
     gradeMin: (grade) => t('mobile.search.gradeMin', { grade }),
@@ -29,10 +61,9 @@ export function buildFilterLabels(t: TFunction<'climbs'>): Required<FilterSummar
     betaOnly: () => t('mobile.filter.betaVideosShort'),
     // i18n-keep mobile.filter.status.drafts mobile.filter.status.established mobile.filter.status.projects
     status: (kind) => t(`mobile.filter.status.${kind}`),
-    hideAttempted: () => t('mobile.filter.progress.hideAttempted'),
-    hideCompleted: () => t('mobile.filter.progress.hideCompleted'),
-    showOnlyAttempted: () => t('mobile.filter.progress.onlyAttempted'),
-    showOnlyCompleted: () => t('mobile.filter.progress.onlyCompleted'),
+    // A single part for the collapsed progress selector (getBaseFilterParts reads
+    // the current value via flagsToProgress); 'all' is never passed here.
+    progress: (value) => progressFilterLabel(value, t),
   };
 }
 

--- a/packages/mobile/src/lib/filter-tokens.ts
+++ b/packages/mobile/src/lib/filter-tokens.ts
@@ -16,6 +16,8 @@ import {
   getGradeName,
   applyStatusChange,
   countFilteredHolds,
+  flagsToProgress,
+  progressToFlags,
   DEFAULT_CLIMB_FILTER_STATE,
   type ClimbFilterState,
   type ClimbBoardFilterState,
@@ -162,35 +164,15 @@ export function getActiveFilterTokens({
     });
   }
 
-  if (filters.hideAttempted) {
+  // The four per-user tick flags collapse into one "Your progress" token, so a
+  // single Projects selection (showOnlyAttempted + hideCompleted) never reads as
+  // two tokens. Clearing resets every progress flag to its default.
+  const progress = flagsToProgress(filters);
+  if (progress !== 'all') {
     tokens.push({
-      key: 'hideAttempted',
-      label: labels.hideAttempted(),
-      clear: () => patchFilters({ hideAttempted: undefined }),
-    });
-  }
-
-  if (filters.hideCompleted) {
-    tokens.push({
-      key: 'hideCompleted',
-      label: labels.hideCompleted(),
-      clear: () => patchFilters({ hideCompleted: undefined }),
-    });
-  }
-
-  if (filters.showOnlyAttempted) {
-    tokens.push({
-      key: 'showOnlyAttempted',
-      label: labels.showOnlyAttempted(),
-      clear: () => patchFilters({ showOnlyAttempted: undefined }),
-    });
-  }
-
-  if (filters.showOnlyCompleted) {
-    tokens.push({
-      key: 'showOnlyCompleted',
-      label: labels.showOnlyCompleted(),
-      clear: () => patchFilters({ showOnlyCompleted: undefined }),
+      key: 'progress',
+      label: labels.progress(progress),
+      clear: () => patchFilters(progressToFlags('all')),
     });
   }
 

--- a/packages/shared/climb-filters/src/__tests__/progress-filter.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/progress-filter.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PROGRESS_FILTER_VALUES,
+  progressToFlags,
+  flagsToProgress,
+  isProgressFilterActive,
+  type ProgressFilter,
+} from '../progress-filter';
+
+describe('progressToFlags', () => {
+  it('maps each value to its tick flags', () => {
+    expect(progressToFlags('all')).toEqual({
+      hideAttempted: undefined,
+      hideCompleted: undefined,
+      showOnlyAttempted: undefined,
+      showOnlyCompleted: undefined,
+    });
+    expect(progressToFlags('untried')).toEqual({
+      hideAttempted: true,
+      hideCompleted: true,
+      showOnlyAttempted: undefined,
+      showOnlyCompleted: undefined,
+    });
+    expect(progressToFlags('projects')).toEqual({
+      hideAttempted: undefined,
+      hideCompleted: true,
+      showOnlyAttempted: true,
+      showOnlyCompleted: undefined,
+    });
+    expect(progressToFlags('sent')).toEqual({
+      hideAttempted: undefined,
+      hideCompleted: undefined,
+      showOnlyAttempted: undefined,
+      showOnlyCompleted: true,
+    });
+    expect(progressToFlags('unsent')).toEqual({
+      hideAttempted: undefined,
+      hideCompleted: true,
+      showOnlyAttempted: undefined,
+      showOnlyCompleted: undefined,
+    });
+  });
+
+  it('always returns all four keys so switching clears stale flags', () => {
+    // Simulate switching Projects -> Sent over prior state.
+    const prior = { ...progressToFlags('projects'), minGrade: 5 };
+    const next = { ...prior, ...progressToFlags('sent') };
+    expect(next.hideCompleted).toBeUndefined();
+    expect(next.showOnlyAttempted).toBeUndefined();
+    expect(next.showOnlyCompleted).toBe(true);
+    expect(next.minGrade).toBe(5);
+  });
+});
+
+describe('flagsToProgress', () => {
+  it('round-trips every value', () => {
+    for (const value of PROGRESS_FILTER_VALUES) {
+      expect(flagsToProgress(progressToFlags(value))).toBe(value);
+    }
+  });
+
+  it('reads an empty/default state as "all"', () => {
+    expect(flagsToProgress({})).toBe('all');
+  });
+
+  it('distinguishes projects (attempted, not sent) from unsent (hide sent)', () => {
+    expect(flagsToProgress({ showOnlyAttempted: true, hideCompleted: true })).toBe('projects');
+    expect(flagsToProgress({ hideCompleted: true })).toBe('unsent');
+  });
+
+  it('resolves legacy stand-alone "only attempted" to projects', () => {
+    expect(flagsToProgress({ showOnlyAttempted: true })).toBe('projects');
+  });
+
+  it('prefers sent when completed and attempted flags collide', () => {
+    expect(flagsToProgress({ showOnlyCompleted: true, showOnlyAttempted: true })).toBe('sent');
+  });
+
+  it('resolves a lone legacy hideAttempted to all (no dedicated lens)', () => {
+    expect(flagsToProgress({ hideAttempted: true })).toBe('all');
+  });
+});
+
+describe('isProgressFilterActive', () => {
+  it('is false only for "all"', () => {
+    expect(isProgressFilterActive({})).toBe(false);
+    const active: ProgressFilter[] = ['untried', 'projects', 'sent', 'unsent'];
+    for (const value of active) {
+      expect(isProgressFilterActive(progressToFlags(value))).toBe(true);
+    }
+  });
+});

--- a/packages/shared/climb-filters/src/active-filter-count.ts
+++ b/packages/shared/climb-filters/src/active-filter-count.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_CLIMB_FILTER_STATE, type ClimbFilterState } from './filter-state';
+import { isProgressFilterActive } from './progress-filter';
 import type { ClimbBoardFilterState } from './board-filter-state';
 
 /**
@@ -17,10 +18,9 @@ export function countActiveFiltersBeyondGrade(filters: ClimbFilterState, boardFi
   if (filters.onlyTallClimbs) count += 1;
   if (filters.onlyWideClimbs) count += 1;
   if (filters.onlyWithBetaVideos) count += 1;
-  if (filters.hideAttempted) count += 1;
-  if (filters.hideCompleted) count += 1;
-  if (filters.showOnlyAttempted) count += 1;
-  if (filters.showOnlyCompleted) count += 1;
+  // The four tick flags are one conceptual axis (the "Your progress" selector),
+  // so they contribute at most one — "Not tried" sets two flags but is one choice.
+  if (isProgressFilterActive(filters)) count += 1;
   // Climb-type defaults to boulders-only; "active" = routes on or boulders off.
   if ((filters.boulders ?? true) !== true || (filters.routes ?? false) !== false) count += 1;
   if (

--- a/packages/shared/climb-filters/src/filter-summary.ts
+++ b/packages/shared/climb-filters/src/filter-summary.ts
@@ -1,5 +1,6 @@
 import type { Grade } from '@boardsesh/shared-schema';
 import { getGradeName } from './grade-lookup';
+import { flagsToProgress, type ProgressFilter } from './progress-filter';
 
 export type FilterSummaryLabels = {
   gradeRange: (min: string, max: string) => string;
@@ -20,6 +21,10 @@ export type FilterSummaryLabels = {
   hideCompleted?: () => string;
   showOnlyAttempted?: () => string;
   showOnlyCompleted?: () => string;
+  // When supplied, the four tick flags collapse into a single "Your progress"
+  // part (e.g. "Projects") instead of one part per flag. Callers on the old
+  // four-switch model omit this and keep the per-flag parts above.
+  progress?: (value: Exclude<ProgressFilter, 'all'>) => string;
 };
 
 export type BaseFilters = {
@@ -112,20 +117,29 @@ export function getBaseFilterParts(
     parts.push(labels.status(filters.status));
   }
 
-  if (filters.hideAttempted && labels.hideAttempted) {
-    parts.push(labels.hideAttempted());
-  }
+  // Progress: a `progress` label collapses the four flags into one part; without
+  // it, fall back to one part per active flag (the old four-switch model).
+  if (labels.progress) {
+    const progress = flagsToProgress(filters);
+    if (progress !== 'all') {
+      parts.push(labels.progress(progress));
+    }
+  } else {
+    if (filters.hideAttempted && labels.hideAttempted) {
+      parts.push(labels.hideAttempted());
+    }
 
-  if (filters.hideCompleted && labels.hideCompleted) {
-    parts.push(labels.hideCompleted());
-  }
+    if (filters.hideCompleted && labels.hideCompleted) {
+      parts.push(labels.hideCompleted());
+    }
 
-  if (filters.showOnlyAttempted && labels.showOnlyAttempted) {
-    parts.push(labels.showOnlyAttempted());
-  }
+    if (filters.showOnlyAttempted && labels.showOnlyAttempted) {
+      parts.push(labels.showOnlyAttempted());
+    }
 
-  if (filters.showOnlyCompleted && labels.showOnlyCompleted) {
-    parts.push(labels.showOnlyCompleted());
+    if (filters.showOnlyCompleted && labels.showOnlyCompleted) {
+      parts.push(labels.showOnlyCompleted());
+    }
   }
 
   return parts;

--- a/packages/shared/climb-filters/src/index.ts
+++ b/packages/shared/climb-filters/src/index.ts
@@ -3,6 +3,7 @@ export * from './grade-range';
 export * from './filter-normalization';
 export * from './filter-summary';
 export * from './filter-state';
+export * from './progress-filter';
 export * from './board-filter-state';
 export * from './active-filter-count';
 export * from './climb-zone-math';

--- a/packages/shared/climb-filters/src/progress-filter.ts
+++ b/packages/shared/climb-filters/src/progress-filter.ts
@@ -1,0 +1,100 @@
+import type { ClimbFilterState } from './filter-state';
+
+/**
+ * The user's relationship to a climb, expressed as a single choice — the model
+ * behind the "Your progress" selector. It collapses the four independent tick
+ * flags ({@link ProgressFlags}) into one mutually-exclusive lens, so a UI can
+ * offer "All / Not tried / Projects / Sent / Unsent" instead of a bag of
+ * switches that can silently contradict each other.
+ *
+ * All four flags query the per-user `boardsesh_ticks` table in
+ * @boardsesh/db create-climb-filters.ts — there is no new query behind this,
+ * only a cleaner front-end model over the existing levers:
+ *
+ * - `all`      — no progress constraint.
+ * - `untried`  — no tick of any kind (never attempted, never sent).
+ * - `projects` — attempted but not sent (the classic "project").
+ * - `sent`     — flashed or sent.
+ * - `unsent`   — everything not yet sent = `untried` ∪ `projects`. This is the
+ *                behaviour of the old "Hide climbs I've sent" switch, kept so no
+ *                one loses a filter they already rely on.
+ *
+ * Note `unsent` is a superset of `untried` and `projects`; that overlap is fine
+ * for a single-select — each value is just a different view of the same axis.
+ */
+export const PROGRESS_FILTER_VALUES = ['all', 'untried', 'projects', 'sent', 'unsent'] as const;
+export type ProgressFilter = (typeof PROGRESS_FILTER_VALUES)[number];
+
+/** The four per-user tick flags this selector owns. */
+export type ProgressFlags = Pick<
+  ClimbFilterState,
+  'hideAttempted' | 'hideCompleted' | 'showOnlyAttempted' | 'showOnlyCompleted'
+>;
+
+/**
+ * The patch shape {@link progressToFlags} returns: every flag key present, each
+ * either `true` or `undefined`. Written as a `Record` rather than
+ * `Required<ProgressFlags>` because `Required` (and the `-?` modifier) strip
+ * `undefined` from the value — leaving `boolean` and rejecting the explicit
+ * `undefined` clears below. Keys stay required so a spread reliably overwrites
+ * stale flags.
+ */
+export type ProgressFlagsPatch = Record<keyof ProgressFlags, boolean | undefined>;
+
+/**
+ * The flag patch for a given progress choice. Every key is present (set to
+ * `undefined` when off) so applying the patch over prior state clears stale
+ * flags — switching from "Projects" to "Sent" must not leave `hideCompleted`
+ * behind. Spread it as `setState((prev) => ({ ...prev, ...progressToFlags(p) }))`.
+ */
+export function progressToFlags(progress: ProgressFilter): ProgressFlagsPatch {
+  const cleared: ProgressFlagsPatch = {
+    hideAttempted: undefined,
+    hideCompleted: undefined,
+    showOnlyAttempted: undefined,
+    showOnlyCompleted: undefined,
+  };
+  switch (progress) {
+    case 'all':
+      return cleared;
+    case 'untried':
+      return { ...cleared, hideAttempted: true, hideCompleted: true };
+    case 'projects':
+      return { ...cleared, showOnlyAttempted: true, hideCompleted: true };
+    case 'sent':
+      return { ...cleared, showOnlyCompleted: true };
+    case 'unsent':
+      return { ...cleared, hideCompleted: true };
+  }
+}
+
+/**
+ * Reads the current progress choice back out of the flags, for a control that
+ * needs to show its selected value. Precedence is deliberate and total so every
+ * flag combination — including legacy ones from the old independent switches —
+ * resolves to exactly one value:
+ *
+ * 1. `showOnlyCompleted`  → `sent`
+ * 2. `showOnlyAttempted`  → `projects` (with or without `hideCompleted`; the old
+ *    stand-alone "Only attempted" switch resolves here, its closest lens)
+ * 3. `hideAttempted` + `hideCompleted` → `untried`
+ * 4. `hideCompleted`      → `unsent`
+ *
+ * A lone `hideAttempted` (an old switch state with no dedicated lens — "hide
+ * climbs I've attempted", i.e. show untried + sent) has no bucket and resolves
+ * to `all`; it self-heals the moment the user picks any value, since
+ * {@link progressToFlags} writes a full patch. Only pre-existing stored searches
+ * can carry it, and this selector is the only writer going forward.
+ */
+export function flagsToProgress(flags: ProgressFlags): ProgressFilter {
+  if (flags.showOnlyCompleted) return 'sent';
+  if (flags.showOnlyAttempted) return 'projects';
+  if (flags.hideAttempted && flags.hideCompleted) return 'untried';
+  if (flags.hideCompleted) return 'unsent';
+  return 'all';
+}
+
+/** True when any progress lens is active (i.e. the selector is not on "All"). */
+export function isProgressFilterActive(flags: ProgressFlags): boolean {
+  return flagsToProgress(flags) !== 'all';
+}

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -662,8 +662,6 @@
         "refine": "Refine",
         "advanced": "Advanced"
       },
-      "hideSent": "Hide climbs I've sent",
-      "hideSentDescription": "Only show climbs you haven't completed",
       "popularity": "Popularity",
       "established2plus": "Established 2+",
       "benchmark": "Benchmarks only",
@@ -699,10 +697,12 @@
         "tight": "Tight"
       },
       "progress": {
-        "hideAttempted": "Hide attempted",
-        "hideCompleted": "Hide completed",
-        "onlyAttempted": "Only attempted",
-        "onlyCompleted": "Only completed"
+        "label": "Your progress",
+        "all": "All",
+        "untried": "Not tried",
+        "projects": "Projects",
+        "sent": "Sent",
+        "unsent": "Unsent"
       },
       "signInForDrafts": "Sign in to filter your drafts",
       "setters": "Setters",
@@ -745,7 +745,6 @@
       "allClimbs": "All climbs",
       "clearRecentSearches": "Clear recent searches",
       "chips": {
-        "show": "Show",
         "filtersWithCount": "Filters · {{count}}",
         "tall": "Tall",
         "wide": "Wide",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -662,8 +662,6 @@
         "refine": "Afinar",
         "advanced": "Avanzado"
       },
-      "hideSent": "Ocultar lo que ya encadené",
-      "hideSentDescription": "Mostrar solo vías que no has completado",
       "popularity": "Popularidad",
       "established2plus": "Establecido 2+",
       "benchmark": "Solo benchmarks",
@@ -699,10 +697,12 @@
         "tight": "Estricta"
       },
       "progress": {
-        "hideAttempted": "Ocultar intentadas",
-        "hideCompleted": "Ocultar completadas",
-        "onlyAttempted": "Solo intentadas",
-        "onlyCompleted": "Solo completadas"
+        "label": "Tu progreso",
+        "all": "Todos",
+        "untried": "Sin intentar",
+        "projects": "Proyectos",
+        "sent": "Encadenados",
+        "unsent": "Sin encadenar"
       },
       "signInForDrafts": "Inicia sesión para filtrar tus borradores",
       "setters": "Equipadores",
@@ -745,7 +745,6 @@
       "allClimbs": "Todas las vías",
       "clearRecentSearches": "Borrar búsquedas recientes",
       "chips": {
-        "show": "Mostrar",
         "filtersWithCount": "Filtros · {{count}}",
         "tall": "Altas",
         "wide": "Anchas",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -662,8 +662,6 @@
         "refine": "Affiner",
         "advanced": "Avancé"
       },
-      "hideSent": "Masquer mes voies enchaînées",
-      "hideSentDescription": "N'afficher que les voies que vous n'avez pas enchaînées",
       "popularity": "Popularité",
       "established2plus": "Établies 2+",
       "benchmark": "Benchmarks uniquement",
@@ -699,10 +697,12 @@
         "tight": "Stricte"
       },
       "progress": {
-        "hideAttempted": "Masquer essayées",
-        "hideCompleted": "Masquer enchaînées",
-        "onlyAttempted": "Uniquement essayées",
-        "onlyCompleted": "Uniquement enchaînées"
+        "label": "Ta progression",
+        "all": "Toutes",
+        "untried": "Non essayées",
+        "projects": "Projets",
+        "sent": "Enchaînées",
+        "unsent": "Non enchaînées"
       },
       "signInForDrafts": "Connecte-toi pour filtrer tes brouillons",
       "setters": "Ouvreurs",
@@ -745,7 +745,6 @@
       "allClimbs": "Toutes les voies",
       "clearRecentSearches": "Effacer les recherches récentes",
       "chips": {
-        "show": "Afficher",
         "filtersWithCount": "Filtres · {{count}}",
         "tall": "Hautes",
         "wide": "Larges",


### PR DESCRIPTION
## Summary

Adds a **Projects** filter to the mobile climbs search — show only climbs you've attempted but not sent — and cleans up the progress/benchmarks grouping the "Show" control muddled together.

The four loose per-user tick switches ("Hide climbs I've sent" in the primary card, plus "Hide attempted / Only attempted / Only completed" buried in Advanced) collapse into one single-select **Your progress** selector:

- **All** — no filter
- **Not tried** — never logged anything on it
- **Projects** — attempted, not sent *(new)*
- **Sent** — flashed or sent
- **Unsent** — everything not yet sent (= the old "Hide climbs I've sent")

**Benchmarks only** is pulled out of the progress grouping into its own top-tier row/chip — it's a climb attribute, not a progress state, and no longer shares a card or the "Show" menu with your tick history.

No DB or query changes: all five options map onto the existing `boardsesh_ticks` flags (`hideCompleted` / `showOnlyAttempted` / `showOnlyCompleted`) via a new shared `ProgressFilter` mapping in `@boardsesh/climb-filters`. Web is untouched (its accordion keeps the four switches); the shared mapping is backward-compatible so web can adopt the selector in a follow-up.

Surfaces changed: the `ClimbFilterSheet` primary card, the Advanced section (three switches removed), and the persistent `FilterChipRow` ("Show" chip → progress selector; Benchmarks → its own chip).

## Release Notes

- Filter for your projects — show only the climbs you've tried but haven't sent yet
- Cleaner filters: pick where you're at on a climb (not tried, projects, sent) in one tap, with benchmarks on their own

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — pass (4018 tests), incl. new progress-selector coverage on the chip row + sheet
- `vp run check:mobile-bundle` — pass
- `vp check` (lint + format) — pass
- Shared: `vp test run progress-filter active-filter-count filter-summary` — pass (round-trip mapping, single-count, backward-compatible summary)
- i18n catalog completeness — pass (new `mobile.filter.progress.*` keys added to en-US / es / fr)
- Independent code review over the diff: mapping round-trips, no double-counted/double-shown progress token, auth gating preserved, no `any`.

Not yet exercised on a running simulator — visual pass to follow.
