### PR TITLE
fix: select PlaybackStateChanged fields in mobile QUEUE_UPDATES_SUBSCRIPTION

### DIFF
--- a/packages/backend/src/__tests__/operations-schema-validation.test.ts
+++ b/packages/backend/src/__tests__/operations-schema-validation.test.ts
@@ -262,6 +262,70 @@ describe('mobile SUBSCRIPTION_CLIMB_FIELDS is a superset of the shared queue-ses
   });
 });
 
+// Regression test for issue #3358: QUEUE_UPDATES_SUBSCRIPTION shipped with NO
+// `... on PlaybackStateChanged` fragment at all. Per GraphQL union selection
+// semantics that meant the server returned a `__typename`-only payload for
+// every PlaybackStateChanged event — `event.climbUuid` was always `undefined`,
+// so `use-mobile-playback.ts`'s `event.climbUuid !== climbUuid` guard always
+// short-circuited and inbound peer route-playback sync silently did nothing on
+// mobile. TypeScript never caught it because `use-session-realtime.ts` reads
+// the raw wire payload through an `as unknown as SubscriptionQueueEvent` cast
+// (tracked separately as TODO(#2507)) — this parser-driven check is the
+// backstop until that cast is removed.
+describe('mobile QUEUE_UPDATES_SUBSCRIPTION selects the same PlaybackStateChanged fields as the shared queue-session subscription', () => {
+  // Collect the field names selected inside every inline fragment for a given
+  // type condition (e.g. `... on PlaybackStateChanged { ... }`), anywhere in
+  // the document. Mirrors climbFieldNames' parser-driven approach above so
+  // this compares field sets, not raw strings.
+  function inlineFragmentFieldNames(operationSource: string, typeName: string): Set<string> {
+    const fields = new Set<string>();
+    visit(parse(operationSource), {
+      InlineFragment(node) {
+        if (node.typeCondition?.name.value !== typeName || !node.selectionSet) return;
+        for (const selection of node.selectionSet.selections) {
+          if (selection.kind === 'Field') fields.add(selection.name.value);
+        }
+      },
+    });
+    return fields;
+  }
+
+  const mobileOperationsSource = readMobileOperationsSource();
+  const subscriptionClimbFields = extractTemplateConst(mobileOperationsSource, 'SUBSCRIPTION_CLIMB_FIELDS');
+  // Same placeholder-substitution technique as the "mobile plain-string
+  // subscription documents" describe block above — QUEUE_UPDATES_SUBSCRIPTION
+  // interpolates `${SUBSCRIPTION_CLIMB_FIELDS}` at build time, so replicate
+  // that before parsing raw extracted source text as GraphQL.
+  const mobileQueueUpdates = extractTemplateConst(mobileOperationsSource, 'QUEUE_UPDATES_SUBSCRIPTION').replaceAll(
+    '${SUBSCRIPTION_CLIMB_FIELDS}',
+    subscriptionClimbFields,
+  );
+
+  const sharedPlaybackFields = inlineFragmentFieldNames(queueSessionOperations.QUEUE_UPDATES, 'PlaybackStateChanged');
+  const mobilePlaybackFields = inlineFragmentFieldNames(mobileQueueUpdates, 'PlaybackStateChanged');
+
+  it('both subscriptions select a non-empty PlaybackStateChanged field set', () => {
+    expect(sharedPlaybackFields.size).toBeGreaterThan(0);
+    expect(mobilePlaybackFields.size).toBeGreaterThan(0);
+  });
+
+  it('every shared PlaybackStateChanged field is present in the mobile subscription', () => {
+    const missing = [...sharedPlaybackFields].filter((field) => !mobilePlaybackFields.has(field));
+    if (missing.length > 0) {
+      throw new Error(
+        `mobile QUEUE_UPDATES_SUBSCRIPTION is missing PlaybackStateChanged fields the shared subscription selects: ${missing.join(', ')}.\n` +
+          'Without them, inbound peer route-playback sync is dead on mobile (issue #3358) — add the missing fields to the ' +
+          '`... on PlaybackStateChanged` fragment in packages/mobile/src/lib/graphql/operations.ts.',
+      );
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('carries climbUuid specifically, since that field gates whether use-mobile-playback applies the event at all', () => {
+    expect(mobilePlaybackFields.has('climbUuid')).toBe(true);
+  });
+});
+
 // Workstream B7 (reduced variant, 2026-07) removed ONLY the takeControl/releaseControl
 // mutations. Session.driverParticipantId, the DriverChanged type, and its SessionEvent
 // union membership are DEFERRED: telemetry found a real tail of stale mobile JS bundles

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -1254,6 +1254,16 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
         mirroredUuid: uuid
         mirrored
       }
+      ... on PlaybackStateChanged {
+        sequence
+        climbUuid
+        frameIndex
+        isPlaying
+        speed
+        paceMs
+        anchorTimestamp
+        clientId
+      }
     }
   }
 `;

--- a/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
@@ -280,6 +280,24 @@ function wireQueueItemAdded(sequence: number, stateHash: string, item: ReturnTyp
   };
 }
 
+// Wire-shaped PlaybackStateChanged matching QUEUE_UPDATES_SUBSCRIPTION's `...
+// on PlaybackStateChanged` fragment (issue #3358) — no top-level `stateHash`,
+// since this event doesn't mutate queue state.
+function wirePlaybackStateChanged(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    __typename: 'PlaybackStateChanged',
+    sequence: 1,
+    climbUuid: 'c1',
+    frameIndex: 3,
+    isPlaying: true,
+    speed: 1.5,
+    paceMs: 250,
+    anchorTimestamp: '1700000000000',
+    clientId: 'peer-client',
+    ...overrides,
+  };
+}
+
 function queueStateResponse(
   items: ClimbQueueItem[],
   current: ClimbQueueItem | null = null,
@@ -717,19 +735,33 @@ describe('QueueProvider queue sync gate', () => {
       queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1') } });
     });
 
-    // The real wire payload for PlaybackStateChanged carries only
-    // `__typename` — QUEUE_UPDATES_SUBSCRIPTION has no `... on
-    // PlaybackStateChanged` fragment, so no sequence/stateHash is selected.
+    // Defensive case: a `__typename`-only payload (e.g. a stale client bundle
+    // still missing the `... on PlaybackStateChanged` fragment, or a future
+    // union member this listener doesn't recognise) must still be forwarded
+    // and must not throw or otherwise disrupt the gate.
     act(() => {
       queueUpdatesSink.next({ data: { queueUpdates: { __typename: 'PlaybackStateChanged' } } });
     });
 
-    await waitFor(() => {
-      expect(received.map((event) => event.__typename)).toContain('PlaybackStateChanged');
+    // Realistic case (issue #3358): QUEUE_UPDATES_SUBSCRIPTION now selects the
+    // full `... on PlaybackStateChanged` fragment, so the real wire payload
+    // carries all 8 fields — assert they reach the listener unchanged, since
+    // `use-mobile-playback.ts` reads `climbUuid`/`frameIndex`/etc directly off
+    // the forwarded event.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wirePlaybackStateChanged() } });
     });
+
+    await waitFor(() => {
+      expect(received.filter((event) => event.__typename === 'PlaybackStateChanged')).toHaveLength(2);
+    });
+    const [minimalEvent, fullEvent] = received.filter((event) => event.__typename === 'PlaybackStateChanged');
+    expect(minimalEvent).toEqual({ __typename: 'PlaybackStateChanged' });
+    expect(fullEvent).toEqual(wirePlaybackStateChanged());
+
     // It must not have touched the reducer or the gate's tracking: the very
     // next real delta at sequence 2 (contiguous with the FullSync's 1) still
-    // applies cleanly — proving PlaybackStateChanged never occupied a
+    // applies cleanly — proving neither PlaybackStateChanged event occupied a
     // sequence slot or otherwise got gated.
     act(() => {
       queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(2, 'hash-2', wireItem('q1', 'c1')) } });


### PR DESCRIPTION
## Summary

Party-mode route playback sync on mobile was outbound-only: a phone could broadcast its own play/pause/seek/speed state to peers, but could never receive one.

`QUEUE_UPDATES_SUBSCRIPTION` (`packages/mobile/src/lib/graphql/operations.ts`) had inline fragments for `FullSync`, `QueueItemAdded`, `QueueItemRemoved`, `QueueReordered`, `CurrentClimbChanged`, and `ClimbMirrored` — but no `... on PlaybackStateChanged` fragment. Per GraphQL union selection semantics, the server therefore returned every `PlaybackStateChanged` event as a `__typename`-only payload. The consumer (`use-mobile-playback.ts`) reads `event.climbUuid` to decide whether to apply the update; since that field was always `undefined`, its `event.climbUuid !== climbUuid` guard always short-circuited and inbound peer playback sync silently did nothing.

Fix: add the same 8-field fragment web already selects (`sequence`, `climbUuid`, `frameIndex`, `isPlaying`, `speed`, `paceMs`, `anchorTimestamp`, `clientId`), matching the schema type and the shared `SubscriptionQueueEvent` TS union exactly.

This is a pure wire-selection fix. Everything downstream was already correct and dormant:
- `use-mobile-playback.ts` already reads and applies all 8 fields.
- The shared `SubscriptionQueueEvent` type already models the full `PlaybackStateChanged` variant (TypeScript never caught the mismatch because `use-session-realtime.ts` reads the raw wire payload through an `as unknown as SubscriptionQueueEvent` cast — tracked separately as `TODO(#2507)`).
- The sync gate already exempts `PlaybackStateChanged` from sequence gating.
- Backend already stamps and broadcasts the full event (web already consumes it correctly).

No backend, schema, codegen, or native changes. JS-only, rides OTA.

**Out of scope** (kept narrow per plan review):
- `NATIVE_IOS_QUEUE_UPDATES` — a separate native Live Activity/widget decode path that never consumed playback animation.
- `TODO(#2507)` — adopting the shared `@boardsesh/graphql` selection wholesale on mobile (bigger, separately-risky refactor).
- #2428 — backend Zod validation for `PlaybackStateInput` (orthogonal input hardening, doesn't block this fix).

Closes #3358

## Release Notes

- In a party session your phone now follows the crew's route playback live — play, pause, and speed changes from other phones show up instead of freezing.

## Test plan

- Added a parser-driven regression test in `packages/backend/src/__tests__/operations-schema-validation.test.ts` (mirrors the existing climb-fields superset check): asserts mobile's `QUEUE_UPDATES_SUBSCRIPTION` selects the same `PlaybackStateChanged` fields as the shared queue-session fragment, so this can't silently drift again.
- Updated `packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx`'s `PlaybackStateChanged` test: its old comment asserted the missing-fields wire shape as *expected* behaviour (documenting the bug). Reframed the minimal-payload case as a defensive/backward-compat check and added a realistic full-fields case asserting all 8 fields reach `subscribeToQueueEvents` listeners unchanged.
- `SKIP_TEST_INFRA=1 VITEST_POOL_ID=solo-issue3358 vp test run --project backend operations-schema-validation --reporter=agent` — 220 passed.
- `vp test run --project mobile queue-provider-sync-gate --reporter=agent` — 8 passed.
- `vp run test:mobile` — 4359 passed (533 files), full suite green since `queue-provider` tests were touched.
- `vp run typecheck:mobile` — clean.
- `vp run check:mobile-bundle` — Android bundle export OK.
- `vp check` — clean on the changed files (one pre-existing, unrelated formatting drift in `packages/mobile/public/index.html`, not touched by this change).

### Party-mode QA steps

1. Start two mobile clients (simulator/device) joined to the same party session on a route (multi-frame) climb.
2. On device A, open the play drawer and hit play — advance a few frames, pause, change speed.
3. On device B, confirm the play drawer's frame position / play-state / speed visibly track device A's within the extrapolation window (not frozen at frame 0 / stale).
4. Swap driver roles (B drives, A observes) — confirm bidirectional sync now that A can also receive.
5. Confirm solo (non-party) playback is unaffected — no console warnings, no BLE double-writes.
