### PR TITLE
feat(mobile): track play-drawer shares; add source to share analytics

### DIFF
--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -125,7 +125,13 @@ function ClimbActionsSheet({
         climbName: climb.name,
       })}`;
       await Clipboard.setStringAsync(url);
-      track(SHARED_EVENTS.ClimbShared, { method: 'copy_link', climbUuid: climb.uuid, boardName, layoutId });
+      track(SHARED_EVENTS.ClimbShared, {
+        method: 'copy_link',
+        source: 'climb_actions_sheet',
+        climbUuid: climb.uuid,
+        boardName,
+        layoutId,
+      });
       showToast(t('mobile.climbActions.linkCopied'), 'info');
     } finally {
       onClose();

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -350,7 +350,13 @@ export function useClimbActions({
         // Dismiss the overlay, then open the native share sheet (same as the play
         // drawer). .catch so a dismissed/failed share isn't an unhandled rejection.
         after();
-        track(SHARED_EVENTS.ClimbShared, { method: 'share', climbUuid: climb.uuid, boardName, layoutId });
+        track(SHARED_EVENTS.ClimbShared, {
+          method: 'share',
+          source: 'climb_actions_menu',
+          climbUuid: climb.uuid,
+          boardName,
+          layoutId,
+        });
         void shareClimb().catch(() => {});
       },
     });

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -467,10 +467,12 @@ export function PlayDrawer({
   // Android can throw on share cancellation; surface anything we didn't expect
   // rather than silently swallowing the rejection.
   const handleShare = useCallback(() => {
+    if (!displayedClimb) return;
+    // Tracks share intent (like the actions-menu site), not share completion.
     track(SHARED_EVENTS.ClimbShared, {
       method: 'share',
       source: 'play_drawer',
-      climbUuid: displayedClimb?.uuid,
+      climbUuid: displayedClimb.uuid,
       boardName,
       layoutId,
     });
@@ -478,7 +480,7 @@ export function PlayDrawer({
       console.warn('[playDrawer] share failed:', error);
       showToast(t('playView.shareError'), 'error');
     });
-  }, [shareClimb, displayedClimb?.uuid, boardName, layoutId, showToast, t]);
+  }, [shareClimb, displayedClimb, boardName, layoutId, showToast, t]);
 
   // Long-press the climb name to copy it — handy for pasting into a chat when
   // sharing beta. Delegates to the unit-tested copyClimbName helper; haptic for

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -467,11 +467,18 @@ export function PlayDrawer({
   // Android can throw on share cancellation; surface anything we didn't expect
   // rather than silently swallowing the rejection.
   const handleShare = useCallback(() => {
+    track(SHARED_EVENTS.ClimbShared, {
+      method: 'share',
+      source: 'play_drawer',
+      climbUuid: displayedClimb?.uuid,
+      boardName,
+      layoutId,
+    });
     shareClimb().catch((error) => {
       console.warn('[playDrawer] share failed:', error);
       showToast(t('playView.shareError'), 'error');
     });
-  }, [shareClimb, showToast, t]);
+  }, [shareClimb, displayedClimb?.uuid, boardName, layoutId, showToast, t]);
 
   // Long-press the climb name to copy it — handy for pasting into a chat when
   // sharing beta. Delegates to the unit-tested copyClimbName helper; haptic for

--- a/packages/web/app/components/climb-actions/actions/share-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/share-action.tsx
@@ -39,7 +39,7 @@ export function ShareAction({
         title: climb.name,
         text: t('share.actionText', { climbName: climb.name, difficulty: climb.difficulty }),
         trackingEvent: 'Climb Shared',
-        trackingProps: { boardName: boardDetails.board_name, climbUuid: climb.uuid },
+        trackingProps: { boardName: boardDetails.board_name, climbUuid: climb.uuid, source: 'climb_actions' },
         onClipboardSuccess: () => showMessage(t('share.linkCopied'), 'success'),
         onError: () => showMessage(t('share.shareFailed'), 'error'),
       });


### PR DESCRIPTION
## Summary

Share instrumentation audit for "how often are shares used": web and the mobile actions menu/sheet already fired `Climb Shared`, but the play drawer — the primary share surface — fired nothing. That's fixed, and every share site now tags a `source` property (`play_drawer`, `climb_actions_menu`, `climb_actions_sheet`, web `climb_actions`) so volume can be split by surface, alongside the existing `method` (`share` / `copy_link` / `native` / `clipboard`).

JS-only — rides OTA to the existing fleet.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run test:mobile` — 4340 green; `vp run typecheck:mobile` + `typecheck:web` clean
- Targeted web share tests green (11)
- Post-merge: PostHog `Climb Shared` events carry `source`; play-drawer shares appear within a day of the OTA landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfrRx9USHPkdtaPXuLo3Zb