### PR TITLE
fix(mobile): scan unfiltered for Aurora boards so Android finds them

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -71,8 +71,8 @@ function setupConnectableAdapter(
   mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
   mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
 
-  // MoonBoards advertise no service UUID (unfiltered scan); Aurora boards carry
-  // the advertised service so they survive the UUID-filtered scan.
+  // The scan is unfiltered; isLikelyBoardDevice keeps board-like results. Aurora
+  // boards are given the advertised service UUID here; MoonBoards a name only.
   const scanName = family === 'aurora' ? 'Kilter Board#TEST@3' : 'MoonBoard A1';
   const serviceUUIDs = family === 'aurora' ? ['aurora-uuid'] : undefined;
   mockBleManager.startDeviceScan.mockImplementation(
@@ -687,7 +687,7 @@ describe('RNBleAdapter', () => {
       expect(seenDevices.map((device) => device.deviceId)).toEqual(['moon-device']);
     });
 
-    it('uses the Aurora service filter and rejects non-board peripherals on Aurora scans', async () => {
+    it('scans unfiltered and rejects non-board peripherals on Aurora scans', async () => {
       mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
       mockBleManager.startDeviceScan.mockImplementation(
         (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
@@ -726,8 +726,56 @@ describe('RNBleAdapter', () => {
       const adapter = new RNBleAdapter(devicePicker, 'aurora');
       await adapter.requestAndConnect();
 
-      expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(['aurora-uuid'], null, expect.any(Function));
+      expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(null, null, expect.any(Function));
       expect(seenDevices.map((device) => device.deviceId)).toEqual(['kilter-device']);
+    });
+
+    it('surfaces Aurora boxes discovered by name when no service UUID is advertised', async () => {
+      // Regression guard (0710be7a8): a hardware service-UUID ScanFilter dropped
+      // Aurora boxes on Android when the 128-bit UUID rode the scan-response PDU,
+      // leaving an empty device picker. With the unfiltered scan the JS filter
+      // surfaces both the Aurora-built (`#serial@N`) and Kilter-built bare-name
+      // boxes by name alone — neither carries serviceUUIDs here.
+      mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
+      mockBleManager.startDeviceScan.mockImplementation(
+        (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
+          callback(null, {
+            id: 'kilter-serial',
+            localName: 'Kilter Board#751737@3',
+            name: 'Kilter Board#751737@3',
+            rssi: -50,
+          });
+          callback(null, { id: 'kilter-bare', localName: 'Kilter Board', name: 'Kilter Board', rssi: -55 });
+        },
+      );
+
+      const seenDevices: Array<{ deviceId: string }> = [];
+      const devicePicker: DevicePickerFn = (subscribe) => {
+        subscribe((devices) => {
+          seenDevices.splice(0, seenDevices.length, ...devices);
+        });
+        return Promise.resolve('kilter-serial');
+      };
+
+      const mockDeviceWithServices = {
+        id: 'kilter-serial',
+        characteristicsForService: vi
+          .fn()
+          .mockResolvedValue([{ uuid: 'uart-write-uuid', writeWithoutResponse: vi.fn() }]),
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
+        discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
+      };
+      mockBleManager.connectToDevice.mockResolvedValue({
+        id: 'kilter-serial',
+        requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
+        discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
+      });
+
+      const adapter = new RNBleAdapter(devicePicker, 'aurora');
+      await adapter.requestAndConnect();
+
+      expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(null, null, expect.any(Function));
+      expect(seenDevices.map((device) => device.deviceId).sort()).toEqual(['kilter-bare', 'kilter-serial']);
     });
 
     it('deduplicates repeated board names even when the native device id changes', async () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
@@ -35,8 +35,13 @@ vi.mock('react-native-ble-plx', () => ({
 vi.mock('../ble-manager', () => ({ bleManager: mockBleManager }));
 
 vi.mock('@boardsesh/ble-protocol', () => ({
-  // Treat the device name as the serial for test simplicity.
-  parseSerialNumber: (name?: string) => name,
+  // board-device-filter (used by the real, unmocked filter below) reads these
+  // service-UUID constants at module load; parseSerialNumber pulls the serial
+  // from an Aurora "#serial@api" name, like the real helper.
+  AURORA_ADVERTISED_SERVICE_UUID: 'aurora-uuid',
+  UART_SERVICE_UUID: 'uart-uuid',
+  REDBEARLAB_SERVICE_UUID: 'redbearlab-uuid',
+  parseSerialNumber: (name?: string) => name?.match(/#([^@]+)/)?.[1],
 }));
 
 import { useBoardScan } from '../use-board-scan';
@@ -187,12 +192,30 @@ describe('useBoardScan', () => {
 
     act(() => {
       const cb = scanCallback();
-      cb(null, { localName: 'board-A' });
-      cb(null, { localName: 'board-B' });
-      cb(null, { localName: 'board-A' }); // duplicate
+      cb(null, { localName: 'Kilter Board#alpha@3' });
+      cb(null, { localName: 'Tension Board#beta@3' });
+      cb(null, { localName: 'Kilter Board#alpha@3' }); // duplicate
     });
 
-    expect(result.current.serials).toEqual(['board-A', 'board-B']);
+    expect(result.current.serials).toEqual(['alpha', 'beta']);
+  });
+
+  it('ignores non-board peripherals so no spurious serial lookup fires', async () => {
+    const { result } = renderHook(() => useBoardScan());
+    await act(async () => {
+      await result.current.start();
+    });
+
+    act(() => {
+      const cb = scanCallback();
+      // Both parse a "#serial" but are not Aurora boards — must be dropped before
+      // any boardsBySerialNumbers lookup (regression from unfiltering the scan).
+      cb(null, { localName: 'Printer #751737' });
+      cb(null, { localName: "Marco's AirPods #1" });
+      cb(null, { localName: 'Kilter Board#alpha@3' });
+    });
+
+    expect(result.current.serials).toEqual(['alpha']);
   });
 
   it('stops scanning and reports done after the timeout', async () => {
@@ -229,9 +252,9 @@ describe('useBoardScan', () => {
       await result.current.start();
     });
     act(() => {
-      scanCallback()(null, { localName: 'board-A' });
+      scanCallback()(null, { localName: 'Kilter Board#alpha@3' });
     });
-    expect(result.current.serials).toEqual(['board-A']);
+    expect(result.current.serials).toEqual(['alpha']);
 
     act(() => {
       result.current.reset();

--- a/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
@@ -35,8 +35,6 @@ vi.mock('react-native-ble-plx', () => ({
 vi.mock('../ble-manager', () => ({ bleManager: mockBleManager }));
 
 vi.mock('@boardsesh/ble-protocol', () => ({
-  AURORA_ADVERTISED_SERVICE_UUID: 'aurora-uuid',
-  UART_SERVICE_UUID: 'uart-uuid',
   // Treat the device name as the serial for test simplicity.
   parseSerialNumber: (name?: string) => name,
 }));
@@ -94,7 +92,9 @@ describe('useBoardScan', () => {
     });
 
     expect(result.current.status).toBe('scanning');
-    expect(mockBleManager.startDeviceScan).toHaveBeenCalled();
+    // Regression guard: scan UNFILTERED. A hardware service-UUID filter dropped
+    // Aurora boxes on Android when the UUID rode the scan-response PDU (#3806).
+    expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(null, null, expect.any(Function));
   });
 
   it('does not start scanning after reset during Bluetooth readiness wait', async () => {

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -1,6 +1,5 @@
 import { type Device, type Characteristic, type BleError } from 'react-native-ble-plx';
 import {
-  AURORA_ADVERTISED_SERVICE_UUID,
   UART_SERVICE_UUID,
   UART_WRITE_CHARACTERISTIC_UUID,
   REDBEARLAB_SERVICE_UUID,
@@ -125,10 +124,17 @@ export class RNBleAdapter implements BluetoothAdapter {
     let scanTimeoutId: ReturnType<typeof setTimeout> | undefined;
     let selectedDeviceId: string;
     try {
-      // Aurora scans can stay service-filtered. MoonBoard scans stay unfiltered
-      // so name-prefix controllers without advertised UART still surface.
-      const scanServiceUuids = this.scanFamily === 'aurora' ? [AURORA_ADVERTISED_SERVICE_UUID] : null;
-      void bleManager.startDeviceScan(scanServiceUuids, null, (scanError, scannedDevice) => {
+      // Scan UNFILTERED and filter results in JS (isLikelyBoardDevice below).
+      // A hardware service-UUID ScanFilter never matches by name and, on Android,
+      // is unreliable for a 128-bit UUID a box carries only in its scan-response
+      // PDU — so it silently drops Aurora (Kilter/Tension) boxes whose UUID/name
+      // arrives that way, giving an empty device picker (regression 0710be7a8:
+      // Android 2.2.2 Kilter empty-picker rate ~23% vs ~6% on 2.1.0). MoonBoard
+      // already required an unfiltered scan; Aurora now matches it. The JS filter
+      // reads ble-plx's merged advertise+scan-response record, so it still
+      // surfaces both Aurora-built (`Kilter Board#serial@N`) and Kilter-built
+      // bare-name (`Kilter Board`) boxes while rejecting non-boards.
+      void bleManager.startDeviceScan(null, null, (scanError, scannedDevice) => {
         if (scanError) {
           void bleManager.stopDeviceScan();
           // Surface the failure immediately so the user sees feedback instead

--- a/packages/mobile/src/lib/ble/use-board-scan.ts
+++ b/packages/mobile/src/lib/ble/use-board-scan.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { parseSerialNumber } from '@boardsesh/ble-protocol';
 import { bleManager } from './ble-manager';
 import { waitForBlePoweredOn } from './availability';
+import { isLikelyBoardDevice } from './board-device-filter';
 import { requestBleRuntimePermissions } from './use-ble-permissions';
 
 const SCAN_TIMEOUT_MS = 15_000;
@@ -85,7 +86,17 @@ export function useBoardScan(): BoardScan {
         return;
       }
       if (!device) return;
-      const serial = parseSerialNumber(device.localName ?? device.name ?? undefined);
+      const deviceName = device.localName ?? device.name ?? undefined;
+      // The unfiltered scan surfaces every nearby peripheral, so gate on the same
+      // Aurora board/service check the picker uses before treating a "#serial" as
+      // a board serial. Otherwise a stray "Printer #751737" or "AirPods #1" would
+      // parse a serial and fire a spurious boardsBySerialNumbers lookup (which
+      // could even resolve to a real, not-actually-present board).
+      const advertisedServiceUuids = [...(device.serviceUUIDs ?? []), ...(device.overflowServiceUUIDs ?? [])];
+      if (!isLikelyBoardDevice({ name: deviceName, serviceUuids: advertisedServiceUuids, scanFamily: 'aurora' })) {
+        return;
+      }
+      const serial = parseSerialNumber(deviceName);
       if (serial && !found.has(serial)) {
         found.add(serial);
         setSerials([...found]);

--- a/packages/mobile/src/lib/ble/use-board-scan.ts
+++ b/packages/mobile/src/lib/ble/use-board-scan.ts
@@ -6,7 +6,7 @@
 // opened here; connecting happens later when the user enters play mode.
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID, parseSerialNumber } from '@boardsesh/ble-protocol';
+import { parseSerialNumber } from '@boardsesh/ble-protocol';
 import { bleManager } from './ble-manager';
 import { waitForBlePoweredOn } from './availability';
 import { requestBleRuntimePermissions } from './use-ble-permissions';
@@ -73,7 +73,11 @@ export function useBoardScan(): BoardScan {
     setStatus('scanning');
     scanningRef.current = true;
 
-    bleManager.startDeviceScan([AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID], null, (error, device) => {
+    // Scan UNFILTERED, then keep only devices whose name carries an Aurora serial
+    // (parseSerialNumber below). A hardware service-UUID ScanFilter drops boards
+    // on Android when the UUID rides the scan-response PDU, leaving an empty
+    // quickstart list — same root cause as the picker scan in adapter.ts.
+    void bleManager.startDeviceScan(null, null, (error, device) => {
       if (!isCurrentScanAttempt()) return;
       if (error) {
         stop();


### PR DESCRIPTION
## Summary

The Android device picker showed an **empty Bluetooth sheet** for many Kilter/Tension users — no board to tap, so no connecting and no logging. Surfaced by a user on a Samsung Galaxy S24+ / Android 16 / 2.2.2 ("same problems as before, no connecting, can't log — haven't used it since").

**Root cause:** `RNBleAdapter` (the Android BLE path) scanned Aurora boards with a hardware service-UUID `ScanFilter`. On Android that filter never matches by name and is unreliable for a 128-bit UUID a box carries in its **scan-response** PDU, so it silently dropped boards before JS ever saw them → `devicesTotal = 0`.

Introduced by `0710be7a8` ("fix mobile bluetooth picker filtering", shipped in 2.2.x), which replaced an unfiltered scan whose own comment warned against exactly this. PostHog, Android 16, `BLE Picker Devices Resolved` empty-rate (`devicesTotal = 0`):

| Board (scan mode) | 2.1.0 | 2.2.2 |
| --- | --- | --- |
| Kilter (Aurora, filtered) | 5.8% | **22.9%** |
| Tension (Aurora, filtered) | 6.1% | **13.5%** |
| MoonBoard (unfiltered — control) | 15.9% | 25.1% |

The two *filtered* families jumped hardest while the *unfiltered* MoonBoard control rose far less on the same OS — the signature of the filter.

**Fix:** scan unfiltered and let the existing JS `isLikelyBoardDevice` filter decide — what MoonBoard already does and what Aurora did before 2.2. It reads ble-plx's merged advertise+scan-response record, so it still surfaces both **Aurora-built** (`Kilter Board#serial@N`) and **Kilter-built bare-name** (`Kilter Board`) boxes while rejecting non-boards, and is a **strict superset** of the old filtered scan — it can't lose a board, only add the ones Android dropped. Same fix for the "Bluetooth quickstart" scanner in `use-board-scan.ts`.

JS-only → the native fingerprint is unchanged, so this **OTAs to the existing 2.2.2 store binary** and reaches affected users without a store release.

## Release Notes

- Android: your board shows up in the Bluetooth list again when you reconnect — no more empty picker

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 4290 pass. New `adapter.test.ts` case proves both an Aurora-built (serial name) and a Kilter-built bare-name box surface on the unfiltered scan **with no advertised service UUID** — the exact shape the old filter dropped. Existing Aurora test flipped to assert an unfiltered `startDeviceScan(null, …)` while still rejecting AirPods.
- `vp check` — 0 errors
- `vp run check:mobile-bundle` — OK
- **Still needed:** real-device QA on Samsung / Android 16 + Kilter box — connect, disconnect, reconnect via the lightbulb; confirm the board reappears (`devicesTotal > 0`) instead of an empty sheet. Cover a Kilter-built bare-name box too if available (exercises the name-only path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BY48HrcqZ1KJ1VNcJM2kJK
