### PR TITLE
feat(web): gym staff roles — My Gyms membership, role clarity, grant heads-up

### DIFF
--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -422,6 +422,90 @@ describe('enrichGym canGrantAccess and canClaim', () => {
   });
 });
 
+describe('grant notifies the new staff member', () => {
+  it('grantGymWriteAccess creates a "you now manage this gym" notification for the new editor', async () => {
+    await socialGymMutations.grantGymWriteAccess(null, { input: { gymUuid, userId: EDITOR_TARGET } }, authCtx(OWNER));
+
+    // Same shape as a claim approval: gym-typed, deep-links by gym UUID, no actor.
+    const notifications = await claimApprovedNotifications(EDITOR_TARGET);
+    expect(notifications).toEqual([{ entity_type: 'gym', entity_id: gymUuid, actor_id: null }]);
+  });
+
+  it('does NOT notify when the grant is a no-op re-grant of an existing gym admin', async () => {
+    // GYM_ADMIN_MEMBER is already admin — the setWhere skips the update, so no
+    // row is returned and no redundant "you now manage" ping fires.
+    await socialGymMutations.grantGymWriteAccess(
+      null,
+      { input: { gymUuid, userId: GYM_ADMIN_MEMBER } },
+      authCtx(OWNER),
+    );
+    expect(await claimApprovedNotifications(GYM_ADMIN_MEMBER)).toEqual([]);
+  });
+
+  it('addGymMember notifies a fresh admin but not a plain member', async () => {
+    await socialGymMutations.addGymMember(
+      null,
+      { input: { gymUuid, userId: EDITOR_TARGET, role: 'admin' } },
+      authCtx(OWNER),
+    );
+    expect(await claimApprovedNotifications(EDITOR_TARGET)).toEqual([
+      { entity_type: 'gym', entity_id: gymUuid, actor_id: null },
+    ]);
+
+    // A plain member is social-only (no manage access) — no notification.
+    await socialGymMutations.addGymMember(
+      null,
+      { input: { gymUuid, userId: SECOND_TARGET, role: 'member' } },
+      authCtx(OWNER),
+    );
+    expect(await claimApprovedNotifications(SECOND_TARGET)).toEqual([]);
+  });
+});
+
+describe('myGyms includes owned + membership', () => {
+  const myGymRoleFor = async (ctx: ConnectionContext, uuid: string): Promise<string | null | undefined> => {
+    const result = await socialGymQueries.myGyms(null, { input: {} }, ctx);
+    const match = result.gyms.find((g) => g.uuid === uuid);
+    return match ? match.myRole : null;
+  };
+
+  it('the owner sees their owned gym with myRole=admin', async () => {
+    expect(await myGymRoleFor(authCtx(OWNER), gymUuid)).toBe('admin');
+  });
+
+  it('a gym admin member sees the gym they administer with myRole=admin', async () => {
+    // GYM_ADMIN_MEMBER holds an admin row on the shared gym but does not own it.
+    const result = await socialGymQueries.myGyms(null, { input: {} }, authCtx(GYM_ADMIN_MEMBER));
+    expect(result.gyms.map((g) => g.uuid)).toContain(gymUuid);
+    expect(await myGymRoleFor(authCtx(GYM_ADMIN_MEMBER), gymUuid)).toBe('admin');
+  });
+
+  it('an editor sees the gym they were granted on with myRole=editor', async () => {
+    await socialGymMutations.grantGymWriteAccess(null, { input: { gymUuid, userId: EDITOR_TARGET } }, authCtx(OWNER));
+    expect(await myGymRoleFor(authCtx(EDITOR_TARGET), gymUuid)).toBe('editor');
+  });
+
+  it('a plain member sees the gym with myRole=member', async () => {
+    await insertGymMember(gymId, PLAIN_USER, 'member');
+    expect(await myGymRoleFor(authCtx(PLAIN_USER), gymUuid)).toBe('member');
+  });
+
+  it('a user with no owner/member relationship does not see the gym', async () => {
+    const result = await socialGymQueries.myGyms(null, { input: {} }, authCtx(EDITOR_TARGET));
+    expect(result.gyms.map((g) => g.uuid)).not.toContain(gymUuid);
+    expect(result.totalCount).toBe(0);
+  });
+
+  it('does not duplicate a gym when the viewer is both owner and (impossibly) a member row', async () => {
+    // Contrived: plant a member row for the owner on their own gym. The OR over a
+    // single gyms table still resolves to one row — no dupe, counted once.
+    await insertGymMember(gymId, OWNER, 'member');
+    const result = await socialGymQueries.myGyms(null, { input: {} }, authCtx(OWNER));
+    expect(result.gyms.filter((g) => g.uuid === gymUuid)).toHaveLength(1);
+    expect(result.totalCount).toBe(1);
+  });
+});
+
 describe('addGymMember role restriction', () => {
   it('rejects the editor role — write access must go through grantGymWriteAccess', async () => {
     // `editor` is not addable via member management; it's planted only by the

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -442,6 +442,29 @@ describe('grant notifies the new staff member', () => {
     expect(await claimApprovedNotifications(GYM_ADMIN_MEMBER)).toEqual([]);
   });
 
+  it('does NOT re-notify when re-granting an existing editor (only the first grant pings)', async () => {
+    await socialGymMutations.grantGymWriteAccess(null, { input: { gymUuid, userId: EDITOR_TARGET } }, authCtx(OWNER));
+    // Second grant on the same editor is a no-op — the setWhere only promotes a
+    // plain member, so RETURNING is empty and no second notification fires.
+    await socialGymMutations.grantGymWriteAccess(null, { input: { gymUuid, userId: EDITOR_TARGET } }, authCtx(OWNER));
+
+    expect(await claimApprovedNotifications(EDITOR_TARGET)).toEqual([
+      { entity_type: 'gym', entity_id: gymUuid, actor_id: null },
+    ]);
+    // The editor row survived the no-op re-grant.
+    expect(await gymMemberRole(gymId, EDITOR_TARGET)).toBe('editor');
+  });
+
+  it('notifies when a plain member is promoted to editor', async () => {
+    await insertGymMember(gymId, PLAIN_USER, 'member');
+    await socialGymMutations.grantGymWriteAccess(null, { input: { gymUuid, userId: PLAIN_USER } }, authCtx(OWNER));
+
+    expect(await gymMemberRole(gymId, PLAIN_USER)).toBe('editor');
+    expect(await claimApprovedNotifications(PLAIN_USER)).toEqual([
+      { entity_type: 'gym', entity_id: gymUuid, actor_id: null },
+    ]);
+  });
+
   it('addGymMember notifies a fresh admin but not a plain member', async () => {
     await socialGymMutations.addGymMember(
       null,

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -527,6 +527,31 @@ describe('myGyms includes owned + membership', () => {
     expect(result.gyms.filter((g) => g.uuid === gymUuid)).toHaveLength(1);
     expect(result.totalCount).toBe(1);
   });
+
+  it('paginates and counts a mixed owned + member result set correctly', async () => {
+    // PLAIN_USER owns two gyms and is a member of the shared gym → three total,
+    // spanning both the owner and the member branch of the OR.
+    const owned1 = await insertGym({ ownerId: PLAIN_USER, name: 'PU Owned 1' });
+    const owned2 = await insertGym({ ownerId: PLAIN_USER, name: 'PU Owned 2' });
+    await insertGymMember(gymId, PLAIN_USER, 'editor');
+    const expectedUuids = new Set([owned1.uuid, owned2.uuid, gymUuid]);
+
+    const page1 = await socialGymQueries.myGyms(null, { input: { limit: 2, offset: 0 } }, authCtx(PLAIN_USER));
+    expect(page1.totalCount).toBe(3);
+    expect(page1.gyms).toHaveLength(2);
+    expect(page1.hasMore).toBe(true);
+
+    const page2 = await socialGymQueries.myGyms(null, { input: { limit: 2, offset: 2 } }, authCtx(PLAIN_USER));
+    expect(page2.totalCount).toBe(3);
+    expect(page2.gyms).toHaveLength(1);
+    expect(page2.hasMore).toBe(false);
+
+    // The two pages together cover all three gyms exactly once — count and
+    // cursor stay consistent across the owned/member union.
+    const seen = [...page1.gyms, ...page2.gyms].map((g) => g.uuid);
+    expect(seen).toHaveLength(3);
+    expect(new Set(seen)).toEqual(expectedUuids);
+  });
 });
 
 describe('addGymMember role restriction', () => {

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -7,7 +7,7 @@ import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import { requireAdmin } from './roles';
 import { userCanEditGym } from './gyms';
-import { createGymClaimApprovedNotification } from './gym-notifications';
+import { createGymManageAccessNotification } from './gym-notifications';
 import {
   RequestGymClaimInputSchema,
   ReviewGymClaimInputSchema,
@@ -113,7 +113,7 @@ export async function applyGymClaim(
  * a heads-up.
  */
 async function notifyClaimApplied(result: ClaimApplied): Promise<void> {
-  await createGymClaimApprovedNotification(result.claimantUserId, result.gymUuid, result.gymName);
+  await createGymManageAccessNotification(result.claimantUserId, result.gymUuid, result.gymName);
   if (result.claimEmail) {
     void sendGymClaimApprovedEmail(result.claimEmail, result.gymName);
   }

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -7,6 +7,7 @@ import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import { requireAdmin } from './roles';
 import { userCanEditGym } from './gyms';
+import { createGymClaimApprovedNotification } from './gym-notifications';
 import {
   RequestGymClaimInputSchema,
   ReviewGymClaimInputSchema,
@@ -19,7 +20,6 @@ import {
   sendGymClaimApprovedEmail,
   sendGymClaimOwnershipLostEmail,
 } from '../../../email/email-service';
-import { pubsub } from '../../../pubsub/index';
 import { logger } from '../../../utils/logger';
 
 const CLAIM_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
@@ -38,45 +38,6 @@ type ClaimApplied = {
   claimEmail: string | null;
   priorOwnerId: string | null;
 };
-
-/**
- * Create the in-app "you now manage this gym" notification for the claimant and
- * push it live (best-effort). System notification — no actor, so the feed shows
- * a gym icon rather than a person. The gym name is carried on the live payload
- * and re-derived from `entityId` (the gym UUID) when the feed is fetched later.
- */
-export async function createGymClaimApprovedNotification(
-  recipientId: string,
-  gymUuid: string,
-  gymName: string,
-): Promise<void> {
-  try {
-    const uuid = randomUUID();
-    await db.insert(dbSchema.notifications).values({
-      uuid,
-      recipientId,
-      actorId: null,
-      type: 'gym_claim_approved',
-      entityType: 'gym',
-      entityId: gymUuid,
-    });
-
-    pubsub.publishNotificationEvent(recipientId, {
-      notification: {
-        uuid,
-        type: 'gym_claim_approved',
-        actorId: null,
-        entityType: 'gym',
-        entityId: gymUuid,
-        gymName,
-        isRead: false,
-        createdAt: new Date().toISOString(),
-      },
-    });
-  } catch (error) {
-    logger.error('[GymClaim] Failed to create approval notification:', error);
-  }
-}
 
 /**
  * Apply a claim: transfer gym ownership to the claimant. The pending row is

--- a/packages/backend/src/graphql/resolvers/social/gym-notifications.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-notifications.ts
@@ -1,0 +1,54 @@
+import { randomUUID } from 'node:crypto';
+import { db } from '../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { pubsub } from '../../../pubsub/index';
+import { logger } from '../../../utils/logger';
+
+/**
+ * Create the in-app "you now manage this gym" notification for a user and push it
+ * live (best-effort). Shared by two flows that both hand someone the keys to a
+ * gym:
+ *  - a claim that transfers ownership (gym-claims.ts), and
+ *  - an owner/admin granting a staff member admin/editor access (gyms.ts).
+ *
+ * Both mean the same thing to the recipient — "you can manage this gym now" — so
+ * they reuse the `gym_claim_approved` notification type: its copy is already
+ * "You now manage {{gym}}" and it deep-links to /gym/[slug]/manage. Reusing the
+ * type keeps this to zero new enum values and no migration.
+ *
+ * System notification — no actor, so the feed shows a gym icon rather than a
+ * person. The gym name rides the live payload and is re-derived from `entityId`
+ * (the gym UUID) when the feed is fetched later.
+ */
+export async function createGymClaimApprovedNotification(
+  recipientId: string,
+  gymUuid: string,
+  gymName: string,
+): Promise<void> {
+  try {
+    const uuid = randomUUID();
+    await db.insert(dbSchema.notifications).values({
+      uuid,
+      recipientId,
+      actorId: null,
+      type: 'gym_claim_approved',
+      entityType: 'gym',
+      entityId: gymUuid,
+    });
+
+    pubsub.publishNotificationEvent(recipientId, {
+      notification: {
+        uuid,
+        type: 'gym_claim_approved',
+        actorId: null,
+        entityType: 'gym',
+        entityId: gymUuid,
+        gymName,
+        isRead: false,
+        createdAt: new Date().toISOString(),
+      },
+    });
+  } catch (error) {
+    logger.error('[GymNotifications] Failed to create manage-access notification:', error);
+  }
+}

--- a/packages/backend/src/graphql/resolvers/social/gym-notifications.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-notifications.ts
@@ -20,7 +20,7 @@ import { logger } from '../../../utils/logger';
  * person. The gym name rides the live payload and is re-derived from `entityId`
  * (the gym UUID) when the feed is fetched later.
  */
-export async function createGymClaimApprovedNotification(
+export async function createGymManageAccessNotification(
   recipientId: string,
   gymUuid: string,
   gymName: string,

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -6,7 +6,7 @@ import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import { getUserCommunityRoles, rolesGrantAdminOrLeader } from './roles';
-import { createGymClaimApprovedNotification } from './gym-notifications';
+import { createGymManageAccessNotification } from './gym-notifications';
 import {
   CreateGymInputSchema,
   UpdateGymInputSchema,
@@ -502,15 +502,15 @@ export const socialGymQueries = {
     const offset = validatedInput.offset ?? 0;
     const includeFollowed = validatedInput.includeFollowed ?? false;
 
-    // Gyms the viewer holds a gym_members row on (admin/editor/member). Staff
-    // access shows up in My Gyms alongside owned gyms, so a climber granted
-    // editor/admin actually sees the gym they can manage — enrichGym then fills
-    // in myRole/canEdit so the drawer's role chips light up.
-    const memberGyms = await db
+    // Gyms the viewer holds a gym_members row on (admin/editor/member) as a
+    // correlated subquery — no extra round trip, no shipping an id array back to
+    // the app. Staff access shows up in My Gyms alongside owned gyms, so a climber
+    // granted editor/admin actually sees the gym they can manage; enrichGym then
+    // fills in myRole/canEdit so the drawer's role chips light up.
+    const memberGymIdsSubquery = db
       .select({ gymId: dbSchema.gymMembers.gymId })
       .from(dbSchema.gymMembers)
       .where(eq(dbSchema.gymMembers.userId, userId));
-    const memberGymIds = memberGyms.map((m) => m.gymId);
 
     // Get IDs of gyms the user follows (if requested)
     let followedGymIds: number[] = [];
@@ -522,17 +522,17 @@ export const socialGymQueries = {
       followedGymIds = followedGyms.map((f) => f.gymId);
     }
 
-    // Build WHERE: owned OR a member OR followed, and not deleted. All three are
-    // OR'd against the single `gyms` table, so a gym matching more than one (an
-    // owner who somehow also has a member row) still resolves to one row —
-    // dedupe is inherent, no DISTINCT needed.
+    // Build WHERE: owned OR a member OR followed, and not deleted. All are OR'd
+    // against the single `gyms` table, so a gym matching more than one (an owner
+    // who somehow also has a member row) still resolves to one row — dedupe is
+    // inherent, no DISTINCT needed. The member subquery is always included; when
+    // the viewer holds no member rows it simply matches nothing.
     const ownerCondition = eq(dbSchema.gyms.ownerId, userId);
-    const memberCondition = memberGymIds.length > 0 ? inArray(dbSchema.gyms.id, memberGymIds) : undefined;
+    const memberCondition = inArray(dbSchema.gyms.id, memberGymIdsSubquery);
     const followedCondition = followedGymIds.length > 0 ? inArray(dbSchema.gyms.id, followedGymIds) : undefined;
-    const matchConditions: SQL[] = [ownerCondition];
-    if (memberCondition) matchConditions.push(memberCondition);
+    const matchConditions: SQL[] = [ownerCondition, memberCondition];
     if (followedCondition) matchConditions.push(followedCondition);
-    const matchCondition = matchConditions.length > 1 ? or(...matchConditions)! : matchConditions[0];
+    const matchCondition = or(...matchConditions)!;
     const whereClause = and(matchCondition, isNull(dbSchema.gyms.deletedAt));
 
     const [countResult] = await db.select({ count: count() }).from(dbSchema.gyms).where(whereClause);
@@ -942,7 +942,7 @@ export const socialGymMutations = {
     // empty on an onConflictDoNothing no-op, so a re-add of an existing member
     // stays silent.
     if (validatedInput.role === 'admin' && inserted.length > 0) {
-      await createGymClaimApprovedNotification(validatedInput.userId, gym.uuid, gym.name);
+      await createGymManageAccessNotification(validatedInput.userId, gym.uuid, gym.name);
     }
 
     return true;
@@ -1019,7 +1019,7 @@ export const socialGymMutations = {
     // Tell the new editor they can manage the gym now (best-effort; the helper
     // swallows its own errors so a notification hiccup never fails the grant).
     if (granted.length > 0) {
-      await createGymClaimApprovedNotification(validatedInput.userId, gym.uuid, gym.name);
+      await createGymManageAccessNotification(validatedInput.userId, gym.uuid, gym.name);
     }
 
     return true;

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -995,11 +995,13 @@ export const socialGymMutations = {
       throw new Error('The gym owner already has full access');
     }
 
-    // Upsert an editor row. Never downgrade an existing admin — only promote a
-    // plain member (or a no-op re-grant of an editor) to editor. RETURNING gives
-    // us the rows the grant actually planted/updated: an existing admin fails the
-    // setWhere and returns nothing, so we don't ping someone who already manages
-    // the gym.
+    // Upsert an editor row. The setWhere promotes ONLY a plain member — it leaves
+    // an existing admin untouched (never downgraded) AND an existing editor
+    // untouched (already editor, nothing to change). That makes RETURNING an
+    // honest "a real grant happened" signal: it's non-empty exactly on a fresh
+    // insert or a member→editor promotion, and empty on a no-op re-grant of an
+    // existing editor/admin — so we don't re-ping someone who already manages the
+    // gym.
     const granted = await db
       .insert(dbSchema.gymMembers)
       .values({
@@ -1010,7 +1012,7 @@ export const socialGymMutations = {
       .onConflictDoUpdate({
         target: [dbSchema.gymMembers.gymId, dbSchema.gymMembers.userId],
         set: { role: 'editor' },
-        setWhere: sql`${dbSchema.gymMembers.role} <> 'admin'`,
+        setWhere: sql`${dbSchema.gymMembers.role} = 'member'`,
       })
       .returning({ userId: dbSchema.gymMembers.userId });
 

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -6,6 +6,7 @@ import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import { getUserCommunityRoles, rolesGrantAdminOrLeader } from './roles';
+import { createGymClaimApprovedNotification } from './gym-notifications';
 import {
   CreateGymInputSchema,
   UpdateGymInputSchema,
@@ -501,6 +502,16 @@ export const socialGymQueries = {
     const offset = validatedInput.offset ?? 0;
     const includeFollowed = validatedInput.includeFollowed ?? false;
 
+    // Gyms the viewer holds a gym_members row on (admin/editor/member). Staff
+    // access shows up in My Gyms alongside owned gyms, so a climber granted
+    // editor/admin actually sees the gym they can manage — enrichGym then fills
+    // in myRole/canEdit so the drawer's role chips light up.
+    const memberGyms = await db
+      .select({ gymId: dbSchema.gymMembers.gymId })
+      .from(dbSchema.gymMembers)
+      .where(eq(dbSchema.gymMembers.userId, userId));
+    const memberGymIds = memberGyms.map((m) => m.gymId);
+
     // Get IDs of gyms the user follows (if requested)
     let followedGymIds: number[] = [];
     if (includeFollowed) {
@@ -511,10 +522,17 @@ export const socialGymQueries = {
       followedGymIds = followedGyms.map((f) => f.gymId);
     }
 
-    // Build WHERE: owned OR followed, and not deleted
+    // Build WHERE: owned OR a member OR followed, and not deleted. All three are
+    // OR'd against the single `gyms` table, so a gym matching more than one (an
+    // owner who somehow also has a member row) still resolves to one row —
+    // dedupe is inherent, no DISTINCT needed.
     const ownerCondition = eq(dbSchema.gyms.ownerId, userId);
+    const memberCondition = memberGymIds.length > 0 ? inArray(dbSchema.gyms.id, memberGymIds) : undefined;
     const followedCondition = followedGymIds.length > 0 ? inArray(dbSchema.gyms.id, followedGymIds) : undefined;
-    const matchCondition = followedCondition ? or(ownerCondition, followedCondition)! : ownerCondition;
+    const matchConditions: SQL[] = [ownerCondition];
+    if (memberCondition) matchConditions.push(memberCondition);
+    if (followedCondition) matchConditions.push(followedCondition);
+    const matchCondition = matchConditions.length > 1 ? or(...matchConditions)! : matchConditions[0];
     const whereClause = and(matchCondition, isNull(dbSchema.gyms.deletedAt));
 
     const [countResult] = await db.select({ count: count() }).from(dbSchema.gyms).where(whereClause);
@@ -908,14 +926,24 @@ export const socialGymMutations = {
       throw new Error('User not found');
     }
 
-    await db
+    const inserted = await db
       .insert(dbSchema.gymMembers)
       .values({
         gymId: gym.id,
         userId: validatedInput.userId,
         role: validatedInput.role,
       })
-      .onConflictDoNothing();
+      .onConflictDoNothing()
+      .returning({ userId: dbSchema.gymMembers.userId });
+
+    // A fresh admin member gets the same "you now manage this gym" heads-up as a
+    // granted editor — admins manage staff, so they're being handed the keys too.
+    // Plain members (social-only, no edit access) are not notified. RETURNING is
+    // empty on an onConflictDoNothing no-op, so a re-add of an existing member
+    // stays silent.
+    if (validatedInput.role === 'admin' && inserted.length > 0) {
+      await createGymClaimApprovedNotification(validatedInput.userId, gym.uuid, gym.name);
+    }
 
     return true;
   },
@@ -968,8 +996,11 @@ export const socialGymMutations = {
     }
 
     // Upsert an editor row. Never downgrade an existing admin — only promote a
-    // plain member (or a no-op re-grant of an editor) to editor.
-    await db
+    // plain member (or a no-op re-grant of an editor) to editor. RETURNING gives
+    // us the rows the grant actually planted/updated: an existing admin fails the
+    // setWhere and returns nothing, so we don't ping someone who already manages
+    // the gym.
+    const granted = await db
       .insert(dbSchema.gymMembers)
       .values({
         gymId: gym.id,
@@ -980,7 +1011,14 @@ export const socialGymMutations = {
         target: [dbSchema.gymMembers.gymId, dbSchema.gymMembers.userId],
         set: { role: 'editor' },
         setWhere: sql`${dbSchema.gymMembers.role} <> 'admin'`,
-      });
+      })
+      .returning({ userId: dbSchema.gymMembers.userId });
+
+    // Tell the new editor they can manage the gym now (best-effort; the helper
+    // swallows its own errors so a notification hiccup never fails the grant).
+    if (granted.length > 0) {
+      await createGymClaimApprovedNotification(validatedInput.userId, gym.uuid, gym.name);
+    }
 
     return true;
   },

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -459,6 +459,12 @@
       "editor": "Editor",
       "member": "Member"
     },
+    "roleHelp": {
+      "title": "What each role can do",
+      "admin": "Admins manage everything, including boards, kiosks, branding, and who's on staff.",
+      "editor": "Editors can change the gym, boards, and kiosks, but not delete it or manage staff.",
+      "member": "Members are part of the crew and can't edit anything."
+    },
     "grant": {
       "button": "Grant write access",
       "revoke": "Revoke write access",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -459,6 +459,12 @@
       "editor": "Editor",
       "member": "Miembro"
     },
+    "roleHelp": {
+      "title": "Qué puede hacer cada rol",
+      "admin": "Los administradores gestionan todo, incluidos los plafones, los kioscos, la marca y el personal.",
+      "editor": "Los editores pueden cambiar el gimnasio, los plafones y los kioscos, pero no eliminarlo ni gestionar al personal.",
+      "member": "Los miembros forman parte del equipo y no pueden editar nada."
+    },
     "grant": {
       "button": "Dar acceso de edición",
       "revoke": "Revocar acceso de edición",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -459,6 +459,12 @@
       "editor": "Éditeur",
       "member": "Membre"
     },
+    "roleHelp": {
+      "title": "Ce que chaque rôle peut faire",
+      "admin": "Les admins gèrent tout : les boards, les bornes, l’identité visuelle et l’équipe.",
+      "editor": "Les éditeurs peuvent modifier la salle, les boards et les bornes, mais pas la supprimer ni gérer l’équipe.",
+      "member": "Les membres font partie de l’équipe et ne peuvent rien modifier."
+    },
     "grant": {
       "button": "Donner l’accès en écriture",
       "revoke": "Révoquer l’accès en écriture",

--- a/packages/web/app/components/gym-entity/gym-member-management.tsx
+++ b/packages/web/app/components/gym-entity/gym-member-management.tsx
@@ -25,6 +25,7 @@ import RemoveCircleOutlined from '@mui/icons-material/RemoveCircleOutline';
 import PersonAddOutlined from '@mui/icons-material/PersonAddOutlined';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { themeTokens } from '@/app/theme/theme-config';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
   GET_GYM_MEMBERS,
@@ -251,6 +252,26 @@ export default function GymMemberManagement({
           </MuiButton>
         </Box>
       )}
+
+      {/* Plain-language legend so whoever assigns roles knows what each one can
+          actually do before they hand out access. */}
+      <Paper variant="outlined" sx={{ p: 1.5, mb: 2 }}>
+        <MuiTypography
+          variant="caption"
+          sx={{ display: 'block', mb: 0.5, fontWeight: themeTokens.typography.fontWeight.semibold }}
+        >
+          {t('gymMemberManagement.roleHelp.title')}
+        </MuiTypography>
+        <MuiTypography variant="caption" color="text.secondary" component="p" sx={{ mb: 0.25 }}>
+          {t('gymMemberManagement.roleHelp.admin')}
+        </MuiTypography>
+        <MuiTypography variant="caption" color="text.secondary" component="p" sx={{ mb: 0.25 }}>
+          {t('gymMemberManagement.roleHelp.editor')}
+        </MuiTypography>
+        <MuiTypography variant="caption" color="text.secondary" component="p">
+          {t('gymMemberManagement.roleHelp.member')}
+        </MuiTypography>
+      </Paper>
 
       {loading && members.length === 0 ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>

--- a/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
@@ -7,13 +7,16 @@ import { useSession } from 'next-auth/react';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import MuiLink from '@mui/material/Link';
 import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined';
+import type { TFunction } from 'i18next';
 import type { Gym } from '@boardsesh/shared-schema';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
+import { resolveGymRole, type GymRoleKind } from '@/app/lib/gym-role';
 import { themeTokens } from '@/app/theme/theme-config';
 import GymMemberManagement from '@/app/components/gym-entity/gym-member-management';
 import { canManageGymBoards } from '@/app/components/gym-entity/manage/gym-board-permissions';
@@ -30,6 +33,22 @@ import { decideManageNavigation, type ManageNavigation } from '@/app/components/
 type ManageTab = 'overview' | 'kiosks' | 'insights' | 'branding' | 'profile' | 'boards' | 'members';
 const VALID_TABS: ManageTab[] = ['overview', 'kiosks', 'insights', 'branding', 'profile', 'boards', 'members'];
 const DEFAULT_TAB: ManageTab = 'overview';
+
+// Reuses the My Gyms role labels (common:myGyms.*) so the console header and the
+// drawer name the viewer's standing the same way. Static-literal keys — the i18n
+// linter forbids t(variable).
+function roleChipLabel(t: TFunction, role: GymRoleKind): string {
+  switch (role) {
+    case 'owner':
+      return t('common:myGyms.roleOwner');
+    case 'admin':
+      return t('common:myGyms.roleAdmin');
+    case 'editor':
+      return t('common:myGyms.roleEditor');
+    case 'member':
+      return t('common:myGyms.roleMember');
+  }
+}
 
 export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
   const { t } = useTranslation('kiosk');
@@ -48,6 +67,10 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
 
   const currentUserId = session?.user?.id ?? null;
   const isOwnerOrAdmin = canManageGymBoards(gym, currentUserId);
+  // The viewer's standing at this gym (owner/admin/editor), shown as a chip in
+  // the header. Null for a community moderator who can edit via a community role
+  // but holds no gym_members row — no gym-level standing to badge.
+  const viewerRole = resolveGymRole(gym, currentUserId);
 
   const tabParam = searchParams.get('tab');
   const activeTab: ManageTab = VALID_TABS.includes(tabParam as ManageTab) ? (tabParam as ManageTab) : DEFAULT_TAB;
@@ -135,9 +158,12 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
         </Box>
       )}
 
-      <Typography variant="h4" component="h1" sx={{ fontWeight: themeTokens.typography.fontWeight.bold, mb: 3 }}>
-        {t('manage.title', { gymName: gym.name })}
-      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1.5, mb: 3 }}>
+        <Typography variant="h4" component="h1" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+          {t('manage.title', { gymName: gym.name })}
+        </Typography>
+        {viewerRole && <Chip size="small" color="primary" label={roleChipLabel(t, viewerRole)} />}
+      </Box>
 
       {!gym.slug && <GymSlugGuard gym={gym} onSlugSet={handleSlugSet} />}
 

--- a/packages/web/app/hooks/use-my-gyms.ts
+++ b/packages/web/app/hooks/use-my-gyms.ts
@@ -9,11 +9,10 @@ import { GET_MY_GYMS, type GetMyGymsQueryResponse, type GetMyGymsQueryVariables 
 import type { Gym, GymConnection } from '@boardsesh/shared-schema';
 
 /**
- * Fetches the gyms the current user owns via GraphQL. Membership-based listing
- * (admin/editor) arrives with the staff-roles PR — today the `myGyms` resolver
- * only returns gyms where `ownerId = userId` (no gym_members join). The role-chip
- * logic already handles admin/editor rows; they become reachable once `myGyms`
- * includes gym_members.
+ * Fetches the gyms the current user owns OR holds a gym_members row on
+ * (admin/editor/member) via GraphQL — the `myGyms` resolver unions owned +
+ * membership, so a climber granted editor/admin sees the gym here and the
+ * role-chip logic lights up from each gym's `myRole`.
  * Gyms are fetched when `enabled` becomes true and the user is authenticated.
  *
  * Built on `useInfiniteQuery` so the homepage card and the My Gyms drawer share a

--- a/packages/web/app/lib/gym-role.ts
+++ b/packages/web/app/lib/gym-role.ts
@@ -9,11 +9,11 @@ export type GymRoleKind = 'owner' | 'admin' | 'editor' | 'member';
 
 /**
  * Resolve the viewer's standing at a gym. Returns null for a gym the viewer
- * only follows. Shared by the My Gyms drawer and the homepage gym card so both
- * surface the same role.
+ * only follows. Shared by the My Gyms drawer, the homepage gym card, and the
+ * manage console header so they all surface the same role.
  *
- * Admin/editor rows only become reachable once `myGyms` includes gym_members
- * (staff-roles PR); until then every listed gym resolves to `owner`.
+ * `myGyms` unions owned + gym_members, so admin/editor/member rows arrive with
+ * their `myRole` populated and resolve to the matching standing here.
  */
 export function resolveGymRole(gym: Gym, currentUserId: string | null): GymRoleKind | null {
   if (currentUserId && gym.ownerId === currentUserId) return 'owner';


### PR DESCRIPTION
## Summary

Staff you add to a gym couldn't find it. The `myGyms` resolver only returned gyms where `ownerId = viewer`, so a climber granted **editor**/**admin** never saw the gym in the My Gyms drawer or the mobile My Gyms route — the role-chip UI (`resolveGymRole`) was dead for them. This PR makes staff access visible end-to-end and gives people a heads-up when they get the keys.

**Backend**
- `myGyms` now unions **owned** gyms with **gym_members** rows (admin/editor/member), keeping the existing limit/pagination + `includeFollowed` semantics. Dedupe is inherent — the three conditions OR against a single `gyms` table, so a gym matching more than one still resolves to one row. `enrichGym` already fills in `myRole`/`canEdit`, so the drawer's role chips light up.
- When someone is granted management access, they get an in-app **"You now manage \<gym\>"** notification that deep-links to `/gym/[slug]/manage`. It reuses the recently-merged `gym_claim_approved` notification type (identical copy + deep link), so **no new enum value and no migration**. Fires from `grantGymWriteAccess` (editor) and `addGymMember` when the role is `admin`, gated on the grant actually taking effect via `RETURNING` — a no-op re-grant of an existing admin stays silent.
- The notification helper was extracted from `gym-claims.ts` into a new `gym-notifications.ts` so both `gyms.ts` and `gym-claims.ts` share it without a circular import.

**Web**
- Members management UI: a plain-language legend of what **admin / editor / member** can each do, so whoever hands out roles knows what they're granting.
- Manage console header: a chip showing the viewer's role next to the gym name, reusing the My Gyms role labels. Header-only change (no touch to the tab list).

## Release Notes

- Staff you add to your gym now see it in My Gyms, and get a heads-up the moment they're handed the keys.
- Assigning roles is clearer: a quick note on what admins, editors, and members can each do.

## Test plan

- Backend: extended `gym-write-access-and-claims.test.ts` — owner/admin/editor/member each see the right gym with the right `myRole` via `myGyms`; no dupes when a viewer is both owner and a member row; a stranger sees nothing; grant + fresh-admin fire the notification while a no-op admin re-grant and a plain member do not. `VITEST_POOL_ID=solo-p14b vp test run --project backend gym-write-access-and-claims` → 54/54 pass.
- `vp run typecheck` (backend + web) — clean.
- `vp test run --project web` — 5753/5753 pass.
- `vp run check:i18n`, `check:i18n:orphans`, i18n catalog completeness — all pass (new `boards.roleHelp.*` keys across en-US/es/fr).
- `vp check` (lint + format) — clean.

_No database migration in this PR._