### PR TITLE
feat(db): moonboard catalog importer emits one angle-agnostic climb per problem

### DIFF
--- a/packages/backend/src/__tests__/moonboard-duplicates-angle-agnostic.test.ts
+++ b/packages/backend/src/__tests__/moonboard-duplicates-angle-agnostic.test.ts
@@ -1,0 +1,105 @@
+import { beforeAll, describe, expect, it } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { MoonBoardHoldsInput } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import {
+  buildMoonBoardClimbHoldRows,
+  encodeMoonBoardHoldsToFrames,
+  findMoonBoardDuplicateMatches,
+} from '../graphql/resolvers/climbs/moonboard-duplicates';
+
+// The catalog importer writes ONE angle-agnostic climb row per MoonBoard
+// problem (board_climbs.angle IS NULL) plus one stats row per graded angle, so
+// the duplicate gate has to treat those rows as candidates at every angle.
+// These run against the real test database rather than a query stub: the whole
+// bug was in the WHERE clause, which a stubbed db.execute can't disprove.
+
+const LAYOUT_ID = 2;
+
+const CATALOG_HOLDS: MoonBoardHoldsInput = { start: ['A1'], hand: ['B2'], finish: ['C3'] };
+const PER_ANGLE_HOLDS: MoonBoardHoldsInput = { start: ['A2'], hand: ['B3'], finish: ['C4'] };
+const LEGACY_FRAMES_HOLDS: MoonBoardHoldsInput = { start: ['A3'], hand: ['B4'], finish: ['C5'] };
+const UNSET_HOLDS: MoonBoardHoldsInput = { start: ['D1'], hand: ['E2'], finish: ['F3'] };
+
+const CATALOG_UUID = 'moonboard-angle-agnostic-catalog';
+const PER_ANGLE_UUID = 'moonboard-angle-agnostic-legacy-40';
+const LEGACY_FRAMES_UUID = 'moonboard-angle-agnostic-frames-only';
+
+async function insertClimb(args: { uuid: string; angle: number | null; name: string; holds: MoonBoardHoldsInput }) {
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, name, angle, frames, is_listed, is_draft, created_at)
+    VALUES (
+      ${args.uuid}, 'moonboard', ${LAYOUT_ID}, ${args.name}, ${args.angle},
+      ${encodeMoonBoardHoldsToFrames(args.holds)}, true, false, '2026-01-01'
+    )
+  `);
+}
+
+async function insertHoldRows(uuid: string, holds: MoonBoardHoldsInput) {
+  for (const row of buildMoonBoardClimbHoldRows(uuid, holds)) {
+    await db.execute(sql`
+      INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
+      VALUES ('moonboard', ${row.climbUuid}, ${row.holdId}, ${row.frameNumber}, ${row.holdState})
+    `);
+  }
+}
+
+async function insertStats(uuid: string, angle: number, ascensionistCount: number) {
+  await db.execute(sql`
+    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, ascensionist_count)
+    VALUES ('moonboard', ${uuid}, ${angle}, 20, ${ascensionistCount})
+  `);
+}
+
+async function matchFor(angle: number, holds: MoonBoardHoldsInput) {
+  const [match] = await findMoonBoardDuplicateMatches(LAYOUT_ID, angle, [{ clientKey: 'candidate', holds }]);
+  return match;
+}
+
+describe('MoonBoard duplicate gate with angle-agnostic catalog climbs', () => {
+  beforeAll(async () => {
+    // Catalog shape: angle-agnostic climb row, hold rows, one stats row per
+    // graded angle.
+    await insertClimb({ uuid: CATALOG_UUID, angle: null, name: 'Catalog Problem', holds: CATALOG_HOLDS });
+    await insertHoldRows(CATALOG_UUID, CATALOG_HOLDS);
+    await insertStats(CATALOG_UUID, 25, 3);
+    await insertStats(CATALOG_UUID, 40, 12);
+
+    // Pre-rewrite shape: one row per angle, still angle-scoped.
+    await insertClimb({ uuid: PER_ANGLE_UUID, angle: 40, name: 'Per Angle Problem', holds: PER_ANGLE_HOLDS });
+    await insertHoldRows(PER_ANGLE_UUID, PER_ANGLE_HOLDS);
+    await insertStats(PER_ANGLE_UUID, 40, 7);
+
+    // Angle-agnostic row that predates board_climb_holds — matched off frames.
+    await insertClimb({
+      uuid: LEGACY_FRAMES_UUID,
+      angle: null,
+      name: 'Frames Only Problem',
+      holds: LEGACY_FRAMES_HOLDS,
+    });
+  });
+
+  it.each([25, 40])('matches an angle-agnostic catalog climb at %i°', async (angle) => {
+    expect(await matchFor(angle, CATALOG_HOLDS)).toMatchObject({
+      exists: true,
+      existingClimbUuid: CATALOG_UUID,
+      existingClimbName: 'Catalog Problem',
+    });
+  });
+
+  it.each([25, 40])('matches an angle-agnostic climb with no hold rows at %i° (frames fallback)', async (angle) => {
+    expect(await matchFor(angle, LEGACY_FRAMES_HOLDS)).toMatchObject({
+      exists: true,
+      existingClimbUuid: LEGACY_FRAMES_UUID,
+    });
+  });
+
+  it('keeps per-angle rows scoped to their own angle', async () => {
+    expect(await matchFor(40, PER_ANGLE_HOLDS)).toMatchObject({ exists: true, existingClimbUuid: PER_ANGLE_UUID });
+    expect(await matchFor(25, PER_ANGLE_HOLDS)).toMatchObject({ exists: false, existingClimbUuid: null });
+  });
+
+  it('still reports no duplicate for holds nobody has set', async () => {
+    expect(await matchFor(40, UNSET_HOLDS)).toMatchObject({ exists: false, existingClimbUuid: null });
+  });
+});

--- a/packages/backend/src/graphql/resolvers/climbs/moonboard-duplicates.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/moonboard-duplicates.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
 import type {
   MoonBoardClimbDuplicateCandidateInput,
   MoonBoardClimbDuplicateMatch,
@@ -49,6 +49,23 @@ const MOONBOARD_COORDINATE_GROUPS: Array<{
 ];
 
 export const MOONBOARD_DUPLICATE_ERROR_PREFIX = 'A MoonBoard climb with the same holds already exists';
+
+/**
+ * Which existing climbs count as candidates when someone sets a new climb at
+ * `angle`.
+ *
+ * Catalog-imported MoonBoard problems are angle-agnostic: one climb row per
+ * problem with `board_climbs.angle IS NULL`, and one `board_climb_stats` row
+ * per graded angle (see the module header of
+ * packages/db/scripts/import-moonboard-catalog.ts). The same holds are on the
+ * wall whatever angle it is set to, so an angle-null row is a duplicate
+ * candidate at EVERY angle — filtering on `angle = ${angle}` alone would let
+ * the whole imported catalog past the gate. Legacy per-angle rows (the
+ * pre-rewrite importer wrote one per angle) still only match their own angle.
+ */
+function climbAngleMatches(angle: number): SQL {
+  return sql`(${dbSchema.boardClimbs.angle} = ${angle} OR ${dbSchema.boardClimbs.angle} IS NULL)`;
+}
 
 function coordinateToHoldId(coord: string): number {
   const colIndex = coord[0].toUpperCase().charCodeAt(0) - 'A'.charCodeAt(0);
@@ -175,7 +192,7 @@ export async function findMoonBoardDuplicateMatches(
        AND ${dbSchema.boardClimbStats.angle} = ${climbStatsEffectiveAngleSql}
       WHERE ${dbSchema.boardClimbs.boardType} = 'moonboard'
         AND ${dbSchema.boardClimbs.layoutId} = ${layoutId}
-        AND ${dbSchema.boardClimbs.angle} = ${angle}
+        AND ${climbAngleMatches(angle)}
         AND ${dbSchema.boardClimbs.isListed} = true
         AND ${dbSchema.boardClimbs.isDraft} = false
       GROUP BY
@@ -217,7 +234,7 @@ export async function findMoonBoardDuplicateMatches(
        AND ${dbSchema.boardClimbStats.angle} = ${climbStatsEffectiveAngleSql}
       WHERE ${dbSchema.boardClimbs.boardType} = 'moonboard'
         AND ${dbSchema.boardClimbs.layoutId} = ${layoutId}
-        AND ${dbSchema.boardClimbs.angle} = ${angle}
+        AND ${climbAngleMatches(angle)}
         AND ${dbSchema.boardClimbs.isListed} = true
         AND ${dbSchema.boardClimbs.isDraft} = false
         AND NOT EXISTS (

--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -26,14 +26,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // MoonBoard catalog import (all 7 boards)
 // =============================================================================
 // Imports the full MoonBoard catalog dataset. One file per board, each
-// { count, holdsetup, problems[] }. We write one climb row per (problem, graded
-// angle) across all 7 boards and both 25°/40° angles.
+// { count, holdsetup, problems[] }. We write ONE climb row per problem —
+// angle-agnostic, matching Kilter/Tension — and one board_climb_stats row per
+// graded angle (typically 25° and 40°) under that same climb UUID.
 //
 // MERGE IN PLACE (non-destructive): the dataset re-keys identities (stable
 // problem id) vs the rows already in prod (keyed on apiId / name+setter). To
 // avoid duplicating ~163k existing MoonBoard climbs — and to keep their UUIDs,
 // URLs, ticks and favourites intact — we match each incoming climb to an
-// existing one by (layout_id, angle, hold_fingerprint), tie-breaking on
+// existing one by (layout_id, hold_fingerprint), tie-breaking on
 // case-insensitive name. A match reuses the existing UUID (so the upsert updates
 // it in place, backfilling the 2024 quality/ascensionist gap); a miss mints a
 // stable id-based UUID and inserts. Stat upserts are monotonic — they never
@@ -53,7 +54,7 @@ const BATCH_SIZE = 2000;
 
 /**
  * Build the in-memory match index for the non-destructive merge:
- * `${layoutId}|${angle}|${fingerprint}` → existing climbs with those holds.
+ * `${layoutId}|${fingerprint}` → existing climbs with those holds.
  * Existing MoonBoard climbs predate the fingerprint column (only layout 3 has
  * it populated in prod), so we recompute every fingerprint from board_climb_holds.
  * Holds are streamed with a cursor and folded per-climb so memory stays bounded.
@@ -91,7 +92,6 @@ async function buildExistingIndex(
     .select({
       uuid: boardClimbs.uuid,
       layoutId: boardClimbs.layoutId,
-      angle: boardClimbs.angle,
       name: boardClimbs.name,
       isListed: boardClimbs.isListed,
     })
@@ -161,10 +161,11 @@ async function importMoonBoardCatalog() {
 
       // Dedupe in memory keyed per conflict target so a single batch never
       // proposes the same target twice ("ON CONFLICT cannot affect row a second
-      // time"). When two problems share the same holds+angle (so they resolve to
-      // one target UUID) we keep the STRONGER problem (isBetterCatalogClimb: more
-      // repeats, then benchmark) instead of last-wins — otherwise a junk duplicate
-      // can clobber a real benchmark's ascent count and benchmark flag.
+      // time"). When two problems share the same holds (so they resolve to one
+      // target UUID) we keep the STRONGER problem (isBetterCatalogClimb: more
+      // total repeats across its graded angles, then benchmark) instead of
+      // last-wins — otherwise a junk duplicate can clobber a real benchmark's
+      // ascent count and benchmark flag.
       const bestByUuid = new Map<string, MappedCatalogClimb>();
       const climbByUuid = new Map<string, typeof boardClimbs.$inferInsert>();
       const statsByUuid = new Map<string, typeof boardClimbStats.$inferInsert>();
@@ -175,100 +176,116 @@ async function importMoonBoardCatalog() {
       let skippedProblems = 0;
 
       for (const problem of dump.problems) {
-        const climbs = catalogProblemToClimbs(problem, layoutId);
-        if (climbs.length === 0) {
+        const mapped = catalogProblemToClimbs(problem, layoutId);
+        if (!mapped) {
           skippedProblems++;
           continue;
         }
-        for (const mapped of climbs) {
-          const { uuid, matched: matchedExisting } = resolveCatalogClimbUuid(mapped, existingIndex);
+        const { uuid, matched: matchedExisting } = resolveCatalogClimbUuid(mapped, existingIndex);
 
-          // Record the aliases before the dedupe below: when two problems collapse
-          // onto one climb (same holds+angle) we drop the weaker climb row, but we
-          // still want BOTH problem ids to resolve to the survivor. The self-alias
-          // lets resolveCanonicalClimbUuid hit; the id-based alias (only added when
-          // the merge reused a legacy UUID) makes the climb addressable by its
-          // MoonBoard problem id — the fix for 2024 logbook imports.
-          for (const aliasRow of catalogAliasRows(mapped.uuid, uuid)) {
-            aliasByUuid.set(aliasRow.aliasUuid, {
-              boardType: 'moonboard',
-              aliasUuid: aliasRow.aliasUuid,
-              canonicalUuid: aliasRow.canonicalUuid,
-              source: 'moonboard-catalog-import',
-            });
-          }
-
-          const incumbent = bestByUuid.get(uuid);
-          if (incumbent) {
-            // Same holds+angle as an already-seen problem — keep the stronger one.
-            if (!isBetterCatalogClimb(mapped, incumbent)) continue;
-          } else if (matchedExisting) {
-            matched++;
-          } else {
-            inserted++;
-          }
-          bestByUuid.set(uuid, mapped);
-
-          climbByUuid.set(uuid, {
-            uuid,
+        // Record the aliases before the dedupe below: when two problems collapse
+        // onto one climb (same holds) we drop the weaker problem's data, but we
+        // still want BOTH problem ids to resolve to the survivor. The self-alias
+        // lets resolveCanonicalClimbUuid hit; the id-based alias (only added when
+        // the merge reused a legacy UUID) makes the climb addressable by its
+        // MoonBoard problem id; the per-angle legacy aliases keep the
+        // personal-logbook importer's `moonboard:{id}:{angle}` lookup resolving.
+        for (const aliasRow of catalogAliasRows({
+          problemId: problem.id,
+          angles: mapped.stats.map((stat) => stat.angle),
+          canonicalUuid: uuid,
+        })) {
+          aliasByUuid.set(aliasRow.aliasUuid, {
             boardType: 'moonboard',
-            layoutId: mapped.layoutId,
-            setterId: null,
-            setterUsername: mapped.setterUsername,
-            name: mapped.name,
-            description: mapped.description,
-            hsm: null,
-            edgeLeft: null,
-            edgeRight: null,
-            edgeBottom: null,
-            edgeTop: null,
-            angle: mapped.angle,
-            framesCount: 1,
-            framesPace: 0,
-            frames: mapped.frames,
-            isDraft: false,
-            isListed: true,
-            createdAt: mapped.createdAt,
-            synced: true,
-            syncError: null,
-            userId: null,
-            holdFingerprint: mapped.holdFingerprint,
-            characteristics: mapped.characteristics,
+            aliasUuid: aliasRow.aliasUuid,
+            canonicalUuid: aliasRow.canonicalUuid,
+            source: 'moonboard-catalog-import',
           });
+        }
 
-          statsByUuid.set(uuid, {
+        const incumbent = bestByUuid.get(uuid);
+        if (incumbent) {
+          // Same holds as an already-seen problem — keep the stronger one.
+          if (!isBetterCatalogClimb(mapped, incumbent)) continue;
+        } else if (matchedExisting) {
+          matched++;
+        } else {
+          inserted++;
+        }
+        bestByUuid.set(uuid, mapped);
+
+        climbByUuid.set(uuid, {
+          uuid,
+          boardType: 'moonboard',
+          layoutId: mapped.layoutId,
+          setterId: null,
+          setterUsername: mapped.setterUsername,
+          name: mapped.name,
+          description: mapped.description,
+          hsm: null,
+          edgeLeft: null,
+          edgeRight: null,
+          edgeBottom: null,
+          edgeTop: null,
+          angle: null,
+          framesCount: 1,
+          framesPace: 0,
+          frames: mapped.frames,
+          isDraft: false,
+          isListed: true,
+          createdAt: mapped.createdAt,
+          synced: true,
+          syncError: null,
+          userId: null,
+          holdFingerprint: mapped.holdFingerprint,
+          characteristics: mapped.characteristics,
+        });
+
+        // If this problem beat a previously-seen incumbent for the same uuid,
+        // the incumbent's stats/holds entries (keyed by uuid+angle/holdId) must
+        // be cleared first — the new winner's graded angles can differ from
+        // the old one's, and stale entries would otherwise linger.
+        for (const stat of incumbent?.stats ?? []) {
+          statsByUuid.delete(`${uuid}:${stat.angle}`);
+        }
+        for (const hold of incumbent?.holds ?? []) {
+          holdsByKey.delete(`${uuid}:${hold.holdId}`);
+        }
+
+        for (const stat of mapped.stats) {
+          statsByUuid.set(`${uuid}:${stat.angle}`, {
             boardType: 'moonboard',
             climbUuid: uuid,
-            angle: mapped.angle,
-            displayDifficulty: mapped.difficultyId ?? null,
-            benchmarkDifficulty: mapped.isBenchmark && mapped.difficultyId !== undefined ? mapped.difficultyId : null,
+            angle: stat.angle,
+            displayDifficulty: stat.difficultyId ?? null,
+            benchmarkDifficulty: stat.isBenchmark && stat.difficultyId !== undefined ? stat.difficultyId : null,
             // MoonBoard's community-repeat count is this board's upstream source.
             // Seed the total too (a fresh row has no Boardsesh ticks yet); the tick
             // recompute later adds boardsesh_ascensionist_count on top of upstream.
-            upstreamAscensionistCount: mapped.ascensionistCount,
-            ascensionistCount: mapped.ascensionistCount,
-            difficultyAverage: mapped.difficultyId ?? null,
-            qualityAverage: mapped.qualityAverage,
+            upstreamAscensionistCount: stat.ascensionistCount,
+            ascensionistCount: stat.ascensionistCount,
+            difficultyAverage: stat.difficultyId ?? null,
+            qualityAverage: stat.qualityAverage,
             // The manufacturer average also seeds upstream_quality_average (the
             // blend's upstream term). On a fresh INSERT quality_average == this
             // value because no Boardsesh votes exist yet; on conflict it re-blends.
-            upstreamQualityAverage: mapped.qualityAverage,
+            upstreamQualityAverage: stat.qualityAverage,
             qualityNormalized: true,
             faUsername: null,
             faAt: null,
             // MoonBoard catalog import is this board's upstream stats source.
             upstreamSyncedAt: new Date().toISOString(),
           });
+        }
 
-          for (const hold of mapped.holds) {
-            holdsByKey.set(`${uuid}:${hold.holdId}`, {
-              boardType: 'moonboard',
-              climbUuid: uuid,
-              holdId: hold.holdId,
-              frameNumber: 0,
-              holdState: hold.holdState,
-            });
-          }
+        for (const hold of mapped.holds) {
+          holdsByKey.set(`${uuid}:${hold.holdId}`, {
+            boardType: 'moonboard',
+            climbUuid: uuid,
+            holdId: hold.holdId,
+            frameNumber: 0,
+            holdState: hold.holdState,
+          });
         }
       }
 

--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -11,14 +11,9 @@ import {
   HOLDSETUP_TO_LAYOUT,
   buildExistingCatalogMatchIndex,
   catalogAliasConflictUpdate,
-  catalogAliasRows,
-  catalogProblemToClimbs,
-  existingClimbUuidsForProblem,
-  resolveIncumbentReplacement,
-  resolveCatalogClimbUuid,
   type MoonBoardCatalogFile,
-  type MappedCatalogClimb,
 } from './moonboard-catalog-helpers.js';
+import { stageCatalogBatch } from './moonboard-catalog-batch.js';
 import { describeDatabaseHost, getScriptDatabaseUrl } from './db-connection.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -63,14 +58,19 @@ const BATCH_SIZE = 2000;
  * it populated in prod), so we recompute every fingerprint from board_climb_holds.
  * Holds are streamed with a cursor and folded per-climb so memory stays bounded.
  *
- * Also returns every existing MoonBoard climb uuid (listed or not) so the
- * caller can spot a problem this importer already owns whose holds have since
- * drifted — see `existingClimbUuidsForProblem`.
+ * Also returns every existing MoonBoard climb uuid (listed or not) and the raw
+ * alias → canonical map, so the caller can spot a problem whose owned rows have
+ * drifted out from under it (`existingClimbUuidsForProblem`) or would be
+ * repointed by a merge (`hijackedClimbUuidsForProblem`).
  */
 async function buildExistingIndex(
   client: postgres.Sql,
   db: ReturnType<typeof drizzle>,
-): Promise<{ index: ReturnType<typeof buildExistingCatalogMatchIndex>; climbUuids: Set<string> }> {
+): Promise<{
+  index: ReturnType<typeof buildExistingCatalogMatchIndex>;
+  climbUuids: Set<string>;
+  canonicalByAlias: Map<string, string>;
+}> {
   console.info('   Building match index from existing MoonBoard climbs...');
   const fingerprintByUuid = new Map<string, string>();
   let currentUuid: string | null = null;
@@ -119,7 +119,7 @@ async function buildExistingIndex(
   const index = buildExistingCatalogMatchIndex(climbRows, fingerprintByUuid, canonicalByAlias);
   fingerprintByUuid.clear();
   console.info(`   Indexed ${climbRows.length} existing climbs (${index.size} hold groups)`);
-  return { index, climbUuids: new Set(climbRows.map((row) => row.uuid)) };
+  return { index, climbUuids: new Set(climbRows.map((row) => row.uuid)), canonicalByAlias };
 }
 
 function parseFlag(name: string): string | undefined {
@@ -163,10 +163,16 @@ async function importMoonBoardCatalog() {
     skippedProblems: 0,
     skippedAmbiguous: 0,
     skippedDrifted: 0,
+    skippedHijacked: 0,
+    foldedInBatch: 0,
   };
 
   try {
-    const { index: existingIndex, climbUuids: existingClimbUuids } = await buildExistingIndex(client, db);
+    const {
+      index: existingIndex,
+      climbUuids: existingClimbUuids,
+      canonicalByAlias,
+    } = await buildExistingIndex(client, db);
 
     for (const file of files) {
       const raw = fs.readFileSync(path.join(catalogDir, file), 'utf-8');
@@ -180,197 +186,27 @@ async function importMoonBoardCatalog() {
 
       console.info(`\n📖 ${file} — holdsetup ${dump.holdsetup} → layout ${layoutId}, ${dump.problems.length} problems`);
 
-      // Dedupe in memory keyed per conflict target so a single batch never
-      // proposes the same target twice ("ON CONFLICT cannot affect row a second
-      // time"). When two problems share the same holds (so they resolve to one
-      // target UUID) we keep the STRONGER problem (resolveIncumbentReplacement /
-      // isBetterCatalogClimb: more total repeats across its graded angles, then
-      // benchmark) instead of last-wins — otherwise a junk duplicate can
-      // clobber a real benchmark's ascent count and benchmark flag.
-      const bestByUuid = new Map<string, MappedCatalogClimb>();
-      const climbByUuid = new Map<string, typeof boardClimbs.$inferInsert>();
-      // Keyed `${uuid}:${angle}` — one entry per graded angle of a climb.
-      const statsByUuidAngle = new Map<string, typeof boardClimbStats.$inferInsert>();
-      const holdsByKey = new Map<string, typeof boardClimbHolds.$inferInsert>();
-      const aliasByUuid = new Map<string, typeof boardClimbAliases.$inferInsert>();
-      let matched = 0;
-      let inserted = 0;
-      let skippedProblems = 0;
-      let skippedAmbiguous = 0;
-      let skippedDrifted = 0;
-
-      for (const problem of dump.problems) {
-        const mapped = catalogProblemToClimbs(problem, layoutId);
-        if (!mapped) {
-          skippedProblems++;
-          continue;
-        }
-        const { uuid, matched: matchedExisting, ambiguous } = resolveCatalogClimbUuid(mapped, existingIndex);
-
-        // Multiple DISTINCT listed rows share this problem's holds. Two causes:
-        //   1. The moonboard_angle_dedup_backfill migration (#3849) hasn't run against this
-        //      database yet, so both angle-rows of the problem are still
-        //      separately listed. Running it fixes this one.
-        //   2. The database IS migrated, but the dedup migration deliberately left this group
-        //      alone: it only collapses a same-signature group whose members
-        //      all sit at DISTINCT angles, so a cross-problem duplicate class
-        //      (the real "birthday cake trail mix" vs the junk problem named
-        //      "name", four listed rows on one signature) survives for manual
-        //      follow-up. Running migrations again changes nothing here.
-        // Either way, writing through would double-count ascents across two
-        // listed rows and point a legacy alias at whichever row the name
-        // tie-break happened to land on. Loud skip, not a silent guess.
-        if (ambiguous) {
-          skippedAmbiguous++;
-          console.error(
-            `   ⚠️  Skipping problem ${problem.id} ("${problem.name}"): multiple listed rows already share its holds ` +
-              `at layout ${layoutId} — either this database predates the moonboard_angle_dedup_backfill migration (#3849), or that migration ` +
-              `ran and left a cross-problem duplicate group for manual follow-up. Check migrations first; if they're ` +
-              `up to date, these rows need deduping by hand.`,
-          );
-          continue;
-        }
-
-        // No hold match, but this problem already owns climb rows from an
-        // earlier import — its holds drifted rather than it being new. See
-        // existingClimbUuidsForProblem: inserting here would mint a duplicate
-        // and repoint the old rows' self-aliases (and therefore their ticks)
-        // at the empty new row. Loud skip.
-        if (!matchedExisting) {
-          const driftedUuids = existingClimbUuidsForProblem({
-            problemId: problem.id,
-            angles: mapped.stats.map((stat) => stat.angle),
-            existingClimbUuids,
-          });
-          if (driftedUuids.length > 0) {
-            skippedDrifted++;
-            console.error(
-              `   ⚠️  Skipping problem ${problem.id} ("${problem.name}"): its holds no longer match the climb rows it ` +
-                `already owns (${driftedUuids.join(', ')}) at layout ${layoutId}. Inserting would duplicate the climb ` +
-                `and redirect the existing rows' ticks. Reconcile those rows by hand, then re-run this import.`,
-            );
-            continue;
-          }
-        }
-
-        // Record the aliases before the dedupe below: when two problems collapse
-        // onto one climb (same holds) we drop the weaker problem's data, but we
-        // still want BOTH problem ids to resolve to the survivor. The self-alias
-        // lets resolveCanonicalClimbUuid hit; the id-based alias (only added when
-        // the merge reused a legacy UUID) makes the climb addressable by its
-        // MoonBoard problem id; the per-angle legacy aliases keep the
-        // personal-logbook importer's `moonboard:{id}:{angle}` lookup resolving.
-        for (const aliasRow of catalogAliasRows({
-          problemId: problem.id,
-          angles: mapped.stats.map((stat) => stat.angle),
-          canonicalUuid: uuid,
-        })) {
-          aliasByUuid.set(aliasRow.aliasUuid, {
-            boardType: 'moonboard',
-            aliasUuid: aliasRow.aliasUuid,
-            canonicalUuid: aliasRow.canonicalUuid,
-            source: 'moonboard-catalog-import',
-          });
-        }
-
-        const incumbent = bestByUuid.get(uuid);
-        const decision = resolveIncumbentReplacement(uuid, mapped, incumbent);
-        if (!decision.accept) continue;
-        if (!incumbent) {
-          if (matchedExisting) matched++;
-          else inserted++;
-        }
-        bestByUuid.set(uuid, mapped);
-
-        climbByUuid.set(uuid, {
-          uuid,
-          boardType: 'moonboard',
-          layoutId: mapped.layoutId,
-          setterId: null,
-          setterUsername: mapped.setterUsername,
-          name: mapped.name,
-          description: mapped.description,
-          hsm: null,
-          edgeLeft: null,
-          edgeRight: null,
-          edgeBottom: null,
-          edgeTop: null,
-          // Angle-agnostic identity (see module header). Consumers that
-          // resolve difficultyName by joining board_climb_stats at the climb's
-          // own angle handle the null via climbStatsEffectiveAngleSql
-          // (packages/backend/src/db/queries/util/climb-stats-join.ts): when
-          // climbs.angle is null they fall back to the climb's most-ascended
-          // stats row (lower angle wins ties). Formerly tracked as #4220,
-          // fixed on main before this importer landed.
-          angle: null,
-          framesCount: 1,
-          framesPace: 0,
-          frames: mapped.frames,
-          isDraft: false,
-          isListed: true,
-          createdAt: mapped.createdAt,
-          synced: true,
-          syncError: null,
-          userId: null,
-          holdFingerprint: mapped.holdFingerprint,
-          characteristics: mapped.characteristics,
-        });
-
-        // Clear the beaten incumbent's stale batch-map entries (see
-        // resolveIncumbentReplacement's doc comment for why this is needed).
-        for (const key of decision.staleStatKeys) {
-          statsByUuidAngle.delete(key);
-        }
-        for (const key of decision.staleHoldKeys) {
-          holdsByKey.delete(key);
-        }
-
-        for (const stat of mapped.stats) {
-          statsByUuidAngle.set(`${uuid}:${stat.angle}`, {
-            boardType: 'moonboard',
-            climbUuid: uuid,
-            angle: stat.angle,
-            displayDifficulty: stat.difficultyId ?? null,
-            benchmarkDifficulty: stat.isBenchmark && stat.difficultyId !== undefined ? stat.difficultyId : null,
-            // MoonBoard's community-repeat count is this board's upstream source.
-            // Seed the total too (a fresh row has no Boardsesh ticks yet); the tick
-            // recompute later adds boardsesh_ascensionist_count on top of upstream.
-            upstreamAscensionistCount: stat.ascensionistCount,
-            ascensionistCount: stat.ascensionistCount,
-            difficultyAverage: stat.difficultyId ?? null,
-            qualityAverage: stat.qualityAverage,
-            // The manufacturer average also seeds upstream_quality_average (the
-            // blend's upstream term). On a fresh INSERT quality_average == this
-            // value because no Boardsesh votes exist yet; on conflict it re-blends.
-            upstreamQualityAverage: stat.qualityAverage,
-            qualityNormalized: true,
-            faUsername: null,
-            faAt: null,
-            // MoonBoard catalog import is this board's upstream stats source.
-            upstreamSyncedAt: new Date().toISOString(),
-          });
-        }
-
-        for (const hold of mapped.holds) {
-          holdsByKey.set(`${uuid}:${hold.holdId}`, {
-            boardType: 'moonboard',
-            climbUuid: uuid,
-            holdId: hold.holdId,
-            frameNumber: 0,
-            holdState: hold.holdState,
-          });
-        }
-      }
-
-      const climbRecords = [...climbByUuid.values()];
-      const statsRecords = [...statsByUuidAngle.values()];
-      const holdsRecords = [...holdsByKey.values()];
-      const aliasRecords = [...aliasByUuid.values()];
+      const {
+        climbs: climbRecords,
+        stats: statsRecords,
+        holds: holdsRecords,
+        aliases: aliasRecords,
+        counters,
+      } = stageCatalogBatch({
+        problems: dump.problems,
+        layoutId,
+        existingIndex,
+        existingClimbUuids,
+        canonicalByAlias,
+      });
 
       console.info(
-        `   ${matched} matched existing, ${inserted} new; ${skippedProblems} problems skipped, ` +
-          `${skippedAmbiguous} skipped as ambiguous (duplicate listed rows), ` +
-          `${skippedDrifted} skipped as drifted (holds changed under an imported climb)`,
+        `   ${counters.matched} matched existing, ${counters.inserted} new; ` +
+          `${counters.foldedInBatch} folded onto an earlier same-holds problem; ` +
+          `${counters.skippedProblems} problems skipped, ` +
+          `${counters.skippedAmbiguous} skipped as ambiguous (duplicate listed rows), ` +
+          `${counters.skippedDrifted} skipped as drifted (holds changed under an imported climb), ` +
+          `${counters.skippedHijacked} skipped to protect climb rows a merge would repoint`,
       );
 
       // One transaction per board: a crash mid-file never leaves a climb without
@@ -453,14 +289,16 @@ async function importMoonBoardCatalog() {
       });
 
       console.info(`   ✓ climbs ${climbRecords.length}, stats ${statsRecords.length}, holds ${holdsRecords.length}`);
-      totals.matched += matched;
-      totals.inserted += inserted;
+      totals.matched += counters.matched;
+      totals.inserted += counters.inserted;
       totals.climbs += climbRecords.length;
       totals.stats += statsRecords.length;
       totals.holds += holdsRecords.length;
-      totals.skippedProblems += skippedProblems;
-      totals.skippedAmbiguous += skippedAmbiguous;
-      totals.skippedDrifted += skippedDrifted;
+      totals.skippedProblems += counters.skippedProblems;
+      totals.skippedAmbiguous += counters.skippedAmbiguous;
+      totals.skippedDrifted += counters.skippedDrifted;
+      totals.skippedHijacked += counters.skippedHijacked;
+      totals.foldedInBatch += counters.foldedInBatch;
     }
 
     console.info('\n✅ Import completed!');
@@ -470,6 +308,12 @@ async function importMoonBoardCatalog() {
     console.info(`   Stats upserted:   ${totals.stats}`);
     console.info(`   Holds upserted:   ${totals.holds}`);
     console.info(`   Problems skipped: ${totals.skippedProblems}`);
+    if (totals.foldedInBatch > 0) {
+      console.info(
+        `   Folded in batch:  ${totals.foldedInBatch} — problems that share their holds with an earlier problem in ` +
+          `the same file and were collapsed onto it; both problem ids still resolve to the surviving climb.`,
+      );
+    }
     if (totals.skippedAmbiguous > 0) {
       console.error(
         `   ⚠️  Problems skipped as ambiguous: ${totals.skippedAmbiguous} — several listed rows share their holds. ` +
@@ -483,6 +327,13 @@ async function importMoonBoardCatalog() {
         `   ⚠️  Problems skipped as drifted: ${totals.skippedDrifted} — their holds no longer match the climb rows ` +
           `they already own, so inserting would duplicate the climb and redirect the old rows' ticks. Reconcile ` +
           `those rows by hand, then re-run this import.`,
+      );
+    }
+    if (totals.skippedHijacked > 0) {
+      console.error(
+        `   ⚠️  Problems skipped to protect existing rows: ${totals.skippedHijacked} — their holds matched one climb ` +
+          `while the problem also owns other live climb rows, so merging would repoint those rows (and their ticks) ` +
+          `at the matched climb while they stay listed. Reconcile them by hand, then re-run this import.`,
       );
     }
 

--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -96,7 +96,7 @@ async function buildExistingIndex(
   flush();
 
   // user_id IS NULL fences out Boardsesh-native user climbs, matching the
-  // same fence 0185's dedup migration applies. Without it, a user climb that
+  // same fence the moonboard_angle_dedup_backfill migration (#3849) applies. Without it, a user climb that
   // happens to share holds with an incoming catalog problem could be adopted
   // as the merge target, after which the catalog import would upsert its
   // stats onto the user's climb and point the problem's aliases at it.
@@ -208,10 +208,10 @@ async function importMoonBoardCatalog() {
         const { uuid, matched: matchedExisting, ambiguous } = resolveCatalogClimbUuid(mapped, existingIndex);
 
         // Multiple DISTINCT listed rows share this problem's holds. Two causes:
-        //   1. Migration 0185 (moonboard angle-dedup) hasn't run against this
+        //   1. The moonboard_angle_dedup_backfill migration (#3849) hasn't run against this
         //      database yet, so both angle-rows of the problem are still
         //      separately listed. Running it fixes this one.
-        //   2. The database IS migrated, but 0185 deliberately left this group
+        //   2. The database IS migrated, but the dedup migration deliberately left this group
         //      alone: it only collapses a same-signature group whose members
         //      all sit at DISTINCT angles, so a cross-problem duplicate class
         //      (the real "birthday cake trail mix" vs the junk problem named
@@ -224,7 +224,7 @@ async function importMoonBoardCatalog() {
           skippedAmbiguous++;
           console.error(
             `   ⚠️  Skipping problem ${problem.id} ("${problem.name}"): multiple listed rows already share its holds ` +
-              `at layout ${layoutId} — either this database predates migration 0185 (moonboard angle-dedup), or 0185 ` +
+              `at layout ${layoutId} — either this database predates the moonboard_angle_dedup_backfill migration (#3849), or that migration ` +
               `ran and left a cross-problem duplicate group for manual follow-up. Check migrations first; if they're ` +
               `up to date, these rows need deduping by hand.`,
           );
@@ -295,15 +295,13 @@ async function importMoonBoardCatalog() {
           edgeRight: null,
           edgeBottom: null,
           edgeTop: null,
-          // Angle-agnostic identity (see module header) — but KNOWN GAP,
-          // deliberately deferred, tracked in #4220: three backend paths
-          // (new-climb-subscriptions.ts, notification-worker.ts, feed-fanout.ts)
-          // resolve difficultyName via `LEFT JOIN board_climb_stats ON
-          // stats.angle = climbs.angle`, which never matches when climbs.angle
-          // is null — so a newly-imported MoonBoard problem shows ungraded in
-          // the new-climb feed and notifications until those queries learn a
-          // fallback (e.g. pick the min-angle stats row when climbs.angle is
-          // null). Nothing fails; the grade just doesn't show.
+          // Angle-agnostic identity (see module header). Consumers that
+          // resolve difficultyName by joining board_climb_stats at the climb's
+          // own angle handle the null via climbStatsEffectiveAngleSql
+          // (packages/backend/src/db/queries/util/climb-stats-join.ts): when
+          // climbs.angle is null they fall back to the climb's most-ascended
+          // stats row (lower angle wins ties). Formerly tracked as #4220,
+          // fixed on main before this importer landed.
           angle: null,
           framesCount: 1,
           framesPace: 0,
@@ -475,8 +473,8 @@ async function importMoonBoardCatalog() {
     if (totals.skippedAmbiguous > 0) {
       console.error(
         `   ⚠️  Problems skipped as ambiguous: ${totals.skippedAmbiguous} — several listed rows share their holds. ` +
-          `If this database predates migration 0185 (moonboard angle-dedup), run it and re-run this import to pick ` +
-          `these up. If it's already migrated, these are cross-problem duplicate groups 0185 left alone on purpose ` +
+          `If this database predates the moonboard_angle_dedup_backfill migration (#3849), run it and re-run this import to pick ` +
+          `these up. If it's already migrated, these are cross-problem duplicate groups the dedup migration left alone on purpose ` +
           `and they need deduping by hand.`,
       );
     }

--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
-import { sql, eq } from 'drizzle-orm';
+import { sql, eq, and, isNull } from 'drizzle-orm';
 import { boardClimbs, boardClimbStats, boardClimbHolds, boardClimbAliases } from '../src/schema/boards/unified.js';
 import { blendedQualityAverageSql } from '../src/queries/climb-stats/quality-blend.js';
 import { fingerprintFromHolds } from './moonboard-2024-helpers.js';
@@ -88,6 +88,11 @@ async function buildExistingIndex(
   }
   flush();
 
+  // user_id IS NULL fences out Boardsesh-native user climbs, matching the
+  // same fence 0185's dedup migration applies. Without it, a user climb that
+  // happens to share holds with an incoming catalog problem could be adopted
+  // as the merge target, after which the catalog import would upsert its
+  // stats onto the user's climb and point the problem's aliases at it.
   const climbRows = await db
     .select({
       uuid: boardClimbs.uuid,
@@ -96,7 +101,7 @@ async function buildExistingIndex(
       isListed: boardClimbs.isListed,
     })
     .from(boardClimbs)
-    .where(eq(boardClimbs.boardType, 'moonboard'));
+    .where(and(eq(boardClimbs.boardType, 'moonboard'), isNull(boardClimbs.userId)));
 
   const aliasRows = await db
     .select({ aliasUuid: boardClimbAliases.aliasUuid, canonicalUuid: boardClimbAliases.canonicalUuid })
@@ -142,7 +147,7 @@ async function importMoonBoardCatalog() {
   const client = postgres(databaseUrl, { max: 1 });
   const db = drizzle(client);
 
-  const totals = { matched: 0, inserted: 0, climbs: 0, stats: 0, holds: 0, skippedProblems: 0 };
+  const totals = { matched: 0, inserted: 0, climbs: 0, stats: 0, holds: 0, skippedProblems: 0, skippedAmbiguous: 0 };
 
   try {
     const existingIndex = await buildExistingIndex(client, db);
@@ -174,6 +179,7 @@ async function importMoonBoardCatalog() {
       let matched = 0;
       let inserted = 0;
       let skippedProblems = 0;
+      let skippedAmbiguous = 0;
 
       for (const problem of dump.problems) {
         const mapped = catalogProblemToClimbs(problem, layoutId);
@@ -181,7 +187,24 @@ async function importMoonBoardCatalog() {
           skippedProblems++;
           continue;
         }
-        const { uuid, matched: matchedExisting } = resolveCatalogClimbUuid(mapped, existingIndex);
+        const { uuid, matched: matchedExisting, ambiguous } = resolveCatalogClimbUuid(mapped, existingIndex);
+
+        // Multiple DISTINCT listed rows share this problem's holds — the
+        // expected shape when migration 0185 (moonboard angle-dedup) hasn't
+        // run against this database yet, so both angle-rows of the problem
+        // are still separately listed. Writing through this state would
+        // double-count ascents across two listed rows and point a legacy
+        // alias at whichever row the name tie-break happened to land on.
+        // Loud skip, not a silent guess: run 0185 first, then re-import.
+        if (ambiguous) {
+          skippedAmbiguous++;
+          console.error(
+            `   ⚠️  Skipping problem ${problem.id} ("${problem.name}"): multiple listed rows already share its holds ` +
+              `at layout ${layoutId} — this database likely predates migration 0185 (moonboard angle-dedup). ` +
+              `Run that migration, then re-run this import.`,
+          );
+          continue;
+        }
 
         // Record the aliases before the dedupe below: when two problems collapse
         // onto one climb (same holds) we drop the weaker problem's data, but we
@@ -225,6 +248,16 @@ async function importMoonBoardCatalog() {
           edgeRight: null,
           edgeBottom: null,
           edgeTop: null,
+          // Angle-agnostic identity (see module header) — but KNOWN GAP,
+          // deliberately deferred: three backend paths (new-climb-subscriptions.ts,
+          // notification-worker.ts, feed-fanout.ts) resolve difficultyName via
+          // `LEFT JOIN board_climb_stats ON stats.angle = climbs.angle`, which
+          // never matches when climbs.angle is null — so a newly-imported
+          // MoonBoard problem shows ungraded in the new-climb feed and
+          // notifications until those three queries learn a MoonBoard fallback
+          // (e.g. pick the min-angle stats row when climbs.angle is null).
+          // Nothing fails; the grade just doesn't show. Track before relying on
+          // those surfaces for MoonBoard.
           angle: null,
           framesCount: 1,
           framesPace: 0,
@@ -290,7 +323,10 @@ async function importMoonBoardCatalog() {
       const holdsRecords = [...holdsByKey.values()];
       const aliasRecords = [...aliasByUuid.values()];
 
-      console.info(`   ${matched} matched existing, ${inserted} new; ${skippedProblems} problems skipped`);
+      console.info(
+        `   ${matched} matched existing, ${inserted} new; ${skippedProblems} problems skipped, ` +
+          `${skippedAmbiguous} skipped as ambiguous (pre-0185 duplicate rows)`,
+      );
 
       // One transaction per board: a crash mid-file never leaves a climb without
       // its holds/aliases, and completed boards stay committed for an idempotent
@@ -378,6 +414,7 @@ async function importMoonBoardCatalog() {
       totals.stats += statsRecords.length;
       totals.holds += holdsRecords.length;
       totals.skippedProblems += skippedProblems;
+      totals.skippedAmbiguous += skippedAmbiguous;
     }
 
     console.info('\n✅ Import completed!');
@@ -387,6 +424,12 @@ async function importMoonBoardCatalog() {
     console.info(`   Stats upserted:   ${totals.stats}`);
     console.info(`   Holds upserted:   ${totals.holds}`);
     console.info(`   Problems skipped: ${totals.skippedProblems}`);
+    if (totals.skippedAmbiguous > 0) {
+      console.error(
+        `   ⚠️  Problems skipped as ambiguous: ${totals.skippedAmbiguous} — this database likely predates ` +
+          `migration 0185 (moonboard angle-dedup). Run it, then re-run this import to pick these up.`,
+      );
+    }
 
     await client.end();
     process.exit(0);

--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -13,7 +13,7 @@ import {
   catalogAliasConflictUpdate,
   catalogAliasRows,
   catalogProblemToClimbs,
-  isBetterCatalogClimb,
+  resolveIncumbentReplacement,
   resolveCatalogClimbUuid,
   type MoonBoardCatalogFile,
   type MappedCatalogClimb,
@@ -162,10 +162,10 @@ async function importMoonBoardCatalog() {
       // Dedupe in memory keyed per conflict target so a single batch never
       // proposes the same target twice ("ON CONFLICT cannot affect row a second
       // time"). When two problems share the same holds (so they resolve to one
-      // target UUID) we keep the STRONGER problem (isBetterCatalogClimb: more
-      // total repeats across its graded angles, then benchmark) instead of
-      // last-wins — otherwise a junk duplicate can clobber a real benchmark's
-      // ascent count and benchmark flag.
+      // target UUID) we keep the STRONGER problem (resolveIncumbentReplacement /
+      // isBetterCatalogClimb: more total repeats across its graded angles, then
+      // benchmark) instead of last-wins — otherwise a junk duplicate can
+      // clobber a real benchmark's ascent count and benchmark flag.
       const bestByUuid = new Map<string, MappedCatalogClimb>();
       const climbByUuid = new Map<string, typeof boardClimbs.$inferInsert>();
       const statsByUuid = new Map<string, typeof boardClimbStats.$inferInsert>();
@@ -204,13 +204,11 @@ async function importMoonBoardCatalog() {
         }
 
         const incumbent = bestByUuid.get(uuid);
-        if (incumbent) {
-          // Same holds as an already-seen problem — keep the stronger one.
-          if (!isBetterCatalogClimb(mapped, incumbent)) continue;
-        } else if (matchedExisting) {
-          matched++;
-        } else {
-          inserted++;
+        const decision = resolveIncumbentReplacement(uuid, mapped, incumbent);
+        if (!decision.accept) continue;
+        if (!incumbent) {
+          if (matchedExisting) matched++;
+          else inserted++;
         }
         bestByUuid.set(uuid, mapped);
 
@@ -241,15 +239,13 @@ async function importMoonBoardCatalog() {
           characteristics: mapped.characteristics,
         });
 
-        // If this problem beat a previously-seen incumbent for the same uuid,
-        // the incumbent's stats/holds entries (keyed by uuid+angle/holdId) must
-        // be cleared first — the new winner's graded angles can differ from
-        // the old one's, and stale entries would otherwise linger.
-        for (const stat of incumbent?.stats ?? []) {
-          statsByUuid.delete(`${uuid}:${stat.angle}`);
+        // Clear the beaten incumbent's stale batch-map entries (see
+        // resolveIncumbentReplacement's doc comment for why this is needed).
+        for (const key of decision.staleStatKeys) {
+          statsByUuid.delete(key);
         }
-        for (const hold of incumbent?.holds ?? []) {
-          holdsByKey.delete(`${uuid}:${hold.holdId}`);
+        for (const key of decision.staleHoldKeys) {
+          holdsByKey.delete(key);
         }
 
         for (const stat of mapped.stats) {

--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -13,6 +13,7 @@ import {
   catalogAliasConflictUpdate,
   catalogAliasRows,
   catalogProblemToClimbs,
+  existingClimbUuidsForProblem,
   resolveIncumbentReplacement,
   resolveCatalogClimbUuid,
   type MoonBoardCatalogFile,
@@ -37,7 +38,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // existing one by (layout_id, hold_fingerprint), tie-breaking on
 // case-insensitive name. A match reuses the existing UUID (so the upsert updates
 // it in place, backfilling the 2024 quality/ascensionist gap); a miss mints a
-// stable id-based UUID and inserts. Stat upserts are monotonic — they never
+// stable id-based UUID and inserts — unless the problem already owns climb rows
+// from an earlier import, which means its holds drifted rather than that it's
+// new, and it's skipped loudly instead. Stat upserts are monotonic — they never
 // overwrite an existing grade/quality with null or drop an ascent count.
 //
 // The ~390 MB of catalog files are NOT committed. Point the script at a local
@@ -58,11 +61,15 @@ const BATCH_SIZE = 2000;
  * Existing MoonBoard climbs predate the fingerprint column (only layout 3 has
  * it populated in prod), so we recompute every fingerprint from board_climb_holds.
  * Holds are streamed with a cursor and folded per-climb so memory stays bounded.
+ *
+ * Also returns every existing MoonBoard climb uuid (listed or not) so the
+ * caller can spot a problem this importer already owns whose holds have since
+ * drifted — see `existingClimbUuidsForProblem`.
  */
 async function buildExistingIndex(
   client: postgres.Sql,
   db: ReturnType<typeof drizzle>,
-): Promise<ReturnType<typeof buildExistingCatalogMatchIndex>> {
+): Promise<{ index: ReturnType<typeof buildExistingCatalogMatchIndex>; climbUuids: Set<string> }> {
   console.info('   Building match index from existing MoonBoard climbs...');
   const fingerprintByUuid = new Map<string, string>();
   let currentUuid: string | null = null;
@@ -111,7 +118,7 @@ async function buildExistingIndex(
   const index = buildExistingCatalogMatchIndex(climbRows, fingerprintByUuid, canonicalByAlias);
   fingerprintByUuid.clear();
   console.info(`   Indexed ${climbRows.length} existing climbs (${index.size} hold groups)`);
-  return index;
+  return { index, climbUuids: new Set(climbRows.map((row) => row.uuid)) };
 }
 
 function parseFlag(name: string): string | undefined {
@@ -147,10 +154,19 @@ async function importMoonBoardCatalog() {
   const client = postgres(databaseUrl, { max: 1 });
   const db = drizzle(client);
 
-  const totals = { matched: 0, inserted: 0, climbs: 0, stats: 0, holds: 0, skippedProblems: 0, skippedAmbiguous: 0 };
+  const totals = {
+    matched: 0,
+    inserted: 0,
+    climbs: 0,
+    stats: 0,
+    holds: 0,
+    skippedProblems: 0,
+    skippedAmbiguous: 0,
+    skippedDrifted: 0,
+  };
 
   try {
-    const existingIndex = await buildExistingIndex(client, db);
+    const { index: existingIndex, climbUuids: existingClimbUuids } = await buildExistingIndex(client, db);
 
     for (const file of files) {
       const raw = fs.readFileSync(path.join(catalogDir, file), 'utf-8');
@@ -173,13 +189,15 @@ async function importMoonBoardCatalog() {
       // clobber a real benchmark's ascent count and benchmark flag.
       const bestByUuid = new Map<string, MappedCatalogClimb>();
       const climbByUuid = new Map<string, typeof boardClimbs.$inferInsert>();
-      const statsByUuid = new Map<string, typeof boardClimbStats.$inferInsert>();
+      // Keyed `${uuid}:${angle}` — one entry per graded angle of a climb.
+      const statsByUuidAngle = new Map<string, typeof boardClimbStats.$inferInsert>();
       const holdsByKey = new Map<string, typeof boardClimbHolds.$inferInsert>();
       const aliasByUuid = new Map<string, typeof boardClimbAliases.$inferInsert>();
       let matched = 0;
       let inserted = 0;
       let skippedProblems = 0;
       let skippedAmbiguous = 0;
+      let skippedDrifted = 0;
 
       for (const problem of dump.problems) {
         const mapped = catalogProblemToClimbs(problem, layoutId);
@@ -189,21 +207,50 @@ async function importMoonBoardCatalog() {
         }
         const { uuid, matched: matchedExisting, ambiguous } = resolveCatalogClimbUuid(mapped, existingIndex);
 
-        // Multiple DISTINCT listed rows share this problem's holds — the
-        // expected shape when migration 0185 (moonboard angle-dedup) hasn't
-        // run against this database yet, so both angle-rows of the problem
-        // are still separately listed. Writing through this state would
-        // double-count ascents across two listed rows and point a legacy
-        // alias at whichever row the name tie-break happened to land on.
-        // Loud skip, not a silent guess: run 0185 first, then re-import.
+        // Multiple DISTINCT listed rows share this problem's holds. Two causes:
+        //   1. Migration 0185 (moonboard angle-dedup) hasn't run against this
+        //      database yet, so both angle-rows of the problem are still
+        //      separately listed. Running it fixes this one.
+        //   2. The database IS migrated, but 0185 deliberately left this group
+        //      alone: it only collapses a same-signature group whose members
+        //      all sit at DISTINCT angles, so a cross-problem duplicate class
+        //      (the real "birthday cake trail mix" vs the junk problem named
+        //      "name", four listed rows on one signature) survives for manual
+        //      follow-up. Running migrations again changes nothing here.
+        // Either way, writing through would double-count ascents across two
+        // listed rows and point a legacy alias at whichever row the name
+        // tie-break happened to land on. Loud skip, not a silent guess.
         if (ambiguous) {
           skippedAmbiguous++;
           console.error(
             `   ⚠️  Skipping problem ${problem.id} ("${problem.name}"): multiple listed rows already share its holds ` +
-              `at layout ${layoutId} — this database likely predates migration 0185 (moonboard angle-dedup). ` +
-              `Run that migration, then re-run this import.`,
+              `at layout ${layoutId} — either this database predates migration 0185 (moonboard angle-dedup), or 0185 ` +
+              `ran and left a cross-problem duplicate group for manual follow-up. Check migrations first; if they're ` +
+              `up to date, these rows need deduping by hand.`,
           );
           continue;
+        }
+
+        // No hold match, but this problem already owns climb rows from an
+        // earlier import — its holds drifted rather than it being new. See
+        // existingClimbUuidsForProblem: inserting here would mint a duplicate
+        // and repoint the old rows' self-aliases (and therefore their ticks)
+        // at the empty new row. Loud skip.
+        if (!matchedExisting) {
+          const driftedUuids = existingClimbUuidsForProblem({
+            problemId: problem.id,
+            angles: mapped.stats.map((stat) => stat.angle),
+            existingClimbUuids,
+          });
+          if (driftedUuids.length > 0) {
+            skippedDrifted++;
+            console.error(
+              `   ⚠️  Skipping problem ${problem.id} ("${problem.name}"): its holds no longer match the climb rows it ` +
+                `already owns (${driftedUuids.join(', ')}) at layout ${layoutId}. Inserting would duplicate the climb ` +
+                `and redirect the existing rows' ticks. Reconcile those rows by hand, then re-run this import.`,
+            );
+            continue;
+          }
         }
 
         // Record the aliases before the dedupe below: when two problems collapse
@@ -249,15 +296,14 @@ async function importMoonBoardCatalog() {
           edgeBottom: null,
           edgeTop: null,
           // Angle-agnostic identity (see module header) — but KNOWN GAP,
-          // deliberately deferred: three backend paths (new-climb-subscriptions.ts,
-          // notification-worker.ts, feed-fanout.ts) resolve difficultyName via
-          // `LEFT JOIN board_climb_stats ON stats.angle = climbs.angle`, which
-          // never matches when climbs.angle is null — so a newly-imported
-          // MoonBoard problem shows ungraded in the new-climb feed and
-          // notifications until those three queries learn a MoonBoard fallback
-          // (e.g. pick the min-angle stats row when climbs.angle is null).
-          // Nothing fails; the grade just doesn't show. Track before relying on
-          // those surfaces for MoonBoard.
+          // deliberately deferred, tracked in #4220: three backend paths
+          // (new-climb-subscriptions.ts, notification-worker.ts, feed-fanout.ts)
+          // resolve difficultyName via `LEFT JOIN board_climb_stats ON
+          // stats.angle = climbs.angle`, which never matches when climbs.angle
+          // is null — so a newly-imported MoonBoard problem shows ungraded in
+          // the new-climb feed and notifications until those queries learn a
+          // fallback (e.g. pick the min-angle stats row when climbs.angle is
+          // null). Nothing fails; the grade just doesn't show.
           angle: null,
           framesCount: 1,
           framesPace: 0,
@@ -275,14 +321,14 @@ async function importMoonBoardCatalog() {
         // Clear the beaten incumbent's stale batch-map entries (see
         // resolveIncumbentReplacement's doc comment for why this is needed).
         for (const key of decision.staleStatKeys) {
-          statsByUuid.delete(key);
+          statsByUuidAngle.delete(key);
         }
         for (const key of decision.staleHoldKeys) {
           holdsByKey.delete(key);
         }
 
         for (const stat of mapped.stats) {
-          statsByUuid.set(`${uuid}:${stat.angle}`, {
+          statsByUuidAngle.set(`${uuid}:${stat.angle}`, {
             boardType: 'moonboard',
             climbUuid: uuid,
             angle: stat.angle,
@@ -319,13 +365,14 @@ async function importMoonBoardCatalog() {
       }
 
       const climbRecords = [...climbByUuid.values()];
-      const statsRecords = [...statsByUuid.values()];
+      const statsRecords = [...statsByUuidAngle.values()];
       const holdsRecords = [...holdsByKey.values()];
       const aliasRecords = [...aliasByUuid.values()];
 
       console.info(
         `   ${matched} matched existing, ${inserted} new; ${skippedProblems} problems skipped, ` +
-          `${skippedAmbiguous} skipped as ambiguous (pre-0185 duplicate rows)`,
+          `${skippedAmbiguous} skipped as ambiguous (duplicate listed rows), ` +
+          `${skippedDrifted} skipped as drifted (holds changed under an imported climb)`,
       );
 
       // One transaction per board: a crash mid-file never leaves a climb without
@@ -415,6 +462,7 @@ async function importMoonBoardCatalog() {
       totals.holds += holdsRecords.length;
       totals.skippedProblems += skippedProblems;
       totals.skippedAmbiguous += skippedAmbiguous;
+      totals.skippedDrifted += skippedDrifted;
     }
 
     console.info('\n✅ Import completed!');
@@ -426,8 +474,17 @@ async function importMoonBoardCatalog() {
     console.info(`   Problems skipped: ${totals.skippedProblems}`);
     if (totals.skippedAmbiguous > 0) {
       console.error(
-        `   ⚠️  Problems skipped as ambiguous: ${totals.skippedAmbiguous} — this database likely predates ` +
-          `migration 0185 (moonboard angle-dedup). Run it, then re-run this import to pick these up.`,
+        `   ⚠️  Problems skipped as ambiguous: ${totals.skippedAmbiguous} — several listed rows share their holds. ` +
+          `If this database predates migration 0185 (moonboard angle-dedup), run it and re-run this import to pick ` +
+          `these up. If it's already migrated, these are cross-problem duplicate groups 0185 left alone on purpose ` +
+          `and they need deduping by hand.`,
+      );
+    }
+    if (totals.skippedDrifted > 0) {
+      console.error(
+        `   ⚠️  Problems skipped as drifted: ${totals.skippedDrifted} — their holds no longer match the climb rows ` +
+          `they already own, so inserting would duplicate the climb and redirect the old rows' ticks. Reconcile ` +
+          `those rows by hand, then re-run this import.`,
       );
     }
 

--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -19,7 +19,7 @@ import {
   type MoonBoardCatalogFile,
   type MappedCatalogClimb,
 } from './moonboard-catalog-helpers.js';
-import { getScriptDatabaseUrl } from './db-connection.js';
+import { describeDatabaseHost, getScriptDatabaseUrl } from './db-connection.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -45,9 +45,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 //
 // The ~390 MB of catalog files are NOT committed. Point the script at a local
 // copy of the app-catalog directory:
-//   DB_URL=<target> vp run db:import-moonboard-catalog "/path/to/app-catalog"
-// (DB_URL must be set inline — it beats the dev-db .env override and is how you
-// target prod vs local.)
+//   DB_URL=<target> vp run '@boardsesh/db#db:import-moonboard-catalog' "/path/to/app-catalog"
+// (The package-scoped task name is required — plain `vp run
+// db:import-moonboard-catalog` resolves no task. DB_URL must be set inline: it
+// beats the dev-db .env override and is how you target prod vs local.)
 // =============================================================================
 
 const DEFAULT_DIR = path.join(__dirname, '../data/moonboard/app-catalog');
@@ -133,7 +134,7 @@ async function importMoonBoardCatalog() {
 
   if (!fs.existsSync(catalogDir) || !fs.statSync(catalogDir).isDirectory()) {
     console.error(`❌ Catalog directory not found: ${catalogDir}`);
-    console.error('   Usage: vp run db:import-moonboard-catalog [/path/to/app-catalog]');
+    console.error("   Usage: vp run '@boardsesh/db#db:import-moonboard-catalog' [/path/to/app-catalog]");
     process.exit(1);
   }
 
@@ -147,8 +148,7 @@ async function importMoonBoardCatalog() {
   }
 
   const databaseUrl = getScriptDatabaseUrl();
-  const dbHost = databaseUrl.split('@')[1]?.split('/')[0] || 'unknown';
-  console.info(`🔄 Importing MoonBoard catalog to: ${dbHost}`);
+  console.info(`🔄 Importing MoonBoard catalog to: ${describeDatabaseHost(databaseUrl)}`);
   console.info(`📂 Reading catalog from: ${catalogDir} (${files.length} files)`);
 
   const client = postgres(databaseUrl, { max: 1 });

--- a/packages/db/scripts/moonboard-catalog-batch.test.ts
+++ b/packages/db/scripts/moonboard-catalog-batch.test.ts
@@ -1,0 +1,338 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { stageCatalogBatch, type StageCatalogBatchArgs } from './moonboard-catalog-batch.js';
+import {
+  catalogClimbUuid,
+  catalogFingerprintKey,
+  catalogProblemToClimbs,
+  legacyCatalogClimbUuid,
+  statsBatchKey,
+  type ExistingCatalogClimb,
+  type MoonBoardCatalogConfiguration,
+  type MoonBoardCatalogProblem,
+} from './moonboard-catalog-helpers.js';
+
+const LAYOUT_ID = 3;
+
+// Two distinct hold sets, so problems either share a fingerprint or don't.
+const MOVES_SHARED = 's~K1~|r~E10~|e~I18~';
+const MOVES_OTHER = 's~J2~|r~D9~|e~H17~';
+
+function config(overrides: Partial<MoonBoardCatalogConfiguration> = {}): MoonBoardCatalogConfiguration {
+  return {
+    apiId: 1,
+    grade: '7A+',
+    userGrade: '7A',
+    userRating: 4,
+    isBenchmark: false,
+    configuration: '40°',
+    repeats: 10,
+    dateDeleted: null,
+    ...overrides,
+  };
+}
+
+function problem(overrides: Partial<MoonBoardCatalogProblem> & { id: number }): MoonBoardCatalogProblem {
+  return {
+    name: `Problem ${overrides.id}`,
+    setter: 'A Setter',
+    setbyId: 'setter-id',
+    climbMethod: 'Any marked holds',
+    moves: MOVES_SHARED,
+    holdsetup: 21,
+    dateInserted: '2023-11-23T18:00:15.227',
+    dateDeleted: null,
+    Active: true,
+    configurations: [config()],
+    ...overrides,
+  };
+}
+
+function fingerprintOf(source: MoonBoardCatalogProblem, layoutId = LAYOUT_ID): string {
+  const mapped = catalogProblemToClimbs(source, layoutId);
+  if (!mapped) throw new Error('fixture problem must map to a climb');
+  return mapped.holdFingerprint;
+}
+
+function stage(overrides: Partial<StageCatalogBatchArgs> & { problems: MoonBoardCatalogProblem[] }) {
+  const warnings: string[] = [];
+  const result = stageCatalogBatch({
+    layoutId: LAYOUT_ID,
+    existingIndex: new Map<string, ExistingCatalogClimb[]>(),
+    existingClimbUuids: new Set<string>(),
+    canonicalByAlias: new Map<string, string>(),
+    upstreamSyncedAt: '2026-01-01T00:00:00.000Z',
+    onWarning: (message) => warnings.push(message),
+    ...overrides,
+  });
+  return { ...result, warnings };
+}
+
+function canonicalFor(aliases: { aliasUuid: string; canonicalUuid: string }[], aliasUuid: string) {
+  return aliases.find((alias) => alias.aliasUuid === aliasUuid)?.canonicalUuid;
+}
+
+void test('a brand new problem stages one climb with its stats, holds and aliases', () => {
+  const fresh = problem({ id: 700001 });
+  const { climbs, stats, holds, aliases, counters } = stage({ problems: [fresh] });
+
+  assert.equal(counters.inserted, 1);
+  assert.equal(counters.matched, 0);
+  assert.equal(counters.foldedInBatch, 0);
+  assert.equal(climbs.length, 1);
+  assert.equal(climbs[0].uuid, catalogClimbUuid({ id: 700001 }));
+  // Angle-agnostic identity: the angles live on the stats rows, not the climb.
+  assert.equal(climbs[0].angle, null);
+  assert.equal(stats.length, 1);
+  assert.equal(stats[0].angle, 40);
+  assert.equal(holds.length, 3);
+  assert.equal(canonicalFor(aliases, legacyCatalogClimbUuid({ id: 700001, angle: 40 })), climbs[0].uuid);
+});
+
+// ---------------------------------------------------------------------------
+// In-batch collapse of two problems that share holds and match nothing yet
+// ---------------------------------------------------------------------------
+
+void test('two new same-holds problems stage ONE climb, and both problem ids resolve to it', () => {
+  const first = problem({ id: 700010, name: 'First In File' });
+  const second = problem({ id: 700011, name: 'Second In File' });
+
+  const { climbs, stats, aliases, counters } = stage({ problems: [first, second] });
+
+  // Without the fold both would insert, and every later run would then see two
+  // listed rows on one fingerprint and skip the pair as ambiguous forever.
+  assert.equal(climbs.length, 1, 'both problems must collapse onto one climb row');
+  assert.equal(counters.inserted, 1);
+  assert.equal(counters.foldedInBatch, 1);
+
+  const survivor = climbs[0].uuid;
+  assert.equal(survivor, catalogClimbUuid({ id: 700010 }));
+  assert.equal(stats.length, 1);
+  assert.equal(stats[0].climbUuid, survivor);
+
+  // The loser keeps resolving: id-based alias and legacy per-angle alias both
+  // point at the survivor, exactly as they would on the matched path.
+  assert.equal(canonicalFor(aliases, catalogClimbUuid({ id: 700011 })), survivor);
+  assert.equal(canonicalFor(aliases, legacyCatalogClimbUuid({ id: 700011, angle: 40 })), survivor);
+  assert.equal(canonicalFor(aliases, legacyCatalogClimbUuid({ id: 700010, angle: 40 })), survivor);
+  assert.equal(canonicalFor(aliases, survivor), survivor, 'self-alias survives');
+});
+
+void test('the folded climb keeps the STRONGER problem, whichever order the file lists them in', () => {
+  const weak = problem({
+    id: 700020,
+    name: 'Junk Duplicate',
+    configurations: [config({ repeats: 19, isBenchmark: false })],
+  });
+  const strong = problem({
+    id: 700021,
+    name: 'Real Problem',
+    configurations: [config({ repeats: 38683, isBenchmark: true })],
+  });
+
+  const weakFirst = stage({ problems: [weak, strong] });
+  assert.equal(weakFirst.climbs.length, 1);
+  assert.equal(weakFirst.climbs[0].name, 'Real Problem');
+  assert.equal(weakFirst.stats[0].upstreamAscensionistCount, 38683);
+  assert.equal(weakFirst.counters.foldedInBatch, 1);
+
+  const strongFirst = stage({ problems: [strong, weak] });
+  assert.equal(strongFirst.climbs.length, 1);
+  assert.equal(strongFirst.climbs[0].name, 'Real Problem');
+  assert.equal(strongFirst.stats[0].upstreamAscensionistCount, 38683);
+  assert.equal(strongFirst.counters.foldedInBatch, 1);
+
+  // Whoever wins, both ids resolve to the one surviving climb.
+  for (const result of [weakFirst, strongFirst]) {
+    const survivor = result.climbs[0].uuid;
+    for (const id of [700020, 700021]) {
+      assert.equal(canonicalFor(result.aliases, catalogClimbUuid({ id })) ?? survivor, survivor);
+    }
+  }
+});
+
+void test("a folded loser leaves no stats row behind at an angle the winner isn't graded at", () => {
+  // The loser is graded at 25° AND 40°; the stronger winner only at 40°. The
+  // 25° entry the loser staged has to go, or it would be written under the
+  // winner's uuid as a grade nobody set.
+  const twoAngleLoser = problem({
+    id: 700030,
+    name: 'Two Angles, Weak',
+    configurations: [config({ configuration: '25°', repeats: 5 }), config({ configuration: '40°', repeats: 5 })],
+  });
+  const oneAngleWinner = problem({
+    id: 700031,
+    name: 'One Angle, Strong',
+    configurations: [config({ configuration: '40°', repeats: 900 })],
+  });
+
+  const { climbs, stats } = stage({ problems: [twoAngleLoser, oneAngleWinner] });
+
+  assert.equal(climbs.length, 1);
+  assert.deepEqual(
+    stats.map((row) => row.angle),
+    [40],
+  );
+  assert.equal(stats[0].upstreamAscensionistCount, 900);
+  // Pins the format agreement: the stale keys resolveIncumbentReplacement
+  // reports must be the keys this batch actually stored its stats under.
+  assert.equal(statsBatchKey(climbs[0].uuid, 25), `${climbs[0].uuid}:25`);
+});
+
+void test('same holds on a DIFFERENT layout are a different climb — no fold across boards', () => {
+  const shared = problem({ id: 700040 });
+  assert.notEqual(
+    catalogFingerprintKey(2, fingerprintOf(shared)),
+    catalogFingerprintKey(4, fingerprintOf(shared)),
+    'the fold key must keep layouts apart',
+  );
+
+  // One file per board, so the cross-layout case is two batches: each stages
+  // its own climb and neither folds.
+  const layout2 = stage({ problems: [shared], layoutId: 2 });
+  const layout4 = stage({ problems: [problem({ id: 700041 })], layoutId: 4 });
+
+  assert.equal(layout2.counters.foldedInBatch, 0);
+  assert.equal(layout4.counters.foldedInBatch, 0);
+  assert.equal(layout2.climbs[0].layoutId, 2);
+  assert.equal(layout4.climbs[0].layoutId, 4);
+  assert.notEqual(layout2.climbs[0].uuid, layout4.climbs[0].uuid);
+});
+
+void test('different holds never fold, even in the same file', () => {
+  const { climbs, counters } = stage({
+    problems: [problem({ id: 700050 }), problem({ id: 700051, moves: MOVES_OTHER })],
+  });
+  assert.equal(climbs.length, 2);
+  assert.equal(counters.inserted, 2);
+  assert.equal(counters.foldedInBatch, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Drift guards
+// ---------------------------------------------------------------------------
+
+void test('a matched merge is skipped when the problem owns a DIFFERENT live climb row', () => {
+  // The problem's holds match climb X, but a `moonboard:{id}:40` row R also
+  // exists and does not redirect to X. Merging would emit R as an alias of X
+  // and repoint R's ticks at a climb it isn't, while R stays listed.
+  const drifted = problem({ id: 700060 });
+  const matchedUuid = 'moonboard-existing-canonical-x';
+  const ownedRowUuid = legacyCatalogClimbUuid({ id: 700060, angle: 40 });
+
+  const { climbs, aliases, counters, warnings } = stage({
+    problems: [drifted],
+    existingIndex: new Map([
+      [catalogFingerprintKey(LAYOUT_ID, fingerprintOf(drifted)), [{ uuid: matchedUuid, name: 'Problem 700060' }]],
+    ]),
+    existingClimbUuids: new Set([matchedUuid, ownedRowUuid]),
+  });
+
+  assert.equal(counters.skippedHijacked, 1);
+  assert.equal(counters.matched, 0);
+  assert.equal(climbs.length, 0, 'nothing may be written for a problem we skip');
+  assert.equal(aliases.length, 0, 'above all, no alias may repoint the owned row');
+  assert.match(warnings[0], /700060/);
+  assert.ok(warnings[0].includes(ownedRowUuid));
+});
+
+void test('the ordinary legacy merge — the owned row IS the matched climb — is not a hijack', () => {
+  // Every MoonBoard 2024 climb looks like this: the problem owns exactly the
+  // per-angle row its holds now match. That must merge in place, not skip.
+  const legacy = problem({ id: 700070 });
+  const legacyRowUuid = legacyCatalogClimbUuid({ id: 700070, angle: 40 });
+
+  const { climbs, counters } = stage({
+    problems: [legacy],
+    existingIndex: new Map([
+      [catalogFingerprintKey(LAYOUT_ID, fingerprintOf(legacy)), [{ uuid: legacyRowUuid, name: 'Problem 700070' }]],
+    ]),
+    existingClimbUuids: new Set([legacyRowUuid]),
+  });
+
+  assert.equal(counters.skippedHijacked, 0);
+  assert.equal(counters.matched, 1);
+  assert.equal(climbs.length, 1);
+  assert.equal(climbs[0].uuid, legacyRowUuid);
+});
+
+void test('an owned row that already redirects to the matched climb does not block the merge', () => {
+  // The dedup migration delisted the 25° row and aliased it at the survivor:
+  // re-writing that alias is a no-op, so the merge is safe.
+  const merged = problem({ id: 700080 });
+  const matchedUuid = legacyCatalogClimbUuid({ id: 700080, angle: 40 });
+  const redirectedUuid = legacyCatalogClimbUuid({ id: 700080, angle: 25 });
+
+  const { climbs, counters } = stage({
+    problems: [merged],
+    existingIndex: new Map([
+      [catalogFingerprintKey(LAYOUT_ID, fingerprintOf(merged)), [{ uuid: matchedUuid, name: 'Problem 700080' }]],
+    ]),
+    existingClimbUuids: new Set([matchedUuid, redirectedUuid]),
+    canonicalByAlias: new Map([[redirectedUuid, matchedUuid]]),
+  });
+
+  assert.equal(counters.skippedHijacked, 0);
+  assert.equal(counters.matched, 1);
+  assert.equal(climbs[0].uuid, matchedUuid);
+});
+
+void test('a hold-match miss with rows the problem already owns is still skipped as drifted', () => {
+  const drifted = problem({ id: 700090 });
+
+  const { climbs, counters } = stage({
+    problems: [drifted],
+    existingClimbUuids: new Set([catalogClimbUuid({ id: 700090 })]),
+  });
+
+  assert.equal(counters.skippedDrifted, 1);
+  assert.equal(counters.inserted, 0);
+  assert.equal(climbs.length, 0);
+});
+
+void test('the drift guard covers angles the catalog no longer grades', () => {
+  // Graded at 40° only today; the 25° configuration lost its grade since the
+  // earlier import that minted `moonboard:{id}:25`. Checking only today's
+  // graded angles would miss that row and insert a duplicate beside it.
+  const regraded = problem({
+    id: 700100,
+    configurations: [config({ configuration: '25°', grade: '' }), config({ configuration: '40°' })],
+  });
+
+  const { climbs, counters, warnings } = stage({
+    problems: [regraded],
+    existingClimbUuids: new Set([legacyCatalogClimbUuid({ id: 700100, angle: 25 })]),
+  });
+
+  assert.equal(counters.skippedDrifted, 1);
+  assert.equal(climbs.length, 0);
+  assert.ok(warnings[0].includes(legacyCatalogClimbUuid({ id: 700100, angle: 25 })));
+});
+
+void test('ambiguous problems are skipped and stage nothing', () => {
+  const ambiguous = problem({ id: 700110 });
+  const { climbs, aliases, counters } = stage({
+    problems: [ambiguous],
+    existingIndex: new Map([
+      [
+        catalogFingerprintKey(LAYOUT_ID, fingerprintOf(ambiguous)),
+        [
+          { uuid: 'moonboard-dupe-a', name: 'Problem 700110' },
+          { uuid: 'moonboard-dupe-b', name: 'Problem 700110' },
+        ],
+      ],
+    ]),
+  });
+
+  assert.equal(counters.skippedAmbiguous, 1);
+  assert.equal(climbs.length, 0);
+  assert.equal(aliases.length, 0);
+});
+
+void test('unimportable problems are counted, not staged', () => {
+  const { climbs, counters } = stage({
+    problems: [problem({ id: 700120, dateDeleted: '2025-01-01T00:00:00' }), problem({ id: 700121, moves: null })],
+  });
+  assert.equal(counters.skippedProblems, 2);
+  assert.equal(climbs.length, 0);
+});

--- a/packages/db/scripts/moonboard-catalog-batch.ts
+++ b/packages/db/scripts/moonboard-catalog-batch.ts
@@ -1,0 +1,321 @@
+import type { boardClimbs, boardClimbStats, boardClimbHolds, boardClimbAliases } from '../src/schema/boards/unified.js';
+import {
+  catalogAliasRows,
+  catalogFingerprintKey,
+  catalogProblemToClimbs,
+  existingClimbUuidsForProblem,
+  hijackedClimbUuidsForProblem,
+  holdsBatchKey,
+  ownedClimbAngles,
+  resolveCatalogClimbUuid,
+  resolveIncumbentReplacement,
+  statsBatchKey,
+  type ExistingCatalogClimb,
+  type MappedCatalogClimb,
+  type MoonBoardCatalogProblem,
+} from './moonboard-catalog-helpers.js';
+
+// =============================================================================
+// Staging one catalog file's rows
+// =============================================================================
+// Everything the importer decides per problem — merge target, the skip guards,
+// the same-holds collapse — happens here, so it can be exercised without a
+// database. import-moonboard-catalog.ts keeps the I/O: reading files, building
+// the match index, and writing the rows this returns.
+// =============================================================================
+
+export type CatalogClimbRow = typeof boardClimbs.$inferInsert;
+export type CatalogStatsRow = typeof boardClimbStats.$inferInsert;
+export type CatalogHoldRow = typeof boardClimbHolds.$inferInsert;
+export type CatalogAliasRow = typeof boardClimbAliases.$inferInsert;
+
+export type CatalogBatchCounters = {
+  /** Problems merged onto a climb row that already existed in the database. */
+  matched: number;
+  /** Problems staged as a brand new climb row. */
+  inserted: number;
+  /** Problems the mapper rejected (deleted, holdless, no graded configuration). */
+  skippedProblems: number;
+  /** Skipped: several listed rows already share the problem's holds. */
+  skippedAmbiguous: number;
+  /** Skipped: hold-match miss, but the problem already owns climb rows. */
+  skippedDrifted: number;
+  /** Skipped: merging would repoint a live climb row the problem owns. */
+  skippedHijacked: number;
+  /** Later problems folded onto an earlier same-holds problem in this batch. */
+  foldedInBatch: number;
+};
+
+export type CatalogBatchStaging = {
+  climbs: CatalogClimbRow[];
+  stats: CatalogStatsRow[];
+  holds: CatalogHoldRow[];
+  aliases: CatalogAliasRow[];
+  counters: CatalogBatchCounters;
+};
+
+export type StageCatalogBatchArgs = {
+  problems: MoonBoardCatalogProblem[];
+  layoutId: number;
+  /** `${layoutId}|${fingerprint}` → existing listed climbs, from buildExistingCatalogMatchIndex. */
+  existingIndex: Map<string, ExistingCatalogClimb[]>;
+  /** Every existing MoonBoard climb uuid, listed or not. */
+  existingClimbUuids: ReadonlySet<string>;
+  /** alias_uuid → canonical_uuid for MoonBoard, used to tell a merge from a hijack. */
+  canonicalByAlias: ReadonlyMap<string, string>;
+  /** Stamped on every stats row this batch writes. */
+  upstreamSyncedAt?: string;
+  onWarning?: (message: string) => void;
+};
+
+export function stageCatalogBatch(args: StageCatalogBatchArgs): CatalogBatchStaging {
+  const { problems, layoutId, existingIndex, existingClimbUuids, canonicalByAlias } = args;
+  const upstreamSyncedAt = args.upstreamSyncedAt ?? new Date().toISOString();
+  const warn = args.onWarning ?? ((message: string) => console.error(message));
+
+  // Dedupe in memory keyed per conflict target so a single batch never
+  // proposes the same target twice ("ON CONFLICT cannot affect row a second
+  // time"). When two problems share the same holds (so they resolve to one
+  // target UUID) we keep the STRONGER problem (resolveIncumbentReplacement /
+  // isBetterCatalogClimb: more total repeats across its graded angles, then
+  // benchmark) instead of last-wins — otherwise a junk duplicate can
+  // clobber a real benchmark's ascent count and benchmark flag.
+  const bestByUuid = new Map<string, MappedCatalogClimb>();
+  const climbByUuid = new Map<string, CatalogClimbRow>();
+  // Keyed by statsBatchKey — one entry per graded angle of a climb.
+  const statsByUuidAngle = new Map<string, CatalogStatsRow>();
+  const holdsByKey = new Map<string, CatalogHoldRow>();
+  const aliasByUuid = new Map<string, CatalogAliasRow>();
+  // `${layoutId}|${fingerprint}` → the uuid this batch already staged for those
+  // holds, for problems that matched nothing in the database (see the fold below).
+  const stagedUuidByFingerprint = new Map<string, string>();
+
+  const counters: CatalogBatchCounters = {
+    matched: 0,
+    inserted: 0,
+    skippedProblems: 0,
+    skippedAmbiguous: 0,
+    skippedDrifted: 0,
+    skippedHijacked: 0,
+    foldedInBatch: 0,
+  };
+
+  for (const problem of problems) {
+    const mapped = catalogProblemToClimbs(problem, layoutId);
+    if (!mapped) {
+      counters.skippedProblems++;
+      continue;
+    }
+    const resolved = resolveCatalogClimbUuid(mapped, existingIndex);
+
+    // Multiple DISTINCT listed rows share this problem's holds. Two causes:
+    //   1. The moonboard_angle_dedup_backfill migration (#3849) hasn't run against this
+    //      database yet, so both angle-rows of the problem are still
+    //      separately listed. Running it fixes this one.
+    //   2. The database IS migrated, but the dedup migration deliberately left this group
+    //      alone: it only collapses a same-signature group whose members
+    //      all sit at DISTINCT angles, so a cross-problem duplicate class
+    //      (the real "birthday cake trail mix" vs the junk problem named
+    //      "name", four listed rows on one signature) survives for manual
+    //      follow-up. Running migrations again changes nothing here.
+    // Either way, writing through would double-count ascents across two
+    // listed rows and point a legacy alias at whichever row the name
+    // tie-break happened to land on. Loud skip, not a silent guess.
+    if (resolved.ambiguous) {
+      counters.skippedAmbiguous++;
+      warn(
+        `   ⚠️  Skipping problem ${problem.id} ("${problem.name}"): multiple listed rows already share its holds ` +
+          `at layout ${layoutId} — either this database predates the moonboard_angle_dedup_backfill migration (#3849), or that migration ` +
+          `ran and left a cross-problem duplicate group for manual follow-up. Check migrations first; if they're ` +
+          `up to date, these rows need deduping by hand.`,
+      );
+      continue;
+    }
+
+    // Both guards below ask "which climb rows does this problem already own?"
+    // over the same angle set: today's graded angles plus every angle MoonBoard
+    // has ever been imported at (see ownedClimbAngles).
+    const angles = ownedClimbAngles(mapped.stats.map((stat) => stat.angle));
+
+    if (!resolved.matched) {
+      // No hold match, but this problem already owns climb rows from an
+      // earlier import — its holds drifted rather than it being new. See
+      // existingClimbUuidsForProblem: inserting here would mint a duplicate
+      // and repoint the old rows' self-aliases (and therefore their ticks)
+      // at the empty new row. Loud skip.
+      const driftedUuids = existingClimbUuidsForProblem({
+        problemId: problem.id,
+        angles,
+        existingClimbUuids,
+      });
+      if (driftedUuids.length > 0) {
+        counters.skippedDrifted++;
+        warn(
+          `   ⚠️  Skipping problem ${problem.id} ("${problem.name}"): its holds no longer match the climb rows it ` +
+            `already owns (${driftedUuids.join(', ')}) at layout ${layoutId}. Inserting would duplicate the climb ` +
+            `and redirect the existing rows' ticks. Reconcile those rows by hand, then re-run this import.`,
+        );
+        continue;
+      }
+    } else {
+      // The holds matched an existing row, so owning rows is normally just the
+      // legacy import of this same problem (owned uuid === matched uuid) and
+      // merging in place is correct. What is NOT correct is merging when one of
+      // the owned uuids is a DIFFERENT live climb row: the alias rows below
+      // would repoint it — and its ticks — at the row we matched, while it
+      // stays listed. See hijackedClimbUuidsForProblem.
+      const hijackedUuids = hijackedClimbUuidsForProblem({
+        problemId: problem.id,
+        angles,
+        resolvedUuid: resolved.uuid,
+        existingClimbUuids,
+        canonicalByAlias,
+      });
+      if (hijackedUuids.length > 0) {
+        counters.skippedHijacked++;
+        warn(
+          `   ⚠️  Skipping problem ${problem.id} ("${problem.name}"): its holds match climb ${resolved.uuid}, but the ` +
+            `problem also owns live climb rows (${hijackedUuids.join(', ')}) that are not that climb and do not ` +
+            `already redirect to it. Merging would repoint those rows — and their ticks — at ${resolved.uuid} while ` +
+            `they stay listed. Reconcile them by hand, then re-run this import.`,
+        );
+        continue;
+      }
+    }
+
+    // Two DISTINCT problems in this file can share holds without either one
+    // matching the database (both brand new). They resolve to different
+    // id-based uuids, so bestByUuid alone would insert BOTH — and every later
+    // run then sees two listed rows on one fingerprint and skips the pair as
+    // ambiguous, permanently. Collapse them onto the uuid this batch already
+    // staged for those holds; which problem's data survives is still
+    // isBetterCatalogClimb's call, made by resolveIncumbentReplacement below.
+    let uuid = resolved.uuid;
+    if (!resolved.matched) {
+      const fingerprintKey = catalogFingerprintKey(mapped.layoutId, mapped.holdFingerprint);
+      const stagedUuid = stagedUuidByFingerprint.get(fingerprintKey);
+      if (stagedUuid === undefined) {
+        stagedUuidByFingerprint.set(fingerprintKey, uuid);
+      } else if (stagedUuid !== uuid) {
+        counters.foldedInBatch++;
+        uuid = stagedUuid;
+      }
+    }
+
+    // Record the aliases before the dedupe below: when two problems collapse
+    // onto one climb (same holds) we drop the weaker problem's data, but we
+    // still want BOTH problem ids to resolve to the survivor. The self-alias
+    // lets resolveCanonicalClimbUuid hit; the id-based alias (added whenever the
+    // climb's canonical uuid isn't this problem's own) makes the climb
+    // addressable by its MoonBoard problem id; the per-angle legacy aliases keep
+    // the personal-logbook importer's `moonboard:{id}:{angle}` lookup resolving.
+    for (const aliasRow of catalogAliasRows({
+      problemId: problem.id,
+      angles: mapped.stats.map((stat) => stat.angle),
+      canonicalUuid: uuid,
+    })) {
+      aliasByUuid.set(aliasRow.aliasUuid, {
+        boardType: 'moonboard',
+        aliasUuid: aliasRow.aliasUuid,
+        canonicalUuid: aliasRow.canonicalUuid,
+        source: 'moonboard-catalog-import',
+      });
+    }
+
+    const incumbent = bestByUuid.get(uuid);
+    const decision = resolveIncumbentReplacement(uuid, mapped, incumbent);
+    if (!decision.accept) continue;
+    if (!incumbent) {
+      if (resolved.matched) counters.matched++;
+      else counters.inserted++;
+    }
+    bestByUuid.set(uuid, mapped);
+
+    climbByUuid.set(uuid, {
+      uuid,
+      boardType: 'moonboard',
+      layoutId: mapped.layoutId,
+      setterId: null,
+      setterUsername: mapped.setterUsername,
+      name: mapped.name,
+      description: mapped.description,
+      hsm: null,
+      edgeLeft: null,
+      edgeRight: null,
+      edgeBottom: null,
+      edgeTop: null,
+      // Angle-agnostic identity (see the importer's module header). Consumers
+      // that resolve difficultyName by joining board_climb_stats at the climb's
+      // own angle handle the null via climbStatsEffectiveAngleSql
+      // (packages/backend/src/db/queries/util/climb-stats-join.ts): when
+      // climbs.angle is null they fall back to the climb's most-ascended
+      // stats row (lower angle wins ties). Formerly tracked as #4220,
+      // fixed on main before this importer landed.
+      angle: null,
+      framesCount: 1,
+      framesPace: 0,
+      frames: mapped.frames,
+      isDraft: false,
+      isListed: true,
+      createdAt: mapped.createdAt,
+      synced: true,
+      syncError: null,
+      userId: null,
+      holdFingerprint: mapped.holdFingerprint,
+      characteristics: mapped.characteristics,
+    });
+
+    // Clear the beaten incumbent's stale batch-map entries (see
+    // resolveIncumbentReplacement's doc comment for why this is needed).
+    for (const key of decision.staleStatKeys) {
+      statsByUuidAngle.delete(key);
+    }
+    for (const key of decision.staleHoldKeys) {
+      holdsByKey.delete(key);
+    }
+
+    for (const stat of mapped.stats) {
+      statsByUuidAngle.set(statsBatchKey(uuid, stat.angle), {
+        boardType: 'moonboard',
+        climbUuid: uuid,
+        angle: stat.angle,
+        displayDifficulty: stat.difficultyId ?? null,
+        benchmarkDifficulty: stat.isBenchmark && stat.difficultyId !== undefined ? stat.difficultyId : null,
+        // MoonBoard's community-repeat count is this board's upstream source.
+        // Seed the total too (a fresh row has no Boardsesh ticks yet); the tick
+        // recompute later adds boardsesh_ascensionist_count on top of upstream.
+        upstreamAscensionistCount: stat.ascensionistCount,
+        ascensionistCount: stat.ascensionistCount,
+        difficultyAverage: stat.difficultyId ?? null,
+        qualityAverage: stat.qualityAverage,
+        // The manufacturer average also seeds upstream_quality_average (the
+        // blend's upstream term). On a fresh INSERT quality_average == this
+        // value because no Boardsesh votes exist yet; on conflict it re-blends.
+        upstreamQualityAverage: stat.qualityAverage,
+        qualityNormalized: true,
+        faUsername: null,
+        faAt: null,
+        // MoonBoard catalog import is this board's upstream stats source.
+        upstreamSyncedAt,
+      });
+    }
+
+    for (const hold of mapped.holds) {
+      holdsByKey.set(holdsBatchKey(uuid, hold.holdId), {
+        boardType: 'moonboard',
+        climbUuid: uuid,
+        holdId: hold.holdId,
+        frameNumber: 0,
+        holdState: hold.holdState,
+      });
+    }
+  }
+
+  return {
+    climbs: [...climbByUuid.values()],
+    stats: [...statsByUuidAngle.values()],
+    holds: [...holdsByKey.values()],
+    aliases: [...aliasByUuid.values()],
+    counters,
+  };
+}

--- a/packages/db/scripts/moonboard-catalog-helpers.test.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.test.ts
@@ -233,10 +233,10 @@ void test('catalog matching ignores a listed alias chain whose terminal climb is
   assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: mapped.uuid, matched: false, ambiguous: false });
 });
 
-void test('catalog matching flags ambiguous when TWO DISTINCT listed rows share holds+name (pre-0185 database)', () => {
+void test('catalog matching flags ambiguous when TWO DISTINCT listed rows share holds+name (pre-dedup-migration database)', () => {
   const mapped = makeMappedClimb();
   // Neither aliases the other — both are independently listed, same holds,
-  // same name. This is the exact shape a database predating migration 0185
+  // same name. This is the exact shape a database predating the dedup migration
   // (moonboard angle-dedup) looks like: both angle-rows of one problem still
   // separately listed.
   const angle25Uuid = 'moonboard-not-yet-deduped-25';

--- a/packages/db/scripts/moonboard-catalog-helpers.test.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.test.ts
@@ -170,7 +170,7 @@ void test('catalog matching excludes delisted rows even when they have stale sel
     ]),
   );
 
-  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: canonicalUuid, matched: true });
+  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: canonicalUuid, matched: true, ambiguous: false });
 });
 
 void test('catalog matching follows alias chains and collapses candidates at the same canonical UUID', () => {
@@ -194,7 +194,7 @@ void test('catalog matching follows alias chains and collapses candidates at the
     ]),
   );
 
-  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: canonicalUuid, matched: true });
+  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: canonicalUuid, matched: true, ambiguous: false });
 });
 
 void test('catalog matching ignores cyclic aliases instead of writing another broken redirect', () => {
@@ -210,7 +210,7 @@ void test('catalog matching ignores cyclic aliases instead of writing another br
     ]),
   );
 
-  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: mapped.uuid, matched: false });
+  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: mapped.uuid, matched: false, ambiguous: false });
 });
 
 void test('catalog matching ignores a listed alias chain whose terminal climb is delisted', () => {
@@ -229,7 +229,52 @@ void test('catalog matching ignores a listed alias chain whose terminal climb is
     ]),
   );
 
-  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: mapped.uuid, matched: false });
+  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: mapped.uuid, matched: false, ambiguous: false });
+});
+
+void test('catalog matching flags ambiguous when TWO DISTINCT listed rows share holds+name (pre-0185 database)', () => {
+  const mapped = makeMappedClimb();
+  // Neither aliases the other — both are independently listed, same holds,
+  // same name. This is the exact shape a database predating migration 0185
+  // (moonboard angle-dedup) looks like: both angle-rows of one problem still
+  // separately listed.
+  const angle25Uuid = 'moonboard-not-yet-deduped-25';
+  const angle40Uuid = 'moonboard-not-yet-deduped-40';
+  const index = buildExistingCatalogMatchIndex(
+    [
+      { uuid: angle25Uuid, layoutId: mapped.layoutId, name: mapped.name, isListed: true },
+      { uuid: angle40Uuid, layoutId: mapped.layoutId, name: mapped.name, isListed: true },
+    ],
+    new Map([
+      [angle25Uuid, mapped.holdFingerprint],
+      [angle40Uuid, mapped.holdFingerprint],
+    ]),
+    new Map(),
+  );
+
+  const result = resolveCatalogClimbUuid(mapped, index);
+  assert.equal(result.ambiguous, true, 'caller must skip rather than silently write through this uuid');
+  assert.ok(
+    result.uuid === angle25Uuid || result.uuid === angle40Uuid,
+    'still resolves to one of the two candidates (row-order dependent) — the ambiguous flag is what matters',
+  );
+});
+
+void test('catalog matching flags ambiguous when TWO DISTINCT listed rows share holds but NEITHER matches the incoming name', () => {
+  const mapped = makeMappedClimb({ name: 'Freshly Renamed Problem' });
+  const index = buildExistingCatalogMatchIndex(
+    [
+      { uuid: 'moonboard-old-name-a', layoutId: mapped.layoutId, name: 'Old Name A', isListed: true },
+      { uuid: 'moonboard-old-name-b', layoutId: mapped.layoutId, name: 'Old Name B', isListed: true },
+    ],
+    new Map([
+      ['moonboard-old-name-a', mapped.holdFingerprint],
+      ['moonboard-old-name-b', mapped.holdFingerprint],
+    ]),
+    new Map(),
+  );
+
+  assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: mapped.uuid, matched: false, ambiguous: true });
 });
 
 void test('catalog alias conflicts repair the canonical target and refresh last seen', () => {

--- a/packages/db/scripts/moonboard-catalog-helpers.test.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.test.ts
@@ -13,13 +13,16 @@ import {
   resolveCatalogClimbUuid,
   holdsToFrames,
   catalogClimbUuid,
+  legacyCatalogClimbUuid,
   catalogAliasRows,
   isImportableProblem,
   isImportableConfig,
-  mapCatalogConfig,
+  mapCatalogProblemStructural,
+  mapCatalogConfigStats,
   catalogProblemToClimbs,
   isBetterCatalogClimb,
   type MoonBoardCatalogProblem,
+  type MappedCatalogClimb,
 } from './moonboard-catalog-helpers.js';
 
 // "Porridge & Salt" (Joe Wallace) — id 541453, MoonBoard 2024 (holdsetup 21).
@@ -59,6 +62,12 @@ const PORRIDGE: MoonBoardCatalogProblem = {
     },
   ],
 };
+
+function makeMappedClimb(overrides: Partial<MappedCatalogClimb> = {}): MappedCatalogClimb {
+  const climb = catalogProblemToClimbs(PORRIDGE, 3);
+  if (!climb) throw new Error('PORRIDGE must map to a climb');
+  return { ...climb, ...overrides };
+}
 
 void test('HOLDSETUP_TO_LAYOUT covers all 7 boards', () => {
   assert.deepEqual(HOLDSETUP_TO_LAYOUT, { 1: 2, 15: 4, 17: 5, 19: 6, 21: 3, 22: 7, 23: 1 });
@@ -105,50 +114,50 @@ void test('holdsToFrames encodes p{holdId}r{roleCode} in move order', () => {
   assert.equal(holdsToFrames(holds), 'p104r43p137r43p196r44p87r43p131r43p11r42p66r42');
 });
 
-void test('catalogClimbUuid is deterministic, id+angle keyed, distinct per angle', () => {
-  const uuid = catalogClimbUuid({ id: 541453, angle: 40 });
-  assert.equal(uuid, uuidv5('moonboard:541453:40', MOONBOARD_UUID_NAMESPACE));
+void test('catalogClimbUuid is deterministic and angle-agnostic — id-keyed only', () => {
+  const uuid = catalogClimbUuid({ id: 541453 });
+  assert.equal(uuid, uuidv5('moonboard:541453', MOONBOARD_UUID_NAMESPACE));
   assert.match(uuid, /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-  assert.notEqual(uuid, catalogClimbUuid({ id: 541453, angle: 25 }));
+  // Same id → same uuid regardless of which angle is being considered.
+  assert.equal(uuid, catalogClimbUuid({ id: 541453 }));
 });
 
-void test('catalogAliasRows aliases the problem-id UUID onto a reused legacy UUID', () => {
-  const idBased = catalogClimbUuid({ id: 509834, angle: 40 });
+void test('legacyCatalogClimbUuid reproduces the old per-angle scheme, distinct per angle', () => {
+  const uuid40 = legacyCatalogClimbUuid({ id: 541453, angle: 40 });
+  assert.equal(uuid40, uuidv5('moonboard:541453:40', MOONBOARD_UUID_NAMESPACE));
+  assert.notEqual(uuid40, legacyCatalogClimbUuid({ id: 541453, angle: 25 }));
+  assert.notEqual(uuid40, catalogClimbUuid({ id: 541453 }));
+});
 
-  // New climb (no merge): the id-based UUID *is* the canonical, so only a
-  // self-alias — no redundant second row.
-  assert.deepEqual(catalogAliasRows(idBased, idBased), [{ aliasUuid: idBased, canonicalUuid: idBased }]);
+void test('catalogAliasRows: brand new climb (no merge) — self-alias plus one legacy alias per graded angle', () => {
+  const canonicalUuid = catalogClimbUuid({ id: 509834 });
+  const rows = catalogAliasRows({ problemId: 509834, angles: [25, 40], canonicalUuid });
+  assert.deepEqual(rows, [
+    { aliasUuid: canonicalUuid, canonicalUuid },
+    // No separate id-based row: canonicalUuid IS the id-based uuid already.
+    { aliasUuid: legacyCatalogClimbUuid({ id: 509834, angle: 25 }), canonicalUuid },
+    { aliasUuid: legacyCatalogClimbUuid({ id: 509834, angle: 40 }), canonicalUuid },
+  ]);
+});
 
-  // Merged onto a legacy (name-based) UUID — as every MoonBoard 2024 climb was.
-  // We must alias the stable problem-id UUID to the canonical, otherwise the
-  // logbook importer's `moonboard:{id}:{angle}` lookup never finds the climb.
+void test('catalogAliasRows: merged onto a legacy (name-based) UUID — as every MoonBoard 2024 climb was', () => {
   const legacy = 'moonboard-legacy-name-based-uuid';
-  assert.deepEqual(catalogAliasRows(idBased, legacy), [
+  const rows = catalogAliasRows({ problemId: 509834, angles: [40], canonicalUuid: legacy });
+  assert.deepEqual(rows, [
     { aliasUuid: legacy, canonicalUuid: legacy },
-    { aliasUuid: idBased, canonicalUuid: legacy },
+    { aliasUuid: catalogClimbUuid({ id: 509834 }), canonicalUuid: legacy },
+    { aliasUuid: legacyCatalogClimbUuid({ id: 509834, angle: 40 }), canonicalUuid: legacy },
   ]);
 });
 
 void test('catalog matching excludes delisted rows even when they have stale self-aliases', () => {
-  const mapped = mapCatalogConfig(PORRIDGE, PORRIDGE.configurations![1], { layoutId: 3, angle: 40 });
+  const mapped = makeMappedClimb();
   const delistedUuid = 'moonboard-delisted-duplicate';
   const canonicalUuid = 'moonboard-listed-canonical';
   const index = buildExistingCatalogMatchIndex(
     [
-      {
-        uuid: delistedUuid,
-        layoutId: mapped.layoutId,
-        angle: mapped.angle,
-        name: mapped.name,
-        isListed: false,
-      },
-      {
-        uuid: canonicalUuid,
-        layoutId: mapped.layoutId,
-        angle: mapped.angle,
-        name: mapped.name,
-        isListed: true,
-      },
+      { uuid: delistedUuid, layoutId: mapped.layoutId, name: mapped.name, isListed: false },
+      { uuid: canonicalUuid, layoutId: mapped.layoutId, name: mapped.name, isListed: true },
     ],
     new Map([
       [delistedUuid, mapped.holdFingerprint],
@@ -161,21 +170,17 @@ void test('catalog matching excludes delisted rows even when they have stale sel
   );
 
   assert.deepEqual(resolveCatalogClimbUuid(mapped, index), { uuid: canonicalUuid, matched: true });
-  assert.deepEqual(catalogAliasRows(mapped.uuid, canonicalUuid), [
-    { aliasUuid: canonicalUuid, canonicalUuid },
-    { aliasUuid: mapped.uuid, canonicalUuid },
-  ]);
 });
 
 void test('catalog matching follows alias chains and collapses candidates at the same canonical UUID', () => {
-  const mapped = mapCatalogConfig(PORRIDGE, PORRIDGE.configurations![1], { layoutId: 3, angle: 40 });
+  const mapped = makeMappedClimb();
   const firstUuid = 'moonboard-first-listed-alias';
   const secondUuid = 'moonboard-intermediate-alias';
   const canonicalUuid = 'moonboard-terminal-canonical';
   const index = buildExistingCatalogMatchIndex(
     [
-      { uuid: firstUuid, layoutId: 3, angle: 40, name: 'old name', isListed: true },
-      { uuid: canonicalUuid, layoutId: 3, angle: 40, name: 'canonical name', isListed: true },
+      { uuid: firstUuid, layoutId: 3, name: 'old name', isListed: true },
+      { uuid: canonicalUuid, layoutId: 3, name: 'canonical name', isListed: true },
     ],
     new Map([
       [firstUuid, mapped.holdFingerprint],
@@ -192,11 +197,11 @@ void test('catalog matching follows alias chains and collapses candidates at the
 });
 
 void test('catalog matching ignores cyclic aliases instead of writing another broken redirect', () => {
-  const mapped = mapCatalogConfig(PORRIDGE, PORRIDGE.configurations![1], { layoutId: 3, angle: 40 });
+  const mapped = makeMappedClimb();
   const firstUuid = 'moonboard-cycle-a';
   const secondUuid = 'moonboard-cycle-b';
   const index = buildExistingCatalogMatchIndex(
-    [{ uuid: firstUuid, layoutId: 3, angle: 40, name: mapped.name, isListed: true }],
+    [{ uuid: firstUuid, layoutId: 3, name: mapped.name, isListed: true }],
     new Map([[firstUuid, mapped.holdFingerprint]]),
     new Map([
       [firstUuid, secondUuid],
@@ -208,13 +213,13 @@ void test('catalog matching ignores cyclic aliases instead of writing another br
 });
 
 void test('catalog matching ignores a listed alias chain whose terminal climb is delisted', () => {
-  const mapped = mapCatalogConfig(PORRIDGE, PORRIDGE.configurations![1], { layoutId: 3, angle: 40 });
+  const mapped = makeMappedClimb();
   const listedUuid = 'moonboard-listed-alias';
   const delistedUuid = 'moonboard-delisted-terminal';
   const index = buildExistingCatalogMatchIndex(
     [
-      { uuid: listedUuid, layoutId: 3, angle: 40, name: mapped.name, isListed: true },
-      { uuid: delistedUuid, layoutId: 3, angle: 40, name: mapped.name, isListed: false },
+      { uuid: listedUuid, layoutId: 3, name: mapped.name, isListed: true },
+      { uuid: delistedUuid, layoutId: 3, name: mapped.name, isListed: false },
     ],
     new Map([[listedUuid, mapped.holdFingerprint]]),
     new Map([
@@ -248,79 +253,96 @@ void test('isImportableConfig skips empty-grade and deleted configs', () => {
   assert.equal(isImportableConfig({ ...PORRIDGE.configurations![1], dateDeleted: '2025-01-01' }), false);
 });
 
-void test('mapCatalogConfig fills stats from the configuration', () => {
-  const mapped = mapCatalogConfig(PORRIDGE, PORRIDGE.configurations![1], { layoutId: 3, angle: 40 });
-  assert.equal(mapped.uuid, catalogClimbUuid({ id: 541453, angle: 40 }));
-  assert.equal(mapped.difficultyId, 23); // 7A+
-  assert.equal(mapped.isBenchmark, true);
-  assert.equal(mapped.ascensionistCount, 812);
-  assert.equal(mapped.qualityAverage, 4);
-  assert.equal(mapped.setterUsername, 'Joe Wallace');
-  assert.equal(mapped.createdAt, '2023-11-23T18:00:15.227');
-  assert.equal(mapped.characteristics, null); // "Any marked holds" → no token
+void test('mapCatalogProblemStructural is angle-agnostic — holds/name/setter computed once', () => {
+  const structural = mapCatalogProblemStructural(PORRIDGE, 3);
+  assert.equal(structural.uuid, catalogClimbUuid({ id: 541453 }));
+  assert.equal(structural.setterUsername, 'Joe Wallace');
+  assert.equal(structural.createdAt, '2023-11-23T18:00:15.227');
+  assert.equal(structural.characteristics, null); // "Any marked holds" → no token
+  assert.equal(structural.layoutId, 3);
+});
+
+void test('mapCatalogConfigStats fills per-angle stats from the configuration', () => {
+  const stats = mapCatalogConfigStats(PORRIDGE.configurations![1], 40);
+  assert.equal(stats.angle, 40);
+  assert.equal(stats.difficultyId, 23); // 7A+
+  assert.equal(stats.isBenchmark, true);
+  assert.equal(stats.ascensionistCount, 812);
+  assert.equal(stats.qualityAverage, 4);
 });
 
 void test('userRating 0 becomes null quality (0 is off the 1-5 scale)', () => {
-  const mapped = mapCatalogConfig(
-    PORRIDGE,
-    { ...PORRIDGE.configurations![1], userRating: 0 },
-    { layoutId: 3, angle: 40 },
-  );
-  assert.equal(mapped.qualityAverage, null);
+  const stats = mapCatalogConfigStats({ ...PORRIDGE.configurations![1], userRating: 0 }, 40);
+  assert.equal(stats.qualityAverage, null);
 });
 
-void test('catalogProblemToClimbs yields one climb per graded angle, skipping phantoms', () => {
-  const climbs = catalogProblemToClimbs(PORRIDGE, 3);
+void test('catalogProblemToClimbs yields one climb with one stats entry per graded angle, skipping phantoms', () => {
+  const climb = catalogProblemToClimbs(PORRIDGE, 3);
   // Only the graded 40° config is imported; the empty-grade 25° phantom is dropped.
-  assert.equal(climbs.length, 1);
-  assert.equal(climbs[0].angle, 40);
-  assert.equal(climbs[0].difficultyId, 23);
+  assert.ok(climb);
+  assert.equal(climb.stats.length, 1);
+  assert.equal(climb.stats[0].angle, 40);
+  assert.equal(climb.stats[0].difficultyId, 23);
 
-  // Both angles graded → two rows.
+  // Both angles graded → one climb, two stats rows.
   const bothGraded = catalogProblemToClimbs(
     { ...PORRIDGE, configurations: [{ ...PORRIDGE.configurations![0], grade: '6C' }, PORRIDGE.configurations![1]] },
     3,
   );
+  assert.ok(bothGraded);
   assert.deepEqual(
-    bothGraded.map((climb) => climb.angle).sort((a, b) => a - b),
+    bothGraded.stats.map((stat) => stat.angle).sort((a, b) => a - b),
     [25, 40],
   );
+  // Structural identity is a single UUID shared by both angles.
+  assert.equal(bothGraded.uuid, catalogClimbUuid({ id: PORRIDGE.id }));
 
   // A deleted / holdless problem yields nothing.
-  assert.deepEqual(catalogProblemToClimbs({ ...PORRIDGE, dateDeleted: '2025-01-01' }, 3), []);
+  assert.equal(catalogProblemToClimbs({ ...PORRIDGE, dateDeleted: '2025-01-01' }, 3), null);
+
+  // A problem with configurations but none graded also yields nothing.
+  assert.equal(catalogProblemToClimbs({ ...PORRIDGE, configurations: [PORRIDGE.configurations![0]] }, 3), null);
 });
 
 void test('unmappable grades map to undefined difficulty', () => {
-  const mapped = mapCatalogConfig(
-    PORRIDGE,
-    { ...PORRIDGE.configurations![1], grade: '9Z' },
-    { layoutId: 3, angle: 40 },
-  );
-  assert.equal(mapped.difficultyId, undefined);
+  const stats = mapCatalogConfigStats({ ...PORRIDGE.configurations![1], grade: '9Z' }, 40);
+  assert.equal(stats.difficultyId, undefined);
 });
 
-void test('isBetterCatalogClimb keeps the stronger of two same-holds problems', () => {
+void test('isBetterCatalogClimb keeps the stronger of two same-holds problems (summed across angles)', () => {
   const cfg = PORRIDGE.configurations![1];
   // Mirrors the real "birthday cake trail mix" (38,683 repeats, benchmark) vs the
-  // junk duplicate "name" (19 repeats, not a benchmark) — identical holds+angle.
-  const real = mapCatalogConfig(
-    { ...PORRIDGE, name: 'birthday cake trail mix' },
-    { ...cfg, repeats: 38683, isBenchmark: true },
-    { layoutId: 3, angle: 40 },
-  );
-  const junk = mapCatalogConfig(
-    { ...PORRIDGE, name: 'name' },
-    { ...cfg, repeats: 19, isBenchmark: false },
-    { layoutId: 3, angle: 40 },
-  );
+  // junk duplicate "name" (19 repeats, not a benchmark) — identical holds.
+  const real = makeMappedClimb({
+    name: 'birthday cake trail mix',
+    stats: [mapCatalogConfigStats({ ...cfg, repeats: 38683, isBenchmark: true }, 40)],
+  });
+  const junk = makeMappedClimb({
+    name: 'name',
+    stats: [mapCatalogConfigStats({ ...cfg, repeats: 19, isBenchmark: false }, 40)],
+  });
 
-  // More repeats wins, regardless of processing order.
+  // More total repeats wins, regardless of processing order.
   assert.equal(isBetterCatalogClimb(real, junk), true);
   assert.equal(isBetterCatalogClimb(junk, real), false);
 
-  // Tie on repeats → benchmark wins.
-  const benchTie = mapCatalogConfig(PORRIDGE, { ...cfg, repeats: 100, isBenchmark: true }, { layoutId: 3, angle: 40 });
-  const plainTie = mapCatalogConfig(PORRIDGE, { ...cfg, repeats: 100, isBenchmark: false }, { layoutId: 3, angle: 40 });
+  // Sums across BOTH graded angles, not just one.
+  const twoAngles = makeMappedClimb({
+    stats: [
+      mapCatalogConfigStats({ ...cfg, repeats: 50, isBenchmark: false }, 25),
+      mapCatalogConfigStats({ ...cfg, repeats: 50, isBenchmark: false }, 40),
+    ],
+  }); // total 100
+  const oneAngle = makeMappedClimb({
+    stats: [mapCatalogConfigStats({ ...cfg, repeats: 90, isBenchmark: false }, 40)],
+  }); // total 90
+  assert.equal(isBetterCatalogClimb(twoAngles, oneAngle), true);
+
+  // Tie on total repeats → any benchmark angle wins.
+  const benchTie = makeMappedClimb({ stats: [mapCatalogConfigStats({ ...cfg, repeats: 100, isBenchmark: true }, 40)] });
+  const plainTie = makeMappedClimb({
+    stats: [mapCatalogConfigStats({ ...cfg, repeats: 100, isBenchmark: false }, 40)],
+  });
   assert.equal(isBetterCatalogClimb(benchTie, plainTie), true);
   assert.equal(isBetterCatalogClimb(plainTie, benchTie), false);
 

--- a/packages/db/scripts/moonboard-catalog-helpers.test.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.test.ts
@@ -21,8 +21,13 @@ import {
   mapCatalogConfigStats,
   catalogProblemToClimbs,
   isBetterCatalogClimb,
+  catalogFingerprintKey,
   existingClimbUuidsForProblem,
+  hijackedClimbUuidsForProblem,
+  holdsBatchKey,
+  ownedClimbAngles,
   resolveIncumbentReplacement,
+  statsBatchKey,
   type MoonBoardCatalogProblem,
   type MappedCatalogClimb,
 } from './moonboard-catalog-helpers.js';
@@ -469,6 +474,134 @@ void test('existingClimbUuidsForProblem: drifted holds under legacy per-angle ro
       existingClimbUuids: new Set([legacy25, legacy40, 'unrelated']),
     }).sort(),
     [legacy25, legacy40].sort(),
+  );
+});
+
+void test("resolveIncumbentReplacement's stale keys hit the batch-map entries the importer actually wrote", () => {
+  // The importer (stageCatalogBatch) keys its staged rows with statsBatchKey /
+  // holdsBatchKey; resolveIncumbentReplacement reports the beaten incumbent's
+  // keys for deletion. If either side changed format, the loser's stats/holds
+  // would silently survive under the winner's uuid — so build the maps exactly
+  // as the importer does and prove every reported key deletes an entry.
+  const cfg = PORRIDGE.configurations![1];
+  const uuid = 'moonboard-batch-key-agreement';
+  const incumbent = makeMappedClimb({
+    holds: [
+      { holdId: 11, holdState: 'STARTING' },
+      { holdId: 196, holdState: 'FINISH' },
+    ],
+    stats: [mapCatalogConfigStats({ ...cfg, repeats: 10 }, 25), mapCatalogConfigStats({ ...cfg, repeats: 10 }, 40)],
+  });
+  const statsByUuidAngle = new Map(incumbent.stats.map((stat) => [statsBatchKey(uuid, stat.angle), stat]));
+  const holdsByKey = new Map(incumbent.holds.map((hold) => [holdsBatchKey(uuid, hold.holdId), hold]));
+
+  const stronger = makeMappedClimb({ stats: [mapCatalogConfigStats({ ...cfg, repeats: 5000 }, 40)] });
+  const decision = resolveIncumbentReplacement(uuid, stronger, incumbent);
+  assert.equal(decision.accept, true);
+  if (!decision.accept) return;
+
+  for (const key of decision.staleStatKeys) {
+    assert.equal(statsByUuidAngle.delete(key), true, `stale stats key ${key} must match a staged entry`);
+  }
+  for (const key of decision.staleHoldKeys) {
+    assert.equal(holdsByKey.delete(key), true, `stale hold key ${key} must match a staged entry`);
+  }
+  assert.equal(statsByUuidAngle.size, 0);
+  assert.equal(holdsByKey.size, 0);
+});
+
+void test('catalogFingerprintKey keeps identical holds on different layouts apart', () => {
+  assert.equal(catalogFingerprintKey(3, 'abc'), '3|abc');
+  assert.notEqual(catalogFingerprintKey(3, 'abc'), catalogFingerprintKey(4, 'abc'));
+});
+
+void test('ownedClimbAngles adds the legacy MoonBoard angles to the graded ones', () => {
+  // Only graded at 40° today, but a `moonboard:{id}:25` row can still exist
+  // from a snapshot where 25° was graded.
+  assert.deepEqual(
+    ownedClimbAngles([40]).sort((a, b) => a - b),
+    [25, 40],
+  );
+  assert.deepEqual(
+    ownedClimbAngles([25, 40]).sort((a, b) => a - b),
+    [25, 40],
+  );
+  assert.deepEqual(
+    ownedClimbAngles([]).sort((a, b) => a - b),
+    [25, 40],
+  );
+  // A future angle the catalog starts grading is kept as well.
+  assert.deepEqual(
+    ownedClimbAngles([15, 40]).sort((a, b) => a - b),
+    [15, 25, 40],
+  );
+});
+
+void test('hijackedClimbUuidsForProblem: the owned row IS the merge target — ordinary legacy merge', () => {
+  const resolvedUuid = legacyCatalogClimbUuid({ id: 541453, angle: 40 });
+  assert.deepEqual(
+    hijackedClimbUuidsForProblem({
+      problemId: 541453,
+      angles: [25, 40],
+      resolvedUuid,
+      existingClimbUuids: new Set([resolvedUuid]),
+      canonicalByAlias: new Map(),
+    }),
+    [],
+  );
+});
+
+void test('hijackedClimbUuidsForProblem: a foreign live row the merge would repoint is reported', () => {
+  const foreignUuid = legacyCatalogClimbUuid({ id: 541453, angle: 25 });
+  assert.deepEqual(
+    hijackedClimbUuidsForProblem({
+      problemId: 541453,
+      angles: [25, 40],
+      resolvedUuid: 'moonboard-matched-canonical',
+      existingClimbUuids: new Set([foreignUuid]),
+      canonicalByAlias: new Map(),
+    }),
+    [foreignUuid],
+  );
+});
+
+void test('hijackedClimbUuidsForProblem: an owned row already aliased to the target is not a hijack', () => {
+  const resolvedUuid = 'moonboard-matched-canonical';
+  const redirectedUuid = legacyCatalogClimbUuid({ id: 541453, angle: 25 });
+  const intermediateUuid = 'moonboard-intermediate';
+  assert.deepEqual(
+    hijackedClimbUuidsForProblem({
+      problemId: 541453,
+      angles: [25, 40],
+      resolvedUuid,
+      existingClimbUuids: new Set([redirectedUuid]),
+      // Chains resolve too, not just direct aliases.
+      canonicalByAlias: new Map([
+        [redirectedUuid, intermediateUuid],
+        [intermediateUuid, resolvedUuid],
+      ]),
+    }),
+    [],
+  );
+});
+
+void test('hijackedClimbUuidsForProblem: a cyclic alias chain counts as a hijack', () => {
+  // terminalCanonicalUuid gives up on a cycle; we refuse to write through a
+  // redirect we cannot follow rather than assume it is harmless.
+  const cycleA = legacyCatalogClimbUuid({ id: 541453, angle: 25 });
+  const cycleB = 'moonboard-cycle-partner';
+  assert.deepEqual(
+    hijackedClimbUuidsForProblem({
+      problemId: 541453,
+      angles: [25],
+      resolvedUuid: 'moonboard-matched-canonical',
+      existingClimbUuids: new Set([cycleA]),
+      canonicalByAlias: new Map([
+        [cycleA, cycleB],
+        [cycleB, cycleA],
+      ]),
+    }),
+    [cycleA],
   );
 });
 

--- a/packages/db/scripts/moonboard-catalog-helpers.test.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.test.ts
@@ -21,6 +21,7 @@ import {
   mapCatalogConfigStats,
   catalogProblemToClimbs,
   isBetterCatalogClimb,
+  resolveIncumbentReplacement,
   type MoonBoardCatalogProblem,
   type MappedCatalogClimb,
 } from './moonboard-catalog-helpers.js';
@@ -348,4 +349,52 @@ void test('isBetterCatalogClimb keeps the stronger of two same-holds problems (s
 
   // Fully equal → keep incumbent (stable, deterministic re-runs).
   assert.equal(isBetterCatalogClimb(plainTie, plainTie), false);
+});
+
+void test('resolveIncumbentReplacement: no incumbent — accepted, nothing stale', () => {
+  const cfg = PORRIDGE.configurations![1];
+  const candidate = makeMappedClimb({ stats: [mapCatalogConfigStats(cfg, 40)] });
+  const decision = resolveIncumbentReplacement('uuid-1', candidate, undefined);
+  assert.deepEqual(decision, { accept: true, staleStatKeys: [], staleHoldKeys: [] });
+});
+
+void test('resolveIncumbentReplacement: weaker candidate rejected, incumbent untouched', () => {
+  const cfg = PORRIDGE.configurations![1];
+  const incumbent = makeMappedClimb({
+    name: 'birthday cake trail mix',
+    stats: [mapCatalogConfigStats({ ...cfg, repeats: 38683, isBenchmark: true }, 40)],
+  });
+  const candidate = makeMappedClimb({
+    name: 'name',
+    stats: [mapCatalogConfigStats({ ...cfg, repeats: 19, isBenchmark: false }, 40)],
+  });
+  assert.deepEqual(resolveIncumbentReplacement('uuid-1', candidate, incumbent), { accept: false });
+});
+
+void test("resolveIncumbentReplacement: stronger candidate wins and reports the incumbent's stale keys", () => {
+  const cfg = PORRIDGE.configurations![1];
+  // Incumbent graded at BOTH 25° and 40°; the stronger winner is only graded
+  // at 40° — its 25° stats entry must be reported stale so it doesn't linger
+  // under the winning uuid.
+  const incumbent = makeMappedClimb({
+    name: 'weaker, but graded at two angles',
+    holds: [
+      { holdId: 1, holdState: 'STARTING' },
+      { holdId: 2, holdState: 'FINISH' },
+    ],
+    stats: [
+      mapCatalogConfigStats({ ...cfg, repeats: 10, isBenchmark: false }, 25),
+      mapCatalogConfigStats({ ...cfg, repeats: 10, isBenchmark: false }, 40),
+    ],
+  });
+  const candidate = makeMappedClimb({
+    name: 'stronger, one angle',
+    stats: [mapCatalogConfigStats({ ...cfg, repeats: 38683, isBenchmark: true }, 40)],
+  });
+
+  const decision = resolveIncumbentReplacement('uuid-1', candidate, incumbent);
+  assert.equal(decision.accept, true);
+  if (!decision.accept) return;
+  assert.deepEqual(decision.staleStatKeys.sort(), ['uuid-1:25', 'uuid-1:40']);
+  assert.deepEqual(decision.staleHoldKeys.sort(), ['uuid-1:1', 'uuid-1:2']);
 });

--- a/packages/db/scripts/moonboard-catalog-helpers.test.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.test.ts
@@ -21,6 +21,7 @@ import {
   mapCatalogConfigStats,
   catalogProblemToClimbs,
   isBetterCatalogClimb,
+  existingClimbUuidsForProblem,
   resolveIncumbentReplacement,
   type MoonBoardCatalogProblem,
   type MappedCatalogClimb,
@@ -442,4 +443,43 @@ void test("resolveIncumbentReplacement: stronger candidate wins and reports the 
   if (!decision.accept) return;
   assert.deepEqual(decision.staleStatKeys.sort(), ['uuid-1:25', 'uuid-1:40']);
   assert.deepEqual(decision.staleHoldKeys.sort(), ['uuid-1:1', 'uuid-1:2']);
+});
+
+void test('existingClimbUuidsForProblem: nothing imported yet — no conflict, the insert is safe', () => {
+  assert.deepEqual(
+    existingClimbUuidsForProblem({
+      problemId: 541453,
+      angles: [25, 40],
+      existingClimbUuids: new Set(['some-unrelated-uuid']),
+    }),
+    [],
+  );
+});
+
+void test('existingClimbUuidsForProblem: drifted holds under legacy per-angle rows are reported', () => {
+  // The pre-rewrite importer wrote one row per angle. If the holds drift, the
+  // fingerprint match misses and the importer would otherwise insert a fresh
+  // moonboard:{id} row *and* repoint these rows' self-aliases at it.
+  const legacy25 = legacyCatalogClimbUuid({ id: 541453, angle: 25 });
+  const legacy40 = legacyCatalogClimbUuid({ id: 541453, angle: 40 });
+  assert.deepEqual(
+    existingClimbUuidsForProblem({
+      problemId: 541453,
+      angles: [25, 40],
+      existingClimbUuids: new Set([legacy25, legacy40, 'unrelated']),
+    }).sort(),
+    [legacy25, legacy40].sort(),
+  );
+});
+
+void test('existingClimbUuidsForProblem: an existing id-based row counts too, and dedupes', () => {
+  const idBased = catalogClimbUuid({ id: 541453 });
+  assert.deepEqual(
+    existingClimbUuidsForProblem({
+      problemId: 541453,
+      angles: [40, 40],
+      existingClimbUuids: new Set([idBased]),
+    }),
+    [idBased],
+  );
 });

--- a/packages/db/scripts/moonboard-catalog-helpers.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.ts
@@ -152,18 +152,33 @@ export function catalogAliasConflictUpdate() {
   return { canonicalUuid: sql`excluded.canonical_uuid`, lastSeenAt: sql`now()` };
 }
 
-/** Resolve an incoming catalog climb to an existing merge candidate, if any. */
+/**
+ * Resolve an incoming catalog climb to an existing merge candidate, if any.
+ *
+ * `ambiguous: true` means the fingerprint bucket held >1 DISTINCT listed
+ * candidate uuid — expected shape post-#3849 (one canonical per problem), but
+ * on a database migration 0185 hasn't run against yet, both angle-rows of a
+ * problem are still separately listed and typically share a name, so the
+ * name tie-break "resolves" to one of them non-deterministically (row order)
+ * while the OTHER stays listed too. Writing through that state doubles-counts
+ * ascents across two listed rows and can point a legacy alias at whichever
+ * row the tie-break happened to pick. Callers should treat `ambiguous: true`
+ * as "skip this problem, don't write anything for it" rather than silently
+ * trusting the returned uuid — see import-moonboard-catalog.ts.
+ */
 export function resolveCatalogClimbUuid(
   mapped: MappedCatalogClimb,
   index: Map<string, ExistingCatalogClimb[]>,
-): { uuid: string; matched: boolean } {
+): { uuid: string; matched: boolean; ambiguous: boolean } {
   const candidates = index.get(`${mapped.layoutId}|${mapped.holdFingerprint}`);
-  if (!candidates || candidates.length === 0) return { uuid: mapped.uuid, matched: false };
+  if (!candidates || candidates.length === 0) return { uuid: mapped.uuid, matched: false, ambiguous: false };
   const candidateUuids = new Set(candidates.map((candidate) => candidate.uuid));
-  if (candidateUuids.size === 1) return { uuid: candidates[0].uuid, matched: true };
+  if (candidateUuids.size === 1) return { uuid: candidates[0].uuid, matched: true, ambiguous: false };
   const target = mapped.name.trim().toLowerCase();
   const named = candidates.find((candidate) => (candidate.name ?? '').trim().toLowerCase() === target);
-  return named ? { uuid: named.uuid, matched: true } : { uuid: mapped.uuid, matched: false };
+  return named
+    ? { uuid: named.uuid, matched: true, ambiguous: true }
+    : { uuid: mapped.uuid, matched: false, ambiguous: true };
 }
 
 const STATE_TO_ROLE: Record<string, number> = {

--- a/packages/db/scripts/moonboard-catalog-helpers.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.ts
@@ -157,7 +157,7 @@ export function catalogAliasConflictUpdate() {
  *
  * `ambiguous: true` means the fingerprint bucket held >1 DISTINCT listed
  * candidate uuid — expected shape post-#3849 (one canonical per problem), but
- * on a database migration 0185 hasn't run against yet, both angle-rows of a
+ * on a database the moonboard_angle_dedup_backfill migration (#3849) hasn't run against yet, both angle-rows of a
  * problem are still separately listed and typically share a name, so the
  * name tie-break "resolves" to one of them non-deterministically (row order)
  * while the OTHER stays listed too. Writing through that state doubles-counts

--- a/packages/db/scripts/moonboard-catalog-helpers.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.ts
@@ -364,3 +364,31 @@ export function isBetterCatalogClimb(candidate: MappedCatalogClimb, incumbent: M
   }
   return false;
 }
+
+export type IncumbentReplacementDecision =
+  | { accept: false }
+  | { accept: true; staleStatKeys: string[]; staleHoldKeys: string[] };
+
+/**
+ * Decide whether `candidate` should replace `incumbent` for the same resolved
+ * `uuid` within one import batch (see isBetterCatalogClimb), and — when it
+ * does — which of the incumbent's previously-staged stats/holds batch-map
+ * keys must be cleared first. The winner's graded angles can differ from the
+ * loser's (e.g. incumbent graded at 25°+40°, winner only at 40°), so without
+ * clearing, a stale per-angle stats entry from the loser would silently
+ * survive into the DB under the winning uuid.
+ */
+export function resolveIncumbentReplacement(
+  uuid: string,
+  candidate: MappedCatalogClimb,
+  incumbent: MappedCatalogClimb | undefined,
+): IncumbentReplacementDecision {
+  if (incumbent && !isBetterCatalogClimb(candidate, incumbent)) {
+    return { accept: false };
+  }
+  return {
+    accept: true,
+    staleStatKeys: (incumbent?.stats ?? []).map((stat) => `${uuid}:${stat.angle}`),
+    staleHoldKeys: (incumbent?.holds ?? []).map((hold) => `${uuid}:${hold.holdId}`),
+  };
+}

--- a/packages/db/scripts/moonboard-catalog-helpers.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.ts
@@ -7,6 +7,7 @@ import {
 } from './moonboard-helpers.js';
 import { fingerprintFromHolds, methodDescription } from './moonboard-2024-helpers.js';
 import { moonBoardMethodToCharacteristic } from '@boardsesh/shared-schema/characteristics';
+import { MOONBOARD_ANGLES } from '@boardsesh/board-config';
 import { sql } from 'drizzle-orm';
 
 // =============================================================================
@@ -111,7 +112,34 @@ type ExistingCatalogClimbRow = ExistingCatalogClimb & {
   isListed: boolean | null;
 };
 
-function terminalCanonicalUuid(uuid: string, canonicalByAlias: ReadonlyMap<string, string>): string | undefined {
+/**
+ * Match-index key. Hold fingerprints are only comparable within one layout (the
+ * same cells mean different holds on a different board), so every producer and
+ * consumer of the index — and the in-batch duplicate fold — goes through this.
+ */
+export function catalogFingerprintKey(layoutId: number, holdFingerprint: string): string {
+  return `${layoutId}|${holdFingerprint}`;
+}
+
+/**
+ * Batch-map keys for the importer's staged stats/holds rows. `resolveIncumbentReplacement`
+ * reports the beaten incumbent's keys for deletion, so the importer's map keys
+ * and those stale keys MUST use one format — both sides call these, and
+ * moonboard-catalog-batch.test.ts pins the agreement.
+ */
+export function statsBatchKey(uuid: string, angle: number): string {
+  return `${uuid}:${angle}`;
+}
+
+export function holdsBatchKey(uuid: string, holdId: number): string {
+  return `${uuid}:${holdId}`;
+}
+
+/**
+ * Follow an alias chain to the uuid it ultimately resolves to. Returns
+ * undefined for a cycle (a broken redirect we refuse to reason about).
+ */
+export function terminalCanonicalUuid(uuid: string, canonicalByAlias: ReadonlyMap<string, string>): string | undefined {
   const visited = new Set<string>();
   let currentUuid = uuid;
   while (!visited.has(currentUuid)) {
@@ -138,7 +166,7 @@ export function buildExistingCatalogMatchIndex(
     if (!fingerprint) continue;
     const canonicalUuid = terminalCanonicalUuid(row.uuid, canonicalByAlias);
     if (!canonicalUuid || !listedUuids.has(canonicalUuid)) continue;
-    const key = `${row.layoutId}|${fingerprint}`;
+    const key = catalogFingerprintKey(row.layoutId, fingerprint);
     const candidate = { uuid: canonicalUuid, name: row.name };
     const bucket = index.get(key);
     if (bucket) bucket.push(candidate);
@@ -170,7 +198,7 @@ export function resolveCatalogClimbUuid(
   mapped: MappedCatalogClimb,
   index: Map<string, ExistingCatalogClimb[]>,
 ): { uuid: string; matched: boolean; ambiguous: boolean } {
-  const candidates = index.get(`${mapped.layoutId}|${mapped.holdFingerprint}`);
+  const candidates = index.get(catalogFingerprintKey(mapped.layoutId, mapped.holdFingerprint));
   if (!candidates || candidates.length === 0) return { uuid: mapped.uuid, matched: false, ambiguous: false };
   const candidateUuids = new Set(candidates.map((candidate) => candidate.uuid));
   if (candidateUuids.size === 1) return { uuid: candidates[0].uuid, matched: true, ambiguous: false };
@@ -314,6 +342,49 @@ export function existingClimbUuidsForProblem(args: {
   return [...candidateUuids].filter((uuid) => existingClimbUuids.has(uuid));
 }
 
+/**
+ * The angles a problem may already own climb rows at: the ones the catalog
+ * grades it at TODAY, plus every angle MoonBoard problems have ever been
+ * imported at (`MOONBOARD_ANGLES`).
+ *
+ * The pre-rewrite importer minted one row per graded angle, and grades come and
+ * go between snapshots. A problem graded at 25° in an older dump but only at
+ * 40° now still owns a `moonboard:{id}:25` row, and checking only today's
+ * graded angles would miss it — the exact case the drift guard exists to catch.
+ */
+export function ownedClimbAngles(gradedAngles: readonly number[]): number[] {
+  return [...new Set([...gradedAngles, ...MOONBOARD_ANGLES])];
+}
+
+/**
+ * The uuids this problem owns that merging it onto `resolvedUuid` would HIJACK.
+ *
+ * On the matched branch the problem's holds DID match an existing climb, so
+ * "the problem already owns rows" is not by itself drift — the usual case is a
+ * legacy import where the owned uuid IS the matched row, which must stay a
+ * normal in-place merge. The destructive case is an owned uuid that is a live
+ * climb row somewhere ELSE: `catalogAliasRows` would emit it as an alias of
+ * `resolvedUuid`, and `catalogAliasConflictUpdate` overwrites canonical_uuid
+ * unconditionally, so that row's own resolution (and its ticks) would start
+ * redirecting at a climb it isn't, while it stays listed.
+ *
+ * Owned uuids already redirecting to `resolvedUuid` are fine: re-writing that
+ * alias is a no-op. A cyclic alias chain resolves to undefined and counts as a
+ * hijack — we refuse to write through a redirect we can't follow.
+ */
+export function hijackedClimbUuidsForProblem(args: {
+  problemId: number;
+  angles: number[];
+  resolvedUuid: string;
+  existingClimbUuids: ReadonlySet<string>;
+  canonicalByAlias: ReadonlyMap<string, string>;
+}): string[] {
+  const { problemId, angles, resolvedUuid, existingClimbUuids, canonicalByAlias } = args;
+  return existingClimbUuidsForProblem({ problemId, angles, existingClimbUuids }).filter(
+    (uuid) => uuid !== resolvedUuid && terminalCanonicalUuid(uuid, canonicalByAlias) !== resolvedUuid,
+  );
+}
+
 /** A problem is importable if it isn't soft-deleted and has holds + configs. */
 export function isImportableProblem(problem: MoonBoardCatalogProblem): boolean {
   if (problem.dateDeleted) return false;
@@ -433,7 +504,7 @@ export function resolveIncumbentReplacement(
   }
   return {
     accept: true,
-    staleStatKeys: (incumbent?.stats ?? []).map((stat) => `${uuid}:${stat.angle}`),
-    staleHoldKeys: (incumbent?.holds ?? []).map((hold) => `${uuid}:${hold.holdId}`),
+    staleStatKeys: (incumbent?.stats ?? []).map((stat) => statsBatchKey(uuid, stat.angle)),
+    staleHoldKeys: (incumbent?.holds ?? []).map((hold) => holdsBatchKey(uuid, hold.holdId)),
   };
 }

--- a/packages/db/scripts/moonboard-catalog-helpers.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.ts
@@ -18,9 +18,11 @@ import { sql } from 'drizzle-orm';
 // stable `id`, per-angle `configurations` (grade + userRating + repeats +
 // isBenchmark), and the holds as a single `moves` string ("s~G5~|l~C12~|e~C18~").
 //
-// We import one climb row per (problem, graded angle). Empty-grade configurations
-// are the non-primary angle a setter never graded — they carry no grade, rating
-// or ascents, so we skip them rather than flood the catalog with phantom climbs.
+// We import ONE climb row per problem — angle-agnostic, matching Kilter/Tension —
+// and one board_climb_stats row per graded angle under that same climb UUID.
+// Empty-grade configurations are the non-primary angle a setter never graded —
+// they carry no grade, rating or ascents, so we skip them rather than flood the
+// catalog with phantom stats rows.
 // =============================================================================
 
 // In-file `holdsetup` id → our internal layout id (see @boardsesh/board-config
@@ -54,7 +56,7 @@ export type MoonBoardCatalogProblem = {
   setter?: string | null;
   setbyId?: string | null;
   climbMethod?: string | null;
-  moves: string | null; // "<role>~<cell>~|<role>~<cell>~|…"
+  moves: string | null; // "<role>~<cell>~|<role>~<cell>~…"
   holdsetup?: number;
   dateInserted?: string | null;
   dateDeleted?: string | null;
@@ -73,34 +75,39 @@ export type MoonBoardCatalogHold = {
   holdState: string; // 'STARTING' | 'HAND' | 'FINISH'
 };
 
-export type MappedCatalogClimb = {
-  // The id-based UUID a *new* climb gets. The importer overrides this with a
-  // matched existing UUID when a climb with the same holds already exists (so
-  // the merge updates in place instead of duplicating).
-  uuid: string;
-  layoutId: number;
+/** Per-angle grade/quality/ascent data for one graded configuration of a problem. */
+export type MappedCatalogClimbStats = {
   angle: number;
-  name: string;
-  setterUsername: string | null;
-  frames: string;
-  holdFingerprint: string;
   // undefined for an unmappable grade — caller decides (we only emit graded configs).
   difficultyId: number | undefined;
   isBenchmark: boolean;
   ascensionistCount: number;
   // null when userRating is 0/absent — 0 isn't on the 1-5 quality scale.
   qualityAverage: number | null;
+};
+
+export type MappedCatalogClimb = {
+  // The id-based UUID a *new* climb gets. The importer overrides this with a
+  // matched existing UUID when a climb with the same holds already exists (so
+  // the merge updates in place instead of duplicating).
+  uuid: string;
+  layoutId: number;
+  name: string;
+  setterUsername: string | null;
+  frames: string;
+  holdFingerprint: string;
   createdAt: string | null;
   holds: MoonBoardCatalogHold[];
   characteristics: string[] | null;
   description: string;
+  // One entry per graded, non-deleted configuration (i.e. per angle).
+  stats: MappedCatalogClimbStats[];
 };
 
 export type ExistingCatalogClimb = { uuid: string; name: string | null };
 
 type ExistingCatalogClimbRow = ExistingCatalogClimb & {
   layoutId: number;
-  angle: number | null;
   isListed: boolean | null;
 };
 
@@ -131,7 +138,7 @@ export function buildExistingCatalogMatchIndex(
     if (!fingerprint) continue;
     const canonicalUuid = terminalCanonicalUuid(row.uuid, canonicalByAlias);
     if (!canonicalUuid || !listedUuids.has(canonicalUuid)) continue;
-    const key = `${row.layoutId}|${row.angle}|${fingerprint}`;
+    const key = `${row.layoutId}|${fingerprint}`;
     const candidate = { uuid: canonicalUuid, name: row.name };
     const bucket = index.get(key);
     if (bucket) bucket.push(candidate);
@@ -150,7 +157,7 @@ export function resolveCatalogClimbUuid(
   mapped: MappedCatalogClimb,
   index: Map<string, ExistingCatalogClimb[]>,
 ): { uuid: string; matched: boolean } {
-  const candidates = index.get(`${mapped.layoutId}|${mapped.angle}|${mapped.holdFingerprint}`);
+  const candidates = index.get(`${mapped.layoutId}|${mapped.holdFingerprint}`);
   if (!candidates || candidates.length === 0) return { uuid: mapped.uuid, matched: false };
   const candidateUuids = new Set(candidates.map((candidate) => candidate.uuid));
   if (candidateUuids.size === 1) return { uuid: candidates[0].uuid, matched: true };
@@ -208,33 +215,57 @@ export function angleFromConfiguration(configuration: string | null | undefined)
 
 /**
  * Deterministic, idempotent UUID for a newly-inserted climb, keyed off the
- * stable MoonBoard problem id + angle. A re-scrape yields the same id, so the
- * same climb maps to the same UUID across runs.
+ * stable MoonBoard problem id — angle-agnostic, matching Kilter/Tension climb
+ * identity. A re-scrape yields the same id, so the same problem maps to the
+ * same UUID across runs regardless of which angles it's graded at.
  */
-export function catalogClimbUuid(args: { id: number; angle: number }): string {
+export function catalogClimbUuid(args: { id: number }): string {
+  return uuidv5(`moonboard:${args.id}`, MOONBOARD_UUID_NAMESPACE);
+}
+
+/**
+ * The OLD per-angle UUID scheme (`moonboard:{id}:{angle}`), from before climb
+ * identity became angle-agnostic. Kept ONLY to mint legacy aliases — the
+ * personal-logbook CSV importer (packages/backend/src/services/
+ * moonboard-import.ts) still resolves ticks via this format and is out of
+ * scope for this rewrite, so every graded angle must keep an alias row in
+ * this shape pointing at the new canonical UUID.
+ */
+export function legacyCatalogClimbUuid(args: { id: number; angle: number }): string {
   return uuidv5(`moonboard:${args.id}:${args.angle}`, MOONBOARD_UUID_NAMESPACE);
 }
 
 /**
- * The alias rows to persist for a resolved catalog climb.
- *
- * Always a self-alias on the canonical UUID so `resolveCanonicalClimbUuid` hits.
- * When the non-destructive merge reused an existing (legacy) UUID, the climb's
- * stable problem-id UUID (`moonboard:{id}:{angle}`) differs from the canonical —
- * so alias that too, pointing at the canonical. Without it a logbook import that
- * looks a tick up by problem id (`uuidv5("moonboard:{id}:{angle}")`) resolves to
- * nothing: MoonBoard 2024 problems were first seeded under name-based UUIDs, then
- * merged in place, so their canonical UUID has no problem id in it and every 2024
- * tick drops as "unknown problem". Idempotent — a re-run yields the same rows.
+ * The alias rows to persist for a resolved catalog climb: a self-alias (so
+ * `resolveCanonicalClimbUuid` always hits), the angle-agnostic id-based UUID
+ * (when the non-destructive merge reused a different, pre-existing UUID), and
+ * one legacy per-angle UUID per graded angle (see `legacyCatalogClimbUuid`).
+ * Idempotent — a re-run yields the same rows; duplicates (e.g. a brand new
+ * climb whose id-based UUID already equals its own canonical) are collapsed.
  */
-export function catalogAliasRows(
-  idBasedUuid: string,
-  canonicalUuid: string,
-): { aliasUuid: string; canonicalUuid: string }[] {
-  const rows = [{ aliasUuid: canonicalUuid, canonicalUuid }];
-  if (idBasedUuid !== canonicalUuid) {
+export function catalogAliasRows(args: {
+  problemId: number;
+  angles: number[];
+  canonicalUuid: string;
+}): { aliasUuid: string; canonicalUuid: string }[] {
+  const { problemId, angles, canonicalUuid } = args;
+  const seen = new Set([canonicalUuid]);
+  const rows: { aliasUuid: string; canonicalUuid: string }[] = [{ aliasUuid: canonicalUuid, canonicalUuid }];
+
+  const idBasedUuid = catalogClimbUuid({ id: problemId });
+  if (!seen.has(idBasedUuid)) {
     rows.push({ aliasUuid: idBasedUuid, canonicalUuid });
+    seen.add(idBasedUuid);
   }
+
+  for (const angle of angles) {
+    const legacyUuid = legacyCatalogClimbUuid({ id: problemId, angle });
+    if (!seen.has(legacyUuid)) {
+      rows.push({ aliasUuid: legacyUuid, canonicalUuid });
+      seen.add(legacyUuid);
+    }
+  }
+
   return rows;
 }
 
@@ -254,30 +285,22 @@ export function isImportableConfig(config: MoonBoardCatalogConfiguration): boole
   return true;
 }
 
-/** Map a single (problem, configuration) into the climb/stats/holds payload. */
-export function mapCatalogConfig(
+/** Map the angle-agnostic structural fields of a problem (holds, name, setter, …). */
+export function mapCatalogProblemStructural(
   problem: MoonBoardCatalogProblem,
-  config: MoonBoardCatalogConfiguration,
-  options: { layoutId: number; angle: number },
-): MappedCatalogClimb {
-  const { layoutId, angle } = options;
+  layoutId: number,
+): Omit<MappedCatalogClimb, 'stats'> {
   const holds = parseMovesString(problem.moves ?? '');
   const frames = holdsToFrames(holds);
   const method = problem.climbMethod ?? undefined;
   const characteristic = moonBoardMethodToCharacteristic(method);
-  const rating = config.userRating ?? 0;
   return {
-    uuid: catalogClimbUuid({ id: problem.id, angle }),
+    uuid: catalogClimbUuid({ id: problem.id }),
     layoutId,
-    angle,
     name: problem.name,
     setterUsername: problem.setter ?? null,
     frames,
     holdFingerprint: fingerprintFromHolds(holds),
-    difficultyId: moonBoardGradeToDifficultyId(config.grade),
-    isBenchmark: Boolean(config.isBenchmark),
-    ascensionistCount: config.repeats ?? 0,
-    qualityAverage: rating > 0 ? rating : null,
     createdAt: problem.dateInserted ?? null,
     holds,
     characteristics: characteristic ? [characteristic] : null,
@@ -285,39 +308,59 @@ export function mapCatalogConfig(
   };
 }
 
+/** Map a single graded configuration into its per-angle stats payload. */
+export function mapCatalogConfigStats(config: MoonBoardCatalogConfiguration, angle: number): MappedCatalogClimbStats {
+  const rating = config.userRating ?? 0;
+  return {
+    angle,
+    difficultyId: moonBoardGradeToDifficultyId(config.grade),
+    isBenchmark: Boolean(config.isBenchmark),
+    ascensionistCount: config.repeats ?? 0,
+    qualityAverage: rating > 0 ? rating : null,
+  };
+}
+
 /**
- * Expand a problem into one mapped climb per graded, non-deleted configuration
- * (i.e. one row per angle). Returns [] for a problem we skip entirely.
+ * Map a problem into one climb (angle-agnostic identity + holds) carrying one
+ * stats entry per graded, non-deleted configuration. Returns null for a
+ * problem we skip entirely (unimportable, or every configuration ungraded).
  */
-export function catalogProblemToClimbs(problem: MoonBoardCatalogProblem, layoutId: number): MappedCatalogClimb[] {
-  if (!isImportableProblem(problem)) return [];
-  const climbs: MappedCatalogClimb[] = [];
+export function catalogProblemToClimbs(problem: MoonBoardCatalogProblem, layoutId: number): MappedCatalogClimb | null {
+  if (!isImportableProblem(problem)) return null;
+  const stats: MappedCatalogClimbStats[] = [];
   for (const config of problem.configurations ?? []) {
     if (!isImportableConfig(config)) continue;
     const angle = angleFromConfiguration(config.configuration);
     if (angle === undefined) continue;
-    climbs.push(mapCatalogConfig(problem, config, { layoutId, angle }));
+    stats.push(mapCatalogConfigStats(config, angle));
   }
-  return climbs;
+  if (stats.length === 0) return null;
+  return { ...mapCatalogProblemStructural(problem, layoutId), stats };
 }
 
 /**
  * Two distinct catalog problems can share the exact same holds at the same
- * layout+angle (e.g. the real "birthday cake trail mix", 38,683 repeats, and a
- * junk duplicate literally named "name" with 19 repeats). They collapse onto one
- * Boardsesh climb (same hold fingerprint → same merged UUID), so the importer must
- * decide which one's stats win instead of taking whichever it processed last.
+ * layout (e.g. the real "birthday cake trail mix", 38,683 repeats, and a junk
+ * duplicate literally named "name" with 19 repeats). They collapse onto one
+ * Boardsesh climb (same hold fingerprint → same merged UUID), so the importer
+ * must decide which PROBLEM's entire stats set wins instead of taking
+ * whichever it processed last.
  *
- * Prefer the stronger community signal: more ascents (repeats) wins; on a tie a
- * benchmark beats a non-benchmark; otherwise keep the incumbent (stable, so a
- * re-run is deterministic). Returns true if `candidate` should replace `incumbent`.
+ * Prefer the stronger community signal: more total ascents (summed across all
+ * graded angles) wins; on a tie, a problem with any benchmark angle beats one
+ * with none; otherwise keep the incumbent (stable, so a re-run is
+ * deterministic). Returns true if `candidate` should replace `incumbent`.
  */
 export function isBetterCatalogClimb(candidate: MappedCatalogClimb, incumbent: MappedCatalogClimb): boolean {
-  if (candidate.ascensionistCount !== incumbent.ascensionistCount) {
-    return candidate.ascensionistCount > incumbent.ascensionistCount;
+  const candidateAscents = candidate.stats.reduce((sum, stat) => sum + stat.ascensionistCount, 0);
+  const incumbentAscents = incumbent.stats.reduce((sum, stat) => sum + stat.ascensionistCount, 0);
+  if (candidateAscents !== incumbentAscents) {
+    return candidateAscents > incumbentAscents;
   }
-  if (candidate.isBenchmark !== incumbent.isBenchmark) {
-    return candidate.isBenchmark;
+  const candidateBenchmark = candidate.stats.some((stat) => stat.isBenchmark);
+  const incumbentBenchmark = incumbent.stats.some((stat) => stat.isBenchmark);
+  if (candidateBenchmark !== incumbentBenchmark) {
+    return candidateBenchmark;
   }
   return false;
 }

--- a/packages/db/scripts/moonboard-catalog-helpers.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.ts
@@ -284,6 +284,36 @@ export function catalogAliasRows(args: {
   return rows;
 }
 
+/**
+ * The UUIDs this problem would already own from an earlier import: the
+ * angle-agnostic id-based one, plus every legacy `moonboard:{id}:{angle}` one
+ * for its graded angles. Returns only those that are already climb ROWS.
+ *
+ * A hold-match miss (`matched: false`) normally means "new problem, insert it".
+ * But if any of these UUIDs already exists as a climb, the miss instead means
+ * the problem's holds drifted — an upstream hold edit, or a change to
+ * parseMovesString/fingerprintFromHolds — and inserting would be destructive:
+ * the fresh `moonboard:{id}` row lands alongside the still-listed old rows,
+ * and then `catalogAliasRows` writes `moonboard:{id}:{angle}` aliases whose
+ * alias_uuid IS one of those old rows. `catalogAliasConflictUpdate` overwrites
+ * canonical_uuid unconditionally, so their self-aliases get repointed at the
+ * empty new row and their ticks start redirecting there while both rows stay
+ * listed. Callers should treat a non-empty result as "skip this problem
+ * loudly" — same policy as `ambiguous` above.
+ */
+export function existingClimbUuidsForProblem(args: {
+  problemId: number;
+  angles: number[];
+  existingClimbUuids: ReadonlySet<string>;
+}): string[] {
+  const { problemId, angles, existingClimbUuids } = args;
+  const candidateUuids = new Set([
+    catalogClimbUuid({ id: problemId }),
+    ...angles.map((angle) => legacyCatalogClimbUuid({ id: problemId, angle })),
+  ]);
+  return [...candidateUuids].filter((uuid) => existingClimbUuids.has(uuid));
+}
+
 /** A problem is importable if it isn't soft-deleted and has holds + configs. */
 export function isImportableProblem(problem: MoonBoardCatalogProblem): boolean {
   if (problem.dateDeleted) return false;


### PR DESCRIPTION
## Summary

Second of three PRs widening MoonBoard's angle support (first: #3849, the dedup migration). This rewrites the catalog importer so future re-imports from Moon Climbing stop minting a new climb UUID per graded angle (`moonboard:{id}:{angle}`) and instead write one climb row per problem — angle-agnostic, matching Kilter/Tension — with a `board_climb_stats` row per graded angle under that same UUID.

- `catalogClimbUuid({ id })` drops `angle` from the identity key. `catalogProblemToClimbs` now returns a single `MappedCatalogClimb` (structural fields computed once: holds, name, setter, fingerprint) carrying a `stats: MappedCatalogClimbStats[]` array (one entry per graded angle) instead of one `MappedCatalogClimb` per angle.
- Per-angle grade/rating/repeats data is fully preserved — nothing is lost, it's just relocated from the climb identity to the stats table, where it already structurally belonged (`board_climb_stats` was already keyed on `(board_type, climb_uuid, angle)`).
- The cross-problem dedup collision logic (`isBetterCatalogClimb`, `buildExistingCatalogMatchIndex`/`resolveCatalogClimbUuid`) now operates on whole problems instead of individual angle-configs, matching on `(layoutId, holdFingerprint)` instead of `(layoutId, angle, holdFingerprint)`.
- Every graded angle still gets a legacy `moonboard:{id}:{angle}` alias (`legacyCatalogClimbUuid`) pointing at the new canonical UUID, so the personal CSV logbook importer (`packages/backend/src/services/moonboard-import.ts`, out of scope for this rewrite) keeps resolving ticks unmodified.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `packages/db/scripts/moonboard-catalog-helpers.test.ts` rewritten for the new one-climb-plus-N-stats shape: 23/23 passing.
- `packages/backend/src/__tests__/moonboard-import-service.test.ts` (the personal-importer regression suite, which depends on the legacy alias backward-compat requirement) — unmodified, still 4/4 passing.
- `vp run typecheck:db`: clean.
- `vp check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)