### PR TITLE
fix(mobile): always clear Metro's transform cache in the expo-web export

### DIFF
--- a/docs/expo-web-deployment.md
+++ b/docs/expo-web-deployment.md
@@ -50,6 +50,18 @@ fingerprint graph), runs `BOARDSESH_WEB=1 BOARDSESH_WEB_BASE_URL=/
 EXPO_NO_WEB_SETUP=1 bunx expo export --platform web`, and asserts the shell +
 board-renderer WASM assets landed.
 
+The export always passes `--clear` to wipe Metro's transform cache first.
+`expo export` reuses that cache across `EXPO_PUBLIC_*` env changes — it does
+not key on env — so a rebuild with a different backend/WS URL can silently
+ship a bundle with the _previous_ build's values baked in. Every caller of
+this script builds the artifact once (Docker builder stage, CI deploy, the
+bundle check), so the cache buys nothing and the staleness risk is real.
+Deploy pipelines should also set `BOARDSESH_EXPORT_EXPECT_URLS` (space-
+separated substrings, e.g. `"https://ws.boardsesh.com https://www.boardsesh.com"`)
+so the script greps the emitted JS bundles for each expected origin and fails
+loudly if one is missing — the direct detector for a stale-env artifact
+reaching production.
+
 ### What the host must do
 
 - **Serve the export directory at the origin root.** `index.html`, `_expo/*`,

--- a/scripts/build-expo-web-export.sh
+++ b/scripts/build-expo-web-export.sh
@@ -98,8 +98,14 @@ export TAILSCALE_HOSTS="${TAILSCALE_HOSTS-}"
 # app.config.ts's resolveWebPlatforms reads BOARDSESH_WEB_BASE_URL (default
 # /app). Setting it explicitly here keeps the export deterministic regardless of
 # any ambient value; --subdomain sets it to / for root serving.
+#
+# --clear: expo export reuses Metro's transform cache across EXPO_PUBLIC_* env
+# changes, silently shipping a stale bundle with old env values inlined
+# (verified 2026-07-18..20). Every consumer of this script is a
+# build-the-artifact-once path (Docker builder stage, CI deploy, bundle
+# check), so the cache buys nothing here and the staleness risk is real.
 BOARDSESH_WEB=1 BOARDSESH_WEB_BASE_URL="$WEB_BASE_URL" EXPO_NO_WEB_SETUP=1 EXPO_NO_TELEMETRY=1 \
-  bunx expo export --platform web --output-dir "$OUTPUT_DIR"
+  bunx expo export --platform web --output-dir "$OUTPUT_DIR" --clear
 
 if [[ ! -f "$OUTPUT_DIR/index.html" ]]; then
   echo "[build-expo-web-export] missing index.html in $OUTPUT_DIR" >&2
@@ -109,6 +115,43 @@ fi
 if [[ ! -f "$OUTPUT_DIR/wasm/board_renderer_wasm.js" || ! -f "$OUTPUT_DIR/wasm/board_renderer_wasm_bg.wasm" ]]; then
   echo "[build-expo-web-export] missing board-renderer WASM assets in $OUTPUT_DIR" >&2
   exit 1
+fi
+
+# BOARDSESH_EXPORT_EXPECT_URLS (space-separated substrings, e.g.
+# "https://ws.boardsesh.com https://www.boardsesh.com") is the direct detector
+# for the stale-cache bug the --clear flag above guards against: assert every
+# substring actually landed in an emitted JS bundle. CI deploy workflows set
+# this so a regression of --clear fails loudly instead of shipping a bundle
+# with stale baked-in origins.
+assert_baked_urls() {
+  local js_dir="$OUTPUT_DIR/_expo/static/js/web"
+  if [[ ! -d "$js_dir" ]]; then
+    echo "[build-expo-web-export] BOARDSESH_EXPORT_EXPECT_URLS is set but no JS bundles were found in $js_dir" >&2
+    exit 1
+  fi
+
+  local missing=()
+  local expected_url
+  for expected_url in $BOARDSESH_EXPORT_EXPECT_URLS; do
+    if ! grep -rqF -- "$expected_url" "$js_dir"; then
+      missing+=("$expected_url")
+    fi
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "[build-expo-web-export] expected URL(s) not found in any bundle under $js_dir:" >&2
+    local missing_url
+    for missing_url in "${missing[@]}"; do
+      echo "  - $missing_url" >&2
+    done
+    exit 1
+  fi
+
+  echo "[build-expo-web-export] verified baked URL(s): $BOARDSESH_EXPORT_EXPECT_URLS"
+}
+
+if [[ -n "${BOARDSESH_EXPORT_EXPECT_URLS:-}" ]]; then
+  assert_baked_urls
 fi
 
 echo "[build-expo-web-export] Expo web export (baseUrl $WEB_BASE_URL) written to $OUTPUT_DIR"


### PR DESCRIPTION
## Summary

- `expo export` reuses Metro's transform cache across `EXPO_PUBLIC_*` env changes — it does not key on env — so rebuilding `scripts/build-expo-web-export.sh` with a different backend/WS URL could silently ship a bundle with the *previous* build's values baked in (verified 2026-07-18..20). Every consumer of this script (`Dockerfile.web` builder stage, CI deploy, `vp run check:mobile-web-bundle`) builds the artifact exactly once, so the cache buys nothing and the staleness risk is real. Adds `--clear` unconditionally to the `bunx expo export --platform web` invocation.
- Adds an opt-in bake assertion: when `BOARDSESH_EXPORT_EXPECT_URLS` (space-separated substrings) is set, the script greps the emitted JS bundles under `<output-dir>/_expo/static/js/web/` for each substring after export succeeds, and fails with a clear error naming any substring not found in any bundle. This is the direct detector for stale-env artifacts; CI deploy workflows will use it.
- Documents both changes in `docs/expo-web-deployment.md` near the `--subdomain` build instructions.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check --fix scripts/build-expo-web-export.sh docs/expo-web-deployment.md` — passed (formatting only).
- `vp run check:mobile-web-bundle` — passed end-to-end against the changed script (exports the Expo browser app with `--clear` and verifies shell/WASM assets).
- Manual bake-assertion verification, both directions, against a real export output:
  - Positive: ran the script directly with `BOARDSESH_EXPORT_EXPECT_URLS=https://ws.boardsesh.com` (the default backend fallback baked via `packages/mobile/src/lib/env.ts`) — exited 0, logged `verified baked URL(s): https://ws.boardsesh.com`.
  - Negative: ran the script's `assert_baked_urls` function against the same export output with `BOARDSESH_EXPORT_EXPECT_URLS=https://definitely-not-baked.example` — exited 1 with `expected URL(s) not found in any bundle under .../_expo/static/js/web: - https://definitely-not-baked.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kuGeWgw8brWzMLw1QeD3U