### PR TITLE
perf(mobile): paint a splash placeholder while auth resolves (web FCP)

### DIFF
--- a/packages/mobile/src/components/AppLoadingSplash.tsx
+++ b/packages/mobile/src/components/AppLoadingSplash.tsx
@@ -1,0 +1,28 @@
+import { View, StyleSheet } from 'react-native';
+import { BoardseshLogo } from './BoardseshLogo';
+
+// Full-screen placeholder shown while auth is still resolving. On native the OS
+// splash screen covers this until `SplashScreen.hideAsync()` runs (auth + fonts
+// ready), so it's never actually visible there. On web there is no native
+// splash, so a blank render leaves the page white until the session round-trip
+// finishes (~2s on a cold load) — this is what paints instead, giving an
+// immediate first contentful paint. Matches the expo-splash-screen config: the
+// Boardsesh mark centered on black, in both light and dark.
+export function AppLoadingSplash() {
+  return (
+    <View style={styles.container}>
+      <BoardseshLogo size={96} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    // Mirrors the expo-splash-screen backgroundColor (#000000, same for dark)
+    // so the hand-off from the native splash to this placeholder is seamless.
+    backgroundColor: '#000000',
+  },
+});

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, render, waitFor, act } from '@testing-library/react';
+import { renderHook, render, screen, waitFor, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -45,10 +45,11 @@ vi.mock('react-native', () => ({
 }));
 
 // The loading-state splash renders react-native/expo-image primitives this
-// jsdom-mocked env doesn't provide; stub it — these tests exercise auth logic,
-// not the placeholder's pixels.
+// jsdom-mocked env doesn't provide; stub it to a detectable text marker (a
+// component may return a raw string) so a test can assert the loading window
+// renders the splash rather than a blank tree.
 vi.mock('../../components/AppLoadingSplash', () => ({
-  AppLoadingSplash: () => null,
+  AppLoadingSplash: () => 'app-loading-splash',
 }));
 
 vi.mock('../../lib/screenshot-mode', () => ({
@@ -262,6 +263,36 @@ vi.mock('../../lib/auth-interceptor', () => ({
 }));
 
 import { AuthProvider, useAuth } from '../auth-provider';
+
+describe('AuthProvider loading state', () => {
+  beforeEach(() => {
+    // A signed-in, fresh-token session so checkAuth flips isLoading false and
+    // isAuthenticated true (segments=[] keeps it out of the redirect branches),
+    // letting the tree swap from the splash to the app children.
+    getAuthTokenMock.mockResolvedValue('jwt-token');
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+  });
+
+  it('renders the splash placeholder (not a blank tree) while auth resolves, then swaps to children', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <span data-testid="app-children">ready</span>
+        </AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    // Synchronously after mount, auth is still loading: the splash shows and the
+    // app tree is withheld. This is the web FCP win — a painted splash, not blank.
+    expect(screen.getByText('app-loading-splash')).toBeTruthy();
+    expect(screen.queryByTestId('app-children')).toBeNull();
+
+    // Once the session resolves, the placeholder is replaced by the app tree.
+    await waitFor(() => expect(screen.queryByTestId('app-children')).not.toBeNull());
+    expect(screen.queryByText('app-loading-splash')).toBeNull();
+  });
+});
 
 describe('AuthProvider.signOut', () => {
   beforeEach(() => {

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -44,6 +44,13 @@ vi.mock('react-native', () => ({
   },
 }));
 
+// The loading-state splash renders react-native/expo-image primitives this
+// jsdom-mocked env doesn't provide; stub it — these tests exercise auth logic,
+// not the placeholder's pixels.
+vi.mock('../../components/AppLoadingSplash', () => ({
+  AppLoadingSplash: () => null,
+}));
+
 vi.mock('../../lib/screenshot-mode', () => ({
   SCREENSHOT_USER_EMAIL: 'screenshots@example.com',
   SCREENSHOT_USER_PASSWORD: 'screenshot-password',

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -3,6 +3,7 @@ import { AppState, Platform } from 'react-native';
 import { useSegments, Redirect } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { AppLoadingSplash } from '../components/AppLoadingSplash';
 import { resolveAuthSession } from '../lib/auth-session';
 import { captureAuthCredentialGeneration, isAuthCredentialGenerationCurrent } from '../lib/auth-store';
 import { subscribeAuthTokenChanges } from '../lib/auth-token-events';
@@ -762,7 +763,12 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   );
 
   if (isLoading) {
-    return null;
+    // Not `null`: on web there's no native splash to cover a blank render, so
+    // returning nothing here leaves the page white until the session round-trip
+    // resolves (~2s cold). Paint the splash placeholder instead — instant FCP on
+    // web, invisible on native (the OS splash is still up). Redirect/auth logic
+    // below is unchanged; it only runs once the session has actually resolved.
+    return <AppLoadingSplash />;
   }
 
   const inAuthGroup = segments[0] === 'auth';


### PR DESCRIPTION
## Summary

Profiling `app.boardsesh.com/home` (the Expo web build) showed first contentful paint at **~1.9s** — the page was blank white until then. Cause: `AuthProvider` returns `null` while the auth session round-trip (`/api/auth/session` → `/api/internal/ws-auth`, ~2s on a cold load) is in flight. On native the OS splash screen covers that gap, but **web has no native splash**, so the user stares at a white page until the session resolves.

This renders `<AppLoadingSplash />` — the Boardsesh mark on the splash's black background — during the loading window instead of `null`. On web that paints immediately, so FCP is now the splash rather than a blank page. On native it's invisible: the OS splash is still up and only hides once auth + fonts are ready (unchanged). All redirect/auth logic below the guard is untouched — it still runs only once the session has actually resolved.

Note: this improves FCP / perceived load, not LCP (the feed still waits on its data). The LCP win is in the companion PRs (feed tick N+1, session DB query).

## Release Notes

- The app shows the Boardsesh splash right away on the web instead of a blank white screen while it signs you in.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp test run --project mobile auth-provider.test.tsx` — 35 passed (added a stub mock for the splash since that suite runs in a hand-mocked jsdom RN env)
- `vp run check:mobile-bundle` and `vp run check:mobile-web-bundle` — both pass (web export builds with the new component)
- `vp check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015opNzGRdXpUkcfZEvmwosw