### PR TITLE
fix(web): exact-host allowlist for the PostHog prod gate

### DIFF
--- a/packages/web/app/lib/__tests__/analytics.test.ts
+++ b/packages/web/app/lib/__tests__/analytics.test.ts
@@ -116,8 +116,14 @@ describe('analytics wrapper', () => {
 
   it('falls back to direct PostHog ingestion when the proxy URL cannot be derived', async () => {
     vi.stubEnv('NEXT_PUBLIC_POSTHOG_HOST', '');
-    vi.stubEnv('NEXT_PUBLIC_WS_URL', '');
-    setWindowLocation('https://app.boardsesh.com/b/kilter');
+    // Every host in the production allowlist (boardsesh.com, www.boardsesh.com)
+    // is resolvable by backend-url.ts's deriveWsUrlFromHost, so "production
+    // host + no derivable proxy" isn't reachable via a real hostname anymore
+    // (it was previously only reachable through app.boardsesh.com, which the
+    // old substring-matching gate wrongly treated as production — see #3814).
+    // Mock the resolver directly to exercise analytics.ts's own defensive
+    // fallback/warning in isolation from backend-url.ts's host table.
+    vi.doMock('../backend-url', () => ({ getBackendHttpUrl: () => null }));
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { track } = await import('../analytics');
 
@@ -137,6 +143,7 @@ describe('analytics wrapper', () => {
     );
 
     consoleWarn.mockRestore();
+    vi.doUnmock('../backend-url');
   });
 
   it('does not warn about a missing key outside production hosts', async () => {
@@ -152,6 +159,21 @@ describe('analytics wrapper', () => {
 
   it('keeps Vercel tracking in previews while PostHog remains production-gated', async () => {
     setWindowLocation('https://boardsesh-preview.vercel.app/b/kilter');
+    const { track } = await import('../analytics');
+
+    track('Preview Event');
+
+    expect(mocks.vercelTrack).toHaveBeenCalledWith('Preview Event', undefined, undefined);
+    expect(mocks.PostHog).not.toHaveBeenCalled();
+    expect(mocks.posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it('regression #3814: does not leak PR-preview sessions into prod PostHog', async () => {
+    // <pr>.preview.boardsesh.com (branch-deploy.yml) CONTAINS "boardsesh.com"
+    // as a substring — the exact host that leaked into prod PostHog under the
+    // old `.includes('boardsesh.com')` gate. Vercel tracking still fires;
+    // only PostHog must stay gated.
+    setWindowLocation('https://123.preview.boardsesh.com/b/kilter');
     const { track } = await import('../analytics');
 
     track('Preview Event');

--- a/packages/web/app/lib/__tests__/production-hosts.test.ts
+++ b/packages/web/app/lib/__tests__/production-hosts.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { PRODUCTION_HOSTS, isProductionHost } from '../production-hosts';
+
+describe('isProductionHost', () => {
+  it.each(['boardsesh.com', 'www.boardsesh.com'])('treats %s as production', (hostname) => {
+    expect(isProductionHost(hostname)).toBe(true);
+  });
+
+  it.each([
+    // app.boardsesh.com is a separate deployment (standalone Expo-web export
+    // on Cloudflare Pages) and never loads this Next.js app — see
+    // docs/expo-web-deployment.md.
+    'app.boardsesh.com',
+    // The exact bug this module fixes: preview deploys contain "boardsesh.com"
+    // as a substring and must NOT match.
+    '123.preview.boardsesh.com',
+    'pr-42.preview.boardsesh.com',
+    'foo.boardsesh.com',
+    // Look-alike hosts that a substring check would also wrongly accept.
+    'boardsesh.com.evil.com',
+    'evil-boardsesh.com',
+    'boardsesh-preview.vercel.app',
+    'localhost',
+  ])('does not treat %s as production', (hostname) => {
+    expect(isProductionHost(hostname)).toBe(false);
+  });
+
+  it('exposes the exact-match host set used by the Sentry gate', () => {
+    expect(PRODUCTION_HOSTS.has('boardsesh.com')).toBe(true);
+    expect(PRODUCTION_HOSTS.has('www.boardsesh.com')).toBe(true);
+    expect(PRODUCTION_HOSTS.size).toBe(2);
+  });
+});

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -4,6 +4,7 @@ import { PostHog } from 'posthog-js-lite';
 import { createAnalytics } from '@boardsesh/analytics';
 import { analyticsPathname, isAdminAnalyticsUrl } from './analytics-paths';
 import { getBackendHttpUrl } from './backend-url';
+import { isProductionHost } from './production-hosts';
 
 // Mirror @vercel/analytics' AllowedPropertyValues so existing call sites
 // type-check unchanged when they swap to this wrapper.
@@ -22,9 +23,12 @@ function getPosthog(): PostHog | null {
   if (posthogInitAttempted) return null;
   posthogInitAttempted = true;
 
-  // Hostname-gate to production, mirroring Sentry. Dev/preview deploys stay
-  // out of the prod PostHog project.
-  if (!window.location.hostname.includes('boardsesh.com')) return null;
+  // Hostname-gate to production, mirroring Sentry (instrumentation-client.ts).
+  // Exact-host match via production-hosts.ts, NOT a substring: preview deploys
+  // run at `<pr>.preview.boardsesh.com`, which contains "boardsesh.com" and
+  // would pass a naive `.includes()` check, leaking preview sessions into the
+  // prod PostHog project (#3814).
+  if (!isProductionHost(window.location.hostname)) return null;
 
   const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
   if (!apiKey) {

--- a/packages/web/app/lib/production-hosts.ts
+++ b/packages/web/app/lib/production-hosts.ts
@@ -1,0 +1,19 @@
+// Single source of truth for "is this browser tab running on a production
+// boardsesh.com host". Exact-host match, NOT a substring: preview deploys run
+// at `<pr>.preview.boardsesh.com` (branch-deploy.yml), which CONTAINS
+// "boardsesh.com" and would pass a naive `.includes()` check. That gap let
+// every PR-preview browser session leak into prod Sentry (#3808) and prod
+// PostHog (#3814).
+//
+// Deliberately excludes app.boardsesh.com: that host is a fully separate
+// deployment (the standalone Expo-web static export served by Cloudflare
+// Pages — see docs/expo-web-deployment.md), not this Next.js app, so it can
+// never legitimately load this code.
+//
+// Shared by instrumentation-client.ts (Sentry) and analytics.ts (PostHog) so
+// the two production-gates can't drift apart the way they did before #3808.
+export const PRODUCTION_HOSTS: ReadonlySet<string> = new Set(['boardsesh.com', 'www.boardsesh.com']);
+
+export function isProductionHost(hostname: string): boolean {
+  return PRODUCTION_HOSTS.has(hostname);
+}

--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -3,15 +3,16 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
+import { isProductionHost } from './app/lib/production-hosts';
 
-// Only enable Sentry on the production boardsesh.com hosts. Exact-host match, NOT
-// a substring: preview deploys run at `<pr>.preview.boardsesh.com`
-// (branch-deploy.yml), which contains "boardsesh.com" and would pass an
-// `.includes()` check — so every PR-preview browser session (and any browser test
-// pointed at a preview host via PLAYWRIGHT_TEST_BASE_URL) leaked into the prod
-// project. Listing apex + www covers whichever the live host redirects to.
-const PRODUCTION_HOSTS = new Set(['boardsesh.com', 'www.boardsesh.com']);
-const isProductionDomain = typeof window !== 'undefined' && PRODUCTION_HOSTS.has(window.location.hostname);
+// Only enable Sentry on the production boardsesh.com hosts. Exact-host match
+// (see production-hosts.ts for why), NOT a substring: preview deploys run at
+// `<pr>.preview.boardsesh.com` (branch-deploy.yml), which contains
+// "boardsesh.com" and would pass an `.includes()` check — so every
+// PR-preview browser session (and any browser test pointed at a preview host
+// via PLAYWRIGHT_TEST_BASE_URL) leaked into the prod project. Shared with
+// analytics.ts's PostHog gate so the two production-checks can't drift apart.
+const isProductionDomain = typeof window !== 'undefined' && isProductionHost(window.location.hostname);
 
 Sentry.init({
   dsn: 'https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400',


### PR DESCRIPTION
## Summary

- `getPosthog()` in `packages/web/app/lib/analytics.ts` gated the production PostHog client with `window.location.hostname.includes('boardsesh.com')` — a **substring** match. Every PR-preview deploy runs at `<pr>.preview.boardsesh.com` (`.github/workflows/branch-deploy.yml`), which contains `"boardsesh.com"`, so preview browser sessions were sending events into the production PostHog project. Same class of bug #3808 fixed for Sentry.
- Fixed by extracting the exact-host allowlist already proven correct in `instrumentation-client.ts`'s Sentry gate (`#3808`) into a shared `packages/web/app/lib/production-hosts.ts` (`PRODUCTION_HOSTS` / `isProductionHost`), and consuming it from **both** `analytics.ts` and `instrumentation-client.ts`. Two independent literal host-sets for the same concept is exactly the failure mode that caused this bug (analytics.ts's PostHog gate drifted to a looser substring check while Sentry's got the exact-host fix) — one source of truth now.
- Deliberately excludes `app.boardsesh.com`: confirmed via `docs/expo-web-deployment.md` / `deploy/app-subdomain/README.md` that host is a fully separate deployment (the standalone Expo-web static export served by Cloudflare Pages), not this Next.js app — it can never load this code, so it was never a legitimate "production" case for this file. `instrumentation-client.ts`'s Sentry gate already excluded it for the same reason; this stays consistent.
- Checked the Vercel Analytics `track()` dual-write path in the same file for the same substring pattern — it has no hostname gate at all (Vercel's own dashboard separates preview/prod natively), so no change was needed there.

## Test plan

- New `packages/web/app/lib/__tests__/production-hosts.test.ts`: exact-match assertions for `boardsesh.com` / `www.boardsesh.com` (true) vs. `app.boardsesh.com`, `<pr>.preview.boardsesh.com`, look-alike hosts, and `localhost` (false).
- `packages/web/app/lib/__tests__/analytics.test.ts`:
  - Fixed a latent false-positive: the "falls back to direct PostHog ingestion" case used `app.boardsesh.com` as a stand-in "production" host and asserted PostHog *initializes* there — under the new exact-host gate that's correctly excluded, so the case now mocks `getBackendHttpUrl` directly to exercise the fallback in isolation instead of relying on a hostname that no longer qualifies.
  - Added a regression case for the exact reported bug: `123.preview.boardsesh.com` (a `*.boardsesh.com` substring match) must not initialize PostHog, while Vercel Analytics still fires.
- `vp check` — clean (0 errors/warnings) on all changed files.
- `vp run typecheck:web` — pass.
- `vp test run --project web --reporter=agent` — 462 files / 5783 tests pass.

## Release Notes

- [x] none (internal analytics hygiene, no user-facing change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkJuDx4nCQPYQzeEjNd6Q3