### PR TITLE
feat(web): serve the Expo web export at /app in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,9 @@ packages/web/public/uploads
 
 # generated API documentation
 packages/web/public/openapi.json
+
+# static Expo web export served at /app (scripts/build-expo-web-export.sh)
+packages/web/public/app
 .claude/settings.local.json
 packages/db/docker/tmp/g
 packages/db/docker/tmp/

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -27,6 +27,9 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
+# bash runs scripts/build-expo-web-export.sh (repo scripts are bash, not sh)
+RUN apk add --no-cache bash
+
 # Copy bun binary from deps stage (avoid re-downloading)
 COPY --from=deps /root/.bun/bin/bun /usr/local/bin/bun
 RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
@@ -35,16 +38,51 @@ RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
 COPY --from=deps /app/node_modules ./node_modules
 
 # Source-only edits land after install, so they do not invalidate the dependency layer.
+# The full workspace manifest set comes first: the lockfile spans every
+# workspace, while source/ only carries this service's packages, so the frozen
+# relink below needs the remaining package.json stubs to accept the lockfile.
+# source/packages then overwrites its subset with identical manifests + source.
+COPY manifests/packages ./packages
 COPY source/package.json source/bun.lock ./
 COPY source/patches ./patches
 COPY source/packages ./packages
+COPY source/scripts ./scripts
+
+# Bun's isolated linker resolves workspace deps through per-package symlink
+# farms (packages/*/node_modules -> ../../node_modules/.bun). The deps stage
+# created them next to the manifests, but only the root node_modules (with the
+# .bun store) crosses the stage boundary, so relink before the Expo export
+# resolves modules from the source tree — `bunx expo` must find the workspace's
+# pinned expo, never fall back to fetching a floating version.
+RUN bun install --frozen-lockfile
 
 # Accept build arguments for environment variables baked into the Next.js build
 ARG NEXT_PUBLIC_WS_URL
 ARG BASE_URL
+# BOARDSESH_WEB=1 turns on the Expo web export below AND the /app serving
+# branch that next.config.mjs bakes into the standalone build. Rollback lever:
+# build with --build-arg BOARDSESH_WEB=0 to ship an image without the Expo web
+# app — /app then 404s while the rest of the site is untouched.
+ARG BOARDSESH_WEB=1
 
 ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
 ENV BASE_URL=$BASE_URL
+ENV BOARDSESH_WEB=$BOARDSESH_WEB
+
+# Static Expo web export served by Next at /app. The nested web-runtime install
+# supplies the web-only renderer (react-native-web, react-dom, the gorhom sheet)
+# outside the native fingerprint graph — the export script runs it when missing.
+# The export lands in packages/web/public/app, which the runner stage picks up
+# through the existing public/ COPY and Next's standalone server then serves
+# statically. EXPO_PUBLIC_WEB_URL feeds the Expo Router head origin; the app's
+# runtime URLs (backend/WS) fall back to production defaults in src/lib/env.ts.
+# Only export EXPO_PUBLIC_WEB_URL when BASE_URL is non-empty: Expo inlines
+# EXPO_PUBLIC_* values verbatim, and a set-but-empty value would override the
+# production fallback in src/lib/env.ts with ''.
+RUN if [ "$BOARDSESH_WEB" = "1" ]; then \
+      if [ -n "$BASE_URL" ]; then export EXPO_PUBLIC_WEB_URL="$BASE_URL"; fi; \
+      bash scripts/build-expo-web-export.sh packages/web/public/app; \
+    fi
 
 # Build the Next.js application (standalone output)
 RUN bun run --filter=@boardsesh/web build

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -94,6 +94,16 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
+# BOARDSESH_WEB is read at REQUEST time by the standalone server, not just at
+# build: app/layout.tsx gates the Expo auth session bridge on it
+# (enableExpoAuthBridge) and middleware.ts gates the /app dev proxy. The builder
+# ARG/ENV above does not cross the stage boundary, so redeclare it here or the
+# runtime flag is undefined and the bridge stays off even though /app is served.
+# The default mirrors the builder so a single --build-arg BOARDSESH_WEB=0
+# rollback disables both the export AND the runtime bridge consistently.
+ARG BOARDSESH_WEB=1
+ENV BOARDSESH_WEB=$BOARDSESH_WEB
+
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs

--- a/docs/expo-web-deployment.md
+++ b/docs/expo-web-deployment.md
@@ -1,0 +1,66 @@
+# Expo web at /app: dev proxy vs production static serving
+
+The Expo app's browser target is served by the Next.js site under `/app`. There
+are two serving modes, both gated on `BOARDSESH_WEB=1` and both keeping the
+noindex + security headers that `packages/web/middleware.ts` and
+`packages/web/next.config.mjs` attach to every `/app` path.
+
+## Development: proxy to Metro
+
+`vp run dev:mobile:web` starts Metro alongside Next and sets
+`BOARDSESH_EXPO_WEB_ORIGIN` to Metro's origin. `next.config.mjs` then installs
+`beforeFiles` rewrites that forward `/app`, `/app/wasm/*`, `/app/:path*`,
+`/packages/mobile/*`, and `/assets*` to Metro. `beforeFiles` (not the default
+phase) so a stale local export sitting in `packages/web/public/app` can never
+shadow the live dev server.
+
+## Production: static export served by Next
+
+With `BOARDSESH_WEB=1` and **no** `BOARDSESH_EXPO_WEB_ORIGIN`, `next.config.mjs`
+switches to static mode:
+
+- The export artifact lives in `packages/web/public/app` (gitignored), so
+  Next — including the standalone `server.js` used by `Dockerfile.web` — serves
+  the real files directly: `/app/_expo/*` bundles, `/app/assets/*`,
+  `/app/wasm/*`, `/app/index.html`. Content-hashed paths (`_expo`, `assets`)
+  get `Cache-Control: immutable`.
+- Two afterFiles rewrites (`/app`, `/app/:path*` → `/app/index.html`) give the
+  Expo Router SPA its deep-link fallback: any `/app/...` path that is not a
+  real file serves the exported shell.
+
+### Artifact flow
+
+`scripts/build-expo-web-export.sh [output-dir]` is the single export recipe
+(default output: `packages/web/public/app`). It installs the isolated
+`packages/mobile/web-runtime` dependencies when missing (react-native-web and
+friends stay out of the native fingerprint graph) and runs
+`BOARDSESH_WEB=1 EXPO_NO_WEB_SETUP=1 bunx expo export --platform web`, then
+asserts the shell and board-renderer WASM assets landed. Consumers:
+
+- **`Dockerfile.web` (builder stage)** — the deployed path. The generated web
+  Docker context includes `packages/mobile` + its workspace deps and this
+  script (`scripts/create-service-docker-context.mjs`). The builder runs the
+  export into `packages/web/public/app` before `next build`, and the runner
+  stage's existing `public/` COPY ships it. `BASE_URL` is forwarded as
+  `EXPO_PUBLIC_WEB_URL` (Expo Router head origin); backend/WS URLs use the
+  production fallbacks in `packages/mobile/src/lib/env.ts`.
+- **`vp run build:expo-web`** — local verification: run it, then
+  `BOARDSESH_WEB=1 vp run build:web`, copy `public/` + `.next/static` into the
+  standalone output, and `/app` serves exactly like production.
+- **`vp run check:mobile-web-bundle`** — CI bundle check; exports to a temp dir
+  via the same script.
+
+The Vercel production web deploy (`production-deploy.yml`) does not run the
+export step yet; `/app` there simply 404s (see rollback below) until it is
+wired up or web serving moves to the Docker image.
+
+### Rollback
+
+Ship a web image without the export: `--build-arg BOARDSESH_WEB=0` on the
+`Dockerfile.web` build (or simply don't produce/copy the export in whatever
+pipeline builds web). Without the flag the Next build bakes no `/app` rewrites;
+without the artifact the SPA fallback rewrite finds no `/app/index.html` and
+`/app` 404s. Either way the failure is contained to `/app`: the middleware's
+`/app` branch only sets headers and never routes, so the rest of the site is
+unaffected. Native apps are untouched — this surface is browser-only and none
+of it enters the OTA fingerprint graph.

--- a/packages/web/app/__tests__/next-config-expo-web.test.ts
+++ b/packages/web/app/__tests__/next-config-expo-web.test.ts
@@ -88,8 +88,31 @@ describe('Expo web Next proxy', () => {
     );
     expect(appRewrites).toEqual([
       { source: '/app', destination: '/app/index.html' },
-      { source: '/app/:path*', destination: '/app/index.html' },
+      { source: '/app/:path((?!_expo/|assets/|wasm/).*)', destination: '/app/index.html' },
     ]);
+  });
+
+  it('keeps content-hashed and WASM namespaces out of the SPA fallback so missing assets 404', async () => {
+    process.env.BOARDSESH_WEB = '1';
+    delete process.env.BOARDSESH_EXPO_WEB_ORIGIN;
+
+    const appRewrites = flattenRewrites((await nextConfig.rewrites?.()) ?? []).filter(
+      ({ source }) => source === '/app' || source.startsWith('/app/'),
+    );
+
+    // The fallback source is a path-to-regexp pattern with a negative lookahead.
+    // Compile it and confirm hashed-asset / WASM paths do NOT fall back to the
+    // shell (they must miss public/ and 404), while real Expo Router routes do.
+    const fallback = appRewrites.find(({ source }) => source !== '/app');
+    expect(fallback?.destination).toBe('/app/index.html');
+    const capturedTail = /:path\((.*)\)/.exec(fallback?.source ?? '');
+    expect(capturedTail).not.toBeNull();
+    const tailMatcher = new RegExp(`^${capturedTail?.[1]}$`);
+
+    expect(tailMatcher.test('_expo/static/js/entry-abc123.js')).toBe(false);
+    expect(tailMatcher.test('assets/node_modules/expo/deadbeef.png')).toBe(false);
+    expect(tailMatcher.test('wasm/board_renderer_wasm.js')).toBe(false);
+    expect(tailMatcher.test('session/history')).toBe(true);
   });
 
   it('keeps Metro-only support namespaces out of the production static configuration', async () => {

--- a/packages/web/app/__tests__/next-config-expo-web.test.ts
+++ b/packages/web/app/__tests__/next-config-expo-web.test.ts
@@ -53,6 +53,62 @@ describe('Expo web Next proxy', () => {
     expect(rewrites).toContainEqual({ source: '/assets/:path*', destination: 'http://localhost:8082/assets/:path*' });
   });
 
+  it('proxies to Metro before the filesystem so a stale local export cannot shadow the dev server', async () => {
+    process.env.BOARDSESH_WEB = '1';
+    process.env.BOARDSESH_EXPO_WEB_ORIGIN = 'http://localhost:8082';
+
+    const rewriteResult = (await nextConfig.rewrites?.()) ?? [];
+
+    expect(Array.isArray(rewriteResult)).toBe(false);
+    const phasedRewrites = rewriteResult as Exclude<RewriteResult, Rewrite[]>;
+    const isExpoNamespace = ({ source }: Rewrite) =>
+      source === '/app' ||
+      source.startsWith('/app/') ||
+      source === '/assets' ||
+      source.startsWith('/assets/') ||
+      source.startsWith('/packages/mobile/');
+    expect((phasedRewrites.beforeFiles ?? []).filter(isExpoNamespace).length).toBeGreaterThan(0);
+    expect((phasedRewrites.afterFiles ?? []).filter(isExpoNamespace)).toEqual([]);
+    expect((phasedRewrites.fallback ?? []).filter(isExpoNamespace)).toEqual([]);
+  });
+
+  it('falls back /app routes to the exported SPA shell when no proxy origin is configured', async () => {
+    process.env.BOARDSESH_WEB = '1';
+    delete process.env.BOARDSESH_EXPO_WEB_ORIGIN;
+
+    const rewriteResult = (await nextConfig.rewrites?.()) ?? [];
+
+    // Array form = afterFiles: real export files under public/app (the _expo
+    // bundles, assets, wasm) win before the SPA fallback is consulted. The
+    // Sentry tunnel wrapper appends unrelated /monitoring rewrites, so scope
+    // the exact-shape assertion to the /app namespace.
+    expect(Array.isArray(rewriteResult)).toBe(true);
+    const appRewrites = flattenRewrites(rewriteResult).filter(
+      ({ source }) => source === '/app' || source.startsWith('/app/'),
+    );
+    expect(appRewrites).toEqual([
+      { source: '/app', destination: '/app/index.html' },
+      { source: '/app/:path*', destination: '/app/index.html' },
+    ]);
+  });
+
+  it('keeps Metro-only support namespaces out of the production static configuration', async () => {
+    process.env.BOARDSESH_WEB = '1';
+    delete process.env.BOARDSESH_EXPO_WEB_ORIGIN;
+
+    const rewrites = flattenRewrites((await nextConfig.rewrites?.()) ?? []);
+
+    expect(
+      rewrites.some(
+        ({ source, destination }) =>
+          source === '/assets' ||
+          source.startsWith('/assets/') ||
+          source.startsWith('/packages/mobile/') ||
+          (source.startsWith('/app') && destination.startsWith('http')),
+      ),
+    ).toBe(false);
+  });
+
   it('does not expose the Expo proxy in the normal Next configuration', async () => {
     delete process.env.BOARDSESH_WEB;
     process.env.BOARDSESH_EXPO_WEB_ORIGIN = 'http://localhost:8082';
@@ -78,5 +134,13 @@ describe('Expo web Next proxy', () => {
       source: '/app/:path*',
       headers: [{ key: 'X-Robots-Tag', value: 'noindex, follow' }],
     });
+  });
+
+  it('marks content-hashed export bundles as immutable without touching the SPA shell or wasm', async () => {
+    const headers = (await nextConfig.headers?.()) ?? [];
+
+    const immutableRule = headers.find(({ source }) => source.includes('_expo'));
+    expect(immutableRule?.source).toBe('/app/:hashedDir(_expo|assets)/:path*');
+    expect(immutableRule?.headers).toEqual([{ key: 'Cache-Control', value: 'public, max-age=31536000, immutable' }]);
   });
 });

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -158,7 +158,14 @@ const nextConfig = {
       // docs/expo-web-deployment.md).
       return [
         { source: '/app', destination: '/app/index.html' },
-        { source: '/app/:path*', destination: '/app/index.html' },
+        // SPA fallback for Expo Router routes ONLY. The content-hashed namespaces
+        // (_expo/, assets/) and the fixed-name WASM glue (wasm/) are excluded so a
+        // request for a missing hashed bundle 404s instead of falling through to
+        // the shell. Otherwise Next's headers() would stamp the index.html body
+        // with the immutable Cache-Control that matches the incoming .js/.wasm path
+        // (line 105), and a stale-shell or mid-deploy client would cache an HTML
+        // page at a bundle URL forever — permanently bricking that URL.
+        { source: '/app/:path((?!_expo/|assets/|wasm/).*)', destination: '/app/index.html' },
       ];
     }
 

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -98,6 +98,14 @@ const nextConfig = {
         headers: [{ key: 'X-Robots-Tag', value: 'noindex, follow' }],
       },
       {
+        // Exported Expo web bundles are content-hashed (entry-<hash>.js under
+        // _expo/static, md5-named files under assets/), so they can be cached
+        // forever. The SPA shell (/app/index.html) and the fixed-name WASM glue
+        // under /app/wasm keep the default no-store-ish behaviour on purpose.
+        source: '/app/:hashedDir(_expo|assets)/:path*',
+        headers: [{ key: 'Cache-Control', value: 'public, max-age=31536000, immutable' }],
+      },
+      {
         // Every route EXCEPT /embed/** keeps the frame-denying default.
         // If this exclusion ever regresses, the fail-safe is SAMEORIGIN
         // (embeds break visibly rather than the whole site becoming frameable).
@@ -138,43 +146,62 @@ const nextConfig = {
     if (process.env.BOARDSESH_WEB !== '1') return [];
 
     const expoWebOrigin = resolveExpoWebDevOrigin(process.env.BOARDSESH_EXPO_WEB_ORIGIN);
-    if (!expoWebOrigin) return [];
+    if (!expoWebOrigin) {
+      // Production: no Metro to proxy to. The static Expo web export is copied
+      // into public/app (scripts/build-expo-web-export.sh; Dockerfile.web runs
+      // it in the builder stage), so real files — /app/_expo/* bundles,
+      // /app/assets/*, /app/wasm/* — are served straight from public/ before
+      // these afterFiles rewrites are consulted. Everything else under /app is
+      // an Expo Router SPA route and falls back to the exported shell. When the
+      // export was not built into the deploy, /app/index.html resolves to
+      // nothing and /app 404s — that absence is the rollback lever (see
+      // docs/expo-web-deployment.md).
+      return [
+        { source: '/app', destination: '/app/index.html' },
+        { source: '/app/:path*', destination: '/app/index.html' },
+      ];
+    }
 
-    return [
-      {
-        source: '/app',
-        destination: `${expoWebOrigin}/app`,
-      },
-      {
-        // Expo serves public/ from its server root during `expo start`, while
-        // the production baseUrl makes browser imports point under /app.
-        // Resolve the committed WASM glue/binary before the SPA catch-all.
-        source: '/app/wasm/:path*',
-        destination: `${expoWebOrigin}/wasm/:path*`,
-      },
-      {
-        source: '/app/:path*',
-        destination: `${expoWebOrigin}/app/:path*`,
-      },
-      {
-        // Expo's development shell emits the Metro entry URL from the
-        // monorepo-relative module path even when baseUrl is /app. Keep that
-        // narrow namespace on the same browser origin while forwarding it to
-        // Metro; application/API routes remain owned by Next.
-        source: '/packages/mobile/:path*',
-        destination: `${expoWebOrigin}/packages/mobile/:path*`,
-      },
-      {
-        // Metro serves vector-icon fonts and other resolved module assets from
-        // this query-driven endpoint (for example `/assets?unstable_path=...`).
-        source: '/assets',
-        destination: `${expoWebOrigin}/assets`,
-      },
-      {
-        source: '/assets/:path*',
-        destination: `${expoWebOrigin}/assets/:path*`,
-      },
-    ];
+    // Development: proxy /app (and Metro's support namespaces) to the Expo dev
+    // server. beforeFiles, not the default afterFiles, so a stale local export
+    // sitting in public/app can never shadow Metro while the proxy is active.
+    return {
+      beforeFiles: [
+        {
+          source: '/app',
+          destination: `${expoWebOrigin}/app`,
+        },
+        {
+          // Expo serves public/ from its server root during `expo start`, while
+          // the production baseUrl makes browser imports point under /app.
+          // Resolve the committed WASM glue/binary before the SPA catch-all.
+          source: '/app/wasm/:path*',
+          destination: `${expoWebOrigin}/wasm/:path*`,
+        },
+        {
+          source: '/app/:path*',
+          destination: `${expoWebOrigin}/app/:path*`,
+        },
+        {
+          // Expo's development shell emits the Metro entry URL from the
+          // monorepo-relative module path even when baseUrl is /app. Keep that
+          // narrow namespace on the same browser origin while forwarding it to
+          // Metro; application/API routes remain owned by Next.
+          source: '/packages/mobile/:path*',
+          destination: `${expoWebOrigin}/packages/mobile/:path*`,
+        },
+        {
+          // Metro serves vector-icon fonts and other resolved module assets from
+          // this query-driven endpoint (for example `/assets?unstable_path=...`).
+          source: '/assets',
+          destination: `${expoWebOrigin}/assets`,
+        },
+        {
+          source: '/assets/:path*',
+          destination: `${expoWebOrigin}/assets/:path*`,
+        },
+      ],
+    };
   },
   async redirects() {
     return [

--- a/scripts/build-expo-web-export.sh
+++ b/scripts/build-expo-web-export.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds the static Expo web export (the /app SPA) and verifies the shell and
+# board-renderer WASM assets landed. This is the single export recipe shared by:
+#   - `vp run build:expo-web` (defaults to packages/web/public/app so a local
+#     BOARDSESH_WEB=1 `vp run build:web` serves /app exactly like production),
+#   - Dockerfile.web's builder stage (same default target),
+#   - scripts/mobile-web-bundle-check.sh (temp dir; export-only validation).
+#
+# Usage: bash scripts/build-expo-web-export.sh [output-dir]
+#
+# The output directory is wiped first, so never point it at a directory with
+# hand-maintained content. See docs/expo-web-deployment.md.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${1:-$ROOT_DIR/packages/web/public/app}"
+if [[ "$OUTPUT_DIR" != /* ]]; then
+  OUTPUT_DIR="$PWD/$OUTPUT_DIR"
+fi
+
+if [[ "$OUTPUT_DIR" == "$ROOT_DIR" || "$ROOT_DIR" == "$OUTPUT_DIR"/* ]]; then
+  echo "[build-expo-web-export] refusing to export over $OUTPUT_DIR" >&2
+  exit 1
+fi
+
+WEB_RUNTIME_DIR="$ROOT_DIR/packages/mobile/web-runtime"
+if [[ ! -d "$WEB_RUNTIME_DIR/node_modules/react-native-web" ]]; then
+  # The web-only renderer lives in an isolated nested install so it never
+  # enters the native fingerprint graph. `vp run build:expo-web` installs it
+  # via its task dependency; direct callers (Docker) land here.
+  echo "[build-expo-web-export] installing packages/mobile/web-runtime dependencies"
+  bun install --cwd "$WEB_RUNTIME_DIR" --frozen-lockfile
+fi
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+cd "$ROOT_DIR/packages/mobile"
+
+# TAILSCALE_HOSTS= short-circuits app.config.ts's tailscale-CLI probe when the
+# caller has not expressed a preference (CI/Docker have no tailscaled anyway).
+export TAILSCALE_HOSTS="${TAILSCALE_HOSTS-}"
+
+BOARDSESH_WEB=1 EXPO_NO_WEB_SETUP=1 EXPO_NO_TELEMETRY=1 \
+  bunx expo export --platform web --output-dir "$OUTPUT_DIR"
+
+if [[ ! -f "$OUTPUT_DIR/index.html" ]]; then
+  echo "[build-expo-web-export] missing index.html in $OUTPUT_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -f "$OUTPUT_DIR/wasm/board_renderer_wasm.js" || ! -f "$OUTPUT_DIR/wasm/board_renderer_wasm_bg.wasm" ]]; then
+  echo "[build-expo-web-export] missing board-renderer WASM assets in $OUTPUT_DIR" >&2
+  exit 1
+fi
+
+echo "[build-expo-web-export] Expo web export written to $OUTPUT_DIR"

--- a/scripts/build-expo-web-export.sh
+++ b/scripts/build-expo-web-export.sh
@@ -11,8 +11,8 @@ set -euo pipefail
 # Usage: bash scripts/build-expo-web-export.sh [output-dir]
 #
 # The output directory is wiped first. As a guard, the script refuses to wipe a
-# non-empty directory that isn't already an export (no index.html), and refuses
-# any target at or above the repo root. See docs/expo-web-deployment.md.
+# non-empty directory that isn't already an Expo web export (no `_expo/`), and
+# refuses any target at or above the repo root. See docs/expo-web-deployment.md.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -25,22 +25,26 @@ OUTPUT_DIR="${1:-$ROOT_DIR/packages/web/public/app}"
 if [[ "$OUTPUT_DIR" != /* ]]; then
   OUTPUT_DIR="$PWD/$OUTPUT_DIR"
 fi
-# Strip trailing slashes (shell tab-completion appends one) before the guards —
-# otherwise `<root>/` slips past the repo-root check and rm -rf wipes the repo.
-OUTPUT_DIR="${OUTPUT_DIR%/}"
+# Strip ALL trailing slashes (shell tab-completion appends one; `<root>//` needs
+# more than one strip) before the guards — otherwise `<root>/` slips past the
+# repo-root check and rm -rf wipes the repo.
+while [[ "$OUTPUT_DIR" == */ ]]; do OUTPUT_DIR="${OUTPUT_DIR%/}"; done
 
 if [[ -z "$OUTPUT_DIR" || "$OUTPUT_DIR" == "$ROOT_DIR" || "$ROOT_DIR" == "$OUTPUT_DIR"/* ]]; then
   echo "[build-expo-web-export] refusing to export over $OUTPUT_DIR" >&2
   exit 1
 fi
 
-# Refuse to wipe a directory that isn't already an export. The guard above only
-# protects the repo root and its ancestors; a one-segment typo like
+# Refuse to wipe a directory that isn't already an Expo web export. The guard
+# above only protects the repo root and its ancestors; a one-segment typo like
 # `packages/web/public` (instead of `.../public/app`) or any real directory
-# outside the repo would otherwise be rm -rf'd. A previous export always carries
-# index.html, so only wipe when the target is absent, empty, or a prior export.
-if [[ -d "$OUTPUT_DIR" && -n "$(ls -A "$OUTPUT_DIR" 2>/dev/null)" && ! -f "$OUTPUT_DIR/index.html" ]]; then
-  echo "[build-expo-web-export] refusing to wipe non-empty $OUTPUT_DIR (no index.html — not a previous export)" >&2
+# outside the repo would otherwise be rm -rf'd. The marker is the `_expo/`
+# directory, which `expo export --platform web` always emits — index.html is NOT
+# a safe marker because the committed `packages/web/public` (the exact typo this
+# guards against) already carries one. Only wipe when the target is absent,
+# empty, or a prior export.
+if [[ -d "$OUTPUT_DIR" && -n "$(ls -A "$OUTPUT_DIR" 2>/dev/null)" && ! -d "$OUTPUT_DIR/_expo" ]]; then
+  echo "[build-expo-web-export] refusing to wipe non-empty $OUTPUT_DIR (no _expo/ — not a previous Expo web export)" >&2
   exit 1
 fi
 

--- a/scripts/build-expo-web-export.sh
+++ b/scripts/build-expo-web-export.sh
@@ -10,17 +10,37 @@ set -euo pipefail
 #
 # Usage: bash scripts/build-expo-web-export.sh [output-dir]
 #
-# The output directory is wiped first, so never point it at a directory with
-# hand-maintained content. See docs/expo-web-deployment.md.
+# The output directory is wiped first. As a guard, the script refuses to wipe a
+# non-empty directory that isn't already an export (no index.html), and refuses
+# any target at or above the repo root. See docs/expo-web-deployment.md.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# vp forwards the literal `--` separator into a script's argv (known repo
+# footgun), so `vp run build:expo-web -- <dir>` arrives here as `-- <dir>`.
+# Drop it so the output dir isn't taken as "--" (which would export into ./--).
+if [[ "${1:-}" == "--" ]]; then shift; fi
+
 OUTPUT_DIR="${1:-$ROOT_DIR/packages/web/public/app}"
 if [[ "$OUTPUT_DIR" != /* ]]; then
   OUTPUT_DIR="$PWD/$OUTPUT_DIR"
 fi
+# Strip trailing slashes (shell tab-completion appends one) before the guards —
+# otherwise `<root>/` slips past the repo-root check and rm -rf wipes the repo.
+OUTPUT_DIR="${OUTPUT_DIR%/}"
 
-if [[ "$OUTPUT_DIR" == "$ROOT_DIR" || "$ROOT_DIR" == "$OUTPUT_DIR"/* ]]; then
+if [[ -z "$OUTPUT_DIR" || "$OUTPUT_DIR" == "$ROOT_DIR" || "$ROOT_DIR" == "$OUTPUT_DIR"/* ]]; then
   echo "[build-expo-web-export] refusing to export over $OUTPUT_DIR" >&2
+  exit 1
+fi
+
+# Refuse to wipe a directory that isn't already an export. The guard above only
+# protects the repo root and its ancestors; a one-segment typo like
+# `packages/web/public` (instead of `.../public/app`) or any real directory
+# outside the repo would otherwise be rm -rf'd. A previous export always carries
+# index.html, so only wipe when the target is absent, empty, or a prior export.
+if [[ -d "$OUTPUT_DIR" && -n "$(ls -A "$OUTPUT_DIR" 2>/dev/null)" && ! -f "$OUTPUT_DIR/index.html" ]]; then
+  echo "[build-expo-web-export] refusing to wipe non-empty $OUTPUT_DIR (no index.html — not a previous export)" >&2
   exit 1
 fi
 

--- a/scripts/check-service-deploy-inputs.test.mjs
+++ b/scripts/check-service-deploy-inputs.test.mjs
@@ -26,6 +26,10 @@ function createFixtureRepo() {
   writeFixtureFile(repoRoot, 'bun.lock', '');
   writeFixtureFile(repoRoot, '.dockerignore', '**/node_modules\n**/dist\n.docker-context\n');
   writeFixtureFile(repoRoot, 'railway.toml', '[deploy]\nstartCommand = "echo ok"\n');
+  // Declared as extraSourceFiles entries on the web service; context
+  // generation fails when one is missing, so the fixture repo carries stubs.
+  writeFixtureFile(repoRoot, 'scripts/build-expo-web-export.sh', '#!/usr/bin/env bash\n');
+  writeFixtureFile(repoRoot, 'scripts/lib/tailscale-hostname.ts', 'export {};\n');
 
   writePackage(repoRoot, 'packages/backend', {
     name: 'boardsesh-backend',

--- a/scripts/create-service-docker-context.mjs
+++ b/scripts/create-service-docker-context.mjs
@@ -58,6 +58,14 @@ const ignoredDirectoryNames = new Set([
   'test-results',
 ]);
 const ignoredFileNames = new Set(['.DS_Store']);
+// Repo-relative directory paths to keep out of every context. Unlike
+// `ignoredDirectoryNames` (matched by basename, so it can't target `public/app`
+// without also dropping `packages/web/app` / `packages/mobile/app`), these match
+// the exact path from the repo root. `packages/web/public/app` is the default
+// local output of `vp run build:expo-web`; a stale copy must never ride into the
+// web image (it would ship the old shell at /app/index.html and defeat the
+// BOARDSESH_WEB=0 rollback). The Dockerfile.web builder rebuilds it from source.
+const ignoredRepoRelativePaths = new Set(['packages/web/public/app']);
 
 const toPosix = (filePath) => filePath.split(sep).join(posix.sep);
 const readJson = (filePath) => JSON.parse(readFileSync(filePath, 'utf8'));
@@ -166,24 +174,26 @@ function copyFileCreatingParent(sourcePath, destinationPath) {
   copyFileSync(sourcePath, destinationPath);
 }
 
-function shouldSkipSourceEntry(entryName, entryRelativePath, isDirectory) {
+function shouldSkipSourceEntry(entryName, entryRelativePath, repoRelativePath, isDirectory) {
   if (ignoredFileNames.has(entryName)) return true;
   if (isDirectory && ignoredDirectoryNames.has(entryName)) return true;
+  if (ignoredRepoRelativePaths.has(repoRelativePath)) return true;
   if (entryRelativePath.endsWith('.tsbuildinfo')) return true;
   return false;
 }
 
-function copyDirectory(sourceDirectory, destinationDirectory, rootSourceDirectory = sourceDirectory) {
+function copyDirectory(sourceDirectory, destinationDirectory, repoRoot, rootSourceDirectory = sourceDirectory) {
   mkdirSync(destinationDirectory, { recursive: true });
 
   for (const entry of readdirSync(sourceDirectory, { withFileTypes: true })) {
     const sourcePath = join(sourceDirectory, entry.name);
     const relativeSourcePath = toPosix(relative(rootSourceDirectory, sourcePath));
-    if (shouldSkipSourceEntry(entry.name, relativeSourcePath, entry.isDirectory())) continue;
+    const repoRelativePath = toPosix(relative(repoRoot, sourcePath));
+    if (shouldSkipSourceEntry(entry.name, relativeSourcePath, repoRelativePath, entry.isDirectory())) continue;
 
     const destinationPath = join(destinationDirectory, entry.name);
     if (entry.isDirectory()) {
-      copyDirectory(sourcePath, destinationPath, rootSourceDirectory);
+      copyDirectory(sourcePath, destinationPath, repoRoot, rootSourceDirectory);
     } else if (entry.isSymbolicLink()) {
       mkdirSync(dirname(destinationPath), { recursive: true });
       symlinkSync(readlinkSync(sourcePath), destinationPath);
@@ -243,7 +253,11 @@ function createServiceDockerContext({ serviceName, repoRoot = defaultRepoRoot, o
   }
 
   for (const packageDirectory of getServiceSourcePackageDirs(serviceName, absoluteRepoRoot)) {
-    copyDirectory(join(absoluteRepoRoot, packageDirectory), join(absoluteOutputDir, 'source', packageDirectory));
+    copyDirectory(
+      join(absoluteRepoRoot, packageDirectory),
+      join(absoluteOutputDir, 'source', packageDirectory),
+      absoluteRepoRoot,
+    );
   }
 
   for (const extraSourceFile of service.extraSourceFiles ?? []) {

--- a/scripts/create-service-docker-context.mjs
+++ b/scripts/create-service-docker-context.mjs
@@ -23,7 +23,16 @@ const services = {
   },
   web: {
     dockerfile: 'Dockerfile.web',
-    rootPackageName: '@boardsesh/web',
+    // @boardsesh/mobile rides along because Dockerfile.web's builder stage runs
+    // the static Expo web export (served by Next at /app); the union walk pulls
+    // in the mobile app plus its transitive workspace deps.
+    rootPackageNames: ['@boardsesh/web', '@boardsesh/mobile'],
+    // Repo-root scripts the web image build needs, copied under source/scripts:
+    // the Expo web export recipe the Dockerfile invokes, plus the tailscale
+    // helper that packages/web/scripts/dev-with-tailscale.ts imports — Next's
+    // production type-check covers packages/web/scripts, so the module must
+    // resolve inside the build context.
+    extraSourceFiles: ['scripts/build-expo-web-export.sh', 'scripts/lib/tailscale-hostname.ts'],
   },
   sync: {
     dockerfile: 'Dockerfile.sync',
@@ -235,6 +244,14 @@ function createServiceDockerContext({ serviceName, repoRoot = defaultRepoRoot, o
 
   for (const packageDirectory of getServiceSourcePackageDirs(serviceName, absoluteRepoRoot)) {
     copyDirectory(join(absoluteRepoRoot, packageDirectory), join(absoluteOutputDir, 'source', packageDirectory));
+  }
+
+  for (const extraSourceFile of service.extraSourceFiles ?? []) {
+    const absoluteExtraSourcePath = join(absoluteRepoRoot, extraSourceFile);
+    if (!existsSync(absoluteExtraSourcePath)) {
+      throw new Error(`${serviceName} extra source file ${extraSourceFile} is missing`);
+    }
+    copyFileCreatingParent(absoluteExtraSourcePath, join(absoluteOutputDir, 'source', extraSourceFile));
   }
 
   return {

--- a/scripts/mobile-web-bundle-check.sh
+++ b/scripts/mobile-web-bundle-check.sh
@@ -32,18 +32,8 @@ verify_synced_artifact() {
 verify_synced_artifact "$SOURCE_GLUE" "$PUBLIC_GLUE" "JavaScript glue"
 verify_synced_artifact "$SOURCE_WASM" "$PUBLIC_WASM" "WASM"
 
-cd "$ROOT_DIR/packages/mobile"
-
-BOARDSESH_WEB=1 EXPO_NO_WEB_SETUP=1 bunx expo export --platform web --output-dir "$OUTPUT_DIR"
-
-if [[ ! -f "$OUTPUT_DIR/index.html" ]]; then
-  echo "[mobile-web-bundle] missing index.html" >&2
-  exit 1
-fi
-
-if [[ ! -f "$OUTPUT_DIR/wasm/board_renderer_wasm.js" || ! -f "$OUTPUT_DIR/wasm/board_renderer_wasm_bg.wasm" ]]; then
-  echo "[mobile-web-bundle] missing board-renderer WASM assets" >&2
-  exit 1
-fi
+# Single export recipe shared with the production build path (Dockerfile.web /
+# `vp run build:expo-web`); it also asserts the shell and WASM assets landed.
+bash "$ROOT_DIR/scripts/build-expo-web-export.sh" "$OUTPUT_DIR"
 
 echo "[mobile-web-bundle] Expo web export is complete and contains the required shell and WASM assets"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -310,6 +310,20 @@ export default defineConfig({
       'build:web': {
         command: 'bun run --filter=@boardsesh/web build',
         dependsOn: ['build:shared', 'build:crypto', 'build:db', 'build:constants'],
+        // Forwarded into the task (vp runs tasks with a filtered environment)
+        // and part of the cache key: BOARDSESH_WEB=1 bakes the /app static
+        // serving rewrites into the standalone build (see next.config.mjs).
+        env: ['BOARDSESH_WEB'],
+      },
+      'build:expo-web': {
+        // Static Expo web export into packages/web/public/app — the same
+        // artifact Dockerfile.web bakes into the production image. Run this
+        // before a BOARDSESH_WEB=1 `vp run build:web` to verify /app serving
+        // locally; pass `-- <output-dir>` for a different target. The output
+        // is gitignored (packages/web/public/app).
+        command: 'bash scripts/build-expo-web-export.sh',
+        dependsOn: ['mobile:web-runtime:install'],
+        cache: false,
       },
       'verify:graphql-treeshake': {
         command: 'bun packages/web/scripts/verify-graphql-treeshake.ts',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -319,8 +319,9 @@ export default defineConfig({
         // Static Expo web export into packages/web/public/app — the same
         // artifact Dockerfile.web bakes into the production image. Run this
         // before a BOARDSESH_WEB=1 `vp run build:web` to verify /app serving
-        // locally; pass `-- <output-dir>` for a different target. The output
-        // is gitignored (packages/web/public/app).
+        // locally; pass `-- <output-dir>` for a different target (the script
+        // strips vp's forwarded `--`). The output is gitignored
+        // (packages/web/public/app).
         command: 'bash scripts/build-expo-web-export.sh',
         dependsOn: ['mobile:web-runtime:install'],
         cache: false,


### PR DESCRIPTION
## Summary

Serves the static Expo web export at `/app` in production, so the mobile-app-as-web-app works off a deployed artifact and not just the dev Metro proxy.

- **`next.config.mjs`**: with `BOARDSESH_WEB=1` and no `BOARDSESH_EXPO_WEB_ORIGIN` (production), `rewrites()` returns SPA fallbacks `/app` and `/app/:path*` → `/app/index.html` (afterFiles, so real export files win first); the dev-proxy branch moved to beforeFiles so a stale local export can't shadow Metro. Immutable `Cache-Control` on `/app/(_expo|assets)/:path*`; `X-Robots-Tag: noindex, follow` + security headers preserved on all `/app` paths.
- **Build**: new `scripts/build-expo-web-export.sh` (single export recipe, default output `packages/web/public/app`); `scripts/mobile-web-bundle-check.sh` delegates to it; `vite.config.ts` gains `build:expo-web` and `build:web` declares `env: ['BOARDSESH_WEB']`. `Dockerfile.web` builder relinks bun's isolated per-package node_modules, runs the export, and builds Next with `ARG BOARDSESH_WEB=1`; the runner's existing `public/` COPY ships the artifact.
- **docs/expo-web-deployment.md**: dev proxy vs prod static, artifact flow, rollback (don't ship the export → `/app` 404s, gated by the middleware).

## Verification

- **Full `docker build -f Dockerfile.web` + `docker run` + curl**: `/app` → 200 shell with noindex + security headers; deep route → 200 shell; hashed `_expo` bundle → 200 JS `Cache-Control: immutable`; `/app/wasm/*.wasm` → 200 `application/wasm`; `/` unaffected. Same against a local `vp run build:expo-web` + `BOARDSESH_WEB=1 vp run build:web` standalone server.
- `vp run typecheck:web`, scoped web tests (8/8), `vp run check:mobile-web-bundle`, deploy-inputs check, `vp check` — all green. No changes to `packages/mobile`, root `package.json`, or `bun.lock` (fingerprint-safe, diff-verified).

## Notes for review

- **Pre-existing latent CI break fixed**: `packages/web/scripts/dev-with-tailscale.ts` imports repo-root `scripts/lib/tailscale-hostname`, which was absent from the web Docker context — Next's production type-check failed on it, so the base branch's web preview image was already unbuildable. Now shipped via `extraSourceFiles`.
- **Deferred — Vercel production path**: `production-deploy.yml` builds prod web via `vercel build`, not `Dockerfile.web`, so prod-on-Vercel `/app` 404s (the documented rollback state) until the export step is added to that job or web moves to the Docker image. Branch previews (Docker) get `/app` automatically now.

## Release Notes

- [x] No release note needed (internal / infrastructure change)

_Stacked on #3752 (Expo web Phase 0). Review after #3752._
