### PR TITLE
fix(sync): don't let one bad bid/ascent row wedge a user's whole sync

### DIFF
--- a/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
@@ -494,6 +494,7 @@ describe('applyAuroraBids — malformed-row isolation (#3520)', () => {
       expect(calls.filter((c) => c.kind === 'insert')).toHaveLength(1);
       expect(insertValues[0]).toHaveLength(1);
       expect(insertValues[0][0]).toMatchObject({ auroraId: 'bid-good' });
+      expect(recomputeMock).toHaveBeenCalledTimes(1);
     } finally {
       warnSpy.mockRestore();
     }
@@ -514,6 +515,7 @@ describe('applyAuroraAscents — malformed-row isolation (#3520)', () => {
       expect(calls.filter((c) => c.kind === 'insert')).toHaveLength(1);
       expect(insertValues[0]).toHaveLength(1);
       expect(insertValues[0][0]).toMatchObject({ auroraId: 'aur-good' });
+      expect(recomputeMock).toHaveBeenCalledTimes(1);
     } finally {
       warnSpy.mockRestore();
     }

--- a/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
@@ -98,6 +98,20 @@ function ascent(overrides: Row = {}): Row {
   };
 }
 
+function bid(overrides: Row = {}): Row {
+  return {
+    uuid: 'bid-1',
+    climb_uuid: 'climb-2',
+    angle: 25,
+    is_mirror: false,
+    bid_count: 2,
+    comment: '',
+    climbed_at: '2026-05-01 09:00:00',
+    created_at: '2026-05-01 09:05:00',
+    ...overrides,
+  };
+}
+
 beforeEach(() => recomputeMock.mockClear());
 
 describe('applyAuroraAscents — timezone + insert', () => {
@@ -415,5 +429,93 @@ describe('applyAuroraBids', () => {
       climbedAt: '2026-05-01T09:00:00.000Z',
       attemptCount: 2,
     });
+  });
+});
+
+// #3520: the reported crash site (an unguarded `new Date(item.created_at)`
+// directly in the bids upsert case of user-sync.ts) was already removed by
+// the 71937db6a timezone-correctness refactor, which routed both ascents and
+// bids through the shared normalize functions below with an identical
+// created_at → climbed_at fallback. This block is a regression test for that
+// fallback on the bids side specifically (previously only asserted for
+// ascents), plus coverage for the same-family gaps that refactor left open:
+// climbedAt has no fallback at all, and the created_at ternary only guards
+// falsy values, not malformed-but-truthy ones.
+describe('applyAuroraBids — created_at guard', () => {
+  it('falls back to climbed_at when created_at is missing (mirrors the ascents guard)', async () => {
+    const { tx, insertValues } = createTx({ selectResults: [[], []] });
+    await applyAuroraBids(tx as unknown as Db, 'kilter', 'user-1', [bid({ created_at: undefined })]);
+
+    expect(insertValues[0][0]).toMatchObject({
+      climbedAt: '2026-05-01T09:00:00.000Z',
+      createdAt: '2026-05-01T09:00:00.000Z',
+    });
+  });
+});
+
+// The actual remaining bug behind #3520 staying open: applyAuroraBids and
+// applyAuroraAscents run inside syncUserData's single cross-table
+// transaction, so an uncaught throw while normalizing ONE row rolls back
+// every other table already synced this attempt and blocks the checkpoint
+// from advancing — the next attempt just re-fetches and re-crashes on the
+// same poison row forever. These tests assert a malformed row is logged and
+// skipped instead of thrown, and every other row in the same payload still
+// lands.
+describe('applyAuroraBids — malformed-row isolation (#3520)', () => {
+  it('skips a bid with an unparseable created_at, warns, and still inserts the rest of the batch', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, insertValues, calls } = createTx({ selectResults: [[], []] });
+      await applyAuroraBids(tx as unknown as Db, 'kilter', 'user-1', [
+        bid({ uuid: 'bid-bad', created_at: 'not-a-date' }),
+        bid({ uuid: 'bid-good' }),
+      ]);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('bid-bad'));
+      expect(calls.filter((c) => c.kind === 'insert')).toHaveLength(1);
+      expect(insertValues[0]).toHaveLength(1);
+      expect(insertValues[0][0]).toMatchObject({ auroraId: 'bid-good' });
+      expect(recomputeMock).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('skips a bid with a missing climbed_at, warns, and still inserts the rest of the batch', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, insertValues, calls } = createTx({ selectResults: [[], []] });
+      await applyAuroraBids(tx as unknown as Db, 'kilter', 'user-1', [
+        bid({ uuid: 'bid-bad', climbed_at: undefined }),
+        bid({ uuid: 'bid-good' }),
+      ]);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('bid-bad'));
+      expect(calls.filter((c) => c.kind === 'insert')).toHaveLength(1);
+      expect(insertValues[0]).toHaveLength(1);
+      expect(insertValues[0][0]).toMatchObject({ auroraId: 'bid-good' });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('applyAuroraAscents — malformed-row isolation (#3520)', () => {
+  it('skips an ascent with a missing climbed_at, warns, and still inserts the rest of the batch', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, insertValues, calls } = createTx({ selectResults: [[], []] });
+      await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+        ascent({ uuid: 'aur-bad', climbed_at: undefined }),
+        ascent({ uuid: 'aur-good' }),
+      ]);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('aur-bad'));
+      expect(calls.filter((c) => c.kind === 'insert')).toHaveLength(1);
+      expect(insertValues[0]).toHaveLength(1);
+      expect(insertValues[0][0]).toMatchObject({ auroraId: 'aur-good' });
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/aurora-sync/src/sync/apply-user-logbook.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.ts
@@ -544,7 +544,23 @@ export async function applyAuroraAscents(
     if (isAuroraListedFalse(item.is_listed)) {
       tombstoneIds.push(String(item.uuid));
     } else {
-      live.push(normalizeAscent(item));
+      // A single row with an unparseable timestamp (missing/garbage
+      // climbed_at, or a created_at so malformed the climbed_at fallback
+      // above doesn't save it) must not abort the whole payload: this runs
+      // inside syncUserData's one cross-table transaction, so an uncaught
+      // throw here rolls back every OTHER table that already synced this
+      // attempt AND blocks the checkpoint from advancing — the next attempt
+      // just re-fetches and re-crashes on the same poison row forever (#3520).
+      // Skip-and-log the one row; every other row in the payload still lands.
+      try {
+        live.push(normalizeAscent(item));
+      } catch (error) {
+        console.warn(
+          `[aurora-sync] skipping malformed ascent row (uuid=${String(item.uuid)}, user=${userId}, board=${boardName}): ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
     }
   }
 
@@ -568,7 +584,21 @@ export async function applyAuroraBids(
   const now = new Date().toISOString();
   const touchedKeys: ClimbStatsKey[] = [];
 
-  const live = data.map(normalizeBid);
+  // Same skip-and-log rationale as applyAuroraAscents above: one malformed
+  // bid must not throw out of the eager normalize pass and abort every other
+  // table in the caller's transaction (#3520).
+  const live: NormalizedLogbookRow[] = [];
+  for (const item of data) {
+    try {
+      live.push(normalizeBid(item));
+    } catch (error) {
+      console.warn(
+        `[aurora-sync] skipping malformed bid row (uuid=${String(item.uuid)}, user=${userId}, board=${boardName}): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
   for (const batch of chunk(live, WRITE_CHUNK_SIZE)) {
     touchedKeys.push(...(await applyLogbookChunk(db, boardName, userId, batch, now, 'bids', ['attempt'])));
   }


### PR DESCRIPTION
## Summary

#3520 reported that a bids row missing `created_at` threw an unguarded `new Date(item.created_at).toISOString()` at `packages/aurora-sync/src/sync/user-sync.ts:232`, and that this crash aborted the user's entire sync batch.

**The literal crash site the issue cites no longer exists.** The day after the issue was filed, an unrelated refactor (71937db6a, "timezone-correct live pull with cross-source claim") moved both ascents and bids upserts out of `user-sync.ts` into a shared module, `packages/aurora-sync/src/sync/apply-user-logbook.ts`, used by both the daemon sync path and the web cron sync path. That module already guards `created_at` identically for ascents and bids (falls back to `climbed_at` when missing) — the asymmetry the issue describes is gone.

What's still broken, and what actually keeps #3520's user-facing symptom alive, is two same-family gaps that refactor left open, plus the blast-radius mechanism that turns either one into "the user's whole logbook silently stops updating":

1. `climbedAt: normalizeTimestamp(String(item.climbed_at))` has **no fallback at all** — a row with missing/null `climbed_at` throws the identical `RangeError: Invalid time value`.
2. The `created_at` fallback is a **falsy check only**, not a validity check — a garbage-but-truthy value (`created_at: "N/A"`) still reaches `normalizeTimestamp` and still throws.
3. **The actual bug:** `applyAuroraAscents`/`applyAuroraBids` eagerly normalize their entire payload up front, before any DB write. Both run inside `syncUserData`'s single transaction spanning *every* synced table (`users`, `walls`, `ascents`, `bids`, `tags`, `circuits`, ...). If normalizing one row throws, it rolls back every other table that already synced that attempt, and the sync checkpoint never advances — so the next attempt just re-fetches and re-crashes on the same row, forever.

## Fix

Wrap each row's normalize call in `applyAuroraAscents` and `applyAuroraBids` in try/catch. A row that fails to normalize (bad `climbed_at`, bad `created_at`, or anything else `normalizeAscent`/`normalizeBid` might choke on) is logged with identifying context (aurora uuid, user, board) and skipped — every other row in the same payload, and every other table in the same sync attempt, proceeds normally and the checkpoint advances. The existing `created_at` → `climbed_at` fallback ternary is left in place as-is; the try/catch is defense-in-depth on top of it, not a replacement.

Scope is deliberately narrow: the single cross-table transaction in `syncUserData` is untouched, and tables other than ascents/bids aren't touched by this fix.

## Follow-ups (not fixed here)

- **#3871** (P3): a row that parses fine in JS but fails a Postgres type/constraint check inside `applyLogbookChunk`'s *batched* SQL write (e.g. a non-numeric `angle`) still crashes a whole 100-row chunk and rolls back the transaction — same structural family, different layer (DB-execution-time vs JS-parse-time). Isolating that needs row-by-row write fallback, a bigger change than this PR's scope.
- Skipped rows are logged (`console.warn`) but not counted anywhere visible (`UpsertResult` doesn't track ascents/bids skips today) — a dashboard-visible counter would be a reasonable fast-follow, not built here.

## Test plan

- [x] New tests in `packages/aurora-sync/src/sync/apply-user-logbook.test.ts`:
  - bids: `created_at` missing falls back to `climbed_at` (regression test for the existing guard, previously only asserted for ascents)
  - bids: unparseable `created_at` is skipped + warned, rest of the batch still inserts
  - bids: missing `climbed_at` is skipped + warned, rest of the batch still inserts
  - ascents: missing `climbed_at` is skipped + warned, rest of the batch still inserts
- [x] `VITEST_POOL_ID=solo-issue3520 vp test run --project aurora-sync --reporter=agent -- apply-user-logbook` — 9 files, 95 tests passing
- [x] `VITEST_POOL_ID=solo-issue3520 vp test run --project aurora-sync --reporter=agent` (full project) — 9 files, 95 tests passing
- [x] `vp check` on the changed files — clean (repo-wide `vp check` has one pre-existing, unrelated formatting issue in `packages/mobile/public/index.html` from a prior commit, not touched by this PR)
- [x] `vp run typecheck:aurora` — clean

## Release Notes

Logbook sync no longer gets stuck for good when one old attempt has a broken date — Boardsesh skips that one attempt and keeps syncing the rest of your sends.

Fixes #3520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkJuDx4nCQPYQzeEjNd6Q3