### PR TITLE
fix: stop non-prod contexts polluting the prod Sentry project

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -165,6 +165,7 @@ jobs:
               -e BOARDSESH_URL=https://${PR_NUM}.preview.boardsesh.com \
               -e NEXTAUTH_SECRET=${NEXTAUTH_SECRET} \
               -e NODE_ENV=production \
+              -e SENTRY_ENVIRONMENT=preview \
               --label "traefik.enable=true" \
               --label "traefik.http.routers.backend-pr-${PR_NUM}.rule=Host(\`${PR_NUM}.ws.preview.boardsesh.com\`)" \
               --label "traefik.http.routers.backend-pr-${PR_NUM}.priority=100" \
@@ -196,6 +197,7 @@ jobs:
             -e BACKEND_INTERNAL_URL=${BACKEND_INTERNAL_URL} \
             -e VERCEL_ENV=preview \
             -e NODE_ENV=production \
+            -e SENTRY_ENVIRONMENT=preview \
             --label "traefik.enable=true" \
             --label "traefik.http.routers.web-pr-${PR_NUM}.rule=Host(\`${PR_NUM}.preview.boardsesh.com\`)" \
             --label "traefik.http.services.web-pr-${PR_NUM}.loadbalancer.server.port=3000" \

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -93,6 +93,12 @@ env:
   # doesn't enter the resolved config, so it never moves the fingerprint. Kept in
   # lockstep with the other mobile fingerprint workflows. See docs/mobile-ota-updates.md.
   EXPO_PUBLIC_USE_RN_FETCH: '1'
+  # Preview-only tag: pr-<number> OTA bundles report `environment: preview` to Sentry
+  # so testers' crashes stay out of the production view (packages/mobile/src/lib/sentry.ts).
+  # DELIBERATELY diverges from production — do NOT add to SHARED_ENV_KEYS in
+  # scripts/mobile-ci-env-parity.test.ts. Bundle-only (EXPO_PUBLIC_*, JS-inlined), so it
+  # doesn't move the fingerprint; store/production builds leave it unset → 'production'.
+  EXPO_PUBLIC_SENTRY_ENVIRONMENT: preview
 
 jobs:
   # ── Decide what to do, with NO secrets (read-only). Resolves the PR number and

--- a/packages/backend/src/instrument.ts
+++ b/packages/backend/src/instrument.ts
@@ -42,30 +42,30 @@ import * as Sentry from '@sentry/node';
 // Leaf config module — pure env-detection helpers with no side effects and no
 // postgres/driver imports, so pulling it in here can't defeat the OTel patching
 // this file must run before.
-import { isLocalDevelopment, isTestEnvironment } from '@boardsesh/db/client/config';
+import { isProductionSentryEnvironment, resolveSentryEnvironment } from '@boardsesh/db/client/config';
 
-// Enable in any prod-like environment, not only NODE_ENV === 'production':
-// Railway leaves NODE_ENV unset, so the old `=== 'production'` gate meant the
-// backend never reported to Sentry in production (issue #3603 / #3183).
+// Report only from the *production* environment. Railway prod leaves NODE_ENV
+// unset, so we can't gate on `NODE_ENV === 'production'` (that regressed prod to
+// silence — issue #3603 / #3183); but "any non-dev, non-test runtime" was too
+// broad and let preview/staging backends (branch-deploy.yml runs them with
+// NODE_ENV=production) pollute the prod project, disguised as `environment:
+// production`. resolveSentryEnvironment() collapses both: prod resolves to
+// 'production' and stays on, while preview/staging declare SENTRY_ENVIRONMENT and
+// opt out. See @boardsesh/db/client/config.
 const dsn =
   process.env.SENTRY_DSN ??
   'https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400';
-const isProductionLike = !isLocalDevelopment() && !isTestEnvironment();
 
 Sentry.init({
   dsn,
-  enabled: isProductionLike && Boolean(dsn),
+  enabled: isProductionSentryEnvironment() && Boolean(dsn),
   enableLogs: true,
   // Matches the web service. Backend tags events with userId / clientIp from
   // ConnectionContext for incident triage; the data is already in our own
   // logs and is not exfiltrated beyond Sentry.
   sendDefaultPii: true,
-  // Read SENTRY_ENVIRONMENT (Sentry's standard env var) first. Otherwise fall
-  // back to 'production' when prod-like (NODE_ENV is unset on Railway), so
-  // real prod events aren't mislabelled 'development'. Platform-neutral — no
-  // RAILWAY_*-style branching.
-  environment:
-    process.env.SENTRY_ENVIRONMENT ?? (isProductionLike ? 'production' : (process.env.NODE_ENV ?? 'development')),
+  // Platform-neutral — no RAILWAY_*-style branching. See resolveSentryEnvironment.
+  environment: resolveSentryEnvironment(),
   serverName: 'boardsesh-backend',
 });
 

--- a/packages/backend/src/utils/__tests__/sentry-transport.test.ts
+++ b/packages/backend/src/utils/__tests__/sentry-transport.test.ts
@@ -119,6 +119,29 @@ describe('SentryWinstonTransport', () => {
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 
+  it('no-ops when SENTRY_ENVIRONMENT is an explicit non-production value, even with NODE_ENV=production', async () => {
+    // Preview / staging backends run with NODE_ENV=production (branch-deploy.yml)
+    // but declare SENTRY_ENVIRONMENT=preview so they don't pollute the prod
+    // project. The opt-out must win over the nodeEnv seam.
+    const previous = process.env.SENTRY_ENVIRONMENT;
+    process.env.SENTRY_ENVIRONMENT = 'preview';
+    try {
+      const transport = makeTransport('production', captureExceptionMock);
+      expect(transport.enabled).toBe(false);
+
+      await runTransport(transport, {
+        level: 'error',
+        message: 'Preview error',
+        [ERROR_INSTANCE]: new Error('preview-only'),
+      });
+
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) delete process.env.SENTRY_ENVIRONMENT;
+      else process.env.SENTRY_ENVIRONMENT = previous;
+    }
+  });
+
   it('swallows errors thrown by capture without breaking the pipeline', async () => {
     captureExceptionMock.mockImplementationOnce(() => {
       throw new Error('sentry internal failure');

--- a/packages/backend/src/utils/sentry-transport.ts
+++ b/packages/backend/src/utils/sentry-transport.ts
@@ -1,19 +1,24 @@
 import TransportStream from 'winston-transport';
 import * as Sentry from '@sentry/node';
-import { isLocalDevelopment, isTestEnvironment } from '@boardsesh/db/client/config';
+import { isProductionSentryEnvironment } from '@boardsesh/db/client/config';
 
-// Mirrors the `Sentry.init({ enabled })` gate in instrument.ts: capture in any
-// prod-like environment (Railway leaves NODE_ENV unset), but never in local dev
-// or under the test runner.
+// Mirrors the `Sentry.init({ enabled })` gate in instrument.ts: forward error
+// logs only from the production environment. An explicit non-'production'
+// SENTRY_ENVIRONMENT (preview / staging deploys — branch-deploy.yml) opts out
+// even when NODE_ENV=production, so per-PR backends can't forward error logs to
+// the prod Sentry project. Local dev and the test runner are excluded too.
 //
 // The optional `nodeEnv` seam lets tests assert the gate without mutating
-// process.env; when supplied it fully determines the decision, so a test that
-// runs with VITEST=1 can still exercise the "production" branch.
+// process.env; when supplied it fully determines the prod-like decision, so a
+// test that runs with VITEST=1 can still exercise the "production" branch. The
+// SENTRY_ENVIRONMENT opt-out is checked first so the seam can't override it.
 function isSentryLoggingEnabled(nodeEnvOverride?: string): boolean {
+  const sentryEnvironment = process.env.SENTRY_ENVIRONMENT;
+  if (sentryEnvironment && sentryEnvironment !== 'production') return false;
   if (nodeEnvOverride !== undefined) {
     return nodeEnvOverride !== 'development' && nodeEnvOverride !== 'test';
   }
-  return !isLocalDevelopment() && !isTestEnvironment();
+  return isProductionSentryEnvironment();
 }
 
 const SPLAT = Symbol.for('splat');

--- a/packages/db/src/client/__tests__/sentry-environment.test.ts
+++ b/packages/db/src/client/__tests__/sentry-environment.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isProductionSentryEnvironment, resolveSentryEnvironment } from '../config';
+
+// These helpers read process.env at call time, so each case sets exactly the vars
+// it cares about and the afterEach hook restores the runner's original values.
+// Cast away the repo's readonly NODE_ENV augmentation so the test can mutate it.
+const env = process.env as Record<string, string | undefined>;
+const TOUCHED = ['SENTRY_ENVIRONMENT', 'NODE_ENV', 'VERCEL_ENV', 'VITEST'] as const;
+const original = new Map<string, string | undefined>(TOUCHED.map((key) => [key, env[key]]));
+
+function setEnv(overrides: Partial<Record<(typeof TOUCHED)[number], string | undefined>>): void {
+  for (const key of TOUCHED) {
+    const value = key in overrides ? overrides[key] : undefined;
+    if (value === undefined) delete env[key];
+    else env[key] = value;
+  }
+}
+
+void describe('resolveSentryEnvironment', () => {
+  afterEach(() => {
+    for (const key of TOUCHED) {
+      const value = original.get(key);
+      if (value === undefined) delete env[key];
+      else env[key] = value;
+    }
+  });
+
+  void it('prefers an explicit SENTRY_ENVIRONMENT', () => {
+    setEnv({ SENTRY_ENVIRONMENT: 'preview', NODE_ENV: 'production' });
+    assert.equal(resolveSentryEnvironment(), 'preview');
+    assert.equal(isProductionSentryEnvironment(), false);
+  });
+
+  void it("resolves to 'production' when nothing is set (mirrors Railway prod)", () => {
+    setEnv({});
+    assert.equal(resolveSentryEnvironment(), 'production');
+    assert.equal(isProductionSentryEnvironment(), true);
+  });
+
+  void it("treats an explicit SENTRY_ENVIRONMENT='production' as production", () => {
+    setEnv({ SENTRY_ENVIRONMENT: 'production' });
+    assert.equal(isProductionSentryEnvironment(), true);
+  });
+
+  void it('is not production in local development', () => {
+    setEnv({ NODE_ENV: 'development' });
+    assert.equal(resolveSentryEnvironment(), 'development');
+    assert.equal(isProductionSentryEnvironment(), false);
+  });
+
+  void it('is not production under the test runner', () => {
+    setEnv({ NODE_ENV: 'test' });
+    assert.equal(isProductionSentryEnvironment(), false);
+  });
+
+  void it('keeps preview/staging deploys (NODE_ENV=production) out of the prod project', () => {
+    setEnv({ SENTRY_ENVIRONMENT: 'staging', NODE_ENV: 'production' });
+    assert.equal(isProductionSentryEnvironment(), false);
+  });
+});

--- a/packages/db/src/client/config.ts
+++ b/packages/db/src/client/config.ts
@@ -13,6 +13,35 @@ export function isTestEnvironment(): boolean {
   return process.env.NODE_ENV === 'test' || process.env.VITEST === 'true';
 }
 
+/**
+ * The backend's resolved Sentry `environment`. SENTRY_ENVIRONMENT (Sentry's
+ * standard var) wins when set; otherwise 'production' in a prod-like runtime
+ * (Railway leaves NODE_ENV unset — see issue #3603) and NODE_ENV / 'development'
+ * in local dev or under the test runner.
+ *
+ * Single source of truth for both the `Sentry.init({ enabled, environment })`
+ * gate in the backend's instrument.ts and the SentryWinstonTransport gate, so
+ * the two can't drift.
+ */
+export function resolveSentryEnvironment(): string {
+  const explicit = process.env.SENTRY_ENVIRONMENT;
+  if (explicit) return explicit;
+  const isProductionLike = !isLocalDevelopment() && !isTestEnvironment();
+  return isProductionLike ? 'production' : (process.env.NODE_ENV ?? 'development');
+}
+
+/**
+ * Whether the backend should report to the *production* Sentry project. Only a
+ * resolved environment of 'production' sends. Preview / staging deploys run with
+ * NODE_ENV=production too (branch-deploy.yml) and are otherwise indistinguishable
+ * from real prod, so they declare SENTRY_ENVIRONMENT=preview and stay out. Railway
+ * prod leaves both NODE_ENV and SENTRY_ENVIRONMENT unset, so it resolves to
+ * 'production' and remains enabled (no ops change, keeps the #3603 fix intact).
+ */
+export function isProductionSentryEnvironment(): boolean {
+  return resolveSentryEnvironment() === 'production';
+}
+
 export function getConnectionConfig(): ConnectionConfig {
   const connectionString = process.env.DATABASE_URL;
   const readReplicaUrl = process.env.READ_REPLICA_URL || null;

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import type { ComponentType } from 'react';
 
 // Spy on the SDK so we can assert the disabled-build contract. Under vitest
@@ -27,12 +27,36 @@ import {
   setOtaSentryTags,
   wrapWithSentry,
   isSentryEnabled,
+  resolveSentryEnvironment,
   toSentryTag,
 } from '../sentry';
 
 describe('isSentryEnabled', () => {
   it('is false in dev / test (no DSN + __DEV__)', () => {
     expect(isSentryEnabled).toBe(false);
+  });
+});
+
+describe('resolveSentryEnvironment', () => {
+  const previous = process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
+  afterEach(() => {
+    if (previous === undefined) delete process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
+    else process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT = previous;
+  });
+
+  it("defaults to 'production' when EXPO_PUBLIC_SENTRY_ENVIRONMENT is unset", () => {
+    delete process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
+    expect(resolveSentryEnvironment()).toBe('production');
+  });
+
+  it("defaults to 'production' when EXPO_PUBLIC_SENTRY_ENVIRONMENT is empty", () => {
+    process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT = '';
+    expect(resolveSentryEnvironment()).toBe('production');
+  });
+
+  it('uses the preview value published onto pr-* OTA bundles', () => {
+    process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT = 'preview';
+    expect(resolveSentryEnvironment()).toBe('preview');
   });
 });
 

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -22,6 +22,21 @@ const sentryDsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
  */
 export const isSentryEnabled = !!sentryDsn && !__DEV__;
 
+/**
+ * The Sentry `environment` for this build. Preview OTA bundles (the `pr-*`
+ * channels) are published with EXPO_PUBLIC_SENTRY_ENVIRONMENT=preview
+ * (mobile-ota-preview.yml) — the value is inlined into that JS bundle, so a
+ * tester who switches to a pr channel reports `environment: preview` and their
+ * crashes stay out of the production view. Store / production builds leave it
+ * unset and default to 'production'. `environment` is init-only in this SDK
+ * (there's no runtime setter), so it can't be derived from Updates.channel after
+ * launch; the build-time env var is the equivalent signal. Exported as a pure
+ * function so the mapping is unit-testable behind the isSentryEnabled init gate.
+ */
+export function resolveSentryEnvironment(): string {
+  return process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT || 'production';
+}
+
 // @expo/ui's Android bottom sheet fires `sheetRef.partialExpand()` / `expand()`
 // fire-and-forget inside `snapToIndex` (community/bottom-sheet/BottomSheet.android.tsx).
 // A store binary built against an older @expo/ui native layer never registered that
@@ -62,6 +77,9 @@ export function isExpoUiSheetNoHandlerRejection(event: SentryEventLike, original
 if (isSentryEnabled) {
   Sentry.init({
     dsn: sentryDsn,
+    // production for store/TestFlight bundles; 'preview' for pr-* OTA bundles so
+    // their crashes are filterable out of the prod view. See resolveSentryEnvironment.
+    environment: resolveSentryEnvironment(),
     tracesSampleRate: 0.1,
     // Drop the benign @expo/ui Android sheet "No handler registered" unhandled rejection
     // (partialExpand/expand on a binary whose native layer predates the method). Scoped

--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -4,14 +4,24 @@
 
 import * as Sentry from '@sentry/nextjs';
 
-// Only enable Sentry on boardsesh.com to avoid polluting error tracking
-const isProductionDomain = typeof window !== 'undefined' && window.location.hostname.includes('boardsesh.com');
+// Only enable Sentry on the production boardsesh.com hosts. Exact-host match, NOT
+// a substring: preview deploys run at `<pr>.preview.boardsesh.com`
+// (branch-deploy.yml), which contains "boardsesh.com" and would pass an
+// `.includes()` check — so every PR-preview browser session (and any browser test
+// pointed at a preview host via PLAYWRIGHT_TEST_BASE_URL) leaked into the prod
+// project. Listing apex + www covers whichever the live host redirects to.
+const PRODUCTION_HOSTS = new Set(['boardsesh.com', 'www.boardsesh.com']);
+const isProductionDomain = typeof window !== 'undefined' && PRODUCTION_HOSTS.has(window.location.hostname);
 
 Sentry.init({
   dsn: 'https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400',
 
-  // Only send errors when running on boardsesh.com
+  // Only send errors when running on the production boardsesh.com hosts
   enabled: isProductionDomain,
+
+  // Sentry only initializes here on a production host (see the gate above), so
+  // tag events accordingly for the environment:production filter.
+  environment: 'production',
 
   // Enable logs to be sent to Sentry
   enableLogs: true,

--- a/packages/web/sentry.edge.config.ts
+++ b/packages/web/sentry.edge.config.ts
@@ -14,6 +14,10 @@ Sentry.init({
   // Only send errors when running on boardsesh.com
   enabled: isProductionDomain,
 
+  // Only initializes on VERCEL_ENV === 'production' (see the gate above), so tag
+  // events accordingly for the environment:production filter.
+  environment: 'production',
+
   // Enable logs to be sent to Sentry
   enableLogs: true,
 

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -13,6 +13,10 @@ Sentry.init({
   // Only send errors when running on boardsesh.com
   enabled: isProductionDomain,
 
+  // Only initializes on VERCEL_ENV === 'production' (see the gate above), so tag
+  // events accordingly for the environment:production filter.
+  environment: 'production',
+
   // Enable logs to be sent to Sentry
   enableLogs: true,
 


### PR DESCRIPTION
## Summary

Unit-test/localhost/preview activity was landing in our production Sentry project. All four Sentry clients (web browser, web server, backend, mobile) share **one DSN / one project** with almost no `environment` separation, and several non-production contexts slipped past the enablement gates:

**1. Web browser — the preview/localhost leak.** `instrumentation-client.ts` enabled Sentry on `window.location.hostname.includes('boardsesh.com')` — a *substring* match. Every branch deploy runs at `<pr>.preview.boardsesh.com` (contains `boardsesh.com`), so **every PR-preview browser session** sent client errors + logs into prod, untagged. A browser/e2e run pointed at any `*.boardsesh.com` host via `PLAYWRIGHT_TEST_BASE_URL` did the same — that's the "unit tests polluting Sentry" path (real unit tests all mock `@sentry/nextjs`, so they were already clean). → tightened to an exact-host allowlist (`boardsesh.com` / `www.boardsesh.com`).

**2. Backend — preview errors disguised as production.** The gate was `!isLocalDevelopment() && !isTestEnvironment()` — **default-on**. Railway prod leaves `NODE_ENV` unset (so the older `=== 'production'` gate had regressed prod to *silence*, issue #3603/#3183), but "any non-dev, non-test runtime" is too broad: preview/staging backends run with `NODE_ENV=production` (`branch-deploy.yml`) and so reported to prod, tagged `environment: production`, indistinguishable from real prod. → gate on a **resolved Sentry environment of `production`**. Railway prod still resolves to `production` (both `NODE_ENV` and `SENTRY_ENVIRONMENT` unset), so **prod tracking is unchanged and needs no ops change**; preview/staging declare `SENTRY_ENVIRONMENT=preview` and opt out. Mirrored in the winston `SentryWinstonTransport`, with a single source of truth in the leaf `@boardsesh/db/client/config` so the two gates can't drift.

**3. Environment separation everywhere.** Set an explicit `environment` on every SDK (web client/server/edge → `production`; mobile → `EXPO_PUBLIC_SENTRY_ENVIRONMENT ?? production`) so the default Sentry view filters cleanly to `environment:production`.

**4. Mobile.** `pr-*` OTA preview bundles now publish `EXPO_PUBLIC_SENTRY_ENVIRONMENT=preview` (`mobile-ota-preview.yml`, preview-only — deliberately **not** a shared fingerprint key, JS-inlined so it doesn't move the fingerprint) so a tester on a pr channel reports `environment: preview` and their crashes stay out of the prod view. Store/production builds leave it unset → `production`. `environment` is init-only in this SDK (no runtime setter), so the build-time var is the equivalent of deriving it from `Updates.channel`.

The web *server*/edge gate (`VERCEL_ENV === 'production'`) was already correct and is unchanged apart from the `environment` tag.

### Known residual (documented, not a systemic leak)
Prod (Railway) and a bare local `bun run backend:start` (`tsx src/index.ts`, no `NODE_ENV`) are indistinguishable by env, and we deliberately avoid `RAILWAY_*` branching. `vp run dev` sets `NODE_ENV=development` (excluded); only explicitly running the *prod* backend command locally would still report — set `SENTRY_ENVIRONMENT=development` there.

### Not touched (possible follow-up)
`packages/web/app/lib/analytics.ts` gates **PostHog** with the same `hostname.includes('boardsesh.com')` substring — preview deploys likely pollute prod PostHog too. Left out to keep this PR Sentry-scoped; flagging for a follow-up.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:backend` / `:mobile` / `:web` — pass
- `vp test run --project mobile src/lib/__tests__/sentry.test.ts` — 30 pass (adds `resolveSentryEnvironment` coverage)
- `vp test run --project backend src/utils/__tests__/sentry-transport.test.ts` — 12 pass (adds the `SENTRY_ENVIRONMENT=preview` opt-out case)
- `packages/db` `sentry-environment.test.ts` (node test runner) — 6 pass
- `vp test run scripts/mobile-ci-env-parity.test.ts` — 24 pass (preview-only `EXPO_PUBLIC_SENTRY_ENVIRONMENT` doesn't break fingerprint parity)
- `vp check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)