### PR TITLE
fix(asc): don't abort TestFlight feedback sync on a missing crash log

### DIFF
--- a/scripts/__tests__/testflight-feedback-to-issues.test.ts
+++ b/scripts/__tests__/testflight-feedback-to-issues.test.ts
@@ -1,6 +1,7 @@
 import { createVerify, generateKeyPairSync } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  AppStoreConnectClient,
   buildIssueDraft,
   chunkText,
   createAppStoreConnectJwt,
@@ -214,5 +215,67 @@ describe('syncTestFlightFeedback', () => {
     expect(result).toEqual({ created: 0, dryRun: 1, skippedExisting: 0 });
     expect(issueExists).not.toHaveBeenCalled();
     expect(createIssue).not.toHaveBeenCalled();
+  });
+});
+
+describe('AppStoreConnectClient.listCrashFeedback', () => {
+  const crashListResponse = {
+    data: [
+      {
+        attributes: { comment: 'Crashes on launch', createdDate: '2026-06-11T00:00:00Z', deviceModel: 'iPhone 15' },
+        id: 'crash-404',
+        relationships: { build: { data: { id: 'build-1', type: 'builds' } } },
+        type: 'betaFeedbackCrashSubmissions',
+      },
+    ],
+    included: [{ attributes: { uploadedDate: '2026-06-10T10:00:00Z', version: '42' }, id: 'build-1', type: 'builds' }],
+  };
+  const listOptions = { maxPages: 1, pageLimit: 100, since: new Date('2026-06-10T00:00:00Z') };
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), { status, statusText: status === 200 ? 'OK' : 'Error' });
+  }
+
+  it('treats a 404 crash log as unavailable and keeps the submission', async () => {
+    const warn = vi.fn();
+    const fetcher = vi.fn(async (input: string | URL) => {
+      if (new URL(input).pathname.endsWith('/crashLog')) {
+        return jsonResponse({ errors: [{ code: 'NOT_FOUND', status: '404' }] }, 404);
+      }
+      return jsonResponse(crashListResponse);
+    });
+
+    const client = new AppStoreConnectClient({
+      apiBase: 'https://api.appstoreconnect.example',
+      fetcher,
+      logger: { error: vi.fn(), log: vi.fn(), warn },
+      token: 'test-token',
+    });
+
+    const feedback = await client.listCrashFeedback('app-1', listOptions);
+
+    expect(feedback).toHaveLength(1);
+    expect(feedback[0].id).toBe('crash-404');
+    expect(feedback[0].crashLog).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('crash-404');
+  });
+
+  it('still throws when the crash log fetch fails with a non-404 status', async () => {
+    const fetcher = vi.fn(async (input: string | URL) => {
+      if (new URL(input).pathname.endsWith('/crashLog')) {
+        return jsonResponse({ errors: [{ status: '500' }] }, 500);
+      }
+      return jsonResponse(crashListResponse);
+    });
+
+    const client = new AppStoreConnectClient({
+      apiBase: 'https://api.appstoreconnect.example',
+      fetcher,
+      logger: { error: vi.fn(), log: vi.fn(), warn: vi.fn() },
+      token: 'test-token',
+    });
+
+    await expect(client.listCrashFeedback('app-1', listOptions)).rejects.toThrow(/500/);
   });
 });

--- a/scripts/testflight-feedback-to-issues.ts
+++ b/scripts/testflight-feedback-to-issues.ts
@@ -286,15 +286,17 @@ async function readJsonResponse<T>(response: Response, context: string): Promise
   return JSON.parse(bodyText) as T;
 }
 
-class AppStoreConnectClient implements FeedbackSource {
+export class AppStoreConnectClient implements FeedbackSource {
   private readonly fetcher: Fetcher;
   private readonly token: string;
   private readonly apiBase: string;
+  private readonly logger: Logger;
 
-  constructor(args: { fetcher?: Fetcher; token: string; apiBase?: string }) {
+  constructor(args: { fetcher?: Fetcher; token: string; apiBase?: string; logger?: Logger }) {
     this.fetcher = args.fetcher ?? fetch;
     this.token = args.token;
     this.apiBase = args.apiBase ?? APP_STORE_CONNECT_API_BASE;
+    this.logger = args.logger ?? console;
   }
 
   async resolveAppId(bundleId: string): Promise<string> {
@@ -341,8 +343,18 @@ class AppStoreConnectClient implements FeedbackSource {
   private async readCrashLog(submissionId: string): Promise<string | null> {
     const url = this.apiUrl(`/v1/betaFeedbackCrashSubmissions/${submissionId}/crashLog`);
     url.searchParams.set('fields[betaCrashLogs]', 'logText');
-    const response = await this.fetchJson<JsonApiSingleResponse<BetaCrashLogResource>>(url);
-    return response.data.attributes?.logText ?? null;
+    const response = await this.fetchRaw(url);
+    // App Store Connect sometimes drops the crash log for a submission (404 NOT_FOUND on the
+    // crashLog sub-resource). Treat a missing log as unavailable so one gap does not abort the
+    // whole sync; genuine failures (auth, outages, other statuses) still throw via readJsonResponse.
+    if (response.status === 404) {
+      this.logger.warn(
+        `[testflight-feedback] Crash log unavailable for submission ${submissionId} (App Store Connect returned 404); continuing without it`,
+      );
+      return null;
+    }
+    const parsed = await readJsonResponse<JsonApiSingleResponse<BetaCrashLogResource>>(response, url.pathname);
+    return parsed.data.attributes?.logText ?? null;
   }
 
   private async listFeedbackResources<TResource extends { id: string; attributes?: { createdDate?: string } }>(args: {
@@ -390,13 +402,17 @@ class AppStoreConnectClient implements FeedbackSource {
     return new URL(path, this.apiBase);
   }
 
-  private async fetchJson<T>(url: URL): Promise<T> {
-    const response = await this.fetcher(url, {
+  private async fetchRaw(url: URL): Promise<Response> {
+    return this.fetcher(url, {
       headers: {
         Accept: 'application/json',
         Authorization: `Bearer ${this.token}`,
       },
     });
+  }
+
+  private async fetchJson<T>(url: URL): Promise<T> {
+    const response = await this.fetchRaw(url);
     return readJsonResponse<T>(response, url.pathname);
   }
 }
@@ -981,7 +997,7 @@ async function runCli(argv: string[], env: NodeJS.ProcessEnv, logger: Logger): P
     const githubToken = cliOptions.dryRun ? null : getRequiredEnv('GITHUB_TOKEN', env);
     const since = cliOptions.since ?? new Date(Date.now() - cliOptions.lookbackHours * 60 * 60 * 1000);
 
-    const feedbackSource = new AppStoreConnectClient({ token });
+    const feedbackSource = new AppStoreConnectClient({ logger, token });
     const issueSink = githubToken
       ? new GitHubIssueClient({ repositoryFullName: cliOptions.githubRepository, token: githubToken })
       : dryRunIssueSink();


### PR DESCRIPTION
## Summary

The scheduled "TestFlight Feedback Issues" workflow (`scripts/testflight-feedback-to-issues.ts`) has been failing on every run. When it fetches a crash submission's crash log from App Store Connect (`/v1/betaFeedbackCrashSubmissions/<id>/crashLog`), the API sometimes returns `404 NOT_FOUND` ("There is no resource of type 'betaCrashLogs' with id '…'"). `readCrashLog` ran that response through `readJsonResponse`, which threw, and `runCli` exited 1 — so a single missing crash log aborted the entire sync (observed on run 29707884291 and repeatedly since).

This makes a 404 on the crash-log sub-resource non-fatal: log a warning, treat the crash log as unavailable (`crashLog = null`, which the issue body already handles via "_No crash log returned by App Store Connect._"), and keep processing the rest of the feedback. Non-404 failures still throw, so genuine problems (auth failures, API outages, other error statuses) remain fatal and fail the job.

Changes:
- Split `fetchRaw` out of `fetchJson` and have `readCrashLog` inspect `response.status`, mirroring the existing 404 handling in `GitHubIssueClient.ensureLabel`.
- Add an optional `logger` to `AppStoreConnectClient` (defaults to `console`) for the warning; wire the CLI logger through.
- Export `AppStoreConnectClient` and add tests for the 404-continue and non-404-throw paths.

## Release Notes

- [x] No release note needed (internal / technical change)

`none` — internal CI/tooling fix, nothing user-facing.

## Test plan

- `vp test run --reporter=agent scripts/__tests__/testflight-feedback-to-issues.test.ts` — 9 passed (7 existing + 2 new: 404 keeps the submission with `crashLog` null and logs one warning; non-404 still throws).
- `vp check` — no new errors or warnings from the changed files. (The 2 pre-existing `TS2307: Cannot find module '@gorhom/bottom-sheet'` errors in `packages/mobile/src/web-shims/bottom-sheet.tsx` are present on clean `main` in a fresh worktree, unrelated to this change, and resolve in CI where the nested `web-runtime` install is populated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YhZoDyMf6971aonNhjpYd