### PR TITLE
feat(shared): render OG cards with the thumbnail stroke treatment

### DIFF
--- a/packages/shared/board-render/src/__tests__/render-config.test.ts
+++ b/packages/shared/board-render/src/__tests__/render-config.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { HOLD_STATE_MAP } from '@boardsesh/board-constants/hold-states';
+import { getBoardDetailsForBoard } from '../board-details';
+import { buildRenderConfig, THUMBNAIL_WIDTH } from '../render-config';
+
+const kilterDetails = getBoardDetailsForBoard({
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 10,
+  set_ids: [1, 20],
+});
+
+const baseParams = {
+  boardName: 'kilter',
+  boardDetails: kilterDetails,
+  frames: 'p1080r15',
+  boardStates: HOLD_STATE_MAP.kilter,
+};
+
+describe('buildRenderConfig', () => {
+  it('renders the OG variant with the thumbnail stroke treatment at OG scale', () => {
+    const { config, ogScale } = buildRenderConfig({ ...baseParams, thumbnail: false, isOgVariant: true });
+    expect(config.thumbnail).toBe(true);
+    expect(ogScale).not.toBeNull();
+    expect(config.output_width).toBe(Math.max(1, Math.round(kilterDetails.boardWidth * (ogScale ?? 1))));
+  });
+
+  it('renders plain thumbnails at THUMBNAIL_WIDTH', () => {
+    const { config } = buildRenderConfig({ ...baseParams, thumbnail: true, isOgVariant: false });
+    expect(config.thumbnail).toBe(true);
+    expect(config.output_width).toBe(THUMBNAIL_WIDTH);
+  });
+
+  it('renders native requests without the thumbnail treatment at native width', () => {
+    const { config, ogScale } = buildRenderConfig({ ...baseParams, thumbnail: false, isOgVariant: false });
+    expect(config.thumbnail).toBe(false);
+    expect(config.output_width).toBe(kilterDetails.boardWidth);
+    expect(ogScale).toBeNull();
+  });
+});

--- a/packages/shared/board-render/src/__tests__/render-config.test.ts
+++ b/packages/shared/board-render/src/__tests__/render-config.test.ts
@@ -21,8 +21,10 @@ describe('buildRenderConfig', () => {
   it('renders the OG variant with the thumbnail stroke treatment at OG scale', () => {
     const { config, ogScale } = buildRenderConfig({ ...baseParams, thumbnail: false, isOgVariant: true });
     expect(config.thumbnail).toBe(true);
-    expect(ogScale).not.toBeNull();
-    expect(config.output_width).toBe(Math.max(1, Math.round(kilterDetails.boardWidth * (ogScale ?? 1))));
+    // Kilter 12x12 (1080x1170 board units) fitted into the padded 1200x630
+    // canvas: height-limited to scale (630-96)/1170, so 1080 * 0.4564… = 493.
+    expect(ogScale).toBeCloseTo(0.4564, 4);
+    expect(config.output_width).toBe(493);
   });
 
   it('renders plain thumbnails at THUMBNAIL_WIDTH', () => {

--- a/packages/shared/board-render/src/render-config.ts
+++ b/packages/shared/board-render/src/render-config.ts
@@ -66,7 +66,9 @@ export function buildRenderConfig({
     output_width: outputWidth,
     frames,
     mirrored: false,
-    thumbnail,
+    // OG cards get the thumbnail stroke treatment (thicker rings, larger
+    // markers) so holds stay readable at chat-preview sizes.
+    thumbnail: thumbnail || isOgVariant,
     holds: boardDetails.holdsData.map((hold) => ({
       id: hold.id,
       mirroredHoldId: hold.mirroredHoldId,


### PR DESCRIPTION
## Summary

Share cards render at chat-preview sizes where the standard hold-ring stroke weight gets hard to read. The OG variant now uses the same treatment thumbnails get in the Rust renderer — 8px strokes (vs 6px) and larger mirror markers (0.62×r vs 0.48×r) — at unchanged OG output scale. One-line change in the shared `buildRenderConfig`, so the backend `/og/climb` cards and the web fallback path both pick it up.

Before/after comparison rendered for the same climb: holds are clearly distinguishable at small sizes with the new treatment.

Since OG URLs are content-addressed (frames determine the image) and immutable-cached, previously scraped cards keep the old look on platform CDNs; new scrapes and new shares get the new rendering. The backend's in-memory caches clear on deploy.

## Release Notes

Shared climb cards are easier to read in chat previews — hold rings are thicker at small sizes

## Test plan

- New `render-config.test.ts` in `@boardsesh/board-render` pins: OG variant → thumbnail treatment at OG scale; plain thumbnail → `THUMBNAIL_WIDTH`; native → untouched
- `vp test run --project board-render` — 56 tests green
- `vp run test:web` — 5721 tests green (no web test pinned the OG thumbnail flag)
- `vp run typecheck` clean
- Rendered before/after locally via the backend service and visually compared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfrRx9USHPkdtaPXuLo3Zb