### PR TITLE
feat(mobile): "Check for a fix" OTA recovery button on the crash screen

### DIFF
--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -385,6 +385,24 @@ vp run mobile:ota-rollback -- --mode republish   # re-point to a previous update
 Both need `EXPO_UPDATES_URL` + `EXPO_TOKEN` (same as the publish). After rolling back, land the real
 fix (a revert or a corrected commit) on `main` so the next publish moves the fleet forward again.
 
+### Crash-screen recovery button ("Check for a fix")
+
+When a bad OTA crashes the app hard enough to reach the root `ErrorBoundary`
+(`packages/mobile/app/_layout.tsx`), the built-in "Try again" only re-renders the same broken
+in-memory bundle. The **"Check for a fix"** button next to it runs `checkForUpdateAsync →
+fetchUpdateAsync → reloadAsync` in one tap, so it applies **both** a newer fixed bundle **and** a
+published rollback-to-embedded directive (and any update already downloaded in the background). That
+means either recovery lever above unbricks a stuck user without the old two-blind-cold-start dance:
+run `vp run mobile:ota-rollback` (or land the fixed bundle on `main`) and every crashed install gets
+back to a working app the next time someone taps the button. It only appears on a real
+store/TestFlight binary (`Updates.isEnabled && !__DEV__` — the calls throw `ERR_UPDATES_DISABLED` in
+dev), and when there's nothing to apply it says so rather than reloading the broken bundle again. The
+screen also fires an `Error Screen Shown` event (tagged with the OTA update id / channel) and an
+`OTA Recovery Attempted` event carrying the outcome, so the crash-and-recovery path is visible in
+PostHog. The reloaded-\* success outcomes are tracked (and the client flushed) **just before** the
+reload — `reloadAsync()` restarts the app immediately, so a post-reload capture would be lost;
+delivery is still best-effort since the restart can pre-empt the flush.
+
 ## PR-time OTA-compatibility signal
 
 The native gate above answers "should `main` rebuild?". `mobile-ota-check.yml` answers the same

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -22,6 +22,7 @@ import {
   DarkTheme,
   DefaultTheme,
 } from 'expo-router';
+import * as Updates from 'expo-updates';
 import { SystemBars } from 'react-native-edge-to-edge';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@expo/ui/community/bottom-sheet';
@@ -65,7 +66,9 @@ import { brandColors } from '../src/theme/colors';
 import { iosDarkColors } from '../src/theme/ios-colors';
 import { spacing } from '../src/theme/tokens';
 import { glassStackScreenOptions } from '../src/theme/navigation';
-import { reportError } from '../src/lib/error-reporting';
+import { reportError, reportHandledError } from '../src/lib/error-reporting';
+import { track, getAnalyticsClient } from '../src/lib/analytics';
+import { performOtaRecovery, type OtaRecoveryPhase } from '../src/lib/ota-recovery';
 import { loadRequiredFonts } from '../src/lib/required-fonts';
 import { useImageCacheMemoryManagement } from '../src/hooks/use-image-cache-memory-management';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
@@ -162,8 +165,17 @@ const errorStyles = StyleSheet.create({
   pressedButton: {
     opacity: 0.72,
   },
+  disabledButton: {
+    opacity: 0.5,
+  },
   buttonLabel: {
     fontWeight: '700',
+  },
+  statusText: {
+    textAlign: 'center',
+    marginTop: spacing[4],
+    maxWidth: 280,
+    opacity: 0.7,
   },
 });
 
@@ -172,23 +184,96 @@ type ErrorBoundaryProps = {
   retry: () => void;
 };
 
+// Recovery-button UI state. `busy` carries the live phase so the button label
+// doubles as a status line; the two terminal non-reload results each surface a
+// short message under the buttons (the reload results restart the app, so they
+// never render a follow-up state here).
+type RecoveryState =
+  | { kind: 'idle' }
+  | { kind: 'busy'; phase: OtaRecoveryPhase }
+  | { kind: 'no-fix-available' }
+  | { kind: 'failed' };
+
 export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
   // No useTranslation here: Expo Router renders this before any of our
   // providers mount, so i18next isn't initialized. Calling the hook would
   // return raw key strings exactly when the user most needs readable copy.
   // Hardcode English as the last-resort safe fallback.
   const reportedRef = useRef<Error | null>(null);
+  const [recovery, setRecovery] = useState<RecoveryState>({ kind: 'idle' });
+
+  // useUpdates() subscribes to expo-updates' native emitter directly (no provider
+  // of ours), so it's safe in this pre-provider boundary. Called unconditionally —
+  // the recovery button is gated below, never the hook.
+  const { isUpdatePending } = Updates.useUpdates();
+  // Mirror into a ref so a long-running recovery attempt (up to 30s) reads the
+  // latest pending state, not the snapshot captured when the attempt started.
+  const isUpdatePendingRef = useRef(isUpdatePending);
+  isUpdatePendingRef.current = isUpdatePending;
+
+  // The check/fetch/reload calls throw ERR_UPDATES_DISABLED in dev, so only offer
+  // recovery on a real store/TestFlight binary that ships with updates enabled.
+  const showRecoveryButton = Updates.isEnabled && !__DEV__;
+  const isBusy = recovery.kind === 'busy';
 
   useEffect(() => {
     if (reportedRef.current !== error) {
       reportedRef.current = error;
       reportError(error);
+      // Module-level track() works without AnalyticsProvider (it drives the same
+      // lazily-built PostHog client), so the crash screen is observable. Tag the
+      // OTA cohort so a broken-bundle spike is sliceable by update id / channel.
+      track('Error Screen Shown', {
+        ota_update_id: Updates.updateId,
+        ota_is_embedded: Updates.isEmbeddedLaunch,
+        ota_channel: Updates.channel,
+      });
     }
   }, [error]);
 
   const handleGoHome = () => {
     router.replace('/(tabs)/home');
   };
+
+  const handleCheckForFix = useCallback(async () => {
+    setRecovery({ kind: 'busy', phase: 'checking' });
+    const { result, error: recoveryError } = await performOtaRecovery(
+      {
+        checkForUpdate: () => Updates.checkForUpdateAsync(),
+        fetchUpdate: () => Updates.fetchUpdateAsync(),
+        reload: () => Updates.reloadAsync(),
+        isUpdatePending: () => isUpdatePendingRef.current,
+      },
+      {
+        onPhase: (phase) => setRecovery({ kind: 'busy', phase }),
+        // Track the reloaded-* outcomes BEFORE the reload — a post-return track()
+        // would race the app restart and typically be lost. track() only enqueues,
+        // so flush best-effort (fire-and-forget; the reload follows immediately, we
+        // don't delay it — delivery is best-effort) to give it a window.
+        onBeforeReload: (result) => {
+          track('OTA Recovery Attempted', { result });
+          void getAnalyticsClient()?.flush();
+        },
+      },
+    );
+    // The reloaded-* outcomes are tracked in onBeforeReload above (before the
+    // restart). Only these non-reload terminal results reliably reach here, so
+    // guard the post-return track to avoid double-counting a reloaded-* result if
+    // JS happens to survive the reload.
+    if (result === 'failed' || result === 'no-fix-available') {
+      track('OTA Recovery Attempted', { result });
+    }
+    if (result === 'failed') {
+      reportHandledError(recoveryError, { tags: { source: 'ota-error-screen' } });
+      setRecovery({ kind: 'failed' });
+    } else if (result === 'no-fix-available') {
+      setRecovery({ kind: 'no-fix-available' });
+    }
+    // A reloaded-* result means the app is restarting — leave the busy state be.
+  }, []);
+
+  const recoveryLabel =
+    recovery.kind === 'busy' ? (recovery.phase === 'downloading' ? 'Downloading…' : 'Checking…') : 'Check for a fix';
 
   return (
     <View style={errorStyles.container}>
@@ -205,13 +290,43 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
         The app hit an unexpected error. You can try again or head back home.
       </Text>
       <View style={errorStyles.buttonRow}>
+        {/* On a real binary, offer the one-tap OTA recovery first: check for a
+            newer bundle (or a published rollback directive), download it, and
+            reload onto it. It takes the primary slot; "Try again" demotes to the
+            secondary style. In dev / when the button is hidden, "Try again" keeps
+            the primary style. */}
+        {showRecoveryButton && (
+          <Pressable
+            onPress={() => void handleCheckForFix()}
+            disabled={isBusy}
+            accessibilityRole="button"
+            accessibilityLabel="Check for a fix"
+            accessibilityState={{ disabled: isBusy, busy: isBusy }}
+            style={({ pressed }) => [
+              errorStyles.primaryButton,
+              pressed && errorStyles.pressedButton,
+              isBusy && errorStyles.disabledButton,
+            ]}
+          >
+            <Text variant="body" color={brandColors.onPrimary} style={errorStyles.buttonLabel}>
+              {recoveryLabel}
+            </Text>
+          </Pressable>
+        )}
         <Pressable
           onPress={retry}
           accessibilityRole="button"
           accessibilityLabel="Try again"
-          style={({ pressed }) => [errorStyles.primaryButton, pressed && errorStyles.pressedButton]}
+          style={({ pressed }) => [
+            showRecoveryButton ? errorStyles.secondaryButton : errorStyles.primaryButton,
+            pressed && errorStyles.pressedButton,
+          ]}
         >
-          <Text variant="body" color={brandColors.onPrimary} style={errorStyles.buttonLabel}>
+          <Text
+            variant="body"
+            color={showRecoveryButton ? brandColors.primary : brandColors.onPrimary}
+            style={errorStyles.buttonLabel}
+          >
             Try again
           </Text>
         </Pressable>
@@ -226,6 +341,16 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
           </Text>
         </Pressable>
       </View>
+      {recovery.kind === 'no-fix-available' && (
+        <Text variant="footnote" style={errorStyles.statusText}>
+          No fix available yet — try again in a few minutes.
+        </Text>
+      )}
+      {recovery.kind === 'failed' && (
+        <Text variant="footnote" style={errorStyles.statusText}>
+          Couldn&apos;t reach the update server. Check your connection and try again.
+        </Text>
+      )}
     </View>
   );
 }

--- a/packages/mobile/src/lib/__tests__/ota-recovery.test.ts
+++ b/packages/mobile/src/lib/__tests__/ota-recovery.test.ts
@@ -48,6 +48,19 @@ describe('performOtaRecovery', () => {
     expect(onBeforeReload).toHaveBeenCalledWith('reloaded-rollback');
   });
 
+  it('both a newer update and a rollback directive: the newer bundle wins → reloaded-update', async () => {
+    const deps = makeDeps({
+      checkForUpdate: vi.fn().mockResolvedValue({ isAvailable: true, isRollBackToEmbedded: true }),
+    });
+    const onBeforeReload = vi.fn();
+    const { result } = await performOtaRecovery(deps, { onBeforeReload });
+
+    expect(result).toBe('reloaded-update');
+    expect(deps.fetchUpdate).toHaveBeenCalledOnce();
+    expect(deps.reload).toHaveBeenCalledOnce();
+    expect(onBeforeReload).toHaveBeenCalledWith('reloaded-update');
+  });
+
   it('nothing on the server but an update is pending: reloads WITHOUT fetching → reloaded-pending', async () => {
     const deps = makeDeps({
       checkForUpdate: vi.fn().mockResolvedValue({ isAvailable: false, isRollBackToEmbedded: false }),
@@ -109,14 +122,22 @@ describe('performOtaRecovery', () => {
   });
 
   it('fetch hangs past the timeout: resolves failed, never reloads', async () => {
-    const deps = makeDeps({
-      // Never resolves — stands in for a stalled download.
-      fetchUpdate: vi.fn().mockReturnValue(new Promise(() => {})),
-      timeoutMs: 10,
-    });
-    const { result } = await performOtaRecovery(deps);
+    vi.useFakeTimers();
+    try {
+      const deps = makeDeps({
+        // Never resolves — stands in for a stalled download.
+        fetchUpdate: vi.fn().mockReturnValue(new Promise(() => {})),
+      });
+      const recovery = performOtaRecovery(deps, { timeoutMs: 10 });
+      // Advance past the timeout; advanceTimersByTimeAsync settles the pending
+      // microtask chain so the race rejection is caught before we assert.
+      await vi.advanceTimersByTimeAsync(20);
+      const { result } = await recovery;
 
-    expect(result).toBe('failed');
-    expect(deps.reload).not.toHaveBeenCalled();
+      expect(result).toBe('failed');
+      expect(deps.reload).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/mobile/src/lib/__tests__/ota-recovery.test.ts
+++ b/packages/mobile/src/lib/__tests__/ota-recovery.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+import { performOtaRecovery, type OtaRecoveryDeps } from '../ota-recovery';
+
+function makeDeps(overrides: Partial<OtaRecoveryDeps> = {}): OtaRecoveryDeps {
+  return {
+    checkForUpdate: vi.fn().mockResolvedValue({ isAvailable: true, isRollBackToEmbedded: false }),
+    fetchUpdate: vi.fn().mockResolvedValue(undefined),
+    reload: vi.fn().mockResolvedValue(undefined),
+    isUpdatePending: vi.fn().mockReturnValue(false),
+    ...overrides,
+  };
+}
+
+describe('performOtaRecovery', () => {
+  it('update available: fetches, reloads, tracks the outcome BEFORE reload → reloaded-update', async () => {
+    const deps = makeDeps();
+    const onBeforeReload = vi.fn();
+    const { result } = await performOtaRecovery(deps, { onBeforeReload });
+
+    expect(result).toBe('reloaded-update');
+    expect(deps.fetchUpdate).toHaveBeenCalledOnce();
+    expect(deps.reload).toHaveBeenCalledOnce();
+    expect(onBeforeReload).toHaveBeenCalledWith('reloaded-update');
+    // The outcome must be emitted before the reload is initiated, or the restart
+    // can tear the app down before the event is delivered.
+    const reloadMock = deps.reload as ReturnType<typeof vi.fn>;
+    expect(onBeforeReload.mock.invocationCallOrder[0]).toBeLessThan(reloadMock.mock.invocationCallOrder[0]);
+  });
+
+  it('reports phases in order: checking then downloading', async () => {
+    const deps = makeDeps();
+    const onPhase = vi.fn();
+    await performOtaRecovery(deps, { onPhase });
+
+    expect(onPhase.mock.calls.map((call) => call[0])).toEqual(['checking', 'downloading']);
+  });
+
+  it('rollback directive (no newer update): fetches, reloads → reloaded-rollback', async () => {
+    const deps = makeDeps({
+      checkForUpdate: vi.fn().mockResolvedValue({ isAvailable: false, isRollBackToEmbedded: true }),
+    });
+    const onBeforeReload = vi.fn();
+    const { result } = await performOtaRecovery(deps, { onBeforeReload });
+
+    expect(result).toBe('reloaded-rollback');
+    expect(deps.fetchUpdate).toHaveBeenCalledOnce();
+    expect(deps.reload).toHaveBeenCalledOnce();
+    expect(onBeforeReload).toHaveBeenCalledWith('reloaded-rollback');
+  });
+
+  it('nothing on the server but an update is pending: reloads WITHOUT fetching → reloaded-pending', async () => {
+    const deps = makeDeps({
+      checkForUpdate: vi.fn().mockResolvedValue({ isAvailable: false, isRollBackToEmbedded: false }),
+      isUpdatePending: vi.fn().mockReturnValue(true),
+    });
+    const onBeforeReload = vi.fn();
+    const { result } = await performOtaRecovery(deps, { onBeforeReload });
+
+    expect(result).toBe('reloaded-pending');
+    expect(deps.fetchUpdate).not.toHaveBeenCalled();
+    expect(deps.reload).toHaveBeenCalledOnce();
+    expect(onBeforeReload).toHaveBeenCalledWith('reloaded-pending');
+  });
+
+  it('nothing new and nothing pending: does NOT reload → no-fix-available', async () => {
+    const deps = makeDeps({
+      checkForUpdate: vi.fn().mockResolvedValue({ isAvailable: false, isRollBackToEmbedded: false }),
+      isUpdatePending: vi.fn().mockReturnValue(false),
+    });
+    const { result } = await performOtaRecovery(deps);
+
+    expect(result).toBe('no-fix-available');
+    expect(deps.fetchUpdate).not.toHaveBeenCalled();
+    expect(deps.reload).not.toHaveBeenCalled();
+  });
+
+  it('checkForUpdate rejects: captures the error, never reloads → failed', async () => {
+    const checkError = new Error('offline');
+    const deps = makeDeps({ checkForUpdate: vi.fn().mockRejectedValue(checkError) });
+    const { result, error } = await performOtaRecovery(deps);
+
+    expect(result).toBe('failed');
+    expect(error).toBe(checkError);
+    expect(deps.fetchUpdate).not.toHaveBeenCalled();
+    expect(deps.reload).not.toHaveBeenCalled();
+  });
+
+  it('fetch rejects after the check found an update: captures the error, never reloads → failed', async () => {
+    const fetchError = new Error('download interrupted');
+    const deps = makeDeps({ fetchUpdate: vi.fn().mockRejectedValue(fetchError) });
+    const onBeforeReload = vi.fn();
+    const { result, error } = await performOtaRecovery(deps, { onBeforeReload });
+
+    expect(result).toBe('failed');
+    expect(error).toBe(fetchError);
+    expect(deps.fetchUpdate).toHaveBeenCalledOnce();
+    expect(deps.reload).not.toHaveBeenCalled();
+    expect(onBeforeReload).not.toHaveBeenCalled();
+  });
+
+  it('reload rejects: the machine catches it rather than leaking → failed', async () => {
+    const reloadError = new Error('reload blew up');
+    const deps = makeDeps({ reload: vi.fn().mockRejectedValue(reloadError) });
+    const { result, error } = await performOtaRecovery(deps);
+
+    expect(result).toBe('failed');
+    expect(error).toBe(reloadError);
+    expect(deps.reload).toHaveBeenCalledOnce();
+  });
+
+  it('fetch hangs past the timeout: resolves failed, never reloads', async () => {
+    const deps = makeDeps({
+      // Never resolves — stands in for a stalled download.
+      fetchUpdate: vi.fn().mockReturnValue(new Promise(() => {})),
+      timeoutMs: 10,
+    });
+    const { result } = await performOtaRecovery(deps);
+
+    expect(result).toBe('failed');
+    expect(deps.reload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/ota-recovery.ts
+++ b/packages/mobile/src/lib/ota-recovery.ts
@@ -1,0 +1,133 @@
+// Pure orchestration for the crash-screen OTA recovery button ("Check for a fix").
+// All platform I/O (expo-updates) is injected so the check/fetch/reload state
+// machine can be unit-tested without a rendered component or native modules. The
+// root ErrorBoundary (app/_layout.tsx) is a thin UI layer over this.
+//
+// The incident this exists for (2026-07-17): a broken production OTA crashed the
+// app at the root ErrorBoundary, where "Try again" only re-renders the same
+// broken in-memory bundle. Recovery required an invisible dance — dwell in the
+// foreground so expo-updates background-downloads the fix, then force-quit and
+// relaunch. This collapses that into one tap: check → fetch → reload, which also
+// applies a published rollback-to-embedded directive and any already-downloaded
+// pending update.
+
+export type OtaRecoveryResult =
+  // The server had a newer update for this build's fingerprint: fetched + reloaded.
+  | 'reloaded-update'
+  // The server published a rollback-to-embedded directive: fetched + reloaded onto
+  // the binary's known-good embedded bundle.
+  | 'reloaded-rollback'
+  // Nothing new on the server, but an update was already downloaded (pending): reloaded
+  // to launch it without re-fetching.
+  | 'reloaded-pending'
+  // Nothing new, nothing pending — did NOT reload, because reloading would just
+  // relaunch the same broken bundle.
+  | 'no-fix-available'
+  // The check or fetch threw, or the whole check+fetch stalled past the timeout.
+  | 'failed';
+
+export type OtaRecoveryPhase = 'checking' | 'downloading';
+
+export type OtaRecoveryDeps = {
+  // Ask the OTA server whether a newer update (isAvailable) or a rollback directive
+  // (isRollBackToEmbedded) is published for this build's fingerprint.
+  checkForUpdate: () => Promise<{ isAvailable: boolean; isRollBackToEmbedded: boolean }>;
+  // Download the update the check found (a newer bundle, or the rollback directive).
+  fetchUpdate: () => Promise<unknown>;
+  // Restart onto the downloaded/pending update. In production the app relaunches here.
+  reload: () => Promise<void>;
+  // Whether an update is already downloaded and staged to launch on the next reload.
+  isUpdatePending: () => boolean;
+  // Overall budget for the check+fetch network work before we give up (default 30s).
+  timeoutMs?: number;
+};
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+// A descriptor of what the check resolved to, so `reload()` stays OUTSIDE the
+// timeout race (once we commit to reloading, the app restarts — there's nothing
+// left to time out).
+type RecoveryPlan = {
+  shouldReload: boolean;
+  result: OtaRecoveryResult;
+};
+
+// Race `work` against a timeout, clearing the timer whichever side wins so a
+// resolved happy path never leaves a pending timer to reject unobserved.
+function withTimeout<T>(work: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`OTA recovery timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  return Promise.race([work, timeout]).finally(() => clearTimeout(timer));
+}
+
+// The network portion: check, then download when there's something to download.
+// Returns the plan; the caller performs the reload afterward so it isn't raced
+// against the timeout.
+async function resolveRecoveryPlan(
+  deps: OtaRecoveryDeps,
+  onPhase?: (phase: OtaRecoveryPhase) => void,
+): Promise<RecoveryPlan> {
+  onPhase?.('checking');
+  const check = await deps.checkForUpdate();
+
+  if (check.isAvailable || check.isRollBackToEmbedded) {
+    onPhase?.('downloading');
+    await deps.fetchUpdate();
+    // A real newer bundle wins over a rollback directive when both are somehow set:
+    // moving the fleet forward is the preferred fix.
+    return { shouldReload: true, result: check.isAvailable ? 'reloaded-update' : 'reloaded-rollback' };
+  }
+
+  // Nothing new on the server, but an earlier foreground dwell may have already
+  // downloaded the fix — launch it without re-fetching.
+  if (deps.isUpdatePending()) {
+    return { shouldReload: true, result: 'reloaded-pending' };
+  }
+
+  // Nothing to apply. Deliberately do NOT reload: it would relaunch the same
+  // broken bundle and drop the user right back on this screen.
+  return { shouldReload: false, result: 'no-fix-available' };
+}
+
+/**
+ * Run one recovery attempt: check the OTA server, download whatever fix it has
+ * (a newer bundle or a rollback-to-embedded directive), then reload onto it. If
+ * the server has nothing new but an update is already downloaded, reload onto
+ * that. If there's nothing to apply, resolve `no-fix-available` WITHOUT reloading
+ * (reloading would just relaunch the broken bundle).
+ *
+ * The check+fetch network work is bounded by `deps.timeoutMs` (default 30s) so a
+ * hung request resolves to `failed` instead of leaving the caller stuck; `reload`
+ * runs outside that budget. Any throw resolves `{ result: 'failed', error }`.
+ * `onPhase` drives the button's live status ('checking' → 'downloading').
+ *
+ * `onBeforeReload` fires synchronously right before each reload with the outcome
+ * result, so the caller can emit success telemetry that would otherwise be lost:
+ * reloadAsync() resolves right before the app restarts, so anything the caller
+ * does after this function returns a reloaded-* result can be torn down first.
+ */
+export async function performOtaRecovery(
+  deps: OtaRecoveryDeps,
+  callbacks?: {
+    onPhase?: (phase: OtaRecoveryPhase) => void;
+    onBeforeReload?: (result: OtaRecoveryResult) => void;
+  },
+): Promise<{ result: OtaRecoveryResult; error?: unknown }> {
+  try {
+    const plan = await withTimeout(resolveRecoveryPlan(deps, callbacks?.onPhase), deps.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    if (plan.shouldReload) {
+      // Emit outcome telemetry BEFORE the reload — both the fetched and the pending
+      // path funnel through here, so a post-return track() would race the restart
+      // and typically be lost.
+      callbacks?.onBeforeReload?.(plan.result);
+      // Nothing meaningful can run after this: expo-updates resolves reloadAsync()
+      // right before it posts the reload, so the app is on its way out here.
+      await deps.reload();
+    }
+    return { result: plan.result };
+  } catch (error) {
+    return { result: 'failed', error };
+  }
+}

--- a/packages/mobile/src/lib/ota-recovery.ts
+++ b/packages/mobile/src/lib/ota-recovery.ts
@@ -38,6 +38,13 @@ export type OtaRecoveryDeps = {
   reload: () => Promise<void>;
   // Whether an update is already downloaded and staged to launch on the next reload.
   isUpdatePending: () => boolean;
+};
+
+// Options bag for a recovery attempt: progress callbacks plus the timeout tuning
+// constant (a plain number, kept out of OtaRecoveryDeps, which is platform I/O only).
+export type OtaRecoveryOptions = {
+  onPhase?: (phase: OtaRecoveryPhase) => void;
+  onBeforeReload?: (result: OtaRecoveryResult) => void;
   // Overall budget for the check+fetch network work before we give up (default 30s).
   timeoutMs?: number;
 };
@@ -98,9 +105,9 @@ async function resolveRecoveryPlan(
  * that. If there's nothing to apply, resolve `no-fix-available` WITHOUT reloading
  * (reloading would just relaunch the broken bundle).
  *
- * The check+fetch network work is bounded by `deps.timeoutMs` (default 30s) so a
- * hung request resolves to `failed` instead of leaving the caller stuck; `reload`
- * runs outside that budget. Any throw resolves `{ result: 'failed', error }`.
+ * The check+fetch network work is bounded by `options.timeoutMs` (default 30s) so
+ * a hung request resolves to `failed` instead of leaving the caller stuck;
+ * `reload` runs outside that budget. Any throw resolves `{ result: 'failed', error }`.
  * `onPhase` drives the button's live status ('checking' → 'downloading').
  *
  * `onBeforeReload` fires synchronously right before each reload with the outcome
@@ -110,18 +117,18 @@ async function resolveRecoveryPlan(
  */
 export async function performOtaRecovery(
   deps: OtaRecoveryDeps,
-  callbacks?: {
-    onPhase?: (phase: OtaRecoveryPhase) => void;
-    onBeforeReload?: (result: OtaRecoveryResult) => void;
-  },
+  options?: OtaRecoveryOptions,
 ): Promise<{ result: OtaRecoveryResult; error?: unknown }> {
   try {
-    const plan = await withTimeout(resolveRecoveryPlan(deps, callbacks?.onPhase), deps.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    const plan = await withTimeout(
+      resolveRecoveryPlan(deps, options?.onPhase),
+      options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
     if (plan.shouldReload) {
       // Emit outcome telemetry BEFORE the reload — both the fetched and the pending
       // path funnel through here, so a post-return track() would race the restart
       // and typically be lost.
-      callbacks?.onBeforeReload?.(plan.result);
+      options?.onBeforeReload?.(plan.result);
       // Nothing meaningful can run after this: expo-updates resolves reloadAsync()
       // right before it posts the reload, so the app is on its way out here.
       await deps.reload();


### PR DESCRIPTION
## Summary

Follow-up to the 2026-07-17 production OTA incident (PR #3756). When a broken OTA bricks the app, users land on the root error screen with no real way out: "Try again" re-renders the same crashed in-memory bundle, and the actual recovery path (leave the app foregrounded long enough for the background download, then force-quit and relaunch twice) is invisible — even Marco's device didn't heal from open/close cycling during the incident.

This adds a **"Check for a fix"** button to that screen. One tap runs `checkForUpdateAsync → fetchUpdateAsync → reloadAsync`, which covers every server-driven recovery path:

- a newer fixed bundle published to the channel,
- a rollback-to-embedded directive (`vp run mobile:ota-rollback` / `eoas rollback`, surfaced as `isRollBackToEmbedded`),
- a fix that was already background-downloaded (plain reload applies it).

If the server has nothing, it says so ("No fix available yet") instead of pointlessly relaunching the broken bundle. A client-side "revert to embedded" button was considered and rejected: expo-updates 57.0.6 exposes no client API for it (no `clearUpdateCacheExperimentalAsync`) — reverts are server-authorized via the rollback directive, which this button applies.

Implementation:
- `packages/mobile/src/lib/ota-recovery.ts` — pure dep-injected state machine (modeled on `channel-switch.ts`), 30s timeout so a hung fetch can't strand the button on "Checking…".
- `packages/mobile/app/_layout.tsx` — ErrorBoundary wiring, gated on `Updates.isEnabled && !__DEV__`, provider-free (static tokens, hardcoded strings, module-level `track`/`reportHandledError`). Also fires an `Error Screen Shown` PostHog event — the incident was diagnosed by the *absence* of launch telemetry from crashed sessions; this makes bricked fleets directly visible.
- `packages/mobile/src/lib/__tests__/ota-recovery.test.ts` — full truth-table coverage incl. timeout.
- `docs/mobile-ota-updates.md` — incident-runbook note: publishing a rollback directive or fixed bundle now unbricks stuck users in one tap.

## Release Notes

- Stuck on the error screen? A new "Check for a fix" button grabs the latest update and reloads the app on the spot

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 4006 tests pass (7 new state-machine cases: update available, rollback directive, pending-only, no-fix, check failure, timeout, phase ordering)
- `vp run check:mobile-bundle` — iOS + Android bundles OK
- Adversarial QA review of the diff by a second agent (provider-free constraints, hooks discipline, reload-after-await hazard, timeout semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
