### PR TITLE
feat(backend): serve climb OG images from the backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ Read relevant `docs/` before working on the matching area; update docs when the 
 - `docs/ai-design-guidelines.md` — Velvet Send design system (mobile-canonical: palette, typography, tokens, Liquid Glass / Material variants; web now consumes it too via `@boardsesh/velvet-tokens` + the foreground/fill split — see the "Web (consuming Velvet Send)" section)
 - `docs/live-activity-push-testing.md` — APNs Live Activity push testing
 - `docs/logging.md` — backend structured logger (winston)
+- `docs/og-climb.md` — backend-served climb OG share cards (`GET /og/climb`: caches, env vars, timings)
 - `docs/mobile-sheets-vs-routes.md` — mobile: which surface to use (bottom sheet vs route), with the decision tree + the hard rules (incl. why `fullScreenModal` breaks the iOS 26 native tab bar)
 
 ## Architecture Overview

--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,8 @@
         "@boardsesh/aurora-sync": "*",
         "@boardsesh/board-config": "*",
         "@boardsesh/board-constants": "*",
+        "@boardsesh/board-render": "*",
+        "@boardsesh/board-renderer-wasm": "*",
         "@boardsesh/crypto": "*",
         "@boardsesh/db": "*",
         "@boardsesh/email": "*",
@@ -450,6 +452,26 @@
         "react": "^19",
       },
     },
+    "packages/shared/board-render": {
+      "name": "@boardsesh/board-render",
+      "version": "1.0.0",
+      "dependencies": {
+        "@boardsesh/board-config": "*",
+        "@boardsesh/board-constants": "*",
+        "@boardsesh/board-renderer-wasm": "*",
+        "@boardsesh/play-view": "*",
+        "@boardsesh/shared-schema": "*",
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.3",
+        "sharp": "^0.34.5",
+        "typescript": "~6.0.3",
+      },
+      "peerDependencies": {
+        "sharp": "^0.34.5",
+      },
+    },
     "packages/shared/climb-actions": {
       "name": "@boardsesh/climb-actions",
       "version": "1.0.0",
@@ -744,6 +766,7 @@
         "@boardsesh/board-presence": "*",
         "@boardsesh/board-presence-react": "*",
         "@boardsesh/board-react": "*",
+        "@boardsesh/board-render": "*",
         "@boardsesh/board-renderer-wasm": "*",
         "@boardsesh/climb-actions": "*",
         "@boardsesh/climb-filters": "*",
@@ -1167,6 +1190,8 @@
     "@boardsesh/board-presence-react": ["@boardsesh/board-presence-react@workspace:packages/shared/board-presence-react"],
 
     "@boardsesh/board-react": ["@boardsesh/board-react@workspace:packages/shared/board-react"],
+
+    "@boardsesh/board-render": ["@boardsesh/board-render@workspace:packages/shared/board-render"],
 
     "@boardsesh/board-renderer-wasm": ["@boardsesh/board-renderer-wasm@workspace:packages/board-renderer/wasm"],
 

--- a/docs/og-climb.md
+++ b/docs/og-climb.md
@@ -1,0 +1,68 @@
+# Climb OG share cards (`GET /og/climb`)
+
+The backend renders the Open Graph card crawlers fetch when someone shares a
+climb link. It moved here from the Vercel-hosted web route because Vercel
+lambdas paid a cold-start + render cost (~1s TTFB, worse when idle) on every
+CDN miss, and platforms like Facebook drop embeds that respond slowly.
+
+## Endpoint
+
+```
+GET https://ws.boardsesh.com/og/climb
+  ?board_name=kilter          # enum: kilter|tension|moonboard|decoy|touchstone|grasshopper|soill
+  &layout_id=1
+  &size_id=10
+  &set_ids=1,20               # canonicalised (sorted + deduped) by the zod schema
+  &frames=p1080r15p1202r12    # fully determines the image — no DB involved
+  &format=jpeg                # optional; jpeg (default) | png | webp
+```
+
+Responses are immutable (`Cache-Control: … immutable`, 1 year): the query
+fully determines the bytes. Invalid params are rejected with 400 before any
+render CPU runs; per-IP rate limit is 120/min (fails open to the in-memory
+limiter when Redis is down). `Server-Timing` breaks down wasm/base/encode ms
+and reports the cache outcome (`hit` | `base-hit` | `miss`).
+
+## How a render works
+
+Implementation: `packages/backend/src/services/board-render.ts` +
+`src/handlers/og-climb.ts`, on top of the shared `@boardsesh/board-render`
+package (`packages/shared/board-render` — also used by the web
+`/api/internal/board-render` route, which keeps serving in-app images).
+
+1. WASM (`@boardsesh/board-renderer-wasm`) renders the hold overlay — eagerly
+   initialised at server boot, so requests never pay init. If boot init failed
+   (transient I/O), requests re-attempt init at most every 30s; until it
+   succeeds the endpoint returns 503.
+2. The 1200×630 backdrop + board photos are composited once per board config
+   and cached as raw RGBA (**base cache**, LRU, 24 entries by default). The
+   fallback preview config for every supported board is pre-warmed after boot.
+3. Overlay is composited onto the base and encoded — JPEG by default
+   (mozjpeg, quality 85, 4:4:4 chroma), ~50–80KB.
+4. Final bytes land in the **byte cache** (LRU, 32MB by default), so repeat
+   fetches (FB, Twitter, WhatsApp, Slack each fetch independently) are served
+   from memory.
+
+Steady-state timings: ~250ms for a new climb on a warm board config, ~0ms for
+repeats, ~700ms worst-case first render of a never-seen board config.
+
+## Env vars
+
+| Var                     | Default               | Meaning                                                                                                                                                                            |
+| ----------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BOARD_IMAGES_ROOT`     | `<cwd>/../web/public` | Directory containing `images/` (board photos). The backend Docker context ships `packages/web/public/images` via `extraSourceDirs` in `scripts/create-service-docker-context.mjs`. |
+| `OG_BYTE_CACHE_MB`      | `32`                  | Byte budget for the final-image LRU.                                                                                                                                               |
+| `OG_BASE_CACHE_ENTRIES` | `24`                  | Entry budget for the per-board-config base LRU (~3MB raw RGBA each).                                                                                                               |
+
+## Operational notes
+
+- Winston logs one line per render: `[OGClimb] served` with
+  `{ boardName, layoutId, sizeId, cache, totalMs, wasmMs, encodeMs, bytes, format }`;
+  renders over 1s log at `warn`.
+- A missing images directory logs an error at boot and cards render
+  backdrop-only (no board photo) rather than failing.
+- Quick prod check:
+  `curl -o /dev/null -s -w 'code=%{http_code} ttfb=%{time_starttransfer}s\n' 'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=10&set_ids=1,20&frames=p1080r15p1202r12'`
+- Web points `og:image` here via `buildOgBoardRenderUrl`
+  (`packages/web/app/components/board-renderer/util.ts`), which derives the
+  backend origin from `NEXT_PUBLIC_WS_URL`.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,6 +28,8 @@
     "@boardsesh/aurora-sync": "*",
     "@boardsesh/board-config": "*",
     "@boardsesh/board-constants": "*",
+    "@boardsesh/board-render": "*",
+    "@boardsesh/board-renderer-wasm": "*",
     "@boardsesh/crypto": "*",
     "@boardsesh/db": "*",
     "@boardsesh/email": "*",

--- a/packages/backend/src/__tests__/og-climb.test.ts
+++ b/packages/backend/src/__tests__/og-climb.test.ts
@@ -110,6 +110,16 @@ describe('handleOgClimb', () => {
       expect(renderOgClimb).not.toHaveBeenCalled();
     });
 
+    it('rejects missing or empty frames with 400 — a blank board must not get immutable 200 headers', async () => {
+      const { frames: _omit, ...paramsWithoutFrames } = validParams;
+      const missingFramesResponse = await run(paramsWithoutFrames);
+      expect(missingFramesResponse.statusCode).toBe(400);
+
+      const emptyFramesResponse = await run({ ...validParams, frames: '' });
+      expect(emptyFramesResponse.statusCode).toBe(400);
+      expect(renderOgClimb).not.toHaveBeenCalled();
+    });
+
     it('rejects malformed frames with 400', async () => {
       const res = await run({ ...validParams, frames: 'p1073r42<script>' });
       expect(res.statusCode).toBe(400);

--- a/packages/backend/src/__tests__/og-climb.test.ts
+++ b/packages/backend/src/__tests__/og-climb.test.ts
@@ -152,6 +152,20 @@ describe('handleOgClimb', () => {
     });
   });
 
+  describe('rate-limit identity', () => {
+    it('buckets headerless clients under "unknown" rather than skipping the limit', async () => {
+      const url = new URL('http://localhost:8080/og/climb');
+      for (const [key, value] of Object.entries(validParams)) {
+        url.searchParams.set(key, value);
+      }
+      const req = { method: 'GET', headers: {}, socket: {} } as unknown as IncomingMessage;
+      const res = makeResponse();
+      await handleOgClimb(req, res as unknown as ServerResponse, url);
+      expect(res.statusCode).toBe(200);
+      expect(vi.mocked(checkRateLimitRedis).mock.calls[0][0]).toBe('unknown');
+    });
+  });
+
   describe('CORS preflight', () => {
     it('short-circuits OPTIONS before rate limiting and rendering', async () => {
       const { req, url } = makeRequest(validParams, 'OPTIONS');

--- a/packages/backend/src/__tests__/og-climb.test.ts
+++ b/packages/backend/src/__tests__/og-climb.test.ts
@@ -10,7 +10,7 @@ import { RateLimitError } from '../utils/rate-limiter';
 // handling, headers, availability) is exercised in isolation; the real service
 // is pulled in via vi.importActual for the render smoke test at the end.
 vi.mock('../services/board-render', () => ({
-  isBoardRendererAvailable: vi.fn(() => true),
+  ensureBoardRendererAvailable: vi.fn(async () => true),
   renderOgClimb: vi.fn(),
   initBoardRenderer: vi.fn(),
 }));
@@ -19,7 +19,7 @@ vi.mock('../utils/redis-rate-limiter', () => ({
 }));
 
 import { handleOgClimb } from '../handlers/og-climb';
-import { isBoardRendererAvailable, renderOgClimb } from '../services/board-render';
+import { ensureBoardRendererAvailable, renderOgClimb } from '../services/board-render';
 import { checkRateLimitRedis } from '../utils/redis-rate-limiter';
 
 type MockRes = {
@@ -80,7 +80,7 @@ async function run(params: Record<string, string>): Promise<MockRes> {
 describe('handleOgClimb', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(isBoardRendererAvailable).mockReturnValue(true);
+    vi.mocked(ensureBoardRendererAvailable).mockResolvedValue(true);
     vi.mocked(checkRateLimitRedis).mockResolvedValue(undefined);
     vi.mocked(renderOgClimb).mockResolvedValue({
       buffer: Buffer.from([0xff, 0xd8, 0xff, 0x00]),
@@ -135,9 +135,20 @@ describe('handleOgClimb', () => {
 
   describe('availability', () => {
     it('returns 503 when the renderer is unavailable, without rendering', async () => {
-      vi.mocked(isBoardRendererAvailable).mockReturnValue(false);
+      vi.mocked(ensureBoardRendererAvailable).mockResolvedValue(false);
       const res = await run(validParams);
       expect(res.statusCode).toBe(503);
+      expect(renderOgClimb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('CORS preflight', () => {
+    it('short-circuits OPTIONS before rate limiting and rendering', async () => {
+      const { req, url } = makeRequest(validParams, 'OPTIONS');
+      const res = makeResponse();
+      await handleOgClimb(req, res as unknown as ServerResponse, url);
+      expect(res.statusCode).toBe(200);
+      expect(checkRateLimitRedis).not.toHaveBeenCalled();
       expect(renderOgClimb).not.toHaveBeenCalled();
     });
   });
@@ -192,7 +203,7 @@ describe('renderOgClimb (real render)', () => {
     const service = await vi.importActual<typeof import('../services/board-render')>('../services/board-render');
 
     await service.initBoardRenderer();
-    expect(service.isBoardRendererAvailable()).toBe(true);
+    expect(await service.ensureBoardRendererAvailable()).toBe(true);
 
     const params = {
       boardName: 'kilter',
@@ -220,5 +231,14 @@ describe('renderOgClimb (real render)', () => {
     expect(second.cache).toBe('hit');
     expect(second.timings.wasmMs).toBe(0);
     expect(second.buffer).toBe(first.buffer);
+
+    // Concurrent requests for the same uncached climb coalesce into a single
+    // render: both callers resolve to the exact same result object.
+    const uncachedParams = { ...params, frames: 'p1096r15p1234r12' };
+    const [concurrentFirst, concurrentSecond] = await Promise.all([
+      service.renderOgClimb(uncachedParams),
+      service.renderOgClimb(uncachedParams),
+    ]);
+    expect(concurrentSecond).toBe(concurrentFirst);
   }, 30_000);
 });

--- a/packages/backend/src/__tests__/og-climb.test.ts
+++ b/packages/backend/src/__tests__/og-climb.test.ts
@@ -1,0 +1,224 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import sharp from 'sharp';
+import { RateLimitError } from '../utils/rate-limiter';
+
+// The handler under test talks to the board-render service and the Redis rate
+// limiter. Both are mocked so the handler's own logic (validation, rate-limit
+// handling, headers, availability) is exercised in isolation; the real service
+// is pulled in via vi.importActual for the render smoke test at the end.
+vi.mock('../services/board-render', () => ({
+  isBoardRendererAvailable: vi.fn(() => true),
+  renderOgClimb: vi.fn(),
+  initBoardRenderer: vi.fn(),
+}));
+vi.mock('../utils/redis-rate-limiter', () => ({
+  checkRateLimitRedis: vi.fn(async () => {}),
+}));
+
+import { handleOgClimb } from '../handlers/og-climb';
+import { isBoardRendererAvailable, renderOgClimb } from '../services/board-render';
+import { checkRateLimitRedis } from '../utils/redis-rate-limiter';
+
+type MockRes = {
+  statusCode: number;
+  body: string | Buffer;
+  headers: Record<string, unknown>;
+  writeHead: (status: number, headers?: Record<string, unknown>) => void;
+  end: (body?: string | Buffer) => void;
+  setHeader: (name: string, value: unknown) => void;
+};
+
+function makeResponse(): MockRes {
+  return {
+    statusCode: 0,
+    body: '',
+    headers: {},
+    writeHead(status, headers) {
+      this.statusCode = status;
+      if (headers) Object.assign(this.headers, headers);
+    },
+    end(body) {
+      if (body !== undefined) this.body = body;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+  };
+}
+
+function makeRequest(params: Record<string, string>, method = 'GET'): { req: IncomingMessage; url: URL } {
+  const url = new URL('http://localhost:8080/og/climb');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  const req = {
+    method,
+    headers: {},
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as IncomingMessage;
+  return { req, url };
+}
+
+const validParams = {
+  board_name: 'kilter',
+  layout_id: '1',
+  size_id: '10',
+  set_ids: '1,20',
+  frames: 'p1080r15p1202r12',
+};
+
+async function run(params: Record<string, string>): Promise<MockRes> {
+  const { req, url } = makeRequest(params);
+  const res = makeResponse();
+  await handleOgClimb(req, res as unknown as ServerResponse, url);
+  return res;
+}
+
+describe('handleOgClimb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isBoardRendererAvailable).mockReturnValue(true);
+    vi.mocked(checkRateLimitRedis).mockResolvedValue(undefined);
+    vi.mocked(renderOgClimb).mockResolvedValue({
+      buffer: Buffer.from([0xff, 0xd8, 0xff, 0x00]),
+      contentType: 'image/jpeg',
+      cache: 'miss',
+      timings: { wasmMs: 12, baseMs: 8, encodeMs: 4 },
+    });
+  });
+
+  describe('validation (before any render work)', () => {
+    it('rejects an invalid board_name with 400 and never renders', async () => {
+      const res = await run({ ...validParams, board_name: 'evil' });
+      expect(res.statusCode).toBe(400);
+      expect(renderOgClimb).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing board_name with 400', async () => {
+      const { board_name: _omit, ...params } = validParams;
+      const res = await run(params);
+      expect(res.statusCode).toBe(400);
+      expect(renderOgClimb).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-numeric set_ids with 400', async () => {
+      const res = await run({ ...validParams, set_ids: '1,a' });
+      expect(res.statusCode).toBe(400);
+      expect(renderOgClimb).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed frames with 400', async () => {
+      const res = await run({ ...validParams, frames: 'p1073r42<script>' });
+      expect(res.statusCode).toBe(400);
+      expect(renderOgClimb).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown format with 400', async () => {
+      const res = await run({ ...validParams, format: 'gif' });
+      expect(res.statusCode).toBe(400);
+      expect(renderOgClimb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('returns 429 with Retry-After when the limiter throws, without rendering', async () => {
+      vi.mocked(checkRateLimitRedis).mockRejectedValueOnce(new RateLimitError(30));
+      const res = await run(validParams);
+      expect(res.statusCode).toBe(429);
+      expect(res.headers['Retry-After']).toBe('30');
+      expect(renderOgClimb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('availability', () => {
+    it('returns 503 when the renderer is unavailable, without rendering', async () => {
+      vi.mocked(isBoardRendererAvailable).mockReturnValue(false);
+      const res = await run(validParams);
+      expect(res.statusCode).toBe(503);
+      expect(renderOgClimb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('success response', () => {
+    it('sends 200 with immutable cache headers, Content-Length, and nosniff', async () => {
+      const res = await run(validParams);
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['Content-Type']).toBe('image/jpeg');
+      expect(String(res.headers['Cache-Control'])).toContain('immutable');
+      expect(res.headers['Content-Length']).toBe(4);
+      expect(res.headers['X-Content-Type-Options']).toBe('nosniff');
+      expect(String(res.headers['Server-Timing'])).toContain('cache;desc=miss');
+    });
+
+    it('defaults to JPEG when no format is given', async () => {
+      await run(validParams);
+      expect(vi.mocked(renderOgClimb).mock.calls[0][0].format).toBe('jpeg');
+    });
+
+    it('honours an explicit png format', async () => {
+      await run({ ...validParams, format: 'png' });
+      expect(vi.mocked(renderOgClimb).mock.calls[0][0].format).toBe('png');
+    });
+
+    it('surfaces a byte-cache hit in Server-Timing', async () => {
+      vi.mocked(renderOgClimb).mockResolvedValueOnce({
+        buffer: Buffer.from([0xff, 0xd8, 0xff, 0x00]),
+        contentType: 'image/jpeg',
+        cache: 'hit',
+        timings: { wasmMs: 0, baseMs: 0, encodeMs: 0 },
+      });
+      const res = await run(validParams);
+      expect(res.statusCode).toBe(200);
+      expect(String(res.headers['Server-Timing'])).toContain('cache;desc=hit');
+    });
+
+    it('returns 500 when the renderer throws', async () => {
+      vi.mocked(renderOgClimb).mockRejectedValueOnce(new Error('boom'));
+      const res = await run(validParams);
+      expect(res.statusCode).toBe(500);
+    });
+  });
+});
+
+// Real render path: resolves the WASM binary from the workspace and uses real
+// sharp. Board photos come from packages/web/public if present; the render
+// succeeds (backdrop-only) even when they are not.
+describe('renderOgClimb (real render)', () => {
+  it('renders a 1200x630 JPEG and serves an identical second request from the byte cache', async () => {
+    process.env.BOARD_IMAGES_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../web/public');
+    const service = await vi.importActual<typeof import('../services/board-render')>('../services/board-render');
+
+    await service.initBoardRenderer();
+    expect(service.isBoardRendererAvailable()).toBe(true);
+
+    const params = {
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,20',
+      frames: 'p1080r15p1202r12',
+      format: 'jpeg' as const,
+    };
+
+    const first = await service.renderOgClimb(params);
+    expect(first.contentType).toBe('image/jpeg');
+    // JPEG magic bytes.
+    expect(first.buffer[0]).toBe(0xff);
+    expect(first.buffer[1]).toBe(0xd8);
+    expect(first.buffer[2]).toBe(0xff);
+
+    const metadata = await sharp(first.buffer).metadata();
+    expect(metadata.format).toBe('jpeg');
+    expect(metadata.width).toBe(1200);
+    expect(metadata.height).toBe(630);
+
+    // Second identical request is a byte-cache hit — no WASM render runs.
+    const second = await service.renderOgClimb(params);
+    expect(second.cache).toBe('hit');
+    expect(second.timings.wasmMs).toBe(0);
+    expect(second.buffer).toBe(first.buffer);
+  }, 30_000);
+});

--- a/packages/backend/src/handlers/og-climb.ts
+++ b/packages/backend/src/handlers/og-climb.ts
@@ -1,0 +1,124 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import {
+  createOgImageHeaders,
+  normalizeOutputFormat,
+  ogClimbQuerySchema,
+  type OutputFormat,
+} from '@boardsesh/board-render';
+import { applyCorsHeaders } from './cors';
+import { checkRateLimitRedis } from '../utils/redis-rate-limiter';
+import { RateLimitError } from '../utils/rate-limiter';
+import { isBoardRendererAvailable, renderOgClimb } from '../services/board-render';
+import { logger } from '../utils/logger';
+
+const RATE_LIMIT_MAX = 120;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const SLOW_RENDER_MS = 1000;
+
+/** Best-effort client IP for rate limiting. Prefers the proxy-forwarded IP. */
+function getClientIp(req: IncomingMessage): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  const firstHop = Array.isArray(forwarded) ? forwarded[0] : forwarded?.split(',')[0];
+  const realIp = req.headers['x-real-ip'];
+  return (
+    firstHop?.trim() || (Array.isArray(realIp) ? realIp[0] : realIp)?.trim() || req.socket.remoteAddress || 'unknown'
+  );
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+/**
+ * GET /og/climb — render a climb's Open Graph share card. Strict validation
+ * runs before any CPU-heavy work; the render is served from in-memory caches
+ * when possible. Returns an immutably cacheable JPEG (default), PNG, or WebP.
+ */
+export async function handleOgClimb(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+
+  // Validate BEFORE any render work — a bad request is cheap to reject and can't
+  // push this public CPU-heavy endpoint into wasted WASM/sharp renders.
+  const parsed = ogClimbQuerySchema.safeParse({
+    board_name: url.searchParams.get('board_name'),
+    layout_id: url.searchParams.get('layout_id'),
+    size_id: url.searchParams.get('size_id'),
+    set_ids: url.searchParams.get('set_ids'),
+    frames: url.searchParams.get('frames') ?? '',
+    format: url.searchParams.get('format') ?? undefined,
+  });
+  if (!parsed.success) {
+    sendJson(res, 400, { error: 'Invalid parameters', details: parsed.error.issues.map((issue) => issue.message) });
+    return;
+  }
+
+  // Per-IP rate limit. Fails open when Redis is unavailable (falls back to the
+  // in-memory limiter inside checkRateLimitRedis).
+  try {
+    await checkRateLimitRedis(getClientIp(req), 'og-climb', RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS);
+  } catch (error) {
+    if (error instanceof RateLimitError) {
+      res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': String(error.retryAfterSeconds) });
+      res.end(JSON.stringify({ error: 'Rate limit exceeded' }));
+      return;
+    }
+    throw error;
+  }
+
+  if (!isBoardRendererAvailable()) {
+    sendJson(res, 503, { error: 'Board renderer unavailable' });
+    return;
+  }
+
+  const query = parsed.data;
+  const format: OutputFormat = query.format ? (normalizeOutputFormat(query.format) ?? 'jpeg') : 'jpeg';
+
+  try {
+    const totalT0 = performance.now();
+    const { buffer, contentType, cache, timings } = await renderOgClimb({
+      boardName: query.board_name,
+      layoutId: query.layout_id,
+      sizeId: query.size_id,
+      setIds: query.set_ids,
+      frames: query.frames,
+      format,
+    });
+    const totalMs = performance.now() - totalT0;
+
+    const serverTiming = [
+      `total;dur=${totalMs.toFixed(1)}`,
+      `wasm;dur=${timings.wasmMs.toFixed(1)}`,
+      `base;dur=${timings.baseMs.toFixed(1)}`,
+      `encode;dur=${timings.encodeMs.toFixed(1)}`,
+      `cache;desc=${cache}`,
+    ].join(', ');
+
+    res.writeHead(200, {
+      ...createOgImageHeaders({ contentType, version: 'immutable', serverTiming }),
+      'Content-Length': buffer.length,
+      'X-Content-Type-Options': 'nosniff',
+    });
+    res.end(buffer);
+
+    const logPayload = {
+      boardName: query.board_name,
+      layoutId: query.layout_id,
+      sizeId: query.size_id,
+      cache,
+      totalMs: Math.round(totalMs),
+      wasmMs: Math.round(timings.wasmMs),
+      encodeMs: Math.round(timings.encodeMs),
+      bytes: buffer.length,
+      format,
+    };
+    if (totalMs > SLOW_RENDER_MS) {
+      logger.warn('[OGClimb] served (slow)', logPayload);
+    } else {
+      logger.info('[OGClimb] served', logPayload);
+    }
+  } catch (error) {
+    logger.error('[OGClimb] render failed:', error);
+    sendJson(res, 500, { error: 'Render failed' });
+  }
+}

--- a/packages/backend/src/handlers/og-climb.ts
+++ b/packages/backend/src/handlers/og-climb.ts
@@ -109,8 +109,15 @@ export async function handleOgClimb(req: IncomingMessage, res: ServerResponse, u
       `cache;desc=${cache}`,
     ].join(', ');
 
+    // The shared helper also emits Vercel-CDN-Cache-Control for the web route;
+    // that header is meaningless from this origin, so drop it.
+    const { 'Vercel-CDN-Cache-Control': _vercelOnlyHeader, ...ogImageHeaders } = createOgImageHeaders({
+      contentType,
+      version: 'immutable',
+      serverTiming,
+    });
     res.writeHead(200, {
-      ...createOgImageHeaders({ contentType, version: 'immutable', serverTiming }),
+      ...ogImageHeaders,
       'Content-Length': buffer.length,
       'X-Content-Type-Options': 'nosniff',
     });

--- a/packages/backend/src/handlers/og-climb.ts
+++ b/packages/backend/src/handlers/og-climb.ts
@@ -12,6 +12,11 @@ import { ensureBoardRendererAvailable, renderOgClimb } from '../services/board-r
 import { logger } from '../utils/logger';
 
 const RATE_LIMIT_MAX = 120;
+// Secondary bucket keyed by the TCP peer: on Railway that is the edge proxy,
+// so this acts as a high global ceiling that still caps abuse if the service
+// is ever reached through a proxy that forwards x-forwarded-for without
+// appending (which would let clients mint fresh per-IP buckets at will).
+const SOCKET_RATE_LIMIT_MAX = 600;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const SLOW_RENDER_MS = 1000;
 
@@ -56,10 +61,17 @@ export async function handleOgClimb(req: IncomingMessage, res: ServerResponse, u
     return;
   }
 
-  // Per-IP rate limit. Fails open when Redis is unavailable (falls back to the
-  // in-memory limiter inside checkRateLimitRedis).
+  // Per-IP rate limit plus a per-socket-peer ceiling (see SOCKET_RATE_LIMIT_MAX).
+  // Fails open when Redis is unavailable (falls back to the in-memory limiter
+  // inside checkRateLimitRedis).
   try {
     await checkRateLimitRedis(getClientIp(req), 'og-climb', RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS);
+    await checkRateLimitRedis(
+      req.socket.remoteAddress || 'unknown',
+      'og-climb-peer',
+      SOCKET_RATE_LIMIT_MAX,
+      RATE_LIMIT_WINDOW_MS,
+    );
   } catch (error) {
     if (error instanceof RateLimitError) {
       res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': String(error.retryAfterSeconds) });

--- a/packages/backend/src/handlers/og-climb.ts
+++ b/packages/backend/src/handlers/og-climb.ts
@@ -8,21 +8,24 @@ import {
 import { applyCorsHeaders } from './cors';
 import { checkRateLimitRedis } from '../utils/redis-rate-limiter';
 import { RateLimitError } from '../utils/rate-limiter';
-import { isBoardRendererAvailable, renderOgClimb } from '../services/board-render';
+import { ensureBoardRendererAvailable, renderOgClimb } from '../services/board-render';
 import { logger } from '../utils/logger';
 
 const RATE_LIMIT_MAX = 120;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const SLOW_RENDER_MS = 1000;
 
-/** Best-effort client IP for rate limiting. Prefers the proxy-forwarded IP. */
+/**
+ * Client IP for rate limiting. Uses the LAST x-forwarded-for entry: the edge
+ * proxy (Railway) appends the IP it observed, while earlier entries are
+ * client-supplied and spoofable — trusting the first hop would let a client
+ * mint a fresh identity per request and bypass the per-IP limit.
+ */
 function getClientIp(req: IncomingMessage): string {
   const forwarded = req.headers['x-forwarded-for'];
-  const firstHop = Array.isArray(forwarded) ? forwarded[0] : forwarded?.split(',')[0];
-  const realIp = req.headers['x-real-ip'];
-  return (
-    firstHop?.trim() || (Array.isArray(realIp) ? realIp[0] : realIp)?.trim() || req.socket.remoteAddress || 'unknown'
-  );
+  const forwardedChain = Array.isArray(forwarded) ? forwarded.join(',') : forwarded;
+  const lastHop = forwardedChain?.split(',').at(-1)?.trim();
+  return lastHop || req.socket.remoteAddress || 'unknown';
 }
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
@@ -66,7 +69,7 @@ export async function handleOgClimb(req: IncomingMessage, res: ServerResponse, u
     throw error;
   }
 
-  if (!isBoardRendererAvailable()) {
+  if (!(await ensureBoardRendererAvailable())) {
     sendJson(res, 503, { error: 'Board renderer unavailable' });
     return;
   }

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -12,6 +12,8 @@ import { handleSessionJoin } from './handlers/join';
 import { handleAvatarUpload } from './handlers/avatars';
 import { handleGymLogoUpload } from './handlers/gym-logos';
 import { handleStaticAvatar, handleStaticBetaThumbnail, handleStaticGymLogo } from './handlers/static';
+import { handleOgClimb } from './handlers/og-climb';
+import { initBoardRenderer } from './services/board-render';
 import { parseSizeParam } from './lib/image-resize';
 import { handleOcrTestDataUpload } from './handlers/ocr-test-data';
 import { handlePosthogProxy } from './handlers/posthog';
@@ -97,6 +99,10 @@ export async function startServer(): Promise<ServerResources> {
   // Initialize PubSub (connects to Redis if configured)
   // This must happen before we start accepting connections
   await pubsub.initialize();
+
+  // Initialize the OG climb renderer (loads the WASM overlay module + resolves
+  // the board images root). Never throws — on failure GET /og/climb returns 503.
+  await initBoardRenderer();
 
   // Wire the durable seq-floor lookup for board-presence's dormancy reseed
   // (A3) — pubsub stays DB-free at import time, but the running server needs
@@ -315,6 +321,13 @@ export async function startServer(): Promise<ServerResources> {
       // Health check endpoint
       if (pathname === '/health' && req.method === 'GET') {
         await handleHealthCheck(req, res);
+        return;
+      }
+
+      // Climb Open Graph share-card renderer (moved off Vercel; long-running
+      // process warms WASM + caches rendered bytes in memory).
+      if (pathname === '/og/climb' && (req.method === 'GET' || req.method === 'OPTIONS')) {
+        await handleOgClimb(req, res, url);
         return;
       }
 

--- a/packages/backend/src/services/board-render.ts
+++ b/packages/backend/src/services/board-render.ts
@@ -10,13 +10,15 @@ import type { BoardName } from '@boardsesh/shared-schema';
 import { logger } from '../utils/logger';
 
 /**
- * Default board configs used to warm the OG base cache at boot. Copied from
- * web's FALLBACK_BOARD_PREVIEW_CONFIGS (not imported — the backend must not
- * depend on packages/web).
+ * Default board configs used to warm the OG base cache at boot. Mirrors web's
+ * FALLBACK_BOARD_PREVIEW_CONFIGS (not imported — the backend must not depend
+ * on packages/web) plus a MoonBoard 2016 entry so every supported board gets a
+ * warm base.
  */
 const FALLBACK_BOARD_PREVIEW_CONFIGS: Record<string, { layout_id: number; size_id: number; set_ids: number[] }> = {
   kilter: { layout_id: 1, size_id: 10, set_ids: [1, 20] },
   tension: { layout_id: 1, size_id: 10, set_ids: [1] },
+  moonboard: { layout_id: 2, size_id: 1, set_ids: [2, 3, 4] },
   decoy: { layout_id: 2, size_id: 1, set_ids: [1, 2] },
   touchstone: { layout_id: 1, size_id: 1, set_ids: [1] },
   grasshopper: { layout_id: 1, size_id: 4, set_ids: [1, 2] },
@@ -36,15 +38,24 @@ const byteCache = new BoundedLru<{ buffer: Buffer; contentType: string }>({
 
 // Pre-composited OG backdrop + board photos (raw RGBA), keyed by board config.
 // Every climb on the same board reuses it, so only the cheap overlay composite
-// + encode runs per climb. Entry-bounded (each base is ~3 MB raw).
+// + encode runs per climb. Entry-bounded (each base is ~3 MB raw), so no byte
+// budget applies.
 const baseCache = new BoundedLru<OgBaseResult>({
   maxEntries: OG_BASE_CACHE_ENTRIES,
-  maxBytes: Number.MAX_SAFE_INTEGER,
+  maxBytes: Infinity,
   sizeOf: (value) => value.base.length,
 });
 
+// Coalesces concurrent requests for the same uncached climb into one render —
+// simultaneous crawler fetches (FB + Twitter + WhatsApp) must not each pay
+// WASM + sharp for identical bytes.
+const inFlightRenders = new Map<string, Promise<OgClimbRenderResult>>();
+
+const INIT_RETRY_INTERVAL_MS = 30_000;
+
 let overlayRenderer: OverlayRenderer | null = null;
 let rendererAvailable = false;
+let lastInitAttemptAtMs = 0;
 let imagesRoot = '';
 
 function resolveImagePath(relPath: string): string | null {
@@ -59,6 +70,7 @@ function resolveImagePath(relPath: string): string | null {
  * 503) — this never throws, so a missing asset can't crash the server.
  */
 export async function initBoardRenderer(): Promise<void> {
+  lastInitAttemptAtMs = Date.now();
   try {
     const require = createRequire(import.meta.url);
     const wasmJsPath = require.resolve('@boardsesh/board-renderer-wasm');
@@ -89,7 +101,16 @@ export async function initBoardRenderer(): Promise<void> {
   }
 }
 
-export function isBoardRendererAvailable(): boolean {
+/**
+ * True when the renderer is ready. When boot-time init failed (e.g. a transient
+ * I/O error), re-attempts init at most once per INIT_RETRY_INTERVAL_MS so the
+ * endpoint recovers without a process restart.
+ */
+export async function ensureBoardRendererAvailable(): Promise<boolean> {
+  if (rendererAvailable) return true;
+  if (Date.now() - lastInitAttemptAtMs >= INIT_RETRY_INTERVAL_MS) {
+    await initBoardRenderer();
+  }
   return rendererAvailable;
 }
 
@@ -128,9 +149,27 @@ export async function renderOgClimb(params: OgClimbRenderParams): Promise<OgClim
     throw new Error('Board renderer is not initialised');
   }
 
-  const cached = byteCache.get(byteCacheKey(params));
+  const cacheKey = byteCacheKey(params);
+  const cached = byteCache.get(cacheKey);
   if (cached) {
     return { ...cached, cache: 'hit', timings: { wasmMs: 0, baseMs: 0, encodeMs: 0 } };
+  }
+
+  const inFlight = inFlightRenders.get(cacheKey);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const renderPromise = renderOgClimbUncached(params, cacheKey).finally(() => {
+    inFlightRenders.delete(cacheKey);
+  });
+  inFlightRenders.set(cacheKey, renderPromise);
+  return renderPromise;
+}
+
+async function renderOgClimbUncached(params: OgClimbRenderParams, cacheKey: string): Promise<OgClimbRenderResult> {
+  if (!overlayRenderer) {
+    throw new Error('Board renderer is not initialised');
   }
 
   const parsedSetIds = params.setIds
@@ -186,7 +225,7 @@ export async function renderOgClimb(params: OgClimbRenderParams): Promise<OgClim
   });
   const encodeMs = performance.now() - encodeT0;
 
-  byteCache.set(byteCacheKey(params), { buffer, contentType });
+  byteCache.set(cacheKey, { buffer, contentType });
 
   return { buffer, contentType, cache, timings: { wasmMs, baseMs, encodeMs } };
 }

--- a/packages/backend/src/services/board-render.ts
+++ b/packages/backend/src/services/board-render.ts
@@ -135,8 +135,8 @@ function byteCacheKey(params: OgClimbRenderParams): string {
   return `${params.boardName}:${params.layoutId}:${params.sizeId}:${params.setIds}:${params.frames}:${params.format}`;
 }
 
-function baseCacheKey(params: OgClimbRenderParams): string {
-  return `${params.boardName}:${params.layoutId}:${params.sizeId}:${params.setIds}`;
+function baseCacheKey(boardName: string, layoutId: number, sizeId: number, setIds: string): string {
+  return `${boardName}:${layoutId}:${sizeId}:${setIds}`;
 }
 
 /**
@@ -177,6 +177,11 @@ async function renderOgClimbUncached(params: OgClimbRenderParams, cacheKey: stri
     .map(Number)
     .filter((setId) => !Number.isNaN(setId));
 
+  const boardStates = HOLD_STATE_MAP[params.boardName as BoardName];
+  if (!boardStates) {
+    throw new Error(`No hold states defined for board ${params.boardName}`);
+  }
+
   const boardDetails = getBoardDetailsForBoard({
     board_name: params.boardName,
     layout_id: params.layoutId,
@@ -190,14 +195,14 @@ async function renderOgClimbUncached(params: OgClimbRenderParams, cacheKey: stri
     frames: params.frames,
     thumbnail: false,
     isOgVariant: true,
-    boardStates: HOLD_STATE_MAP[params.boardName as BoardName],
+    boardStates,
   });
 
   const wasmT0 = performance.now();
   const overlay = await overlayRenderer.render(JSON.stringify(config));
   const wasmMs = performance.now() - wasmT0;
 
-  const baseKey = baseCacheKey(params);
+  const baseKey = baseCacheKey(params.boardName, params.layoutId, params.sizeId, params.setIds);
   let base = baseCache.get(baseKey);
   let cache: OgClimbRenderResult['cache'];
   let baseMs = 0;
@@ -232,22 +237,60 @@ async function renderOgClimbUncached(params: OgClimbRenderParams, cacheKey: stri
 
 /**
  * Non-blocking warm of the fallback board bases so the first real crawler fetch
- * for a common board is a cheap base-hit. Failures are logged, never thrown.
+ * for a common board is a cheap base-hit. Composes bases directly into the base
+ * cache — no byte-cache entries, which real requests could never hit (the
+ * handler requires non-empty frames). Failures are logged, never thrown.
  */
 async function warmFallbackBoardPreviews(): Promise<void> {
-  for (const [boardName, config] of Object.entries(FALLBACK_BOARD_PREVIEW_CONFIGS)) {
-    try {
-      await renderOgClimb({
-        boardName,
-        layoutId: config.layout_id,
-        sizeId: config.size_id,
-        setIds: config.set_ids.join(','),
-        frames: '',
-        format: 'jpeg',
-      });
-    } catch (error) {
-      logger.warn(`[OGClimb] Warm-up failed for ${boardName}:`, error instanceof Error ? error.message : error);
-    }
-  }
+  await Promise.allSettled(
+    Object.entries(FALLBACK_BOARD_PREVIEW_CONFIGS).map(async ([boardName, config]) => {
+      try {
+        await warmBoardBase(boardName, config);
+      } catch (error) {
+        logger.warn(`[OGClimb] Warm-up failed for ${boardName}:`, error instanceof Error ? error.message : error);
+      }
+    }),
+  );
   logger.info('[OGClimb] Fallback board preview warm-up complete');
+}
+
+async function warmBoardBase(
+  boardName: string,
+  config: { layout_id: number; size_id: number; set_ids: number[] },
+): Promise<void> {
+  if (!overlayRenderer) return;
+
+  const setIds = config.set_ids.join(',');
+  const baseKey = baseCacheKey(boardName, config.layout_id, config.size_id, setIds);
+  if (baseCache.has(baseKey)) return;
+
+  const boardStates = HOLD_STATE_MAP[boardName as BoardName];
+  if (!boardStates) return;
+
+  const boardDetails = getBoardDetailsForBoard({
+    board_name: boardName,
+    layout_id: config.layout_id,
+    size_id: config.size_id,
+    set_ids: config.set_ids,
+  });
+
+  // An empty-frames overlay render is the cheap way to learn the board's
+  // output dimensions, which the base composite is sized to.
+  const { config: renderConfig } = buildRenderConfig({
+    boardName,
+    boardDetails,
+    frames: '',
+    thumbnail: false,
+    isOgVariant: true,
+    boardStates,
+  });
+  const overlay = await overlayRenderer.render(JSON.stringify(renderConfig));
+
+  const base = await composeOgBaseBuffer({
+    boardDetails,
+    boardWidth: overlay.width,
+    boardHeight: overlay.height,
+    resolveImagePath,
+  });
+  baseCache.set(baseKey, base);
 }

--- a/packages/backend/src/services/board-render.ts
+++ b/packages/backend/src/services/board-render.ts
@@ -1,0 +1,214 @@
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { HOLD_STATE_MAP } from '@boardsesh/board-constants/hold-states';
+import { BoundedLru, buildRenderConfig, getBoardDetailsForBoard, type OutputFormat } from '@boardsesh/board-render';
+import { composeOgBaseBuffer, encodeOgImage, type OgBaseResult } from '@boardsesh/board-render/pipeline';
+import { createOverlayRenderer, type OverlayRenderer } from '@boardsesh/board-render/wasm';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { logger } from '../utils/logger';
+
+/**
+ * Default board configs used to warm the OG base cache at boot. Copied from
+ * web's FALLBACK_BOARD_PREVIEW_CONFIGS (not imported — the backend must not
+ * depend on packages/web).
+ */
+const FALLBACK_BOARD_PREVIEW_CONFIGS: Record<string, { layout_id: number; size_id: number; set_ids: number[] }> = {
+  kilter: { layout_id: 1, size_id: 10, set_ids: [1, 20] },
+  tension: { layout_id: 1, size_id: 10, set_ids: [1] },
+  decoy: { layout_id: 2, size_id: 1, set_ids: [1, 2] },
+  touchstone: { layout_id: 1, size_id: 1, set_ids: [1] },
+  grasshopper: { layout_id: 1, size_id: 4, set_ids: [1, 2] },
+  soill: { layout_id: 1, size_id: 1, set_ids: [1] },
+};
+
+const OG_BYTE_CACHE_MB = Number(process.env.OG_BYTE_CACHE_MB) || 32;
+const OG_BASE_CACHE_ENTRIES = Number(process.env.OG_BASE_CACHE_ENTRIES) || 24;
+
+// Final encoded bytes, keyed by the full canonical param string. Bytes-budgeted
+// so a burst of unique climbs can't grow memory without bound.
+const byteCache = new BoundedLru<{ buffer: Buffer; contentType: string }>({
+  maxEntries: 10_000,
+  maxBytes: OG_BYTE_CACHE_MB * 1024 * 1024,
+  sizeOf: (value) => value.buffer.length,
+});
+
+// Pre-composited OG backdrop + board photos (raw RGBA), keyed by board config.
+// Every climb on the same board reuses it, so only the cheap overlay composite
+// + encode runs per climb. Entry-bounded (each base is ~3 MB raw).
+const baseCache = new BoundedLru<OgBaseResult>({
+  maxEntries: OG_BASE_CACHE_ENTRIES,
+  maxBytes: Number.MAX_SAFE_INTEGER,
+  sizeOf: (value) => value.base.length,
+});
+
+let overlayRenderer: OverlayRenderer | null = null;
+let rendererAvailable = false;
+let imagesRoot = '';
+
+function resolveImagePath(relPath: string): string | null {
+  const absolutePath = join(imagesRoot, relPath);
+  return existsSync(absolutePath) ? absolutePath : null;
+}
+
+/**
+ * Eagerly initialise the OG climb renderer at boot: resolve + load the WASM
+ * binary, initialise the shared overlay renderer, and locate the board images
+ * root. On any failure the renderer is marked unavailable (the endpoint returns
+ * 503) — this never throws, so a missing asset can't crash the server.
+ */
+export async function initBoardRenderer(): Promise<void> {
+  try {
+    const require = createRequire(import.meta.url);
+    const wasmJsPath = require.resolve('@boardsesh/board-renderer-wasm');
+    const wasmBinaryPath = join(dirname(wasmJsPath), 'board_renderer_wasm_bg.wasm');
+    if (!existsSync(wasmBinaryPath)) {
+      throw new Error(`WASM binary not found at ${wasmBinaryPath}`);
+    }
+
+    imagesRoot = process.env.BOARD_IMAGES_ROOT || resolve(process.cwd(), '../web/public');
+    const imagesDir = join(imagesRoot, 'images');
+    if (!existsSync(imagesDir)) {
+      logger.error(
+        `[OGClimb] Board images directory missing at ${imagesDir} — OG cards will render without board photos. ` +
+          'Set BOARD_IMAGES_ROOT to the directory that contains images/.',
+      );
+    }
+
+    overlayRenderer = createOverlayRenderer(async () => readFile(wasmBinaryPath));
+    await overlayRenderer.ensureInitialized();
+    rendererAvailable = true;
+    logger.info(`[OGClimb] Board renderer initialised (images root: ${imagesRoot})`);
+
+    // Warm the fallback board bases in the background — never block boot.
+    void warmFallbackBoardPreviews();
+  } catch (error) {
+    rendererAvailable = false;
+    logger.error('[OGClimb] Board renderer init failed — /og/climb will return 503:', error);
+  }
+}
+
+export function isBoardRendererAvailable(): boolean {
+  return rendererAvailable;
+}
+
+export type OgClimbRenderParams = {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  /** Canonical comma-separated set ids, e.g. "1,20". */
+  setIds: string;
+  frames: string;
+  format: OutputFormat;
+};
+
+export type OgClimbRenderResult = {
+  buffer: Buffer;
+  contentType: string;
+  cache: 'hit' | 'base-hit' | 'miss';
+  timings: { wasmMs: number; baseMs: number; encodeMs: number };
+};
+
+function byteCacheKey(params: OgClimbRenderParams): string {
+  return `${params.boardName}:${params.layoutId}:${params.sizeId}:${params.setIds}:${params.frames}:${params.format}`;
+}
+
+function baseCacheKey(params: OgClimbRenderParams): string {
+  return `${params.boardName}:${params.layoutId}:${params.sizeId}:${params.setIds}`;
+}
+
+/**
+ * Render a climb OG card. Serves from the final-bytes cache when possible,
+ * otherwise renders the WASM overlay, composites it onto a (cached or freshly
+ * built) OG base, encodes, and stores both caches.
+ */
+export async function renderOgClimb(params: OgClimbRenderParams): Promise<OgClimbRenderResult> {
+  if (!overlayRenderer) {
+    throw new Error('Board renderer is not initialised');
+  }
+
+  const cached = byteCache.get(byteCacheKey(params));
+  if (cached) {
+    return { ...cached, cache: 'hit', timings: { wasmMs: 0, baseMs: 0, encodeMs: 0 } };
+  }
+
+  const parsedSetIds = params.setIds
+    .split(',')
+    .map(Number)
+    .filter((setId) => !Number.isNaN(setId));
+
+  const boardDetails = getBoardDetailsForBoard({
+    board_name: params.boardName,
+    layout_id: params.layoutId,
+    size_id: params.sizeId,
+    set_ids: parsedSetIds,
+  });
+
+  const { config } = buildRenderConfig({
+    boardName: params.boardName,
+    boardDetails,
+    frames: params.frames,
+    thumbnail: false,
+    isOgVariant: true,
+    boardStates: HOLD_STATE_MAP[params.boardName as BoardName],
+  });
+
+  const wasmT0 = performance.now();
+  const overlay = await overlayRenderer.render(JSON.stringify(config));
+  const wasmMs = performance.now() - wasmT0;
+
+  const baseKey = baseCacheKey(params);
+  let base = baseCache.get(baseKey);
+  let cache: OgClimbRenderResult['cache'];
+  let baseMs = 0;
+  if (base) {
+    cache = 'base-hit';
+  } else {
+    const baseT0 = performance.now();
+    base = await composeOgBaseBuffer({
+      boardDetails,
+      boardWidth: overlay.width,
+      boardHeight: overlay.height,
+      resolveImagePath,
+    });
+    baseMs = performance.now() - baseT0;
+    baseCache.set(baseKey, base);
+    cache = 'miss';
+  }
+
+  const overlayBuffer = Buffer.from(overlay.rgba.buffer, overlay.rgba.byteOffset, overlay.rgba.byteLength);
+  const encodeT0 = performance.now();
+  const { buffer, contentType } = await encodeOgImage({
+    base: base.base,
+    overlay: { buffer: overlayBuffer, width: overlay.width, height: overlay.height, left: base.left, top: base.top },
+    format: params.format,
+  });
+  const encodeMs = performance.now() - encodeT0;
+
+  byteCache.set(byteCacheKey(params), { buffer, contentType });
+
+  return { buffer, contentType, cache, timings: { wasmMs, baseMs, encodeMs } };
+}
+
+/**
+ * Non-blocking warm of the fallback board bases so the first real crawler fetch
+ * for a common board is a cheap base-hit. Failures are logged, never thrown.
+ */
+async function warmFallbackBoardPreviews(): Promise<void> {
+  for (const [boardName, config] of Object.entries(FALLBACK_BOARD_PREVIEW_CONFIGS)) {
+    try {
+      await renderOgClimb({
+        boardName,
+        layoutId: config.layout_id,
+        sizeId: config.size_id,
+        setIds: config.set_ids.join(','),
+        frames: '',
+        format: 'jpeg',
+      });
+    } catch (error) {
+      logger.warn(`[OGClimb] Warm-up failed for ${boardName}:`, error instanceof Error ? error.message : error);
+    }
+  }
+  logger.info('[OGClimb] Fallback board preview warm-up complete');
+}

--- a/packages/crypto/src/__tests__/crypto.test.ts
+++ b/packages/crypto/src/__tests__/crypto.test.ts
@@ -43,8 +43,12 @@ describe('encrypt and decrypt', () => {
 
   it('throws on tampered ciphertext', () => {
     const encrypted = encrypt('test');
-    // Modify the last character to corrupt the auth tag
-    const tampered = encrypted.slice(0, -1) + 'X';
+    // Flip the bits of the final ciphertext byte to corrupt the auth tag.
+    // (Replacing the last base64 character was flaky: the replacement could
+    // equal the original, or differ only in base64's unused trailing bits.)
+    const tamperedBytes = Buffer.from(encrypted, 'base64');
+    tamperedBytes[tamperedBytes.length - 1] ^= 0xff;
+    const tampered = tamperedBytes.toString('base64');
     expect(() => decrypt(tampered)).toThrow();
   });
 

--- a/packages/shared/board-render/package.json
+++ b/packages/shared/board-render/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@boardsesh/board-render",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./pipeline": {
+      "types": "./src/pipeline.ts",
+      "import": "./src/pipeline.ts",
+      "default": "./src/pipeline.ts"
+    },
+    "./wasm": {
+      "types": "./src/wasm.ts",
+      "import": "./src/wasm.ts",
+      "default": "./src/wasm.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@boardsesh/board-config": "*",
+    "@boardsesh/board-constants": "*",
+    "@boardsesh/board-renderer-wasm": "*",
+    "@boardsesh/play-view": "*",
+    "@boardsesh/shared-schema": "*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.3",
+    "sharp": "^0.34.5",
+    "typescript": "~6.0.3"
+  },
+  "peerDependencies": {
+    "sharp": "^0.34.5"
+  }
+}

--- a/packages/shared/board-render/src/__tests__/background.test.ts
+++ b/packages/shared/board-render/src/__tests__/background.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { createOgBackgroundBuffer, getBackgroundRelPaths, toWebpPath } from '../background';
+
+describe('toWebpPath', () => {
+  it('rewrites a .png filename to .webp under the given dir', () => {
+    expect(toWebpPath('images/kilter', 'product_sizes_layouts_sets/36-1.png', false)).toBe(
+      'images/kilter/product_sizes_layouts_sets/36-1.webp',
+    );
+  });
+
+  it('inserts /thumbs/ before the filename for thumbnails', () => {
+    expect(toWebpPath('images/kilter', 'product_sizes_layouts_sets/36-1.png', true)).toBe(
+      'images/kilter/product_sizes_layouts_sets/thumbs/36-1.webp',
+    );
+  });
+
+  it('inserts thumbs at the top level when the filename has no directory', () => {
+    expect(toWebpPath('images/moonboard', 'background.png', true)).toBe('images/moonboard/thumbs/background.webp');
+  });
+});
+
+describe('getBackgroundRelPaths', () => {
+  it('builds Aurora paths from images_to_holds keys', () => {
+    const paths = getBackgroundRelPaths(
+      {
+        board_name: 'kilter',
+        images_to_holds: { 'product_sizes_layouts_sets/36-1.png': [], 'product_sizes_layouts_sets/36-20.png': [] },
+      },
+      false,
+    );
+    expect(paths).toEqual([
+      'images/kilter/product_sizes_layouts_sets/36-1.webp',
+      'images/kilter/product_sizes_layouts_sets/36-20.webp',
+    ]);
+  });
+
+  it('builds thumbnail Aurora paths', () => {
+    const paths = getBackgroundRelPaths({ board_name: 'tension', images_to_holds: { 'a/1.png': [] } }, true);
+    expect(paths).toEqual(['images/tension/a/thumbs/1.webp']);
+  });
+
+  it('falls back to layoutFolder + holdSetImages when images_to_holds is empty (MoonBoard)', () => {
+    const paths = getBackgroundRelPaths(
+      {
+        board_name: 'moonboard',
+        images_to_holds: {},
+        layoutFolder: 'moonboard2024',
+        holdSetImages: ['holdsetd.png', 'holdsete.png'],
+      },
+      false,
+    );
+    // First entry is the layout's background image, then each hold-set image.
+    expect(paths).toHaveLength(3);
+    expect(paths[0]).toMatch(/^images\/moonboard\/.+\.webp$/);
+    expect(paths[1]).toBe('images/moonboard/moonboard2024/holdsetd.webp');
+    expect(paths[2]).toBe('images/moonboard/moonboard2024/holdsete.webp');
+  });
+
+  it('returns an empty list when there are no keys and no MoonBoard fallback', () => {
+    expect(getBackgroundRelPaths({ board_name: 'kilter', images_to_holds: {} }, false)).toEqual([]);
+  });
+});
+
+describe('createOgBackgroundBuffer', () => {
+  it('emits a deterministic 1200x630 SVG for the same board dimensions', () => {
+    const first = createOgBackgroundBuffer(900, 500).toString('utf8');
+    const second = createOgBackgroundBuffer(900, 500).toString('utf8');
+    expect(first).toBe(second);
+    expect(first).toContain('width="1200" height="630"');
+  });
+
+  it('centres the framed board region', () => {
+    const svg = createOgBackgroundBuffer(800, 400).toString('utf8');
+    // board 800 wide on a 1200 canvas → boardX = 200, frameX = 184.
+    expect(svg).toContain('x="184"');
+  });
+});

--- a/packages/shared/board-render/src/__tests__/board-details.test.ts
+++ b/packages/shared/board-render/src/__tests__/board-details.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { getBoardDetails, getBoardDetailsForBoard } from '../board-details';
+
+describe('getBoardDetails (Kilter)', () => {
+  const details = getBoardDetails({ board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 20] });
+
+  it('resolves positive board dimensions', () => {
+    expect(details.boardWidth).toBeGreaterThan(0);
+    expect(details.boardHeight).toBeGreaterThan(0);
+  });
+
+  it('maps one image per requested set', () => {
+    expect(Object.keys(details.images_to_holds)).toHaveLength(2);
+  });
+
+  it('computes hold placements inside the board edges', () => {
+    expect(details.holdsData.length).toBeGreaterThan(0);
+    for (const hold of details.holdsData) {
+      expect(hold.cx).toBeGreaterThanOrEqual(0);
+      expect(hold.cx).toBeLessThanOrEqual(details.boardWidth);
+      expect(hold.cy).toBeGreaterThanOrEqual(0);
+      expect(hold.cy).toBeLessThanOrEqual(details.boardHeight);
+    }
+  });
+
+  it('carries board identity and metadata through', () => {
+    expect(details.board_name).toBe('kilter');
+    expect(details.layout_id).toBe(1);
+    expect(details.size_id).toBe(10);
+    expect(details.set_ids).toEqual([1, 20]);
+    expect(typeof details.size_name).toBe('string');
+  });
+
+  it('throws for a size that does not exist', () => {
+    expect(() => getBoardDetails({ board_name: 'kilter', layout_id: 1, size_id: 999999, set_ids: [1] })).toThrow();
+  });
+});
+
+describe('getBoardDetailsForBoard (MoonBoard)', () => {
+  const details = getBoardDetailsForBoard({ board_name: 'moonboard', layout_id: 3, size_id: 0, set_ids: [5, 6] });
+
+  it('routes MoonBoard to the grid-based details', () => {
+    expect(details.board_name).toBe('moonboard');
+    expect(details.layoutFolder).toBe('moonboard2024');
+    expect(details.holdSetImages).toEqual(['holdsetd.png', 'holdsete.png']);
+  });
+
+  it('resolves positive geometry and grid holds', () => {
+    expect(details.boardWidth).toBeGreaterThan(0);
+    expect(details.boardHeight).toBeGreaterThan(0);
+    expect(details.holdsData.length).toBeGreaterThan(0);
+  });
+
+  it('keys images_to_holds by background + hold-set images', () => {
+    const keys = Object.keys(details.images_to_holds);
+    // Background image plus one entry per selected set.
+    expect(keys.length).toBe(3);
+  });
+});
+
+describe('getBoardDetailsForBoard (Aurora)', () => {
+  it('delegates non-MoonBoard boards to getBoardDetails', () => {
+    const viaForBoard = getBoardDetailsForBoard({ board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 20] });
+    const direct = getBoardDetails({ board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 20] });
+    expect(viaForBoard.boardWidth).toBe(direct.boardWidth);
+    expect(viaForBoard.boardHeight).toBe(direct.boardHeight);
+    expect(Object.keys(viaForBoard.images_to_holds)).toEqual(Object.keys(direct.images_to_holds));
+  });
+});

--- a/packages/shared/board-render/src/__tests__/lru.test.ts
+++ b/packages/shared/board-render/src/__tests__/lru.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { BoundedLru } from '../lru';
+
+const byteLru = (maxEntries: number, maxBytes: number) =>
+  new BoundedLru<Buffer>({ maxEntries, maxBytes, sizeOf: (buffer) => buffer.byteLength });
+
+describe('BoundedLru', () => {
+  it('evicts the oldest entry when maxEntries is exceeded', () => {
+    const cache = byteLru(2, 1_000);
+    cache.set('first', Buffer.alloc(1));
+    cache.set('second', Buffer.alloc(1));
+    cache.set('third', Buffer.alloc(1));
+
+    expect(cache.size).toBe(2);
+    expect(cache.has('first')).toBe(false);
+    expect(cache.has('second')).toBe(true);
+    expect(cache.has('third')).toBe(true);
+  });
+
+  it('evicts by byte budget even when under the entry limit', () => {
+    const cache = byteLru(10, 100);
+    cache.set('first', Buffer.alloc(60));
+    cache.set('second', Buffer.alloc(60));
+
+    expect(cache.has('first')).toBe(false);
+    expect(cache.has('second')).toBe(true);
+    expect(cache.byteSize).toBe(60);
+  });
+
+  it('re-accounts bytes when overwriting an existing key', () => {
+    const cache = byteLru(10, 100);
+    cache.set('key', Buffer.alloc(80));
+    cache.set('key', Buffer.alloc(30));
+
+    expect(cache.size).toBe(1);
+    expect(cache.byteSize).toBe(30);
+
+    // The freed budget must be reusable without evicting the overwritten key.
+    cache.set('other', Buffer.alloc(60));
+    expect(cache.has('key')).toBe(true);
+    expect(cache.has('other')).toBe(true);
+    expect(cache.byteSize).toBe(90);
+  });
+
+  it('get marks an entry as most-recently-used', () => {
+    const cache = byteLru(2, 1_000);
+    cache.set('first', Buffer.alloc(1));
+    cache.set('second', Buffer.alloc(1));
+
+    expect(cache.get('first')).toBeDefined();
+    cache.set('third', Buffer.alloc(1));
+
+    expect(cache.has('first')).toBe(true);
+    expect(cache.has('second')).toBe(false);
+    expect(cache.has('third')).toBe(true);
+  });
+
+  it('immediately evicts a single entry larger than the byte budget', () => {
+    const cache = byteLru(10, 100);
+    cache.set('huge', Buffer.alloc(200));
+
+    expect(cache.size).toBe(0);
+    expect(cache.byteSize).toBe(0);
+    expect(cache.get('huge')).toBeUndefined();
+  });
+
+  it('returns undefined for missing keys and tracks sizes accurately across evictions', () => {
+    const cache = byteLru(3, 100);
+    expect(cache.get('missing')).toBeUndefined();
+
+    cache.set('first', Buffer.alloc(40));
+    cache.set('second', Buffer.alloc(40));
+    cache.set('third', Buffer.alloc(40));
+
+    expect(cache.size).toBe(2);
+    expect(cache.byteSize).toBe(80);
+  });
+});

--- a/packages/shared/board-render/src/__tests__/validation.test.ts
+++ b/packages/shared/board-render/src/__tests__/validation.test.ts
@@ -97,8 +97,8 @@ describe('ogClimbQuerySchema', () => {
     expect(parsed.frames).toBe('p1080r15p1202r12');
   });
 
-  it('accepts an empty frames string', () => {
-    expect(ogClimbQuerySchema.parse({ ...valid, frames: '' }).frames).toBe('');
+  it('rejects an empty frames string (a blank board must not be cacheable as a climb card)', () => {
+    expect(ogClimbQuerySchema.safeParse({ ...valid, frames: '' }).success).toBe(false);
   });
 
   it('accepts a single set id', () => {

--- a/packages/shared/board-render/src/__tests__/validation.test.ts
+++ b/packages/shared/board-render/src/__tests__/validation.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidFrameSegment,
+  isValidFramesString,
+  normalizeOutputFormat,
+  ogClimbQuerySchema,
+  VALID_BOARD_NAMES,
+  MAX_FRAMES_LENGTH,
+} from '../validation';
+
+describe('normalizeOutputFormat', () => {
+  it('maps jpg to jpeg', () => {
+    expect(normalizeOutputFormat('jpg')).toBe('jpeg');
+  });
+
+  it('passes through webp, png, jpeg', () => {
+    expect(normalizeOutputFormat('webp')).toBe('webp');
+    expect(normalizeOutputFormat('png')).toBe('png');
+    expect(normalizeOutputFormat('jpeg')).toBe('jpeg');
+  });
+
+  it('returns null for unknown formats', () => {
+    expect(normalizeOutputFormat('gif')).toBeNull();
+    expect(normalizeOutputFormat('')).toBeNull();
+  });
+});
+
+describe('isValidFrameSegment', () => {
+  it('accepts a simple placement/role run', () => {
+    expect(isValidFrameSegment('p1073r42p1090r43')).toBe(true);
+  });
+
+  it('accepts a quoted Aurora delta marker', () => {
+    expect(isValidFrameSegment('"p1090r43')).toBe(true);
+  });
+
+  it('accepts x-removals interleaved with placements', () => {
+    expect(isValidFrameSegment('x1073p1100r44')).toBe(true);
+  });
+
+  it('rejects an empty segment', () => {
+    expect(isValidFrameSegment('')).toBe(false);
+  });
+
+  it('rejects a lone quote', () => {
+    expect(isValidFrameSegment('"')).toBe(false);
+  });
+
+  it('rejects malformed content', () => {
+    expect(isValidFrameSegment('p1073r42<script>')).toBe(false);
+    expect(isValidFrameSegment('p1073')).toBe(false);
+    expect(isValidFrameSegment('pr42')).toBe(false);
+  });
+});
+
+describe('isValidFramesString', () => {
+  it('accepts an empty frames string', () => {
+    expect(isValidFramesString('')).toBe(true);
+  });
+
+  it('accepts multiple comma-separated segments', () => {
+    expect(isValidFramesString('p1073r42,"p1090r43,"x1073p1100r44')).toBe(true);
+  });
+
+  it.each([',', 'p1r42,,p2r43', 'p1r42"p2r43', '"'])('rejects malformed separators: %s', (frames) => {
+    expect(isValidFramesString(frames)).toBe(false);
+  });
+});
+
+describe('VALID_BOARD_NAMES', () => {
+  it('includes every supported board', () => {
+    for (const name of ['kilter', 'tension', 'moonboard', 'decoy', 'touchstone', 'grasshopper', 'soill']) {
+      expect(VALID_BOARD_NAMES.has(name)).toBe(true);
+    }
+  });
+
+  it('rejects unknown boards', () => {
+    expect(VALID_BOARD_NAMES.has('evil')).toBe(false);
+  });
+});
+
+describe('ogClimbQuerySchema', () => {
+  const valid = {
+    board_name: 'kilter',
+    layout_id: '1',
+    size_id: '10',
+    set_ids: '1,20',
+    frames: 'p1080r15p1202r12',
+  };
+
+  it('parses and coerces a valid query', () => {
+    const parsed = ogClimbQuerySchema.parse(valid);
+    expect(parsed.board_name).toBe('kilter');
+    expect(parsed.layout_id).toBe(1);
+    expect(parsed.size_id).toBe(10);
+    expect(parsed.set_ids).toBe('1,20');
+    expect(parsed.frames).toBe('p1080r15p1202r12');
+  });
+
+  it('accepts an empty frames string', () => {
+    expect(ogClimbQuerySchema.parse({ ...valid, frames: '' }).frames).toBe('');
+  });
+
+  it('accepts a single set id', () => {
+    expect(ogClimbQuerySchema.parse({ ...valid, set_ids: '1' }).set_ids).toBe('1');
+  });
+
+  it('rejects an invalid board_name', () => {
+    expect(ogClimbQuerySchema.safeParse({ ...valid, board_name: 'evil' }).success).toBe(false);
+  });
+
+  it('rejects non-numeric set_ids', () => {
+    expect(ogClimbQuerySchema.safeParse({ ...valid, set_ids: '1,a' }).success).toBe(false);
+    expect(ogClimbQuerySchema.safeParse({ ...valid, set_ids: '1,' }).success).toBe(false);
+  });
+
+  it('canonicalises set_ids by sorting and deduplicating', () => {
+    expect(ogClimbQuerySchema.parse({ ...valid, set_ids: '20,1' }).set_ids).toBe('1,20');
+    expect(ogClimbQuerySchema.parse({ ...valid, set_ids: '20,1,20,1' }).set_ids).toBe('1,20');
+    expect(ogClimbQuerySchema.parse({ ...valid, set_ids: '007,20' }).set_ids).toBe('7,20');
+  });
+
+  it('rejects more set_ids than MAX_SET_IDS', () => {
+    const tooManySetIds = Array.from({ length: 11 }, (_, index) => index + 1).join(',');
+    expect(ogClimbQuerySchema.safeParse({ ...valid, set_ids: tooManySetIds }).success).toBe(false);
+  });
+
+  it('rejects malformed frames', () => {
+    expect(ogClimbQuerySchema.safeParse({ ...valid, frames: 'p1073r42<script>' }).success).toBe(false);
+  });
+
+  it('rejects a frames string over the cap', () => {
+    expect(ogClimbQuerySchema.safeParse({ ...valid, frames: 'p1r42'.repeat(MAX_FRAMES_LENGTH) }).success).toBe(false);
+  });
+
+  it('accepts jpg/jpeg/png/webp formats and omitted format', () => {
+    for (const format of ['jpg', 'jpeg', 'png', 'webp']) {
+      expect(ogClimbQuerySchema.safeParse({ ...valid, format }).success).toBe(true);
+    }
+    expect(ogClimbQuerySchema.parse(valid).format).toBeUndefined();
+  });
+
+  it('rejects an unknown format', () => {
+    expect(ogClimbQuerySchema.safeParse({ ...valid, format: 'gif' }).success).toBe(false);
+  });
+});

--- a/packages/shared/board-render/src/__tests__/validation.test.ts
+++ b/packages/shared/board-render/src/__tests__/validation.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { HOLD_STATE_MAP } from '@boardsesh/board-constants/hold-states';
 import {
   isValidFrameSegment,
   isValidFramesString,
@@ -76,6 +77,12 @@ describe('VALID_BOARD_NAMES', () => {
 
   it('rejects unknown boards', () => {
     expect(VALID_BOARD_NAMES.has('evil')).toBe(false);
+  });
+
+  it('every valid board has hold states — buildRenderConfig requires them at render time', () => {
+    for (const boardName of VALID_BOARD_NAMES) {
+      expect(HOLD_STATE_MAP, `HOLD_STATE_MAP is missing "${boardName}"`).toHaveProperty(boardName);
+    }
   });
 });
 

--- a/packages/shared/board-render/src/background.ts
+++ b/packages/shared/board-render/src/background.ts
@@ -1,0 +1,93 @@
+import { getMoonBoardGeometryByFolder } from '@boardsesh/board-config';
+import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from './headers';
+
+/**
+ * Symmetric padding around the board photo inside the OG canvas. Used by
+ * `buildRenderConfig` to size the board down so it fits the social card with a
+ * border, and mirrored by the backdrop frame below.
+ */
+export const OG_BOARD_PADDING_X = 48;
+export const OG_BOARD_PADDING_Y = 48;
+
+/** Convert a raw image filename to its WebP equivalent, optionally as a thumbnail. */
+export function toWebpPath(dir: string, filename: string, isThumbnail: boolean): string {
+  const webpName = filename.replace(/\.png$/, '.webp');
+  if (isThumbnail) {
+    const lastSlash = webpName.lastIndexOf('/');
+    if (lastSlash >= 0) {
+      return `${dir}/${webpName.substring(0, lastSlash)}/thumbs${webpName.substring(lastSlash)}`;
+    }
+    return `${dir}/thumbs/${webpName}`;
+  }
+  return `${dir}/${webpName}`;
+}
+
+type BoardDetailsForBg = {
+  board_name: string;
+  images_to_holds: Record<string, unknown>;
+  layoutFolder?: string;
+  holdSetImages?: string[];
+};
+
+/**
+ * Build the ordered list of public/-relative paths for background images.
+ * Kilter/Tension use images_to_holds keys; MoonBoard uses layoutFolder +
+ * holdSetImages.
+ */
+export function getBackgroundRelPaths(boardDetails: BoardDetailsForBg, isThumbnail: boolean): string[] {
+  const paths: string[] = [];
+  const imageKeys = Object.keys(boardDetails.images_to_holds);
+
+  if (imageKeys.length > 0) {
+    // Aurora boards (Kilter, Tension): keys like "product_sizes_layouts_sets/36-1.png"
+    for (const key of imageKeys) {
+      paths.push(toWebpPath(`images/${boardDetails.board_name}`, key, isThumbnail));
+    }
+  } else if (boardDetails.layoutFolder && boardDetails.holdSetImages) {
+    // MoonBoard fallback (getMoonBoardDetails normally populates images_to_holds,
+    // so this runs only if a caller passes an empty map). Mini boards use their
+    // own background, so resolve it from the layout's geometry.
+    const bgFile = getMoonBoardGeometryByFolder(boardDetails.layoutFolder).backgroundImage;
+    paths.push(toWebpPath('images/moonboard', bgFile, isThumbnail));
+    for (const holdSetImage of boardDetails.holdSetImages) {
+      paths.push(toWebpPath(`images/moonboard/${boardDetails.layoutFolder}`, holdSetImage, isThumbnail));
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * Build the OG social-card backdrop: a gradient canvas with soft blurred
+ * accent circles and a rounded frame sized around the centred board photo.
+ * Returns an SVG buffer sharp can rasterise.
+ */
+export function createOgBackgroundBuffer(boardWidth: number, boardHeight: number): Buffer {
+  const boardX = Math.round((OG_IMAGE_WIDTH - boardWidth) / 2);
+  const boardY = Math.round((OG_IMAGE_HEIGHT - boardHeight) / 2);
+  const frameX = Math.max(boardX - 16, 16);
+  const frameY = Math.max(boardY - 16, 16);
+  const frameWidth = Math.min(boardWidth + 32, OG_IMAGE_WIDTH - frameX * 2);
+  const frameHeight = Math.min(boardHeight + 32, OG_IMAGE_HEIGHT - frameY * 2);
+
+  return Buffer.from(
+    `
+      <svg width="${OG_IMAGE_WIDTH}" height="${OG_IMAGE_HEIGHT}" viewBox="0 0 ${OG_IMAGE_WIDTH} ${OG_IMAGE_HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#071018" />
+            <stop offset="100%" stop-color="#0D1218" />
+          </linearGradient>
+          <filter id="blur">
+            <feGaussianBlur stdDeviation="48" />
+          </filter>
+        </defs>
+        <rect width="${OG_IMAGE_WIDTH}" height="${OG_IMAGE_HEIGHT}" fill="url(#bg)" />
+        <circle cx="212" cy="144" r="156" fill="#0d9488" opacity="0.18" filter="url(#blur)" />
+        <circle cx="984" cy="468" r="188" fill="#f43f5e" opacity="0.16" filter="url(#blur)" />
+        <rect x="24" y="24" width="${OG_IMAGE_WIDTH - 48}" height="${OG_IMAGE_HEIGHT - 48}" rx="28" fill="none" stroke="rgba(255,255,255,0.08)" />
+        <rect x="${frameX}" y="${frameY}" width="${frameWidth}" height="${frameHeight}" rx="22" fill="rgba(6, 10, 14, 0.55)" stroke="rgba(255,255,255,0.10)" />
+      </svg>
+    `,
+  );
+}

--- a/packages/shared/board-render/src/board-details.ts
+++ b/packages/shared/board-render/src/board-details.ts
@@ -1,0 +1,116 @@
+import type { BoardName } from '@boardsesh/shared-schema';
+import { boardSupportsMirroring } from '@boardsesh/play-view';
+import {
+  PRODUCT_SIZES,
+  getProductSize,
+  getLayout,
+  getSetsForLayoutAndSize,
+  getImageFilename,
+  getHolePlacements,
+} from '@boardsesh/board-constants/product-sizes';
+import { BOARD_IMAGE_DIMENSIONS, getMoonBoardDetails, type SetIdList } from '@boardsesh/board-config';
+import type { BoardRenderDetails, RenderableHold } from './types';
+
+/** Tuple stored per hold in the generated placement tables. */
+type HoldTuple = [number, number | null, number, number];
+
+type BoardDetailsParams = {
+  board_name: BoardName;
+  layout_id: number;
+  size_id: number;
+  set_ids: SetIdList;
+};
+
+/**
+ * Compute board geometry + hold placements for an Aurora board (Kilter,
+ * Tension, and the smaller Aurora-derived boards). Pure computation, no DB.
+ */
+export const getBoardDetails = ({
+  board_name,
+  layout_id,
+  size_id,
+  set_ids,
+}: BoardDetailsParams): BoardRenderDetails => {
+  const sizeData = getProductSize(board_name, size_id);
+  if (!sizeData) {
+    const availableSizes = Object.keys(PRODUCT_SIZES[board_name] || {});
+    throw new Error(
+      `Size dimensions not found for board_name=${board_name}, size_id=${size_id}. Available sizes: [${availableSizes.join(', ')}]`,
+    );
+  }
+
+  const layoutData = getLayout(board_name, layout_id);
+  const setsResult = getSetsForLayoutAndSize(board_name, layout_id, size_id);
+
+  const imagesToHolds: Record<string, HoldTuple[]> = {};
+  for (const setId of set_ids) {
+    const imageFilename = getImageFilename(board_name, layout_id, size_id, setId);
+    if (!imageFilename) {
+      throw new Error(`Could not find image for set_id ${setId} for layout_id: ${layout_id} and size_id: ${size_id}`);
+    }
+    imagesToHolds[imageFilename] = getHolePlacements(board_name, layout_id, setId);
+  }
+
+  const { edgeLeft: edge_left, edgeRight: edge_right, edgeBottom: edge_bottom, edgeTop: edge_top } = sizeData;
+
+  const firstImage = Object.keys(imagesToHolds)[0];
+  const dimensions = BOARD_IMAGE_DIMENSIONS[board_name][firstImage];
+  const boardWidth = dimensions?.width ?? 1080;
+  const boardHeight = dimensions?.height ?? 1920;
+
+  const xSpacing = boardWidth / (edge_right - edge_left);
+  const ySpacing = boardHeight / (edge_top - edge_bottom);
+
+  const holdsData: RenderableHold[] = Object.values(imagesToHolds).flatMap((holds: HoldTuple[]) =>
+    holds
+      .filter(([, , x, y]) => x > edge_left && x < edge_right && y > edge_bottom && y < edge_top)
+      .map(([holdId, mirroredHoldId, x, y]) => ({
+        id: holdId,
+        mirroredHoldId,
+        cx: (x - edge_left) * xSpacing,
+        cy: boardHeight - (y - edge_bottom) * ySpacing,
+        r: xSpacing * 4,
+      })),
+  );
+
+  const selectedSets = setsResult.filter((set) => set_ids.includes(set.id));
+
+  return {
+    images_to_holds: imagesToHolds,
+    holdsData,
+    edge_left,
+    edge_right,
+    edge_bottom,
+    edge_top,
+    boardHeight,
+    boardWidth,
+    board_name,
+    layout_id,
+    size_id,
+    set_ids,
+    supportsMirroring: boardSupportsMirroring(board_name, layout_id),
+    layout_name: layoutData?.name,
+    size_name: sizeData.name,
+    size_description: sizeData.description,
+    set_names: selectedSets.map((set) => set.name),
+  };
+};
+
+/**
+ * Get board details for any board type (Aurora or MoonBoard). Routes to
+ * `getMoonBoardDetails` for MoonBoard; to `getBoardDetails` for Aurora boards.
+ */
+export function getBoardDetailsForBoard(params: {
+  board_name: string;
+  layout_id: number;
+  size_id: number;
+  set_ids: SetIdList;
+}): BoardRenderDetails {
+  if (params.board_name === 'moonboard') {
+    return getMoonBoardDetails({
+      layout_id: params.layout_id,
+      set_ids: params.set_ids,
+    });
+  }
+  return getBoardDetails(params as BoardDetailsParams);
+}

--- a/packages/shared/board-render/src/headers.ts
+++ b/packages/shared/board-render/src/headers.ts
@@ -1,0 +1,39 @@
+export const OG_IMAGE_WIDTH = 1200;
+export const OG_IMAGE_HEIGHT = 630;
+
+const ONE_YEAR_SECONDS = 31_536_000;
+const SHORT_TTL_SECONDS = 300;
+const STALE_TTL_SECONDS = 86_400;
+
+/**
+ * Build the cache + content headers for an OG image response. Versioned
+ * requests (a content hash / timestamp in the URL) get immutable one-year
+ * caching; unversioned ones get a short TTL with a stale-while-revalidate
+ * window. Emits the Vercel-CDN-Cache-Control variant too — harmless on other
+ * CDNs, load-bearing on Vercel.
+ */
+export function createOgImageHeaders({
+  contentType,
+  version,
+  serverTiming,
+}: {
+  contentType: string;
+  version?: string | null;
+  serverTiming?: string;
+}): Record<string, string> {
+  const isVersioned = version !== null && version !== undefined;
+  const browserCacheControl = isVersioned
+    ? `public, max-age=${ONE_YEAR_SECONDS}, s-maxage=${ONE_YEAR_SECONDS}, immutable`
+    : `public, max-age=0, s-maxage=${SHORT_TTL_SECONDS}, stale-while-revalidate=${STALE_TTL_SECONDS}`;
+  const cdnCacheControl = isVersioned
+    ? `public, s-maxage=${ONE_YEAR_SECONDS}, immutable`
+    : `public, s-maxage=${SHORT_TTL_SECONDS}, stale-while-revalidate=${STALE_TTL_SECONDS}`;
+
+  return {
+    'Content-Type': contentType,
+    'Cache-Control': browserCacheControl,
+    'CDN-Cache-Control': cdnCacheControl,
+    'Vercel-CDN-Cache-Control': cdnCacheControl,
+    ...(serverTiming ? { 'Server-Timing': serverTiming } : {}),
+  };
+}

--- a/packages/shared/board-render/src/index.ts
+++ b/packages/shared/board-render/src/index.ts
@@ -1,0 +1,11 @@
+// The barrel intentionally excludes the sharp-dependent `pipeline` module and
+// the WASM `wasm` module — import those via `@boardsesh/board-render/pipeline`
+// and `@boardsesh/board-render/wasm` so consumers that only need board details
+// or validation (e.g. web's board-constants) don't pull sharp into their graph.
+export * from './types';
+export * from './board-details';
+export * from './validation';
+export * from './background';
+export * from './headers';
+export * from './render-config';
+export * from './lru';

--- a/packages/shared/board-render/src/lru.ts
+++ b/packages/shared/board-render/src/lru.ts
@@ -1,0 +1,71 @@
+type LruEntry<V> = {
+  value: V;
+  bytes: number;
+};
+
+/**
+ * A small bounded LRU keyed by string. Evicts least-recently-used entries when
+ * either the entry count or the total byte budget is exceeded. `sizeOf` reports
+ * each value's weight in bytes; pass a constant `() => 1` when only the entry
+ * count matters. Insertion + read are O(1) amortised (Map preserves insertion
+ * order; a get re-inserts to mark recency).
+ */
+export class BoundedLru<V> {
+  private readonly store = new Map<string, LruEntry<V>>();
+  private totalBytes = 0;
+
+  constructor(
+    private readonly options: {
+      maxEntries: number;
+      maxBytes: number;
+      sizeOf: (value: V) => number;
+    },
+  ) {}
+
+  get(key: string): V | undefined {
+    const entry = this.store.get(key);
+    if (entry === undefined) return undefined;
+    // Mark as most-recently-used by re-inserting at the tail.
+    this.store.delete(key);
+    this.store.set(key, entry);
+    return entry.value;
+  }
+
+  has(key: string): boolean {
+    return this.store.has(key);
+  }
+
+  set(key: string, value: V): void {
+    const bytes = this.options.sizeOf(value);
+    const existing = this.store.get(key);
+    if (existing !== undefined) {
+      this.totalBytes -= existing.bytes;
+      this.store.delete(key);
+    }
+    this.store.set(key, { value, bytes });
+    this.totalBytes += bytes;
+    this.evictIfNeeded();
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
+
+  get byteSize(): number {
+    return this.totalBytes;
+  }
+
+  private evictIfNeeded(): void {
+    while (
+      this.store.size > this.options.maxEntries ||
+      (this.totalBytes > this.options.maxBytes && this.store.size > 0)
+    ) {
+      // Oldest entry is the first key in insertion order.
+      const oldestKey = this.store.keys().next().value;
+      if (oldestKey === undefined) break;
+      const oldest = this.store.get(oldestKey);
+      if (oldest !== undefined) this.totalBytes -= oldest.bytes;
+      this.store.delete(oldestKey);
+    }
+  }
+}

--- a/packages/shared/board-render/src/pipeline.ts
+++ b/packages/shared/board-render/src/pipeline.ts
@@ -1,0 +1,325 @@
+import sharp from 'sharp';
+import { createOgBackgroundBuffer, getBackgroundRelPaths } from './background';
+import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from './headers';
+import type { OutputFormat, RenderableBoardDetails } from './types';
+
+const THUMBNAIL_WEBP_OPTIONS: sharp.WebpOptions = {
+  quality: 60,
+  alphaQuality: 70,
+  effort: 4,
+};
+
+const DEFAULT_WEBP_OPTIONS: sharp.WebpOptions = {
+  quality: 80,
+};
+
+const DEFAULT_PNG_OPTIONS: sharp.PngOptions = {
+  compressionLevel: 9,
+  adaptiveFiltering: true,
+};
+
+const THUMBNAIL_JPEG_OPTIONS: sharp.JpegOptions = {
+  quality: 85,
+  chromaSubsampling: '4:4:4',
+  progressive: false,
+  optimiseScans: false,
+};
+
+const DEFAULT_JPEG_OPTIONS: sharp.JpegOptions = {
+  quality: 90,
+  chromaSubsampling: '4:4:4',
+  mozjpeg: true,
+};
+
+/**
+ * OG social-card JPEG encode: mozjpeg at quality 85 with full chroma so hold
+ * rings stay crisp (~50–80KB at 1200×630).
+ */
+export const OG_JPEG_OPTIONS: sharp.JpegOptions = {
+  quality: 85,
+  chromaSubsampling: '4:4:4',
+  mozjpeg: true,
+};
+
+function getJpegOptions(thumbnail: boolean): sharp.JpegOptions {
+  return thumbnail ? THUMBNAIL_JPEG_OPTIONS : DEFAULT_JPEG_OPTIONS;
+}
+
+/** Resolve a public/-relative image path to an absolute filesystem path, or null if absent. */
+export type ResolveImagePath = (relPath: string) => string | null;
+
+export type RenderBoardImageParams = {
+  /** Raw RGBA overlay pixels from the WASM renderer (already header-stripped). */
+  overlayBuffer: Buffer;
+  width: number;
+  height: number;
+  isOgVariant: boolean;
+  format: OutputFormat;
+  thumbnail: boolean;
+  includeBackground: boolean;
+  /** Scrim opacity (0–1) painted over the board photo before the overlay; 0 = none. */
+  dimBackground: number;
+  boardDetails: RenderableBoardDetails;
+  resolveImagePath: ResolveImagePath;
+};
+
+export type RenderTimings = {
+  sharpMs: number;
+  composeMs: number;
+  encodeMs: number;
+  bgMs: number;
+};
+
+export type RenderBoardImageResult = {
+  buffer: Buffer;
+  contentType: string;
+  timings: RenderTimings;
+};
+
+/**
+ * Single-shot render used by the web `board-render` route: takes the WASM
+ * overlay RGBA and produces the final encoded image, optionally compositing
+ * background board photos and (for the OG variant) the social-card backdrop.
+ */
+export async function renderBoardImageBuffer({
+  overlayBuffer,
+  width,
+  height,
+  isOgVariant,
+  format,
+  thumbnail,
+  includeBackground,
+  dimBackground,
+  boardDetails,
+  resolveImagePath,
+}: RenderBoardImageParams): Promise<RenderBoardImageResult> {
+  const sharpT0 = performance.now();
+  let imageBuffer: Buffer | null = null;
+  let outputBuffer: Buffer | null = null;
+  let outputContentType = 'image/png';
+  let bgMs = 0;
+  let composeMs = 0;
+  let didCompositeBackground = false;
+
+  if (includeBackground) {
+    const bgT0 = performance.now();
+    const bgRelPaths = getBackgroundRelPaths(boardDetails, thumbnail);
+    const bgFsPaths = bgRelPaths
+      .map((relPath) => resolveImagePath(relPath))
+      .filter((path): path is string => path !== null);
+    bgMs = performance.now() - bgT0;
+
+    if (bgFsPaths.length > 0) {
+      // Load and resize background images, skipping any that fail.
+      const results = await Promise.allSettled(
+        bgFsPaths.map((fsPath) => sharp(fsPath).resize(width, height, { fit: 'fill' }).toBuffer()),
+      );
+      const resizedBuffers = results
+        .filter((result): result is PromiseFulfilledResult<Buffer> => result.status === 'fulfilled')
+        .map((result) => result.value);
+
+      const [firstBg, ...restBgs] = resizedBuffers;
+
+      if (firstBg) {
+        // Composite: first background as base → remaining backgrounds → optional
+        // dim scrim → WASM overlay on top.
+        const composeT0 = performance.now();
+        const dimLayer =
+          dimBackground > 0
+            ? await sharp({
+                create: { width, height, channels: 4, background: { r: 0, g: 0, b: 0, alpha: dimBackground } },
+              })
+                .png()
+                .toBuffer()
+            : null;
+        const compositedImage = sharp(firstBg).composite([
+          ...restBgs.map((buf) => ({ input: buf, blend: 'over' as const })),
+          ...(dimLayer ? [{ input: dimLayer, blend: 'over' as const }] : []),
+          {
+            input: overlayBuffer,
+            raw: { width, height, channels: 4 as const },
+            blend: 'over' as const,
+          },
+        ]);
+        if (!isOgVariant && format === 'webp') {
+          outputBuffer = await compositedImage
+            .webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : DEFAULT_WEBP_OPTIONS)
+            .toBuffer();
+          outputContentType = 'image/webp';
+        } else if (!isOgVariant && format === 'jpeg') {
+          outputBuffer = await compositedImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
+          outputContentType = 'image/jpeg';
+        } else {
+          imageBuffer = await compositedImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
+        }
+        composeMs = performance.now() - composeT0;
+        didCompositeBackground = true;
+      } else {
+        // All background loads failed — fall back to overlay-only.
+        const composeT0 = performance.now();
+        const overlayImage = sharp(overlayBuffer, { raw: { width, height, channels: 4 } });
+        if (!isOgVariant && format === 'webp') {
+          outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
+          outputContentType = 'image/webp';
+        } else if (!isOgVariant && format === 'jpeg') {
+          outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
+          outputContentType = 'image/jpeg';
+        } else {
+          imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
+        }
+        composeMs = performance.now() - composeT0;
+      }
+    } else {
+      // No background images found — fall back to overlay-only lossless.
+      const composeT0 = performance.now();
+      const overlayImage = sharp(overlayBuffer, { raw: { width, height, channels: 4 } });
+      if (!isOgVariant && format === 'webp') {
+        outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
+        outputContentType = 'image/webp';
+      } else if (!isOgVariant && format === 'jpeg') {
+        outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
+        outputContentType = 'image/jpeg';
+      } else {
+        imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
+      }
+      composeMs = performance.now() - composeT0;
+    }
+  } else {
+    // Default: overlay-only lossless WebP (25-30% smaller than PNG).
+    const composeT0 = performance.now();
+    const overlayImage = sharp(overlayBuffer, { raw: { width, height, channels: 4 } });
+    if (!isOgVariant && format === 'webp') {
+      outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
+      outputContentType = 'image/webp';
+    } else if (!isOgVariant && format === 'jpeg') {
+      outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
+      outputContentType = 'image/jpeg';
+    } else {
+      imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
+    }
+    composeMs = performance.now() - composeT0;
+  }
+
+  const encodeT0 = performance.now();
+
+  if (outputBuffer === null && isOgVariant && imageBuffer) {
+    const ogImage = sharp(createOgBackgroundBuffer(width, height)).composite([
+      {
+        input: imageBuffer,
+        left: Math.round((OG_IMAGE_WIDTH - width) / 2),
+        top: Math.round((OG_IMAGE_HEIGHT - height) / 2),
+        blend: 'over',
+      },
+    ]);
+    if (format === 'jpeg') {
+      outputBuffer = await ogImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
+      outputContentType = 'image/jpeg';
+    } else {
+      outputBuffer = await ogImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
+      outputContentType = 'image/png';
+    }
+  } else if (outputBuffer === null && imageBuffer && format === 'webp') {
+    const getWebpOptions = () => {
+      if (thumbnail) return THUMBNAIL_WEBP_OPTIONS;
+      if (didCompositeBackground) return DEFAULT_WEBP_OPTIONS;
+      return { lossless: true };
+    };
+    outputBuffer = await sharp(imageBuffer).webp(getWebpOptions()).toBuffer();
+    outputContentType = 'image/webp';
+  } else if (outputBuffer === null && imageBuffer && format === 'jpeg') {
+    outputBuffer = await sharp(imageBuffer).jpeg(getJpegOptions(thumbnail)).toBuffer();
+    outputContentType = 'image/jpeg';
+  } else if (outputBuffer === null && imageBuffer) {
+    outputBuffer = imageBuffer;
+    outputContentType = 'image/png';
+  }
+
+  if (!outputBuffer) {
+    throw new Error('no output buffer generated');
+  }
+
+  const encodeMs = performance.now() - encodeT0;
+  const sharpMs = performance.now() - sharpT0;
+
+  return {
+    buffer: outputBuffer,
+    contentType: outputContentType,
+    timings: { sharpMs, composeMs, encodeMs, bgMs },
+  };
+}
+
+export type OgBaseResult = {
+  /** Raw RGBA pixels of the composited backdrop + board photos, `OG_IMAGE_WIDTH`×`OG_IMAGE_HEIGHT`. */
+  base: Buffer;
+  /** X offset where the board photo (and later the overlay) sits on the canvas. */
+  left: number;
+  /** Y offset where the board photo (and later the overlay) sits on the canvas. */
+  top: number;
+};
+
+/**
+ * Compose the OG social-card base for a board config: the gradient backdrop
+ * with the board photos composited (no climb overlay). The result is a raw
+ * RGBA buffer the backend caches per board config — every climb on the same
+ * board reuses it, so only the cheap overlay composite + encode runs per climb.
+ */
+export async function composeOgBaseBuffer(params: {
+  boardDetails: RenderableBoardDetails;
+  boardWidth: number;
+  boardHeight: number;
+  resolveImagePath: ResolveImagePath;
+}): Promise<OgBaseResult> {
+  const { boardDetails, boardWidth, boardHeight, resolveImagePath } = params;
+  const left = Math.round((OG_IMAGE_WIDTH - boardWidth) / 2);
+  const top = Math.round((OG_IMAGE_HEIGHT - boardHeight) / 2);
+
+  const bgRelPaths = getBackgroundRelPaths(boardDetails, false);
+  const bgFsPaths = bgRelPaths
+    .map((relPath) => resolveImagePath(relPath))
+    .filter((path): path is string => path !== null);
+
+  const results = await Promise.allSettled(
+    bgFsPaths.map((fsPath) => sharp(fsPath).resize(boardWidth, boardHeight, { fit: 'fill' }).toBuffer()),
+  );
+  const resizedBoardPhotos = results
+    .filter((result): result is PromiseFulfilledResult<Buffer> => result.status === 'fulfilled')
+    .map((result) => result.value);
+
+  const backdrop = sharp(createOgBackgroundBuffer(boardWidth, boardHeight)).composite(
+    resizedBoardPhotos.map((buf) => ({ input: buf, left, top, blend: 'over' as const })),
+  );
+
+  const base = await backdrop.raw().toBuffer();
+  return { base, left, top };
+}
+
+/**
+ * Composite the climb overlay onto a cached OG base and encode. JPEG is the OG
+ * default (mozjpeg, quality 85); PNG and WebP are honoured when requested.
+ */
+export async function encodeOgImage(params: {
+  base: Buffer;
+  overlay: { buffer: Buffer; width: number; height: number; left: number; top: number };
+  format: OutputFormat;
+}): Promise<{ buffer: Buffer; contentType: string }> {
+  const { base, overlay, format } = params;
+  const composited = sharp(base, {
+    raw: { width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT, channels: 4 },
+  }).composite([
+    {
+      input: overlay.buffer,
+      raw: { width: overlay.width, height: overlay.height, channels: 4 as const },
+      left: overlay.left,
+      top: overlay.top,
+      blend: 'over',
+    },
+  ]);
+
+  if (format === 'png') {
+    return { buffer: await composited.png(DEFAULT_PNG_OPTIONS).toBuffer(), contentType: 'image/png' };
+  }
+  if (format === 'webp') {
+    return { buffer: await composited.webp(DEFAULT_WEBP_OPTIONS).toBuffer(), contentType: 'image/webp' };
+  }
+  return { buffer: await composited.jpeg(OG_JPEG_OPTIONS).toBuffer(), contentType: 'image/jpeg' };
+}

--- a/packages/shared/board-render/src/render-config.ts
+++ b/packages/shared/board-render/src/render-config.ts
@@ -1,0 +1,81 @@
+import { OG_BOARD_PADDING_X, OG_BOARD_PADDING_Y } from './background';
+import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from './headers';
+import type { HoldStateRecord, RenderableBoardDetails, WasmRenderConfig } from './types';
+
+/** Thumbnail render width in pixels. Covers 3x retina at ~64px CSS display. */
+export const THUMBNAIL_WIDTH = 200;
+
+type BuildRenderConfigParams = {
+  boardName: string;
+  boardDetails: RenderableBoardDetails;
+  frames: string;
+  thumbnail: boolean;
+  isOgVariant: boolean;
+  /** Per-board hold-state colour/style map (from HOLD_STATE_MAP[boardName]). */
+  boardStates: HoldStateRecord;
+  /** Injected so web can pass its (mockable) THUMBNAIL_WIDTH; defaults to the shared constant. */
+  thumbnailWidth?: number;
+};
+
+export type RenderConfigResult = {
+  config: WasmRenderConfig;
+  outputWidth: number;
+  ogScale: number | null;
+};
+
+/**
+ * Assemble the WASM render config for a climb: computes the output width
+ * (OG-scaled, thumbnail, or native), builds the hold-state colour map, and
+ * emits the config object the overlay renderer consumes. Pure — no I/O.
+ */
+export function buildRenderConfig({
+  boardName,
+  boardDetails,
+  frames,
+  thumbnail,
+  isOgVariant,
+  boardStates,
+  thumbnailWidth = THUMBNAIL_WIDTH,
+}: BuildRenderConfigParams): RenderConfigResult {
+  const ogScale = isOgVariant
+    ? Math.min(
+        (OG_IMAGE_WIDTH - OG_BOARD_PADDING_X * 2) / boardDetails.boardWidth,
+        (OG_IMAGE_HEIGHT - OG_BOARD_PADDING_Y * 2) / boardDetails.boardHeight,
+      )
+    : null;
+
+  const computeOutputWidth = () => {
+    if (isOgVariant) return Math.max(1, Math.round(boardDetails.boardWidth * (ogScale || 1)));
+    if (thumbnail) return thumbnailWidth;
+    return boardDetails.boardWidth;
+  };
+  const outputWidth = computeOutputWidth();
+
+  const holdStateMap: Record<number, { color: string; renderStyle?: string }> = {};
+  for (const [code, info] of Object.entries(boardStates)) {
+    holdStateMap[Number(code)] = {
+      color: info.color,
+      ...(info.renderStyle ? { renderStyle: info.renderStyle } : {}),
+    };
+  }
+
+  const config: WasmRenderConfig = {
+    board_name: boardName,
+    board_width: boardDetails.boardWidth,
+    board_height: boardDetails.boardHeight,
+    output_width: outputWidth,
+    frames,
+    mirrored: false,
+    thumbnail,
+    holds: boardDetails.holdsData.map((hold) => ({
+      id: hold.id,
+      mirroredHoldId: hold.mirroredHoldId,
+      cx: hold.cx,
+      cy: hold.cy,
+      r: hold.r,
+    })),
+    hold_state_map: holdStateMap,
+  };
+
+  return { config, outputWidth, ogScale };
+}

--- a/packages/shared/board-render/src/types.ts
+++ b/packages/shared/board-render/src/types.ts
@@ -1,0 +1,72 @@
+import type { BoardName } from '@boardsesh/shared-schema';
+import type { SetIdList } from '@boardsesh/board-config';
+
+/** Minimal hold shape the WASM overlay config consumes. */
+export type RenderableHold = {
+  id: number;
+  mirroredHoldId: number | null;
+  cx: number;
+  cy: number;
+  r: number;
+};
+
+/**
+ * Structural subset of board details the render pipeline reads. Web's
+ * `BoardDetails` and the shared `getBoardDetails` / `getMoonBoardDetails`
+ * results all satisfy this — the renderer never touches the metadata fields
+ * (layout_name, size_name, …), only geometry + background image keys.
+ */
+export type RenderableBoardDetails = {
+  board_name: string;
+  boardWidth: number;
+  boardHeight: number;
+  holdsData: RenderableHold[];
+  images_to_holds: Record<string, unknown>;
+  layoutFolder?: string;
+  holdSetImages?: string[];
+};
+
+/**
+ * Full board details returned by `getBoardDetails` / `getBoardDetailsForBoard`.
+ * Field-for-field compatible with web's `BoardDetails` so web can re-export the
+ * shared implementation without changing its public surface.
+ */
+export type BoardRenderDetails = {
+  images_to_holds: Record<string, Array<[number, number | null, number, number]>>;
+  holdsData: RenderableHold[];
+  edge_left: number;
+  edge_right: number;
+  edge_bottom: number;
+  edge_top: number;
+  boardHeight: number;
+  boardWidth: number;
+  board_name: BoardName;
+  layout_id: number;
+  size_id: number;
+  set_ids: SetIdList;
+  supportsMirroring?: boolean;
+  layout_name?: string;
+  size_name?: string;
+  size_description?: string;
+  set_names?: string[];
+  layoutFolder?: string;
+  holdSetImages?: string[];
+};
+
+export type OutputFormat = 'webp' | 'png' | 'jpeg';
+
+/** Per-board hold-state colour/style map (subset of board-constants HoldStateInfo). */
+export type HoldStateRecord = Record<number | string, { color: string; renderStyle?: string; name?: string }>;
+
+/** The JSON payload the WASM `render_overlay` entry point consumes. */
+export type WasmRenderConfig = {
+  board_name: string;
+  board_width: number;
+  board_height: number;
+  output_width: number;
+  frames: string;
+  mirrored: boolean;
+  thumbnail: boolean;
+  holds: RenderableHold[];
+  hold_state_map: Record<number, { color: string; renderStyle?: string }>;
+};

--- a/packages/shared/board-render/src/validation.ts
+++ b/packages/shared/board-render/src/validation.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+import type { OutputFormat } from './types';
+
+/** Board names the render pipeline accepts. */
+export const VALID_BOARD_NAMES = new Set([
+  'kilter',
+  'tension',
+  'moonboard',
+  'decoy',
+  'touchstone',
+  'grasshopper',
+  'soill',
+]);
+
+/** Hard cap on the encoded frames string, to bound WASM work per request. */
+export const MAX_FRAMES_LENGTH = 16_384;
+
+export const MAX_SET_IDS = 10;
+
+export function normalizeOutputFormat(format: string): OutputFormat | null {
+  if (format === 'jpg') return 'jpeg';
+  if (format === 'webp' || format === 'png' || format === 'jpeg') return format;
+  return null;
+}
+
+/**
+ * Validate a single frames segment. A segment is a run of `p{placement}r{role}`
+ * pairs, optionally prefixed with a `"` (Aurora delta marker) and interleaved
+ * with `x{placement}` removals.
+ */
+export function isValidFrameSegment(segment: string): boolean {
+  if (segment.length === 0) return false;
+  let cursor = 0;
+
+  if (segment[cursor] === '"') {
+    cursor++;
+  }
+
+  if (cursor >= segment.length) return false;
+
+  while (cursor < segment.length) {
+    const current = segment[cursor];
+    if (current === 'x') {
+      cursor++;
+      const start = cursor;
+      while (cursor < segment.length && segment[cursor] >= '0' && segment[cursor] <= '9') {
+        cursor++;
+      }
+      if (cursor === start) return false;
+      continue;
+    }
+
+    if (current !== 'p') return false;
+    cursor++;
+    const placementStart = cursor;
+    while (cursor < segment.length && segment[cursor] >= '0' && segment[cursor] <= '9') {
+      cursor++;
+    }
+    if (cursor === placementStart || segment[cursor] !== 'r') return false;
+
+    cursor++;
+    const roleStart = cursor;
+    while (cursor < segment.length && segment[cursor] >= '0' && segment[cursor] <= '9') {
+      cursor++;
+    }
+    if (cursor === roleStart) return false;
+  }
+
+  return true;
+}
+
+export function isValidFramesString(frames: string): boolean {
+  if (frames.length === 0) return true;
+  return frames.split(',').every(isValidFrameSegment);
+}
+
+/**
+ * Strict query validation for the public `GET /og/climb` endpoint. Runs before
+ * any CPU-heavy work: rejects bad input cheaply with a 400 so a crawler can't
+ * push the backend into wasted WASM/sharp renders.
+ */
+export const ogClimbQuerySchema = z.object({
+  board_name: z.enum(['kilter', 'tension', 'moonboard', 'decoy', 'touchstone', 'grasshopper', 'soill']),
+  layout_id: z.coerce.number().int().nonnegative(),
+  size_id: z.coerce.number().int().nonnegative(),
+  set_ids: z
+    .string()
+    .regex(/^\d+(,\d+)*$/, 'set_ids must be a comma-separated list of integers')
+    .refine((setIdsCsv) => setIdsCsv.split(',').length <= MAX_SET_IDS, `set_ids accepts at most ${MAX_SET_IDS} ids`)
+    // Canonicalise (sort + dedupe) so equivalent queries render and cache identically.
+    .transform((setIdsCsv) => [...new Set(setIdsCsv.split(',').map(Number))].sort((a, b) => a - b).join(',')),
+  frames: z
+    .string()
+    .max(MAX_FRAMES_LENGTH, 'frames string is too large')
+    .refine(isValidFramesString, 'frames contains invalid syntax'),
+  format: z.enum(['webp', 'png', 'jpeg', 'jpg']).optional(),
+});
+
+export type OgClimbQuery = z.infer<typeof ogClimbQuerySchema>;

--- a/packages/shared/board-render/src/validation.ts
+++ b/packages/shared/board-render/src/validation.ts
@@ -93,6 +93,9 @@ export const ogClimbQuerySchema = z.object({
     .transform((setIdsCsv) => [...new Set(setIdsCsv.split(',').map(Number))].sort((a, b) => a - b).join(',')),
   frames: z
     .string()
+    // Required: an empty frames string would render a blank board and cache it
+    // with immutable headers as if it were a real climb card.
+    .min(1, 'frames is required')
     .max(MAX_FRAMES_LENGTH, 'frames string is too large')
     .refine(isValidFramesString, 'frames contains invalid syntax'),
   format: z.enum(['webp', 'png', 'jpeg', 'jpg']).optional(),

--- a/packages/shared/board-render/src/validation.ts
+++ b/packages/shared/board-render/src/validation.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { OutputFormat } from './types';
 
-/** Board names the render pipeline accepts. */
-export const VALID_BOARD_NAMES = new Set([
+/** Board names the render pipeline accepts. Single source for the Set and the zod enum. */
+const VALID_BOARD_NAME_LIST = [
   'kilter',
   'tension',
   'moonboard',
@@ -10,7 +10,9 @@ export const VALID_BOARD_NAMES = new Set([
   'touchstone',
   'grasshopper',
   'soill',
-]);
+] as const;
+
+export const VALID_BOARD_NAMES: ReadonlySet<string> = new Set(VALID_BOARD_NAME_LIST);
 
 /** Hard cap on the encoded frames string, to bound WASM work per request. */
 export const MAX_FRAMES_LENGTH = 16_384;
@@ -80,7 +82,7 @@ export function isValidFramesString(frames: string): boolean {
  * push the backend into wasted WASM/sharp renders.
  */
 export const ogClimbQuerySchema = z.object({
-  board_name: z.enum(['kilter', 'tension', 'moonboard', 'decoy', 'touchstone', 'grasshopper', 'soill']),
+  board_name: z.enum(VALID_BOARD_NAME_LIST),
   layout_id: z.coerce.number().int().nonnegative(),
   size_id: z.coerce.number().int().nonnegative(),
   set_ids: z

--- a/packages/shared/board-render/src/wasm.ts
+++ b/packages/shared/board-render/src/wasm.ts
@@ -34,7 +34,12 @@ export function createOverlayRenderer(loadWasmBytes: () => Promise<Uint8Array | 
         const wasmBytes = await loadWasmBytes();
         wasmModule.initSync({ module: wasmBytes });
         renderOverlay = wasmModule.render_overlay;
-      })();
+      })().catch((initError: unknown) => {
+        // Clear the lock so a transient failure (e.g. I/O) can be retried by a
+        // later call instead of pinning every caller to the same rejection.
+        initPromise = null;
+        throw initError;
+      });
     }
     await initPromise;
   }

--- a/packages/shared/board-render/src/wasm.ts
+++ b/packages/shared/board-render/src/wasm.ts
@@ -1,0 +1,59 @@
+/** Raw overlay render result: dimensions parsed from the 8-byte WASM header. */
+export type OverlayRenderResult = {
+  width: number;
+  height: number;
+  /** Raw RGBA pixels (the WASM output with its 8-byte dimension header stripped). */
+  rgba: Uint8Array;
+};
+
+export type OverlayRenderer = {
+  /** Eagerly initialise the WASM module (used at backend boot). Idempotent. */
+  ensureInitialized: () => Promise<void>;
+  /** True once the WASM module is initialised and ready to render. */
+  isReady: () => boolean;
+  /** Render an overlay for a config JSON string, returning parsed dimensions + RGBA. */
+  render: (configJson: string) => Promise<OverlayRenderResult>;
+};
+
+/**
+ * Create an overlay renderer backed by the `@boardsesh/board-renderer-wasm`
+ * module. Byte loading is injected (`loadWasmBytes`) so each host resolves the
+ * `.wasm` file however it must — web probes its Vercel file-traced candidates,
+ * the backend resolves the package deterministically. Init is promise-locked to
+ * prevent a thundering-herd double-init under concurrent first requests.
+ */
+export function createOverlayRenderer(loadWasmBytes: () => Promise<Uint8Array | Buffer>): OverlayRenderer {
+  let renderOverlay: ((configJson: string) => Uint8Array) | null = null;
+  let initPromise: Promise<void> | null = null;
+
+  async function ensureInitialized(): Promise<void> {
+    if (renderOverlay) return;
+    if (!initPromise) {
+      initPromise = (async () => {
+        const wasmModule = await import('@boardsesh/board-renderer-wasm');
+        const wasmBytes = await loadWasmBytes();
+        wasmModule.initSync({ module: wasmBytes });
+        renderOverlay = wasmModule.render_overlay;
+      })();
+    }
+    await initPromise;
+  }
+
+  return {
+    ensureInitialized,
+    isReady: () => renderOverlay !== null,
+    async render(configJson: string): Promise<OverlayRenderResult> {
+      await ensureInitialized();
+      if (!renderOverlay) {
+        throw new Error('WASM renderer failed to initialize');
+      }
+      const rawBytes = renderOverlay(configJson);
+      // Dimension header: first 8 bytes are width + height as u32 LE.
+      const view = new DataView(rawBytes.buffer, rawBytes.byteOffset, rawBytes.byteLength);
+      const width = view.getUint32(0, true);
+      const height = view.getUint32(4, true);
+      const rgba = rawBytes.subarray(8);
+      return { width, height, rgba };
+    },
+  };
+}

--- a/packages/shared/board-render/tsconfig.json
+++ b/packages/shared/board-render/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shared/board-render/vite.config.ts
+++ b/packages/shared/board-render/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'board-render',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/web/app/api/internal/board-render/route.ts
+++ b/packages/web/app/api/internal/board-render/route.ts
@@ -2,52 +2,29 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
-import sharp from 'sharp';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
-import { getMoonBoardGeometryByFolder } from '@/app/lib/moonboard-config';
 import { HOLD_STATE_MAP, THUMBNAIL_WIDTH } from '@/app/components/board-renderer/types';
 import type { BoardName } from '@/app/lib/types';
-import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
+import { createOgImageHeaders } from '@/app/lib/seo/og';
+import {
+  buildRenderConfig,
+  isValidFramesString,
+  MAX_FRAMES_LENGTH,
+  normalizeOutputFormat,
+  VALID_BOARD_NAMES,
+} from '@boardsesh/board-render';
+import { createOverlayRenderer } from '@boardsesh/board-render/wasm';
+import { renderBoardImageBuffer } from '@boardsesh/board-render/pipeline';
 
 // Node.js runtime for reliable WASM loading via filesystem
 export const runtime = 'nodejs';
 
-const THUMBNAIL_WEBP_OPTIONS: sharp.WebpOptions = {
-  quality: 60,
-  alphaQuality: 70,
-  effort: 4,
-};
-
-const DEFAULT_WEBP_OPTIONS: sharp.WebpOptions = {
-  quality: 80,
-};
-
-const DEFAULT_PNG_OPTIONS: sharp.PngOptions = {
-  compressionLevel: 9,
-  adaptiveFiltering: true,
-};
-
-const THUMBNAIL_JPEG_OPTIONS: sharp.JpegOptions = {
-  quality: 85,
-  chromaSubsampling: '4:4:4',
-  progressive: false,
-  optimiseScans: false,
-};
-
-const DEFAULT_JPEG_OPTIONS: sharp.JpegOptions = {
-  quality: 90,
-  chromaSubsampling: '4:4:4',
-  mozjpeg: true,
-};
-
-const OG_BOARD_PADDING_X = 48;
-const OG_BOARD_PADDING_Y = 48;
-const MAX_FRAMES_LENGTH = 16_384;
-
-// Lazily initialized WASM module with promise lock to prevent thundering herd
-let renderOverlay: ((configJson: string) => Uint8Array) | null = null;
-let wasmInitPromise: Promise<void> | null = null;
-
+/**
+ * Resolve the board-renderer WASM binary. Probes the candidate paths that
+ * Next's file tracing / Vercel standalone builds place the file in. The render
+ * pipeline itself lives in @boardsesh/board-render; only byte resolution is
+ * web/Vercel-specific, so it stays here and is injected into the shared renderer.
+ */
 function findWasmPath(): string {
   const wasmFilename = 'board_renderer_wasm_bg.wasm';
   const candidates = [
@@ -68,33 +45,17 @@ function findWasmPath(): string {
   return candidates[0];
 }
 
-async function ensureWasmInitialized() {
-  if (renderOverlay) return;
-  if (!wasmInitPromise) {
-    wasmInitPromise = (async () => {
-      const wasmModule = await import('@boardsesh/board-renderer-wasm');
-      const wasmPath = findWasmPath();
-      const wasmBytes = await readFile(wasmPath);
-      wasmModule.initSync({ module: wasmBytes });
-      renderOverlay = wasmModule.render_overlay;
-    })();
-  }
-  await wasmInitPromise;
-}
-
-const VALID_BOARD_NAMES = new Set(['kilter', 'tension', 'moonboard', 'decoy', 'touchstone', 'grasshopper', 'soill']);
-
-// THUMBNAIL_WIDTH imported from @/app/components/board-renderer/types
-// Full: native board resolution for crisp rendering in climb drawer/card cover
-
-// ---------------------------------------------------------------------------
-// Background image helpers (for include_background=1 compositing)
-// ---------------------------------------------------------------------------
+// Module-level overlay renderer with promise-locked init, shared across requests
+// (WASM inits once). Byte loading uses the Vercel-aware findWasmPath probe.
+const overlayRenderer = createOverlayRenderer(async () => {
+  const wasmPath = findWasmPath();
+  return readFile(wasmPath);
+});
 
 /**
- * Resolve a public/-relative path to an absolute filesystem path.
- * Tries multiple candidate directories to work across dev, monorepo root,
- * and Vercel standalone builds.
+ * Resolve a public/-relative path to an absolute filesystem path. Tries multiple
+ * candidate directories to work across dev, monorepo root, and Vercel standalone
+ * builds. Injected into the shared render pipeline as its image resolver.
  */
 function findPublicImagePath(relPath: string): string | null {
   const candidates = [
@@ -107,141 +68,6 @@ function findPublicImagePath(relPath: string): string | null {
     if (existsSync(candidate)) return candidate;
   }
   return null;
-}
-
-/** Convert a raw image filename to its WebP equivalent, optionally as a thumbnail. */
-function toWebpPath(dir: string, filename: string, isThumbnail: boolean): string {
-  const webpName = filename.replace(/\.png$/, '.webp');
-  if (isThumbnail) {
-    const lastSlash = webpName.lastIndexOf('/');
-    if (lastSlash >= 0) {
-      return `${dir}/${webpName.substring(0, lastSlash)}/thumbs${webpName.substring(lastSlash)}`;
-    }
-    return `${dir}/thumbs/${webpName}`;
-  }
-  return `${dir}/${webpName}`;
-}
-
-type BoardDetailsForBg = {
-  board_name: string;
-  images_to_holds: Record<string, unknown>;
-  layoutFolder?: string;
-  holdSetImages?: string[];
-};
-
-/**
- * Build the ordered list of public/-relative paths for background images.
- * Kilter/Tension use images_to_holds keys; MoonBoard uses layoutFolder + holdSetImages.
- */
-function getBackgroundRelPaths(boardDetails: BoardDetailsForBg, isThumbnail: boolean): string[] {
-  const paths: string[] = [];
-  const imageKeys = Object.keys(boardDetails.images_to_holds);
-
-  if (imageKeys.length > 0) {
-    // Aurora boards (Kilter, Tension): keys like "product_sizes_layouts_sets/36-1.png"
-    for (const key of imageKeys) {
-      paths.push(toWebpPath(`images/${boardDetails.board_name}`, key, isThumbnail));
-    }
-  } else if (boardDetails.layoutFolder && boardDetails.holdSetImages) {
-    // MoonBoard fallback (getMoonBoardDetails normally populates images_to_holds,
-    // so this runs only if a caller passes an empty map). Mini boards use their
-    // own background, so resolve it from the layout's geometry.
-    const bgFile = getMoonBoardGeometryByFolder(boardDetails.layoutFolder).backgroundImage;
-    paths.push(toWebpPath('images/moonboard', bgFile, isThumbnail));
-    for (const holdSetImage of boardDetails.holdSetImages) {
-      paths.push(toWebpPath(`images/moonboard/${boardDetails.layoutFolder}`, holdSetImage, isThumbnail));
-    }
-  }
-
-  return paths;
-}
-
-function createOgBackgroundBuffer(boardWidth: number, boardHeight: number): Buffer {
-  const boardX = Math.round((OG_IMAGE_WIDTH - boardWidth) / 2);
-  const boardY = Math.round((OG_IMAGE_HEIGHT - boardHeight) / 2);
-  const frameX = Math.max(boardX - 16, 16);
-  const frameY = Math.max(boardY - 16, 16);
-  const frameWidth = Math.min(boardWidth + 32, OG_IMAGE_WIDTH - frameX * 2);
-  const frameHeight = Math.min(boardHeight + 32, OG_IMAGE_HEIGHT - frameY * 2);
-
-  return Buffer.from(
-    `
-      <svg width="${OG_IMAGE_WIDTH}" height="${OG_IMAGE_HEIGHT}" viewBox="0 0 ${OG_IMAGE_WIDTH} ${OG_IMAGE_HEIGHT}" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stop-color="#071018" />
-            <stop offset="100%" stop-color="#0D1218" />
-          </linearGradient>
-          <filter id="blur">
-            <feGaussianBlur stdDeviation="48" />
-          </filter>
-        </defs>
-        <rect width="${OG_IMAGE_WIDTH}" height="${OG_IMAGE_HEIGHT}" fill="url(#bg)" />
-        <circle cx="212" cy="144" r="156" fill="#0d9488" opacity="0.18" filter="url(#blur)" />
-        <circle cx="984" cy="468" r="188" fill="#f43f5e" opacity="0.16" filter="url(#blur)" />
-        <rect x="24" y="24" width="${OG_IMAGE_WIDTH - 48}" height="${OG_IMAGE_HEIGHT - 48}" rx="28" fill="none" stroke="rgba(255,255,255,0.08)" />
-        <rect x="${frameX}" y="${frameY}" width="${frameWidth}" height="${frameHeight}" rx="22" fill="rgba(6, 10, 14, 0.55)" stroke="rgba(255,255,255,0.10)" />
-      </svg>
-    `,
-  );
-}
-
-type OutputFormat = 'webp' | 'png' | 'jpeg';
-
-function normalizeOutputFormat(format: string): OutputFormat | null {
-  if (format === 'jpg') return 'jpeg';
-  if (format === 'webp' || format === 'png' || format === 'jpeg') return format;
-  return null;
-}
-
-function isValidFrameSegment(segment: string): boolean {
-  if (segment.length === 0) return false;
-  let cursor = 0;
-
-  if (segment[cursor] === '"') {
-    cursor++;
-  }
-
-  if (cursor >= segment.length) return false;
-
-  while (cursor < segment.length) {
-    const current = segment[cursor];
-    if (current === 'x') {
-      cursor++;
-      const start = cursor;
-      while (cursor < segment.length && segment[cursor] >= '0' && segment[cursor] <= '9') {
-        cursor++;
-      }
-      if (cursor === start) return false;
-      continue;
-    }
-
-    if (current !== 'p') return false;
-    cursor++;
-    const placementStart = cursor;
-    while (cursor < segment.length && segment[cursor] >= '0' && segment[cursor] <= '9') {
-      cursor++;
-    }
-    if (cursor === placementStart || segment[cursor] !== 'r') return false;
-
-    cursor++;
-    const roleStart = cursor;
-    while (cursor < segment.length && segment[cursor] >= '0' && segment[cursor] <= '9') {
-      cursor++;
-    }
-    if (cursor === roleStart) return false;
-  }
-
-  return true;
-}
-
-function isValidFramesString(frames: string): boolean {
-  if (frames.length === 0) return true;
-  return frames.split(',').every(isValidFrameSegment);
-}
-
-function getJpegOptions(thumbnail: boolean): sharp.JpegOptions {
-  return thumbnail ? THUMBNAIL_JPEG_OPTIONS : DEFAULT_JPEG_OPTIONS;
 }
 
 export async function GET(request: NextRequest) {
@@ -293,7 +119,7 @@ export async function GET(request: NextRequest) {
     const parsedSetIds = setIds
       .split(',')
       .map(Number)
-      .filter((n) => !isNaN(n));
+      .filter((setId) => !isNaN(setId));
 
     // Get board details (pure computation, no DB)
     const boardDetails = getBoardDetailsForBoard({
@@ -302,226 +128,49 @@ export async function GET(request: NextRequest) {
       size_id: Number(sizeId),
       set_ids: parsedSetIds,
     });
-    const ogScale = isOgVariant
-      ? Math.min(
-          (OG_IMAGE_WIDTH - OG_BOARD_PADDING_X * 2) / boardDetails.boardWidth,
-          (OG_IMAGE_HEIGHT - OG_BOARD_PADDING_Y * 2) / boardDetails.boardHeight,
-        )
-      : null;
-    const computeOutputWidth = () => {
-      if (isOgVariant) return Math.max(1, Math.round(boardDetails.boardWidth * (ogScale || 1)));
-      if (thumbnail) return THUMBNAIL_WIDTH;
-      return boardDetails.boardWidth;
-    };
-    const outputWidth = computeOutputWidth();
 
-    // Build hold state map for this board
-    const holdStateMap: Record<number, { color: string; renderStyle?: string }> = {};
-    const boardStates = HOLD_STATE_MAP[boardName as BoardName];
-    for (const [code, info] of Object.entries(boardStates)) {
-      holdStateMap[Number(code)] = {
-        color: info.color,
-        ...(info.renderStyle ? { renderStyle: info.renderStyle } : {}),
-      };
-    }
-
-    // Build the render config
-    const config = {
-      board_name: boardName,
-      board_width: boardDetails.boardWidth,
-      board_height: boardDetails.boardHeight,
-      output_width: outputWidth,
+    const { config } = buildRenderConfig({
+      boardName,
+      boardDetails,
       frames,
-      mirrored: false,
       thumbnail,
-      holds: boardDetails.holdsData.map((h) => ({
-        id: h.id,
-        mirroredHoldId: h.mirroredHoldId,
-        cx: h.cx,
-        cy: h.cy,
-        r: h.r,
-      })),
-      hold_state_map: holdStateMap,
-    };
+      isOgVariant,
+      boardStates: HOLD_STATE_MAP[boardName as BoardName],
+      thumbnailWidth: THUMBNAIL_WIDTH,
+    });
 
-    // Initialize WASM if needed and render
-    await ensureWasmInitialized();
-    if (!renderOverlay) {
-      return NextResponse.json({ error: 'WASM renderer failed to initialize' }, { status: 500 });
-    }
+    // Initialize WASM if needed and render the overlay.
     const wasmT0 = performance.now();
-    const rawBytes = renderOverlay(JSON.stringify(config));
+    const { width, height, rgba } = await overlayRenderer.render(JSON.stringify(config));
     const wasmMs = performance.now() - wasmT0;
 
-    // Parse dimension header: first 8 bytes are width + height as u32 LE
-    const view = new DataView(rawBytes.buffer, rawBytes.byteOffset, rawBytes.byteLength);
-    const width = view.getUint32(0, true);
-    const height = view.getUint32(4, true);
-    const rgbaData = rawBytes.subarray(8);
+    const overlayBuffer = Buffer.from(rgba.buffer, rgba.byteOffset, rgba.byteLength);
 
-    // Encode to WebP, optionally compositing background images first
-    const overlayBuffer = Buffer.from(rgbaData.buffer, rgbaData.byteOffset, rgbaData.byteLength);
-
-    const sharpT0 = performance.now();
-    let imageBuffer: Buffer | null = null;
-    let outputBuffer: Buffer | null = null;
-    let outputContentType = 'image/png';
-    let bgMs = 0;
-    let composeMs = 0;
-    let didCompositeBackground = false;
-
-    if (includeBackground) {
-      const bgT0 = performance.now();
-      const bgRelPaths = getBackgroundRelPaths(boardDetails, thumbnail);
-      const bgFsPaths = bgRelPaths.map((rp) => findPublicImagePath(rp)).filter((p): p is string => p !== null);
-      bgMs = performance.now() - bgT0;
-
-      if (bgFsPaths.length > 0) {
-        // Load and resize background images, skipping any that fail
-        const results = await Promise.allSettled(
-          bgFsPaths.map((fsPath) => sharp(fsPath).resize(width, height, { fit: 'fill' }).toBuffer()),
-        );
-        const resizedBuffers = results
-          .filter((r): r is PromiseFulfilledResult<Buffer> => r.status === 'fulfilled')
-          .map((r) => r.value);
-
-        const [firstBg, ...restBgs] = resizedBuffers;
-
-        if (firstBg) {
-          // Composite: first background as base → remaining backgrounds →
-          // optional dim scrim → WASM overlay on top. The dim scrim (a black
-          // layer at dim_background opacity) darkens the board photo behind the
-          // holds; mirrors LayeredClimbImage's background→dim→holds stack.
-          const composeT0 = performance.now();
-          const dimLayer =
-            dimBackground > 0
-              ? await sharp({
-                  create: { width, height, channels: 4, background: { r: 0, g: 0, b: 0, alpha: dimBackground } },
-                })
-                  .png()
-                  .toBuffer()
-              : null;
-          const compositedImage = sharp(firstBg).composite([
-            ...restBgs.map((buf) => ({ input: buf, blend: 'over' as const })),
-            ...(dimLayer ? [{ input: dimLayer, blend: 'over' as const }] : []),
-            {
-              input: overlayBuffer,
-              raw: { width, height, channels: 4 as const },
-              blend: 'over' as const,
-            },
-          ]);
-          if (!isOgVariant && format === 'webp') {
-            outputBuffer = await compositedImage
-              .webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : DEFAULT_WEBP_OPTIONS)
-              .toBuffer();
-            outputContentType = 'image/webp';
-          } else if (!isOgVariant && format === 'jpeg') {
-            outputBuffer = await compositedImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
-            outputContentType = 'image/jpeg';
-          } else {
-            imageBuffer = await compositedImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
-          }
-          composeMs = performance.now() - composeT0;
-          didCompositeBackground = true;
-        } else {
-          // All background loads failed — fall back to overlay-only
-          const composeT0 = performance.now();
-          const overlayImage = sharp(overlayBuffer, { raw: { width, height, channels: 4 } });
-          if (!isOgVariant && format === 'webp') {
-            outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
-            outputContentType = 'image/webp';
-          } else if (!isOgVariant && format === 'jpeg') {
-            outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
-            outputContentType = 'image/jpeg';
-          } else {
-            imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
-          }
-          composeMs = performance.now() - composeT0;
-        }
-      } else {
-        // No background images found — fall back to overlay-only lossless
-        const composeT0 = performance.now();
-        const overlayImage = sharp(overlayBuffer, { raw: { width, height, channels: 4 } });
-        if (!isOgVariant && format === 'webp') {
-          outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
-          outputContentType = 'image/webp';
-        } else if (!isOgVariant && format === 'jpeg') {
-          outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
-          outputContentType = 'image/jpeg';
-        } else {
-          imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
-        }
-        composeMs = performance.now() - composeT0;
-      }
-    } else {
-      // Default: overlay-only lossless WebP (25-30% smaller than PNG)
-      const composeT0 = performance.now();
-      const overlayImage = sharp(overlayBuffer, { raw: { width, height, channels: 4 } });
-      if (!isOgVariant && format === 'webp') {
-        outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
-        outputContentType = 'image/webp';
-      } else if (!isOgVariant && format === 'jpeg') {
-        outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
-        outputContentType = 'image/jpeg';
-      } else {
-        imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
-      }
-      composeMs = performance.now() - composeT0;
-    }
-
-    const encodeT0 = performance.now();
-
-    if (outputBuffer === null && isOgVariant && imageBuffer) {
-      const ogImage = sharp(createOgBackgroundBuffer(width, height)).composite([
-        {
-          input: imageBuffer,
-          left: Math.round((OG_IMAGE_WIDTH - width) / 2),
-          top: Math.round((OG_IMAGE_HEIGHT - height) / 2),
-          blend: 'over',
-        },
-      ]);
-      if (format === 'jpeg') {
-        outputBuffer = await ogImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
-        outputContentType = 'image/jpeg';
-      } else {
-        outputBuffer = await ogImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
-        outputContentType = 'image/png';
-      }
-    } else if (outputBuffer === null && imageBuffer && format === 'webp') {
-      const getWebpOptions = () => {
-        if (thumbnail) return THUMBNAIL_WEBP_OPTIONS;
-        if (didCompositeBackground) return DEFAULT_WEBP_OPTIONS;
-        return { lossless: true };
-      };
-      outputBuffer = await sharp(imageBuffer).webp(getWebpOptions()).toBuffer();
-      outputContentType = 'image/webp';
-    } else if (outputBuffer === null && imageBuffer && format === 'jpeg') {
-      outputBuffer = await sharp(imageBuffer).jpeg(getJpegOptions(thumbnail)).toBuffer();
-      outputContentType = 'image/jpeg';
-    } else if (outputBuffer === null && imageBuffer) {
-      outputBuffer = imageBuffer;
-      outputContentType = 'image/png';
-    }
-
-    if (!outputBuffer) {
-      return NextResponse.json({ error: 'Render failed: no output buffer generated' }, { status: 500 });
-    }
-
-    const encodeMs = performance.now() - encodeT0;
-    const sharpMs = performance.now() - sharpT0;
+    const { buffer, contentType, timings } = await renderBoardImageBuffer({
+      overlayBuffer,
+      width,
+      height,
+      isOgVariant,
+      format,
+      thumbnail,
+      includeBackground,
+      dimBackground,
+      boardDetails,
+      resolveImagePath: findPublicImagePath,
+    });
 
     const timingParts = [
       `wasm;dur=${wasmMs.toFixed(1)}`,
-      `sharp;dur=${sharpMs.toFixed(1)}`,
-      `compose;dur=${composeMs.toFixed(1)}`,
-      `encode;dur=${encodeMs.toFixed(1)}`,
+      `sharp;dur=${timings.sharpMs.toFixed(1)}`,
+      `compose;dur=${timings.composeMs.toFixed(1)}`,
+      `encode;dur=${timings.encodeMs.toFixed(1)}`,
     ];
-    if (bgMs > 0) timingParts.push(`bg;dur=${bgMs.toFixed(1)}`);
+    if (timings.bgMs > 0) timingParts.push(`bg;dur=${timings.bgMs.toFixed(1)}`);
 
-    return new NextResponse(new Uint8Array(outputBuffer), {
+    return new NextResponse(new Uint8Array(buffer), {
       headers: {
         ...createOgImageHeaders({
-          contentType: outputContentType,
+          contentType,
           version: 'immutable',
           serverTiming: timingParts.join(', '),
         }),

--- a/packages/web/app/components/board-renderer/types.ts
+++ b/packages/web/app/components/board-renderer/types.ts
@@ -32,5 +32,6 @@ export type HeatmapData = {
   userAttempts?: number;
 };
 
-/** Thumbnail render width in pixels. Covers 3x retina at ~64px CSS display. */
-export const THUMBNAIL_WIDTH = 200;
+// Thumbnail render width (px). Defined in @boardsesh/board-render (shared with
+// the backend OG renderer); re-exported here so importers keep the same path.
+export { THUMBNAIL_WIDTH } from '@boardsesh/board-render';

--- a/packages/web/app/lib/board-constants.ts
+++ b/packages/web/app/lib/board-constants.ts
@@ -1,18 +1,8 @@
 import { AURORA_BOARDS, SUPPORTED_BOARDS, type AuroraBoardName } from '@boardsesh/shared-schema';
-import { boardSupportsMirroring } from '@boardsesh/play-view';
-import type { HoldRenderData } from '@/app/components/board-renderer/types';
-import type { BoardDetails, ImageFileName } from '@/app/lib/types';
+import { getBoardDetails as computeBoardDetails } from '@boardsesh/board-render';
+import type { BoardDetails } from '@/app/lib/types';
 import type { SetIdList } from '@/app/lib/board-data';
-import {
-  PRODUCT_SIZES,
-  getProductSize,
-  getLayout,
-  getSetsForLayoutAndSize,
-  getImageFilename,
-  getHolePlacements,
-} from '@boardsesh/board-constants/product-sizes';
-import { BOARD_IMAGE_DIMENSIONS } from './board-data';
-import type { BoardName, HoldTuple } from './types';
+import type { BoardName } from './types';
 
 export * from '@boardsesh/board-constants/product-sizes';
 
@@ -36,78 +26,12 @@ export function isAuroraBoardName(boardName: string): boardName is AuroraBoardNa
   return AURORA_BOARD_NAMES.includes(boardName as AuroraBoardName);
 }
 
-export const getBoardDetails = ({
-  board_name,
-  layout_id,
-  size_id,
-  set_ids,
-}: {
+// The Aurora board-details computation lives in the shared @boardsesh/board-render
+// package (also consumed by the always-on backend OG renderer). Web keeps this
+// export + its BoardDetails return type so every existing importer is unchanged.
+export const getBoardDetails = (params: {
   board_name: BoardName;
   layout_id: number;
   size_id: number;
   set_ids: SetIdList;
-}): BoardDetails => {
-  const sizeData = getProductSize(board_name, size_id);
-  if (!sizeData) {
-    const availableSizes = Object.keys(PRODUCT_SIZES[board_name] || {});
-    throw new Error(
-      `Size dimensions not found for board_name=${board_name}, size_id=${size_id}. Available sizes: [${availableSizes.join(', ')}]`,
-    );
-  }
-
-  const layoutData = getLayout(board_name, layout_id);
-  const setsResult = getSetsForLayoutAndSize(board_name, layout_id, size_id);
-
-  const imagesToHolds: Record<ImageFileName, HoldTuple[]> = {};
-  for (const setId of set_ids) {
-    const imageFilename = getImageFilename(board_name, layout_id, size_id, setId);
-    if (!imageFilename) {
-      throw new Error(`Could not find image for set_id ${setId} for layout_id: ${layout_id} and size_id: ${size_id}`);
-    }
-    imagesToHolds[imageFilename] = getHolePlacements(board_name, layout_id, setId);
-  }
-
-  const { edgeLeft: edge_left, edgeRight: edge_right, edgeBottom: edge_bottom, edgeTop: edge_top } = sizeData;
-
-  const firstImage = Object.keys(imagesToHolds)[0];
-  const dimensions = BOARD_IMAGE_DIMENSIONS[board_name][firstImage];
-  const boardWidth = dimensions?.width ?? 1080;
-  const boardHeight = dimensions?.height ?? 1920;
-
-  const xSpacing = boardWidth / (edge_right - edge_left);
-  const ySpacing = boardHeight / (edge_top - edge_bottom);
-
-  const holdsData: HoldRenderData[] = Object.values(imagesToHolds).flatMap((holds: HoldTuple[]) =>
-    holds
-      .filter(([, , x, y]) => x > edge_left && x < edge_right && y > edge_bottom && y < edge_top)
-      .map(([holdId, mirroredHoldId, x, y]) => ({
-        id: holdId,
-        mirroredHoldId,
-        cx: (x - edge_left) * xSpacing,
-        cy: boardHeight - (y - edge_bottom) * ySpacing,
-        r: xSpacing * 4,
-      })),
-  );
-
-  const selectedSets = setsResult.filter((set) => set_ids.includes(set.id));
-
-  return {
-    images_to_holds: imagesToHolds,
-    holdsData,
-    edge_left,
-    edge_right,
-    edge_bottom,
-    edge_top,
-    boardHeight,
-    boardWidth,
-    board_name,
-    layout_id,
-    size_id,
-    set_ids,
-    supportsMirroring: boardSupportsMirroring(board_name, layout_id),
-    layout_name: layoutData?.name,
-    size_name: sizeData.name,
-    size_description: sizeData.description,
-    set_names: selectedSets.map((set) => set.name),
-  };
-};
+}): BoardDetails => computeBoardDetails(params);

--- a/packages/web/app/lib/board-utils.ts
+++ b/packages/web/app/lib/board-utils.ts
@@ -1,7 +1,6 @@
 import type { BoardDetails, ParsedBoardRouteParameters } from './types';
 import type { SetIdList } from './board-data';
-import { getBoardDetails } from './board-constants';
-import { getMoonBoardDetails } from './moonboard-config';
+import { getBoardDetailsForBoard as computeBoardDetailsForBoard } from '@boardsesh/board-render';
 
 /**
  * Get board details for any board type (Aurora or MoonBoard).
@@ -49,14 +48,11 @@ export function generateBoardTitle(boardDetails: BoardDetails): string {
   return `${parts.join(' ')} | Boardsesh`;
 }
 
+// Board-details routing (Aurora vs MoonBoard) lives in @boardsesh/board-render
+// so the backend OG renderer shares one implementation. Web keeps this export +
+// its BoardDetails return type for every existing importer.
 export function getBoardDetailsForBoard(
   params: ParsedBoardRouteParameters | { board_name: string; layout_id: number; size_id: number; set_ids: SetIdList },
 ): BoardDetails {
-  if (params.board_name === 'moonboard') {
-    return getMoonBoardDetails({
-      layout_id: params.layout_id,
-      set_ids: params.set_ids,
-    });
-  }
-  return getBoardDetails(params as Parameters<typeof getBoardDetails>[0]);
+  return computeBoardDetailsForBoard(params);
 }

--- a/packages/web/app/lib/seo/og.ts
+++ b/packages/web/app/lib/seo/og.ts
@@ -1,9 +1,7 @@
-export const OG_IMAGE_WIDTH = 1200;
-export const OG_IMAGE_HEIGHT = 630;
-
-const ONE_YEAR_SECONDS = 31_536_000;
-const SHORT_TTL_SECONDS = 300;
-const STALE_TTL_SECONDS = 86_400;
+// OG canvas dimensions + the immutable/short-TTL header builder live in the
+// shared @boardsesh/board-render package (also used by the backend OG renderer).
+// Re-exported here so web's existing importers keep the same module path.
+export { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT, createOgImageHeaders } from '@boardsesh/board-render';
 
 function toVersionMillis(value: Date | string | number | null | undefined): number | null {
   if (value === null || value === undefined) {
@@ -64,30 +62,4 @@ export function buildVersionedOgImagePath(
 
   const query = searchParams.toString();
   return query ? `${path}?${query}` : path;
-}
-
-export function createOgImageHeaders({
-  contentType,
-  version,
-  serverTiming,
-}: {
-  contentType: string;
-  version?: string | null;
-  serverTiming?: string;
-}): Record<string, string> {
-  const isVersioned = version !== null && version !== undefined;
-  const browserCacheControl = isVersioned
-    ? `public, max-age=${ONE_YEAR_SECONDS}, s-maxage=${ONE_YEAR_SECONDS}, immutable`
-    : `public, max-age=0, s-maxage=${SHORT_TTL_SECONDS}, stale-while-revalidate=${STALE_TTL_SECONDS}`;
-  const cdnCacheControl = isVersioned
-    ? `public, s-maxage=${ONE_YEAR_SECONDS}, immutable`
-    : `public, s-maxage=${SHORT_TTL_SECONDS}, stale-while-revalidate=${STALE_TTL_SECONDS}`;
-
-  return {
-    'Content-Type': contentType,
-    'Cache-Control': browserCacheControl,
-    'CDN-Cache-Control': cdnCacheControl,
-    'Vercel-CDN-Cache-Control': cdnCacheControl,
-    ...(serverTiming ? { 'Server-Timing': serverTiming } : {}),
-  };
 }

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -57,6 +57,7 @@ const nextConfig = {
     '@boardsesh/moonboard-ocr',
     '@boardsesh/ble-protocol',
     '@boardsesh/board-config',
+    '@boardsesh/board-render',
     '@boardsesh/graphql',
     '@boardsesh/graphql-client',
     '@boardsesh/queue',

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,6 +36,7 @@
     "@boardsesh/board-presence": "*",
     "@boardsesh/board-presence-react": "*",
     "@boardsesh/board-react": "*",
+    "@boardsesh/board-render": "*",
     "@boardsesh/board-renderer-wasm": "*",
     "@boardsesh/climb-actions": "*",
     "@boardsesh/climb-filters": "*",

--- a/scripts/check-service-deploy-inputs.test.mjs
+++ b/scripts/check-service-deploy-inputs.test.mjs
@@ -30,6 +30,8 @@ function createFixtureRepo() {
   // generation fails when one is missing, so the fixture repo carries stubs.
   writeFixtureFile(repoRoot, 'scripts/build-expo-web-export.sh', '#!/usr/bin/env bash\n');
   writeFixtureFile(repoRoot, 'scripts/lib/tailscale-hostname.ts', 'export {};\n');
+  // Same for the backend service's extraSourceDirs entry.
+  writeFixtureFile(repoRoot, 'packages/web/public/images/stub.webp', '');
 
   writePackage(repoRoot, 'packages/backend', {
     name: 'boardsesh-backend',

--- a/scripts/create-service-docker-context.mjs
+++ b/scripts/create-service-docker-context.mjs
@@ -20,6 +20,11 @@ const services = {
   backend: {
     dockerfile: 'Dockerfile.backend',
     rootPackageName: 'boardsesh-backend',
+    // The OG climb renderer (GET /og/climb) composites board photos onto the
+    // social card, so the backend image needs the board images tree (~70MB).
+    // The prebuilt .wasm rides in automatically via the
+    // @boardsesh/board-renderer-wasm workspace-dep walk.
+    extraSourceDirs: ['packages/web/public/images'],
   },
   web: {
     dockerfile: 'Dockerfile.web',
@@ -266,6 +271,17 @@ function createServiceDockerContext({ serviceName, repoRoot = defaultRepoRoot, o
       throw new Error(`${serviceName} extra source file ${extraSourceFile} is missing`);
     }
     copyFileCreatingParent(absoluteExtraSourcePath, join(absoluteOutputDir, 'source', extraSourceFile));
+  }
+
+  // Whole directories a service needs beyond its workspace-dep source packages
+  // (e.g. the backend's board images tree). Copied verbatim under source/<dir>
+  // with the same ignore rules the package walk uses.
+  for (const extraSourceDir of service.extraSourceDirs ?? []) {
+    const absoluteExtraSourceDir = join(absoluteRepoRoot, extraSourceDir);
+    if (!existsSync(absoluteExtraSourceDir)) {
+      throw new Error(`${serviceName} extra source directory ${extraSourceDir} is missing`);
+    }
+    copyDirectory(absoluteExtraSourceDir, join(absoluteOutputDir, 'source', extraSourceDir), absoluteRepoRoot);
   }
 
   return {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,6 +102,7 @@ export default defineConfig({
       './packages/crypto/vite.config.ts',
       './packages/shared/ble-protocol/vite.config.ts',
       './packages/shared/board-config/vite.config.ts',
+      './packages/shared/board-render/vite.config.ts',
       './packages/shared/velvet-tokens/vite.config.ts',
       './packages/shared/board-react/vite.config.ts',
       './packages/shared/create-climb-react/vite.config.ts',
@@ -477,6 +478,10 @@ export default defineConfig({
       'typecheck:board-config': {
         command: 'bun run --filter=@boardsesh/board-config typecheck',
       },
+      'typecheck:board-render': {
+        command: 'bun run --filter=@boardsesh/board-render typecheck',
+        dependsOn: ['build:constants'],
+      },
       'typecheck:play-view': {
         command: 'bun run --filter=@boardsesh/play-view typecheck',
       },
@@ -558,6 +563,7 @@ export default defineConfig({
           'typecheck:climb-actions',
           'typecheck:key-value-storage',
           'typecheck:board-config',
+          'typecheck:board-render',
           'typecheck:play-view',
           'typecheck:playback-react',
           'typecheck:profile-stats',


### PR DESCRIPTION
## Summary

First of two PRs moving climb OG share cards off Vercel (part of winding down Vercel hosting — the embeds are slow enough that platforms like Facebook sometimes refuse to render them).

Production measurements that motivated this: the climb og:image costs ~1.0s TTFB per origin render on Vercel (plus lambda cold-start doing lazy WASM init), at 324KB of PNG — and FB/Twitter/WhatsApp/Slack each fetch it independently.

This PR extracts the render pipeline into a new shared package `@boardsesh/board-render` and adds `GET /og/climb` to the always-on backend:

- **Web**: `/api/internal/board-render` becomes a thin shell over the shared package — zero behavior change, route tests pass unchanged. In-app rendering stays on the web route.
- **Backend**: eager WASM init at boot (no cold starts), pre-composited per-board-config OG base cache + final-bytes LRU, JPEG default for OG cards (mozjpeg q85, 4:4:4 chroma — ~78KB vs 324KB), strict zod validation before any CPU, per-IP rate limiting (fail-open without Redis), winston render logs + `Server-Timing`, 503 instead of crash if WASM init fails.
- **Docker**: new `extraSourceDirs` mechanism in the context script ships `packages/web/public/images` (70MB board photos) into the backend image; the prebuilt `.wasm` rides in via the existing workspace-dep walk.

Measured on the new endpoint (tsx, local): first render per board config 682ms (one-time, warmed at boot), new climb on warm config **~263ms**, repeat fetch **~0ms** from cache.

PR 2 (after this deploys and is verified in prod) flips web's `og:image` URLs to `https://ws.boardsesh.com/og/climb` — until then this endpoint serves no traffic, so there is no crawler-facing 404 window.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` clean; `vp run typecheck` clean (all packages)
- `vp test run --project board-render` — 52 tests (validation incl. set_ids canonicalisation, backgrounds, board details, LRU bounds)
- `vp test run --project backend` — 2573 tests green against real postgres+redis; includes `og-climb.test.ts` (13 tests: 400 paths before any render CPU, 429, immutable headers, byte-cache hit, and a real WASM+sharp render smoke asserting a 1200×630 JPEG)
- `vp run test:web` — 5719 tests green; `board-render/__tests__/route.test.ts` passes **unchanged** (proves the extraction kept web behavior identical)
- `node scripts/create-service-docker-context.mjs backend` verified: wasm binary, shared package, and the images tree all land in the context
- Post-deploy: curl `https://ws.boardsesh.com/og/climb?...` for miss/hit timings + headers (commands in the plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfrRx9USHPkdtaPXuLo3Zb