### PR TITLE
fix(deps): patch board-controller Python deps for Dependabot alerts

### DIFF
--- a/packages/web/board-controller/requirements.txt
+++ b/packages/web/board-controller/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]==0.32.1
 
 # WebSocket support
 websockets==13.1
-python-multipart==0.0.27
+python-multipart==0.0.31
 
 # Database
 aiosqlite==0.20.0
@@ -22,7 +22,7 @@ pydantic==2.10.3
 aiofiles==24.1.0
 
 # Environment variables
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 
 # Bluetooth dependencies (already installed for controller.py)
 # adafruit-circuitpython-neopixel-spi
@@ -33,4 +33,4 @@ python-dotenv==1.0.1
 uuid==1.30
 
 # SSL certificate generation (for development)
-cryptography==46.0.7
+cryptography==48.0.1


### PR DESCRIPTION
## What & why

Bumps the three vulnerable pinned dependencies in `packages/web/board-controller/requirements.txt` to the patched releases Dependabot flagged. `board-controller` is a small standalone Python FastAPI WebSocket server (shipped as its own Docker image) that gives Kilter/Tension boards persistent queue state and collaborative control.

| Package | From | To | Alert |
| --- | --- | --- | --- |
| cryptography | 46.0.7 | 48.0.1 | HIGH — vulnerable OpenSSL bundled in wheels |
| python-multipart | 0.0.27 | 0.0.31 | HIGH quadratic-time form parsing + 3 LOW (0.0.31 covers all) |
| python-dotenv | 1.0.1 | 1.2.2 | MEDIUM — symlink following in `set_key` |

### Compatibility

All three are API-compatible with the controller code:

- **cryptography** is used only for self-signed dev-cert generation (`generate_cert.py`, `main.py`) via long-stable `x509` / `rsa` / `serialization` / `hashes` APIs. Verified the full cert-gen path runs clean on 48.0.1.
- **python-multipart** is a FastAPI form-parsing transitive; this server never uses `Form`/`UploadFile`, so the bump is security-only with no code impact.
- **python-dotenv** isn't imported anywhere (env is read via `os.getenv`), so the `set_key` symlink CVE isn't even reachable; bump is defensive.

Smoke-installed and import-tested (plus the cert-gen path) against Python 3.13.

### Not included: excon (fastlane/Gemfile.lock)

Left out on purpose. Two blockers: (1) no Ruby/bundler toolchain in this environment, and per repo policy `Gemfile.lock` must not be hand-edited; (2) `fastlane 2.236.1` constrains `excon (>= 0.71.0, < 1.0.0)`, so the alert's target `excon 1.5.0` can't be reached without also upgrading fastlane. Needs a bundler-equipped environment and likely a fastlane bump — tracked separately.

## Release Notes

none