### PR TITLE
ci(mobile): auto-prompt maintainers to publish OTA previews on fork PRs

### DIFF
--- a/.github/workflows/mobile-ota-preview-prompt.yml
+++ b/.github/workflows/mobile-ota-preview-prompt.yml
@@ -1,0 +1,107 @@
+name: Mobile OTA Preview Prompt (fork PRs)
+
+# Companion to mobile-ota-preview.yml. A fork PR can't auto-publish an OTA preview
+# (fork `pull_request` runs get no secrets, and the OTA token is production-capable),
+# so that workflow SKIPS the publish for forks and instead uploads a tiny
+# `mobile-ota-fork-prompt` artifact holding the PR number. This workflow_run follow-up
+# runs in the BASE-repo context — so its GITHUB_TOKEN can comment even on a fork PR —
+# and posts a sticky nudge telling maintainers they can run `/ota-preview`.
+#
+# ─── SECURITY ─────────────────────────────────────────────────────────────────────
+# This is the SAFE half of the split: it holds NO OTA secret, NEVER checks out or runs
+# fork code, and only reads the PR number from the artifact (re-validated as an integer
+# before use) to post/refresh one PR comment. All it can do is comment. It does NOT
+# widen the mobile-ota-preview.yml threat boundary. Same pattern as
+# publish-test-reports.yml (fork-PR reporting via workflow_run).
+
+on:
+  workflow_run:
+    workflows: ['Mobile OTA Preview (Per-PR Channel)']
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write # sticky comment on the PR
+
+jobs:
+  prompt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Present only when the triggering run skipped a fork PR. Absent for same-repo
+      # publishes, cleanups, and comment/dispatch runs — so those no-op below.
+      - name: Download fork-preview prompt (if any)
+        id: download
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: mobile-ota-fork-prompt
+          path: fork-prompt
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: |
+          if [ -f fork-prompt/pr_number ]; then
+            pr_number="$(cat fork-prompt/pr_number)"
+            # Defense-in-depth: the artifact rode a fork run — trust nothing but digits.
+            if printf '%s' "$pr_number" | grep -Eq '^[0-9]+$'; then
+              echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+            else
+              echo "::warning::Ignoring non-numeric PR number '$pr_number' from artifact."
+            fi
+          fi
+
+      - name: Post maintainer prompt (sticky)
+        if: steps.pr.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) return;
+
+            const channel = `pr-${prNumber}`;
+            const marker = '<!-- mobile-ota-preview-prompt -->';
+            const publishedMarker = '<!-- mobile-ota-preview -->';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+            });
+            const existingPrompt = comments.find((comment) => comment.body?.includes(marker));
+
+            // A real preview supersedes the nudge — a maintainer already ran /ota-preview.
+            // Remove any lingering prompt and stop; don't nag alongside a live preview.
+            const hasPublished = comments.some((comment) => comment.body?.includes(publishedMarker));
+            if (hasPublished) {
+              if (existingPrompt) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner, repo: context.repo.repo, comment_id: existingPrompt.id,
+                });
+              }
+              return;
+            }
+
+            const body = [
+              marker,
+              `### 📱 OTA preview — available on request`,
+              '',
+              `This is a fork PR, so it can't auto-publish an OTA preview — fork runs don't get the ` +
+                `OTA token. A maintainer can comment **\`/ota-preview\`** to publish **\`${channel}\`** ` +
+                `to the in-app switcher (What's New → Try a preview → pick this PR).`,
+              '',
+              '<sub>Re-comment `/ota-preview` after new pushes to refresh the preview. A native change ' +
+                "can't ride OTA — ship a TestFlight/Play build instead.</sub>",
+            ].join('\n');
+
+            if (existingPrompt) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo, comment_id: existingPrompt.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber, body,
+              });
+            }

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -29,6 +29,11 @@ name: Mobile OTA Preview (Per-PR Channel)
 #     other workflows.
 #   * `^pr-[0-9]+$` guards every channel mutation (defense-in-depth, not the control).
 #
+# Fork PRs are SKIPPED here (no secrets), so the companion workflow_run file
+# mobile-ota-preview-prompt.yml posts a "a maintainer can /ota-preview" nudge on the
+# PR. That file only COMMENTS (base-context write token, never checks out fork code),
+# so it doesn't widen this threat boundary — the publish path is unchanged.
+#
 # Hardening (optional, for hard same-repo enforcement): make EXPO_TOKEN an
 # `ota-preview` ENVIRONMENT secret (not a repo secret) so a same-repo PR can't drop
 # the environment to reach it; the sweep then needs a main-only environment and
@@ -112,6 +117,7 @@ jobs:
       action: ${{ steps.decide.outputs.action }}
       pr_number: ${{ steps.decide.outputs.pr_number }}
       channel: ${{ steps.decide.outputs.channel }}
+      fork_skip: ${{ steps.decide.outputs.fork_skip }}
     steps:
       - name: Decide action + resolve PR
         id: decide
@@ -121,6 +127,11 @@ jobs:
             const repoFull = `${context.repo.owner}/${context.repo.repo}`;
             let action = 'skip';
             let prNumber = '';
+            // Set for a fork PR we deliberately skip — its OWN copy of this job has a
+            // read-only token and can't comment, so the companion workflow_run file
+            // (mobile-ota-preview-prompt.yml) posts the "a maintainer can /ota-preview"
+            // nudge. We only signal it via an artifact; no secrets, no fork code run.
+            let forkSkip = false;
 
             if (context.eventName === 'pull_request') {
               const pr = context.payload.pull_request;
@@ -133,6 +144,7 @@ jobs:
                 // Fork PRs can't receive secrets via pull_request — use the
                 // /ota-preview comment or workflow_dispatch for those.
                 action = !isFork ? 'publish' : 'skip';
+                forkSkip = isFork;
               }
             } else if (context.eventName === 'issue_comment') {
               const assoc = context.payload.comment.author_association;
@@ -156,13 +168,32 @@ jobs:
             if (!/^[0-9]+$/.test(String(prNumber))) {
               action = 'skip';
               prNumber = '';
+              forkSkip = false;
             }
 
             const channel = prNumber ? `pr-${prNumber}` : '';
-            core.info(`event=${context.eventName} action=${action} channel=${channel || '(none)'}`);
+            core.info(`event=${context.eventName} action=${action} channel=${channel || '(none)'} fork_skip=${forkSkip}`);
             core.setOutput('action', action);
             core.setOutput('pr_number', String(prNumber));
             core.setOutput('channel', channel);
+            core.setOutput('fork_skip', String(forkSkip));
+
+      # Hand the fork PR number to the companion workflow_run file. This job's token
+      # is read-only on a fork PR (can't comment), and workflow_run.pull_requests is
+      # empty for forks — so an artifact is the only channel. No checkout, no secrets.
+      - name: Stage fork-preview prompt
+        if: steps.decide.outputs.fork_skip == 'true'
+        run: |
+          mkdir -p "$RUNNER_TEMP/fork-prompt"
+          printf '%s' "${{ steps.decide.outputs.pr_number }}" > "$RUNNER_TEMP/fork-prompt/pr_number"
+
+      - name: Upload fork-preview prompt
+        if: steps.decide.outputs.fork_skip == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-ota-fork-prompt
+          path: ${{ runner.temp }}/fork-prompt/pr_number
+          retention-days: 1
 
   # ── Publish pr-<number> to the self-hosted server. Holds EXPO_TOKEN and runs
   # PR-author code → gated by `environment: ota-preview` (configure required

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -593,7 +593,13 @@ above — no per-tester build. Workflow: `.github/workflows/mobile-ota-preview.y
   - **Fork / on-demand previews** run only from a maintainer **`/ota-preview` comment**
     (`author_association` OWNER/MEMBER/COLLABORATOR) or `workflow_dispatch`. Those events run the
     **default-branch (main)** copy of the workflow, so their maintainer gate is not PR-editable; the
-    publish then waits on the `ota-preview` environment.
+    publish then waits on the `ota-preview` environment. To make that path discoverable, a fork PR now
+    gets an **auto-posted nudge**: the skipped fork run uploads a `mobile-ota-fork-prompt` artifact
+    with the PR number, and the companion `mobile-ota-preview-prompt.yml` (`workflow_run`, base-repo
+    context so it can comment on forks) posts a sticky "a maintainer can `/ota-preview`" comment. That
+    file only comments — it holds no OTA secret and never checks out fork code — so the boundary above
+    is unchanged; `/ota-preview` still does the actual publish. The nudge is removed once a real
+    preview is published.
   - **Same-repo collaborators are trusted.** For `pull_request`, GitHub runs the PR's **own** copy of
     the workflow with repo secrets. Any same-repo PR touching the relevant paths auto-publishes; the
     **`ota-preview` environment** reviewer gate (if required reviewers are configured) is the human


### PR DESCRIPTION
## Summary

Fork PRs — like #3753 (`alexpooley/boardsesh`) — silently got **no OTA preview**. The `mobile-ota-preview.yml` gate resolves `action=skip` for forks because fork `pull_request` runs get no secrets (and `EXPO_TOKEN` is the production-capable OTA token). The sanctioned fork path — a maintainer commenting `/ota-preview` — worked, but the skip was **silent**, so maintainers never knew they could trigger it and fork previews effectively never happened.

This keeps the security model **exactly as-is** and only closes the discoverability gap:

- The `gate` job now flags a skipped fork PR (`fork_skip` output) and uploads its PR number as a tiny `mobile-ota-fork-prompt` artifact. The gate's fork token is read-only and `workflow_run.pull_requests` is empty for forks, so an artifact is the only way to hand the number across.
- New companion **`mobile-ota-preview-prompt.yml`** (`workflow_run`, runs in base-repo context so its token can comment on a fork PR) posts a sticky **"a maintainer can `/ota-preview`"** nudge. It re-validates the PR number as an integer, updates in place on repushes, and removes itself once a real preview publishes.

### Why this doesn't widen the threat boundary

The companion file **only comments** — it holds **no OTA secret** and **never checks out or runs fork code**. `/ota-preview` still does the actual publish, gated by the `ota-preview` environment exactly as before. This is the same `workflow_run` pattern already used by `publish-test-reports.yml` to report on fork PRs. The repo's "NEVER `pull_request_target`, NEVER auto-run `/ota-preview` on fork pushes" rules are untouched.

## Validation

- `vp check` — 0 errors
- `vp test run mobile-ci-env-parity` — 24 passed (parses the edited workflow; env parity holds — the new file carries no fingerprint env and isn't in the parity list)
- New workflow parses; no changes to the workflow-level fingerprint `env`

## Test plan

Merge-time behaviour (can't fully exercise a fork PR from CI here):
1. Open a fork PR touching `packages/mobile/**` → gate skips, uploads `mobile-ota-fork-prompt`; the prompt workflow posts the sticky nudge. Repush → nudge updates in place (no duplicate).
2. Maintainer comments `/ota-preview` → existing publish job runs and posts the `<!-- mobile-ota-preview -->` sticky. Next fork push → nudge is removed (published preview supersedes it).
3. Same-repo branch PR → still auto-publishes, **no** nudge (no artifact uploaded).

## Release Notes

none