### PR TITLE
perf: prime share-page and og-image caches at share time

### DIFF
--- a/docs/og-climb.md
+++ b/docs/og-climb.md
@@ -54,6 +54,14 @@ repeats, ~700ms worst-case first render of a never-seen board config.
 | `OG_BYTE_CACHE_MB`      | `32`                  | Byte budget for the final-image LRU.                                                                                                                                               |
 | `OG_BASE_CACHE_ENTRIES` | `24`                  | Entry budget for the per-board-config base LRU (~3MB raw RGBA each).                                                                                                               |
 
+## Cache prewarming (why the endpoint sees browser-initiated hits)
+
+Crawlers scrape seconds after a share, so clients prime the caches ahead of
+them: climb view SSR fire-and-forgets one og render per page view (via
+`scheduleOverlayWarming`), and the Share button on web and mobile fetches both
+the share page URL and the og image URL before opening the share sheet. All
+best-effort — failures are swallowed and never delay sharing.
+
 ## Operational notes
 
 - Winston logs one line per render: `[OGClimb] served` with

--- a/packages/board-constants/src/hold-states.ts
+++ b/packages/board-constants/src/hold-states.ts
@@ -279,3 +279,11 @@ export function convertLitUpHoldsStringToMap(litUpHolds: string, board: BoardNam
       {} as Record<number, LitUpHoldsMap>,
     );
 }
+
+/** Collapse a possibly multi-frame frames string to its final lit snapshot. */
+export function toFlatFrames(frames: string | null | undefined, board: BoardName): string {
+  if (!frames) return '';
+  if (!frames.includes(',') && !frames.includes('x')) return frames;
+  const maps = accumulateFramesToMaps(frames, board);
+  return accumulatedMapsToFrameStrings(maps, board).at(-1) ?? '';
+}

--- a/packages/mobile/src/hooks/__tests__/use-share-climb.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-share-climb.test.ts
@@ -88,6 +88,8 @@ describe('useShareClimb', () => {
         await result.current();
       });
       expect(fetchMock).toHaveBeenCalledWith(expectedReadableShareUrl);
+      // Exactly one warm: the no-frames climb must not fire an og request.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(shareMock).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/mobile/src/hooks/__tests__/use-share-climb.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-share-climb.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 const ctrl = vi.hoisted(() => ({ os: 'ios' as string }));
@@ -11,6 +11,9 @@ type SharePayload = IOSPayload | AndroidPayload;
 const shareMock = vi.fn<(payload: SharePayload) => Promise<{ action: string }>>(async () => ({
   action: 'sharedAction',
 }));
+
+// Fire-and-forget prewarm fetches hit this mock; never a real network.
+const fetchMock = vi.fn<(input: string) => Promise<{ ok: boolean }>>(async () => ({ ok: true }));
 
 vi.mock('react-native', () => ({
   Platform: {
@@ -25,6 +28,7 @@ vi.mock('react-native', () => ({
 
 vi.mock('../../lib/env', () => ({
   WEB_BASE_URL: 'https://www.boardsesh.com',
+  BACKEND_URL: 'https://ws.boardsesh.com',
 }));
 
 import { useShareClimb } from '../use-share-climb';
@@ -45,10 +49,27 @@ const baseArgs = {
 const expectedReadableShareUrl =
   'https://www.boardsesh.com/kilter/original/12x14-commerical/screw_bolt/40/view/test-climb-climb-uuid-123';
 
+const climbWithFrames = {
+  uuid: 'climb-uuid-123',
+  name: 'Test Climb',
+  frames: 'p1145r15p1146r12',
+} as unknown as Parameters<typeof useShareClimb>[0]['climb'];
+
+// The backend canonicalises set_ids server-side; the client sorts them too so
+// the raw URL is stable regardless of input order.
+const expectedOgImageUrl =
+  'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=7&set_ids=1%2C20&frames=p1145r15p1146r12&format=jpeg';
+
 describe('useShareClimb', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     ctrl.os = 'ios';
+    fetchMock.mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('returns a no-op when climb is null and does not call Share', async () => {
@@ -57,6 +78,44 @@ describe('useShareClimb', () => {
       await result.current();
     });
     expect(shareMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  describe('share-time cache prewarm', () => {
+    it('warms the share page url before opening the share sheet', async () => {
+      const { result } = renderHook(() => useShareClimb({ climb, ...baseArgs }));
+      await act(async () => {
+        await result.current();
+      });
+      expect(fetchMock).toHaveBeenCalledWith(expectedReadableShareUrl);
+      expect(shareMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('warms the backend og image url too when the climb has frames', async () => {
+      const { result } = renderHook(() => useShareClimb({ climb: climbWithFrames, ...baseArgs }));
+      await act(async () => {
+        await result.current();
+      });
+      expect(fetchMock).toHaveBeenNthCalledWith(1, expectedReadableShareUrl);
+      expect(fetchMock).toHaveBeenNthCalledWith(2, expectedOgImageUrl);
+    });
+
+    it('sorts unsorted set_ids in the warmed og url', async () => {
+      const { result } = renderHook(() => useShareClimb({ climb: climbWithFrames, ...baseArgs, setIds: '20,1' }));
+      await act(async () => {
+        await result.current();
+      });
+      expect(fetchMock).toHaveBeenNthCalledWith(2, expectedOgImageUrl);
+    });
+
+    it('still opens the share sheet when a prewarm fetch rejects', async () => {
+      fetchMock.mockRejectedValue(new Error('network down'));
+      const { result } = renderHook(() => useShareClimb({ climb: climbWithFrames, ...baseArgs }));
+      await act(async () => {
+        await result.current();
+      });
+      expect(shareMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('iOS', () => {

--- a/packages/mobile/src/hooks/use-share-climb.ts
+++ b/packages/mobile/src/hooks/use-share-climb.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { Platform, Share } from 'react-native';
 import { buildReadableClimbViewPath } from '@boardsesh/play-view/readable-url-utils';
-import { accumulateFramesToMaps, accumulatedMapsToFrameStrings } from '@boardsesh/board-constants/hold-states';
+import { toFlatFrames } from '@boardsesh/board-constants/hold-states';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { BACKEND_URL, WEB_BASE_URL } from '../lib/env';
 
@@ -13,18 +13,6 @@ type ShareClimbArgs = {
   setIds: string;
   angle: number;
 };
-
-// Mirror of web's `packages/web/app/components/board-renderer/util.ts`
-// `toFlatFrames` (keep the two in sync): collapse a possibly
-// multi-frame Aurora frames string to its final lit snapshot — the exact frames
-// the shared climb page's og:image is rendered from, so the prewarm hits the
-// backend's cache key. Single-frame strings round-trip unchanged.
-function toFlatFrames(frames: string, boardName: BoardName): string {
-  if (!frames) return '';
-  if (!frames.includes(',') && !frames.includes('x')) return frames;
-  const maps = accumulateFramesToMaps(frames, boardName);
-  return accumulatedMapsToFrameStrings(maps, boardName).at(-1) ?? '';
-}
 
 // Local builder for the backend og:image URL. Kept local rather than pulling in
 // @boardsesh/board-render, whose graph drags the WASM renderer + sharp into the
@@ -63,9 +51,8 @@ function buildOgImageUrl(args: {
 // warm-the-CDN-and-og-caches trick web does. Never blocks or breaks sharing:
 // each fetch is voided and every failure (async rejection or a synchronous
 // throw when fetch is unavailable) is swallowed.
-function prewarmShareCaches(pageUrl: string, ogImageUrl: string | null): void {
-  const targets = ogImageUrl ? [pageUrl, ogImageUrl] : [pageUrl];
-  for (const target of targets) {
+function prewarmShareCaches(urls: string[]): void {
+  for (const target of urls) {
     try {
       void fetch(target)
         .then((response) => response.body?.cancel())
@@ -89,7 +76,8 @@ export function useShareClimb({ climb, boardName, layoutId, sizeId, setIds, angl
       climbName: climb.name,
     })}`;
 
-    prewarmShareCaches(url, buildOgImageUrl({ boardName, layoutId, sizeId, setIds, frames: climb.frames }));
+    const ogImageUrl = buildOgImageUrl({ boardName, layoutId, sizeId, setIds, frames: climb.frames });
+    prewarmShareCaches(ogImageUrl ? [url, ogImageUrl] : [url]);
 
     await Share.share(Platform.OS === 'ios' ? { message: climb.name, url } : { message: `${climb.name}\n${url}` });
   }, [climb, boardName, layoutId, sizeId, setIds, angle]);

--- a/packages/mobile/src/hooks/use-share-climb.ts
+++ b/packages/mobile/src/hooks/use-share-climb.ts
@@ -25,7 +25,7 @@ function buildOgImageUrl(args: {
   layoutId: number;
   sizeId: number;
   setIds: string;
-  frames: string;
+  frames: string | null | undefined;
 }): string | null {
   const flatFrames = toFlatFrames(args.frames, args.boardName as BoardName);
   // The backend rejects an empty frames string (a blank board would cache as a

--- a/packages/mobile/src/hooks/use-share-climb.ts
+++ b/packages/mobile/src/hooks/use-share-climb.ts
@@ -14,7 +14,8 @@ type ShareClimbArgs = {
   angle: number;
 };
 
-// Mirror of web's board-renderer/util `toFlatFrames`: collapse a possibly
+// Mirror of web's `packages/web/app/components/board-renderer/util.ts`
+// `toFlatFrames` (keep the two in sync): collapse a possibly
 // multi-frame Aurora frames string to its final lit snapshot — the exact frames
 // the shared climb page's og:image is rendered from, so the prewarm hits the
 // backend's cache key. Single-frame strings round-trip unchanged.

--- a/packages/mobile/src/hooks/use-share-climb.ts
+++ b/packages/mobile/src/hooks/use-share-climb.ts
@@ -1,8 +1,9 @@
 import { useCallback } from 'react';
 import { Platform, Share } from 'react-native';
 import { buildReadableClimbViewPath } from '@boardsesh/play-view/readable-url-utils';
-import type { Climb } from '@boardsesh/shared-schema';
-import { WEB_BASE_URL } from '../lib/env';
+import { accumulateFramesToMaps, accumulatedMapsToFrameStrings } from '@boardsesh/board-constants/hold-states';
+import type { BoardName, Climb } from '@boardsesh/shared-schema';
+import { BACKEND_URL, WEB_BASE_URL } from '../lib/env';
 
 type ShareClimbArgs = {
   climb: Climb | null;
@@ -12,6 +13,67 @@ type ShareClimbArgs = {
   setIds: string;
   angle: number;
 };
+
+// Mirror of web's board-renderer/util `toFlatFrames`: collapse a possibly
+// multi-frame Aurora frames string to its final lit snapshot — the exact frames
+// the shared climb page's og:image is rendered from, so the prewarm hits the
+// backend's cache key. Single-frame strings round-trip unchanged.
+function toFlatFrames(frames: string, boardName: BoardName): string {
+  if (!frames) return '';
+  if (!frames.includes(',') && !frames.includes('x')) return frames;
+  const maps = accumulateFramesToMaps(frames, boardName);
+  return accumulatedMapsToFrameStrings(maps, boardName).at(-1) ?? '';
+}
+
+// Local builder for the backend og:image URL. Kept local rather than pulling in
+// @boardsesh/board-render, whose graph drags the WASM renderer + sharp into the
+// mobile bundle — far heavier than assembling a query string warrants. The raw
+// query string need not byte-match web's buildOgBoardRenderUrl: the backend
+// canonicalises set_ids (sort + dedupe) before keying its caches, so both
+// platforms' URLs collapse to the same cache entry.
+function buildOgImageUrl(args: {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  frames: string;
+}): string | null {
+  const flatFrames = toFlatFrames(args.frames, args.boardName as BoardName);
+  // The backend rejects an empty frames string (a blank board would cache as a
+  // real card), so there is nothing to warm without frames.
+  if (!flatFrames) return null;
+  const sortedSetIds = args.setIds
+    .split(',')
+    .map(Number)
+    .sort((first, second) => first - second)
+    .join(',');
+  const query = [
+    `board_name=${encodeURIComponent(args.boardName)}`,
+    `layout_id=${args.layoutId}`,
+    `size_id=${args.sizeId}`,
+    `set_ids=${encodeURIComponent(sortedSetIds)}`,
+    `frames=${encodeURIComponent(flatFrames)}`,
+    'format=jpeg',
+  ].join('&');
+  return `${BACKEND_URL}/og/climb?${query}`;
+}
+
+// Fire-and-forget priming before the native share sheet opens — the same
+// warm-the-CDN-and-og-caches trick web does. Never blocks or breaks sharing:
+// each fetch is voided and every failure (async rejection or a synchronous
+// throw when fetch is unavailable) is swallowed.
+function prewarmShareCaches(pageUrl: string, ogImageUrl: string | null): void {
+  const targets = ogImageUrl ? [pageUrl, ogImageUrl] : [pageUrl];
+  for (const target of targets) {
+    try {
+      void fetch(target)
+        .then((response) => response.body?.cancel())
+        .catch(() => {});
+    } catch {
+      // Priming is best-effort; a warm miss must never affect the share sheet.
+    }
+  }
+}
 
 export function useShareClimb({ climb, boardName, layoutId, sizeId, setIds, angle }: ShareClimbArgs) {
   return useCallback(async () => {
@@ -25,6 +87,9 @@ export function useShareClimb({ climb, boardName, layoutId, sizeId, setIds, angl
       climbUuid: climb.uuid,
       climbName: climb.name,
     })}`;
+
+    prewarmShareCaches(url, buildOgImageUrl({ boardName, layoutId, sizeId, setIds, frames: climb.frames }));
+
     await Share.share(Platform.OS === 'ios' ? { message: climb.name, url } : { message: `${climb.name}\n${url}` });
   }, [climb, boardName, layoutId, sizeId, setIds, angle]);
 }

--- a/packages/web/app/components/board-renderer/util.ts
+++ b/packages/web/app/components/board-renderer/util.ts
@@ -73,6 +73,11 @@ export const buildBoardRenderUrl = (
  * always run user-facing frames through this before crossing that
  * boundary. The empty string is preserved unchanged.
  */
+/**
+ * Flatten a possibly multi-frame frames string before it crosses the renderer
+ * or BLE boundary — raw multi-frame strings render only frame 0 or emit
+ * garbage. Delegates to the shared implementation in board-constants.
+ */
 export const toFlatFrames = (frames: string | null | undefined, boardName: BoardName): string =>
   toFlatFramesShared(frames, boardName);
 

--- a/packages/web/app/components/board-renderer/util.ts
+++ b/packages/web/app/components/board-renderer/util.ts
@@ -1,4 +1,4 @@
-import { accumulateFramesToMaps, accumulatedMapsToFrameStrings } from '@boardsesh/board-constants/hold-states';
+import { toFlatFrames as toFlatFramesShared } from '@boardsesh/board-constants/hold-states';
 import type { BoardDetails, BoardName } from '@/app/lib/types';
 import { getPublicBackendHttpUrl } from '@/app/lib/backend-url';
 import { BOARD_IMAGE_DIMENSIONS } from '../../lib/board-data';
@@ -73,12 +73,8 @@ export const buildBoardRenderUrl = (
  * always run user-facing frames through this before crossing that
  * boundary. The empty string is preserved unchanged.
  */
-export const toFlatFrames = (frames: string | null | undefined, boardName: BoardName): string => {
-  if (!frames) return '';
-  if (!frames.includes(',') && !frames.includes('x')) return frames;
-  const maps = accumulateFramesToMaps(frames, boardName);
-  return accumulatedMapsToFrameStrings(maps, boardName).at(-1) ?? '';
-};
+export const toFlatFrames = (frames: string | null | undefined, boardName: BoardName): string =>
+  toFlatFramesShared(frames, boardName);
 
 export const buildOverlayUrl = (boardDetails: BoardDetails, frames: string, thumbnail?: boolean) =>
   buildBoardRenderUrl(boardDetails, toFlatFrames(frames, boardDetails.board_name), {

--- a/packages/web/app/components/climb-actions/actions/__tests__/share-action.test.tsx
+++ b/packages/web/app/components/climb-actions/actions/__tests__/share-action.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { renderHook, act } from '@testing-library/react';
+import type { ClimbActionProps } from '../../types';
+import type { BoardDetails, Climb } from '@/app/lib/types';
+
+const VIEW_PATH = '/kilter/original/12x14/screw_bolt/40/view/test-climb-test-uuid-789';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const showMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage }),
+}));
+
+vi.mock('@/app/lib/url-utils', () => ({
+  getContextAwareClimbViewUrl: () => VIEW_PATH,
+}));
+
+const shareWithFallback = vi.fn().mockResolvedValue(true);
+vi.mock('@/app/lib/share-utils', () => ({
+  shareWithFallback: (options: unknown) => shareWithFallback(options),
+}));
+
+vi.mock('@/app/components/board-renderer/util', () => ({
+  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb?og'),
+}));
+
+vi.mock('@mui/icons-material/IosShare', () => ({ default: () => 'IosShareIcon' }));
+vi.mock('@mui/material/Button', () => ({ default: ({ children }: { children?: React.ReactNode }) => children }));
+vi.mock('../../action-tooltip', () => ({
+  ActionTooltip: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: { colors: {}, spacing: { 4: '16px' }, typography: { fontSize: { base: '14px' } } },
+}));
+
+import { ShareAction } from '../share-action';
+import { buildOgBoardRenderUrl } from '@/app/components/board-renderer/util';
+
+function createTestClimb(overrides?: Partial<Climb>): Climb {
+  return {
+    uuid: 'test-uuid-789',
+    name: 'Test Climb',
+    setter_username: 'testuser',
+    description: 'A test climb',
+    frames: 'p1r12p2r13',
+    angle: 40,
+    ascensionist_count: 5,
+    difficulty: '6a/V3',
+    quality_average: '3.5',
+    stars: 3,
+    difficulty_error: '0.50',
+    benchmark_difficulty: null,
+    ...overrides,
+  };
+}
+
+function createTestBoardDetails(): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: '1,2',
+  } as unknown as BoardDetails;
+}
+
+const onComplete = vi.fn();
+function createTestProps(overrides?: Partial<ClimbActionProps>): ClimbActionProps {
+  return {
+    climb: createTestClimb(),
+    boardDetails: createTestBoardDetails(),
+    angle: 40,
+    viewMode: 'icon',
+    onComplete,
+    ...overrides,
+  };
+}
+
+const expectedShareUrl = `${window.location.origin}${VIEW_PATH}`;
+
+describe('ShareAction prewarm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(buildOgBoardRenderUrl).mockReturnValue('https://ws.boardsesh.com/og/climb?og');
+    shareWithFallback.mockResolvedValue(true);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ body: null }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fires both warm fetches (share page + og image) before sharing', async () => {
+    const { result } = renderHook(() => ShareAction(createTestProps()));
+
+    await act(async () => {
+      result.current.menuItem.onClick?.();
+      await Promise.resolve();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenNthCalledWith(1, expectedShareUrl);
+    expect(fetch).toHaveBeenNthCalledWith(2, 'https://ws.boardsesh.com/og/climb?og', { mode: 'no-cors' });
+    expect(shareWithFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('still shares when the warm fetches reject', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => ShareAction(createTestProps()));
+
+    await act(async () => {
+      result.current.menuItem.onClick?.();
+      await Promise.resolve();
+    });
+
+    expect(shareWithFallback).toHaveBeenCalledTimes(1);
+    expect(shareWithFallback).toHaveBeenCalledWith(expect.objectContaining({ url: expectedShareUrl }));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('warms only the share page when the og url is the relative fallback', async () => {
+    vi.mocked(buildOgBoardRenderUrl).mockReturnValue('/api/og/climb?relative');
+
+    const { result } = renderHook(() => ShareAction(createTestProps()));
+
+    await act(async () => {
+      result.current.menuItem.onClick?.();
+      await Promise.resolve();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(expectedShareUrl);
+  });
+});

--- a/packages/web/app/components/climb-actions/actions/__tests__/share-action.test.tsx
+++ b/packages/web/app/components/climb-actions/actions/__tests__/share-action.test.tsx
@@ -98,10 +98,11 @@ describe('ShareAction prewarm', () => {
 
     await act(async () => {
       result.current.menuItem.onClick?.();
-      await Promise.resolve();
+      // Both prewarm fetches are floating promises; wait for the exact count so
+      // a slow second fire can't flake the assertion below.
+      await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
     });
 
-    expect(fetch).toHaveBeenCalledTimes(2);
     expect(fetch).toHaveBeenNthCalledWith(1, expectedShareUrl);
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://ws.boardsesh.com/og/climb?og', { mode: 'no-cors' });
     expect(shareWithFallback).toHaveBeenCalledTimes(1);
@@ -114,7 +115,7 @@ describe('ShareAction prewarm', () => {
 
     await act(async () => {
       result.current.menuItem.onClick?.();
-      await Promise.resolve();
+      await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
     });
 
     expect(shareWithFallback).toHaveBeenCalledTimes(1);
@@ -129,7 +130,7 @@ describe('ShareAction prewarm', () => {
 
     await act(async () => {
       result.current.menuItem.onClick?.();
-      await Promise.resolve();
+      await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
     });
 
     expect(fetch).toHaveBeenCalledTimes(1);

--- a/packages/web/app/components/climb-actions/actions/share-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/share-action.tsx
@@ -28,6 +28,8 @@ export function ShareAction({
   const { iconSize } = computeActionDisplay(viewMode, size, showLabel);
 
   const viewUrl = getContextAwareClimbViewUrl(currentPathname ?? '', boardDetails, angle, climb.uuid, climb.name);
+  // Computed at render so the callback deps stay primitive strings.
+  const ogImageUrl = buildOgBoardRenderUrl(boardDetails, climb.frames);
 
   const handleClick = useCallback(
     async (e?: React.MouseEvent) => {
@@ -40,7 +42,6 @@ export function ShareAction({
       // Share, before the crawler scrapes the freshly shared URL. Fire-and-forget
       // (no await) so it never delays or breaks the share sheet. The relative og
       // fallback (backend origin unresolvable) is not worth warming.
-      const ogImageUrl = buildOgBoardRenderUrl(boardDetails, climb.frames);
       prewarmShareCaches(ogImageUrl.startsWith('http') ? [shareUrl, ogImageUrl] : [shareUrl]);
 
       const shared = await shareWithFallback({
@@ -56,7 +57,7 @@ export function ShareAction({
         onComplete?.();
       }
     },
-    [climb, viewUrl, boardDetails, onComplete, showMessage, t],
+    [climb, viewUrl, ogImageUrl, boardDetails.board_name, onComplete, showMessage, t],
   );
 
   const icon = <IosShare sx={{ fontSize: iconSize }} />;

--- a/packages/web/app/components/climb-actions/actions/share-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/share-action.tsx
@@ -7,6 +7,8 @@ import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { getContextAwareClimbViewUrl } from '@/app/lib/url-utils';
 import { buildActionResult, computeActionDisplay } from '../action-view-renderer';
 import { shareWithFallback } from '@/app/lib/share-utils';
+import { prewarmShareCaches } from '@/app/lib/prewarm-share-cache';
+import { buildOgBoardRenderUrl } from '@/app/components/board-renderer/util';
 import { useTranslation } from 'react-i18next';
 
 export function ShareAction({
@@ -34,6 +36,13 @@ export function ShareAction({
 
       const shareUrl = typeof window !== 'undefined' ? `${window.location.origin}${viewUrl}` : viewUrl;
 
+      // Prime the CDN page cache + backend og caches the instant the user taps
+      // Share, before the crawler scrapes the freshly shared URL. Fire-and-forget
+      // (no await) so it never delays or breaks the share sheet. The relative og
+      // fallback (backend origin unresolvable) is not worth warming.
+      const ogImageUrl = buildOgBoardRenderUrl(boardDetails, climb.frames);
+      prewarmShareCaches(ogImageUrl.startsWith('http') ? [shareUrl, ogImageUrl] : [shareUrl]);
+
       const shared = await shareWithFallback({
         url: shareUrl,
         title: climb.name,
@@ -47,7 +56,7 @@ export function ShareAction({
         onComplete?.();
       }
     },
-    [climb, viewUrl, boardDetails.board_name, onComplete, showMessage, t],
+    [climb, viewUrl, boardDetails, onComplete, showMessage, t],
   );
 
   const icon = <IosShare sx={{ fontSize: iconSize }} />;

--- a/packages/web/app/lib/__tests__/warm-overlay-cache.test.ts
+++ b/packages/web/app/lib/__tests__/warm-overlay-cache.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+
+// Isolate the warming logic from the real URL builders — the test only cares
+// which URLs get fetched, not how they're assembled.
+vi.mock('@/app/components/board-renderer/util', () => ({
+  buildOverlayUrl: vi.fn(() => '/api/internal/board-render?overlay'),
+  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb?og'),
+}));
+
+import { warmOverlays } from '../warm-overlay-cache';
+import { buildOgBoardRenderUrl } from '@/app/components/board-renderer/util';
+
+type WarmOverlaysArg = Parameters<typeof warmOverlays>[0];
+const boardDetails = { board_name: 'kilter' } as unknown as WarmOverlaysArg['boardDetails'];
+const climbs = [{ frames: 'p1r12p2r13' }];
+
+describe('warmOverlays', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(buildOgBoardRenderUrl).mockReturnValue('https://ws.boardsesh.com/og/climb?og');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ body: null }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('warms both the overlay and the absolute og image on the full climb-view path', async () => {
+    await warmOverlays({ boardDetails, climbs, variant: 'full' });
+
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/api/internal/board-render?overlay'));
+    expect(fetch).toHaveBeenCalledWith('https://ws.boardsesh.com/og/climb?og');
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('warms only the overlay for a thumbnail list — no per-row og render', async () => {
+    await warmOverlays({ boardDetails, climbs, variant: 'thumbnail' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/api/internal/board-render?overlay'));
+    expect(buildOgBoardRenderUrl).not.toHaveBeenCalled();
+  });
+
+  it('skips the relative og fallback (backend origin unresolvable)', async () => {
+    vi.mocked(buildOgBoardRenderUrl).mockReturnValue('/api/og/climb?relative');
+
+    await warmOverlays({ boardDetails, climbs, variant: 'full' });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalledWith('/api/og/climb?relative');
+  });
+
+  it('swallows fetch failures instead of rejecting', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('network down'));
+
+    await expect(warmOverlays({ boardDetails, climbs, variant: 'full' })).resolves.toBeUndefined();
+  });
+});

--- a/packages/web/app/lib/prewarm-share-cache.ts
+++ b/packages/web/app/lib/prewarm-share-cache.ts
@@ -1,0 +1,37 @@
+/**
+ * Fire-and-forget cache priming issued the instant a user taps Share — seconds
+ * before a crawler scrapes the freshly shared URL. Warms two cold caches so the
+ * crawler's fetches land as warm hits:
+ *   - the share page HTML on the Vercel CDN (same-origin GET; the first crawler
+ *     hit would otherwise pay a full cold-lambda SSR)
+ *   - the backend og:image caches (cross-origin to ws.boardsesh.com; `no-cors`
+ *     so an opaque response resolves instead of throwing)
+ *
+ * Best-effort only: every fetch is voided (never awaited) and all failures are
+ * swallowed, so priming can never delay or break the share flow.
+ *
+ * Known gap: for a sharer with a non-default locale cookie, the page fetch
+ * follows the sticky-locale 307 and warms the /es|/fr CDN entry rather than the
+ * unprefixed URL crawlers fetch — a harmless no-op (never a wrong cache entry;
+ * the redirect returns before cache headers attach). The og warm is
+ * locale-independent and works for everyone.
+ */
+export function prewarmShareCaches(urls: string[]): void {
+  if (typeof window === 'undefined') return;
+  for (const url of urls) {
+    void primeShareTarget(url);
+  }
+}
+
+async function primeShareTarget(url: string): Promise<void> {
+  try {
+    const isCrossOrigin = new URL(url, window.location.href).origin !== window.location.origin;
+    // Cross-origin (backend og image): no-cors so an opaque response resolves
+    // instead of throwing. Same-origin (share page): a plain GET that lands in
+    // the CDN cache. Either way the body is discarded.
+    const response = isCrossOrigin ? await fetch(url, { mode: 'no-cors' }) : await fetch(url);
+    await response.body?.cancel();
+  } catch {
+    // Swallow — priming is best-effort and must not surface to the user.
+  }
+}

--- a/packages/web/app/lib/prewarm-share-cache.ts
+++ b/packages/web/app/lib/prewarm-share-cache.ts
@@ -1,20 +1,9 @@
 /**
- * Fire-and-forget cache priming issued the instant a user taps Share — seconds
- * before a crawler scrapes the freshly shared URL. Warms two cold caches so the
- * crawler's fetches land as warm hits:
- *   - the share page HTML on the Vercel CDN (same-origin GET; the first crawler
- *     hit would otherwise pay a full cold-lambda SSR)
- *   - the backend og:image caches (cross-origin to ws.boardsesh.com; `no-cors`
- *     so an opaque response resolves instead of throwing)
- *
- * Best-effort only: every fetch is voided (never awaited) and all failures are
- * swallowed, so priming can never delay or break the share flow.
- *
- * Known gap: for a sharer with a non-default locale cookie, the page fetch
- * follows the sticky-locale 307 and warms the /es|/fr CDN entry rather than the
- * unprefixed URL crawlers fetch — a harmless no-op (never a wrong cache entry;
- * the redirect returns before cache headers attach). The og warm is
- * locale-independent and works for everyone.
+ * Fire-and-forget cache priming on Share tap: warms the share page on the
+ * Vercel CDN and the backend og:image caches seconds before a crawler scrapes.
+ * Best-effort — voided, all failures swallowed, never delays the share flow.
+ * (Non-default-locale sharers' page fetch follows the sticky-locale 307 and
+ * warms the prefixed entry instead — a harmless no-op, never a wrong entry.)
  */
 export function prewarmShareCaches(urls: string[]): void {
   if (typeof window === 'undefined') return;
@@ -29,7 +18,12 @@ async function primeShareTarget(url: string): Promise<void> {
     // Cross-origin (backend og image): no-cors so an opaque response resolves
     // instead of throwing. Same-origin (share page): a plain GET that lands in
     // the CDN cache. Either way the body is discarded.
-    const response = isCrossOrigin ? await fetch(url, { mode: 'no-cors' }) : await fetch(url);
+    if (isCrossOrigin) {
+      // no-cors: opaque response, nothing to read or cancel.
+      await fetch(url, { mode: 'no-cors' });
+      return;
+    }
+    const response = await fetch(url);
     await response.body?.cancel();
   } catch {
     // Swallow — priming is best-effort and must not surface to the user.

--- a/packages/web/app/lib/warm-overlay-cache.ts
+++ b/packages/web/app/lib/warm-overlay-cache.ts
@@ -41,6 +41,8 @@ export async function warmOverlays(options: WarmOverlaysOptions): Promise<void> 
 
       // Only the full climb-view pages warm the og card. A thumbnail list would
       // fan out one backend og render per row for images no crawler fetches.
+      // Both full-variant call sites pass a single climb, so this is one og
+      // request per view render (worst case maxImages og warms if that changes).
       // Skip the relative web-render fallback: only the absolute backend URL
       // primes the long-running renderer's base+byte caches.
       if (variant === 'full') {

--- a/packages/web/app/lib/warm-overlay-cache.ts
+++ b/packages/web/app/lib/warm-overlay-cache.ts
@@ -1,45 +1,62 @@
-import { buildOverlayUrl } from '@/app/components/board-renderer/util';
+import { buildOgBoardRenderUrl, buildOverlayUrl } from '@/app/components/board-renderer/util';
 import { SITE_URL } from '@/app/lib/seo/base-url';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 
 const BASE_URL = process.env.VERCEL_URL ? SITE_URL : 'http://localhost:3000';
+
+type WarmOverlaysOptions = {
+  boardDetails: BoardDetails;
+  climbs: Pick<Climb, 'frames'>[];
+  variant: 'thumbnail' | 'full';
+  maxImages?: number;
+};
 
 /**
  * Fire-and-forget fetches to warm the Vercel Edge CDN cache for
  * WASM-rendered board overlay images. Fetches start immediately
  * (overlapping with SSR response streaming) so overlays are cached
  * before the client hydrates and requests them.
+ *
+ * On the climb view pages (`variant: 'full'`) this also warms the shared
+ * og:image on the backend, so the base+byte caches are primed before anyone
+ * shares the climb — the first crawler fetch is then a warm hit.
  */
-export function scheduleOverlayWarming(options: {
-  boardDetails: BoardDetails;
-  climbs: Pick<Climb, 'frames'>[];
-  variant: 'thumbnail' | 'full';
-  maxImages?: number;
-}): void {
+export function scheduleOverlayWarming(options: WarmOverlaysOptions): void {
   // Fire-and-forget — don't await. The serverless function stays alive
   // while the SSR response is still streaming, giving these fetches
   // time to complete and populate the CDN cache.
   void warmOverlays(options);
 }
 
-async function warmOverlays(options: {
-  boardDetails: BoardDetails;
-  climbs: Pick<Climb, 'frames'>[];
-  variant: 'thumbnail' | 'full';
-  maxImages?: number;
-}): Promise<void> {
+// Exported for tests; `scheduleOverlayWarming` is the production entry point.
+export async function warmOverlays(options: WarmOverlaysOptions): Promise<void> {
   try {
     const { boardDetails, climbs, variant, maxImages = 20 } = options;
     const isThumbnail = variant === 'thumbnail';
     const toWarm = climbs.slice(0, maxImages);
 
+    const warmTargets: string[] = [];
+    for (const climb of toWarm) {
+      warmTargets.push(`${BASE_URL}${buildOverlayUrl(boardDetails, climb.frames, isThumbnail)}`);
+
+      // Only the full climb-view pages warm the og card. A thumbnail list would
+      // fan out one backend og render per row for images no crawler fetches.
+      // Skip the relative web-render fallback: only the absolute backend URL
+      // primes the long-running renderer's base+byte caches.
+      if (variant === 'full') {
+        const ogUrl = buildOgBoardRenderUrl(boardDetails, climb.frames);
+        if (ogUrl.startsWith('http')) {
+          warmTargets.push(ogUrl);
+        }
+      }
+    }
+
     await Promise.allSettled(
-      toWarm.map((climb) => {
-        const path = buildOverlayUrl(boardDetails, climb.frames, isThumbnail);
-        return fetch(`${BASE_URL}${path}`)
-          .then((r) => r.body?.cancel())
-          .catch(() => {});
-      }),
+      warmTargets.map((url) =>
+        fetch(url)
+          .then((response) => response.body?.cancel())
+          .catch(() => {}),
+      ),
     );
   } catch {
     // Warming failures must never propagate


### PR DESCRIPTION
## Summary

Closes the last slow leg in climb share unfurls. After #3829/#3830/#3833, repeat fetches of a shared link are fast — but a *freshly* shared URL is by definition new to the Vercel CDN, so the first crawler fetch still paid a full cold SSR (measured 1–2.4s). Crawlers scrape seconds after a share, and at share time we know the exact URL they'll fetch — so prime everything then:

- **Viewing a climb** (always precedes sharing it) now also warms the backend og image server-side, via the existing `scheduleOverlayWarming` fire-and-forget machinery (full variant only — list thumbnails don't fan out; the relative Vercel fallback URL is never warmed).
- **Tapping share on web** fires two fire-and-forget fetches before the share sheet opens: the share page URL (primes the CDN HTML entry) and the og image URL (`mode: 'no-cors'`, primes the backend caches).
- **Tapping share on mobile** does the same via plain RN `fetch`. The og URL is built by a small local helper — importing `@boardsesh/board-render` would drag the WASM renderer + sharp into the bundle. Raw URL parity with web isn't required: the backend canonicalises `set_ids` before keying its caches, so both platforms' URLs collapse to the same entry (QA-verified).

Priming is strictly best-effort: voided fetches, all failures (including rejections and a missing fetch) swallowed, the share sheet is never delayed. Cache-poisoning reviewed: a non-default-locale sharer's page fetch follows the sticky-locale 307 (which returns before cache headers attach), so it can warm the wrong-locale entry as a no-op but can never write a bad one.

## Release Notes

Shared climbs unfurl instantly in chats — the preview is ready before your link lands

## Test plan

- Web: `warm-overlay-cache.test.ts` (og warmed on full variant, not thumbnails, fallback skipped, failures swallowed) + `share-action.test.tsx` (both warm fetches fire with correct modes, sharing survives rejected fetches) — `vp run test:web` 5760 green
- Mobile: `use-share-climb.test.ts` extended (page + og warm, unsorted `set_ids` sorted in the URL, share sheet opens when prewarm rejects) — `vp run test:mobile` 4344 green
- `vp run typecheck:web` + `typecheck:mobile` clean; `vp run check:mobile-bundle` OK
- Post-deploy: share a climb from the app, then immediately curl the shared URL and its og:image — both should be cache HITs by the time a crawler would scrape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfrRx9USHPkdtaPXuLo3Zb