### PR TITLE
fix(mobile): drop MoonBoard on dead-link write so the lightbulb goes out

### DIFF
--- a/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
+++ b/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
@@ -11,6 +11,7 @@ type BluetoothCtx = {
   disconnect: ReturnType<typeof vi.fn>;
   armUndoWallChangeToast: ReturnType<typeof vi.fn>;
   reconnectSerialForCurrentBoard: string | null;
+  reconnectDeviceIdForCurrentBoard: string | null;
 } | null;
 
 const ctrl = vi.hoisted(() => ({
@@ -48,6 +49,7 @@ function makeBluetooth(over: Partial<NonNullable<BluetoothCtx>> = {}): NonNullab
     disconnect: vi.fn().mockResolvedValue(undefined),
     armUndoWallChangeToast: vi.fn(),
     reconnectSerialForCurrentBoard: null,
+    reconnectDeviceIdForCurrentBoard: null,
     ...over,
   };
 }
@@ -178,12 +180,21 @@ describe('useLightbulbControl press action', () => {
     const { result } = renderControl();
     result.current.onPress();
     expect(ctrl.bluetooth?.armUndoWallChangeToast).toHaveBeenCalledOnce();
-    expect(ctrl.bluetooth?.connect).toHaveBeenCalledWith(undefined, undefined, 'serial-1');
+    expect(ctrl.bluetooth?.connect).toHaveBeenCalledWith(undefined, undefined, 'serial-1', undefined);
     expect(ctrl.bluetooth?.disconnect).not.toHaveBeenCalled();
     expect(trackMock).toHaveBeenCalledWith(
       'Board Lightbulb Connect',
       expect.objectContaining({ source: 'lightbulb_toolbar' }),
     );
+  });
+
+  it('reconnects a MoonBoard by its remembered device id (no serial)', () => {
+    ctrl.bluetooth = makeBluetooth({ isConnected: false, reconnectDeviceIdForCurrentBoard: 'moon-abc' });
+    const { result } = renderControl();
+    result.current.onPress();
+    // Serial arg stays undefined; the device id is forwarded so the adapter
+    // silently reconnects to the same MoonBoard instead of opening the picker.
+    expect(ctrl.bluetooth?.connect).toHaveBeenCalledWith(undefined, undefined, undefined, 'moon-abc');
   });
 
   it('disconnects (no connect, no track) when already connected', () => {

--- a/packages/mobile/src/components/ble/use-lightbulb-control.ts
+++ b/packages/mobile/src/components/ble/use-lightbulb-control.ts
@@ -91,7 +91,14 @@ export function useLightbulbControl(options: UseLightbulbControlOptions): Lightb
       climbUuid: climbUuid ?? null,
     });
     bluetooth.armUndoWallChangeToast();
-    void bluetooth.connect(undefined, undefined, bluetooth.reconnectSerialForCurrentBoard ?? undefined);
+    // Reconnect straight to the same board — by serial (Aurora) or device id
+    // (MoonBoard). With neither remembered, the adapter opens the picker.
+    void bluetooth.connect(
+      undefined,
+      undefined,
+      bluetooth.reconnectSerialForCurrentBoard ?? undefined,
+      bluetooth.reconnectDeviceIdForCurrentBoard ?? undefined,
+    );
   }, [bluetooth, source, sessionId, boardLayout, climbUuid]);
 
   const onLongPress = useCallback(() => {

--- a/packages/mobile/src/lib/ble/__tests__/last-connected-board-store.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/last-connected-board-store.test.ts
@@ -63,4 +63,18 @@ describe('last-connected-board-store', () => {
     const { getStoredLastConnectedBoard } = await import('../last-connected-board-store');
     await expect(getStoredLastConnectedBoard()).resolves.toBeNull();
   });
+
+  it('rejects a stored payload with both a serial and a device id set', async () => {
+    // The two handles are mutually exclusive by board generation — the writer
+    // never sets both. A record with both is an unvalidated/foreign write, so
+    // it must fail visibly (null → picker fallback) rather than silently
+    // reconnecting on an ambiguous pairing.
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default;
+    await asyncStorage.setItem(
+      'boardsesh_last_connected_board_v1',
+      JSON.stringify({ configKey: 'moonboard::1::2', serial: 'ABC123', deviceId: 'device-1' }),
+    );
+    const { getStoredLastConnectedBoard } = await import('../last-connected-board-store');
+    await expect(getStoredLastConnectedBoard()).resolves.toBeNull();
+  });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -995,6 +995,50 @@ describe('useBoardBluetooth', () => {
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Stolen')).toBeUndefined();
   });
 
+  it('reports the first ambiguous MoonBoard write_failed as an error, only downgrading once the streak confirms a dead link', async () => {
+    // The first `write_failed` could be a genuine write bug unrelated to a dead
+    // link — it must still surface at 'error' level so it isn't drowned out.
+    // Only the second (streak-confirmed) failure, which drops the connection,
+    // downgrades to 'warning' — mirroring the routine-disconnect treatment.
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'moon-1', deviceName: 'MoonBoard' }),
+      write: vi.fn().mockRejectedValue(new Error('Write failed')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x09]),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 1,
+      isClear: false,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    await act(async () => {
+      await result.current.sendFramesToBoard('p100r12');
+    });
+    const sendFailureCalls = vi
+      .mocked(reportHandledError)
+      .mock.calls.filter(([, options]) => options?.tags?.source === 'ble-send');
+    expect(sendFailureCalls).toHaveLength(1);
+    expect(sendFailureCalls[0][1]).toMatchObject({ level: 'error' });
+
+    await act(async () => {
+      await result.current.sendFramesToBoard('p101r12');
+    });
+    const sendFailureCallsAfterDrop = vi
+      .mocked(reportHandledError)
+      .mock.calls.filter(([, options]) => options?.tags?.source === 'ble-send');
+    expect(sendFailureCallsAfterDrop).toHaveLength(2);
+    expect(sendFailureCallsAfterDrop[1][1]).toMatchObject({ level: 'warning' });
+  });
+
   it('resets the MoonBoard dead-link streak after a successful write (no drop on isolated glitches)', async () => {
     // Two write failures with a success between them must not drop the link: the
     // success proves the board is alive, so the streak resets and the second

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -946,12 +946,13 @@ describe('useBoardBluetooth', () => {
     expect(result.current.isConnected).toBe(false);
   });
 
-  it('drops a MoonBoard when a write fails on a dead link so the lightbulb goes out', async () => {
-    // The 2016 MoonBoard drops the link with a CoreBluetooth supervision timeout;
-    // the native write error for the gone peripheral does NOT match the
-    // isDisconnectionError signatures, so it classifies as the generic
-    // `write_failed`. Left alone the link would stay "connected" with the bulb
-    // lit on a dark wall. On a MoonBoard we treat that as a lost link.
+  it('drops a MoonBoard only after consecutive dead-link writes so the lightbulb goes out', async () => {
+    // A 2016 MoonBoard supervision-timeout drop surfaces as a generic
+    // `write_failed` (the native "No board is connected" slips past
+    // isDisconnectionError). But a one-off transient write error looks identical,
+    // and force-dropping a live MoonBoard is costly — some controllers need a
+    // power cycle before a new connection — so a single failure must NOT drop the
+    // link; only a genuine drop, which fails every subsequent send, does.
     const fakeAdapter = makeFakeAdapter({
       requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'moon-1', deviceName: 'MoonBoard' }),
       write: vi.fn().mockRejectedValue(new Error('Write failed')),
@@ -973,16 +974,68 @@ describe('useBoardBluetooth', () => {
     });
     expect(result.current.isConnected).toBe(true);
 
+    // First dead-link write: reported, but the link is kept (could be transient).
     await act(async () => {
       await result.current.sendFramesToBoard('p100r12');
     });
+    expect(result.current.isConnected).toBe(true);
+    expect(fakeAdapter.disconnect).not.toHaveBeenCalled();
 
-    const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');
-    expect(failureCall?.[1]).toMatchObject({ failureReason: 'write_failed' });
+    // Second consecutive failure: now treat it as dead and drop so the bulb goes out.
+    await act(async () => {
+      await result.current.sendFramesToBoard('p101r12');
+    });
     expect(result.current.isConnected).toBe(false);
     expect(fakeAdapter.disconnect).toHaveBeenCalled();
+
+    const failures = mockTrack.mock.calls.filter(([name]) => name === 'Climb Sent to Board Failure');
+    expect(failures).toHaveLength(2);
+    expect(failures[0][1]).toMatchObject({ failureReason: 'write_failed' });
     // A link timeout isn't a steal — don't fire the tug-of-war event.
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Stolen')).toBeUndefined();
+  });
+
+  it('resets the MoonBoard dead-link streak after a successful write (no drop on isolated glitches)', async () => {
+    // Two write failures with a success between them must not drop the link: the
+    // success proves the board is alive, so the streak resets and the second
+    // failure is treated as a fresh glitch, not a dead link.
+    const write = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Write failed'))
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('Write failed'));
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'moon-1', deviceName: 'MoonBoard' }),
+      write,
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x09]),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 1,
+      isClear: false,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    await act(async () => {
+      await result.current.sendFramesToBoard('a'); // fail → streak 1
+    });
+    await act(async () => {
+      await result.current.sendFramesToBoard('b'); // success → streak reset to 0
+    });
+    await act(async () => {
+      await result.current.sendFramesToBoard('c'); // fail → streak 1 (not 2)
+    });
+
+    expect(result.current.isConnected).toBe(true);
+    expect(fakeAdapter.disconnect).not.toHaveBeenCalled();
   });
 
   it('keeps a MoonBoard connected when a write stalls (write_timeout self-recovers)', async () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1180,6 +1180,26 @@ describe('useBoardBluetooth native connection adoption', () => {
     expect(result.current.isConnected).toBe(true);
   });
 
+  it('remembers an adopted MoonBoard by its device id (no serial)', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'moon-native-dev', deviceName: 'MoonBoard A1' });
+    });
+
+    expect(adapter.adoptConnection).toHaveBeenCalledWith('moon-native-dev');
+    expect(result.current.isConnected).toBe(true);
+    // A MoonBoard has no serial, so an adopted native connection is remembered by
+    // device id — so a later drop can reconnect to the same board on one tap.
+    expect(mockLastConnectedBoardStore.setStoredLastConnectedBoard).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceId: 'moon-native-dev' }),
+    );
+    expect(result.current.reconnectDeviceIdForCurrentBoard).toBe('moon-native-dev');
+  });
+
   it('reconfigures adopted native boards when role colour overrides change', async () => {
     const adapter = makeAdoptableAdapter();
     vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -96,7 +96,9 @@ vi.mock('../adapter', () => ({
 // mock it so the hook's persist/hydrate wiring can be asserted without a native
 // module, and so its behaviour is observable via these spies (#3609).
 const mockLastConnectedBoardStore = vi.hoisted(() => ({
-  getStoredLastConnectedBoard: vi.fn(async (): Promise<{ serial: string; configKey: string } | null> => null),
+  getStoredLastConnectedBoard: vi.fn(
+    async (): Promise<{ configKey: string; serial?: string; deviceId?: string } | null> => null,
+  ),
   setStoredLastConnectedBoard: vi.fn(async () => {}),
   clearStoredLastConnectedBoard: vi.fn(async () => {}),
 }));
@@ -942,6 +944,135 @@ describe('useBoardBluetooth', () => {
     const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');
     expect(failureCall).toBeUndefined();
     expect(result.current.isConnected).toBe(false);
+  });
+
+  it('drops a MoonBoard when a write fails on a dead link so the lightbulb goes out', async () => {
+    // The 2016 MoonBoard drops the link with a CoreBluetooth supervision timeout;
+    // the native write error for the gone peripheral does NOT match the
+    // isDisconnectionError signatures, so it classifies as the generic
+    // `write_failed`. Left alone the link would stay "connected" with the bulb
+    // lit on a dark wall. On a MoonBoard we treat that as a lost link.
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'moon-1', deviceName: 'MoonBoard' }),
+      write: vi.fn().mockRejectedValue(new Error('Write failed')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x09]),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 1,
+      isClear: false,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+    expect(result.current.isConnected).toBe(true);
+
+    await act(async () => {
+      await result.current.sendFramesToBoard('p100r12');
+    });
+
+    const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');
+    expect(failureCall?.[1]).toMatchObject({ failureReason: 'write_failed' });
+    expect(result.current.isConnected).toBe(false);
+    expect(fakeAdapter.disconnect).toHaveBeenCalled();
+    // A link timeout isn't a steal — don't fire the tug-of-war event.
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Stolen')).toBeUndefined();
+  });
+
+  it('keeps a MoonBoard connected when a write stalls (write_timeout self-recovers)', async () => {
+    // write_timeout is the native layer's own self-recovery path (#3181); it must
+    // NOT be torn down here even on a MoonBoard.
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'moon-1', deviceName: 'MoonBoard' }),
+      write: vi.fn().mockRejectedValue(new Error('BLE write timed out waiting for the board to accept data')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x09]),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 1,
+      isClear: false,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+    await act(async () => {
+      await result.current.sendFramesToBoard('p100r12');
+    });
+
+    const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');
+    expect(failureCall?.[1]).toMatchObject({ failureReason: 'write_timeout' });
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it('does not drop a Kilter connection on a generic write_failed (MoonBoard-scoped)', async () => {
+    // The dead-link-on-write_failed teardown is scoped to MoonBoard; an Aurora
+    // board keeps the existing behaviour (only explicit disconnect signatures
+    // tear it down), so a one-off Kilter write hiccup doesn't drop the link.
+    const fakeAdapter = makeFakeAdapter({
+      write: vi.fn().mockRejectedValue(new Error('Write failed')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetLedPlacements.mockReturnValue({ 100: 7 });
+    mockGetAuroraBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x09]),
+      skippedPositionCount: 0,
+      skippedRoleCount: 0,
+      totalPlacements: 1,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+    await act(async () => {
+      await result.current.sendFramesToBoard('p100r12');
+    });
+
+    const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');
+    expect(failureCall?.[1]).toMatchObject({ failureReason: 'write_failed' });
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it('remembers a MoonBoard by device id and reconnects to it without the picker', async () => {
+    // MoonBoards carry no parseable serial, so we remember the BLE peripheral id
+    // and pass it back as the reconnect target; the adapter then silently
+    // auto-selects that device instead of opening the picker.
+    const requestAndConnect = vi.fn().mockResolvedValue({ deviceId: 'moon-abc', deviceName: 'MoonBoard' });
+    const fakeAdapter = makeFakeAdapter({ requestAndConnect });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(mockLastConnectedBoardStore.setStoredLastConnectedBoard).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceId: 'moon-abc' }),
+    );
+    expect(result.current.reconnectDeviceIdForCurrentBoard).toBe('moon-abc');
+    expect(result.current.reconnectSerialForCurrentBoard).toBeNull();
+
+    await act(async () => {
+      await result.current.connect(undefined, undefined, undefined, 'moon-abc');
+    });
+    // The reconnect forwards the device id as the second requestAndConnect arg.
+    expect(requestAndConnect.mock.calls.at(-1)).toEqual([undefined, 'moon-abc']);
   });
 });
 

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -80,7 +80,7 @@ export class RNBleAdapter implements BluetoothAdapter {
   // The scan/select flow (silent serial auto-select → grace-window picker
   // fallback → scan timeout) mirrors NativeIosBleAdapter.requestAndConnect and
   // the web adapters. Kept in lockstep by hand; if you change one, change the others.
-  async requestAndConnect(targetSerial?: string): Promise<BleConnection> {
+  async requestAndConnect(targetSerial?: string, targetDeviceId?: string): Promise<BleConnection> {
     // Reset up front so a reused adapter whose reconnect fails before MTU
     // negotiation can't write with the previous connection's stale MTU.
     this.negotiatedMtu = DEFAULT_ATT_MTU;
@@ -89,8 +89,9 @@ export class RNBleAdapter implements BluetoothAdapter {
     let scanStoppedListener: (() => void) | null = null;
     const pushDevices = () => updateListener?.([...devices.values()]);
 
-    // One selection promise, resolved by either the silent serial auto-select
-    // or — if that serial never shows up — the picker the grace window opens.
+    // One selection promise, resolved by either the silent auto-select (by serial
+    // or device id) or — if the target never shows up — the picker the grace
+    // window opens.
     let resolveSelection!: (deviceId: string) => void;
     let rejectSelection!: (error: Error) => void;
     const selectionPromise = new Promise<string>((resolve, reject) => {
@@ -98,9 +99,9 @@ export class RNBleAdapter implements BluetoothAdapter {
       rejectSelection = reject;
     });
 
-    // True only while we're still silently matching the target serial — flips
+    // True only while we're still silently matching the reconnect target — flips
     // false the moment we auto-select or hand off to the picker.
-    let autoSelecting = Boolean(targetSerial);
+    let autoSelecting = Boolean(targetSerial || targetDeviceId);
     let pickerOpened = false;
     const openPicker = () => {
       if (pickerOpened) return;
@@ -113,8 +114,8 @@ export class RNBleAdapter implements BluetoothAdapter {
       }).then(resolveSelection, rejectSelection);
     };
 
-    // No target serial → straight to the picker.
-    if (!targetSerial) {
+    // No reconnect target → straight to the picker.
+    if (!targetSerial && !targetDeviceId) {
       openPicker();
     }
 
@@ -173,25 +174,29 @@ export class RNBleAdapter implements BluetoothAdapter {
           pushDevices();
         }
 
-        // Auto-select the stored board only until the picker takes over.
-        if (autoSelecting && targetSerial) {
-          const serial = parseSerialNumber(device.name);
-          if (serial === targetSerial) {
+        // Auto-select the stored board only until the picker takes over. A
+        // MoonBoard has no serial, so it matches on the remembered BLE device id;
+        // Aurora boards match on the serial parsed from the advertised name.
+        if (autoSelecting) {
+          const matchesDeviceId = targetDeviceId !== undefined && device.deviceId === targetDeviceId;
+          const matchesSerial = targetSerial !== undefined && parseSerialNumber(device.name) === targetSerial;
+          if (matchesDeviceId || matchesSerial) {
             autoSelecting = false;
             resolveSelection(device.deviceId);
           }
         }
       });
 
-      // Grace window: if the stored serial hasn't matched shortly, open the
+      // Grace window: if the remembered board hasn't matched shortly, open the
       // picker (scan keeps running so it live-updates) instead of waiting out
       // the full scan window and failing. Matches the web reconnect-by-serial
       // fallback.
-      pickerFallbackId = targetSerial
-        ? setTimeout(() => {
-            if (autoSelecting) openPicker();
-          }, SERIAL_RECONNECT_GRACE_MS)
-        : undefined;
+      pickerFallbackId =
+        targetSerial || targetDeviceId
+          ? setTimeout(() => {
+              if (autoSelecting) openPicker();
+            }, SERIAL_RECONNECT_GRACE_MS)
+          : undefined;
 
       scanTimeoutId = setTimeout(() => {
         void bleManager.stopDeviceScan();

--- a/packages/mobile/src/lib/ble/last-connected-board-store.ts
+++ b/packages/mobile/src/lib/ble/last-connected-board-store.ts
@@ -1,12 +1,18 @@
-// The last board we held a BLE link to — its serial plus the board config it was
-// paired against — persisted in **unsecure** AsyncStorage (via preference-store)
-// so a one-tap silent reconnect survives a cold start or provider remount, not
-// just the in-memory session (#3609).
+// The last board we held a BLE link to — the board config it was paired against
+// plus a reconnect handle — persisted in **unsecure** AsyncStorage (via
+// preference-store) so a one-tap silent reconnect survives a cold start or
+// provider remount, not just the in-memory session (#3609).
+//
+// The reconnect handle is one of two, depending on board generation:
+//   - `serial` — Aurora boards advertise a parseable serial; reconnect matches it.
+//   - `deviceId` — MoonBoards carry no serial, so we remember the BLE peripheral
+//     id (a stable per-device identifier on iOS) and match on that instead.
+// At least one is always present.
 //
 // This ONLY remembers the reconnect *target*; it never auto-connects. The
-// lightbulb tap reads it and reconnects by serial, keeping the deliberate,
-// user-initiated, no-auto-reconnect policy (bluetooth-provider.tsx) intact — so
-// it can't fight another climber for a last-connection-wins box.
+// lightbulb tap reads it and reconnects, keeping the deliberate, user-initiated,
+// no-auto-reconnect policy (bluetooth-provider.tsx) intact — so it can't fight
+// another climber for a last-connection-wins box.
 //
 // A deliberate disconnect forgets the board (clears this), matching the
 // in-memory `lastConnectedBoard` semantics in use-board-bluetooth.ts. Only an
@@ -14,7 +20,7 @@
 //
 // The stored `configKey` is `boardConfigKey(boardName, layoutId, sizeId)`. The
 // caller only rehydrates when it matches the board currently in view, so a
-// serial recorded against a different board is never offered as a reconnect
+// handle recorded against a different board is never offered as a reconnect
 // target for the wrong config.
 
 import { getPreference, setPreference, removePreference } from '../preference-store';
@@ -22,14 +28,24 @@ import { getPreference, setPreference, removePreference } from '../preference-st
 const LAST_CONNECTED_BOARD_KEY = 'boardsesh_last_connected_board_v1';
 
 export type StoredLastConnectedBoard = {
-  serial: string;
   configKey: string;
+  // Aurora reconnect handle (parsed from the advertised name). Absent for MoonBoard.
+  serial?: string;
+  // MoonBoard reconnect handle (BLE peripheral id). Absent for serial-bearing boards.
+  deviceId?: string;
 };
 
 function isStoredLastConnectedBoard(value: unknown): value is StoredLastConnectedBoard {
   if (typeof value !== 'object' || value === null) return false;
   const candidate = value as Record<string, unknown>;
-  return typeof candidate.serial === 'string' && typeof candidate.configKey === 'string';
+  if (typeof candidate.configKey !== 'string') return false;
+  const hasSerial = typeof candidate.serial === 'string';
+  const hasDeviceId = typeof candidate.deviceId === 'string';
+  // Reject stray non-string handles, and require at least one usable handle so a
+  // config-only record can never be offered as a reconnect target.
+  if (candidate.serial !== undefined && !hasSerial) return false;
+  if (candidate.deviceId !== undefined && !hasDeviceId) return false;
+  return hasSerial || hasDeviceId;
 }
 
 export async function getStoredLastConnectedBoard(): Promise<StoredLastConnectedBoard | null> {

--- a/packages/mobile/src/lib/ble/last-connected-board-store.ts
+++ b/packages/mobile/src/lib/ble/last-connected-board-store.ts
@@ -45,6 +45,12 @@ function isStoredLastConnectedBoard(value: unknown): value is StoredLastConnecte
   // config-only record can never be offered as a reconnect target.
   if (candidate.serial !== undefined && !hasSerial) return false;
   if (candidate.deviceId !== undefined && !hasDeviceId) return false;
+  // The two handles are mutually exclusive by board generation (Aurora serial vs.
+  // MoonBoard device id) — the writer only ever sets one. Reject a record with
+  // both rather than silently picking one, so a future writer bug that sets both
+  // fails visibly (falls back to the picker) instead of reconnecting on an
+  // unvalidated pairing.
+  if (hasSerial && hasDeviceId) return false;
   return hasSerial || hasDeviceId;
 }
 

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -97,15 +97,16 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
   // The scan/select flow (silent serial auto-select → grace-window picker
   // fallback → scan timeout) mirrors RNBleAdapter.requestAndConnect and the web
   // adapters. Kept in lockstep by hand; if you change one, change the others.
-  async requestAndConnect(targetSerial?: string): Promise<BleConnection> {
+  async requestAndConnect(targetSerial?: string, targetDeviceId?: string): Promise<BleConnection> {
     const native = this.requireNative();
     const devices = new Map<string, DiscoveredDevice>();
     let updateListener: ((devices: DiscoveredDevice[]) => void) | null = null;
     let scanStoppedListener: (() => void) | null = null;
     const pushDevices = () => updateListener?.([...devices.values()]);
 
-    // One selection promise, resolved by either the silent serial auto-select
-    // or — if that serial never shows up — the picker the grace window opens.
+    // One selection promise, resolved by either the silent auto-select (by serial
+    // or device id) or — if the target never shows up — the picker the grace
+    // window opens.
     let resolveSelection!: (deviceId: string) => void;
     let rejectSelection!: (error: Error) => void;
     const selectionPromise = new Promise<string>((resolve, reject) => {
@@ -113,9 +114,9 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       rejectSelection = reject;
     });
 
-    // True only while we're still silently matching the target serial — flips
+    // True only while we're still silently matching the reconnect target — flips
     // false the moment we auto-select or hand off to the picker.
-    let autoSelecting = Boolean(targetSerial);
+    let autoSelecting = Boolean(targetSerial || targetDeviceId);
     let pickerOpened = false;
     const openPicker = () => {
       if (pickerOpened) return;
@@ -128,8 +129,8 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       }).then(resolveSelection, rejectSelection);
     };
 
-    // No target serial → straight to the picker.
-    if (!targetSerial) {
+    // No reconnect target → straight to the picker.
+    if (!targetSerial && !targetDeviceId) {
       openPicker();
     }
 
@@ -161,10 +162,13 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
         pushDevices();
       }
 
-      // Auto-select the stored board only until the picker takes over.
-      if (autoSelecting && targetSerial) {
-        const serial = parseSerialNumber(device.name);
-        if (serial === targetSerial) {
+      // Auto-select the stored board only until the picker takes over. A
+      // MoonBoard has no serial, so it matches on the remembered BLE device id;
+      // Aurora boards match on the serial parsed from the advertised name.
+      if (autoSelecting) {
+        const matchesDeviceId = targetDeviceId !== undefined && device.deviceId === targetDeviceId;
+        const matchesSerial = targetSerial !== undefined && parseSerialNumber(device.name) === targetSerial;
+        if (matchesDeviceId || matchesSerial) {
           autoSelecting = false;
           resolveSelection(device.deviceId);
         }
@@ -190,15 +194,16 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
               [UART_SERVICE_UUID, REDBEARLAB_SERVICE_UUID];
       await native.startScan(scanServiceUuids);
 
-      // Grace window: if the stored serial hasn't matched shortly, open the
+      // Grace window: if the remembered board hasn't matched shortly, open the
       // picker (scan keeps running so it live-updates) instead of waiting out
       // the full scan window and failing. Matches the web reconnect-by-serial
       // fallback.
-      pickerFallbackId = targetSerial
-        ? setTimeout(() => {
-            if (autoSelecting) openPicker();
-          }, SERIAL_RECONNECT_GRACE_MS)
-        : undefined;
+      pickerFallbackId =
+        targetSerial || targetDeviceId
+          ? setTimeout(() => {
+              if (autoSelecting) openPicker();
+            }, SERIAL_RECONNECT_GRACE_MS)
+          : undefined;
 
       scanTimeoutId = setTimeout(() => {
         void native.stopScan();

--- a/packages/mobile/src/lib/ble/types.ts
+++ b/packages/mobile/src/lib/ble/types.ts
@@ -101,7 +101,9 @@ export type BleConnectDiagnostics = {
 
 export type BluetoothAdapter = {
   isAvailable(): Promise<boolean>;
-  requestAndConnect(targetSerial?: string): Promise<BleConnection>;
+  // `targetSerial` (Aurora) / `targetDeviceId` (MoonBoard) silently auto-select
+  // the remembered board on the reconnect scan; with neither, the picker opens.
+  requestAndConnect(targetSerial?: string, targetDeviceId?: string): Promise<BleConnection>;
   disconnect(): Promise<void>;
   write(data: Uint8Array, signal?: AbortSignal): Promise<void>;
   onDisconnect(callback: (info?: BleDisconnectInfo) => void): () => void;

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -48,6 +48,7 @@ import {
   clearStoredLastConnectedBoard,
   getStoredLastConnectedBoard,
   setStoredLastConnectedBoard,
+  type StoredLastConnectedBoard,
 } from './last-connected-board-store';
 
 // Exported for testing. Decides how a connect-failure category reaches error
@@ -329,12 +330,14 @@ export function useBoardBluetooth({
   const [loading, setLoading] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
 
-  // Remember the board (serial + which config it was paired against) so a later
-  // involuntary drop can be recovered with a silent reconnect to the same board
-  // (the lightbulb tap, native shells). Only valid while the current route still
-  // points at the same board — switching board/layout/size invalidates it and
-  // callers fall back to the picker. Mirrors the web `reconnectSerialForCurrentBoard`.
-  const [lastConnectedBoard, setLastConnectedBoard] = useState<{ serial: string; configKey: string } | null>(null);
+  // Remember the board (its reconnect handle + which config it was paired
+  // against) so a later involuntary drop can be recovered with a silent reconnect
+  // to the same board (the lightbulb tap, native shells). The handle is a serial
+  // for Aurora boards and a BLE peripheral id for MoonBoards. Only valid while the
+  // current route still points at the same board — switching board/layout/size
+  // invalidates it and callers fall back to the picker. Mirrors the web
+  // `reconnectSerialForCurrentBoard`.
+  const [lastConnectedBoard, setLastConnectedBoard] = useState<StoredLastConnectedBoard | null>(null);
   const lastConnectedBoardRef = useRef(lastConnectedBoard);
   lastConnectedBoardRef.current = lastConnectedBoard;
 
@@ -342,8 +345,7 @@ export function useBoardBluetooth({
   // one-tap silent reconnect survives a cold start or provider remount, not just
   // the current session (#3609). Storage writes are fire-and-forget: a failure
   // just means the next launch falls back to the picker, never a thrown error.
-  const rememberConnectedBoard = useCallback((serial: string, configKey: string) => {
-    const board = { serial, configKey };
+  const rememberConnectedBoard = useCallback((board: StoredLastConnectedBoard) => {
     setLastConnectedBoard(board);
     void setStoredLastConnectedBoard(board).catch(() => {});
   }, []);
@@ -680,27 +682,38 @@ export function useBoardBluetooth({
             failureReason: bleFailureReason,
             ...bleWriteDiagnosticsProperties(writeDiagnostics),
           });
+          // A write that fails because the link is gone is a lost link. Two
+          // signatures land here: the predicate matches the native adapters'
+          // "not connected" / "disconnected during write" wording, and — on a
+          // MoonBoard — a genuine link-timeout drop (CoreBluetooth error 6) whose
+          // native error slips past that predicate ("No board is connected") and
+          // falls into the generic `write_failed` bucket. Both mean the same for
+          // these last-connection-wins boards: the wall went dark and we should
+          // stop showing "connected". The native self-recovery buckets
+          // (`write_timeout` / `write_recovery_failed`) are excluded — the native
+          // layer is already cycling those and must not be torn down here.
+          const lostLink = isDisconnectionError(error);
+          const moonboardDeadLink = boardName === 'moonboard' && bleFailureReason === 'write_failed';
           // A dropped link is routine on these last-connection-wins boards
           // (another climber grabbed it, or it disconnected mid-session), so keep
           // it a filterable warning rather than a full error that drowns real
           // write bugs. Already tracked above via ClimbSentToBoardFailure.
           reportHandledError(error, {
-            level: bleFailureReason === 'disconnected' ? 'warning' : 'error',
+            level: lostLink || moonboardDeadLink ? 'warning' : 'error',
             tags: { source: 'ble-send', failure_reason: bleFailureReason },
             extra: writeDiagnostics ? { bleWriteDiagnostics: writeDiagnostics } : undefined,
           });
-          // A write that fails because the link is gone (the board dropped or
-          // another device grabbed it — these boards are last-connection-wins) is
-          // often the only signal we get: the adapter's disconnect event may never
-          // fire. Mark the connection lost so the lightbulb stops showing
-          // "connected" and a deliberate reconnect can run. The native adapters
-          // throw the plain-Error signatures the predicate matches ("Not
-          // connected", "Device disconnected during write").
-          if (isDisconnectionError(error)) {
-            // The tug-of-war signal: we believed we were connected but a write just
-            // failed on a dead link. On a shared board this is usually another
-            // device having grabbed it. Recorded so the two-climber case is visible.
-            track(SHARED_EVENTS.BluetoothConnectionStolen, { boardName, layoutId, sizeId });
+          // Mark the connection lost so the lightbulb stops showing "connected"
+          // and a deliberate reconnect can run. The adapter's disconnect event may
+          // never fire (or arrive only after iOS's slow supervision timeout), so a
+          // failed write is often the first — sometimes only — signal we get.
+          if (lostLink || moonboardDeadLink) {
+            // The tug-of-war signal (another device grabbed a shared board) only
+            // fits the predicate-matched case; a MoonBoard link timeout isn't a
+            // steal, so don't mislabel it.
+            if (lostLink) {
+              track(SHARED_EVENTS.BluetoothConnectionStolen, { boardName, layoutId, sizeId });
+            }
             handleDisconnection({ source: 'write-failure' });
           }
           return false;
@@ -735,7 +748,7 @@ export function useBoardBluetooth({
   );
 
   const connect = useCallback(
-    async (initialFrames?: string, mirrored?: boolean, targetSerial?: string) => {
+    async (initialFrames?: string, mirrored?: boolean, targetSerial?: string, targetDeviceId?: string) => {
       if (!boardName) {
         console.error('Cannot connect to Bluetooth without board name');
         return false;
@@ -797,11 +810,16 @@ export function useBoardBluetooth({
         }
 
         // Surface the scan on the session-recording timeline / PostHog. `reconnect`
-        // distinguishes a deliberate same-board serial reconnect (lightbulb) from a
-        // fresh picker-driven connect.
-        track(SHARED_EVENTS.BluetoothScanStarted, { boardName, layoutId, sizeId, reconnect: !!targetSerial });
+        // distinguishes a deliberate same-board reconnect (lightbulb — by serial for
+        // Aurora, by device id for MoonBoard) from a fresh picker-driven connect.
+        track(SHARED_EVENTS.BluetoothScanStarted, {
+          boardName,
+          layoutId,
+          sizeId,
+          reconnect: !!targetSerial || !!targetDeviceId,
+        });
 
-        const connection = await adapter.requestAndConnect(targetSerial);
+        const connection = await adapter.requestAndConnect(targetSerial, targetDeviceId);
         apiLevelRef.current = parseApiLevel(connection.deviceName);
         configuredDeviceNameRef.current = connection.deviceName;
 
@@ -853,12 +871,18 @@ export function useBoardBluetooth({
         }
 
         // Remember the board (keyed to the config it was paired against) so an
-        // involuntary drop can be recovered with a silent reconnect. Only Aurora
-        // boards expose a parseable serial; moonboard can't be reconnected by
-        // serial. Without a full config there is no usable key (and the
-        // reconnect comparison against currentConfigKey could never match).
-        if (parsedSerial && layoutId !== undefined && sizeId !== undefined) {
-          rememberConnectedBoard(parsedSerial, boardConfigKey(boardName, layoutId, sizeId));
+        // involuntary drop can be recovered by a one-tap reconnect. Aurora boards
+        // reconnect by their parseable serial; a MoonBoard has none, so we remember
+        // its BLE peripheral id and reconnect by matching that on the next scan.
+        // Without a full config there is no usable key (the reconnect comparison
+        // against currentConfigKey could never match).
+        if (layoutId !== undefined && sizeId !== undefined) {
+          const configKey = boardConfigKey(boardName, layoutId, sizeId);
+          if (parsedSerial) {
+            rememberConnectedBoard({ configKey, serial: parsedSerial });
+          } else if (boardName === 'moonboard') {
+            rememberConnectedBoard({ configKey, deviceId: connection.deviceId });
+          }
         }
 
         // Send initial frames if provided; seed the AutoSender's dedup with
@@ -1139,7 +1163,9 @@ export function useBoardBluetooth({
 
       const serial = deviceName ? (parseSerialNumber(deviceName) ?? null) : (rememberedBoard?.serial ?? null);
       if (serial) {
-        rememberConnectedBoard(serial, currentConfigKey);
+        rememberConnectedBoard({ configKey: currentConfigKey, serial });
+      } else if (boardName === 'moonboard') {
+        rememberConnectedBoard({ configKey: currentConfigKey, deviceId });
       }
       connectedConfigKeyRef.current = currentConfigKey;
       lastDisconnectInfoRef.current = null;
@@ -1225,10 +1251,17 @@ export function useBoardBluetooth({
   // provider.
   const currentConfigKey =
     boardName && layoutId !== undefined && sizeId !== undefined ? boardConfigKey(boardName, layoutId, sizeId) : null;
-  const reconnectSerialForCurrentBoard =
+  // The remembered board only counts while the route still points at the same
+  // config; a stored handle for a different board is never offered as a target.
+  const rememberedForCurrentBoard =
     lastConnectedBoard && currentConfigKey && lastConnectedBoard.configKey === currentConfigKey
-      ? lastConnectedBoard.serial
+      ? lastConnectedBoard
       : null;
+  // Aurora reconnects by serial; MoonBoard (no serial) reconnects by BLE device
+  // id. The lightbulb passes whichever is set so the tap silently reconnects to
+  // the same board instead of dropping the user into the picker.
+  const reconnectSerialForCurrentBoard = rememberedForCurrentBoard?.serial ?? null;
+  const reconnectDeviceIdForCurrentBoard = rememberedForCurrentBoard?.deviceId ?? null;
 
   // Rehydrate the remembered board from storage on mount so a one-tap silent
   // reconnect survives a cold start / provider remount, not just the in-memory
@@ -1271,6 +1304,7 @@ export function useBoardBluetooth({
     sendFramesToBoard,
     pickerState,
     reconnectSerialForCurrentBoard,
+    reconnectDeviceIdForCurrentBoard,
     connectInitialSendRef,
     lastDisconnectInfoRef,
   };

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -140,6 +140,17 @@ export function moonboardNumRowsForNative(boardName: string | undefined, layoutI
   return boardName === 'moonboard' ? getMoonBoardGeometryByLayoutId(layoutId).numRows : undefined;
 }
 
+// How many consecutive MoonBoard write failures (with no successful write in
+// between) must occur before we conclude the link is dead and drop it. A
+// MoonBoard's dead-link write surfaces as a generic `write_failed` — the same
+// bucket a one-off transient hiccup lands in — and force-dropping a still-live
+// link is costly on these boards: some controllers need a physical power cycle
+// before they'll accept a new connection, so a wrong teardown can leave the user
+// unable to reconnect at all. A genuine supervision-timeout drop fails every
+// subsequent send, so a small streak separates it from a transient glitch (whose
+// next send succeeds and resets the count) without dropping a live board.
+export const MOONBOARD_WRITE_FAILURE_DROP_THRESHOLD = 2;
+
 export type PickerState = {
   devices: DiscoveredDevice[];
   isScanning: boolean;
@@ -372,6 +383,10 @@ export function useBoardBluetooth({
   // both. Mirrors the web hook's writeChainRef; reset on connect/disconnect
   // so a hung write can't wedge the next connection's sends.
   const writeChainRef = useRef<Promise<void>>(Promise.resolve());
+  // Consecutive MoonBoard `write_failed` count, reset by any successful write and
+  // on connect/drop. Gates the dead-link teardown so a single transient write
+  // error never drops a live board — see MOONBOARD_WRITE_FAILURE_DROP_THRESHOLD.
+  const moonboardWriteFailureStreakRef = useRef(0);
   // True while a connect attempt is running. Guards against a second
   // concurrent connect (double-tapped lightbulb): both attempts would share
   // the singleton BLE manager, and the first attempt's scan teardown kills
@@ -465,6 +480,7 @@ export function useBoardBluetooth({
     writeAbortRef.current?.abort();
     writeAbortRef.current = null;
     writeChainRef.current = Promise.resolve();
+    moonboardWriteFailureStreakRef.current = 0;
     setIsConnected(false);
     onConnectionChange?.(false);
     // Drop the connect-time BLE diagnostic tags so a later unrelated error
@@ -561,6 +577,8 @@ export function useBoardBluetooth({
               });
               return false;
             }
+            // A write just landed, so the link is alive — clear the dead-link streak.
+            moonboardWriteFailureStreakRef.current = 0;
             if (frames === '') {
               // Deliberate clear-all just went out as `l##`: community firmware
               // (ArduinoMoonBoardLED) clears every LED on each incoming frame;
@@ -682,24 +700,31 @@ export function useBoardBluetooth({
             failureReason: bleFailureReason,
             ...bleWriteDiagnosticsProperties(writeDiagnostics),
           });
-          // A write that fails because the link is gone is a lost link. Two
-          // signatures land here: the predicate matches the native adapters'
-          // "not connected" / "disconnected during write" wording, and — on a
-          // MoonBoard — a genuine link-timeout drop (CoreBluetooth error 6) whose
-          // native error slips past that predicate ("No board is connected") and
-          // falls into the generic `write_failed` bucket. Both mean the same for
-          // these last-connection-wins boards: the wall went dark and we should
-          // stop showing "connected". The native self-recovery buckets
-          // (`write_timeout` / `write_recovery_failed`) are excluded — the native
-          // layer is already cycling those and must not be torn down here.
+          // A write that fails because the link is gone is a lost link. The
+          // predicate matches the native adapters' "not connected" / "disconnected
+          // during write" wording — a definite drop — so tear down immediately.
           const lostLink = isDisconnectionError(error);
-          const moonboardDeadLink = boardName === 'moonboard' && bleFailureReason === 'write_failed';
+          // On a MoonBoard a genuine link-timeout drop (CoreBluetooth error 6)
+          // slips past that predicate ("No board is connected") and falls into the
+          // generic `write_failed` bucket — but so does a one-off transient write
+          // error on a still-live link. Dropping a live MoonBoard is costly (some
+          // controllers need a power cycle before a new connection), so we only
+          // treat it as dead after consecutive failures with no success between:
+          // a real drop fails every send, a glitch's next send resets the streak.
+          // The native self-recovery buckets (`write_timeout` /
+          // `write_recovery_failed`) never count — the native layer cycles those.
+          const moonboardWriteFailed = boardName === 'moonboard' && bleFailureReason === 'write_failed';
+          if (moonboardWriteFailed) {
+            moonboardWriteFailureStreakRef.current += 1;
+          }
+          const moonboardDeadLink =
+            moonboardWriteFailed && moonboardWriteFailureStreakRef.current >= MOONBOARD_WRITE_FAILURE_DROP_THRESHOLD;
           // A dropped link is routine on these last-connection-wins boards
           // (another climber grabbed it, or it disconnected mid-session), so keep
           // it a filterable warning rather than a full error that drowns real
           // write bugs. Already tracked above via ClimbSentToBoardFailure.
           reportHandledError(error, {
-            level: lostLink || moonboardDeadLink ? 'warning' : 'error',
+            level: lostLink || moonboardWriteFailed ? 'warning' : 'error',
             tags: { source: 'ble-send', failure_reason: bleFailureReason },
             extra: writeDiagnostics ? { bleWriteDiagnostics: writeDiagnostics } : undefined,
           });
@@ -794,6 +819,8 @@ export function useBoardBluetooth({
         writeAbortRef.current?.abort();
         writeAbortRef.current = null;
         writeChainRef.current = Promise.resolve();
+        // Fresh connection generation — a stale dead-link streak must not carry over.
+        moonboardWriteFailureStreakRef.current = 0;
 
         // Clean up any existing adapter
         if (adapterRef.current) {

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -722,9 +722,13 @@ export function useBoardBluetooth({
           // A dropped link is routine on these last-connection-wins boards
           // (another climber grabbed it, or it disconnected mid-session), so keep
           // it a filterable warning rather than a full error that drowns real
-          // write bugs. Already tracked above via ClimbSentToBoardFailure.
+          // write bugs. Already tracked above via ClimbSentToBoardFailure. Only
+          // downgrade a MoonBoard `write_failed` once the streak *confirms* a dead
+          // link (moonboardDeadLink) — the first, still-ambiguous failure could be
+          // a genuine write bug unrelated to the supervision-timeout pattern, and
+          // that should still surface as an error.
           reportHandledError(error, {
-            level: lostLink || moonboardWriteFailed ? 'warning' : 'error',
+            level: lostLink || moonboardDeadLink ? 'warning' : 'error',
             tags: { source: 'ble-send', failure_reason: bleFailureReason },
             extra: writeDiagnostics ? { bleWriteDiagnostics: writeDiagnostics } : undefined,
           });

--- a/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -260,6 +260,7 @@ describe('LiveActivityBridge lightbulb (boardControl)', () => {
     bt.armUndoWallChangeToast.mockClear();
     bt.reassertWall.mockClear();
     bt.reconnectSerialForCurrentBoard = 'serial-123';
+    bt.reconnectDeviceIdForCurrentBoard = null;
     analytics.track.mockClear();
     climbRender.overlayUri = null;
     climbRender.backgroundPaths = [];
@@ -345,7 +346,6 @@ describe('LiveActivityBridge lightbulb (boardControl)', () => {
     });
 
     expect(bt.connect).toHaveBeenCalledWith(undefined, undefined, undefined, 'moon-abc');
-    bt.reconnectDeviceIdForCurrentBoard = null;
   });
 
   it('reassert: re-pushes the current climb without reconnecting (no undo toast — nothing changed)', () => {

--- a/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -46,6 +46,7 @@ const bt = vi.hoisted(() => ({
   armUndoWallChangeToast: vi.fn(),
   reassertWall: vi.fn(),
   reconnectSerialForCurrentBoard: 'serial-123' as string | null,
+  reconnectDeviceIdForCurrentBoard: null as string | null,
 }));
 
 const boardState = vi.hoisted(() => ({
@@ -300,7 +301,7 @@ describe('LiveActivityBridge lightbulb (boardControl)', () => {
 
     expect(bt.armUndoWallChangeToast).toHaveBeenCalledTimes(1);
     expect(bt.connect).toHaveBeenCalledTimes(1);
-    expect(bt.connect).toHaveBeenCalledWith(undefined, undefined, 'serial-123');
+    expect(bt.connect).toHaveBeenCalledWith(undefined, undefined, 'serial-123', undefined);
     expect(bt.reassertWall).not.toHaveBeenCalled();
     // The lock-screen reconnect is measured like the in-app bulb.
     expect(analytics.track).toHaveBeenCalledWith(
@@ -331,7 +332,20 @@ describe('LiveActivityBridge lightbulb (boardControl)', () => {
       widget.boardControlListener?.({ action: 'reconnect', correlationId: 'bulb-2' });
     });
 
-    expect(bt.connect).toHaveBeenCalledWith(undefined, undefined, undefined);
+    expect(bt.connect).toHaveBeenCalledWith(undefined, undefined, undefined, undefined);
+  });
+
+  it('reconnect: forwards a remembered MoonBoard device id (no serial)', () => {
+    bt.reconnectSerialForCurrentBoard = null;
+    bt.reconnectDeviceIdForCurrentBoard = 'moon-abc';
+    renderBridge();
+
+    act(() => {
+      widget.boardControlListener?.({ action: 'reconnect', correlationId: 'bulb-3' });
+    });
+
+    expect(bt.connect).toHaveBeenCalledWith(undefined, undefined, undefined, 'moon-abc');
+    bt.reconnectDeviceIdForCurrentBoard = null;
   });
 
   it('reassert: re-pushes the current climb without reconnecting (no undo toast — nothing changed)', () => {

--- a/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
+++ b/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
@@ -161,7 +161,13 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
           climbUuid: climbUuidRef.current ?? null,
         });
         bluetoothCtx.armUndoWallChangeToast();
-        void bluetoothCtx.connect(undefined, undefined, bluetoothCtx.reconnectSerialForCurrentBoard ?? undefined);
+        // By serial (Aurora) or device id (MoonBoard); neither → adapter picker.
+        void bluetoothCtx.connect(
+          undefined,
+          undefined,
+          bluetoothCtx.reconnectSerialForCurrentBoard ?? undefined,
+          bluetoothCtx.reconnectDeviceIdForCurrentBoard ?? undefined,
+        );
       } else if (event.action === 'reassert') {
         // A re-push of the current climb — no climb change to undo, so no toast.
         bluetoothCtx.reassertWall();

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -45,7 +45,12 @@ import { getBluetoothColorOverrides, useHoldColorOverrides } from '../lib/hold-c
 type BluetoothContextValue = {
   isConnected: boolean;
   loading: boolean;
-  connect: (initialFrames?: string, mirrored?: boolean, targetSerial?: string) => Promise<boolean>;
+  connect: (
+    initialFrames?: string,
+    mirrored?: boolean,
+    targetSerial?: string,
+    targetDeviceId?: string,
+  ) => Promise<boolean>;
   disconnect: () => Promise<void>;
   sendFramesToBoard: SendFramesToBoard;
   clearBoard: () => Promise<boolean | undefined>;
@@ -80,9 +85,16 @@ type BluetoothContextValue = {
   /**
    * Serial to silently reconnect to for the board currently in view, or null
    * when nothing is remembered or the user switched boards — in which case
-   * callers open the device picker instead.
+   * callers open the device picker instead. Aurora boards only.
    */
   reconnectSerialForCurrentBoard: string | null;
+  /**
+   * BLE device id to silently reconnect to for a MoonBoard currently in view
+   * (MoonBoards carry no serial), or null when nothing is remembered or the user
+   * switched boards. The lightbulb passes this so the tap reconnects to the same
+   * board instead of opening the picker.
+   */
+  reconnectDeviceIdForCurrentBoard: string | null;
 };
 
 const BluetoothContext = createContext<BluetoothContextValue | null>(null);
@@ -779,6 +791,7 @@ export function BluetoothProvider({
     sendFramesToBoard,
     pickerState,
     reconnectSerialForCurrentBoard,
+    reconnectDeviceIdForCurrentBoard,
     connectInitialSendRef,
     lastDisconnectInfoRef,
   } = useBoardBluetooth({
@@ -1283,6 +1296,7 @@ export function BluetoothProvider({
       relightPresenceClimb,
       armUndoWallChangeToast,
       reconnectSerialForCurrentBoard,
+      reconnectDeviceIdForCurrentBoard,
     }),
     [
       isConnected,
@@ -1296,6 +1310,7 @@ export function BluetoothProvider({
       relightPresenceClimb,
       armUndoWallChangeToast,
       reconnectSerialForCurrentBoard,
+      reconnectDeviceIdForCurrentBoard,
     ],
   );
 


### PR DESCRIPTION
## Summary

A user reported that their 2016 MoonBoard on iOS connects, but "when I try to change the problem it disconnects and will not reconnect." PostHog telemetry (project 412845) shows what's really going on:

- The board drops the BLE link with a **CoreBluetooth supervision timeout (error 6)**. This is chronic hardware behaviour — the disconnect rate is flat across every app version (~0.8 per connection since 2.0.0) and identical for write-with-response (2016) and write-without-response (newer) boards. **Not a 2.2.2 regression, and not caused by the write type.**
- The real app-side bug: the native write error for the gone peripheral ("No board is connected") doesn't match `isDisconnectionError`, so a failed send on the dead link classifies as the generic **`write_failed`** (416/45d — the top MoonBoard-iOS send failure) and the connection stays `isConnected === true`. The lightbulb stays lit on a dark wall, with no way to trigger a reconnect.
- Reconnect had extra friction too: a MoonBoard has no serial, so tapping the bulb could only open the device picker — `user_cancelled` is the #1 connection-failure reason (150 on 2.2.2).

Per the reporter's steer, this keeps the manual model (**no auto-reconnect**):

**Part 1 — the bulb goes out on a drop.** When sends keep failing on a MoonBoard, the connection is treated as lost so `handleDisconnection` runs and the lightbulb goes dark, prompting a reconnect — instead of the app sitting on a dead link with the bulb lit (waiting on iOS's slow supervision timeout, or never). To avoid dropping a still-**live** board on a one-off transient write error — costly here, since some MoonBoard controllers need a power cycle before they'll accept a new connection — the teardown is gated on **consecutive** failures with no success in between (a real supervision-timeout drop fails every send; a transient glitch's next send resets the streak). `isDisconnectionError` signatures still tear down immediately (a definite drop), the native self-recovery buckets (`write_timeout` / `write_recovery_failed`) never count, and the "Connection Stolen" tug-of-war event only fires for the real steal signature — a link timeout isn't a steal.

**Part 2 — one tap gets you back on.** The MoonBoard's BLE peripheral id is remembered on connect, and the lightbulb press reconnects straight to that board (`requestAndConnect` auto-selects by device id, mirroring the existing serial auto-select), with the picker as the grace-window fallback.

Both are JS-only, so this ships over **OTA** — no new binary needed to reach the 2.2.2 fleet.

## Release Notes

- MoonBoard on iPhone: when the board drops mid-session, the bulb now goes dark right away — one tap reconnects you to the same board, no more digging through the device list.

## Test plan

- `vp check` — 0 errors (261 pre-existing repo-wide warnings, none in changed files)
- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 4295 passed, incl. new cases: a MoonBoard `write_failed` drops the link (bulb out) while `write_timeout` does not, the teardown is MoonBoard-scoped (Kilter `write_failed` doesn't drop), a MoonBoard is remembered by device id and reconnects without the picker, and the lightbulb/Live-Activity press forwards the device id.
- `vp run check:mobile-bundle` — OK

On-device QA is still needed and can't run here (BLE has no simulator, and no physical 2016 MoonBoard was available). Suggested gate: OTA-preview/TestFlight to a tester with a 2016 board — connect, change problems, force a drop (walk out of range / power the board), confirm the bulb goes dark on the next problem change, then tap it and confirm it reconnects to the same board (or falls back to the picker if the board is slow to re-advertise). After rollout, watch MoonBoard-iOS `write_failed` and `user_cancelled` volume fall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnsSj4JF9CBhrc5rp4D3UM
