### PR TITLE
feat(mobile-ota): serve gzip board snapshots to the fleet (v1 → v1-gzip)

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -84,7 +84,7 @@ env:
   # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
   # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
   # export-board-snapshots.yml.
-  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-gzip
   # Pin RN's fetch as the global `fetch` (not expo/fetch), which crashes Hermes by
   # tearing down JSI promises off-thread (Sentry 7595562195). Bundle-only flag — it
   # doesn't enter the resolved config, so it never moves the fingerprint. Kept in

--- a/.github/workflows/export-board-snapshots.yml
+++ b/.github/workflows/export-board-snapshots.yml
@@ -7,14 +7,15 @@ name: Export Board Snapshots
 # records. Idempotent — each run mints new content-addressed artifacts and
 # rewrites the manifest last.
 #
-# The run publishes the catalog under TWO prefixes side by side during the gzip
-# transition (see docs/board-snapshots.md):
-#   - board-snapshots/v1       identity-encoded — what the current fleet reads. Unchanged.
-#   - board-snapshots/v1-gzip  gzip-encoded (~2.6x smaller) — what newer builds read once
-#                              transparent Content-Encoding decode is validated on-device.
+# The run publishes the catalog under TWO prefixes side by side
+# (see docs/board-snapshots.md):
+#   - board-snapshots/v1-gzip  gzip-encoded (~2.6x smaller) — what the fleet reads. Every
+#                              mobile workflow's EXPO_PUBLIC_SNAPSHOT_BASE_URL points here.
+#   - board-snapshots/v1       identity-encoded — nothing points at it any more; kept live
+#                              as the one-revert rollback target and the public dataset base.
 # Each prefix is a self-contained, single-encoding manifest; the export merges
-# and prunes strictly within the prefix it targets. The follow-up that cuts the
-# whole fleet to gzip drops the identity pass and deletes the v1 prefix.
+# and prunes strictly within the prefix it targets. A later cleanup drops the
+# identity pass and deletes the v1 prefix.
 on:
   schedule:
     - cron: '15 7 * * *' # 07:15 UTC daily (off-peak; distinct from the 06:00/06:30 refresh crons)
@@ -77,9 +78,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # Identity pass → board-snapshots/v1. This is what the live fleet reads, so
-      # it stays byte-for-byte the pre-gzip run. Skipped only when a manual
-      # dispatch asks to refresh just the gzip artifacts.
+      # Identity pass → board-snapshots/v1. The fleet no longer reads this prefix
+      # (it moved to v1-gzip), but it stays byte-for-byte the pre-gzip run so
+      # reverting the mobile workflows' EXPO_PUBLIC_SNAPSHOT_BASE_URL is a
+      # complete rollback on its own. It's also the base the public dataset doc
+      # hands out. Skipped only when a manual dispatch asks to refresh just the
+      # gzip artifacts.
       #
       # BOARD/LAYOUT come through `env` and are read as shell variables, never
       # interpolated into the run script with `${{ }}` — a dispatch input must not
@@ -106,8 +110,11 @@ jobs:
           if [ -n "$LAYOUT" ]; then args+=("--layout=$LAYOUT"); fi
           node --import tsx src/scripts/export-board-snapshots.ts "${args[@]}"
 
-      # Gzip pass → board-snapshots/v1-gzip. Additive: newer builds point their
-      # EXPO_PUBLIC_SNAPSHOT_BASE_URL at this prefix once decode is validated.
+      # Gzip pass → board-snapshots/v1-gzip. This is the live prefix: every mobile
+      # workflow's EXPO_PUBLIC_SNAPSHOT_BASE_URL points here, so this pass must
+      # stay in the nightly (a gzip-pass failure strands the fleet on whatever the
+      # manifest last named). Clients verify the gzip magic bytes and fall back to
+      # the paged crawl if a body arrives undecoded.
       - name: Export board snapshots (gzip → board-snapshots/v1-gzip)
         working-directory: packages/backend
         env:

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -60,7 +60,7 @@ env:
   # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
   # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
   # export-board-snapshots.yml.
-  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-gzip
   # Pin RN's fetch as the global `fetch` (not expo/fetch), which crashes Hermes by
   # tearing down JSI promises off-thread (Sentry 7595562195). Bundle-only flag — it
   # doesn't enter the resolved config, so it never moves the fingerprint. Kept in

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -70,7 +70,7 @@ env:
   # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
   # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
   # export-board-snapshots.yml.
-  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-gzip
   EXPO_UPDATES_CHANNEL: production
   EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
   # Pin RN's fetch as the global `fetch` (not expo/fetch), which crashes Hermes by

--- a/.github/workflows/mobile-ota-check.yml
+++ b/.github/workflows/mobile-ota-check.yml
@@ -60,7 +60,7 @@ env:
   # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
   # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
   # export-board-snapshots.yml.
-  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-gzip
   EXPO_UPDATES_CHANNEL: production
   EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
   # Pin RN's fetch as the global `fetch` (not expo/fetch), which crashes Hermes by

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -98,7 +98,7 @@ env:
   # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
   # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
   # export-board-snapshots.yml.
-  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-gzip
   EXPO_UPDATES_CHANNEL: production
   EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
   # Pin RN's fetch as the global `fetch` (not expo/fetch), which crashes Hermes by

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -80,7 +80,7 @@ env:
   # Manifest base for the offline snapshot bootstrap (bundle-only, no fingerprint
   # effect). Public Tigris bucket; keep in sync with SNAPSHOT_PUBLIC_BASE_URL in
   # export-board-snapshots.yml.
-  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1
+  EXPO_PUBLIC_SNAPSHOT_BASE_URL: https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-gzip
   # Baked into the binary by `expo prebuild`; the server maps this channel to a
   # same-named branch. Part of the resolved config, so it's fingerprint-relevant.
   EXPO_UPDATES_CHANNEL: production

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -28,17 +28,18 @@ now — typically under a day.
 `concurrency.group: export-board-snapshots` with `cancel-in-progress: false` means overlapping runs queue
 instead of stepping on each other.
 
-**Dual-publish during the gzip transition.** The nightly runs the export **twice**, targeting two
-prefixes via `--key-prefix` (default `board-snapshots/v1`):
+**Dual-publish.** The nightly runs the export **twice**, targeting two prefixes via `--key-prefix`
+(default `board-snapshots/v1`):
 
-- `board-snapshots/v1` — **identity**-encoded, exactly the pre-gzip run. This is what the current fleet
-  reads (all mobile workflows' `EXPO_PUBLIC_SNAPSHOT_BASE_URL` still point here), so it is left unchanged.
-- `board-snapshots/v1-gzip` — `--gzip`, ~2.6× smaller (`kilter:1` 258 MB → ~99 MB). Newer builds point at
-  this prefix once transparent `Content-Encoding: gzip` decode is validated on-device.
+- `board-snapshots/v1-gzip` — `--gzip`, ~2.6× smaller (`kilter:1` 271 MB → 103 MB as of 2026-07-27).
+  **This is what the fleet reads**: every mobile workflow's `EXPO_PUBLIC_SNAPSHOT_BASE_URL` points here.
+- `board-snapshots/v1` — **identity**-encoded, exactly the pre-gzip run. Nothing points at it any more; it
+  stays live as the one-revert rollback target and as the public dataset base
+  (`docs/board-snapshots-dataset.md`).
 
 Each prefix is a self-contained, single-encoding manifest: the merge and prune logic below scope entirely
-to whichever prefix the run targets, so a gzip run never reads or prunes the identity prefix. The follow-up
-that cuts the whole fleet to gzip drops the identity pass and deletes the `v1` prefix (see Rollout plan).
+to whichever prefix the run targets, so a gzip run never reads or prunes the identity prefix. A later
+cleanup drops the identity pass and deletes the `v1` prefix (see Rollout plan).
 
 For every `(board_type, layout_id)` pair with at least one climb (`discoverLayoutPairs`), each pass:
 
@@ -119,7 +120,8 @@ Artifacts superseded by a newer build for the same `(boardType, layoutId)` are d
 - the run was **unfiltered** (a filtered run doesn't have the full manifest picture to prune safely), and
 - the run had **zero layout failures** (a failed night just defers pruning to the next green run).
 
-An object is eligible for deletion when it's under `board-snapshots/v1/` and NOT referenced by the manifest
+An object is eligible for deletion when it's under the prefix the run targets (`board-snapshots/v1/` for
+the identity pass, `board-snapshots/v1-gzip/` for the gzip pass) and NOT referenced by the manifest
 just written, **and** its `lastModified` is older than a **14-day grace window**
 (`PRUNE_GRACE_MS`). The grace window exists because the manifest is CDN-cached for up to 5 minutes and a
 client may hold a fetched manifest (with a now-superseded artifact URL) far longer than that before it
@@ -360,7 +362,7 @@ builds (`https://t3.storage.dev/<bucket>/<key>`) returns 403 for anonymous GETs 
 bucket. The workflow therefore sets `SNAPSHOT_PUBLIC_BASE_URL` (not a secret — it appears in every
 manifest) and the export re-bases entry URLs onto it. Keep it consistent with
 `EXPO_PUBLIC_SNAPSHOT_BASE_URL` in the mobile workflows: the mobile value is
-`${SNAPSHOT_PUBLIC_BASE_URL}/board-snapshots/v1`.
+`${SNAPSHOT_PUBLIC_BASE_URL}/board-snapshots/v1-gzip`.
 
 ### Kill switches
 
@@ -368,7 +370,8 @@ manifest) and the export re-bases entry URLs onto it. Keep it consistent with
   to the paged crawl for newly-enabled boards; nothing already bootstrapped is affected (it's already past
   the eligibility check).
 - **Nuclear, affects every client regardless of flag state after cache expiry**: delete the
-  `board-snapshots/v1/manifest.json` object from the bucket. The manifest is cached for up to 5 minutes
+  `board-snapshots/v1-gzip/manifest.json` object from the bucket — that's the prefix the fleet reads;
+  deleting `board-snapshots/v1/manifest.json` stops nothing. The manifest is cached for up to 5 minutes
   (`Cache-Control: public, max-age=300`), so clients that already fetched it may keep bootstrapping until
   that cache entry expires. After that, `fetchManifest` returns a 404 → `absent` → permanent miss, no
   attempt burned, straight to the paged crawl. Restoring after a manifest delete must use an unfiltered
@@ -440,37 +443,35 @@ page — that's the trigger to prioritize the fix.
      crawl (see Mobile wiring above).
    - One real on-device bootstrap, confirmed end to end: the `ATTACH` uses a bare filesystem path (no
      `file://` scheme — SQLite's ATTACH resolution isn't guaranteed URI-mode-safe on either platform's
-     bundled sqlite3), and identity artifacts attach/import without a gzip-magic-byte failure. If `--gzip`
-     is tested separately, verify no gzip-magic-byte handled error is reported to Sentry for that download.
+     bundled sqlite3), the artifact attaches and imports, and Sentry reports no gzip-magic-byte handled
+     error for that download (the fleet reads the gzip prefix, so decode is on the live path).
 3. **Percentage ramp**: increase the PostHog rollout gradually, watching `Offline Board Download Completed`
    duration percentiles split by `method`, and the Sentry `snapshot-bootstrap` failure rate, at each step.
    Hold or roll back on a `snapshot` p95 that doesn't clearly beat `paged`, or a failure-rate step change.
 
 ## Gzip transition & cutover
 
-Gzip cuts artifact size ~2.6× (`kilter:1` 258 MB → ~99 MB), directly shrinking the download portion of
-`durationMs`. It ships in stages so the live fleet is never regressed while transparent decode is unverified:
+Gzip cuts artifact size ~2.6× (`kilter:1` 271 MB → 103 MB, whole catalog 595 MB → 220 MB, measured
+2026-07-27), directly shrinking the download portion of `durationMs`. It shipped in stages so the live
+fleet was never regressed while transparent decode was unverified:
 
-1. **Dual-publish (shipped).** The nightly publishes both `board-snapshots/v1` (identity, unchanged) and
-   `board-snapshots/v1-gzip` (`--gzip`). Every mobile workflow's `EXPO_PUBLIC_SNAPSHOT_BASE_URL` still
-   points at `v1`, so the fleet is untouched. After merging, dispatch the workflow once (or wait a night) to
-   populate `v1-gzip`.
-2. **Validate transparent decode on-device, iOS + Android.** Build a dev-client with
-   `EXPO_PUBLIC_SNAPSHOT_BASE_URL=<base>/board-snapshots/v1-gzip` (build-time only, **not** committed — the
-   parity test below forbids a single-workflow change), flags on, and enable a fresh board. Pass =
-   PostHog `Offline Board Download Completed` `method: 'snapshot'`, `durationMs` down markedly, and **no**
-   Sentry handled error `kind: 'snapshot-bootstrap'` "arrived still gzip-compressed". Android is runnable
-   via `vp run mobile:android-shots` (real OkHttp); iOS needs a Mac.
-3. **Cutover (follow-up PR).** Flip `EXPO_PUBLIC_SNAPSHOT_BASE_URL` to the `v1-gzip` path in **all** the
-   mobile fingerprint workflows **at once** — `mobile-ota-production.yml`, `ios-testflight-rn.yml`,
-   `android-apk-rn.yml`, `mobile-ota-check.yml`, `mobile-ota-preview.yml`, `mobile-ota-backport.yml` —
-   because `scripts/mobile-ci-env-parity.test.ts` requires this var byte-identical across them (a
-   single-workflow change fails CI, and the `pr-<number>` preview channel bakes the same env as
-   production, so there is no "preview-only" pointer). The production OTA then migrates the fleet on next
-   launch; any straggler where decode fails degrades to the paged crawl, never a crash. Watch the same
-   telemetry as the ramp above.
-4. **Cleanup (later PR).** Once the fleet has migrated, drop the identity pass from the export workflow and
-   delete the `board-snapshots/v1` artifacts + manifest.
+1. **Dual-publish — shipped.** The nightly publishes both `board-snapshots/v1` (identity) and
+   `board-snapshots/v1-gzip` (`--gzip`), one manifest each, ~80s apart in the same run.
+2. **Transparent decode validated on-device, iOS + Android — done.** Android: the real `downloadArtifact`
+   path on an emulator (OkHttp) inflated the artifact to a decoded SQLite file, no
+   `SnapshotPermanentMissError`. iOS 26.5.2: via the `pr-3816` gzip OTA preview — fresh downloads took the
+   snapshot path and Sentry reported no `kind: 'snapshot-bootstrap'` "arrived still gzip-compressed".
+3. **Cutover — shipped.** `EXPO_PUBLIC_SNAPSHOT_BASE_URL` points at `.../board-snapshots/v1-gzip` in **all
+   six** mobile fingerprint workflows — `mobile-ota-production.yml`, `ios-testflight-rn.yml`,
+   `android-apk-rn.yml`, `mobile-ota-check.yml`, `mobile-ota-preview.yml`, `mobile-ota-backport.yml`. They
+   must move together: `scripts/mobile-ci-env-parity.test.ts` requires the var byte-identical across them
+   (a single-workflow change fails CI, and the `pr-<number>` preview channel bakes the same env as
+   production, so there is no "preview-only" pointer). It's a bundle-only var, so the cutover rode the
+   production OTA rather than a native release; any straggler where decode fails degrades to the paged
+   crawl, never a crash.
+4. **Cleanup (not done yet).** Once the fleet has migrated, drop the identity pass from the export workflow
+   and delete the `board-snapshots/v1` artifacts + manifest. `docs/board-snapshots-dataset.md` publishes
+   `v1` URLs to outside users, so that doc has to be repointed at `v1-gzip` in the same change.
 
-**Rollback** at any stage: point the workflows back at `v1` (identity is always live) — no export change
-needed.
+**Rollback**: point the six workflows back at `v1` (identity is still published nightly) — a one-commit
+revert, no export change needed.

--- a/packages/mobile/src/lib/env.ts
+++ b/packages/mobile/src/lib/env.ts
@@ -29,8 +29,9 @@ export function webApiUrl(path: string): string {
 // Base URL for the board-snapshot manifest directory (offline-sync Phase 2/4):
 // `${SNAPSHOT_BASE_URL}/manifest.json` is the manifest; each entry's own `url`
 // is an absolute artifact URL, so this constant is only used for the manifest
-// fetch. Mirrors packages/backend/src/scripts/export-board-snapshots.ts's
-// `board-snapshots/v1` key prefix, served from the same Tigris/S3 bucket
+// fetch. Mirrors one of packages/backend/src/scripts/export-board-snapshots.ts's
+// key prefixes — the CI workflows point it at the gzip-encoded catalog,
+// `board-snapshots/v1-gzip` — served from the same Tigris/S3 bucket
 // packages/backend/src/storage/s3.ts uploads to. This must be supplied by the
 // EAS build environment; there is deliberately no guessed production fallback.
 //

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -4,10 +4,12 @@
 // instead of paging the whole catalog over GraphQL. See
 // packages/backend/src/scripts/export-board-snapshots.ts for what this
 // downloads: a per-(boardType, layoutId) SQLite file uploaded to Tigris/S3
-// under `board-snapshots/v1/`, plus `manifest.json` listing every artifact's
-// URL, stored size, content encoding, and resume watermarks. Artifacts default
-// to identity encoding; gzip is opt-in and verified by this adapter before the
-// file is handed to SQLite.
+// under `board-snapshots/v1-gzip/` (the prefix the shipped builds point at),
+// plus `manifest.json` listing every artifact's URL, stored size, content
+// encoding, and resume watermarks. Live artifacts are gzip-encoded and this
+// adapter verifies the body was decoded before handing the file to SQLite; the
+// identity prefix (`board-snapshots/v1/`) is still published as a rollback
+// target, so the identity path below stays load-bearing.
 //
 // The engine only consumes what this returns — it never fetches, downloads, or
 // gunzips anything itself (see snapshot-bootstrap.ts's `SnapshotSource`
@@ -153,9 +155,11 @@ async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePat
       safeDeleteFile(downloaded);
       // Expected behaviour is that the native HTTP stack (NSURLSession /
       // OkHttp) auto-decodes a gzip Content-Encoding while downloading — this
-      // path should be rare-to-never. Report it as a handled error (not just a
-      // dev warning) so a real pattern shows up in Sentry before gzip is enabled
-      // for mobile artifacts.
+      // path should be rare-to-never (validated on Android/OkHttp and iOS 26.5.2
+      // before the fleet was cut over to the gzip prefix). Report it as a handled
+      // error (not just a dev warning) so a real pattern shows up in Sentry —
+      // it's now the live download path, and a spike here is the cutover's
+      // rollback signal.
       reportHandledError(
         new Error('snapshot artifact arrived still gzip-compressed (Content-Encoding was not auto-decoded)'),
         {


### PR DESCRIPTION
## What

Point all six mobile fingerprint workflows' `EXPO_PUBLIC_SNAPSHOT_BASE_URL` from `board-snapshots/v1` (identity) to `board-snapshots/v1-gzip`. The dual-publish export ([#3796](https://github.com/boardsesh/boardsesh/pull/3796)) has been publishing `v1-gzip` in parallel — this hands the fleet to it. All six flip together so `scripts/mobile-ci-env-parity.test.ts` stays green (bundle-only var, no fingerprint change — the OTA-compat check confirms iOS + Android fingerprints still match `main`).

Second commit updates the docs and the export workflow's comments, which still described the cutover as a future step. Two of them were about to become actively wrong:

- the "nuclear" kill switch in `docs/board-snapshots.md` pointed at `board-snapshots/v1/manifest.json` — after this change, deleting that stops nothing;
- the prune description claimed `v1`-scoped deletion, when `pruneStaleArtifacts` is scoped to whichever prefix the run targets.

## Why

Fresh-board offline downloads shrink **~2.6×**. Measured against today's manifests (2026-07-27), not the old estimates:

| | `v1` (identity) | `v1-gzip` |
| --- | --- | --- |
| `kilter:1` (Kilter Original) | 270.9 MB | 102.9 MB |
| Whole catalog (22 layouts) | 595.0 MB | 219.6 MB |

The flagship Kilter board drove a multi-minute download tail; this is the fix.

## Dual-publish verified live (not assumed)

Both prefixes were re-exported by today's nightly, ~80s apart in the same run:

- `v1/manifest.json` — `Last-Modified: Mon, 27 Jul 2026 10:52:23 GMT`, 22 entries, all `contentEncoding: identity`, `schemaVersion: 4`
- `v1-gzip/manifest.json` — `Last-Modified: Mon, 27 Jul 2026 10:53:44 GMT`, 22 entries, all `contentEncoding: gzip`, `schemaVersion: 4`
- The last 8 scheduled `export-board-snapshots` runs are all green.
- Fetched a live gzip artifact: Tigris serves `Content-Encoding: gzip`, and the transparently-decoded body is a real SQLite file (`SQLite 3.x database … schema 4`).

So the prefix this PR points at is fully populated, same catalog, same schema version, refreshed nightly.

## Validated on-device before flipping

Transparent `Content-Encoding: gzip` decode is the one thing this rests on, and both platforms are confirmed:

- **Android** — OkHttp via `expo-file-system` inflates the artifact to disk (ran the real `downloadArtifact` path on an emulator → decoded SQLite, no `SnapshotPermanentMissError`).
- **iOS 26.5.2** — tested on the `pr-3816` gzip preview: fresh downloads take the snapshot path (fast, not the slow paged fallback), and Sentry shows **no** `snapshot-bootstrap` "arrived still gzip-compressed" error.

If a straggler client somehow can't decode, `snapshot-source.ts` catches it on the gzip magic bytes, reports a handled error to Sentry, and degrades to the paged crawl. Slower, never a crash.

## ⚠️ Merging republishes the production OTA — watch the fleet

`mobile-ota-production.yml` fires on push to `main`, so **merging this ships a production OTA to the whole fleet** and every subsequent native build bakes `v1-gzip` too. After merge, watch:

- Sentry handled errors tagged `kind: 'snapshot-bootstrap'` — a step change in "arrived still gzip-compressed" is the rollback signal.
- PostHog `Offline Board Download Completed` split by `method` — the `snapshot` share should hold and `durationMs` p95 should drop. A rise in `method: 'paged'` means clients are falling back.

**Rollback** = revert this commit. `v1` (identity) is still published nightly and nothing else has to change. That's why the identity pass stays in the export workflow; the docs now say so explicitly.

## Follow-ups (not this PR)

- Close [#3816](https://github.com/boardsesh/boardsesh/pull/3816) — the throwaway iOS decode-test preview — once this lands.
- Later cleanup: drop the identity pass from `export-board-snapshots.yml` and delete the `v1` prefix. `docs/board-snapshots-dataset.md` publishes `v1` URLs to outside users, so that doc has to be repointed in the same change — now noted in the rollout plan.

## Release Notes

Downloading a board for offline just got a lot lighter. The big boards drop from about 270 MB to about 100 MB, so your first download over a gym's wifi finishes noticeably sooner and eats far less data.
