### PR TITLE
chore(mobile-ota): [throwaway] pr preview on v1-gzip for iOS decode test

### DIFF
--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -321,6 +321,13 @@ jobs:
       - name: Publish iOS OTA
         id: publish_ios
         if: steps.compat.outputs.verdict_ios != 'native-change-required'
+        # THROWAWAY (test/ios-gzip-ota-preview — do NOT merge): point this preview at
+        # the gzip snapshot prefix to validate on-device transparent gzip decode on a
+        # real iOS binary via the pr-<n> channel. Step-level override (bundle-only,
+        # no fingerprint effect) — the workflow-level EXPO_PUBLIC_SNAPSHOT_BASE_URL
+        # stays v1 so mobile-ci-env-parity.test.ts stays green.
+        env:
+          EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-gzip
         run: vp run mobile:publish -- --channel "$CHANNEL" --platform ios
 
       - name: Publish Android OTA
@@ -328,6 +335,8 @@ jobs:
         if: steps.compat.outputs.verdict_android != 'native-change-required'
         env:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          # THROWAWAY (see iOS step) — gzip prefix for the pr-<n> preview bundle.
+          EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-gzip
         run: vp run mobile:publish -- --channel "$CHANNEL" --platform android
 
       # Sticky comment + deployment status, reflecting per-platform outcome. Always


### PR DESCRIPTION
**⚠️ THROWAWAY — do not merge / do not review. Close after the iOS gzip test.**

## Purpose
Validate transparent `Content-Encoding: gzip` decode on a **real iOS binary** via the `pr-<n>` OTA channel, without a local Mac build. Android already validated on-device (2026-07-20); this is the iOS gate for the gzip cutover (#3796).

## What it does
Adds a **step-level** `EXPO_PUBLIC_SNAPSHOT_BASE_URL=…/board-snapshots/v1-gzip` override to the iOS + Android publish steps only. Bundle-only (no fingerprint change), and the workflow-level line stays `v1`, so `mobile-ci-env-parity.test.ts` stays green. The `pr-<n>` bundle therefore reads the gzip snapshot prefix; everything else is main.

## How to test (iOS)
1. Approve this PR's `ota-preview` environment deployment (Actions → the Mobile OTA Preview run).
2. On a current TestFlight/store iOS build: **More → Development → OTA Channel Switcher**, type `pr-<this-PR-number>`, reload.
3. **My Boards → enable a fresh board** (one not already downloaded).
4. It should download and light up normally.

I'll confirm from telemetry: PostHog `Offline Board Download Completed` with `method: 'snapshot'` (not `paged`) for your download, and **no** Sentry `environment: preview` handled error `kind: 'snapshot-bootstrap'` "arrived still gzip-compressed". If it shows `paged` / a gzip Sentry error → iOS NSURLSession doesn't auto-decode, and we hold iOS on `v1`.

## Release Notes
none
