### PR TITLE
feat(mobile): reaction menu — quick-action buttons, play-drawer layout, sharper art, ⋮ on by default

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -190,8 +190,8 @@ function ClimbListInner() {
     setRevealTipVisible(false);
   }, [openBoardSheet]);
   const { systemColors, variant, brandColors, features } = useTheme();
-  // The ⋮ quick-actions button is a user setting whose default is set by the
-  // climb-quick-actions-button experiment flag (More → Display lets climbers override).
+  // The ⋮ quick-actions button is a user setting that defaults on (More → Display
+  // lets climbers turn it off).
   const { enabled: quickActionsButtonEnabled } = useClimbQuickActionsButton();
   const { addToQueue } = useQueueActions();
   const {

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -186,10 +186,9 @@ type ClimbListRowProps = {
   showPlaylistChips?: boolean;
   /**
    * Show a trailing ⋮ button that opens the reaction menu on tap — a visible,
-   * discoverable entry point beside the long-press. Opt-in; the climbs list passes
-   * the "Show quick-actions button" user setting (whose default is set by the
-   * climb-quick-actions-button experiment flag), other surfaces keep long-press only.
-   * No-op without `onOpenActions`.
+   * discoverable entry point beside the long-press. The climbs list passes the
+   * "Show quick-actions button" user setting (on by default), other surfaces keep
+   * long-press only. No-op without `onOpenActions`.
    */
   showMoreButton?: boolean;
 };

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -264,11 +264,8 @@ export function ClimbReactionMenu({
   // The board is the hero, but the whole card (title + board + button row + the ENTIRE
   // action list) has to fit on screen without scrolling — so the board takes the space
   // left once the title, buttons and full list are reserved. A tall phone with a short
-  // list leaves the board width-bounded; a long list or short phone shrinks it, floored
-  // so it never vanishes (a rare overflow then scrolls the list instead). Fitting to a
-  // box (not a square) lets a portrait board grow tall while a near-square board stays
-  // in its frame.
-  const boardMinSize = 140;
+  // list leaves the board width-bounded; a long list shrinks it. Fitting to a box (not a
+  // square) lets a portrait board grow tall while a near-square board stays in its frame.
   const heroHeightBudget =
     windowHeight -
     insets.top -
@@ -278,10 +275,26 @@ export function ClimbReactionMenu({
     listContentHeight -
     (insets.bottom + spacing[5]) -
     previewTextReserve;
+  // Ceiling that always keeps the button row + ~2 list rows on screen: a short phone or
+  // landscape can't fit a big board AND all the actions, so the board yields rather than
+  // pushing the menu off the bottom. The floor keeps the board visible unless even that
+  // won't fit; below the ceiling a long list simply scrolls.
+  const boardCeiling = Math.max(
+    0,
+    windowHeight -
+      insets.top -
+      contentTopOffset -
+      previewTextReserve -
+      primaryRowHeight -
+      2 * actionRowHeight -
+      (insets.bottom + spacing[5]) -
+      spacing[5] * 2,
+  );
+  const boardMinSize = Math.min(140, boardCeiling);
   const largeArtMaxSize = fitBoardMaxSize(
     aspect,
     Math.min(PREVIEW_MAX_WIDTH, windowWidth - spacing[6] * 2),
-    Math.min(windowHeight * 0.55, Math.max(boardMinSize, heroHeightBudget)),
+    Math.min(windowHeight * 0.55, boardCeiling, Math.max(boardMinSize, heroHeightBudget)),
   );
   // Rasterize the holds overlay at the large hero's displayed width × DPR — matching
   // the play drawer (SwipeBoardCarousel) instead of the list-thumbnail's fixed 400px,

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -307,10 +307,7 @@ export function ClimbReactionMenu({
   const overlayRenderWidth = Math.round(largeArtWidth * PixelRatio.get());
   // compactArtMaxSize: the shrunk size used only when the create-playlist keyboard is up,
   // so the board + form + keyboard still fit. Otherwise the board keeps its full size.
-  const compactArtMaxSize = Math.min(
-    Math.round(windowHeight * 0.18),
-    Math.round(windowWidth * 0.66),
-  );
+  const compactArtMaxSize = Math.min(Math.round(windowHeight * 0.18), Math.round(windowWidth * 0.66));
   // The board stays the same size across the menu and the Add-to-playlist view — the
   // difference wasn't worth the jump. It only shrinks when the create-playlist form's
   // keyboard is up (playlist view + keyboardHeight > 0), to keep the form reachable.

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -1,10 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Keyboard,
   type LayoutChangeEvent,
   Modal,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   type OpaqueColorValue,
   PixelRatio,
   Platform,
@@ -44,16 +42,6 @@ import { fitBoardArt, fitBoardMaxSize } from './board-art-fit';
 // fixed horizontal button row at the top of the card — the most-reached actions,
 // one tap away. The rest stay in the list below. Order here is the row order.
 const PRIMARY_ACTION_IDS: readonly ClimbActionId[] = ['tick', 'playlist', 'share'];
-
-/**
- * Scroll-to-expand hysteresis. Scrolling the action list a little compacts the hero
- * (giving the list room); it stays compact until the list is dragged back near the
- * very top. Two thresholds so a content-fits resize settling a few px off the top
- * can't flip it back. Pure + exported so the thresholds are unit-testable.
- */
-export function nextMenuScrolledState(current: boolean, offsetY: number): boolean {
-  return current ? offsetY > 2 : offsetY > 20;
-}
 
 type ClimbReactionMenuProps = {
   climb: Climb;
@@ -138,20 +126,6 @@ export function ClimbReactionMenu({
   // playlist picker (no second sheet — that's the #3294 fix).
   const [view, setView] = useState<'menu' | 'playlist'>('menu');
 
-  // Scrolling the action list a little shrinks the hero to the compact size (the
-  // same transition "Add to playlist" runs), giving the list more room; scrolling
-  // back to the very top restores the large hero. Ref-gated so onScroll only
-  // setStates on the boolean flip, never per frame (RN perf rule).
-  const [menuScrolled, setMenuScrolled] = useState(false);
-  const menuScrolledRef = useRef(false);
-  const handleMenuScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    const next = nextMenuScrolledState(menuScrolledRef.current, event.nativeEvent.contentOffset.y);
-    if (next !== menuScrolledRef.current) {
-      menuScrolledRef.current = next;
-      setMenuScrolled(next);
-    }
-  }, []);
-
   const finishClose = useCallback(() => onClose(), [onClose]);
 
   useEffect(() => {
@@ -168,13 +142,7 @@ export function ClimbReactionMenu({
     });
   }, [progress, reduceMotion, finishClose]);
 
-  const backToMenu = useCallback(() => {
-    // The action list unmounts in the playlist view, so its native offset is 0 on
-    // return — reset our tracked state so the menu always reopens at the large hero.
-    menuScrolledRef.current = false;
-    setMenuScrolled(false);
-    setView('menu');
-  }, []);
+  const backToMenu = useCallback(() => setView('menu'), []);
   // Stable so useClimbActions' memo doesn't rebuild the action list every render.
   const openPlaylist = useCallback(() => setView('playlist'), []);
 
@@ -264,9 +232,11 @@ export function ClimbReactionMenu({
   // Small breathing room below the top safe area — the preview sits just under the
   // status bar so the top isn't wasted and the action list gets more room below.
   const contentTopOffset = Math.round(windowHeight * 0.02);
-  // The action list never shrinks below this — at least ~2 rows peek under the hero so
-  // the scroll affordance stays visible. Reused by the hero budget and the menu cap.
-  const menuMinHeight = 180;
+  // Row height for the action list (ListRow: minHeight 44 + 12pt vertical padding, text
+  // growing with fontScale). The whole list is shown without scrolling, so its full
+  // height is reserved up front and the board takes whatever space is left below it.
+  const actionRowHeight = Math.max(44, Math.round(24 + 22 * fontScale));
+  const listContentHeight = listActions.length * actionRowHeight + spacing[1] * 2;
   // Height of the fixed primary-action button row, reserved out of the card so the list
   // cap is accurate. Measured via onLayout (fires only on layout change, not per frame)
   // so a large Dynamic Type / RTL wrap can't over- or under-reserve; the fontScale-scaled
@@ -291,23 +261,27 @@ export function ClimbReactionMenu({
   // never re-renders the menu (see reservedForPreview). Scaled by fontScale so a large
   // Dynamic Type setting reserves the taller text instead of overlapping the art.
   const previewTextReserve = Math.round(56 * fontScale);
-  // Height the hero may take once top chrome, text, gap, menu floor and bottom inset are
-  // reserved — capped at 48% so the reclaimed top space grows the action list, not the
-  // hero. Fitting to a box (width bounded by the preview frame, not a square) lets a
-  // portrait board grow tall while a near-square board stays in its frame.
+  // The board is the hero, but the whole card (title + board + button row + the ENTIRE
+  // action list) has to fit on screen without scrolling — so the board takes the space
+  // left once the title, buttons and full list are reserved. A tall phone with a short
+  // list leaves the board width-bounded; a long list or short phone shrinks it, floored
+  // so it never vanishes (a rare overflow then scrolls the list instead). Fitting to a
+  // box (not a square) lets a portrait board grow tall while a near-square board stays
+  // in its frame.
+  const boardMinSize = 140;
   const heroHeightBudget =
     windowHeight -
     insets.top -
     contentTopOffset -
     spacing[5] -
-    menuMinHeight -
     primaryRowHeight -
+    listContentHeight -
     (insets.bottom + spacing[5]) -
     previewTextReserve;
   const largeArtMaxSize = fitBoardMaxSize(
     aspect,
     Math.min(PREVIEW_MAX_WIDTH, windowWidth - spacing[6] * 2),
-    Math.min(windowHeight * 0.48, heroHeightBudget),
+    Math.min(windowHeight * 0.55, Math.max(boardMinSize, heroHeightBudget)),
   );
   // Rasterize the holds overlay at the large hero's displayed width × DPR — matching
   // the play drawer (SwipeBoardCarousel) instead of the list-thumbnail's fixed 400px,
@@ -325,10 +299,9 @@ export function ClimbReactionMenu({
     Math.round(windowHeight * 0.31),
     Math.round(windowWidth * 0.66),
   );
-  // In the menu view there is no text input, so keyboardHeight is 0 there; the keyboard
-  // only appears in the playlist create form, which is the compact path above. The hero
-  // is compact whenever the playlist view is open OR the action list is scrolled.
-  const targetArtMax = view === 'menu' && !menuScrolled ? largeArtMaxSize : compactArtMaxSize;
+  // The board is large in the menu; opening a sub-view (Add to playlist) springs it down
+  // to the compact size and back. That inline transition is the only board resize now.
+  const targetArtMax = view === 'menu' ? largeArtMaxSize : compactArtMaxSize;
 
   // The animating max-size (px). Springs between large (menu) and compact (sub-action)
   // whenever the view — or the keyboard height feeding compactArtMaxSize — changes, so
@@ -356,37 +329,16 @@ export function ClimbReactionMenu({
   const reservedForPreview = targetArtHeight + previewTextReserve;
   const bottomReserve = keyboardHeight > 0 ? keyboardHeight : insets.bottom + spacing[5];
   const menuMaxHeight = Math.max(
-    menuMinHeight,
+    actionRowHeight,
     windowHeight - insets.top - contentTopOffset - spacing[5] - reservedForPreview - bottomReserve,
   );
 
-  // The scrollable list (everything below the fixed primary-button row) shares the card
-  // with that row, so it gets menuMaxHeight minus the row. Row height (ListRow: minHeight
-  // 44 + 12pt vertical padding, text growing with fontScale) drives the scroll math with
-  // no per-frame scroll state. The playlist view owns its own scroll.
-  const actionRowHeight = Math.max(44, Math.round(24 + 22 * fontScale));
+  // The list (below the fixed primary-button row) gets the card height minus that row.
+  // Its full height was reserved when sizing the board, so it normally shows every row
+  // without scrolling; only a floored board on a small phone leaves it short, in which
+  // case it scrolls and the bottom fade cues more. The playlist view owns its own scroll.
   const listMaxHeight = Math.max(actionRowHeight, menuMaxHeight - primaryRowHeight);
-  const menuContentHeight = listActions.length * actionRowHeight + spacing[1] * 2;
-  let menuScrollHeight: number;
-  if (!menuScrolled) {
-    // At rest (large hero): fill all the space under the hero. maxHeight caps an
-    // overflowing list at listMaxHeight — the last row clips there (with the bottom
-    // fade cueing more) — while a short list shrinks to its content. Filling the space
-    // instead of snapping to whole-rows-minus-a-half leaves no dead gap below the card.
-    menuScrollHeight = listMaxHeight;
-  } else {
-    // Scrolled: the hero has shrunk and listMaxHeight has grown, so give the list
-    // that room. But if the taller viewport would now fit the whole list, the
-    // ScrollView would clamp the offset back to 0 — which reads as "scrolled to the
-    // top" and would bounce the hero back to large. Keep the viewport one row short
-    // of the content so a little scroll range always remains and the collapse only
-    // happens when the climber actually drags to the top. Floor at one row so a short
-    // list can never collapse the viewport to zero.
-    menuScrollHeight = Math.min(listMaxHeight, Math.max(actionRowHeight, menuContentHeight - actionRowHeight));
-  }
-  // Show the bottom fade whenever the list is actually clipped — the at-rest peek or
-  // the one-row-short scrolled viewport both hide content worth cueing.
-  const menuScrollable = menuContentHeight > menuScrollHeight + 0.5;
+  const menuScrollable = listContentHeight > listMaxHeight + 0.5;
   const menuFadeColors = colorScheme === 'dark' ? MENU_FADE_COLORS.dark : MENU_FADE_COLORS.light;
 
   const backdropStyle = useAnimatedStyle(() => ({ opacity: progress.value }));
@@ -516,16 +468,14 @@ export function ClimbReactionMenu({
                       ))}
                     </View>
                   ) : null}
+                  {/* The full list is reserved when sizing the board, so this normally
+                      shows every row without scrolling; maxHeight only bites (and scrolls)
+                      if a floored board on a small phone can't leave room. */}
                   <ScrollView
-                    style={{ maxHeight: menuScrollHeight }}
+                    style={{ maxHeight: listMaxHeight }}
                     bounces={false}
                     showsVerticalScrollIndicator={false}
                     keyboardShouldPersistTaps="handled"
-                    onScroll={handleMenuScroll}
-                    // The ref-gated handler only setStates on a boolean flip, and the
-                    // 2/20px hysteresis still catches the gesture at this cadence, so a
-                    // coarser throttle keeps the JS thread quiet during the scroll.
-                    scrollEventThrottle={64}
                     contentContainerStyle={styles.menuContent}
                   >
                     {listActions.map((action, index) => (

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -4,6 +4,7 @@ import {
   Modal,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
+  type OpaqueColorValue,
   PixelRatio,
   Platform,
   Pressable,
@@ -35,8 +36,13 @@ import { useTheme } from '../../providers/theme-provider';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { springs, timing } from '../../theme/animations';
 import { spacing, borderRadius } from '../../theme/tokens';
-import { useClimbActions } from './use-climb-actions';
+import { useClimbActions, type ClimbActionId, type ClimbActionItem } from './use-climb-actions';
 import { fitBoardArt, fitBoardMaxSize } from './board-art-fit';
+
+// Log a tick / Add to playlist / Share get pulled out of the scrollable list into a
+// fixed horizontal button row at the top of the card — the most-reached actions,
+// one tap away. The rest stay in the list below. Order here is the row order.
+const PRIMARY_ACTION_IDS: readonly ClimbActionId[] = ['tick', 'playlist', 'share'];
 
 type ClimbReactionMenuProps = {
   climb: Climb;
@@ -108,7 +114,7 @@ export function ClimbReactionMenu({
   reduceMotion,
   onClose,
 }: ClimbReactionMenuProps) {
-  const { colorScheme } = useTheme();
+  const { colorScheme, systemColors } = useTheme();
   const { t } = useTranslation('climbs');
   const insets = useSafeAreaInsets();
   const { width: windowWidth, height: windowHeight, fontScale } = useWindowDimensions();
@@ -183,6 +189,15 @@ export function ClimbReactionMenu({
     onTick,
   });
 
+  // Split the actions into the fixed top button row (tick / playlist / share, in that
+  // order) and the scrollable remainder. Both preserve `useClimbActions`' identity so
+  // they only rebuild when the action list itself changes.
+  const primaryActions = useMemo(() => {
+    const byId = new Map(actions.map((action) => [action.id, action]));
+    return PRIMARY_ACTION_IDS.map((id) => byId.get(id)).filter((action): action is ClimbActionItem => action != null);
+  }, [actions]);
+  const listActions = useMemo(() => actions.filter((action) => !PRIMARY_ACTION_IDS.includes(action.id)), [actions]);
+
   const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
   const formattedGrade = formatGrade(climb.difficulty);
 
@@ -241,6 +256,10 @@ export function ClimbReactionMenu({
   // The action list never shrinks below this — at least ~2 rows peek under the hero so
   // the scroll affordance stays visible. Reused by the hero budget and the menu cap.
   const menuMinHeight = 180;
+  // Estimated height of the fixed primary-action button row (icon + up-to-2-line label +
+  // padding), reserved like previewTextReserve — an estimate, not an onLayout measure, so
+  // the list cap doesn't re-render every frame. Zero when there are no primary actions.
+  const primaryRowHeight = primaryActions.length > 0 ? Math.round(84 + 26 * fontScale) : 0;
 
   // Enlarged board art. Rendered at play-drawer quality — full-res board photo and a
   // holds overlay sized to the displayed width × DPR (see overlayRenderWidth below) —
@@ -262,6 +281,7 @@ export function ClimbReactionMenu({
     contentTopOffset -
     spacing[5] -
     menuMinHeight -
+    primaryRowHeight -
     (insets.bottom + spacing[5]) -
     previewTextReserve;
   const largeArtMaxSize = fitBoardMaxSize(
@@ -320,29 +340,31 @@ export function ClimbReactionMenu({
     windowHeight - insets.top - contentTopOffset - spacing[5] - reservedForPreview - bottomReserve,
   );
 
-  // When the action list can't all fit, hint that it scrolls: snap the scroll viewport
-  // to a half-row "peek" (last row clipped at its midpoint) and fade its bottom edge.
-  // Derived from actions.length + row height (ListRow: minHeight 44 + 12pt vertical
-  // padding, text growing with fontScale) — no per-frame scroll state. Applies to the
-  // action list only; the playlist view owns its own scroll.
+  // When the scrollable list (everything below the fixed primary-button row) can't all
+  // fit, hint that it scrolls: snap the viewport to a half-row "peek" (last row clipped
+  // at its midpoint) and fade its bottom edge. Derived from listActions.length + row
+  // height (ListRow: minHeight 44 + 12pt vertical padding, text growing with fontScale)
+  // — no per-frame scroll state. The list shares the card with the primary row, so it
+  // gets menuMaxHeight minus that row. The playlist view owns its own scroll.
   const actionRowHeight = Math.max(44, Math.round(24 + 22 * fontScale));
-  const menuContentHeight = actions.length * actionRowHeight + spacing[1] * 2;
-  const menuOverflows = menuContentHeight > menuMaxHeight;
+  const listMaxHeight = Math.max(actionRowHeight, menuMaxHeight - primaryRowHeight);
+  const menuContentHeight = listActions.length * actionRowHeight + spacing[1] * 2;
+  const menuOverflows = menuContentHeight > listMaxHeight;
   let menuScrollHeight: number;
   if (!menuScrolled) {
     // At rest (large hero): snap an overflowing list to the half-row "peek" that
     // cues scrolling; a fitting list uses its full height.
     menuScrollHeight = menuOverflows
-      ? Math.max(menuMinHeight, (Math.floor(menuMaxHeight / actionRowHeight) - 0.5) * actionRowHeight)
-      : menuMaxHeight;
+      ? Math.max(actionRowHeight, (Math.floor(listMaxHeight / actionRowHeight) - 0.5) * actionRowHeight)
+      : listMaxHeight;
   } else {
-    // Scrolled: the hero has shrunk and menuMaxHeight has grown, so give the list
+    // Scrolled: the hero has shrunk and listMaxHeight has grown, so give the list
     // that room. But if the taller viewport would now fit the whole list, the
     // ScrollView would clamp the offset back to 0 — which reads as "scrolled to the
     // top" and would bounce the hero back to large. Keep the viewport one row short
     // of the content so a little scroll range always remains and the collapse only
     // happens when the climber actually drags to the top.
-    menuScrollHeight = Math.min(menuMaxHeight, menuContentHeight - actionRowHeight);
+    menuScrollHeight = Math.min(listMaxHeight, menuContentHeight - actionRowHeight);
   }
   // Show the bottom fade whenever the list is actually clipped — the at-rest peek or
   // the one-row-short scrolled viewport both hide content worth cueing.
@@ -460,6 +482,20 @@ export function ClimbReactionMenu({
                 />
               ) : (
                 <View>
+                  {/* Fixed quick-action row — the three most-reached actions as tappable
+                      buttons, above the scrollable remainder. */}
+                  {primaryActions.length > 0 ? (
+                    <View style={styles.primaryRow}>
+                      {primaryActions.map((action) => (
+                        <PrimaryActionButton
+                          key={action.id}
+                          action={action}
+                          fillColor={systemColors.fill}
+                          labelColor={systemColors.label}
+                        />
+                      ))}
+                    </View>
+                  ) : null}
                   <ScrollView
                     style={{ maxHeight: menuScrollHeight }}
                     bounces={false}
@@ -469,13 +505,13 @@ export function ClimbReactionMenu({
                     scrollEventThrottle={16}
                     contentContainerStyle={styles.menuContent}
                   >
-                    {actions.map((action, index) => (
+                    {listActions.map((action, index) => (
                       <ListRow
                         key={action.id}
                         title={action.title}
                         leading={<Icon name={action.icon} size={22} color={action.color} />}
                         onPress={action.run}
-                        showSeparator={index < actions.length - 1}
+                        showSeparator={index < listActions.length - 1}
                         separatorInset={56}
                       />
                     ))}
@@ -492,6 +528,37 @@ export function ClimbReactionMenu({
         </View>
       </View>
     </OverlayPortal>
+  );
+}
+
+type PrimaryActionButtonProps = {
+  action: ClimbActionItem;
+  /** Translucent control fill for the button surface (systemColors.fill). */
+  fillColor: string | OpaqueColorValue;
+  /** Label foreground (systemColors.label); the icon keeps the action's own colour. */
+  labelColor: string | OpaqueColorValue;
+};
+
+// One quick-action button: the action's icon over its (up-to-2-line) label, on a
+// translucent fill. `alignItems: 'stretch'` on the row makes every button match the
+// tallest, so "Add to Playlist" wrapping to two lines keeps all three the same height.
+function PrimaryActionButton({ action, fillColor, labelColor }: PrimaryActionButtonProps) {
+  return (
+    <Pressable
+      onPress={action.run}
+      accessibilityRole="button"
+      accessibilityLabel={action.title}
+      style={({ pressed }) => [
+        styles.primaryButton,
+        { backgroundColor: fillColor },
+        pressed && styles.primaryButtonPressed,
+      ]}
+    >
+      <Icon name={action.icon} size={24} color={action.color} />
+      <Text variant="caption1" numberOfLines={2} style={[styles.primaryButtonLabel, { color: labelColor }]}>
+        {action.title}
+      </Text>
+    </Pressable>
   );
 }
 
@@ -559,6 +626,32 @@ const styles = StyleSheet.create({
   menuCard: {
     borderRadius: borderRadius.xl,
     overflow: 'hidden',
+  },
+  // Fixed quick-action row above the scrollable list. `stretch` keeps every button the
+  // height of the tallest (the two-line "Add to Playlist").
+  primaryRow: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    gap: spacing[2],
+    paddingHorizontal: spacing[3],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[2],
+  },
+  primaryButton: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[1],
+    borderRadius: borderRadius.lg,
+  },
+  primaryButtonPressed: {
+    opacity: 0.6,
+  },
+  primaryButtonLabel: {
+    fontWeight: '600',
+    textAlign: 'center',
   },
   menuContent: {
     paddingVertical: spacing[1],

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -627,7 +627,7 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 6,
+    gap: spacing[2],
     paddingVertical: spacing[3],
     paddingHorizontal: spacing[1],
     borderRadius: borderRadius.lg,

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -1,7 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Keyboard,
   Modal,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  PixelRatio,
   Platform,
   Pressable,
   ScrollView,
@@ -116,6 +119,22 @@ export function ClimbReactionMenu({
   // playlist picker (no second sheet — that's the #3294 fix).
   const [view, setView] = useState<'menu' | 'playlist'>('menu');
 
+  // Scrolling the action list a little shrinks the hero to the compact size (the
+  // same transition "Add to playlist" runs), giving the list more room; scrolling
+  // back to the very top restores the large hero. Ref-gated so onScroll only
+  // setStates on the boolean flip, never per frame (RN perf rule).
+  const [menuScrolled, setMenuScrolled] = useState(false);
+  const menuScrolledRef = useRef(false);
+  const handleMenuScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const offsetY = event.nativeEvent.contentOffset.y;
+    // Hysteresis: expand once scrolled a little, collapse only back near the top.
+    const next = menuScrolledRef.current ? offsetY > 2 : offsetY > 20;
+    if (next !== menuScrolledRef.current) {
+      menuScrolledRef.current = next;
+      setMenuScrolled(next);
+    }
+  }, []);
+
   const finishClose = useCallback(() => onClose(), [onClose]);
 
   useEffect(() => {
@@ -132,7 +151,13 @@ export function ClimbReactionMenu({
     });
   }, [progress, reduceMotion, finishClose]);
 
-  const backToMenu = useCallback(() => setView('menu'), []);
+  const backToMenu = useCallback(() => {
+    // The action list unmounts in the playlist view, so its native offset is 0 on
+    // return — reset our tracked state so the menu always reopens at the large hero.
+    menuScrolledRef.current = false;
+    setMenuScrolled(false);
+    setView('menu');
+  }, []);
   // Stable so useClimbActions' memo doesn't rebuild the action list every render.
   const openPlaylist = useCallback(() => setView('playlist'), []);
 
@@ -217,9 +242,11 @@ export function ClimbReactionMenu({
   // the scroll affordance stays visible. Reused by the hero budget and the menu cap.
   const menuMinHeight = 180;
 
-  // Enlarged board art, reusing the list thumbnail's cache (filledStyle + renderWidth
-  // 400) so no new render is needed. The menu view shows a large hero; a sub-action that
-  // stays inline (the playlist picker) shrinks it to the compact "current" size.
+  // Enlarged board art. Rendered at play-drawer quality — full-res board photo and a
+  // holds overlay sized to the displayed width × DPR (see overlayRenderWidth below) —
+  // rather than piggybacking the tiny list-thumbnail cache, so the hero stays crisp.
+  // The menu view shows a large hero; a sub-action that stays inline (the playlist
+  // picker) shrinks it to the compact "current" size.
   //
   // name+byline reserve, an estimate (not an onLayout measurement) so resizing the art
   // never re-renders the menu (see reservedForPreview). Scaled by fontScale so a large
@@ -242,6 +269,15 @@ export function ClimbReactionMenu({
     Math.min(PREVIEW_MAX_WIDTH, windowWidth - spacing[6] * 2),
     Math.min(windowHeight * 0.48, heroHeightBudget),
   );
+  // Rasterize the holds overlay at the large hero's displayed width × DPR — matching
+  // the play drawer (SwipeBoardCarousel) instead of the list-thumbnail's fixed 400px,
+  // so the enlarged art stays crisp. Derived from the large size (not the animating
+  // one) so the cache key is stable as the hero springs between large and compact;
+  // useNativeClimbRender clamps it to the board's native width and never upscales.
+  const largeArtWidth = boardRenderData
+    ? fitBoardArt(boardRenderData.boardWidth, boardRenderData.boardHeight, largeArtMaxSize).width
+    : largeArtMaxSize;
+  const overlayRenderWidth = Math.round(largeArtWidth * PixelRatio.get());
   // compactArtMaxSize: the "current" size for the inline sub-action view — today's
   // sizing, keeping the keyboard-up shrink (the create form focuses a TextInput).
   const compactArtMaxSize = Math.min(
@@ -250,8 +286,9 @@ export function ClimbReactionMenu({
     Math.round(windowWidth * 0.66),
   );
   // In the menu view there is no text input, so keyboardHeight is 0 there; the keyboard
-  // only appears in the playlist create form, which is the compact path above.
-  const targetArtMax = view === 'menu' ? largeArtMaxSize : compactArtMaxSize;
+  // only appears in the playlist create form, which is the compact path above. The hero
+  // is compact whenever the playlist view is open OR the action list is scrolled.
+  const targetArtMax = view === 'menu' && !menuScrolled ? largeArtMaxSize : compactArtMaxSize;
 
   // The animating max-size (px). Springs between large (menu) and compact (sub-action)
   // whenever the view — or the keyboard height feeding compactArtMaxSize — changes, so
@@ -291,9 +328,25 @@ export function ClimbReactionMenu({
   const actionRowHeight = Math.max(44, Math.round(24 + 22 * fontScale));
   const menuContentHeight = actions.length * actionRowHeight + spacing[1] * 2;
   const menuOverflows = menuContentHeight > menuMaxHeight;
-  const menuScrollHeight = menuOverflows
-    ? Math.max(menuMinHeight, (Math.floor(menuMaxHeight / actionRowHeight) - 0.5) * actionRowHeight)
-    : menuMaxHeight;
+  let menuScrollHeight: number;
+  if (!menuScrolled) {
+    // At rest (large hero): snap an overflowing list to the half-row "peek" that
+    // cues scrolling; a fitting list uses its full height.
+    menuScrollHeight = menuOverflows
+      ? Math.max(menuMinHeight, (Math.floor(menuMaxHeight / actionRowHeight) - 0.5) * actionRowHeight)
+      : menuMaxHeight;
+  } else {
+    // Scrolled: the hero has shrunk and menuMaxHeight has grown, so give the list
+    // that room. But if the taller viewport would now fit the whole list, the
+    // ScrollView would clamp the offset back to 0 — which reads as "scrolled to the
+    // top" and would bounce the hero back to large. Keep the viewport one row short
+    // of the content so a little scroll range always remains and the collapse only
+    // happens when the climber actually drags to the top.
+    menuScrollHeight = Math.min(menuMaxHeight, menuContentHeight - actionRowHeight);
+  }
+  // Show the bottom fade whenever the list is actually clipped — the at-rest peek or
+  // the one-row-short scrolled viewport both hide content worth cueing.
+  const menuScrollable = menuContentHeight > menuScrollHeight + 0.5;
   const menuFadeColors = colorScheme === 'dark' ? MENU_FADE_COLORS.dark : MENU_FADE_COLORS.light;
 
   const backdropStyle = useAnimatedStyle(() => ({ opacity: progress.value }));
@@ -362,8 +415,8 @@ export function ClimbReactionMenu({
                   boardWidth={boardRenderData.boardWidth}
                   boardHeight={boardRenderData.boardHeight}
                   mirrored={climb.mirrored === true}
-                  filledStyle
-                  renderWidth={400}
+                  renderWidth={overlayRenderWidth}
+                  backgroundVariant="full"
                   style={styles.artFill}
                 />
               </Animated.View>
@@ -412,6 +465,8 @@ export function ClimbReactionMenu({
                     bounces={false}
                     showsVerticalScrollIndicator={false}
                     keyboardShouldPersistTaps="handled"
+                    onScroll={handleMenuScroll}
+                    scrollEventThrottle={16}
                     contentContainerStyle={styles.menuContent}
                   >
                     {actions.map((action, index) => (
@@ -425,9 +480,9 @@ export function ClimbReactionMenu({
                       />
                     ))}
                   </ScrollView>
-                  {/* Bottom-edge fade cueing "more below" — only when the list overflows.
+                  {/* Bottom-edge fade cueing "more below" — only when the list is clipped.
                       pointerEvents none so it never eats a tap on the peeking row. */}
-                  {menuOverflows ? (
+                  {menuScrollable ? (
                     <LinearGradient pointerEvents="none" colors={menuFadeColors} style={styles.menuScrollFade} />
                   ) : null}
                 </View>

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -80,7 +80,9 @@ type ClimbReactionMenuProps = {
 
 // Frame width shared by the preview and the action card, and the ceiling the hero art
 // is clamped to so an explicit art width can't bleed past the (unclipped) preview frame.
-const PREVIEW_MAX_WIDTH = 320;
+// Wide enough that on a phone the board + card fill the screen width (bounded by the
+// content's horizontal padding); on tablets this caps how wide the floating card gets.
+const PREVIEW_MAX_WIDTH = 400;
 
 // Bottom-edge fade for the scrollable action list — transparent → the scheme's surface
 // base. Concrete rgba, never a systemColors PlatformColor: feeding a PlatformColor into
@@ -378,8 +380,9 @@ export function ClimbReactionMenu({
     // ScrollView would clamp the offset back to 0 — which reads as "scrolled to the
     // top" and would bounce the hero back to large. Keep the viewport one row short
     // of the content so a little scroll range always remains and the collapse only
-    // happens when the climber actually drags to the top.
-    menuScrollHeight = Math.min(listMaxHeight, menuContentHeight - actionRowHeight);
+    // happens when the climber actually drags to the top. Floor at one row so a short
+    // list can never collapse the viewport to zero.
+    menuScrollHeight = Math.min(listMaxHeight, Math.max(actionRowHeight, menuContentHeight - actionRowHeight));
   }
   // Show the bottom fade whenever the list is actually clipped — the at-rest peek or
   // the one-row-short scrolled viewport both hide content worth cueing.
@@ -441,23 +444,8 @@ export function ClimbReactionMenu({
               cap is derived from the target art size (reservedForPreview), not measured
               here, so the shrink animation never re-renders the menu. */}
           <Animated.View pointerEvents="box-none" style={[styles.preview, previewStyle]}>
-            {boardRenderData ? (
-              <Animated.View style={[styles.art, animatedArtStyle]}>
-                <BoardImageNative
-                  frames={climb.frames}
-                  boardName={boardConfig.boardName as BoardName}
-                  layoutId={boardConfig.layoutId}
-                  sizeId={boardConfig.sizeId}
-                  setIds={boardConfig.setIds}
-                  boardWidth={boardRenderData.boardWidth}
-                  boardHeight={boardRenderData.boardHeight}
-                  mirrored={climb.mirrored === true}
-                  renderWidth={overlayRenderWidth}
-                  backgroundVariant="full"
-                  style={styles.artFill}
-                />
-              </Animated.View>
-            ) : null}
+            {/* Name · grade · byline sit ABOVE the board (like the play drawer header),
+                so the board reads as the hero below its title. */}
             <View style={styles.previewText}>
               <View style={styles.nameRow}>
                 <Text variant="headline" numberOfLines={1} style={styles.name}>
@@ -479,6 +467,23 @@ export function ClimbReactionMenu({
                 </Text>
               ) : null}
             </View>
+            {boardRenderData ? (
+              <Animated.View style={[styles.art, animatedArtStyle]}>
+                <BoardImageNative
+                  frames={climb.frames}
+                  boardName={boardConfig.boardName as BoardName}
+                  layoutId={boardConfig.layoutId}
+                  sizeId={boardConfig.sizeId}
+                  setIds={boardConfig.setIds}
+                  boardWidth={boardRenderData.boardWidth}
+                  boardHeight={boardRenderData.boardHeight}
+                  mirrored={climb.mirrored === true}
+                  renderWidth={overlayRenderWidth}
+                  backgroundVariant="full"
+                  style={styles.artFill}
+                />
+              </Animated.View>
+            ) : null}
           </Animated.View>
 
           <Animated.View style={[styles.menuWrap, menuStyle]}>

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -305,16 +305,16 @@ export function ClimbReactionMenu({
     ? fitBoardArt(boardRenderData.boardWidth, boardRenderData.boardHeight, largeArtMaxSize).width
     : largeArtMaxSize;
   const overlayRenderWidth = Math.round(largeArtWidth * PixelRatio.get());
-  // compactArtMaxSize: the "current" size for the inline sub-action view — today's
-  // sizing, keeping the keyboard-up shrink (the create form focuses a TextInput).
+  // compactArtMaxSize: the shrunk size used only when the create-playlist keyboard is up,
+  // so the board + form + keyboard still fit. Otherwise the board keeps its full size.
   const compactArtMaxSize = Math.min(
-    keyboardHeight > 0 ? Math.round(windowHeight * 0.18) : 235,
-    Math.round(windowHeight * 0.31),
+    Math.round(windowHeight * 0.18),
     Math.round(windowWidth * 0.66),
   );
-  // The board is large in the menu; opening a sub-view (Add to playlist) springs it down
-  // to the compact size and back. That inline transition is the only board resize now.
-  const targetArtMax = view === 'menu' ? largeArtMaxSize : compactArtMaxSize;
+  // The board stays the same size across the menu and the Add-to-playlist view — the
+  // difference wasn't worth the jump. It only shrinks when the create-playlist form's
+  // keyboard is up (playlist view + keyboardHeight > 0), to keep the form reachable.
+  const targetArtMax = view === 'playlist' && keyboardHeight > 0 ? compactArtMaxSize : largeArtMaxSize;
 
   // The animating max-size (px). Springs between large (menu) and compact (sub-action)
   // whenever the view — or the keyboard height feeding compactArtMaxSize — changes, so

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Keyboard,
+  type LayoutChangeEvent,
   Modal,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
@@ -43,6 +44,16 @@ import { fitBoardArt, fitBoardMaxSize } from './board-art-fit';
 // fixed horizontal button row at the top of the card — the most-reached actions,
 // one tap away. The rest stay in the list below. Order here is the row order.
 const PRIMARY_ACTION_IDS: readonly ClimbActionId[] = ['tick', 'playlist', 'share'];
+
+/**
+ * Scroll-to-expand hysteresis. Scrolling the action list a little compacts the hero
+ * (giving the list room); it stays compact until the list is dragged back near the
+ * very top. Two thresholds so a content-fits resize settling a few px off the top
+ * can't flip it back. Pure + exported so the thresholds are unit-testable.
+ */
+export function nextMenuScrolledState(current: boolean, offsetY: number): boolean {
+  return current ? offsetY > 2 : offsetY > 20;
+}
 
 type ClimbReactionMenuProps = {
   climb: Climb;
@@ -132,9 +143,7 @@ export function ClimbReactionMenu({
   const [menuScrolled, setMenuScrolled] = useState(false);
   const menuScrolledRef = useRef(false);
   const handleMenuScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    const offsetY = event.nativeEvent.contentOffset.y;
-    // Hysteresis: expand once scrolled a little, collapse only back near the top.
-    const next = menuScrolledRef.current ? offsetY > 2 : offsetY > 20;
+    const next = nextMenuScrolledState(menuScrolledRef.current, event.nativeEvent.contentOffset.y);
     if (next !== menuScrolledRef.current) {
       menuScrolledRef.current = next;
       setMenuScrolled(next);
@@ -256,10 +265,19 @@ export function ClimbReactionMenu({
   // The action list never shrinks below this — at least ~2 rows peek under the hero so
   // the scroll affordance stays visible. Reused by the hero budget and the menu cap.
   const menuMinHeight = 180;
-  // Estimated height of the fixed primary-action button row (icon + up-to-2-line label +
-  // padding), reserved like previewTextReserve — an estimate, not an onLayout measure, so
-  // the list cap doesn't re-render every frame. Zero when there are no primary actions.
-  const primaryRowHeight = primaryActions.length > 0 ? Math.round(84 + 26 * fontScale) : 0;
+  // Height of the fixed primary-action button row, reserved out of the card so the list
+  // cap is accurate. Measured via onLayout (fires only on layout change, not per frame)
+  // so a large Dynamic Type / RTL wrap can't over- or under-reserve; the fontScale-scaled
+  // estimate stands in for the first frame before the measurement lands. Zero when there
+  // are no primary actions.
+  const primaryRowHeightEstimate = primaryActions.length > 0 ? Math.round(84 + 26 * fontScale) : 0;
+  const [measuredPrimaryRowHeight, setMeasuredPrimaryRowHeight] = useState(0);
+  const primaryRowHeight = primaryActions.length === 0 ? 0 : measuredPrimaryRowHeight || primaryRowHeightEstimate;
+  const handlePrimaryRowLayout = useCallback((event: LayoutChangeEvent) => {
+    const height = Math.round(event.nativeEvent.layout.height);
+    // Gate the setState on a real change so a re-render can't loop through onLayout.
+    setMeasuredPrimaryRowHeight((previous) => (previous === height ? previous : height));
+  }, []);
 
   // Enlarged board art. Rendered at play-drawer quality — full-res board photo and a
   // holds overlay sized to the displayed width × DPR (see overlayRenderWidth below) —
@@ -340,23 +358,20 @@ export function ClimbReactionMenu({
     windowHeight - insets.top - contentTopOffset - spacing[5] - reservedForPreview - bottomReserve,
   );
 
-  // When the scrollable list (everything below the fixed primary-button row) can't all
-  // fit, hint that it scrolls: snap the viewport to a half-row "peek" (last row clipped
-  // at its midpoint) and fade its bottom edge. Derived from listActions.length + row
-  // height (ListRow: minHeight 44 + 12pt vertical padding, text growing with fontScale)
-  // — no per-frame scroll state. The list shares the card with the primary row, so it
-  // gets menuMaxHeight minus that row. The playlist view owns its own scroll.
+  // The scrollable list (everything below the fixed primary-button row) shares the card
+  // with that row, so it gets menuMaxHeight minus the row. Row height (ListRow: minHeight
+  // 44 + 12pt vertical padding, text growing with fontScale) drives the scroll math with
+  // no per-frame scroll state. The playlist view owns its own scroll.
   const actionRowHeight = Math.max(44, Math.round(24 + 22 * fontScale));
   const listMaxHeight = Math.max(actionRowHeight, menuMaxHeight - primaryRowHeight);
   const menuContentHeight = listActions.length * actionRowHeight + spacing[1] * 2;
-  const menuOverflows = menuContentHeight > listMaxHeight;
   let menuScrollHeight: number;
   if (!menuScrolled) {
-    // At rest (large hero): snap an overflowing list to the half-row "peek" that
-    // cues scrolling; a fitting list uses its full height.
-    menuScrollHeight = menuOverflows
-      ? Math.max(actionRowHeight, (Math.floor(listMaxHeight / actionRowHeight) - 0.5) * actionRowHeight)
-      : listMaxHeight;
+    // At rest (large hero): fill all the space under the hero. maxHeight caps an
+    // overflowing list at listMaxHeight — the last row clips there (with the bottom
+    // fade cueing more) — while a short list shrinks to its content. Filling the space
+    // instead of snapping to whole-rows-minus-a-half leaves no dead gap below the card.
+    menuScrollHeight = listMaxHeight;
   } else {
     // Scrolled: the hero has shrunk and listMaxHeight has grown, so give the list
     // that room. But if the taller viewport would now fit the whole list, the
@@ -485,7 +500,7 @@ export function ClimbReactionMenu({
                   {/* Fixed quick-action row — the three most-reached actions as tappable
                       buttons, above the scrollable remainder. */}
                   {primaryActions.length > 0 ? (
-                    <View style={styles.primaryRow}>
+                    <View style={styles.primaryRow} onLayout={handlePrimaryRowLayout}>
                       {primaryActions.map((action) => (
                         <PrimaryActionButton
                           key={action.id}
@@ -502,7 +517,10 @@ export function ClimbReactionMenu({
                     showsVerticalScrollIndicator={false}
                     keyboardShouldPersistTaps="handled"
                     onScroll={handleMenuScroll}
-                    scrollEventThrottle={16}
+                    // The ref-gated handler only setStates on a boolean flip, and the
+                    // 2/20px hysteresis still catches the gesture at this cadence, so a
+                    // coarser throttle keeps the JS thread quiet during the scroll.
+                    scrollEventThrottle={64}
                     contentContainerStyle={styles.menuContent}
                   >
                     {listActions.map((action, index) => (

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -36,7 +36,7 @@ import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { springs, timing } from '../../theme/animations';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useClimbActions, type ClimbActionId, type ClimbActionItem } from './use-climb-actions';
-import { fitBoardArt, fitBoardMaxSize } from './board-art-fit';
+import { fitBoardArt, computeReactionBoardMaxSize } from './board-art-fit';
 
 // Log a tick / Add to playlist / Share get pulled out of the scrollable list into a
 // fixed horizontal button row at the top of the card — the most-reached actions,
@@ -261,41 +261,25 @@ export function ClimbReactionMenu({
   // never re-renders the menu (see reservedForPreview). Scaled by fontScale so a large
   // Dynamic Type setting reserves the taller text instead of overlapping the art.
   const previewTextReserve = Math.round(56 * fontScale);
-  // The board is the hero, but the whole card (title + board + button row + the ENTIRE
-  // action list) has to fit on screen without scrolling — so the board takes the space
-  // left once the title, buttons and full list are reserved. A tall phone with a short
-  // list leaves the board width-bounded; a long list shrinks it. Fitting to a box (not a
-  // square) lets a portrait board grow tall while a near-square board stays in its frame.
-  const heroHeightBudget =
-    windowHeight -
-    insets.top -
-    contentTopOffset -
-    spacing[5] -
-    primaryRowHeight -
-    listContentHeight -
-    (insets.bottom + spacing[5]) -
-    previewTextReserve;
-  // Ceiling that always keeps the button row + ~2 list rows on screen: a short phone or
-  // landscape can't fit a big board AND all the actions, so the board yields rather than
-  // pushing the menu off the bottom. The floor keeps the board visible unless even that
-  // won't fit; below the ceiling a long list simply scrolls.
-  const boardCeiling = Math.max(
-    0,
-    windowHeight -
-      insets.top -
-      contentTopOffset -
-      previewTextReserve -
-      primaryRowHeight -
-      2 * actionRowHeight -
-      (insets.bottom + spacing[5]) -
-      spacing[5] * 2,
-  );
-  const boardMinSize = Math.min(140, boardCeiling);
-  const largeArtMaxSize = fitBoardMaxSize(
+  // Size the board the way the play drawer does — contain-fit into the space left after
+  // the title, button row and full list are reserved, so it renders SMALLER on smaller
+  // screens instead of crowding the actions off the bottom. Bounds/floor live in the pure
+  // computeReactionBoardMaxSize, which is unit-tested across device sizes.
+  const largeArtMaxSize = computeReactionBoardMaxSize({
+    windowWidth,
+    windowHeight,
+    insetTop: insets.top,
+    insetBottom: insets.bottom,
+    contentTopOffset,
+    sectionGap: spacing[5],
+    sideMargin: spacing[6],
+    previewMaxWidth: PREVIEW_MAX_WIDTH,
     aspect,
-    Math.min(PREVIEW_MAX_WIDTH, windowWidth - spacing[6] * 2),
-    Math.min(windowHeight * 0.55, boardCeiling, Math.max(boardMinSize, heroHeightBudget)),
-  );
+    primaryRowHeight,
+    listContentHeight,
+    textReserve: previewTextReserve,
+    rowHeight: actionRowHeight,
+  });
   // Rasterize the holds overlay at the large hero's displayed width × DPR — matching
   // the play drawer (SwipeBoardCarousel) instead of the list-thumbnail's fixed 400px,
   // so the enlarged art stays crisp. Derived from the large size (not the animating

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -81,7 +81,9 @@ vi.mock('../../playlist/InlinePlaylistPicker', () => ({
 vi.mock('../../../lib/board-details', () => ({ getBoardRenderData: () => null }));
 vi.mock('../../../lib/format-climb-stats', () => ({ formatSends: () => '', formatQuality: () => '' }));
 vi.mock('../../../hooks/use-grade-format', () => ({ useGradeFormat: () => ({ formatGrade: () => 'V4' }) }));
-vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ colorScheme: 'dark' }) }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ colorScheme: 'dark', systemColors: { fill: '#222', label: '#fff' } }),
+}));
 vi.mock('../../../theme/animations', () => ({ springs: { gentle: {} }, timing: { fast: 150 } }));
 vi.mock('../../../theme/tokens', () => ({
   spacing: { 1: 4, 2: 8, 3: 12, 5: 20, 6: 24 },
@@ -109,7 +111,7 @@ vi.mock('../use-climb-actions', () => ({
   },
 }));
 
-import { ClimbReactionMenu } from '../ClimbReactionMenu';
+import { ClimbReactionMenu, nextMenuScrolledState } from '../ClimbReactionMenu';
 
 const climb = { uuid: 'climb-1', name: 'Big Move', frames: '', difficulty: 'V4', quality_average: '0' } as Climb;
 const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
@@ -129,6 +131,30 @@ function renderMenu(onClose = vi.fn(), extraProps: Record<string, unknown> = {})
     ),
   };
 }
+
+describe('nextMenuScrolledState (scroll-to-expand hysteresis)', () => {
+  it('expands only after scrolling past the upper threshold', () => {
+    // From collapsed, small offsets keep it collapsed; >20px expands.
+    expect(nextMenuScrolledState(false, 0)).toBe(false);
+    expect(nextMenuScrolledState(false, 20)).toBe(false);
+    expect(nextMenuScrolledState(false, 21)).toBe(true);
+  });
+
+  it('collapses only when dragged back near the very top', () => {
+    // From expanded, it stays expanded until the offset returns to ~0.
+    expect(nextMenuScrolledState(true, 40)).toBe(true);
+    expect(nextMenuScrolledState(true, 3)).toBe(true);
+    expect(nextMenuScrolledState(true, 2)).toBe(false);
+    expect(nextMenuScrolledState(true, 0)).toBe(false);
+  });
+
+  it('holds state in the hysteresis band between the two thresholds', () => {
+    // A 2–20px offset never flips the current state either way — the guard that
+    // stops a content-fits resize from bouncing the hero.
+    expect(nextMenuScrolledState(false, 10)).toBe(false);
+    expect(nextMenuScrolledState(true, 10)).toBe(true);
+  });
+});
 
 describe('ClimbReactionMenu view switching', () => {
   beforeEach(() => {

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -11,6 +11,7 @@ const captured = vi.hoisted(() => ({
   pickerOnBack: undefined as undefined | (() => void),
   modalOnRequestClose: undefined as undefined | (() => void),
   boardImageProps: null as Record<string, unknown> | null,
+  ran: undefined as undefined | string,
 }));
 
 vi.mock('react-native', () => ({
@@ -105,7 +106,7 @@ vi.mock('../use-climb-actions', () => ({
     captured.actionArgs = args;
     return [
       { id: 'preview', title: 'Preview', icon: 'visibility', color: '#00f', run: () => {} },
-      { id: 'tick', title: 'Log a tick', icon: 'tick', color: '#0f0', run: () => {} },
+      { id: 'tick', title: 'Log a tick', icon: 'tick', color: '#0f0', run: () => (captured.ran = 'tick') },
       {
         id: 'playlist',
         title: 'Add to Playlist',
@@ -114,7 +115,7 @@ vi.mock('../use-climb-actions', () => ({
         run: () => (args.onSelectPlaylist as (() => void) | undefined)?.(),
       },
       { id: 'favorite', title: 'Favorite', icon: 'favorite', color: '#f00', run: () => {} },
-      { id: 'share', title: 'Share', icon: 'share', color: '#00f', run: () => {} },
+      { id: 'share', title: 'Share', icon: 'share', color: '#00f', run: () => (captured.ran = 'share') },
     ];
   },
 }));
@@ -146,6 +147,15 @@ describe('ClimbReactionMenu view switching', () => {
     captured.pickerOnBack = undefined;
     captured.modalOnRequestClose = undefined;
     captured.boardImageProps = null;
+    captured.ran = undefined;
+  });
+
+  it('runs the action when a primary button is pressed', () => {
+    const { getByLabelText } = renderMenu();
+    act(() => fireEvent.click(getByLabelText('Log a tick')));
+    expect(captured.ran).toBe('tick');
+    act(() => fireEvent.click(getByLabelText('Share')));
+    expect(captured.ran).toBe('share');
   });
 
   it('renders the board at play-drawer quality (full background, DPR overlay, outlined holds)', () => {

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -25,6 +25,7 @@ vi.mock('react-native', () => ({
   TextInput: () => null,
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (s: Record<string, unknown>) => s, absoluteFill: {}, hairlineWidth: 1 },
+  PixelRatio: { get: () => 2 },
   useWindowDimensions: () => ({ width: 400, height: 800 }),
 }));
 

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -19,8 +19,15 @@ vi.mock('react-native', () => ({
     captured.modalOnRequestClose = onRequestClose;
     return createElement('div', { 'data-modal': 'true' }, children);
   },
-  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
-    createElement('button', { onClick: onPress }, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
   ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   TextInput: () => null,
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -58,7 +65,7 @@ vi.mock('../../Text', () => ({
 vi.mock('../../Icon', () => ({ Icon: () => null }));
 vi.mock('../../ListRow', () => ({
   ListRow: ({ title, onPress }: { title: string; onPress?: () => void }) =>
-    createElement('button', { onClick: onPress, 'aria-label': title }, title),
+    createElement('button', { onClick: onPress, 'aria-label': title, 'data-listrow': 'true' }, title),
 }));
 vi.mock('../../GlassSurface', () => ({
   GlassSurface: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -88,6 +95,7 @@ vi.mock('../use-climb-actions', () => ({
     captured.actionArgs = args;
     return [
       { id: 'preview', title: 'Preview', icon: 'visibility', color: '#00f', run: () => {} },
+      { id: 'tick', title: 'Log a tick', icon: 'tick', color: '#0f0', run: () => {} },
       {
         id: 'playlist',
         title: 'Add to Playlist',
@@ -95,6 +103,8 @@ vi.mock('../use-climb-actions', () => ({
         color: '#00f',
         run: () => (args.onSelectPlaylist as (() => void) | undefined)?.(),
       },
+      { id: 'favorite', title: 'Favorite', icon: 'favorite', color: '#f00', run: () => {} },
+      { id: 'share', title: 'Share', icon: 'share', color: '#00f', run: () => {} },
     ];
   },
 }));
@@ -125,6 +135,24 @@ describe('ClimbReactionMenu view switching', () => {
     captured.actionArgs = null;
     captured.pickerOnBack = undefined;
     captured.modalOnRequestClose = undefined;
+  });
+
+  it('pulls tick, playlist and share into the primary button row and leaves the rest in the list', () => {
+    const { getByLabelText, container } = renderMenu();
+
+    // All five actions render.
+    for (const label of ['Log a tick', 'Add to Playlist', 'Share', 'Preview', 'Favorite']) {
+      expect(getByLabelText(label)).not.toBeNull();
+    }
+
+    // The three primary actions are NOT list rows (they're the button row); the
+    // remainder are.
+    for (const label of ['Log a tick', 'Add to Playlist', 'Share']) {
+      expect(container.querySelector(`[data-listrow="true"][aria-label="${label}"]`)).toBeNull();
+    }
+    for (const label of ['Preview', 'Favorite']) {
+      expect(container.querySelector(`[data-listrow="true"][aria-label="${label}"]`)).not.toBeNull();
+    }
   });
 
   it('renders the action list first and swaps to the inline picker when the playlist action runs', () => {

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -10,7 +10,6 @@ const captured = vi.hoisted(() => ({
   actionArgs: null as Record<string, unknown> | null,
   pickerOnBack: undefined as undefined | (() => void),
   modalOnRequestClose: undefined as undefined | (() => void),
-  actionScroll: undefined as undefined | ((event: { nativeEvent: { contentOffset: { y: number } } }) => void),
 }));
 
 vi.mock('react-native', () => ({
@@ -29,16 +28,7 @@ vi.mock('react-native', () => ({
     onPress?: () => void;
     accessibilityLabel?: string;
   }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
-  ScrollView: ({
-    children,
-    onScroll,
-  }: {
-    children?: ReactNode;
-    onScroll?: (event: { nativeEvent: { contentOffset: { y: number } } }) => void;
-  }) => {
-    captured.actionScroll = onScroll;
-    return createElement('div', null, children);
-  },
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   TextInput: () => null,
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (s: Record<string, unknown>) => s, absoluteFill: {}, hairlineWidth: 1 },
@@ -121,7 +111,7 @@ vi.mock('../use-climb-actions', () => ({
   },
 }));
 
-import { ClimbReactionMenu, nextMenuScrolledState } from '../ClimbReactionMenu';
+import { ClimbReactionMenu } from '../ClimbReactionMenu';
 
 const climb = { uuid: 'climb-1', name: 'Big Move', frames: '', difficulty: 'V4', quality_average: '0' } as Climb;
 const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
@@ -142,46 +132,11 @@ function renderMenu(onClose = vi.fn(), extraProps: Record<string, unknown> = {})
   };
 }
 
-describe('nextMenuScrolledState (scroll-to-expand hysteresis)', () => {
-  it('expands only after scrolling past the upper threshold', () => {
-    // From collapsed, small offsets keep it collapsed; >20px expands.
-    expect(nextMenuScrolledState(false, 0)).toBe(false);
-    expect(nextMenuScrolledState(false, 20)).toBe(false);
-    expect(nextMenuScrolledState(false, 21)).toBe(true);
-  });
-
-  it('collapses only when dragged back near the very top', () => {
-    // From expanded, it stays expanded until the offset returns to ~0.
-    expect(nextMenuScrolledState(true, 40)).toBe(true);
-    expect(nextMenuScrolledState(true, 3)).toBe(true);
-    expect(nextMenuScrolledState(true, 2)).toBe(false);
-    expect(nextMenuScrolledState(true, 0)).toBe(false);
-  });
-
-  it('holds state in the hysteresis band between the two thresholds', () => {
-    // A 2–20px offset never flips the current state either way — the guard that
-    // stops a content-fits resize from bouncing the hero.
-    expect(nextMenuScrolledState(false, 10)).toBe(false);
-    expect(nextMenuScrolledState(true, 10)).toBe(true);
-  });
-});
-
 describe('ClimbReactionMenu view switching', () => {
   beforeEach(() => {
     captured.actionArgs = null;
     captured.pickerOnBack = undefined;
     captured.modalOnRequestClose = undefined;
-    captured.actionScroll = undefined;
-  });
-
-  it('handles list scroll (expand past the threshold, then collapse at the top) without crashing', () => {
-    const { getByLabelText } = renderMenu();
-    // A >20px scroll drives handleMenuScroll → menuScrolled true → re-render.
-    act(() => captured.actionScroll?.({ nativeEvent: { contentOffset: { y: 40 } } }));
-    expect(getByLabelText('Preview')).not.toBeNull();
-    // Scrolling back to the top drives the collapse path.
-    act(() => captured.actionScroll?.({ nativeEvent: { contentOffset: { y: 0 } } }));
-    expect(getByLabelText('Preview')).not.toBeNull();
   });
 
   it('pulls tick, playlist and share into the primary button row and leaves the rest in the list', () => {

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -10,6 +10,7 @@ const captured = vi.hoisted(() => ({
   actionArgs: null as Record<string, unknown> | null,
   pickerOnBack: undefined as undefined | (() => void),
   modalOnRequestClose: undefined as undefined | (() => void),
+  boardImageProps: null as Record<string, unknown> | null,
 }));
 
 vi.mock('react-native', () => ({
@@ -33,7 +34,7 @@ vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (s: Record<string, unknown>) => s, absoluteFill: {}, hairlineWidth: 1 },
   PixelRatio: { get: () => 2 },
-  useWindowDimensions: () => ({ width: 400, height: 800 }),
+  useWindowDimensions: () => ({ width: 400, height: 800, fontScale: 1 }),
 }));
 
 vi.mock('react-native-reanimated', () => ({
@@ -70,7 +71,12 @@ vi.mock('../../ListRow', () => ({
 vi.mock('../../GlassSurface', () => ({
   GlassSurface: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));
-vi.mock('../../BoardImageNative', () => ({ BoardImageNative: () => null }));
+vi.mock('../../BoardImageNative', () => ({
+  BoardImageNative: (props: Record<string, unknown>) => {
+    captured.boardImageProps = props;
+    return null;
+  },
+}));
 vi.mock('../../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => null }));
 vi.mock('../../playlist/InlinePlaylistPicker', () => ({
   InlinePlaylistPicker: ({ onBack }: { onBack?: () => void }) => {
@@ -78,7 +84,9 @@ vi.mock('../../playlist/InlinePlaylistPicker', () => ({
     return createElement('div', { 'data-picker': 'true' }, 'picker');
   },
 }));
-vi.mock('../../../lib/board-details', () => ({ getBoardRenderData: () => null }));
+vi.mock('../../../lib/board-details', () => ({
+  getBoardRenderData: () => ({ boardWidth: 120, boardHeight: 120 }),
+}));
 vi.mock('../../../lib/format-climb-stats', () => ({ formatSends: () => '', formatQuality: () => '' }));
 vi.mock('../../../hooks/use-grade-format', () => ({ useGradeFormat: () => ({ formatGrade: () => 'V4' }) }));
 vi.mock('../../../providers/theme-provider', () => ({
@@ -137,6 +145,20 @@ describe('ClimbReactionMenu view switching', () => {
     captured.actionArgs = null;
     captured.pickerOnBack = undefined;
     captured.modalOnRequestClose = undefined;
+    captured.boardImageProps = null;
+  });
+
+  it('renders the board at play-drawer quality (full background, DPR overlay, outlined holds)', () => {
+    renderMenu();
+    const props = captured.boardImageProps;
+    expect(props).not.toBeNull();
+    // Full-resolution board photo (not the 416px thumbnail).
+    expect(props?.backgroundVariant).toBe('full');
+    // Outlined holds like the play drawer, not the filled-dot thumbnail style.
+    expect(props?.filledStyle).toBeUndefined();
+    // Overlay rasterized at the displayed width × DPR (PixelRatio.get() → 2 here).
+    expect(typeof props?.renderWidth).toBe('number');
+    expect(props?.renderWidth as number).toBeGreaterThan(0);
   });
 
   it('pulls tick, playlist and share into the primary button row and leaves the rest in the list', () => {

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -10,6 +10,7 @@ const captured = vi.hoisted(() => ({
   actionArgs: null as Record<string, unknown> | null,
   pickerOnBack: undefined as undefined | (() => void),
   modalOnRequestClose: undefined as undefined | (() => void),
+  actionScroll: undefined as undefined | ((event: { nativeEvent: { contentOffset: { y: number } } }) => void),
 }));
 
 vi.mock('react-native', () => ({
@@ -28,7 +29,16 @@ vi.mock('react-native', () => ({
     onPress?: () => void;
     accessibilityLabel?: string;
   }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
-  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({
+    children,
+    onScroll,
+  }: {
+    children?: ReactNode;
+    onScroll?: (event: { nativeEvent: { contentOffset: { y: number } } }) => void;
+  }) => {
+    captured.actionScroll = onScroll;
+    return createElement('div', null, children);
+  },
   TextInput: () => null,
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (s: Record<string, unknown>) => s, absoluteFill: {}, hairlineWidth: 1 },
@@ -161,6 +171,17 @@ describe('ClimbReactionMenu view switching', () => {
     captured.actionArgs = null;
     captured.pickerOnBack = undefined;
     captured.modalOnRequestClose = undefined;
+    captured.actionScroll = undefined;
+  });
+
+  it('handles list scroll (expand past the threshold, then collapse at the top) without crashing', () => {
+    const { getByLabelText } = renderMenu();
+    // A >20px scroll drives handleMenuScroll → menuScrolled true → re-render.
+    act(() => captured.actionScroll?.({ nativeEvent: { contentOffset: { y: 40 } } }));
+    expect(getByLabelText('Preview')).not.toBeNull();
+    // Scrolling back to the top drives the collapse path.
+    act(() => captured.actionScroll?.({ nativeEvent: { contentOffset: { y: 0 } } }));
+    expect(getByLabelText('Preview')).not.toBeNull();
   });
 
   it('pulls tick, playlist and share into the primary button row and leaves the rest in the list', () => {

--- a/packages/mobile/src/components/climb-actions/__tests__/board-art-fit.test.ts
+++ b/packages/mobile/src/components/climb-actions/__tests__/board-art-fit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fitBoardArt, fitBoardMaxSize } from '../board-art-fit';
+import { fitBoardArt, fitBoardMaxSize, computeReactionBoardMaxSize } from '../board-art-fit';
 
 describe('fitBoardArt', () => {
   it('portrait: height is the max edge, width scales down by aspect', () => {
@@ -58,5 +58,67 @@ describe('fitBoardMaxSize', () => {
     expect(fitBoardMaxSize(0, 320, 460)).toBe(320);
     expect(fitBoardMaxSize(-1, 460, 320)).toBe(320);
     expect(fitBoardMaxSize(Number.NaN, 200, 500)).toBe(200);
+  });
+});
+
+describe('computeReactionBoardMaxSize', () => {
+  // Approximate the reaction menu's reserves at fontScale 1: a 3-button row (~110),
+  // a 56pt title reserve, and 46pt list rows. Screen-size + item count vary per case.
+  const ROW = 46;
+  function boardFor(
+    windowWidth: number,
+    windowHeight: number,
+    items: number,
+    { insetTop = 0, insetBottom = 0, aspect = 1 }: { insetTop?: number; insetBottom?: number; aspect?: number } = {},
+  ): number {
+    return computeReactionBoardMaxSize({
+      windowWidth,
+      windowHeight,
+      insetTop,
+      insetBottom,
+      contentTopOffset: Math.round(windowHeight * 0.02),
+      sectionGap: 20,
+      sideMargin: 24,
+      previewMaxWidth: 400,
+      aspect,
+      primaryRowHeight: 110,
+      listContentHeight: items * ROW + 4,
+      textReserve: 56,
+      rowHeight: ROW,
+    });
+  }
+
+  it('renders the climb smaller as the screen gets smaller (same list)', () => {
+    const proMax = boardFor(440, 956, 4, { insetTop: 59, insetBottom: 34 });
+    const pro = boardFor(393, 852, 4, { insetTop: 59, insetBottom: 34 });
+    const se = boardFor(375, 667, 4, { insetTop: 20 });
+    const smallest = boardFor(320, 568, 4, { insetTop: 20 });
+    expect(proMax).toBeGreaterThan(pro);
+    expect(pro).toBeGreaterThan(se);
+    expect(se).toBeGreaterThan(smallest);
+  });
+
+  it('stays within the width cap and the window-height fraction', () => {
+    const board = boardFor(393, 852, 6, { insetTop: 59, insetBottom: 34 });
+    expect(board).toBeLessThanOrEqual(852 * 0.55);
+    expect(board).toBeLessThanOrEqual(393 - 24 * 2); // square board bounded by width
+  });
+
+  it('shrinks the climb toward the floor when a small screen has a long list', () => {
+    // 11 actions on an SE-sized screen: the board yields so the list can scroll.
+    const board = boardFor(375, 667, 11, { insetTop: 20 });
+    expect(board).toBeLessThanOrEqual(145);
+    expect(board).toBeGreaterThan(0);
+  });
+
+  it('never goes negative, even on a cramped landscape viewport', () => {
+    const board = boardFor(852, 375, 10, { insetBottom: 21 });
+    expect(board).toBeGreaterThanOrEqual(0);
+  });
+
+  it('lets a portrait board grow taller than a square one on the same screen', () => {
+    const square = boardFor(393, 852, 4, { insetTop: 59, insetBottom: 34, aspect: 1 });
+    const portrait = boardFor(393, 852, 4, { insetTop: 59, insetBottom: 34, aspect: 0.6 });
+    expect(portrait).toBeGreaterThanOrEqual(square);
   });
 });

--- a/packages/mobile/src/components/climb-actions/board-art-fit.ts
+++ b/packages/mobile/src/components/climb-actions/board-art-fit.ts
@@ -77,11 +77,16 @@ export function computeReactionBoardMaxSize(input: ReactionBoardLayoutInput): nu
   } = input;
   const topReserve = insetTop + contentTopOffset;
   const bottomReserve = insetBottom + sectionGap;
-  // Space the board fills once the title, buttons and the whole list are reserved.
+  // Space the board fills once the title, buttons and the whole list are reserved. Two
+  // section gaps are counted — the board→card gap (explicit) and the bottom padding gap
+  // (inside bottomReserve). The smaller title→board gap is deliberately NOT counted here:
+  // textReserve reserves more than the title actually needs, and that slack absorbs it.
   const heroHeightBudget =
     windowHeight - topReserve - sectionGap - primaryRowHeight - listContentHeight - bottomReserve - textReserve;
   // The most the board may take while still leaving the button row + ~2 list rows on
-  // screen; on a short screen the board yields to this instead of overflowing.
+  // screen; on a short screen the board yields to this instead of overflowing. This is a
+  // deliberately conservative cap (one extra section gap of headroom), so it can bind
+  // before heroHeightBudget on mid-range screens without ever letting the board overflow.
   const boardCeiling = Math.max(
     0,
     windowHeight - topReserve - textReserve - primaryRowHeight - 2 * rowHeight - bottomReserve - sectionGap * 2,

--- a/packages/mobile/src/components/climb-actions/board-art-fit.ts
+++ b/packages/mobile/src/components/climb-actions/board-art-fit.ts
@@ -20,3 +20,74 @@ export function fitBoardMaxSize(aspect: number, maxWidth: number, maxHeight: num
   if (!Number.isFinite(aspect) || aspect <= 0) return Math.min(maxWidth, maxHeight);
   return aspect >= 1 ? Math.min(maxWidth, maxHeight * aspect) : Math.min(maxHeight, maxWidth / aspect);
 }
+
+export type ReactionBoardLayoutInput = {
+  windowWidth: number;
+  windowHeight: number;
+  /** Safe-area insets. */
+  insetTop: number;
+  insetBottom: number;
+  /** Breathing room below the top safe area before the title. */
+  contentTopOffset: number;
+  /** Gap token stacked between the title, board and card (spacing[5]). */
+  sectionGap: number;
+  /** Horizontal content padding on ONE side (spacing[6]). */
+  sideMargin: number;
+  /** Ceiling on the preview/card width (PREVIEW_MAX_WIDTH). */
+  previewMaxWidth: number;
+  /** Board aspect ratio, width / height. */
+  aspect: number;
+  /** Reserved heights of the fixed sections the board shares the screen with. */
+  primaryRowHeight: number;
+  listContentHeight: number;
+  textReserve: number;
+  /** One action-list row height, used to keep ~2 rows visible under the board. */
+  rowHeight: number;
+  /** Smallest board the layout aims for before it lets the list scroll instead. */
+  boardFloor?: number;
+  /** Hard ceiling on the board as a fraction of the window height. */
+  heightFraction?: number;
+};
+
+// Size the reaction-menu board the way the play drawer sizes its board: contain-fit the
+// climb into the space that's left once the title, the quick-action button row and the
+// full action list are reserved, so on a smaller screen the climb renders SMALLER rather
+// than pushing the actions off the bottom. Bounded three ways — the preview width, a
+// window-height fraction, and a ceiling that always keeps the button row + ~2 list rows
+// on screen — and floored so the board stays visible until a very small screen genuinely
+// has no room (past that the list simply scrolls). Pure so it's unit-tested across the
+// install base's screen sizes, mirroring `play-drawer-layout.ts`.
+export function computeReactionBoardMaxSize(input: ReactionBoardLayoutInput): number {
+  const {
+    windowWidth,
+    windowHeight,
+    insetTop,
+    insetBottom,
+    contentTopOffset,
+    sectionGap,
+    sideMargin,
+    previewMaxWidth,
+    aspect,
+    primaryRowHeight,
+    listContentHeight,
+    textReserve,
+    rowHeight,
+    boardFloor = 140,
+    heightFraction = 0.55,
+  } = input;
+  const topReserve = insetTop + contentTopOffset;
+  const bottomReserve = insetBottom + sectionGap;
+  // Space the board fills once the title, buttons and the whole list are reserved.
+  const heroHeightBudget =
+    windowHeight - topReserve - sectionGap - primaryRowHeight - listContentHeight - bottomReserve - textReserve;
+  // The most the board may take while still leaving the button row + ~2 list rows on
+  // screen; on a short screen the board yields to this instead of overflowing.
+  const boardCeiling = Math.max(
+    0,
+    windowHeight - topReserve - textReserve - primaryRowHeight - 2 * rowHeight - bottomReserve - sectionGap * 2,
+  );
+  const minSize = Math.min(boardFloor, boardCeiling);
+  const maxWidth = Math.min(previewMaxWidth, windowWidth - sideMargin * 2);
+  const maxHeight = Math.min(windowHeight * heightFraction, boardCeiling, Math.max(minSize, heroHeightBudget));
+  return fitBoardMaxSize(aspect, maxWidth, maxHeight);
+}

--- a/packages/mobile/src/lib/climb-quick-actions-button-preference.ts
+++ b/packages/mobile/src/lib/climb-quick-actions-button-preference.ts
@@ -1,20 +1,19 @@
 import { useCallback, useEffect, useSyncExternalStore } from 'react';
 import { getPreference, setPreference } from './preference-store';
-import { useFeatureFlag } from '../providers/feature-flags-provider';
 
 // Whether the climbs list shows the ⋮ quick-actions button on each row. This is a
-// user setting (More → Display), but its DEFAULT is set by the
-// `climb-quick-actions-button` experiment flag: the treatment cohort defaults ON
-// (opted in, can turn it off), everyone else defaults OFF (opted out, can turn it
-// on). So the store is TRI-STATE — `choice` is `undefined` until the climber makes
-// an explicit choice, at which point their value wins over the flag default.
+// user setting (More → Display) that defaults ON. The store is TRI-STATE — `choice`
+// is `undefined` until the climber makes an explicit choice, at which point their
+// value wins over the default; so anyone who has already opted out stays opted out.
 //
 // Structure mirrors `boardsesh-grades-preference.ts`: a module-level store read via
 // `useSyncExternalStore` with a referentially-stable cached snapshot (rebuilt only
 // inside `notify()`), plus a promise-singleton one-time load so any number of
-// mounted consumers trigger the AsyncStorage read exactly once. The flag→default
-// resolution happens in the hook, not the store, since the flag is a React value.
+// mounted consumers trigger the AsyncStorage read exactly once.
 const STORAGE_KEY = 'showClimbQuickActionsButton';
+
+// Default when the climber hasn't made an explicit choice — the ⋮ button is on.
+const DEFAULT_ENABLED = true;
 
 type ChoiceSnapshot = { choice: boolean | undefined; loaded: boolean };
 
@@ -81,8 +80,8 @@ function getServerSnapshot(): ChoiceSnapshot {
 
 /**
  * The effective ⋮-button setting: the climber's explicit choice if they've made
- * one, otherwise the flag-driven default (treatment cohort ON, everyone else OFF).
- * Backs both the climbs-list gate and the Display settings toggle.
+ * one, otherwise the default (on). Backs both the climbs-list gate and the Display
+ * settings toggle.
  */
 export function useClimbQuickActionsButton(): {
   enabled: boolean;
@@ -90,7 +89,6 @@ export function useClimbQuickActionsButton(): {
   setEnabled: (enabled: boolean) => void;
 } {
   const { choice, loaded } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-  const flagDefault = useFeatureFlag('climb-quick-actions-button') === true;
 
   useEffect(() => {
     // Swallow read failures here — the load already clears its cached promise so a
@@ -102,5 +100,5 @@ export function useClimbQuickActionsButton(): {
     void setClimbQuickActionsButtonPreference(next);
   }, []);
 
-  return { enabled: choice ?? flagDefault, loaded, setEnabled };
+  return { enabled: choice ?? DEFAULT_ENABLED, loaded, setEnabled };
 }

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -76,12 +76,6 @@ export const FEATURE_FLAG_DEFINITIONS = [
     description:
       'Show the data-science "Boardsesh grade" section in the play drawer (cross-board grade, confidence tier, send counts). Off hides the section.',
   },
-  {
-    key: 'climb-quick-actions-button',
-    label: 'Climb ⋮ quick-actions button (default)',
-    description:
-      'Experiment (2-cohort A/B): sets the DEFAULT of the "Show quick-actions button" setting. On = treatment (button on by default, climber can opt out); off = control (off by default, climber can opt in). The setting override always wins.',
-  },
 ] as const satisfies readonly FeatureFlagDefinition[];
 
 // The literal key union (e.g. `'strava-integration'`), preserved via the


### PR DESCRIPTION
## Summary

Reworks the mobile climb reaction menu (the iMessage-style long-press overlay) and flips one climbs-list default.

**Play-drawer-style layout.** The climb name · grade · byline now sit above the board art, like the play drawer header. The board is the hero beneath its title, sized to fill the space left once the title, the quick-action button row and the entire action list are reserved — so everything fits on one screen without scrolling. The board sizing is a pure, unit-tested function (`computeReactionBoardMaxSize`, mirroring the play drawer's `play-drawer-layout.ts`): it contain-fits the climb and renders it **smaller on smaller screens**, falling back to scrolling the list when a short screen genuinely runs out of room. Verified from iPhone Pro Max down to a 320×568 display and landscape.

**Quick-action button row.** The three most-reached actions — Log a tick, Add to playlist, Share — sit in a fixed horizontal button row at the top of the action card, one tap away. The remaining actions stay in the list below. `useClimbActions` is the single source; the menu splits it (`PRIMARY_ACTION_IDS = ['tick','playlist','share']`).

**Play-drawer-quality board art.** The hero preview was piggybacking the 76px list-thumbnail's cached render: a 416px background photo stretched to the hero, plus a fixed 400px overlay upscaled at DPR 2–3. It now matches `SwipeBoardCarousel` — outlined holds (dropped `filledStyle`), the full-resolution board photo (`backgroundVariant="full"`), and a holds overlay rasterized at the displayed width × `PixelRatio.get()`. The preview + card are also wider so the board uses the full phone width.

**Consistent board size in the Add-to-playlist view.** Opening Add to playlist keeps the board the same size as the menu and swaps in the inline picker — the size difference wasn't worth the jump, and it lines the picker card up with the menu's action card. The board only shrinks (springs to the compact size) when the create-playlist form's keyboard is up, so the form stays reachable.

**⋮ quick-actions button on by default.** Removes the `climb-quick-actions-button` experiment flag and defaults the preference to on. It stays a user setting (More → Display) via the existing tri-state store, so anyone who already opted out keeps it off.

Files: `ClimbReactionMenu.tsx` (layout, button row, image quality) + `board-art-fit.ts` (board-size math), `climb-quick-actions-button-preference.ts` + `feature-flags-provider.tsx` (de-flag), plus the reaction-menu and board-art-fit tests.

## Release Notes

- The long-press menu leads with Log a tick, Add to playlist, and Share as buttons — your go-to actions in one tap.
- The climb title now sits above the board, and every action fits on one screen — no scrolling.
- Long-press board art is crisp now, matching the play view.
- The ⋮ quick-actions button shows on every climb by default; hide it in More → Display if you'd rather long-press.

## Test plan

- [ ] `vp run typecheck:mobile`
- [ ] `vp run test:mobile` (ClimbReactionMenu tests cover the tick/playlist/share split, board art quality, the inline playlist switch, and hardware-back; `board-art-fit` tests cover board sizing across device sizes)
- [ ] `vp run check:mobile-bundle`
- [ ] `vp check`
- [ ] Manual (device/sim): long-press a climb → title above the board, board sharp with outlined holds, tick/playlist/share as a button row, all actions visible without scrolling; tap Add to playlist → the inline picker appears at the same board size; tap + to create a playlist → the board springs to compact so the form + keyboard fit; back returns to the full menu. Repeat on a small phone/landscape → the climb renders smaller and the list scrolls.

> Note: local validation couldn't run in this session — `bun install` hangs in dependency resolution here (bun 1.3.11 spins on the 16-workspace graph; registry is reachable, so it's an environment/resolver issue, not the diff). CI is the validation gate; every push has gone green there.