### PR TITLE
fix(sync): stable MoonBoard name+coarse-cell gym source key (#3715)

### DIFF
--- a/docs/moonboard-sync.md
+++ b/docs/moonboard-sync.md
@@ -15,6 +15,22 @@ MoonBoard locations intentionally cover every configured layout, not just the 20
 
 Rows are upserted by deterministic UUID. The sync does not delete rows that disappear upstream.
 
+## Gym identity (source keys)
+
+MoonBoard's `GetMapMarkers` payload has **no upstream id** — only a name and coordinates. A gym's stable identity is therefore derived from its name plus a coarse location cell:
+
+```
+moonboard:<normalized name>:<lat cell>:<lng cell>
+```
+
+`<lat cell>`/`<lng cell>` are integer hundredths of a degree (`Math.round(coord * 100)`), a ~1.1 km north-south grid. The name is normalized (lowercase, single-spaced) so casing/whitespace jitter can't split one gym into two identities; the human-readable name is stored separately for display.
+
+Why not full-precision coordinates: they made the key change on every pin nudge, so any move beyond the 20 m physical-match tier minted a permanent duplicate gym — a 20-150 m move tripped the same-provider guard, a larger move missed the match radius entirely (issue #3715). Why not the name alone: genuinely distinct gyms share names (the prod collisions — e.g. "MoonBoard" vs "Moonboard" — sit thousands of km apart), and a name-only key would merge them into one flip-flopping gym.
+
+The coarse cell keeps the key stable across the whole realistic pin-correction range while keeping far-apart same-named gyms distinct. The rare correction that crosses a cell boundary **and** lands in the 20-150 m band mints one twin that surfaces in `/admin/gym-duplicates` for a human merge — the fallback is a manual merge, never a silently wrong one.
+
+When the sync first runs against a database whose MoonBoard gyms were seeded without source aliases (as in prod today), each marker resolves its existing gym through the name + location physical match and adopts it (aliases the stable key onto it), so no separate backfill migration is needed.
+
 ## CLI
 
 ```bash

--- a/packages/location-sync/src/upsert.ts
+++ b/packages/location-sync/src/upsert.ts
@@ -459,12 +459,13 @@ function classifyGymMatch(
   const unclaimedUserOwnedSkips: CandidateReference[] = [];
   const eligibleCandidates: GymMatchCandidate[] = [];
   for (const candidate of guardedCandidates) {
-    // NOTE: moonboard embeds the pin's coordinates in its source key
-    // (`moonboard:<name>:<lat>:<lng>`), so a pin that moves > 20 m mints a new
-    // source key. The same-provider guard then sees that key as a different
-    // moonboard source on the old gym and refuses to re-merge — the moved pin
-    // warns here, then mints a permanent twin. Tracked for a key-scheme redesign
-    // (follow-up issue); see docs and the same-provider log below.
+    // A same-provider alias already on this candidate means it's a genuinely
+    // distinct wall 20-150 m away (two provider sources for one physical gym is
+    // what aliasing is for; two 150 m apart are more likely two gyms), so we
+    // refuse to auto-merge here and log below. (Every provider now uses a stable,
+    // coordinate-free identity — MoonBoard's name + coarse-cell key, issue #3715,
+    // was the last coordinate-embedding source key that made a moved pin look
+    // like a new same-provider source and trip this guard.)
     const conflictingSourceKeys = candidate.aliasSourceKeys.filter(
       (aliasSourceKey) => aliasSourceKey !== sourceKey && providerPrefixOf(aliasSourceKey) === providerPrefix,
     );

--- a/packages/moonboard-sync/src/sync/locations-sync.integration.test.ts
+++ b/packages/moonboard-sync/src/sync/locations-sync.integration.test.ts
@@ -1,0 +1,133 @@
+// Integration test for issue #3715: a MoonBoard pin move must NOT mint a
+// duplicate gym.
+//
+// Before the fix, the gym/board source key embedded the pin's full-precision
+// coordinates (`moonboard:<name>:<lat>:<lng>`), so any coordinate change produced
+// a new key. A move > 20 m then tripped the same-provider guard (or missed the
+// 150 m radius entirely) and minted a permanent twin gym. The fix keys on the
+// normalized name + a coarse ~1.1 km cell, so a realistic pin correction keeps
+// the same key and resolves back to the same gym via the source alias.
+//
+// This test drives the real `upsertPublicBoardLocations` against a migrated
+// Postgres (the dev DB). It self-skips when DATABASE_URL is not a local database,
+// and runs entirely inside a transaction that is always rolled back, so it never
+// leaves rows behind. Run locally with:
+//
+//   DATABASE_URL=postgres://…@localhost:5432/… VITEST_POOL_ID=solo-issue3715 \
+//     vp test run --reporter=agent packages/moonboard-sync/src/sync/locations-sync.integration.test.ts
+
+import { describe, it, expect } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { createDb, closePool, executeRows } from '@boardsesh/db/client';
+import { upsertPublicBoardLocations } from '@boardsesh/location-sync';
+import { buildMoonBoardLocationRecords } from './locations-sync';
+import type { MoonBoardMarker } from '../api/moonboard-client';
+
+function localDatabaseUrl(): string | null {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    return null;
+  }
+  const hostname = new URL(databaseUrl).hostname.toLowerCase();
+  return ['localhost', '127.0.0.1', 'postgres'].includes(hostname) ? databaseUrl : null;
+}
+
+function marker(name: string, latitude: number, longitude: number): MoonBoardMarker {
+  return { Name: name, Latitude: latitude, Longitude: longitude, LatLng: [latitude, longitude] };
+}
+
+const describeIntegration = localDatabaseUrl() ? describe : describe.skip;
+
+describeIntegration('MoonBoard pin move does not mint a duplicate gym (issue #3715)', () => {
+  it('keeps one gym across 50 m and 500 m pin corrections', async (testContext) => {
+    const db = createDb();
+
+    // Cheap availability probe: the source-alias table must exist (migrated DB).
+    try {
+      const [schema] = await executeRows<{ aliasTable: string | null }>(
+        db,
+        sql`SELECT to_regclass('public.location_sync_gym_sources')::text AS "aliasTable"`,
+      );
+      if (!schema?.aliasTable) {
+        testContext.skip();
+        return;
+      }
+    } catch {
+      // DB unreachable / not migrated — treat as "not available" and skip.
+      testContext.skip();
+      return;
+    }
+
+    const tag = `mb-3715-${Date.now()}`;
+    const gymName = `Integration MoonBoard ${tag}`;
+
+    // A cell centre (51.50, -0.10) so that a +500 m northward move (0.0045 deg,
+    // rounds to the same integer-hundredths cell) stays inside one identity key.
+    const startLat = 51.5;
+    const startLng = -0.1;
+    const records1 = buildMoonBoardLocationRecords([marker(gymName, startLat, startLng)]);
+    const records2 = buildMoonBoardLocationRecords([marker(gymName, startLat + 0.00045, startLng)]); // ~50 m N
+    const records3 = buildMoonBoardLocationRecords([marker(gymName, startLat + 0.0045, startLng)]); // ~500 m N
+
+    const gymSourceKey = records1[0]?.gymSourceKey;
+    expect(gymSourceKey).toBe(`moonboard:integration moonboard ${tag}:5150:-10`);
+    // The coarse cell is identical across all three positions — the core invariant.
+    expect(records2[0]?.gymSourceKey).toBe(gymSourceKey);
+    expect(records3[0]?.gymSourceKey).toBe(gymSourceKey);
+
+    const rollback = new Error('rollback issue-3715 integration fixture');
+    try {
+      await db.transaction(async (transaction) => {
+        const runSync = async (records: typeof records1) => {
+          await upsertPublicBoardLocations(transaction as unknown as typeof db, records);
+        };
+
+        const gymCount = async (): Promise<number> => {
+          const [row] = await executeRows<{ n: number | string }>(
+            transaction,
+            sql`SELECT count(*)::int AS n FROM gyms WHERE name = ${gymName} AND deleted_at IS NULL`,
+          );
+          return Number(row?.n ?? 0);
+        };
+
+        await runSync(records1);
+        expect(await gymCount()).toBe(1);
+
+        await runSync(records2); // +50 m
+        expect(await gymCount()).toBe(1);
+
+        await runSync(records3); // +500 m
+        expect(await gymCount()).toBe(1);
+
+        // Exactly one gym, reached through exactly one moonboard source alias.
+        const [aliasSummary] = await executeRows<{ gyms: number | string; aliases: number | string }>(
+          transaction,
+          sql`
+            SELECT count(DISTINCT s.gym_id)::int AS gyms, count(*)::int AS aliases
+            FROM location_sync_gym_sources s
+            JOIN gyms g ON g.id = s.gym_id
+            WHERE g.name = ${gymName} AND s.source_key LIKE 'moonboard:%'
+          `,
+        );
+        expect(Number(aliasSummary?.gyms)).toBe(1);
+        expect(Number(aliasSummary?.aliases)).toBe(1);
+
+        // The gym's coordinates were refreshed to the latest pin, not left stale.
+        const [coords] = await executeRows<{ lat: number | string; lng: number | string }>(
+          transaction,
+          sql`SELECT latitude::float8 AS lat, longitude::float8 AS lng FROM gyms WHERE name = ${gymName} AND deleted_at IS NULL`,
+        );
+        expect(Number(coords?.lat)).toBeCloseTo(startLat + 0.0045, 4);
+        expect(Number(coords?.lng)).toBeCloseTo(startLng, 4);
+
+        throw rollback;
+      });
+    } catch (error: unknown) {
+      if (error !== rollback) {
+        throw error;
+      }
+    } finally {
+      await closePool();
+    }
+  });
+});

--- a/packages/moonboard-sync/src/sync/locations-sync.test.ts
+++ b/packages/moonboard-sync/src/sync/locations-sync.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { buildMoonBoardLocationRecords } from './locations-sync';
+import type { MoonBoardMarker } from '../api/moonboard-client';
+
+function defaultBoardKey(marker: MoonBoardMarker): string | undefined {
+  const records = buildMoonBoardLocationRecords([marker]);
+  return records.find((record) => record.layoutId === 2 && record.angle === 40)?.sourceKey;
+}
 
 describe('buildMoonBoardLocationRecords', () => {
   it('creates all supported MoonBoard layout and angle boards per marker', () => {
@@ -20,12 +26,20 @@ describe('buildMoonBoardLocationRecords', () => {
     expect(records.map((record) => `${record.layoutId}:${record.angle}`)).toContain('2:25');
     expect(records.map((record) => `${record.layoutId}:${record.angle}`)).toContain('2:40');
     expect(records.map((record) => `${record.layoutId}:${record.angle}`)).toContain('7:40');
+    // Identity keys are the normalized name + a coarse ~1.1 km cell (integer
+    // hundredths of a degree), not the raw full-precision coordinates. The
+    // 2016/40deg default keeps the bare base key; other configs get suffixed.
     expect(records.find((record) => record.layoutId === 2 && record.angle === 40)?.sourceKey).toBe(
-      'moonboard:Board House:-33.86:151.2',
+      'moonboard:board house:-3386:15120',
     );
     expect(records.find((record) => record.layoutId === 2 && record.angle === 25)?.sourceKey).toBe(
-      'moonboard:Board House:-33.86:151.2:2:25',
+      'moonboard:board house:-3386:15120:2:25',
     );
+    // The gym identity key matches the default board's base key, and the display
+    // name keeps its original casing (only the key is normalized).
+    const defaultRecord = records.find((record) => record.layoutId === 2 && record.angle === 40);
+    expect(defaultRecord?.gymSourceKey).toBe('moonboard:board house:-3386:15120');
+    expect(defaultRecord?.gymName).toBe('Board House');
     expect(records.every((record) => record.gymAddress === null)).toBe(true);
   });
 
@@ -41,9 +55,35 @@ describe('buildMoonBoardLocationRecords', () => {
     ]);
 
     expect(records.find((record) => record.layoutId === 2 && record.angle === 40)).toMatchObject({
-      sourceKey: 'moonboard:LatLng Board:10.5:20.25',
+      sourceKey: 'moonboard:latlng board:1050:2025',
       latitude: 10.5,
       longitude: 20.25,
     });
+  });
+
+  it('keeps the same source key when a pin moves a few tens of metres within the cell', () => {
+    // ~50 m nudge (0.0005 deg) that stays inside the same coarse cell. Before
+    // #3715 this changed the full-precision key and minted a duplicate gym.
+    const original = defaultBoardKey({ Name: 'The School Room', Latitude: 53.386, Longitude: -1.476 });
+    const nudged = defaultBoardKey({ Name: 'The School Room', Latitude: 53.3865, Longitude: -1.4755 });
+    expect(original).toBe('moonboard:the school room:5339:-148');
+    expect(nudged).toBe(original);
+  });
+
+  it('gives two same-named gyms in different places distinct keys', () => {
+    // The real prod collisions ("MoonBoard" vs "Moonboard") sit thousands of km
+    // apart; a coarse cell keeps them on separate identities so they are not
+    // wrongly merged into one gym.
+    const sydney = defaultBoardKey({ Name: 'MoonBoard', Latitude: -33.86, Longitude: 151.2 });
+    const newYork = defaultBoardKey({ Name: 'MoonBoard', Latitude: 40.71, Longitude: -74.0 });
+    expect(sydney).toBe('moonboard:moonboard:-3386:15120');
+    expect(newYork).toBe('moonboard:moonboard:4071:-7400');
+    expect(sydney).not.toBe(newYork);
+  });
+
+  it('normalizes casing and whitespace in the identity key', () => {
+    const canonical = defaultBoardKey({ Name: 'Board House', Latitude: -33.86, Longitude: 151.2 });
+    const noisy = defaultBoardKey({ Name: '  BOARD   house ', Latitude: -33.86, Longitude: 151.2 });
+    expect(noisy).toBe(canonical);
   });
 });

--- a/packages/moonboard-sync/src/sync/locations-sync.ts
+++ b/packages/moonboard-sync/src/sync/locations-sync.ts
@@ -6,6 +6,7 @@ import {
   type LocationSyncSummary,
   type PublicBoardLocationInput,
 } from '@boardsesh/location-sync';
+import { normalizeGymName } from '@boardsesh/db/queries';
 import { MoonBoardClient, type MoonBoardMarker } from '../api/moonboard-client';
 
 type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
@@ -25,15 +26,43 @@ function markerCoordinates(marker: MoonBoardMarker): MarkerCoordinates {
   return { latitude, longitude };
 }
 
+/**
+ * Snaps a coordinate to a coarse ~1.1 km grid (integer hundredths of a degree
+ * north-south) for use as the *stable* part of a MoonBoard gym's identity.
+ *
+ * MoonBoard's map-marker payload carries no upstream id, so a gym's identity has
+ * to come from its name + location. Full-precision coordinates made the source
+ * key change on every pin nudge, which minted a permanent duplicate gym on any
+ * move beyond the 20 m physical-match tier (issue #3715: the moved pin trips the
+ * same-provider guard at 20-150 m and mints a twin). Rounding to a coarse cell
+ * keeps the key stable across the whole realistic pin-correction range (GPS /
+ * map-click jitter), while two same-named gyms in genuinely different places
+ * (the collisions we see in prod sit thousands of km apart) still land on
+ * distinct keys. A rare correction that crosses a cell boundary AND lands in the
+ * 20-150 m band mints one twin that surfaces in the /admin/gym-duplicates queue
+ * for a human merge.
+ *
+ * Integer grid units (not `toFixed`) avoid floating-point / `-0` string
+ * artifacts, so the same coordinate always yields the same key.
+ */
+function coarseGeoCell(latitude: number, longitude: number): string {
+  return `${Math.round(latitude * 100)}:${Math.round(longitude * 100)}`;
+}
+
 function baseSourceKey(marker: MoonBoardMarker): string {
   const coordinates = markerCoordinates(marker);
-  return `moonboard:${marker.Name}:${coordinates.latitude}:${coordinates.longitude}`;
+  // The key is normalized (lowercase, single-spaced) so casing / whitespace
+  // jitter in the upstream marker name can't split one gym into two identities;
+  // the human-readable name is kept separately for display (see gymName below).
+  const name = normalizeGymName(marker.Name || 'MoonBoard Gym');
+  return `moonboard:${name}:${coarseGeoCell(coordinates.latitude, coordinates.longitude)}`;
 }
 
 function sourceKeyForConfig(marker: MoonBoardMarker, layoutId: number, angle: number): string {
   const base = baseSourceKey(marker);
-  // Preserve the old seed UUID for the previous single default MoonBoard
-  // install: MoonBoard 2016, all 2016 sets, 40 degrees.
+  // The 2016 / 40 degree install keeps the bare base key (no layout:angle
+  // suffix) so it stays the gym's default board; every other layout/angle gets a
+  // suffixed key.
   return layoutId === 2 && angle === 40 ? base : `${base}:${layoutId}:${angle}`;
 }
 


### PR DESCRIPTION
## Summary

Closes #3715.

MoonBoard gym/board source keys embedded the pin's **full-precision** coordinates:

```
moonboard:<name>:<lat>:<lng>
```

(`packages/moonboard-sync/src/sync/locations-sync.ts` `baseSourceKey`). Because the gym UUID, the board UUIDs, and the `location_sync_gym_sources` alias lookup all derive from this key, any coordinate change produced a brand-new identity. A pin move **> 20 m** then either tripped the same-provider guard added in #3713 (in the 20-150 m tier) or missed the 150 m match radius entirely (> 150 m), and in both cases minted a **permanent duplicate gym**. (Moves <= 20 m re-aliased onto the same gym at the physical-match tier-1, which is why the bug started at 20 m.)

### Fix

Key on the **normalized name + a coarse ~1.1 km cell** instead:

```
moonboard:<normalized name>:<lat cell>:<lng cell>
```

where the cells are integer hundredths of a degree (`Math.round(coord * 100)`). A realistic pin correction keeps the same key and resolves back to the same gym through the source alias (`findAliasedGym` -> metadata refresh, which also updates the coordinates), so no new gym is minted and the board rows stop churning too. The name is normalized (lowercase, single-spaced) so casing/whitespace jitter can't split one gym into two; the display name keeps its original casing.

**Cell implementation - 2-decimal-degree rounding, not geohash-6:** I use integer-hundredths-of-a-degree rounding because it needs no dependency or lookup table, yields deterministic integer cell coordinates that are trivial to unit-test, and offers effectively the same real-world uniformity as geohash (both narrow identically east-west toward the poles, so geohash buys no uniformity here).

**Why not name-only** (the maintainer's first instinct, ruled out by prod data): genuinely distinct gyms share names. The only two same-normalized-name collisions among prod's seeded MoonBoard gyms - "MoonBoard"/"Moonboard" and "Darkside of the Moonboard"/"...moonboard" - sit **6,000 km and 9,480 km apart**. A name-only key would collapse each pair into one gym whose coordinates flip-flop every sync, and would override the `GENERIC_GYM_NAMES` design that deliberately keeps board-brand/home-wall names (`moonboard`, `garage`, `home wall`, ...) distinct. The coarse cell keeps them distinct while still absorbing pin corrections.

### Migration / backfill

**None needed.** Prod has **zero** coordinate-keyed `moonboard:` aliases (`location_sync_gym_sources` holds kilter/tension/grasshopper/decoy/soill/touchstone only), and the recurring MoonBoard location sync has never populated prod. The ~167 SYSTEM-owned MoonBoard gyms are a one-time April-2026 seed, alias-less. On the next sync run each marker resolves its existing gym through the name + location physical match and adopts it (aliases the stable key onto it), so no separate pre-alias backfill script is required - kept out per the plan to keep the PR minimal.

### Interaction with the adjacent gym-dedup work

- **#3845 (freeze `sync_frozen_at`):** no overlap - this change is the provider key builder in `moonboard-sync`; the freeze is in shared `location-sync/upsert.ts`. With stable keys the sync resolves via alias and calls `refreshSyncedGymMetadata`, which #3845 gates on `sync_frozen_at IS NULL`, so human-curated MoonBoard gyms stay protected. **No migration here, so no 0185 slot collision.**
- **#3699 (merge tooling):** a rare cell-boundary-crossing twin surfaces in `/admin/gym-duplicates` (tier A/B same-name) for a human merge; the merge re-points the stable-key alias onto the survivor and subsequent syncs resolve it directly. Adopting the seed gyms also shrinks #3699's orphan-gyms list.
- **#3847 (report a duplicate):** additive, feeds the same queue - no interaction.

The same-provider-guard comment in `upsert.ts` that flagged this as a "follow-up issue" is reworded now that the last coordinate-embedding source key is gone (the guard itself stays - it still protects genuinely-distinct twins).

### Pre-existing, not fixed here (noted per plan)

The current builder writes 14 board configs per marker; the April seed wrote ~9 per gym with a different key scheme. On the first recurring sync each adopted gym gains a fresh board set alongside the older seed boards - a board-level duplication that predates this change and happens under any key scheme. Out of scope. No data deletion is proposed anywhere; any merges stay in the human `/admin/gym-duplicates` queue.

### Follow-up filed

The MoonBoard location sync has no runner/cron - the recurring sync never runs MoonBoard against prod (only Kilter/Aurora have `runner/sync-runner.ts`). This stable-key fix is the prerequisite for scheduling it. Filed as #3863.

## Release Notes

- [x] No release note needed (internal / technical change)

The recurring MoonBoard location sync isn't live in prod (see #3863), so this change is user-invisible today.

## Test plan

- `vp run typecheck` - green (exit 0).
- `vp lint packages/moonboard-sync packages/location-sync` - 0 warnings, 0 errors.
- `vp test run --reporter=agent packages/moonboard-sync packages/location-sync` - 39 passed, 1 skipped (the DB integration test self-skips without a local `DATABASE_URL`).
- **Unit** (`locations-sync.test.ts`): identity key uses name + coarse cell; a ~50 m nudge keeps the same key; two same-named gyms in different places get distinct keys; casing/whitespace is normalized.
- **Integration** (`locations-sync.integration.test.ts`, self-skips without a local `DATABASE_URL`, runs inside a rolled-back transaction): drives the real `upsertPublicBoardLocations` - seed a gym, move the pin **+50 m** then **+500 m**, re-run each time, and assert **exactly one** gym reached through **one** source alias, with its coordinates refreshed to the latest pin. Ran locally against the dev DB (`DATABASE_URL=postgres://...@localhost:5432/main VITEST_POOL_ID=solo-issue3715`): **1 passed**.

> Note: `vp check` also flags a formatting issue in `packages/mobile/public/index.html`, which is untouched by this PR and identical to `origin/main` (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkJuDx4nCQPYQzeEjNd6Q3
