### PR TITLE
fix(mobile): relight the board on every climb over Web Bluetooth (Expo web)

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -135,6 +135,7 @@ import {
   convertToMirroredFramesString,
   dispatchMoonboardPacket,
   moonboardNumRowsForNative,
+  resolveWriteSignal,
   useBoardBluetooth,
 } from '../use-board-bluetooth';
 import type { BleWriteDiagnostics } from '../types';
@@ -1748,5 +1749,80 @@ describe('bleWriteDiagnosticsProperties', () => {
       bleCanSendAtTrip: true,
       bleWriteDurationMs: 88,
     });
+  });
+});
+
+describe('resolveWriteSignal', () => {
+  // The Expo-web relight regression: after the connect-time first send (which
+  // carries no caller signal), every AutoSender send passed a caller signal
+  // through the native generation-signal merge. Web now bypasses that merge and
+  // passes the caller signal straight through, mirroring the proven Next.js web
+  // app. These lock in that platform split.
+
+  it('web: passes the caller signal straight through (no merge wrapper)', () => {
+    const caller = new AbortController();
+    const generation = new AbortController();
+    const { combinedSignal } = resolveWriteSignal(caller.signal, generation.signal, 'web');
+    // Same object — not a merged wrapper — so nothing the app does to the
+    // generation controller can touch this write.
+    expect(combinedSignal).toBe(caller.signal);
+  });
+
+  it('web: aborting the generation controller does NOT abort the write signal', () => {
+    const caller = new AbortController();
+    const generation = new AbortController();
+    const { combinedSignal } = resolveWriteSignal(caller.signal, generation.signal, 'web');
+
+    generation.abort();
+
+    // The whole point of the fix: a generation-controller abort can no longer
+    // silently no-op a web relight the way the merged signal could.
+    expect(combinedSignal.aborted).toBe(false);
+  });
+
+  it('web: falls back to the generation signal when there is no caller signal (connect-time send)', () => {
+    const generation = new AbortController();
+    const { combinedSignal } = resolveWriteSignal(undefined, generation.signal, 'web');
+    expect(combinedSignal).toBe(generation.signal);
+  });
+
+  it('native: merges caller + generation so a reconnect (generation abort) cancels the write', () => {
+    const caller = new AbortController();
+    const generation = new AbortController();
+    const { combinedSignal } = resolveWriteSignal(caller.signal, generation.signal, 'ios');
+
+    // A distinct merged signal, not either input by identity.
+    expect(combinedSignal).not.toBe(caller.signal);
+    expect(combinedSignal).not.toBe(generation.signal);
+    expect(combinedSignal.aborted).toBe(false);
+
+    generation.abort();
+    expect(combinedSignal.aborted).toBe(true);
+  });
+
+  it('native: the merged signal also aborts when the caller signal aborts', () => {
+    const caller = new AbortController();
+    const generation = new AbortController();
+    const { combinedSignal } = resolveWriteSignal(caller.signal, generation.signal, 'android');
+
+    caller.abort();
+    expect(combinedSignal.aborted).toBe(true);
+  });
+
+  it('native: dispose detaches the merge listeners so a later abort is inert', () => {
+    const caller = new AbortController();
+    const generation = new AbortController();
+    const { combinedSignal, dispose } = resolveWriteSignal(caller.signal, generation.signal, 'android');
+
+    dispose();
+    generation.abort();
+    // Detached before the abort — the merged controller never saw it.
+    expect(combinedSignal.aborted).toBe(false);
+  });
+
+  it('native: falls back to the generation signal when there is no caller signal', () => {
+    const generation = new AbortController();
+    const { combinedSignal } = resolveWriteSignal(undefined, generation.signal, 'ios');
+    expect(combinedSignal).toBe(generation.signal);
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1786,6 +1786,17 @@ describe('resolveWriteSignal', () => {
     expect(combinedSignal).toBe(generation.signal);
   });
 
+  it('web: a caller signal already aborted before the call stays aborted (no silent swallow)', () => {
+    const caller = new AbortController();
+    caller.abort();
+    const generation = new AbortController();
+    const { combinedSignal } = resolveWriteSignal(caller.signal, generation.signal, 'web');
+    // Passed straight through — an already-aborted caller signal must read as
+    // aborted immediately, not get lost in a merge wrapper.
+    expect(combinedSignal).toBe(caller.signal);
+    expect(combinedSignal.aborted).toBe(true);
+  });
+
   it('native: merges caller + generation so a reconnect (generation abort) cancels the write', () => {
     const caller = new AbortController();
     const generation = new AbortController();

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -330,7 +330,7 @@ function mergeAbortSignals(signalA: AbortSignal, signalB: AbortSignal): { signal
 export function resolveWriteSignal(
   callerSignal: AbortSignal | undefined,
   generationSignal: AbortSignal,
-  platformOS: string,
+  platformOS: typeof Platform.OS,
 ): { combinedSignal: AbortSignal; dispose: () => void } {
   const mergeGenerationSignal = platformOS !== 'web';
   const merged = callerSignal && mergeGenerationSignal ? mergeAbortSignals(callerSignal, generationSignal) : null;
@@ -524,20 +524,7 @@ export function useBoardBluetooth({
 
   const sendFramesToBoard = useCallback(
     async (frames: string, mirrored: boolean = false, signal?: AbortSignal, sendContext?: BleSendContext) => {
-      if (!adapterRef.current || !boardName || layoutId === undefined || sizeId === undefined) {
-        // TEMP DIAG (ble-relight-diag): remove once the Expo-web relight regression
-        // is confirmed fixed on a real board.
-        if (__DEV__) {
-          console.warn('[ble-relight-diag] send bailed at precondition', {
-            hasAdapter: !!adapterRef.current,
-            boardName,
-            layoutId,
-            sizeId,
-            sendSource: sendContext?.sendSource,
-          });
-        }
-        return;
-      }
+      if (!adapterRef.current || !boardName || layoutId === undefined || sizeId === undefined) return;
       // Resolved here (where layoutId is narrowed to a number) so the nested
       // performSend closure can use it. Mini LED strips are 12 rows, standard 18.
       const moonNumRows = getMoonBoardGeometryByLayoutId(layoutId).numRows;
@@ -563,21 +550,6 @@ export function useBoardBluetooth({
       // straight through (see resolveWriteSignal).
       const { combinedSignal, dispose: disposeWriteSignal } = resolveWriteSignal(signal, generationSignal, Platform.OS);
 
-      // TEMP DIAG (ble-relight-diag): remove once the Expo-web relight regression
-      // is confirmed fixed on a real board.
-      if (__DEV__) {
-        console.warn('[ble-relight-diag] send start', {
-          platform: Platform.OS,
-          sendSource: sendContext?.sendSource,
-          framesHead: frames.slice(0, 24),
-          hasCallerSignal: !!signal,
-          callerAborted: signal?.aborted ?? null,
-          generationAborted: generationSignal.aborted,
-          combinedAborted: combinedSignal.aborted,
-          combinedIsCaller: combinedSignal === signal,
-        });
-      }
-
       const performSend = async (): Promise<boolean | undefined> => {
         // Transport diagnostics of the write that just settled (#3230) — iOS
         // native adapter (full flow-control story) or ble-plx (MTU/chunking
@@ -594,17 +566,7 @@ export function useBoardBluetooth({
           // The send may have queued behind another write; by the time it runs
           // the connection generation may be gone (reconnect/disconnect) — bail
           // before touching the (possibly new) adapter.
-          if (combinedSignal.aborted || !adapterRef.current) {
-            // TEMP DIAG (ble-relight-diag): remove once confirmed fixed on a board.
-            if (__DEV__) {
-              console.warn('[ble-relight-diag] performSend bailed', {
-                combinedAborted: combinedSignal.aborted,
-                hasAdapter: !!adapterRef.current,
-                sendSource: sendContext?.sendSource,
-              });
-            }
-            return;
-          }
+          if (combinedSignal.aborted || !adapterRef.current) return;
           sendAdapter = adapterRef.current;
 
           if (boardName === 'moonboard') {
@@ -729,13 +691,6 @@ export function useBoardBluetooth({
           }
 
           await adapterRef.current.write(result.packet, combinedSignal);
-          // TEMP DIAG (ble-relight-diag): remove once confirmed fixed on a board.
-          if (__DEV__) {
-            console.warn('[ble-relight-diag] write resolved (packet sent)', {
-              packetBytes: result.packet.length,
-              sendSource: sendContext?.sendSource,
-            });
-          }
           track(SHARED_EVENTS.ClimbSentToBoardSuccess, {
             ...boardAnalyticsProperties,
             ...bleWriteDiagnosticsProperties(await fetchWriteDiagnostics()),

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, AppState } from 'react-native';
+import { Alert, AppState, Platform } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import {
@@ -309,6 +309,37 @@ function mergeAbortSignals(signalA: AbortSignal, signalB: AbortSignal): { signal
   return { signal: controller.signal, dispose: detach };
 }
 
+/**
+ * Resolve the AbortSignal an adapter write runs under, plus a `dispose` to detach
+ * any listeners the merge added.
+ *
+ * - **Native** (`platformOS !== 'web'`): merge the caller signal with the
+ *   per-connection generation controller, so a reconnect (which aborts the
+ *   generation controller) cancels this in-flight write.
+ * - **Web** (`platformOS === 'web'`): pass the caller signal straight through with
+ *   NO generation merge, mirroring the proven Next.js web app. On web a reconnect
+ *   swaps in a fresh WebBluetoothAdapter + characteristic and disconnects the old
+ *   one, so a stale write fails closed on its own — the merge buys nothing. The
+ *   merge was also the one wrapper the working web path never had, sitting on the
+ *   exact seam where Expo web relit the FIRST climb (connect() sends it with no
+ *   caller signal, bypassing the merge) but risked silently no-op'ing the ones
+ *   after (every AutoSender send passes a caller signal through the merge).
+ *
+ * Exported for testing.
+ */
+export function resolveWriteSignal(
+  callerSignal: AbortSignal | undefined,
+  generationSignal: AbortSignal,
+  platformOS: string,
+): { combinedSignal: AbortSignal; dispose: () => void } {
+  const mergeGenerationSignal = platformOS !== 'web';
+  const merged = callerSignal && mergeGenerationSignal ? mergeAbortSignals(callerSignal, generationSignal) : null;
+  return {
+    combinedSignal: merged ? merged.signal : (callerSignal ?? generationSignal),
+    dispose: merged ? merged.dispose : () => {},
+  };
+}
+
 export function useBoardBluetooth({
   boardName,
   layoutId,
@@ -493,7 +524,20 @@ export function useBoardBluetooth({
 
   const sendFramesToBoard = useCallback(
     async (frames: string, mirrored: boolean = false, signal?: AbortSignal, sendContext?: BleSendContext) => {
-      if (!adapterRef.current || !boardName || layoutId === undefined || sizeId === undefined) return;
+      if (!adapterRef.current || !boardName || layoutId === undefined || sizeId === undefined) {
+        // TEMP DIAG (ble-relight-diag): remove once the Expo-web relight regression
+        // is confirmed fixed on a real board.
+        if (__DEV__) {
+          console.warn('[ble-relight-diag] send bailed at precondition', {
+            hasAdapter: !!adapterRef.current,
+            boardName,
+            layoutId,
+            sizeId,
+            sendSource: sendContext?.sendSource,
+          });
+        }
+        return;
+      }
       // Resolved here (where layoutId is narrowed to a number) so the nested
       // performSend closure can use it. Mini LED strips are 12 rows, standard 18.
       const moonNumRows = getMoonBoardGeometryByLayoutId(layoutId).numRows;
@@ -514,9 +558,25 @@ export function useBoardBluetooth({
       }
       const generationSignal = writeAbortRef.current.signal;
 
-      // Combine caller-provided signal with the generation controller.
-      const merged = signal ? mergeAbortSignals(signal, generationSignal) : null;
-      const combinedSignal = merged ? merged.signal : generationSignal;
+      // Resolve the signal the adapter write runs under. Native merges the caller
+      // signal with the generation controller; web passes the caller signal
+      // straight through (see resolveWriteSignal).
+      const { combinedSignal, dispose: disposeWriteSignal } = resolveWriteSignal(signal, generationSignal, Platform.OS);
+
+      // TEMP DIAG (ble-relight-diag): remove once the Expo-web relight regression
+      // is confirmed fixed on a real board.
+      if (__DEV__) {
+        console.warn('[ble-relight-diag] send start', {
+          platform: Platform.OS,
+          sendSource: sendContext?.sendSource,
+          framesHead: frames.slice(0, 24),
+          hasCallerSignal: !!signal,
+          callerAborted: signal?.aborted ?? null,
+          generationAborted: generationSignal.aborted,
+          combinedAborted: combinedSignal.aborted,
+          combinedIsCaller: combinedSignal === signal,
+        });
+      }
 
       const performSend = async (): Promise<boolean | undefined> => {
         // Transport diagnostics of the write that just settled (#3230) — iOS
@@ -534,7 +594,17 @@ export function useBoardBluetooth({
           // The send may have queued behind another write; by the time it runs
           // the connection generation may be gone (reconnect/disconnect) — bail
           // before touching the (possibly new) adapter.
-          if (combinedSignal.aborted || !adapterRef.current) return;
+          if (combinedSignal.aborted || !adapterRef.current) {
+            // TEMP DIAG (ble-relight-diag): remove once confirmed fixed on a board.
+            if (__DEV__) {
+              console.warn('[ble-relight-diag] performSend bailed', {
+                combinedAborted: combinedSignal.aborted,
+                hasAdapter: !!adapterRef.current,
+                sendSource: sendContext?.sendSource,
+              });
+            }
+            return;
+          }
           sendAdapter = adapterRef.current;
 
           if (boardName === 'moonboard') {
@@ -659,6 +729,13 @@ export function useBoardBluetooth({
           }
 
           await adapterRef.current.write(result.packet, combinedSignal);
+          // TEMP DIAG (ble-relight-diag): remove once confirmed fixed on a board.
+          if (__DEV__) {
+            console.warn('[ble-relight-diag] write resolved (packet sent)', {
+              packetBytes: result.packet.length,
+              sendSource: sendContext?.sendSource,
+            });
+          }
           track(SHARED_EVENTS.ClimbSentToBoardSuccess, {
             ...boardAnalyticsProperties,
             ...bleWriteDiagnosticsProperties(await fetchWriteDiagnostics()),
@@ -705,7 +782,7 @@ export function useBoardBluetooth({
           }
           return false;
         } finally {
-          merged?.dispose();
+          disposeWriteSignal();
         }
       };
 

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -277,6 +277,15 @@ function BluetoothAutoSender({
       colorSignature,
     };
 
+    // TEMP DIAG (ble-relight-diag): remove once the Expo-web relight regression
+    // is confirmed fixed on a real board.
+    if (__DEV__) {
+      console.warn('[ble-relight-diag] AutoSender fired', {
+        climbUuid: currentClimbQueueItem.climb.uuid,
+        isWriting: isWritingRef.current,
+      });
+    }
+
     if (isWritingRef.current) {
       pendingSendRef.current = sendRequest;
       return;
@@ -373,6 +382,15 @@ function BluetoothAutoSender({
               climbBoardType: item.climb.boardType,
               climbLayoutId: item.climb.layoutId,
             });
+
+            // TEMP DIAG (ble-relight-diag): remove once confirmed fixed on a board.
+            if (__DEV__) {
+              console.warn('[ble-relight-diag] AutoSender send result', {
+                climbUuid: item.climb.uuid,
+                result,
+                signalAborted: signal?.aborted ?? null,
+              });
+            }
 
             // After the await, the AutoSender may have unmounted — skip
             // post-send side effects.

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -277,15 +277,6 @@ function BluetoothAutoSender({
       colorSignature,
     };
 
-    // TEMP DIAG (ble-relight-diag): remove once the Expo-web relight regression
-    // is confirmed fixed on a real board.
-    if (__DEV__) {
-      console.warn('[ble-relight-diag] AutoSender fired', {
-        climbUuid: currentClimbQueueItem.climb.uuid,
-        isWriting: isWritingRef.current,
-      });
-    }
-
     if (isWritingRef.current) {
       pendingSendRef.current = sendRequest;
       return;
@@ -382,15 +373,6 @@ function BluetoothAutoSender({
               climbBoardType: item.climb.boardType,
               climbLayoutId: item.climb.layoutId,
             });
-
-            // TEMP DIAG (ble-relight-diag): remove once confirmed fixed on a board.
-            if (__DEV__) {
-              console.warn('[ble-relight-diag] AutoSender send result', {
-                climbUuid: item.climb.uuid,
-                result,
-                signalAborted: signal?.aborted ?? null,
-              });
-            }
 
             // After the await, the AutoSender may have unmounted — skip
             // post-send side effects.


### PR DESCRIPTION
## Summary

On **app.boardsesh.com** (the Expo-web build), connecting a board over Web Bluetooth lit the **first** climb correctly, but every later climb change — swiping *or* the next/prev arrows — left the board LEDs stuck. Silently: no error, still shown as "connected", and the on-screen climb art advanced normally the whole time.

Root cause is a divergence from the proven Next.js web app, which relights on every swipe over the *same* shared transport (`@boardsesh/ble-protocol/web-transport`). The Expo-web hook wrapped every send's `AbortSignal` in a native-only generation-signal merge (`mergeAbortSignals`) that the working web path never had:

- The **first** send is issued by `connect()` with **no caller signal**, so it bypassed the merge → always lit.
- Every **subsequent** send comes from the `BluetoothAutoSender` **with** a caller signal → the only path routed through the merge, where it could silently no-op (the merged/aborted signal makes `performSend` bail with no LED, no haptic, no error).

**Fix:** align the Expo-web write path with the proven web path — on web, pass the caller's signal straight through with no generation merge. Native keeps the merge (it cancels in-flight writes across a reconnect). Extracted into a pure, tested `resolveWriteSignal(callerSignal, generationSignal, platformOS)`.

### Why this diagnosis
- Shared transport is byte-identical to the Next.js web app (proven) → not the transport.
- Native iOS/Android adapters work → not the encoder/protocol.
- On-screen climb advances + both swipe and arrows fail → `currentClimbQueueItem` updates fine; the fault is purely the per-send BLE write. (Confirmed with reporter.)

## Release Notes

- The board now relights every climb as you swipe or tap through your queue on the web app — not just the first one.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 4358 passed; BLE suite alone is 71 passed, incl. `resolveWriteSignal` tests proving web passes the caller signal through untouched (including an already-aborted caller signal), and that a generation-controller abort can no longer touch a web write signal
- `vp run check:mobile-web-bundle` — Expo-web export builds with shell + WASM assets
- `vp run check:mobile-bundle` — native Android bundle unaffected
- **Pending (reporter):** on-board Expo-web check — `vp run dev:mobile:web`, connect a board, swipe/arrow through ≥3 climbs, confirm LEDs relight every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gEjkJx4zeMaZ6bYgN2aUi
