### PR TITLE
fix(db): guard statsDrivenSearch against parallel-worker DSM exhaustion

### DIFF
--- a/packages/db/src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts
@@ -215,6 +215,62 @@ if (!EXPLAIN_DB_URL) {
       );
     });
 
+    void it(
+      'stats-driven narrow-filter page>0 search (#3856 repro) runs SET LOCAL before the SELECT and ' +
+        'avoids a parallel Gather',
+      async () => {
+        // Mirrors the exact production repro from Sentry BOARDSESH-AK: narrow
+        // grade band (minGrade=maxGrade), onlyTallClimbs + boulders, pageSize 100,
+        // page 1 (OFFSET 100). This is the shape that tipped the planner into a
+        // parallel plan and exhausted /dev/shm before #3856's fix — statsDrivenSearch
+        // was the one hot search path with no SET LOCAL guard.
+        const repro: ClimbSearchParams = {
+          page: 1,
+          pageSize: 100,
+          sortBy: 'ascents',
+          sortOrder: 'desc',
+          minGrade: 15,
+          maxGrade: 15,
+          onlyTallClimbs: true,
+          boulders: true,
+        };
+
+        const statements = await runSearch(repro);
+        const setLocalIdx = statements.findIndex((s) =>
+          /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i.test(s.query),
+        );
+        const selectIdx = statements.findIndex((s) => /select/i.test(s.query) && /board_climb/i.test(s.query));
+        assert.ok(setLocalIdx >= 0, 'stats-driven path must issue SET LOCAL max_parallel_workers_per_gather = 0');
+        assert.ok(setLocalIdx < selectIdx, 'SET LOCAL must run before the SELECT');
+
+        const selects = tableSelects(statements);
+        assert.ok(selects.length >= 1, 'expected a stats-driven SELECT');
+
+        // Control: when parallelism is available the planner CAN pick a Gather for
+        // this exact query shape, so the guarded assertion below is a real gate,
+        // not a vacuous pass (same control pattern as the broad-count regression
+        // test below).
+        const unguarded = await explainNodes(selects[0].query, selects[0].params, FORCE_PARALLEL);
+        assert.equal(
+          hasGatherNode(unguarded),
+          true,
+          `control: the #3856 repro shape must go parallel when unguarded; saw: ${unguarded.map((n) => n.type).join(', ')}`,
+        );
+
+        // statsDrivenSearch now runs this exact shape inside a transaction with
+        // SET LOCAL max_parallel_workers_per_gather = 0 (mirroring standardSearch) —
+        // no Gather, no per-worker DSM allocation.
+        const guarded = await explainNodes(selects[0].query, selects[0].params, GUARD);
+        assert.equal(
+          hasGatherNode(guarded),
+          false,
+          'the statsDrivenSearch SET LOCAL guard must eliminate the parallel Gather that exhausted /dev/shm in #3856',
+        );
+
+        if (RUN_ANALYZE) await logTiming('stats-driven #3856 repro (guarded)', selects[0]);
+      },
+    );
+
     void it('random sort is deterministic per seed, reshuffles across seeds, and paginates without overlap', async () => {
       const uuidsFor = async (sortSeed: string, page = 0) =>
         (await searchClimbs(db, PARAMS, { page, pageSize: 15, sortBy: 'random', sortSeed })).climbs.map((c) => c.uuid);

--- a/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
@@ -255,8 +255,11 @@ void describe('statsDrivenSearch — DSM parallelism guard (#3856)', () => {
       sortOrder: 'desc',
     });
 
-    assert.deepEqual(callOrder, ['execute', 'select']);
+    assert.deepEqual(callOrder, ['execute', 'select'], 'SET LOCAL must run before the stats-driven SELECT');
     const renderedGuards = executedStatements.map((statement) => dialect.sqlToQuery(statement).sql);
-    assert.ok(renderedGuards.some((statement) => GUARD_PATTERN.test(statement)));
+    assert.ok(
+      renderedGuards.some((statement) => GUARD_PATTERN.test(statement)),
+      `expected a SET LOCAL max_parallel_workers_per_gather = 0 guard; saw: ${renderedGuards.join(', ')}`,
+    );
   });
 });

--- a/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
@@ -1,7 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chooseSearchPath, getStatsDrivenSort, clampSearchPage, MAX_SEARCH_PAGE } from '../search-climbs';
-import { mapSearchInputToParams, normalizeSearchSortBy } from '../types';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import { chooseSearchPath, getStatsDrivenSort, clampSearchPage, MAX_SEARCH_PAGE, searchClimbs } from '../search-climbs';
+import { mapSearchInputToParams, normalizeSearchSortBy, type BoardRouteParams } from '../types';
+import type { DbInstance } from '../../../client/postgres';
 
 const baseInput = {
   statsDrivenSort: 'ascents' as const,
@@ -161,5 +164,99 @@ void describe('normalizeSearchSortBy', () => {
     // Empty / absent seed collapses to undefined so the query falls back to the constant salt.
     assert.equal(mapSearchInputToParams({ sortBy: 'random', sortSeed: '' }).sortSeed, undefined);
     assert.equal(mapSearchInputToParams({ sortBy: 'random' }).sortSeed, undefined);
+  });
+});
+
+// Fake SearchDb: a minimal stand-in for a top-level Drizzle instance. Every
+// select chain method returns the same builder object, and awaiting it (via a
+// real `.then`) records that the query ran — so a test can assert the query
+// executed AFTER the SET LOCAL guard, not before or instead of it. Mirrors the
+// mock in packages/web/app/lib/db/queries/climbs/__tests__/holds-heatmap.test.ts,
+// adapted to node:test (no module mocking needed — searchClimbs takes `db` as
+// a plain parameter).
+function createFakeSearchDb() {
+  const callOrder: string[] = [];
+  const executedStatements: SQL[] = [];
+
+  const makeSelectBuilder = () => {
+    const builder: Record<string, unknown> = {};
+    for (const method of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'offset']) {
+      builder[method] = () => builder;
+    }
+    // A real, spec-compliant thenable so drizzle's internal `await` can't
+    // swallow a rejection and so this reliably resolves like a genuine query.
+    builder.then = (
+      onFulfilled?: ((value: unknown) => unknown) | null,
+      onRejected?: ((reason: unknown) => unknown) | null,
+    ) => {
+      callOrder.push('select');
+      return Promise.resolve([]).then(onFulfilled, onRejected);
+    };
+    return builder;
+  };
+
+  const tx = {
+    execute: (statement: SQL) => {
+      callOrder.push('execute');
+      executedStatements.push(statement);
+      return Promise.resolve([]);
+    },
+    select: () => makeSelectBuilder(),
+  };
+
+  const fakeDb = {
+    transaction: (callback: (transactionDb: typeof tx) => unknown) => callback(tx),
+  };
+
+  return { fakeDb, callOrder, executedStatements };
+}
+
+const dialect = new PgDialect();
+const GUARD_PATTERN = /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i;
+
+const SEARCH_PARAMS: BoardRouteParams = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 10,
+  set_ids: [1, 20],
+  angle: 40,
+};
+
+void describe('statsDrivenSearch — DSM parallelism guard (#3856)', () => {
+  void it('runs the stats-driven query inside a transaction that disables per-gather parallelism first', async () => {
+    const { fakeDb, callOrder, executedStatements } = createFakeSearchDb();
+
+    // page:1 forces chooseSearchPath to 'stats-driven-only' (no standardSearch
+    // fallback), isolating this assertion to statsDrivenSearch's own guard —
+    // the same page shape as the production repro (Sentry BOARDSESH-AK: page 1,
+    // narrow grade band, pageSize 100).
+    await searchClimbs(fakeDb as unknown as DbInstance, SEARCH_PARAMS, {
+      page: 1,
+      pageSize: 100,
+      sortBy: 'ascents',
+      sortOrder: 'desc',
+    });
+
+    assert.deepEqual(callOrder, ['execute', 'select'], 'SET LOCAL must run before the stats-driven SELECT');
+    const renderedGuards = executedStatements.map((statement) => dialect.sqlToQuery(statement).sql);
+    assert.ok(
+      renderedGuards.some((statement) => GUARD_PATTERN.test(statement)),
+      `expected a SET LOCAL max_parallel_workers_per_gather = 0 guard; saw: ${renderedGuards.join(', ')}`,
+    );
+  });
+
+  void it('also guards the quality-sort stats-driven path', async () => {
+    const { fakeDb, callOrder, executedStatements } = createFakeSearchDb();
+
+    await searchClimbs(fakeDb as unknown as DbInstance, SEARCH_PARAMS, {
+      page: 1,
+      pageSize: 20,
+      sortBy: 'quality',
+      sortOrder: 'desc',
+    });
+
+    assert.deepEqual(callOrder, ['execute', 'select']);
+    const renderedGuards = executedStatements.map((statement) => dialect.sqlToQuery(statement).sql);
+    assert.ok(renderedGuards.some((statement) => GUARD_PATTERN.test(statement)));
   });
 });

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -128,7 +128,7 @@ function getExecute(db: SearchDb): SearchDbExecute | null {
  *
  * @param db Top-level Drizzle database instance. Transaction-scoped callers
  * would need an explicit signature change and must preserve standardSearch's
- * transaction-scoped SET LOCAL guard.
+ * and statsDrivenSearch's transaction-scoped SET LOCAL guards.
  * @param params Board route parameters
  * @param searchParams Search/filter parameters
  * @param userId Optional user ID for personal progress filters
@@ -252,8 +252,13 @@ export function chooseSearchPath(input: {
 
 /**
  * Stats-driven search: FROM board_climb_stats INNER JOIN board_climbs.
- * PostgreSQL reads the relevant stats covering index in sort order and stops
- * after pageSize+1 qualifying rows.
+ * PostgreSQL usually reads the relevant stats covering index in sort order and
+ * stops after pageSize+1 qualifying rows — but with a narrow grade band + size
+ * predicates + a larger pageSize + a page>0 OFFSET, the planner can still pick a
+ * parallel plan, and each worker's DSM allocation can exhaust a small /dev/shm
+ * (#3856). Disable per-gather parallelism inside a transaction (SET LOCAL needs
+ * one; the pool runs prepare:false behind PgBouncer transaction pooling),
+ * mirroring the standardSearch / countClimbs / getHoldHeatmapData guards.
  *
  * The INNER JOIN excludes climbs without a stats row at this angle. The caller
  * (`searchClimbs`) compensates only on page 0 without stats filters, where
@@ -264,6 +269,34 @@ export function chooseSearchPath(input: {
  * the WHERE clause — not the JOIN ON — so they apply correctly to the result set.
  */
 async function statsDrivenSearch(
+  db: SearchDb,
+  params: BoardRouteParams,
+  filters: ReturnType<typeof createClimbFilters>,
+  sortBy: StatsDrivenSort,
+  page: number,
+  pageSize: number,
+): Promise<ClimbSearchResult> {
+  const transaction = getTransaction(db);
+  if (transaction) {
+    return transaction(async (transactionDb) => {
+      await transactionDb.execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
+      return runStatsDrivenSearch(transactionDb, params, filters, sortBy, page, pageSize);
+    });
+  }
+
+  // Reached only by execute-only query test doubles. Production call sites pass
+  // top-level DbInstance values so the transaction branch scopes SET LOCAL
+  // correctly; do not broaden searchClimbs to TransactionDb without revisiting
+  // that planner guard.
+  const execute = getExecute(db);
+  if (execute) {
+    await execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
+  }
+
+  return runStatsDrivenSearch(db, params, filters, sortBy, page, pageSize);
+}
+
+async function runStatsDrivenSearch(
   db: SearchDb,
   params: BoardRouteParams,
   filters: ReturnType<typeof createClimbFilters>,


### PR DESCRIPTION
## Summary

`statsDrivenSearch()` (`packages/db/src/queries/climbs/search-climbs.ts`) was the one hot search path that never got the `SET LOCAL max_parallel_workers_per_gather = 0` guard that PR #1969 added to its siblings (`standardSearch`, `countClimbs`, `getHoldHeatmapData`). With a narrow grade band + size/tall predicates + a larger `pageSize` + a page>0 `OFFSET`, the planner can still pick a parallel `Gather` plan — and each worker's dynamic-shared-memory allocation can exhaust the small `/dev/shm` on Railway's Postgres container, throwing `could not resize shared memory segment` (pgCode `53100`). That surfaced as intermittent `SearchClimbs` failures in prod (Sentry BOARDSESH-AK/AJ, ~1% of the app's busiest query, concentrated on iOS).

Fix: split `statsDrivenSearch` into a thin transaction-guard wrapper + `runStatsDrivenSearch` (the query body, unchanged), mirroring `standardSearch`/`runStandardSearch` exactly — same `getTransaction`/`getExecute` helpers, same guard statement, same fallback shape for the execute-only test-double branch. No behavior change to filters, ordering, or pagination; the query itself is unchanged, so the covering-index scan stays just as fast.

Closes #3856

### EXPLAIN evidence (dev DB, exact production repro shape)

Repro: kilter, layout 1, size 10, set_ids [1,20], angle 40, page 1, pageSize 100, sortBy ascents desc, minGrade=maxGrade=15, onlyTallClimbs, boulders (matches the Sentry BOARDSESH-AK event's `SearchClimbs` variables).

**Before** (unguarded — this is what prod runs today, no forcing needed to reproduce):
```
Limit
  Gather Merge (Workers Planned: 2)
    Sort
      Hash Join
        Nested Loop
          Bitmap Heap Scan on board_climb_stats
            Bitmap Index Scan using board_climb_stats_difficulty_rounded_idx
          Index Scan using board_climbs_pkey on board_climbs
        Hash
          Index Scan using board_climb_grades_board_type_climb_uuid_angle_pk on board_climb_grades
```

**After** (`SET LOCAL max_parallel_workers_per_gather = 0`, the fix):
```
Limit
  Sort
    Nested Loop
      Nested Loop
        Bitmap Heap Scan on board_climb_stats
          Bitmap Index Scan using board_climb_stats_difficulty_rounded_idx
        Index Scan using board_climbs_pkey on board_climbs
      Materialize
        Index Scan using board_climb_grades_board_type_climb_uuid_angle_pk on board_climb_grades
```

The `Gather Merge` (and its per-worker DSM allocation) is gone — pure serial index scan, no forcing required in either direction. Captured via the SQL the app actually generates (drizzle query logger, not hand-reconstructed).

### Blast radius

Both production callers converge on this shared function: web SSR (`packages/web/app/lib/db/queries/climbs/search-climbs.ts`) and the GraphQL backend resolver (`packages/backend/src/db/queries/climbs/search-climbs.ts`, hit by mobile + web client-side search — this is the `SearchClimbs` operation from the Sentry event). `packages/db` is consumed as source by both, so merging to `main` redeploys both Vercel (web) and Railway (backend) in the same `production-deploy.yml` run. No mobile/OTA implications — mobile only talks to the GraphQL backend; this is a pure server-side query-plan change with no schema, API, or wire-format change.

### Out of scope (follow-ups)

- The issue's "belt-and-suspenders" suggestion — a server-level `max_parallel_workers_per_gather` default and/or sizing up Railway's `/dev/shm` — is infra-level and intentionally not actioned here; this PR is the surgical code-level fix.
- While validating: discovered `packages/db`'s own `node:test` suite (this PR's regression test included) isn't wired into any CI job — filed #3861.
- While capturing EXPLAIN evidence: two *pre-existing* EXPLAIN-harness assertions ("hot path must not go parallel") fail against the current dev DB — confirmed via `git stash` that this reproduces identically on unmodified `main`, unrelated to this change. This fix's guard covers that path too regardless (it wraps every `statsDrivenSearch` call, not just page>0), so no known prod exposure. Filed #3862 for investigation.

## Release Notes

- Climb search no longer randomly comes up empty on busy filters.

## Test plan

- `cd packages/db && tsx --test src/queries/climbs/__tests__/search-climbs.test.ts` — new unit tests assert the stats-driven path issues `SET LOCAL max_parallel_workers_per_gather = 0` before the SELECT (both the `ascents` and `quality` stats-driven sorts), using a hand-rolled fake `SearchDb` that records call order (mirrors the existing `getHoldHeatmapData` guard test pattern).
- `EXPLAIN_DB_URL=postgresql://postgres:password@localhost:5432/main EXPLAIN_ANALYZE=1 tsx --test src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts` — extended the opt-in EXPLAIN harness with a case reproducing the exact production repro shape: asserts `SET LOCAL` precedes the SELECT, that the shape *can* go parallel unguarded (control, not vacuous), and that the guard eliminates the `Gather` node. Passes.
- `vp check` — clean (one pre-existing, unrelated formatting drift in `packages/mobile/public/index.html`, confirmed untouched by this diff).
- `vp run typecheck` — full repo, 0 errors.
- `vp test run --changed origin/main --reporter=agent` — no other packages' tests touched by this change.
