### PR TITLE
fix(sync): pause SQLite sync/drain loops while app is backgrounded

### DIFF
--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -14,11 +14,14 @@ vi.mock('../../sync', () => ({
 }));
 
 const drainMutationQueueMock = vi.fn(async (..._args: unknown[]) => {});
+const startBackgroundTrackingStop = vi.fn();
+const startBackgroundTrackingMock = vi.fn(() => startBackgroundTrackingStop);
 // The scheduler + drain bindings live in the adapter (which statically imports
 // react-native — mock it so Rolldown's scan never parses the RN Flow entry).
 vi.mock('../../offline/offline-sync-adapter', () => ({
   startSyncScheduler: (...args: unknown[]) => startSyncSchedulerMock(...(args as [])),
   drainMutationQueue: (...args: unknown[]) => drainMutationQueueMock(...args),
+  startBackgroundTracking: () => startBackgroundTrackingMock(),
 }));
 
 // A stable sentinel so tests can assert the bridge passes THIS reference

--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -208,9 +208,12 @@ describe('OfflineSyncBridge — flag OFF', () => {
     await waitFor(() => expect(setupNotificationHandlersMock).toHaveBeenCalledTimes(1));
   });
 
-  it('still starts background tracking (not flag-gated — covers the leftover drain too)', async () => {
-    render(<Harness flags={FLAG_OFF} queryClient={makeQueryClient()} />);
+  it('still starts background tracking (not flag-gated — covers the leftover drain too) and tears it down on unmount', async () => {
+    const { unmount } = render(<Harness flags={FLAG_OFF} queryClient={makeQueryClient()} />);
     await waitFor(() => expect(startBackgroundTrackingMock).toHaveBeenCalledTimes(1));
+    expect(startBackgroundTrackingStop).not.toHaveBeenCalled();
+    unmount();
+    expect(startBackgroundTrackingStop).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -159,6 +159,14 @@ describe('OfflineSyncBridge — flag ON', () => {
     expect(startSyncSchedulerStop).toHaveBeenCalledTimes(1);
   });
 
+  it('starts background tracking on mount and tears it down on unmount', async () => {
+    const { unmount } = render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
+    await waitFor(() => expect(startBackgroundTrackingMock).toHaveBeenCalledTimes(1));
+    expect(startBackgroundTrackingStop).not.toHaveBeenCalled();
+    unmount();
+    expect(startBackgroundTrackingStop).toHaveBeenCalledTimes(1);
+  });
+
   it('passes no snapshotSource when offline-snapshot-bootstrap is off', async () => {
     render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
     await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalledTimes(1));
@@ -199,14 +207,21 @@ describe('OfflineSyncBridge — flag OFF', () => {
     render(<Harness flags={FLAG_OFF} queryClient={makeQueryClient()} />);
     await waitFor(() => expect(setupNotificationHandlersMock).toHaveBeenCalledTimes(1));
   });
+
+  it('still starts background tracking (not flag-gated — covers the leftover drain too)', async () => {
+    render(<Harness flags={FLAG_OFF} queryClient={makeQueryClient()} />);
+    await waitFor(() => expect(startBackgroundTrackingMock).toHaveBeenCalledTimes(1));
+  });
 });
 
 describe('OfflineSyncBridge — auth gating', () => {
   it('signed out: no scheduler, no leftover drain, no sync traffic at all', async () => {
     isAuthenticated = false;
     render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
-    // Notifications still set up — they are the only auth-independent effect.
+    // Notifications and background tracking still set up — they are
+    // auth-independent effects.
     await waitFor(() => expect(setupNotificationHandlersMock).toHaveBeenCalledTimes(1));
+    expect(startBackgroundTrackingMock).toHaveBeenCalledTimes(1);
     expect(startSyncSchedulerMock).not.toHaveBeenCalled();
     expect(getPendingCountMock).not.toHaveBeenCalled();
     expect(drainMutationQueueMock).not.toHaveBeenCalled();

--- a/packages/mobile/src/components/offline-sync-bridge.tsx
+++ b/packages/mobile/src/components/offline-sync-bridge.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import { setSyncProgress } from '../sync';
 import { getPendingCount, type GraphQLFetch } from '@boardsesh/offline-sync';
-import { startSyncScheduler, drainMutationQueue } from '../offline/offline-sync-adapter';
+import { startSyncScheduler, drainMutationQueue, startBackgroundTracking } from '../offline/offline-sync-adapter';
 import { getSetting } from '../settings';
 import { setupNotificationHandlers } from '../notifications';
 import { getHttpClient } from '../lib/graphql/client';
@@ -56,6 +56,12 @@ export function OfflineSyncBridge() {
   // getHttpClient() already carries auth + endpoint; binding .request keeps the
   // GraphQLFetch shape the scheduler and drainer expect.
   const graphqlFetch = useMemo<GraphQLFetch>(() => (query, variables) => getHttpClient().request(query, variables), []);
+
+  // Unconditional (unlike the scheduler effect below): the offline-sync
+  // engine's backgrounding guard must cover ad-hoc drainMutationQueue() calls
+  // from mutation hooks too, not just the scheduler's own pull/drain loop —
+  // see startBackgroundTracking's doc.
+  useEffect(() => startBackgroundTracking(), []);
 
   // On the flag flipping OFF mid-session, caches populated from local SQLite
   // must refetch from the network. `undefined` initial value skips the mount

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -38,11 +38,13 @@ const drainMutationQueueCore = vi.fn(async (..._args: unknown[]) => {});
 const startSyncSchedulerCore = vi.fn((..._args: unknown[]) => vi.fn());
 const triggerSyncCore = vi.fn();
 const pullSyncCore = vi.fn(async (..._args: unknown[]) => {});
+const setBackgroundedCore = vi.fn();
 vi.mock('@boardsesh/offline-sync', () => ({
   drainMutationQueue: (...args: unknown[]) => drainMutationQueueCore(...args),
   startSyncScheduler: (...args: unknown[]) => startSyncSchedulerCore(...args),
   triggerSync: (...args: unknown[]) => triggerSyncCore(...args),
   pullSync: (...args: unknown[]) => pullSyncCore(...args),
+  setBackgrounded: (...args: unknown[]) => setBackgroundedCore(...args),
 }));
 
 const reportHandledError = vi.fn();
@@ -54,7 +56,7 @@ const trackMock = vi.fn();
 vi.mock('../../lib/analytics', () => ({ track: (...args: unknown[]) => trackMock(...args) }));
 
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { drainMutationQueue, startSyncScheduler, triggerSync, pullSync } from '../offline-sync-adapter';
+import { drainMutationQueue, startSyncScheduler, triggerSync, pullSync, startBackgroundTracking } from '../offline-sync-adapter';
 import type {
   OfflineDatabase,
   DrainOptions,
@@ -95,6 +97,26 @@ describe('drainMutationQueue binding', () => {
     expect(customProbe).toHaveBeenCalled();
     expect(onlineManagerIsOnline).not.toHaveBeenCalled();
     expect(options.maxCycleAttempts).toBe(2);
+  });
+});
+
+describe('startBackgroundTracking', () => {
+  it('flips the engine guard on background/active transitions, ignoring the transient inactive state', () => {
+    const unsubscribe = startBackgroundTracking();
+
+    appStateListener?.('background');
+    expect(setBackgroundedCore).toHaveBeenCalledTimes(1);
+    expect(setBackgroundedCore).toHaveBeenLastCalledWith(true);
+
+    appStateListener?.('inactive');
+    expect(setBackgroundedCore).toHaveBeenCalledTimes(1);
+
+    appStateListener?.('active');
+    expect(setBackgroundedCore).toHaveBeenCalledTimes(2);
+    expect(setBackgroundedCore).toHaveBeenLastCalledWith(false);
+
+    unsubscribe();
+    expect(appStateRemove).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -56,7 +56,13 @@ const trackMock = vi.fn();
 vi.mock('../../lib/analytics', () => ({ track: (...args: unknown[]) => trackMock(...args) }));
 
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { drainMutationQueue, startSyncScheduler, triggerSync, pullSync, startBackgroundTracking } from '../offline-sync-adapter';
+import {
+  drainMutationQueue,
+  startSyncScheduler,
+  triggerSync,
+  pullSync,
+  startBackgroundTracking,
+} from '../offline-sync-adapter';
 import type {
   OfflineDatabase,
   DrainOptions,

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -77,21 +77,7 @@ const warnCycleError = (error: unknown) => {
   }
 };
 
-/**
- * Tracks app backgrounding for the offline-sync engine's setBackgrounded()
- * guard (Sentry BOARDSESH-AN — see drainer.ts), independent of whether the
- * sync scheduler is currently running: ad-hoc drainMutationQueue() calls
- * (mutation hooks, the leftover-drain path OfflineSyncBridge runs when the
- * offline-downloads flag is off) need the same pause the scheduler's own
- * pull/drain loop gets. Call once, unconditionally, for the app's lifetime —
- * OfflineSyncBridge does this from a top-level effect that mounts regardless
- * of auth state, NOT from inside the auth/flag-gated scheduler effect.
- *
- * Mirrors app-visibility.ts's choice of transition: only 'background' flips
- * the guard, not the transient 'inactive' state (control center, an incoming
- * call) — pausing on every 'inactive' blip would stall sync for
- * interruptions that never actually suspend the process.
- */
+// Feeds the offline-sync engine's setBackgrounded() guard (Sentry BOARDSESH-AN); call once, unconditionally, for the app's lifetime — see OfflineSyncBridge.
 export function startBackgroundTracking(): () => void {
   const subscription = AppState.addEventListener('change', (nextState: AppStateStatus) => {
     if (nextState === 'background') setBackgrounded(true);

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -77,7 +77,7 @@ const warnCycleError = (error: unknown) => {
   }
 };
 
-// Feeds the offline-sync engine's setBackgrounded() guard (Sentry BOARDSESH-AN); call once, unconditionally, for the app's lifetime — see OfflineSyncBridge.
+// Feeds setBackgrounded() (Sentry BOARDSESH-AN); call once for the app's lifetime — see OfflineSyncBridge.
 export function startBackgroundTracking(): () => void {
   const subscription = AppState.addEventListener('change', (nextState: AppStateStatus) => {
     if (nextState === 'background') setBackgrounded(true);

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -22,6 +22,7 @@ import {
   startSyncScheduler as startSyncSchedulerCore,
   triggerSync as triggerSyncCore,
   pullSync as pullSyncCore,
+  setBackgrounded,
   type DrainOptions,
   type DrainQueue,
   type GraphQLFetch,
@@ -75,6 +76,29 @@ const warnCycleError = (error: unknown) => {
     console.warn('[Sync] Sync cycle failed:', error instanceof Error ? error.message : 'unknown');
   }
 };
+
+/**
+ * Tracks app backgrounding for the offline-sync engine's setBackgrounded()
+ * guard (Sentry BOARDSESH-AN — see drainer.ts), independent of whether the
+ * sync scheduler is currently running: ad-hoc drainMutationQueue() calls
+ * (mutation hooks, the leftover-drain path OfflineSyncBridge runs when the
+ * offline-downloads flag is off) need the same pause the scheduler's own
+ * pull/drain loop gets. Call once, unconditionally, for the app's lifetime —
+ * OfflineSyncBridge does this from a top-level effect that mounts regardless
+ * of auth state, NOT from inside the auth/flag-gated scheduler effect.
+ *
+ * Mirrors app-visibility.ts's choice of transition: only 'background' flips
+ * the guard, not the transient 'inactive' state (control center, an incoming
+ * call) — pausing on every 'inactive' blip would stall sync for
+ * interruptions that never actually suspend the process.
+ */
+export function startBackgroundTracking(): () => void {
+  const subscription = AppState.addEventListener('change', (nextState: AppStateStatus) => {
+    if (nextState === 'background') setBackgrounded(true);
+    if (nextState === 'active') setBackgrounded(false);
+  });
+  return () => subscription.remove();
+}
 
 const schedulerTriggers: SchedulerTriggers = {
   subscribeForeground(callback) {

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -43,6 +43,8 @@ export {
   isSigningOut,
   getWipeEpoch,
   beginLocalPurge,
+  setBackgrounded,
+  isBackgrounded,
 } from './mutation-queue/drainer';
 export type { DrainOptions } from './mutation-queue/drainer';
 export { ensureMutationQueueTable, MUTATION_QUEUE_SCHEMA } from './mutation-queue/schema';

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
@@ -290,10 +290,39 @@ describe('drainMutationQueue', () => {
       // (markCompleted) landing right as the process suspends.
       expect(mockProcessMutation).toHaveBeenCalledTimes(1);
       expect(mockPeekPending).toHaveBeenCalledTimes(1);
+      // Sentry BOARDSESH-AN: mutation #1's send already succeeded, but
+      // backgrounding was detected right after that network await — the
+      // markCompleted SQLite write must be skipped too (row stays pending;
+      // idempotency_key makes a resend on the next drain safe).
+      expect(mockMarkCompleted).not.toHaveBeenCalled();
     } finally {
       // Explicit reset (not just relying on the next test's beforeEach —
       // __resetDrainerStateForTests already covers it, but a leaked `true`
       // would otherwise silently skip every subsequent test until then).
+      setBackgrounded(false);
+    }
+  });
+
+  it('Sentry BOARDSESH-AN: skips the failure-bookkeeping write when the app backgrounds right after a retryable error', async () => {
+    const mutation = makeMutation({ id: 1 });
+    mockPeekPending.mockResolvedValue([mutation]);
+
+    const retryableError = new Error('Server unavailable');
+    mockProcessMutation.mockImplementationOnce(async () => {
+      setBackgrounded(true);
+      throw retryableError;
+    });
+    mockIsRetryable.mockReturnValue(true);
+
+    const queryClient = createMockQueryClient();
+    try {
+      await drainMutationQueue(mockDb, queryClient, mockGraphqlFetch, { ...ONLINE });
+
+      // recordFailure would normally bump retry_count here — backgrounding must
+      // pre-empt that SQLite write too, leaving the mutation pending as-is.
+      expect(mockRecordFailure).not.toHaveBeenCalled();
+      expect(mockMarkDeadLetter).not.toHaveBeenCalled();
+    } finally {
       setBackgrounded(false);
     }
   });

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
@@ -18,7 +18,7 @@ vi.mock('../error-classification', () => ({
   isNetworkError: vi.fn().mockReturnValue(false),
 }));
 
-import { drainMutationQueue, __resetDrainerStateForTests, setSigningOut } from '../drainer';
+import { drainMutationQueue, __resetDrainerStateForTests, setSigningOut, setBackgrounded } from '../drainer';
 import { peekPending, markCompleted, recordFailure, markDeadLetter } from '../queue';
 import { processMutation } from '../handlers';
 import { isRetryable, isNetworkError } from '../error-classification';
@@ -246,6 +246,47 @@ describe('drainMutationQueue', () => {
     await drainMutationQueue(mockDb, queryClient, mockGraphqlFetch, { ...ONLINE });
 
     // Mutation #2 must never have been sent.
+    expect(mockProcessMutation).toHaveBeenCalledTimes(1);
+    expect(mockPeekPending).toHaveBeenCalledTimes(1);
+  });
+
+  it('early-returns without touching the queue while the app is backgrounded', async () => {
+    const mutation = makeMutation({ id: 1 });
+    mockPeekPending.mockResolvedValue([mutation]);
+
+    const queryClient = createMockQueryClient();
+
+    // Backgrounded (Sentry BOARDSESH-AN): further SQLite calls risk running
+    // right as iOS suspends the process — a scheduler/listener drain must not
+    // start until the app is foregrounded again.
+    setBackgrounded(true);
+    await drainMutationQueue(mockDb, queryClient, mockGraphqlFetch, { ...ONLINE });
+
+    expect(mockPeekPending).not.toHaveBeenCalled();
+    expect(mockProcessMutation).not.toHaveBeenCalled();
+
+    // Once foregrounded, draining resumes normally.
+    setBackgrounded(false);
+    mockPeekPending.mockResolvedValueOnce([mutation]).mockResolvedValueOnce([]);
+    await drainMutationQueue(mockDb, queryClient, mockGraphqlFetch, { ...ONLINE });
+    expect(mockProcessMutation).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts mid-batch when the app backgrounds during a mutation send', async () => {
+    const first = makeMutation({ id: 1, idempotency_key: 'key-1' });
+    const second = makeMutation({ id: 2, idempotency_key: 'key-2' });
+    mockPeekPending.mockResolvedValue([first, second]);
+
+    mockProcessMutation.mockImplementationOnce(async () => {
+      // The app backgrounds while mutation #1 is on the wire.
+      setBackgrounded(true);
+    });
+
+    const queryClient = createMockQueryClient();
+    await drainMutationQueue(mockDb, queryClient, mockGraphqlFetch, { ...ONLINE });
+
+    // Mutation #2 must never have been sent — issuing it risks a SQLite call
+    // (markCompleted) landing right as the process suspends.
     expect(mockProcessMutation).toHaveBeenCalledTimes(1);
     expect(mockPeekPending).toHaveBeenCalledTimes(1);
   });

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
@@ -283,12 +283,18 @@ describe('drainMutationQueue', () => {
     });
 
     const queryClient = createMockQueryClient();
-    await drainMutationQueue(mockDb, queryClient, mockGraphqlFetch, { ...ONLINE });
+    try {
+      await drainMutationQueue(mockDb, queryClient, mockGraphqlFetch, { ...ONLINE });
 
-    // Mutation #2 must never have been sent — issuing it risks a SQLite call
-    // (markCompleted) landing right as the process suspends.
-    expect(mockProcessMutation).toHaveBeenCalledTimes(1);
-    expect(mockPeekPending).toHaveBeenCalledTimes(1);
+      // Mutation #2 must never have been sent — issuing it risks a SQLite call
+      // (markCompleted) landing right as the process suspends.
+      expect(mockProcessMutation).toHaveBeenCalledTimes(1);
+      expect(mockPeekPending).toHaveBeenCalledTimes(1);
+    } finally {
+      // Explicit reset (not just relying on the next test's beforeEach) —
+      // mirrors the early-return test above.
+      setBackgrounded(false);
+    }
   });
 
   it('invalidates correct query keys for boardsesh_ticks', async () => {

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
@@ -291,8 +291,9 @@ describe('drainMutationQueue', () => {
       expect(mockProcessMutation).toHaveBeenCalledTimes(1);
       expect(mockPeekPending).toHaveBeenCalledTimes(1);
     } finally {
-      // Explicit reset (not just relying on the next test's beforeEach) —
-      // mirrors the early-return test above.
+      // Explicit reset (not just relying on the next test's beforeEach —
+      // __resetDrainerStateForTests already covers it, but a leaked `true`
+      // would otherwise silently skip every subsequent test until then).
       setBackgrounded(false);
     }
   });

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -69,7 +69,7 @@ export function getWipeEpoch(): number {
   return _wipeEpoch;
 }
 
-// Backgrounding guard (Sentry BOARDSESH-AN): stops new SQLite calls once the app backgrounds, same shape as the sign-out guard above.
+// Backgrounding guard (Sentry BOARDSESH-AN), same shape as the sign-out guard above.
 let _isBackgrounded = false;
 
 export function setBackgrounded(value: boolean): void {

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -69,18 +69,7 @@ export function getWipeEpoch(): number {
   return _wipeEpoch;
 }
 
-// Backgrounding guard (Sentry BOARDSESH-AN: EXC_BAD_ACCESS in expo-sqlite's
-// native `columnName`). iOS can suspend the process mid-statement once the app
-// backgrounds; a query issued (or still resolving) right at that boundary can
-// have the native binding read column metadata off a `sqlite3_stmt*` that's
-// already been torn down, which crashes natively — a JS try/catch can't save
-// it. The mobile adapter flips this on AppState 'background' and off on
-// 'active' (packages/mobile/src/offline/offline-sync-adapter.ts); the drainer
-// and the pull client both check it between statements, same shape as the
-// sign-out guard above. This only narrows the window (it stops issuing NEW
-// queries once backgrounded — a statement already dispatched to native can't
-// be recalled), but every loop here awaits network or a single short
-// statement between checks, so the in-flight tail is small.
+// Backgrounding guard (Sentry BOARDSESH-AN): stops new SQLite calls once the app backgrounds, same shape as the sign-out guard above.
 let _isBackgrounded = false;
 
 export function setBackgrounded(value: boolean): void {

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -208,6 +208,15 @@ export async function drainMutationQueue(
         }
         try {
           await processMutation(mutation, graphqlFetch);
+          // Re-check after the network await: backgrounding (or a sign-out wipe)
+          // may have started while the send was in flight. The send already
+          // reached the server, but the local bookkeeping write must not — leave
+          // the row pending (idempotency_key makes a resend on the next drain
+          // safe) rather than dispatch a SQLite call right as iOS suspends.
+          if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded) {
+            networkStop = true; // reuse the "end cycle now" path
+            break;
+          }
           await markCompleted(db, mutation.id);
           invalidateForTable(queryClient, mutation.table_name);
         } catch (error: unknown) {
@@ -218,6 +227,13 @@ export async function drainMutationQueue(
             // advancing retry_count — an offline write must never dead-letter for
             // lack of a connection; it drains when connectivity returns. Stop the
             // cycle rather than backing off against a network that's gone.
+            networkStop = true;
+            break;
+          }
+
+          // Same re-check as the success path above, before the retry/dead-letter
+          // bookkeeping writes below.
+          if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded) {
             networkStop = true;
             break;
           }

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -69,6 +69,28 @@ export function getWipeEpoch(): number {
   return _wipeEpoch;
 }
 
+// Backgrounding guard (Sentry BOARDSESH-AN: EXC_BAD_ACCESS in expo-sqlite's
+// native `columnName`). iOS can suspend the process mid-statement once the app
+// backgrounds; a query issued (or still resolving) right at that boundary can
+// have the native binding read column metadata off a `sqlite3_stmt*` that's
+// already been torn down, which crashes natively — a JS try/catch can't save
+// it. The mobile adapter flips this on AppState 'background' and off on
+// 'active' (packages/mobile/src/offline/offline-sync-adapter.ts); the drainer
+// and the pull client both check it between statements, same shape as the
+// sign-out guard above. This only narrows the window (it stops issuing NEW
+// queries once backgrounded — a statement already dispatched to native can't
+// be recalled), but every loop here awaits network or a single short
+// statement between checks, so the in-flight tail is small.
+let _isBackgrounded = false;
+
+export function setBackgrounded(value: boolean): void {
+  _isBackgrounded = value;
+}
+
+export function isBackgrounded(): boolean {
+  return _isBackgrounded;
+}
+
 // Bounded exponential backoff between drain attempts within a single cycle
 // (I7). A transient failure (network blip, 5xx) recovers on its own instead of
 // stalling until the next external trigger. Capped so we never busy-loop or
@@ -159,6 +181,7 @@ export async function drainMutationQueue(
 ): Promise<void> {
   // Don't start (or re-enter) a drain while sign-out is wiping local data.
   if (_isSigningOut) return;
+  if (_isBackgrounded) return;
   if (_isDraining) return;
   // Offline: nothing can be pushed, and attempting would only churn retry counts
   // and burn backoff sleeps. Skip; the reconnect/foreground trigger drains later.
@@ -182,7 +205,7 @@ export async function drainMutationQueue(
 
   try {
     while (true) {
-      if (_isSigningOut || _wipeEpoch !== startEpoch) break;
+      if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded) break;
       const batch = await peekPending(db, 10);
       if (batch.length === 0) break;
 
@@ -190,7 +213,7 @@ export async function drainMutationQueue(
       let networkStop = false;
 
       for (const mutation of batch) {
-        if (_isSigningOut || _wipeEpoch !== startEpoch) {
+        if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded) {
           networkStop = true; // reuse the "end cycle now" path
           break;
         }
@@ -257,6 +280,7 @@ export function isDraining(): boolean {
 export function __resetDrainerStateForTests(): void {
   _isDraining = false;
   _isSigningOut = false;
+  _isBackgrounded = false;
   // Epoch checks are relative (capture-then-compare), so a residual value is
   // technically harmless — reset anyway so no test inherits another's wipes.
   _wipeEpoch = 0;

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -20,7 +20,7 @@ vi.mock('../table-config', async () => {
 });
 
 import { pullSync } from '../pull-client';
-import { setSigningOut } from '../../mutation-queue/drainer';
+import { setSigningOut, setBackgrounded } from '../../mutation-queue/drainer';
 import { getCheckpoint, setCheckpoint, getCheckpointKey, markScopeDownloadComplete } from '../checkpoints';
 import { TABLE_CONFIGS, USER_DATA_TABLES, BOARD_DATA_TABLES } from '../table-config';
 
@@ -761,5 +761,54 @@ describe('pullSync', () => {
       String(args[1]).includes('boardsesh_ticks'),
     );
     expect(tickCheckpointWrites).toHaveLength(0);
+  });
+
+  it('stops pulling while the app is backgrounded (no fetches, no writes, no checkpoint advance)', async () => {
+    // Sentry BOARDSESH-AN: a SQLite call dispatched right as iOS suspends the
+    // process crashed natively. Mirrors the sign-out guard above.
+    setupGraphqlFetchForAllTables();
+    setBackgrounded(true);
+    try {
+      await pullSync(db, queryClient, graphqlFetch);
+      expect(graphqlFetch).not.toHaveBeenCalled();
+      expect(sqlCalls.filter((call) => call.sql.startsWith('INSERT OR REPLACE'))).toHaveLength(0);
+      expect(setCheckpoint).not.toHaveBeenCalled();
+    } finally {
+      setBackgrounded(false);
+    }
+  });
+
+  it('stops mid-cycle when the app backgrounds while a page is on the wire', async () => {
+    graphqlFetch.mockImplementation(async (query: string) => {
+      if (query.includes('syncDeletions')) {
+        return makeDeletionsResult([], false);
+      }
+      if (query.includes('syncTicks')) {
+        // The app backgrounds while this page is "on the wire".
+        setBackgrounded(true);
+        return makeSyncResult('syncTicks', [{ uuid: 'some-tick' }], false);
+      }
+      for (const config of Object.values(TABLE_CONFIGS)) {
+        if (query.includes(config.queryName)) {
+          return makeSyncResult(config.queryName, [], false);
+        }
+      }
+      throw new Error(`Unexpected query: ${query}`);
+    });
+
+    try {
+      await pullSync(db, queryClient, graphqlFetch);
+
+      // The page already in flight when backgrounding was detected must not be
+      // upserted, and its checkpoint must not advance.
+      const tickWrites = sqlCalls.filter((call) => call.params?.some((value) => value === 'some-tick'));
+      expect(tickWrites).toHaveLength(0);
+      const tickCheckpointWrites = (setCheckpoint as ReturnType<typeof vi.fn>).mock.calls.filter((args: unknown[]) =>
+        String(args[1]).includes('boardsesh_ticks'),
+      );
+      expect(tickCheckpointWrites).toHaveLength(0);
+    } finally {
+      setBackgrounded(false);
+    }
   });
 });

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -24,7 +24,7 @@ import {
 import { getCheckpoint, setCheckpoint, DELETIONS_CHECKPOINT_KEY } from '../checkpoints';
 import { runMigrations, LATEST_SCHEMA_VERSION } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
-import { setSigningOut, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
+import { setSigningOut, setBackgrounded, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
 import { SCHEMA_STATEMENTS } from '../../db/schema';
 import type { OfflineBoardScope } from '../../offline-board-key';
@@ -996,6 +996,59 @@ describe('pullSync snapshot bootstrap', () => {
     expect(run3.capturedClimbCursors[0]).toBeUndefined();
     // downloadArtifact was NOT called on run 3 (bootstrap skipped entirely).
     expect(source.downloadArtifact).toHaveBeenCalledTimes(2);
+  });
+
+  it('Sentry BOARDSESH-AN: stops before the attempt-bookkeeping write when the app backgrounds during the manifest fetch', async () => {
+    const source: SnapshotSource = {
+      fetchManifest: async () => {
+        setBackgrounded(true);
+        throw new Error('network down');
+      },
+      downloadArtifact: vi.fn(),
+      deleteArtifact: vi.fn(async () => {}),
+    };
+    const { fetch } = makeGraphqlFetch();
+
+    try {
+      await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+      // A manifest fetch failure normally counts a bootstrap attempt; backgrounding
+      // mid-await must pre-empt that SQLite write, same as a sign-out/wipe caught
+      // mid-flight — and abort the whole cycle before deletions/table pulls run.
+      expect(
+        await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
+      ).toBeNull();
+      expect(fetch).not.toHaveBeenCalled();
+    } finally {
+      setBackgrounded(false);
+    }
+  });
+
+  it('Sentry BOARDSESH-AN: stops before importing when the app backgrounds during the artifact download', async () => {
+    const source: SnapshotSource = {
+      fetchManifest: async () => makeManifest([makeEntry()]),
+      downloadArtifact: async () => {
+        setBackgrounded(true);
+        return { filePath: join(workDir, 'unused.db') };
+      },
+      deleteArtifact: vi.fn(async () => {}),
+    };
+    const { fetch } = makeGraphqlFetch();
+
+    try {
+      await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+      // The artifact "downloaded" successfully, but backgrounding was detected
+      // right after that await — the import transaction (SQLite work) must never
+      // run, and no attempt should be recorded either.
+      expect(await countRows('board_climbs')).toBe(0);
+      expect(
+        await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
+      ).toBeNull();
+      expect(fetch).not.toHaveBeenCalled();
+    } finally {
+      setBackgrounded(false);
+    }
   });
 });
 

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -624,7 +624,8 @@ async function runBootstrapPhase(
       } catch (error) {
         // A wipe mid-import rolls the transaction back and bails the phase — no
         // attempt (the pull is being torn down, not failing).
-        if (error instanceof SnapshotWipedError || isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
+        if (error instanceof SnapshotWipedError || isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded())
+          break;
         if (error instanceof SnapshotSchemaStaleError) {
           // The artifact predates this client's schema — importing it would
           // NULL-fill newer columns and stamp the cursor past them forever.

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -684,8 +684,8 @@ export async function pullSync(
   // Sign-out never hit this because `isSigningOut()` is a persistent flag that stays
   // true for every subsequent table; the epoch alone is not a substitute for it.
   const cycleEpoch = getWipeEpoch();
-  // Unlike the other two checks, isBackgrounded() is live, not latched — a cycle that
-  // resumes foreground mid-pull is meant to keep going, not restart.
+  // Unlike the other two checks, isBackgrounded() is live, not latched — a background
+  // dip that clears before the next check runs won't abort a cycle it can no longer affect.
   const cycleAborted = (): boolean => isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded();
 
   // Parse the enabled scope keys once; malformed keys are dropped (a stray value

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -655,6 +655,11 @@ export async function pullSync(
   graphqlFetch: <T>(query: string, variables?: Record<string, unknown>) => Promise<T>,
   options?: SyncOptions,
 ): Promise<void> {
+  // Mirrors drainMutationQueue's entry guard: don't even start the snapshot
+  // bootstrap phase below (which runs before the first cycleAborted() check)
+  // when the app is already backgrounded.
+  if (isBackgrounded()) return;
+
   const enabledBoards = options?.enabledBoards ?? [];
   const onProgress = options?.onProgress;
   let totalDocuments = 0;

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -24,7 +24,7 @@ import {
 } from './snapshot-bootstrap';
 import { parseSnapshotManifest, type SnapshotManifest } from './snapshot-manifest';
 import { findSnapshotEntry, isSnapshotEntryUsable } from './snapshot-estimate';
-import { isSigningOut, getWipeEpoch } from '../mutation-queue/drainer';
+import { isSigningOut, getWipeEpoch, isBackgrounded } from '../mutation-queue/drainer';
 import { parseOfflineBoardKey, type OfflineBoardScope } from '../offline-board-key';
 
 /**
@@ -289,7 +289,7 @@ async function syncTable(
   while (hasMore) {
     // Sign-out is wiping local data: stop before this page writes the old
     // user's rows back (mirrors the drainer's guard).
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch) return { reachedTail: false };
+    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return { reachedTail: false };
     const variables: Record<string, unknown> = { cursor, limit: PAGE_LIMIT };
     if (config.isPerBoard && boardScope) {
       variables.boardType = boardScope.boardType;
@@ -302,7 +302,7 @@ async function syncTable(
 
     // Re-check after the await: the wipe may have started (or fully completed)
     // while this page was on the wire.
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch) return { reachedTail: false };
+    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return { reachedTail: false };
 
     // An empty page would not advance the cursor; if the backend ever returns
     // documents:[] with hasMore:true we'd spin forever. Stop here (I2).
@@ -357,14 +357,14 @@ async function processDeletions(
   while (hasMore) {
     // Sign-out is wiping local data: stop before this page writes the old
     // user's rows back (mirrors the drainer's guard).
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch) return;
+    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return;
     const response = await graphqlFetch<{ syncDeletions: SyncDeletionsResult }>(SYNC_DELETIONS_QUERY, {
       cursor,
       limit: PAGE_LIMIT,
     });
     const result = response.syncDeletions;
 
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch) return;
+    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return;
 
     // Empty page can't advance the cursor; break to avoid an infinite loop if
     // the backend returns deletions:[] with hasMore:true (I2).
@@ -525,7 +525,7 @@ async function runBootstrapPhase(
 
   try {
     for (const scope of scopes) {
-      if (isSigningOut() || getWipeEpoch() !== cycleEpoch) break;
+      if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
 
       // Duration telemetry starts here — before the eligibility check — so a
       // snapshot scope's durationMs covers its manifest/download/import work.
@@ -624,7 +624,7 @@ async function runBootstrapPhase(
       } catch (error) {
         // A wipe mid-import rolls the transaction back and bails the phase — no
         // attempt (the pull is being torn down, not failing).
-        if (error instanceof SnapshotWipedError || isSigningOut() || getWipeEpoch() !== cycleEpoch) break;
+        if (error instanceof SnapshotWipedError || isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
         if (error instanceof SnapshotSchemaStaleError) {
           // The artifact predates this client's schema — importing it would
           // NULL-fill newer columns and stamp the cursor past them forever.
@@ -672,7 +672,7 @@ export async function pullSync(
   // Sign-out never hit this because `isSigningOut()` is a persistent flag that stays
   // true for every subsequent table; the epoch alone is not a substitute for it.
   const cycleEpoch = getWipeEpoch();
-  const cycleAborted = (): boolean => isSigningOut() || getWipeEpoch() !== cycleEpoch;
+  const cycleAborted = (): boolean => isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded();
 
   // Parse the enabled scope keys once; malformed keys are dropped (a stray value
   // can't crash the pull) so both the bootstrap phase and the paged board loop

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -684,7 +684,8 @@ export async function pullSync(
   // Sign-out never hit this because `isSigningOut()` is a persistent flag that stays
   // true for every subsequent table; the epoch alone is not a substitute for it.
   const cycleEpoch = getWipeEpoch();
-  // isBackgrounded() is a live check (unlike the other two, which latch): a cycle that resumes foreground mid-pull is meant to keep going, not restart.
+  // Unlike the other two checks, isBackgrounded() is live, not latched — a cycle that
+  // resumes foreground mid-pull is meant to keep going, not restart.
   const cycleAborted = (): boolean => isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded();
 
   // Parse the enabled scope keys once; malformed keys are dropped (a stray value

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -678,6 +678,7 @@ export async function pullSync(
   // Sign-out never hit this because `isSigningOut()` is a persistent flag that stays
   // true for every subsequent table; the epoch alone is not a substitute for it.
   const cycleEpoch = getWipeEpoch();
+  // isBackgrounded() is a live check (unlike the other two, which latch): a cycle that resumes foreground mid-pull is meant to keep going, not restart.
   const cycleAborted = (): boolean => isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded();
 
   // Parse the enabled scope keys once; malformed keys are dropped (a stray value

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -540,6 +540,9 @@ async function runBootstrapPhase(
       onProgress?.({ phase: 'bootstrap', currentTable: scope.scopeKey, documentsProcessed: 0 });
 
       const resolution = await resolveManifestOnce(source, manifestCache);
+      // Re-check after the manifest network await: every branch below either
+      // writes to SQLite (recordBootstrapAttempt) or leads to one further down.
+      if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
       if (resolution.status === 'absent') continue; // permanent miss, no attempt
       if (resolution.status === 'error') {
         const attempt = await recordBootstrapAttempt(db, scope.scopeKey);
@@ -575,6 +578,9 @@ async function runBootstrapPhase(
         downloadByLayout.set(layoutKey, cachedDownload);
         if (cachedDownload.file) downloadedPaths.add(cachedDownload.file.filePath);
       }
+      // Re-check after the (potentially multi-MB) artifact download await, same
+      // reason as the manifest check above.
+      if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
       const download = cachedDownload.file;
       if (!download) {
         if (cachedDownload.permanentMiss) {


### PR DESCRIPTION
## Summary

Fixes a fatal `EXC_BAD_ACCESS` crash reported in Sentry (BOARDSESH-AN): a native `KERN_INVALID_ADDRESS` inside expo-sqlite's `columnName` binding, called from `SQLiteModule.definition`'s async closure. The crash breadcrumbs show the app transitioning to `background` immediately before the crash — the offline-sync engine's pull/drain loops kept issuing SQLite calls with no awareness of `AppState`, so a statement could be dispatched to the native queue right as iOS suspends the process, leaving the native binding to read column metadata off a stale/finalized statement handle.

- Added a `setBackgrounded()` / `isBackgrounded()` guard to `@boardsesh/offline-sync`, mirroring the package's existing sign-out/wipe-epoch guards (`packages/shared/offline-sync/src/mutation-queue/drainer.ts`).
- `pullSync`'s per-table loop (`syncTable`), the deletions loop (`processDeletions`), the snapshot-bootstrap phase loop, and `drainMutationQueue`'s batch loop all check the guard between statements/pages and bail out early once the app backgrounds — same shape as the existing sign-out check, so it only narrows the crash window (a statement already dispatched to native can't be recalled) rather than trying to cancel in-flight native work.
- Added `startBackgroundTracking()` to the mobile adapter (`packages/mobile/src/offline/offline-sync-adapter.ts`): a single `AppState` listener that flips the guard on `'background'`/`'active'` transitions (mirroring `app-visibility.ts`'s choice to ignore the transient `'inactive'` state).
- Wired it into `OfflineSyncBridge` from a **top-level, unconditional** effect (`packages/mobile/src/components/offline-sync-bridge.tsx`) — not inside the auth/flag-gated scheduler effect — so it also covers one-off `drainMutationQueue()` calls fired from mutation hooks, not just the scheduler's own pull/drain loop.

## Release Notes

- Fixed a rare crash when the app was sent to the background mid-sync.

## Test plan

- `vp run typecheck:mobile`, `vp run typecheck:offline-sync` — pass.
- `vp test run --project mobile --reporter=agent` — 495 files / 4015 tests pass.
- `vp test run --project offline-sync --reporter=agent` — 18 files / 253 tests pass.
- `vp check` — clean on all changed files (one pre-existing formatting issue elsewhere fixed by `--fix`, unrelated warnings in the codebase left untouched).
- `vp run check:mobile-offline-sync-imports` — passes (new export still only reached through the adapter boundary).
- Not reproduced live against a physical device/simulator background-suspend — this fixes the documented race by construction (query loops now check `AppState` between statements) but a native EXC_BAD_ACCESS can't be reliably triggered on demand in a dev environment; will monitor Sentry for BOARDSESH-AN recurrence after this ships.


---
_Generated by [Claude Code](https://claude.ai/code/session_01441RsWYPVsQ68BfZpoypgN)_