### PR TITLE
fix(mobile): high-power (LowLatency) foreground board scans

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -49,6 +49,7 @@ vi.mock('@boardsesh/ble-protocol', () => ({
 // ── Import after mocks ─────────────────────────────────────────────────
 
 import { RNBleAdapter } from '../adapter';
+import { HIGH_POWER_BOARD_SCAN_OPTIONS } from '../scan-options';
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
 import { parseSerialNumber, splitMessages } from '@boardsesh/ble-protocol';
 import { State } from 'react-native-ble-plx';
@@ -683,7 +684,11 @@ describe('RNBleAdapter', () => {
       await adapter.requestAndConnect();
 
       // Unfiltered scan: UUID filter must be null (a service filter hides MoonBoards).
-      expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(null, null, expect.any(Function));
+      expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(
+        null,
+        HIGH_POWER_BOARD_SCAN_OPTIONS,
+        expect.any(Function),
+      );
       expect(seenDevices.map((device) => device.deviceId)).toEqual(['moon-device']);
     });
 
@@ -726,7 +731,11 @@ describe('RNBleAdapter', () => {
       const adapter = new RNBleAdapter(devicePicker, 'aurora');
       await adapter.requestAndConnect();
 
-      expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(null, null, expect.any(Function));
+      expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(
+        null,
+        HIGH_POWER_BOARD_SCAN_OPTIONS,
+        expect.any(Function),
+      );
       expect(seenDevices.map((device) => device.deviceId)).toEqual(['kilter-device']);
     });
 
@@ -774,7 +783,11 @@ describe('RNBleAdapter', () => {
       const adapter = new RNBleAdapter(devicePicker, 'aurora');
       await adapter.requestAndConnect();
 
-      expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(null, null, expect.any(Function));
+      expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(
+        null,
+        HIGH_POWER_BOARD_SCAN_OPTIONS,
+        expect.any(Function),
+      );
       expect(seenDevices.map((device) => device.deviceId).sort()).toEqual(['kilter-bare', 'kilter-serial']);
     });
 

--- a/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
@@ -45,6 +45,7 @@ vi.mock('@boardsesh/ble-protocol', () => ({
 }));
 
 import { useBoardScan } from '../use-board-scan';
+import { HIGH_POWER_BOARD_SCAN_OPTIONS } from '../scan-options';
 
 /** Grab the scan callback react-native-ble-plx was handed so tests can feed it devices. */
 function scanCallback() {
@@ -97,9 +98,14 @@ describe('useBoardScan', () => {
     });
 
     expect(result.current.status).toBe('scanning');
-    // Regression guard: scan UNFILTERED. A hardware service-UUID filter dropped
-    // Aurora boxes on Android when the UUID rode the scan-response PDU (#3806).
-    expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(null, null, expect.any(Function));
+    // Regression guard: scan UNFILTERED (#3806) with high-power options — a
+    // service-UUID filter dropped scan-response boxes, and the default LowPower
+    // scan mode missed boards after the RN 0.86 upgrade.
+    expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(
+      null,
+      HIGH_POWER_BOARD_SCAN_OPTIONS,
+      expect.any(Function),
+    );
   });
 
   it('does not start scanning after reset during Bluetooth readiness wait', async () => {

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -14,6 +14,7 @@ import { bleManager } from './ble-manager';
 import { uint8ArrayToBase64, base64ToHex, serviceDataToHex } from './base64';
 import { waitForBlePoweredOn } from './availability';
 import { isLikelyBoardDevice } from './board-device-filter';
+import { HIGH_POWER_BOARD_SCAN_OPTIONS } from './scan-options';
 import { upsertDiscoveredDevice } from './scan-device-cache';
 import type {
   BluetoothAdapter,
@@ -134,7 +135,8 @@ export class RNBleAdapter implements BluetoothAdapter {
       // reads ble-plx's merged advertise+scan-response record, so it still
       // surfaces both Aurora-built (`Kilter Board#serial@N`) and Kilter-built
       // bare-name (`Kilter Board`) boxes while rejecting non-boards.
-      void bleManager.startDeviceScan(null, null, (scanError, scannedDevice) => {
+      // High-power scan options (LowLatency on Android) — see scan-options.ts.
+      void bleManager.startDeviceScan(null, HIGH_POWER_BOARD_SCAN_OPTIONS, (scanError, scannedDevice) => {
         if (scanError) {
           void bleManager.stopDeviceScan();
           // Surface the failure immediately so the user sees feedback instead

--- a/packages/mobile/src/lib/ble/scan-options.ts
+++ b/packages/mobile/src/lib/ble/scan-options.ts
@@ -1,0 +1,25 @@
+import type { ScanOptions } from 'react-native-ble-plx';
+
+/**
+ * ble-plx scan options for the foreground "find my board" scans — the device
+ * picker (`adapter.ts`) and the Bluetooth quickstart (`use-board-scan.ts`).
+ * High-power on purpose: locating the user's board quickly matters more than the
+ * radio cost of a short, user-initiated foreground scan.
+ *
+ * - `scanMode: LowLatency` (Android only) runs a ~100% scan duty cycle instead of
+ *   ble-plx's default LowPower (~10%). The Expo 57 / React Native 0.86 upgrade
+ *   degraded Android BLE discovery and roughly doubled the empty-picker rate;
+ *   LowLatency is the community mitigation for "Android scan misses devices".
+ * - `allowDuplicates` (iOS only) reports each advertisement repeatedly, so a name
+ *   or service UUID that arrives in a later ADV / scan-response packet still
+ *   reaches the JS filter instead of being dropped after a nameless first report.
+ *
+ * `scanMode` is typed as the ScanMode enum, where `2 === ScanMode.LowLatency`. We
+ * use the numeric literal (cast to the field's type) so this module stays a
+ * type-only import of react-native-ble-plx and never pulls the native package
+ * into the web bundle — the web build only type-imports ble-plx today.
+ */
+export const HIGH_POWER_BOARD_SCAN_OPTIONS: ScanOptions = {
+  scanMode: 2 as ScanOptions['scanMode'], // ScanMode.LowLatency (Android)
+  allowDuplicates: true, // iOS
+};

--- a/packages/mobile/src/lib/ble/scan-options.ts
+++ b/packages/mobile/src/lib/ble/scan-options.ts
@@ -14,12 +14,17 @@ import type { ScanOptions } from 'react-native-ble-plx';
  *   or service UUID that arrives in a later ADV / scan-response packet still
  *   reaches the JS filter instead of being dropped after a nameless first report.
  *
- * `scanMode` is typed as the ScanMode enum, where `2 === ScanMode.LowLatency`. We
- * use the numeric literal (cast to the field's type) so this module stays a
- * type-only import of react-native-ble-plx and never pulls the native package
- * into the web bundle — the web build only type-imports ble-plx today.
+ * `scanMode` is the numeric literal `2`, not an enum value import, so this module
+ * stays a type-only import of react-native-ble-plx and never pulls the native
+ * package into the web bundle (the web build only type-imports ble-plx today).
+ * `2` is ABI-stable rather than a fragile ble-plx-internal number: it is Android's
+ * platform constant `ScanSettings.SCAN_MODE_LOW_LATENCY` (== ble-plx
+ * `ScanMode.LowLatency`), which ble-plx passes straight through to
+ * `ScanSettings.Builder().setScanMode(int)` — the value can't be renumbered
+ * without breaking the Android SDK.
  */
 export const HIGH_POWER_BOARD_SCAN_OPTIONS: ScanOptions = {
-  scanMode: 2 as ScanOptions['scanMode'], // ScanMode.LowLatency (Android)
+  // Android ScanSettings.SCAN_MODE_LOW_LATENCY / ble-plx ScanMode.LowLatency.
+  scanMode: 2 as ScanOptions['scanMode'],
   allowDuplicates: true, // iOS
 };

--- a/packages/mobile/src/lib/ble/use-board-scan.ts
+++ b/packages/mobile/src/lib/ble/use-board-scan.ts
@@ -10,6 +10,7 @@ import { parseSerialNumber } from '@boardsesh/ble-protocol';
 import { bleManager } from './ble-manager';
 import { waitForBlePoweredOn } from './availability';
 import { isLikelyBoardDevice } from './board-device-filter';
+import { HIGH_POWER_BOARD_SCAN_OPTIONS } from './scan-options';
 import { requestBleRuntimePermissions } from './use-ble-permissions';
 
 const SCAN_TIMEOUT_MS = 15_000;
@@ -78,7 +79,8 @@ export function useBoardScan(): BoardScan {
     // (parseSerialNumber below). A hardware service-UUID ScanFilter drops boards
     // on Android when the UUID rides the scan-response PDU, leaving an empty
     // quickstart list — same root cause as the picker scan in adapter.ts.
-    void bleManager.startDeviceScan(null, null, (error, device) => {
+    // High-power scan options (LowLatency on Android) — see scan-options.ts.
+    void bleManager.startDeviceScan(null, HIGH_POWER_BOARD_SCAN_OPTIONS, (error, device) => {
       if (!isCurrentScanAttempt()) return;
       if (error) {
         stop();


### PR DESCRIPTION
## Summary

Follow-up to #3806. A bisect of the Android empty-picker regression (`BLE Picker Devices Resolved` with `devicesTotal = 0`) traced the real cause to the **Expo SDK 57 / React Native 0.86 native upgrade** (`02b6a6610`), which recompiled the Android BLE stack and degraded scan discovery. Clean causal data (same calendar week, same Android 16, varying only app version):

| Board | 2.1.0 | 2.2.2 |
| --- | --- | --- |
| Kilter | 5.6% | **26.0%** |
| MoonBoard | 12.7% | **19.9%** |

Both families regressed (MoonBoard never used the scan filter #3806 removed), the JS scan path is byte-identical across the regression, and `react-native-ble-plx` is unchanged at **3.5.1** — already the latest published version, with no upstream fix. The library's own tracker documents "Android scan misses devices" as a long-standing issue whose community mitigation is a **high-power scan mode**.

The foreground "find my board" scans passed `null` scan options, so ble-plx used its default **`LowPower`** (~10% duty cycle). This switches the device picker (`adapter.ts`) and the Bluetooth quickstart (`use-board-scan.ts`) to a shared `HIGH_POWER_BOARD_SCAN_OPTIONS`:

- **`scanMode: LowLatency`** (Android only) — ~100% scan duty cycle.
- **`allowDuplicates: true`** (iOS only) — reports each advertisement repeatedly, so a name/UUID arriving in a later ADV/scan-response packet still reaches the JS filter.

For a user actively trying to light their board, high power is the right trade. `scan-options.ts` uses a type-only ble-plx import so it never pulls the native package into the web bundle. JS-only → the native fingerprint is unchanged, so this **OTAs onto the existing 2.2.2 fleet**.

> ⚠️ **This is a mitigation, not a root-cause fix.** The root cause is native (RN 0.86); there's no ble-plx version to bump to. If LowLatency doesn't fully recover discovery on-device, the next step is a hand-written ble-plx native patch. **It must be validated on a real Android device** — BLE discovery can't be exercised in CI or an emulator.

## Release Notes

- Android: faster, more reliable Bluetooth — your board turns up quicker when you go to connect

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — BLE adapter + quickstart tests updated to assert the high-power options; 115 BLE tests pass
- `vp check` — 0 errors
- `vp run check:mobile-bundle` — OK (web bundle unaffected: scan-options.ts is a type-only ble-plx import)
- **Required before merge:** on-device QA on a real Android phone (ideally a Samsung / Android 16) with a Kilter/Tension board — open the connect picker, confirm the board shows up reliably (`devicesTotal > 0`) where it was coming up empty. Validate via the `pr-<number>` OTA channel (More → Development → OTA Channel Switcher). Watch the Aurora×Android empty-rate on the "Mobile BLE Health" PostHog dashboard afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BY48HrcqZ1KJ1VNcJM2kJK
