### PR TITLE
feat(web): gym comments in the manage console

### DIFF
--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -363,9 +363,8 @@
       "description": "Your gym's name, address, and what climbers see on the public page."
     },
     "comments": {
-      "intro": "See what your crew's saying and reply, right from here.",
-      "count_one": "{{count}} comment",
-      "count_other": "{{count}} comments",
+      "intro": "Reply to your gym's comment thread without leaving the console.",
+      "heading": "What your crew's saying",
       "empty": "No one's chimed in yet."
     }
   },

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -364,8 +364,7 @@
     },
     "comments": {
       "intro": "Reply to your gym's comment thread without leaving the console.",
-      "heading": "What your crew's saying",
-      "empty": "No one's chimed in yet."
+      "heading": "What your crew's saying"
     }
   },
   "branding": {

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -138,7 +138,8 @@
       "members": "Members",
       "insights": "Insights",
       "overview": "Overview",
-      "profile": "Profile"
+      "profile": "Profile",
+      "comments": "Comments"
     },
     "insights": {
       "subtitle": "How your boards did this week compared with last.",
@@ -360,6 +361,12 @@
     "profile": {
       "heading": "Gym profile",
       "description": "Your gym's name, address, and what climbers see on the public page."
+    },
+    "comments": {
+      "intro": "See what your crew's saying and reply, right from here.",
+      "count_one": "{{count}} comment",
+      "count_other": "{{count}} comments",
+      "empty": "No one's chimed in yet."
     }
   },
   "branding": {

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -138,7 +138,8 @@
       "members": "Miembros",
       "insights": "Estadísticas",
       "overview": "Resumen",
-      "profile": "Perfil"
+      "profile": "Perfil",
+      "comments": "Comentarios"
     },
     "insights": {
       "subtitle": "Cómo fueron tus plafones esta semana frente a la anterior.",
@@ -360,6 +361,12 @@
     "profile": {
       "heading": "Perfil del rocódromo",
       "description": "El nombre, la dirección y lo que ven los escaladores en la página pública."
+    },
+    "comments": {
+      "intro": "Mira lo que dice tu equipo y responde, sin salir de la consola.",
+      "count_one": "{{count}} comentario",
+      "count_other": "{{count}} comentarios",
+      "empty": "Nadie ha comentado todavía."
     }
   },
   "branding": {

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -363,9 +363,8 @@
       "description": "El nombre, la dirección y lo que ven los escaladores en la página pública."
     },
     "comments": {
-      "intro": "Mira lo que dice tu equipo y responde, sin salir de la consola.",
-      "count_one": "{{count}} comentario",
-      "count_other": "{{count}} comentarios",
+      "intro": "Responde al hilo de comentarios de tu rocódromo sin salir de la consola.",
+      "heading": "Lo que dice tu equipo",
       "empty": "Nadie ha comentado todavía."
     }
   },

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -364,8 +364,7 @@
     },
     "comments": {
       "intro": "Responde al hilo de comentarios de tu rocódromo sin salir de la consola.",
-      "heading": "Lo que dice tu equipo",
-      "empty": "Nadie ha comentado todavía."
+      "heading": "Lo que dice tu equipo"
     }
   },
   "branding": {

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -364,8 +364,7 @@
     },
     "comments": {
       "intro": "Réponds au fil de commentaires de ta salle sans quitter la console.",
-      "heading": "Ce que dit ton crew",
-      "empty": "Personne n'a encore commenté."
+      "heading": "Ce que dit ton crew"
     }
   },
   "branding": {

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -363,9 +363,8 @@
       "description": "Le nom, l'adresse et ce que les grimpeurs voient sur la page publique."
     },
     "comments": {
-      "intro": "Vois ce que dit ton crew et réponds, sans quitter la console.",
-      "count_one": "{{count}} commentaire",
-      "count_other": "{{count}} commentaires",
+      "intro": "Réponds au fil de commentaires de ta salle sans quitter la console.",
+      "heading": "Ce que dit ton crew",
       "empty": "Personne n'a encore commenté."
     }
   },

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -138,7 +138,8 @@
       "members": "Membres",
       "insights": "Statistiques",
       "overview": "Aperçu",
-      "profile": "Profil"
+      "profile": "Profil",
+      "comments": "Commentaires"
     },
     "insights": {
       "subtitle": "Comment tes boards ont tourné cette semaine par rapport à la dernière.",
@@ -360,6 +361,12 @@
     "profile": {
       "heading": "Profil de la salle",
       "description": "Le nom, l'adresse et ce que les grimpeurs voient sur la page publique."
+    },
+    "comments": {
+      "intro": "Vois ce que dit ton crew et réponds, sans quitter la console.",
+      "count_one": "{{count}} commentaire",
+      "count_other": "{{count}} commentaires",
+      "empty": "Personne n'a encore commenté."
     }
   },
   "branding": {

--- a/packages/web/app/components/gym-entity/manage/__tests__/comments-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/comments-tab.test.tsx
@@ -70,4 +70,13 @@ describe('CommentsTab', () => {
     render(<CommentsTab gym={makeGym()} />);
     expect(screen.getByText(/reply, right from here/i)).toBeTruthy();
   });
+
+  it('re-labels the header when the comment count changes', () => {
+    const { rerender } = render(<CommentsTab gym={makeGym({ commentCount: 0 })} />);
+    expect(screen.getByText("No one's chimed in yet.")).toBeTruthy();
+
+    rerender(<CommentsTab gym={makeGym({ commentCount: 1 })} />);
+    expect(screen.getByText('1 comment')).toBeTruthy();
+    expect(screen.queryByText("No one's chimed in yet.")).toBeNull();
+  });
 });

--- a/packages/web/app/components/gym-entity/manage/__tests__/comments-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/comments-tab.test.tsx
@@ -64,6 +64,7 @@ describe('CommentsTab', () => {
   it('explains that replies happen without leaving the console', () => {
     render(<CommentsTab gym={makeGym()} />);
 
-    expect(screen.getByText(/without leaving the console/i)).toBeTruthy();
+    // queryByText returns null rather than throwing, so this is a real assertion.
+    expect(screen.queryByText(/without leaving the console/i)).not.toBeNull();
   });
 });

--- a/packages/web/app/components/gym-entity/manage/__tests__/comments-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/comments-tab.test.tsx
@@ -48,35 +48,36 @@ describe('CommentsTab', () => {
     expect(section.getAttribute('data-entity-id')).toBe('gym-abc');
   });
 
-  it('labels the thread with the live comment count when the crew has been talking', () => {
+  it('heads the thread with a climber-voice title when the crew has been talking', () => {
     render(<CommentsTab gym={makeGym({ commentCount: 5 })} />);
-    // The count doubles as the section header — plural form for >1.
-    expect(screen.getByText('5 comments')).toBeTruthy();
-  });
-
-  it('uses the singular count label for a single comment', () => {
-    render(<CommentsTab gym={makeGym({ commentCount: 1 })} />);
-    expect(screen.getByText('1 comment')).toBeTruthy();
+    // The header stays count-free — the live tally is CommentSection's job, so a
+    // load-time snapshot can never show a stale number here.
+    expect(screen.getByText("What your crew's saying")).toBeTruthy();
+    expect(screen.queryByText("No one's chimed in yet.")).toBeNull();
   });
 
   it('shows the climber-voice empty state when the thread is empty', () => {
     render(<CommentsTab gym={makeGym({ commentCount: 0 })} />);
     expect(screen.getByText("No one's chimed in yet.")).toBeTruthy();
-    // No count label when there's nothing to count.
-    expect(screen.queryByText(/\d+ comments?/)).toBeNull();
+    expect(screen.queryByText("What your crew's saying")).toBeNull();
   });
 
-  it('explains that this is the same thread as the public gym page', () => {
+  it('treats a missing commentCount as an empty thread', () => {
+    render(<CommentsTab gym={makeGym({ commentCount: undefined as unknown as number })} />);
+    expect(screen.getByText("No one's chimed in yet.")).toBeTruthy();
+  });
+
+  it('explains that replies happen without leaving the console', () => {
     render(<CommentsTab gym={makeGym()} />);
-    expect(screen.getByText(/reply, right from here/i)).toBeTruthy();
+    expect(screen.getByText(/without leaving the console/i)).toBeTruthy();
   });
 
-  it('re-labels the header when the comment count changes', () => {
+  it('re-heads the thread when the comment count crosses zero', () => {
     const { rerender } = render(<CommentsTab gym={makeGym({ commentCount: 0 })} />);
     expect(screen.getByText("No one's chimed in yet.")).toBeTruthy();
 
     rerender(<CommentsTab gym={makeGym({ commentCount: 1 })} />);
-    expect(screen.getByText('1 comment')).toBeTruthy();
+    expect(screen.getByText("What your crew's saying")).toBeTruthy();
     expect(screen.queryByText("No one's chimed in yet.")).toBeNull();
   });
 });

--- a/packages/web/app/components/gym-entity/manage/__tests__/comments-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/comments-tab.test.tsx
@@ -14,8 +14,9 @@ vi.mock('react-i18next', () => ({
 }));
 
 // The tab reuses the public gym page's CommentSection wholesale. Stub it so the
-// test proves the wiring (entity + title) without dragging in its GraphQL-WS
-// subscription; the real thing is covered by the social comment tests.
+// test proves the wiring (entity + heading) without dragging in its GraphQL-WS
+// subscription; the real thing — including the live count and empty state — is
+// covered by the social comment tests.
 vi.mock('@/app/components/social/comment-section', () => ({
   default: ({ entityType, entityId, title }: { entityType: string; entityId: string; title?: string }) => (
     <div data-testid="comment-section" data-entity-type={entityType} data-entity-id={entityId}>
@@ -41,43 +42,28 @@ function makeGym(overrides: Partial<Gym> = {}): Gym {
 
 describe('CommentsTab', () => {
   it('mounts the shared CommentSection against the gym entity by uuid', () => {
-    render(<CommentsTab gym={makeGym({ uuid: 'gym-abc', commentCount: 5 })} />);
+    render(<CommentsTab gym={makeGym({ uuid: 'gym-abc' })} />);
 
     const section = screen.getByTestId('comment-section');
     expect(section.getAttribute('data-entity-type')).toBe('gym');
     expect(section.getAttribute('data-entity-id')).toBe('gym-abc');
   });
 
-  it('heads the thread with a climber-voice title when the crew has been talking', () => {
-    render(<CommentsTab gym={makeGym({ commentCount: 5 })} />);
-    // The header stays count-free — the live tally is CommentSection's job, so a
-    // load-time snapshot can never show a stale number here.
-    expect(screen.getByText("What your crew's saying")).toBeTruthy();
-    expect(screen.queryByText("No one's chimed in yet.")).toBeNull();
-  });
+  it('gives the thread a stable climber-voice heading, not a snapshot count', () => {
+    // The header must not be derived from the load-time commentCount — the live
+    // count and empty state are CommentSection's job — so it reads the same
+    // whether the gym loaded with no comments or a full thread. This is the
+    // regression guard against a stale header after an in-tab post.
+    const { rerender } = render(<CommentsTab gym={makeGym({ commentCount: 0 })} />);
+    expect(screen.getByTestId('comment-section').textContent).toContain("What your crew's saying");
 
-  it('shows the climber-voice empty state when the thread is empty', () => {
-    render(<CommentsTab gym={makeGym({ commentCount: 0 })} />);
-    expect(screen.getByText("No one's chimed in yet.")).toBeTruthy();
-    expect(screen.queryByText("What your crew's saying")).toBeNull();
-  });
-
-  it('treats a missing commentCount as an empty thread', () => {
-    render(<CommentsTab gym={makeGym({ commentCount: undefined as unknown as number })} />);
-    expect(screen.getByText("No one's chimed in yet.")).toBeTruthy();
+    rerender(<CommentsTab gym={makeGym({ commentCount: 5 })} />);
+    expect(screen.getByTestId('comment-section').textContent).toContain("What your crew's saying");
   });
 
   it('explains that replies happen without leaving the console', () => {
     render(<CommentsTab gym={makeGym()} />);
+
     expect(screen.getByText(/without leaving the console/i)).toBeTruthy();
-  });
-
-  it('re-heads the thread when the comment count crosses zero', () => {
-    const { rerender } = render(<CommentsTab gym={makeGym({ commentCount: 0 })} />);
-    expect(screen.getByText("No one's chimed in yet.")).toBeTruthy();
-
-    rerender(<CommentsTab gym={makeGym({ commentCount: 1 })} />);
-    expect(screen.getByText("What your crew's saying")).toBeTruthy();
-    expect(screen.queryByText("No one's chimed in yet.")).toBeNull();
   });
 });

--- a/packages/web/app/components/gym-entity/manage/__tests__/comments-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/comments-tab.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { Gym } from '@boardsesh/shared-schema';
+import CommentsTab from '../comments-tab';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+// The tab reuses the public gym page's CommentSection wholesale. Stub it so the
+// test proves the wiring (entity + title) without dragging in its GraphQL-WS
+// subscription; the real thing is covered by the social comment tests.
+vi.mock('@/app/components/social/comment-section', () => ({
+  default: ({ entityType, entityId, title }: { entityType: string; entityId: string; title?: string }) => (
+    <div data-testid="comment-section" data-entity-type={entityType} data-entity-id={entityId}>
+      {title}
+    </div>
+  ),
+}));
+
+function makeGym(overrides: Partial<Gym> = {}): Gym {
+  return {
+    uuid: 'gym-uuid-1',
+    slug: 'test-gym',
+    ownerId: 'user-owner',
+    name: 'Test Gym',
+    boardCount: 3,
+    memberCount: 4,
+    followerCount: 7,
+    commentCount: 0,
+    isPublic: true,
+    ...overrides,
+  } as unknown as Gym;
+}
+
+describe('CommentsTab', () => {
+  it('mounts the shared CommentSection against the gym entity by uuid', () => {
+    render(<CommentsTab gym={makeGym({ uuid: 'gym-abc', commentCount: 5 })} />);
+
+    const section = screen.getByTestId('comment-section');
+    expect(section.getAttribute('data-entity-type')).toBe('gym');
+    expect(section.getAttribute('data-entity-id')).toBe('gym-abc');
+  });
+
+  it('labels the thread with the live comment count when the crew has been talking', () => {
+    render(<CommentsTab gym={makeGym({ commentCount: 5 })} />);
+    // The count doubles as the section header — plural form for >1.
+    expect(screen.getByText('5 comments')).toBeTruthy();
+  });
+
+  it('uses the singular count label for a single comment', () => {
+    render(<CommentsTab gym={makeGym({ commentCount: 1 })} />);
+    expect(screen.getByText('1 comment')).toBeTruthy();
+  });
+
+  it('shows the climber-voice empty state when the thread is empty', () => {
+    render(<CommentsTab gym={makeGym({ commentCount: 0 })} />);
+    expect(screen.getByText("No one's chimed in yet.")).toBeTruthy();
+    // No count label when there's nothing to count.
+    expect(screen.queryByText(/\d+ comments?/)).toBeNull();
+  });
+
+  it('explains that this is the same thread as the public gym page', () => {
+    render(<CommentsTab gym={makeGym()} />);
+    expect(screen.getByText(/reply, right from here/i)).toBeTruthy();
+  });
+});

--- a/packages/web/app/components/gym-entity/manage/comments-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/comments-tab.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import type { Gym } from '@boardsesh/shared-schema';
+import CommentSection from '@/app/components/social/comment-section';
+
+/**
+ * Comments tab: surfaces the gym's public comment thread inside the manage
+ * console so owners and editors can read and reply without opening the public
+ * page (and turning up in search). It mounts the very same CommentSection the
+ * public gym page uses — same gym entity, same thread, same live-update
+ * subscription — so there's no second comment store to keep in step, and no new
+ * query to maintain.
+ */
+export default function CommentsTab({ gym }: { gym: Gym }) {
+  const { t } = useTranslation('kiosk');
+  const hasComments = gym.commentCount > 0;
+
+  // The section header doubles as the count / empty line: the thread count when
+  // the crew's talking, a climber-voice nudge when it's quiet. The gym already
+  // ships its own commentCount, so labelling the tab costs no extra round-trip.
+  const threadTitle = hasComments
+    ? t('manage.comments.count', { count: gym.commentCount })
+    : t('manage.comments.empty');
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="body2" color="text.secondary">
+        {t('manage.comments.intro')}
+      </Typography>
+      <CommentSection entityType="gym" entityId={gym.uuid} title={threadTitle} />
+    </Box>
+  );
+}

--- a/packages/web/app/components/gym-entity/manage/comments-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/comments-tab.tsx
@@ -9,21 +9,18 @@ import CommentSection from '@/app/components/social/comment-section';
 
 // Comments tab: mounts the same CommentSection the public gym page uses (same
 // gym entity, same thread, same subscription) so owners and editors can reply
-// from the console — no second comment store, no new query.
+// from the console. CommentSection owns the live count and empty state, so the
+// header stays a stable topic title — nothing here is derived from a load-time
+// snapshot that could go stale once a comment lands.
 export default function CommentsTab({ gym }: { gym: Gym }) {
   const { t } = useTranslation('kiosk');
-  // Frame the header off the gym's load-time commentCount only to pick between a
-  // heading and the empty-state nudge — the accurate, live count is rendered by
-  // the CommentSection below, so a snapshot here never shows a stale number.
-  const hasComments = (gym.commentCount ?? 0) > 0;
-  const threadTitle = hasComments ? t('manage.comments.heading') : t('manage.comments.empty');
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       <Typography variant="body2" color="text.secondary">
         {t('manage.comments.intro')}
       </Typography>
-      <CommentSection entityType="gym" entityId={gym.uuid} title={threadTitle} />
+      <CommentSection entityType="gym" entityId={gym.uuid} title={t('manage.comments.heading')} />
     </Box>
   );
 }

--- a/packages/web/app/components/gym-entity/manage/comments-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/comments-tab.tsx
@@ -12,13 +12,11 @@ import CommentSection from '@/app/components/social/comment-section';
 // from the console — no second comment store, no new query.
 export default function CommentsTab({ gym }: { gym: Gym }) {
   const { t } = useTranslation('kiosk');
-  const hasComments = gym.commentCount > 0;
-
-  // commentCount rides in with the gym, so the count / empty label costs no
-  // extra round-trip (it's a load-time snapshot, not a live tally).
-  const threadTitle = hasComments
-    ? t('manage.comments.count', { count: gym.commentCount })
-    : t('manage.comments.empty');
+  // Frame the header off the gym's load-time commentCount only to pick between a
+  // heading and the empty-state nudge — the accurate, live count is rendered by
+  // the CommentSection below, so a snapshot here never shows a stale number.
+  const hasComments = (gym.commentCount ?? 0) > 0;
+  const threadTitle = hasComments ? t('manage.comments.heading') : t('manage.comments.empty');
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/packages/web/app/components/gym-entity/manage/comments-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/comments-tab.tsx
@@ -7,21 +7,15 @@ import Typography from '@mui/material/Typography';
 import type { Gym } from '@boardsesh/shared-schema';
 import CommentSection from '@/app/components/social/comment-section';
 
-/**
- * Comments tab: surfaces the gym's public comment thread inside the manage
- * console so owners and editors can read and reply without opening the public
- * page (and turning up in search). It mounts the very same CommentSection the
- * public gym page uses — same gym entity, same thread, same live-update
- * subscription — so there's no second comment store to keep in step, and no new
- * query to maintain.
- */
+// Comments tab: mounts the same CommentSection the public gym page uses (same
+// gym entity, same thread, same subscription) so owners and editors can reply
+// from the console — no second comment store, no new query.
 export default function CommentsTab({ gym }: { gym: Gym }) {
   const { t } = useTranslation('kiosk');
   const hasComments = gym.commentCount > 0;
 
-  // The section header doubles as the count / empty line: the thread count when
-  // the crew's talking, a climber-voice nudge when it's quiet. The gym already
-  // ships its own commentCount, so labelling the tab costs no extra round-trip.
+  // commentCount rides in with the gym, so the count / empty label costs no
+  // extra round-trip (it's a load-time snapshot, not a live tally).
   const threadTitle = hasComments
     ? t('manage.comments.count', { count: gym.commentCount })
     : t('manage.comments.empty');

--- a/packages/web/app/gym/[gym_slug]/manage/__tests__/manage-gym-content.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/__tests__/manage-gym-content.test.tsx
@@ -39,6 +39,7 @@ vi.mock('@/app/components/gym-entity/manage/kiosks-tab', () => ({ default: () =>
 vi.mock('@/app/components/gym-entity/manage/insights-tab', () => ({ default: () => <div data-testid="insights" /> }));
 vi.mock('@/app/components/gym-entity/manage/branding-tab', () => ({ default: () => <div data-testid="branding" /> }));
 vi.mock('@/app/components/gym-entity/manage/gym-boards-tab', () => ({ default: () => <div data-testid="boards" /> }));
+vi.mock('@/app/components/gym-entity/manage/comments-tab', () => ({ default: () => <div data-testid="comments" /> }));
 vi.mock('@/app/components/gym-entity/gym-member-management', () => ({ default: () => <div data-testid="members" /> }));
 
 // Controllable Profile-tab stub: buttons that fire the same callbacks the real
@@ -97,6 +98,18 @@ describe('ManageGymContent default tab', () => {
 
     // Overview is the default landing surface; the Profile stub must not mount.
     expect(screen.getByTestId('overview')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'make-dirty' })).toBeNull();
+  });
+});
+
+describe('ManageGymContent comments tab', () => {
+  it('registers the Comments tab and renders it for ?tab=comments', () => {
+    searchState.params = 'tab=comments';
+    render(<ManageGymContent initialGym={makeGym()} />);
+
+    expect(screen.getByRole('tab', { name: 'Comments' })).toBeTruthy();
+    expect(screen.getByTestId('comments')).toBeTruthy();
+    // The profile stub must not mount while Comments is the active tab.
     expect(screen.queryByRole('button', { name: 'make-dirty' })).toBeNull();
   });
 });

--- a/packages/web/app/gym/[gym_slug]/manage/__tests__/manage-gym-content.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/__tests__/manage-gym-content.test.tsx
@@ -107,8 +107,9 @@ describe('ManageGymContent comments tab', () => {
     searchState.params = 'tab=comments';
     render(<ManageGymContent initialGym={makeGym()} />);
 
-    expect(screen.getByRole('tab', { name: 'Comments' })).toBeTruthy();
-    expect(screen.getByTestId('comments')).toBeTruthy();
+    // queryBy* returns null rather than throwing, so these assert presence for real.
+    expect(screen.queryByRole('tab', { name: 'Comments' })).not.toBeNull();
+    expect(screen.queryByTestId('comments')).not.toBeNull();
     // The profile stub must not mount while Comments is the active tab.
     expect(screen.queryByRole('button', { name: 'make-dirty' })).toBeNull();
   });

--- a/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
@@ -23,12 +23,22 @@ import InsightsTab from '@/app/components/gym-entity/manage/insights-tab';
 import BrandingTab from '@/app/components/gym-entity/manage/branding-tab';
 import OverviewTab from '@/app/components/gym-entity/manage/overview-tab';
 import ProfileTab from '@/app/components/gym-entity/manage/profile-tab';
+import CommentsTab from '@/app/components/gym-entity/manage/comments-tab';
 import GymSlugGuard from '@/app/components/gym-entity/manage/gym-slug-guard';
 import ConfirmDialog from '@/app/components/gym-entity/manage/confirm-dialog';
 import { decideManageNavigation, type ManageNavigation } from '@/app/components/gym-entity/manage/manage-nav-guard';
 
-type ManageTab = 'overview' | 'kiosks' | 'insights' | 'branding' | 'profile' | 'boards' | 'members';
-const VALID_TABS: ManageTab[] = ['overview', 'kiosks', 'insights', 'branding', 'profile', 'boards', 'members'];
+type ManageTab = 'overview' | 'kiosks' | 'insights' | 'branding' | 'profile' | 'boards' | 'members' | 'comments';
+const VALID_TABS: ManageTab[] = [
+  'overview',
+  'kiosks',
+  'insights',
+  'branding',
+  'profile',
+  'boards',
+  'members',
+  'comments',
+];
 const DEFAULT_TAB: ManageTab = 'overview';
 
 export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
@@ -155,6 +165,7 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
         <Tab value="profile" label={t('manage.tabs.profile')} sx={{ textTransform: 'none' }} />
         <Tab value="boards" label={t('manage.tabs.boards')} sx={{ textTransform: 'none' }} />
         <Tab value="members" label={t('manage.tabs.members')} sx={{ textTransform: 'none' }} />
+        <Tab value="comments" label={t('manage.tabs.comments')} sx={{ textTransform: 'none' }} />
       </Tabs>
 
       {activeTab === 'overview' && <OverviewTab gym={gym} />}
@@ -172,6 +183,7 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
           canGrantAccess={gym.canGrantAccess ?? false}
         />
       )}
+      {activeTab === 'comments' && <CommentsTab gym={gym} />}
 
       <ConfirmDialog
         open={pendingNavigation !== null}


### PR DESCRIPTION
## Summary

Adds a **Comments** tab to the gym manage console so owners and editors can read and reply to their gym's comment thread without visiting the public gym page (and finding themselves in search).

The tab mounts the exact same `CommentSection` the public gym page already uses — same gym entity (`entityType="gym"`, `entityId={gym.uuid}`), same GET_COMMENTS query, same `commentUpdates` live subscription, same reply mutation. No new comment infrastructure or query was built; it's the same thread, just surfaced in the console. Reply works for any editor because the tab lives inside the existing `canEdit`-gated console, so no new auth was added.

`CommentSection` (via `CommentList`) already renders the live comment count and the empty state from its own query + subscription, so the tab stays thin: a short console-context intro line plus a stable topic heading handed to `CommentSection`. Nothing in the tab is derived from a load-time snapshot, so the header never goes stale once a comment lands.

### Files changed
- `packages/web/app/components/gym-entity/manage/comments-tab.tsx` (new) — the tab; reuses `CommentSection`.
- `packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx` — register the tab (minimal: one import, one `ManageTab`/`VALID_TABS` entry, one `Tab`, one render branch).
- `packages/web/app/components/gym-entity/manage/__tests__/comments-tab.test.tsx` (new) — entity wiring, stable-heading regression guard, intro copy.
- `packages/web/app/gym/[gym_slug]/manage/__tests__/manage-gym-content.test.tsx` — tab registration/render.
- `packages/shared/i18n/locales/{en-US,es,fr}/kiosk.json` — new strings ×3 locales (es: rocódromo/equipo, fr: salle/crew).

## Release Notes

- See what your crew's saying about your gym, and reply, right from the manage console.

## Test plan

- `vp run typecheck` — pass
- `vp test run --project web --reporter=agent` — full web suite green (incl. comments-tab + shell registration)
- `vp run check:i18n` + `vp run check:i18n:orphans` — pass
- `vp check` on the changed files — pass (pre-commit hook green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)