### PR TITLE
perf(mobile): collapse home-feed tick N+1 into one grouped aggregate

### DIFF
--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -115,6 +115,9 @@ const callUserTicks = (userId: string, boardType: string) =>
     Array<{ uuid: string; quality: number | null; effectiveQuality: number | null }>
   >;
 
+const callUserTickCountsByBoard = (userId: string) =>
+  tickQueries.userTickCountsByBoard(undefined, { userId }) as Promise<Array<{ boardType: string; count: number }>>;
+
 const insertUser = async (id: string) => {
   await db.execute(sql`
     INSERT INTO "users" (id, email, name, created_at, updated_at)
@@ -910,6 +913,49 @@ describe('tickQueries — behavior fixes', () => {
         percentile: 0,
         totalActiveUsers: 88,
       });
+    });
+  });
+
+  describe('userTickCountsByBoard — grouped per-board counts', () => {
+    it('returns one row per board type with the tick count, scoped to the user', async () => {
+      const kilterClimb = CLIMB_PREFIX + 'counts-kilter';
+      const tensionClimb = CLIMB_PREFIX + 'counts-tension';
+      await insertClimb(kilterClimb, 'Counts kilter', { boardType: 'kilter' });
+      await insertClimb(tensionClimb, 'Counts tension', { boardType: 'tension' });
+
+      // 3 kilter + 1 tension for the test user; another user's ticks must not leak.
+      await insertTick({ uuid: CLIMB_PREFIX + 'c1', climbUuid: kilterClimb, climbedAt: '2024-01-01', status: 'send' });
+      await insertTick({ uuid: CLIMB_PREFIX + 'c2', climbUuid: kilterClimb, climbedAt: '2024-01-02', status: 'send' });
+      await insertTick({
+        uuid: CLIMB_PREFIX + 'c3',
+        climbUuid: kilterClimb,
+        climbedAt: '2024-01-03',
+        status: 'attempt',
+      });
+      await insertTick({
+        uuid: CLIMB_PREFIX + 'c4',
+        climbUuid: tensionClimb,
+        climbedAt: '2024-01-04',
+        status: 'flash',
+        boardType: 'tension',
+      });
+      await insertTick({
+        uuid: CLIMB_PREFIX + 'c5',
+        userId: OTHER_USER_ID,
+        climbUuid: kilterClimb,
+        climbedAt: '2024-01-05',
+        status: 'send',
+      });
+
+      const rows = await callUserTickCountsByBoard(TEST_USER_ID);
+      const byBoard = Object.fromEntries(rows.map((row) => [row.boardType, row.count]));
+
+      expect(byBoard).toEqual({ kilter: 3, tension: 1 });
+    });
+
+    it('returns an empty array for a user with no ticks and for a blank userId', async () => {
+      expect(await callUserTickCountsByBoard(OTHER_USER_ID)).toEqual([]);
+      expect(await callUserTickCountsByBoard('')).toEqual([]);
     });
   });
 

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -425,6 +425,31 @@ export const tickQueries = {
   },
 
   /**
+   * Per-board-type tick counts for a user, as ONE grouped aggregate.
+   *
+   * The home feed infers a default board when a user owns more than one wall and
+   * hasn't picked an active board. That inference only needs to know which board
+   * type the climber has logged the most on — not the ticks themselves — so this
+   * returns `COUNT(*) GROUP BY board_type` in a single indexed round trip instead
+   * of the caller fetching a full `userTicks` list per board (6-7 requests on the
+   * home-load critical path). Public, like `userTicks`; counts aren't sensitive.
+   */
+  userTickCountsByBoard: async (
+    _: unknown,
+    { userId }: { userId: string },
+  ): Promise<Array<{ boardType: string; count: number }>> => {
+    if (!userId || typeof userId !== 'string' || userId.trim() === '') return [];
+
+    const rows = await db
+      .select({ boardType: dbSchema.boardseshTicks.boardType, tickCount: count() })
+      .from(dbSchema.boardseshTicks)
+      .where(eq(dbSchema.boardseshTicks.userId, userId))
+      .groupBy(dbSchema.boardseshTicks.boardType);
+
+    return rows.map((row) => ({ boardType: row.boardType, count: Number(row.tickCount) }));
+  },
+
+  /**
    * Get ascent activity feed for a specific user (public query)
    * Returns ticks with enriched climb data for display in a feed
    */

--- a/packages/mobile/src/lib/__tests__/use-home-board.test.ts
+++ b/packages/mobile/src/lib/__tests__/use-home-board.test.ts
@@ -6,12 +6,12 @@ import type { UserBoard } from '@boardsesh/shared-schema';
 vi.mock('../../providers/auth-provider', () => ({ useAuth: vi.fn() }));
 vi.mock('../graphql/use-active-board', () => ({ useActiveBoard: vi.fn() }));
 vi.mock('../graphql/hooks/index', () => ({ useMyBoards: vi.fn(), useProfile: vi.fn() }));
-vi.mock('../graphql/hooks/use-you-data', () => ({ useAllBoardsTicks: vi.fn() }));
+vi.mock('../graphql/hooks/use-you-data', () => ({ useUserTickCountsByBoard: vi.fn() }));
 
 import { useAuth } from '../../providers/auth-provider';
 import { useActiveBoard } from '../graphql/use-active-board';
 import { useMyBoards, useProfile } from '../graphql/hooks/index';
-import { useAllBoardsTicks } from '../graphql/hooks/use-you-data';
+import { useUserTickCountsByBoard } from '../graphql/hooks/use-you-data';
 import { useHomeBoard } from '../graphql/hooks/use-home-board';
 
 function board(overrides: Partial<UserBoard>): UserBoard {
@@ -24,7 +24,7 @@ beforeEach(() => {
   vi.mocked(useProfile).mockReturnValue({ data: { id: 'u1' }, isLoading: false } as never);
   vi.mocked(useActiveBoard).mockReturnValue({ data: null, isLoading: false } as never);
   vi.mocked(useMyBoards).mockReturnValue({ data: undefined, isLoading: false } as never);
-  vi.mocked(useAllBoardsTicks).mockReturnValue({ data: undefined, isLoading: false } as never);
+  vi.mocked(useUserTickCountsByBoard).mockReturnValue({ data: undefined, isLoading: false } as never);
 });
 
 describe('useHomeBoard', () => {
@@ -55,8 +55,8 @@ describe('useHomeBoard', () => {
       },
       isLoading: false,
     } as never);
-    vi.mocked(useAllBoardsTicks).mockReturnValue({
-      data: { kilter: [1, 2, 3], tension: [1] },
+    vi.mocked(useUserTickCountsByBoard).mockReturnValue({
+      data: { kilter: 3, tension: 1 },
       isLoading: false,
     } as never);
     const { result } = renderHook(() => useHomeBoard());
@@ -71,7 +71,7 @@ describe('useHomeBoard', () => {
       data: { boards: [board({ uuid: 'a', boardType: 'kilter' }), board({ uuid: 'b', boardType: 'tension' })] },
       isLoading: false,
     } as never);
-    vi.mocked(useAllBoardsTicks).mockReturnValue({ data: {}, isLoading: false } as never);
+    vi.mocked(useUserTickCountsByBoard).mockReturnValue({ data: {}, isLoading: false } as never);
     const { result } = renderHook(() => useHomeBoard());
     expect(result.current.board).toBeNull();
   });
@@ -102,7 +102,7 @@ describe('useHomeBoard', () => {
       isLoading: false,
     } as never);
     vi.mocked(useProfile).mockReturnValue({ data: undefined, isLoading: true } as never);
-    vi.mocked(useAllBoardsTicks).mockReturnValue({ data: undefined, isLoading: false } as never);
+    vi.mocked(useUserTickCountsByBoard).mockReturnValue({ data: undefined, isLoading: false } as never);
     const { result } = renderHook(() => useHomeBoard());
     expect(result.current.isResolving).toBe(true);
     expect(result.current.board).toBeNull();

--- a/packages/mobile/src/lib/graphql/hooks/use-home-board.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-home-board.ts
@@ -3,7 +3,7 @@ import type { UserBoard } from '@boardsesh/shared-schema';
 import { useAuth } from '../../../providers/auth-provider';
 import { useActiveBoard } from '../use-active-board';
 import { useMyBoards, useProfile } from './index';
-import { useAllBoardsTicks } from './use-you-data';
+import { useUserTickCountsByBoard } from './use-you-data';
 
 export type HomeBoardResult = {
   /** The board the home feed scopes to by default, or `null` when none can be
@@ -52,19 +52,24 @@ export function useHomeBoard(): HomeBoardResult {
   // Only pay for the per-board-type tick scan when it can actually change the
   // answer: no active board AND more than one owned board to disambiguate.
   const needsTicks = !activeBoard && (boards?.length ?? 0) > 1;
-  const { data: ticksByBoard, isLoading: ticksLoading } = useAllBoardsTicks(needsTicks ? profile?.id : undefined);
+  // Counts only (one grouped aggregate), not full tick histories — the inference
+  // just needs the most-logged board type. This keeps the home-load critical
+  // path to one request instead of a userTicks fetch per board type.
+  const { data: tickCountsByBoard, isLoading: ticksLoading } = useUserTickCountsByBoard(
+    needsTicks ? profile?.id : undefined,
+  );
 
   const board = useMemo<UserBoard | null>(() => {
     if (activeBoard) return activeBoard;
     if (!boards || boards.length === 0) return null;
     if (boards.length === 1) return boards[0];
 
-    if (ticksByBoard) {
+    if (tickCountsByBoard) {
       let topType: string | null = null;
       let topCount = 0;
-      for (const [boardType, entries] of Object.entries(ticksByBoard)) {
-        if (entries.length > topCount) {
-          topCount = entries.length;
+      for (const [boardType, tickCount] of Object.entries(tickCountsByBoard)) {
+        if (tickCount > topCount) {
+          topCount = tickCount;
           topType = boardType;
         }
       }
@@ -79,7 +84,7 @@ export function useHomeBoard(): HomeBoardResult {
     }
 
     return null;
-  }, [activeBoard, boards, ticksByBoard]);
+  }, [activeBoard, boards, tickCountsByBoard]);
 
   // The active board is read from AsyncStorage, so it's `undefined` for the
   // first render(s). Treat that pending read as "still resolving" — otherwise a

--- a/packages/mobile/src/lib/graphql/hooks/use-you-data.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-you-data.ts
@@ -1,6 +1,7 @@
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import {
   GET_USER_TICKS,
+  GET_USER_TICK_COUNTS_BY_BOARD,
   GET_USER_PROFILE_STATS,
   GET_USER_CLIMB_PERCENTILE,
   GET_USER_ASCENTS_FEED,
@@ -9,6 +10,7 @@ import {
   GET_ACTIVITY_FEED,
   GET_SESSION_GROUPED_FEED,
   type GetUserTicksQueryResponse,
+  type GetUserTickCountsByBoardQueryResponse,
   type GetUserProfileStatsQueryResponse,
   type GetUserClimbPercentileQueryResponse,
   type GetUserAscentsFeedQueryResponse,
@@ -60,6 +62,31 @@ export function useAllBoardsTicks(userId: string | undefined) {
         }),
       );
       return collected;
+    },
+    enabled: !!userId,
+    staleTime: PROFILE_STALE_TIME_MS,
+  });
+}
+
+/**
+ * Per-board-type tick counts for a user, as a single grouped aggregate — the
+ * input the home-board inference needs (which board type has the most ticks)
+ * without pulling every tick per board. One request instead of `useAllBoardsTicks`'
+ * 6-7. Returns a `Record<boardType, count>` for O(1) lookups.
+ */
+export function useUserTickCountsByBoard(userId: string | undefined) {
+  return useQuery({
+    queryKey: ['userTickCountsByBoard', userId],
+    queryFn: async () => {
+      const response = await getHttpClient().request<GetUserTickCountsByBoardQueryResponse>(
+        GET_USER_TICK_COUNTS_BY_BOARD,
+        { userId },
+      );
+      const counts: Record<string, number> = {};
+      for (const row of response.userTickCountsByBoard) {
+        counts[row.boardType] = row.count;
+      }
+      return counts;
     },
     enabled: !!userId,
     staleTime: PROFILE_STALE_TIME_MS,

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1057,6 +1057,18 @@ input GetTicksInput {
 }
 
 """
+Number of ticks a user has logged on a given board type. A lightweight
+aggregate (COUNT grouped by board_type) used to infer a default "home board"
+without fetching every tick history per board.
+"""
+type BoardTickCount {
+  "Board type"
+  boardType: String!
+  "Number of ticks logged on this board type"
+  count: Int!
+}
+
+"""
 Input for attaching an Instagram or TikTok video as beta for a climb.
 """
 input AttachBetaLinkInput {
@@ -4758,6 +4770,13 @@ type Query {
   Get public ticks for any user by their ID.
   """
   userTicks(userId: ID!, boardType: String!): [Tick!]!
+
+  """
+  Per-board-type tick counts for a user, as a single grouped aggregate.
+  Lets the home feed infer a default board without fetching every tick per
+  board type (avoids one userTicks request per board on cold load).
+  """
+  userTickCountsByBoard(userId: ID!): [BoardTickCount!]!
 
   """
   Get public ascent activity feed for a user.

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -779,6 +779,19 @@ export type BoardStatsUpdated = {
 };
 
 /**
+ * Number of ticks a user has logged on a given board type. A lightweight
+ * aggregate (COUNT grouped by board_type) used to infer a default "home board"
+ * without fetching every tick history per board.
+ */
+export type BoardTickCount = {
+  __typename?: 'BoardTickCount';
+  /** Board type */
+  boardType: Scalars['String']['output'];
+  /** Number of ticks logged on this board type */
+  count: Scalars['Int']['output'];
+};
+
+/**
  * The Boardsesh grade for a climb at one angle: the data-science-backed grade
  * produced by the nightly refresh job. Null query result means no grade has been
  * computed for that climb+angle (e.g. MoonBoard, or too few ascents).
@@ -4738,6 +4751,12 @@ export type Query = {
   userPlaylists: Array<Playlist>;
   /** Get profile statistics with distinct climb counts per grade. */
   userProfileStats: ProfileStats;
+  /**
+   * Per-board-type tick counts for a user, as a single grouped aggregate.
+   * Lets the home feed infer a default board without fetching every tick per
+   * board type (avoids one userTicks request per board on cold load).
+   */
+  userTickCountsByBoard: Array<BoardTickCount>;
   /** Get public ticks for any user by their ID. */
   userTicks: Array<Tick>;
   /** Get vote summary for a single entity. */
@@ -5336,6 +5355,11 @@ export type QueryUserPlaylistsArgs = {
 
 /** Root query type for all read operations. */
 export type QueryUserProfileStatsArgs = {
+  userId: Scalars['ID']['input'];
+};
+
+/** Root query type for all read operations. */
+export type QueryUserTickCountsByBoardArgs = {
   userId: Scalars['ID']['input'];
 };
 
@@ -7495,6 +7519,7 @@ export type ResolversTypes = ResolversObject<{
   BoardQueuePreviewItem: ResolverTypeWrapper<BoardQueuePreviewItem>;
   BoardSerialConfig: ResolverTypeWrapper<BoardSerialConfig>;
   BoardStatsUpdated: ResolverTypeWrapper<BoardStatsUpdated>;
+  BoardTickCount: ResolverTypeWrapper<BoardTickCount>;
   BoardseshGrade: ResolverTypeWrapper<BoardseshGrade>;
   BoardseshGradeForAngle: ResolverTypeWrapper<BoardseshGradeForAngle>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
@@ -7834,6 +7859,7 @@ export type ResolversParentTypes = ResolversObject<{
   BoardQueuePreviewItem: BoardQueuePreviewItem;
   BoardSerialConfig: BoardSerialConfig;
   BoardStatsUpdated: BoardStatsUpdated;
+  BoardTickCount: BoardTickCount;
   BoardseshGrade: BoardseshGrade;
   BoardseshGradeForAngle: BoardseshGradeForAngle;
   Boolean: Scalars['Boolean']['output'];
@@ -8530,6 +8556,15 @@ export type BoardStatsUpdatedResolvers<
 > = ResolversObject<{
   seq?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stats?: Resolver<ResolversTypes['BoardPresenceStats'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type BoardTickCountResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['BoardTickCount'] = ResolversParentTypes['BoardTickCount'],
+> = ResolversObject<{
+  boardType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -11042,6 +11077,12 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QueryUserProfileStatsArgs, 'userId'>
   >;
+  userTickCountsByBoard?: Resolver<
+    Array<ResolversTypes['BoardTickCount']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryUserTickCountsByBoardArgs, 'userId'>
+  >;
   userTicks?: Resolver<
     Array<ResolversTypes['Tick']>,
     ParentType,
@@ -12097,6 +12138,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   BoardQueuePreviewItem?: BoardQueuePreviewItemResolvers<ContextType>;
   BoardSerialConfig?: BoardSerialConfigResolvers<ContextType>;
   BoardStatsUpdated?: BoardStatsUpdatedResolvers<ContextType>;
+  BoardTickCount?: BoardTickCountResolvers<ContextType>;
   BoardseshGrade?: BoardseshGradeResolvers<ContextType>;
   BoardseshGradeForAngle?: BoardseshGradeForAngleResolvers<ContextType>;
   Climb?: ClimbResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -200,6 +200,13 @@ export const queriesTypeDefs = /* GraphQL */ `
     userTicks(userId: ID!, boardType: String!): [Tick!]!
 
     """
+    Per-board-type tick counts for a user, as a single grouped aggregate.
+    Lets the home feed infer a default board without fetching every tick per
+    board type (avoids one userTicks request per board on cold load).
+    """
+    userTickCountsByBoard(userId: ID!): [BoardTickCount!]!
+
+    """
     Get public ascent activity feed for a user.
     Includes enriched climb data for display.
     """

--- a/packages/shared-schema/src/schema/ticks.ts
+++ b/packages/shared-schema/src/schema/ticks.ts
@@ -157,6 +157,18 @@ export const ticksTypeDefs = /* GraphQL */ `
   }
 
   """
+  Number of ticks a user has logged on a given board type. A lightweight
+  aggregate (COUNT grouped by board_type) used to infer a default "home board"
+  without fetching every tick history per board.
+  """
+  type BoardTickCount {
+    "Board type"
+    boardType: String!
+    "Number of ticks logged on this board type"
+    count: Int!
+  }
+
+  """
   Input for attaching an Instagram or TikTok video as beta for a climb.
   """
   input AttachBetaLinkInput {

--- a/packages/shared/graphql/src/generated/gql.ts
+++ b/packages/shared/graphql/src/generated/gql.ts
@@ -123,6 +123,7 @@ type Documents = {
   '\n  query SearchUsersAndSetters($input: SearchUsersInput!) {\n    searchUsersAndSetters(input: $input) {\n      results {\n        user {\n          id\n          displayName\n          avatarUrl\n          followerCount\n          followingCount\n          isFollowedByMe\n        }\n        setter {\n          username\n          climbCount\n          boardTypes\n          isFollowedByMe\n        }\n        recentAscentCount\n        matchReason\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.SearchUsersAndSettersDocument;
   '\n  query GetTicks($input: GetTicksInput!) {\n    ticks(input: $input) {\n      uuid\n      climbUuid\n      angle\n      isMirror\n      status\n      attemptCount\n      quality\n      effectiveQuality\n      difficulty\n      boardseshDifficulty\n      boardseshConfidence\n      isBenchmark\n      comment\n      climbedAt\n      upvotes\n      downvotes\n      commentCount\n    }\n  }\n': typeof types.GetTicksDocument;
   '\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      effectiveDifficulty\n      boardseshDifficulty\n      boardseshConfidence\n      climbedAt\n      layoutId\n    }\n  }\n': typeof types.GetUserTicksDocument;
+  '\n  query GetUserTickCountsByBoard($userId: ID!) {\n    userTickCountsByBoard(userId: $userId) {\n      boardType\n      count\n    }\n  }\n': typeof types.GetUserTickCountsByBoardDocument;
   '\n  mutation SaveTick($input: SaveTickInput!) {\n    saveTick(input: $input) {\n      uuid\n      climbUuid\n      angle\n      isMirror\n      status\n      attemptCount\n      quality\n      difficulty\n      comment\n      climbedAt\n    }\n  }\n': typeof types.SaveTickDocument;
   '\n  mutation DeleteTick($uuid: ID!) {\n    deleteTick(uuid: $uuid)\n  }\n': typeof types.DeleteTickDocument;
   '\n  query GetUserAscentsFeed($userId: ID!, $input: AscentFeedInput) {\n    userAscentsFeed(userId: $userId, input: $input) {\n      items {\n        uuid\n        climbUuid\n        climbName\n        setterUsername\n        boardType\n        boardId\n        boardDisplayName\n        layoutId\n        angle\n        isMirror\n        status\n        attemptCount\n        quality\n        effectiveQuality\n        difficulty\n        difficultyName\n        consensusDifficulty\n        consensusDifficultyName\n        boardseshDifficulty\n        boardseshConfidence\n        qualityAverage\n        isBenchmark\n        isNoMatch\n        comment\n        climbedAt\n        frames\n        hasBetaVideo\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.GetUserAscentsFeedDocument;
@@ -347,6 +348,8 @@ const documents: Documents = {
     types.GetTicksDocument,
   '\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      effectiveDifficulty\n      boardseshDifficulty\n      boardseshConfidence\n      climbedAt\n      layoutId\n    }\n  }\n':
     types.GetUserTicksDocument,
+  '\n  query GetUserTickCountsByBoard($userId: ID!) {\n    userTickCountsByBoard(userId: $userId) {\n      boardType\n      count\n    }\n  }\n':
+    types.GetUserTickCountsByBoardDocument,
   '\n  mutation SaveTick($input: SaveTickInput!) {\n    saveTick(input: $input) {\n      uuid\n      climbUuid\n      angle\n      isMirror\n      status\n      attemptCount\n      quality\n      difficulty\n      comment\n      climbedAt\n    }\n  }\n':
     types.SaveTickDocument,
   '\n  mutation DeleteTick($uuid: ID!) {\n    deleteTick(uuid: $uuid)\n  }\n': types.DeleteTickDocument,
@@ -1032,6 +1035,12 @@ export function graphql(
 export function graphql(
   source: '\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      effectiveDifficulty\n      boardseshDifficulty\n      boardseshConfidence\n      climbedAt\n      layoutId\n    }\n  }\n',
 ): (typeof documents)['\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      effectiveDifficulty\n      boardseshDifficulty\n      boardseshConfidence\n      climbedAt\n      layoutId\n    }\n  }\n'];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query GetUserTickCountsByBoard($userId: ID!) {\n    userTickCountsByBoard(userId: $userId) {\n      boardType\n      count\n    }\n  }\n',
+): (typeof documents)['\n  query GetUserTickCountsByBoard($userId: ID!) {\n    userTickCountsByBoard(userId: $userId) {\n      boardType\n      count\n    }\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -776,6 +776,19 @@ export type BoardStatsUpdated = {
 };
 
 /**
+ * Number of ticks a user has logged on a given board type. A lightweight
+ * aggregate (COUNT grouped by board_type) used to infer a default "home board"
+ * without fetching every tick history per board.
+ */
+export type BoardTickCount = {
+  __typename?: 'BoardTickCount';
+  /** Board type */
+  boardType: Scalars['String']['output'];
+  /** Number of ticks logged on this board type */
+  count: Scalars['Int']['output'];
+};
+
+/**
  * The Boardsesh grade for a climb at one angle: the data-science-backed grade
  * produced by the nightly refresh job. Null query result means no grade has been
  * computed for that climb+angle (e.g. MoonBoard, or too few ascents).
@@ -4735,6 +4748,12 @@ export type Query = {
   userPlaylists: Array<Playlist>;
   /** Get profile statistics with distinct climb counts per grade. */
   userProfileStats: ProfileStats;
+  /**
+   * Per-board-type tick counts for a user, as a single grouped aggregate.
+   * Lets the home feed infer a default board without fetching every tick per
+   * board type (avoids one userTicks request per board on cold load).
+   */
+  userTickCountsByBoard: Array<BoardTickCount>;
   /** Get public ticks for any user by their ID. */
   userTicks: Array<Tick>;
   /** Get vote summary for a single entity. */
@@ -5333,6 +5352,11 @@ export type QueryUserPlaylistsArgs = {
 
 /** Root query type for all read operations. */
 export type QueryUserProfileStatsArgs = {
+  userId: Scalars['ID']['input'];
+};
+
+/** Root query type for all read operations. */
+export type QueryUserTickCountsByBoardArgs = {
   userId: Scalars['ID']['input'];
 };
 
@@ -9578,6 +9602,15 @@ export type GetUserTicksQuery = {
     climbedAt: string;
     layoutId?: number | null;
   }>;
+};
+
+export type GetUserTickCountsByBoardQueryVariables = Exact<{
+  userId: Scalars['ID']['input'];
+}>;
+
+export type GetUserTickCountsByBoardQuery = {
+  __typename?: 'Query';
+  userTickCountsByBoard: Array<{ __typename?: 'BoardTickCount'; boardType: string; count: number }>;
 };
 
 export type SaveTickMutationVariables = Exact<{
@@ -15641,6 +15674,46 @@ export const GetUserTicksDocument = {
     },
   ],
 } as unknown as DocumentNode<GetUserTicksQuery, GetUserTicksQueryVariables>;
+export const GetUserTickCountsByBoardDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'GetUserTickCountsByBoard' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'userId' } },
+          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'ID' } } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'userTickCountsByBoard' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'userId' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'userId' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'boardType' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'count' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetUserTickCountsByBoardQuery, GetUserTickCountsByBoardQueryVariables>;
 export const SaveTickDocument = {
   kind: 'Document',
   definitions: [

--- a/packages/shared/graphql/src/operations/ticks.ts
+++ b/packages/shared/graphql/src/operations/ticks.ts
@@ -42,6 +42,26 @@ export const GET_USER_TICKS = gql`
   }
 `;
 
+// Lightweight per-board tick counts — one grouped aggregate instead of a full
+// GET_USER_TICKS list per board type. Used to infer the home feed's default
+// board without pulling every tick on cold load.
+export const GET_USER_TICK_COUNTS_BY_BOARD = gql`
+  query GetUserTickCountsByBoard($userId: ID!) {
+    userTickCountsByBoard(userId: $userId) {
+      boardType
+      count
+    }
+  }
+`;
+
+export type GetUserTickCountsByBoardQueryVariables = {
+  userId: string;
+};
+
+export type GetUserTickCountsByBoardQueryResponse = {
+  userTickCountsByBoard: Array<{ boardType: string; count: number }>;
+};
+
 export const SAVE_TICK = gql`
   mutation SaveTick($input: SaveTickInput!) {
     saveTick(input: $input) {


### PR DESCRIPTION
## Summary

Profiling `app.boardsesh.com/home` (the Expo web build) showed LCP at **3.5s**, dominated by a serial chain before the feed can render. One link in that chain: the home feed holds its beta-shelf + crew-feed queries until "home-board inference" settles (an intentional anti-flicker gate). That inference only needs to know *which board type the climber has logged the most on* — but it was fetching a **full `userTicks` history per board type**: 6–7 GraphQL round trips on the cold-load critical path just to compare list lengths.

This replaces that fan-out with `userTickCountsByBoard`, a single `COUNT(*) GROUP BY board_type` aggregate, and has `useHomeBoard` compare per-board counts directly. **One lightweight request instead of 6–7**, so the feed — and LCP — render sooner.

`useAllBoardsTicks` stays in place for the You/profile page, which genuinely needs full tick histories.

### Changes
- **backend**: `userTickCountsByBoard` resolver (one grouped aggregate, public like `userTicks`) + `BoardTickCount` type; regenerated schema/types.
- **mobile**: `useUserTickCountsByBoard` hook; `useHomeBoard` reads counts instead of full ticks.

## Release Notes

- The home feed loads faster on a cold start — fewer requests before your crew's sends show up.

## Test plan

- `vp run typecheck:mobile`, `vp run typecheck:backend` — clean
- `vp test run --project mobile use-home-board.test.ts` — 8 passed (updated to counts-based inference)
- `vp test run --project backend tick-queries.test.ts` — 59 passed, incl. 2 new `userTickCountsByBoard` cases (per-board counts, user-scoping, empty/blank-userId)
- `vp check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015opNzGRdXpUkcfZEvmwosw