### PR TITLE
perf(web): cache profile claims on the JWT instead of a per-read DB query

### DIFF
--- a/packages/web/app/lib/auth/__tests__/auth-options.test.ts
+++ b/packages/web/app/lib/auth/__tests__/auth-options.test.ts
@@ -303,64 +303,58 @@ describe('authOptions.callbacks.session', () => {
     mockDbLimit.mockResolvedValue([]);
   });
 
-  it('overrides session.user.name with userProfiles.displayName when present', async () => {
-    mockDbLimit.mockResolvedValue([{ avatarUrl: null, displayName: 'jojo' }]);
-
+  // The session callback now reads the avatar/display name off the JWT (the
+  // `jwt` callback keeps them fresh), so it must NOT query the DB — that's the
+  // whole point of the perf change. Assert that below, and drive the display
+  // fields from token claims here.
+  it('overrides session.user.name with the JWT-cached displayName without hitting the DB', async () => {
     const result = await callSession({
       session: { user: { id: 'user-1', name: 'speedywalker8392', email: 'user@example.com' }, expires: '2099-01-01' },
-      token: { sub: 'user-1' },
+      token: { sub: 'user-1', profileDisplayName: 'jojo' },
     });
 
     expect(result.user?.name).toBe('jojo');
+    expect(mockDbSelect).not.toHaveBeenCalled();
   });
 
-  it('leaves session.user.name unchanged when no userProfiles row exists', async () => {
-    mockDbLimit.mockResolvedValue([]);
-
+  it('leaves session.user.name unchanged when the JWT has no cached displayName', async () => {
     const result = await callSession({
       session: { user: { id: 'user-1', name: 'speedywalker8392' }, expires: '2099-01-01' },
       token: { sub: 'user-1' },
     });
 
     expect(result.user?.name).toBe('speedywalker8392');
+    expect(mockDbSelect).not.toHaveBeenCalled();
   });
 
-  it('leaves session.user.name unchanged when the profile row has a null displayName', async () => {
-    mockDbLimit.mockResolvedValue([{ avatarUrl: 'https://cdn.example.com/avatar.jpg', displayName: null }]);
-
+  it('leaves session.user.name unchanged when the cached displayName is null', async () => {
     const result = await callSession({
       session: { user: { id: 'user-1', name: 'speedywalker8392' }, expires: '2099-01-01' },
-      token: { sub: 'user-1' },
+      token: { sub: 'user-1', profileAvatarUrl: 'https://cdn.example.com/avatar.jpg', profileDisplayName: null },
     });
 
     expect(result.user?.name).toBe('speedywalker8392');
   });
 
-  it('leaves session.user.name unchanged when the profile row has an empty-string displayName (known gap: clearing the field does not live-revert to the auto-generated handle)', async () => {
-    mockDbLimit.mockResolvedValue([{ avatarUrl: null, displayName: '' }]);
-
+  it('leaves session.user.name unchanged when the cached displayName is an empty string (clearing does not live-revert to the auto-generated handle)', async () => {
     const result = await callSession({
       session: { user: { id: 'user-1', name: 'speedywalker8392' }, expires: '2099-01-01' },
-      token: { sub: 'user-1' },
+      token: { sub: 'user-1', profileAvatarUrl: null, profileDisplayName: '' },
     });
 
     expect(result.user?.name).toBe('speedywalker8392');
   });
 
-  it('still overrides session.user.image with userProfiles.avatarUrl when present (regression guard)', async () => {
-    mockDbLimit.mockResolvedValue([{ avatarUrl: 'https://cdn.example.com/avatar.jpg', displayName: null }]);
-
+  it('overrides session.user.image with the JWT-cached avatarUrl when present (regression guard)', async () => {
     const result = await callSession({
       session: { user: { id: 'user-1', name: 'speedywalker8392', image: 'old.png' }, expires: '2099-01-01' },
-      token: { sub: 'user-1' },
+      token: { sub: 'user-1', profileAvatarUrl: 'https://cdn.example.com/avatar.jpg' },
     });
 
     expect(result.user?.image).toBe('https://cdn.example.com/avatar.jpg');
   });
 
   it('sets session.user.id from token.sub', async () => {
-    mockDbLimit.mockResolvedValue([]);
-
     const result = await callSession({
       session: { user: { id: 'user-99', name: 'speedywalker8392' }, expires: '2099-01-01' },
       token: { sub: 'user-42' },
@@ -392,6 +386,16 @@ async function callJwt(params: Partial<JwtParams>) {
 }
 
 describe('authOptions.callbacks.jwt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default DB chain: select().from().where().limit() resolves to empty so the
+    // profile-claim refresh below doesn't throw when a test doesn't care about it.
+    mockDbSelect.mockReturnValue({ from: mockDbFrom });
+    mockDbFrom.mockReturnValue({ where: mockDbWhere });
+    mockDbWhere.mockReturnValue({ limit: mockDbLimit });
+    mockDbLimit.mockResolvedValue([]);
+  });
+
   it('preserves an existing login generation through cookie refreshes', async () => {
     const result = await callJwt({ token: { sub: 'user-1', authSessionId: 'login-generation-1' } });
 
@@ -409,6 +413,88 @@ describe('authOptions.callbacks.jwt', () => {
 
     expect(result.authSessionId).toEqual(expect.any(String));
     expect(result.authSessionId).not.toBe('');
+  });
+
+  // Profile-claim caching (the perf change): the jwt callback fetches
+  // avatar/display name and stamps them on the token so the session callback
+  // reads them for free.
+  it('caches userProfiles avatar/displayName onto the token on a first (uncached) read', async () => {
+    mockDbLimit.mockResolvedValue([{ avatarUrl: 'https://cdn.example.com/a.jpg', displayName: 'jojo' }]);
+
+    const result = await callJwt({ token: { sub: 'user-1' } });
+
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
+    expect(result.profileAvatarUrl).toBe('https://cdn.example.com/a.jpg');
+    expect(result.profileDisplayName).toBe('jojo');
+    expect(result.profileClaimsRefreshedAt).toEqual(expect.any(Number));
+  });
+
+  it('does NOT re-query the DB when the cached claims are still within the TTL', async () => {
+    const result = await callJwt({
+      token: {
+        sub: 'user-1',
+        authSessionId: 'login-1',
+        profileAvatarUrl: 'https://cdn.example.com/a.jpg',
+        profileDisplayName: 'jojo',
+        profileClaimsRefreshedAt: Date.now(),
+      },
+    });
+
+    expect(mockDbSelect).not.toHaveBeenCalled();
+    // Cached claims survive untouched.
+    expect(result.profileDisplayName).toBe('jojo');
+  });
+
+  it('re-queries the DB when the cached claims have aged past the TTL', async () => {
+    mockDbLimit.mockResolvedValue([{ avatarUrl: null, displayName: 'renamed' }]);
+
+    const result = await callJwt({
+      token: {
+        sub: 'user-1',
+        authSessionId: 'login-1',
+        profileDisplayName: 'stale',
+        // 6 minutes ago — past the 5-minute TTL.
+        profileClaimsRefreshedAt: Date.now() - 6 * 60 * 1000,
+      },
+    });
+
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
+    expect(result.profileDisplayName).toBe('renamed');
+    expect(result.profileAvatarUrl).toBeNull();
+  });
+
+  it('force-refreshes on an explicit session update() even when the cache is fresh', async () => {
+    mockDbLimit.mockResolvedValue([{ avatarUrl: null, displayName: 'edited-just-now' }]);
+
+    const result = await callJwt({
+      token: {
+        sub: 'user-1',
+        authSessionId: 'login-1',
+        profileDisplayName: 'old',
+        profileClaimsRefreshedAt: Date.now(),
+      },
+      trigger: 'update',
+    });
+
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
+    expect(result.profileDisplayName).toBe('edited-just-now');
+  });
+
+  it('keeps the previously cached claims when the profile refresh query throws', async () => {
+    mockDbLimit.mockRejectedValue(new Error('DB exploded'));
+
+    const result = await callJwt({
+      token: {
+        sub: 'user-1',
+        authSessionId: 'login-1',
+        profileDisplayName: 'kept',
+        profileClaimsRefreshedAt: Date.now() - 6 * 60 * 1000,
+      },
+    });
+
+    // Refresh failed → prior claims stand, and the token read still succeeds.
+    expect(result.profileDisplayName).toBe('kept');
+    expect(result.authSessionId).toBe('login-1');
   });
 });
 

--- a/packages/web/app/lib/auth/__tests__/auth-options.test.ts
+++ b/packages/web/app/lib/auth/__tests__/auth-options.test.ts
@@ -429,6 +429,21 @@ describe('authOptions.callbacks.jwt', () => {
     expect(result.profileClaimsRefreshedAt).toEqual(expect.any(Number));
   });
 
+  it('caches null claims (not undefined) at sign-in when the new user has no profile row yet', async () => {
+    // events.createUser inserts an empty userProfiles row for OAuth users, but a
+    // brand-new credentials user can reach the jwt callback before any row
+    // exists — the query returns []. Cache null so the session callback falls
+    // back to the provider-supplied name/image instead of re-querying forever.
+    mockDbLimit.mockResolvedValue([]);
+
+    const result = await callJwt({ token: { sub: 'new-user' }, user: { id: 'new-user', email: 'new@example.com' } });
+
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
+    expect(result.profileAvatarUrl).toBeNull();
+    expect(result.profileDisplayName).toBeNull();
+    expect(result.profileClaimsRefreshedAt).toEqual(expect.any(Number));
+  });
+
   it('does NOT re-query the DB when the cached claims are still within the TTL', async () => {
     const result = await callJwt({
       token: {

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -13,6 +13,14 @@ import { verifyNativeOAuthTransferToken } from '@/app/lib/auth/native-oauth-tran
 import { isSecureCookieContext, sessionCookieDomain } from '@/app/lib/auth/secure-cookies';
 import { isAllowedAppOrigin } from '@/app/lib/auth/app-origin-allowlist';
 
+// How long a JWT-cached profile avatar/name stays authoritative before the
+// `jwt` callback re-reads userProfiles. A Settings edit refreshes it instantly
+// (the client calls `update()` → `trigger: 'update'`); this TTL is only the
+// safety net for changes made elsewhere (another device, a backend avatar
+// swap). Long enough that ordinary browsing never re-queries the DB, short
+// enough that out-of-band edits still surface within a few minutes.
+const PROFILE_CLAIMS_TTL_MS = 5 * 60 * 1000;
+
 // Build providers array conditionally based on available env vars
 const providers: NextAuthOptions['providers'] = [];
 
@@ -322,25 +330,19 @@ export const authOptions: NextAuthOptions = {
       if (session?.user && token?.sub) {
         session.user.id = token.sub;
 
-        // Fetch custom avatar/display name from userProfiles on every session read so the
-        // drawer/header reflect the latest Settings edit instead of whatever was baked into
-        // the JWT at sign-in (the JWT's name/image claims are never refreshed otherwise).
-        const db = getDb();
-        const profiles = await db
-          .select({ avatarUrl: schema.userProfiles.avatarUrl, displayName: schema.userProfiles.displayName })
-          .from(schema.userProfiles)
-          .where(eq(schema.userProfiles.userId, token.sub))
-          .limit(1);
-        if (profiles[0]?.avatarUrl) {
-          session.user.image = profiles[0].avatarUrl;
+        // Custom avatar/display name come off the JWT, which the `jwt` callback
+        // keeps fresh (sign-in, Settings `update()`, or a TTL refresh) — so a
+        // session read no longer runs a userProfiles DB query on every call.
+        if (token.profileAvatarUrl) {
+          session.user.image = token.profileAvatarUrl;
         }
-        if (profiles[0]?.displayName) {
-          session.user.name = profiles[0].displayName;
+        if (token.profileDisplayName) {
+          session.user.name = token.profileDisplayName;
         }
       }
       return session;
     },
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger }) {
       // Stable for one NextAuth login across cookie rotations and tabs, but new
       // for a later login even when it belongs to the same user. Existing JWTs
       // can reuse their standard jti so rollout does not force a sign-out.
@@ -350,6 +352,34 @@ export const authOptions: NextAuthOptions = {
       // Persist the OAuth access_token and user id to the token right after signin
       if (user) {
         token.id = user.id;
+      }
+
+      // Cache the userProfiles avatar/display name ON the token so the `session`
+      // callback (which runs on every /api/auth/session read — each page load,
+      // plus NextAuth's client polling) doesn't hit the DB every time. Refresh
+      // on sign-in (`user`), on an explicit `update()` after a Settings edit
+      // (`trigger === 'update'`), or when the cache has aged past the TTL;
+      // otherwise the previously cached claims stand.
+      const profileCacheStale =
+        typeof token.profileClaimsRefreshedAt !== 'number' ||
+        Date.now() - token.profileClaimsRefreshedAt > PROFILE_CLAIMS_TTL_MS;
+      if (token.sub && (Boolean(user) || trigger === 'update' || profileCacheStale)) {
+        try {
+          const db = getDb();
+          const profiles = await db
+            .select({ avatarUrl: schema.userProfiles.avatarUrl, displayName: schema.userProfiles.displayName })
+            .from(schema.userProfiles)
+            .where(eq(schema.userProfiles.userId, token.sub))
+            .limit(1);
+          token.profileAvatarUrl = profiles[0]?.avatarUrl ?? null;
+          token.profileDisplayName = profiles[0]?.displayName ?? null;
+          token.profileClaimsRefreshedAt = Date.now();
+        } catch (error) {
+          // Keep whatever claims are already cached rather than failing the
+          // whole token read — a briefly stale avatar/name is fine; a broken
+          // session (signed-out header, failed page load) is not.
+          console.warn('Failed to refresh profile claims for session JWT:', error);
+        }
       }
       return token;
     },

--- a/packages/web/app/lib/auth/types.ts
+++ b/packages/web/app/lib/auth/types.ts
@@ -14,5 +14,12 @@ declare module 'next-auth/jwt' {
   // eslint-disable-next-line typescript/consistent-type-definitions
   interface JWT {
     authSessionId?: string;
+    // Cached userProfiles claims so the `session` callback doesn't run a DB
+    // query on every /api/auth/session read. `null` means "fetched, but the
+    // profile has none" (distinct from `undefined` = never fetched yet).
+    // `profileClaimsRefreshedAt` is an epoch-ms timestamp gating the TTL refresh.
+    profileAvatarUrl?: string | null;
+    profileDisplayName?: string | null;
+    profileClaimsRefreshedAt?: number;
   }
 }


### PR DESCRIPTION
## Summary

Profiling `app.boardsesh.com` showed the app blocking **~695ms** on `/api/auth/session` before it could load anything. That endpoint's NextAuth `session` callback ran a `userProfiles` SELECT **on every read** — every page load, plus NextAuth's periodic client polling — purely to keep the header/drawer avatar and display name fresh after a Settings edit. On JWT session strategy there's otherwise no per-read DB access, so this one query dominates the latency.

This caches `avatarUrl` / `displayName` on the JWT and refreshes them in the `jwt` callback only when they can actually have changed:
- at sign-in (`user` present),
- on an explicit `update()` after a Settings edit (`trigger === 'update'` — the Settings page already calls `updateSession()`),
- or once the cache ages past a **5-minute TTL** (safety net for edits made on another device / out of band).

The `session` callback then reads those cached claims with **no DB access**. Same freshness on the common edit path; ordinary navigation stops hitting the DB entirely.

### Behaviour notes
- Same-session Settings edit stays instant (unchanged — driven by `updateSession()`).
- Out-of-band avatar/name changes surface within ≤5 min instead of immediately — an acceptable trade for dropping a DB round trip off every authenticated request.
- If the refresh query throws, the previously cached claims stand and the session read still succeeds (no signed-out flash).

## Release Notes

- Signed-in pages load a little quicker — the app no longer re-checks your profile from the database on every request.

## Test plan

- `vp run typecheck:web` — clean
- `vp test run --project web auth-options.test.ts` — 53 passed. Reworked the `session`-callback tests to read cached JWT claims (and assert no DB call), and added `jwt`-callback tests: caches on first read, skips the DB within TTL, re-queries past TTL, force-refreshes on `trigger: 'update'`, and keeps prior claims when the query throws.
- `vp check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015opNzGRdXpUkcfZEvmwosw