### PR TITLE
feat(web): point climb og:image at the backend /og/climb endpoint

### DIFF
--- a/packages/web/app/api/og/climb/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/climb/__tests__/route.test.tsx
@@ -39,7 +39,7 @@ vi.mock('@/app/lib/board-utils', () => ({
 }));
 
 vi.mock('@/app/components/board-renderer/util', () => ({
-  buildOgBoardRenderUrl: vi.fn(() => '/api/internal/board-render?board_name=kilter&variant=og&format=png'),
+  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb?board_name=kilter&variant=og&format=jpeg'),
 }));
 
 function makeRequest(params: Record<string, string>): NextRequest {
@@ -64,12 +64,12 @@ describe('api/og/climb legacy redirect', () => {
     vi.clearAllMocks();
   });
 
-  it('redirects legacy climb OG requests to the immutable Rust-render URL', async () => {
+  it('redirects legacy climb OG requests to the absolute backend OG image URL', async () => {
     const response = await GET(makeRequest(validParams));
 
     expect(response.status).toBe(307);
     expect(response.headers.get('location')).toBe(
-      'http://localhost:3000/api/internal/board-render?board_name=kilter&variant=og&format=png',
+      'https://ws.boardsesh.com/og/climb?board_name=kilter&variant=og&format=jpeg',
     );
     expect(response.headers.get('Cache-Control')).toContain('s-maxage=300');
   });

--- a/packages/web/app/api/og/climb/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/climb/__tests__/route.test.tsx
@@ -39,7 +39,7 @@ vi.mock('@/app/lib/board-utils', () => ({
 }));
 
 vi.mock('@/app/components/board-renderer/util', () => ({
-  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb?board_name=kilter&variant=og&format=jpeg'),
+  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=10&set_ids=1%2C20&frames=p1r42&format=jpeg'),
 }));
 
 function makeRequest(params: Record<string, string>): NextRequest {
@@ -69,7 +69,7 @@ describe('api/og/climb legacy redirect', () => {
 
     expect(response.status).toBe(307);
     expect(response.headers.get('location')).toBe(
-      'https://ws.boardsesh.com/og/climb?board_name=kilter&variant=og&format=jpeg',
+      'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=10&set_ids=1%2C20&frames=p1r42&format=jpeg',
     );
     expect(response.headers.get('Cache-Control')).toContain('s-maxage=300');
   });

--- a/packages/web/app/api/og/climb/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/climb/__tests__/route.test.tsx
@@ -39,7 +39,10 @@ vi.mock('@/app/lib/board-utils', () => ({
 }));
 
 vi.mock('@/app/components/board-renderer/util', () => ({
-  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=10&set_ids=1%2C20&frames=p1r42&format=jpeg'),
+  buildOgBoardRenderUrl: vi.fn(
+    () =>
+      'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=10&set_ids=1%2C20&frames=p1r42&format=jpeg',
+  ),
 }));
 
 function makeRequest(params: Record<string, string>): NextRequest {

--- a/packages/web/app/api/og/climb/route.tsx
+++ b/packages/web/app/api/og/climb/route.tsx
@@ -51,8 +51,10 @@ export async function GET(request: NextRequest) {
       `db;dur=${dbMs.toFixed(1)}, route;dur=${(performance.now() - routeT0).toFixed(1)}`,
     );
 
+    // Only the cache headers are applied to the redirect (Content-Type is
+    // skipped below); the contentType argument is a required formality.
     const cacheHeaders = createOgImageHeaders({
-      contentType: 'image/png',
+      contentType: 'image/jpeg',
       serverTiming: response.headers.get('Server-Timing') || undefined,
     });
 

--- a/packages/web/app/api/og/climb/route.tsx
+++ b/packages/web/app/api/og/climb/route.tsx
@@ -52,7 +52,7 @@ export async function GET(request: NextRequest) {
     );
 
     // Only the cache headers are applied to the redirect (Content-Type is
-    // skipped below); the contentType argument is a required formality.
+    // skipped below). image/jpeg mirrors what the backend target serves.
     const cacheHeaders = createOgImageHeaders({
       contentType: 'image/jpeg',
       serverTiming: response.headers.get('Server-Timing') || undefined,

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/page-metadata.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/page-metadata.test.tsx
@@ -83,7 +83,7 @@ vi.mock('@/app/lib/url-utils', () => ({
 }));
 
 vi.mock('@/app/components/board-renderer/util', () => ({
-  buildOgBoardRenderUrl: vi.fn(() => '/api/internal/board-render?board_name=kilter&variant=og&format=png'),
+  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb?board_name=kilter&variant=og&format=jpeg'),
   buildOverlayUrl: vi.fn(() => '/api/internal/board-render?board_name=kilter&variant=overlay'),
 }));
 
@@ -115,7 +115,7 @@ function getOpenGraphImageUrl(image: string | URL | { url: string | URL } | unde
 }
 
 describe('board slug climb metadata', () => {
-  it('uses the immutable Rust board render URL for social images', async () => {
+  it('uses the absolute backend OG image URL for social images', async () => {
     const metadata = await pageModule.generateMetadata({
       params: Promise.resolve({
         board_slug: 'my-board',
@@ -127,7 +127,9 @@ describe('board slug climb metadata', () => {
     const image = Array.isArray(metadata.openGraph?.images) ? metadata.openGraph.images[0] : metadata.openGraph?.images;
     const imageUrl = getOpenGraphImageUrl(image);
 
-    expect(imageUrl).toBe('/api/internal/board-render?board_name=kilter&variant=og&format=png');
+    // The absolute backend URL must pass through createPageMetadata/normalizePath
+    // untouched — no leading slash mangling it into `/https://…`.
+    expect(imageUrl).toBe('https://ws.boardsesh.com/og/climb?board_name=kilter&variant=og&format=jpeg');
     expect(imageUrl).not.toContain('/api/og/climb');
   });
 

--- a/packages/web/app/components/board-renderer/__tests__/util.test.ts
+++ b/packages/web/app/components/board-renderer/__tests__/util.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vite-plus/test';
+import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
 import { getImageUrl, buildBoardRenderUrl, buildOverlayUrl, buildOgBoardRenderUrl } from '../util';
 import type { BoardDetails } from '@/app/lib/types';
 
@@ -136,13 +136,34 @@ describe('buildOgBoardRenderUrl', () => {
     boardHeight: 1350,
   } as unknown as BoardDetails;
 
-  it('builds the public OG board render URL', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('points at the backend /og/climb endpoint as an absolute JPEG URL when the origin resolves', () => {
+    vi.stubEnv('NEXT_PUBLIC_WS_URL', 'wss://ws.boardsesh.com/graphql');
+
+    const url = buildOgBoardRenderUrl(boardDetails, 'p1r12,p2r13');
+
+    expect(url).toBe(
+      'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=7&set_ids=1,20' +
+        '&frames=p1r42p2r43&include_background=1&variant=og&format=jpeg',
+    );
+    expect(url).toContain('format=jpeg');
+    expect(url).not.toContain('/api/internal/board-render');
+    expect(url).not.toContain('/api/og/climb');
+  });
+
+  it('falls back to the relative web board-render PNG URL when the backend origin is unset', () => {
+    vi.stubEnv('NEXT_PUBLIC_WS_URL', '');
+
     const url = buildOgBoardRenderUrl(boardDetails, 'p1r12,p2r13');
 
     expect(url).toContain('/api/internal/board-render');
     expect(url).toContain('include_background=1');
     expect(url).toContain('variant=og');
     expect(url).toContain('format=png');
+    expect(url).not.toContain('ws.boardsesh.com');
     expect(url).not.toContain('/api/og/climb');
   });
 });

--- a/packages/web/app/components/board-renderer/__tests__/util.test.ts
+++ b/packages/web/app/components/board-renderer/__tests__/util.test.ts
@@ -146,8 +146,8 @@ describe('buildOgBoardRenderUrl', () => {
     const url = buildOgBoardRenderUrl(boardDetails, 'p1r12,p2r13');
 
     expect(url).toBe(
-      'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=7&set_ids=1,20' +
-        '&frames=p1r42p2r43&include_background=1&variant=og&format=jpeg',
+      'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=7&set_ids=1%2C20' +
+        '&frames=p1r42p2r43&format=jpeg',
     );
     expect(url).toContain('format=jpeg');
     expect(url).not.toContain('/api/internal/board-render');

--- a/packages/web/app/components/board-renderer/__tests__/util.test.ts
+++ b/packages/web/app/components/board-renderer/__tests__/util.test.ts
@@ -149,9 +149,6 @@ describe('buildOgBoardRenderUrl', () => {
       'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=7&set_ids=1%2C20' +
         '&frames=p1r42p2r43&format=jpeg',
     );
-    expect(url).toContain('format=jpeg');
-    expect(url).not.toContain('/api/internal/board-render');
-    expect(url).not.toContain('/api/og/climb');
   });
 
   it('falls back to the relative web board-render PNG URL when the backend origin is unset', () => {

--- a/packages/web/app/components/board-renderer/util.ts
+++ b/packages/web/app/components/board-renderer/util.ts
@@ -1,5 +1,6 @@
 import { accumulateFramesToMaps, accumulatedMapsToFrameStrings } from '@boardsesh/board-constants/hold-states';
 import type { BoardDetails, BoardName } from '@/app/lib/types';
+import { getPublicBackendHttpUrl } from '@/app/lib/backend-url';
 import { BOARD_IMAGE_DIMENSIONS } from '../../lib/board-data';
 export { convertLitUpHoldsStringToMap } from './types';
 // Multi-frame playback primitives now live in the shared, renderer-agnostic
@@ -85,12 +86,36 @@ export const buildOverlayUrl = (boardDetails: BoardDetails, frames: string, thum
     includeBackground: true,
   });
 
-export const buildOgBoardRenderUrl = (boardDetails: BoardDetails, frames: string) =>
-  buildBoardRenderUrl(boardDetails, toFlatFrames(frames, boardDetails.board_name), {
+/**
+ * OG card image for a shared climb. Points at the backend `/og/climb` endpoint
+ * (long-running process, warm renderer, JPEG by default) as an absolute URL so
+ * crawlers fetch it directly instead of the slow Vercel render path. When the
+ * backend origin can't be resolved (misconfigured env, some test contexts) it
+ * falls back to the web board-render route unchanged.
+ */
+export const buildOgBoardRenderUrl = (boardDetails: BoardDetails, frames: string) => {
+  const flatFrames = toFlatFrames(frames, boardDetails.board_name);
+  const backendOrigin = getPublicBackendHttpUrl();
+
+  if (backendOrigin) {
+    return (
+      `${backendOrigin}/og/climb?board_name=${boardDetails.board_name}` +
+      `&layout_id=${boardDetails.layout_id}` +
+      `&size_id=${boardDetails.size_id}` +
+      `&set_ids=${boardDetails.set_ids.join(',')}` +
+      `&frames=${encodeURIComponent(flatFrames)}` +
+      // include_background/variant are inert on the backend (it always renders
+      // the OG composite); kept so the URL family stays param-compatible.
+      `&include_background=1&variant=og&format=jpeg`
+    );
+  }
+
+  return buildBoardRenderUrl(boardDetails, flatFrames, {
     includeBackground: true,
     variant: 'og',
     format: 'png',
   });
+};
 
 const USE_SELF_HOSTED_IMAGES = true;
 

--- a/packages/web/app/components/board-renderer/util.ts
+++ b/packages/web/app/components/board-renderer/util.ts
@@ -98,16 +98,15 @@ export const buildOgBoardRenderUrl = (boardDetails: BoardDetails, frames: string
   const backendOrigin = getPublicBackendHttpUrl();
 
   if (backendOrigin) {
-    return (
-      `${backendOrigin}/og/climb?board_name=${boardDetails.board_name}` +
-      `&layout_id=${boardDetails.layout_id}` +
-      `&size_id=${boardDetails.size_id}` +
-      `&set_ids=${boardDetails.set_ids.join(',')}` +
-      `&frames=${encodeURIComponent(flatFrames)}` +
-      // include_background/variant are inert on the backend (it always renders
-      // the OG composite); kept so the URL family stays param-compatible.
-      `&include_background=1&variant=og&format=jpeg`
-    );
+    const backendParams = new URLSearchParams({
+      board_name: boardDetails.board_name,
+      layout_id: String(boardDetails.layout_id),
+      size_id: String(boardDetails.size_id),
+      set_ids: boardDetails.set_ids.join(','),
+      frames: flatFrames,
+      format: 'jpeg',
+    });
+    return `${backendOrigin}/og/climb?${backendParams}`;
   }
 
   return buildBoardRenderUrl(boardDetails, flatFrames, {

--- a/packages/web/app/lib/seo/__tests__/metadata.test.ts
+++ b/packages/web/app/lib/seo/__tests__/metadata.test.ts
@@ -58,6 +58,20 @@ describe('SEO metadata helper', () => {
       });
     });
 
+    it('passes an absolute image URL through untouched for OG and Twitter', () => {
+      const absoluteImageUrl = 'https://ws.boardsesh.com/og/climb?board_name=kilter&variant=og&format=jpeg';
+      const metadata = createPageMetadata({
+        title: 'Kilter Climb',
+        description: 'A shared climb card.',
+        path: 'b/my-board/40/view/test-climb',
+        imagePath: absoluteImageUrl,
+      });
+
+      const image = Array.isArray(metadata.openGraph?.images) ? metadata.openGraph.images[0] : undefined;
+      expect(image).toMatchObject({ url: absoluteImageUrl });
+      expect(metadata.twitter?.images).toEqual([absoluteImageUrl]);
+    });
+
     it('supports pages without a canonical path or social image', () => {
       const metadata = createPageMetadata({
         title: 'Standalone',

--- a/packages/web/app/lib/seo/metadata.ts
+++ b/packages/web/app/lib/seo/metadata.ts
@@ -28,6 +28,12 @@ function normalizePath(path?: string): string | undefined {
     return undefined;
   }
 
+  // Absolute URLs (e.g. the backend-hosted OG image) pass through untouched —
+  // prefixing a slash would mangle them into `/https://…`.
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
   if (path === '/') {
     return '/';
   }


### PR DESCRIPTION
## Summary

Second of two PRs moving climb OG share cards off Vercel. #3829 added the backend `GET /og/climb` endpoint (warm WASM renderer, in-memory caches, ~250ms steady-state renders, 78KB JPEG vs 324KB PNG); this PR flips web's climb `og:image` metadata to point at it.

⚠️ **Do not merge until #3829 has deployed and been curl-verified in production** — the og:image URLs this emits must resolve. Verification commands are in `docs/og-climb.md` (added in #3829).

- `buildOgBoardRenderUrl` emits the absolute `https://ws.boardsesh.com/og/climb?…&format=jpeg` URL (origin derived from `NEXT_PUBLIC_WS_URL`; local dev resolves to `http://localhost:8080`). When the origin can't be resolved it falls back to the current relative web URL, byte-identical to today's.
- `normalizePath` in `createPageMetadata` passes absolute `https?://` image URLs through untouched (previously it would mangle them into `/https://…`); covers both openGraph and twitter images.
- The legacy `/api/og/climb` redirect keeps working for previously-shared links, now 307ing to the backend URL.
- In-app board rendering (`/api/internal/board-render`) is untouched.

## Release Notes

Shared climb links now show their preview card instantly on Facebook, WhatsApp, Slack and friends

## Test plan

- `vp run typecheck:web` clean (full `next build` — validates no client/server boundary issues)
- `vp run test:web` — 5721 tests green; new assertions pin the absolute URL shape (host, `/og/climb`, `format=jpeg`), the relative fallback when the env is unset, absolute-URL passthrough in metadata for both OG and Twitter images, and the legacy redirect's absolute target
- QA-reviewed for param compatibility against the backend zod schema (set_ids regex, frames validity, format enum) — all compatible
- Post-merge: curl a live climb page as `facebookexternalhit` and confirm `og:image` points at `ws.boardsesh.com/og/climb…format=jpeg`; scrape in the Facebook Sharing Debugger and confirm the image renders with no timeout warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfrRx9USHPkdtaPXuLo3Zb