### PR TITLE
fix(mobile): render collapsible body without FadeIn so iOS Tuning shows

### DIFF
--- a/packages/mobile/src/components/CollapsibleSection.tsx
+++ b/packages/mobile/src/components/CollapsibleSection.tsx
@@ -197,11 +197,8 @@ function CollapsibleSectionInternal({
         </Animated.View>
       </Pressable>
 
-      {/* Body renders in a plain View, not a Reanimated entering/exiting
-          Animated.View: inside a FlashList ListHeaderComponent (the session
-          generator's Tuning section) the iOS FadeIn settled at ~0 height and
-          got clipped by the container's overflow:'hidden', painting blank.
-          Matches the keepExpanded branch above. */}
+      {/* Plain View, not a FadeIn/FadeOut Animated.View: inside a FlashList header
+          the iOS entering animation settles at ~0 height and paints the body blank. */}
       {expanded && <View style={styles.content}>{children}</View>}
     </View>
   );

--- a/packages/mobile/src/components/CollapsibleSection.tsx
+++ b/packages/mobile/src/components/CollapsibleSection.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { View, Pressable, StyleSheet, type LayoutChangeEvent } from 'react-native';
-import Animated, { FadeIn, FadeOut, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { Text } from './Text';
 import { Icon } from './Icon';
 import { hapticSelection } from '../lib/haptics';
@@ -197,11 +197,12 @@ function CollapsibleSectionInternal({
         </Animated.View>
       </Pressable>
 
-      {expanded && (
-        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(150)} style={styles.content}>
-          {children}
-        </Animated.View>
-      )}
+      {/* Body renders in a plain View, not a Reanimated entering/exiting
+          Animated.View: inside a FlashList ListHeaderComponent (the session
+          generator's Tuning section) the iOS FadeIn settled at ~0 height and
+          got clipped by the container's overflow:'hidden', painting blank.
+          Matches the keepExpanded branch above. */}
+      {expanded && <View style={styles.content}>{children}</View>}
     </View>
   );
 }

--- a/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
+++ b/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
@@ -126,3 +126,34 @@ describe('CollapsibleSection persistence', () => {
     expect(onToggle).toHaveBeenLastCalledWith(false);
   });
 });
+
+describe('CollapsibleSection body rendering', () => {
+  beforeEach(async () => {
+    resetSectionExpandStoreForTests();
+    (await getMockStorage()).__reset();
+  });
+
+  // Guards the mount/unmount contract of the expanded body. NOTE: Vitest mocks
+  // react-native-reanimated (the `entering` prop is ignored) and .ios.tsx files
+  // resolve to stubs, so this cannot reproduce the native iOS FadeIn-blank bug
+  // this change fixes — that is verified on-device. It does pin that the body
+  // renders when expanded and unmounts when collapsed.
+  it('renders the body only while expanded, toggling on header tap', () => {
+    const { getByRole, queryByText } = render(
+      createElement(CollapsibleSection, {
+        title: 'Logbook',
+        defaultExpanded: false,
+        children: createElement('span', null, BODY),
+      }),
+    );
+
+    // Collapsed by default → body absent.
+    expect(queryByText(BODY)).toBeNull();
+    // Tap to expand → body present (plain View, no FadeIn gate).
+    fireEvent.click(getByRole('button'));
+    expect(queryByText(BODY)).toBeTruthy();
+    // Tap again to collapse → body removed.
+    fireEvent.click(getByRole('button'));
+    expect(queryByText(BODY)).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
+++ b/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
@@ -37,8 +37,6 @@ vi.mock('react-native', () => ({
 }));
 vi.mock('react-native-reanimated', () => ({
   default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
-  FadeIn: { duration: () => ({}) },
-  FadeOut: { duration: () => ({}) },
   useSharedValue: (value: number) => ({ value }),
   useAnimatedStyle: (factory: () => Record<string, unknown>) => factory(),
   withTiming: (value: number) => value,


### PR DESCRIPTION
## Summary

Fixes the blank **Tuning** section in the mobile session/workout generator on iOS. Reported by a user on iOS 26.5.2: when building a session (Volume/Pyramid/Ladder/Grade Focus), expanding the Tuning drawer showed nothing. Works on web.

**Root cause:** The Tuning `CollapsibleSection` is the only collapsible hosted inside a `FlashList` `ListHeaderComponent` (`PreSessionView.tsx` → `GeneratorPickerCard`). Its body was mounted inside a Reanimated `entering={FadeIn}`/`exiting={FadeOut}` `Animated.View`. On iOS that entering animation settled at ~0 height inside the virtualized header and got clipped by the container's `overflow: 'hidden'`, so the section painted blank. It only bites users who expand the collapsed-by-default drawer, which is why it wasn't reproducible fleet-wide.

**Fix:** Render the expanded body in a plain `View` (matching the existing `keepExpanded` branch). The fix is in the shared `CollapsibleSection`, so it hardens every FlashList-hosted collapsible at once — not just Tuning. The chevron rotation animation is unchanged. No caller changes.

**Behaviour change for other callers:** every `CollapsibleSection` (the climb Filter sheet, You → Logbook filter sheet, play-drawer sections, Open Drafts, Beta Videos) now expands **instantly** instead of with the old ~200ms fade-in / 150ms fade-out. That fade was purely cosmetic; no caller relied on it, and none had the blank bug (only the FlashList-header one did). The trade is a snappier expand across the board in exchange for dropping the fade everywhere.

### Telemetry note (not a bug — please don't chase it)

While diagnosing this I noticed `Workout Generated` / `Workout Type Selected` sit at ~0 on mobile since ~Jun 29. That's **web-only-by-design** since the late-June generator redesign (`packages/shared/analytics/src/events.ts:64-67`) — mobile's generator is a live auto-regenerating preview, so its cross-platform funnel is `Workout Generator Opened → Session Queue Generated`, which is healthy (~34% conversion on both iOS and Android over 28d). Unrelated to this fix.

## Release Notes

- Fixed a blank fine-tuning panel when building a session on iPhone — the workout builder's Tuning controls show up again

## Test plan

- `vp run typecheck:mobile` — clean
- `vp test run --project mobile collapsible-section` — pass (added a mount/expand render-contract test)
- `vp run check:mobile-bundle` — Android bundle OK

**Needs on-device iOS verification** (author is on Linux; the simulator path is macOS-only). Vitest mocks Reanimated and resolves `.ios.tsx` to stubs, so no unit test can reproduce the native FadeIn-blank — that's why the added test only pins the mount/unmount contract. To confirm on **iOS 26.5.2**: Record tab → open the session generator → pick a workout type → expand **Tuning** → confirm all four subsections render (Min Ascents, Min Rating, Climb Bias, Tall/Wide). Spot-check that the climb Filter sheet and You → Logbook filter sheet still expand (now without the fade).
