### PR TITLE
ci: scope production secrets to the steps that use them

### DIFF
--- a/.github/workflows/export-board-snapshots.yml
+++ b/.github/workflows/export-board-snapshots.yml
@@ -50,16 +50,10 @@ jobs:
     # cover rows absent from the artifact — bootstrapped clients would skip
     # those rows forever.
     environment: Production
+    # Production DB/S3 credentials are NOT declared here: job-level env would leak
+    # them to actions/checkout, the setup actions, and `bun install` before the
+    # export ever runs. They're scoped to the two export steps below instead.
     env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      # Accept the Tigris console's exported names (AWS_ENDPOINT_URL_S3 /
-      # AWS_REGION) so rotating keys stays copy-paste, with the plain names
-      # as fallback for any other S3-compatible store.
-      AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL_S3 || secrets.AWS_ENDPOINT_URL }}
-      AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || secrets.AWS_DEFAULT_REGION }}
       # Tigris serves public objects only on the bucket's virtual-host
       # domain — the S3 endpoint's path-style URLs 403 unauthenticated GETs
       # even on a public bucket, so manifest entry URLs must be built here.
@@ -97,6 +91,15 @@ jobs:
         env:
           BOARD: ${{ inputs.board }}
           LAYOUT: ${{ inputs.layout }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # Accept the Tigris console's exported names (AWS_ENDPOINT_URL_S3 /
+          # AWS_REGION) so rotating keys stays copy-paste, with the plain names
+          # as fallback for any other S3-compatible store.
+          AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL_S3 || secrets.AWS_ENDPOINT_URL }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || secrets.AWS_DEFAULT_REGION }}
         run: |
           args=()
           if [ -n "$BOARD" ]; then args+=("--board=$BOARD"); fi
@@ -110,6 +113,15 @@ jobs:
         env:
           BOARD: ${{ inputs.board }}
           LAYOUT: ${{ inputs.layout }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # Accept the Tigris console's exported names (AWS_ENDPOINT_URL_S3 /
+          # AWS_REGION) so rotating keys stays copy-paste, with the plain names
+          # as fallback for any other S3-compatible store.
+          AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL_S3 || secrets.AWS_ENDPOINT_URL }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || secrets.AWS_DEFAULT_REGION }}
         run: |
           args=(--gzip --key-prefix board-snapshots/v1-gzip)
           if [ -n "$BOARD" ]; then args+=("--board=$BOARD"); fi

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -103,8 +103,9 @@ jobs:
       fail-fast: false
       matrix:
         platform: ${{ fromJSON(needs.setup.outputs.platforms) }}
-    env:
-      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+    # EXPO_TOKEN is NOT a job-level env: that would expose the publish-capable token
+    # to checkout, setup-vp/bun, `bun install`, and the cherry-pick before the
+    # publish. It's scoped to the "Publish OTA" step below instead.
 
     steps:
       - name: Checkout repository
@@ -231,6 +232,7 @@ jobs:
       - name: Publish OTA to the approved release
         if: ${{ !inputs.dry_run }}
         env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           PLATFORM: ${{ matrix.platform }}
           GOOGLE_MAPS_API_KEY: ${{ matrix.platform == 'android' && secrets.GOOGLE_MAPS_API_KEY || '' }}
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/mobile-ota-preview-sweep.yml
+++ b/.github/workflows/mobile-ota-preview-sweep.yml
@@ -26,12 +26,14 @@ jobs:
   sweep:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # EXPO_TOKEN / GH_TOKEN are NOT job-level env: that would expose them to
+    # checkout, setup-bun, and `bun install`. Each is scoped to the step that
+    # uses it — EXPO_TOKEN to the gate + delete steps, GH_TOKEN to the delete step.
     steps:
       - name: Skip if OTA isn't wired
         id: gate
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           if [ -z "$EXPO_TOKEN" ] || [ -z "${{ vars.EXPO_UPDATES_URL }}" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -54,6 +56,9 @@ jobs:
       - name: Delete preview channels for non-open PRs
         if: steps.gate.outputs.run == 'true'
         working-directory: packages/mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
 

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -209,8 +209,12 @@ jobs:
       # number straight from the event (one of these is set per trigger).
       group: mobile-ota-preview-publish-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr }}
       cancel-in-progress: true
+    # EXPO_TOKEN is NOT a job-level env: this job checks out PR-head and runs
+    # PR-author code (`bun install` on the PR tree, app.config execSync) — a
+    # job-level token would be live throughout that. It's scoped to the three steps
+    # that publish (channel create + iOS/Android publish) instead. This is
+    # defense-in-depth on top of the `environment: ota-preview` reviewer gate.
     env:
-      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       CHANNEL: ${{ needs.gate.outputs.channel }}
       PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
     steps:
@@ -300,6 +304,8 @@ jobs:
       # setupExpoChannel). eoas publish requires a pre-created+mapped channel.
       - name: Create + map Expo channel
         working-directory: packages/mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           run_eas() {
             echo "+ eas-cli $* --non-interactive"
@@ -315,12 +321,15 @@ jobs:
       - name: Publish iOS OTA
         id: publish_ios
         if: steps.compat.outputs.verdict_ios != 'native-change-required'
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: vp run mobile:publish -- --channel "$CHANNEL" --platform ios
 
       - name: Publish Android OTA
         id: publish_android
         if: steps.compat.outputs.verdict_android != 'native-change-required'
         env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         run: vp run mobile:publish -- --channel "$CHANNEL" --platform android
 
@@ -447,7 +456,10 @@ jobs:
       group: mobile-ota-preview-cleanup-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     env:
-      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      # Presence flag only (a boolean, NOT the token) so the delete step's `if:` can
+      # skip a fork-PR close where secrets are absent. The token itself is scoped to
+      # that step, off checkout / setup-bun / `bun install`.
+      HAS_EXPO_TOKEN: ${{ secrets.EXPO_TOKEN != '' }}
       CHANNEL: ${{ needs.gate.outputs.channel }}
     steps:
       - name: Assert preview channel name
@@ -471,8 +483,10 @@ jobs:
       # objects are reclaimed by the bucket's `pr-` lifecycle rule (there is no
       # branch-delete primitive). Skipped when EXPO_TOKEN is absent (fork close).
       - name: Delete Expo channel + branch
-        if: env.EXPO_TOKEN != ''
+        if: env.HAS_EXPO_TOKEN == 'true'
         working-directory: packages/mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           run_eas() {
             echo "+ eas-cli $* --non-interactive"

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -100,8 +100,11 @@ jobs:
     # Gates EXPO_TOKEN + GOOGLE_MAPS_API_KEY + the EXPO_UPDATES_URL variable.
     environment: Production
 
+    # EXPO_TOKEN is NOT a job-level env: that would expose the publish-capable token
+    # to checkout, setup-vp/bun, `bun install`, and the changelog commit/push before
+    # the publish. It's scoped to the two publish steps below. INPUT_* stay here —
+    # they're plain inputs referenced in the publish steps' `if:` expressions.
     env:
-      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       INPUT_PLATFORM: ${{ github.event.inputs.platform || 'all' }}
       INPUT_MESSAGE: ${{ github.event.inputs.message }}
 
@@ -235,6 +238,8 @@ jobs:
       - name: Publish iOS OTA
         id: publish_ios
         if: steps.gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'ios')
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         # No EXPO_UPDATES_FINGERPRINT_OVERRIDE here: the publish resolves the CURRENT
         # commit's fingerprint (app.config's `fingerprint` policy) and serves the JS
         # under it. That matches the shipped binary — which embeds the same Linux gate
@@ -251,6 +256,7 @@ jobs:
         id: publish_android
         if: steps.gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'android')
         env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           # Must match the Android native prebuild (android-apk-rn.yml) so the
           # resolved android.config.googleMaps block — and the freshly-resolved
           # fingerprint — agree with the binary. (No fingerprint override: see the


### PR DESCRIPTION
## Summary

Several workflows declared production/sensitive secrets at the **job-level `env:`** (one at **workflow-level**). GitHub injects those into *every* step of the job — `actions/checkout`, the third-party setup actions (`setup-bun`, `setup-vp`, …), and `bun install` — all of which run *before* the step that actually needs the secret. A compromised setup action or a malicious install script (including PR-author code in the OTA preview publish job) therefore saw credentials it never needed. This moves each secret down onto the specific step(s) that consume it.

An audit of all 33 secret-referencing workflows found the deploy / refresh / CI / store workflows already scope correctly. Fixed here:

| Workflow | Was leaked | Now scoped to |
| --- | --- | --- |
| `export-board-snapshots.yml` | `DATABASE_URL` + 5 S3 creds (job env) | the two export steps; non-secret `SNAPSHOT_PUBLIC_BASE_URL` / `SYNC_STABILITY_WINDOW_SECONDS` stay at job level |
| `mobile-ota-backport.yml` | `EXPO_TOKEN` (job env) | the final Publish OTA step |
| `mobile-ota-production.yml` | `EXPO_TOKEN` (job env) | the two publish steps; `INPUT_*` stay (used in the steps' `if:`) |
| `mobile-ota-preview-sweep.yml` | `EXPO_TOKEN`, `GH_TOKEN` (job env) | `EXPO_TOKEN` → gate + delete steps; `GH_TOKEN` → delete step |
| `mobile-ota-preview.yml` | `EXPO_TOKEN` (publish + cleanup job env) | the 3 publish steps (off the untrusted PR-head checkout + `bun install`); cleanup keeps its fork-close skip via a non-secret `HAS_EXPO_TOKEN` presence flag, token scoped to the delete step |

The `mobile-ota-preview.yml` publish job is the highest-value fix: it checks out PR-head and runs PR-author code (`bun install` on the PR tree) with the publish-capable `EXPO_TOKEN` live. This is defense-in-depth on top of the existing `environment: ota-preview` reviewer gate — that gate's threat note in the file header stays accurate.

Out of scope (lower severity, deliberately deferred): `android-apk-rn.yml` (`GOOGLE_MAPS_API_KEY`) and the two `mobile-screenshots-*.yml` (`SCREENSHOT_USER_*`, which fall back to public test creds).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Parsed all five files as YAML and asserted no job/workflow-level `env:` still holds a `${{ secrets.* }}` value (only the deliberate `HAS_EXPO_TOKEN` boolean presence flag remains, which evaluates to `true`/`false`, never the token).
- Verified the two `if:`-guard cases survive the move: the preview-sweep gate reads `$EXPO_TOKEN` as a runtime shell check (step env is fine), and the preview-cleanup delete step now guards on `env.HAS_EXPO_TOKEN == 'true'` (a step-level `env:` is not reliably visible to its own step `if:`, so the token itself couldn't drive that guard).
- Runtime confirmation happens on GitHub, since these secrets only resolve in their environments: e.g. `export-board-snapshots.yml` via `workflow_dispatch` (both passes still reach Postgres + Tigris) and `mobile-ota-backport.yml` with `dry_run: true` (fingerprint-verify runs without `EXPO_TOKEN`; the publish step, which now holds it, is skipped). Watching CI's `vp check` for YAML formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jxh8fjQvCYUyFiNDexEkn

---
_Generated by [Claude Code](https://claude.ai/code/session_011jxh8fjQvCYUyFiNDexEkn)_