### PR TITLE
fix(ci): report the app.boardsesh.com deploy in the success notification

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -773,13 +773,29 @@ jobs:
   # is pinning prod, nothing failed or got cancelled, and at least one
   # component actually deployed. No-ops if DISCORD_DEPLOY_WEBHOOK is unset.
   notify-success:
-    needs: [check-rollback, detect-changes, build-web, build-backend, migrate, deploy-web, deploy-production-backend]
+    needs:
+      [
+        check-rollback,
+        detect-changes,
+        build-web,
+        build-backend,
+        migrate,
+        deploy-web,
+        deploy-production-backend,
+        deploy-app-web,
+      ]
+    # deploy-app-web is both a dependency and a success trigger: a mobile-only
+    # push deploys app.boardsesh.com while deploy-web/backend skip, and without
+    # it in the trigger list that deploy would ship with no Discord message at
+    # all. Listing it in needs also stops the success ping racing ahead of an
+    # app deploy that is still uploading.
     if: >-
       always()
       && needs.check-rollback.outputs.active != 'true'
       && !contains(needs.*.result, 'failure')
       && !contains(needs.*.result, 'cancelled')
-      && (needs.deploy-web.result == 'success' || needs.deploy-production-backend.result == 'success')
+      && (needs.deploy-web.result == 'success' || needs.deploy-production-backend.result == 'success' ||
+      needs.deploy-app-web.result == 'success')
     runs-on: ubuntu-latest
     environment: Production
     permissions:
@@ -807,6 +823,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WEB_RESULT: ${{ needs.deploy-web.result }}
           BACKEND_RESULT: ${{ needs.deploy-production-backend.result }}
+          APP_WEB_RESULT: ${{ needs.deploy-app-web.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
           BEFORE_SHA: ${{ github.event.before }}
@@ -821,6 +838,8 @@ jobs:
           if [ "$WEB_RESULT" = "success" ]; then WEB_LINE="deployed"; fi
           BACKEND_LINE="unchanged"
           if [ "$BACKEND_RESULT" = "success" ]; then BACKEND_LINE="deployed"; fi
+          APP_WEB_LINE="unchanged"
+          if [ "$APP_WEB_RESULT" = "success" ]; then APP_WEB_LINE="deployed"; fi
 
           # Pull PR numbers from merge-commit subjects in BEFORE..SHA. Skip the
           # section entirely if BEFORE is missing/zero (workflow_dispatch, first
@@ -852,8 +871,8 @@ jobs:
           fi
 
           # RUN_URL wrapped in <…> so Discord suppresses the inline preview embed.
-          CONTENT=$(printf '✅ **Production deployed** on `%s`\n• web: %s\n• backend: %s%s\n<%s>' \
-            "${COMMIT_SHA:0:7}" "$WEB_LINE" "$BACKEND_LINE" "$SHIPPED_SECTION" "$RUN_URL")
+          CONTENT=$(printf '✅ **Production deployed** on `%s`\n• web: %s\n• backend: %s\n• app.boardsesh.com: %s%s\n<%s>' \
+            "${COMMIT_SHA:0:7}" "$WEB_LINE" "$BACKEND_LINE" "$APP_WEB_LINE" "$SHIPPED_SECTION" "$RUN_URL")
           # allowed_mentions.parse=[] blocks @everyone/@here/role/user pings —
           # critical here because PR titles flow straight into $content.
           jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \


### PR DESCRIPTION
## What

`notify-failure` already listed `deploy-app-web` (from #3801), but `notify-success` neither depended on it nor mentioned it. This closes both gaps.

## Why

Two real consequences, not just a missing line:

1. **A mobile-only push shipped silently.** The success gate required `deploy-web` **or** `deploy-production-backend` to have succeeded. A push touching only `packages/mobile/**` skips both of those and runs just `deploy-app-web` — so app.boardsesh.com deployed to production with **no Discord message at all**.
2. **The success ping could race the app deploy.** Without `deploy-app-web` in `needs`, "Production deployed" could post while the Pages upload was still running.

## Changes

- `deploy-app-web` added to `notify-success`'s `needs` and to the success trigger condition.
- Discord body gains `• app.boardsesh.com: deployed|unchanged`, matching the existing web/backend lines.

Message now reads:

```
✅ Production deployed on `abc1234`
• web: deployed
• backend: unchanged
• app.boardsesh.com: deployed
```

## Testing

YAML validated. Not dispatch-testable in isolation — the notification path only exercises on a real push to `main`; the next production deploy is the verification.

## Release Notes

- [x] No release note needed