### PR TITLE
fix(mobile): bump expo-image 57.0.0 → 57.0.1 (native fingerprint change)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -266,7 +266,7 @@
         "expo-font": "57.0.0",
         "expo-glass-effect": "57.0.0",
         "expo-haptics": "57.0.0",
-        "expo-image": "57.0.0",
+        "expo-image": "57.0.1",
         "expo-image-manipulator": "57.0.2",
         "expo-image-picker": "57.0.2",
         "expo-keep-awake": "57.0.0",
@@ -2979,7 +2979,7 @@
 
     "expo-haptics": ["expo-haptics@57.0.0", "", { "peerDependencies": { "expo": "*" } }, "sha512-va+uB/DoMlT9f0OJ8v24iNqs+YH6Q6wip+LLjVvalbJzGK8LvZQ+gIiauogFxAAFLQIJzrQVJGf+0BmV3q13bQ=="],
 
-    "expo-image": ["expo-image@57.0.0", "", { "dependencies": { "sf-symbols-typescript": "^2.2.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-vR7q07izYiPzUDBCBZf9t6EmtCPp9mIvWimX0TqWQb17AKg/wZytuJD6VWLQxnUlzqXsVBysNcz1jnXkBBQrIg=="],
+    "expo-image": ["expo-image@57.0.1", "", { "dependencies": { "sf-symbols-typescript": "^2.2.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-EP0lisd2bUqtErry4weRcMW9bLMxtKsht/MLLK3/3do5u4ZMiJbWkY5zfYV+WYmeGab7x9G0sjbeFeEagYGjMw=="],
 
     "expo-image-loader": ["expo-image-loader@57.0.0", "", { "peerDependencies": { "expo": "*" } }, "sha512-EhwnoPC4T/EMdB7Nsg7qITzhO/qB0hUnmVghmtAKQwwDVaLWWYCGE4NLkes3zk9Ub451SmS/swgPp4PCPzOlnw=="],
 

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -63,7 +63,7 @@
     "expo-font": "57.0.0",
     "expo-glass-effect": "57.0.0",
     "expo-haptics": "57.0.0",
-    "expo-image": "57.0.0",
+    "expo-image": "57.0.1",
     "expo-image-manipulator": "57.0.2",
     "expo-image-picker": "57.0.2",
     "expo-keep-awake": "57.0.0",


### PR DESCRIPTION
> **⚠️ NATIVE FINGERPRINT CHANGE — do not merge until a store binary release is planned; merging pauses OTA delivery to the current fleet until that binary ships.**
>
> Production OTAs auto-publish on every push to `main` and `runtimeVersion` uses the `fingerprint` policy. `expo-image` is a fingerprint source, so the moment this merges every subsequent production OTA resolves to a fingerprint no fleet binary has — OTA updates silently stop landing on the existing fleet until the next TestFlight/store binary ships, and then the whole backlog lands at once. (This is the failure mode that bricked prod on 2026-07-17.) Hold in draft for the maintainer's release train.

## Summary

Bumps `expo-image` `57.0.0 → 57.0.1` (one patch behind; sibling packages are already on `57.0.2`). This is the **native** half of the #3803 iPad-crash mitigation. The crash is an `EXC_BAD_ACCESS` deep in the expo-image / SDWebImage decode path; the patch (and the SDWebImage pod it resolves at prebuild) rides along with a store build. The JS/OTA-able hardening ships separately in the sibling PR (#3867) so it can reach the current fleet immediately without a fingerprint change.

Only `packages/mobile/package.json` + `bun.lock` change.

### Fingerprint evidence (iOS, `CI=1 @expo/fingerprint`)

`expo-image` is confirmed present as a fingerprint source, and the hash changes:

| | iOS fingerprint |
| --- | --- |
| before (`expo-image@57.0.0`) | `43d6674dfb0890e9359f92f4f8723cc3c8472de4` |
| after (`expo-image@57.0.1`) | `f89bb94f1716aac4f84098ed6490e0e5cb8cbc93` |

(`bunx expo-updates runtimeversion:resolve` reports `workflow: managed` / `runtimeVersion: null` in this checkout because `ios/` is prebuild-generated and not committed, so the raw `@expo/fingerprint` hash is used to prove the change.)

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `bun install` updates the lockfile to `expo-image@57.0.1` (verified).
- iOS fingerprint recomputed before/after to prove the native-fingerprint change (table above).
- Full validation + on-device iPad QA to run as part of the store-binary release train (this PR stays draft until then).

Refs #3803.
