### PR TITLE
feat: report a duplicate gym (owner-facing → admin queue)

### DIFF
--- a/packages/backend/src/__tests__/gym-report-duplicate.test.ts
+++ b/packages/backend/src/__tests__/gym-report-duplicate.test.ts
@@ -22,6 +22,7 @@ const anonCtx = (): ConnectionContext =>
   ({ connectionId: `conn-anon-${connectionCounter++}`, isAuthenticated: false }) as ConnectionContext;
 
 const REPORTER = 'gdr-reporter';
+const STRANGER = 'gdr-stranger';
 
 const insertUser = (id: string, name: string) =>
   db.execute(sql`
@@ -32,14 +33,16 @@ const insertUser = (id: string, name: string) =>
 
 const insertGym = async (opts: {
   name: string;
+  ownerId?: string;
+  isPublic?: boolean;
   deleted?: boolean;
   mergedIntoId?: number | null;
 }): Promise<{ id: number; uuid: string }> => {
-  const { name, deleted = false, mergedIntoId = null } = opts;
+  const { name, ownerId = REPORTER, isPublic = true, deleted = false, mergedIntoId = null } = opts;
   const uuid = uuidv4();
   const result = await db.execute(sql`
     INSERT INTO gyms (uuid, name, slug, owner_id, is_public, deleted_at, merged_into_gym_id, created_at, updated_at)
-    VALUES (${uuid}, ${name}, ${uuid}, ${REPORTER}, true, ${deleted ? sql`now()` : null}, ${mergedIntoId}, now(), now())
+    VALUES (${uuid}, ${name}, ${uuid}, ${ownerId}, ${isPublic}, ${deleted ? sql`now()` : null}, ${mergedIntoId}, now(), now())
     RETURNING id
   `);
   return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
@@ -56,6 +59,7 @@ beforeEach(async () => {
   vi.mocked(sendGymDuplicateReportAdminNotification).mockImplementation(() => Promise.resolve());
   await db.execute(sql`TRUNCATE TABLE "gym_members", "gyms" RESTART IDENTITY CASCADE`);
   await insertUser(REPORTER, 'Reporter Rae');
+  await insertUser(STRANGER, 'Strange Stranger');
 });
 
 describe('reportGymDuplicate — validation', () => {
@@ -101,6 +105,27 @@ describe('reportGymDuplicate — validation', () => {
     await expect(
       reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: merged.uuid }, authCtx(REPORTER)),
     ).rejects.toMatchObject({ extensions: { code: 'NOT_FOUND' } });
+  });
+
+  it("won't confirm or email a stranger's private gym (no existence oracle)", async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    // A private gym owned by someone else — invisible to this reporter.
+    const strangerPrivate = await insertGym({ name: 'Secret Home Wall', ownerId: STRANGER, isPublic: false });
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: strangerPrivate.uuid }, authCtx(REPORTER)),
+    ).rejects.toMatchObject({ extensions: { code: 'NOT_FOUND' } });
+    expect(sendGymDuplicateReportAdminNotification).not.toHaveBeenCalled();
+  });
+
+  it('lets a reporter flag their OWN private gym as a duplicate', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const ownPrivate = await insertGym({ name: 'My Garage', ownerId: REPORTER, isPublic: false });
+    const result = await reportGymDuplicate(
+      { gymUuid: gym.uuid, duplicateGymUuid: ownPrivate.uuid },
+      authCtx(REPORTER),
+    );
+    expect(result).toEqual({ status: 'reported' });
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/backend/src/__tests__/gym-report-duplicate.test.ts
+++ b/packages/backend/src/__tests__/gym-report-duplicate.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, vi } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { resetAllRateLimits } from '../utils/rate-limiter';
+
+// The resolver imports the email module via '../../../email/email-service', which
+// resolves to the same absolute path as '../email/email-service' from here, so this
+// mock intercepts it. vi.mock is hoisted; the `import` below binds to the mock.
+vi.mock('../email/email-service', () => ({
+  sendGymDuplicateReportAdminNotification: vi.fn(() => Promise.resolve()),
+}));
+
+import { socialGymReportMutations } from '../graphql/resolvers/social/gym-reports';
+import { sendGymDuplicateReportAdminNotification } from '../email/email-service';
+
+let connectionCounter = 0;
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}-${connectionCounter++}`, isAuthenticated: true, userId }) as ConnectionContext;
+const anonCtx = (): ConnectionContext =>
+  ({ connectionId: `conn-anon-${connectionCounter++}`, isAuthenticated: false }) as ConnectionContext;
+
+const REPORTER = 'gdr-reporter';
+
+const insertUser = (id: string, name: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${name}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+const insertGym = async (opts: {
+  name: string;
+  deleted?: boolean;
+  mergedIntoId?: number | null;
+}): Promise<{ id: number; uuid: string }> => {
+  const { name, deleted = false, mergedIntoId = null } = opts;
+  const uuid = uuidv4();
+  const result = await db.execute(sql`
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, deleted_at, merged_into_gym_id, created_at, updated_at)
+    VALUES (${uuid}, ${name}, ${uuid}, ${REPORTER}, true, ${deleted ? sql`now()` : null}, ${mergedIntoId}, now(), now())
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
+};
+
+const reportGymDuplicate = (input: unknown, ctx: ConnectionContext) =>
+  socialGymReportMutations.reportGymDuplicate(null, { input }, ctx) as Promise<{
+    status: 'reported' | 'already_reported';
+  }>;
+
+beforeEach(async () => {
+  resetAllRateLimits();
+  vi.mocked(sendGymDuplicateReportAdminNotification).mockClear();
+  vi.mocked(sendGymDuplicateReportAdminNotification).mockImplementation(() => Promise.resolve());
+  await db.execute(sql`TRUNCATE TABLE "gym_members", "gyms" RESTART IDENTITY CASCADE`);
+  await insertUser(REPORTER, 'Reporter Rae');
+});
+
+describe('reportGymDuplicate — validation', () => {
+  it('requires authentication', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+    await expect(reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, anonCtx())).rejects.toThrow(
+      /Authentication required/,
+    );
+    expect(sendGymDuplicateReportAdminNotification).not.toHaveBeenCalled();
+  });
+
+  it('rejects a gym reported as a duplicate of itself', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: gym.uuid }, authCtx(REPORTER)),
+    ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } });
+    expect(sendGymDuplicateReportAdminNotification).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the reporting gym does not exist', async () => {
+    const dup = await insertGym({ name: 'Bahnhof Bloc' });
+    await expect(
+      reportGymDuplicate({ gymUuid: uuidv4(), duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
+    ).rejects.toMatchObject({ extensions: { code: 'NOT_FOUND' } });
+    expect(sendGymDuplicateReportAdminNotification).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the reported duplicate does not exist', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: uuidv4() }, authCtx(REPORTER)),
+    ).rejects.toMatchObject({ extensions: { code: 'NOT_FOUND' } });
+  });
+
+  it('treats a soft-deleted or already-merged gym as gone', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const deleted = await insertGym({ name: 'Bahnhof Bloc', deleted: true });
+    const merged = await insertGym({ name: 'Bahnhof Bloc', mergedIntoId: gym.id });
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: deleted.uuid }, authCtx(REPORTER)),
+    ).rejects.toMatchObject({ extensions: { code: 'NOT_FOUND' } });
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: merged.uuid }, authCtx(REPORTER)),
+    ).rejects.toMatchObject({ extensions: { code: 'NOT_FOUND' } });
+  });
+});
+
+describe('reportGymDuplicate — admin notification', () => {
+  it('emails the team with both gyms and the reporter name, then returns reported', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+
+    const result = await reportGymDuplicate(
+      { gymUuid: gym.uuid, duplicateGymUuid: dup.uuid, note: 'Same wall, two entries' },
+      authCtx(REPORTER),
+    );
+
+    expect(result).toEqual({ status: 'reported' });
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledWith({
+      gymName: 'Bahnhof Bloc',
+      gymUuid: gym.uuid,
+      duplicateGymName: 'Bahnhof Bloc (Kilter)',
+      duplicateGymUuid: dup.uuid,
+      reporterName: 'Reporter Rae',
+      note: 'Same wall, two entries',
+    });
+  });
+});
+
+describe('reportGymDuplicate — de-duplication', () => {
+  it('de-dupes a repeat report of the same pair without re-emailing', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+
+    const first = await reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER));
+    const second = await reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER));
+
+    expect(first).toEqual({ status: 'reported' });
+    expect(second).toEqual({ status: 'already_reported' });
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('de-dupes regardless of which gym is named first', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+
+    await reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER));
+    const flipped = await reportGymDuplicate({ gymUuid: dup.uuid, duplicateGymUuid: gym.uuid }, authCtx(REPORTER));
+
+    expect(flipped).toEqual({ status: 'already_reported' });
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the pair when the email send fails, so a retry goes through', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+
+    vi.mocked(sendGymDuplicateReportAdminNotification).mockRejectedValueOnce(new Error('SMTP down'));
+
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
+    ).rejects.toMatchObject({ extensions: { code: 'INTERNAL_SERVER_ERROR' } });
+
+    const retry = await reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER));
+    expect(retry).toEqual({ status: 'reported' });
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('reportGymDuplicate — rate limit', () => {
+  it('rate limits repeated reports with a RATE_LIMITED code', async () => {
+    const rateLimitUser = `gdr-rl-${uuidv4()}`;
+    await insertUser(rateLimitUser, 'Rate Limited');
+    const ctx = authCtx(rateLimitUser);
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+
+    // Distinct duplicate targets so the per-pair de-dup never short-circuits before
+    // the per-user limiter (10/min) trips. The bound is generous, so this holds
+    // whether Redis is connected or the in-memory fallback is active.
+    const dups = await Promise.all(Array.from({ length: 40 }, (_, index) => insertGym({ name: `Twin ${index}` })));
+
+    let code: string | undefined;
+    for (const dup of dups) {
+      try {
+        await reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, ctx);
+      } catch (error) {
+        code = (error as { extensions?: { code?: string } }).extensions?.code;
+        if (code === 'RATE_LIMITED') break;
+      }
+    }
+    expect(code).toBe('RATE_LIMITED');
+  });
+});

--- a/packages/backend/src/email/email-service.ts
+++ b/packages/backend/src/email/email-service.ts
@@ -176,6 +176,46 @@ export async function sendGymClaimAdminNotification(details: {
 }
 
 /**
+ * Notify the Boardsesh team that a gym owner (or a signed-in climber) flagged two
+ * listings as the same gym, so an admin can fold them together in the merge queue.
+ */
+export async function sendGymDuplicateReportAdminNotification(details: {
+  gymName: string;
+  gymUuid: string;
+  duplicateGymName: string;
+  duplicateGymUuid: string;
+  reporterName: string;
+  note?: string | null;
+}): Promise<void> {
+  // Static path, no user input — used raw in the href (see the verify email note).
+  const reviewUrl = `${webPublicUrl()}/admin/gym-duplicates`;
+  const safeGym = escapeHtml(details.gymName);
+  const safeDuplicate = escapeHtml(details.duplicateGymName);
+  const safeReporter = escapeHtml(details.reporterName);
+  const safeNote = details.note ? escapeHtml(details.note) : null;
+
+  await getTransporter().sendMail({
+    from: fromAddress(),
+    to: ADMIN_NOTIFICATION_EMAIL,
+    subject: headerSafe(`Duplicate gym report: ${details.gymName}`),
+    html: shell(
+      'Duplicate gym report',
+      `
+      <p style="color: ${colors.textPrimary}; font-size: 16px; line-height: 1.5;">
+        <strong>${safeReporter}</strong> says <strong>${safeGym}</strong> and <strong>${safeDuplicate}</strong> are the same gym.
+      </p>
+      ${safeNote ? `<p style="color: ${colors.textSecondary}; font-size: 15px; line-height: 1.5;">"${safeNote}"</p>` : ''}
+      ${button(reviewUrl, 'Review duplicates')}
+      <hr style="border: none; border-top: 1px solid ${colors.border}; margin: 32px 0;" />
+      <p style="color: ${colors.textMuted}; font-size: 12px;">Gym UUID: ${escapeHtml(details.gymUuid)}</p>
+      <p style="color: ${colors.textMuted}; font-size: 12px;">Reported duplicate UUID: ${escapeHtml(details.duplicateGymUuid)}</p>
+    `,
+    ),
+    text: `${details.reporterName} says ${details.gymName} and ${details.duplicateGymName} are the same gym.${details.note ? `\n\nNote: ${details.note}` : ''}\n\nReview: ${reviewUrl}\n\nGym UUID: ${details.gymUuid}\nReported duplicate UUID: ${details.duplicateGymUuid}`,
+  });
+}
+
+/**
  * Let the claimant know their claim went through (domain-verified or approved).
  * Best-effort — failures are logged, never thrown, so they don't undo an
  * already-applied ownership transfer.

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -42,6 +42,7 @@ import { socialGymKioskQueries, socialGymKioskMutations } from './social/gym-kio
 import { socialGymInsightsQueries } from './social/gym-insights';
 import { socialGymClaimQueries, socialGymClaimMutations } from './social/gym-claims';
 import { socialGymDuplicateQueries, socialGymDuplicateMutations } from './social/gym-duplicates';
+import { socialGymReportMutations } from './social/gym-reports';
 import {
   socialNotificationQueries,
   socialNotificationMutations,
@@ -127,6 +128,7 @@ export const resolvers = {
     ...socialGymKioskMutations,
     ...socialGymClaimMutations,
     ...socialGymDuplicateMutations,
+    ...socialGymReportMutations,
     ...socialNotificationMutations,
     ...socialProposalMutations,
     ...socialRoleMutations,

--- a/packages/backend/src/graphql/resolvers/social/gym-reports.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-reports.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, or } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import * as dbSchema from '@boardsesh/db/schema';
@@ -15,7 +15,9 @@ import { logger } from '../../../utils/logger';
 // in-memory window limiter below rather than a persisted row. This is per-instance,
 // best-effort de-dup — enough to stop one flurry of clicks (or two climbers flagging
 // the same pair) from spamming the team, while the per-user `applyRateLimit` bounds
-// overall volume. A durable reports table can replace this in a later PR.
+// overall volume. Known limitation: in-memory de-dup resets on deploy and doesn't
+// span instances, so the same pair can re-email after a restart or from another node.
+// A Redis-backed (SET NX EX) de-dup + a durable reports table are the follow-up.
 const REPORT_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 /** One stable key per unordered gym pair, so (A,B) and (B,A) de-dupe together. */
@@ -35,12 +37,29 @@ async function loadReporterName(userId: string): Promise<string> {
   return reporter?.displayName || reporter?.name || 'A Boardsesh user';
 }
 
-/** A live (not soft-deleted, not already merged away) gym by uuid, or undefined. */
-async function loadLiveGym(gymUuid: string): Promise<{ id: number; uuid: string; name: string } | undefined> {
+/**
+ * A live (not soft-deleted, not already merged away) gym by uuid, visible to the
+ * viewer, or undefined. Visibility mirrors findSimilarGyms: public gyms and the
+ * viewer's own private gyms only. Without this gate a stranger's private gym would
+ * report as NOT_FOUND vs reported, an oracle confirming the private gym exists (and
+ * leaking its name to admins over email). A viewer can still report their own
+ * private gym as a duplicate.
+ */
+async function loadLiveGym(
+  gymUuid: string,
+  viewerUserId: string,
+): Promise<{ id: number; uuid: string; name: string } | undefined> {
   const [gym] = await db
     .select({ id: dbSchema.gyms.id, uuid: dbSchema.gyms.uuid, name: dbSchema.gyms.name })
     .from(dbSchema.gyms)
-    .where(and(eq(dbSchema.gyms.uuid, gymUuid), isNull(dbSchema.gyms.deletedAt), isNull(dbSchema.gyms.mergedIntoGymId)))
+    .where(
+      and(
+        eq(dbSchema.gyms.uuid, gymUuid),
+        isNull(dbSchema.gyms.deletedAt),
+        isNull(dbSchema.gyms.mergedIntoGymId),
+        or(eq(dbSchema.gyms.isPublic, true), eq(dbSchema.gyms.ownerId, viewerUserId)),
+      ),
+    )
     .limit(1);
   return gym;
 }
@@ -51,6 +70,10 @@ export const socialGymReportMutations = {
     { input }: { input: unknown },
     ctx: ConnectionContext,
   ): Promise<{ status: 'reported' | 'already_reported' }> => {
+    // Intentionally NOT owner-gated: a duplicate report is a community data-quality
+    // signal, so any signed-in climber who spots two listings of a gym can flag them
+    // (not just the owner). The 10/min per-user ceiling — shared with the gym-claim
+    // flow — bounds abuse. Do not tighten this to owners-only.
     requireAuthenticated(ctx);
     await applyRateLimit(ctx, 10, 'reportGymDuplicate');
 
@@ -64,8 +87,8 @@ export const socialGymReportMutations = {
     }
 
     const [gym, duplicate] = await Promise.all([
-      loadLiveGym(validatedInput.gymUuid),
-      loadLiveGym(validatedInput.duplicateGymUuid),
+      loadLiveGym(validatedInput.gymUuid, userId),
+      loadLiveGym(validatedInput.duplicateGymUuid, userId),
     ]);
     if (!gym) {
       throw new GraphQLError('The gym you are reporting from no longer exists.', {
@@ -77,6 +100,12 @@ export const socialGymReportMutations = {
         extensions: { code: 'NOT_FOUND' },
       });
     }
+
+    // Resolve the reporter name BEFORE claiming the de-dup window: if this read
+    // threw after marking, the catch below (which only fires for the send) would
+    // never run, stranding the pair as 'reported' for the full window with no email
+    // ever sent — the report would be silently lost.
+    const reporterName = await loadReporterName(userId);
 
     // De-dup: the first report of this pair claims the window; a repeat inside it
     // returns without re-emailing. Marked BEFORE the send so concurrent clicks
@@ -91,7 +120,6 @@ export const socialGymReportMutations = {
       throw error;
     }
 
-    const reporterName = await loadReporterName(userId);
     try {
       await sendGymDuplicateReportAdminNotification({
         gymName: gym.name,

--- a/packages/backend/src/graphql/resolvers/social/gym-reports.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-reports.ts
@@ -1,0 +1,116 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import * as dbSchema from '@boardsesh/db/schema';
+import { db } from '../../../db/client';
+import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
+import { ReportGymDuplicateInputSchema } from '../../../validation/schemas';
+import { sendGymDuplicateReportAdminNotification } from '../../../email/email-service';
+import { checkRateLimit, cleanupRateLimit, RateLimitError } from '../../../utils/rate-limiter';
+import { logger } from '../../../utils/logger';
+
+// Owner-facing "report a duplicate" surfaces the pair to admins by email (the same
+// admin-notification path a queued gym claim uses). It is deliberately migration-free:
+// no dedicated table, so repeated reports of the SAME pair are de-duplicated with the
+// in-memory window limiter below rather than a persisted row. This is per-instance,
+// best-effort de-dup — enough to stop one flurry of clicks (or two climbers flagging
+// the same pair) from spamming the team, while the per-user `applyRateLimit` bounds
+// overall volume. A durable reports table can replace this in a later PR.
+const REPORT_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/** One stable key per unordered gym pair, so (A,B) and (B,A) de-dupe together. */
+function duplicateReportDedupKey(firstUuid: string, secondUuid: string): string {
+  const [low, high] = [firstUuid, secondUuid].sort();
+  return `gymDuplicateReport:${low}:${high}`;
+}
+
+/** The reporter's display name for the admin email, falling back to a neutral label. */
+async function loadReporterName(userId: string): Promise<string> {
+  const [reporter] = await db
+    .select({ name: dbSchema.users.name, displayName: dbSchema.userProfiles.displayName })
+    .from(dbSchema.users)
+    .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
+    .where(eq(dbSchema.users.id, userId))
+    .limit(1);
+  return reporter?.displayName || reporter?.name || 'A Boardsesh user';
+}
+
+/** A live (not soft-deleted, not already merged away) gym by uuid, or undefined. */
+async function loadLiveGym(gymUuid: string): Promise<{ id: number; uuid: string; name: string } | undefined> {
+  const [gym] = await db
+    .select({ id: dbSchema.gyms.id, uuid: dbSchema.gyms.uuid, name: dbSchema.gyms.name })
+    .from(dbSchema.gyms)
+    .where(and(eq(dbSchema.gyms.uuid, gymUuid), isNull(dbSchema.gyms.deletedAt), isNull(dbSchema.gyms.mergedIntoGymId)))
+    .limit(1);
+  return gym;
+}
+
+export const socialGymReportMutations = {
+  reportGymDuplicate: async (
+    _: unknown,
+    { input }: { input: unknown },
+    ctx: ConnectionContext,
+  ): Promise<{ status: 'reported' | 'already_reported' }> => {
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, 10, 'reportGymDuplicate');
+
+    const validatedInput = validateInput(ReportGymDuplicateInputSchema, input, 'input');
+    const userId = ctx.userId!;
+
+    if (validatedInput.gymUuid === validatedInput.duplicateGymUuid) {
+      throw new GraphQLError("A gym can't be a duplicate of itself.", {
+        extensions: { code: 'BAD_USER_INPUT' },
+      });
+    }
+
+    const [gym, duplicate] = await Promise.all([
+      loadLiveGym(validatedInput.gymUuid),
+      loadLiveGym(validatedInput.duplicateGymUuid),
+    ]);
+    if (!gym) {
+      throw new GraphQLError('The gym you are reporting from no longer exists.', {
+        extensions: { code: 'NOT_FOUND' },
+      });
+    }
+    if (!duplicate) {
+      throw new GraphQLError('The gym you picked as a duplicate no longer exists.', {
+        extensions: { code: 'NOT_FOUND' },
+      });
+    }
+
+    // De-dup: the first report of this pair claims the window; a repeat inside it
+    // returns without re-emailing. Marked BEFORE the send so concurrent clicks
+    // collapse to one, and released on send failure so a retry isn't stranded.
+    const dedupKey = duplicateReportDedupKey(gym.uuid, duplicate.uuid);
+    try {
+      checkRateLimit(dedupKey, 1, REPORT_DEDUP_WINDOW_MS);
+    } catch (error) {
+      if (error instanceof RateLimitError) {
+        return { status: 'already_reported' };
+      }
+      throw error;
+    }
+
+    const reporterName = await loadReporterName(userId);
+    try {
+      await sendGymDuplicateReportAdminNotification({
+        gymName: gym.name,
+        gymUuid: gym.uuid,
+        duplicateGymName: duplicate.name,
+        duplicateGymUuid: duplicate.uuid,
+        reporterName,
+        note: validatedInput.note ?? null,
+      });
+    } catch (error) {
+      // The email IS the record for this pair, so a failed send must not leave the
+      // pair marked reported — release it so the climber can try again.
+      cleanupRateLimit(dedupKey);
+      logger.error('[GymDuplicateReport] Failed to send admin notification:', error);
+      throw new GraphQLError("We couldn't send that report. Try again in a moment.", {
+        extensions: { code: 'INTERNAL_SERVER_ERROR' },
+      });
+    }
+
+    return { status: 'reported' };
+  },
+};

--- a/packages/backend/src/validation/schemas/gyms.ts
+++ b/packages/backend/src/validation/schemas/gyms.ts
@@ -122,6 +122,17 @@ export const RequestGymClaimInputSchema = z.object({
 });
 
 /**
+ * Report-a-duplicate input validation schema. An owner (or any signed-in climber)
+ * who sees a second listing of a gym flags the pair for the admin merge queue.
+ * The resolver additionally checks the two uuids are distinct and both live.
+ */
+export const ReportGymDuplicateInputSchema = z.object({
+  gymUuid: UUIDSchema,
+  duplicateGymUuid: UUIDSchema,
+  note: z.string().max(GYM_CLAIM_MESSAGE_MAX_LENGTH, 'Note too long').optional(),
+});
+
+/**
  * Review gym claim input validation schema (admin)
  */
 export const ReviewGymClaimInputSchema = z.object({

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -3357,6 +3357,27 @@ input DismissGymClusterInput {
   canonicalGymUuid: ID!
 }
 
+"Input for an owner-facing duplicate report: the gym being viewed and the listing the reporter believes is the same gym."
+input ReportGymDuplicateInput {
+  "The gym the report is filed from (usually the one the reporter is viewing)."
+  gymUuid: ID!
+  "The other listing the reporter believes is the same gym."
+  duplicateGymUuid: ID!
+  "Optional free-text context for the admin who reviews the pair."
+  note: String
+}
+
+"Outcome of a reportGymDuplicate call."
+type ReportGymDuplicateResult {
+  "`reported` when the pair was surfaced to admins; `already_reported` when the same pair was flagged recently and no duplicate signal was sent."
+  status: ReportGymDuplicateStatus!
+}
+
+enum ReportGymDuplicateStatus {
+  reported
+  already_reported
+}
+
 # ============================================
 # Gym Kiosk Types (smart-TV wall dashboard)
 # ============================================
@@ -6204,6 +6225,13 @@ type Mutation {
   not a duplicate so the review queue hides it. Touches no gym row.
   """
   dismissGymCluster(input: DismissGymClusterInput!): Boolean!
+
+  """
+  Report that two gym listings are the same gym (any signed-in user). Surfaces the
+  pair to admins for review in the merge queue. Rate-limited and de-duplicated per
+  pair so repeated reports don't spam the team.
+  """
+  reportGymDuplicate(input: ReportGymDuplicateInput!): ReportGymDuplicateResult!
 
   # ============================================
   # Gym Kiosk Mutations (require gym edit access)

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -3134,6 +3134,12 @@ export type Mutation = {
    */
   reportBoardDisconnect: Scalars['Boolean']['output'];
   /**
+   * Report that two gym listings are the same gym (any signed-in user). Surfaces the
+   * pair to admins for review in the merge queue. Rate-limited and de-duplicated per
+   * pair so repeated reports don't spam the team.
+   */
+  reportGymDuplicate: ReportGymDuplicateResult;
+  /**
    * Report that this client's BLE link to the wall dropped (explicit lightbulb-off or a
    * detected drop), so every session participant turns the queue-control-bar lightbulb off.
    * The current climb is unchanged — pressing the lightbulb re-asserts (re-sends) it.
@@ -3673,6 +3679,11 @@ export type MutationReportBoardClimbArgs = {
 /** Root mutation type for all write operations. */
 export type MutationReportBoardDisconnectArgs = {
   boardId: Scalars['Int']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationReportGymDuplicateArgs = {
+  input: ReportGymDuplicateInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -5811,6 +5822,25 @@ export type ReorderPlaylistClimbInput = {
   /** Playlist ID */
   playlistId: Scalars['ID']['input'];
 };
+
+/** Input for an owner-facing duplicate report: the gym being viewed and the listing the reporter believes is the same gym. */
+export type ReportGymDuplicateInput = {
+  /** The other listing the reporter believes is the same gym. */
+  duplicateGymUuid: Scalars['ID']['input'];
+  /** The gym the report is filed from (usually the one the reporter is viewing). */
+  gymUuid: Scalars['ID']['input'];
+  /** Optional free-text context for the admin who reviews the pair. */
+  note?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Outcome of a reportGymDuplicate call. */
+export type ReportGymDuplicateResult = {
+  __typename?: 'ReportGymDuplicateResult';
+  /** `reported` when the pair was surfaced to admins; `already_reported` when the same pair was flagged recently and no duplicate signal was sent. */
+  status: ReportGymDuplicateStatus;
+};
+
+export type ReportGymDuplicateStatus = 'already_reported' | 'reported';
 
 /** Input for requesting ownership of a gym. */
 export type RequestGymClaimInput = {
@@ -7974,6 +8004,9 @@ export type ResolversTypes = ResolversObject<{
   RemoveFavoriteInput: RemoveFavoriteInput;
   RemoveGymMemberInput: RemoveGymMemberInput;
   ReorderPlaylistClimbInput: ReorderPlaylistClimbInput;
+  ReportGymDuplicateInput: ReportGymDuplicateInput;
+  ReportGymDuplicateResult: ResolverTypeWrapper<ReportGymDuplicateResult>;
+  ReportGymDuplicateStatus: ReportGymDuplicateStatus;
   RequestGymClaimInput: RequestGymClaimInput;
   RequestGymClaimResult: ResolverTypeWrapper<RequestGymClaimResult>;
   ResolveBoardResult: ResolverTypeWrapper<ResolveBoardResult>;
@@ -8312,6 +8345,8 @@ export type ResolversParentTypes = ResolversObject<{
   RemoveFavoriteInput: RemoveFavoriteInput;
   RemoveGymMemberInput: RemoveGymMemberInput;
   ReorderPlaylistClimbInput: ReorderPlaylistClimbInput;
+  ReportGymDuplicateInput: ReportGymDuplicateInput;
+  ReportGymDuplicateResult: ReportGymDuplicateResult;
   RequestGymClaimInput: RequestGymClaimInput;
   RequestGymClaimResult: RequestGymClaimResult;
   ResolveBoardResult: ResolveBoardResult;
@@ -10239,6 +10274,12 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationReportBoardDisconnectArgs, 'boardId'>
   >;
+  reportGymDuplicate?: Resolver<
+    ResolversTypes['ReportGymDuplicateResult'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationReportGymDuplicateArgs, 'input'>
+  >;
   reportWallDisconnect?: Resolver<ResolversTypes['Session'], ParentType, ContextType>;
   requestGymClaim?: Resolver<
     ResolversTypes['RequestGymClaimResult'],
@@ -11618,6 +11659,15 @@ export type RecentBetaLinkResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type ReportGymDuplicateResultResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['ReportGymDuplicateResult'] =
+    ResolversParentTypes['ReportGymDuplicateResult'],
+> = ResolversObject<{
+  status?: Resolver<ResolversTypes['ReportGymDuplicateStatus'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type RequestGymClaimResultResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['RequestGymClaimResult'] = ResolversParentTypes['RequestGymClaimResult'],
@@ -12665,6 +12715,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   QueueReordered?: QueueReorderedResolvers<ContextType>;
   QueueState?: QueueStateResolvers<ContextType>;
   RecentBetaLink?: RecentBetaLinkResolvers<ContextType>;
+  ReportGymDuplicateResult?: ReportGymDuplicateResultResolvers<ContextType>;
   RequestGymClaimResult?: RequestGymClaimResultResolvers<ContextType>;
   ResolveBoardResult?: ResolveBoardResultResolvers<ContextType>;
   ResolvedBoard?: ResolvedBoardResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -759,4 +759,25 @@ export const gymsTypeDefs = /* GraphQL */ `
     "The suggested canonical member, recorded on the dismissal audit row."
     canonicalGymUuid: ID!
   }
+
+  "Input for an owner-facing duplicate report: the gym being viewed and the listing the reporter believes is the same gym."
+  input ReportGymDuplicateInput {
+    "The gym the report is filed from (usually the one the reporter is viewing)."
+    gymUuid: ID!
+    "The other listing the reporter believes is the same gym."
+    duplicateGymUuid: ID!
+    "Optional free-text context for the admin who reviews the pair."
+    note: String
+  }
+
+  "Outcome of a reportGymDuplicate call."
+  type ReportGymDuplicateResult {
+    "\`reported\` when the pair was surfaced to admins; \`already_reported\` when the same pair was flagged recently and no duplicate signal was sent."
+    status: ReportGymDuplicateStatus!
+  }
+
+  enum ReportGymDuplicateStatus {
+    reported
+    already_reported
+  }
 `;

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -551,6 +551,13 @@ export const mutationsTypeDefs = /* GraphQL */ `
     """
     dismissGymCluster(input: DismissGymClusterInput!): Boolean!
 
+    """
+    Report that two gym listings are the same gym (any signed-in user). Surfaces the
+    pair to admins for review in the merge queue. Rate-limited and de-duplicated per
+    pair so repeated reports don't spam the team.
+    """
+    reportGymDuplicate(input: ReportGymDuplicateInput!): ReportGymDuplicateResult!
+
     # ============================================
     # Gym Kiosk Mutations (require gym edit access)
     # ============================================

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -374,3 +374,15 @@ export type DismissGymClusterInput = {
   gymUuids: string[];
   canonicalGymUuid: string;
 };
+
+export type ReportGymDuplicateInput = {
+  gymUuid: string;
+  duplicateGymUuid: string;
+  note?: string;
+};
+
+export type ReportGymDuplicateStatus = 'reported' | 'already_reported';
+
+export type ReportGymDuplicateResult = {
+  status: ReportGymDuplicateStatus;
+};

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -3131,6 +3131,12 @@ export type Mutation = {
    */
   reportBoardDisconnect: Scalars['Boolean']['output'];
   /**
+   * Report that two gym listings are the same gym (any signed-in user). Surfaces the
+   * pair to admins for review in the merge queue. Rate-limited and de-duplicated per
+   * pair so repeated reports don't spam the team.
+   */
+  reportGymDuplicate: ReportGymDuplicateResult;
+  /**
    * Report that this client's BLE link to the wall dropped (explicit lightbulb-off or a
    * detected drop), so every session participant turns the queue-control-bar lightbulb off.
    * The current climb is unchanged — pressing the lightbulb re-asserts (re-sends) it.
@@ -3670,6 +3676,11 @@ export type MutationReportBoardClimbArgs = {
 /** Root mutation type for all write operations. */
 export type MutationReportBoardDisconnectArgs = {
   boardId: Scalars['Int']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationReportGymDuplicateArgs = {
+  input: ReportGymDuplicateInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -5808,6 +5819,25 @@ export type ReorderPlaylistClimbInput = {
   /** Playlist ID */
   playlistId: Scalars['ID']['input'];
 };
+
+/** Input for an owner-facing duplicate report: the gym being viewed and the listing the reporter believes is the same gym. */
+export type ReportGymDuplicateInput = {
+  /** The other listing the reporter believes is the same gym. */
+  duplicateGymUuid: Scalars['ID']['input'];
+  /** The gym the report is filed from (usually the one the reporter is viewing). */
+  gymUuid: Scalars['ID']['input'];
+  /** Optional free-text context for the admin who reviews the pair. */
+  note?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Outcome of a reportGymDuplicate call. */
+export type ReportGymDuplicateResult = {
+  __typename?: 'ReportGymDuplicateResult';
+  /** `reported` when the pair was surfaced to admins; `already_reported` when the same pair was flagged recently and no duplicate signal was sent. */
+  status: ReportGymDuplicateStatus;
+};
+
+export type ReportGymDuplicateStatus = 'already_reported' | 'reported';
 
 /** Input for requesting ownership of a gym. */
 export type RequestGymClaimInput = {

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -31,6 +31,8 @@ import type {
   MergeGymsInput,
   MergeGymsResult,
   DismissGymClusterInput,
+  ReportGymDuplicateInput,
+  ReportGymDuplicateResult,
 } from '@boardsesh/shared-schema';
 
 // ============================================
@@ -411,6 +413,14 @@ export const DISMISS_GYM_CLUSTER = gql`
   }
 `;
 
+export const REPORT_GYM_DUPLICATE = gql`
+  mutation ReportGymDuplicate($input: ReportGymDuplicateInput!) {
+    reportGymDuplicate(input: $input) {
+      status
+    }
+  }
+`;
+
 // ============================================
 // Query/Mutation Variable Types
 // ============================================
@@ -613,4 +623,12 @@ export type DismissGymClusterMutationVariables = {
 
 export type DismissGymClusterMutationResponse = {
   dismissGymCluster: boolean;
+};
+
+export type ReportGymDuplicateMutationVariables = {
+  input: ReportGymDuplicateInput;
+};
+
+export type ReportGymDuplicateMutationResponse = {
+  reportGymDuplicate: ReportGymDuplicateResult;
 };

--- a/packages/shared/i18n/locales/en-US/admin.json
+++ b/packages/shared/i18n/locales/en-US/admin.json
@@ -296,6 +296,9 @@
       "name": "Gym",
       "address": "Address",
       "counts": "Counts"
+    },
+    "ownerReports": {
+      "note": "Owners can now flag duplicates from their gym page. Those reports arrive as team email for now, so keep an eye on the inbox alongside this queue."
     }
   }
 }

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -615,5 +615,21 @@
         "serverError": "Something went wrong on our end. Try again in a bit."
       }
     }
+  },
+  "reportDuplicate": {
+    "cta": "Report a duplicate",
+    "title": "Report a duplicate",
+    "description": "Seeing {{gym}} listed twice? Point us at the other listing and we'll merge them.",
+    "searchLabel": "Find the duplicate listing",
+    "searchPlaceholder": "Gym name",
+    "noResults": "No matches yet. Try a different name.",
+    "noteLabel": "Anything else? (optional)",
+    "notePlaceholder": "What makes you sure it's the same gym",
+    "submit": "Send report",
+    "cancel": "Cancel",
+    "done": "Done",
+    "sent": "Thanks, we'll take a look and merge them.",
+    "alreadyReported": "You've already flagged this pair. We're on it.",
+    "errorGeneric": "Something went wrong. Try again."
   }
 }

--- a/packages/shared/i18n/locales/es/admin.json
+++ b/packages/shared/i18n/locales/es/admin.json
@@ -296,6 +296,9 @@
       "name": "Gimnasio",
       "address": "Dirección",
       "counts": "Totales"
+    },
+    "ownerReports": {
+      "note": "Los propietarios ahora pueden señalar duplicados desde la página de su gimnasio. Por ahora esos reportes llegan por correo al equipo, así que revisa la bandeja junto a esta cola."
     }
   }
 }

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -615,5 +615,21 @@
         "serverError": "Algo salió mal por nuestra parte. Inténtalo de nuevo en un momento."
       }
     }
+  },
+  "reportDuplicate": {
+    "cta": "Reportar un duplicado",
+    "title": "Reportar un duplicado",
+    "description": "¿Aparece {{gym}} dos veces? Señálanos el otro listado y los fusionamos.",
+    "searchLabel": "Encuentra el listado duplicado",
+    "searchPlaceholder": "Nombre del gimnasio",
+    "noResults": "Aún no hay coincidencias. Prueba con otro nombre.",
+    "noteLabel": "¿Algo más? (opcional)",
+    "notePlaceholder": "Qué te hace pensar que es el mismo gimnasio",
+    "submit": "Enviar reporte",
+    "cancel": "Cancelar",
+    "done": "Listo",
+    "sent": "Gracias, le echamos un vistazo y los fusionamos.",
+    "alreadyReported": "Ya has señalado este par. Estamos en ello.",
+    "errorGeneric": "Algo salió mal. Inténtalo de nuevo."
   }
 }

--- a/packages/shared/i18n/locales/fr/admin.json
+++ b/packages/shared/i18n/locales/fr/admin.json
@@ -296,6 +296,9 @@
       "name": "Salle",
       "address": "Adresse",
       "counts": "Totaux"
+    },
+    "ownerReports": {
+      "note": "Les propriétaires peuvent désormais signaler des doublons depuis la page de leur salle. Pour l'instant ces signalements arrivent par e-mail à l'équipe, alors surveillez la boîte de réception en plus de cette file."
     }
   }
 }

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -615,5 +615,21 @@
         "serverError": "Une erreur est survenue de notre côté. Réessayez dans un instant."
       }
     }
+  },
+  "reportDuplicate": {
+    "cta": "Signaler un doublon",
+    "title": "Signaler un doublon",
+    "description": "Vous voyez {{gym}} en double ? Indiquez-nous l'autre fiche et on les fusionne.",
+    "searchLabel": "Trouver la fiche en double",
+    "searchPlaceholder": "Nom de la salle",
+    "noResults": "Aucune correspondance pour l'instant. Essayez un autre nom.",
+    "noteLabel": "Autre chose ? (facultatif)",
+    "notePlaceholder": "Ce qui vous fait dire que c'est la même salle",
+    "submit": "Envoyer le signalement",
+    "cancel": "Annuler",
+    "done": "Terminé",
+    "sent": "Merci, on regarde ça et on les fusionne.",
+    "alreadyReported": "Vous avez déjà signalé cette paire. On s'en occupe.",
+    "errorGeneric": "Une erreur s'est produite. Réessayez."
   }
 }

--- a/packages/web/app/components/admin/gym-duplicates-panel.tsx
+++ b/packages/web/app/components/admin/gym-duplicates-panel.tsx
@@ -196,6 +196,12 @@ function DuplicatesQueue() {
 
   return (
     <Box>
+      {/* Owner-reported duplicates arrive as team emails (see reportGymDuplicate);
+          there's no persisted reports table yet, so surface where to find them. */}
+      <Alert severity="info" sx={{ mb: 2 }}>
+        {t('gymDuplicates.ownerReports.note')}
+      </Alert>
+
       {kioskWarnings.length > 0 && (
         <Alert severity="warning" sx={{ mb: 2 }} onClose={() => setKioskWarnings([])}>
           <Stack spacing={0.5}>

--- a/packages/web/app/components/gym-entity/__tests__/gym-detail.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/gym-detail.test.tsx
@@ -25,6 +25,7 @@ vi.mock('@/app/components/ui/follow-button', () => ({ default: () => <div data-t
 vi.mock('@/app/components/social/comment-section', () => ({ default: () => <div data-testid="comment-section" /> }));
 vi.mock('../gym-member-management', () => ({ default: () => <div data-testid="member-management" /> }));
 vi.mock('../claim-gym-dialog', () => ({ default: () => null }));
+vi.mock('../report-duplicate-dialog', () => ({ default: () => null }));
 vi.mock('../edit-gym-form', () => ({ default: () => null }));
 
 vi.mock('@/app/hooks/use-ws-auth-token', () => ({

--- a/packages/web/app/components/gym-entity/__tests__/report-duplicate-dialog.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/report-duplicate-dialog.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import type { SimilarGym } from '@boardsesh/shared-schema';
+
+// Minimal i18n: echo the key (with {{var}} interpolation) so assertions target keys.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (!vars) return key;
+      return Object.entries(vars).reduce((out, [name, value]) => out.replace(`{{${name}}}`, String(value)), key);
+    },
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token' }),
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@boardsesh/graphql/operations', () => ({
+  FIND_SIMILAR_GYMS: 'FIND_SIMILAR_GYMS',
+  REPORT_GYM_DUPLICATE: 'REPORT_GYM_DUPLICATE',
+}));
+
+vi.mock('@boardsesh/gym-claim', () => ({
+  GYM_CLAIM_MESSAGE_MAX_LENGTH: 1000,
+}));
+
+import ReportDuplicateDialog from '../report-duplicate-dialog';
+
+const gymFixture = (overrides: Partial<SimilarGym> = {}): SimilarGym => ({
+  uuid: 'gym-2',
+  slug: 'bahnhof-bloc-annex',
+  name: 'Bahnhof Bloc Annex',
+  address: 'Zurich',
+  website: null,
+  distanceMeters: 60,
+  ownerType: 'SYSTEM',
+  isClaimable: false,
+  providerOrigins: ['kilter'],
+  ...overrides,
+});
+
+// The FIND query returns suggestions; the REPORT mutation returns a status. Branch
+// on the (mocked) operation constant so one mock serves both round-trips.
+function wireRequests(opts: { suggestions: SimilarGym[]; reportStatus?: 'reported' | 'already_reported' }) {
+  mockRequest.mockImplementation((operation: string) => {
+    if (operation === 'REPORT_GYM_DUPLICATE') {
+      return Promise.resolve({ reportGymDuplicate: { status: opts.reportStatus ?? 'reported' } });
+    }
+    return Promise.resolve({ findSimilarGyms: opts.suggestions });
+  });
+}
+
+function renderDialog() {
+  return render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <ReportDuplicateDialog
+        gymUuid="gym-self"
+        gymName="Bahnhof Bloc"
+        latitude={47.0}
+        longitude={8.0}
+        open
+        onClose={vi.fn()}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ReportDuplicateDialog', () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it('reuses findSimilarGyms for suggestions and never offers the gym itself', async () => {
+    wireRequests({
+      suggestions: [gymFixture(), gymFixture({ uuid: 'gym-self', name: 'This Very Gym' })],
+    });
+
+    renderDialog();
+
+    // The seeded search (the gym's own name) fires the lookup after the debounce.
+    await waitFor(() => expect(screen.getByText('Bahnhof Bloc Annex')).toBeTruthy(), { timeout: 3000 });
+    // The current gym is filtered out of its own duplicate suggestions.
+    expect(screen.queryByText('This Very Gym')).toBeNull();
+
+    // The FIND query was seeded with the gym's own name.
+    const findCall = mockRequest.mock.calls.find((call) => call[0] === 'FIND_SIMILAR_GYMS');
+    expect(findCall?.[1]).toMatchObject({ input: { name: 'Bahnhof Bloc', latitude: 47.0, longitude: 8.0 } });
+  });
+
+  it('submits a report for the picked duplicate and confirms', async () => {
+    wireRequests({ suggestions: [gymFixture()], reportStatus: 'reported' });
+
+    renderDialog();
+
+    await waitFor(() => expect(screen.getByText('Bahnhof Bloc Annex')).toBeTruthy(), { timeout: 3000 });
+
+    // Submit is gated until a candidate is picked.
+    expect(screen.getByText('reportDuplicate.submit').closest('button')?.disabled).toBe(true);
+
+    fireEvent.click(screen.getByText('Bahnhof Bloc Annex'));
+    await waitFor(() => expect(screen.getByText('reportDuplicate.submit').closest('button')?.disabled).toBe(false));
+
+    fireEvent.click(screen.getByText('reportDuplicate.submit'));
+
+    await waitFor(() => expect(screen.getByText('reportDuplicate.sent')).toBeTruthy(), { timeout: 3000 });
+
+    const reportCall = mockRequest.mock.calls.find((call) => call[0] === 'REPORT_GYM_DUPLICATE');
+    expect(reportCall?.[1]).toMatchObject({ input: { gymUuid: 'gym-self', duplicateGymUuid: 'gym-2' } });
+  });
+
+  it('shows the already-reported message when the pair was flagged before', async () => {
+    wireRequests({ suggestions: [gymFixture()], reportStatus: 'already_reported' });
+
+    renderDialog();
+
+    await waitFor(() => expect(screen.getByText('Bahnhof Bloc Annex')).toBeTruthy(), { timeout: 3000 });
+    fireEvent.click(screen.getByText('Bahnhof Bloc Annex'));
+    fireEvent.click(screen.getByText('reportDuplicate.submit'));
+
+    await waitFor(() => expect(screen.getByText('reportDuplicate.alreadyReported')).toBeTruthy(), { timeout: 3000 });
+  });
+});

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -26,6 +26,7 @@ import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
 import ChatBubbleOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
+import FlagOutlined from '@mui/icons-material/FlagOutlined';
 import type { Gym } from '@boardsesh/shared-schema';
 import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
@@ -51,6 +52,7 @@ import { GYM_KIOSK_FLAG } from '@/app/flags';
 import EditGymForm from './edit-gym-form';
 import GymMemberManagement from './gym-member-management';
 import ClaimGymDialog from './claim-gym-dialog';
+import ReportDuplicateDialog from './report-duplicate-dialog';
 import GymStatChip from './gym-stat-chip';
 import CommentSection from '@/app/components/social/comment-section';
 
@@ -73,6 +75,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
   const [isDeleting, setIsDeleting] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showClaimDialog, setShowClaimDialog] = useState(false);
+  const [showReportDialog, setShowReportDialog] = useState(false);
   const { token } = useWsAuthToken();
   const { data: session } = useSession();
   const { showMessage } = useSnackbar();
@@ -101,6 +104,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
       setActiveTab(0);
       // This is a single reused instance across gyms — clear per-gym dialog state.
       setShowClaimDialog(false);
+      setShowReportDialog(false);
       setShowDeleteDialog(false);
     }
   }, [open, fetchGym]);
@@ -321,6 +325,19 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
               </MuiButton>
             )}
           </Box>
+
+          {/* Low-key "see two of this gym?" flag for any signed-in climber. */}
+          {currentUserId && (
+            <MuiButton
+              variant="text"
+              size="small"
+              startIcon={<FlagOutlined sx={{ fontSize: 16 }} />}
+              onClick={() => setShowReportDialog(true)}
+              sx={{ textTransform: 'none', mt: 1, color: 'text.secondary' }}
+            >
+              {t('reportDuplicate.cta')}
+            </MuiButton>
+          )}
         </Box>
 
         <Divider />
@@ -369,6 +386,18 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
           website={gym.website}
           open={showClaimDialog}
           onClose={() => setShowClaimDialog(false)}
+        />
+      )}
+
+      {/* Report a duplicate dialog */}
+      {gym && (
+        <ReportDuplicateDialog
+          gymUuid={gym.uuid}
+          gymName={gym.name}
+          latitude={gym.latitude}
+          longitude={gym.longitude}
+          open={showReportDialog}
+          onClose={() => setShowReportDialog(false)}
         />
       )}
 

--- a/packages/web/app/components/gym-entity/report-duplicate-dialog.tsx
+++ b/packages/web/app/components/gym-entity/report-duplicate-dialog.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import MuiButton from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import Chip from '@mui/material/Chip';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
+import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutline';
+import type { SimilarGym } from '@boardsesh/shared-schema';
+import {
+  FIND_SIMILAR_GYMS,
+  REPORT_GYM_DUPLICATE,
+  type FindSimilarGymsQueryResponse,
+  type FindSimilarGymsQueryVariables,
+  type ReportGymDuplicateMutationResponse,
+  type ReportGymDuplicateMutationVariables,
+} from '@boardsesh/graphql/operations';
+import { GYM_CLAIM_MESSAGE_MAX_LENGTH } from '@boardsesh/gym-claim';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { useDebouncedValue } from '@/app/hooks/use-debounced-value';
+import { themeTokens } from '@/app/theme/theme-config';
+
+type ReportDuplicateDialogProps = {
+  gymUuid: string;
+  gymName: string;
+  latitude?: number | null;
+  longitude?: number | null;
+  open: boolean;
+  onClose: () => void;
+};
+
+const MIN_NAME_LENGTH = 2;
+
+function graphqlErrorMessage(error: unknown): string | null {
+  const response = (error as { response?: { errors?: Array<{ message?: string }> } })?.response;
+  return response?.errors?.[0]?.message ?? null;
+}
+
+export default function ReportDuplicateDialog({
+  gymUuid,
+  gymName,
+  latitude,
+  longitude,
+  open,
+  onClose,
+}: ReportDuplicateDialogProps) {
+  const { t } = useTranslation('boards');
+  const { token } = useWsAuthToken();
+  const [search, setSearch] = useState(gymName);
+  const [selected, setSelected] = useState<SimilarGym | null>(null);
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [outcome, setOutcome] = useState<'reported' | 'already_reported' | null>(null);
+
+  // A single dialog instance is reused across gyms, so re-seed the search with the
+  // current gym's name (its likely duplicates share it) every time it opens.
+  useEffect(() => {
+    if (open) {
+      setSearch(gymName);
+      setSelected(null);
+      setNote('');
+      setError(null);
+      setOutcome(null);
+      setSubmitting(false);
+    }
+  }, [open, gymName]);
+
+  const debounced = useDebouncedValue(
+    useMemo(() => ({ name: search.trim(), latitude, longitude }), [search, latitude, longitude]),
+    400,
+  );
+
+  const enabled = open && Boolean(token) && debounced.name.length >= MIN_NAME_LENGTH;
+
+  const { data, isFetching } = useQuery<SimilarGym[]>({
+    queryKey: ['reportDuplicateSuggestions', debounced.name, debounced.latitude, debounced.longitude],
+    enabled,
+    staleTime: 30_000,
+    retry: false,
+    queryFn: async () => {
+      const client = createGraphQLHttpClient(token);
+      const response = await client.request<FindSimilarGymsQueryResponse, FindSimilarGymsQueryVariables>(
+        FIND_SIMILAR_GYMS,
+        {
+          input: {
+            name: debounced.name,
+            latitude: debounced.latitude ?? undefined,
+            longitude: debounced.longitude ?? undefined,
+          },
+        },
+      );
+      return response.findSimilarGyms;
+    },
+  });
+
+  // Never offer the gym itself as its own duplicate.
+  const candidates = (data ?? []).filter((candidate) => candidate.uuid !== gymUuid);
+
+  const formatDistance = (distanceMeters: number | null | undefined): string | null => {
+    if (distanceMeters == null) return null;
+    if (distanceMeters < 1000) {
+      return t('similarGyms.distanceMeters', { meters: Math.round(distanceMeters) });
+    }
+    return t('similarGyms.distanceKm', { km: (distanceMeters / 1000).toFixed(1) });
+  };
+
+  const submit = async () => {
+    if (!token || !selected) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const client = createGraphQLHttpClient(token);
+      const response = await client.request<ReportGymDuplicateMutationResponse, ReportGymDuplicateMutationVariables>(
+        REPORT_GYM_DUPLICATE,
+        { input: { gymUuid, duplicateGymUuid: selected.uuid, note: note.trim() || undefined } },
+      );
+      setOutcome(response.reportGymDuplicate.status);
+    } catch (err) {
+      setError(graphqlErrorMessage(err) ?? t('reportDuplicate.errorGeneric'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  let body: React.ReactNode;
+  if (outcome) {
+    body = (
+      <Box
+        sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1.5, py: 2, textAlign: 'center' }}
+      >
+        <CheckCircleOutlined color="success" sx={{ fontSize: 40 }} />
+        <DialogContentText>
+          {outcome === 'already_reported' ? t('reportDuplicate.alreadyReported') : t('reportDuplicate.sent')}
+        </DialogContentText>
+      </Box>
+    );
+  } else {
+    body = (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <DialogContentText>{t('reportDuplicate.description', { gym: gymName })}</DialogContentText>
+        {error && <Alert severity="error">{error}</Alert>}
+        <TextField
+          label={t('reportDuplicate.searchLabel')}
+          value={search}
+          onChange={(event) => {
+            setSearch(event.target.value);
+            setSelected(null);
+          }}
+          fullWidth
+          size="small"
+          placeholder={t('reportDuplicate.searchPlaceholder')}
+          autoFocus
+        />
+
+        {isFetching && candidates.length === 0 ? (
+          <Box sx={{ textAlign: 'center', py: 1 }}>
+            <CircularProgress size={20} />
+          </Box>
+        ) : candidates.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            {t('reportDuplicate.noResults')}
+          </Typography>
+        ) : (
+          <Stack spacing={1}>
+            {candidates.map((candidate) => {
+              const isSelected = selected?.uuid === candidate.uuid;
+              const distanceLabel = formatDistance(candidate.distanceMeters);
+              return (
+                <Card
+                  key={candidate.uuid}
+                  variant="outlined"
+                  sx={{
+                    borderRadius: `${themeTokens.borderRadius.md}px`,
+                    borderColor: isSelected ? themeTokens.colors.primary : undefined,
+                    borderWidth: isSelected ? 2 : 1,
+                  }}
+                >
+                  <CardActionArea onClick={() => setSelected(candidate)} sx={{ p: 1.5 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{
+                          fontWeight: themeTokens.typography.fontWeight.semibold,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {candidate.name}
+                      </Typography>
+                      {isSelected && <CheckCircleOutlined color="primary" sx={{ fontSize: 20, flexShrink: 0 }} />}
+                    </Box>
+                    {candidate.address && (
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
+                        <LocationOnOutlined sx={{ fontSize: 14, color: themeTokens.neutral[400] }} />
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                        >
+                          {candidate.address}
+                        </Typography>
+                      </Box>
+                    )}
+                    {distanceLabel && (
+                      <Box sx={{ mt: 0.75 }}>
+                        <Chip size="small" variant="outlined" label={distanceLabel} />
+                      </Box>
+                    )}
+                  </CardActionArea>
+                </Card>
+              );
+            })}
+          </Stack>
+        )}
+
+        <TextField
+          label={t('reportDuplicate.noteLabel')}
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+          fullWidth
+          size="small"
+          multiline
+          minRows={2}
+          maxRows={5}
+          placeholder={t('reportDuplicate.notePlaceholder')}
+          slotProps={{ htmlInput: { maxLength: GYM_CLAIM_MESSAGE_MAX_LENGTH } }}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('reportDuplicate.title')}</DialogTitle>
+      <DialogContent>{body}</DialogContent>
+      <DialogActions>
+        <MuiButton onClick={onClose} sx={{ textTransform: 'none' }}>
+          {outcome ? t('reportDuplicate.done') : t('reportDuplicate.cancel')}
+        </MuiButton>
+        {!outcome && (
+          <MuiButton
+            variant="contained"
+            onClick={submit}
+            disabled={submitting || !selected}
+            sx={{ textTransform: 'none' }}
+          >
+            {submitting ? <CircularProgress size={18} color="inherit" /> : t('reportDuplicate.submit')}
+          </MuiButton>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/gym-report-duplicate-cta.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-report-duplicate-cta.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSession } from 'next-auth/react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import FlagOutlined from '@mui/icons-material/FlagOutlined';
+import ReportDuplicateDialog from '@/app/components/gym-entity/report-duplicate-dialog';
+
+type GymReportDuplicateCtaProps = {
+  gymUuid: string;
+  gymName: string;
+  latitude?: number | null;
+  longitude?: number | null;
+};
+
+/**
+ * Client island: a low-key "report a duplicate" flag on the public gym page. Any
+ * signed-in climber who spots a second listing of this gym can point us at it; the
+ * island renders nothing for logged-out visitors (the page's main SEO audience).
+ */
+export default function GymReportDuplicateCta({ gymUuid, gymName, latitude, longitude }: GymReportDuplicateCtaProps) {
+  const { t } = useTranslation('boards');
+  const { status } = useSession();
+  const [open, setOpen] = useState(false);
+
+  if (status !== 'authenticated') return null;
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Button
+        variant="text"
+        size="small"
+        startIcon={<FlagOutlined sx={{ fontSize: 16 }} />}
+        onClick={() => setOpen(true)}
+        sx={{ textTransform: 'none', color: 'text.secondary' }}
+      >
+        {t('reportDuplicate.cta')}
+      </Button>
+      <ReportDuplicateDialog
+        gymUuid={gymUuid}
+        gymName={gymName}
+        latitude={latitude}
+        longitude={longitude}
+        open={open}
+        onClose={() => setOpen(false)}
+      />
+    </Box>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -40,6 +40,7 @@ import GymPageManageButton from './gym-page-manage-button';
 import GymFollowButton from './gym-follow-button';
 import GymClaimCta from './gym-claim-cta';
 import GymOwnerPrompts from './gym-owner-prompts';
+import GymReportDuplicateCta from './gym-report-duplicate-cta';
 import { getPublicBackendHttpUrl } from '@/app/lib/backend-url';
 import { resolveGymLogoDisplayUrl } from '@/app/lib/gym-logo-display-url';
 
@@ -259,6 +260,13 @@ export default async function GymPage(props: GymRouteProps) {
         />
 
         {gym.canClaim && <GymClaimCta gymUuid={gym.uuid} gymName={gym.name} website={gym.website} />}
+
+        <GymReportDuplicateCta
+          gymUuid={gym.uuid}
+          gymName={gym.name}
+          latitude={gym.latitude}
+          longitude={gym.longitude}
+        />
 
         <Divider sx={{ mb: 3 }} />
 


### PR DESCRIPTION
## Summary

Adds an owner-facing **Report a duplicate** path so a gym owner (or any signed-in climber) who spots a second listing of a gym can flag the pair for the admin merge queue #3699 introduced. Until now `/admin/gym-duplicates` only auto-surfaced duplicates by name+distance matching — a real owner who saw a duplicate of their own gym had no way to point at it.

- **Gym page + preview sheet** — a low-key "Report a duplicate" action for signed-in users on `/gym/[slug]` and the `GymDetail` sheet. It opens a small dialog that reuses the existing `findSimilarGyms` resolver (#3701) to suggest nearby same/similar-named candidates (the current gym is filtered out of its own suggestions). Pick one, add an optional note, submit.
- **Backend `reportGymDuplicate` mutation** — validates both gyms exist, are live, and are distinct; rate-limits per user; de-dupes per pair; emails the team so the pair surfaces for a merge decision.
- **Admin** — a small note on `/admin/gym-duplicates` pointing admins at where owner reports land.

### Persistence tradeoff (no migration — called out per the ask)

Per the wave's no-migration constraint (avoiding the `0185` slot collision with #3831), reports are **not** given their own table. I checked every migration-free persistence option and none fit:

- `gym_merge_audit.action` enum is `merged` | `dismissed` only — adding `reported` is a migration.
- `notification_type` / `feed_item_type` enums have no fitting value, and both rows require a specific recipient user (no "admins" recipient) — adding a type is a migration.
- `app_feedback` is tightly coupled to bug reports → GitHub-issue sync; reusing it would misfile reports and risk side effects.

So this v1 surfaces the pair to admins via the **existing admin-notification path the gym-claim flow uses (team email)** — the same way `requestGymClaim` notifies admins via `sendGymClaimAdminNotification`. Consequences, stated honestly:

- **De-dup is per-instance, best-effort**: an in-memory time-windowed guard on the sorted gym pair (reusing the rate-limiter store), released on send failure so a retry isn't stranded. Enough to stop a click flurry or two climbers flagging the same pair from spamming the team; the per-user rate limit bounds overall volume.
- **De-dup durability (Redis) deferred to follow-up**: switching the per-pair guard to a Redis `SET NX EX` would survive restarts and span instances, but (a) it's ~35 lines with a connection-branch + fallback, over the "keep it small" bar, and (b) the backend test harness doesn't connect the Redis client manager, so that path would ship **unexercised by CI**. Left as a follow-up; in-memory de-dup + the per-user rate limit are the v1 bound.
- **No durable admin queue for reports yet** — they arrive as email; the admin panel gets an info note rather than a live list. A dedicated `gym_duplicate_reports` table + a "Reported by owners" section can land in a follow-up once the migration slot is free.

### Review follow-ups applied (Fable review)

- **Silent-loss guard**: resolve the reporter's name *before* claiming the de-dup window, so a DB read that throws can't strand the pair as `reported` with no email ever sent.
- **No private-gym existence oracle**: `loadLiveGym` now gates on `isPublic = true OR ownerId = viewer` (mirrors `findSimilarGyms`), so a stranger's private gym reports as `NOT_FOUND` rather than confirming it exists and emailing its name to admins. A viewer can still report their own private gym. Covered by two new tests.
- **Intent comment**: the mutation is intentionally *not* owner-gated (community data-quality signal, shares the 10/min claim ceiling); a comment records this so it isn't tightened later.

## Release Notes

- See two listings of your gym? Report a duplicate right from the gym page and we'll get them merged.

## Test plan

- `vp check`, `vp run typecheck` — green
- `vp test run --project backend` — new `gym-report-duplicate` suite (auth, distinct/self, live-gym checks, private-gym visibility both directions, admin email payload, per-pair de-dup incl. direction-independent, send-failure release, rate limit) passes 12/12 in isolation
- `vp test run --project web` — new `report-duplicate-dialog` suite (suggestion reuse + self-exclusion, submit, already-reported) + full web suite (5756) green; `gym-detail` test updated to stub the new dialog
- `vp run check:i18n`, `vp run check:i18n:orphans` — green; en-US/es/fr catalogs at parity (`catalog-completeness` 60/60)

> Note: a local full-suite backend run showed unrelated FK/seed failures caused by a **sibling agent's concurrent backend run on the shared dev postgres** (the documented "no concurrent runs" gotcha), not by this change — my files are additive to the gym domain and pass in isolation. CI runs with isolated per-job services.
