### PR TITLE
feat(web): flag-gated Expo-web rollout redirect map

### DIFF
--- a/docs/expo-web-rollout.md
+++ b/docs/expo-web-rollout.md
@@ -1,0 +1,98 @@
+# Expo-web rollout
+
+How logged-in web visitors get moved onto the `/app` Expo-web SPA, one surface
+at a time, behind a PostHog flag — and how to turn it off instantly.
+
+This is the rollout layer on top of the `/app` serving work
+(`docs/expo-web-deployment.md`). Serving `/app` is a prerequisite; this doc
+covers only the flag-gated redirect that sends classic web surfaces there.
+
+## The flag
+
+- **Key:** `expo-web-app`
+- **PostHog id:** 767179 (project 412845)
+- Starts **inactive / 0% rollout**. While it is off (or a visitor is outside the
+  rollout cohort), nothing changes — the classic web UI renders.
+
+The web app evaluates PostHog flags **only on the client** (posthog-js-lite, via
+`FeatureFlagsProvider`). Middleware runs on the edge and cannot call PostHog, so
+we bridge the flag to a cookie:
+
+1. `ExpoWebRolloutCookieSync` (mounted in `app/layout.tsx` inside
+   `FeatureFlagsProvider`) reads the resolved `expo-web-app` value and mirrors it
+   into the non-HttpOnly `bs_expo_web` cookie (`1` when on, cleared when off).
+2. `middleware.ts` reads `bs_expo_web` on the edge and redirects matching
+   surfaces.
+
+Because the cookie is written client-side after the flag resolves, the **first**
+navigation after login always stays classic (no cookie yet); the redirect kicks
+in on the next navigation. That lag is deliberate — the safe default is classic.
+
+## The redirect map
+
+`mapToExpoWebTarget` (`app/lib/expo-web-rollout.ts`) is the single source of
+truth. The `/app` SPA is client-routed (`baseUrl: '/app'`, web output `single`),
+so a plain path redirect resolves to `index.html` and Expo Router takes over.
+Locale prefixes (`/es/…`, `/fr/…`) are stripped — `/app` is locale-neutral.
+
+| Classic web surface | Redirects to | Board context carried |
+| --- | --- | --- |
+| `/[board]/[layout]/[size]/[sets]/[angle]/list` | `/app/climbs` | `?boardName&layoutId&sizeId&setIds&angle` |
+| `/b/[slug]/[angle]/list` | `/app/climbs` | `?boardSlug&angle` |
+| `/[board]/[layout]/[size]/[sets]/[angle]/view/[uuid]` | `/app/climbs/[uuid]` | `?boardName&layoutId&sizeId&setIds&angle` |
+| `/b/[slug]/[angle]/view/[uuid]` | `/app/climbs/[uuid]` | `?boardSlug&angle` |
+
+`/app/climbs/[uuid]` is the Expo Router **ClimbDetail** route, the native app's
+own deep-link target for a climb — it opens the play drawer. The legacy-numeric
+form carries the exact param contract that route reads
+(`boardName`/`layoutId`/`sizeId`/`setIds`/`angle`); the slug form carries
+`boardSlug` + `angle` and relies on the SPA to resolve the slug.
+
+Everything else stays classic: board create/queue pages, profiles, playlists,
+gyms, setters, API routes, and the homepage all return `null` from the map.
+
+## The three gates (off in every dimension by default)
+
+The redirect fires only when **all** hold:
+
+1. `BOARDSESH_WEB=1` — the site is built with the `/app` surface available
+   (`isExpoWebRolloutEnabled()`). Production static-export builds set this; a
+   plain classic build does not.
+2. `bs_expo_web=1` cookie — the visitor's `expo-web-app` flag resolved true.
+3. A next-auth session cookie — the visitor is logged in. Logged-out visitors
+   and crawlers (no session cookie) never redirect, so public/SEO board views
+   stay canonical.
+
+Login is detected by cookie **presence** (`__Secure-next-auth.session-token` or
+`next-auth.session-token`), the same heuristic as `getServerAuthToken`. The edge
+does not verify the JWT; a stale cookie at worst lands the visitor on the SPA,
+which does its own auth.
+
+## Escape hatch: back to classic
+
+A user (or a bug report) can always force classic:
+
+- `?classic=1` on any URL — middleware strips the param, 307s to the clean
+  classic URL, and pins the `bs_classic` cookie (one year). From then on the
+  cookie alone forces classic on every page.
+- The `bs_classic` cookie short-circuits the redirect while it is present.
+
+There is no UI affordance yet; `?classic=1` is the documented lever.
+
+## Rolling out
+
+1. Confirm the `/app` export is deployed and healthy (`docs/expo-web-deployment.md`).
+2. In PostHog, activate `expo-web-app` (id 767179) and dial the rollout
+   percentage up gradually (start with an internal cohort / small %).
+3. Watch: do flagged users land on `/app/climbs` and `/app/climbs/[uuid]`
+   correctly (board resolves, climb opens in the play drawer)? Verify the
+   slug-view path resolves before widening, since it depends on SPA-side slug
+   resolution.
+
+## Rollback
+
+- **Instant, everyone:** set `expo-web-app` to 0% in PostHog. Clients clear
+  `bs_expo_web` on their next page load and stop redirecting. No deploy.
+- **Per-user:** `?classic=1` (see the escape hatch above).
+- **Whole build:** ship without `BOARDSESH_WEB=1` — gate 1 fails and the
+  rollout is inert regardless of flag or cookie state.

--- a/docs/expo-web-rollout.md
+++ b/docs/expo-web-rollout.md
@@ -21,6 +21,8 @@ we bridge the flag to a cookie:
 1. `ExpoWebRolloutCookieSync` (mounted in `app/layout.tsx` inside
    `FeatureFlagsProvider`) reads the resolved `expo-web-app` value and mirrors it
    into the non-HttpOnly `bs_expo_web` cookie (`1` when on, cleared when off).
+   The on-value has a **4-hour TTL**, refreshed on every classic-side
+   navigation — see Rollback for why it is short.
 2. `middleware.ts` reads `bs_expo_web` on the edge and redirects matching
    surfaces.
 
@@ -35,18 +37,35 @@ truth. The `/app` SPA is client-routed (`baseUrl: '/app'`, web output `single`),
 so a plain path redirect resolves to `index.html` and Expo Router takes over.
 Locale prefixes (`/es/…`, `/fr/…`) are stripped — `/app` is locale-neutral.
 
-| Classic web surface | Redirects to | Board context carried |
-| --- | --- | --- |
-| `/[board]/[layout]/[size]/[sets]/[angle]/list` | `/app/climbs` | `?boardName&layoutId&sizeId&setIds&angle` |
-| `/b/[slug]/[angle]/list` | `/app/climbs` | `?boardSlug&angle` |
-| `/[board]/[layout]/[size]/[sets]/[angle]/view/[uuid]` | `/app/climbs/[uuid]` | `?boardName&layoutId&sizeId&setIds&angle` |
-| `/b/[slug]/[angle]/view/[uuid]` | `/app/climbs/[uuid]` | `?boardSlug&angle` |
+The map only emits URLs the SPA genuinely handles today — no redirect may land
+on a broken screen:
+
+| Classic web surface                                                                | Redirects to         | Board context carried                     |
+| ---------------------------------------------------------------------------------- | -------------------- | ----------------------------------------- |
+| `/[board]/[layout]/[size]/[sets]/[angle]/list` (numeric or named segments)         | `/app/climbs`        | none (see below)                          |
+| `/b/[slug]/[angle]/list`                                                           | `/app/climbs`        | none (see below)                          |
+| `/[board]/[layout]/[size]/[sets]/[angle]/view/[uuid]` — **fully-numeric IDs only** | `/app/climbs/[uuid]` | `?boardName&layoutId&sizeId&setIds&angle` |
+| `/[board]/[layout]/[size]/[sets]/[angle]/view/[uuid]` — named segments             | stays classic        | —                                         |
+| `/b/[slug]/[angle]/view/[uuid]`                                                    | stays classic        | —                                         |
 
 `/app/climbs/[uuid]` is the Expo Router **ClimbDetail** route, the native app's
-own deep-link target for a climb — it opens the play drawer. The legacy-numeric
-form carries the exact param contract that route reads
-(`boardName`/`layoutId`/`sizeId`/`setIds`/`angle`); the slug form carries
-`boardSlug` + `angle` and relies on the SPA to resolve the slug.
+own deep-link target for a climb — it opens the play drawer. It reads exactly
+`boardName`/`layoutId`/`sizeId`/`setIds`/`angle` and `Number(...)`s the IDs, so
+only the fully-numeric legacy form redirects there. The canonical named-segment
+form (what `constructClimbViewUrlWithSlugs` emits) and the `/b/[slug]` form stay
+classic until the SPA can resolve name slugs — redirecting them today would
+dead-end on a not-found screen.
+
+The list redirect carries **no board context**: the Climbs tab
+(`packages/mobile/app/(tabs)/climbs/index.tsx`) takes its board from the
+visitor's persisted active board and reads no board search params, so a flagged
+visitor following a shared list link lands on _their_ active board. That loss is
+deliberate and bounded — carrying the link's board requires SPA-side support
+first.
+
+A classic board URL with a query string (`?minGrade=…`, `?name=…`, `?sortBy=…`)
+never redirects: the SPA does not read filter state from the URL, so shared
+filtered links are served classic instead of silently dropping the filters.
 
 Everything else stays classic: board create/queue pages, profiles, playlists,
 gyms, setters, API routes, and the homepage all return `null` from the map.
@@ -85,14 +104,19 @@ There is no UI affordance yet; `?classic=1` is the documented lever.
 2. In PostHog, activate `expo-web-app` (id 767179) and dial the rollout
    percentage up gradually (start with an internal cohort / small %).
 3. Watch: do flagged users land on `/app/climbs` and `/app/climbs/[uuid]`
-   correctly (board resolves, climb opens in the play drawer)? Verify the
-   slug-view path resolves before widening, since it depends on SPA-side slug
-   resolution.
+   correctly (board resolves, climb opens in the play drawer)? Named-segment
+   and `/b/[slug]` climb-view URLs stay classic by design — widening them into
+   the map requires SPA-side slug resolution first.
 
 ## Rollback
 
-- **Instant, everyone:** set `expo-web-app` to 0% in PostHog. Clients clear
-  `bs_expo_web` on their next page load and stop redirecting. No deploy.
-- **Per-user:** `?classic=1` (see the escape hatch above).
+- **Flag off, no deploy:** set `expo-web-app` to 0% in PostHog. Visitors who
+  load any classic page clear `bs_expo_web` immediately. Visitors who live
+  entirely inside `/app` (the SPA never touches the cookie) are covered by the
+  cookie's 4-hour TTL: it expires, their next migrated-surface hit falls
+  through to classic, and the classic page re-evaluates the flag. Worst-case
+  rollback lag is therefore the TTL, not the cookie lifetime.
+- **Per-user:** `?classic=1` (see the escape hatch above) — works immediately,
+  even inside the TTL window.
 - **Whole build:** ship without `BOARDSESH_WEB=1` — gate 1 fails and the
   rollout is inert regardless of flag or cookie state.

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -461,6 +461,16 @@ describe('middleware Expo web rollout redirect', () => {
     expect(redirectedToAppPath(response)).toBeNull();
   });
 
+  it('redirects when the session rides the __Secure-next-auth.session-token cookie (https contexts)', () => {
+    const request = makeRequest('/kilter/1/10/1,20/40/view/climb-uuid');
+    request.cookies.set('__Secure-next-auth.session-token', 'token-123');
+    request.cookies.set(EXPO_WEB_ENABLED_COOKIE, '1');
+    const response = middleware(request);
+    const location = redirectedToAppPath(response);
+    expect(location).not.toBeNull();
+    expect(new URL(location!).pathname).toBe('/app/climbs/climb-uuid');
+  });
+
   it('does not redirect when the flag cookie is absent (flag off / unresolved)', () => {
     const request = makeRequest(LEGACY_LIST);
     request.cookies.set(AUTH_COOKIE, 'token-123');
@@ -501,5 +511,26 @@ describe('middleware Expo web rollout redirect', () => {
     request.cookies.set(EXPO_WEB_CLASSIC_COOKIE, '1');
     const response = middleware(request);
     expect(redirectedToAppPath(response)).toBeNull();
+  });
+
+  it('leaves a ?classic=1 API request alone (no 307, no cookie): the param belongs to the endpoint', () => {
+    const response = middleware(loggedInFlaggedRequest('/api/v1/kilter/proxy/login?classic=1'));
+    expect(response.status).not.toBe(307);
+    expect(response.headers.get('set-cookie') ?? '').not.toContain(EXPO_WEB_CLASSIC_COOKIE);
+  });
+
+  it('marks the bs_classic cookie Secure in an https context (mirrors the auth session cookie)', () => {
+    const originalNextAuthUrl = process.env.NEXTAUTH_URL;
+    process.env.NEXTAUTH_URL = 'https://www.boardsesh.com';
+    try {
+      const response = middleware(loggedInFlaggedRequest(`${SLUG_LIST}?classic=1`));
+      expect(response.status).toBe(307);
+      const setCookie = response.headers.get('set-cookie')!;
+      expect(setCookie).toContain(EXPO_WEB_CLASSIC_COOKIE);
+      expect(setCookie).toMatch(/secure/i);
+    } finally {
+      if (originalNextAuthUrl === undefined) delete process.env.NEXTAUTH_URL;
+      else process.env.NEXTAUTH_URL = originalNextAuthUrl;
+    }
   });
 });

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -416,14 +416,14 @@ describe('middleware Expo web rollout redirect', () => {
     return request;
   }
 
-  it('redirects a logged-in flagged visitor from a legacy board-list URL to /app/climbs', () => {
+  it('redirects a logged-in flagged visitor from a legacy board-list URL to /app/climbs with no query', () => {
     const response = middleware(loggedInFlaggedRequest(LEGACY_LIST));
     const location = redirectedToAppPath(response);
     expect(location).not.toBeNull();
     const url = new URL(location!);
     expect(url.pathname).toBe('/app/climbs');
-    expect(url.searchParams.get('boardName')).toBe('kilter');
-    expect(url.searchParams.get('angle')).toBe('40');
+    // The Climbs tab reads no board-context search params — don't imply otherwise.
+    expect(url.search).toBe('');
   });
 
   it('redirects a logged-in flagged visitor from a slug board-list URL to /app/climbs', () => {
@@ -433,11 +433,32 @@ describe('middleware Expo web rollout redirect', () => {
     expect(new URL(location!).pathname).toBe('/app/climbs');
   });
 
-  it('redirects a logged-in flagged visitor from a climb-view URL to the /app climb deep-link', () => {
-    const response = middleware(loggedInFlaggedRequest('/b/kilter-original-12x12/40/view/climb-uuid'));
+  it('redirects a numeric climb-view URL to the /app climb deep-link with the ClimbDetail param contract', () => {
+    const response = middleware(loggedInFlaggedRequest('/kilter/1/10/1,20/40/view/climb-uuid'));
     const location = redirectedToAppPath(response);
     expect(location).not.toBeNull();
-    expect(new URL(location!).pathname).toBe('/app/climbs/climb-uuid');
+    const url = new URL(location!);
+    expect(url.pathname).toBe('/app/climbs/climb-uuid');
+    expect(url.searchParams.get('boardName')).toBe('kilter');
+    expect(url.searchParams.get('layoutId')).toBe('1');
+    expect(url.searchParams.get('sizeId')).toBe('10');
+    expect(url.searchParams.get('setIds')).toBe('1,20');
+    expect(url.searchParams.get('angle')).toBe('40');
+  });
+
+  it('keeps a slug climb-view URL classic (the SPA has no boardSlug resolution)', () => {
+    const response = middleware(loggedInFlaggedRequest('/b/kilter-original-12x12/40/view/climb-uuid'));
+    expect(redirectedToAppPath(response)).toBeNull();
+  });
+
+  it('keeps a named-segment climb-view URL classic (ClimbDetail would get layoutId=NaN)', () => {
+    const response = middleware(loggedInFlaggedRequest('/kilter/original/12x12-square/screw_bolt/40/view/climb-uuid'));
+    expect(redirectedToAppPath(response)).toBeNull();
+  });
+
+  it('keeps a list URL with filter query params classic (the SPA cannot consume them)', () => {
+    const response = middleware(loggedInFlaggedRequest(`${LEGACY_LIST}?minGrade=10&sortBy=difficulty`));
+    expect(redirectedToAppPath(response)).toBeNull();
   });
 
   it('does not redirect when the flag cookie is absent (flag off / unresolved)', () => {

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it, expect } from 'vite-plus/test';
 import { NextRequest } from 'next/server';
 import { CLIMB_SESSION_COOKIE } from '@/app/lib/climb-session-cookie';
 import { DEFAULT_LOCALE, LOCALE_COOKIE, LOCALE_HEADER } from '@/app/lib/i18n/config';
+import { EXPO_WEB_CLASSIC_COOKIE, EXPO_WEB_ENABLED_COOKIE } from '@/app/lib/expo-web-rollout';
 
 const { getListPageCacheTTL, hasUserSpecificFilters } = await import('@/app/lib/list-page-cache');
 const { middleware } = await import('@/middleware');
@@ -386,5 +387,98 @@ describe('middleware cache headers on list pages', () => {
     const response = middleware(makeRequest('/some/page'));
     expect(response.headers.has('Vercel-CDN-Cache-Control')).toBe(false);
     expect(response.headers.has('CDN-Cache-Control')).toBe(false);
+  });
+});
+
+describe('middleware Expo web rollout redirect', () => {
+  const AUTH_COOKIE = 'next-auth.session-token';
+
+  beforeEach(() => {
+    process.env.BOARDSESH_WEB = '1';
+  });
+
+  afterEach(() => {
+    if (originalExpoWebFlag === undefined) delete process.env.BOARDSESH_WEB;
+    else process.env.BOARDSESH_WEB = originalExpoWebFlag;
+  });
+
+  function redirectedToAppPath(response: ReturnType<typeof middleware>): string | null {
+    const location = response.headers.get('location');
+    if (response.status !== 307 || location === null) return null;
+    const { pathname } = new URL(location);
+    return pathname.startsWith('/app') ? location : null;
+  }
+
+  function loggedInFlaggedRequest(url: string): NextRequest {
+    const request = makeRequest(url);
+    request.cookies.set(AUTH_COOKIE, 'token-123');
+    request.cookies.set(EXPO_WEB_ENABLED_COOKIE, '1');
+    return request;
+  }
+
+  it('redirects a logged-in flagged visitor from a legacy board-list URL to /app/climbs', () => {
+    const response = middleware(loggedInFlaggedRequest(LEGACY_LIST));
+    const location = redirectedToAppPath(response);
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe('/app/climbs');
+    expect(url.searchParams.get('boardName')).toBe('kilter');
+    expect(url.searchParams.get('angle')).toBe('40');
+  });
+
+  it('redirects a logged-in flagged visitor from a slug board-list URL to /app/climbs', () => {
+    const response = middleware(loggedInFlaggedRequest(SLUG_LIST));
+    const location = redirectedToAppPath(response);
+    expect(location).not.toBeNull();
+    expect(new URL(location!).pathname).toBe('/app/climbs');
+  });
+
+  it('redirects a logged-in flagged visitor from a climb-view URL to the /app climb deep-link', () => {
+    const response = middleware(loggedInFlaggedRequest('/b/kilter-original-12x12/40/view/climb-uuid'));
+    const location = redirectedToAppPath(response);
+    expect(location).not.toBeNull();
+    expect(new URL(location!).pathname).toBe('/app/climbs/climb-uuid');
+  });
+
+  it('does not redirect when the flag cookie is absent (flag off / unresolved)', () => {
+    const request = makeRequest(LEGACY_LIST);
+    request.cookies.set(AUTH_COOKIE, 'token-123');
+    const response = middleware(request);
+    expect(redirectedToAppPath(response)).toBeNull();
+  });
+
+  it('does not redirect a logged-out visitor even with the flag cookie (public page stays canonical)', () => {
+    const request = makeRequest(LEGACY_LIST);
+    request.cookies.set(EXPO_WEB_ENABLED_COOKIE, '1');
+    const response = middleware(request);
+    expect(redirectedToAppPath(response)).toBeNull();
+  });
+
+  it('does not redirect on a public/SEO route (playlists) even when flagged + logged in', () => {
+    const response = middleware(loggedInFlaggedRequest('/playlists'));
+    expect(redirectedToAppPath(response)).toBeNull();
+  });
+
+  it('does not redirect when BOARDSESH_WEB is not set (master env gate off)', () => {
+    delete process.env.BOARDSESH_WEB;
+    const response = middleware(loggedInFlaggedRequest(LEGACY_LIST));
+    expect(redirectedToAppPath(response)).toBeNull();
+  });
+
+  it('?classic=1 sets the bs_classic cookie and lands on the classic URL, not /app', () => {
+    const response = middleware(loggedInFlaggedRequest(`${SLUG_LIST}?classic=1`));
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get('location')!);
+    expect(location.pathname).toBe(SLUG_LIST);
+    expect(location.pathname.startsWith('/app')).toBe(false);
+    expect(location.searchParams.has('classic')).toBe(false);
+    expect(response.headers.get('set-cookie')).toContain(EXPO_WEB_CLASSIC_COOKIE);
+  });
+
+  it('honours the bs_classic opt-out cookie: no /app redirect while flagged + logged in', () => {
+    const request = loggedInFlaggedRequest(LEGACY_LIST);
+    request.cookies.set(EXPO_WEB_CLASSIC_COOKIE, '1');
+    const response = middleware(request);
+    expect(redirectedToAppPath(response)).toBeNull();
   });
 });

--- a/packages/web/app/components/providers/expo-web-rollout-cookie-sync.tsx
+++ b/packages/web/app/components/providers/expo-web-rollout-cookie-sync.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
 import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
 import { EXPO_WEB_FLAG, setExpoWebEnabledCookie } from '@/app/lib/expo-web-rollout';
 
@@ -15,13 +16,21 @@ import { EXPO_WEB_FLAG, setExpoWebEnabledCookie } from '@/app/lib/expo-web-rollo
  * the safe default. Once resolved true the cookie is written and the *next*
  * navigation to a migrated board surface redirects to `/app`. Flip the flag off
  * and the cookie clears on the visitor's next page load, instantly reverting.
+ *
+ * The cookie's short TTL is refreshed on every classic-side navigation
+ * (`pathname` dep — this component lives in the root layout and survives soft
+ * navs, so the flag value alone wouldn't re-fire). The `/app` SPA never writes
+ * the cookie, which is the rollback guarantee: a visitor living entirely inside
+ * `/app` loses the cookie within the TTL, lands back on classic, and re-runs
+ * this sync against the current flag state.
  */
 export function ExpoWebRolloutCookieSync(): null {
   const expoWebFlagEnabled = useFeatureFlag(EXPO_WEB_FLAG);
+  const pathname = usePathname();
 
   useEffect(() => {
     setExpoWebEnabledCookie(expoWebFlagEnabled === true);
-  }, [expoWebFlagEnabled]);
+  }, [expoWebFlagEnabled, pathname]);
 
   return null;
 }

--- a/packages/web/app/components/providers/expo-web-rollout-cookie-sync.tsx
+++ b/packages/web/app/components/providers/expo-web-rollout-cookie-sync.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
+import { EXPO_WEB_FLAG, setExpoWebEnabledCookie } from '@/app/lib/expo-web-rollout';
+
+/**
+ * Bridges the client-evaluated `expo-web-app` PostHog flag to the `bs_expo_web`
+ * cookie that middleware reads on the edge (middleware cannot call PostHog). The
+ * web app evaluates flags only on the client, so this is how the edge learns a
+ * visitor is in the rollout cohort. Renders nothing.
+ *
+ * Until the flag resolves the value is `undefined` (falsy) and the cookie is
+ * cleared, so the first navigation after login always stays on the classic UI —
+ * the safe default. Once resolved true the cookie is written and the *next*
+ * navigation to a migrated board surface redirects to `/app`. Flip the flag off
+ * and the cookie clears on the visitor's next page load, instantly reverting.
+ */
+export function ExpoWebRolloutCookieSync(): null {
+  const expoWebFlagEnabled = useFeatureFlag(EXPO_WEB_FLAG);
+
+  useEffect(() => {
+    setExpoWebEnabledCookie(expoWebFlagEnabled === true);
+  }, [expoWebFlagEnabled]);
+
+  return null;
+}

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -1,3 +1,5 @@
+import { EXPO_WEB_FLAG } from '@/app/lib/expo-web-rollout';
+
 // A flat bag of runtime feature flags. `Record<string, boolean | undefined>` (rather than
 // the prior `Record<string, never>`, which made `useFeatureFlag` resolve to
 // `never` and was therefore unusable) so consumers can call
@@ -35,6 +37,10 @@ export const FEATURE_FLAG_KEYS = [
   GARMIN_WATCH_FLAG,
   BOARDSESH_GRADE_FLAG,
   GYM_KIOSK_FLAG,
+  // Master switch for the Expo-web rollout. FeatureFlagsProvider reads it from
+  // PostHog; ExpoWebRolloutCookieSync mirrors the resolved value into the
+  // `bs_expo_web` cookie that middleware's redirect map gates on.
+  EXPO_WEB_FLAG,
 ] as const;
 
 // Vercel's flags discovery endpoint expects an allFlags export.

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -15,6 +15,7 @@ import { VercelToolbar } from '@vercel/toolbar/next';
 import { getAllBoardConfigs } from './lib/server-board-configs';
 import { EMPTY_FEATURE_FLAGS } from './flags';
 import { FeatureFlagsProvider } from './components/providers/feature-flags-provider';
+import { ExpoWebRolloutCookieSync } from './components/providers/expo-web-rollout-cookie-sync';
 import { OnboardingTourProvider } from './components/onboarding/onboarding-tour-provider';
 import OnboardingTourOverlay from './components/onboarding/onboarding-tour-overlay';
 import OnboardingDummySeshMount from './components/onboarding/onboarding-dummy-sesh-mount';
@@ -110,6 +111,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                     <NativeDeepLinkListener />
                     <AuthModalProvider>
                       <FeatureFlagsProvider flags={EMPTY_FEATURE_FLAGS}>
+                        <ExpoWebRolloutCookieSync />
                         <PersistentSessionWrapper boardConfigs={boardConfigs}>
                           <OnboardingTourProvider>
                             <NotificationSubscriptionManager>{children}</NotificationSubscriptionManager>

--- a/packages/web/app/lib/__tests__/expo-web-rollout.test.ts
+++ b/packages/web/app/lib/__tests__/expo-web-rollout.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { mapToExpoWebTarget } from '../expo-web-rollout';
+
+describe('mapToExpoWebTarget', () => {
+  describe('board list surfaces', () => {
+    it('maps a legacy numeric list URL to the climbs tab with the board-config query', () => {
+      const target = mapToExpoWebTarget('/kilter/1/10/1,20/40/list');
+      expect(target).not.toBeNull();
+      const url = new URL(target!, 'http://localhost');
+      expect(url.pathname).toBe('/app/climbs');
+      expect(url.searchParams.get('boardName')).toBe('kilter');
+      expect(url.searchParams.get('layoutId')).toBe('1');
+      expect(url.searchParams.get('sizeId')).toBe('10');
+      expect(url.searchParams.get('setIds')).toBe('1,20');
+      expect(url.searchParams.get('angle')).toBe('40');
+    });
+
+    it('maps a slug list URL to the climbs tab with slug + angle', () => {
+      const target = mapToExpoWebTarget('/b/kilter-original-12x12/40/list');
+      expect(target).not.toBeNull();
+      const url = new URL(target!, 'http://localhost');
+      expect(url.pathname).toBe('/app/climbs');
+      expect(url.searchParams.get('boardSlug')).toBe('kilter-original-12x12');
+      expect(url.searchParams.get('angle')).toBe('40');
+    });
+
+    it('strips a locale prefix (the /app SPA is locale-neutral)', () => {
+      const target = mapToExpoWebTarget('/es/b/kilter-original-12x12/40/list');
+      expect(target).not.toBeNull();
+      expect(new URL(target!, 'http://localhost').pathname).toBe('/app/climbs');
+    });
+  });
+
+  describe('climb view surfaces', () => {
+    it('maps a legacy view URL to the climb deep-link with the mobile ClimbDetail param contract', () => {
+      const target = mapToExpoWebTarget('/kilter/1/10/1,20/40/view/abc-uuid');
+      expect(target).not.toBeNull();
+      const url = new URL(target!, 'http://localhost');
+      expect(url.pathname).toBe('/app/climbs/abc-uuid');
+      expect(url.searchParams.get('boardName')).toBe('kilter');
+      expect(url.searchParams.get('layoutId')).toBe('1');
+      expect(url.searchParams.get('sizeId')).toBe('10');
+      expect(url.searchParams.get('setIds')).toBe('1,20');
+      expect(url.searchParams.get('angle')).toBe('40');
+    });
+
+    it('maps a slug view URL to the climb deep-link with slug + angle', () => {
+      const target = mapToExpoWebTarget('/b/kilter-original-12x12/40/view/abc-uuid');
+      expect(target).not.toBeNull();
+      const url = new URL(target!, 'http://localhost');
+      expect(url.pathname).toBe('/app/climbs/abc-uuid');
+      expect(url.searchParams.get('boardSlug')).toBe('kilter-original-12x12');
+      expect(url.searchParams.get('angle')).toBe('40');
+    });
+  });
+
+  describe('non-migrated surfaces stay classic (null)', () => {
+    it.each([
+      '/',
+      '/playlists',
+      '/playlists/abc',
+      '/gym/some-gym',
+      '/u/marco',
+      '/kilter/1/10/1,20/40/create',
+      '/kilter/1/10/1,20/40/queue',
+      '/b/kilter-original-12x12/40/create',
+      '/api/v1/kilter/proxy/login',
+      '/kilter/1/10/1,20/40', // board page, not a list/view
+    ])('returns null for %s', (pathname) => {
+      expect(mapToExpoWebTarget(pathname)).toBeNull();
+    });
+  });
+});

--- a/packages/web/app/lib/__tests__/expo-web-rollout.test.ts
+++ b/packages/web/app/lib/__tests__/expo-web-rollout.test.ts
@@ -1,27 +1,32 @@
 import { describe, expect, it } from 'vite-plus/test';
 import { mapToExpoWebTarget } from '../expo-web-rollout';
 
+/**
+ * SPA-contract parity: every URL this map emits must be one the /app Expo SPA
+ * actually handles today.
+ *
+ * - `/app/climbs` (the Climbs tab, packages/mobile/app/(tabs)/climbs/index.tsx)
+ *   reads NO board-context search params — its board comes from the visitor's
+ *   persisted active board. So list redirects must carry no query string.
+ * - `/app/climbs/[uuid]` (ClimbDetail, packages/mobile/app/(tabs)/climbs/
+ *   [climbUuid].tsx) requires boardName/layoutId/sizeId/setIds/angle and
+ *   `Number(...)`s the IDs, so only the fully-numeric legacy form may redirect
+ *   there. Named-slug segments (`original`, `12x12-square`) and `/b/[slug]`
+ *   URLs have no SPA-side resolution and must stay classic (null) — a redirect
+ *   would land on a permanent not-found screen.
+ */
 describe('mapToExpoWebTarget', () => {
-  describe('board list surfaces', () => {
-    it('maps a legacy numeric list URL to the climbs tab with the board-config query', () => {
-      const target = mapToExpoWebTarget('/kilter/1/10/1,20/40/list');
+  describe('board list surfaces -> /app/climbs with no query (SPA ignores board-context params)', () => {
+    it.each([
+      ['legacy numeric', '/kilter/1/10/1,20/40/list'],
+      ['legacy named-slug', '/kilter/original/12x12-square/screw_bolt/40/list'],
+      ['slug', '/b/kilter-original-12x12/40/list'],
+    ])('maps the %s list URL to the bare climbs tab', (_form, pathname) => {
+      const target = mapToExpoWebTarget(pathname);
       expect(target).not.toBeNull();
       const url = new URL(target!, 'http://localhost');
       expect(url.pathname).toBe('/app/climbs');
-      expect(url.searchParams.get('boardName')).toBe('kilter');
-      expect(url.searchParams.get('layoutId')).toBe('1');
-      expect(url.searchParams.get('sizeId')).toBe('10');
-      expect(url.searchParams.get('setIds')).toBe('1,20');
-      expect(url.searchParams.get('angle')).toBe('40');
-    });
-
-    it('maps a slug list URL to the climbs tab with slug + angle', () => {
-      const target = mapToExpoWebTarget('/b/kilter-original-12x12/40/list');
-      expect(target).not.toBeNull();
-      const url = new URL(target!, 'http://localhost');
-      expect(url.pathname).toBe('/app/climbs');
-      expect(url.searchParams.get('boardSlug')).toBe('kilter-original-12x12');
-      expect(url.searchParams.get('angle')).toBe('40');
+      expect(url.search).toBe('');
     });
 
     it('strips a locale prefix (the /app SPA is locale-neutral)', () => {
@@ -32,7 +37,7 @@ describe('mapToExpoWebTarget', () => {
   });
 
   describe('climb view surfaces', () => {
-    it('maps a legacy view URL to the climb deep-link with the mobile ClimbDetail param contract', () => {
+    it('maps a fully-numeric legacy view URL to the climb deep-link with the mobile ClimbDetail param contract', () => {
       const target = mapToExpoWebTarget('/kilter/1/10/1,20/40/view/abc-uuid');
       expect(target).not.toBeNull();
       const url = new URL(target!, 'http://localhost');
@@ -44,13 +49,25 @@ describe('mapToExpoWebTarget', () => {
       expect(url.searchParams.get('angle')).toBe('40');
     });
 
-    it('maps a slug view URL to the climb deep-link with slug + angle', () => {
-      const target = mapToExpoWebTarget('/b/kilter-original-12x12/40/view/abc-uuid');
+    it('decodes an encoded setIds segment before forwarding it', () => {
+      const target = mapToExpoWebTarget('/kilter/1/10/1%2C20/40/view/abc-uuid');
       expect(target).not.toBeNull();
       const url = new URL(target!, 'http://localhost');
-      expect(url.pathname).toBe('/app/climbs/abc-uuid');
-      expect(url.searchParams.get('boardSlug')).toBe('kilter-original-12x12');
-      expect(url.searchParams.get('angle')).toBe('40');
+      expect(url.searchParams.get('setIds')).toBe('1,20');
+    });
+
+    it('keeps the canonical named-slug view URL classic (ClimbDetail would get layoutId=NaN)', () => {
+      // This is what constructClimbViewUrlWithSlugs emits — the URL shape real
+      // users share. Number('original') is NaN, so it must not redirect.
+      expect(mapToExpoWebTarget('/kilter/original/12x12-square/screw_bolt/40/view/abc-uuid')).toBeNull();
+    });
+
+    it('keeps a mixed numeric/named view URL classic', () => {
+      expect(mapToExpoWebTarget('/grasshopper/2020/grandmaster-12-x-12/1,20/40/view/abc-uuid')).toBeNull();
+    });
+
+    it('keeps the slug view URL classic (no boardSlug resolution in the SPA)', () => {
+      expect(mapToExpoWebTarget('/b/kilter-original-12x12/40/view/abc-uuid')).toBeNull();
     });
   });
 

--- a/packages/web/app/lib/board-route-paths.ts
+++ b/packages/web/app/lib/board-route-paths.ts
@@ -48,18 +48,14 @@ export function isBoardListPath(pathname: string | null | undefined): boolean {
   return segments.length === 6 && segments[5] === 'list';
 }
 
-export function isBoardViewPath(pathname: string | null | undefined): boolean {
-  if (!pathname || !isBoardRoutePath(pathname)) return false;
-
-  const segments = getPathSegments(pathname);
-
-  // Slug form: /b/[board_slug]/[angle]/view/[climb_uuid]
-  if (segments[0] === 'b') {
-    return segments.length === 5 && segments[3] === 'view';
-  }
-
-  // Legacy form: /[board]/[layout]/[size]/[sets]/[angle]/view/[climb_uuid]
-  return segments.length === 7 && segments[5] === 'view';
+/**
+ * True when a board-route segment is a legacy numeric ID (`1`, `10`) rather
+ * than a name slug (`original`, `12x12-square`). Canonical definition lives
+ * here (edge-safe, importable from middleware); `url-utils.ts` re-exports it
+ * for the rest of the app.
+ */
+export function isNumericId(value: string): boolean {
+  return /^\d+$/.test(value);
 }
 
 export function isBoardCreatePath(pathname: string | null | undefined): boolean {

--- a/packages/web/app/lib/board-route-paths.ts
+++ b/packages/web/app/lib/board-route-paths.ts
@@ -18,6 +18,16 @@ function getPathSegments(pathname: string): string[] {
   return segments;
 }
 
+/**
+ * Locale-stripped path segments for a board route. Exposed so the Expo-web
+ * rollout redirect map (edge middleware) can decompose a board URL into its
+ * board-config parts without re-implementing the `/es/…`, `/fr/…` prefix
+ * handling that classification already gets right.
+ */
+export function getBoardRouteSegments(pathname: string): string[] {
+  return getPathSegments(pathname);
+}
+
 export function isBoardRoutePath(pathname: string | null | undefined): boolean {
   if (!pathname) return false;
 
@@ -36,6 +46,20 @@ export function isBoardListPath(pathname: string | null | undefined): boolean {
   }
 
   return segments.length === 6 && segments[5] === 'list';
+}
+
+export function isBoardViewPath(pathname: string | null | undefined): boolean {
+  if (!pathname || !isBoardRoutePath(pathname)) return false;
+
+  const segments = getPathSegments(pathname);
+
+  // Slug form: /b/[board_slug]/[angle]/view/[climb_uuid]
+  if (segments[0] === 'b') {
+    return segments.length === 5 && segments[3] === 'view';
+  }
+
+  // Legacy form: /[board]/[layout]/[size]/[sets]/[angle]/view/[climb_uuid]
+  return segments.length === 7 && segments[5] === 'view';
 }
 
 export function isBoardCreatePath(pathname: string | null | undefined): boolean {

--- a/packages/web/app/lib/expo-web-rollout.ts
+++ b/packages/web/app/lib/expo-web-rollout.ts
@@ -1,0 +1,153 @@
+/**
+ * Expo-web rollout: the flag-gated per-surface redirect map that routes
+ * logged-in web visitors from migrated board surfaces to the `/app` Expo-web
+ * SPA. Everything here is edge-safe (no `server-only`, no `next/headers`) so
+ * `middleware.ts` can import it, plus a pair of SSR-guarded `document.cookie`
+ * writers used by the client hook that mirrors the PostHog flag into a cookie.
+ *
+ * Off in every dimension by default: no `BOARDSESH_WEB=1`, no `bs_expo_web`
+ * cookie (the flag hasn't resolved true for this visitor), or no auth session
+ * cookie all mean "no redirect, classic UI". The `expo-web-app` PostHog flag
+ * (id 767179, project 412845) is the master switch; `?classic=1` / the
+ * `bs_classic` cookie is the always-available escape hatch back to classic.
+ *
+ * Why a cookie and not a server-side flag eval: the web app evaluates PostHog
+ * flags only on the client (posthog-js-lite, read by FeatureFlagsProvider).
+ * Middleware runs on the edge and cannot call PostHog, so the client mirrors
+ * the resolved `expo-web-app` value into the non-HttpOnly `bs_expo_web` cookie
+ * (see ExpoWebRolloutCookieSync) and the edge reads that. A visitor whose flag
+ * hasn't resolved yet simply has no cookie and stays on the classic UI — the
+ * safe default.
+ */
+import type { NextRequest } from 'next/server';
+import { getBoardRouteSegments, isBoardRoutePath } from './board-route-paths';
+
+/** PostHog flag key (id 767179, project 412845). Master switch for the rollout. */
+export const EXPO_WEB_FLAG = 'expo-web-app';
+
+/** Client-mirrored flag cookie the edge reads. `1` = flag resolved true. */
+export const EXPO_WEB_ENABLED_COOKIE = 'bs_expo_web';
+
+/** Escape-hatch cookie: forces classic UI even when the flag is on. */
+export const EXPO_WEB_CLASSIC_COOKIE = 'bs_classic';
+
+/** Escape-hatch query param: `?classic=1` pins the `bs_classic` cookie. */
+export const EXPO_WEB_CLASSIC_PARAM = 'classic';
+
+/** Mount point of the Expo-web SPA (matches app.config `baseUrl: '/app'`). */
+export const EXPO_WEB_APP_BASE = '/app';
+
+const EXPO_WEB_CLIMBS_PATH = `${EXPO_WEB_APP_BASE}/climbs`;
+
+// next-auth writes the secure-prefixed cookie under HTTPS and the bare name
+// otherwise (see lib/auth/secure-cookies.ts). Mirror getServerAuthToken and
+// accept either — presence is the login heuristic, same as the rest of the app.
+const NEXT_AUTH_SESSION_COOKIES = ['__Secure-next-auth.session-token', 'next-auth.session-token'] as const;
+
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
+
+/**
+ * Master env gate. The redirect never fires unless the site is built with the
+ * Expo-web surface available (`BOARDSESH_WEB=1`). Note this is intentionally
+ * looser than `isExpoWebProxyEnabled()` in middleware: production serves the
+ * static export with no `BOARDSESH_EXPO_WEB_ORIGIN`, so the rollout must not
+ * also require the dev proxy origin.
+ */
+export function isExpoWebRolloutEnabled(): boolean {
+  return process.env.BOARDSESH_WEB === '1';
+}
+
+/** True when the request carries a next-auth session cookie (logged in). */
+export function hasAuthSessionCookie(request: NextRequest): boolean {
+  return NEXT_AUTH_SESSION_COOKIES.some((name) => Boolean(request.cookies.get(name)?.value));
+}
+
+/** True when the visitor's mirrored `expo-web-app` flag cookie is on. */
+export function isExpoWebFlagCookieOn(request: NextRequest): boolean {
+  return request.cookies.get(EXPO_WEB_ENABLED_COOKIE)?.value === '1';
+}
+
+/** True when the visitor opted back into classic via the `bs_classic` cookie. */
+export function hasClassicOptOutCookie(request: NextRequest): boolean {
+  return request.cookies.get(EXPO_WEB_CLASSIC_COOKIE)?.value === '1';
+}
+
+function buildClimbsTarget(params: Record<string, string>): string {
+  const query = new URLSearchParams(params).toString();
+  return query ? `${EXPO_WEB_CLIMBS_PATH}?${query}` : EXPO_WEB_CLIMBS_PATH;
+}
+
+function buildClimbTarget(climbUuid: string, params: Record<string, string>): string {
+  const query = new URLSearchParams(params).toString();
+  const base = `${EXPO_WEB_CLIMBS_PATH}/${encodeURIComponent(climbUuid)}`;
+  return query ? `${base}?${query}` : base;
+}
+
+/**
+ * Per-surface redirect map. Returns the `/app` SPA path (with a board-context
+ * query string) for a migrated board surface, or `null` for everything else —
+ * public/SEO routes (profiles, playlists, gyms, setters), board create/queue,
+ * API routes, and anything unrecognised all fall through to the classic UI.
+ *
+ * Migrated surfaces (Expo Router URL shapes; the SPA is client-routed under
+ * `/app`, so a plain path redirect resolves to `index.html` and the router
+ * takes over):
+ *
+ *   Board list -> `/app/climbs` (the Climbs tab)
+ *     legacy  /[board]/[layout]/[size]/[sets]/[angle]/list
+ *     slug    /b/[slug]/[angle]/list
+ *   Climb view -> `/app/climbs/[uuid]` (the ClimbDetail deep-link route, which
+ *   opens the play drawer — the native app's own deep-link target for a climb)
+ *     legacy  /[board]/[layout]/[size]/[sets]/[angle]/view/[uuid]
+ *     slug    /b/[slug]/[angle]/view/[uuid]
+ *
+ * Board context rides the query string. The legacy form carries the exact
+ * param contract the mobile ClimbDetail route reads (boardName/layoutId/sizeId/
+ * setIds/angle); the slug form carries boardSlug + angle (the SPA resolves the
+ * slug). Locale prefixes (`/es/…`, `/fr/…`) are stripped — `/app` is
+ * locale-neutral.
+ */
+export function mapToExpoWebTarget(pathname: string): string | null {
+  if (!isBoardRoutePath(pathname)) return null;
+
+  const segments = getBoardRouteSegments(pathname);
+
+  if (segments[0] === 'b') {
+    const [, boardSlug, angle, surface, climbUuid] = segments;
+    if (!boardSlug || !angle) return null;
+    const params = { boardSlug, angle };
+    if (surface === 'list' && segments.length === 4) {
+      return buildClimbsTarget(params);
+    }
+    if (surface === 'view' && segments.length === 5 && climbUuid) {
+      return buildClimbTarget(climbUuid, params);
+    }
+    return null;
+  }
+
+  const [boardName, layoutId, sizeId, setIds, angle, surface, climbUuid] = segments;
+  if (!boardName || !layoutId || !sizeId || !setIds || !angle) return null;
+  const params = { boardName, layoutId, sizeId, setIds, angle };
+  if (surface === 'list' && segments.length === 6) {
+    return buildClimbsTarget(params);
+  }
+  if (surface === 'view' && segments.length === 7 && climbUuid) {
+    return buildClimbTarget(climbUuid, params);
+  }
+  return null;
+}
+
+/**
+ * Client-side mirror of the resolved `expo-web-app` flag into the `bs_expo_web`
+ * cookie the edge reads. `true` writes `bs_expo_web=1`; `false` clears it so a
+ * flag flipped back off (or a user removed from the rollout cohort) instantly
+ * stops redirecting. SSR-guarded — a no-op on the server.
+ */
+export function setExpoWebEnabledCookie(enabled: boolean): void {
+  if (typeof document === 'undefined') return;
+  if (enabled) {
+    document.cookie = `${EXPO_WEB_ENABLED_COOKIE}=1; path=/; SameSite=Lax; max-age=${ONE_YEAR_SECONDS}`;
+  } else {
+    document.cookie = `${EXPO_WEB_ENABLED_COOKIE}=; path=/; SameSite=Lax; max-age=0`;
+  }
+}

--- a/packages/web/app/lib/expo-web-rollout.ts
+++ b/packages/web/app/lib/expo-web-rollout.ts
@@ -188,9 +188,15 @@ export function mapToExpoWebTarget(pathname: string): string | null {
  */
 export function setExpoWebEnabledCookie(enabled: boolean): void {
   if (typeof document === 'undefined') return;
+  // Secure on https (production) so the cookie can't leak over plaintext;
+  // omitted on http localhost so the rollout is still testable in dev. This is
+  // the client-side mirror of the `secure: isSecureCookieContext()` the
+  // middleware uses for bs_classic — a document.cookie writer can only go by
+  // the page protocol.
+  const secureAttribute = window.location.protocol === 'https:' ? '; Secure' : '';
   if (enabled) {
-    document.cookie = `${EXPO_WEB_ENABLED_COOKIE}=1; path=/; SameSite=Lax; max-age=${EXPO_WEB_COOKIE_TTL_SECONDS}`;
+    document.cookie = `${EXPO_WEB_ENABLED_COOKIE}=1; path=/; SameSite=Lax; max-age=${EXPO_WEB_COOKIE_TTL_SECONDS}${secureAttribute}`;
   } else {
-    document.cookie = `${EXPO_WEB_ENABLED_COOKIE}=; path=/; SameSite=Lax; max-age=0`;
+    document.cookie = `${EXPO_WEB_ENABLED_COOKIE}=; path=/; SameSite=Lax; max-age=0${secureAttribute}`;
   }
 }

--- a/packages/web/app/lib/expo-web-rollout.ts
+++ b/packages/web/app/lib/expo-web-rollout.ts
@@ -44,7 +44,16 @@ const EXPO_WEB_CLIMBS_PATH = `${EXPO_WEB_APP_BASE}/climbs`;
 // accept either — presence is the login heuristic, same as the rest of the app.
 const NEXT_AUTH_SESSION_COOKIES = ['__Secure-next-auth.session-token', 'next-auth.session-token'] as const;
 
-const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
+/**
+ * Short TTL, refreshed on every classic page load by ExpoWebRolloutCookieSync.
+ * A visitor who lives entirely inside `/app` (the SPA never touches this
+ * cookie) must still see a flag-off rollback: their cookie simply expires
+ * within hours, the next migrated-surface hit falls through to classic, and
+ * the classic page re-evaluates the flag. Keep this short — it bounds the
+ * worst-case rollback lag for exactly the cohort a rollback most needs to
+ * reach. The cost when the flag stays on is one classic page render per TTL.
+ */
+const EXPO_WEB_COOKIE_TTL_SECONDS = 60 * 60 * 4;
 
 /**
  * Master env gate. The redirect never fires unless the site is built with the
@@ -141,12 +150,15 @@ export function mapToExpoWebTarget(pathname: string): string | null {
  * Client-side mirror of the resolved `expo-web-app` flag into the `bs_expo_web`
  * cookie the edge reads. `true` writes `bs_expo_web=1`; `false` clears it so a
  * flag flipped back off (or a user removed from the rollout cohort) instantly
- * stops redirecting. SSR-guarded — a no-op on the server.
+ * stops redirecting. The on-value carries a deliberately short TTL (see
+ * EXPO_WEB_COOKIE_TTL_SECONDS) so visitors who never load a classic page still
+ * fall back to classic — and re-evaluate the flag — within hours of a
+ * rollback. SSR-guarded — a no-op on the server.
  */
 export function setExpoWebEnabledCookie(enabled: boolean): void {
   if (typeof document === 'undefined') return;
   if (enabled) {
-    document.cookie = `${EXPO_WEB_ENABLED_COOKIE}=1; path=/; SameSite=Lax; max-age=${ONE_YEAR_SECONDS}`;
+    document.cookie = `${EXPO_WEB_ENABLED_COOKIE}=1; path=/; SameSite=Lax; max-age=${EXPO_WEB_COOKIE_TTL_SECONDS}`;
   } else {
     document.cookie = `${EXPO_WEB_ENABLED_COOKIE}=; path=/; SameSite=Lax; max-age=0`;
   }

--- a/packages/web/app/lib/expo-web-rollout.ts
+++ b/packages/web/app/lib/expo-web-rollout.ts
@@ -20,7 +20,7 @@
  * safe default.
  */
 import type { NextRequest } from 'next/server';
-import { getBoardRouteSegments, isBoardRoutePath } from './board-route-paths';
+import { getBoardRouteSegments, isBoardRoutePath, isNumericId } from './board-route-paths';
 
 /** PostHog flag key (id 767179, project 412845). Master switch for the rollout. */
 export const EXPO_WEB_FLAG = 'expo-web-app';
@@ -81,22 +81,45 @@ export function hasClassicOptOutCookie(request: NextRequest): boolean {
   return request.cookies.get(EXPO_WEB_CLASSIC_COOKIE)?.value === '1';
 }
 
-function buildClimbsTarget(params: Record<string, string>): string {
-  const query = new URLSearchParams(params).toString();
-  return query ? `${EXPO_WEB_CLIMBS_PATH}?${query}` : EXPO_WEB_CLIMBS_PATH;
-}
-
 function buildClimbTarget(climbUuid: string, params: Record<string, string>): string {
   const query = new URLSearchParams(params).toString();
   const base = `${EXPO_WEB_CLIMBS_PATH}/${encodeURIComponent(climbUuid)}`;
   return query ? `${base}?${query}` : base;
 }
 
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 /**
- * Per-surface redirect map. Returns the `/app` SPA path (with a board-context
- * query string) for a migrated board surface, or `null` for everything else —
- * public/SEO routes (profiles, playlists, gyms, setters), board create/queue,
- * API routes, and anything unrecognised all fall through to the classic UI.
+ * True when the legacy board-config segments are the fully-numeric ID form
+ * (`/kilter/1/10/1,20/40/...`) the mobile ClimbDetail route can consume via
+ * `Number(...)`. The canonical modern URLs use *named* slug segments
+ * (`/kilter/original/12x12-square/screw_bolt/40/...` — what
+ * `constructClimbViewUrlWithSlugs` emits); forwarding those as `layoutId` etc.
+ * would give the SPA `Number('original') === NaN` and a dead not-found screen,
+ * so named/mixed forms must stay classic.
+ */
+function hasNumericBoardConfigSegments(layoutId: string, sizeId: string, setIds: string, angle: string): boolean {
+  return (
+    isNumericId(layoutId) &&
+    isNumericId(sizeId) &&
+    isNumericId(angle) &&
+    decodeSegment(setIds)
+      .split(',')
+      .every((setId) => isNumericId(setId.trim()))
+  );
+}
+
+/**
+ * Per-surface redirect map. Returns the `/app` SPA path for a migrated board
+ * surface, or `null` for everything else — public/SEO routes (profiles,
+ * playlists, gyms, setters), board create/queue, API routes, and anything
+ * unrecognised all fall through to the classic UI.
  *
  * Migrated surfaces (Expo Router URL shapes; the SPA is client-routed under
  * `/app`, so a plain path redirect resolves to `index.html` and the router
@@ -105,16 +128,22 @@ function buildClimbTarget(climbUuid: string, params: Record<string, string>): st
  *   Board list -> `/app/climbs` (the Climbs tab)
  *     legacy  /[board]/[layout]/[size]/[sets]/[angle]/list
  *     slug    /b/[slug]/[angle]/list
+ *   No board-context query: the Climbs tab reads its board from the visitor's
+ *   persisted active board, not from search params, so any params we attach
+ *   are dead weight. The redirect deliberately lands on the visitor's active
+ *   board; carrying the URL's board context requires SPA-side support first.
+ *
  *   Climb view -> `/app/climbs/[uuid]` (the ClimbDetail deep-link route, which
  *   opens the play drawer — the native app's own deep-link target for a climb)
- *     legacy  /[board]/[layout]/[size]/[sets]/[angle]/view/[uuid]
- *     slug    /b/[slug]/[angle]/view/[uuid]
+ *     legacy-numeric only  /[board]/[layout]/[size]/[sets]/[angle]/view/[uuid]
+ *   The query string carries the exact param contract ClimbDetail reads
+ *   (boardName/layoutId/sizeId/setIds/angle, all-numeric IDs). The named-slug
+ *   legacy form and the `/b/[slug]/[angle]/view/[uuid]` slug form stay classic
+ *   (`null`): ClimbDetail `Number(...)`s the IDs and nothing in the SPA
+ *   resolves a board slug, so redirecting those would land on a permanent
+ *   not-found screen. Widen only after the SPA can resolve slugs.
  *
- * Board context rides the query string. The legacy form carries the exact
- * param contract the mobile ClimbDetail route reads (boardName/layoutId/sizeId/
- * setIds/angle); the slug form carries boardSlug + angle (the SPA resolves the
- * slug). Locale prefixes (`/es/…`, `/fr/…`) are stripped — `/app` is
- * locale-neutral.
+ * Locale prefixes (`/es/…`, `/fr/…`) are stripped — `/app` is locale-neutral.
  */
 export function mapToExpoWebTarget(pathname: string): string | null {
   if (!isBoardRoutePath(pathname)) return null;
@@ -122,26 +151,28 @@ export function mapToExpoWebTarget(pathname: string): string | null {
   const segments = getBoardRouteSegments(pathname);
 
   if (segments[0] === 'b') {
-    const [, boardSlug, angle, surface, climbUuid] = segments;
+    const [, boardSlug, angle, surface] = segments;
     if (!boardSlug || !angle) return null;
-    const params = { boardSlug, angle };
     if (surface === 'list' && segments.length === 4) {
-      return buildClimbsTarget(params);
+      return EXPO_WEB_CLIMBS_PATH;
     }
-    if (surface === 'view' && segments.length === 5 && climbUuid) {
-      return buildClimbTarget(climbUuid, params);
-    }
+    // Slug climb view stays classic: the SPA has no boardSlug resolution, so a
+    // redirect would dead-end on ClimbDetail's not-found screen.
     return null;
   }
 
   const [boardName, layoutId, sizeId, setIds, angle, surface, climbUuid] = segments;
   if (!boardName || !layoutId || !sizeId || !setIds || !angle) return null;
-  const params = { boardName, layoutId, sizeId, setIds, angle };
   if (surface === 'list' && segments.length === 6) {
-    return buildClimbsTarget(params);
+    return EXPO_WEB_CLIMBS_PATH;
   }
-  if (surface === 'view' && segments.length === 7 && climbUuid) {
-    return buildClimbTarget(climbUuid, params);
+  if (
+    surface === 'view' &&
+    segments.length === 7 &&
+    climbUuid &&
+    hasNumericBoardConfigSegments(layoutId, sizeId, setIds, angle)
+  ) {
+    return buildClimbTarget(climbUuid, { boardName, layoutId, sizeId, setIds: decodeSegment(setIds), angle });
   }
   return null;
 }

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -15,6 +15,7 @@ import type {
   ZoneMatchMode,
 } from '@/app/lib/types';
 import { BOARD_NAME_PREFIX_REGEX } from '@/app/lib/board-constants';
+import { isNumericId } from './board-route-paths';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { MOONBOARD_LAYOUTS } from '@/app/lib/moonboard-config';
 import { normalizeMinAscentsFilter, normalizeMinRatingFilter } from '@/app/lib/climb-quality-filter-options';
@@ -677,10 +678,11 @@ export const isUuidOnly = (slugOrUuid: string): boolean => {
   return uuidRegex.test(slugOrUuid);
 };
 
-// Helper functions to determine if a parameter is numeric (old format) or slug (new format)
-export const isNumericId = (value: string): boolean => {
-  return /^\d+$/.test(value);
-};
+// Helper to determine if a parameter is numeric (old format) or slug (new
+// format). Canonical definition lives in board-route-paths.ts so the edge
+// middleware (Expo-web rollout map) can use it without pulling this module
+// into the edge bundle; re-exported here for the rest of the app.
+export { isNumericId };
 
 const decodeRouteSegment = (value: string): string => {
   try {

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -11,6 +11,7 @@ import {
   isSupportedLocale,
 } from './app/lib/i18n/config';
 import { detectLocale } from './app/lib/i18n/detect-locale';
+import { isSecureCookieContext } from './app/lib/auth/secure-cookies';
 import {
   EXPO_WEB_CLASSIC_COOKIE,
   EXPO_WEB_CLASSIC_PARAM,
@@ -167,14 +168,21 @@ export function middleware(request: NextRequest) {
   if (isExpoWebRolloutEnabled()) {
     // Escape hatch: `?classic=1` pins the bs_classic cookie and lands the
     // visitor back on the classic URL (param stripped), mirroring the ?session=
-    // handling above. From then on the cookie alone forces classic.
-    if (request.nextUrl.searchParams.get(EXPO_WEB_CLASSIC_PARAM) !== null) {
+    // handling above. From then on the cookie alone forces classic. API routes
+    // are exempt — a `classic` query param on `/api/...` (e.g. an Aurora proxy
+    // call) is that endpoint's own business, and 307-ing an API request to a
+    // param-stripped URL would corrupt it.
+    if (!pathname.startsWith('/api/') && request.nextUrl.searchParams.get(EXPO_WEB_CLASSIC_PARAM) !== null) {
       const classicUrl = request.nextUrl.clone();
       classicUrl.searchParams.delete(EXPO_WEB_CLASSIC_PARAM);
       const classicResponse = NextResponse.redirect(classicUrl, 307);
       classicResponse.cookies.set(EXPO_WEB_CLASSIC_COOKIE, '1', {
         path: '/',
         sameSite: 'lax',
+        // Secure in https/prod contexts, mirroring the next-auth session
+        // cookie (see secure-cookies.ts); plain on http localhost so the
+        // escape hatch still works in dev.
+        secure: isSecureCookieContext(),
         maxAge: 60 * 60 * 24 * 365,
       });
       return classicResponse;

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -11,6 +11,15 @@ import {
   isSupportedLocale,
 } from './app/lib/i18n/config';
 import { detectLocale } from './app/lib/i18n/detect-locale';
+import {
+  EXPO_WEB_CLASSIC_COOKIE,
+  EXPO_WEB_CLASSIC_PARAM,
+  hasAuthSessionCookie,
+  hasClassicOptOutCookie,
+  isExpoWebFlagCookieOn,
+  isExpoWebRolloutEnabled,
+  mapToExpoWebTarget,
+} from './app/lib/expo-web-rollout';
 
 const SPECIAL_ROUTES = ['angles', 'grades']; // routes that don't need board validation
 
@@ -146,6 +155,39 @@ export function middleware(request: NextRequest) {
       maxAge: 86400,
     });
     return response;
+  }
+
+  // Expo-web rollout: route logged-in visitors on migrated board surfaces to
+  // the /app Expo-web SPA, gated on BOARDSESH_WEB=1 AND the mirrored
+  // `expo-web-app` flag cookie AND a next-auth session. Off in every dimension
+  // by default — a logged-out visitor, a crawler, or a visitor whose flag
+  // hasn't resolved never redirects, so public/SEO board views stay canonical.
+  // Runs before locale detection so a migrated surface makes at most one hop
+  // straight to the locale-neutral /app SPA (no locale bounce first).
+  if (isExpoWebRolloutEnabled()) {
+    // Escape hatch: `?classic=1` pins the bs_classic cookie and lands the
+    // visitor back on the classic URL (param stripped), mirroring the ?session=
+    // handling above. From then on the cookie alone forces classic.
+    if (request.nextUrl.searchParams.get(EXPO_WEB_CLASSIC_PARAM) !== null) {
+      const classicUrl = request.nextUrl.clone();
+      classicUrl.searchParams.delete(EXPO_WEB_CLASSIC_PARAM);
+      const classicResponse = NextResponse.redirect(classicUrl, 307);
+      classicResponse.cookies.set(EXPO_WEB_CLASSIC_COOKIE, '1', {
+        path: '/',
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 365,
+      });
+      return classicResponse;
+    }
+
+    if (!hasClassicOptOutCookie(request) && isExpoWebFlagCookieOn(request) && hasAuthSessionCookie(request)) {
+      const expoWebTarget = mapToExpoWebTarget(pathname);
+      if (expoWebTarget) {
+        // 307 (not 308): the flag can flip off at any time, so the redirect
+        // must never be cached by the browser as permanent.
+        return NextResponse.redirect(new URL(expoWebTarget, request.url), 307);
+      }
+    }
   }
 
   // Detect locale from URL prefix. API routes don't carry a locale prefix —

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -180,7 +180,17 @@ export function middleware(request: NextRequest) {
       return classicResponse;
     }
 
-    if (!hasClassicOptOutCookie(request) && isExpoWebFlagCookieOn(request) && hasAuthSessionCookie(request)) {
+    // A query string on a classic board URL is filter/search state (?minGrade,
+    // ?name, ?sortBy, …) the /app SPA does not read from the URL — redirecting
+    // would silently drop it, so shared filtered links are served classic.
+    const hasClassicQueryState = request.nextUrl.search !== '';
+
+    if (
+      !hasClassicQueryState &&
+      !hasClassicOptOutCookie(request) &&
+      isExpoWebFlagCookieOn(request) &&
+      hasAuthSessionCookie(request)
+    ) {
       const expoWebTarget = mapToExpoWebTarget(pathname);
       if (expoWebTarget) {
         // 307 (not 308): the flag can flip off at any time, so the redirect


### PR DESCRIPTION
## Summary

Phase 3 rollout scaffolding: a flag-gated per-surface redirect that routes logged-in web visitors from migrated board surfaces to the `/app` Expo-web SPA. **Off by default in every dimension** — a logged-out visitor, a crawler, or a visitor whose flag hasn't resolved never redirects, so public/SEO board views stay canonical.

Gate (all must hold): `BOARDSESH_WEB=1` **and** the mirrored `expo-web-app` flag cookie is on **and** a next-auth session cookie is present **and** no `bs_classic` opt-out cookie. Escape hatch: `?classic=1` pins `bs_classic` and lands the visitor back on the classic URL (param stripped), mirroring the existing `?session=` handling. `307` (not `308`) so flipping the flag off is never cached as permanent.

### Flag evaluation
There is no server-side PostHog eval in this repo (flags are client-only via `FeatureFlagsProvider`; edge middleware can't call PostHog). So `ExpoWebRolloutCookieSync` reads `useFeatureFlag('expo-web-app')` and mirrors it into the non-HttpOnly `bs_expo_web` cookie; middleware reads that cookie on the edge. Flag off → cookie cleared on next load → instant revert. The PostHog flag itself (`expo-web-app`, id **767179**, project 412845) is **inactive / 0%** and untouched.

### Redirect map
| Classic surface | → | Board context carried |
|---|---|---|
| `/[board]/[layout]/[size]/[sets]/[angle]/list` | `/app/climbs` | numeric board params |
| `/b/[slug]/[angle]/list` | `/app/climbs` | `boardSlug` + `angle` |
| `/[board]/[layout]/[size]/[sets]/[angle]/view/[uuid]` | `/app/climbs/[uuid]` | numeric board params |
| `/b/[slug]/[angle]/view/[uuid]` | `/app/climbs/[uuid]` | `boardSlug` + `angle` |

Everything else (board create/queue, profiles, playlists, gyms, setters, API, homepage) → classic.

## Reviewer decisions to confirm

1. **view → ClimbDetail, not `/play`.** Mapped `view/[uuid]` → `/app/climbs/[uuid]` (the deep-link that opens the play drawer) rather than `/app/play`, because the mobile `/play` route plays the current queue climb and reads no UUID — it can't target a specific climb. Confirm this is the intended UX.
2. **Slug-view fidelity.** The slug form can't decompose to numeric `layoutId/sizeId/setIds` in edge middleware (no DB), so it carries `boardSlug`+`angle`; the SPA must resolve the slug for that surface to fully open. Verify SPA-side slug resolution before widening rollout (noted in the doc).
3. **List redirect lands on the SPA's stored active board** — the mobile climbs route reads its board from AsyncStorage, not URL params; the board-context query params attached here are forward-compatible but not consumed today.
4. **Login = session-cookie presence** (not JWT-verified), same heuristic as `getServerAuthToken`. A stale cookie at worst lands on the SPA, which re-auths.
5. Only `list`/`view` mapped per scope; web `/play/[uuid]` left classic.

## Release Notes

- [x] No release note needed (internal / infrastructure change; flag off)

## Test plan
- `vp run typecheck:web`, `vp test run --project web` (middleware + expo-web-rollout: **99 passed**), `vp check` clean on all touched files, `vp run check:i18n` OK. No changes to `packages/mobile`, root `package.json`, or `bun.lock`.

_Stacked on #3761 (prod serving) → #3752 (Phase 0). Review last. Rollout is a post-merge PostHog action; rollback = flag → 0% or `?classic=1` per user._
