### PR TITLE
fix(web): board-aware Discover + cross-board playlist clarity (#3825)

### DIFF
--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -46,6 +46,10 @@
       "title": "Won't fit your board",
       "description": "This one runs off the edge of your wall. You'll need a bigger size to send it."
     },
+    "crossBoard": {
+      "title": "Different board",
+      "description": "These climbs are for the {{board}} board — switch boards to get on them."
+    },
     "sort": {
       "ascents": "Ascents",
       "popular": "Popular",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -46,6 +46,10 @@
       "title": "No cabe en tu plafón",
       "description": "Este se sale del borde de tu pared. Necesitas un tamaño mayor para encadenarlo."
     },
+    "crossBoard": {
+      "title": "Es de otro plafón",
+      "description": "Estos bloques son para el plafón {{board}}. Cambia de plafón para probarlos."
+    },
     "sort": {
       "ascents": "Encadenes",
       "popular": "Popular",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -46,6 +46,10 @@
       "title": "Ne rentre pas sur votre board",
       "description": "Celui-ci sort du mur. Il vous faut une taille au-dessus pour l'enchaîner."
     },
+    "crossBoard": {
+      "title": "Une autre board",
+      "description": "Ces blocs sont pour la board {{board}}. Changez de board pour les grimper."
+    },
     "sort": {
       "ascents": "Enchaînements",
       "popular": "Populaires",

--- a/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
@@ -416,6 +416,31 @@ describe('ClimbsList thumbnail and row click both open the play drawer', () => {
     expect(drawerEvents[0].detail).toMatchObject({ climb: expect.objectContaining({ uuid: 'climb-0' }) });
     dispatchSpy.mockRestore();
   });
+
+  it('shows a cross-board hint instead of silently ignoring a tap on an unrenderable climb (#3825)', async () => {
+    const onClimbSelect = vi.fn();
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs.slice(0, 3)}
+        isFetching={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+        onClimbSelect={onClimbSelect}
+        unsupportedClimbs={new Set(['climb-0'])}
+      />,
+    );
+
+    // Tapping the greyed cross-board climb must not strand the user with a
+    // silent no-op — it surfaces an explanatory alert and skips selection.
+    fireEvent.click(screen.getByTestId('row-climb-0'));
+    expect(onClimbSelect).not.toHaveBeenCalled();
+    expect(await screen.findByRole('alert')).toBeDefined();
+
+    // A renderable climb still selects normally.
+    fireEvent.click(screen.getByTestId('row-climb-1'));
+    expect(onClimbSelect).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'climb-1' }));
+  });
 });
 
 describe('ClimbsList infinite scroll', () => {

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -31,6 +31,7 @@ import { useOptionalQueueActions } from '../graphql-queue';
 import { useOnboardingTourOptional } from '@/app/components/onboarding/onboarding-tour-provider';
 import { dispatchTourClimbListPick } from '@/app/components/onboarding/onboarding-tour-events';
 import { useTranslation } from 'react-i18next';
+import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import listStyles from './climbs-list.module.css';
 
 const SwipeableDrawer = dynamic(() => import('../swipeable-drawer/swipeable-drawer'), {
@@ -408,6 +409,12 @@ const ClimbsList = ({
     isFetching,
   });
 
+  // Cross-board hint: shown when a tapped climb belongs to a board the active
+  // wall can't render (#3825). The name is retained through the close
+  // transition so the message doesn't flicker to empty while fading out.
+  const [crossBoardOpen, setCrossBoardOpen] = useState(false);
+  const [crossBoardName, setCrossBoardName] = useState('');
+
   // Row / thumbnail / card-cover click: opens the play drawer with the tapped
   // climb. In solo, also sends to the wall; in party, the drawer shows the
   // climb locally without broadcasting (see previewClimbFromBrowse).
@@ -415,11 +422,15 @@ const ClimbsList = ({
     (index: number) => {
       const climb = climbs[index];
       if (!climb) return;
-      // Tap target is inert for climbs the active board can't render — the
-      // row is already greyed via the `unsupported` prop, this aligns the
-      // tap target with the visual state so a user who picks an incompatible
-      // playlist climb doesn't see a generic snackbar.
-      if (unsupportedClimbs?.has(climb.uuid)) return;
+      // Climbs the active board can't render are greyed via the `unsupported`
+      // prop. Opening the play drawer for one would strand the user, but a
+      // silent no-op reads as "nothing works" (#3825) — so instead tell them
+      // which board the climb belongs to and how to get on it.
+      if (unsupportedClimbs?.has(climb.uuid)) {
+        setCrossBoardName(getBoardDisplayName(climb.boardType ?? ''));
+        setCrossBoardOpen(true);
+        return;
+      }
       // During the onboarding tour's "climb-list" step, swallow the drawer
       // open and signal the tour — we want the user to just pick a climb so
       // the tour can advance, not fall into the play view.
@@ -460,6 +471,7 @@ const ClimbsList = ({
   const [biggerBoardOpen, setBiggerBoardOpen] = useState(false);
   const handleNeedsBiggerBoard = useCallback(() => setBiggerBoardOpen(true), []);
   const handleCloseBiggerBoard = useCallback(() => setBiggerBoardOpen(false), []);
+  const handleCloseCrossBoard = useCallback(() => setCrossBoardOpen(false), []);
 
   const handleOpenActions = useCallback((climb: Climb) => {
     if (process.env.NODE_ENV !== 'production' && !drawerRef.current) {
@@ -760,6 +772,18 @@ const ClimbsList = ({
           <Alert severity="warning" onClose={handleCloseBiggerBoard} variant="filled">
             <AlertTitle>{t('list.biggerBoard.title')}</AlertTitle>
             {t('list.biggerBoard.description')}
+          </Alert>
+        </Snackbar>
+
+        <Snackbar
+          open={crossBoardOpen}
+          autoHideDuration={4000}
+          onClose={handleCloseCrossBoard}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        >
+          <Alert severity="info" onClose={handleCloseCrossBoard} variant="filled">
+            <AlertTitle>{t('list.crossBoard.title')}</AlertTitle>
+            {t('list.crossBoard.description', { board: crossBoardName })}
           </Alert>
         </Snackbar>
       </Box>

--- a/packages/web/app/components/library/__tests__/playlist-card.test.tsx
+++ b/packages/web/app/components/library/__tests__/playlist-card.test.tsx
@@ -99,6 +99,28 @@ describe('PlaylistCard', () => {
     expect(link?.getAttribute('href')).toBe('/playlists/linked-id');
   });
 
+  it('renders the board label on the scroll variant when provided', () => {
+    render(
+      <PlaylistCard
+        name="Cross-board playlist"
+        climbCount={8}
+        boardType="tension"
+        boardLabel="Tension"
+        href="/playlists/xyz"
+        variant="scroll"
+      />,
+    );
+
+    expect(screen.getByText('Tension')).toBeDefined();
+  });
+
+  it('omits the board label when none is provided', () => {
+    render(<PlaylistCard name="No label" climbCount={4} boardType="kilter" href="/playlists/xyz" variant="scroll" />);
+
+    // The board's brand name should not appear anywhere on the card.
+    expect(screen.queryByText('Kilter')).toBeNull();
+  });
+
   it('passes isLikedClimbs through to PlaylistPreviewSquare', () => {
     mockPreviewSquare.mockClear();
 

--- a/packages/web/app/components/library/library.module.css
+++ b/packages/web/app/components/library/library.module.css
@@ -206,6 +206,18 @@
   text-overflow: ellipsis;
 }
 
+.cardBoardLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--neutral-500);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
 .cardMeta {
   font-size: 12px;
   color: var(--neutral-500);

--- a/packages/web/app/components/library/playlist-card.tsx
+++ b/packages/web/app/components/library/playlist-card.tsx
@@ -13,6 +13,9 @@ export type PlaylistCardProps = {
   climbCount: number;
   boardType: string;
   layoutId?: number | null;
+  /** Human board name (e.g. "Kilter", "Tension") shown on the scroll card so a
+   *  cross-board playlist is legible before it's opened (#3825). */
+  boardLabel?: string;
   color?: string;
   icon?: string;
   href: string;
@@ -31,6 +34,7 @@ export default function PlaylistCard({
   climbCount,
   boardType,
   layoutId,
+  boardLabel,
   color,
   icon,
   href,
@@ -103,6 +107,7 @@ export default function PlaylistCard({
         />
       </div>
       <div className={styles.cardName}>{name}</div>
+      {boardLabel && <div className={styles.cardBoardLabel}>{boardLabel}</div>}
       <div className={styles.cardMeta}>
         {climbCount} {climbCount === 1 ? 'climb' : 'climbs'}
       </div>

--- a/packages/web/app/playlists/__tests__/library-page-content.test.tsx
+++ b/packages/web/app/playlists/__tests__/library-page-content.test.tsx
@@ -63,8 +63,25 @@ vi.mock('@/app/hooks/use-my-boards', () => ({
   }),
 }));
 
+// Mutable active-session board info so tests can simulate a user browsing a
+// wall (with or without an owned board). Read lazily inside the mock.
+const mockBoardInfo: {
+  boardDetails: { board_name: string; layout_id: number } | null;
+  hasActiveQueue: boolean;
+  isHydrated: boolean;
+} = { boardDetails: null, hasActiveQueue: false, isHydrated: true };
 vi.mock('@/app/components/queue-control/queue-bridge-context', () => ({
-  useQueueBridgeBoardInfo: () => ({ boardDetails: null, hasActiveQueue: false }),
+  useQueueBridgeBoardInfo: () => mockBoardInfo,
+}));
+
+// Capture the board filter the Discover hook is called with so we can assert
+// the feed is scoped to the board the user is actually on (#3825).
+const discoverCapture = vi.hoisted(() => ({ last: null as { boardType?: string; layoutId?: number } | null }));
+vi.mock('@/app/hooks/use-discover-playlists', () => ({
+  useDiscoverPlaylists: (opts: { boardType?: string; layoutId?: number }) => {
+    discoverCapture.last = { boardType: opts.boardType, layoutId: opts.layoutId };
+    return { popular: [], recent: [], isLoading: false, isLoadingMore: false, hasMore: false, loadMore: () => {} };
+  },
 }));
 
 const mockExecuteGraphQL = vi.fn();
@@ -281,6 +298,10 @@ beforeEach(() => {
   });
   mockSession.data = { user: { id: 'user-1' } };
   mockSession.status = 'authenticated';
+  mockBoardInfo.boardDetails = null;
+  mockBoardInfo.hasActiveQueue = false;
+  mockBoardInfo.isHydrated = true;
+  discoverCapture.last = null;
 });
 
 describe('LibraryPageContent FAB orchestration', () => {
@@ -486,5 +507,72 @@ describe('LibraryPageContent FAB orchestration', () => {
       />,
     );
     expect(screen.queryByLabelText(tFromCatalog('playlists', 'library.createFab.ariaLabel'))).toBeNull();
+  });
+});
+
+describe('LibraryPageContent board-aware Discover (#3825)', () => {
+  it('scopes Discover to the active session board even when the user owns no matching board', async () => {
+    // Boardless user (no saved boards) browsing a Kilter wall — the ownership-
+    // gated auto-select can't set selectedBoard, so Discover must fall back to
+    // the active session board instead of an all-boards feed.
+    mockBoardInfo.boardDetails = { board_name: 'kilter', layout_id: 8 };
+    mockBoardInfo.hasActiveQueue = true;
+    mockBoardInfo.isHydrated = true;
+
+    render(
+      <LibraryPageContent
+        initialMyBoards={[]}
+        initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
+        boardConfigs={fakeBoardConfigs}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(discoverCapture.last).toEqual({ boardType: 'kilter', layoutId: 8 });
+    });
+  });
+
+  it('keeps Discover unfiltered when there is no board context at all', async () => {
+    mockBoardInfo.boardDetails = null;
+    mockBoardInfo.hasActiveQueue = false;
+    mockBoardInfo.isHydrated = true;
+
+    render(
+      <LibraryPageContent
+        initialMyBoards={[]}
+        initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
+        boardConfigs={fakeBoardConfigs}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(discoverCapture.last).toEqual({ boardType: undefined, layoutId: undefined });
+    });
+  });
+
+  it('prefers an explicitly selected board over the active session board', async () => {
+    // Session says Kilter, but the user picked a Tension board chip — the chip
+    // wins so Discover matches what they filtered to.
+    mockBoardInfo.boardDetails = { board_name: 'kilter', layout_id: 8 };
+    mockBoardInfo.hasActiveQueue = true;
+    mockBoardInfo.isHydrated = true;
+
+    const tensionBoard = makeBoard('tension-uuid', { boardType: 'tension', layoutId: 10 });
+    render(
+      <LibraryPageContent
+        initialMyBoards={[tensionBoard]}
+        initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
+        initialDiscoverPlaylists={{ popular: [], recent: [], popularHasMore: false, recentHasMore: false }}
+        boardConfigs={fakeBoardConfigs}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId(`filter-pick-${tensionBoard.uuid}`));
+
+    await waitFor(() => {
+      expect(discoverCapture.last).toEqual({ boardType: 'tension', layoutId: 10 });
+    });
   });
 });

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -20,6 +20,7 @@ import { useMyBoards } from '@/app/hooks/use-my-boards';
 import { useQueueBridgeBoardInfo } from '@/app/components/queue-control/queue-bridge-context';
 import { constructBoardSlugPlaylistsUrl } from '@/app/lib/url-utils';
 import { findMatchingBoard } from '@/app/lib/find-matching-board';
+import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import { deriveIsAuthenticated } from '@/app/lib/derive-auth-status';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
@@ -104,7 +105,11 @@ export default function LibraryPageContent({
   );
 
   // Get current session/queue board info to use as default selection (global route only)
-  const { boardDetails: currentBoardDetails, hasActiveQueue } = useQueueBridgeBoardInfo();
+  const {
+    boardDetails: currentBoardDetails,
+    hasActiveQueue,
+    isHydrated: isSessionHydrated,
+  } = useQueueBridgeBoardInfo();
 
   // Auto-select the matching board once boards finish loading (fallback for non-SSR paths)
   useEffect(() => {
@@ -168,6 +173,23 @@ export default function LibraryPageContent({
     candidatePlaylists: playlists,
   });
 
+  // Board-aware Discover: match the board the user is actually on so a Kilter
+  // user isn't shown an all-boards feed dominated by another board type
+  // (#3825). An explicit board chip wins; otherwise fall back to the active
+  // session / route board even when the user owns no *saved* board — the
+  // ownership-gated auto-select above (findMatchingBoard) can't cover a
+  // boardless user browsing a wall. With no board context at all, keep the
+  // multi-board feed (cards carry a board label so it's still legible).
+  const discoverBoardFilter = useMemo<{ boardType?: string; layoutId?: number }>(() => {
+    if (selectedBoard) {
+      return { boardType: selectedBoard.boardType, layoutId: selectedBoard.layoutId };
+    }
+    if (isSessionHydrated && hasActiveQueue && currentBoardDetails) {
+      return { boardType: currentBoardDetails.board_name, layoutId: currentBoardDetails.layout_id };
+    }
+    return {};
+  }, [selectedBoard, isSessionHydrated, hasActiveQueue, currentBoardDetails]);
+
   // Discover playlists — paginated horizontal scroll. Reset on board filter
   // change. Two parallel cursors (popular + recent) live inside the hook;
   // exhausted streams stop pulling additional pages.
@@ -179,8 +201,8 @@ export default function LibraryPageContent({
     hasMore: discoverHasMore,
     loadMore: loadMoreDiscover,
   } = useDiscoverPlaylists({
-    boardType: selectedBoard?.boardType,
-    layoutId: selectedBoard?.layoutId,
+    boardType: discoverBoardFilter.boardType,
+    layoutId: discoverBoardFilter.layoutId,
     pageSize: 10,
     initialData: hasInitialDiscoverData
       ? { popular: initialDiscoverPlaylists.popular, recent: initialDiscoverPlaylists.recent }
@@ -513,6 +535,7 @@ export default function LibraryPageContent({
               climbCount={p.climbCount}
               boardType={p.boardType}
               layoutId={p.layoutId}
+              boardLabel={getBoardDisplayName(p.boardType)}
               color={p.color}
               icon={p.icon}
               href={getPlaylistUrl(p.uuid)}
@@ -525,11 +548,14 @@ export default function LibraryPageContent({
 
       {/* Discover — paginated horizontal scroll, popular + recent streams
           merged client-side. Same IntersectionObserver-driven loadMore as
-          "Jump Back In". */}
-      {(discoverLoading || discoverItems.length > 0) && (
+          "Jump Back In". Held in the loading state until the persistent
+          session hydrates so a boardless user doesn't briefly see the
+          unfiltered all-boards feed before it resolves to their board
+          (#3825). */}
+      {(discoverLoading || !isSessionHydrated || discoverItems.length > 0) && (
         <PlaylistScrollSection
           title={t('library.sections.discover')}
-          loading={discoverLoading}
+          loading={discoverLoading || !isSessionHydrated}
           onLoadMore={loadMoreDiscover}
           hasMore={discoverHasMore}
           isLoadingMore={discoverLoadingMore}
@@ -541,6 +567,7 @@ export default function LibraryPageContent({
               climbCount={p.climbCount}
               boardType={p.boardType}
               layoutId={p.layoutId}
+              boardLabel={getBoardDisplayName(p.boardType)}
               color={p.color}
               icon={p.icon}
               href={getPlaylistUrl(p.uuid)}


### PR DESCRIPTION
## Summary

Closes #3825.

A boardless user browsing a Kilter wall opened the Discover tab (`/playlists`) and got a feed dominated by **Tension** recommendation playlists. Traced the reporter's session: they opened three different playlists, all confirmed Tension in prod, bounced between them in seconds with zero climb interactions, then gave up — "nothing is working."

Two root causes:

1. **Discover wasn't board-aware for the viewer.** The global `/playlists` page fetches Discover with no board filter, and the client only scoped it to a board the user *owns* (via `findMatchingBoard`). A boardless user browsing a Kilter wall kept the all-boards feed — which skews Tension (the public pool is ~2:1 Tension:Kilter, and "popular" ranks by climb count where 50-climb generated playlists lead).
2. **Cross-board playlists were a silent dead end.** For a user who *does* own a board, opening a wrong-board playlist greyed every climb and made taps silently inert — the same "nothing works with no explanation" failure.

### Changes

- **Board-aware Discover** (`library-page-content.tsx`): the rail now falls back to the active session / route board even when the user owns no *saved* board, so it matches the wall they're on. An explicit board chip still wins; with no board context at all it stays a multi-board feed. The rail is held in its loading state until the persistent session hydrates, so a boardless user never flashes the unfiltered feed before it resolves to their board.
- **Board label on cards** (`playlist-card.tsx`): Discover and Jump Back In cards now show the board's brand name (Kilter / Tension / MoonBoard) so a cross-board playlist is legible before it's opened.
- **Cross-board tap hint** (`climbs-list.tsx`): tapping a climb the active board can't render now tells you which board it's for and to switch boards, instead of a silent no-op. New `list.crossBoard` strings in en/es/fr (Spanish uses *plafón*; French per glossary).

### Not in scope — spun off

The issue comment (@artbegolli) reports **mobile-app** symptoms on iOS (unreliable add-to-playlist, can't scroll a playlist's climbs) — a different surface. Filed separately as #3891.

## Release Notes

- Discover now shows playlists for the board you're actually on — and every playlist says which board it's for, so you're not opening one you can't climb.
- Tap a climb that's for a different board and we tell you which one, instead of just doing nothing.

## Test plan

- `vp run typecheck:web` — clean.
- `vp check` — lint + format clean.
- `vp run check:i18n` + `vp run check:i18n:orphans` — clean; catalog parity test (60) green.
- `vp test run --project web` for the three touched areas (38 tests): discover-hook board-filter (session board when boardless / unfiltered with no context / explicit chip wins), card board-label render, and cross-board tap surfaces a hint instead of a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkJuDx4nCQPYQzeEjNd6Q3