### PR TITLE
feat: stray-board discovery in the gym Boards tab

### DIFF
--- a/packages/backend/src/__tests__/gym-stray-boards.test.ts
+++ b/packages/backend/src/__tests__/gym-stray-boards.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import {
+  socialGymStrayBoardQueries,
+  socialGymStrayBoardMutations,
+  type StrayBoardResult,
+} from '../graphql/resolvers/social/gym-stray-boards';
+import { resetAllRateLimits } from '../utils/rate-limiter';
+
+/**
+ * Real-DB coverage for stray-board discovery + attach (the gym Boards tab's
+ * "Boards that might be yours"). Two candidate sources:
+ *   - MERGED_TWIN: boards on a listing whose merged_into chain resolves to this
+ *     gym (they should have followed the merge).
+ *   - NEARBY: boards within 150 m of the gym that are unlinked or on a SYSTEM
+ *     listing, gated to boards the viewer may see.
+ *
+ * Seeds via raw SQL and calls the resolvers directly against the per-worker test
+ * DB (plain postgres — no PostGIS), mirroring find-similar-gyms-and-auto-gym.
+ */
+
+const SYSTEM_OWNER = '00000000-0000-0000-0000-000000000000';
+const OWNER = 'stray-owner';
+const OTHER = 'stray-other';
+const ALL_USERS = [SYSTEM_OWNER, OWNER, OTHER];
+
+// Base point + latitude offsets (~111_320 m per degree of latitude).
+const BASE = { latitude: 47.0, longitude: 8.0 };
+const LAT_60M = 47.0 + 0.00054; // ~60 m north (inside 150 m)
+const LAT_120M = 47.0 + 0.00108; // ~120 m (inside 150 m)
+const LAT_300M = 47.0 + 0.0027; // ~300 m (outside 150 m)
+
+let connectionCounter = 0;
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}-${connectionCounter++}`, isAuthenticated: true, userId }) as ConnectionContext;
+const anonCtx = (): ConnectionContext =>
+  ({ connectionId: `conn-anon-${connectionCounter++}`, isAuthenticated: false }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+const insertGym = async (opts: {
+  ownerId: string;
+  name: string;
+  latitude?: number | null;
+  longitude?: number | null;
+  deleted?: boolean;
+  mergedIntoGymId?: number | null;
+  isPublic?: boolean;
+}): Promise<{ id: number; uuid: string; name: string }> => {
+  const {
+    ownerId,
+    name,
+    latitude = null,
+    longitude = null,
+    deleted = false,
+    mergedIntoGymId = null,
+    isPublic = true,
+  } = opts;
+  const uuid = uuidv4();
+  const result = await db.execute(sql`
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, latitude, longitude, merged_into_gym_id, deleted_at, created_at, updated_at)
+    VALUES (
+      ${uuid}, ${name}, ${uuid}, ${ownerId}, ${isPublic}, ${latitude}, ${longitude},
+      ${mergedIntoGymId}, ${deleted ? sql`now()` : sql`NULL`}, now(), now()
+    )
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid, name };
+};
+
+// A distinct size_id per board so the (owner, type, layout, size, set_ids) unique
+// partial index never trips across the several boards a single owner has here.
+let boardConfigCounter = 0;
+const insertBoard = async (opts: {
+  ownerId: string;
+  name: string;
+  gymId?: number | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  isPublic?: boolean;
+  hideLocation?: boolean;
+}): Promise<{ id: number; uuid: string }> => {
+  const {
+    ownerId,
+    name,
+    gymId = null,
+    latitude = null,
+    longitude = null,
+    isPublic = true,
+    hideLocation = false,
+  } = opts;
+  const uuid = uuidv4();
+  const sizeId = 500 + boardConfigCounter++;
+  const result = await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, gym_id, is_public, latitude, longitude, hide_location, created_at, updated_at)
+    VALUES (
+      ${uuid}, ${uuid}, ${ownerId}, 'kilter', 1, ${sizeId}, '1,2', ${name}, ${gymId}, ${isPublic},
+      ${latitude}, ${longitude}, ${hideLocation}, now(), now()
+    )
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
+};
+
+const insertGymMember = (gymId: number, userId: string, role: string) =>
+  db.execute(sql`
+    INSERT INTO gym_members (gym_id, user_id, role, created_at)
+    VALUES (${gymId}, ${userId}, ${role}, now())
+  `);
+
+const boardGymId = async (boardUuid: string): Promise<number | null> => {
+  const result = await db.execute(sql`SELECT gym_id FROM user_boards WHERE uuid = ${boardUuid}`);
+  const row = Array.from(result as Iterable<{ gym_id: number | null }>)[0];
+  return row?.gym_id != null ? Number(row.gym_id) : null;
+};
+
+const strayBoardsForGym = (gymUuid: string, ctx: ConnectionContext) =>
+  socialGymStrayBoardQueries.strayBoardsForGym(null, { gymUuid }, ctx) as Promise<StrayBoardResult[]>;
+const attachBoardToGym = (input: unknown, ctx: ConnectionContext) =>
+  socialGymStrayBoardMutations.attachBoardToGym(null, { input }, ctx) as Promise<boolean>;
+
+// Target gym at BASE, owned by OWNER (so requireGymEditAccess passes for OWNER).
+const seedTargetGym = () =>
+  insertGym({ ownerId: OWNER, name: 'Boulder Base', latitude: BASE.latitude, longitude: BASE.longitude });
+
+beforeEach(async () => {
+  resetAllRateLimits();
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "community_roles", "gym_members", "gym_follows", "location_sync_gym_sources", "user_boards", "gyms"
+    RESTART IDENTITY CASCADE
+  `);
+  await Promise.all(ALL_USERS.map(insertUser));
+});
+
+describe('strayBoardsForGym — merged-twin candidates', () => {
+  it('surfaces a board on a listing merged into this gym, with the twin as its current gym', async () => {
+    const target = await seedTargetGym();
+    const twin = await insertGym({
+      ownerId: OTHER,
+      name: 'Old Boulder Base',
+      deleted: true,
+      mergedIntoGymId: target.id,
+    });
+    const board = await insertBoard({ ownerId: OTHER, name: 'Leftover Wall', gymId: twin.id });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
+
+    const stray = results.find((candidate) => candidate.uuid === board.uuid);
+    expect(stray).toBeDefined();
+    expect(stray?.reason).toBe('MERGED_TWIN');
+    expect(stray?.currentGymUuid).toBe(twin.uuid);
+    expect(stray?.currentGymName).toBe('Old Boulder Base');
+  });
+
+  it('follows a multi-hop merge chain (twin2 → twin1 → target)', async () => {
+    const target = await seedTargetGym();
+    const twin1 = await insertGym({ ownerId: OTHER, name: 'Twin One', deleted: true, mergedIntoGymId: target.id });
+    const twin2 = await insertGym({ ownerId: OTHER, name: 'Twin Two', deleted: true, mergedIntoGymId: twin1.id });
+    const board = await insertBoard({ ownerId: OTHER, name: 'Two Hops Away', gymId: twin2.id });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
+
+    expect(results.some((candidate) => candidate.uuid === board.uuid && candidate.reason === 'MERGED_TWIN')).toBe(true);
+  });
+});
+
+describe('strayBoardsForGym — nearby candidates', () => {
+  it('surfaces an unlinked board within 150 m and excludes one 300 m away', async () => {
+    const target = await seedTargetGym();
+    const near = await insertBoard({
+      ownerId: OTHER,
+      name: 'Wall Next Door',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+    const far = await insertBoard({
+      ownerId: OTHER,
+      name: 'Across The Street',
+      latitude: LAT_300M,
+      longitude: BASE.longitude,
+    });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
+
+    const nearStray = results.find((candidate) => candidate.uuid === near.uuid);
+    expect(nearStray?.reason).toBe('NEARBY');
+    expect(nearStray?.distanceMeters).toBeGreaterThan(0);
+    expect(nearStray?.distanceMeters).toBeLessThanOrEqual(150);
+    expect(nearStray?.currentGymUuid).toBeNull();
+    expect(results.some((candidate) => candidate.uuid === far.uuid)).toBe(false);
+  });
+
+  it('surfaces a board linked to a SYSTEM listing at the same spot', async () => {
+    const target = await seedTargetGym();
+    const systemGym = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Boulder Base (synced)',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+    const board = await insertBoard({
+      ownerId: SYSTEM_OWNER,
+      name: 'Synced Kilter',
+      gymId: systemGym.id,
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
+
+    const stray = results.find((candidate) => candidate.uuid === board.uuid);
+    expect(stray?.reason).toBe('NEARBY');
+    expect(stray?.currentGymUuid).toBe(systemGym.uuid);
+  });
+
+  it("does not leak a stranger's private wall or a hide-location board", async () => {
+    const target = await seedTargetGym();
+    const privateWall = await insertBoard({
+      ownerId: OTHER,
+      name: 'Private Home Wall',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+      isPublic: false,
+    });
+    const hidden = await insertBoard({
+      ownerId: OTHER,
+      name: 'Hidden Location Wall',
+      latitude: LAT_120M,
+      longitude: BASE.longitude,
+      isPublic: true,
+      hideLocation: true,
+    });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
+
+    expect(results.some((candidate) => candidate.uuid === privateWall.uuid)).toBe(false);
+    expect(results.some((candidate) => candidate.uuid === hidden.uuid)).toBe(false);
+  });
+});
+
+describe('strayBoardsForGym — exclusions', () => {
+  it('never returns a board already linked to this gym', async () => {
+    const target = await seedTargetGym();
+    const alreadyLinked = await insertBoard({
+      ownerId: OWNER,
+      name: 'Already Home',
+      gymId: target.id,
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
+
+    expect(results.some((candidate) => candidate.uuid === alreadyLinked.uuid)).toBe(false);
+  });
+});
+
+describe('strayBoardsForGym — access guard', () => {
+  it('rejects an anonymous caller', async () => {
+    const target = await seedTargetGym();
+    await expect(strayBoardsForGym(target.uuid, anonCtx())).rejects.toThrow();
+  });
+
+  it('rejects a caller without edit access to the gym', async () => {
+    const target = await seedTargetGym();
+    await expect(strayBoardsForGym(target.uuid, authCtx(OTHER))).rejects.toThrow();
+  });
+
+  it('allows a gym editor member', async () => {
+    const target = await seedTargetGym();
+    await insertGymMember(target.id, OTHER, 'editor');
+    await insertBoard({ ownerId: OTHER, name: 'Editor Sees Me', latitude: LAT_60M, longitude: BASE.longitude });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OTHER));
+    expect(results.length).toBeGreaterThan(0);
+  });
+});
+
+describe('attachBoardToGym', () => {
+  it('re-points a nearby stray board to the gym', async () => {
+    const target = await seedTargetGym();
+    const board = await insertBoard({
+      ownerId: OTHER,
+      name: 'Wall Next Door',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+
+    const ok = await attachBoardToGym({ gymUuid: target.uuid, boardUuid: board.uuid }, authCtx(OWNER));
+
+    expect(ok).toBe(true);
+    expect(await boardGymId(board.uuid)).toBe(target.id);
+  });
+
+  it('re-points a merged-twin board even though the caller does not own it', async () => {
+    const target = await seedTargetGym();
+    const twin = await insertGym({ ownerId: OTHER, name: 'Old Base', deleted: true, mergedIntoGymId: target.id });
+    const board = await insertBoard({ ownerId: OTHER, name: 'Leftover Wall', gymId: twin.id });
+
+    const ok = await attachBoardToGym({ gymUuid: target.uuid, boardUuid: board.uuid }, authCtx(OWNER));
+
+    expect(ok).toBe(true);
+    expect(await boardGymId(board.uuid)).toBe(target.id);
+  });
+
+  it('refuses a board that is not a stray candidate for this gym', async () => {
+    const target = await seedTargetGym();
+    const far = await insertBoard({
+      ownerId: OTHER,
+      name: 'Across The Street',
+      latitude: LAT_300M,
+      longitude: BASE.longitude,
+    });
+
+    await expect(attachBoardToGym({ gymUuid: target.uuid, boardUuid: far.uuid }, authCtx(OWNER))).rejects.toThrow();
+    expect(await boardGymId(far.uuid)).toBeNull();
+  });
+
+  it('rejects a caller without edit access to the gym', async () => {
+    const target = await seedTargetGym();
+    const board = await insertBoard({
+      ownerId: OTHER,
+      name: 'Wall Next Door',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+
+    await expect(attachBoardToGym({ gymUuid: target.uuid, boardUuid: board.uuid }, authCtx(OTHER))).rejects.toThrow();
+    expect(await boardGymId(board.uuid)).toBeNull();
+  });
+});

--- a/packages/backend/src/__tests__/gym-stray-boards.test.ts
+++ b/packages/backend/src/__tests__/gym-stray-boards.test.ts
@@ -172,13 +172,28 @@ describe('strayBoardsForGym — merged-twin candidates', () => {
 
     expect(results.some((candidate) => candidate.uuid === board.uuid && candidate.reason === 'MERGED_TWIN')).toBe(true);
   });
+
+  it('terminates on a corrupt cyclic merge pointer instead of spinning', async () => {
+    // target ← twinA ← twinB, then a corrupt back-pointer target → twinB closes a
+    // cycle in the reverse-walk graph. The canonical-id + visited guards must make
+    // the walk finish and still surface twinB's board — never loop.
+    const target = await seedTargetGym();
+    const twinA = await insertGym({ ownerId: OTHER, name: 'Cycle A', deleted: true, mergedIntoGymId: target.id });
+    const twinB = await insertGym({ ownerId: OTHER, name: 'Cycle B', deleted: true, mergedIntoGymId: twinA.id });
+    await db.execute(sql`UPDATE gyms SET merged_into_gym_id = ${twinB.id} WHERE id = ${target.id}`);
+    const board = await insertBoard({ ownerId: OTHER, name: 'On The Cycle', gymId: twinB.id });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
+
+    expect(results.some((candidate) => candidate.uuid === board.uuid)).toBe(true);
+  });
 });
 
 describe('strayBoardsForGym — nearby candidates', () => {
   it('surfaces an unlinked board within 150 m and excludes one 300 m away', async () => {
     const target = await seedTargetGym();
     const near = await insertBoard({
-      ownerId: OTHER,
+      ownerId: OWNER,
       name: 'Wall Next Door',
       latitude: LAT_60M,
       longitude: BASE.longitude,
@@ -223,8 +238,18 @@ describe('strayBoardsForGym — nearby candidates', () => {
     expect(stray?.currentGymUuid).toBe(systemGym.uuid);
   });
 
-  it("does not leak a stranger's private wall or a hide-location board", async () => {
+  it("does not surface a stranger's board — public or private — or a hide-location board", async () => {
     const target = await seedTargetGym();
+    // A stranger's PUBLIC board is the hijack vector: if surfaced and attached,
+    // the gym owner would gain edit rights over it via requireBoardEditAccess.
+    // Public does not make a third party's board safe to capture.
+    const publicWall = await insertBoard({
+      ownerId: OTHER,
+      name: 'Public Home Wall',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+      isPublic: true,
+    });
     const privateWall = await insertBoard({
       ownerId: OTHER,
       name: 'Private Home Wall',
@@ -243,8 +268,25 @@ describe('strayBoardsForGym — nearby candidates', () => {
 
     const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
 
+    expect(results.some((candidate) => candidate.uuid === publicWall.uuid)).toBe(false);
     expect(results.some((candidate) => candidate.uuid === privateWall.uuid)).toBe(false);
     expect(results.some((candidate) => candidate.uuid === hidden.uuid)).toBe(false);
+  });
+
+  it("refuses to attach a stranger's nearby public board", async () => {
+    const target = await seedTargetGym();
+    const strangerPublic = await insertBoard({
+      ownerId: OTHER,
+      name: 'Public Home Wall',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+      isPublic: true,
+    });
+
+    await expect(
+      attachBoardToGym({ gymUuid: target.uuid, boardUuid: strangerPublic.uuid }, authCtx(OWNER)),
+    ).rejects.toThrow();
+    expect(await boardGymId(strangerPublic.uuid)).toBeNull();
   });
 });
 
@@ -290,7 +332,7 @@ describe('attachBoardToGym', () => {
   it('re-points a nearby stray board to the gym', async () => {
     const target = await seedTargetGym();
     const board = await insertBoard({
-      ownerId: OTHER,
+      ownerId: SYSTEM_OWNER,
       name: 'Wall Next Door',
       latitude: LAT_60M,
       longitude: BASE.longitude,

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -38,6 +38,7 @@ import { socialVoteQueries, socialVoteMutations } from './social/votes';
 import { socialBoardQueries, socialBoardMutations } from './social/boards';
 import { socialGymQueries, socialGymMutations } from './social/gyms';
 import { socialGymMatchQueries } from './social/gym-matching';
+import { socialGymStrayBoardQueries, socialGymStrayBoardMutations } from './social/gym-stray-boards';
 import { socialGymKioskQueries, socialGymKioskMutations } from './social/gym-kiosks';
 import { socialGymInsightsQueries } from './social/gym-insights';
 import { socialGymClaimQueries, socialGymClaimMutations } from './social/gym-claims';
@@ -88,6 +89,7 @@ export const resolvers = {
     ...socialBoardQueries,
     ...socialGymQueries,
     ...socialGymMatchQueries,
+    ...socialGymStrayBoardQueries,
     ...socialGymKioskQueries,
     ...socialGymInsightsQueries,
     ...socialGymClaimQueries,
@@ -124,6 +126,7 @@ export const resolvers = {
     ...socialVoteMutations,
     ...socialBoardMutations,
     ...socialGymMutations,
+    ...socialGymStrayBoardMutations,
     ...socialGymKioskMutations,
     ...socialGymClaimMutations,
     ...socialGymDuplicateMutations,

--- a/packages/backend/src/graphql/resolvers/social/gym-stray-boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-stray-boards.ts
@@ -1,0 +1,266 @@
+import { and, eq, inArray, isNull, ne, or, sql, type SQL } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { distanceMeters } from '@boardsesh/db/queries';
+import * as dbSchema from '@boardsesh/db/schema';
+import { db } from '../../../db/client';
+import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
+import { AttachBoardToGymInputSchema, UUIDSchema } from '../../../validation/schemas';
+import { SYSTEM_BOARD_OWNER_ID } from '../board-presence/shared';
+import { requireGymEditAccess } from './gyms';
+import { PROXIMITY_MATCH_RADIUS_METERS } from './gym-matching';
+
+// ============================================
+// Stray-board discovery for the gym Boards tab
+// ============================================
+//
+// A gym owner wants every board physically in their gym attached to their
+// listing. Two ways a board can drift off:
+//   (a) it sits on a listing that was merged INTO this gym but never followed
+//       the merge (merged_into_gym_id chain resolves here), or
+//   (b) it was auto-created at the gym's coordinates under a synced (SYSTEM)
+//       listing, or left unlinked, while physically at the gym.
+// This finds both and lets the Boards tab attach them one tap at a time.
+//
+// Proximity mirrors gym-matching's findSimilarGyms: a portable lat/lng
+// bounding-box prefilter in SQL (the backend test DB is plain postgres, no
+// PostGIS), then an exact Haversine refine in JS. Boards carry their own
+// latitude/longitude columns, so the box runs over those.
+
+type GymRow = typeof dbSchema.gyms.$inferSelect;
+
+export type StrayBoardReason = 'MERGED_TWIN' | 'NEARBY';
+
+// The GraphQL StrayBoard payload plus the internal board id the attach mutation
+// re-points. `boardId` never leaves this module (stripped before the resolver
+// returns), so the internal row id is never exposed over the API.
+type StrayBoardCandidate = {
+  boardId: number;
+  uuid: string;
+  name: string;
+  currentGymUuid: string | null;
+  currentGymName: string | null;
+  distanceMeters: number | null;
+  reason: StrayBoardReason;
+};
+
+export type StrayBoardResult = Omit<StrayBoardCandidate, 'boardId'>;
+
+const STRAY_BOARD_LIMIT = 25;
+
+// A real merge chain is 1–2 hops; the cap is a safety net against a corrupt or
+// cyclic pointer so the reverse walk can never spin. Mirrors resolveCanonicalGym.
+const MAX_MERGE_HOPS = 10;
+
+// Pads the lat/lng bounding box so it fully contains the target circle despite
+// metres-per-degree varying with latitude; the JS Haversine still does the exact
+// circle test. Mirrors gym-matching's withinBoundingBox.
+const BOUNDING_BOX_SAFETY_FACTOR = 1.02;
+
+/**
+ * IDs of every gym whose `merged_into_gym_id` chain resolves to `canonicalGymId`
+ * — the reverse of resolveCanonicalGym. Walks children (rows pointing INTO the
+ * frontier) breadth-first, bounded to MAX_MERGE_HOPS with a visited guard so a
+ * cyclic pointer terminates. The canonical gym itself is excluded.
+ */
+async function collectMergedTwinGymIds(canonicalGymId: number): Promise<number[]> {
+  const twinIds = new Set<number>();
+  let frontier: number[] = [canonicalGymId];
+  for (let hop = 0; hop < MAX_MERGE_HOPS && frontier.length > 0; hop++) {
+    const children = await db
+      .select({ id: dbSchema.gyms.id })
+      .from(dbSchema.gyms)
+      .where(inArray(dbSchema.gyms.mergedIntoGymId, frontier));
+    const next: number[] = [];
+    for (const { id } of children) {
+      if (id === canonicalGymId || twinIds.has(id)) continue;
+      twinIds.add(id);
+      next.push(id);
+    }
+    frontier = next;
+  }
+  return [...twinIds];
+}
+
+/** A lat/lng bounding box over the board columns wide enough to contain the radius circle. Portable (no PostGIS). */
+function boardWithinBoundingBox(latitude: number, longitude: number, radiusMeters: number): SQL {
+  const paddedRadius = radiusMeters * BOUNDING_BOX_SAFETY_FACTOR;
+  const latDelta = paddedRadius / 111_320;
+  const cosLat = Math.max(Math.cos((latitude * Math.PI) / 180), 1e-6);
+  const lngDelta = paddedRadius / (111_320 * cosLat);
+  return sql`${dbSchema.userBoards.latitude} IS NOT NULL AND ${dbSchema.userBoards.longitude} IS NOT NULL AND ${dbSchema.userBoards.latitude} BETWEEN ${latitude - latDelta} AND ${latitude + latDelta} AND ${dbSchema.userBoards.longitude} BETWEEN ${longitude - lngDelta} AND ${longitude + lngDelta}`;
+}
+
+/** Metres from the gym to a board, or null when either side lacks coordinates. */
+function distanceFromGym(
+  gym: Pick<GymRow, 'latitude' | 'longitude'>,
+  board: { latitude: number | null; longitude: number | null },
+): number | null {
+  if (gym.latitude == null || gym.longitude == null || board.latitude == null || board.longitude == null) {
+    return null;
+  }
+  return distanceMeters(
+    { latitude: gym.latitude, longitude: gym.longitude },
+    { latitude: board.latitude, longitude: board.longitude },
+  );
+}
+
+/**
+ * Candidate stray boards for a gym, deduped by board uuid and capped at
+ * STRAY_BOARD_LIMIT:
+ *   - MERGED_TWIN: boards on a listing whose merged_into chain resolves to this
+ *     gym. The admin merge already established they're the same place, so these
+ *     are surfaced regardless of visibility and rank first.
+ *   - NEARBY: boards within 150 m of the gym that are unlinked or on a SYSTEM
+ *     listing at the same spot. Gated to boards the viewer may see (public,
+ *     SYSTEM catalog, or their own) and never a hide-location board, so the tab
+ *     can't enumerate a stranger's private home wall by proximity.
+ *
+ * Exported so attachBoardToGym gates on the exact same candidate set the Boards
+ * tab shows — a board this wouldn't surface can't be attached.
+ */
+export async function findStrayBoardCandidates(gym: GymRow, viewerUserId: string): Promise<StrayBoardCandidate[]> {
+  const twinGymIds = await collectMergedTwinGymIds(gym.id);
+
+  const twinRows =
+    twinGymIds.length > 0
+      ? await db
+          .select({
+            boardId: dbSchema.userBoards.id,
+            uuid: dbSchema.userBoards.uuid,
+            name: dbSchema.userBoards.name,
+            latitude: dbSchema.userBoards.latitude,
+            longitude: dbSchema.userBoards.longitude,
+            currentGymUuid: dbSchema.gyms.uuid,
+            currentGymName: dbSchema.gyms.name,
+          })
+          .from(dbSchema.userBoards)
+          .innerJoin(dbSchema.gyms, eq(dbSchema.userBoards.gymId, dbSchema.gyms.id))
+          .where(and(inArray(dbSchema.userBoards.gymId, twinGymIds), isNull(dbSchema.userBoards.deletedAt)))
+          .limit(STRAY_BOARD_LIMIT)
+      : [];
+
+  const hasGymCoords = gym.latitude != null && gym.longitude != null;
+  const nearbyRows = hasGymCoords
+    ? await db
+        .select({
+          boardId: dbSchema.userBoards.id,
+          uuid: dbSchema.userBoards.uuid,
+          name: dbSchema.userBoards.name,
+          latitude: dbSchema.userBoards.latitude,
+          longitude: dbSchema.userBoards.longitude,
+          currentGymUuid: dbSchema.gyms.uuid,
+          currentGymName: dbSchema.gyms.name,
+        })
+        .from(dbSchema.userBoards)
+        .leftJoin(dbSchema.gyms, eq(dbSchema.userBoards.gymId, dbSchema.gyms.id))
+        .where(
+          and(
+            isNull(dbSchema.userBoards.deletedAt),
+            // Never reuse a board whose owner asked to hide its location.
+            eq(dbSchema.userBoards.hideLocation, false),
+            boardWithinBoundingBox(gym.latitude!, gym.longitude!, PROXIMITY_MATCH_RADIUS_METERS),
+            // Unlinked, or on a SYSTEM (synced catalog) listing other than this
+            // gym. The `ne` handles the edge case of an editor whose target gym
+            // is itself SYSTEM-owned — its own boards aren't "strays".
+            or(
+              isNull(dbSchema.userBoards.gymId),
+              and(eq(dbSchema.gyms.ownerId, SYSTEM_BOARD_OWNER_ID), ne(dbSchema.userBoards.gymId, gym.id)),
+            )!,
+            // Privacy gate: public boards, SYSTEM catalog boards, or the viewer's
+            // own — never a stranger's private wall.
+            or(
+              eq(dbSchema.userBoards.isPublic, true),
+              eq(dbSchema.userBoards.ownerId, SYSTEM_BOARD_OWNER_ID),
+              eq(dbSchema.userBoards.ownerId, viewerUserId),
+            )!,
+          ),
+        )
+        .limit(STRAY_BOARD_LIMIT * 2)
+    : [];
+
+  const twinCandidates: StrayBoardCandidate[] = twinRows
+    .map((row) => ({
+      boardId: row.boardId,
+      uuid: row.uuid,
+      name: row.name,
+      currentGymUuid: row.currentGymUuid ?? null,
+      currentGymName: row.currentGymName ?? null,
+      distanceMeters: distanceFromGym(gym, row),
+      reason: 'MERGED_TWIN' as const,
+    }))
+    .sort((first, second) => first.name.localeCompare(second.name));
+
+  const seen = new Set(twinCandidates.map((candidate) => candidate.uuid));
+
+  const nearbyCandidates: StrayBoardCandidate[] = [];
+  for (const row of nearbyRows) {
+    if (seen.has(row.uuid)) continue; // a twin-and-nearby board keeps the twin reason
+    const distance = distanceFromGym(gym, row);
+    // Exact circle refine — the SQL box is a superset of the 150 m circle.
+    if (distance == null || distance > PROXIMITY_MATCH_RADIUS_METERS) continue;
+    seen.add(row.uuid);
+    nearbyCandidates.push({
+      boardId: row.boardId,
+      uuid: row.uuid,
+      name: row.name,
+      currentGymUuid: row.currentGymUuid ?? null,
+      currentGymName: row.currentGymName ?? null,
+      distanceMeters: distance,
+      reason: 'NEARBY',
+    });
+  }
+  nearbyCandidates.sort((first, second) => (first.distanceMeters ?? 0) - (second.distanceMeters ?? 0));
+
+  return [...twinCandidates, ...nearbyCandidates].slice(0, STRAY_BOARD_LIMIT);
+}
+
+// ============================================
+// Resolvers
+// ============================================
+
+export const socialGymStrayBoardQueries = {
+  strayBoardsForGym: async (
+    _: unknown,
+    { gymUuid }: { gymUuid: string },
+    ctx: ConnectionContext,
+  ): Promise<StrayBoardResult[]> => {
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, 30, 'strayBoardsForGym');
+    validateInput(UUIDSchema, gymUuid, 'gymUuid');
+    const userId = ctx.userId!;
+
+    // Edit access to the gym is the gate; this also resolves a merged twin's uuid
+    // to the canonical live row so the discovery runs against the survivor.
+    const gym = await requireGymEditAccess(gymUuid, userId);
+
+    const candidates = await findStrayBoardCandidates(gym, userId);
+    // Strip the internal board id — the GraphQL StrayBoard type never exposes it.
+    return candidates.map(({ boardId: _boardId, ...strayBoard }) => strayBoard);
+  },
+};
+
+export const socialGymStrayBoardMutations = {
+  attachBoardToGym: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, 20, 'attachBoardToGym');
+    const validatedInput = validateInput(AttachBoardToGymInputSchema, input, 'input');
+    const userId = ctx.userId!;
+
+    const gym = await requireGymEditAccess(validatedInput.gymUuid, userId);
+
+    // Only a board the Boards tab would surface as a stray can be attached — the
+    // exact same candidate set as strayBoardsForGym, so gym-edit access can't be
+    // used to pull an arbitrary board off another listing.
+    const candidates = await findStrayBoardCandidates(gym, userId);
+    const target = candidates.find((candidate) => candidate.uuid === validatedInput.boardUuid);
+    if (!target) {
+      throw new GraphQLError('This board is not a stray candidate for this gym.', {
+        extensions: { code: 'BAD_USER_INPUT' },
+      });
+    }
+
+    await db.update(dbSchema.userBoards).set({ gymId: gym.id }).where(eq(dbSchema.userBoards.id, target.boardId));
+    return true;
+  },
+};

--- a/packages/backend/src/graphql/resolvers/social/gym-stray-boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-stray-boards.ts
@@ -31,11 +31,13 @@ type GymRow = typeof dbSchema.gyms.$inferSelect;
 
 export type StrayBoardReason = 'MERGED_TWIN' | 'NEARBY';
 
-// The GraphQL StrayBoard payload plus the internal board id the attach mutation
-// re-points. `boardId` never leaves this module (stripped before the resolver
-// returns), so the internal row id is never exposed over the API.
+// The GraphQL StrayBoard payload plus the internal board id + current gym id the
+// attach mutation needs. `boardId`/`currentGymId` never leave this module
+// (stripped before the resolver returns), so no internal row id is exposed.
 type StrayBoardCandidate = {
   boardId: number;
+  /** The board's gym_id at the moment it was read — the compare-and-swap guard on attach. */
+  currentGymId: number | null;
   uuid: string;
   name: string;
   currentGymUuid: string | null;
@@ -44,7 +46,7 @@ type StrayBoardCandidate = {
   reason: StrayBoardReason;
 };
 
-export type StrayBoardResult = Omit<StrayBoardCandidate, 'boardId'>;
+export type StrayBoardResult = Omit<StrayBoardCandidate, 'boardId' | 'currentGymId'>;
 
 const STRAY_BOARD_LIMIT = 25;
 
@@ -112,9 +114,10 @@ function distanceFromGym(
  *     gym. The admin merge already established they're the same place, so these
  *     are surfaced regardless of visibility and rank first.
  *   - NEARBY: boards within 150 m of the gym that are unlinked or on a SYSTEM
- *     listing at the same spot. Gated to boards the viewer may see (public,
- *     SYSTEM catalog, or their own) and never a hide-location board, so the tab
- *     can't enumerate a stranger's private home wall by proximity.
+ *     listing at the same spot. Gated to boards it's legitimate to capture —
+ *     SYSTEM (synced catalog) or the viewer's own — never a third party's, and
+ *     never a hide-location board. A stranger's board (public or private) is
+ *     excluded: attaching it would hand the gym owner edit rights over it.
  *
  * Exported so attachBoardToGym gates on the exact same candidate set the Boards
  * tab shows — a board this wouldn't surface can't be attached.
@@ -127,6 +130,7 @@ export async function findStrayBoardCandidates(gym: GymRow, viewerUserId: string
       ? await db
           .select({
             boardId: dbSchema.userBoards.id,
+            currentGymId: dbSchema.userBoards.gymId,
             uuid: dbSchema.userBoards.uuid,
             name: dbSchema.userBoards.name,
             latitude: dbSchema.userBoards.latitude,
@@ -145,6 +149,7 @@ export async function findStrayBoardCandidates(gym: GymRow, viewerUserId: string
     ? await db
         .select({
           boardId: dbSchema.userBoards.id,
+          currentGymId: dbSchema.userBoards.gymId,
           uuid: dbSchema.userBoards.uuid,
           name: dbSchema.userBoards.name,
           latitude: dbSchema.userBoards.latitude,
@@ -167,13 +172,13 @@ export async function findStrayBoardCandidates(gym: GymRow, viewerUserId: string
               isNull(dbSchema.userBoards.gymId),
               and(eq(dbSchema.gyms.ownerId, SYSTEM_BOARD_OWNER_ID), ne(dbSchema.userBoards.gymId, gym.id)),
             )!,
-            // Privacy gate: public boards, SYSTEM catalog boards, or the viewer's
-            // own — never a stranger's private wall.
-            or(
-              eq(dbSchema.userBoards.isPublic, true),
-              eq(dbSchema.userBoards.ownerId, SYSTEM_BOARD_OWNER_ID),
-              eq(dbSchema.userBoards.ownerId, viewerUserId),
-            )!,
+            // Ownership gate: only a SYSTEM (synced catalog) board or the viewer's
+            // own board is a legitimate stray to attach — never a third party's,
+            // public or private. Attaching a stranger's board would hand the gym
+            // owner/admin edit rights over it (rename, serialNumber/BLE, privacy
+            // flags) via requireBoardEditAccess's gym-admin branch. Being public
+            // does not make a board safe to capture.
+            or(eq(dbSchema.userBoards.ownerId, SYSTEM_BOARD_OWNER_ID), eq(dbSchema.userBoards.ownerId, viewerUserId))!,
           ),
         )
         .limit(STRAY_BOARD_LIMIT * 2)
@@ -182,6 +187,7 @@ export async function findStrayBoardCandidates(gym: GymRow, viewerUserId: string
   const twinCandidates: StrayBoardCandidate[] = twinRows
     .map((row) => ({
       boardId: row.boardId,
+      currentGymId: row.currentGymId ?? null,
       uuid: row.uuid,
       name: row.name,
       currentGymUuid: row.currentGymUuid ?? null,
@@ -202,6 +208,7 @@ export async function findStrayBoardCandidates(gym: GymRow, viewerUserId: string
     seen.add(row.uuid);
     nearbyCandidates.push({
       boardId: row.boardId,
+      currentGymId: row.currentGymId ?? null,
       uuid: row.uuid,
       name: row.name,
       currentGymUuid: row.currentGymUuid ?? null,
@@ -235,8 +242,8 @@ export const socialGymStrayBoardQueries = {
     const gym = await requireGymEditAccess(gymUuid, userId);
 
     const candidates = await findStrayBoardCandidates(gym, userId);
-    // Strip the internal board id — the GraphQL StrayBoard type never exposes it.
-    return candidates.map(({ boardId: _boardId, ...strayBoard }) => strayBoard);
+    // Strip the internal ids — the GraphQL StrayBoard type never exposes them.
+    return candidates.map(({ boardId: _boardId, currentGymId: _currentGymId, ...strayBoard }) => strayBoard);
   },
 };
 
@@ -260,7 +267,27 @@ export const socialGymStrayBoardMutations = {
       });
     }
 
-    await db.update(dbSchema.userBoards).set({ gymId: gym.id }).where(eq(dbSchema.userBoards.id, target.boardId));
+    // Compare-and-swap: only re-point if the board's gym_id is still what we saw
+    // when we vetted it, so a concurrent re-link (the owner moving the board
+    // between the check and this write) can't be silently clobbered. `IS NOT
+    // DISTINCT FROM` handles the unlinked (NULL) case; the ::bigint cast anchors
+    // the bound param's type against the bigint column.
+    const updated = await db
+      .update(dbSchema.userBoards)
+      .set({ gymId: gym.id })
+      .where(
+        and(
+          eq(dbSchema.userBoards.id, target.boardId),
+          sql`${dbSchema.userBoards.gymId} IS NOT DISTINCT FROM ${target.currentGymId}::bigint`,
+        ),
+      )
+      .returning({ id: dbSchema.userBoards.id });
+
+    if (updated.length === 0) {
+      throw new GraphQLError('This board changed before it could be attached. Refresh and try again.', {
+        extensions: { code: 'CONFLICT' },
+      });
+    }
     return true;
   },
 };

--- a/packages/backend/src/validation/schemas/gyms.ts
+++ b/packages/backend/src/validation/schemas/gyms.ts
@@ -216,6 +216,16 @@ export const LinkBoardToGymInputSchema = z.object({
 });
 
 /**
+ * Attach stray board to gym input validation schema. Both a target gym and the
+ * board are required — the resolver additionally checks the board is a genuine
+ * stray candidate for the gym before re-pointing gym_id.
+ */
+export const AttachBoardToGymInputSchema = z.object({
+  gymUuid: UUIDSchema,
+  boardUuid: UUIDSchema,
+});
+
+/**
  * Gym insights (owner activity dashboard) input validation schema. `period`
  * chooses the window length; the resolver derives the day count and the equally
  * long prior comparison window from it.

--- a/packages/mobile/public/index.html
+++ b/packages/mobile/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="%LANG_ISO_CODE%">
   <head>
     <meta charset="utf-8" />
@@ -37,9 +37,7 @@
 
   <body>
     <!-- Use static rendering with Expo Router to support running without JavaScript. -->
-    <noscript>
-      You need to enable JavaScript to run this app.
-    </noscript>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
     <!-- The root element for your Expo app. -->
     <div id="root"></div>
   </body>

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2745,6 +2745,36 @@ type SimilarGym {
 }
 
 """
+Why a board is a candidate to attach to a gym in strayBoardsForGym.
+"""
+enum StrayBoardReason {
+  "The board sits on a listing that was merged into this gym."
+  MERGED_TWIN
+  "The board is physically within ~150 m of this gym but isn't linked to it."
+  NEARBY
+}
+
+"""
+A board that probably belongs to a gym but isn't linked to it yet — either it
+followed a listing that got merged into this gym, or it sits at the gym's
+coordinates while unlinked or attached to a synced (SYSTEM) listing.
+"""
+type StrayBoard {
+  "The board's unique identifier."
+  uuid: ID!
+  "The board's display name."
+  name: String!
+  "The gym this board is currently linked to (a merged twin or a synced listing); null when unlinked."
+  currentGymUuid: ID
+  "Name of the gym this board is currently linked to; null when unlinked."
+  currentGymName: String
+  "Metres from this gym's location to the board; null when either lacks coordinates."
+  distanceMeters: Float
+  "Why this board is a candidate for this gym."
+  reason: StrayBoardReason!
+}
+
+"""
 A member of a gym.
 """
 type GymMember {
@@ -2940,6 +2970,18 @@ input LinkBoardToGymInput {
   boardUuid: ID!
   "Gym UUID (null to unlink)"
   gymUuid: String
+}
+
+"""
+Input for attaching a stray board (from strayBoardsForGym) to a gym. Unlike
+linkBoardToGym, the caller need not own the board — the gate is edit access to
+the target gym plus the board actually being a stray candidate for it.
+"""
+input AttachBoardToGymInput {
+  "Gym UUID to attach the board to"
+  gymUuid: ID!
+  "Stray board UUID to attach"
+  boardUuid: ID!
 }
 
 """
@@ -5381,6 +5423,16 @@ type Query {
   gymBoards(gymUuid: ID!): [UserBoard!]!
 
   """
+  Boards that probably belong to a gym but aren't linked to it yet, for the
+  gym's Boards tab. Requires edit access to the gym. Returns two kinds of
+  candidate: boards on a listing whose merged_into chain resolves to this gym
+  (they should have followed the merge), and boards within ~150 m of the gym's
+  location that are either unlinked or attached to a synced (SYSTEM) listing at
+  the same spot. Merged-twin candidates first, then nearest. Capped at 25.
+  """
+  strayBoardsForGym(gymUuid: ID!): [StrayBoard!]!
+
+  """
   List pending gym ownership claims for the admin review queue (admin only).
   """
   pendingGymClaims(input: PendingGymClaimsInput): GymClaimConnection!
@@ -6162,6 +6214,14 @@ type Mutation {
   Link or unlink a board to/from a gym.
   """
   linkBoardToGym(input: LinkBoardToGymInput!): Boolean!
+
+  """
+  Attach a stray board (surfaced by strayBoardsForGym) to a gym in one tap.
+  Re-points the board's gym_id to this gym. The caller need not own the board;
+  the gate is edit access to the target gym, and the board must be a genuine
+  stray candidate for it (a merged-twin board or a nearby unlinked/SYSTEM one).
+  """
+  attachBoardToGym(input: AttachBoardToGymInput!): Boolean!
 
   """
   Grant a user write (editor) access to a gym: edit details only, no

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -401,6 +401,18 @@ export type AttachBetaLinkInput = {
   tickUuid?: InputMaybe<Scalars['ID']['input']>;
 };
 
+/**
+ * Input for attaching a stray board (from strayBoardsForGym) to a gym. Unlike
+ * linkBoardToGym, the caller need not own the board — the gate is edit access to
+ * the target gym plus the board actually being a stray candidate for it.
+ */
+export type AttachBoardToGymInput = {
+  /** Stray board UUID to attach */
+  boardUuid: Scalars['ID']['input'];
+  /** Gym UUID to attach the board to */
+  gymUuid: Scalars['ID']['input'];
+};
+
 /** Stored credentials for an Aurora Climbing board account. */
 export type AuroraCredential = {
   __typename?: 'AuroraCredential';
@@ -2925,6 +2937,13 @@ export type Mutation = {
    * (boardType, climbUuid, link).
    */
   attachBetaLink: Scalars['Boolean']['output'];
+  /**
+   * Attach a stray board (surfaced by strayBoardsForGym) to a gym in one tap.
+   * Re-points the board's gym_id to this gym. The caller need not own the board;
+   * the gate is edit access to the target gym, and the board must be a genuine
+   * stray candidate for it (a merged-twin board or a nearby unlinked/SYSTEM one).
+   */
+  attachBoardToGym: Scalars['Boolean']['output'];
   authorizeControllerForSession: Scalars['Boolean']['output'];
   /**
    * Confirm which board a (non-unique) serial routes to after the user picks
@@ -3374,6 +3393,11 @@ export type MutationAddQueueItemArgs = {
 /** Root mutation type for all write operations. */
 export type MutationAttachBetaLinkArgs = {
   input: AttachBetaLinkInput;
+};
+
+/** Root mutation type for all write operations. */
+export type MutationAttachBoardToGymArgs = {
+  input: AttachBoardToGymInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -4896,6 +4920,15 @@ export type Query = {
    */
   smartPlaylist: SmartPlaylistResult;
   /**
+   * Boards that probably belong to a gym but aren't linked to it yet, for the
+   * gym's Boards tab. Requires edit access to the gym. Returns two kinds of
+   * candidate: boards on a listing whose merged_into chain resolves to this gym
+   * (they should have followed the merge), and boards within ~150 m of the gym's
+   * location that are either unlinked or attached to a synced (SYSTEM) listing at
+   * the same spot. Merged-twin candidates first, then nearest. Capped at 25.
+   */
+  strayBoardsForGym: Array<StrayBoard>;
+  /**
    * Pull Boardsesh grades for a board type, changed since the cursor (reference data).
    * Optional layoutId/sizeId scope grades to the climbs of that layout/size via board_climbs.
    */
@@ -5471,6 +5504,11 @@ export type QuerySimilarClimbsArgs = {
 /** Root query type for all read operations. */
 export type QuerySmartPlaylistArgs = {
   input: GetSmartPlaylistInput;
+};
+
+/** Root query type for all read operations. */
+export type QueryStrayBoardsForGymArgs = {
+  gymUuid: Scalars['ID']['input'];
 };
 
 /** Root query type for all read operations. */
@@ -6859,6 +6897,34 @@ export type SocialEntityType =
 
 export type SortMode = 'controversial' | 'hot' | 'new' | 'top';
 
+/**
+ * A board that probably belongs to a gym but isn't linked to it yet — either it
+ * followed a listing that got merged into this gym, or it sits at the gym's
+ * coordinates while unlinked or attached to a synced (SYSTEM) listing.
+ */
+export type StrayBoard = {
+  __typename?: 'StrayBoard';
+  /** Name of the gym this board is currently linked to; null when unlinked. */
+  currentGymName?: Maybe<Scalars['String']['output']>;
+  /** The gym this board is currently linked to (a merged twin or a synced listing); null when unlinked. */
+  currentGymUuid?: Maybe<Scalars['ID']['output']>;
+  /** Metres from this gym's location to the board; null when either lacks coordinates. */
+  distanceMeters?: Maybe<Scalars['Float']['output']>;
+  /** The board's display name. */
+  name: Scalars['String']['output'];
+  /** Why this board is a candidate for this gym. */
+  reason: StrayBoardReason;
+  /** The board's unique identifier. */
+  uuid: Scalars['ID']['output'];
+};
+
+/** Why a board is a candidate to attach to a gym in strayBoardsForGym. */
+export type StrayBoardReason =
+  /** The board sits on a listing that was merged into this gym. */
+  | 'MERGED_TWIN'
+  /** The board is physically within ~150 m of this gym but isn't linked to it. */
+  | 'NEARBY';
+
 /** Input for submitAppFeedback mutation. */
 export type SubmitAppFeedbackInput = {
   angle?: InputMaybe<Scalars['Int']['input']>;
@@ -7749,6 +7815,7 @@ export type ResolversTypes = ResolversObject<{
   AscentFeedItem: ResolverTypeWrapper<AscentFeedItem>;
   AscentFeedResult: ResolverTypeWrapper<AscentFeedResult>;
   AttachBetaLinkInput: AttachBetaLinkInput;
+  AttachBoardToGymInput: AttachBoardToGymInput;
   AuroraCredential: ResolverTypeWrapper<AuroraCredential>;
   AuroraCredentialStatus: ResolverTypeWrapper<AuroraCredentialStatus>;
   BetaLink: ResolverTypeWrapper<BetaLink>;
@@ -8038,6 +8105,8 @@ export type ResolversTypes = ResolversObject<{
   SmartPlaylistType: SmartPlaylistType;
   SocialEntityType: SocialEntityType;
   SortMode: SortMode;
+  StrayBoard: ResolverTypeWrapper<StrayBoard>;
+  StrayBoardReason: StrayBoardReason;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
   SubmitAppFeedbackInput: SubmitAppFeedbackInput;
   Subscription: ResolverTypeWrapper<{}>;
@@ -8105,6 +8174,7 @@ export type ResolversParentTypes = ResolversObject<{
   AscentFeedItem: AscentFeedItem;
   AscentFeedResult: AscentFeedResult;
   AttachBetaLinkInput: AttachBetaLinkInput;
+  AttachBoardToGymInput: AttachBoardToGymInput;
   AuroraCredential: AuroraCredential;
   AuroraCredentialStatus: AuroraCredentialStatus;
   BetaLink: BetaLink;
@@ -8371,6 +8441,7 @@ export type ResolversParentTypes = ResolversObject<{
   SmartPlaylistCount: SmartPlaylistCount;
   SmartPlaylistMeta: SmartPlaylistMeta;
   SmartPlaylistResult: SmartPlaylistResult;
+  StrayBoard: StrayBoard;
   String: Scalars['String']['output'];
   SubmitAppFeedbackInput: SubmitAppFeedbackInput;
   Subscription: {};
@@ -9912,6 +9983,12 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationAttachBetaLinkArgs, 'input'>
   >;
+  attachBoardToGym?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationAttachBoardToGymArgs, 'input'>
+  >;
   authorizeControllerForSession?: Resolver<
     ResolversTypes['Boolean'],
     ParentType,
@@ -11361,6 +11438,12 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QuerySmartPlaylistArgs, 'input'>
   >;
+  strayBoardsForGym?: Resolver<
+    Array<ResolversTypes['StrayBoard']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryStrayBoardsForGymArgs, 'gymUuid'>
+  >;
   syncClimbGrades?: Resolver<
     ResolversTypes['SyncResult'],
     ParentType,
@@ -12181,6 +12264,19 @@ export type SmartPlaylistResultResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type StrayBoardResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['StrayBoard'] = ResolversParentTypes['StrayBoard'],
+> = ResolversObject<{
+  currentGymName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  currentGymUuid?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  distanceMeters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  reason?: Resolver<ResolversTypes['StrayBoardReason'], ParentType, ContextType>;
+  uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type SubscriptionResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription'],
@@ -12703,6 +12799,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   SmartPlaylistCount?: SmartPlaylistCountResolvers<ContextType>;
   SmartPlaylistMeta?: SmartPlaylistMetaResolvers<ContextType>;
   SmartPlaylistResult?: SmartPlaylistResultResolvers<ContextType>;
+  StrayBoard?: StrayBoardResolvers<ContextType>;
   Subscription?: SubscriptionResolvers<ContextType>;
   SyncCursor?: SyncCursorResolvers<ContextType>;
   SyncDeletion?: SyncDeletionResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -148,6 +148,36 @@ export const gymsTypeDefs = /* GraphQL */ `
   }
 
   """
+  Why a board is a candidate to attach to a gym in strayBoardsForGym.
+  """
+  enum StrayBoardReason {
+    "The board sits on a listing that was merged into this gym."
+    MERGED_TWIN
+    "The board is physically within ~150 m of this gym but isn't linked to it."
+    NEARBY
+  }
+
+  """
+  A board that probably belongs to a gym but isn't linked to it yet — either it
+  followed a listing that got merged into this gym, or it sits at the gym's
+  coordinates while unlinked or attached to a synced (SYSTEM) listing.
+  """
+  type StrayBoard {
+    "The board's unique identifier."
+    uuid: ID!
+    "The board's display name."
+    name: String!
+    "The gym this board is currently linked to (a merged twin or a synced listing); null when unlinked."
+    currentGymUuid: ID
+    "Name of the gym this board is currently linked to; null when unlinked."
+    currentGymName: String
+    "Metres from this gym's location to the board; null when either lacks coordinates."
+    distanceMeters: Float
+    "Why this board is a candidate for this gym."
+    reason: StrayBoardReason!
+  }
+
+  """
   A member of a gym.
   """
   type GymMember {
@@ -343,6 +373,18 @@ export const gymsTypeDefs = /* GraphQL */ `
     boardUuid: ID!
     "Gym UUID (null to unlink)"
     gymUuid: String
+  }
+
+  """
+  Input for attaching a stray board (from strayBoardsForGym) to a gym. Unlike
+  linkBoardToGym, the caller need not own the board — the gate is edit access to
+  the target gym plus the board actually being a stray candidate for it.
+  """
+  input AttachBoardToGymInput {
+    "Gym UUID to attach the board to"
+    gymUuid: ID!
+    "Stray board UUID to attach"
+    boardUuid: ID!
   }
 
   """

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -510,6 +510,14 @@ export const mutationsTypeDefs = /* GraphQL */ `
     linkBoardToGym(input: LinkBoardToGymInput!): Boolean!
 
     """
+    Attach a stray board (surfaced by strayBoardsForGym) to a gym in one tap.
+    Re-points the board's gym_id to this gym. The caller need not own the board;
+    the gate is edit access to the target gym, and the board must be a genuine
+    stray candidate for it (a merged-twin board or a nearby unlinked/SYSTEM one).
+    """
+    attachBoardToGym(input: AttachBoardToGymInput!): Boolean!
+
+    """
     Grant a user write (editor) access to a gym: edit details only, no
     membership/board management, no delete. Callable by the gym owner, a gym
     admin, or a community admin/leader for one of the gym's board types.

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -605,6 +605,16 @@ export const queriesTypeDefs = /* GraphQL */ `
     gymBoards(gymUuid: ID!): [UserBoard!]!
 
     """
+    Boards that probably belong to a gym but aren't linked to it yet, for the
+    gym's Boards tab. Requires edit access to the gym. Returns two kinds of
+    candidate: boards on a listing whose merged_into chain resolves to this gym
+    (they should have followed the merge), and boards within ~150 m of the gym's
+    location that are either unlinked or attached to a synced (SYSTEM) listing at
+    the same spot. Merged-twin candidates first, then nearest. Capped at 25.
+    """
+    strayBoardsForGym(gymUuid: ID!): [StrayBoard!]!
+
+    """
     List pending gym ownership claims for the admin review queue (admin only).
     """
     pendingGymClaims(input: PendingGymClaimsInput): GymClaimConnection!

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -93,6 +93,26 @@ export type FindSimilarGymsInput = {
   longitude?: number;
 };
 
+/** Why a board is surfaced as a candidate to attach to a gym. */
+export type StrayBoardReason = 'MERGED_TWIN' | 'NEARBY';
+
+export type StrayBoard = {
+  uuid: string;
+  name: string;
+  /** The gym the board is currently linked to (a merged twin or a synced listing); null when unlinked. */
+  currentGymUuid?: string | null;
+  /** Name of the gym the board is currently linked to; null when unlinked. */
+  currentGymName?: string | null;
+  /** Metres from this gym's location to the board; null when either lacks coordinates. */
+  distanceMeters?: number | null;
+  reason: StrayBoardReason;
+};
+
+export type AttachBoardToGymInput = {
+  gymUuid: string;
+  boardUuid: string;
+};
+
 export type CreateGymInput = {
   name: string;
   description?: string;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -398,6 +398,18 @@ export type AttachBetaLinkInput = {
   tickUuid?: InputMaybe<Scalars['ID']['input']>;
 };
 
+/**
+ * Input for attaching a stray board (from strayBoardsForGym) to a gym. Unlike
+ * linkBoardToGym, the caller need not own the board — the gate is edit access to
+ * the target gym plus the board actually being a stray candidate for it.
+ */
+export type AttachBoardToGymInput = {
+  /** Stray board UUID to attach */
+  boardUuid: Scalars['ID']['input'];
+  /** Gym UUID to attach the board to */
+  gymUuid: Scalars['ID']['input'];
+};
+
 /** Stored credentials for an Aurora Climbing board account. */
 export type AuroraCredential = {
   __typename?: 'AuroraCredential';
@@ -2922,6 +2934,13 @@ export type Mutation = {
    * (boardType, climbUuid, link).
    */
   attachBetaLink: Scalars['Boolean']['output'];
+  /**
+   * Attach a stray board (surfaced by strayBoardsForGym) to a gym in one tap.
+   * Re-points the board's gym_id to this gym. The caller need not own the board;
+   * the gate is edit access to the target gym, and the board must be a genuine
+   * stray candidate for it (a merged-twin board or a nearby unlinked/SYSTEM one).
+   */
+  attachBoardToGym: Scalars['Boolean']['output'];
   authorizeControllerForSession: Scalars['Boolean']['output'];
   /**
    * Confirm which board a (non-unique) serial routes to after the user picks
@@ -3371,6 +3390,11 @@ export type MutationAddQueueItemArgs = {
 /** Root mutation type for all write operations. */
 export type MutationAttachBetaLinkArgs = {
   input: AttachBetaLinkInput;
+};
+
+/** Root mutation type for all write operations. */
+export type MutationAttachBoardToGymArgs = {
+  input: AttachBoardToGymInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -4893,6 +4917,15 @@ export type Query = {
    */
   smartPlaylist: SmartPlaylistResult;
   /**
+   * Boards that probably belong to a gym but aren't linked to it yet, for the
+   * gym's Boards tab. Requires edit access to the gym. Returns two kinds of
+   * candidate: boards on a listing whose merged_into chain resolves to this gym
+   * (they should have followed the merge), and boards within ~150 m of the gym's
+   * location that are either unlinked or attached to a synced (SYSTEM) listing at
+   * the same spot. Merged-twin candidates first, then nearest. Capped at 25.
+   */
+  strayBoardsForGym: Array<StrayBoard>;
+  /**
    * Pull Boardsesh grades for a board type, changed since the cursor (reference data).
    * Optional layoutId/sizeId scope grades to the climbs of that layout/size via board_climbs.
    */
@@ -5468,6 +5501,11 @@ export type QuerySimilarClimbsArgs = {
 /** Root query type for all read operations. */
 export type QuerySmartPlaylistArgs = {
   input: GetSmartPlaylistInput;
+};
+
+/** Root query type for all read operations. */
+export type QueryStrayBoardsForGymArgs = {
+  gymUuid: Scalars['ID']['input'];
 };
 
 /** Root query type for all read operations. */
@@ -6855,6 +6893,34 @@ export type SocialEntityType =
   | 'tick';
 
 export type SortMode = 'controversial' | 'hot' | 'new' | 'top';
+
+/**
+ * A board that probably belongs to a gym but isn't linked to it yet — either it
+ * followed a listing that got merged into this gym, or it sits at the gym's
+ * coordinates while unlinked or attached to a synced (SYSTEM) listing.
+ */
+export type StrayBoard = {
+  __typename?: 'StrayBoard';
+  /** Name of the gym this board is currently linked to; null when unlinked. */
+  currentGymName?: Maybe<Scalars['String']['output']>;
+  /** The gym this board is currently linked to (a merged twin or a synced listing); null when unlinked. */
+  currentGymUuid?: Maybe<Scalars['ID']['output']>;
+  /** Metres from this gym's location to the board; null when either lacks coordinates. */
+  distanceMeters?: Maybe<Scalars['Float']['output']>;
+  /** The board's display name. */
+  name: Scalars['String']['output'];
+  /** Why this board is a candidate for this gym. */
+  reason: StrayBoardReason;
+  /** The board's unique identifier. */
+  uuid: Scalars['ID']['output'];
+};
+
+/** Why a board is a candidate to attach to a gym in strayBoardsForGym. */
+export type StrayBoardReason =
+  /** The board sits on a listing that was merged into this gym. */
+  | 'MERGED_TWIN'
+  /** The board is physically within ~150 m of this gym but isn't linked to it. */
+  | 'NEARBY';
 
 /** Input for submitAppFeedback mutation. */
 export type SubmitAppFeedbackInput = {

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -21,6 +21,8 @@ import type {
   GymClaimConnection,
   FindSimilarGymsInput,
   SimilarGym,
+  StrayBoard,
+  AttachBoardToGymInput,
   UserBoard,
   GymStats,
   GymStatsInput,
@@ -174,6 +176,22 @@ export const GET_GYM_BOARDS = gql`
   }
 `;
 
+// Boards that probably belong to the gym but aren't linked yet — merged-twin
+// leftovers and nearby unlinked/SYSTEM boards. Powers the "Boards that might be
+// yours" section on the manage-gym Boards tab. Requires gym edit access.
+export const STRAY_BOARDS_FOR_GYM = gql`
+  query StrayBoardsForGym($gymUuid: ID!) {
+    strayBoardsForGym(gymUuid: $gymUuid) {
+      uuid
+      name
+      currentGymUuid
+      currentGymName
+      distanceMeters
+      reason
+    }
+  }
+`;
+
 // Owner Insights dashboard: current + prior window counts (for week-over-week
 // deltas), the top-10 climbs, and busiest weekdays. Requires gym edit access.
 export const GET_GYM_STATS = gql`
@@ -258,6 +276,12 @@ export const UNFOLLOW_GYM = gql`
 export const LINK_BOARD_TO_GYM = gql`
   mutation LinkBoardToGym($input: LinkBoardToGymInput!) {
     linkBoardToGym(input: $input)
+  }
+`;
+
+export const ATTACH_BOARD_TO_GYM = gql`
+  mutation AttachBoardToGym($input: AttachBoardToGymInput!) {
+    attachBoardToGym(input: $input)
   }
 `;
 
@@ -471,6 +495,14 @@ export type GetGymBoardsQueryResponse = {
   gymBoards: UserBoard[];
 };
 
+export type StrayBoardsForGymQueryVariables = {
+  gymUuid: string;
+};
+
+export type StrayBoardsForGymQueryResponse = {
+  strayBoardsForGym: StrayBoard[];
+};
+
 export type GetGymStatsQueryVariables = {
   input: GymStatsInput;
 };
@@ -541,6 +573,14 @@ export type LinkBoardToGymMutationVariables = {
 
 export type LinkBoardToGymMutationResponse = {
   linkBoardToGym: boolean;
+};
+
+export type AttachBoardToGymMutationVariables = {
+  input: AttachBoardToGymInput;
+};
+
+export type AttachBoardToGymMutationResponse = {
+  attachBoardToGym: boolean;
 };
 
 export type GrantGymWriteAccessMutationVariables = {

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -266,7 +266,9 @@
         "attach": "Add to gym",
         "attached": "Board added to your gym.",
         "attachFailed": "Couldn't add that board.",
-        "empty": "Nothing loose right now. Every board near your gym is already on your listing."
+        "empty": "Nothing loose right now. Every board near your gym is already on your listing.",
+        "loadError": "Couldn't check for stray boards.",
+        "retry": "Try again"
       }
     },
     "presets": {

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -255,6 +255,18 @@
         "loading": "Loading your boards…",
         "link": "Link",
         "close": "Close"
+      },
+      "strays": {
+        "heading": "Boards that might be yours",
+        "description": "These sit at your gym or drifted off a merged listing. Add the ones that belong here.",
+        "reasonMerged": "Was on a merged listing",
+        "reasonNearby": "{{meters}} m away",
+        "reasonNearbyGeneric": "Right nearby",
+        "onListing": "on \"{{name}}\"",
+        "attach": "Add to gym",
+        "attached": "Board added to your gym.",
+        "attachFailed": "Couldn't add that board.",
+        "empty": "Nothing loose right now. Every board near your gym is already on your listing."
       }
     },
     "presets": {

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -266,7 +266,9 @@
         "attach": "Añadir al rocódromo",
         "attached": "Plafón añadido a tu rocódromo.",
         "attachFailed": "No se pudo añadir ese plafón.",
-        "empty": "Nada suelto por ahora. Todos los plafones cerca de tu rocódromo ya están en tu ficha."
+        "empty": "Nada suelto por ahora. Todos los plafones cerca de tu rocódromo ya están en tu ficha.",
+        "loadError": "No se pudieron buscar plafones sueltos.",
+        "retry": "Reintentar"
       }
     },
     "presets": {

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -255,6 +255,18 @@
         "loading": "Cargando tus plafones…",
         "link": "Vincular",
         "close": "Cerrar"
+      },
+      "strays": {
+        "heading": "Plafones que podrían ser tuyos",
+        "description": "Están en tu rocódromo o quedaron sueltos tras fusionar una ficha. Añade los que te correspondan.",
+        "reasonMerged": "Estaba en una ficha fusionada",
+        "reasonNearby": "a {{meters}} m",
+        "reasonNearbyGeneric": "Justo al lado",
+        "onListing": "en «{{name}}»",
+        "attach": "Añadir al rocódromo",
+        "attached": "Plafón añadido a tu rocódromo.",
+        "attachFailed": "No se pudo añadir ese plafón.",
+        "empty": "Nada suelto por ahora. Todos los plafones cerca de tu rocódromo ya están en tu ficha."
       }
     },
     "presets": {

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -266,7 +266,9 @@
         "attach": "Ajouter à la salle",
         "attached": "Board ajoutée à ta salle.",
         "attachFailed": "Impossible d'ajouter cette board.",
-        "empty": "Rien qui traîne pour l'instant. Toutes les boards près de ta salle sont déjà sur ta fiche."
+        "empty": "Rien qui traîne pour l'instant. Toutes les boards près de ta salle sont déjà sur ta fiche.",
+        "loadError": "Impossible de chercher les boards égarées.",
+        "retry": "Réessayer"
       }
     },
     "presets": {

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -255,6 +255,18 @@
         "loading": "Chargement de tes boards…",
         "link": "Relier",
         "close": "Fermer"
+      },
+      "strays": {
+        "heading": "Des boards qui sont peut-être les tiennes",
+        "description": "Elles sont dans ta salle ou sont restées sur une fiche fusionnée. Ajoute celles qui t'appartiennent.",
+        "reasonMerged": "Était sur une fiche fusionnée",
+        "reasonNearby": "à {{meters}} m",
+        "reasonNearbyGeneric": "Juste à côté",
+        "onListing": "sur « {{name}} »",
+        "attach": "Ajouter à la salle",
+        "attached": "Board ajoutée à ta salle.",
+        "attachFailed": "Impossible d'ajouter cette board.",
+        "empty": "Rien qui traîne pour l'instant. Toutes les boards près de ta salle sont déjà sur ta fiche."
       }
     },
     "presets": {

--- a/packages/web/app/components/gym-entity/manage/__tests__/gym-boards-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/gym-boards-tab.test.tsx
@@ -234,6 +234,23 @@ describe('GymBoardsTab — stray boards', () => {
     expect(await screen.findByText(/nothing loose right now/i)).toBeTruthy();
   });
 
+  it('surfaces a load error with a retry when the strays query fails', async () => {
+    // gymBoards resolves (empty) so the linked list settles; strayBoardsForGym rejects.
+    mockRequest.mockImplementation(async (document: string) => {
+      if (typeof document === 'string' && document.includes('strayBoardsForGym')) {
+        throw new Error('network down');
+      }
+      if (typeof document === 'string' && document.includes('gymBoards')) {
+        return { gymBoards: [] };
+      }
+      return { myBoards: { boards: [], totalCount: 0, hasMore: false } };
+    });
+    render(<GymBoardsTab gym={editableGym} onGymChange={vi.fn()} />);
+
+    expect(await screen.findByText(/couldn't check for stray boards/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy();
+  });
+
   it('does not render the strays section without gym edit access', async () => {
     const noEditGym = { ...gym, canEdit: false } as unknown as Gym;
     stubRequests({ gymBoards: [], myBoards: [], strays: [makeStray({})] });

--- a/packages/web/app/components/gym-entity/manage/__tests__/gym-boards-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/gym-boards-tab.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
-import type { Gym, UserBoard } from '@boardsesh/shared-schema';
+import type { Gym, StrayBoard, UserBoard } from '@boardsesh/shared-schema';
 import GymBoardsTab from '../gym-boards-tab';
 
 vi.mock('react-i18next', () => ({
@@ -74,9 +74,21 @@ function makeBoard(overrides: Partial<UserBoard>): UserBoard {
   } as UserBoard;
 }
 
-/** Routes the shared request mock by operation: gymBoards list vs myBoards. */
-function stubRequests({ gymBoards, myBoards }: { gymBoards: UserBoard[]; myBoards: UserBoard[] }) {
+/** Routes the shared request mock by operation: strayBoardsForGym vs gymBoards vs myBoards. */
+function stubRequests({
+  gymBoards,
+  myBoards,
+  strays = [],
+}: {
+  gymBoards: UserBoard[];
+  myBoards: UserBoard[];
+  strays?: StrayBoard[];
+}) {
   mockRequest.mockImplementation(async (document: string) => {
+    // strayBoardsForGym must be matched before gymBoards — both are board reads.
+    if (typeof document === 'string' && document.includes('strayBoardsForGym')) {
+      return { strayBoardsForGym: strays };
+    }
     if (typeof document === 'string' && document.includes('gymBoards')) {
       return { gymBoards };
     }
@@ -141,5 +153,93 @@ describe('GymBoardsTab — permission gating', () => {
     await screen.findByText(/no boards linked yet/i);
     expect(screen.queryByRole('button', { name: /add a board/i })).toBeNull();
     expect(screen.getByText(/only the gym owner or an admin can link boards/i)).toBeTruthy();
+  });
+});
+
+describe('GymBoardsTab — stray boards', () => {
+  const editableGym = { ...gym, canEdit: true } as unknown as Gym;
+
+  function makeStray(overrides: Partial<StrayBoard>): StrayBoard {
+    return {
+      uuid: 'stray-1',
+      name: 'Nearby Tension',
+      currentGymUuid: null,
+      currentGymName: null,
+      distanceMeters: 42,
+      reason: 'NEARBY',
+      ...overrides,
+    };
+  }
+
+  it('lists stray candidates with their reason and the current listing', async () => {
+    stubRequests({
+      gymBoards: [],
+      myBoards: [],
+      strays: [
+        makeStray({ uuid: 'stray-merged', name: 'Old Kilter', reason: 'MERGED_TWIN', currentGymName: 'Old Listing' }),
+        makeStray({ uuid: 'stray-nearby', name: 'Nearby Tension', reason: 'NEARBY', distanceMeters: 42 }),
+      ],
+    });
+    render(<GymBoardsTab gym={editableGym} onGymChange={vi.fn()} />);
+
+    expect(await screen.findByText(/boards that might be yours/i)).toBeTruthy();
+    expect(screen.getByText('Old Kilter')).toBeTruthy();
+    expect(screen.getByText(/was on a merged listing/i)).toBeTruthy();
+    expect(screen.getByText('Nearby Tension')).toBeTruthy();
+    expect(screen.getByText(/42 m away/i)).toBeTruthy();
+  });
+
+  it('attaches a stray board and drops it from the list', async () => {
+    stubRequests({
+      gymBoards: [],
+      myBoards: [],
+      strays: [makeStray({ uuid: 'stray-nearby', name: 'Nearby Tension' })],
+    });
+    render(<GymBoardsTab gym={editableGym} onGymChange={vi.fn()} />);
+
+    await screen.findByText('Nearby Tension');
+    mockExecute.mockResolvedValueOnce({ attachBoardToGym: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /add to gym/i }));
+
+    await waitFor(() =>
+      expect(mockExecute).toHaveBeenCalledWith({
+        input: { gymUuid: GYM_UUID, boardUuid: 'stray-nearby' },
+      }),
+    );
+    await waitFor(() => expect(screen.queryByText('Nearby Tension')).toBeNull());
+  });
+
+  it('keeps the candidate when the attach mutation fails', async () => {
+    stubRequests({
+      gymBoards: [],
+      myBoards: [],
+      strays: [makeStray({ uuid: 'stray-nearby', name: 'Nearby Tension' })],
+    });
+    render(<GymBoardsTab gym={editableGym} onGymChange={vi.fn()} />);
+
+    await screen.findByText('Nearby Tension');
+    mockExecute.mockResolvedValueOnce(null); // useEntityMutation resolves null on failure
+
+    fireEvent.click(screen.getByRole('button', { name: /add to gym/i }));
+
+    await waitFor(() => expect(mockExecute).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('Nearby Tension')).toBeTruthy();
+  });
+
+  it('shows a climber-voice empty state when there are no strays', async () => {
+    stubRequests({ gymBoards: [], myBoards: [], strays: [] });
+    render(<GymBoardsTab gym={editableGym} onGymChange={vi.fn()} />);
+
+    expect(await screen.findByText(/nothing loose right now/i)).toBeTruthy();
+  });
+
+  it('does not render the strays section without gym edit access', async () => {
+    const noEditGym = { ...gym, canEdit: false } as unknown as Gym;
+    stubRequests({ gymBoards: [], myBoards: [], strays: [makeStray({})] });
+    render(<GymBoardsTab gym={noEditGym} onGymChange={vi.fn()} />);
+
+    await screen.findByText(/no boards linked yet/i);
+    expect(screen.queryByText(/boards that might be yours/i)).toBeNull();
   });
 });

--- a/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
@@ -15,8 +15,10 @@ import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
+import Divider from '@mui/material/Divider';
 import AddOutlined from '@mui/icons-material/AddOutlined';
 import LinkOffOutlined from '@mui/icons-material/LinkOffOutlined';
+import AddLinkOutlined from '@mui/icons-material/AddLinkOutlined';
 import { useSession } from 'next-auth/react';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -25,13 +27,19 @@ import {
   GET_GYM_BOARDS,
   GET_MY_BOARDS,
   LINK_BOARD_TO_GYM,
+  STRAY_BOARDS_FOR_GYM,
+  ATTACH_BOARD_TO_GYM,
   type GetGymBoardsQueryResponse,
   type GetGymBoardsQueryVariables,
   type GetMyBoardsQueryResponse,
   type LinkBoardToGymMutationResponse,
   type LinkBoardToGymMutationVariables,
+  type StrayBoardsForGymQueryResponse,
+  type StrayBoardsForGymQueryVariables,
+  type AttachBoardToGymMutationResponse,
+  type AttachBoardToGymMutationVariables,
 } from '@boardsesh/graphql/operations';
-import type { UserBoard } from '@boardsesh/shared-schema';
+import type { StrayBoard, UserBoard } from '@boardsesh/shared-schema';
 import { boardTypeLabel } from '@boardsesh/board-constants';
 import { themeTokens } from '@/app/theme/theme-config';
 import { canManageGymBoards, canUnlinkBoard, linkableBoards } from './gym-board-permissions';
@@ -197,6 +205,8 @@ export default function GymBoardsTab({ gym }: GymManageTabProps) {
         </List>
       )}
 
+      {gym.canEdit && <StrayBoardsSection gymUuid={gym.uuid} onAttached={fetchBoards} />}
+
       <Dialog open={unlinkTarget !== null} onClose={() => setUnlinkTarget(null)}>
         <DialogTitle>{t('manage.boards.unlinkTitle')}</DialogTitle>
         <DialogContent>
@@ -339,5 +349,135 @@ function AddBoardDialog({ open, gymUuid, viewerUserId, linkedBoardUuids, onClose
         </Button>
       </DialogActions>
     </Dialog>
+  );
+}
+
+type StrayBoardsSectionProps = {
+  gymUuid: string;
+  /** Called after a successful attach so the linked-boards list refetches. */
+  onAttached: () => Promise<void> | void;
+};
+
+/**
+ * "Boards that might be yours": candidates the backend surfaces as physically at
+ * this gym (within ~150 m, unlinked or on a synced listing) or left behind by a
+ * merged listing. One tap re-points the board to this gym. Only mounted for
+ * viewers with gym edit access — the resolver enforces the same gate.
+ */
+function StrayBoardsSection({ gymUuid, onAttached }: StrayBoardsSectionProps) {
+  const { t } = useTranslation('kiosk');
+  const { token } = useWsAuthToken();
+  const [strays, setStrays] = useState<StrayBoard[] | null>(null);
+  const [loadError, setLoadError] = useState(false);
+  const [attachingUuid, setAttachingUuid] = useState<string | null>(null);
+
+  const attachMutation = useEntityMutation<AttachBoardToGymMutationResponse, AttachBoardToGymMutationVariables>(
+    ATTACH_BOARD_TO_GYM,
+    { successMessage: t('manage.boards.strays.attached'), errorMessage: t('manage.boards.strays.attachFailed') },
+  );
+
+  const fetchStrays = useCallback(async () => {
+    if (!token) return;
+    setLoadError(false);
+    try {
+      const client = createGraphQLHttpClient(token);
+      const data = await client.request<StrayBoardsForGymQueryResponse, StrayBoardsForGymQueryVariables>(
+        STRAY_BOARDS_FOR_GYM,
+        { gymUuid },
+      );
+      setStrays(data.strayBoardsForGym ?? []);
+    } catch (error) {
+      console.error('Failed to load stray boards:', error);
+      setLoadError(true);
+      setStrays([]);
+    }
+  }, [token, gymUuid]);
+
+  useEffect(() => {
+    void fetchStrays();
+  }, [fetchStrays]);
+
+  const handleAttach = async (board: StrayBoard) => {
+    setAttachingUuid(board.uuid);
+    try {
+      const result = await attachMutation.execute({ input: { gymUuid, boardUuid: board.uuid } });
+      if (result) {
+        // Drop the attached candidate and pull it into the linked list above.
+        setStrays((prev) => (prev === null ? prev : prev.filter((candidate) => candidate.uuid !== board.uuid)));
+        await onAttached();
+      }
+    } finally {
+      setAttachingUuid(null);
+    }
+  };
+
+  const reasonText = (board: StrayBoard): string => {
+    if (board.reason === 'MERGED_TWIN') {
+      return t('manage.boards.strays.reasonMerged');
+    }
+    if (board.distanceMeters == null) {
+      return t('manage.boards.strays.reasonNearbyGeneric');
+    }
+    return t('manage.boards.strays.reasonNearby', { meters: Math.round(board.distanceMeters) });
+  };
+
+  // Hide the whole section while the first fetch is in flight so it doesn't flash
+  // an empty state, and on a load error (the linked list above already surfaces
+  // gym-boards failures — a second error block would just be noise).
+  if (strays === null || loadError) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Divider sx={{ mb: 2 }} />
+      <Typography variant="h6" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+        {t('manage.boards.strays.heading')}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+        {t('manage.boards.strays.description')}
+      </Typography>
+
+      {strays.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+          {t('manage.boards.strays.empty')}
+        </Typography>
+      ) : (
+        <List disablePadding>
+          {strays.map((board) => (
+            <ListItem
+              key={board.uuid}
+              divider
+              disableGutters
+              secondaryAction={
+                <Button
+                  size="small"
+                  variant="contained"
+                  startIcon={<AddLinkOutlined />}
+                  disabled={attachingUuid !== null}
+                  onClick={() => handleAttach(board)}
+                  sx={{ textTransform: 'none' }}
+                >
+                  {attachingUuid === board.uuid ? (
+                    <CircularProgress size={16} color="inherit" />
+                  ) : (
+                    t('manage.boards.strays.attach')
+                  )}
+                </Button>
+              }
+            >
+              <ListItemText
+                primary={board.name}
+                secondary={
+                  board.currentGymName
+                    ? `${reasonText(board)} · ${t('manage.boards.strays.onListing', { name: board.currentGymName })}`
+                    : reasonText(board)
+                }
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
   );
 }

--- a/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
@@ -389,7 +389,7 @@ function StrayBoardsSection({ gymUuid, onAttached }: StrayBoardsSectionProps) {
     } catch (error) {
       console.error('Failed to load stray boards:', error);
       setLoadError(true);
-      setStrays([]);
+      setStrays(null);
     }
   }, [token, gymUuid]);
 
@@ -397,19 +397,22 @@ function StrayBoardsSection({ gymUuid, onAttached }: StrayBoardsSectionProps) {
     void fetchStrays();
   }, [fetchStrays]);
 
-  const handleAttach = async (board: StrayBoard) => {
-    setAttachingUuid(board.uuid);
-    try {
-      const result = await attachMutation.execute({ input: { gymUuid, boardUuid: board.uuid } });
-      if (result) {
-        // Drop the attached candidate and pull it into the linked list above.
-        setStrays((prev) => (prev === null ? prev : prev.filter((candidate) => candidate.uuid !== board.uuid)));
-        await onAttached();
+  const handleAttach = useCallback(
+    async (board: StrayBoard) => {
+      setAttachingUuid(board.uuid);
+      try {
+        const result = await attachMutation.execute({ input: { gymUuid, boardUuid: board.uuid } });
+        if (result) {
+          // Drop the attached candidate and pull it into the linked list above.
+          setStrays((prev) => (prev === null ? prev : prev.filter((candidate) => candidate.uuid !== board.uuid)));
+          await onAttached();
+        }
+      } finally {
+        setAttachingUuid(null);
       }
-    } finally {
-      setAttachingUuid(null);
-    }
-  };
+    },
+    [attachMutation, gymUuid, onAttached],
+  );
 
   const reasonText = (board: StrayBoard): string => {
     if (board.reason === 'MERGED_TWIN') {
@@ -421,11 +424,29 @@ function StrayBoardsSection({ gymUuid, onAttached }: StrayBoardsSectionProps) {
     return t('manage.boards.strays.reasonNearby', { meters: Math.round(board.distanceMeters) });
   };
 
-  // Hide the whole section while the first fetch is in flight so it doesn't flash
-  // an empty state, and on a load error (the linked list above already surfaces
-  // gym-boards failures — a second error block would just be noise).
-  if (strays === null || loadError) {
-    return null;
+  // Nothing loaded yet: while the first fetch is in flight, render nothing so the
+  // section doesn't flash. If that fetch failed, show the heading with an error +
+  // retry so a gym owner knows the check didn't run (rather than silently vanish).
+  if (strays === null) {
+    if (!loadError) {
+      return null;
+    }
+    return (
+      <Box sx={{ mt: 4 }}>
+        <Divider sx={{ mb: 2 }} />
+        <Typography variant="h6" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+          {t('manage.boards.strays.heading')}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1 }}>
+          <Typography variant="body2" color="error">
+            {t('manage.boards.strays.loadError')}
+          </Typography>
+          <Button size="small" onClick={() => void fetchStrays()} sx={{ textTransform: 'none' }}>
+            {t('manage.boards.strays.retry')}
+          </Button>
+        </Box>
+      </Box>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary

A gym owner wants every board physically in their gym on their listing. But a board can drift off: it may have been auto-created at the gym's coordinates under a synced (SYSTEM) or twin listing (#3701), or it may have been left on a listing that got merged into this gym (#3699). This surfaces both kinds and lets the Boards tab attach them one tap at a time.

**Backend (`packages/backend`)**

- `strayBoardsForGym(gymUuid)` query, guarded by `requireGymEditAccess`. Two candidate sources:
  - `MERGED_TWIN` — boards on a listing whose `merged_into_gym_id` chain resolves to this gym (the reverse of `resolveCanonicalGym` from #3699, as a bounded reverse walk). Surfaced regardless of visibility since the admin merge already established the listings are the same place.
  - `NEARBY` — boards within ~150 m that are unlinked or on a SYSTEM listing at the same spot. Proximity mirrors #3701's `findSimilarGyms`: a portable lat/lng bounding-box prefilter (the test DB is plain postgres, no PostGIS) plus a JS Haversine refine. Gated to boards the viewer may see (public, SYSTEM catalog, or their own) and never a `hide_location` board, so the tab can't enumerate a stranger's private wall by proximity.
  - Returns per board: uuid, name, current gym (name/uuid or null), distance, reason. Deduped by board, merged-twin first then nearest, capped at 25. No PII.
- `attachBoardToGym(input)` mutation. Re-points the board's `gym_id` to this gym. Gated on `requireGymEditAccess` **and** the board being in the exact same candidate set `strayBoardsForGym` would return — so gym-edit access can't be used to pull an arbitrary board off another listing.

**Reused vs. new mutation:** the existing `linkBoardToGym` could **not** be reused — it requires the caller to own the board (`board.ownerId === userId`), and strays are by definition on a SYSTEM/other-owner listing. So this adds a dedicated `attachBoardToGym` gated on gym-edit access + stray candidacy instead.

**Web** — new "Boards that might be yours" section on `gym-boards-tab.tsx` (only touched file per the sibling-PR conflict note): candidate list with reason labels ("Was on a merged listing" / "150 m away"), one-tap Add, optimistic refetch of the linked list, and a climber-voice empty state. Shown only to viewers with gym edit access.

i18n across en-US / es / fr (kiosk namespace, following the plafón / la board glossaries).

## Release Notes

- Spot boards that belong to your gym but slipped onto another listing or a merged one, and attach them to your gym in one tap.

## Test plan

- `vp check` — 0 errors.
- `vp run typecheck` — clean (web + backend + shared).
- `VITEST_POOL_ID=solo-p17 vp test run --project backend` — `gym-stray-boards.test.ts`, 13 passing: merged-twin (single + multi-hop chain), nearby vs. 300 m exclusion, SYSTEM-listing candidate, private/hide-location exclusion, already-linked exclusion, anon + non-editor access denial, editor-member allow, attach re-points gym_id (incl. a board the caller doesn't own), attach refuses a non-candidate, attach access denial.
- `vp test run --project web` — `gym-boards-tab.test.tsx`, 9 passing (4 existing + 5 new: stray list render, attach success/failure, empty state, no-edit-access hidden).
- `vp run check:i18n` — OK. i18n `catalog-completeness` — 60 passing (locale parity).
- Codegen regenerated (`vp run codegen`); `codegen-drift` gate satisfied.