### PR TITLE
feat(backend): dual-publish gzip board snapshots (v1 + v1-gzip)

### DIFF
--- a/.github/workflows/export-board-snapshots.yml
+++ b/.github/workflows/export-board-snapshots.yml
@@ -1,15 +1,37 @@
 name: Export Board Snapshots
 
 # Nightly: build a per-(board, layout) SQLite snapshot of board_climbs +
-# board_climb_stats and upload it to Tigris/S3 under board-snapshots/v1/.
-# A freshly downloaded board on mobile warms from these artifacts instead of
-# paging the whole catalog over GraphQL, then resumes an incremental pull from
-# the watermarks the manifest records. Idempotent — each run mints new
-# content-addressed artifacts and rewrites the manifest last.
+# board_climb_stats and upload it to Tigris/S3. A freshly downloaded board on
+# mobile warms from these artifacts instead of paging the whole catalog over
+# GraphQL, then resumes an incremental pull from the watermarks the manifest
+# records. Idempotent — each run mints new content-addressed artifacts and
+# rewrites the manifest last.
+#
+# The run publishes the catalog under TWO prefixes side by side during the gzip
+# transition (see docs/board-snapshots.md):
+#   - board-snapshots/v1       identity-encoded — what the current fleet reads. Unchanged.
+#   - board-snapshots/v1-gzip  gzip-encoded (~2.6x smaller) — what newer builds read once
+#                              transparent Content-Encoding decode is validated on-device.
+# Each prefix is a self-contained, single-encoding manifest; the export merges
+# and prunes strictly within the prefix it targets. The follow-up that cuts the
+# whole fleet to gzip drops the identity pass and deletes the v1 prefix.
 on:
   schedule:
     - cron: '15 7 * * *' # 07:15 UTC daily (off-peak; distinct from the 06:00/06:30 refresh crons)
   workflow_dispatch:
+    inputs:
+      gzip_only:
+        description: 'Skip the identity (v1) pass; only refresh the gzip (v1-gzip) artifacts'
+        type: boolean
+        default: false
+      board:
+        description: 'Limit both passes to one board type (e.g. kilter). Blank = all boards.'
+        required: false
+        default: ''
+      layout:
+        description: 'Limit both passes to one layout id (needs a board). Blank = all layouts.'
+        required: false
+        default: ''
 
 concurrency:
   group: export-board-snapshots
@@ -18,7 +40,9 @@ concurrency:
 jobs:
   export:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Two sequential read-only passes (identity + gzip). gzip CPU adds ~30s; the
+    # second Postgres stream is the real cost — 45m leaves ample headroom.
+    timeout-minutes: 45
     # DATABASE_URL is read-only-sufficient (snapshots only SELECT) but MUST
     # point at the PRIMARY, never a read replica: the sync cursor
     # (updated_at, sync_seq) is write-time ordered while a replica snapshot is
@@ -26,6 +50,25 @@ jobs:
     # cover rows absent from the artifact — bootstrapped clients would skip
     # those rows forever.
     environment: Production
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # Accept the Tigris console's exported names (AWS_ENDPOINT_URL_S3 /
+      # AWS_REGION) so rotating keys stays copy-paste, with the plain names
+      # as fallback for any other S3-compatible store.
+      AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL_S3 || secrets.AWS_ENDPOINT_URL }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || secrets.AWS_DEFAULT_REGION }}
+      # Tigris serves public objects only on the bucket's virtual-host
+      # domain — the S3 endpoint's path-style URLs 403 unauthenticated GETs
+      # even on a public bucket, so manifest entry URLs must be built here.
+      # Not a secret (it's in every manifest the app fetches). Keep in sync
+      # with EXPO_PUBLIC_SNAPSHOT_BASE_URL in the mobile workflows.
+      SNAPSHOT_PUBLIC_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io
+      # Keep the export's stability window in lockstep with the backend if
+      # it's ever configured off-default (empty → the shared 30s default).
+      SYNC_STABILITY_WINDOW_SECONDS: ${{ vars.SYNC_STABILITY_WINDOW_SECONDS }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,25 +83,35 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Export board snapshots
+      # Identity pass → board-snapshots/v1. This is what the live fleet reads, so
+      # it stays byte-for-byte the pre-gzip run. Skipped only when a manual
+      # dispatch asks to refresh just the gzip artifacts.
+      #
+      # BOARD/LAYOUT come through `env` and are read as shell variables, never
+      # interpolated into the run script with `${{ }}` — a dispatch input must not
+      # be able to inject shell before the CLI's parseBoardFilter/parseLayoutFilter
+      # ever sees it. Empty values add no flag.
+      - name: Export board snapshots (identity → board-snapshots/v1)
+        if: ${{ inputs.gzip_only != true }}
         working-directory: packages/backend
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # Accept the Tigris console's exported names (AWS_ENDPOINT_URL_S3 /
-          # AWS_REGION) so rotating keys stays copy-paste, with the plain names
-          # as fallback for any other S3-compatible store.
-          AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL_S3 || secrets.AWS_ENDPOINT_URL }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || secrets.AWS_DEFAULT_REGION }}
-          # Tigris serves public objects only on the bucket's virtual-host
-          # domain — the S3 endpoint's path-style URLs 403 unauthenticated GETs
-          # even on a public bucket, so manifest entry URLs must be built here.
-          # Not a secret (it's in every manifest the app fetches). Keep in sync
-          # with EXPO_PUBLIC_SNAPSHOT_BASE_URL in the mobile workflows.
-          SNAPSHOT_PUBLIC_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io
-          # Keep the export's stability window in lockstep with the backend if
-          # it's ever configured off-default (empty → the shared 30s default).
-          SYNC_STABILITY_WINDOW_SECONDS: ${{ vars.SYNC_STABILITY_WINDOW_SECONDS }}
-        run: node --import tsx src/scripts/export-board-snapshots.ts
+          BOARD: ${{ inputs.board }}
+          LAYOUT: ${{ inputs.layout }}
+        run: |
+          args=()
+          if [ -n "$BOARD" ]; then args+=("--board=$BOARD"); fi
+          if [ -n "$LAYOUT" ]; then args+=("--layout=$LAYOUT"); fi
+          node --import tsx src/scripts/export-board-snapshots.ts "${args[@]}"
+
+      # Gzip pass → board-snapshots/v1-gzip. Additive: newer builds point their
+      # EXPO_PUBLIC_SNAPSHOT_BASE_URL at this prefix once decode is validated.
+      - name: Export board snapshots (gzip → board-snapshots/v1-gzip)
+        working-directory: packages/backend
+        env:
+          BOARD: ${{ inputs.board }}
+          LAYOUT: ${{ inputs.layout }}
+        run: |
+          args=(--gzip --key-prefix board-snapshots/v1-gzip)
+          if [ -n "$BOARD" ]; then args+=("--board=$BOARD"); fi
+          if [ -n "$LAYOUT" ]; then args+=("--layout=$LAYOUT"); fi
+          node --import tsx src/scripts/export-board-snapshots.ts "${args[@]}"

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -28,7 +28,19 @@ now — typically under a day.
 `concurrency.group: export-board-snapshots` with `cancel-in-progress: false` means overlapping runs queue
 instead of stepping on each other.
 
-For every `(board_type, layout_id)` pair with at least one climb (`discoverLayoutPairs`), the job:
+**Dual-publish during the gzip transition.** The nightly runs the export **twice**, targeting two
+prefixes via `--key-prefix` (default `board-snapshots/v1`):
+
+- `board-snapshots/v1` — **identity**-encoded, exactly the pre-gzip run. This is what the current fleet
+  reads (all mobile workflows' `EXPO_PUBLIC_SNAPSHOT_BASE_URL` still point here), so it is left unchanged.
+- `board-snapshots/v1-gzip` — `--gzip`, ~2.6× smaller (`kilter:1` 258 MB → ~99 MB). Newer builds point at
+  this prefix once transparent `Content-Encoding: gzip` decode is validated on-device.
+
+Each prefix is a self-contained, single-encoding manifest: the merge and prune logic below scope entirely
+to whichever prefix the run targets, so a gzip run never reads or prunes the identity prefix. The follow-up
+that cuts the whole fleet to gzip drops the identity pass and deletes the `v1` prefix (see Rollout plan).
+
+For every `(board_type, layout_id)` pair with at least one climb (`discoverLayoutPairs`), each pass:
 
 1. Opens a `node:sqlite` file and applies DDL derived from the shared client `MIGRATIONS` — every
    migration statement that touches `board_climbs` or `board_climb_stats`, in version order, plus a
@@ -44,10 +56,10 @@ For every `(board_type, layout_id)` pair with at least one climb (`discoverLayou
 4. Computes each table's watermark — the max `(updated_at, sync_seq)` over the exported rows — from the
    **same transaction snapshot** as the row stream, and writes it into `snapshot_meta` alongside
    `row_count`, `schema_version` (`LATEST_SCHEMA_VERSION`), and `format_version`.
-5. Uploads the SQLite file to `board-snapshots/v1/<boardType>/<layoutId>/<builtAt-colon-free>.db`.
-   Artifacts are identity-encoded by default; `--gzip` is available once both mobile platforms have been
-   verified to receive a decompressed file from `expo-file-system`.
-6. After every artifact for the run has landed, writes `board-snapshots/v1/manifest.json` **last**, so a
+5. Uploads the SQLite file to `<keyPrefix>/<boardType>/<layoutId>/<builtAt-colon-free>.db` — identity by
+   default, or `gzip` (with `Content-Encoding: gzip`) under `--gzip`. The manifest's `contentEncoding`
+   field records which, so the client stays agnostic.
+6. After every artifact for the run has landed, writes `<keyPrefix>/manifest.json` **last**, so a
    reader only ever sees a fully-consistent old-or-new manifest, never a manifest pointing at an artifact
    that hasn't finished uploading.
 
@@ -87,16 +99,17 @@ avoid dropping data on a broken read:
 
 ### Storage layout and cache headers
 
-- Artifacts: `board-snapshots/v1/<boardType>/<layoutId>/<builtAt>.db`,
-  `Content-Type: application/x-sqlite3`, with manifest `contentEncoding: 'identity'` by default. `--gzip`
-  uploads with `Content-Encoding: gzip` and records `contentEncoding: 'gzip'` in the manifest, but should
-  stay off for mobile rollout until iOS and Android both prove the downloaded file is decompressed on disk.
-  No explicit `cacheControl` is passed to `uploadToS3`, so artifacts get the storage layer's default:
-  `public, max-age=31536000, immutable`. Content-addressed by build timestamp — safe to cache forever, a
-  new build gets a new key.
-- Manifest: `board-snapshots/v1/manifest.json`, `Content-Type: application/json`,
+- Artifacts: `<keyPrefix>/<boardType>/<layoutId>/<builtAt>.db`, `Content-Type: application/x-sqlite3`. The
+  `v1` prefix uploads `contentEncoding: 'identity'`; the `v1-gzip` prefix (`--gzip`) uploads with
+  `Content-Encoding: gzip` and records `contentEncoding: 'gzip'` in its manifest. `Content-Type` stays
+  `application/x-sqlite3` either way — encoding is layered on top of type. Gzip artifacts are published in
+  parallel so the fleet can be cut over only after iOS **and** Android both prove the downloaded file is
+  decompressed on disk (see Rollout plan). No explicit `cacheControl` is passed to `uploadToS3`, so
+  artifacts get the storage layer's default: `public, max-age=31536000, immutable`. Content-addressed by
+  build timestamp — safe to cache forever, a new build gets a new key.
+- Manifest: `<keyPrefix>/manifest.json`, `Content-Type: application/json`,
   `Cache-Control: public, max-age=300`. Mutable and cheap to refetch, written last so it's the only object
-  in the whole scheme that changes in place.
+  in the whole scheme that changes in place. Each prefix has its own manifest.
 
 ### Pruning
 
@@ -280,8 +293,10 @@ pre-import empty result set.
   `SnapshotPermanentMissError` (no attempt burned, same-cycle paged fallback), and a handled error is
   reported to Sentry with
   `tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' }`. This client does not attempt to gunzip
-  the file itself; keep the export job identity-encoded until gzip has been verified on both mobile
-  platforms.
+  the file itself — it relies on the native stack's transparent decode, and the sniff is the safety net if
+  that assumption is ever wrong on a given platform/build (fresh boards fall back to the paged crawl, never
+  a crash). This is why the fleet is only pointed at the `v1-gzip` prefix after that decode is verified
+  on-device (see Rollout plan).
 - **Telemetry**:
   - `Offline Board Download Completed` (PostHog, `SHARED_EVENTS.OfflineBoardDownloadCompleted`) fires once
     per scope's first-download completion (both board tables reached the tail), with method `snapshot` or
@@ -304,14 +319,18 @@ From a local shell, from `packages/backend/`:
 ```sh
 DATABASE_URL=<primary connection string> \
 AWS_S3_BUCKET_NAME=... AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_ENDPOINT_URL=... AWS_DEFAULT_REGION=... \
-node --import tsx src/scripts/export-board-snapshots.ts [--dry-run] [--gzip] [--board <boardType>] [--layout <layoutId>]
+node --import tsx src/scripts/export-board-snapshots.ts \
+  [--dry-run] [--gzip] [--key-prefix <prefix>] [--board <boardType>] [--layout <layoutId>]
 ```
 
 - `--dry-run` builds artifacts locally (in a temp dir, cleaned up after) and logs sizes/row counts, but
   never uploads anything and never touches the manifest. Works with **no AWS credentials at all**.
 - `--gzip` compresses artifact objects and publishes manifest entries with `contentEncoding: 'gzip'`.
-  Leave it off for mobile rollout until a device check proves iOS and Android both download decompressed
-  SQLite files from the object store path.
+  Pair it with `--key-prefix board-snapshots/v1-gzip` so gzip artifacts land beside — never overwrite — the
+  identity `v1` prefix the live fleet reads.
+- `--key-prefix <prefix>` (default `board-snapshots/v1`) targets a self-contained prefix: its own manifest,
+  merge, and prune, isolated from every other prefix. Validated against a safe key charset. The nightly
+  workflow uses it to publish `v1` (identity) and `v1-gzip` (gzip) in one run.
 - `--board`/`--layout` filter to a subset. A filter matching **zero** `(boardType, layoutId)` pairs is
   treated as an operator error and throws loudly (e.g. `--board=kilterr` typo) rather than silently leaving
   that board's artifacts stale.
@@ -424,3 +443,32 @@ page — that's the trigger to prioritize the fix.
 3. **Percentage ramp**: increase the PostHog rollout gradually, watching `Offline Board Download Completed`
    duration percentiles split by `method`, and the Sentry `snapshot-bootstrap` failure rate, at each step.
    Hold or roll back on a `snapshot` p95 that doesn't clearly beat `paged`, or a failure-rate step change.
+
+## Gzip transition & cutover
+
+Gzip cuts artifact size ~2.6× (`kilter:1` 258 MB → ~99 MB), directly shrinking the download portion of
+`durationMs`. It ships in stages so the live fleet is never regressed while transparent decode is unverified:
+
+1. **Dual-publish (shipped).** The nightly publishes both `board-snapshots/v1` (identity, unchanged) and
+   `board-snapshots/v1-gzip` (`--gzip`). Every mobile workflow's `EXPO_PUBLIC_SNAPSHOT_BASE_URL` still
+   points at `v1`, so the fleet is untouched. After merging, dispatch the workflow once (or wait a night) to
+   populate `v1-gzip`.
+2. **Validate transparent decode on-device, iOS + Android.** Build a dev-client with
+   `EXPO_PUBLIC_SNAPSHOT_BASE_URL=<base>/board-snapshots/v1-gzip` (build-time only, **not** committed — the
+   parity test below forbids a single-workflow change), flags on, and enable a fresh board. Pass =
+   PostHog `Offline Board Download Completed` `method: 'snapshot'`, `durationMs` down markedly, and **no**
+   Sentry handled error `kind: 'snapshot-bootstrap'` "arrived still gzip-compressed". Android is runnable
+   via `vp run mobile:android-shots` (real OkHttp); iOS needs a Mac.
+3. **Cutover (follow-up PR).** Flip `EXPO_PUBLIC_SNAPSHOT_BASE_URL` to the `v1-gzip` path in **all** the
+   mobile fingerprint workflows **at once** — `mobile-ota-production.yml`, `ios-testflight-rn.yml`,
+   `android-apk-rn.yml`, `mobile-ota-check.yml`, `mobile-ota-preview.yml`, `mobile-ota-backport.yml` —
+   because `scripts/mobile-ci-env-parity.test.ts` requires this var byte-identical across them (a
+   single-workflow change fails CI, and the `pr-<number>` preview channel bakes the same env as
+   production, so there is no "preview-only" pointer). The production OTA then migrates the fleet on next
+   launch; any straggler where decode fails degrades to the paged crawl, never a crash. Watch the same
+   telemetry as the ramp above.
+4. **Cleanup (later PR).** Once the fleet has migrated, drop the identity pass from the export workflow and
+   delete the `board-snapshots/v1` artifacts + manifest.
+
+**Rollback** at any stage: point the workflows back at `v1` (identity is always live) — no export change
+needed.

--- a/packages/backend/src/__tests__/snapshot-export-run.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-run.test.ts
@@ -332,3 +332,84 @@ describe('runExport — SNAPSHOT_PUBLIC_BASE_URL', () => {
     expect(entry.url).toBe(`https://cdn.example/${entry.key}`);
   });
 });
+
+describe('runExport — gzip + key-prefix (dual-publish transition)', () => {
+  const GZIP_PREFIX = 'board-snapshots/v1-gzip';
+  const GZIP_MANIFEST_KEY = `${GZIP_PREFIX}/manifest.json`;
+
+  /** uploadToS3 calls for artifacts (everything that isn't a manifest write). */
+  function artifactUploadCalls(): unknown[][] {
+    return vi.mocked(uploadToS3).mock.calls.filter(([, key]) => !String(key).endsWith('/manifest.json'));
+  }
+
+  it('default run stays identity under board-snapshots/v1 (regression guard for the live fleet)', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+
+    await runExport([]);
+
+    const entry = uploadedManifest().entries[0];
+    expect(entry.contentEncoding).toBe('identity');
+    expect(entry.key.startsWith('board-snapshots/v1/')).toBe(true);
+    // No gzip option on the artifact upload → S3 stores it identity-encoded.
+    const [, , , options] = artifactUploadCalls()[0];
+    expect(options).toBeUndefined();
+  });
+
+  it('--gzip --key-prefix publishes a gzip manifest under the new prefix, never touching v1', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+
+    await runExport(['--gzip', '--key-prefix', GZIP_PREFIX]);
+
+    // Reads and writes its OWN manifest, isolated from the identity v1 one.
+    expect(getFromS3Strict).toHaveBeenCalledWith(GZIP_MANIFEST_KEY);
+    const manifestCalls = vi.mocked(uploadToS3).mock.calls.filter(([, key]) => key === GZIP_MANIFEST_KEY);
+    expect(manifestCalls.length).toBe(1);
+    const manifest = JSON.parse((manifestCalls[0][0] as Buffer).toString('utf8')) as SnapshotManifest;
+
+    const entry = manifest.entries[0];
+    expect(entry.contentEncoding).toBe('gzip');
+    expect(entry.key.startsWith(`${GZIP_PREFIX}/kilter/1/`)).toBe(true);
+    expect(entry.url).toContain(GZIP_PREFIX);
+    // The identity (v1) manifest is not written by a gzip run.
+    expect(vi.mocked(uploadToS3).mock.calls.some(([, key]) => key === MANIFEST_KEY)).toBe(false);
+
+    // The artifact object is uploaded gzip-compressed with Content-Encoding: gzip.
+    const [body, key, , options] = artifactUploadCalls()[0];
+    expect(String(key)).toContain(`${GZIP_PREFIX}/kilter/1/`);
+    expect(options).toEqual({ contentEncoding: 'gzip' });
+    expect((body as Buffer)[0]).toBe(0x1f); // gzip magic
+    expect((body as Buffer)[1]).toBe(0x8b);
+  });
+
+  it('rejects an unsafe --key-prefix before any upload', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    await expect(runExport(['--key-prefix', '../evil'])).rejects.toThrow(/--key-prefix expects a safe key/);
+    await expect(runExport(['--key-prefix'])).rejects.toThrow(/--key-prefix expects a safe key/);
+    expect(uploadToS3).not.toHaveBeenCalled();
+  });
+
+  it('prunes only within the gzip prefix, never the identity prefix', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+
+    await runExport(['--gzip', '--key-prefix', GZIP_PREFIX]);
+
+    expect(listS3Objects).toHaveBeenCalledWith(`${GZIP_PREFIX}/`);
+    expect(listS3Objects).not.toHaveBeenCalledWith('board-snapshots/v1/');
+  });
+
+  it('honors --board/--layout under --gzip --key-prefix (filtered canary of one layout)', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    await seedClimb('kilter', 2, 'k2-a');
+
+    await runExport(['--gzip', '--key-prefix', GZIP_PREFIX, '--board', 'kilter', '--layout', '1']);
+
+    const manifestCalls = vi.mocked(uploadToS3).mock.calls.filter(([, key]) => key === GZIP_MANIFEST_KEY);
+    const manifest = JSON.parse((manifestCalls[0][0] as Buffer).toString('utf8')) as SnapshotManifest;
+    // Only the filtered layout was built, gzip-encoded, under the gzip prefix.
+    expect(manifest.entries.map((entry) => `${entry.boardType}:${entry.layoutId}`)).toEqual(['kilter:1']);
+    expect(manifest.entries[0].contentEncoding).toBe('gzip');
+    expect(manifest.entries[0].key.startsWith(`${GZIP_PREFIX}/kilter/1/`)).toBe(true);
+    // A filtered run never prunes.
+    expect(listS3Objects).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -52,8 +52,18 @@ import { logger } from '../utils/logger';
 
 // --- Constants ----------------------------------------------------------------
 
-const SNAPSHOT_KEY_PREFIX = 'board-snapshots/v1';
-const MANIFEST_KEY = `${SNAPSHOT_KEY_PREFIX}/manifest.json`;
+// The default S3 prefix everything lands under (`<prefix>/<board>/<layout>/*.db`
+// + `<prefix>/manifest.json`). `--key-prefix` overrides it so one run can target
+// a parallel prefix — e.g. a gzip transition that publishes `board-snapshots/v1`
+// (identity, unchanged for the live fleet) and `board-snapshots/v1-gzip` side by
+// side. Each prefix is a self-contained, single-encoding manifest: the merge and
+// prune logic below scope entirely to whichever prefix the run targets.
+const DEFAULT_SNAPSHOT_KEY_PREFIX = 'board-snapshots/v1';
+// A safe key prefix: lowercase alphanumerics separated by single `-`/`/`, no
+// leading/trailing separator and no `..`. It's spliced into S3 object keys and
+// the manifest path, so validate it (mirrors SAFE_IDENTIFIER's intent for keys).
+const SAFE_KEY_PREFIX = /^[a-z0-9]+(?:[/-][a-z0-9]+)*$/;
+const manifestKeyForPrefix = (keyPrefix: string): string => `${keyPrefix}/manifest.json`;
 const MANIFEST_CACHE_CONTROL = 'public, max-age=300';
 const ARTIFACT_CONTENT_TYPE = 'application/x-sqlite3';
 
@@ -385,12 +395,13 @@ type ExportOptions = {
   // Content-Encoding: gzip decode is verified on-device (see the encoding
   // comment in the pair loop).
   gzip: boolean;
+  keyPrefix: string;
   boardFilter?: string;
   layoutFilter?: number;
 };
 
 function parseArgs(argv: string[]): ExportOptions {
-  const options: ExportOptions = { dryRun: false, gzip: false };
+  const options: ExportOptions = { dryRun: false, gzip: false, keyPrefix: DEFAULT_SNAPSHOT_KEY_PREFIX };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--') continue; // vp forwards a literal `--` into argv
@@ -398,6 +409,10 @@ function parseArgs(argv: string[]): ExportOptions {
       options.dryRun = true;
     } else if (arg === '--gzip') {
       options.gzip = true;
+    } else if (arg === '--key-prefix') {
+      options.keyPrefix = parseKeyPrefix(argv[(index += 1)]);
+    } else if (arg.startsWith('--key-prefix=')) {
+      options.keyPrefix = parseKeyPrefix(arg.slice('--key-prefix='.length));
     } else if (arg === '--board') {
       options.boardFilter = parseBoardFilter(argv[(index += 1)]);
     } else if (arg.startsWith('--board=')) {
@@ -416,6 +431,16 @@ function parseBoardFilter(raw: string | undefined): string {
     throw new Error(`--board expects a board type, got ${JSON.stringify(raw)}`);
   }
   return raw;
+}
+
+function parseKeyPrefix(raw: string | undefined): string {
+  const keyPrefix = raw?.trim().replace(/\/+$/, '');
+  if (!keyPrefix || !SAFE_KEY_PREFIX.test(keyPrefix)) {
+    // A bad prefix would either silently write to the wrong place or splice an
+    // unsafe value into S3 keys — fail loudly instead.
+    throw new Error(`--key-prefix expects a safe key like "board-snapshots/v1", got ${JSON.stringify(raw)}`);
+  }
+  return keyPrefix;
 }
 
 function parseLayoutFilter(raw: string | undefined): number {
@@ -499,8 +524,11 @@ export function mergeManifestEntries(params: {
  *                                      only vanished layouts' entries are lost,
  *                                      and those drop regardless)
  */
-async function fetchPreviousManifest(options: { isFilteredRun: boolean }): Promise<SnapshotManifest | null> {
-  const manifestObject = await getFromS3Strict(MANIFEST_KEY);
+async function fetchPreviousManifest(options: {
+  isFilteredRun: boolean;
+  manifestKey: string;
+}): Promise<SnapshotManifest | null> {
+  const manifestObject = await getFromS3Strict(options.manifestKey);
   if (!manifestObject) {
     logger.warn('[export-snapshots] no previous manifest on S3 (first run?) — merging against empty');
     return null;
@@ -521,7 +549,7 @@ async function fetchPreviousManifest(options: { isFilteredRun: boolean }): Promi
   if (invalidReason) {
     if (options.isFilteredRun) {
       throw new Error(
-        `previous manifest at ${MANIFEST_KEY} is invalid (${invalidReason}); a filtered run cannot merge safely — aborting before any upload`,
+        `previous manifest at ${options.manifestKey} is invalid (${invalidReason}); a filtered run cannot merge safely — aborting before any upload`,
       );
     }
     logger.warn(
@@ -543,13 +571,13 @@ async function fetchPreviousManifest(options: { isFilteredRun: boolean }): Promi
  * manifest provably references every artifact that must survive. Defensive by
  * design: any prune failure is logged and swallowed, never failing the run.
  */
-async function pruneStaleArtifacts(manifest: SnapshotManifest, nowMs: number): Promise<void> {
+async function pruneStaleArtifacts(manifest: SnapshotManifest, nowMs: number, keyPrefix: string): Promise<void> {
   try {
     const referencedKeys = new Set<string>(manifest.entries.map((entry) => entry.key));
-    referencedKeys.add(MANIFEST_KEY);
+    referencedKeys.add(manifestKeyForPrefix(keyPrefix));
     const cutoffMs = nowMs - PRUNE_GRACE_MS;
 
-    const objects = await listS3Objects(`${SNAPSHOT_KEY_PREFIX}/`);
+    const objects = await listS3Objects(`${keyPrefix}/`);
     let prunedCount = 0;
     for (const object of objects) {
       if (referencedKeys.has(object.key)) continue;
@@ -578,6 +606,8 @@ export async function runExport(argv: string[]): Promise<void> {
   const options = parseArgs(argv);
   const builtAt = new Date().toISOString();
   const isFilteredRun = options.boardFilter !== undefined || options.layoutFilter !== undefined;
+  const keyPrefix = options.keyPrefix;
+  const manifestKey = manifestKeyForPrefix(keyPrefix);
 
   if (!options.dryRun && !isS3Configured()) {
     throw new Error(
@@ -621,6 +651,8 @@ export async function runExport(argv: string[]): Promise<void> {
     logger.info('[export-snapshots] starting run', {
       dryRun: options.dryRun,
       filtered: isFilteredRun,
+      gzip: options.gzip,
+      keyPrefix,
       pairs: pairs.length,
       builtAt,
       stabilityWindowSeconds: DEFAULT_STABILITY_WINDOW_SECONDS,
@@ -628,7 +660,7 @@ export async function runExport(argv: string[]): Promise<void> {
 
     // Fetch the previous manifest BEFORE any upload: if it is unreadable the
     // run aborts with S3 completely untouched (matrix in fetchPreviousManifest).
-    const previousManifest = options.dryRun ? null : await fetchPreviousManifest({ isFilteredRun });
+    const previousManifest = options.dryRun ? null : await fetchPreviousManifest({ isFilteredRun, manifestKey });
 
     for (const pair of pairs) {
       const startedAt = Date.now();
@@ -654,7 +686,7 @@ export async function runExport(argv: string[]): Promise<void> {
         // Colon-free key stamp: ISO colons are legal in S3 keys but historically
         // trip CDNs/URL parsers, and getPublicUrl does no percent-encoding.
         const keyStamp = builtAt.replace(/[:.]/g, '-');
-        const key = `${SNAPSHOT_KEY_PREFIX}/${pair.boardType}/${pair.layoutId}/${keyStamp}.db`;
+        const key = `${keyPrefix}/${pair.boardType}/${pair.layoutId}/${keyStamp}.db`;
 
         if (options.dryRun) {
           logger.info('[export-snapshots] built (dry-run, not uploaded)', {
@@ -742,20 +774,22 @@ export async function runExport(argv: string[]): Promise<void> {
         generatedAt: new Date().toISOString(),
         entries: mergedEntries,
       };
-      await uploadToS3(Buffer.from(JSON.stringify(manifest)), MANIFEST_KEY, 'application/json', {
+      await uploadToS3(Buffer.from(JSON.stringify(manifest)), manifestKey, 'application/json', {
         cacheControl: MANIFEST_CACHE_CONTROL,
       });
       logger.info('[export-snapshots] manifest uploaded', {
         entries: mergedEntries.length,
         refreshed: newEntries.length,
-        key: MANIFEST_KEY,
+        key: manifestKey,
       });
 
       // Prune superseded artifacts only after a fully-successful unfiltered
       // run: filtered runs lack the full picture, and skipping on failure
-      // nights just defers pruning to the next green nightly.
+      // nights just defers pruning to the next green nightly. Scoped to this
+      // run's key prefix, so a gzip run never prunes the identity prefix's
+      // artifacts (and vice versa).
       if (!isFilteredRun && failures.length === 0) {
-        await pruneStaleArtifacts(manifest, Date.now());
+        await pruneStaleArtifacts(manifest, Date.now(), keyPrefix);
       }
     }
 


### PR DESCRIPTION
## What & why

PostHog shows the offline snapshot download has a slow tail driven almost entirely by artifact size. The flagship, most-downloaded board — `kilter:1` — is **258 MB** uncompressed (5× the next board), and every Kilter Original user downloads the whole layout file regardless of size. Snapshot-only durations (n=45, app 2.2.2): median ~55s but **p90 ~7.2 min**, concentrated on the big Kilter boards (`kilter:1` median 238s vs `moonboard:2` 13s).

Artifacts upload uncompressed (`contentEncoding: 'identity'`). Measured on the real `kilter:1` artifact at the exact compression the export emits (`gzipSync` default = level 6): **258.1 MB → 99.5 MB (2.59× smaller)**. The mobile client already handles `contentEncoding: 'gzip'` (downloads, sniffs the gzip magic bytes, and falls back to the paged crawl if a platform doesn't transparently decode — never a crash).

## What this PR does

Publishes gzip artifacts **in parallel** with the existing identity ones, so the live fleet is never touched until gzip is validated:

- **Parameterized export key prefix** (`--key-prefix`, default `board-snapshots/v1`). Each prefix is a self-contained, single-encoding manifest; merge + prune scope entirely to the run's prefix, so a gzip run never reads or prunes the identity prefix. No manifest schema change, no `formatVersion` bump, no client change.
- **Nightly workflow runs twice**: `board-snapshots/v1` (identity, byte-for-byte the pre-gzip run — what the fleet reads) and `board-snapshots/v1-gzip` (`--gzip`). Adds `workflow_dispatch` inputs (`gzip_only`, `board`, `layout`) to populate/canary on demand. Timeout 30→45 min for the second read-only pass.
- **No mobile workflow change.** `scripts/mobile-ci-env-parity.test.ts` requires `EXPO_PUBLIC_SNAPSHOT_BASE_URL` byte-identical across all six mobile fingerprint workflows, and the `pr-<n>` preview channel bakes the same env as production — so there's no "preview-only" pointer. Cutting the fleet to gzip is an all-at-once follow-up, gated on on-device transparent-decode validation.
- Test coverage for the gzip + `--key-prefix` path; docs rewritten for the transition/cutover.

## Validation

- `vp run typecheck:backend` ✅
- `vp test run --project backend snapshot-export` ✅ (26 tests incl. new gzip/prefix cases + golden equivalence)
- `vp test run mobile-ci-env-parity` ✅ (24 — unchanged, parity intact)
- `vp check` ✅ on changed files
- Real-catalog `--dry-run --gzip` is best done post-merge via a `workflow_dispatch` against production data.

## Follow-ups (not this PR)

1. **Validate transparent decode on-device** (iOS + Android) via a dev-client pointed at `v1-gzip` (env override, uncommitted). Pass = `method: 'snapshot'`, `durationMs` down, no Sentry `snapshot-bootstrap` "still gzip-compressed".
2. **Cutover PR**: flip `EXPO_PUBLIC_SNAPSHOT_BASE_URL` to `v1-gzip` in all six mobile workflows at once (keeps parity); the production OTA migrates the fleet.
3. **Cleanup PR**: drop the identity pass and delete the `v1` prefix once the fleet has migrated.

## Release Notes

none
