### PR TITLE
fix(mobile): bound iPad board-art image memory over long sessions

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/_layout.tsx
+++ b/packages/mobile/app/(tabs)/climbs/_layout.tsx
@@ -1,74 +1,77 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+import { BoardArtVisibilityProvider } from '../../../src/providers/board-art-visibility-provider';
 
 export default function ClimbsLayout() {
   const { t } = useTranslation('common');
   const screenOptions = useStackScreenOptions();
 
   return (
-    <Stack screenOptions={screenOptions}>
-      <Stack.Screen
-        name="index"
-        options={{
-          title: t('mobile.nav.climbs'),
-          // The climb list owns its own floating glass search row, so it hides
-          // the native header (which otherwise occluded the in-body controls).
-          headerShown: false,
-        }}
-      />
-      <Stack.Screen
-        name="[climbUuid]"
-        options={{
-          // The climb page is now a thin redirector: it loads the climb by uuid,
-          // opens it in the play drawer, then pops. It only ever flashes a
-          // spinner, so it has no header.
-          headerShown: false,
-        }}
-      />
-      <Stack.Screen
-        name="create"
-        options={{
-          // The create UI is just the drawer floating over the climbs/search
-          // list — a transparent, headerless modal (no separate card around it).
-          headerShown: false,
-          presentation: 'transparentModal',
-          animation: 'fade',
-        }}
-      />
-      <Stack.Screen
-        name="holds"
-        options={{
-          // Full-screen interactive board for the hold-type filter (a pushed route,
-          // not a modal, so the board's pan/pinch never competes with a modal's
-          // pan). The native stack header carries the title + back chevron; "Clear
-          // all" is a headerRight (set per-screen). Opaque, not the app's glass push
-          // header, so the board lays out below the bar (mirrors users/[userId]).
-          title: t('mobile.nav.holdFilter'),
-          headerTransparent: false,
-        }}
-      />
-      <Stack.Screen
-        name="zone"
-        options={{
-          // Full-screen interactive board for the board-region (zone) filter. Same
-          // as the hold filter: native header (title + back chevron), opaque so the
-          // board sits below the bar, headerRight "Clear all" set per-screen.
-          title: t('mobile.nav.zoneFilter'),
-          headerTransparent: false,
-        }}
-      />
-      <Stack.Screen
-        name="setters"
-        options={{
-          // Setter search/multi-select for the climb filter. A pushed route (not a
-          // stacked sheet) because native sheets can't stack above the filter sheet.
-          // Native header (title + back chevron), opaque so the search bar sits below
-          // the bar; headerRight "Clear all" set per-screen.
-          title: t('mobile.nav.setters'),
-          headerTransparent: false,
-        }}
-      />
-    </Stack>
+    <BoardArtVisibilityProvider tab="climbs">
+      <Stack screenOptions={screenOptions}>
+        <Stack.Screen
+          name="index"
+          options={{
+            title: t('mobile.nav.climbs'),
+            // The climb list owns its own floating glass search row, so it hides
+            // the native header (which otherwise occluded the in-body controls).
+            headerShown: false,
+          }}
+        />
+        <Stack.Screen
+          name="[climbUuid]"
+          options={{
+            // The climb page is now a thin redirector: it loads the climb by uuid,
+            // opens it in the play drawer, then pops. It only ever flashes a
+            // spinner, so it has no header.
+            headerShown: false,
+          }}
+        />
+        <Stack.Screen
+          name="create"
+          options={{
+            // The create UI is just the drawer floating over the climbs/search
+            // list — a transparent, headerless modal (no separate card around it).
+            headerShown: false,
+            presentation: 'transparentModal',
+            animation: 'fade',
+          }}
+        />
+        <Stack.Screen
+          name="holds"
+          options={{
+            // Full-screen interactive board for the hold-type filter (a pushed route,
+            // not a modal, so the board's pan/pinch never competes with a modal's
+            // pan). The native stack header carries the title + back chevron; "Clear
+            // all" is a headerRight (set per-screen). Opaque, not the app's glass push
+            // header, so the board lays out below the bar (mirrors users/[userId]).
+            title: t('mobile.nav.holdFilter'),
+            headerTransparent: false,
+          }}
+        />
+        <Stack.Screen
+          name="zone"
+          options={{
+            // Full-screen interactive board for the board-region (zone) filter. Same
+            // as the hold filter: native header (title + back chevron), opaque so the
+            // board sits below the bar, headerRight "Clear all" set per-screen.
+            title: t('mobile.nav.zoneFilter'),
+            headerTransparent: false,
+          }}
+        />
+        <Stack.Screen
+          name="setters"
+          options={{
+            // Setter search/multi-select for the climb filter. A pushed route (not a
+            // stacked sheet) because native sheets can't stack above the filter sheet.
+            // Native header (title + back chevron), opaque so the search bar sits below
+            // the bar; headerRight "Clear all" set per-screen.
+            title: t('mobile.nav.setters'),
+            headerTransparent: false,
+          }}
+        />
+      </Stack>
+    </BoardArtVisibilityProvider>
   );
 }

--- a/packages/mobile/app/(tabs)/discover/_layout.tsx
+++ b/packages/mobile/app/(tabs)/discover/_layout.tsx
@@ -1,47 +1,50 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+import { BoardArtVisibilityProvider } from '../../../src/providers/board-art-visibility-provider';
 
 export default function DiscoverLayout() {
   const { t } = useTranslation('playlists');
   const screenOptions = useStackScreenOptions();
 
   return (
-    <Stack screenOptions={screenOptions}>
-      <Stack.Screen
-        name="index"
-        options={{
-          title: t('bottomTabBar.discover'),
-          // The library owns its own floating glass chrome + in-body large title,
-          // so it hides the native header (which otherwise occluded the controls).
-          headerShown: false,
-        }}
-      />
-      <Stack.Screen
-        name="all"
-        options={{
-          // "My Playlists" — a plain vertical list. A solid native header gives it
-          // a title + automatic back button and avoids the transparent-blur top
-          // inset the index screen manages with its floating chrome.
-          headerShown: true,
-          headerTransparent: false,
-          title: t('library.allPlaylists.title'),
-        }}
-      />
-      <Stack.Screen
-        name="[playlist_uuid]"
-        options={{
-          // The detail view owns its full-bleed gradient hero with a floating
-          // back FAB + action FABs, so it hides the native header bar.
-          headerShown: false,
-        }}
-      />
-      <Stack.Screen
-        name="smart/[type]"
-        options={{
-          headerShown: false,
-        }}
-      />
-    </Stack>
+    <BoardArtVisibilityProvider tab="discover">
+      <Stack screenOptions={screenOptions}>
+        <Stack.Screen
+          name="index"
+          options={{
+            title: t('bottomTabBar.discover'),
+            // The library owns its own floating glass chrome + in-body large title,
+            // so it hides the native header (which otherwise occluded the controls).
+            headerShown: false,
+          }}
+        />
+        <Stack.Screen
+          name="all"
+          options={{
+            // "My Playlists" — a plain vertical list. A solid native header gives it
+            // a title + automatic back button and avoids the transparent-blur top
+            // inset the index screen manages with its floating chrome.
+            headerShown: true,
+            headerTransparent: false,
+            title: t('library.allPlaylists.title'),
+          }}
+        />
+        <Stack.Screen
+          name="[playlist_uuid]"
+          options={{
+            // The detail view owns its full-bleed gradient hero with a floating
+            // back FAB + action FABs, so it hides the native header bar.
+            headerShown: false,
+          }}
+        />
+        <Stack.Screen
+          name="smart/[type]"
+          options={{
+            headerShown: false,
+          }}
+        />
+      </Stack>
+    </BoardArtVisibilityProvider>
   );
 }

--- a/packages/mobile/app/(tabs)/home/_layout.tsx
+++ b/packages/mobile/app/(tabs)/home/_layout.tsx
@@ -1,16 +1,19 @@
 import { Stack } from 'expo-router';
 import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+import { BoardArtVisibilityProvider } from '../../../src/providers/board-art-visibility-provider';
 
 export default function HomeLayout() {
   const screenOptions = useStackScreenOptions();
   return (
-    <Stack screenOptions={screenOptions}>
-      {/* The Home feed owns its top via floating chrome (the avatar island + scope
+    <BoardArtVisibilityProvider tab="home">
+      <Stack screenOptions={screenOptions}>
+        {/* The Home feed owns its top via floating chrome (the avatar island + scope
           title), like the other tabs — so the stack header is hidden here. */}
-      <Stack.Screen name="index" options={{ headerShown: false }} />
-      {/* Session detail keeps the native tab bar + bottom accessory by living in
+        <Stack.Screen name="index" options={{ headerShown: false }} />
+        {/* Session detail keeps the native tab bar + bottom accessory by living in
           this stack. It sets its own header title from the loaded session. */}
-      <Stack.Screen name="session/[sessionId]" options={{ headerShown: true }} />
-    </Stack>
+        <Stack.Screen name="session/[sessionId]" options={{ headerShown: true }} />
+      </Stack>
+    </BoardArtVisibilityProvider>
   );
 }

--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+import { BoardArtVisibilityProvider } from '../../../src/providers/board-art-visibility-provider';
 
 export default function ProfileLayout() {
   const { t } = useTranslation('common');
@@ -8,26 +9,28 @@ export default function ProfileLayout() {
   const screenOptions = useStackScreenOptions();
 
   return (
-    <Stack screenOptions={screenOptions}>
-      {/* The You screen owns its top via the floating ProfileTopChrome (large
+    <BoardArtVisibilityProvider tab="profile">
+      <Stack screenOptions={screenOptions}>
+        {/* The You screen owns its top via the floating ProfileTopChrome (large
           title collapsing into a glass capsule), like the Discover/Climbs tabs —
           so the stack header is hidden here. */}
-      <Stack.Screen name="index" options={{ headerShown: false, title: t('mobile.nav.profile') }} />
-      {/* Session detail keeps the native tab bar + bottom accessory by living in
+        <Stack.Screen name="index" options={{ headerShown: false, title: t('mobile.nav.profile') }} />
+        {/* Session detail keeps the native tab bar + bottom accessory by living in
           this stack. It sets its own header title from the loaded session. */}
-      <Stack.Screen name="session/[sessionId]" options={{ headerShown: true }} />
-      <Stack.Screen name="more" options={{ title: t('mobile.more.title') }} />
-      <Stack.Screen name="accessibility" options={{ title: t('mobile.more.accessibility.title') }} />
-      <Stack.Screen name="storage" options={{ title: t('mobile.more.storage.title') }} />
-      <Stack.Screen name="edit" options={{ title: tSettings('profile.editAction') }} />
-      <Stack.Screen name="integrations" options={{ title: tSettings('integrations.title') }} />
-      <Stack.Screen name="watch-pair" options={{ title: tSettings('watchPairing.title') }} />
-      {/* i18n-ignore-next-line — preview-only screen */}
-      <Stack.Screen name="branch-switcher" options={{ title: 'Branch Switcher' }} />
-      <Stack.Screen name="dev-servers" options={{ title: t('mobile.more.metroServersTitle') }} />
-      {/* i18n-ignore-next-line — tester-only screen */}
-      <Stack.Screen name="feature-flags" options={{ title: 'Feature Flags' }} />
-      <Stack.Screen name="delete-account" options={{ title: tSettings('deleteAccount.title') }} />
-    </Stack>
+        <Stack.Screen name="session/[sessionId]" options={{ headerShown: true }} />
+        <Stack.Screen name="more" options={{ title: t('mobile.more.title') }} />
+        <Stack.Screen name="accessibility" options={{ title: t('mobile.more.accessibility.title') }} />
+        <Stack.Screen name="storage" options={{ title: t('mobile.more.storage.title') }} />
+        <Stack.Screen name="edit" options={{ title: tSettings('profile.editAction') }} />
+        <Stack.Screen name="integrations" options={{ title: tSettings('integrations.title') }} />
+        <Stack.Screen name="watch-pair" options={{ title: tSettings('watchPairing.title') }} />
+        {/* i18n-ignore-next-line — preview-only screen */}
+        <Stack.Screen name="branch-switcher" options={{ title: 'Branch Switcher' }} />
+        <Stack.Screen name="dev-servers" options={{ title: t('mobile.more.metroServersTitle') }} />
+        {/* i18n-ignore-next-line — tester-only screen */}
+        <Stack.Screen name="feature-flags" options={{ title: 'Feature Flags' }} />
+        <Stack.Screen name="delete-account" options={{ title: tSettings('deleteAccount.title') }} />
+      </Stack>
+    </BoardArtVisibilityProvider>
   );
 }

--- a/packages/mobile/app/(tabs)/record/_layout.tsx
+++ b/packages/mobile/app/(tabs)/record/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+import { BoardArtVisibilityProvider } from '../../../src/providers/board-art-visibility-provider';
 
 /**
  * The Record tab renders the session screen inline (its `index` route). The
@@ -12,15 +13,17 @@ export default function RecordLayout() {
   const screenOptions = useStackScreenOptions();
 
   return (
-    <Stack screenOptions={screenOptions}>
-      <Stack.Screen name="index" options={{ headerShown: false }} />
-      <Stack.Screen
-        name="summary"
-        options={{
-          title: t('summary.dialogTitle'),
-          presentation: 'modal',
-        }}
-      />
-    </Stack>
+    <BoardArtVisibilityProvider tab="record">
+      <Stack screenOptions={screenOptions}>
+        <Stack.Screen name="index" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="summary"
+          options={{
+            title: t('summary.dialogTitle'),
+            presentation: 'modal',
+          }}
+        />
+      </Stack>
+    </BoardArtVisibilityProvider>
   );
 }

--- a/packages/mobile/app/(tabs)/wall/_layout.tsx
+++ b/packages/mobile/app/(tabs)/wall/_layout.tsx
@@ -1,5 +1,6 @@
 import { Stack } from 'expo-router';
 import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+import { BoardArtVisibilityProvider } from '../../../src/providers/board-art-visibility-provider';
 
 /**
  * The "On the Wall" tab. iPad-only — it's registered as an `href: null` tab screen
@@ -11,8 +12,10 @@ export default function WallLayout() {
   const screenOptions = useStackScreenOptions();
 
   return (
-    <Stack screenOptions={screenOptions}>
-      <Stack.Screen name="index" options={{ headerShown: false }} />
-    </Stack>
+    <BoardArtVisibilityProvider tab="wall">
+      <Stack screenOptions={screenOptions}>
+        <Stack.Screen name="index" options={{ headerShown: false }} />
+      </Stack>
+    </BoardArtVisibilityProvider>
   );
 }

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -74,6 +74,7 @@ import { loadRequiredFonts } from '../src/lib/required-fonts';
 import { useImageCacheMemoryManagement } from '../src/hooks/use-image-cache-memory-management';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
+import { ImageCacheTabSweeper } from '../src/components/ImageCacheTabSweeper';
 import { AnalyticsPersonProperties } from '../src/components/analytics/AnalyticsPersonProperties';
 import { OtaUpdateTracker } from '../src/components/analytics/OtaUpdateTracker';
 import { InstallReferrerTracker } from '../src/components/analytics/InstallReferrerTracker';
@@ -667,6 +668,7 @@ function RootLayout() {
                                                                 </UserDrawerProvider>
                                                               </TabBarHeightProvider>
                                                               <AnalyticsScreenTracker />
+                                                              <ImageCacheTabSweeper />
                                                               <OtaUpdateTracker />
                                                               <InstallReferrerTracker />
                                                             </ShareTargetProvider>

--- a/packages/mobile/src/components/ImageCacheTabSweeper.tsx
+++ b/packages/mobile/src/components/ImageCacheTabSweeper.tsx
@@ -1,0 +1,10 @@
+import { useIpadTabSwitchImageCacheSweep } from '../hooks/use-image-cache-memory-management';
+
+// Runs the iPad tab-switch image-cache sweep (see useIpadTabSwitchImageCacheSweep).
+// Kept as a mounted-once leaf beside AnalyticsScreenTracker so its useSegments
+// re-render on every navigation stays a null render and never touches the root
+// layout tree.
+export function ImageCacheTabSweeper(): null {
+  useIpadTabSwitchImageCacheSweep();
+  return null;
+}

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Platform, View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { useIsAppBackgrounded } from '../lib/app-visibility';
+import { useBoardArtVisible } from './board-art-visibility-context';
 
 type LayeredClimbImageProps = {
   overlayUri: string | null;
@@ -76,17 +77,23 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   // screen".
   const [overlayPainted, setOverlayPainted] = useState(false);
 
-  // While backgrounded, drop the decoded board-art bitmaps: render an empty
-  // stack so expo-image releases their GPU textures + native-heap bitmaps (the
-  // views stay mounted across a background, so without this they pin ~100 MB+
-  // that raises the OS kill risk). Re-decodes from disk on foreground (#3479).
+  // Drop the decoded board-art bitmaps whenever this surface is hidden: render an
+  // empty stack so expo-image releases their GPU textures + native-heap bitmaps
+  // (the views stay mounted, so without this they pin ~100 MB+ that raises the OS
+  // kill risk). Two hidden cases, both re-decoding from disk in tens of ms when
+  // shown again: the app is backgrounded (#3479), or — on iPad — this tab is not
+  // the focused one but stays mounted (`detachInactiveScreens={false}`), so its
+  // off-screen bitmaps would otherwise linger for the whole session (#3803, see
+  // BoardArtVisibilityProvider).
   const isBackgrounded = useIsAppBackgrounded();
-  // Reset the overlay-painted anchor on background so the screenshot/e2e anchor
-  // re-gates on the next real onLoad after foreground, not before the lit board.
+  const boardArtVisible = useBoardArtVisible();
+  const hidden = isBackgrounded || !boardArtVisible;
+  // Reset the overlay-painted anchor while hidden so the screenshot/e2e anchor
+  // re-gates on the next real onLoad after it shows again, not before the lit board.
   useEffect(() => {
-    if (isBackgrounded) setOverlayPainted(false);
-  }, [isBackgrounded]);
-  if (isBackgrounded) {
+    if (hidden) setOverlayPainted(false);
+  }, [hidden]);
+  if (hidden) {
     return <View style={[styles.stack, mirrored && styles.mirrored]} />;
   }
 

--- a/packages/mobile/src/components/__tests__/layered-climb-image-hidden.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image-hidden.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type ViewMockProps = { children?: ReactNode; testID?: string };
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('expo-image', () => ({
+  Image: ({ source }: { source: { uri: string } }) => createElement('img', { src: source.uri }),
+}));
+
+// Foregrounded: isolate the surface-hidden lever (the inactive-iPad-tab case) from
+// the app-background one covered in layered-climb-image-backgrounded.test.tsx.
+vi.mock('../../lib/app-visibility', () => ({ useIsAppBackgrounded: () => false }));
+
+import { LayeredClimbImage } from '../LayeredClimbImage';
+import { BoardArtVisibilityContext } from '../board-art-visibility-context';
+
+describe('LayeredClimbImage (surface hidden)', () => {
+  it('drops every image layer when the board-art surface is not visible', () => {
+    const { container } = render(
+      createElement(
+        BoardArtVisibilityContext.Provider,
+        { value: false },
+        createElement(LayeredClimbImage, {
+          overlayUri: 'file:///overlay.png',
+          backgroundPaths: ['/bundled/kilter.webp'],
+        }),
+      ),
+    );
+
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('[data-testid="layered-climb-image-empty-fallback"]')).toBeNull();
+  });
+
+  it('renders the layers when the surface is visible', () => {
+    const { container } = render(
+      createElement(
+        BoardArtVisibilityContext.Provider,
+        { value: true },
+        createElement(LayeredClimbImage, {
+          overlayUri: 'file:///overlay.png',
+          backgroundPaths: ['/bundled/kilter.webp'],
+        }),
+      ),
+    );
+
+    expect(container.querySelector('img[src="file:///overlay.png"]')).toBeTruthy();
+  });
+});

--- a/packages/mobile/src/components/board-art-visibility-context.ts
+++ b/packages/mobile/src/components/board-art-visibility-context.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+
+// Whether board art in this subtree is on a currently-visible surface. Default
+// `true`, so any board art rendered outside a provider — every iPhone, the
+// always-visible iPad sidebar cell + play pane, and unit tests — always paints.
+//
+// A per-tab `BoardArtVisibilityProvider` flips this to `false` for an INACTIVE
+// iPad tab. The iPad shell keeps every tab mounted (`detachInactiveScreens={false}`
+// for the #3153 re-attach cost), so an off-screen tab's `LayeredClimbImage` views
+// otherwise pin their decoded board-art bitmaps for the whole session — and
+// `Image.clearMemoryCache()` can't reclaim a bitmap a mounted view still retains,
+// only unreferenced cache copies. Left unbounded across a multi-day foreground
+// session, that is the iPad image-memory growth behind #3803. LayeredClimbImage
+// reads this and drops its `<Image>` layers when hidden (the same lever it uses on
+// app-background), re-decoding from the disk cache in tens of ms on return.
+export const BoardArtVisibilityContext = createContext<boolean>(true);
+
+export function useBoardArtVisible(): boolean {
+  return useContext(BoardArtVisibilityContext);
+}

--- a/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
@@ -157,4 +157,16 @@ describe('useIpadTabSwitchImageCacheSweep', () => {
     rerender();
     expect(clearMemoryCache).toHaveBeenCalledTimes(2);
   });
+
+  it('seeds a null active tab on a root-modal cold start, then sweeps on the first tab nav', () => {
+    // Cold-start straight into a root modal / player (segment 0 is not `(tabs)`),
+    // so tabsActiveSegment is null. The seed must record that null without sweeping,
+    // and the first real tab navigation must then sweep once.
+    segments.value = ['play'];
+    const { rerender } = renderHook(() => useIpadTabSwitchImageCacheSweep());
+    expect(clearMemoryCache).not.toHaveBeenCalled();
+    segments.value = ['(tabs)', 'home'];
+    rerender();
+    expect(clearMemoryCache).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
@@ -37,7 +37,14 @@ vi.mock('../../lib/app-visibility', () => ({
   useIsAppBackgrounded: () => isBackgrounded.value,
 }));
 
-import { useImageCacheMemoryManagement } from '../use-image-cache-memory-management';
+// Drive the focused route segments and the launch-fixed iPad flag directly so the
+// tab-switch sweep can be asserted without a navigation container.
+const segments = vi.hoisted(() => ({ value: ['(tabs)', 'home'] as readonly string[] }));
+vi.mock('expo-router', () => ({ useSegments: () => segments.value }));
+const deviceLayout = vi.hoisted(() => ({ isPad: true }));
+vi.mock('../use-device-layout', () => ({ useDeviceLayout: () => ({ isPad: deviceLayout.isPad }) }));
+
+import { useImageCacheMemoryManagement, useIpadTabSwitchImageCacheSweep } from '../use-image-cache-memory-management';
 
 describe('useImageCacheMemoryManagement', () => {
   beforeEach(() => {
@@ -94,5 +101,60 @@ describe('useImageCacheMemoryManagement', () => {
     expect(clearMemoryCache).toHaveBeenCalledTimes(1);
     unmount();
     expect(appState.removers.memoryWarning).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useIpadTabSwitchImageCacheSweep', () => {
+  beforeEach(() => {
+    clearMemoryCache.mockClear();
+    deviceLayout.isPad = true;
+    segments.value = ['(tabs)', 'home'];
+  });
+
+  it('does not sweep on mount — it seeds the current tab', () => {
+    renderHook(() => useIpadTabSwitchImageCacheSweep());
+    expect(clearMemoryCache).not.toHaveBeenCalled();
+  });
+
+  it('sweeps the memory cache on an iPad top-level tab change', () => {
+    const { rerender } = renderHook(() => useIpadTabSwitchImageCacheSweep());
+    expect(clearMemoryCache).not.toHaveBeenCalled();
+    segments.value = ['(tabs)', 'climbs'];
+    rerender();
+    expect(clearMemoryCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not sweep for a sub-route within the same tab', () => {
+    segments.value = ['(tabs)', 'climbs'];
+    const { rerender } = renderHook(() => useIpadTabSwitchImageCacheSweep());
+    // Pushing climbs/[climbUuid] keeps the active tab 'climbs' (segment 1), so
+    // navigating within a tab must not sweep.
+    segments.value = ['(tabs)', 'climbs', 'abc-uuid'];
+    rerender();
+    expect(clearMemoryCache).not.toHaveBeenCalled();
+  });
+
+  it('does not sweep on a non-iPad device', () => {
+    deviceLayout.isPad = false;
+    const { rerender } = renderHook(() => useIpadTabSwitchImageCacheSweep());
+    segments.value = ['(tabs)', 'climbs'];
+    rerender();
+    expect(clearMemoryCache).not.toHaveBeenCalled();
+  });
+
+  it('dedupes repeated identical tab emissions', () => {
+    const { rerender } = renderHook(() => useIpadTabSwitchImageCacheSweep());
+    segments.value = ['(tabs)', 'home'];
+    rerender();
+    expect(clearMemoryCache).not.toHaveBeenCalled();
+  });
+
+  it('sweeps again on each distinct tab change', () => {
+    const { rerender } = renderHook(() => useIpadTabSwitchImageCacheSweep());
+    segments.value = ['(tabs)', 'climbs'];
+    rerender();
+    segments.value = ['(tabs)', 'profile'];
+    rerender();
+    expect(clearMemoryCache).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/mobile/src/hooks/use-image-cache-memory-management.ts
+++ b/packages/mobile/src/hooks/use-image-cache-memory-management.ts
@@ -1,7 +1,10 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { AppState } from 'react-native';
 import { Image } from 'expo-image';
+import { useSegments } from 'expo-router';
 import { useIsAppBackgrounded } from '../lib/app-visibility';
+import { useDeviceLayout } from './use-device-layout';
+import { tabsActiveSegment } from '../lib/route-segments';
 
 // Sweep expo-image's in-memory decoded-bitmap cache on background and on OS
 // memory-pressure warnings. The foreground `memoryWarning` path is the direct
@@ -24,4 +27,37 @@ export function useImageCacheMemoryManagement(): void {
     // returns no subscription. The background sweep above still works there.
     return () => sub?.remove();
   }, []);
+}
+
+// Sweep expo-image's in-memory decoded-bitmap cache on every iPad top-level tab
+// switch. The iPad shell keeps every tab mounted (`detachInactiveScreens={false}`,
+// for the #3153 re-attach cost), so a long foreground session accumulates decoded
+// board art from every tab that the background / memoryWarning sweeps never reach:
+// an iPad kept open for days never backgrounds, and the OS memory warning can
+// arrive only after an allocation has already failed — the #3803 crash pattern
+// (SIGSEGV mid image-decode, ~3.7 days uptime). Clearing on tab change bounds that
+// growth at a natural seam; the disk cache is untouched, so the incoming tab
+// re-decodes in tens of ms. iPhone opts out (its tabs freeze/detach on blur, and a
+// clear on every switch would needlessly re-decode the destination's art).
+export function useIpadTabSwitchImageCacheSweep(): void {
+  const { isPad } = useDeviceLayout();
+  const segments = useSegments();
+  const activeTab = tabsActiveSegment(segments);
+  const lastTab = useRef<string | null>(null);
+  const seeded = useRef(false);
+
+  useEffect(() => {
+    // Seed the first observation so mounting never sweeps — only a genuine
+    // tab-to-tab change should clear the cache. A pushed sub-route inside a tab
+    // keeps `activeTab` the same (tabsActiveSegment reads segment 1), so
+    // navigating within a tab doesn't sweep.
+    if (!seeded.current) {
+      seeded.current = true;
+      lastTab.current = activeTab;
+      return;
+    }
+    if (activeTab === lastTab.current) return;
+    lastTab.current = activeTab;
+    if (isPad) void Image.clearMemoryCache();
+  }, [activeTab, isPad]);
 }

--- a/packages/mobile/src/providers/__tests__/board-art-visibility-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-art-visibility-provider.test.tsx
@@ -9,14 +9,14 @@ vi.mock('expo-router', () => ({ useSegments: () => segments.value }));
 const deviceLayout = vi.hoisted(() => ({ isPad: true }));
 vi.mock('../../hooks/use-device-layout', () => ({ useDeviceLayout: () => ({ isPad: deviceLayout.isPad }) }));
 
-import { BoardArtVisibilityProvider } from '../board-art-visibility-provider';
+import { BoardArtVisibilityProvider, type BoardArtTab } from '../board-art-visibility-provider';
 import { useBoardArtVisible } from '../../components/board-art-visibility-context';
 
 function VisibleProbe() {
   return createElement('span', { 'data-visible': String(useBoardArtVisible()) });
 }
 
-function renderWithin(tab: string) {
+function renderWithin(tab: BoardArtTab) {
   return render(createElement(BoardArtVisibilityProvider, { tab, children: createElement(VisibleProbe) }));
 }
 

--- a/packages/mobile/src/providers/__tests__/board-art-visibility-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-art-visibility-provider.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+
+const segments = vi.hoisted(() => ({ value: ['(tabs)', 'home'] as readonly string[] }));
+vi.mock('expo-router', () => ({ useSegments: () => segments.value }));
+
+const deviceLayout = vi.hoisted(() => ({ isPad: true }));
+vi.mock('../../hooks/use-device-layout', () => ({ useDeviceLayout: () => ({ isPad: deviceLayout.isPad }) }));
+
+import { BoardArtVisibilityProvider } from '../board-art-visibility-provider';
+import { useBoardArtVisible } from '../../components/board-art-visibility-context';
+
+function VisibleProbe() {
+  return createElement('span', { 'data-visible': String(useBoardArtVisible()) });
+}
+
+function renderWithin(tab: string) {
+  return render(createElement(BoardArtVisibilityProvider, { tab, children: createElement(VisibleProbe) }));
+}
+
+function readVisible(container: HTMLElement): string | null {
+  return container.querySelector('span')?.getAttribute('data-visible') ?? null;
+}
+
+describe('BoardArtVisibilityProvider', () => {
+  beforeEach(() => {
+    deviceLayout.isPad = true;
+    segments.value = ['(tabs)', 'home'];
+  });
+
+  it('reports visible on the focused iPad tab', () => {
+    segments.value = ['(tabs)', 'climbs'];
+    const { container } = renderWithin('climbs');
+    expect(readVisible(container)).toBe('true');
+  });
+
+  it('reports hidden on an inactive iPad tab', () => {
+    segments.value = ['(tabs)', 'home'];
+    const { container } = renderWithin('climbs');
+    expect(readVisible(container)).toBe('false');
+  });
+
+  it('stays visible for a pushed sub-route of the focused tab', () => {
+    // A sub-route keeps the tab active (segment 1 is still 'climbs').
+    segments.value = ['(tabs)', 'climbs', 'abc-uuid'];
+    const { container } = renderWithin('climbs');
+    expect(readVisible(container)).toBe('true');
+  });
+
+  it('hides every tab while a root modal / player route is focused', () => {
+    segments.value = ['play'];
+    const { container } = renderWithin('climbs');
+    expect(readVisible(container)).toBe('false');
+  });
+
+  it('is always visible on a non-iPad device regardless of the focused tab', () => {
+    deviceLayout.isPad = false;
+    segments.value = ['(tabs)', 'home'];
+    const { container } = renderWithin('climbs');
+    expect(readVisible(container)).toBe('true');
+  });
+});

--- a/packages/mobile/src/providers/board-art-visibility-provider.tsx
+++ b/packages/mobile/src/providers/board-art-visibility-provider.tsx
@@ -1,0 +1,30 @@
+import { type ReactNode } from 'react';
+import { useSegments } from 'expo-router';
+import { BoardArtVisibilityContext } from '../components/board-art-visibility-context';
+import { useDeviceLayout } from '../hooks/use-device-layout';
+import { tabsActiveSegment } from '../lib/route-segments';
+
+/**
+ * Wraps one iPad tab's stack so its board art blanks while another tab is the
+ * focused destination. The iPad shell keeps every tab mounted
+ * (`detachInactiveScreens={false}`), so without this an inactive tab's
+ * `LayeredClimbImage` views retain their decoded bitmaps off-screen for the life
+ * of the session — `Image.clearMemoryCache()` reclaims only unreferenced cache
+ * copies, not bitmaps a mounted view still holds (#3803).
+ *
+ * iPhone is opted out by construction (`isPad` is launch-fixed false → always
+ * visible): its tabs already freeze/detach on blur, and re-decoding board art on
+ * every tab return would flash the thumbnails for no memory win.
+ */
+export function BoardArtVisibilityProvider({ tab, children }: { tab: string; children: ReactNode }) {
+  const { isPad } = useDeviceLayout();
+  const segments = useSegments();
+  // Non-iPad: always visible. On iPad: visible only while THIS tab is the focused
+  // top-level destination (segment 1). A pushed sub-route of the tab keeps it active
+  // (`tabsActiveSegment` still returns the tab name); a root modal or the player
+  // (segment 0 is not `(tabs)`) returns null, so every tab blanks — correct, the
+  // shell behind it is occluded. The value is a primitive boolean, so the provider
+  // needs no memo (react/jsx-no-constructed-context-values).
+  const visible = !isPad || tabsActiveSegment(segments) === tab;
+  return <BoardArtVisibilityContext.Provider value={visible}>{children}</BoardArtVisibilityContext.Provider>;
+}

--- a/packages/mobile/src/providers/board-art-visibility-provider.tsx
+++ b/packages/mobile/src/providers/board-art-visibility-provider.tsx
@@ -4,6 +4,11 @@ import { BoardArtVisibilityContext } from '../components/board-art-visibility-co
 import { useDeviceLayout } from '../hooks/use-device-layout';
 import { tabsActiveSegment } from '../lib/route-segments';
 
+// The top-level tab names ((tabs)/<name>). Typing the `tab` prop as this union
+// (not a bare string) makes a typo in a layout's `tab="…"` a compile error rather
+// than a tab that silently reports hidden forever on iPad.
+export type BoardArtTab = 'climbs' | 'discover' | 'home' | 'profile' | 'record' | 'wall';
+
 /**
  * Wraps one iPad tab's stack so its board art blanks while another tab is the
  * focused destination. The iPad shell keeps every tab mounted
@@ -16,7 +21,7 @@ import { tabsActiveSegment } from '../lib/route-segments';
  * visible): its tabs already freeze/detach on blur, and re-decoding board art on
  * every tab return would flash the thumbnails for no memory win.
  */
-export function BoardArtVisibilityProvider({ tab, children }: { tab: string; children: ReactNode }) {
+export function BoardArtVisibilityProvider({ tab, children }: { tab: BoardArtTab; children: ReactNode }) {
   const { isPad } = useDeviceLayout();
   const segments = useSegments();
   // Non-iPad: always visible. On iPad: visible only while THIS tab is the focused


### PR DESCRIPTION
## Summary

JS/OTA-able hardening for the #3803 iPad crash: a `EXC_BAD_ACCESS (SIGSEGV)` deep in the expo-image / SDWebImage decode path on an iPad Pro (iOS 26.5.2) after **~3.7 days of foreground uptime** — consistent with image-memory exhaustion.

The iPad shell keeps every tab mounted (`detachInactiveScreens={false}`, for the #3153 re-attach cost), so an off-screen tab's board-art `<Image>` views retain their decoded bitmaps for the whole session, and the only foreground cache sweep today is the OS `memoryWarning` — which can arrive after an allocation has already failed. Two complementary, **iPad-gated** levers:

- **`BoardArtVisibility` context.** `LayeredClimbImage` now blanks its layers whenever the surface is hidden, not only on app-background. A per-tab `BoardArtVisibilityProvider` (wrapping each of the 6 tab stacks) reports hidden for a tab that is not the focused destination, releasing the view-retained bitmaps that `Image.clearMemoryCache()` cannot reclaim (it only frees unreferenced cache copies, not a bitmap a mounted view still holds).
- **`useIpadTabSwitchImageCacheSweep`.** `Image.clearMemoryCache()` on every iPad top-level tab switch, reclaiming the accumulated decode cache at a natural seam. Mounted as a null leaf beside `AnalyticsScreenTracker`, so its `useSegments` re-render on navigation never touches the root layout.

iPhone is opted out of both (`isPad` is launch-fixed false) — its tabs already freeze/detach on blur, so behaviour is unchanged and thumbnails don't re-decode on every tab switch. The disk cache is untouched, so a shown-again surface re-decodes in tens of ms.

### Delivery split
The native half — `expo-image 57.0.0 → 57.0.1` — is a **separate PR, #3866**, because it changes the native fingerprint (merging it pauses OTA delivery to the fleet until a store binary ships). This PR is intentionally OTA-safe so it can reach the current TestFlight fleet immediately.

### Open question
Frequency/scope is still unknown — no `sntryu_` Sentry read token was available to size this (fleet-wide iPad issue vs. a single long-uptime outlier). This PR is defensible either way (it targets the app's pre-existing, documented iOS image-memory pressure, cf. #3479), but if a token turns up, the Sentry frequency read should confirm whether more is warranted. Issue #3803 stays open to monitor recurrence.

## Release Notes

- iPad: steadier marathon sessions — board art no longer piles up in memory as you hop between tabs, so a long day of browsing won't end in a crash.

## Test plan

- `vp run typecheck:mobile` — pass.
- `vp run test:mobile` — 4363 tests pass, incl. new coverage for the tab-switch sweep (`use-image-cache-memory-management.test.ts`), the visibility provider (`board-art-visibility-provider.test.tsx`), and `LayeredClimbImage` blanking when hidden (`layered-climb-image-hidden.test.tsx`).
- `vp run check:mobile-bundle` — Metro bundle OK.
- `vp check` — clean for changed files.
- On-device iPad QA (soak: browse many climbs across tabs, watch resident image memory plateau; confirm the always-visible sidebar cell + play pane never blank on tab switch; iPhone regression check that thumbnails don't flash on tab switch) — see `.boardsesh/qa-notes.md`.

Refs #3803. Native counterpart: #3866.