### PR TITLE
feat(backend): honor CF-Connecting-IP in og rate limiting

### DIFF
--- a/docs/og-climb.md
+++ b/docs/og-climb.md
@@ -63,6 +63,28 @@ repeats, ~700ms worst-case first render of a never-seen board config.
   backdrop-only (no board photo) rather than failing.
 - Quick prod check:
   `curl -o /dev/null -s -w 'code=%{http_code} ttfb=%{time_starttransfer}s\n' 'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=10&set_ids=1,20&frames=p1080r15p1202r12'`
+
+## Cloudflare in front of ws.boardsesh.com (edge-caching the og image)
+
+`ws.boardsesh.com` is a single-region Railway origin; distant clients (and the
+iOS share sheet, which fetches previews from the sender's phone) pay full RTT
+per image. Fronting it with Cloudflare edge-caches the immutable og responses
+globally. Flip runbook (dashboard):
+
+1. Code prerequisite (shipped): the og rate limiter prefers `CF-Connecting-IP`,
+   so per-client buckets survive the proxy hop.
+2. Cloudflare DNS: toggle the `ws` record to Proxied (orange cloud). SSL/TLS
+   mode must be Full (strict) — Flexible causes redirect loops with Railway.
+3. Cache Rule: host `ws.boardsesh.com` AND path starts with `/og/` → Eligible
+   for cache, respect origin TTL (responses are `immutable`, 1y). Leave every
+   other path default so `/graphql`, REST, and WebSocket upgrades bypass cache.
+4. Confirm WebSockets are enabled for the zone (Network tab; on by default on
+   current plans).
+5. Verify: `wss://ws.boardsesh.com/graphql` still connects (web party mode +
+   mobile app); `curl -sI 'https://ws.boardsesh.com/og/climb?...'` twice —
+   second response shows `cf-cache-status: HIT`. Rollback = grey-cloud the
+   record.
+
 - Web points `og:image` here via `buildOgBoardRenderUrl`
   (`packages/web/app/components/board-renderer/util.ts`), which derives the
   backend origin from `NEXT_PUBLIC_WS_URL`.

--- a/packages/backend/src/__tests__/og-climb.test.ts
+++ b/packages/backend/src/__tests__/og-climb.test.ts
@@ -164,6 +164,22 @@ describe('handleOgClimb', () => {
       expect(res.statusCode).toBe(200);
       expect(vi.mocked(checkRateLimitRedis).mock.calls[0][0]).toBe('unknown');
     });
+
+    it('prefers CF-Connecting-IP over the x-forwarded-for chain when Cloudflare fronts the host', async () => {
+      const url = new URL('http://localhost:8080/og/climb');
+      for (const [key, value] of Object.entries(validParams)) {
+        url.searchParams.set(key, value);
+      }
+      const req = {
+        method: 'GET',
+        headers: { 'cf-connecting-ip': '203.0.113.7', 'x-forwarded-for': '203.0.113.7, 172.68.1.1' },
+        socket: { remoteAddress: '10.0.0.1' },
+      } as unknown as IncomingMessage;
+      const res = makeResponse();
+      await handleOgClimb(req, res as unknown as ServerResponse, url);
+      expect(res.statusCode).toBe(200);
+      expect(vi.mocked(checkRateLimitRedis).mock.calls[0][0]).toBe('203.0.113.7');
+    });
   });
 
   describe('CORS preflight', () => {

--- a/packages/backend/src/handlers/og-climb.ts
+++ b/packages/backend/src/handlers/og-climb.ts
@@ -21,12 +21,19 @@ const RATE_LIMIT_WINDOW_MS = 60_000;
 const SLOW_RENDER_MS = 1000;
 
 /**
- * Client IP for rate limiting. Uses the LAST x-forwarded-for entry: the edge
- * proxy (Railway) appends the IP it observed, while earlier entries are
- * client-supplied and spoofable — trusting the first hop would let a client
- * mint a fresh identity per request and bypass the per-IP limit.
+ * Client IP for rate limiting. Prefers CF-Connecting-IP so that when
+ * Cloudflare fronts ws.boardsesh.com the per-IP buckets track real clients —
+ * the last x-forwarded-for hop is Cloudflare's colo IP there, which would
+ * collapse everyone behind a colo into one bucket. Otherwise uses the LAST
+ * x-forwarded-for entry: the edge proxy (Railway) appends the IP it observed,
+ * while earlier entries are client-supplied and spoofable. A client hitting
+ * Railway directly could spoof CF-Connecting-IP for fresh buckets, but the
+ * per-peer ceiling in the handler still caps total throughput.
  */
 function getClientIp(req: IncomingMessage): string {
+  const cloudflareClientIp = req.headers['cf-connecting-ip'];
+  const cloudflareIp = Array.isArray(cloudflareClientIp) ? cloudflareClientIp[0] : cloudflareClientIp;
+  if (cloudflareIp?.trim()) return cloudflareIp.trim();
   const forwarded = req.headers['x-forwarded-for'];
   const forwardedChain = Array.isArray(forwarded) ? forwarded.join(',') : forwarded;
   const lastHop = forwardedChain?.split(',').at(-1)?.trim();


### PR DESCRIPTION
## Summary

Prep for putting Cloudflare in front of `ws.boardsesh.com` to edge-cache og share-card images globally (the iOS share sheet and far-from-US crawlers currently pay full RTT to the single-region Railway origin per image).

- The og endpoint's rate limiter now prefers `CF-Connecting-IP` over the last `x-forwarded-for` hop — behind Cloudflare that hop is the colo IP, which would collapse everyone behind a colo into one 120/min bucket. A direct-to-origin client spoofing the header only mints fresh per-IP buckets; the per-peer 600/min ceiling still caps total throughput.
- `docs/og-climb.md` gains the dashboard flip runbook: orange-cloud the `ws` record, SSL Full (strict), a `/og/*` cache rule respecting origin TTL, WebSocket verification, and rollback.

**Merge this before flipping the Cloudflare proxy.** The flip itself is dashboard work (steps in the doc).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `og-climb.test.ts` gains a CF-Connecting-IP preference test (17 tests green, incl. the real-render smoke)
- `vp run typecheck:backend` clean
- Post-flip verification commands in the runbook (`cf-cache-status: HIT` on repeat og fetches, WS connectivity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfrRx9USHPkdtaPXuLo3Zb