### PR TITLE
perf(web): CDN-cache climb view pages and fix the numeric-URL redirect race

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/__tests__/layout-redirect.test.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/__tests__/layout-redirect.test.tsx
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { PATHNAME_HEADER } from '@/app/lib/request-pathname-header';
+
+// Regression for the numeric-URL redirect race: this layout owns the
+// numeric→slug redirect for list-family child routes, but must defer for
+// /view/ and /play/ so those pages' climb-preserving redirects run instead.
+
+const { permanentRedirect, notFound, requestHeaders } = vi.hoisted(() => {
+  const hoistedRedirect = vi.fn((url: string) => {
+    const redirectError = new Error('NEXT_REDIRECT') as Error & { digest: string };
+    redirectError.digest = `NEXT_REDIRECT;replace;${url};308;`;
+    throw redirectError;
+  });
+  const hoistedNotFound = vi.fn(() => {
+    throw new Error('NOT_FOUND');
+  });
+  return { permanentRedirect: hoistedRedirect, notFound: hoistedNotFound, requestHeaders: new Map<string, string>() };
+});
+vi.mock('server-only', () => ({}));
+vi.mock('next/navigation', () => ({ permanentRedirect, notFound }));
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => ({ get: (name: string) => requestHeaders.get(name) ?? null })),
+}));
+
+vi.mock('@/app/lib/url-utils.server', () => ({
+  parseRouteParams: vi.fn(async () => ({
+    parsedParams: { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 20], angle: 40 },
+    isNumericFormat: true,
+  })),
+}));
+
+vi.mock('@/app/lib/board-utils', () => ({
+  getBoardDetailsForBoard: vi.fn(() => ({
+    board_name: 'kilter',
+    layout_name: 'Kilter Board Original',
+    size_name: '12 x 12',
+    size_description: 'Commercial',
+    set_names: ['Bolt Ons', 'Screw Ons'],
+  })),
+  generateBoardTitle: vi.fn(() => 'Kilter Board'),
+}));
+
+// The layout's JSX pulls in client providers; none render in this test — the
+// layout function only constructs the element tree — but the modules must load.
+vi.mock('@/app/components/board-page/header', () => ({ default: () => null }));
+vi.mock('@/app/components/graphql-queue', () => ({ GraphQLQueueProvider: () => null }));
+vi.mock('@/app/components/connection-manager/connection-settings-context', () => ({
+  ConnectionSettingsProvider: () => null,
+}));
+vi.mock('@/app/components/connection-manager/websocket-connection-provider', () => ({
+  WebSocketConnectionProvider: () => null,
+}));
+vi.mock('@/app/components/persistent-session', () => ({ BoardSessionBridge: () => null }));
+vi.mock('@/app/components/queue-control/ui-searchparams-provider', () => ({ UISearchParamsProvider: () => null }));
+vi.mock('@/app/components/queue-control/queue-bridge-context', () => ({ QueueBridgeInjector: () => null }));
+vi.mock('@/app/components/board-page/last-used-board-tracker', () => ({ default: () => null }));
+vi.mock('@/app/components/providers/i18n-provider', () => ({ default: () => null }));
+
+import BoardLayout from '../layout';
+
+const layoutProps = {
+  params: Promise.resolve({
+    board_name: 'kilter',
+    layout_id: '1',
+    size_id: '10',
+    set_ids: '1,20',
+    angle: '40',
+  }),
+  children: null,
+};
+
+describe('legacy board layout numeric redirect gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requestHeaders.clear();
+  });
+
+  it('redirects numeric list-family URLs to the slug list URL', async () => {
+    requestHeaders.set(PATHNAME_HEADER, '/kilter/1/10/1,20/40/list');
+    await expect(BoardLayout(layoutProps)).rejects.toMatchObject({ message: 'NEXT_REDIRECT' });
+    expect(permanentRedirect).toHaveBeenCalledTimes(1);
+    expect(permanentRedirect.mock.calls[0][0]).toContain('/list');
+  });
+
+  it('defers for numeric /view/ URLs so the view page can preserve the climb', async () => {
+    requestHeaders.set(PATHNAME_HEADER, '/kilter/1/10/1,20/40/view/abcdef1234567890abcdef1234567890');
+    const rendered = await BoardLayout(layoutProps);
+    expect(permanentRedirect).not.toHaveBeenCalled();
+    expect(rendered).toBeTruthy();
+  });
+
+  it('defers for numeric /play/ URLs', async () => {
+    requestHeaders.set(PATHNAME_HEADER, '/kilter/1/10/1,20/40/play/abcdef1234567890abcdef1234567890');
+    await BoardLayout(layoutProps);
+    expect(permanentRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -1,7 +1,9 @@
 import React, { type PropsWithChildren } from 'react';
+import { headers } from 'next/headers';
 import type { BoardRouteParameters } from '@/app/lib/types';
-import { constructClimbListWithSlugs } from '@/app/lib/url-utils';
+import { constructClimbListWithSlugs, layoutOwnsNumericSlugRedirect } from '@/app/lib/url-utils';
 import { parseRouteParams } from '@/app/lib/url-utils.server';
+import { PATHNAME_HEADER } from '@/app/lib/request-pathname-header';
 import { permanentRedirect } from 'next/navigation';
 import { getBoardDetailsForBoard, generateBoardTitle } from '@/app/lib/board-utils';
 import BoardSeshHeader from '@/app/components/board-page/header';
@@ -48,8 +50,11 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
 
   const { parsedParams, isNumericFormat } = await parseRouteParams(params);
 
-  // Redirect old numeric URLs to new slug format
-  if (isNumericFormat) {
+  // Redirect old numeric URLs to new slug format — but not for the /view and
+  // /play child routes, whose own pages redirect while preserving the climb
+  // uuid. Redirecting those to the bare list here would drop the climb.
+  const pathname = (await headers()).get(PATHNAME_HEADER) ?? '';
+  if (isNumericFormat && layoutOwnsNumericSlugRedirect(pathname)) {
     const boardDetails = getBoardDetailsForBoard(parsedParams);
 
     if (boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names) {

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/redirect.test.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/redirect.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+// Regression for the legacy layout hijacking numeric climb-view URLs: the
+// board `[angle]` layout used to 308 every numeric URL to the bare slug LIST
+// URL, racing (and often beating) this view page's own redirect and dropping
+// the climb. With the layout gated off for `/view/`, this page's redirect — to
+// the slug VIEW URL that preserves the climb uuid — is the one that runs.
+
+const CLIMB_UUID = 'abcdef1234567890abcdef1234567890';
+
+// `permanentRedirect` throws a NEXT_REDIRECT error whose `digest` the page's
+// catch block re-throws (rather than swallowing into a 404). Mirror that shape
+// so the redirect propagates, and capture the target URL.
+const permanentRedirect = vi.fn((url: string) => {
+  const redirectError = new Error('NEXT_REDIRECT') as Error & { digest: string };
+  redirectError.digest = `NEXT_REDIRECT;replace;${url};308;`;
+  throw redirectError;
+});
+const notFound = vi.fn(() => {
+  throw new Error('NOT_FOUND');
+});
+
+vi.mock('next/navigation', () => ({ permanentRedirect, notFound }));
+
+vi.mock('@/app/lib/url-utils.server', () => ({
+  parseRouteParams: vi.fn(async () => ({
+    parsedParams: {
+      board_name: 'kilter',
+      layout_id: 1,
+      size_id: 10,
+      set_ids: [1, 20],
+      angle: 40,
+      climb_uuid: CLIMB_UUID,
+    },
+    isNumericFormat: true,
+  })),
+}));
+
+vi.mock('@/app/lib/data/queries', () => ({
+  getClimb: vi.fn(async () => ({ name: 'My Test Climb', frames: 'p1r12' })),
+  getLayouts: vi.fn(async () => [{ id: 1, name: 'Kilter Board Original' }]),
+  getSizes: vi.fn(async () => [{ id: 10, name: '12 x 12', description: 'Commercial' }]),
+  getSets: vi.fn(async () => [
+    { id: 1, name: 'Bolt Ons' },
+    { id: 20, name: 'Screw Ons' },
+  ]),
+}));
+
+vi.mock('@/app/lib/board-utils', () => ({
+  getBoardDetailsForBoard: vi.fn(() => ({ board_name: 'kilter' })),
+}));
+
+// Body/metadata imports pulled in at module load but never exercised on the
+// redirect path; stub the ones that reach server-only or client code.
+vi.mock('@/app/lib/warm-overlay-cache', () => ({ scheduleOverlayWarming: vi.fn() }));
+vi.mock('@/app/lib/i18n/server', () => ({
+  getServerTranslation: vi.fn(async () => ({ t: (key: string) => key, locale: 'en-US' })),
+}));
+vi.mock('@/app/components/board-renderer/util', () => ({
+  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb'),
+  buildOverlayUrl: vi.fn(() => '/api/internal/board-render'),
+}));
+vi.mock('@/app/components/board-page/board-page-climbs-list', () => ({ default: () => null }));
+vi.mock('@/app/components/climb-detail/climb-view-seo-fragment', () => ({ default: () => null }));
+
+const pageModule = await import('../page');
+
+describe('legacy numeric climb-view redirect', () => {
+  it('redirects a numeric view URL to the slug VIEW URL preserving the climb uuid', async () => {
+    await expect(
+      pageModule.default({
+        params: Promise.resolve({
+          board_name: 'kilter',
+          layout_id: '1',
+          size_id: '10',
+          set_ids: '1,20',
+          angle: '40',
+          climb_uuid: CLIMB_UUID,
+        }),
+      }),
+    ).rejects.toThrow('NEXT_REDIRECT');
+
+    expect(notFound).not.toHaveBeenCalled();
+    expect(permanentRedirect).toHaveBeenCalledTimes(1);
+
+    const target = permanentRedirect.mock.calls[0]![0];
+    // The climb survives the redirect: a `/view/` URL carrying the uuid, never
+    // the bare `/list` URL the layout used to send these links to.
+    expect(target).toContain('/view/');
+    expect(target).toContain(CLIMB_UUID);
+    expect(target).not.toContain('/list');
+  });
+});

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -3,8 +3,10 @@ import { NextRequest } from 'next/server';
 import { CLIMB_SESSION_COOKIE } from '@/app/lib/climb-session-cookie';
 import { DEFAULT_LOCALE, LOCALE_COOKIE, LOCALE_HEADER } from '@/app/lib/i18n/config';
 import { EXPO_WEB_CLASSIC_COOKIE, EXPO_WEB_ENABLED_COOKIE } from '@/app/lib/expo-web-rollout';
+import { PATHNAME_HEADER } from '@/app/lib/request-pathname-header';
 
-const { getListPageCacheTTL, hasUserSpecificFilters } = await import('@/app/lib/list-page-cache');
+const { getClimbViewPageCacheTTL, getListPageCacheTTL, hasUserSpecificFilters } =
+  await import('@/app/lib/list-page-cache');
 const { middleware } = await import('@/middleware');
 
 function sp(params: Record<string, string> = {}): URLSearchParams {
@@ -12,8 +14,13 @@ function sp(params: Record<string, string> = {}): URLSearchParams {
 }
 
 const TTL_24H = 86400;
+const TTL_1H = 3600;
 const LEGACY_LIST = '/kilter/original/12x12-square/screw_bolt/40/list';
 const SLUG_LIST = '/b/kilter-original-12x12/40/list';
+// View pages, all three URL shapes that resolve to the same climb.
+const SLUG_VIEW = '/b/kilter-original-12x12/40/view/test-climb-abcdef1234567890abcdef1234567890';
+const NAMED_VIEW = '/kilter/original/12x12-square/screw_bolt/40/view/test-climb-abcdef1234567890abcdef1234567890';
+const NUMERIC_VIEW = '/kilter/1/10/1,20/40/view/abcdef1234567890abcdef1234567890';
 const originalExpoWebFlag = process.env.BOARDSESH_WEB;
 const originalExpoWebOrigin = process.env.BOARDSESH_EXPO_WEB_ORIGIN;
 
@@ -148,6 +155,69 @@ describe('getListPageCacheTTL', () => {
       expect(getListPageCacheTTL(LEGACY_LIST, sp({ minGrade: '10', hideAttempted: 'false', onlyDrafts: '0' }))).toBe(
         TTL_24H,
       );
+    });
+  });
+});
+
+describe('getClimbViewPageCacheTTL', () => {
+  describe('route matching', () => {
+    it('matches the slug view format', () => {
+      expect(getClimbViewPageCacheTTL(SLUG_VIEW, sp())).toBe(TTL_1H);
+    });
+
+    it('matches the named-segment (legacy) view format', () => {
+      expect(getClimbViewPageCacheTTL(NAMED_VIEW, sp())).toBe(TTL_1H);
+    });
+
+    it('matches the numeric view format (so its redirect is cacheable)', () => {
+      expect(getClimbViewPageCacheTTL(NUMERIC_VIEW, sp())).toBe(TTL_1H);
+    });
+
+    it('matches the tension board view', () => {
+      expect(getClimbViewPageCacheTTL('/tension/original/12x12/screw_bolt/30/view/some-climb-uuid', sp())).toBe(TTL_1H);
+    });
+
+    it('rejects an unsupported board (legacy view shape)', () => {
+      expect(getClimbViewPageCacheTTL('/fakeboard/1/10/1,20/40/view/some-uuid', sp())).toBeNull();
+    });
+
+    it('rejects a list page', () => {
+      expect(getClimbViewPageCacheTTL(LEGACY_LIST, sp())).toBeNull();
+      expect(getClimbViewPageCacheTTL(SLUG_LIST, sp())).toBeNull();
+    });
+
+    it('rejects a play page (the play redirect page carries no OG card worth caching)', () => {
+      expect(getClimbViewPageCacheTTL('/kilter/1/10/1,20/40/play/some-uuid', sp())).toBeNull();
+      expect(getClimbViewPageCacheTTL('/b/kilter-original-12x12/40/play/some-uuid', sp())).toBeNull();
+    });
+
+    it('rejects a create page', () => {
+      expect(getClimbViewPageCacheTTL('/kilter/original/12x12-square/screw_bolt/40/create', sp())).toBeNull();
+    });
+
+    it('rejects the slug view shape with a wrong segment count', () => {
+      // /b/[board_slug]/view/[uuid] is missing the angle segment.
+      expect(getClimbViewPageCacheTTL('/b/kilter-original-12x12/view/some-uuid', sp())).toBeNull();
+    });
+
+    it('rejects the root and settings paths', () => {
+      expect(getClimbViewPageCacheTTL('/', sp())).toBeNull();
+      expect(getClimbViewPageCacheTTL('/settings', sp())).toBeNull();
+    });
+  });
+
+  describe('search params', () => {
+    it('caches with non-user-specific params (tracking/query noise)', () => {
+      expect(getClimbViewPageCacheTTL(SLUG_VIEW, sp({ utm_source: 'twitter' }))).toBe(TTL_1H);
+    });
+
+    it.each([
+      ['hideAttempted', 'true'],
+      ['showOnlyCompleted', '1'],
+      ['onlyDrafts', 'true'],
+    ])('skips cache for user-specific %s=%s (matching list behavior)', (param, value) => {
+      expect(getClimbViewPageCacheTTL(SLUG_VIEW, sp({ [param]: value }))).toBeNull();
+      expect(getClimbViewPageCacheTTL(NAMED_VIEW, sp({ [param]: value }))).toBeNull();
     });
   });
 });
@@ -419,6 +489,74 @@ describe('middleware cache headers on list pages', () => {
     const response = middleware(makeRequest('/some/page'));
     expect(response.headers.has('Vercel-CDN-Cache-Control')).toBe(false);
     expect(response.headers.has('CDN-Cache-Control')).toBe(false);
+  });
+});
+
+describe('middleware cache headers on climb view pages', () => {
+  const expected1h = `s-maxage=${TTL_1H}, stale-while-revalidate=${TTL_1H * 7}`;
+
+  it.each([
+    ['slug view', SLUG_VIEW],
+    ['named-segment view', NAMED_VIEW],
+    // The numeric view URL 308-redirects to its slug form; caching the request
+    // lets the CDN serve that deterministic redirect without re-rendering.
+    ['numeric view (redirect)', NUMERIC_VIEW],
+  ])('sets 1h CDN cache headers on the %s URL', (_shape, url) => {
+    const response = middleware(makeRequest(url));
+    expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe(expected1h);
+    expect(response.headers.get('CDN-Cache-Control')).toBe(expected1h);
+  });
+
+  it('does not cache a play page', () => {
+    const response = middleware(makeRequest('/kilter/1/10/1,20/40/play/some-uuid'));
+    expect(response.headers.has('Vercel-CDN-Cache-Control')).toBe(false);
+  });
+
+  it('does not cache a view page carrying a user-specific filter', () => {
+    const response = middleware(makeRequest(`${SLUG_VIEW}?hideAttempted=true`));
+    expect(response.headers.has('Vercel-CDN-Cache-Control')).toBe(false);
+  });
+
+  it('cache-keys es and en separately (header follows the original locale-prefixed URL)', () => {
+    const enResponse = middleware(makeRequest(SLUG_VIEW));
+    const esResponse = middleware(makeRequest(`/es${SLUG_VIEW}`));
+    // Both are cacheable, but the CDN keys them by their distinct request URLs.
+    expect(enResponse.headers.get('Vercel-CDN-Cache-Control')).toBe(expected1h);
+    expect(esResponse.headers.get('Vercel-CDN-Cache-Control')).toBe(expected1h);
+  });
+
+  it('never caches the sticky-locale redirect — a cookie-varying 307 must not enter the CDN', () => {
+    const request = makeRequest(SLUG_VIEW);
+    request.cookies.set(LOCALE_COOKIE, 'es');
+    const response = middleware(request);
+    // A visitor with a non-default locale cookie on the unprefixed URL gets a
+    // 307 to /es/…; if that response ever carried the CDN header, the redirect
+    // would be cached under the plain URL and served to every visitor.
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/es');
+    expect(response.headers.has('Vercel-CDN-Cache-Control')).toBe(false);
+    expect(response.headers.has('CDN-Cache-Control')).toBe(false);
+  });
+});
+
+describe('middleware forwards the routing pathname header', () => {
+  const requestHeader = `x-middleware-request-${PATHNAME_HEADER}`;
+
+  it('forwards the locale-stripped pathname on a board route', () => {
+    const response = middleware(makeRequest(NUMERIC_VIEW));
+    expect(response.headers.get(requestHeader)).toBe(NUMERIC_VIEW);
+  });
+
+  it('strips the locale prefix from the forwarded pathname', () => {
+    const response = middleware(makeRequest(`/es${SLUG_VIEW}`));
+    expect(response.headers.get(requestHeader)).toBe(SLUG_VIEW);
+  });
+
+  it('overwrites any client-supplied pathname header (no spoofing)', () => {
+    const request = makeRequest(SLUG_VIEW);
+    request.headers.set(PATHNAME_HEADER, '/list');
+    const response = middleware(request);
+    expect(response.headers.get(requestHeader)).toBe(SLUG_VIEW);
   });
 });
 

--- a/packages/web/app/lib/__tests__/url-utils.test.ts
+++ b/packages/web/app/lib/__tests__/url-utils.test.ts
@@ -18,6 +18,7 @@ import {
   isUuidOnly,
   isNumericId,
   hasOnlyNumericBoardRouteSegments,
+  layoutOwnsNumericSlugRedirect,
   getBaseBoardPath,
   extractAngleFromPathname,
   replaceAngleInPathname,
@@ -1096,6 +1097,26 @@ describe('Utility functions', () => {
           set_ids: 'power_flow_engage',
         }),
       ).toBe(false);
+    });
+  });
+
+  describe('layoutOwnsNumericSlugRedirect', () => {
+    it('owns the redirect for a bare list URL', () => {
+      expect(layoutOwnsNumericSlugRedirect('/kilter/1/10/1,20/40/list')).toBe(true);
+    });
+
+    it('owns the redirect for non-climb child routes (create/liked/logbook)', () => {
+      expect(layoutOwnsNumericSlugRedirect('/kilter/1/10/1,20/40/create')).toBe(true);
+      expect(layoutOwnsNumericSlugRedirect('/kilter/1/10/1,20/40/liked')).toBe(true);
+      expect(layoutOwnsNumericSlugRedirect('/kilter/1/10/1,20/40/logbook')).toBe(true);
+    });
+
+    it('defers to the child page for a numeric view URL (the fix: keep the climb)', () => {
+      expect(layoutOwnsNumericSlugRedirect('/kilter/1/10/1,20/40/view/abcdef1234567890abcdef1234567890')).toBe(false);
+    });
+
+    it('defers to the child page for a numeric play URL', () => {
+      expect(layoutOwnsNumericSlugRedirect('/kilter/1/10/1,20/40/play/abcdef1234567890abcdef1234567890')).toBe(false);
     });
   });
 });

--- a/packages/web/app/lib/list-page-cache.ts
+++ b/packages/web/app/lib/list-page-cache.ts
@@ -2,12 +2,35 @@ import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
 import { USER_SPECIFIC_SEARCH_PARAMS } from '@boardsesh/shared-schema';
 import type { SearchRequestPagination } from '@/app/lib/types';
 
+// List data tolerates a full day of staleness (a new/edited climb showing up a
+// little late in a list is harmless), so list pages cache for 24h.
+const LIST_PAGE_CACHE_TTL_SECONDS = 86400;
+
+// A climb view page is fully determined by its URL and reads no server-side
+// personalization (queue/session/auth all live in client components). Its only
+// data source, `getClimb`, is `unstable_cache`d at 3600s — so the page HTML is
+// already up to an hour stale today. Matching that keeps the CDN from adding a
+// new staleness class beyond what the data cache already allows.
+const CLIMB_VIEW_PAGE_CACHE_TTL_SECONDS = 3600;
+
 /**
  * Checks whether search params contain any user-specific filters.
  * Used by SSR pages to decide whether to resolve a user session.
  */
 export function hasUserSpecificFilters(searchParams: SearchRequestPagination): boolean {
   return USER_SPECIFIC_SEARCH_PARAMS.some((param) => !!searchParams[param]);
+}
+
+/**
+ * True when the query string carries a user-specific filter that would make the
+ * server render personalized HTML. Such a request must never share a CDN cache
+ * entry with the anonymous version, so it is not cached.
+ */
+function hasUserSpecificQueryParams(searchParams: URLSearchParams): boolean {
+  return USER_SPECIFIC_SEARCH_PARAMS.some((param) => {
+    const value = searchParams.get(param);
+    return value === 'true' || value === '1';
+  });
 }
 
 /**
@@ -35,14 +58,41 @@ export function getListPageCacheTTL(pathname: string, searchParams: URLSearchPar
     return null;
   }
 
-  const hasUserParams = USER_SPECIFIC_SEARCH_PARAMS.some((param) => {
-    const value = searchParams.get(param);
-    return value === 'true' || value === '1';
-  });
-
-  if (hasUserParams) {
+  if (hasUserSpecificQueryParams(searchParams)) {
     return null;
   }
 
-  return 86400; // 24 hours
+  return LIST_PAGE_CACHE_TTL_SECONDS;
+}
+
+/**
+ * Checks whether a request is a cacheable climb view page and returns the CDN
+ * cache duration in seconds, or null if it should not be CDN-cached.
+ *
+ * Matches both URL shapes, and — because it matches on segment shape rather than
+ * on slug-vs-numeric — it also matches the legacy numeric variants that
+ * permanent-redirect to their slug form. Caching those lets the CDN answer the
+ * deterministic 308 without re-rendering:
+ *   - /[board]/[layout]/[size]/[sets]/[angle]/view/[climb_uuid]  (legacy + numeric, 7 segments)
+ *   - /b/[board_slug]/[angle]/view/[climb_uuid]                  (slug format, 5 segments)
+ */
+export function getClimbViewPageCacheTTL(pathname: string, searchParams: URLSearchParams): number | null {
+  const pathParts = pathname.split('/').filter(Boolean);
+
+  const isSlugFormat = pathParts.length === 5 && pathParts[0] === 'b' && pathParts[3] === 'view';
+
+  const isLegacyFormat =
+    pathParts.length === 7 &&
+    (SUPPORTED_BOARDS as readonly string[]).includes(pathParts[0].toLowerCase()) &&
+    pathParts[5] === 'view';
+
+  if (!isSlugFormat && !isLegacyFormat) {
+    return null;
+  }
+
+  if (hasUserSpecificQueryParams(searchParams)) {
+    return null;
+  }
+
+  return CLIMB_VIEW_PAGE_CACHE_TTL_SECONDS;
 }

--- a/packages/web/app/lib/request-pathname-header.ts
+++ b/packages/web/app/lib/request-pathname-header.ts
@@ -1,0 +1,12 @@
+/**
+ * Middleware forwards the (locale-stripped) request pathname in this header so
+ * a server layout can branch on the child route segment that its own route
+ * params can't reveal. The board `[angle]` layout uses it to tell a `/view/` or
+ * `/play/` request apart from a `/list` one.
+ *
+ * Kept in a dependency-light module (no `next/*`, no `server-only`) so the edge
+ * middleware can import the constant without pulling a heavier module into its
+ * bundle — mirroring `climb-session-cookie.ts`. Middleware always overwrites the
+ * header, so a client-supplied value can never reach a server component.
+ */
+export const PATHNAME_HEADER = 'x-boardsesh-pathname';

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -708,6 +708,20 @@ export const hasOnlyNumericBoardRouteSegments = (
   );
 };
 
+/**
+ * The board `[angle]` layout wraps every child route (list, view, play, …) and
+ * 308-redirects legacy numeric URLs to their slug list URL. But the `/view` and
+ * `/play` child routes run their OWN numeric→slug redirect that preserves the
+ * climb uuid; if the layout redirected them to the bare list first, a shared
+ * legacy climb link would land on the list page (with a generic OG card) instead
+ * of the climb. The layout can't see the child segment from its route params, so
+ * it consults the request pathname (forwarded by middleware) and defers to the
+ * child for these climb-scoped routes.
+ */
+export const layoutOwnsNumericSlugRedirect = (pathname: string): boolean => {
+  return !pathname.includes('/view/') && !pathname.includes('/play/');
+};
+
 export const constructCreateClimbUrl = (
   board_name: string,
   layoutName: string,

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -1,8 +1,9 @@
 // middleware.ts
 import { NextResponse, type NextRequest } from 'next/server';
 import { SUPPORTED_BOARDS } from './app/lib/board-data';
-import { getListPageCacheTTL } from './app/lib/list-page-cache';
+import { getClimbViewPageCacheTTL, getListPageCacheTTL } from './app/lib/list-page-cache';
 import { CLIMB_SESSION_COOKIE } from './app/lib/climb-session-cookie';
+import { PATHNAME_HEADER } from './app/lib/request-pathname-header';
 import { isSecureCookieContext } from './app/lib/auth/secure-cookies';
 import { resolveCrossSubdomainAuthCors } from './app/lib/auth/cross-subdomain-cors';
 import {
@@ -261,6 +262,12 @@ export function middleware(request: NextRequest) {
 
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set(LOCALE_HEADER, locale);
+  // Expose the routing pathname to server layouts, which don't otherwise see
+  // their child route segment. The board `[angle]` layout reads it to leave a
+  // legacy numeric `/view/` or `/play/` URL to the child page's own
+  // climb-preserving redirect. Overwrite (never append) so a client-supplied
+  // value can't reach the layout.
+  requestHeaders.set(PATHNAME_HEADER, strippedPath);
 
   let response: NextResponse;
   if (needsRewrite) {
@@ -290,7 +297,12 @@ export function middleware(request: NextRequest) {
   // Vercel-CDN-Cache-Control is the highest-priority header for Vercel's CDN
   // and is not touched by Next.js rendering.
   // Cache-key follows the original (locale-prefixed) URL, so en and es never collide.
-  const cacheTTL = getListPageCacheTTL(strippedPath, request.nextUrl.searchParams);
+  // Climb view pages are equally URL-determined and personalization-free, so they
+  // cache the same way — including their legacy numeric variants, whose permanent
+  // redirect the CDN can then serve without re-rendering.
+  const cacheTTL =
+    getListPageCacheTTL(strippedPath, request.nextUrl.searchParams) ??
+    getClimbViewPageCacheTTL(strippedPath, request.nextUrl.searchParams);
   if (cacheTTL !== null) {
     const cdnCacheValue = `s-maxage=${cacheTTL}, stale-while-revalidate=${cacheTTL * 7}`;
     response.headers.set('Vercel-CDN-Cache-Control', cdnCacheValue);


### PR DESCRIPTION
## Summary

Completes the slow-share-embed work (#3829/#3830 fixed the og:image; this fixes the HTML legs). Crawlers fetching a shared climb link paid a full dynamic SSR every time (`no-store`, 0.2–1s+ TTFB, worse on cold lambdas) plus, for legacy numeric URLs, an uncached 308 measured at up to 3.7s cold — and that redirect had a bug that dropped the climb entirely.

- **Climb view pages become CDN-cacheable.** Their server HTML is fully URL-determined (all personalization is client-side; the only dynamic API is locale detection reading `headers()`). The existing middleware mechanism that already CDN-caches the equally-dynamic `/list` pages now covers both climb view URL shapes: `s-maxage=3600, stale-while-revalidate=25200` — the same 1h staleness `getClimb`'s data cache already imposes, so no new staleness class.
- **Numeric-URL redirect race fixed.** The legacy `[angle]` layout redirected every numeric URL to the bare slug **list** URL, racing (and in production often beating) the view page's own climb-preserving redirect — shared old links landed on the list page with a generic OG card. Middleware now forwards the locale-stripped pathname (`x-boardsesh-pathname`, set unconditionally so clients can't spoof it) and the layout defers to `/view/` and `/play/` child routes.
- **The deterministic 308s get cache headers too**, so the CDN can absorb repeat crawler hits on legacy links.

Cache-poisoning safety: every cookie-varying middleware response (sticky-locale 307, session redirect, expo-web carve-outs) early-returns before the cache header attaches — traced branch-by-branch in review and now pinned by a regression test for the sticky-locale case.

## Release Notes

Shared climb links unfurl fast and reliably — old-format links now land on the climb, not the board list

## Test plan

- `vp run test:web` — 5753 tests green (32 new): view-shape TTL matching (positive + negative: /play, /create, wrong segment counts, unsupported boards, user-specific filters), es/en cache keying, anti-spoof header overwrite, sticky-locale-redirect-never-cached regression, layout gate (redirects list-family, defers /view/ and /play/), and a page-level redirect regression asserting numeric view URLs redirect to a slug **view** URL containing the climb uuid, never `/list`
- `vp run typecheck:web` clean, `vp check` clean on changed files
- Post-deploy verification (commands in thread): both view shapes + locale variants carry `Vercel-CDN-Cache-Control: s-maxage=3600, stale-while-revalidate=25200`; second hit shows `x-vercel-cache: HIT`; numeric view URL 308 `Location` contains `/view/<slug>-<uuid>`; user-filtered URLs carry no cache header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfrRx9USHPkdtaPXuLo3Zb