### PR TITLE
fix(mobile): don't switch the wall off when a climb is still syncing (#3850)

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/renderable-frames.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/renderable-frames.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { hasRenderableFrames } from '../renderable-frames';
+
+describe('hasRenderableFrames', () => {
+  it('accepts a climb with real frames', () => {
+    expect(hasRenderableFrames({ frames: 'p1234r15p5678r12' })).toBe(true);
+  });
+
+  it('rejects an empty frames string (the "clear all LEDs" command)', () => {
+    expect(hasRenderableFrames({ frames: '' })).toBe(false);
+  });
+
+  it('rejects whitespace-only frames', () => {
+    expect(hasRenderableFrames({ frames: '   ' })).toBe(false);
+  });
+
+  it('rejects a missing frames field (untyped wire boundary)', () => {
+    expect(hasRenderableFrames({ frames: undefined })).toBe(false);
+    expect(hasRenderableFrames({ frames: null })).toBe(false);
+    expect(hasRenderableFrames({})).toBe(false);
+  });
+
+  it('rejects a null / undefined climb', () => {
+    expect(hasRenderableFrames(null)).toBe(false);
+    expect(hasRenderableFrames(undefined)).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/ble/renderable-frames.ts
+++ b/packages/mobile/src/lib/ble/renderable-frames.ts
@@ -1,0 +1,19 @@
+/**
+ * A climb can only be lit on the wall once its `frames` have synced.
+ *
+ * `Climb.frames` is typed non-null, but the queue's wire boundary is untyped: a
+ * party peer can broadcast a partially-synced climb (uuid + name, no frames
+ * yet), and a server FullSync or local snapshot restore can land an unhydrated
+ * item as the current climb. Writing an empty frames string is the Aurora /
+ * MoonBoard "clear all LEDs" command, so auto-sending an unresolved climb would
+ * dark-fire the wall (and silently buzz success). This predicate gates the BLE
+ * auto-sender: hold the write until the frames arrive, then the effect re-runs
+ * on the resolved item (new identity, real frames) and lights it.
+ *
+ * Deliberately narrow — it only asks "are there frames to render". If PR #3763
+ * re-lands its richer `isClimbResolved` (uuid + name + frames), converge on that
+ * where a fuller resolution check is wanted; the auto-sender only needs frames.
+ */
+export function hasRenderableFrames(climb: { frames?: string | null } | null | undefined): boolean {
+  return typeof climb?.frames === 'string' && climb.frames.trim().length > 0;
+}

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -493,7 +493,23 @@ export function useBoardBluetooth({
 
   const sendFramesToBoard = useCallback(
     async (frames: string, mirrored: boolean = false, signal?: AbortSignal, sendContext?: BleSendContext) => {
-      if (!adapterRef.current || !boardName || layoutId === undefined || sizeId === undefined) return;
+      if (!adapterRef.current || !boardName || layoutId === undefined || sizeId === undefined) {
+        // The auto-sender only mounts while connected, so a send arriving here
+        // means a connected-but-not-ready window: the adapter was torn down, or
+        // the active board props haven't propagated yet. Record it — otherwise
+        // the send vanishes with no trace and reads as a dead tap. Not a Failure
+        // (no write was attempted). boardName/layoutId/sizeId may be undefined
+        // (that's why we bailed); undefined props are simply dropped from the event.
+        track(SHARED_EVENTS.ClimbSentToBoardSkipped, {
+          skipReason: !adapterRef.current ? 'no_adapter' : 'no_board_config',
+          boardName,
+          layoutId,
+          sizeId,
+          climbUuid: sendContext?.climbUuid,
+          sendSource: sendContext?.sendSource,
+        });
+        return;
+      }
       // Resolved here (where layoutId is narrowed to a number) so the nested
       // performSend closure can use it. Mini LED strips are 12 rows, standard 18.
       const moonNumRows = getMoonBoardGeometryByLayoutId(layoutId).numRows;
@@ -533,8 +549,18 @@ export function useBoardBluetooth({
         try {
           // The send may have queued behind another write; by the time it runs
           // the connection generation may be gone (reconnect/disconnect) — bail
-          // before touching the (possibly new) adapter.
-          if (combinedSignal.aborted || !adapterRef.current) return;
+          // before touching the (possibly new) adapter. An aborted send is the
+          // routine cancel path (unmount / generation swap) and stays silent; an
+          // adapter that vanished WITHOUT an abort is the surprising "dropped
+          // mid-queue" variant worth recording so it isn't a silent dead tap.
+          if (combinedSignal.aborted) return;
+          if (!adapterRef.current) {
+            track(SHARED_EVENTS.ClimbSentToBoardSkipped, {
+              ...boardAnalyticsProperties,
+              skipReason: 'adapter_lost',
+            });
+            return;
+          }
           sendAdapter = adapterRef.current;
 
           if (boardName === 'moonboard') {

--- a/packages/mobile/src/providers/__tests__/bluetooth-auto-sender.test.ts
+++ b/packages/mobile/src/providers/__tests__/bluetooth-auto-sender.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ClimbQueueItem, Climb } from '@boardsesh/queue';
+import { hasRenderableFrames } from '../../lib/ble/renderable-frames';
 
 // ── Factory helpers ────────────────────────────────────────────────────
 
@@ -39,6 +40,10 @@ type DrainContext = {
   sendCallCount: () => number;
   /** UUIDs passed to sendFramesToBoard, in call order */
   sentUuids: () => string[];
+  /** Queue-item uuids reported as an unresolved current climb (no frames yet). */
+  unresolvedReports: () => string[];
+  /** Queue-item uuids reported as a spill (incompatible board). */
+  spillReports: () => string[];
   /** Resolve the currently in-flight write (simulates BLE latency) */
   resolveCurrentWrite: () => void;
   /** Flush all microtasks so drain loop iterations settle */
@@ -52,20 +57,35 @@ type DrainContext = {
   reassert: () => void;
 };
 
+type DrainLoopOptions = {
+  /** Queue-item uuids the spill classifier treats as incompatible (wrong board). */
+  spillUuids?: Set<string>;
+};
+
 // Mirror of the component's dedup key: uuid + rendered frames + mirror state.
 function signatureOf(item: ClimbQueueItem): string {
   return `${item.climb.uuid}::${item.climb.frames}::${item.climb.mirrored ? 1 : 0}`;
 }
 
-function createDrainLoop(sendDuration: 'instant' | 'deferred' = 'deferred'): DrainContext {
+function createDrainLoop(
+  sendDuration: 'instant' | 'deferred' = 'deferred',
+  options: DrainLoopOptions = {},
+): DrainContext {
+  const spillUuids = options.spillUuids ?? new Set<string>();
   let isWriting = false;
   let pendingClimb: ClimbQueueItem | null = null;
   let lastSentSignature: string | null = null;
   let lastEnqueuedItem: ClimbQueueItem | null = null;
   let reassertPending = false;
+  // Mirror of lastSkipReportedUuidRef / lastUnresolvedReportedUuidRef: report a
+  // given spill / unresolved uuid once, clear it when a sendable climb is seen.
+  let lastSpillReported: string | null = null;
+  let lastUnresolvedReported: string | null = null;
 
   const abortController = new AbortController();
   const sentUuidsList: string[] = [];
+  const unresolvedReportsList: string[] = [];
+  const spillReportsList: string[] = [];
   let totalSendCalls = 0;
 
   // When sendDuration is 'deferred', writes hang until resolveCurrentWrite()
@@ -92,6 +112,34 @@ function createDrainLoop(sendDuration: 'instant' | 'deferred' = 'deferred'): Dra
       while (toSend) {
         if (signal.aborted) return;
         const item = toSend;
+
+        // Spill guard (mirrors the component): an incompatible climb is skipped
+        // BEFORE the resolution/frames logic, so a spill never reaches — and is
+        // never masked by — the unresolved-frames guard below. Dedup per uuid.
+        if (spillUuids.has(item.uuid)) {
+          if (lastSpillReported !== item.uuid) {
+            lastSpillReported = item.uuid;
+            spillReportsList.push(item.uuid);
+          }
+          toSend = pendingClimb;
+          pendingClimb = null;
+          continue;
+        }
+        lastSpillReported = null;
+
+        // Resolution guard (mirrors the component): hold the write for an
+        // unresolved (empty-frames) climb rather than dark-firing the wall.
+        // Report once per uuid; clear the marker once a sendable climb is seen.
+        if (!hasRenderableFrames(item.climb)) {
+          if (lastUnresolvedReported !== item.uuid) {
+            lastUnresolvedReported = item.uuid;
+            unresolvedReportsList.push(item.uuid);
+          }
+          toSend = pendingClimb;
+          pendingClimb = null;
+          continue;
+        }
+        lastUnresolvedReported = null;
 
         // Honour a pending reassert when the climb is picked up (survives an
         // in-flight write that re-set the signature on completion).
@@ -143,6 +191,10 @@ function createDrainLoop(sendDuration: 'instant' | 'deferred' = 'deferred'): Dra
     sendCallCount: () => totalSendCalls,
 
     sentUuids: () => [...sentUuidsList],
+
+    unresolvedReports: () => [...unresolvedReportsList],
+
+    spillReports: () => [...spillReportsList],
 
     resolveCurrentWrite() {
       currentWriteResolve?.();
@@ -585,6 +637,95 @@ describe('BluetoothAutoSender drain loop', () => {
       await loop.flush();
 
       expect(loop.sentUuids()).toEqual(['climb-A', 'climb-B', 'climb-C']);
+    });
+  });
+
+  describe('unresolved-climb guard (#3850 — no dark-fire on empty frames)', () => {
+    it('does NOT write empty frames for an unresolved current climb', async () => {
+      const loop = createDrainLoop('instant');
+
+      // A partially-synced climb: name/grade present, frames not yet hydrated.
+      loop.enqueue(makeQueueItem('soul-siphon', ''));
+      await loop.flush();
+
+      // The wall is never dark-fired: no send at all.
+      expect(loop.sendCallCount()).toBe(0);
+      expect(loop.sentUuids()).toEqual([]);
+      // The window is recorded exactly once.
+      expect(loop.unresolvedReports()).toEqual(['soul-siphon']);
+    });
+
+    it('lights the climb once its frames resolve (navigate-away-and-back / FullSync)', async () => {
+      const loop = createDrainLoop('instant');
+
+      // First selection: unresolved → held, not dark-fired.
+      loop.enqueue(makeQueueItem('soul-siphon', ''));
+      await loop.flush();
+      expect(loop.sendCallCount()).toBe(0);
+
+      // Resolution patches the frames in (new item identity, same uuid).
+      loop.enqueue(makeQueueItem('soul-siphon', 'p1234r15'));
+      await loop.flush();
+
+      // Now it writes the real frames exactly once.
+      expect(loop.sendCallCount()).toBe(1);
+      expect(loop.sentUuids()).toEqual(['soul-siphon']);
+      expect(loop.unresolvedReports()).toEqual(['soul-siphon']);
+    });
+
+    it('reports an unresolved climb only once per uuid across re-renders', async () => {
+      const loop = createDrainLoop('instant');
+
+      // The same unresolved item re-arrives (a colour/reassert re-render).
+      loop.enqueue(makeQueueItem('soul-siphon', ''));
+      await loop.flush();
+      loop.enqueue(makeQueueItem('soul-siphon', ''));
+      await loop.flush();
+      loop.enqueue(makeQueueItem('soul-siphon', ''));
+      await loop.flush();
+
+      expect(loop.sendCallCount()).toBe(0);
+      expect(loop.unresolvedReports()).toEqual(['soul-siphon']);
+    });
+
+    it('re-reports if the current climb relapses to unresolved after being sent', async () => {
+      const loop = createDrainLoop('instant');
+
+      // Resolved → sent.
+      loop.enqueue(makeQueueItem('climb-A', 'p1r15'));
+      await loop.flush();
+      // A FullSync re-staled it to an unresolved placeholder.
+      loop.enqueue(makeQueueItem('climb-A', ''));
+      await loop.flush();
+
+      expect(loop.sentUuids()).toEqual(['climb-A']);
+      expect(loop.unresolvedReports()).toEqual(['climb-A']);
+    });
+
+    it('does NOT interfere with the spill path — an incompatible climb with real frames still skips as a spill', async () => {
+      // 'spill-climb' has renderable frames but belongs to another board.
+      const loop = createDrainLoop('instant', { spillUuids: new Set(['spill-climb']) });
+
+      loop.enqueue(makeQueueItem('spill-climb', 'p1r15'));
+      await loop.flush();
+
+      // Handled by the spill branch (no write, no unresolved report).
+      expect(loop.sendCallCount()).toBe(0);
+      expect(loop.spillReports()).toEqual(['spill-climb']);
+      expect(loop.unresolvedReports()).toEqual([]);
+    });
+
+    it('classifies a spill BEFORE the resolution guard even when it also lacks frames', async () => {
+      // A spill that is ALSO unresolved must take the spill path (checked first),
+      // never the unresolved path — mirrors the component's branch order.
+      const loop = createDrainLoop('instant', { spillUuids: new Set(['spill-climb']) });
+
+      loop.enqueue(makeQueueItem('spill-climb', ''));
+      await loop.flush();
+
+      expect(loop.spillReports()).toEqual(['spill-climb']);
+      expect(loop.unresolvedReports()).toEqual([]);
+      expect(loop.sendCallCount()).toBe(0);
     });
   });
 });

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -16,6 +16,7 @@ import { useBoardPresenceCurrent } from '@boardsesh/board-presence-react';
 import type { BoardPresenceClimb, ClimbQueueItemInput } from '@boardsesh/shared-schema';
 import { emitWallConfirm } from '@boardsesh/play-view';
 import { useBoardBluetooth, boardConfigKey, type SendFramesToBoard } from '../lib/ble/use-board-bluetooth';
+import { hasRenderableFrames } from '../lib/ble/renderable-frames';
 import { useResolvedBleDeviceBoards } from '../lib/ble/resolve-serials';
 import { classifyBleDisconnect } from '../lib/ble/disconnect-category';
 import {
@@ -166,6 +167,7 @@ function BluetoothAutoSender({
   colorSignature,
   activeConfig,
   onSkipSpillClimb,
+  onUnresolvedCurrentClimb,
 }: {
   sendFramesToBoard: SendFramesToBoard;
   /**
@@ -194,6 +196,12 @@ function BluetoothAutoSender({
   // skip count, so it can re-point the queue + toast without the AutoSender
   // owning queue actions or i18n.
   onSkipSpillClimb: (args: { skipped: ClimbQueueItem; next: ClimbQueueItem | null; skippedCount: number }) => void;
+  // Called when the current climb reached the auto-sender with no renderable
+  // frames (a partially-synced peer broadcast, or a FullSync / snapshot restore
+  // that landed before the climb hydrated). Lets the provider record the
+  // unresolved-current-climb window without the AutoSender owning analytics/board
+  // context. Fired once per queue-item uuid.
+  onUnresolvedCurrentClimb: (item: ClimbQueueItem) => void;
 }) {
   type AutoSendRequest = {
     item: ClimbQueueItem;
@@ -218,6 +226,10 @@ function BluetoothAutoSender({
   useEffect(() => {
     onSkipSpillClimbRef.current = onSkipSpillClimb;
   }, [onSkipSpillClimb]);
+  const onUnresolvedCurrentClimbRef = useRef(onUnresolvedCurrentClimb);
+  useEffect(() => {
+    onUnresolvedCurrentClimbRef.current = onUnresolvedCurrentClimb;
+  }, [onUnresolvedCurrentClimb]);
   const queueRef = useRef(state.queue);
   queueRef.current = state.queue;
   // Dedup spill reports: the async drain can re-enter for the same incompatible
@@ -226,6 +238,12 @@ function BluetoothAutoSender({
   // compatible/unknown climb is processed — so deliberately navigating BACK to a
   // skipped spill re-advances and re-toasts instead of silently sticking.
   const lastSkipReportedUuidRef = useRef<string | null>(null);
+  // Dedup unresolved-current-climb reports the same way lastSkipReportedUuidRef
+  // dedups spills: the async drain can re-enter for the same unresolved current
+  // (a colour/reassert re-render races the resolution patch). Report a given uuid
+  // once, then clear it the moment a renderable climb is processed — so a later
+  // relapse to unresolved (a FullSync re-staled the item) re-reports.
+  const lastUnresolvedReportedUuidRef = useRef<string | null>(null);
 
   const isWritingRef = useRef(false);
   const pendingSendRef = useRef<AutoSendRequest | null>(null);
@@ -315,6 +333,26 @@ function BluetoothAutoSender({
           // Reaching here means the item is compatible/unknown and will be sent —
           // clear the spill dedup so a later return to a skipped spill re-reports.
           lastSkipReportedUuidRef.current = null;
+
+          // Resolution guard: a partially-synced climb (a party peer broadcast,
+          // or a server FullSync / snapshot restore that landed before the climb
+          // hydrated) can become the current climb with empty frames. Empty
+          // frames is the board's "clear all LEDs" command, so auto-sending it
+          // would dark-fire the wall and silently buzz success (the exact #3850
+          // report: pick a climb → wall goes dark). Hold the write until the
+          // frames arrive — the board keeps the previous climb lit, and this
+          // effect re-runs on the resolved item (new identity, real frames) to
+          // light it. Report once per uuid so the window is visible in analytics.
+          if (!hasRenderableFrames(item.climb)) {
+            if (lastUnresolvedReportedUuidRef.current !== item.uuid) {
+              lastUnresolvedReportedUuidRef.current = item.uuid;
+              onUnresolvedCurrentClimbRef.current(item);
+            }
+            toSend = pendingSendRef.current;
+            pendingSendRef.current = null;
+            continue;
+          }
+          lastUnresolvedReportedUuidRef.current = null;
 
           // connect() may have just written these exact frames as its
           // initialFrames (connect-and-light flows like the play drawer).
@@ -1134,6 +1172,11 @@ export function BluetoothProvider({
       next: ClimbQueueItem | null;
       skippedCount: number;
     }) => {
+      // The wall is cleared (rather than advanced to a compatible climb) in a
+      // party session — never hijack shared state — or when nothing compatible
+      // remains. First-class so the silent clear is filterable in analytics; the
+      // clear write itself stays untagged (not a user Clear Lights action).
+      const clearedBoard = sessionIdRef.current != null || next === null;
       track(SHARED_EVENTS.BleQueueClimbSkipped, {
         boardName: boardNameRef.current,
         layoutId: layoutIdRef.current,
@@ -1143,6 +1186,7 @@ export function BluetoothProvider({
         skippedClimbLayoutId: skipped.climb.layoutId ?? undefined,
         skippedCount,
         advancedToClimbUuid: next?.climb.uuid ?? null,
+        clearedBoard,
         inSession: sessionIdRef.current != null,
       });
 
@@ -1165,6 +1209,26 @@ export function BluetoothProvider({
     },
     [setCurrentClimb, showToast, sendFramesToBoard, t],
   );
+
+  // The auto-sender reached the current climb but it has no frames yet — a
+  // partially-synced peer broadcast, or a FullSync / snapshot restore that
+  // landed before the climb hydrated. It held the write (so the wall isn't
+  // dark-fired); record the window so this class of "picked a climb, wall went
+  // dark" is diagnosable fleet-wide. Once resolution patches the frames in, the
+  // auto-sender's effect re-runs on the new item identity and lights it.
+  const handleUnresolvedCurrentClimb = useCallback((item: ClimbQueueItem) => {
+    track(SHARED_EVENTS.ClimbSentToBoardSkipped, {
+      skipReason: 'unresolved_climb',
+      boardName: boardNameRef.current,
+      layoutId: layoutIdRef.current,
+      sizeId: sizeIdRef.current,
+      climbUuid: item.climb.uuid,
+      hasName: !!item.climb.name,
+      hasBoardType: !!item.climb.boardType,
+      hasLayout: item.climb.layoutId != null,
+      inSession: sessionIdRef.current != null,
+    });
+  }, []);
 
   // Bumped by `reassertWall()` to force the auto-sender to re-push the current
   // climb once, bypassing the byte-identical dedup.
@@ -1327,6 +1391,7 @@ export function BluetoothProvider({
           colorSignature={holdColorSignature}
           activeConfig={currentBoardConfig}
           onSkipSpillClimb={handleSkipSpillClimb}
+          onUnresolvedCurrentClimb={handleUnresolvedCurrentClimb}
         />
       )}
       <BlePickerHostContext.Provider value={pickerHostValue}>{children}</BlePickerHostContext.Provider>

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -137,6 +137,25 @@ export const SHARED_EVENTS = {
   BleAdvertisementRecon: 'BLE Advertisement Recon',
   ClimbSentToBoardSuccess: 'Climb Sent to Board Success',
   ClimbSentToBoardFailure: 'Climb Sent to Board Failure',
+  // A climb reached the BLE send path but NO packet was written to the wall.
+  // Distinct from Failure (a write was attempted and errored): here nothing is
+  // sent, so the wall is never dark-fired. `skipReason`:
+  //  - 'unresolved_climb' — the current climb has no frames yet (a partially-
+  //    synced peer broadcast, or a FullSync / snapshot restore that landed before
+  //    the climb hydrated). Empty frames is the board's "clear all LEDs" command,
+  //    so the auto-sender holds the write until resolution patches the frames in.
+  //    Fired once per queue-item uuid. Extra props: hasName, hasBoardType,
+  //    hasLayout, inSession.
+  //  - 'no_adapter' / 'no_board_config' — sendFramesToBoard was called while the
+  //    adapter or active board config was missing (a connected-but-not-ready
+  //    window); the send bailed before touching the transport.
+  //  - 'adapter_lost' — the queued send reached the transport after the adapter
+  //    was torn down (reconnect/disconnect) WITHOUT the abort signal firing.
+  //    Routine aborted sends stay silent; this is the surprising "dropped mid-
+  //    queue" variant.
+  // Props: board config (boardName/layoutId/sizeId when known), climbUuid,
+  // sendSource (when known), skipReason.
+  ClimbSentToBoardSkipped: 'Climb Sent to Board Skipped',
   // Fired on a successful USER-INITIATED clear-all write (sendSource 'clear';
   // both Aurora and MoonBoard, the latter via its `l##` empty frame — #3420).
   // Internal clears (spill skip, auto-sent empty frames) are untagged and do
@@ -147,7 +166,9 @@ export const SHARED_EVENTS = {
   // A queued climb set for a DIFFERENT board/layout than the connected board was
   // skipped instead of dark-firing the wall. Props: skippedClimbUuid,
   // skippedCount, advancedToClimbUuid (null when no compatible climb remained),
-  // active board config, and the skipped climb's board config.
+  // clearedBoard (true when the wall was cleared rather than advanced — a party
+  // session, or no compatible climb left), active board config, and the skipped
+  // climb's board config.
   BleQueueClimbSkipped: 'BLE Queue Climb Skipped',
   // The "this controller belongs to another board setup" dialog was shown when a
   // scanned serial resolved to a different board config than the active one, and


### PR DESCRIPTION
## Summary

Fixes #3850 — on iOS, picking a climb could switch every LED off; the workaround was to move to another climb and back.

**Root cause.** The BLE auto-sender had no guard on the current climb's `frames`. A partially-synced queue item (a party peer broadcast, or a FullSync / local-snapshot restore that landed before the climb hydrated) can become the current climb with **empty frames** — `Climb.frames` is typed non-null, but the queue's wire boundary is untyped. Writing empty frames is the Aurora / MoonBoard "clear all LEDs" command, so auto-sending an unresolved climb **dark-fired the wall and silently buzzed success** (an empty Aurora write returns `true` with no analytics event — which is why nothing showed up in PostHog). It re-lit only once the item resolved and the user navigated away and back (a later queue re-sync swaps the item's identity, re-running the effect with real frames). The reporter's fingerprint fits exactly: current climb **name + grade present** ("Soul Siphon", 7b/V8) but the board dark. It is **not** the spill guard — PostHog has no `kilter/1 → kilter/1` spill rows.

**The fix (all OTA-able, no native change):**
- New pure predicate `hasRenderableFrames` (`packages/mobile/src/lib/ble/renderable-frames.ts`). The auto-sender holds the write for an unresolved current climb instead of dark-firing — the board keeps the previous climb lit, and the effect re-lights the moment the frames resolve.
- Telemetry to close this silent-failure class:
  - **`Climb Sent to Board Skipped`** (new) with `skipReason`: `unresolved_climb` (the auto-sender hold, once per uuid) / `no_adapter` / `no_board_config` / `adapter_lost` (the previously-silent `sendFramesToBoard` bail-outs — a "connected but no adapter" window no longer vanishes without a trace).
  - **`clearedBoard`** added to `BLE Queue Climb Skipped` so the spill guard's silent wall-clears (191 events / 59 users on iOS 2.2.2, ~94% clearing the board) are filterable.

**Relationship to #3763** (the #3742 re-land, in flight): that PR stops unresolved items from being selected/broadcast in the first place; this guard is the intended defense-in-depth beneath it and fixes #3850 even if the re-land slips. If #3763 merges first, I'll rebase and converge `hasRenderableFrames` onto its `isClimbResolved` helper where sensible; the auto-sender guard stays either way.

Possible follow-up (out of scope here to keep this tight): a subtle "loading climb…" cue while the current climb resolves, instead of just holding the write.

## Release Notes

- Picking a climb no longer switches the wall off while the climb is still syncing — the holds light up as soon as it's ready, no more jumping to another climb and back.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 4361 passed. New coverage: `renderable-frames.test.ts` (predicate) + `bluetooth-auto-sender.test.ts` (drain-loop model kept in lockstep with the component): no empty-frames write, re-lights on resolve, once-per-uuid unresolved report, relapse re-reports, and **spill-path non-interference** (a real spill with frames still skips as a spill; a spill is classified before the resolution guard).
- `vp check` — clean for changed files (one pre-existing unrelated format nit in `packages/mobile/public/index.html`, untouched here).
- `vp run check:mobile-bundle` — OK.

### Real-device QA (needed — party session, iOS)

This reproduces only with a not-yet-synced current climb, easiest to force via a party session:

1. Phone A: connect to a Kilter/Tension board, start a party session, add several climbs.
2. Phone B (or a second account): join the session on `/record`.
3. On the phone connected to the board, use next/prev (or tap history) to land on a climb **the instant a peer added it** (before its frames finish syncing), or rejoin so the FullSync repopulates the queue and immediately pick a climb.
4. Before this fix: the wall goes fully dark on selection; moving to another climb and back re-lights it. After: the wall holds the previous climb, then lights the picked climb as soon as its frames arrive — no dark flash, no navigate-away workaround.
5. Solo sanity: normal connect + pick climbs on `/record` — every climb lights immediately (no regression), and Clear Lights still clears.
