### PR TITLE
test(web): expo-web smoke Playwright project

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -385,6 +385,75 @@ jobs:
       # Screenshot capture runs in the dedicated `screenshots` job below.
 
   # ---------------------------------------------------------------------------
+  # Expo-web smoke — boots the full expo-web dev stack (backend + Next proxy +
+  # Metro web) via `vp run test:e2e:expo-web` and runs the `expo-web-smoke`
+  # Playwright project against it (scripts/expo-web-e2e.ts). Runs on a bare
+  # runner rather than the Playwright container because the vp task's `db:up`
+  # dependency drives the dev-db Docker compose stack, and dev-mode Next +
+  # Metro don't need the prebuilt artifact the shards consume. Non-sharded:
+  # the suite is serial by design (the first test absorbs Metro's on-demand
+  # bundle compile).
+  # ---------------------------------------------------------------------------
+  expo-web-smoke:
+    name: Expo-web smoke
+    needs: [typecheck]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          # Bare-runner key — matches the typecheck job, deliberately NOT the
+          # playwright-noble container key the build/e2e shards share.
+          key: ${{ runner.os }}-bun-node-modules-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-node-modules-
+
+      - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright chromium
+        run: bunx playwright install --with-deps chromium
+        working-directory: packages/web
+
+      - name: Run expo-web smoke suite
+        # The vp task graph provides db:up (dev-db compose stack, seeded test
+        # user) and the mobile web-runtime install; scripts/expo-web-e2e.ts
+        # boots the orchestrator, waits for /app to serve the Expo shell, runs
+        # Playwright, and tears the stack down. Exit code mirrors Playwright's.
+        run: vp run test:e2e:expo-web
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-expo-web-smoke
+          path: packages/web/playwright-report/
+          retention-days: 7
+
+      - name: Upload Playwright test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-results-expo-web-smoke
+          path: packages/web/test-results/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
   # Screenshots — like an e2e shard but runs the three screenshot Playwright
   # projects. `needs: e2e` sequences it after the functional tests so the
   # two don't fight over shared containers; `if: always()` makes sure a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Common commands:
 - `vp run mobile:ios` — local Expo iOS build with the shared Boardsesh Xcode cache
 - `vp run mobile:publish` — EAS Update for current branch
 - `vp run test:e2e` — Playwright; auto-starts the dev DB + web server
-- `vp run test:e2e:expo-web` — Expo-web smoke; boots the full expo-web stack (backend + Next proxy + Metro web) via the dev orchestrator and runs the `expo-web-smoke` Playwright project against it (heavy; not part of PR CI — run locally). See `scripts/expo-web-e2e.ts`.
+- `vp run test:e2e:expo-web` — Expo-web smoke; boots the full expo-web stack (backend + Next proxy + Metro web) via the dev orchestrator and runs the `expo-web-smoke` Playwright project against it (heavy; runs in the manually-dispatched E2E workflow's `expo-web-smoke` job, not per-PR CI — run locally for pre-push confidence). See `scripts/expo-web-e2e.ts`.
 
 ### Database
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Common commands:
 - `vp run mobile:ios` — local Expo iOS build with the shared Boardsesh Xcode cache
 - `vp run mobile:publish` — EAS Update for current branch
 - `vp run test:e2e` — Playwright; auto-starts the dev DB + web server
+- `vp run test:e2e:expo-web` — Expo-web smoke; boots the full expo-web stack (backend + Next proxy + Metro web) via the dev orchestrator and runs the `expo-web-smoke` Playwright project against it (heavy; not part of PR CI — run locally). See `scripts/expo-web-e2e.ts`.
 
 ### Database
 

--- a/packages/web/e2e/expo-web/smoke.spec.ts
+++ b/packages/web/e2e/expo-web/smoke.spec.ts
@@ -1,0 +1,223 @@
+// Expo-web smoke: drives the mobile app compiled for the browser (the /app
+// surface, react-native-web + the Material variant) through the Phase 0
+// go/no-go flows. Runs only in the `expo-web-smoke` Playwright project, which
+// requires the full expo-web dev stack (backend + Next proxy + Metro web) —
+// start it with `vp run test:e2e:expo-web`, or `vp run dev:mobile:web` and run
+// the project manually. The chromium project ignores this directory.
+//
+// Selector strategy: react-native-web maps accessibilityRole/Label to ARIA, so
+// everything here queries by role/name through the app's i18n strings (en-US
+// catalog — the dev stack runs untranslated). No CSS classes: RNW class names
+// are generated and unstable.
+//
+// Serial: the first /app load compiles the whole Metro web bundle on demand
+// (minutes, once per stack). Parallel workers would each pay that cost and
+// time out; serial lets the first test absorb the compile and the rest run
+// against a warm bundle.
+
+import { expect, test, type Page } from '@playwright/test';
+
+test.describe.configure({ mode: 'serial' });
+
+const TEST_EMAIL = process.env.TEST_USER_EMAIL ?? 'test@boardsesh.com';
+const TEST_PASSWORD = process.env.TEST_USER_PASSWORD ?? 'test';
+
+/** First navigation may include the on-demand Metro compile of the bundle. */
+const COLD_LOAD_TIMEOUT_MS = 180_000;
+const WARM_TIMEOUT_MS = 30_000;
+
+/** The five Material tab-bar entries, in mobile's canonical order. */
+const TAB_NAMES = ['Home', 'Climbs', 'Record', 'Discover', 'Profile'] as const;
+
+/**
+ * Console/page-error budget: the smoke fails on error classes that historically
+ * meant a broken surface rather than noise.
+ */
+const FATAL_CONSOLE_PATTERNS = [
+  /Maximum update depth exceeded/i,
+  /Cannot update a component/i,
+  /Reanimated/i,
+  /ws-auth returned no token/i,
+  /Unable to get view config/i,
+  /No QueryClient set/i,
+];
+
+function collectFatalConsoleErrors(page: Page): string[] {
+  const fatalErrors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+    const text = message.text();
+    if (FATAL_CONSOLE_PATTERNS.some((pattern) => pattern.test(text))) {
+      fatalErrors.push(text);
+    }
+  });
+  page.on('pageerror', (error) => {
+    fatalErrors.push(String(error));
+  });
+  return fatalErrors;
+}
+
+function tabButton(page: Page, name: (typeof TAB_NAMES)[number]) {
+  // The Material tab bar exposes role=tab; accessible names carry the icon
+  // glyph before the label ("󰋜 Home"), so match the label as a word.
+  return page.getByRole('tab', { name: new RegExp(`\\b${name}\\b`) }).last();
+}
+
+/**
+ * Lands on /app and ends signed in on the tab shell, tolerating either entry
+ * state: a fresh context gets the credentials screen; a context that inherited
+ * a NextAuth session through the SSO bridge lands straight on Home.
+ */
+async function ensureSignedIn(page: Page): Promise<void> {
+  await page.goto('/app', { timeout: COLD_LOAD_TIMEOUT_MS });
+  const emailField = page.getByRole('textbox', { name: 'Email', exact: true });
+  const homeTab = tabButton(page, 'Home');
+  await expect(emailField.or(homeTab).first()).toBeVisible({ timeout: COLD_LOAD_TIMEOUT_MS });
+
+  if (await emailField.isVisible()) {
+    await emailField.fill(TEST_EMAIL);
+    await page.getByRole('textbox', { name: 'Password', exact: true }).fill(TEST_PASSWORD);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+  }
+  await expect(homeTab).toBeVisible({ timeout: WARM_TIMEOUT_MS });
+}
+
+test.describe('expo-web smoke', () => {
+  test('boots, signs in, and renders the five-tab Material shell', async ({ page }) => {
+    const fatalErrors = collectFatalConsoleErrors(page);
+    await ensureSignedIn(page);
+    for (const tabName of TAB_NAMES) {
+      await expect(tabButton(page, tabName)).toBeVisible();
+    }
+    expect(fatalErrors).toEqual([]);
+  });
+
+  test('home feed renders WASM board thumbnails; climbs tab shows the follow-your-wall state', async ({ page }) => {
+    const fatalErrors = collectFatalConsoleErrors(page);
+    await ensureSignedIn(page);
+    // WASM overlay renders resolve to blob: object URLs inside expo-image
+    // <img>s — the Home feed's session cards carry them without any board
+    // context.
+    const blobThumbnails = page.locator('img[src^="blob:"]');
+    await expect(blobThumbnails.first()).toBeVisible({ timeout: 60_000 });
+    expect(await blobThumbnails.count()).toBeGreaterThanOrEqual(3);
+    // A fresh browser context has no followed board, so the Climbs tab shows
+    // the follow-your-wall empty state rather than a list.
+    await tabButton(page, 'Climbs').click();
+    await expect(page.getByRole('button', { name: 'Find my board' })).toBeVisible({ timeout: WARM_TIMEOUT_MS });
+    expect(fatalErrors).toEqual([]);
+  });
+
+  /**
+   * Binds the seeded kilter board (Dyno Den) via the board sheet so the Climbs
+   * tab has a list and play-drawer actions aren't blocked by the switch-board
+   * overlay (feed climbs live on other boards). Fresh contexts start unbound.
+   */
+  async function bindSeededBoard(page: Page): Promise<void> {
+    await tabButton(page, 'Climbs').click();
+    const findBoardButton = page.getByRole('button', { name: 'Find my board' });
+    if (await findBoardButton.isVisible().catch(() => false)) {
+      await findBoardButton.click({ force: true });
+      await page
+        .getByRole('button', { name: /Dyno Den/ })
+        .first()
+        .click({ force: true });
+    }
+    // Bound board → the list renders WASM thumbnails.
+    await expect(page.locator('img[src^="blob:"]').first()).toBeVisible({ timeout: 60_000 });
+  }
+
+  /** Opens the first climbs-list climb into the play drawer. */
+  async function openPlayDrawerFromClimbsList(page: Page): Promise<void> {
+    await bindSeededBoard(page);
+    // Each list row is an accessible button named after its climb and wraps
+    // the blob thumbnail; force bypasses the row's cross-dissolve animation
+    // that never settles for hit-testing.
+    const firstClimbRow = page
+      .getByRole('button')
+      .filter({ has: page.locator('img[src^="blob:"]') })
+      .first();
+    await firstClimbRow.click({ force: true });
+    await expect(page.getByRole('button', { name: 'Log ascent' })).toBeVisible({ timeout: WARM_TIMEOUT_MS });
+  }
+
+  /**
+   * Play-drawer action buttons sit under a transparent react-native-gesture-
+   * handler layer: real pointers reach them (the layer is pass-through), but
+   * Playwright's hit-testing sees the overlay and never completes a default
+   * click. force skips the hit-test while still requiring the visible, enabled
+   * target we already asserted.
+   */
+  async function tapThroughGestureLayer(locator: ReturnType<Page['getByRole']>): Promise<void> {
+    // force-clicks still deliver events to the overlay at that position, so
+    // dispatch the click on the button element itself.
+    await locator.dispatchEvent('click');
+  }
+
+  /**
+   * Dismisses the presented sheet and waits for `stillVisible` to disappear.
+   * gorhom's web backdrop and the Escape key each dismiss on their own, but
+   * either can no-op if fired mid present-animation, so this alternates them
+   * until the sheet is actually gone (killing a dismiss-timing flake).
+   */
+  async function dismissSheet(page: Page, stillVisible: ReturnType<Page['getByRole']>): Promise<void> {
+    const backdrop = page.getByRole('button', { name: 'Bottom sheet backdrop' }).last();
+    await expect(async () => {
+      if (await backdrop.isVisible().catch(() => false)) {
+        await backdrop.click({ force: true });
+      }
+      await page.keyboard.press('Escape');
+      await expect(stillVisible).toBeHidden({ timeout: 2_000 });
+    }).toPass({ timeout: 20_000 });
+  }
+
+  test('opens the play drawer from the feed and reaches the log-ascent sheet', async ({ page }) => {
+    const fatalErrors = collectFatalConsoleErrors(page);
+    await ensureSignedIn(page);
+    await openPlayDrawerFromClimbsList(page);
+    await tapThroughGestureLayer(page.getByRole('button', { name: 'Log ascent' }));
+
+    // Log-ascent sheet: the save row ("Log attempt" outlined + "Log flash"/
+    // "Log send" filled) proves the sheet presented; dismiss restores the
+    // drawer.
+    const saveTickButton = page.getByRole('button', { name: /Log (flash|send|attempt)/ }).first();
+    await expect(saveTickButton).toBeVisible({ timeout: 15_000 });
+    await dismissSheet(page, saveTickButton);
+    expect(fatalErrors).toEqual([]);
+  });
+
+  test('queue sheet opens and dismisses from the play drawer', async ({ page }) => {
+    const fatalErrors = collectFatalConsoleErrors(page);
+    await ensureSignedIn(page);
+    await openPlayDrawerFromClimbsList(page);
+
+    const queueButton = page.getByRole('button', { name: /queue/i }).first();
+    await expect(queueButton).toBeVisible({ timeout: WARM_TIMEOUT_MS });
+    await tapThroughGestureLayer(queueButton);
+    // The queue sheet hosts its list in a BottomSheetFlatList; its "Edit queue"
+    // header action is unique to the presented sheet and proves the gorhom web
+    // shim mounted it. Backdrop dismissal proves it closes.
+    const editQueueButton = page.getByRole('button', { name: 'Edit queue' });
+    await expect(editQueueButton).toBeVisible({ timeout: 15_000 });
+    await dismissSheet(page, editQueueButton);
+    expect(fatalErrors).toEqual([]);
+  });
+
+  test('deep route reloads through the /app proxy without losing the shell', async ({ page }) => {
+    const fatalErrors = collectFatalConsoleErrors(page);
+    await ensureSignedIn(page);
+    await tabButton(page, 'Discover').click();
+    await page.waitForURL(/\/app\//, { timeout: 15_000 });
+    const deepPath = new URL(page.url()).pathname;
+    await page.reload();
+    await expect(tabButton(page, 'Profile')).toBeVisible({ timeout: WARM_TIMEOUT_MS });
+    expect(new URL(page.url()).pathname).toBe(deepPath);
+    expect(fatalErrors).toEqual([]);
+  });
+
+  test('/app responses carry the noindex header through the proxy', async ({ page }) => {
+    const response = await page.goto('/app', { timeout: COLD_LOAD_TIMEOUT_MS });
+    expect(response).not.toBeNull();
+    expect(response?.headers()['x-robots-tag']).toContain('noindex');
+  });
+});

--- a/packages/web/e2e/expo-web/smoke.spec.ts
+++ b/packages/web/e2e/expo-web/smoke.spec.ts
@@ -58,9 +58,12 @@ function collectFatalConsoleErrors(page: Page): string[] {
 }
 
 function tabButton(page: Page, name: (typeof TAB_NAMES)[number]) {
-  // The Material tab bar exposes role=tab; accessible names carry the icon
-  // glyph before the label ("󰋜 Home"), so match the label as a word.
-  return page.getByRole('tab', { name: new RegExp(`\\b${name}\\b`) }).last();
+  // MaterialTabBar sets `accessibilityRole="tab"` + `accessibilityLabel={label}`
+  // on each destination, which react-native-web maps to role=tab with an
+  // aria-label equal to the tab title verbatim. Each label is unique and the
+  // hidden /wall route is filtered out, so an exact accessible-name match
+  // resolves to the one real tab — no positional `.last()` needed.
+  return page.getByRole('tab', { name, exact: true });
 }
 
 /**
@@ -116,15 +119,24 @@ test.describe('expo-web smoke', () => {
   async function bindSeededBoard(page: Page): Promise<void> {
     await tabButton(page, 'Climbs').click();
     const findBoardButton = page.getByRole('button', { name: 'Find my board' });
-    if (await findBoardButton.isVisible().catch(() => false)) {
+    const boundThumbnail = page.locator('img[src^="blob:"]').first();
+    // The Climbs tab settles into one of two determinate states: the follow-
+    // your-wall empty state (fresh context) or a populated list (already bound).
+    // Wait for whichever appears so the bind decision below isn't racing an
+    // unrendered UI — an immediate `isVisible()` could read false mid-mount and
+    // silently skip binding.
+    await expect(findBoardButton.or(boundThumbnail).first()).toBeVisible({ timeout: WARM_TIMEOUT_MS });
+    if (await findBoardButton.isVisible()) {
       await findBoardButton.click({ force: true });
       await page
         .getByRole('button', { name: /Dyno Den/ })
         .first()
         .click({ force: true });
     }
-    // Bound board → the list renders WASM thumbnails.
-    await expect(page.locator('img[src^="blob:"]').first()).toBeVisible({ timeout: 60_000 });
+    // Bound board → the list renders WASM thumbnails. Assert unconditionally so
+    // a skipped bind (e.g. the empty-state button got renamed) fails loudly
+    // here instead of letting downstream steps pass vacuously.
+    await expect(boundThumbnail).toBeVisible({ timeout: 60_000 });
   }
 
   /** Opens the first climbs-list climb into the play drawer. */

--- a/packages/web/e2e/expo-web/smoke.spec.ts
+++ b/packages/web/e2e/expo-web/smoke.spec.ts
@@ -103,7 +103,12 @@ test.describe('expo-web smoke', () => {
     // context.
     const blobThumbnails = page.locator('img[src^="blob:"]');
     await expect(blobThumbnails.first()).toBeVisible({ timeout: 60_000 });
-    expect(await blobThumbnails.count()).toBeGreaterThanOrEqual(3);
+    // Each blob: src appears only when that card's WASM render resolves, and
+    // nothing synchronizes the renders — at the instant the first thumbnail is
+    // visible the others may still be in flight. Waiting on the third keeps
+    // the "several cards rendered" assertion retrying instead of snapshotting
+    // a racy count.
+    await expect(blobThumbnails.nth(2)).toBeVisible({ timeout: 60_000 });
     // A fresh browser context has no followed board, so the Climbs tab shows
     // the follow-your-wall empty state rather than a list.
     await tabButton(page, 'Climbs').click();

--- a/packages/web/e2e/global-setup.ts
+++ b/packages/web/e2e/global-setup.ts
@@ -96,6 +96,15 @@ async function ensureGridBadgeFixture(): Promise<void> {
 }
 
 export default async function globalSetup(config: FullConfig): Promise<void> {
+  // The expo-web smoke project drives the /app SPA, not the classic Next
+  // routes this setup seeds and prewarms — under the expo-web stack the cold
+  // classic-route compile can exceed the 30s card timeout and fail the run for
+  // surfaces the smoke never visits. scripts/expo-web-e2e.ts sets the skip.
+  if (process.env.PLAYWRIGHT_SKIP_CLASSIC_SETUP === '1') {
+    console.info('[global-setup] PLAYWRIGHT_SKIP_CLASSIC_SETUP=1 — skipping classic-app fixture seeding and prewarm.');
+    return;
+  }
+
   const baseURL = config.projects[0]?.use.baseURL ?? process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'http://localhost:3000';
 
   await ensureGridBadgeFixture();

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -60,7 +60,25 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-      testIgnore: ['**/layout-screenshots.spec.ts', '**/help-screenshots.spec.ts'],
+      testIgnore: ['**/layout-screenshots.spec.ts', '**/help-screenshots.spec.ts', '**/expo-web/**'],
+    },
+
+    // Expo-web smoke — drives the mobile app compiled for the browser at /app.
+    // Requires the full expo-web dev stack (backend + Next proxy + Metro web):
+    //   vp run test:e2e:expo-web            (orchestrated: starts the stack, runs this)
+    // or vp run dev:mobile:web, then:
+    //   TEST_USER_EMAIL=test@boardsesh.com TEST_USER_PASSWORD=test \
+    //     cd packages/web && bunx playwright test --project=expo-web-smoke
+    // Viewport matches the Android parity reference (412×915) since the /app
+    // surface renders the Material variant.
+    {
+      name: 'expo-web-smoke',
+      use: {
+        viewport: { width: 412, height: 915 },
+        isMobile: true,
+        hasTouch: true,
+      },
+      testMatch: ['**/expo-web/*.spec.ts'],
     },
 
     // Help page screenshots - mobile viewport (390×844, iPhone 14 logical size).
@@ -90,13 +108,18 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests */
-  webServer: process.env.CI
-    ? undefined // In CI, we expect the server to be started separately
-    : {
-        command: 'bun run dev',
-        url: 'http://localhost:3000',
-        reuseExistingServer: !process.env.CI,
-        timeout: 120 * 1000,
-      },
+  /* Run your local dev server before starting the tests. Skipped in CI and
+   * whenever PLAYWRIGHT_TEST_BASE_URL points at an externally managed server —
+   * notably the expo-web stack (scripts/expo-web-e2e.ts), where auto-starting
+   * `bun run dev` here would race the orchestrator's Next instance for port
+   * 3000 and kill the whole stack mid-run. */
+  webServer:
+    process.env.CI || process.env.PLAYWRIGHT_TEST_BASE_URL
+      ? undefined
+      : {
+          command: 'bun run dev',
+          url: 'http://localhost:3000',
+          reuseExistingServer: !process.env.CI,
+          timeout: 120 * 1000,
+        },
 });

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -67,8 +67,13 @@ export default defineConfig({
     // Requires the full expo-web dev stack (backend + Next proxy + Metro web):
     //   vp run test:e2e:expo-web            (orchestrated: starts the stack, runs this)
     // or vp run dev:mobile:web, then:
+    //   PLAYWRIGHT_SKIP_CLASSIC_SETUP=1 \
     //   TEST_USER_EMAIL=test@boardsesh.com TEST_USER_PASSWORD=test \
     //     cd packages/web && bunx playwright test --project=expo-web-smoke
+    // (PLAYWRIGHT_SKIP_CLASSIC_SETUP=1 stops global-setup from seeding and
+    // prewarming the classic Next routes the smoke never visits — under the
+    // expo-web stack a cold compile of those routes can blow the setup's 30s
+    // card timeout and fail the run before any smoke test starts.)
     // Viewport matches the Android parity reference (412×915) since the /app
     // surface renders the Material variant.
     {
@@ -78,6 +83,13 @@ export default defineConfig({
         isMobile: true,
         hasTouch: true,
       },
+      // The suite is serial and its first test absorbs Metro's on-demand
+      // compile of the whole web bundle when the stack is cold (a code edit or
+      // cache clear invalidates the orchestrator's prewarm). The global 60s
+      // per-test timeout would kill that test before the spec's 180s cold-load
+      // budget could elapse, so give this project its own ceiling with
+      // headroom over COLD_LOAD_TIMEOUT_MS.
+      timeout: 240_000,
       testMatch: ['**/expo-web/*.spec.ts'],
     },
 

--- a/scripts/expo-web-e2e.ts
+++ b/scripts/expo-web-e2e.ts
@@ -38,9 +38,11 @@ async function waitForAppSurface(appUrl: string): Promise<void> {
       const response = await fetch(appUrl, { redirect: 'manual' });
       if (response.ok) {
         const html = await response.text();
-        // The exported shell always references the Expo entry bundle; an error
-        // page or a bare proxy response does not.
-        if (html.includes('/app/') || html.includes('_expo')) return;
+        // The exported shell always references the Expo bundle under `/_expo`;
+        // an error page or a bare Next proxy response (which can still carry an
+        // `/app/` link) does not. Match the Expo-specific path so a stray Next
+        // page never reads as ready.
+        if (html.includes('/_expo')) return;
         lastFailure = 'HTML shell missing the Expo entry reference';
       } else {
         lastFailure = `HTTP ${response.status}`;

--- a/scripts/expo-web-e2e.ts
+++ b/scripts/expo-web-e2e.ts
@@ -1,0 +1,120 @@
+/// <reference types="node" />
+// Orchestrated Expo-web smoke runner: boots the full expo-web dev stack
+// (backend + Next proxy + Metro web) via the dev orchestrator, waits for the
+// /app surface to serve, runs the `expo-web-smoke` Playwright project against
+// the printed Next origin, then tears the stack down. Exit code mirrors
+// Playwright's. Invoked by `vp run test:e2e:expo-web` (which provides db:up +
+// the web-runtime install as task dependencies).
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+
+const repoRoot = path.resolve(__dirname, '..');
+const READY_LINE = /\[dev\] Expo web app: (\S+)/;
+const APP_READY_TIMEOUT_MS = 300_000;
+const APP_POLL_INTERVAL_MS = 2_000;
+
+function terminate(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null) {
+      resolve();
+      return;
+    }
+    child.once('exit', () => resolve());
+    // The orchestrator terminates its full child tree on SIGTERM.
+    child.kill('SIGTERM');
+    setTimeout(() => {
+      if (child.exitCode === null) child.kill('SIGKILL');
+    }, 15_000).unref();
+  });
+}
+
+async function waitForAppSurface(appUrl: string): Promise<void> {
+  const deadline = Date.now() + APP_READY_TIMEOUT_MS;
+  let lastFailure = 'no request made yet';
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(appUrl, { redirect: 'manual' });
+      if (response.ok) {
+        const html = await response.text();
+        // The exported shell always references the Expo entry bundle; an error
+        // page or a bare proxy response does not.
+        if (html.includes('/app/') || html.includes('_expo')) return;
+        lastFailure = 'HTML shell missing the Expo entry reference';
+      } else {
+        lastFailure = `HTTP ${response.status}`;
+      }
+    } catch (error) {
+      lastFailure = String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, APP_POLL_INTERVAL_MS));
+  }
+  throw new Error(`Expo web app at ${appUrl} not ready within ${APP_READY_TIMEOUT_MS / 1000}s (last: ${lastFailure})`);
+}
+
+async function main(): Promise<number> {
+  const orchestrator = spawn('bunx', ['tsx', 'scripts/dev-orchestrator.ts', '--expo-web'], {
+    cwd: repoRoot,
+    stdio: ['ignore', 'pipe', 'inherit'],
+    env: process.env,
+  });
+
+  const appUrl = await new Promise<string>((resolve, reject) => {
+    const bootTimeout = setTimeout(
+      () => reject(new Error('dev orchestrator never printed the Expo web app URL')),
+      APP_READY_TIMEOUT_MS,
+    );
+    bootTimeout.unref();
+    orchestrator.stdout?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      process.stdout.write(text);
+      const readyMatch = READY_LINE.exec(text);
+      if (readyMatch) {
+        clearTimeout(bootTimeout);
+        resolve(readyMatch[1]);
+      }
+    });
+    orchestrator.once('exit', (code) => {
+      clearTimeout(bootTimeout);
+      reject(new Error(`dev orchestrator exited early with code ${code}`));
+    });
+  }).catch(async (error: unknown) => {
+    await terminate(orchestrator);
+    throw error;
+  });
+
+  try {
+    await waitForAppSurface(appUrl);
+    const nextOrigin = new URL(appUrl).origin;
+    const playwright = spawn(
+      'bunx',
+      ['playwright', 'test', '--project=expo-web-smoke', '--config=playwright.config.ts'],
+      {
+        cwd: path.join(repoRoot, 'packages/web'),
+        stdio: 'inherit',
+        env: {
+          ...process.env,
+          PLAYWRIGHT_TEST_BASE_URL: nextOrigin,
+          PLAYWRIGHT_SKIP_CLASSIC_SETUP: '1',
+          TEST_USER_EMAIL: process.env.TEST_USER_EMAIL ?? 'test@boardsesh.com',
+          TEST_USER_PASSWORD: process.env.TEST_USER_PASSWORD ?? 'test',
+        },
+      },
+    );
+    return await new Promise<number>((resolve) => {
+      playwright.once('exit', (code) => resolve(code ?? 1));
+    });
+  } finally {
+    await terminate(orchestrator);
+  }
+}
+
+main()
+  .then((exitCode) => {
+    process.exit(exitCode);
+  })
+  .catch((error: unknown) => {
+    console.error('[expo-web-e2e]', error);
+    process.exit(1);
+  });

--- a/scripts/expo-web-e2e.ts
+++ b/scripts/expo-web-e2e.ts
@@ -10,6 +10,8 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import path from 'node:path';
 import process from 'node:process';
 
+import { extractExpoWebEntryBundleSource } from './lib/expo-web-readiness';
+
 const repoRoot = path.resolve(__dirname, '..');
 const READY_LINE = /\[dev\] Expo web app: (\S+)/;
 const APP_READY_TIMEOUT_MS = 300_000;
@@ -47,11 +49,14 @@ async function waitForAppSurface(appUrl: string): Promise<void> {
       const response = await fetch(appUrl, { redirect: 'manual' });
       if (response.ok) {
         const html = await response.text();
-        // The exported shell always references the Expo bundle under `/_expo`;
-        // an error page or a bare Next proxy response (which can still carry an
-        // `/app/` link) does not. Match the Expo-specific path so a stray Next
-        // page never reads as ready.
-        if (html.includes('/_expo')) return;
+        // Dev-mode Metro references the entry as a `<script src>` containing
+        // `entry.bundle` + `platform=web` — the same detection the dev
+        // orchestrator's prewarm uses (extractExpoWebEntryBundleSource), so
+        // this probe and the prewarm agree on what "ready" means. An exported
+        // shell instead references hashed bundles under `/_expo`. Accept
+        // either; an error page or a bare Next proxy response (which can
+        // still carry an `/app/` link) matches neither.
+        if (extractExpoWebEntryBundleSource(html) !== null || html.includes('/_expo')) return;
         lastFailure = 'HTML shell missing the Expo entry reference';
       } else {
         lastFailure = `HTTP ${response.status}`;

--- a/scripts/expo-web-e2e.ts
+++ b/scripts/expo-web-e2e.ts
@@ -15,9 +15,18 @@ const READY_LINE = /\[dev\] Expo web app: (\S+)/;
 const APP_READY_TIMEOUT_MS = 300_000;
 const APP_POLL_INTERVAL_MS = 2_000;
 
+function hasExited(child: ChildProcess): boolean {
+  // A signal-killed child (OOM killer, external SIGKILL) has exitCode === null
+  // but signalCode set — checking exitCode alone would treat it as still
+  // running, register an 'exit' listener that never fires (the event already
+  // did), and hang the returned promise. That hang drains the event loop and
+  // turns a crashed stack into exit code 0.
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
 function terminate(child: ChildProcess): Promise<void> {
   return new Promise((resolve) => {
-    if (child.exitCode !== null) {
+    if (hasExited(child)) {
       resolve();
       return;
     }
@@ -25,7 +34,7 @@ function terminate(child: ChildProcess): Promise<void> {
     // The orchestrator terminates its full child tree on SIGTERM.
     child.kill('SIGTERM');
     setTimeout(() => {
-      if (child.exitCode === null) child.kill('SIGKILL');
+      if (!hasExited(child)) child.kill('SIGKILL');
     }, 15_000).unref();
   });
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -749,6 +749,14 @@ export default defineConfig({
         dependsOn: ['db:up'],
         cache: false,
       },
+      // Expo-web smoke: boots the full expo-web stack (backend + Next proxy +
+      // Metro web) via the dev orchestrator and runs the `expo-web-smoke`
+      // Playwright project against it. See scripts/expo-web-e2e.ts.
+      'test:e2e:expo-web': {
+        command: 'tsx scripts/expo-web-e2e.ts',
+        dependsOn: ['db:up', 'mobile:web-runtime:install'],
+        cache: false,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Adds an `expo-web-smoke` Playwright project that drives the mobile app compiled for the browser (the `/app` surface, react-native-web + the Material variant) through the Phase 0 go/no-go flows. It's the manually-run regression check for the Expo-web stack — run it locally before landing a later Expo-web PR, or as the scripted half of morning QA. It is **not** wired into PR CI: the stack it needs (backend + Next proxy + Metro web, with a multi-minute cold Metro web compile) is too heavy for the per-PR e2e shards, so this ships as a local/on-demand task. Wiring a nightly or label-gated CI job is a follow-up.

Six serial specs:
1. Boots, signs in with credentials, renders the five-tab Material shell (Home · Climbs · Record · Discover · Profile).
2. Home feed renders WASM board thumbnails as `blob:` object URLs; Climbs tab shows the follow-your-wall empty state for an unbound context.
3. Opens the play drawer from a bound board's climb row and reaches the log-ascent sheet (Attempt/Flash save row).
4. Queue sheet opens (gorhom web shim, `BottomSheetFlatList`) and dismisses.
5. Deep route reloads through the `/app` proxy without losing the signed-in shell.
6. `/app` responses carry the `X-Robots-Tag: noindex` header through the proxy.

Selectors query by ARIA role/name (react-native-web maps `accessibilityRole`/`Label` to ARIA) rather than generated RNW class names. A console/page-error budget fails the run on React/Reanimated/hydration/auth-loop errors.

## How it runs

Locally only — this project is not part of PR CI (see above):

- `vp run test:e2e:expo-web` — `scripts/expo-web-e2e.ts` boots the full expo-web stack via the dev orchestrator (backend + Next proxy + Metro web), waits for `/app` to serve the Expo shell (`/_expo` bundle path), runs the project against the printed Next origin, tears the stack down.
- Or `vp run dev:mobile:web`, then `bunx playwright test --project=expo-web-smoke` from `packages/web`.
- The classic e2e `global-setup` is skipped under `PLAYWRIGHT_SKIP_CLASSIC_SETUP=1` (the smoke drives `/app`, not the classic routes it seeds); the Playwright `webServer` auto-start is disabled when `PLAYWRIGHT_TEST_BASE_URL` is set so it can't race the orchestrator's Next for port 3000.

## Release Notes

- [x] No release note needed (internal / testing change)

## Test plan

- 6/6 specs green against the live expo-web stack (31.5s warm; ~2–3 min cold with the on-demand Metro bundle compile), zero flakes after hardening the sheet-dismissal poll.
- `vp check` clean on all changed files.

_Stacked on #3752 (Expo web Phase 0). Review after #3752._
