### PR TITLE
fix(mobile): clear Android 3-button nav bar in bottom sheets

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -195,6 +195,17 @@ Is it a secondary surface OVER the current screen, or its own full surface?
    in the tree shows it. Pick `ModalSheet` for on-demand surfaces (the common case); `Sheet` when
    the sheet's lifetime is bound to parent state.
 
+5. **Sheet content must clear the bottom safe area itself — the native `@expo/ui` sheet does
+   not.** The sheet draws under the system bottom inset on **both** platforms — the Android
+   edge-to-edge nav bar (~48dp 3-button bar / gesture pill) _and_ the iOS home indicator (~34pt) —
+   so a control at the bottom of a sheet needs `insets.bottom` added to its padding, or it sits
+   under the bar (Kilter/Tension users on Android 3-button nav hit this on the board sheet). The
+   shared `Sheet`/`ModalSheet` wrappers add it to their pinned `footer` and, for a **footerless**
+   body, automatically via `withSheetBottomInset` (composed on top of your `contentContainerStyle`).
+   A sheet built on the raw native primitive (its own `BottomSheetModal` + `BottomSheetFlatList`,
+   e.g. the board sheet / queue list) owns this itself: add `insets.bottom + spacing[N]`. Apply on
+   both platforms — `insets.bottom` is 0 when there's nothing to clear, so there's no double-inset.
+
 ## A latency footgun (any route)
 
 A modal route's present animation can't START until React commits the route's first frame. If

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -23,7 +23,7 @@ import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
-import { withSheetBottomInset } from './sheet-content-inset';
+import { useSheetBodyContentStyle } from './sheet-content-inset';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useManagedSheet, type PresenterGroup } from '../providers/sheet-presentation-provider';
 
@@ -122,10 +122,7 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
   // clear the Android edge-to-edge navigation bar itself — the native sheet does
   // not pad content for it. With a footer the body scrolls above the footer, which
   // already carries `insets.bottom`.
-  const bodyContentContainerStyle = useMemo(
-    () => (footer ? contentContainerStyle : withSheetBottomInset(contentContainerStyle, insets.bottom)),
-    [footer, contentContainerStyle, insets.bottom],
-  );
+  const bodyContentContainerStyle = useSheetBodyContentStyle(Boolean(footer), contentContainerStyle, insets.bottom);
   const body = scrollable ? (
     <BottomSheetScrollView
       style={bodyStyle}

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -23,6 +23,7 @@ import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
+import { withSheetBottomInset } from './sheet-content-inset';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useManagedSheet, type PresenterGroup } from '../providers/sheet-presentation-provider';
 
@@ -117,10 +118,18 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
   // sheet sizes to its content and anything past the detent is clipped and
   // unreachable instead of scrolling.
   const bodyStyle = footer ? styles.content : columnStyle;
+  // Without a pinned footer the body sits against the bottom edge, so it has to
+  // clear the Android edge-to-edge navigation bar itself — the native sheet does
+  // not pad content for it. With a footer the body scrolls above the footer, which
+  // already carries `insets.bottom`.
+  const bodyContentContainerStyle = useMemo(
+    () => (footer ? contentContainerStyle : withSheetBottomInset(contentContainerStyle, insets.bottom)),
+    [footer, contentContainerStyle, insets.bottom],
+  );
   const body = scrollable ? (
     <BottomSheetScrollView
       style={bodyStyle}
-      contentContainerStyle={contentContainerStyle}
+      contentContainerStyle={bodyContentContainerStyle}
       showsVerticalScrollIndicator={false}
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
@@ -130,7 +139,7 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
   ) : enableDynamicSizing && !footer && Platform.OS === 'web' ? (
     <BottomSheetView style={[bodyStyle, contentContainerStyle]}>{children}</BottomSheetView>
   ) : (
-    <View style={[bodyStyle, contentContainerStyle]}>{children}</View>
+    <View style={[bodyStyle, bodyContentContainerStyle]}>{children}</View>
   );
 
   const footerBar = footer ? (

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -137,7 +137,7 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
       {children}
     </BottomSheetScrollView>
   ) : enableDynamicSizing && !footer && Platform.OS === 'web' ? (
-    <BottomSheetView style={[bodyStyle, contentContainerStyle]}>{children}</BottomSheetView>
+    <BottomSheetView style={[bodyStyle, bodyContentContainerStyle]}>{children}</BottomSheetView>
   ) : (
     <View style={[bodyStyle, bodyContentContainerStyle]}>{children}</View>
   );

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -19,7 +19,7 @@ import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
-import { withSheetBottomInset } from './sheet-content-inset';
+import { useSheetBodyContentStyle } from './sheet-content-inset';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useManagedSheet, type PresenterGroup } from '../providers/sheet-presentation-provider';
 
@@ -122,10 +122,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   // clear the Android edge-to-edge navigation bar itself — the native sheet does
   // not pad content for it. With a footer the body scrolls above the footer, which
   // already carries `insets.bottom`.
-  const bodyContentContainerStyle = useMemo(
-    () => (footer ? contentContainerStyle : withSheetBottomInset(contentContainerStyle, insets.bottom)),
-    [footer, contentContainerStyle, insets.bottom],
-  );
+  const bodyContentContainerStyle = useSheetBodyContentStyle(Boolean(footer), contentContainerStyle, insets.bottom);
   const body = scrollable ? (
     <BottomSheetScrollView
       style={bodyStyle}

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -19,6 +19,7 @@ import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
+import { withSheetBottomInset } from './sheet-content-inset';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useManagedSheet, type PresenterGroup } from '../providers/sheet-presentation-provider';
 
@@ -117,10 +118,18 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   // sheet sizes to its content and anything past the detent is clipped and
   // unreachable instead of scrolling.
   const bodyStyle = footer ? styles.content : columnStyle;
+  // Without a pinned footer the body sits against the bottom edge, so it has to
+  // clear the Android edge-to-edge navigation bar itself — the native sheet does
+  // not pad content for it. With a footer the body scrolls above the footer, which
+  // already carries `insets.bottom`.
+  const bodyContentContainerStyle = useMemo(
+    () => (footer ? contentContainerStyle : withSheetBottomInset(contentContainerStyle, insets.bottom)),
+    [footer, contentContainerStyle, insets.bottom],
+  );
   const body = scrollable ? (
     <BottomSheetScrollView
       style={bodyStyle}
-      contentContainerStyle={contentContainerStyle}
+      contentContainerStyle={bodyContentContainerStyle}
       showsVerticalScrollIndicator={false}
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
@@ -130,7 +139,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   ) : enableDynamicSizing && !footer && Platform.OS === 'web' ? (
     <BottomSheetView style={[bodyStyle, contentContainerStyle]}>{children}</BottomSheetView>
   ) : (
-    <View style={[bodyStyle, contentContainerStyle]}>{children}</View>
+    <View style={[bodyStyle, bodyContentContainerStyle]}>{children}</View>
   );
 
   const footerBar = footer ? (

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -137,7 +137,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
       {children}
     </BottomSheetScrollView>
   ) : enableDynamicSizing && !footer && Platform.OS === 'web' ? (
-    <BottomSheetView style={[bodyStyle, contentContainerStyle]}>{children}</BottomSheetView>
+    <BottomSheetView style={[bodyStyle, bodyContentContainerStyle]}>{children}</BottomSheetView>
   ) : (
     <View style={[bodyStyle, bodyContentContainerStyle]}>{children}</View>
   );

--- a/packages/mobile/src/components/__tests__/modal-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/modal-sheet.test.tsx
@@ -36,7 +36,24 @@ vi.mock('react-native', () => ({
   View: ({ children }: ViewMockProps) => createElement('div', null, children),
   KeyboardAvoidingView: ({ children }: ViewMockProps) => createElement('div', null, children),
   useWindowDimensions: () => ({ width: 390, height: 844 }),
-  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    hairlineWidth: 1,
+    // Faithful flatten (arrays merge left-to-right, falsy entries skipped) — the
+    // footerless body composes its bottom inset through withSheetBottomInset.
+    flatten: function flatten(style: unknown): Record<string, unknown> | undefined {
+      if (style == null || style === false) return undefined;
+      if (Array.isArray(style)) {
+        const out: Record<string, unknown> = {};
+        for (const entry of style) {
+          const flat = flatten(entry);
+          if (flat) Object.assign(out, flat);
+        }
+        return out;
+      }
+      return style as Record<string, unknown>;
+    },
+  },
 }));
 
 vi.mock('react-native-safe-area-context', () => ({

--- a/packages/mobile/src/components/__tests__/sheet-content-inset.test.ts
+++ b/packages/mobile/src/components/__tests__/sheet-content-inset.test.ts
@@ -49,4 +49,14 @@ describe('withSheetBottomInset', () => {
     const original = { paddingBottom: 12 };
     expect(withSheetBottomInset(original, 0)).toBe(original);
   });
+
+  it('leaves a non-numeric bottom padding untouched instead of replacing it with the bare inset', () => {
+    // A percentage bottom can't compose arithmetically; respect the consumer's
+    // explicit choice rather than silently swapping it for `insetBottom`.
+    const percentage = { paddingBottom: '5%' as unknown as number };
+    expect(withSheetBottomInset(percentage, 48)).toBe(percentage);
+    // Same for a non-numeric paddingVertical falling through the precedence chain.
+    const vertical = { paddingVertical: '5%' as unknown as number };
+    expect(withSheetBottomInset(vertical, 48)).toBe(vertical);
+  });
 });

--- a/packages/mobile/src/components/__tests__/sheet-content-inset.test.ts
+++ b/packages/mobile/src/components/__tests__/sheet-content-inset.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// The mobile vitest setup has no global react-native transform (the real package
+// is Flow-typed), so unit tests mock it per-file. A faithful StyleSheet.flatten
+// (arrays merge left-to-right; falsy entries skipped) is all this helper needs.
+type Style = Record<string, unknown> | undefined | false | null | Style[];
+function flatten(style: Style): Record<string, unknown> | undefined {
+  if (style == null || style === false) return undefined;
+  if (Array.isArray(style)) {
+    const out: Record<string, unknown> = {};
+    for (const entry of style) {
+      const flat = flatten(entry);
+      if (flat) Object.assign(out, flat);
+    }
+    return out;
+  }
+  return style;
+}
+vi.mock('react-native', () => ({ StyleSheet: { flatten } }));
+
+import { withSheetBottomInset } from '../sheet-content-inset';
+
+function effectiveBottom(style: ReturnType<typeof withSheetBottomInset>): number | undefined {
+  return flatten(style as Style)?.paddingBottom as number | undefined;
+}
+
+describe('withSheetBottomInset', () => {
+  it('adds the inset to a consumer paddingBottom rather than replacing it', () => {
+    expect(effectiveBottom(withSheetBottomInset({ paddingBottom: 24 }, 48))).toBe(72);
+  });
+
+  it('uses the inset alone when the consumer sets no bottom padding', () => {
+    const result = withSheetBottomInset({ paddingHorizontal: 16 }, 48);
+    expect(effectiveBottom(result)).toBe(48);
+    // Other consumer padding is preserved.
+    expect(flatten(result as Style)?.paddingHorizontal).toBe(16);
+  });
+
+  it('applies the inset when the consumer passes no style at all', () => {
+    expect(effectiveBottom(withSheetBottomInset(undefined, 34))).toBe(34);
+  });
+
+  it('falls back to paddingVertical, then the padding shorthand, for the existing bottom', () => {
+    expect(effectiveBottom(withSheetBottomInset({ paddingVertical: 10 }, 48))).toBe(58);
+    expect(effectiveBottom(withSheetBottomInset({ padding: 8 }, 48))).toBe(56);
+  });
+
+  it('returns the original style untouched when there is no bottom inset', () => {
+    const original = { paddingBottom: 12 };
+    expect(withSheetBottomInset(original, 0)).toBe(original);
+  });
+});

--- a/packages/mobile/src/components/__tests__/sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet.test.tsx
@@ -14,6 +14,7 @@ const captures = vi.hoisted(() => ({
   scrollUsed: false,
   bottomSheetViewUsed: false,
   scrollStyle: undefined as unknown,
+  scrollContentStyle: undefined as unknown,
   kavBehavior: undefined as string | undefined,
 }));
 const platform = vi.hoisted(() => ({ os: 'ios' }));
@@ -32,9 +33,14 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
     captures.snapPoints = snapPoints;
     return createElement('div', { 'data-sheet': 'true', ref }, children);
   }),
-  BottomSheetScrollView: ({ children, style }: ViewMockProps & { style?: unknown }) => {
+  BottomSheetScrollView: ({
+    children,
+    style,
+    contentContainerStyle,
+  }: ViewMockProps & { style?: unknown; contentContainerStyle?: unknown }) => {
     captures.scrollUsed = true;
     captures.scrollStyle = style;
+    captures.scrollContentStyle = contentContainerStyle;
     return createElement('div', { 'data-scroll': 'true' }, children);
   },
   BottomSheetView: ({ children }: ViewMockProps) => {
@@ -59,7 +65,24 @@ vi.mock('react-native', () => ({
   },
   // Consumed by useSheetColumnStyle to bound the sheet column to the detent on iOS.
   useWindowDimensions: () => ({ width: 390, height: 844 }),
-  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    hairlineWidth: 1,
+    // Faithful flatten (arrays merge left-to-right, falsy entries skipped) — the
+    // footerless body composes its bottom inset through withSheetBottomInset.
+    flatten: function flatten(style: unknown): Record<string, unknown> | undefined {
+      if (style == null || style === false) return undefined;
+      if (Array.isArray(style)) {
+        const out: Record<string, unknown> = {};
+        for (const entry of style) {
+          const flat = flatten(entry);
+          if (flat) Object.assign(out, flat);
+        }
+        return out;
+      }
+      return style as Record<string, unknown>;
+    },
+  },
 }));
 
 vi.mock('react-native-safe-area-context', () => ({
@@ -110,6 +133,7 @@ beforeEach(() => {
   captures.scrollUsed = false;
   captures.bottomSheetViewUsed = false;
   captures.scrollStyle = undefined;
+  captures.scrollContentStyle = undefined;
   captures.kavBehavior = undefined;
   platform.os = 'ios';
   hapticMedium.mockClear();
@@ -213,6 +237,24 @@ describe('Sheet', () => {
       </Sheet>,
     );
     expect(captures.scrollStyle).toEqual({ height: 390 });
+  });
+
+  it('pads a footerless body for the bottom safe-area inset (Android nav bar clearance)', () => {
+    // No footer means the body sits against the bottom edge, so it must clear the
+    // system nav bar itself — the native sheet does not pad content for it. Inset
+    // is 34 in this file's safe-area mock.
+    render(
+      <Sheet scrollable contentContainerStyle={{ paddingBottom: 8 }}>
+        <div>body</div>
+      </Sheet>,
+    );
+    const flat = (
+      Array.isArray(captures.scrollContentStyle)
+        ? Object.assign({}, ...(captures.scrollContentStyle as unknown[]).filter(Boolean))
+        : (captures.scrollContentStyle ?? {})
+    ) as { paddingBottom?: number };
+    // Consumer's 8 is preserved and the 34 inset is added on top.
+    expect(flat.paddingBottom).toBe(42);
   });
 
   it('fires a haptic and onChange only when the sheet opens (index >= 0)', () => {

--- a/packages/mobile/src/components/__tests__/sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet.test.tsx
@@ -15,9 +15,18 @@ const captures = vi.hoisted(() => ({
   bottomSheetViewUsed: false,
   scrollStyle: undefined as unknown,
   scrollContentStyle: undefined as unknown,
+  viewStyle: undefined as unknown,
   kavBehavior: undefined as string | undefined,
 }));
 const platform = vi.hoisted(() => ({ os: 'ios' }));
+
+// Faithful recursive flatten (nested arrays merge left-to-right) so the tests read
+// the effective style the way React Native would, not just a one-level Object.assign.
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) return Object.assign({}, ...style.map(flattenStyle));
+  if (style && typeof style === 'object') return style as Record<string, unknown>;
+  return {};
+}
 
 type SheetMockProps = {
   children?: ReactNode;
@@ -58,7 +67,10 @@ vi.mock('react-native', () => ({
     Version: '26.1',
     select: (options: { ios?: unknown; android?: unknown }) => options.ios,
   },
-  View: ({ children }: ViewMockProps) => createElement('div', null, children),
+  View: ({ children, style }: ViewMockProps & { style?: unknown }) => {
+    captures.viewStyle = style;
+    return createElement('div', null, children);
+  },
   KeyboardAvoidingView: ({ children, behavior }: ViewMockProps & { behavior?: string }) => {
     captures.kavBehavior = behavior;
     return createElement('div', { 'data-kav': 'true' }, children);
@@ -134,6 +146,7 @@ beforeEach(() => {
   captures.bottomSheetViewUsed = false;
   captures.scrollStyle = undefined;
   captures.scrollContentStyle = undefined;
+  captures.viewStyle = undefined;
   captures.kavBehavior = undefined;
   platform.os = 'ios';
   hapticMedium.mockClear();
@@ -239,7 +252,7 @@ describe('Sheet', () => {
     expect(captures.scrollStyle).toEqual({ height: 390 });
   });
 
-  it('pads a footerless body for the bottom safe-area inset (Android nav bar clearance)', () => {
+  it('pads a footerless scrollable body for the bottom safe-area inset (Android nav bar clearance)', () => {
     // No footer means the body sits against the bottom edge, so it must clear the
     // system nav bar itself — the native sheet does not pad content for it. Inset
     // is 34 in this file's safe-area mock.
@@ -248,13 +261,19 @@ describe('Sheet', () => {
         <div>body</div>
       </Sheet>,
     );
-    const flat = (
-      Array.isArray(captures.scrollContentStyle)
-        ? Object.assign({}, ...(captures.scrollContentStyle as unknown[]).filter(Boolean))
-        : (captures.scrollContentStyle ?? {})
-    ) as { paddingBottom?: number };
     // Consumer's 8 is preserved and the 34 inset is added on top.
-    expect(flat.paddingBottom).toBe(42);
+    expect(flattenStyle(captures.scrollContentStyle).paddingBottom).toBe(42);
+  });
+
+  it('pads a footerless non-scrollable body for the bottom safe-area inset', () => {
+    // The non-scrollable branch renders the body in a plain View that also gets the
+    // composed contentContainerStyle, so it must clear the nav bar the same way.
+    render(
+      <Sheet contentContainerStyle={{ paddingBottom: 8 }}>
+        <div>body</div>
+      </Sheet>,
+    );
+    expect(flattenStyle(captures.viewStyle).paddingBottom).toBe(42);
   });
 
   it('fires a haptic and onChange only when the sheet opens (index >= 0)', () => {

--- a/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
+++ b/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
@@ -700,11 +700,14 @@ function NowOnTheWallPanelComponent(
 
   const listContentContainerStyle = useMemo(() => ({ paddingBottom: spacing[4] }), []);
 
-  // Sheet mode sits inside the native sheet chrome (which owns the bottom safe
-  // area), so the footer only needs its own spacing. The inline column and the
-  // full-screen tab render with no chrome, so they own both safe-area insets.
+  // In sheet mode the native drag handle supplies the top spacing, so the header
+  // needs none; the inline column and full-screen tab render with no chrome and
+  // own the top inset themselves. The footer, however, always adds the bottom
+  // safe-area inset on both platforms — the native sheet does NOT pad content for
+  // the Android edge-to-edge navigation bar, so without it the switch-board button
+  // sits under the 3-button nav bar. Matches the shared Sheet/ModalSheet footers.
   const headerTopPadding = variant === 'sheet' ? 0 : insets.top + spacing[2];
-  const footerBottomPadding = variant === 'sheet' ? spacing[3] : insets.bottom + spacing[3];
+  const footerBottomPadding = insets.bottom + spacing[3];
 
   const refreshControl = (
     <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={systemColors.secondaryLabel} />

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -53,6 +53,9 @@ const managedSheet = vi.hoisted(() => ({
 }));
 const climbRows = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
 const thumbnails = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
+// Mutable safe-area inset so a test can simulate an Android 3-button nav bar
+// (a non-zero bottom inset) and assert it reaches the switch-board footer.
+const safeArea = vi.hoisted(() => ({ bottom: 0 }));
 
 type ViewMockProps = { children?: ReactNode; style?: unknown };
 type ClimbListRowMockProps = {
@@ -84,8 +87,19 @@ vi.mock('react-native', () => ({
     children,
     onPress,
     accessibilityLabel,
-  }: ViewMockProps & { onPress?: () => void; accessibilityLabel?: string }) =>
-    createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+    style,
+  }: ViewMockProps & { onPress?: () => void; accessibilityLabel?: string }) => {
+    // Surface the flattened paddingBottom so tests can assert the safe-area inset
+    // reaches bottom-anchored controls (the switch-board footer).
+    const flat = Array.isArray(style)
+      ? Object.assign({}, ...style.filter(Boolean))
+      : ((style as Record<string, unknown>) ?? {});
+    return createElement(
+      'button',
+      { onClick: onPress, 'aria-label': accessibilityLabel, 'data-padding-bottom': flat.paddingBottom },
+      children,
+    );
+  },
   // Surface onRefresh as a clickable element so the pull-to-refresh wiring is testable.
   RefreshControl: ({ onRefresh }: { onRefresh?: () => void }) =>
     createElement('button', { onClick: onRefresh, 'aria-label': 'refresh' }),
@@ -166,7 +180,7 @@ vi.mock('../../../providers/sheet-presentation-provider', () => ({
 }));
 
 vi.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  useSafeAreaInsets: () => ({ top: 0, bottom: safeArea.bottom, left: 0, right: 0 }),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -378,6 +392,7 @@ describe('BoardSheet', () => {
     managedSheet.lastOnFullyDismissed = null;
     climbRows.props = [];
     thumbnails.props = [];
+    safeArea.bottom = 0;
   });
 
   it('presents and dismisses via the imperative ref', () => {
@@ -1222,6 +1237,29 @@ describe('BoardSheet', () => {
     expect(container.textContent).toContain('mobile.boardPresence.switchBoard');
     fireEvent.click(getByLabelText('mobile.boardPresence.switchBoardAria'));
     expect(onSwitchBoard).toHaveBeenCalledTimes(1);
+  });
+
+  it('pads the switch-board footer for the bottom safe-area inset (Android 3-button nav bar)', () => {
+    // Simulate a device whose system nav bar reserves a bottom inset — the native
+    // sheet does not pad content for it, so the footer must add it itself or the
+    // switch-board button sits under the nav bar (the reported bug).
+    safeArea.bottom = 34;
+    const ref = createRef<BoardSheetHandle>();
+    const { getByLabelText } = render(
+      createElement(BoardSheet, {
+        ref,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+      }),
+    );
+    act(() => ref.current?.present());
+
+    // insets.bottom (34) + spacing[3] (12) — the inset is included, not dropped.
+    const footer = getByLabelText('mobile.boardPresence.switchBoardAria');
+    expect(footer.getAttribute('data-padding-bottom')).toBe(String(34 + 12));
   });
 
   it('fires onClose from the header chevron', () => {

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -90,10 +90,15 @@ vi.mock('react-native', () => ({
     style,
   }: ViewMockProps & { onPress?: () => void; accessibilityLabel?: string }) => {
     // Surface the flattened paddingBottom so tests can assert the safe-area inset
-    // reaches bottom-anchored controls (the switch-board footer).
-    const flat = Array.isArray(style)
-      ? Object.assign({}, ...style.filter(Boolean))
-      : ((style as Record<string, unknown>) ?? {});
+    // reaches bottom-anchored controls (the switch-board footer). Recursive so a
+    // nested style array (e.g. withSheetBottomInset output) flattens correctly.
+    const flattenStyle = (input: unknown): Record<string, unknown> =>
+      Array.isArray(input)
+        ? Object.assign({}, ...input.map(flattenStyle))
+        : input && typeof input === 'object'
+          ? (input as Record<string, unknown>)
+          : {};
+    const flat = flattenStyle(style);
     return createElement(
       'button',
       { onClick: onPress, 'aria-label': accessibilityLabel, 'data-padding-bottom': flat.paddingBottom },

--- a/packages/mobile/src/components/board-presence/__tests__/now-on-the-wall-panel.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/now-on-the-wall-panel.test.tsx
@@ -317,11 +317,15 @@ describe('NowOnTheWallPanel', () => {
     presence.refresh.mockClear();
   });
 
-  it('does not double-count the bottom safe area when rendered inside the sheet', () => {
+  it('adds the bottom safe-area inset to the switch-board footer in both sheet and inline variants', () => {
+    // The native sheet does not pad its content for the Android edge-to-edge
+    // navigation bar, so the footer adds insets.bottom (34) + spacing[3] (12)
+    // itself in every variant — otherwise the switch-board button sits under the
+    // 3-button nav bar (the reported bug).
     safeArea.insets = { top: 0, bottom: 34, left: 0, right: 0 };
     const { getByLabelText, rerender } = render(panelElement({ variant: 'sheet' }));
 
-    expect(getByLabelText('mobile.boardPresence.switchBoardAria').getAttribute('data-padding-bottom')).toBe('12');
+    expect(getByLabelText('mobile.boardPresence.switchBoardAria').getAttribute('data-padding-bottom')).toBe('46');
 
     rerender(panelElement({ variant: 'column' }));
 

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { View, Pressable, StyleSheet, type FlatList } from 'react-native';
 import { BottomSheetFlatList } from '@expo/ui/community/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { Climb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import { getPlaylistSuggestedClimbs, createPlaylistSuggestionSource, getQueueBoardKey } from '@boardsesh/queue';
@@ -84,7 +85,15 @@ function QueueListComponent({
 }: QueueListProps) {
   const { t } = useTranslation('session');
   const { systemColors, brandColors } = useTheme();
+  const insets = useSafeAreaInsets();
   const flatListRef = useRef<FlatList<QueueListRow> | null>(null);
+
+  // Clear the queue toolbar (spacing[10]) AND the Android edge-to-edge navigation
+  // bar, so the last row never sits under the 3-button nav bar when fully scrolled.
+  const listContentContainerStyle = useMemo(
+    () => [styles.listContent, { paddingBottom: spacing[10] + insets.bottom }],
+    [insets.bottom],
+  );
 
   const { flatRows, currentItemFlatIndex } = useMemo(
     () =>
@@ -360,7 +369,7 @@ function QueueListComponent({
       data={rows}
       keyExtractor={keyExtractor}
       renderItem={renderRow}
-      contentContainerStyle={styles.listContent}
+      contentContainerStyle={listContentContainerStyle}
       showsVerticalScrollIndicator={false}
       scrollEnabled={!isDragging}
       onScrollToIndexFailed={() => {

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import type { Climb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import { getPlaylistSuggestedClimbs, createPlaylistSuggestionSource, getQueueBoardKey } from '@boardsesh/queue';
 import { buildQueueListModel, type QueueFlatRow } from '@boardsesh/play-view';
+import { withSheetBottomInset } from '../sheet-content-inset';
 import { QueueItemRow, type QueueItemRowBoard, POSITION_SLOT_WIDTH, SEPARATOR_INSET } from '../QueueItemRow';
 import { ClimbListItemContent } from '../ClimbListItemContent';
 import { Text } from '../Text';
@@ -88,10 +89,12 @@ function QueueListComponent({
   const insets = useSafeAreaInsets();
   const flatListRef = useRef<FlatList<QueueListRow> | null>(null);
 
-  // Clear the queue toolbar (spacing[10]) AND the Android edge-to-edge navigation
-  // bar, so the last row never sits under the 3-button nav bar when fully scrolled.
+  // Clear the queue toolbar (styles.listContent's spacing[10]) AND the Android
+  // edge-to-edge navigation bar, so the last row never sits under the 3-button nav
+  // bar when fully scrolled. withSheetBottomInset adds insets.bottom on top of the
+  // toolbar padding (and returns the base unchanged when there's no inset).
   const listContentContainerStyle = useMemo(
-    () => [styles.listContent, { paddingBottom: spacing[10] + insets.bottom }],
+    () => withSheetBottomInset(styles.listContent, insets.bottom),
     [insets.bottom],
   );
 

--- a/packages/mobile/src/components/playlist/PlaylistQueueReplaceSheet.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistQueueReplaceSheet.tsx
@@ -1,5 +1,4 @@
 import { StyleSheet, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { ModalSheet } from '../ModalSheet';
 import { Text } from '../Text';
@@ -30,11 +29,12 @@ export function PlaylistQueueReplaceSheet({
 }: PlaylistQueueReplaceSheetProps) {
   const { t } = useTranslation('playlists');
   const { systemColors } = useTheme();
-  const insets = useSafeAreaInsets();
 
   return (
     <ModalSheet visible={visible} enableDynamicSizing enablePanDownToClose={!isReplacing} onClose={onCancel}>
-      <View style={[styles.content, { paddingBottom: insets.bottom + spacing[3] }]}>
+      {/* The footerless ModalSheet wrapper composes insets.bottom onto the body
+          (withSheetBottomInset), so this content only adds its own spacing. */}
+      <View style={styles.content}>
         <Icon name="queue" size={40} color={systemColors.secondaryLabel} />
 
         <Text variant="title2" style={styles.title}>
@@ -71,6 +71,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: spacing[6],
     paddingTop: spacing[4],
+    paddingBottom: spacing[3],
     gap: spacing[3],
   },
   title: {

--- a/packages/mobile/src/components/playlist/__tests__/playlist-queue-replace-sheet.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-queue-replace-sheet.test.tsx
@@ -121,11 +121,14 @@ describe('PlaylistQueueReplaceSheet', () => {
     expect(button(container, 'detail.queueReplace.confirm')).not.toBeNull();
   });
 
-  it('sizes to content and pads past the safe-area bottom inset', () => {
+  it('sizes to content and adds its own bottom spacing (the footerless ModalSheet wrapper composes the safe-area inset on top)', () => {
     const { container } = render(<PlaylistQueueReplaceSheet {...makeProps()} />);
     expect(container.querySelector('[data-sheet]')?.getAttribute('data-dynamic')).toBe('true');
-    // insets.bottom (34) + spacing[3] (12)
-    expect(container.querySelector('[data-pb="46"]')).not.toBeNull();
+    // The content only carries spacing[3] (12); the footerless ModalSheet wrapper
+    // adds insets.bottom via withSheetBottomInset, so the content must NOT re-add it
+    // (doing so double-padded the sheet — see withSheetBottomInset + modal-sheet tests).
+    expect(container.querySelector('[data-pb="12"]')).not.toBeNull();
+    expect(container.querySelector('[data-pb="46"]')).toBeNull();
   });
 
   it('fires cancel and confirm callbacks from the buttons', () => {

--- a/packages/mobile/src/components/sheet-content-inset.ts
+++ b/packages/mobile/src/components/sheet-content-inset.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 
 /**
@@ -17,6 +18,11 @@ import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
  * `Platform.OS === 'android'` guard would reintroduce the home-indicator overlap on
  * iOS gesture-nav phones.
  *
+ * Numeric-only contract: only numeric bottom padding composes arithmetically. If
+ * the consumer's effective bottom padding is non-numeric (e.g. a `'5%'` string),
+ * the style is returned untouched — that explicit choice is respected rather than
+ * silently overwritten with the bare inset.
+ *
  * Used by the footerless branch of the shared `Sheet` / `ModalSheet` wrappers. With
  * a pinned footer the body scrolls above a footer that already carries the inset, so
  * this is not applied there.
@@ -27,14 +33,33 @@ export function withSheetBottomInset(
 ): StyleProp<ViewStyle> {
   if (insetBottom <= 0) return contentContainerStyle;
   const flattened = StyleSheet.flatten(contentContainerStyle) as ViewStyle | undefined;
-  const numeric = (candidate: unknown): number => (typeof candidate === 'number' ? candidate : 0);
-  // Respect the consumer's existing bottom padding (paddingBottom wins over
-  // paddingVertical over the padding shorthand) and add the inset to it.
-  const existingBottom =
-    flattened?.paddingBottom !== undefined
-      ? numeric(flattened.paddingBottom)
-      : flattened?.paddingVertical !== undefined
-        ? numeric(flattened.paddingVertical)
-        : numeric(flattened?.padding);
-  return [contentContainerStyle, { paddingBottom: existingBottom + insetBottom }];
+  // The consumer's effective bottom padding: paddingBottom wins over
+  // paddingVertical over the padding shorthand.
+  const existingBottom = flattened?.paddingBottom ?? flattened?.paddingVertical ?? flattened?.padding;
+  // Only numbers add arithmetically; leave a non-numeric value (e.g. '5%') as the
+  // consumer set it rather than replacing it with the bare inset.
+  if (existingBottom !== undefined && typeof existingBottom !== 'number') {
+    return contentContainerStyle;
+  }
+  return [contentContainerStyle, { paddingBottom: (existingBottom ?? 0) + insetBottom }];
+}
+
+/**
+ * Footerless body `contentContainerStyle` for the shared `Sheet` / `ModalSheet`
+ * wrappers: with a pinned footer the body scrolls above a footer that already
+ * carries the inset, so nothing is added; without one the body sits against the
+ * bottom edge and must clear the safe area itself (via `withSheetBottomInset`).
+ *
+ * Keyed on `hasFooter` (a boolean), not the footer node, so an inline footer's
+ * per-render identity can't defeat the memo.
+ */
+export function useSheetBodyContentStyle(
+  hasFooter: boolean,
+  contentContainerStyle: StyleProp<ViewStyle>,
+  insetBottom: number,
+): StyleProp<ViewStyle> {
+  return useMemo(
+    () => (hasFooter ? contentContainerStyle : withSheetBottomInset(contentContainerStyle, insetBottom)),
+    [hasFooter, contentContainerStyle, insetBottom],
+  );
 }

--- a/packages/mobile/src/components/sheet-content-inset.ts
+++ b/packages/mobile/src/components/sheet-content-inset.ts
@@ -1,0 +1,31 @@
+import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+
+/**
+ * Compose a sheet body's `contentContainerStyle` so it clears the bottom
+ * safe-area inset — the Android edge-to-edge navigation bar (a ~48dp 3-button bar
+ * or the gesture pill) — ON TOP of whatever bottom padding the consumer already
+ * asked for, rather than replacing it.
+ *
+ * Used by the footerless branch of the shared `Sheet` / `ModalSheet` wrappers: the
+ * native `@expo/ui` sheet does not pad its content for the system nav bar, so a
+ * control at the bottom of a footerless sheet would otherwise sit under it. With a
+ * pinned footer the body scrolls above a footer that already carries the inset, so
+ * this is not applied there.
+ */
+export function withSheetBottomInset(
+  contentContainerStyle: StyleProp<ViewStyle>,
+  insetBottom: number,
+): StyleProp<ViewStyle> {
+  if (insetBottom <= 0) return contentContainerStyle;
+  const flattened = StyleSheet.flatten(contentContainerStyle) as ViewStyle | undefined;
+  const numeric = (candidate: unknown): number => (typeof candidate === 'number' ? candidate : 0);
+  // Respect the consumer's existing bottom padding (paddingBottom wins over
+  // paddingVertical over the padding shorthand) and add the inset to it.
+  const existingBottom =
+    flattened?.paddingBottom !== undefined
+      ? numeric(flattened.paddingBottom)
+      : flattened?.paddingVertical !== undefined
+        ? numeric(flattened.paddingVertical)
+        : numeric(flattened?.padding);
+  return [contentContainerStyle, { paddingBottom: existingBottom + insetBottom }];
+}

--- a/packages/mobile/src/components/sheet-content-inset.ts
+++ b/packages/mobile/src/components/sheet-content-inset.ts
@@ -2,14 +2,23 @@ import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 
 /**
  * Compose a sheet body's `contentContainerStyle` so it clears the bottom
- * safe-area inset — the Android edge-to-edge navigation bar (a ~48dp 3-button bar
- * or the gesture pill) — ON TOP of whatever bottom padding the consumer already
- * asked for, rather than replacing it.
+ * safe-area inset ON TOP of whatever bottom padding the consumer already asked
+ * for, rather than replacing it.
  *
- * Used by the footerless branch of the shared `Sheet` / `ModalSheet` wrappers: the
- * native `@expo/ui` sheet does not pad its content for the system nav bar, so a
- * control at the bottom of a footerless sheet would otherwise sit under it. With a
- * pinned footer the body scrolls above a footer that already carries the inset, so
+ * The native `@expo/ui` sheet does NOT clear the bottom safe area on EITHER
+ * platform — neither the Android edge-to-edge navigation bar (~48dp 3-button bar /
+ * gesture pill) nor the iOS home indicator (~34pt) — so a control at the bottom of
+ * a footerless sheet sits under it unless the content adds `insets.bottom` itself.
+ * Applying it on both platforms is correct and does NOT double-inset: `insets.bottom`
+ * is 0 when there's nothing to clear, and this matches the app's established sheet
+ * convention — the shared `Sheet`/`ModalSheet` footers and bespoke sheets like
+ * `EndSessionSheet` / `InviteSheet` already add `insets.bottom` unconditionally
+ * (see the "~34pt on gesture-nav phones" note in `EndSessionSheet`). A
+ * `Platform.OS === 'android'` guard would reintroduce the home-indicator overlap on
+ * iOS gesture-nav phones.
+ *
+ * Used by the footerless branch of the shared `Sheet` / `ModalSheet` wrappers. With
+ * a pinned footer the body scrolls above a footer that already carries the inset, so
  * this is not applied there.
  */
 export function withSheetBottomInset(


### PR DESCRIPTION
## Summary

On Android, the app runs mandatory edge-to-edge, so the system navigation bar draws *over* app content. On phones using the 3-button navigation bar (back/home/recents), that bar covers anything at the bottom of a sheet. Since the app moved to Expo's native `@expo/ui/community/bottom-sheet` (#3167), which has no `bottomInset` prop, each sheet has to add the bottom safe-area inset itself — and a handful of surfaces padded with a fixed value (or skipped the inset entirely), so their bottom controls sat under the nav bar and couldn't be tapped.

The reported case is the board-presence sheet's **"Switch board"** button; the same pattern recurred elsewhere. This brings the outliers in line with the app's existing convention (`insets.bottom + spacing[N]`, both platforms).

- **Board sheet footer** (`NowOnTheWallPanel.tsx`) — the "Switch board" footer no longer drops `insets.bottom` in sheet mode; it always adds it, matching the shared `Sheet`/`ModalSheet` footers. This is the reported bug.
- **Shared wrappers** (`Sheet.tsx`, `ModalSheet.tsx`) — a footerless sheet body now composes the bottom inset on top of the consumer's `contentContainerStyle` (new `withSheetBottomInset` helper). This fixes the whole class of footerless sheets (Feedback, Claim Gym, Session Edit, Climb Actions, Add to Playlist, and friends) at once and stops new sheets from regressing.
- **Queue list** (`QueueList.tsx`) — the list content padding now adds the nav-bar inset so the last row clears it when fully scrolled.

## Release Notes

- Buttons at the bottom of the board sheet and other panels no longer hide behind Android's on-screen navigation bar.

## Test plan

- `vp run typecheck:mobile` — passes.
- `vp run test:mobile` — 4023 tests pass. Added a unit test for `withSheetBottomInset` (additive composition), a `Sheet` test asserting a footerless body gets the inset, and a `board-sheet` test asserting the "Switch board" footer includes a non-zero bottom inset. Updated the `NowOnTheWallPanel` test that previously encoded the old (buggy) behavior.
- `vp run check:mobile-bundle` — Metro bundle builds for iOS and Android.
- `vp check` — clean for the changed files.
- Not yet exercised on a physical 3-button-nav device / emulator; recommend a visual pass (board sheet → "Switch board" above the nav bar; queue sheet scrolled to the last row; a footerless sheet such as Feedback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnKjXLbcv7xwgMjgd7ivsw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnKjXLbcv7xwgMjgd7ivsw)_