### PR TITLE
fix(mobile): scan Aurora unfiltered on the native iOS BLE path

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
@@ -544,6 +544,25 @@ describe('NativeIosBleAdapter on older binaries (no adoption surface)', () => {
     // Nordic UART service — without an unfiltered scan we must list both.
     expect(nativeMock.startScan).toHaveBeenCalledWith(['UART-UUID', 'REDBEARLAB-UUID']);
   });
+
+  it('filters an Aurora scan on the Aurora service when unfiltered scanning is unavailable', async () => {
+    // Explicit older-binary Aurora coverage: without the adoption surface we
+    // can't scan unfiltered, so we must keep the native Aurora service filter
+    // (an old binary always filters natively regardless). The scan-response-PDU
+    // gap this diff fixes only exists on capable binaries that go unfiltered.
+    const adapter = new NativeIosBleAdapter(
+      (subscribe) =>
+        new Promise<string>(() => {
+          subscribe(() => {});
+        }),
+      'aurora',
+    );
+    void adapter.requestAndConnect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(nativeMock.startScan).toHaveBeenCalledWith(['AURORA-UUID']);
+  });
 });
 
 // ── Per-write transport diagnostics (#3230) ─────────────────────────────────

--- a/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
@@ -465,7 +465,7 @@ describe('NativeIosBleAdapter on newer binaries (adoption surface present)', () 
     expect(nativeMock.connect).toHaveBeenCalledWith('moon-1');
   });
 
-  it('uses the Aurora service filter and drops unrelated devices on Aurora scans', async () => {
+  it('scans unfiltered on Aurora and surfaces boards whose UUID rode the scan-response PDU', async () => {
     let manualPick: (deviceId: string) => void = () => {};
     const seenDeviceIds: string[] = [];
     const adapter = new NativeIosBleAdapter(
@@ -482,27 +482,42 @@ describe('NativeIosBleAdapter on newer binaries (adoption surface present)', () 
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(nativeMock.startScan).toHaveBeenCalledWith(['AURORA-UUID']);
+    // Unfiltered on the newer surface: a native `withServices:[Aurora]` filter
+    // only matches the primary ADV, dropping boxes (Kilter-built bare-name /
+    // NimBLE dev boards) whose UUID rides the scan-response PDU. The JS filter
+    // below narrows instead. Matches the Android adapter (adapter.ts, #3806).
+    expect(nativeMock.startScan).toHaveBeenCalledWith([]);
 
+    // An unrelated peripheral must still be dropped by the JS filter...
     scanListeners[0]?.({
       device: { deviceId: 'airpods', name: "Marco's AirPods #1" },
       localName: "Marco's AirPods #1",
       rssi: -30,
       serviceUuids: [],
     });
+    // ...a board that DID advertise the UUID in its primary ADV must surface...
     scanListeners[0]?.({
       device: { deviceId: 'aurora-1', name: 'Kilter Board#751737@3' },
       localName: 'Kilter Board#751737@3',
       rssi: -40,
       serviceUuids: ['AURORA-UUID'],
     });
+    // ...and so must one whose Aurora UUID never reached `serviceUuids` (rode
+    // the scan-response PDU) — matched by its name alone. The hardware filter
+    // would have dropped this one; the regression that broke the dev board.
+    scanListeners[0]?.({
+      device: { deviceId: 'aurora-devboard', name: 'Kilter Board#123456@3' },
+      localName: 'Kilter Board#123456@3',
+      rssi: -45,
+      serviceUuids: [],
+    });
 
-    expect(seenDeviceIds).toEqual(['aurora-1']);
+    expect(seenDeviceIds).toEqual(['aurora-1', 'aurora-devboard']);
 
-    manualPick('aurora-1');
+    manualPick('aurora-devboard');
     await vi.runAllTimersAsync();
     await connectPromise;
-    expect(nativeMock.connect).toHaveBeenCalledWith('aurora-1');
+    expect(nativeMock.connect).toHaveBeenCalledWith('aurora-devboard');
   });
 });
 

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -133,9 +133,15 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       openPicker();
     }
 
-    // MoonBoard scans are unfiltered on newer binaries (a native service-UUID
-    // filter would hide controllers that only surface via name). Aurora scans
-    // stay filtered to avoid unrelated peripherals reaching the picker.
+    // Both families scan unfiltered on newer binaries, then narrow in JS via
+    // isLikelyBoardDevice. A native service-UUID filter hides any box whose UUID
+    // rides the scan-response PDU rather than the primary advertisement — iOS
+    // `scanForPeripherals(withServices:)` only matches the primary. That drops
+    // Kilter-built bare-name boxes and NimBLE-based controllers (dev boards)
+    // whose 128-bit Aurora UUID + long name can't co-fit in the 31-byte legacy
+    // ADV, giving an empty picker (regression 0710be7a8, the same one adapter.ts
+    // fixed for Android in #3806 — the native iOS path was missed). Older
+    // binaries fall back to the explicit per-family UUID filter they understand.
     const supportsUnfilteredScan = nativeBleSupportsConnectionAdoption();
 
     const scanSubscription = native.addListener('scanResult', (payload: NativeBleScanEvent) => {
@@ -179,15 +185,14 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
     let scanTimeoutId: ReturnType<typeof setTimeout> | undefined;
     let selectedDeviceId: string;
     try {
-      const scanServiceUuids =
-        this.scanFamily === 'aurora'
+      const scanServiceUuids = supportsUnfilteredScan
+        ? []
+        : this.scanFamily === 'aurora'
           ? [AURORA_ADVERTISED_SERVICE_UUID]
-          : supportsUnfilteredScan
-            ? []
-            : // MoonBoard spans two controller generations: newer boards
-              // advertise Nordic UART, the original RedBearLab box its own
-              // service. Filter on both when an unfiltered scan isn't available.
-              [UART_SERVICE_UUID, REDBEARLAB_SERVICE_UUID];
+          : // MoonBoard spans two controller generations: newer boards
+            // advertise Nordic UART, the original RedBearLab box its own
+            // service. Filter on both when an unfiltered scan isn't available.
+            [UART_SERVICE_UUID, REDBEARLAB_SERVICE_UUID];
       await native.startScan(scanServiceUuids);
 
       // Grace window: if the stored serial hasn't matched shortly, open the


### PR DESCRIPTION
## Summary

The iOS **native** BLE adapter still hardware-filtered Aurora scans by service UUID (`native.startScan(['4488b571-…'])`), while the Android adapter (`adapter.ts`) and the Bluetooth quickstart (`use-board-scan.ts`) were reverted to unfiltered scanning in #3806/#3811. The native iOS path was missed.

iOS `scanForPeripherals(withServices:)` only matches the **primary** advertisement. Any box whose 128-bit Aurora UUID rides the **scan-response** PDU — Kilter-built bare-name boxes, and NimBLE-based dev boards (`Kilter Board#123456@3`, whose 16-byte UUID + 21-char name can't co-fit in the 31-byte legacy ADV, per the firmware's own comment in `embedded/libs/nordic-uart-ble/src/nordic_uart_ble.cpp`) — never reached the picker, giving an **empty device list**. TestFlight/production builds always take this native path (`adapter-factory.ts`), so a native OTA "broke" the picker.

This reverts the native iOS Aurora scan to its pre-`0710be7a8` behavior: scan unfiltered on capable binaries and narrow in JS via `isLikelyBoardDevice`, exactly like the Android path. Older binaries keep the explicit per-family UUID fallback. Pure JS — ships over OTA (the native Swift already supports the empty-array unfiltered path).

`0710be7a8` is the same commit `adapter.ts` already blames for the ~23% Android Kilter empty-picker regression; this closes the loop for iOS.

### Why this can't break real climbers (no hardware to test on)

- **Revert to shipped-and-worked behavior**, not a new approach.
- **Android already scans Aurora unfiltered in production** with the same JS filter — real Kilter/Tension boards connect fine.
- **Strict superset:** every real board the hardware filter finds today advertises the Aurora UUID, so the native `scanResult` carries it in `serviceUuids` → the JS filter passes it via the UUID check. Unfiltered can only *add* devices (scan-response-UUID boxes), never remove a currently-working one.

## Release Notes

- Fixes Kilter/Tension boards not showing up in the Bluetooth picker on iPhone for some LED boxes — they'll appear again when you go to connect.

## Test plan

- `vp run test:mobile` (native-ios-adapter, adapter, use-board-scan suites): 77 passed. Added a case proving a board whose Aurora UUID never reached `serviceUuids` (rode the scan-response PDU) now surfaces by name, while an unrelated peripheral is still dropped by the JS filter.
- `vp run typecheck:mobile`: clean.
- `vp check`: 0 errors.
- No real board on hand — see the superset safety argument above. Field-verify on an iPhone TestFlight build once the OTA lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ppKysAzJxvhHt312kzCg3