### PR TITLE
fix(sync): WAL + busy_timeout to stop "database is locked" (#3858)

### DIFF
--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -198,3 +198,45 @@ describe('initializeDatabase optional seed', () => {
     expect(remaining?.uuid).toBe('existing');
   });
 });
+
+// WAL persists on the file header (so it can't be checked on an in-memory DB —
+// PRAGMA journal_mode = WAL returns "memory" there), so these run file-backed.
+describe('initializeDatabase connection PRAGMAs', () => {
+  let dbDir: string;
+  let fileDb: TestSqliteDb & SQLiteDatabase;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbDir = mkdtempSync(join(tmpdir(), 'bs-conn-'));
+    dbPath = join(dbDir, 'boardsesh.db');
+    fileDb = createTestDatabase(dbPath) as unknown as TestSqliteDb & SQLiteDatabase;
+    resolveSeedAssetModuleId.mockReturnValue(null);
+    assetLocalUri.current = null;
+  });
+
+  afterEach(() => {
+    rmSync(dbDir, { recursive: true, force: true });
+  });
+
+  it('puts the main connection in WAL mode with a 5s busy_timeout', async () => {
+    await initializeDatabase(fileDb);
+
+    const journal = await fileDb.getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode');
+    expect(journal?.journal_mode?.toLowerCase()).toBe('wal');
+    const busy = await fileDb.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
+    expect(busy?.timeout).toBe(5000);
+  });
+
+  it('persists WAL on the file so a fresh connection inherits it', async () => {
+    await initializeDatabase(fileDb);
+
+    // A separately-opened connection (mirrors the per-task connection
+    // withExclusiveTransactionAsync spins up) reads WAL from the file header,
+    // but starts with the default busy_timeout of 0 — hence the per-connection set.
+    const other = createTestDatabase(dbPath) as unknown as TestSqliteDb & SQLiteDatabase;
+    const journal = await other.getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode');
+    expect(journal?.journal_mode?.toLowerCase()).toBe('wal');
+    const busy = await other.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
+    expect(busy?.timeout).toBe(0);
+  });
+});

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -13,6 +13,8 @@ import {
   setCheckpoint,
   getCheckpointKey,
   BOARD_DATA_TABLES,
+  applyBusyTimeout,
+  configureMainConnection,
 } from '@boardsesh/offline-sync';
 import { resolveSeedAssetModuleId } from './seed-asset';
 import { reportError } from '../lib/error-reporting';
@@ -127,6 +129,9 @@ async function loadOptionalSeed(db: SQLiteDatabase): Promise<void> {
   await db.execAsync(`ATTACH DATABASE '${seedPath.replace(/'/g, "''")}' AS seed`);
   try {
     await db.withExclusiveTransactionAsync(async (txn) => {
+      // The task runs on its own native connection (busy_timeout defaults to 0);
+      // wait-and-retry instead of failing instantly if the main connection is mid-write.
+      await applyBusyTimeout(txn);
       for (const table of SEEDABLE_BOARD_TABLES) {
         // Transaction extends SQLiteDatabase, so the txn reuses the helpers above.
         if (!(await isTableEmpty(txn, table))) continue;
@@ -178,6 +183,10 @@ export async function initializeDatabase(db: SQLiteDatabase): Promise<void> {
   // On failure we log (dev) and leave the handle unpublished, so getDatabaseHandle()
   // returns null and offline reads/writes degrade to no-ops instead of crashing.
   try {
+    // WAL (persists on the file, so every later connection inherits it) + busy_timeout
+    // on the main connection. Runs first, in autocommit: journal_mode can't change
+    // inside a transaction, and ensureMutationQueueTable/runMigrations open one.
+    await configureMainConnection(db);
     await ensureMutationQueueTable(db);
     await runMigrations(db);
     // Seed is wrapped in its own guard so a bad/absent asset never blocks the
@@ -217,6 +226,9 @@ export async function initializeDatabase(db: SQLiteDatabase): Promise<void> {
  */
 export async function clearUserData(db: SQLiteDatabase): Promise<void> {
   await db.withExclusiveTransactionAsync(async (txn) => {
+    // Sign-out teardown runs on its own connection concurrently with in-flight sync
+    // reads/writes; wait for the lock instead of failing instantly (BOARDSESH-A9).
+    await applyBusyTimeout(txn);
     for (const table of USER_DATA_TABLES_TO_CLEAR) {
       await txn.runAsync(`DELETE FROM ${table}`);
     }

--- a/packages/mobile/src/hooks/use-offline-mutations.ts
+++ b/packages/mobile/src/hooks/use-offline-mutations.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { enqueue, type GraphQLFetch, type OfflineDatabase } from '@boardsesh/offline-sync';
+import { applyBusyTimeout, enqueue, type GraphQLFetch, type OfflineDatabase } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../offline/offline-sync-adapter';
 import type { SaveTickMutationVariables } from '../lib/graphql/operations';
 
@@ -30,6 +30,9 @@ export async function writeTickLocal(db: OfflineDatabase, input: SaveTickInput, 
   const sessionId = input.sessionId ?? null;
 
   await db.withExclusiveTransactionAsync(async (txn) => {
+    // Own connection, busy_timeout defaults to 0 — wait for a held write lock
+    // instead of failing this offline write instantly (BOARDSESH-AB/AX).
+    await applyBusyTimeout(txn);
     await txn.runAsync(
       `INSERT INTO boardsesh_ticks (uuid, board_type, climb_uuid, angle, status,
        attempt_count, quality, difficulty, comment, climbed_at, session_id, is_mirror, is_benchmark,
@@ -70,6 +73,7 @@ export async function addFavoriteLocal(db: OfflineDatabase, input: FavoriteInput
   const now = new Date().toISOString();
 
   await db.withExclusiveTransactionAsync(async (txn) => {
+    await applyBusyTimeout(txn);
     await txn.runAsync(
       `INSERT OR IGNORE INTO user_favorites (board_name, climb_uuid, angle, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?)`,
@@ -85,6 +89,7 @@ export async function addFavoriteLocal(db: OfflineDatabase, input: FavoriteInput
 
 export async function removeFavoriteLocal(db: OfflineDatabase, input: FavoriteInput): Promise<void> {
   await db.withExclusiveTransactionAsync(async (txn) => {
+    await applyBusyTimeout(txn);
     await txn.runAsync(`DELETE FROM user_favorites WHERE board_name = ? AND climb_uuid = ? AND angle = ?`, [
       input.boardName,
       input.climbUuid,
@@ -113,6 +118,7 @@ export function useOfflineFollowUser(db: OfflineDatabase, graphqlFetch: GraphQLF
       const idempotencyKey = `add:user_follows:${followingId}`;
 
       await db.withExclusiveTransactionAsync(async (txn) => {
+        await applyBusyTimeout(txn);
         await txn.runAsync(
           `INSERT OR IGNORE INTO user_follows (following_id, created_at, updated_at)
            VALUES (?, ?, ?)`,
@@ -146,6 +152,7 @@ export function useOfflineUnfollowUser(db: OfflineDatabase, graphqlFetch: GraphQ
       const idempotencyKey = `del:user_follows:${followingId}`;
 
       await db.withExclusiveTransactionAsync(async (txn) => {
+        await applyBusyTimeout(txn);
         await txn.runAsync(`DELETE FROM user_follows WHERE following_id = ?`, [followingId]);
 
         // Cancel a not-yet-drained follow, but ALWAYS enqueue the unfollow —

--- a/packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts
+++ b/packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts
@@ -1,0 +1,81 @@
+// Exercises the connection PRAGMA helpers against the REAL node:sqlite adapter,
+// file-backed so WAL (which persists on the file header) actually applies —
+// PRAGMA journal_mode = WAL returns "memory" on an in-memory database.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { OFFLINE_DB_BUSY_TIMEOUT_MS, applyBusyTimeout, configureMainConnection } from '../pragmas';
+import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+
+let workDir: string;
+let dbPath: string;
+let db: TestSqliteDb;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'bs-pragmas-'));
+  dbPath = join(workDir, 'boardsesh.db');
+  db = createTestDatabase(dbPath);
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('applyBusyTimeout', () => {
+  it('sets busy_timeout to the shared constant on the connection', async () => {
+    const before = await db.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
+    expect(before?.timeout).toBe(0);
+
+    await applyBusyTimeout(db);
+
+    const after = await db.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
+    expect(after?.timeout).toBe(OFFLINE_DB_BUSY_TIMEOUT_MS);
+  });
+});
+
+describe('configureMainConnection', () => {
+  it('switches the file to WAL and sets busy_timeout', async () => {
+    await configureMainConnection(db);
+
+    const journal = await db.getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode');
+    expect(journal?.journal_mode?.toLowerCase()).toBe('wal');
+    const busy = await db.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
+    expect(busy?.timeout).toBe(OFFLINE_DB_BUSY_TIMEOUT_MS);
+  });
+
+  it('persists WAL on the file header for later connections, but not busy_timeout', async () => {
+    await configureMainConnection(db);
+
+    // A second connection to the same file — the shape withExclusiveTransactionAsync
+    // opens per task (useNewConnection: true). WAL comes from the file header;
+    // busy_timeout is per-connection and resets to 0, which is exactly why every
+    // ephemeral task must call applyBusyTimeout itself.
+    const other = createTestDatabase(dbPath);
+    const journal = await other.getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode');
+    expect(journal?.journal_mode?.toLowerCase()).toBe('wal');
+    const busy = await other.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
+    expect(busy?.timeout).toBe(0);
+  });
+});
+
+describe('ephemeral transaction connection', () => {
+  it('has its own busy_timeout of 0 until applyBusyTimeout runs inside the task', async () => {
+    await configureMainConnection(db);
+
+    let insideDefault: number | undefined;
+    let insideAfterApply: number | undefined;
+    await db.withExclusiveTransactionAsync(async (txn) => {
+      // The task runs on a separate connection: it inherits WAL from the file but
+      // starts at busy_timeout = 0, regardless of the main connection's setting.
+      insideDefault = (await txn.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout'))?.timeout;
+      await applyBusyTimeout(txn);
+      insideAfterApply = (await txn.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout'))?.timeout;
+    });
+
+    expect(insideDefault).toBe(0);
+    expect(insideAfterApply).toBe(OFFLINE_DB_BUSY_TIMEOUT_MS);
+  });
+});

--- a/packages/shared/offline-sync/src/db/migrations.ts
+++ b/packages/shared/offline-sync/src/db/migrations.ts
@@ -12,6 +12,7 @@
 // loading native expo-sqlite.
 
 import { SCHEMA_STATEMENTS } from './schema';
+import { applyBusyTimeout } from './pragmas';
 import type { OfflineDatabase, SqlExecutor } from '../database';
 
 export type Migration = {
@@ -105,6 +106,9 @@ export async function runMigrations(db: OfflineDatabase): Promise<void> {
 
   for (const migration of pending) {
     await db.withExclusiveTransactionAsync(async (txn) => {
+      // Migrations run on their own connection (busy_timeout defaults to 0); wait for
+      // any straggling write on the main connection rather than failing the migration.
+      await applyBusyTimeout(txn);
       for (const statement of migration.statements) {
         await txn.execAsync(statement);
       }

--- a/packages/shared/offline-sync/src/db/pragmas.ts
+++ b/packages/shared/offline-sync/src/db/pragmas.ts
@@ -1,0 +1,57 @@
+// Connection PRAGMAs for the offline SQLite database.
+//
+// The engine runs many connections against one `boardsesh.db`: the app's main
+// connection (react-query reads, VACUUM, wal_checkpoint) plus a fresh native
+// connection per `withExclusiveTransactionAsync` task (`useNewConnection: true`),
+// which opens `BEGIN EXCLUSIVE`. Two settings keep those from colliding:
+//
+// - `journal_mode = WAL` PERSISTS in the database file header, so it is set ONCE
+//   on the main connection (configureMainConnection) and every later connection —
+//   including the ephemeral transaction ones — inherits it. WAL lets readers run
+//   against a snapshot instead of blocking on the single writer, which is what
+//   killed the read-vs-write "database is locked" throws (Sentry BOARDSESH-A9/AC).
+// - `busy_timeout` is PER CONNECTION and defaults to 0 — a contending statement
+//   fails instantly instead of waiting for the lock to clear. So it must be applied
+//   to EVERY connection, including each transaction task's own connection, or two
+//   concurrent `BEGIN EXCLUSIVE` writers still race and the loser throws
+//   immediately (BOARDSESH-AB/AX).
+
+import type { SqlExecutor } from '../database';
+
+/**
+ * How long a contending statement waits for a held lock before giving up. Five
+ * seconds comfortably covers the longest offline write (a snapshot import or a
+ * teardown delete on a large layout) without hanging a foreground interaction if
+ * something is genuinely wedged.
+ */
+export const OFFLINE_DB_BUSY_TIMEOUT_MS = 5000;
+
+/**
+ * Set `busy_timeout` on a connection. Call as the first statement of every
+ * `withExclusiveTransactionAsync` task — the task runs on its own native
+ * connection, which starts at `busy_timeout = 0`.
+ */
+export async function applyBusyTimeout(db: SqlExecutor): Promise<void> {
+  await db.execAsync(`PRAGMA busy_timeout = ${OFFLINE_DB_BUSY_TIMEOUT_MS}`);
+}
+
+/**
+ * Configure the app's main connection: switch the database file to WAL journaling
+ * (persists, so every later connection inherits it) and set this connection's
+ * `busy_timeout`. Must run in autocommit — `journal_mode` cannot change inside a
+ * transaction — so call it before any table creation or migration.
+ *
+ * WAL should always succeed on the local app-sandbox filesystem; a device that
+ * refuses it (returns something other than `wal`) still works, just without the
+ * reader/writer concurrency win, so this reads the result back and warns in dev
+ * rather than throwing.
+ */
+export async function configureMainConnection(db: SqlExecutor): Promise<void> {
+  const result = await db.getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode = WAL');
+  // NODE_ENV is the platform-free stand-in for RN's __DEV__ — this package carries
+  // no react-native globals, and Metro inlines it the same way.
+  if (process.env.NODE_ENV !== 'production' && result?.journal_mode?.toLowerCase() !== 'wal') {
+    console.warn(`[SQLite] journal_mode is "${result?.journal_mode}", expected "wal" — reads may contend with writes`);
+  }
+  await applyBusyTimeout(db);
+}

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -121,6 +121,7 @@ export { vacuumDatabase, measureReclaimableBytes } from './db/vacuum';
 export { SCHEMA_STATEMENTS } from './db/schema';
 export { runMigrations, MIGRATIONS, LATEST_SCHEMA_VERSION } from './db/migrations';
 export type { Migration } from './db/migrations';
+export { OFFLINE_DB_BUSY_TIMEOUT_MS, applyBusyTimeout, configureMainConnection } from './db/pragmas';
 
 // --- Offline board scope keys ----------------------------------------------------
 export {

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
@@ -92,6 +92,9 @@ function createMockDb() {
     runAsync: vi.fn(async (sql: string, params: unknown[]) => {
       sqlCalls.push({ sql, params });
     }),
+    // The upsert transaction sets busy_timeout via execAsync first; a no-op that
+    // stays out of sqlCalls keeps the runAsync-based assertions unchanged.
+    execAsync: vi.fn(async () => {}),
   };
   const db = {
     runAsync: vi.fn(async (sql: string, params: unknown[]) => {

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -32,6 +32,9 @@ function createMockDb() {
     runAsync: vi.fn(async (sql: string, params: unknown[]) => {
       sqlCalls.push({ sql, params });
     }),
+    // The upsert transaction sets busy_timeout via execAsync first; a no-op that
+    // stays out of sqlCalls keeps the runAsync-based assertions unchanged.
+    execAsync: vi.fn(async () => {}),
   };
   const db = {
     runAsync: vi.fn(async (sql: string, params: unknown[]) => {

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -24,6 +24,7 @@ import {
 } from './snapshot-bootstrap';
 import { parseSnapshotManifest, type SnapshotManifest } from './snapshot-manifest';
 import { findSnapshotEntry, isSnapshotEntryUsable } from './snapshot-estimate';
+import { applyBusyTimeout } from '../db/pragmas';
 import { isSigningOut, getWipeEpoch, isBackgrounded } from '../mutation-queue/drainer';
 import { parseOfflineBoardKey, type OfflineBoardScope } from '../offline-board-key';
 
@@ -237,6 +238,9 @@ async function upsertDocuments(
   // commit overhead by 10 while giving the drainer no meaningful extra window —
   // it can interleave between pages either way.
   await db.withExclusiveTransactionAsync(async (transaction) => {
+    // This page's insert runs on its own connection (busy_timeout defaults to 0);
+    // wait for a held lock instead of losing the whole page to an instant SQLITE_BUSY.
+    await applyBusyTimeout(transaction);
     for (let chunkStart = 0; chunkStart < documents.length; chunkStart += chunkSize) {
       const chunk = documents.slice(chunkStart, chunkStart + chunkSize);
       const values: SqlValue[] = [];

--- a/packages/shared/offline-sync/src/sync/scope-teardown.ts
+++ b/packages/shared/offline-sync/src/sync/scope-teardown.ts
@@ -28,6 +28,7 @@
 // a checkpoint past it.
 
 import type { OfflineDatabase, SqlExecutor, SqlValue } from '../database';
+import { applyBusyTimeout } from '../db/pragmas';
 import type { OfflineBoardScope } from '../offline-board-key';
 import { climbsScopeFilter, isSizeScopedBoard, sizeMembershipClause } from './board-scope-sql';
 import { getCheckpointKey, SCOPE_COMPLETE_PREFIX } from './checkpoints';
@@ -216,7 +217,7 @@ export async function removeBoardScopeData(params: {
     // These deletes take seconds on a 40k-climb layout; don't lose the BEGIN
     // EXCLUSIVE to a straggling write on the main connection. Same guard
     // bootstrapScopeFromSnapshot uses.
-    await txn.execAsync('PRAGMA busy_timeout = 5000');
+    await applyBusyTimeout(txn);
 
     const { sql, params: predicateParams } = orphanClimbsPredicate(scope, retainedSizeIds);
     const climbUuids = `SELECT uuid FROM board_climbs WHERE ${sql}`;

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -32,6 +32,7 @@ import {
 } from './checkpoints';
 import { getWipeEpoch, isSigningOut } from '../mutation-queue/drainer';
 import { LATEST_SCHEMA_VERSION } from '../db/migrations';
+import { applyBusyTimeout } from '../db/pragmas';
 import type { SchemaDriftReporter } from './pull-client';
 
 /** The two reference tables a snapshot carries; import order is climbs → stats. */
@@ -500,7 +501,7 @@ export async function bootstrapScopeFromSnapshot(params: {
 
         // The import can take seconds on a big layout; don't let a concurrent
         // write on the app's main connection fail it with SQLITE_BUSY.
-        await txn.execAsync('PRAGMA busy_timeout = 5000');
+        await applyBusyTimeout(txn);
         await txn.execAsync('BEGIN EXCLUSIVE');
       } catch (preTransactionError) {
         await txn.execAsync('BEGIN').catch(() => {});


### PR DESCRIPTION
## Summary

Fixes #3858.

The offline-sync engine runs many connections against one `boardsesh.db`, but the main connection was left on SQLite's default rollback journaling with `busy_timeout = 0`, so:

- a writer (snapshot import, board teardown, VACUUM) blocked every reader — a react-query local read's `prepareAsync`/`finalizeAsync` collided with it and threw `database is locked` (Sentry BOARDSESH-A9 / AC), and
- two offline writes each open their own `BEGIN EXCLUSIVE` connection (`withExclusiveTransactionAsync` uses `useNewConnection: true`) and, with `busy_timeout = 0`, the loser failed instantly instead of waiting (BOARDSESH-AB / AX).

72 events across 23 users in 14 days on the 2.2.2 App Store build, all iOS, both 18.7.8 and 26.5.2.

**The fix, in two parts:**

1. **WAL on the main connection.** `journal_mode = WAL` persists in the database file header, so setting it once in `initializeDatabase` (before `ensureMutationQueueTable` / `runMigrations`, in autocommit) converts the file and every later connection inherits it. WAL lets readers run against a snapshot instead of blocking on the single writer — that removes the read-vs-write collisions.
2. **`busy_timeout = 5000` on every connection.** `busy_timeout` is per-connection and resets to 0 on each new connection, so it's applied to the main connection *and* as the first statement of all eight `withExclusiveTransactionAsync` tasks (tick write, favorite add/remove, follow, unfollow, seed import, sign-out teardown, migrations, paged pull). Contending writers now wait-and-retry instead of throwing. The two tasks that already set it inline (scope-teardown, snapshot-bootstrap) now use the shared helper.

New shared helpers live in `@boardsesh/offline-sync` (`OFFLINE_DB_BUSY_TIMEOUT_MS`, `applyBusyTimeout`, `configureMainConnection`) so there's one source of truth instead of scattered literals.

The codebase was already written WAL-aware (storage accounting stats `-wal`/`-shm`; VACUUM does `wal_checkpoint(TRUNCATE)`) — this only turns WAL on. There is no `.db` file copy/move/delete anywhere (the seed and snapshot paths use `ATTACH`, not a file swap), so nothing can orphan the WAL sidecars.

**Deferred as monitored follow-ups** (pending the post-ship Sentry re-check): a `wal_checkpoint(TRUNCATE)` after bulk imports to keep the transient `-wal` small, and an app-level write mutex + VACUUM gate to fully serialize writers. `busy_timeout` only retries `SQLITE_BUSY` (code 5), not `SQLITE_LOCKED` (code 6, the low-volume VACUUM case), so if code-6 events persist the mutex is the next lever. PR #3755 (pausing sync/drain while backgrounded) is complementary.

## Release Notes

- Logging ticks while a board download runs no longer errors out — offline saves go through even mid-sync.
- Browsing your downloaded boards stays smooth while a sync, board removal, or storage cleanup is happening in the background.

## Test plan

- `vp test run --project offline-sync --reporter=agent` — 266 passed. New `db/__tests__/pragmas.test.ts` covers the helper unit behaviour, the file-backed WAL + busy_timeout assertions, WAL persistence across connections, and that an ephemeral transaction connection starts at `busy_timeout = 0` until `applyBusyTimeout` runs inside the task.
- `vp run test:mobile` — 537 files / 4410 tests passed. New file-backed cases in `db/__tests__/connection.test.ts` assert `initializeDatabase` leaves the main connection in WAL with a 5s `busy_timeout` and that a fresh connection inherits WAL from the file header.
- `vp run typecheck:mobile` — clean.
- `vp check` — lint clean on changed files (0 errors).
- `vp run check:mobile-bundle` — Metro bundle OK.

**Pure JS/TS — no native change, so this ships as an OTA to the 2.2.2 fleet (runtimeVersion fingerprint unchanged).** WAL is a one-way file-header conversion but fully backward-compatible: if this OTA is rolled back, old JS opening the now-WAL database simply inherits WAL and reads/writes it correctly.

### Device QA (the real lock-relief isn't reproducible in vitest — needs on-device concurrency)

Validate on a real iOS device via a `pr-<number>` OTA preview channel:

1. **Log ticks while a board download runs.** Enable offline for a large board (snapshot import / paged pull holds the exclusive lock) and, at the same time, log several ticks and open offline-backed screens. Expect: every tick saves, screens render, no `database is locked` in Sentry. An *offline* tick logged during this window must persist (previously it could be dropped silently).
2. **Remove a board while reading.** Remove a downloaded board (teardown + VACUUM) while browsing/searching that board's climbs. Expect: reads keep working, removal completes, storage number drops.
3. **Sign out mid-sync.** Trigger sign-out (`clearUserData`) while a sync is in flight. Expect: clean wipe, no lock error, next account sees no leftover data.
