### PR TITLE
fix(deps): bump happy-dom to ^20.8.9 in shared react test packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -441,7 +441,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19",
         "@vitest/coverage-v8": "^4.1.5",
-        "happy-dom": "^15",
+        "happy-dom": "^20.8.9",
         "react": "^19",
         "typescript": "^5.9.3",
       },
@@ -482,7 +482,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19",
         "@vitest/coverage-v8": "^4.1.5",
-        "happy-dom": "^15",
+        "happy-dom": "^20.8.9",
         "react": "^19",
         "typescript": "^5.9.3",
       },
@@ -609,7 +609,7 @@
       "devDependencies": {
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19",
-        "happy-dom": "^15",
+        "happy-dom": "^20.8.9",
         "react": "^19",
         "react-dom": "^19",
         "typescript": "~6.0.3",
@@ -639,7 +639,7 @@
         "@tanstack/react-query": "^5",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19",
-        "happy-dom": "^15",
+        "happy-dom": "^20.8.9",
         "react": "^19",
         "typescript": "~6.0.3",
       },
@@ -2317,6 +2317,8 @@
 
     "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
@@ -2570,6 +2572,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
@@ -2857,7 +2861,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.22.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -3135,7 +3139,7 @@
 
     "graphql-yoga": ["graphql-yoga@5.21.0", "", { "dependencies": { "@envelop/core": "^5.5.1", "@envelop/instrumentation": "^1.0.0", "@graphql-tools/executor": "^1.5.0", "@graphql-tools/schema": "^10.0.11", "@graphql-tools/utils": "^10.11.0", "@graphql-yoga/logger": "^2.0.1", "@graphql-yoga/subscription": "^5.0.5", "@whatwg-node/fetch": "^0.10.6", "@whatwg-node/promise-helpers": "^1.3.2", "@whatwg-node/server": "^0.10.14", "lru-cache": "^10.0.0", "tslib": "^2.8.1" }, "peerDependencies": { "graphql": "^15.2.0 || ^16.0.0" } }, "sha512-PS37UoDihx8209RRl1ogttzWevNYDnGvP7beHkwHzUpUdfZTHsVRTVe1ysGXre1EjwUAePbpez302YSrq70Ngw=="],
 
-    "happy-dom": ["happy-dom@15.11.7", "", { "dependencies": { "entities": "^4.5.0", "webidl-conversions": "^7.0.0", "whatwg-mimetype": "^3.0.0" } }, "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg=="],
+    "happy-dom": ["happy-dom@20.11.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XogN4asPd1a56di9prVG6bZxteNcXsZxxKmAvcEfc5Px5Ca2hMyMgk8wvqK2K1V8zXg40j9VANXsDaJYh9DeNA=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -4895,6 +4899,8 @@
 
     "cssstyle/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "dot-case/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "drizzle-kit/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
@@ -4948,8 +4954,6 @@
     "graphql-tag/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "graphql-yoga/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "happy-dom/webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
     "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 

--- a/packages/shared/board-react/package.json
+++ b/packages/shared/board-react/package.json
@@ -24,7 +24,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19",
     "@vitest/coverage-v8": "^4.1.5",
-    "happy-dom": "^15",
+    "happy-dom": "^20.8.9",
     "react": "^19",
     "typescript": "^5.9.3"
   },

--- a/packages/shared/create-climb-react/package.json
+++ b/packages/shared/create-climb-react/package.json
@@ -22,7 +22,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19",
     "@vitest/coverage-v8": "^4.1.5",
-    "happy-dom": "^15",
+    "happy-dom": "^20.8.9",
     "react": "^19",
     "typescript": "^5.9.3"
   },

--- a/packages/shared/playback-react/package.json
+++ b/packages/shared/playback-react/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19",
-    "happy-dom": "^15",
+    "happy-dom": "^20.8.9",
     "react": "^19",
     "react-dom": "^19",
     "typescript": "~6.0.3"

--- a/packages/shared/playlists-react/package.json
+++ b/packages/shared/playlists-react/package.json
@@ -27,7 +27,7 @@
     "@tanstack/react-query": "^5",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19",
-    "happy-dom": "^15",
+    "happy-dom": "^20.8.9",
     "react": "^19",
     "typescript": "~6.0.3"
   },


### PR DESCRIPTION
## Summary

Bumps the `happy-dom` devDependency (the vitest DOM environment) from `^15` to `^20.8.9` across the four shared React packages that use it, resolving 8 open Dependabot alerts:

- 4x **CRITICAL** — VM Context Escape can lead to Remote Code Execution (`happy-dom < 20.0.0`, GHSA-37j7-fg3j-429f)
- 4x **HIGH** — `fetch` credentials include uses page-origin cookies (`happy-dom < 20.8.9`)

Affected packages: `board-react`, `create-climb-react`, `playback-react`, `playlists-react`. Each declares `environment: 'happy-dom'` in its `vite.config.ts`, so happy-dom is the actual test runtime here. The lockfile now resolves `happy-dom@20.11.0`.

**Breaking-change assessment:** happy-dom v20's only breaking change is that `<script>` JavaScript evaluation is now disabled by default (that change *is* the VM-escape fix). It does not affect vitest usage — vitest executes test code in Node and only consumes happy-dom's DOM globals; none of these suites rely on happy-dom evaluating `<script>` tags. All 144 tests across the four packages pass unchanged.

## Release Notes

none

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --reporter=agent packages/shared/{board-react,create-climb-react,playback-react,playlists-react}` — 14 files / 144 tests passed
  - board-react: 7 files / 62 tests
  - create-climb-react: 2 files / 46 tests
  - playback-react: 1 file / 13 tests
  - playlists-react: 4 files / 23 tests
- `vp run typecheck:shared` — pass
- `vp check` — 2 errors, both pre-existing (`@gorhom/bottom-sheet` TS2307 from the un-populated `packages/mobile/web-runtime` nested install in fresh worktrees); this diff adds none
