### PR TITLE
fix(mobile): re-broadcast current climb once a thin queue item hydrates

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
@@ -471,5 +471,100 @@ describe('QueueProvider self-healing resolve of partially-synced climbs (#2527)'
       });
       expect(queueMutations.setCurrentClimb).not.toHaveBeenCalled();
     });
+
+    it('suppresses the echo of its own re-broadcast (no current-climb churn)', async () => {
+      http.request.mockImplementation(async (_query: string, variables: { climbUuid: string; angle: number }) => {
+        if (variables.climbUuid === 'climb-thin' && variables.angle === 25) {
+          return { climb: makeClimb('climb-thin', 25, 'V5') };
+        }
+        return { climb: null };
+      });
+
+      const snapshots = renderProvider();
+      await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+      await act(async () => {
+        snapshots.at(-1)?.setCurrentClimb(makeItem('q-thin', makeThinClimb('climb-thin')));
+      });
+      await waitFor(() => expect(queueMutations.setCurrentClimb).toHaveBeenCalledTimes(1));
+
+      // The re-broadcast carries a correlationId that the provider must have
+      // seeded into pendingCurrentClimbUpdates (via the reducer same-uuid branch).
+      const [broadcastItem, , correlationId] = queueMutations.setCurrentClimb.mock.calls.at(-1) as unknown as [
+        ClimbQueueItem,
+        boolean,
+        string,
+      ];
+      const currentBefore = snapshots.at(-1)?.state.currentClimbQueueItem;
+      expect(currentBefore?.uuid).toBe('q-thin');
+      expect(currentBefore?.climb.frames).toBe('p1r12');
+
+      // Deliver the server echo: same correlationId, a FRESH item reference, and a
+      // FOREIGN clientId — so only the correlationId guard (not the dead clientId
+      // fallback) can suppress it.
+      await act(async () => {
+        snapshots.at(-1)?.dispatch({
+          type: 'DELTA_UPDATE_CURRENT_CLIMB',
+          payload: {
+            item: { ...broadcastItem, climb: { ...broadcastItem.climb } },
+            isServerEvent: true,
+            serverCorrelationId: correlationId,
+            eventClientId: 'server-side-client',
+            myClientId: 'our-local-client',
+          },
+        });
+      });
+
+      // Suppressed → the current climb identity did not churn on the echo.
+      expect(snapshots.at(-1)?.state.currentClimbQueueItem).toBe(currentBefore);
+    });
+
+    it('does not let a late deferred echo revert a newer navigation (revert race)', async () => {
+      http.request.mockImplementation(async (_query: string, variables: { climbUuid: string; angle: number }) => {
+        if (variables.climbUuid === 'climb-thin' && variables.angle === 25) {
+          return { climb: makeClimb('climb-thin', 25, 'V5') };
+        }
+        return { climb: null };
+      });
+
+      const snapshots = renderProvider();
+      await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+      // 1) Advance onto the thin item; once it hydrates the effect re-broadcasts it.
+      await act(async () => {
+        snapshots.at(-1)?.setCurrentClimb(makeItem('q-thin', makeThinClimb('climb-thin')));
+      });
+      await waitFor(() => {
+        const calls = queueMutations.setCurrentClimb.mock.calls as unknown as Array<[ClimbQueueItem, boolean, string]>;
+        expect(calls.some(([broadcastItem]) => broadcastItem.uuid === 'q-thin')).toBe(true);
+      });
+      const thinCalls = queueMutations.setCurrentClimb.mock.calls as unknown as Array<
+        [ClimbQueueItem, boolean, string]
+      >;
+      const [thinItem, , thinCorrelationId] = thinCalls.find(([broadcastItem]) => broadcastItem.uuid === 'q-thin')!;
+
+      // 2) The user swipes to a fully-resolved climb X — current is now X.
+      await act(async () => {
+        snapshots.at(-1)?.setCurrentClimb(makeItem('q-x', makeClimb('climb-x', 25, 'V7')));
+      });
+      await waitFor(() => expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('q-x'));
+
+      // 3) q-thin's echo lands late (same correlationId, foreign clientId).
+      await act(async () => {
+        snapshots.at(-1)?.dispatch({
+          type: 'DELTA_UPDATE_CURRENT_CLIMB',
+          payload: {
+            item: { ...thinItem, climb: { ...thinItem.climb } },
+            isServerEvent: true,
+            serverCorrelationId: thinCorrelationId,
+            eventClientId: 'server-side-client',
+            myClientId: 'our-local-client',
+          },
+        });
+      });
+
+      // The late echo is suppressed — current stays X, never reverts to q-thin.
+      expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('q-x');
+    });
   });
 });

--- a/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
@@ -338,4 +338,138 @@ describe('QueueProvider self-healing resolve of partially-synced climbs (#2527)'
     });
     expect(snapshots.at(-1)?.state.queue.find((item) => item.uuid === 'q1')?.climb.name).toBe('Climb climb-thin');
   });
+
+  // #3868: when setCurrentClimb lands on a thin item the broadcast is skipped
+  // (a placeholder ClimbInput can't be sent). Once the resolve hook hydrates that
+  // slot while it's still current, the provider must re-broadcast the now-resolved
+  // climb so peers, late joiners, and a peer-held wall LED link advance.
+  describe('re-broadcasts a deferred current climb after hydration (#3868)', () => {
+    it('fires setCurrentClimb once the still-current thin item hydrates', async () => {
+      http.request.mockImplementation(async (_query: string, variables: { climbUuid: string; angle: number }) => {
+        if (variables.climbUuid === 'climb-thin' && variables.angle === 25) {
+          return { climb: makeClimb('climb-thin', 25, 'V5') };
+        }
+        return { climb: null };
+      });
+
+      const snapshots = renderProvider();
+      await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+      await act(async () => {
+        snapshots.at(-1)?.setCurrentClimb(makeItem('q-thin', makeThinClimb('climb-thin')));
+      });
+
+      // The broadcast is deferred while thin, then fires exactly once with the
+      // resolved climb and shouldAddToQueue=false (the slot is already queued).
+      await waitFor(() => expect(queueMutations.setCurrentClimb).toHaveBeenCalledTimes(1));
+      const [broadcastItem, shouldAddToQueue] = queueMutations.setCurrentClimb.mock.calls.at(-1) as unknown as [
+        ClimbQueueItem,
+        boolean,
+      ];
+      expect(broadcastItem.uuid).toBe('q-thin');
+      expect(broadcastItem.climb.uuid).toBe('climb-thin');
+      expect(broadcastItem.climb.frames).toBe('p1r12');
+      expect(shouldAddToQueue).toBe(false);
+    });
+
+    it('holds the broadcast while the item is still thin, then fires on resolve', async () => {
+      // Hold the resolve fetch open so the deferral window is observable: the
+      // mutation must NOT fire while the current climb is still a placeholder.
+      let releaseFetch: (() => void) | undefined;
+      http.request.mockImplementation(
+        async (_query: string, variables: { climbUuid: string; angle: number }) =>
+          new Promise<{ climb: Climb }>((resolve) => {
+            releaseFetch = () => resolve({ climb: makeClimb(variables.climbUuid, 25, 'V5') });
+          }),
+      );
+
+      const snapshots = renderProvider();
+      await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+      await act(async () => {
+        snapshots.at(-1)?.setCurrentClimb(makeItem('q-thin', makeThinClimb('climb-thin')));
+      });
+
+      // Current is the thin item locally, but nothing was broadcast yet.
+      await waitFor(() => expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('q-thin'));
+      await waitFor(() => expect(http.request).toHaveBeenCalled());
+      expect(queueMutations.setCurrentClimb).not.toHaveBeenCalled();
+
+      // Hydration lands → the deferred broadcast fires exactly once.
+      await act(async () => {
+        releaseFetch?.();
+      });
+      await waitFor(() => expect(queueMutations.setCurrentClimb).toHaveBeenCalledTimes(1));
+    });
+
+    it('does not re-broadcast when current moved to another climb before hydration', async () => {
+      // Hold the thin item's fetch open; a resolved climb is activated meanwhile.
+      let releaseFetch: (() => void) | undefined;
+      http.request.mockImplementation(
+        async (_query: string, variables: { climbUuid: string; angle: number }) =>
+          new Promise<{ climb: Climb }>((resolve) => {
+            releaseFetch = () => resolve({ climb: makeClimb(variables.climbUuid, 25, 'V5') });
+          }),
+      );
+
+      const snapshots = renderProvider();
+      await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+      await act(async () => {
+        snapshots.at(-1)?.setCurrentClimb(makeItem('q-thin', makeThinClimb('climb-thin')));
+      });
+      await waitFor(() => expect(http.request).toHaveBeenCalled());
+
+      // Activate a resolved climb — this broadcasts it and supersedes the deferral.
+      await act(async () => {
+        snapshots.at(-1)?.setCurrentClimb(makeItem('q-ok', makeClimb('climb-ok', 25, 'V4')));
+      });
+      await waitFor(() => expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('q-ok'));
+
+      // Let the thin item hydrate. It's no longer current, so no second broadcast.
+      await act(async () => {
+        releaseFetch?.();
+      });
+      await waitFor(() =>
+        expect(snapshots.at(-1)?.state.queue.find((item) => item.uuid === 'q-thin')?.climb.frames).toBe('p1r12'),
+      );
+
+      // Exactly one broadcast total — the resolved q-ok activation, never q-thin.
+      expect(queueMutations.setCurrentClimb).toHaveBeenCalledTimes(1);
+      // The mock is untyped (vi.fn with no declared params); bridge through
+      // `unknown` to read each call's first arg as the broadcast item.
+      const broadcastCalls = queueMutations.setCurrentClimb.mock.calls as unknown as Array<[ClimbQueueItem, boolean]>;
+      expect(broadcastCalls.map(([broadcastItem]) => broadcastItem.uuid)).toEqual(['q-ok']);
+    });
+
+    it('does not re-broadcast when the deferred item is removed before hydration', async () => {
+      let releaseFetch: (() => void) | undefined;
+      http.request.mockImplementation(
+        async (_query: string, variables: { climbUuid: string; angle: number }) =>
+          new Promise<{ climb: Climb }>((resolve) => {
+            releaseFetch = () => resolve({ climb: makeClimb(variables.climbUuid, 25, 'V5') });
+          }),
+      );
+
+      const snapshots = renderProvider();
+      await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+      await act(async () => {
+        snapshots.at(-1)?.setCurrentClimb(makeItem('q-thin', makeThinClimb('climb-thin')));
+      });
+      await waitFor(() => expect(http.request).toHaveBeenCalled());
+
+      // Remove the deferred item — the reducer nulls the current climb.
+      await act(async () => {
+        snapshots.at(-1)?.dispatch({ type: 'DELTA_REMOVE_QUEUE_ITEM', payload: { uuid: 'q-thin' } });
+      });
+      await waitFor(() => expect(snapshots.at(-1)?.state.currentClimbQueueItem).toBeNull());
+
+      // The held fetch settles against an item that's gone — nothing is broadcast.
+      await act(async () => {
+        releaseFetch?.();
+      });
+      expect(queueMutations.setCurrentClimb).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -338,9 +338,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     sessionIdRef.current = sessionId;
-    // Session teardown / switch: there's no party to re-broadcast a deferred
-    // hydrated current climb to, so drop the deferral (#3868).
-    if (!sessionId) pendingUnsyncedCurrentRef.current = null;
+    // Any session change — start, join, leave, or a direct A→B switch — drops a
+    // deferred re-broadcast (#3868). The pending ref holds only a queue-slot
+    // uuid, which is meaningless in a different session, and the new session's
+    // FullSync is authoritative; without this a late hydrate could push session
+    // A's current climb into session B for every peer.
+    pendingUnsyncedCurrentRef.current = null;
   }, [sessionId]);
 
   // showToast and t aren't stable callbacks — capture via refs so the WS

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -165,6 +165,18 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // gate rather than one captured in a stale closure.
   const queueSyncGateRef = useRef<QueueSyncGate | null>(null);
 
+  // The queue-slot uuid of a current-climb change whose broadcast was skipped
+  // because the target climb was still unresolved (a thin peer item advanced
+  // onto by next/previousClimb — see dispatchSetCurrent, #3868). We can't send a
+  // placeholder ClimbInput (uuid may be empty; name/frames are `String!`
+  // server-side), so we defer: when useQueueResolveClimbs hydrates that slot
+  // WHILE IT'S STILL CURRENT, the effect below fires the real setCurrentClimb so
+  // peers, late joiners, and a peer-held wall LED link finally advance. Cleared
+  // by any other broadcastable change (a resolved setCurrentClimb, setQueue,
+  // clearQueue) and by the effect when current moves off this slot, so a stale
+  // hydrate can never re-broadcast an item the session already moved past.
+  const pendingUnsyncedCurrentRef = useRef<string | null>(null);
+
   // The active board is the angle source of truth. Read it here so the
   // self-healing re-grade effect can compare each queued climb's display angle
   // to the live angle, and so inbound SessionBoardPathChanged events can write
@@ -709,6 +721,8 @@ export function QueueProvider({ children }: { children: ReactNode }) {
 
   const clearQueue = useCallback(() => {
     const itemsToRemove = stateRef.current.queue;
+    // A whole-queue clear supersedes any deferred current re-broadcast (#3868).
+    pendingUnsyncedCurrentRef.current = null;
     dispatch({ type: 'CLEAR_QUEUE' });
     track(SHARED_EVENTS.QueueCleared, { layoutId: activeBoardRef.current?.layoutId, totalCount: itemsToRemove.length });
     setPlaylistSuggestionSourceState(null);
@@ -730,6 +744,9 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // session mutations.
   const setQueue = useCallback(
     (queue: ClimbQueueItem[], currentClimbQueueItem?: ClimbQueueItem | null) => {
+      // A whole-queue replace sets its own current; it supersedes any deferred
+      // current re-broadcast (#3868).
+      pendingUnsyncedCurrentRef.current = null;
       dispatch({ type: 'UPDATE_QUEUE', payload: { queue, currentClimbQueueItem: currentClimbQueueItem ?? null } });
       // Keep the full queue locally, but never broadcast a placeholder/thin item
       // to peers (#2527): drop unresolved items from the wire payload (they can't
@@ -788,11 +805,17 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // required server-side), and next/previousClimb can navigate onto a
       // not-yet-hydrated peer item. The local reducer already applied the change,
       // and useQueueResolveClimbs hydrates the item within a tick. No pending
-      // correlation is tracked since no server echo will arrive.
+      // correlation is tracked since no server echo will arrive. Remember the
+      // slot so the re-broadcast effect fires once it hydrates while still
+      // current (#3868).
       if (!isClimbResolved(item.climb)) {
         if (__DEV__) console.warn('[queue] skipping setCurrentClimb sync for an unresolved climb. See #2527.');
+        pendingUnsyncedCurrentRef.current = item.uuid;
         return;
       }
+      // A real broadcast supersedes any deferred one — drop it so a late hydrate
+      // of the previously-skipped slot can't re-broadcast an item we've moved off.
+      pendingUnsyncedCurrentRef.current = null;
       coordinator.trackPendingMutation(correlationId);
       mutations.setCurrentClimb(item, shouldAddToQueue, correlationId).catch(() => {
         // In a party session the current-climb change never reached peers —
@@ -808,6 +831,49 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     },
     [coordinator, mutations, resyncQueueAfterMutationFailure, showToast, t],
   );
+
+  // Re-broadcast the current climb once a deferred thin item hydrates (#3868).
+  // dispatchSetCurrent skips the broadcast when it lands on an unresolved climb
+  // (a peer item advanced onto before it synced), recording the slot in
+  // pendingUnsyncedCurrentRef. useQueueResolveClimbs then hydrates that slot via
+  // DELTA_REPLACE_QUEUE_ITEM, which the reducer also writes onto the current
+  // climb (new identity, real name/frames) — this effect re-runs on that change.
+  // Firing the real setCurrentClimb here is the only path that tells peers, late
+  // joiners, and a peer-held wall LED link (which follows THEIR local current,
+  // updated solely by our broadcast) to advance. Without it they stay on the old
+  // climb until the next navigation.
+  useEffect(() => {
+    const pendingUuid = pendingUnsyncedCurrentRef.current;
+    if (!pendingUuid) return;
+    const current = state.currentClimbQueueItem;
+    // Current moved off the deferred slot (local nav, a peer's server-driven
+    // CurrentClimbChanged, or a removal) — drop the deferral so a stale hydrate
+    // can't re-broadcast an item the session already moved past.
+    if (!current || current.uuid !== pendingUuid) {
+      pendingUnsyncedCurrentRef.current = null;
+      return;
+    }
+    // Still thin — wait for hydration. isClimbResolved mirrors dispatchSetCurrent's
+    // skip guard exactly (a still-unresolved item can't form a valid ClimbInput).
+    if (!isClimbResolved(current.climb)) return;
+
+    // Hydrated while still current: broadcast the now-resolved climb. Fire once
+    // (clear before firing), track a fresh correlationId so the server echo is
+    // suppressed like any other of our own updates, and reuse the same failure
+    // handling as dispatchSetCurrent. Not session-gated — the shared coalescer's
+    // ensureReady no-ops in solo, matching dispatchSetCurrent. shouldAddToQueue
+    // is false: the slot is already in the queue.
+    pendingUnsyncedCurrentRef.current = null;
+    const correlationId = coordinator.generateCorrelationId();
+    coordinator.trackPendingMutation(correlationId);
+    mutations.setCurrentClimb(current, false, correlationId).catch(() => {
+      if (sessionIdRef.current) {
+        void resyncQueueAfterMutationFailure();
+      } else {
+        showToast(t('mobile.queue.actionFailed'), 'error');
+      }
+    });
+  }, [state.currentClimbQueueItem, coordinator, mutations, resyncQueueAfterMutationFailure, showToast, t]);
 
   const setCurrentClimb = useCallback(
     (item: ClimbQueueItem, options?: SetCurrentClimbOptions) => {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -338,6 +338,9 @@ export function QueueProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     sessionIdRef.current = sessionId;
+    // Session teardown / switch: there's no party to re-broadcast a deferred
+    // hydrated current climb to, so drop the deferral (#3868).
+    if (!sessionId) pendingUnsyncedCurrentRef.current = null;
   }, [sessionId]);
 
   // showToast and t aren't stable callbacks — capture via refs so the WS
@@ -502,6 +505,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         }
         return true;
       }
+      // The authoritative snapshot resets the current climb — drop any deferred
+      // re-broadcast (#3868) so a late hydrate can't re-assert a climb the server
+      // no longer has as current.
+      pendingUnsyncedCurrentRef.current = null;
       dispatch({
         type: 'INITIAL_QUEUE_DATA',
         payload: {
@@ -838,10 +845,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // pendingUnsyncedCurrentRef. useQueueResolveClimbs then hydrates that slot via
   // DELTA_REPLACE_QUEUE_ITEM, which the reducer also writes onto the current
   // climb (new identity, real name/frames) — this effect re-runs on that change.
-  // Firing the real setCurrentClimb here is the only path that tells peers, late
-  // joiners, and a peer-held wall LED link (which follows THEIR local current,
-  // updated solely by our broadcast) to advance. Without it they stay on the old
-  // climb until the next navigation.
+  // Re-broadcasting here is the only path that tells peers, late joiners, and a
+  // peer-held wall LED link (which follows THEIR local current, updated solely by
+  // our broadcast) to advance. Without it they stay on the old climb until the
+  // next navigation.
   useEffect(() => {
     const pendingUuid = pendingUnsyncedCurrentRef.current;
     if (!pendingUuid) return;
@@ -857,23 +864,18 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     // skip guard exactly (a still-unresolved item can't form a valid ClimbInput).
     if (!isClimbResolved(current.climb)) return;
 
-    // Hydrated while still current: broadcast the now-resolved climb. Fire once
-    // (clear before firing), track a fresh correlationId so the server echo is
-    // suppressed like any other of our own updates, and reuse the same failure
-    // handling as dispatchSetCurrent. Not session-gated — the shared coalescer's
-    // ensureReady no-ops in solo, matching dispatchSetCurrent. shouldAddToQueue
-    // is false: the slot is already in the queue.
-    pendingUnsyncedCurrentRef.current = null;
-    const correlationId = coordinator.generateCorrelationId();
-    coordinator.trackPendingMutation(correlationId);
-    mutations.setCurrentClimb(current, false, correlationId).catch(() => {
-      if (sessionIdRef.current) {
-        void resyncQueueAfterMutationFailure();
-      } else {
-        showToast(t('mobile.queue.actionFailed'), 'error');
-      }
-    });
-  }, [state.currentClimbQueueItem, coordinator, mutations, resyncQueueAfterMutationFailure, showToast, t]);
+    // Hydrated while still current: re-broadcast through the normal local path.
+    // dispatchSetCurrent dispatches a LOCAL DELTA_UPDATE_CURRENT_CLIMB with a
+    // fresh correlationId FIRST — for an already-current item that lands in the
+    // reducer's same-uuid branch, which now seeds the id into
+    // pendingCurrentClimbUpdates so the server echo of THIS re-broadcast is
+    // suppressed instead of re-applied. (A raw mutation with only
+    // trackPendingMutation would never seed the id, so the echo would apply
+    // unsuppressed and could revert a newer navigation.) It also clears the
+    // deferral ref, no-ops in solo via the shared coalescer, and reuses the same
+    // failure handling. shouldAddToQueue is false: the slot is already queued.
+    dispatchSetCurrent(current, false);
+  }, [state.currentClimbQueueItem, dispatchSetCurrent]);
 
   const setCurrentClimb = useCallback(
     (item: ClimbQueueItem, options?: SetCurrentClimbOptions) => {

--- a/packages/shared/queue/src/__tests__/reducer.test.ts
+++ b/packages/shared/queue/src/__tests__/reducer.test.ts
@@ -353,6 +353,40 @@ describe('DELTA_UPDATE_CURRENT_CLIMB', () => {
     expect(result.currentClimbQueueItem?.uuid).toBe('new-climb');
   });
 
+  // #3868: a LOCAL re-dispatch of the ALREADY-current climb (re-asserting it to
+  // re-light a peer's wall, or the re-broadcast of a now-hydrated current) hits
+  // the same-uuid early return. It must still seed the correlationId so the echo
+  // of the mutation being sent for it is suppressed instead of re-applied.
+  it('seeds the correlationId when a local re-dispatch targets the already-current climb', () => {
+    const item = makeClimbQueueItem({ uuid: 'climb-1' });
+    const state = makeState({ currentClimbQueueItem: item, pendingCurrentClimbUpdates: [] });
+
+    const result = queueReducer(state, {
+      type: 'DELTA_UPDATE_CURRENT_CLIMB',
+      payload: {
+        item,
+        correlationId: 'reassert-corr-1',
+      },
+    });
+    // The id is recorded so a later server echo with this correlationId is dropped...
+    expect(result.pendingCurrentClimbUpdates).toContain('reassert-corr-1');
+    // ...and nothing about the current climb (or queue) churns.
+    expect(result.currentClimbQueueItem).toBe(state.currentClimbQueueItem);
+    expect(result.queue).toBe(state.queue);
+  });
+
+  it('leaves state untouched for a local re-tap of the current climb with no correlationId', () => {
+    const item = makeClimbQueueItem({ uuid: 'climb-1' });
+    const state = makeState({ currentClimbQueueItem: item });
+
+    const result = queueReducer(state, {
+      type: 'DELTA_UPDATE_CURRENT_CLIMB',
+      payload: { item },
+    });
+    // No broadcast id ⇒ pure local no-op: same state reference back.
+    expect(result).toBe(state);
+  });
+
   // Issue #2217: a peer (or the local light bulb) activating a NEW climb should
   // slot it right after the current climb, pushing the current climb into
   // history — not append it to the end and jump the current pointer there.

--- a/packages/shared/queue/src/reducer.ts
+++ b/packages/shared/queue/src/reducer.ts
@@ -245,7 +245,20 @@ export function queueReducer<TSearchParams extends QueueSearchParams>(
       // board on every broadcast, even when the wall climb's uuid hasn't
       // changed — e.g. a member re-asserting the same climb to re-light the wall).
       if (!isServerEvent && item && state.currentClimbQueueItem?.uuid === item.uuid) {
-        return state;
+        // Nothing about the current climb changes, but when this local
+        // re-dispatch carries a correlationId a server mutation IS being sent for
+        // it (re-asserting the current climb to re-light a peer's wall, or the
+        // #3868 re-broadcast of a now-hydrated current). Record the id so the
+        // echoed CurrentClimbChanged is suppressed by the correlationId guard
+        // above instead of re-applied — an unsuppressed echo would revert a newer
+        // navigation back onto this climb. The seeding block below is unreachable
+        // from this early return, so seed here. No id ⇒ a pure local re-tap with
+        // no broadcast: leave state untouched.
+        if (!correlationId) return state;
+        return {
+          ...state,
+          pendingCurrentClimbUpdates: [...state.pendingCurrentClimbUpdates, correlationId].slice(-50),
+        };
       }
 
       let newQueue = state.queue;


### PR DESCRIPTION
## Summary

In a party session, advancing the current climb onto a **thin** queue item (a peer-added climb that hasn't finished syncing) applied the change locally but skipped the broadcast — a placeholder can't form a valid `ClimbInput` (its uuid may be empty and `name`/`frames` are `String!` server-side). `useQueueResolveClimbs` then hydrated the item **locally only**, so peers, late joiners, and a peer-held wall LED link stayed on the *previous* climb until the local user made another navigation.

This defers the broadcast instead of dropping it: when `setCurrentClimb` skips a thin item it records that queue slot, and the moment the resolve hook hydrates it **while it's still current**, the provider re-broadcasts the now-resolved climb. The wall dependency is the crux — the BLE auto-sender lights from **local** `currentClimbQueueItem`, so the navigator's own wall already recovered on hydration; but when a *different* member holds the link, their wall only advances via this broadcast.

**Echo suppression (the subtle part).** The re-broadcast targets a climb that is *already* the current one, so it can't reuse the normal path blindly. Reducer echo suppression only fires when the broadcast's `correlationId` was seeded into `pendingCurrentClimbUpdates`, and that set is populated solely by a **local** `DELTA_UPDATE_CURRENT_CLIMB` — `coordinator.trackPendingMutation` merely schedules TTL cleanup, and the clientId fallback is dead on mobile (the coordinator's clientId is a random UUID the backend never stamps). A same-uuid local dispatch used to short-circuit *before* the seeding block, so a naive re-broadcast's own echo would apply unsuppressed and could revert a newer navigation (hydrate q-thin → swipe to X → q-thin's echo drags you back). Fixed by:

- **`packages/shared/queue` reducer**: in `DELTA_UPDATE_CURRENT_CLIMB`'s same-uuid early return, a *local* re-dispatch carrying a `correlationId` now records it into `pendingCurrentClimbUpdates` before returning (this also closes the latent re-assert-current-climb gap).
- **Provider**: the re-broadcast routes through `dispatchSetCurrent(current, false)`, whose local dispatch seeds the id *before* the mutation fires, so the server echo is suppressed as usual.

The deferral is also cleared by any other broadcastable change (a resolved `setCurrentClimb`, `setQueue`, `clearQueue`), when the current climb moves off the slot, and on `INITIAL_QUEUE_DATA` (resync) / session teardown — so a stale hydrate can never re-broadcast an item the session already moved past.

Fixes #3868

## Release Notes

- Party mode: when someone lands on a climb a crewmate just added, everyone's wall and queue now catch up to it on their own — no more staying stuck on the last boulder until you swipe again.

## Test plan

- **Reducer unit tests** (`packages/shared/queue`): a local same-uuid re-dispatch with a correlationId seeds it into pending (no current-climb/queue churn); without a correlationId it's an untouched no-op.
- **Provider regression tests** (`queue-provider-resolve-climbs.test.tsx`): fires the re-broadcast once the still-current thin item hydrates (resolved item, `shouldAddToQueue: false`); holds while thin then fires on resolve; no re-broadcast when current moved / the item was removed before hydration; the re-broadcast's own echo (same correlationId, foreign clientId) is suppressed with no current-climb churn; a late deferred echo does **not** revert a newer navigation. Both suppression tests were confirmed to fail without the reducer seed.
- `vp run typecheck` (full, incl. web which consumes the shared reducer) — clean.
- `vp run test:mobile` — 4421 passed. Shared queue package — 114 passed.
- `vp check` — clean for the changed files (one pre-existing, unrelated format issue in `packages/mobile/public/index.html` on `main`, untouched here).
- `vp run check:mobile-bundle` — OK.
- QA notes (`.boardsesh/qa-notes.md`): two-member party session, member A holds the BLE link; on member B advance onto a peer-added climb before it syncs → A's wall + all members' views advance once it hydrates; plus the revert-race (swipe away before hydration) and removed-while-deferred cases.

## Residual risks

- The re-broadcast is a single mutation with echo suppression; a genuinely dropped broadcast still self-heals on the next navigation or the 60s hash watchdog, same as before.
- No native change — ships over-the-air.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkJuDx4nCQPYQzeEjNd6Q3