### PR TITLE
fix(sync): make the aurora credential failure ledger operable

### DIFF
--- a/packages/aurora-sync/src/cli/index.ts
+++ b/packages/aurora-sync/src/cli/index.ts
@@ -45,12 +45,14 @@ function createRunner(verbose: boolean): SyncRunner {
       ]
         .filter((part): part is string => part !== null)
         .join(' ');
-      const suffix = ledger ? ` [${ledger}]` : '';
-      console.error(
-        `Error syncing ${context.userId ?? 'daemon'}/${context.board ?? 'unknown'}:`,
-        error.message,
-        suffix,
-      );
+      const prefix = `Error syncing ${context.userId ?? 'daemon'}/${context.board ?? 'unknown'}:`;
+      // Only pass the ledger token when there is one — never a trailing empty
+      // argument (some formatters render it as a dangling space/token).
+      if (ledger) {
+        console.error(prefix, error.message, `[${ledger}]`);
+      } else {
+        console.error(prefix, error.message);
+      }
     },
   });
 }

--- a/packages/aurora-sync/src/cli/index.ts
+++ b/packages/aurora-sync/src/cli/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { program } from 'commander';
+import { credentialBackoffMs } from '@boardsesh/db/queries';
 import { SyncRunner } from '../runner/sync-runner';
 import { AURORA_BOARDS } from '../api/types';
 import { AURORA_LOCATION_BOARDS, type AuroraLocationBoardName } from '../sync/locations-sync';
@@ -24,13 +25,32 @@ function createRunner(verbose: boolean): SyncRunner {
             msg.includes('Quiet hours') ||
             msg.includes('Waiting') ||
             msg.includes('No users') ||
-            msg.includes('Transient')
+            msg.includes('Transient') ||
+            // Stuck-credential observability events (see SyncRunner):
+            // CREDENTIAL QUARANTINED / CREDENTIAL FLAPPING and the hourly
+            // "Sync health" fleet summary must surface in non-verbose prod logs.
+            msg.includes('CREDENTIAL') ||
+            msg.includes('Sync health')
           ) {
             console.info(msg);
           }
         },
     onError: (error, context) => {
-      console.error(`Error syncing ${context.userId ?? 'daemon'}/${context.board ?? 'unknown'}:`, error.message);
+      // Surface the failure ledger snapshot so a stuck/quarantined credential is
+      // visible in the daemon logs (structured stdout; Railway captures it).
+      const ledger = [
+        context.consecutiveFailures !== undefined ? `consecutiveFailures=${context.consecutiveFailures}` : null,
+        context.syncStatus ? `syncStatus=${context.syncStatus}` : null,
+        context.quarantined ? 'quarantined=true' : null,
+      ]
+        .filter((part): part is string => part !== null)
+        .join(' ');
+      const suffix = ledger ? ` [${ledger}]` : '';
+      console.error(
+        `Error syncing ${context.userId ?? 'daemon'}/${context.board ?? 'unknown'}:`,
+        error.message,
+        suffix,
+      );
     },
   });
 }
@@ -152,6 +172,11 @@ program
           syncStatus: auroraCredentials.syncStatus,
           lastSyncAt: auroraCredentials.lastSyncAt,
           syncError: auroraCredentials.syncError,
+          // Failure ledger: surface the scheduler/backoff fields so an operator
+          // can see WHY a card is stuck and WHEN it retries next.
+          lastSyncAttemptAt: auroraCredentials.lastSyncAttemptAt,
+          consecutiveFailures: auroraCredentials.consecutiveFailures,
+          lastSyncError: auroraCredentials.lastSyncError,
         })
         .from(auroraCredentials);
 
@@ -160,6 +185,7 @@ program
       if (credentials.length === 0) {
         console.info('No credentials found.');
       } else {
+        const now = new Date();
         credentials.forEach((cred) => {
           let status = '○';
           if (cred.syncStatus === 'active') {
@@ -168,12 +194,29 @@ program
             status = '✗';
           }
           const lastSync = cred.lastSyncAt ? new Date(cred.lastSyncAt).toISOString() : 'never';
+          const lastAttempt = cred.lastSyncAttemptAt ? new Date(cred.lastSyncAttemptAt).toISOString() : 'never';
+          const consecutiveFailures = cred.consecutiveFailures ?? 0;
           console.info(`${status} ${cred.userId} (${cred.boardType})`);
           console.info(`    Aurora ID: ${cred.auroraUserId}`);
           console.info(`    Status: ${cred.syncStatus}`);
           console.info(`    Last sync: ${lastSync}`);
+          console.info(`    Last attempt: ${lastAttempt}`);
+          console.info(`    Consecutive failures: ${consecutiveFailures}`);
+          if (consecutiveFailures > 0 && cred.lastSyncAttemptAt) {
+            const backoffMs = credentialBackoffMs(consecutiveFailures);
+            const readyAt = new Date(new Date(cred.lastSyncAttemptAt).getTime() + backoffMs);
+            if (readyAt > now) {
+              const remainingMin = Math.ceil((readyAt.getTime() - now.getTime()) / 60000);
+              console.info(`    Backoff: retry-ready at ${readyAt.toISOString()} (~${remainingMin}m)`);
+            } else {
+              console.info(`    Backoff: retry-ready now`);
+            }
+          }
           if (cred.syncError) {
             console.info(`    Error: ${cred.syncError}`);
+          }
+          if (cred.lastSyncError && cred.lastSyncError !== cred.syncError) {
+            console.info(`    Last attempt error: ${cred.lastSyncError}`);
           }
           console.info('');
         });

--- a/packages/aurora-sync/src/runner/sync-runner.test.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.test.ts
@@ -26,6 +26,7 @@ type SyncRunnerPrivates = {
     cred: CredentialRecord,
     errorMessage: string,
   ) => Promise<{ storedErrorMessage: string; status: string; quarantined: boolean }>;
+  getSyncHealthSnapshot: () => Promise<SyncHealthSnapshot>;
 };
 
 const { mockDecrypt, mockEncrypt, mockSignIn, mockSyncUserData, mockSyncSharedData, mockSyncAuroraBoardLocations } =
@@ -599,5 +600,81 @@ describe('formatSyncHealthSummary', () => {
       oldestAttemptAt: null,
     };
     expect(formatSyncHealthSummary(snapshot)).toContain('oldestAttempt=never');
+  });
+});
+
+describe('SyncRunner.getSyncHealthSnapshot', () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://test:test@localhost:5432/test';
+  });
+
+  // The aggregate SQL (counts + the `not credentialRetryReadySql()` backoff
+  // filter) is exercised against Postgres in prod; the backoff predicate's
+  // correctness is anchored by the tested JS mirror (isCredentialInBackoff in
+  // credential-backoff.test.ts). This test pins the method's JS mapping: string
+  // counts from postgres-js are coerced to numbers and a null min() stays null.
+  it('coerces the aggregate row into a typed snapshot', async () => {
+    const oldest = new Date('2026-05-06T07:08:09.000Z');
+    const dbShim = {
+      select: () => ({
+        from: () => ({
+          // postgres-js returns bigint counts as strings unless cast; assert
+          // the Number() coercion holds even if a driver hands back strings.
+          where: () =>
+            Promise.resolve([
+              {
+                total: '9',
+                active: 5,
+                pending: '1',
+                error: 2,
+                expired: '1',
+                inBackoff: 3,
+                oldestAttemptAt: oldest,
+              },
+            ]),
+        }),
+      }),
+    };
+
+    const runner = new SyncRunner();
+    const runnerPrivates = runner as unknown as SyncRunnerPrivates & {
+      getClient: () => { client: unknown; db: unknown };
+    };
+    vi.spyOn(runnerPrivates, 'getClient').mockReturnValue({ client: {}, db: dbShim });
+
+    const snapshot = await runnerPrivates.getSyncHealthSnapshot();
+
+    expect(snapshot).toEqual({
+      total: 9,
+      active: 5,
+      pending: 1,
+      error: 2,
+      expired: 1,
+      inBackoff: 3,
+      oldestAttemptAt: oldest,
+    });
+  });
+
+  it('defaults counts to 0 and oldestAttemptAt to null when no rows come back', async () => {
+    const dbShim = {
+      select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+    };
+    const runner = new SyncRunner();
+    const runnerPrivates = runner as unknown as SyncRunnerPrivates & {
+      getClient: () => { client: unknown; db: unknown };
+    };
+    vi.spyOn(runnerPrivates, 'getClient').mockReturnValue({ client: {}, db: dbShim });
+
+    const snapshot = await runnerPrivates.getSyncHealthSnapshot();
+
+    expect(snapshot).toEqual({
+      total: 0,
+      active: 0,
+      pending: 0,
+      error: 0,
+      expired: 0,
+      inBackoff: 0,
+      oldestAttemptAt: null,
+    });
   });
 });

--- a/packages/aurora-sync/src/runner/sync-runner.test.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuroraRequestError } from '../api/errors';
-import { SyncRunner } from './sync-runner';
+import { CredentialSyncError, formatSyncHealthSummary, SyncRunner, type SyncHealthSnapshot } from './sync-runner';
 import type { AuroraBoardName } from '../api/types';
-import type { CredentialRecord } from './types';
+import type { CredentialRecord, SyncErrorContext } from './types';
 
 type SyncRunnerPrivates = {
   updateCredentialStatus: (
@@ -22,6 +22,10 @@ type SyncRunnerPrivates = {
   getActiveCredentials: () => Promise<CredentialRecord[]>;
   getNextCredentialToSync: () => Promise<CredentialRecord | null>;
   recordSyncFailure: (cred: CredentialRecord, errorMsg: string) => Promise<void>;
+  recordInvalidCredentialFailure: (
+    cred: CredentialRecord,
+    errorMessage: string,
+  ) => Promise<{ storedErrorMessage: string; status: string; quarantined: boolean }>;
 };
 
 const { mockDecrypt, mockEncrypt, mockSignIn, mockSyncUserData, mockSyncSharedData, mockSyncAuroraBoardLocations } =
@@ -427,5 +431,173 @@ describe('SyncRunner.recordSyncFailure', () => {
     // A transient/generic failure must NOT touch the user-facing status/error.
     expect(updates[0].syncStatus).toBeUndefined();
     expect(updates[0].syncError).toBeUndefined();
+    // A failed cycle must NEVER advance last_sync_at — that is the user-facing
+    // "last successful sync" and only the success path may stamp it.
+    expect(updates[0].lastSyncAt).toBeUndefined();
+  });
+
+  it('logs a FLAPPING event exactly when consecutive_failures crosses the threshold', async () => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://test:test@localhost:5432/test';
+    const dbShim = {
+      update() {
+        return { set: () => ({ where: () => Promise.resolve() }) };
+      },
+    };
+
+    const runFor = async (priorConsecutiveFailures: number): Promise<string[]> => {
+      const logs: string[] = [];
+      const runner = new SyncRunner({ onLog: (msg) => logs.push(msg) });
+      const runnerPrivates = runner as unknown as SyncRunnerPrivates & {
+        getClient: () => { client: unknown; db: unknown };
+      };
+      vi.spyOn(runnerPrivates, 'getClient').mockReturnValue({ client: {}, db: dbShim });
+      await runnerPrivates.recordSyncFailure(
+        createCredential({ consecutiveFailures: priorConsecutiveFailures }),
+        'aurora exploded',
+      );
+      return logs;
+    };
+
+    // Threshold is 5: the 5th consecutive failure (prior 4 → new 5) fires once.
+    const atThreshold = await runFor(4);
+    expect(atThreshold.some((msg) => msg.includes('CREDENTIAL FLAPPING'))).toBe(true);
+    expect(atThreshold.find((msg) => msg.includes('CREDENTIAL FLAPPING'))).toContain('consecutiveFailures=5');
+
+    // One below the threshold (new 4): no flap yet.
+    const belowThreshold = await runFor(3);
+    expect(belowThreshold.some((msg) => msg.includes('CREDENTIAL FLAPPING'))).toBe(false);
+
+    // Already past the threshold (new 6): no repeat — the crossing already fired.
+    const pastThreshold = await runFor(5);
+    expect(pastThreshold.some((msg) => msg.includes('CREDENTIAL FLAPPING'))).toBe(false);
+  });
+});
+
+describe('SyncRunner.recordInvalidCredentialFailure quarantine event', () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://test:test@localhost:5432/test';
+  });
+
+  it('logs a QUARANTINED event only when the credential expires (2nd failure)', async () => {
+    const secondFailureLogs: string[] = [];
+    const secondRunner = new SyncRunner({ onLog: (msg) => secondFailureLogs.push(msg) });
+    const secondPrivates = secondRunner as unknown as SyncRunnerPrivates;
+    vi.spyOn(secondPrivates, 'updateCredentialStatus').mockResolvedValue(undefined);
+
+    const secondResult = await secondPrivates.recordInvalidCredentialFailure(
+      createCredential({ credentialFailureCount: 1 }),
+      'Login failed: Invalid username or password',
+    );
+
+    expect(secondResult).toEqual({
+      storedErrorMessage: expect.stringContaining('expired after 2 failed credential attempts'),
+      status: 'expired',
+      quarantined: true,
+    });
+    const quarantineLine = secondFailureLogs.find((msg) => msg.includes('CREDENTIAL QUARANTINED'));
+    expect(quarantineLine).toBeDefined();
+    expect(quarantineLine).toContain('reason=invalid_credentials');
+
+    // First failure (count 0 → 1): still 'error', no quarantine event.
+    const firstFailureLogs: string[] = [];
+    const firstRunner = new SyncRunner({ onLog: (msg) => firstFailureLogs.push(msg) });
+    const firstPrivates = firstRunner as unknown as SyncRunnerPrivates;
+    vi.spyOn(firstPrivates, 'updateCredentialStatus').mockResolvedValue(undefined);
+
+    const firstResult = await firstPrivates.recordInvalidCredentialFailure(
+      createCredential({ credentialFailureCount: 0 }),
+      'Login failed: Invalid username or password',
+    );
+
+    expect(firstResult.status).toBe('error');
+    expect(firstResult.quarantined).toBe(false);
+    expect(firstFailureLogs.some((msg) => msg.includes('CREDENTIAL QUARANTINED'))).toBe(false);
+  });
+});
+
+describe('SyncRunner enriched onError context', () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://test:test@localhost:5432/test';
+  });
+
+  it('reports the post-attempt failure ledger from a CredentialSyncError', async () => {
+    const contexts: SyncErrorContext[] = [];
+    const runner = new SyncRunner({ onError: (_error, context) => contexts.push(context) });
+    const runnerPrivates = runner as unknown as SyncRunnerPrivates;
+
+    vi.spyOn(runnerPrivates, 'getNextCredentialToSync').mockResolvedValue(
+      createCredential({ userId: 'user-Q', syncStatus: 'error', consecutiveFailures: 1 }),
+    );
+    vi.spyOn(runnerPrivates, 'recordSyncFailure').mockResolvedValue(undefined);
+    vi.spyOn(runnerPrivates, 'syncSingleCredential').mockRejectedValue(
+      new CredentialSyncError('Login failed: bad (expired ...)', { syncStatus: 'expired', quarantined: true }),
+    );
+
+    await runner.syncNextUser();
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]).toEqual({
+      userId: 'user-Q',
+      board: 'decoy',
+      boardType: 'decoy',
+      syncStatus: 'expired',
+      consecutiveFailures: 2,
+      quarantined: true,
+    });
+  });
+
+  it('falls back to pre-attempt status with quarantined=false for a generic (DB) error', async () => {
+    const contexts: SyncErrorContext[] = [];
+    const runner = new SyncRunner({ onError: (_error, context) => contexts.push(context) });
+    const runnerPrivates = runner as unknown as SyncRunnerPrivates;
+
+    vi.spyOn(runnerPrivates, 'getNextCredentialToSync').mockResolvedValue(
+      createCredential({ userId: 'user-D', syncStatus: 'active', consecutiveFailures: 0 }),
+    );
+    vi.spyOn(runnerPrivates, 'recordSyncFailure').mockResolvedValue(undefined);
+    vi.spyOn(runnerPrivates, 'syncSingleCredential').mockRejectedValue(new Error('Database error [code=23503]'));
+
+    await runner.syncNextUser();
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]).toEqual({
+      userId: 'user-D',
+      board: 'decoy',
+      boardType: 'decoy',
+      syncStatus: 'active',
+      consecutiveFailures: 1,
+      quarantined: false,
+    });
+  });
+});
+
+describe('formatSyncHealthSummary', () => {
+  it('renders counts, backoff, and the oldest attempt as an ISO string', () => {
+    const snapshot: SyncHealthSnapshot = {
+      total: 12,
+      active: 8,
+      pending: 1,
+      error: 2,
+      expired: 1,
+      inBackoff: 3,
+      oldestAttemptAt: new Date('2026-01-02T03:04:05.000Z'),
+    };
+    expect(formatSyncHealthSummary(snapshot)).toBe(
+      '[SyncRunner] Sync health: 12 aurora credentials — active=8 pending=1 error=2 expired=1; ' +
+        'inBackoff=3; oldestAttempt=2026-01-02T03:04:05.000Z',
+    );
+  });
+
+  it('renders "never" when some credential has never been attempted', () => {
+    const snapshot: SyncHealthSnapshot = {
+      total: 2,
+      active: 1,
+      pending: 1,
+      error: 0,
+      expired: 0,
+      inBackoff: 0,
+      oldestAttemptAt: null,
+    };
+    expect(formatSyncHealthSummary(snapshot)).toContain('oldestAttempt=never');
   });
 });

--- a/packages/aurora-sync/src/runner/sync-runner.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.ts
@@ -33,6 +33,11 @@ type RunnerDb = ReturnType<typeof drizzle>;
 const DEFAULT_SHARED_SYNC_COOLDOWN_MS = 60 * 60 * 1000;
 const MAX_CREDENTIAL_FAILURES = 2;
 
+// aurora-sync owns every board EXCEPT kilter (which kilter-sync drives via its
+// own OAuth flow), so every credential query here excludes this board_type.
+// Named once so the scheduler filter and the health snapshot can't drift.
+const KILTER_BOARD_TYPE = 'kilter';
+
 // Consecutive-failure count at which we emit a distinct FLAPPING log event.
 // The credential is already backing off and rotating out (the starvation fix);
 // this just makes "this one isn't a one-off blip" greppable for an operator.
@@ -253,6 +258,9 @@ export class SyncRunner {
     // consecutive_failures is incremented in SQL above; mirror the resulting
     // value in JS to fire the FLAPPING event exactly once, when the streak
     // crosses the threshold (it grows by 1 per cycle, so `===` fires once).
+    // Under two overlapping daemon instances (#3539, out of scope here) both
+    // could read the same pre-increment value and each emit the event once —
+    // a harmless duplicate log line, not a correctness issue.
     const consecutiveFailures = (cred.consecutiveFailures ?? 0) + 1;
     if (consecutiveFailures === CREDENTIAL_FLAP_THRESHOLD) {
       const nextRetryMs = credentialBackoffMs(consecutiveFailures);
@@ -377,7 +385,7 @@ export class SyncRunner {
       isNotNull(auroraCredentials.encryptedUsername),
       isNotNull(auroraCredentials.encryptedPassword),
       isNotNull(auroraCredentials.auroraUserId),
-      ne(auroraCredentials.boardType, 'kilter'),
+      ne(auroraCredentials.boardType, KILTER_BOARD_TYPE),
     );
   }
 
@@ -576,7 +584,7 @@ export class SyncRunner {
         oldestAttemptAt: sql<Date | null>`min(${auroraCredentials.lastSyncAttemptAt})`,
       })
       .from(auroraCredentials)
-      .where(ne(auroraCredentials.boardType, 'kilter'));
+      .where(ne(auroraCredentials.boardType, KILTER_BOARD_TYPE));
 
     const row = rows[0];
     return {
@@ -599,6 +607,9 @@ export class SyncRunner {
     if (this.lastHealthSummaryAt !== 0 && now - this.lastHealthSummaryAt < SYNC_HEALTH_SUMMARY_COOLDOWN_MS) {
       return;
     }
+    // Stamp before the query (not after) so a slow/erroring snapshot doesn't
+    // re-fire on the very next cycle — a summary is anti-spam by design, and
+    // it's fine for a one-off DB blip to skip a single hourly line.
     this.lastHealthSummaryAt = now;
     try {
       const snapshot = await this.getSyncHealthSnapshot();

--- a/packages/aurora-sync/src/runner/sync-runner.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.ts
@@ -3,7 +3,7 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import { eq, ne, and, or, isNotNull, sql } from 'drizzle-orm';
 
 import { auroraCredentials } from '@boardsesh/db/schema/auth';
-import { credentialRetryReadySql, selfHealStaleClimbStats } from '@boardsesh/db/queries';
+import { credentialBackoffMs, credentialRetryReadySql, selfHealStaleClimbStats } from '@boardsesh/db/queries';
 import { syncUserData } from '../sync/user-sync';
 import { syncSharedData } from '../sync/shared-sync';
 import {
@@ -18,7 +18,7 @@ import { decrypt, encrypt } from '@boardsesh/crypto';
 import type { LocationSyncSummary } from '@boardsesh/location-sync';
 import type { AuroraBoardName } from '../api/types';
 import { resolveDaemonOptions, runDaemonLoop } from './daemon';
-import type { SyncRunnerConfig, SyncSummary, CredentialRecord, DaemonOptions } from './types';
+import type { SyncRunnerConfig, SyncSummary, CredentialRecord, DaemonOptions, SyncErrorContext } from './types';
 
 type RunnerClient = ReturnType<typeof postgres>;
 type RunnerDb = ReturnType<typeof drizzle>;
@@ -32,6 +32,64 @@ type RunnerDb = ReturnType<typeof drizzle>;
 // (climbs, climb_stats); tune via SyncRunnerConfig.sharedSyncCooldownMs.
 const DEFAULT_SHARED_SYNC_COOLDOWN_MS = 60 * 60 * 1000;
 const MAX_CREDENTIAL_FAILURES = 2;
+
+// Consecutive-failure count at which we emit a distinct FLAPPING log event.
+// The credential is already backing off and rotating out (the starvation fix);
+// this just makes "this one isn't a one-off blip" greppable for an operator.
+// At 5 consecutive failures the backoff has accumulated ~2+4+8+16 = 30 min of
+// skipped windows — a clear signal, and it fires exactly once (at the crossing)
+// because consecutive_failures increments by 1 per cycle.
+const CREDENTIAL_FLAP_THRESHOLD = 5;
+
+// Hourly gate for the read-only fleet health summary logged by the daemon.
+const SYNC_HEALTH_SUMMARY_COOLDOWN_MS = 60 * 60 * 1000;
+
+/**
+ * Failure carrying the credential's *resolved* post-attempt state so the
+ * `syncNextUser` catch can build an accurate {@link SyncErrorContext} without a
+ * re-read. Thrown by the deterministic-failure branches of
+ * syncSingleCredential (decryption, invalid-credential, other login error).
+ * Transient failures re-throw the original AuroraRequestError untouched (they
+ * do NOT change sync_status), and DB errors surface as plain Errors — both fall
+ * back to the credential's pre-attempt state in the catch, which is correct.
+ */
+export class CredentialSyncError extends Error {
+  readonly syncStatus: string;
+  readonly quarantined: boolean;
+
+  constructor(message: string, options: { syncStatus: string; quarantined: boolean }) {
+    super(message);
+    this.name = 'CredentialSyncError';
+    this.syncStatus = options.syncStatus;
+    this.quarantined = options.quarantined;
+  }
+}
+
+/** Read-only snapshot of the aurora credential fleet, for the health-summary log. */
+export type SyncHealthSnapshot = {
+  total: number;
+  active: number;
+  pending: number;
+  error: number;
+  expired: number;
+  /** Syncable credentials currently skipped because they're inside a backoff window. */
+  inBackoff: number;
+  /** Oldest last_sync_attempt_at across aurora credentials (null = some never attempted). */
+  oldestAttemptAt: Date | null;
+};
+
+/**
+ * Format a {@link SyncHealthSnapshot} as a single greppable log line. Pure so
+ * it's unit-testable without a database.
+ */
+export function formatSyncHealthSummary(snapshot: SyncHealthSnapshot): string {
+  const oldest = snapshot.oldestAttemptAt ? snapshot.oldestAttemptAt.toISOString() : 'never';
+  return (
+    `[SyncRunner] Sync health: ${snapshot.total} aurora credentials — ` +
+    `active=${snapshot.active} pending=${snapshot.pending} error=${snapshot.error} expired=${snapshot.expired}; ` +
+    `inBackoff=${snapshot.inBackoff}; oldestAttempt=${oldest}`
+  );
+}
 
 type CredentialFailureUpdate = {
   credentialFailureCount?: number;
@@ -56,6 +114,9 @@ export class SyncRunner {
   // immediately — exactly catching the debounced recomputes that the deploy's
   // restart dropped (the whole point of the self-heal).
   private lastSelfHealAt = 0;
+  // In-memory hourly gate for the fleet health summary. Resets to 0 on process
+  // start so the first daemon cycle after a deploy logs a snapshot immediately.
+  private lastHealthSummaryAt = 0;
 
   constructor(config: SyncRunnerConfig = {}) {
     this.config = config;
@@ -92,7 +153,7 @@ export class SyncRunner {
     }
   }
 
-  private handleError(error: Error, context: { userId?: string; board?: string }): void {
+  private handleError(error: Error, context: SyncErrorContext): void {
     if (this.config.onError) {
       this.config.onError(error, context);
     } else {
@@ -140,14 +201,31 @@ export class SyncRunner {
         boardType: cred.boardType,
         error: errorMsg,
       });
-      this.handleError(error instanceof Error ? error : new Error(errorMsg), {
-        userId: cred.userId,
-        board: cred.boardType,
-      });
+      this.handleError(error instanceof Error ? error : new Error(errorMsg), this.buildErrorContext(cred, error));
       this.log(`[SyncRunner] ✗ Failed to sync user ${cred.userId} for ${cred.boardType}: ${errorMsg}`);
     }
 
     return results;
+  }
+
+  /**
+   * Build the failure ledger snapshot handed to `onError`. `consecutiveFailures`
+   * is the post-attempt count (recordSyncFailure just bumped it by one). The
+   * resolved `syncStatus`/`quarantined` come from the CredentialSyncError thrown
+   * by a deterministic-failure branch; a transient or DB error carries neither,
+   * so we honestly fall back to the credential's pre-attempt status (unchanged
+   * for transient) with `quarantined: false`.
+   */
+  private buildErrorContext(cred: CredentialRecord, error: unknown): SyncErrorContext {
+    const resolved = error instanceof CredentialSyncError ? error : null;
+    return {
+      userId: cred.userId,
+      board: cred.boardType,
+      boardType: cred.boardType,
+      syncStatus: resolved?.syncStatus ?? cred.syncStatus ?? undefined,
+      consecutiveFailures: (cred.consecutiveFailures ?? 0) + 1,
+      quarantined: resolved?.quarantined ?? false,
+    };
   }
 
   /**
@@ -171,6 +249,18 @@ export class SyncRunner {
         updatedAt: attemptAt,
       })
       .where(and(eq(auroraCredentials.userId, cred.userId), eq(auroraCredentials.boardType, cred.boardType)));
+
+    // consecutive_failures is incremented in SQL above; mirror the resulting
+    // value in JS to fire the FLAPPING event exactly once, when the streak
+    // crosses the threshold (it grows by 1 per cycle, so `===` fires once).
+    const consecutiveFailures = (cred.consecutiveFailures ?? 0) + 1;
+    if (consecutiveFailures === CREDENTIAL_FLAP_THRESHOLD) {
+      const nextRetryMs = credentialBackoffMs(consecutiveFailures);
+      this.log(
+        `[SyncRunner] ✗ CREDENTIAL FLAPPING user=${cred.userId} board=${cred.boardType} ` +
+          `consecutiveFailures=${consecutiveFailures} nextRetryMs=${nextRetryMs} lastError=${errorMsg}`,
+      );
+    }
   }
 
   /** @deprecated Use syncNextUser() instead to avoid IP blocking */
@@ -256,6 +346,9 @@ export class SyncRunner {
           // hourly. Runs after the per-user sync so a fresh tick's recompute
           // has had its chance first.
           await this.maybeSelfHealRecomputes();
+          // Hourly read-only fleet health summary so stuck/quarantined/backing-off
+          // credentials are visible in the daemon logs without a manual DB query.
+          await this.maybeLogSyncHealth();
         },
         resolved,
         {
@@ -330,7 +423,7 @@ export class SyncRunner {
     } catch (decryptError) {
       const errorMessage = `Decryption failed: ${this.formatErrorMessage(decryptError)}`;
       await this.updateCredentialStatus(cred.userId, cred.boardType, 'error', errorMessage);
-      throw new Error(errorMessage);
+      throw new CredentialSyncError(errorMessage, { syncStatus: 'error', quarantined: false });
     }
 
     this.log(`[SyncRunner] Getting fresh token for user ${cred.userId} (${boardType})...`);
@@ -353,11 +446,14 @@ export class SyncRunner {
 
       const errorMessage = `Login failed: ${this.formatErrorMessage(loginError)}`;
       if (this.isInvalidCredentialError(loginError)) {
-        const storedErrorMessage = await this.recordInvalidCredentialFailure(cred, errorMessage);
-        throw new Error(storedErrorMessage);
+        const { storedErrorMessage, status, quarantined } = await this.recordInvalidCredentialFailure(
+          cred,
+          errorMessage,
+        );
+        throw new CredentialSyncError(storedErrorMessage, { syncStatus: status, quarantined });
       } else {
         await this.updateCredentialStatus(cred.userId, cred.boardType, 'error', errorMessage);
-        throw new Error(errorMessage);
+        throw new CredentialSyncError(errorMessage, { syncStatus: 'error', quarantined: false });
       }
     }
 
@@ -456,6 +552,63 @@ export class SyncRunner {
     }
   }
 
+  /**
+   * Read-only fleet snapshot for the health summary: counts by sync_status,
+   * how many syncable credentials are currently inside a backoff window, and
+   * the oldest attempt clock. Scoped to aurora credentials (board_type != kilter)
+   * and served by the same partial index the scheduler uses. One aggregate scan
+   * over a small table — safe to run every cycle even under an overlapping
+   * second daemon instance (#3539), since it never writes.
+   */
+  private async getSyncHealthSnapshot(): Promise<SyncHealthSnapshot> {
+    const { db } = this.getClient();
+    const rows = await db
+      .select({
+        total: sql<number>`(count(*))::int`,
+        active: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'active'))::int`,
+        pending: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'pending'))::int`,
+        error: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'error'))::int`,
+        expired: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'expired'))::int`,
+        inBackoff: sql<number>`(count(*) filter (
+          where ${auroraCredentials.syncStatus} in ('pending', 'active', 'error')
+            and not ${credentialRetryReadySql()}
+        ))::int`,
+        oldestAttemptAt: sql<Date | null>`min(${auroraCredentials.lastSyncAttemptAt})`,
+      })
+      .from(auroraCredentials)
+      .where(ne(auroraCredentials.boardType, 'kilter'));
+
+    const row = rows[0];
+    return {
+      total: Number(row?.total ?? 0),
+      active: Number(row?.active ?? 0),
+      pending: Number(row?.pending ?? 0),
+      error: Number(row?.error ?? 0),
+      expired: Number(row?.expired ?? 0),
+      inBackoff: Number(row?.inBackoff ?? 0),
+      oldestAttemptAt: row?.oldestAttemptAt ?? null,
+    };
+  }
+
+  /**
+   * Log the fleet health summary once an hour (in-memory gate, mirroring the
+   * self-heal). Read-only; a failure never breaks the daemon cycle.
+   */
+  private async maybeLogSyncHealth(): Promise<void> {
+    const now = Date.now();
+    if (this.lastHealthSummaryAt !== 0 && now - this.lastHealthSummaryAt < SYNC_HEALTH_SUMMARY_COOLDOWN_MS) {
+      return;
+    }
+    this.lastHealthSummaryAt = now;
+    try {
+      const snapshot = await this.getSyncHealthSnapshot();
+      this.log(formatSyncHealthSummary(snapshot));
+    } catch (error) {
+      this.handleError(error instanceof Error ? error : new Error(String(error)), {});
+      this.log(`[SyncRunner] Sync health summary failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
   async syncLocations(
     board: AuroraLocationBoardName | 'all',
   ): Promise<LocationSyncSummary | Record<AuroraLocationBoardName, LocationSyncSummary>> {
@@ -519,26 +672,34 @@ export class SyncRunner {
     return isAuroraRequestError(error) && error.code === 'invalid_credentials';
   }
 
-  private async recordInvalidCredentialFailure(cred: CredentialRecord, errorMessage: string): Promise<string> {
+  private async recordInvalidCredentialFailure(
+    cred: CredentialRecord,
+    errorMessage: string,
+  ): Promise<{ storedErrorMessage: string; status: string; quarantined: boolean }> {
     const credentialFailureCount = (cred.credentialFailureCount ?? 0) + 1;
-    const expired = credentialFailureCount >= MAX_CREDENTIAL_FAILURES;
-    const storedErrorMessage = expired
+    const quarantined = credentialFailureCount >= MAX_CREDENTIAL_FAILURES;
+    const status = quarantined ? 'expired' : 'error';
+    const storedErrorMessage = quarantined
       ? `${errorMessage} (expired after ${MAX_CREDENTIAL_FAILURES} failed credential attempts; reconnect to resume sync)`
       : errorMessage;
 
-    await this.updateCredentialStatus(
-      cred.userId,
-      cred.boardType,
-      expired ? 'expired' : 'error',
-      storedErrorMessage,
-      undefined,
-      {
-        credentialFailureCount,
-        lastCredentialFailureAt: new Date(),
-      },
-    );
+    await this.updateCredentialStatus(cred.userId, cred.boardType, status, storedErrorMessage, undefined, {
+      credentialFailureCount,
+      lastCredentialFailureAt: new Date(),
+    });
 
-    return storedErrorMessage;
+    if (quarantined) {
+      // Distinct, greppable event at the moment the credential leaves the
+      // syncable pool — the point an operator needs to prompt the user to
+      // reconnect. (The generic ✗ failure line carries the same message, but
+      // this token makes the quarantine transition countable in the logs.)
+      this.log(
+        `[SyncRunner] ✗ CREDENTIAL QUARANTINED user=${cred.userId} board=${cred.boardType} ` +
+          `reason=invalid_credentials failures=${credentialFailureCount} — excluded from sync until reconnect`,
+      );
+    }
+
+    return { storedErrorMessage, status, quarantined };
   }
 
   private async updateStoredToken(userId: string, boardType: string, token: string): Promise<void> {

--- a/packages/aurora-sync/src/runner/types.ts
+++ b/packages/aurora-sync/src/runner/types.ts
@@ -1,6 +1,26 @@
+/**
+ * Context passed to the `onError` callback. `userId`/`board` are the original
+ * pair; the rest is the per-credential failure ledger snapshot so a callback
+ * (a future Sentry/metric wiring) can escalate on the *state* of a credential
+ * — how deep the consecutive-failure streak is and whether the attempt just
+ * quarantined it out of the pool — instead of firing identically for a
+ * one-off transient blip and a credential that's been dead for days.
+ */
+export type SyncErrorContext = {
+  userId?: string;
+  board?: string;
+  boardType?: string;
+  /** Resolved sync_status after this attempt (e.g. 'error', 'expired'). */
+  syncStatus?: string;
+  /** consecutive_failures after this attempt (drives backoff). */
+  consecutiveFailures?: number;
+  /** True when this attempt pushed the credential to 'expired' (out of the pool). */
+  quarantined?: boolean;
+};
+
 export type SyncRunnerConfig = {
   onLog?: (message: string) => void;
-  onError?: (error: Error, context: { userId?: string; board?: string }) => void;
+  onError?: (error: Error, context: SyncErrorContext) => void;
   /**
    * Minimum time between shared-sync attempts on the same board. Multiple users
    * cycling through user-sync within this window only trigger one shared-sync


### PR DESCRIPTION
## Summary

Closes #3331.

The credential-starvation fix that #3331 asks for **already landed in `main`** via commit `f9fd900e3` (sibling work to #3329). The issue's "Root cause" section describes a stale pre-`f9fd900e3` snapshot. Verified against `packages/aurora-sync/src/runner/sync-runner.ts` off latest `main`:

| #3331 proposed fix | Current state | Location |
|---|---|---|
| Order by `last_sync_attempt_at ASC NULLS FIRST` | Done | `sync-runner.ts` `getNextCredentialToSync` |
| Stamp `last_sync_attempt_at` on **every** outcome | Done — success + all failure paths via `recordSyncFailure` + deprecated `all` path | `syncNextUser` / `recordSyncFailure` |
| Keep `last_sync_at` success-only | Done — `recordSyncFailure` never touches `lastSyncAt` | `recordSyncFailure` |
| Runner tests for the above | Done | `sync-runner.test.ts` |

Plus per-credential exponential backoff (`credentialRetryReadySql`) and auth-dead quarantine to `sync_status='expired'` are already in place. So the poison-pill / Touchstone-5-months-stale scenario is no longer reproducible.

What was **missing** was making that ledger operable. A quarantined or long-flapping credential only surfaced in per-cycle stdout or a manual DB query, and the daemon's `onError` callback couldn't distinguish a one-off transient blip from a credential that's been dead for days. This PR completes #3331 by adding observability — **no scheduling change, no schema change, no migration** (the ledger columns already exist):

- **Enriched `onError` context** — carries the post-attempt ledger (`boardType`, `syncStatus`, `consecutiveFailures`, `quarantined`) via a new `CredentialSyncError` thrown by the deterministic-failure branches. Transient/DB errors honestly fall back to the pre-attempt state with `quarantined: false`.
- **Distinct, greppable log events** (structured stdout; Railway captures it — no Sentry dependency added):
  - `CREDENTIAL QUARANTINED user=… board=… reason=invalid_credentials failures=… — excluded from sync until reconnect` — fires when a credential is pushed to `expired` (out of the pool).
  - `CREDENTIAL FLAPPING user=… board=… consecutiveFailures=… nextRetryMs=… lastError=…` — fires **once**, when `consecutive_failures` crosses 5.
- **Hourly, read-only fleet health summary** in the daemon: `Sync health: N aurora credentials — active=… pending=… error=… expired=…; inBackoff=…; oldestAttempt=…`. Single aggregate scan, gated in-memory like the existing self-heal; safe to run even under an overlapping second instance (#3539) because it never writes.
- **`aurora-sync list`** now shows `last_sync_attempt_at`, `consecutive_failures`, computed retry-ready/backoff time, and the last-attempt error.
- The CLI non-verbose log filter passes the new events so they surface in production logs.

**Latent, not fixed here:** Aurora returns HTTP 422 for bad credentials, so a persistent 401/403 would still classify as transient and retry forever rather than quarantine. Noted for a follow-up if 401s are observed in practice.

### Interaction with adjacent open issues
- **#1976** (shared-sync cooldown stamps on failure): different code path (`maybeRunSharedSync`); untouched here.
- **#3539** (no cross-instance mutual exclusion): this adds no locking and doesn't fix it; the new health-summary query is read-only, so it composes cleanly with a future `FOR UPDATE SKIP LOCKED` claim in `getNextCredentialToSync`.
- **#3520** (bids crash aborts a batch): complementary — a poison-row failure already rotates out via the existing scheduler, and this PR now makes such a stuck user visible via `last_sync_error`.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `SKIP_TEST_INFRA=1 vp test run --project aurora-sync --reporter=agent` — 9 files, 97 pass (6 new: FLAPPING crossing, QUARANTINED transition, enriched `onError` context ×2, `formatSyncHealthSummary` ×2).
- Tightened the `recordSyncFailure` test to assert a failed cycle never advances `last_sync_at`.
- `vp run typecheck` — green.
- `vp check` on all four changed files — clean (format + lint).
- No DB-touching tests added; the health-summary query is covered via a pure formatter test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)