### PR TITLE
fix: relax setQueue wrapper-uuid validation + tolerant array parsing

### DIFF
--- a/packages/backend/src/__tests__/queue-item-uuid-validation.test.ts
+++ b/packages/backend/src/__tests__/queue-item-uuid-validation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { ClimbQueueItemSchema } from '../validation/schemas/climbs';
+import { parseArrayTolerant } from '../validation/schemas/primitives';
+
+// Minimal valid `climb` payload — everything but `uuid`/`angle` is `.nullish()`
+// with a default transform in ClimbInputSchema, so this is enough to isolate
+// the wrapper `uuid` field under test.
+const minimalClimb = { uuid: 'aurora-climb-uuid-fixture', angle: 40 };
+
+const buildQueueItem = (uuid: string) => ({ uuid, climb: minimalClimb });
+
+describe('ClimbQueueItemSchema.uuid (issue #3857)', () => {
+  it('accepts a standard v4 uuid (current web/mobile id generation)', () => {
+    const result = ClimbQueueItemSchema.safeParse(buildQueueItem(uuidv4()));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an Aurora-style 32-char uuid without dashes (PR #419 precedent)', () => {
+    const result = ClimbQueueItemSchema.safeParse(buildQueueItem('a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4'));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts the transient playlist-peek synthetic id (@boardsesh/queue playlist-suggestions.ts)', () => {
+    // 9 ("playlist-peek:") + 36 (a v4 uuid) = 46 chars, under the 50-char cap.
+    const result = ClimbQueueItemSchema.safeParse(buildQueueItem(`playlist-peek:${uuidv4()}`));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a 50-char id at the exact upper bound', () => {
+    const result = ClimbQueueItemSchema.safeParse(buildQueueItem('a'.repeat(50)));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty-string uuid', () => {
+    const result = ClimbQueueItemSchema.safeParse(buildQueueItem(''));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a uuid over the 50-char cap', () => {
+    const result = ClimbQueueItemSchema.safeParse(buildQueueItem('a'.repeat(51)));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing uuid field entirely', () => {
+    const result = ClimbQueueItemSchema.safeParse({ climb: minimalClimb });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('parseArrayTolerant (issue #3857)', () => {
+  it('keeps every item and reports zero drops when the whole array is valid', () => {
+    const queue = [buildQueueItem(uuidv4()), buildQueueItem(uuidv4()), buildQueueItem(uuidv4())];
+    const { items, droppedCount } = parseArrayTolerant(ClimbQueueItemSchema, queue, 'queue', 500);
+    expect(items).toHaveLength(3);
+    expect(droppedCount).toBe(0);
+  });
+
+  it('drops only the malformed items and keeps the valid ones, reporting an accurate count', () => {
+    const valid1 = buildQueueItem(uuidv4());
+    const valid2 = buildQueueItem(uuidv4());
+    const malformedEmptyUuid = buildQueueItem('');
+    const malformedNoClimb = { uuid: uuidv4() };
+
+    const { items, droppedCount } = parseArrayTolerant(
+      ClimbQueueItemSchema,
+      [valid1, malformedEmptyUuid, valid2, malformedNoClimb],
+      'queue',
+      500,
+    );
+
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.uuid).sort()).toEqual([valid1.uuid, valid2.uuid].sort());
+    expect(droppedCount).toBe(2);
+  });
+
+  it('throws (rejects the whole batch) when the raw array exceeds the length cap, even before per-item validation', () => {
+    const oversized = Array.from({ length: 6 }, () => buildQueueItem(uuidv4()));
+    expect(() => parseArrayTolerant(ClimbQueueItemSchema, oversized, 'queue', 5)).toThrow(/Invalid queue/);
+  });
+
+  it('throws when the top-level input is not an array at all', () => {
+    expect(() => parseArrayTolerant(ClimbQueueItemSchema, 'not-an-array', 'queue', 500)).toThrow(/Invalid queue/);
+  });
+});

--- a/packages/backend/src/__tests__/queue-sync-fixes.test.ts
+++ b/packages/backend/src/__tests__/queue-sync-fixes.test.ts
@@ -952,4 +952,39 @@ describe('setQueue - tolerant per-item validation (issue #3857)', () => {
     expect(result.queueState?.queue[0]?.uuid).toBe(validItem1.uuid);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Dropped 1/2 invalid initialQueue item'));
   });
+
+  it('joinSession clears initialCurrentClimb to null when its own initialQueue slot is the dropped item', async () => {
+    const sessionId = uuidv4();
+    const connectionId = 'client-join-3857-dangling';
+    await roomManager.registerClient(connectionId);
+
+    const currentUuid = uuidv4();
+    // The initialQueue's copy of "current" is corrupt and gets dropped by
+    // tolerant parsing...
+    const danglingQueueEntry = createStructurallyInvalidQueueItem(currentUuid);
+    const validItem = createTestClimb();
+    // ...but the caller ALSO independently sends a structurally valid
+    // initialCurrentClimb pointing at that same uuid — a slot that no longer
+    // exists in the seeded queue once the array is filtered.
+    const initialCurrentClimb = createTestClimb(currentUuid);
+    const joinCtx = { connectionId, rateLimitTokens: 60, rateLimitLastReset: Date.now() };
+
+    const result = await sessionMutations.joinSession(
+      {},
+      {
+        sessionId,
+        boardPath: '/kilter/1/2/3/40',
+        username: 'User1',
+        initialQueue: [danglingQueueEntry, validItem],
+        initialCurrentClimb,
+      },
+      joinCtx,
+    );
+
+    expect(result.queueState).not.toBeNull();
+    expect(result.queueState?.queue).toHaveLength(1);
+    expect(result.queueState?.queue[0]?.uuid).toBe(validItem.uuid);
+    expect(result.queueState?.currentClimbQueueItem).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('initialCurrentClimb uuid not present'));
+  });
 });

--- a/packages/backend/src/__tests__/queue-sync-fixes.test.ts
+++ b/packages/backend/src/__tests__/queue-sync-fixes.test.ts
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { roomManager, VersionConflictError } from '../services/room-manager';
 import type { ClimbQueueItem } from '@boardsesh/shared-schema';
 import { queueMutations } from '../graphql/resolvers/queue/mutations';
+import { sessionMutations } from '../graphql/resolvers/sessions/mutations';
 import { pubsub } from '../pubsub/index';
 import { logger } from '../utils/logger';
 import { createMockRedis, type MockRedis } from './helpers/mock-redis';
@@ -808,5 +809,147 @@ describe('setCurrentClimb - combined queue/current state publishing', () => {
     expect(state.currentClimbQueueItem?.climb.layoutId).toBe(8);
     expect(state.queue[0]?.climb.boardType).toBe('tension');
     expect(state.queue[0]?.climb.layoutId).toBe(8);
+  });
+});
+
+// Issue #3857 — a single malformed/legacy queue item (historically: a
+// non-RFC-4122 wrapper `uuid`) used to fail Zod's `z.array(...).safeParse`
+// for the ENTIRE queue, rejecting the whole `setQueue`/`joinSession` call and
+// wedging sync indefinitely. `parseArrayTolerant` (validation/schemas/
+// primitives.ts) validates each item independently and drops only the bad
+// one, so the rest of a user's queue keeps syncing.
+describe('setQueue - tolerant per-item validation (issue #3857)', () => {
+  let mockRedis: MockRedis;
+  let publishSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    mockRedis = createMockRedis();
+    roomManager.reset();
+    await roomManager.initialize(mockRedis);
+    publishSpy = vi.spyOn(pubsub, 'publishQueueEvent').mockImplementation(() => {});
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation((() => logger) as unknown as typeof logger.warn);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const ctxFor = (sessionId: string) => ({
+    connectionId: 'client-1',
+    sessionId,
+    rateLimitTokens: 60,
+    rateLimitLastReset: Date.now(),
+  });
+
+  // A queue item whose wrapper `uuid` fails ExternalUUIDSchema's min(1) bound
+  // — same class of malformed item as issue #3857's historical/peer-synced
+  // ids, just past the lenient schema's own boundary. Still a valid TS shape:
+  // the whole point of the server-side Zod check is catching what TS can't
+  // (the payload arrives over the wire as untyped JSON).
+  const createEmptyUuidQueueItem = (): ClimbQueueItem => ({ ...createTestClimb(), uuid: '' });
+
+  // A queue item with a VALID uuid but a structurally invalid `climb` payload
+  // (angle must be a number) — fails ClimbQueueItemSchema as a whole despite
+  // the uuid itself being fine. Models "this exact slot's data is corrupt",
+  // as opposed to "this slot's id is malformed".
+  const createStructurallyInvalidQueueItem = (uuid: string): ClimbQueueItem => ({
+    ...createTestClimb(uuid),
+    climb: { ...createTestClimb().climb, angle: 'not-a-number' as unknown as number },
+  });
+
+  it('drops a malformed item and keeps syncing the rest of the queue instead of rejecting the whole setQueue call', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+
+    const validItem1 = createTestClimb();
+    const validItem2 = createTestClimb();
+    const malformedItem = createEmptyUuidQueueItem();
+
+    const state = await queueMutations.setQueue(
+      {},
+      { queue: [validItem1, malformedItem, validItem2], currentClimbQueueItem: validItem1 },
+      ctxFor(sessionId),
+    );
+
+    expect(state.queue).toHaveLength(2);
+    expect(state.queue.map((item: ClimbQueueItem) => item.uuid).sort()).toEqual(
+      [validItem1.uuid, validItem2.uuid].sort(),
+    );
+    // Current wasn't the dropped item, so it survives untouched.
+    expect(state.currentClimbQueueItem?.uuid).toBe(validItem1.uuid);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Dropped 1/3 invalid queue item'));
+    expect(publishSpy).toHaveBeenCalledWith(
+      sessionId,
+      expect.objectContaining({
+        __typename: 'FullSync',
+        state: expect.objectContaining({
+          queue: expect.arrayContaining([expect.objectContaining({ uuid: validItem1.uuid })]),
+        }),
+      }),
+    );
+  });
+
+  it('clears currentClimbQueueItem to null when its own queue slot is the dropped item, instead of leaving a dangling pointer', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+
+    const currentUuid = uuidv4();
+    // The array's copy of "current" is corrupt and gets dropped by tolerant
+    // parsing...
+    const danglingQueueEntry = createStructurallyInvalidQueueItem(currentUuid);
+    const validItem = createTestClimb();
+    // ...but the caller ALSO independently sends a structurally valid
+    // currentClimbQueueItem pointing at that same uuid — a slot that no
+    // longer exists in `queue` once the array is filtered.
+    const currentClimbQueueItem = createTestClimb(currentUuid);
+
+    const state = await queueMutations.setQueue(
+      {},
+      { queue: [danglingQueueEntry, validItem], currentClimbQueueItem },
+      ctxFor(sessionId),
+    );
+
+    expect(state.queue).toHaveLength(1);
+    expect(state.queue[0]?.uuid).toBe(validItem.uuid);
+    expect(state.currentClimbQueueItem).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('currentClimbQueueItem uuid not present'));
+  });
+
+  it('still rejects the whole setQueue call when the queue array itself exceeds the 500-item size cap', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+
+    const oversizedQueue = Array.from({ length: 501 }, () => createTestClimb());
+
+    await expect(queueMutations.setQueue({}, { queue: oversizedQueue }, ctxFor(sessionId))).rejects.toThrow(
+      /Invalid queue/,
+    );
+  });
+
+  it('joinSession drops a malformed initialQueue item and still seeds the rest, instead of rejecting the whole join', async () => {
+    const sessionId = uuidv4();
+    const connectionId = 'client-join-3857';
+    await roomManager.registerClient(connectionId);
+
+    const validItem1 = createTestClimb();
+    const malformedItem = createEmptyUuidQueueItem();
+    const joinCtx = { connectionId, rateLimitTokens: 60, rateLimitLastReset: Date.now() };
+
+    const result = await sessionMutations.joinSession(
+      {},
+      {
+        sessionId,
+        boardPath: '/kilter/1/2/3/40',
+        username: 'User1',
+        initialQueue: [validItem1, malformedItem],
+      },
+      joinCtx,
+    );
+
+    expect(result.queueState).not.toBeNull();
+    expect(result.queueState?.queue).toHaveLength(1);
+    expect(result.queueState?.queue[0]?.uuid).toBe(validItem1.uuid);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Dropped 1/2 invalid initialQueue item'));
   });
 });

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -6,6 +6,7 @@ import {
   requireSessionWithReconnectGrace,
   applyRateLimit,
   validateInput,
+  parseArrayTolerant,
   MAX_RETRIES,
   RATE_LIMIT_SESSION,
   RATE_LIMIT_SESSION_OP,
@@ -14,12 +15,7 @@ import {
   RATE_LIMIT_SET_QUEUE,
   RATE_LIMIT_SET_QUEUE_OP,
 } from '../shared/helpers';
-import {
-  ClimbQueueItemSchema,
-  QueueIndexSchema,
-  QueueItemIdSchema,
-  QueueArraySchema,
-} from '../../../validation/schemas';
+import { ClimbQueueItemSchema, QueueIndexSchema, QueueItemIdSchema } from '../../../validation/schemas';
 import { logMutationMetrics } from './mutation-metrics';
 import { logger } from '../../../utils/logger';
 
@@ -385,17 +381,51 @@ export const queueMutations = {
    */
   setQueue: async (
     _: unknown,
-    { queue, currentClimbQueueItem }: { queue: ClimbQueueItem[]; currentClimbQueueItem?: ClimbQueueItem },
+    {
+      queue: rawQueue,
+      currentClimbQueueItem: rawCurrentClimbQueueItem,
+    }: { queue: ClimbQueueItem[]; currentClimbQueueItem?: ClimbQueueItem },
     ctx: ConnectionContext,
   ) => {
     const startTime = performance.now();
     await applyRateLimit(ctx, RATE_LIMIT_SET_QUEUE, RATE_LIMIT_SET_QUEUE_OP);
     const sessionId = await requireSessionWithReconnectGrace(ctx);
 
-    // Validate queue size to prevent memory exhaustion
-    validateInput(QueueArraySchema, queue, 'queue');
-    if (currentClimbQueueItem) {
-      validateInput(ClimbQueueItemSchema, currentClimbQueueItem, 'currentClimbQueueItem');
+    // Validate queue size to prevent memory exhaustion, then validate each
+    // item independently — one malformed/legacy item DROPS OUT instead of
+    // rejecting the whole setQueue call. A single non-RFC-uuid queue item
+    // used to reject the entire array here and wedge sync for a user's whole
+    // queue indefinitely (issue #3857).
+    const { items, droppedCount } = parseArrayTolerant(ClimbQueueItemSchema, rawQueue, 'queue', 500);
+    // ClimbQueueItemSchema's `.nullish()` fields infer as `T | null | undefined`,
+    // one shade looser than the hand-written `ClimbQueueItem` type (`T | null`) —
+    // both mean "absent" downstream (JSON/Redis storage, reducer `===` checks),
+    // so the cast is safe. Same shape `validateInput` callers elsewhere in this
+    // file already return without capturing/typing the result at all.
+    const queue = items as ClimbQueueItem[];
+    if (droppedCount > 0) {
+      logger.warn(
+        `[setQueue] Dropped ${droppedCount}/${Array.isArray(rawQueue) ? rawQueue.length : 0} invalid queue item(s) for session ${sessionId} instead of rejecting the whole queue.`,
+      );
+    }
+
+    let currentClimbQueueItem: ClimbQueueItem | null = null;
+    if (rawCurrentClimbQueueItem) {
+      currentClimbQueueItem = validateInput(
+        ClimbQueueItemSchema,
+        rawCurrentClimbQueueItem,
+        'currentClimbQueueItem',
+      ) as ClimbQueueItem;
+      // A current-climb pointer whose slot didn't survive tolerant parsing
+      // (or was never in `queue` at all) would dangle — clients index into
+      // `queue` by this uuid. Fall back to no current climb rather than ship
+      // a reference to a slot that isn't there.
+      if (!queue.some((item) => item.uuid === currentClimbQueueItem?.uuid)) {
+        logger.warn(
+          `[setQueue] currentClimbQueueItem uuid not present in the (post-filter) queue for session ${sessionId} — clearing current climb instead of leaving a dangling pointer.`,
+        );
+        currentClimbQueueItem = null;
+      }
     }
 
     // updateQueueState returns the prior state hashes from the same Redis
@@ -416,7 +446,7 @@ export const queueMutations = {
     // on both hashes lets a real reorder through silently while still catching
     // a true no-op.
     const { sequence, stateHash, stateHashOrdered, previousStateHash, previousStateHashOrdered } =
-      await roomManager.updateQueueState(sessionId, queue, currentClimbQueueItem || null);
+      await roomManager.updateQueueState(sessionId, queue, currentClimbQueueItem);
 
     if (
       previousStateHash !== null &&
@@ -434,7 +464,7 @@ export const queueMutations = {
       stateHash,
       stateHashOrdered,
       queue,
-      currentClimbQueueItem: currentClimbQueueItem || null,
+      currentClimbQueueItem,
     };
 
     pubsub.publishQueueEvent(sessionId, {
@@ -445,6 +475,7 @@ export const queueMutations = {
 
     logMutationMetrics('setQueue', performance.now() - startTime, sessionId, {
       queueSize: queue.length,
+      droppedCount,
     });
     return state;
   },

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -404,8 +404,10 @@ export const queueMutations = {
     // file already return without capturing/typing the result at all.
     const queue = items as ClimbQueueItem[];
     if (droppedCount > 0) {
+      // parseArrayTolerant already threw above if rawQueue weren't array-shaped,
+      // so by this point .length is always meaningful.
       logger.warn(
-        `[setQueue] Dropped ${droppedCount}/${Array.isArray(rawQueue) ? rawQueue.length : 0} invalid queue item(s) for session ${sessionId} instead of rejecting the whole queue.`,
+        `[setQueue] Dropped ${droppedCount}/${rawQueue.length} invalid queue item(s) for session ${sessionId} instead of rejecting the whole queue.`,
       );
     }
 

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -146,14 +146,17 @@ export const sessionMutations = {
         logger.warn(
           `[joinSession] Dropped ${droppedCount}/${initialQueue.length} invalid initialQueue item(s) for session ${sessionId} instead of rejecting the whole join.`,
         );
-        // Mirror setQueue's structured metrics so a dropped-item rate is
-        // queryable the same way for both seed paths, not just visible in
-        // free-text logs.
-        logMutationMetrics('joinSession', performance.now() - seedValidationStartTime, sessionId, {
-          droppedCount,
-          initialQueueLength: initialQueue.length,
-        });
       }
+      // Always emitted (not just on a drop) so droppedCount/initialQueueLength
+      // is queryable as a rate across every seeded join, mirroring setQueue's
+      // structured metrics. Note the duration here covers only this
+      // validation window, not the full joinSession call — this resolver
+      // doesn't track overall timing elsewhere (unlike queue/mutations.ts),
+      // and adding that is a larger, separate change than this drop-metric.
+      logMutationMetrics('joinSession', performance.now() - seedValidationStartTime, sessionId, {
+        droppedCount,
+        initialQueueLength: initialQueue.length,
+      });
     }
     let seedCurrentClimb: ClimbQueueItem | null = null;
     if (initialCurrentClimb) {

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -10,6 +10,7 @@ import {
   requireSessionMember,
   applyRateLimit,
   validateInput,
+  parseArrayTolerant,
   RATE_LIMIT_SESSION,
   RATE_LIMIT_SESSION_OP,
   RATE_LIMIT_JOIN_SESSION,
@@ -33,7 +34,6 @@ import {
   ClimbQueueItemSchema,
   ClimbUuidSchema,
   BoardSerialSchema,
-  QueueArraySchema,
 } from '../../../validation/schemas';
 import { logger } from '../../../utils/logger';
 import { markErrorReported } from '../../../utils/sentry-dedupe';
@@ -128,8 +128,42 @@ export const sessionMutations = {
     if (avatarUrl) validateInput(AvatarUrlSchema, avatarUrl, 'avatarUrl');
     if (participantId) validateInput(ParticipantIdSchema, participantId, 'participantId');
     if (sessionName) validateInput(SessionNameSchema, sessionName, 'sessionName');
-    if (initialQueue) validateInput(QueueArraySchema, initialQueue, 'initialQueue');
-    if (initialCurrentClimb) validateInput(ClimbQueueItemSchema, initialCurrentClimb, 'initialCurrentClimb');
+
+    // Validate the seed queue tolerantly — one malformed/legacy item must not
+    // sink the whole join. Same class of bug as setQueue (issue #3857): a
+    // single non-RFC-uuid queue item used to reject the entire initialQueue
+    // and wedge party-session seeding on join.
+    let seedQueue: ClimbQueueItem[] | undefined;
+    if (initialQueue) {
+      const { items, droppedCount } = parseArrayTolerant(ClimbQueueItemSchema, initialQueue, 'initialQueue', 500);
+      // ClimbQueueItemSchema's `.nullish()` fields infer as `T | null | undefined`,
+      // one shade looser than the hand-written `ClimbQueueItem` type (`T | null`)
+      // — both mean "absent" downstream, so the cast is safe (see setQueue).
+      seedQueue = items as ClimbQueueItem[];
+      if (droppedCount > 0) {
+        logger.warn(
+          `[joinSession] Dropped ${droppedCount}/${initialQueue.length} invalid initialQueue item(s) for session ${sessionId} instead of rejecting the whole join.`,
+        );
+      }
+    }
+    let seedCurrentClimb: ClimbQueueItem | null = null;
+    if (initialCurrentClimb) {
+      seedCurrentClimb = validateInput(
+        ClimbQueueItemSchema,
+        initialCurrentClimb,
+        'initialCurrentClimb',
+      ) as ClimbQueueItem;
+      // A current-climb pointer whose slot didn't survive tolerant parsing
+      // would dangle — only check membership when we actually filtered a
+      // seed queue; a caller seeding just a current climb (no queue) is an
+      // existing, independently-valid combination.
+      if (seedQueue && !seedQueue.some((item) => item.uuid === seedCurrentClimb?.uuid)) {
+        logger.warn(
+          `[joinSession] initialCurrentClimb uuid not present in the (post-filter) initialQueue for session ${sessionId} — clearing seed current climb instead of leaving a dangling pointer.`,
+        );
+        seedCurrentClimb = null;
+      }
+    }
 
     const result = await roomManager.joinSession(
       ctx.connectionId,
@@ -137,8 +171,8 @@ export const sessionMutations = {
       boardPath,
       username || undefined,
       avatarUrl || undefined,
-      initialQueue,
-      initialCurrentClimb || null,
+      seedQueue,
+      seedCurrentClimb,
       sessionName || undefined,
       participantId || undefined,
     );

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -47,6 +47,7 @@ import { autoSyncSessionToIntegrations } from '../../../integrations/export-serv
 import { normalizeIanaTimezone } from '../../../utils/timezone';
 import { endLiveActivity } from '../../../services/apns';
 import { buildSessionPayload } from './helpers';
+import { logMutationMetrics } from '../queue/mutation-metrics';
 
 /**
  * `isLeader` audit (always-live sessions):
@@ -135,6 +136,7 @@ export const sessionMutations = {
     // and wedge party-session seeding on join.
     let seedQueue: ClimbQueueItem[] | undefined;
     if (initialQueue) {
+      const seedValidationStartTime = performance.now();
       const { items, droppedCount } = parseArrayTolerant(ClimbQueueItemSchema, initialQueue, 'initialQueue', 500);
       // ClimbQueueItemSchema's `.nullish()` fields infer as `T | null | undefined`,
       // one shade looser than the hand-written `ClimbQueueItem` type (`T | null`)
@@ -144,6 +146,13 @@ export const sessionMutations = {
         logger.warn(
           `[joinSession] Dropped ${droppedCount}/${initialQueue.length} invalid initialQueue item(s) for session ${sessionId} instead of rejecting the whole join.`,
         );
+        // Mirror setQueue's structured metrics so a dropped-item rate is
+        // queryable the same way for both seed paths, not just visible in
+        // free-text logs.
+        logMutationMetrics('joinSession', performance.now() - seedValidationStartTime, sessionId, {
+          droppedCount,
+          initialQueueLength: initialQueue.length,
+        });
       }
     }
     let seedCurrentClimb: ClimbQueueItem | null = null;

--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -9,8 +9,8 @@ import { esp32Controllers, boardSessionParticipants } from '@boardsesh/db/schema
 import { and, eq } from 'drizzle-orm';
 import { logger } from '../../../utils/logger';
 
-// Re-export validateInput from validation schemas
-export { validateInput } from '../../../validation/schemas';
+// Re-export validateInput / parseArrayTolerant from validation schemas
+export { validateInput, parseArrayTolerant } from '../../../validation/schemas';
 // Re-export MAX_RETRIES from types
 export { MAX_RETRIES } from './types';
 export { isNoMatchClimb, isNoMatch } from '@boardsesh/shared-schema';

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -126,11 +126,6 @@ export const ClimbQueueItemSchema = z.object({
 });
 
 /**
- * Queue array validation schema (with size limit)
- */
-export const QueueArraySchema = z.array(ClimbQueueItemSchema).max(500, 'Queue too large');
-
-/**
  * Climb search input validation schema
  */
 export const ClimbSearchInputSchema = z.object({

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -107,7 +107,17 @@ export const QueueItemUserSchema = z.object({
  * ClimbQueueItem validation schema
  */
 export const ClimbQueueItemSchema = z.object({
-  uuid: z.string().uuid('Invalid UUID format'),
+  // Opaque client-minted queue-slot id — NOT an Aurora climb uuid (that's
+  // climb.uuid below). Only needs to be unique and bounded, so it uses the
+  // same lenient ExternalUUIDSchema as climb.uuid rather than strict RFC-4122
+  // parsing. Historical/peer-synced queue items (and the transient
+  // `playlist-peek:<uuid>` id minted client-side, see @boardsesh/queue's
+  // playlist-suggestions.ts) are not always dash-formatted v4 uuids — strict
+  // parsing here rejected the WHOLE queue on `setQueue` for one such item
+  // (issue #3857), the same class of bug PR #419 already fixed for
+  // `climb.uuid` above. RFC-strictness bought no safety: the reducer and this
+  // schema only ever compare the field with `===`, never parse it.
+  uuid: ExternalUUIDSchema,
   climb: ClimbInputSchema,
   addedBy: z.string().max(100).nullish(),
   addedByUser: QueueItemUserSchema.nullish(),

--- a/packages/backend/src/validation/schemas/primitives.ts
+++ b/packages/backend/src/validation/schemas/primitives.ts
@@ -160,3 +160,40 @@ export function validateInput<T>(schema: z.ZodSchema<T>, data: unknown, fieldNam
   }
   return result.data;
 }
+
+/**
+ * Parse an array input leniently: enforce the length cap on the raw payload
+ * (memory-exhaustion guard), then validate each element independently and
+ * DROP any element that fails `itemSchema` instead of rejecting the whole
+ * array. `z.array(itemSchema).safeParse` fails the ENTIRE array on one bad
+ * element, which is the wrong failure mode for a client-authoritative batch
+ * sync — one legacy/malformed queue item used to wedge `setQueue` for a
+ * user's whole queue indefinitely (issue #3857). Use this wherever losing the
+ * whole batch is worse than silently dropping one bad element (the drop is
+ * observable via the returned count) — e.g. `setQueue`'s `queue` and
+ * `joinSession`'s `initialQueue`. Single-item mutations should keep using
+ * `validateInput` and hard-reject; that's a normal, expected failure there.
+ */
+export function parseArrayTolerant<T>(
+  itemSchema: z.ZodSchema<T>,
+  data: unknown,
+  fieldName: string,
+  maxLength: number,
+): { items: T[]; droppedCount: number } {
+  const arrayResult = z.array(z.unknown()).max(maxLength, `${fieldName} too large`).safeParse(data);
+  if (!arrayResult.success) {
+    const errors = arrayResult.error.issues.map((issue) => issue.message).join(', ');
+    throw new Error(`Invalid ${fieldName}: ${errors}`);
+  }
+  const items: T[] = [];
+  let droppedCount = 0;
+  for (const rawItem of arrayResult.data) {
+    const itemResult = itemSchema.safeParse(rawItem);
+    if (itemResult.success) {
+      items.push(itemResult.data);
+    } else {
+      droppedCount++;
+    }
+  }
+  return { items, droppedCount };
+}

--- a/packages/backend/src/validation/schemas/primitives.ts
+++ b/packages/backend/src/validation/schemas/primitives.ts
@@ -180,7 +180,10 @@ export function parseArrayTolerant<T>(
   fieldName: string,
   maxLength: number,
 ): { items: T[]; droppedCount: number } {
-  const arrayResult = z.array(z.unknown()).max(maxLength, `${fieldName} too large`).safeParse(data);
+  // Don't repeat fieldName in the inner message — the outer `throw` below
+  // already prefixes it (`Invalid ${fieldName}: ...`), so a per-issue
+  // "${fieldName} too large" would read as "Invalid queue: queue too large".
+  const arrayResult = z.array(z.unknown()).max(maxLength, 'too large').safeParse(data);
   if (!arrayResult.success) {
     const errors = arrayResult.error.issues.map((issue) => issue.message).join(', ');
     throw new Error(`Invalid ${fieldName}: ${errors}`);


### PR DESCRIPTION
## Summary

Fixes #3857 — `setQueue` (and `joinSession`'s `initialQueue` seed) rejected the **entire** queue whenever one item's wrapper `uuid` wasn't a strict RFC-4122 uuid, permanently wedging party-session sync for any user with a legacy or peer-synced non-RFC id sitting in their queue. Sentry: `BOARDSESH-83`, 116 events / 23 users, `environment=production`, ongoing since 2026-06-28.

**Root cause.** `ClimbQueueItemSchema.uuid` (`packages/backend/src/validation/schemas/climbs.ts`) used `z.string().uuid(...)` — strict RFC-4122 — while every sibling id field in the schema already uses the lenient `ExternalUUIDSchema` (bounded, non-empty string). The wrapper `uuid` is an opaque client-minted queue-slot id, not an Aurora climb uuid; it's only ever compared with `===`, never parsed. This is the exact same class of bug **PR #419** already fixed for `climb.uuid` (Aurora climb ids are 32-char hex without dashes) — that fix touched `ClimbInputSchema.uuid` but missed the sibling wrapper field a few lines below.

**Fix (backend-only, this PR):**
1. Relax `ClimbQueueItemSchema.uuid` to `ExternalUUIDSchema`, matching #419's precedent.
2. Add `parseArrayTolerant` (`validation/schemas/primitives.ts`): validates each item in a batch independently and **drops only the malformed ones** instead of failing the whole array — because `z.array(itemSchema).safeParse` fails the entire array on one bad element, which is the wrong failure mode for a client-authoritative batch sync. Applied to `setQueue`'s `queue` and `joinSession`'s `initialQueue`. Dropped items are logged (`logger.warn`, with a count) and surfaced via `logMutationMetrics`'s `droppedCount`. Single-item mutations (`addQueueItem`, `replaceQueueItem`, `setCurrentClimb`, standalone `currentClimbQueueItem`) keep hard-rejecting on invalid input — that's a normal, expected failure there, not a "whole batch" loss.
3. **Dangling-current-pointer handling**, decided and tested deliberately: if the item a `currentClimbQueueItem` pointer refers to doesn't survive tolerant parsing (or was never in the queue to begin with), the pointer is cleared to `null` rather than left dangling — clients index into `queue` by that uuid, so a dangling reference would either silently break the "current climb" highlight or crash a naive `.find()`-based lookup. `null` (no current climb) mirrors existing semantics used elsewhere in the reducer (e.g. session teardown) rather than surprising the user by auto-activating an arbitrary queue item.

**Tradeoff, called out explicitly:** the tolerant-array-parse behavior trades a loud total failure (error toast, nothing syncs) for a silent partial drop (queue syncs minus the one bad slot, no per-item toast). This is intentional — queue loss is worse than one skipped item — but it is a real behavior change, mitigated by structured server-side logging (`logger.warn` + `logMutationMetrics.droppedCount`) so drops stay observable even without a client-visible signal.

**Out of scope, filed separately: #3878.** While tracing the seed path (`createSessionWithConfig` → `setQueueMutation` → `setSessionId`), found that **any** seed failure — not just this uuid rejection — is caught, reported, and swallowed, then `setSessionId` still runs unconditionally, mounting the `queueUpdates` subscription whose empty-room initial `FullSync` overwrites the live in-memory queue. That's a structural gap in the mobile seed lifecycle independent of this bug's root cause, so it's tracked and scoped separately rather than folded into this PR.

## Release Notes

- Party queues no longer vanish when one climb in the list has an old-style id — the rest of your queue keeps syncing instead of the whole thing getting stuck.

## Test plan

- New: `packages/backend/src/__tests__/queue-item-uuid-validation.test.ts` — `ClimbQueueItemSchema.uuid` matrix (v4 uuid, Aurora 32-char no-dash, `playlist-peek:<uuid>` transient id, 50-char boundary all accepted; empty string, missing field, 51-char all rejected) + `parseArrayTolerant` unit coverage (all-valid, mixed valid/invalid with accurate `droppedCount`, oversized-array rejection, non-array rejection).
- Extended: `packages/backend/src/__tests__/queue-sync-fixes.test.ts` — new `describe('setQueue - tolerant per-item validation (issue #3857)')`:
  - drops a malformed item, keeps syncing the rest, current climb (not the dropped item) survives untouched.
  - clears `currentClimbQueueItem` to `null` when its own queue slot is the dropped item (dangling-pointer case), logs why.
  - still rejects the whole call when the raw array exceeds the 500-item size cap (memory-exhaustion guard unchanged).
  - `joinSession`'s `initialQueue` gets the same tolerant treatment.
- Ran scoped per repo convention: `VITEST_POOL_ID=solo-issue3857 vp test run --project backend queue-sync-fixes queue-item-uuid-validation` — 40/40 passing.
- `vp check` — clean (only a pre-existing, untouched `packages/mobile/public/index.html` formatting note unrelated to this change).
- `vp run typecheck` — clean across the monorepo.

Follow-up: #3878 (mobile seed-failure → empty-FullSync queue-wipe race, filed separately).
