### PR TITLE
fix(mobile): stop a failed session seed from wiping the live queue

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
@@ -1,0 +1,525 @@
+// @vitest-environment jsdom
+//
+// Regression coverage for #3878: a failed session-queue seed must not let the
+// empty room's initial FullSync wipe the live in-memory queue.
+//
+// createSessionWithConfig seeds a brand-new party session with the user's
+// locally-built queue (setQueue) BEFORE setSessionId mounts the queueUpdates
+// subscription. If that seed throws (network blip, rate limit, validation
+// reject, timeout), the room stays empty server-side; the subscription's
+// FullSync for that empty room would otherwise overwrite the local queue via
+// INITIAL_QUEUE_DATA. The guard in useSessionRealtime skips that FullSync
+// (dispatch AND sync-gate tracking) and re-pushes the whole queue instead.
+//
+// Reuses the WS/HTTP/store/mutations mock harness from
+// queue-provider-sync-gate.test.tsx, extended to drive createSessionWithConfig
+// (startSession) and addToQueue from the probe.
+import { act, render, waitFor } from '@testing-library/react';
+import { createElement, useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { SessionUser, SubscriptionQueueEvent, UserBoard } from '@boardsesh/shared-schema';
+
+const ws = vi.hoisted(() => {
+  type WsEventName = 'connected' | 'closed';
+  type QueueUpdatesSink = { next: (payload: { data?: { queueUpdates?: unknown } }) => void };
+  type SessionUpdatesSink = { next: (payload: { data?: { sessionUpdates?: unknown } }) => void };
+  let queueUpdatesSink: QueueUpdatesSink | null = null;
+  let sessionUpdatesSink: SessionUpdatesSink | null = null;
+  const listeners: Record<WsEventName, Set<() => void>> = {
+    connected: new Set(),
+    closed: new Set(),
+  };
+  return {
+    getQueueUpdatesSink: () => queueUpdatesSink,
+    getSessionUpdatesSink: () => sessionUpdatesSink,
+    emit: (eventName: WsEventName) => {
+      for (const listener of listeners[eventName]) listener();
+    },
+    client: {
+      on: vi.fn((eventName: WsEventName, listener: () => void) => {
+        listeners[eventName].add(listener);
+        return () => {
+          listeners[eventName].delete(listener);
+        };
+      }),
+      subscribe: vi.fn((request: { query: string }, sink: { next: (payload: unknown) => void }) => {
+        if (request.query.includes('queueUpdates')) {
+          queueUpdatesSink = sink as QueueUpdatesSink;
+        }
+        if (request.query.includes('sessionUpdates')) {
+          sessionUpdatesSink = sink as SessionUpdatesSink;
+        }
+        return vi.fn();
+      }),
+    },
+    reset: () => {
+      queueUpdatesSink = null;
+      sessionUpdatesSink = null;
+      listeners.connected.clear();
+      listeners.closed.clear();
+    },
+  };
+});
+
+const graph = vi.hoisted(() => ({
+  execute: vi.fn(),
+}));
+
+const http = vi.hoisted(() => ({
+  request: vi.fn(),
+}));
+
+const analytics = vi.hoisted(() => ({
+  track: vi.fn(),
+}));
+
+const sessionStore = vi.hoisted(() => ({
+  getStoredSessionId: vi.fn(async () => null as string | null),
+  setStoredSessionId: vi.fn(async () => {}),
+  clearStoredSessionId: vi.fn(async () => {}),
+}));
+
+const queueSnapshotStore = vi.hoisted(() => ({
+  getStoredQueueSnapshot: vi.fn(async () => null),
+  setStoredQueueSnapshot: vi.fn(async () => {}),
+  clearStoredQueueSnapshot: vi.fn(async () => {}),
+}));
+
+const activeBoard = vi.hoisted(() => ({
+  stored: {
+    uuid: 'board-1',
+    slug: 'board-1',
+    ownerId: 'owner-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '1,2',
+    name: 'Test board',
+    isPublic: true,
+    isUnlisted: false,
+    hideLocation: false,
+    isOwned: true,
+    angle: 40,
+    isAngleAdjustable: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    totalAscents: 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+  } satisfies UserBoard,
+  getStoredActiveBoard: vi.fn(),
+  setActiveBoard: vi.fn(async () => {}),
+}));
+
+const toast = vi.hoisted(() => ({
+  showToast: vi.fn(),
+}));
+
+const errorReporter = vi.hoisted(() => ({
+  reportError: vi.fn(),
+  reportHandledError: vi.fn(),
+}));
+
+const queueMutations = vi.hoisted(() => ({
+  addQueueItem: vi.fn(async () => {}),
+  removeQueueItem: vi.fn(async () => {}),
+  reorderQueueItem: vi.fn(async () => {}),
+  setCurrentClimb: vi.fn(async () => {}),
+  mirrorCurrentClimb: vi.fn(async () => {}),
+  publishPlaybackState: vi.fn(async () => {}),
+  setQueue: vi.fn(async () => {}),
+  replaceQueueItem: vi.fn(async () => {}),
+  confirmClimbOnWall: vi.fn(async () => {}),
+  reportWallDisconnect: vi.fn(async () => {}),
+  setSessionBoardSerial: vi.fn(async () => {}),
+  setSessionBoardPath: vi.fn(async () => {}),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
+  AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
+}));
+
+vi.mock('expo-crypto', () => ({
+  randomUUID: () => 'test-correlation-id',
+}));
+
+vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/graphql-client')>()),
+  execute: graph.execute,
+}));
+
+vi.mock('@boardsesh/queue-react', () => ({
+  useQueueMutations: () => queueMutations,
+}));
+
+vi.mock('@boardsesh/play-view', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/play-view')>()),
+  emitWallConfirm: vi.fn(),
+}));
+
+vi.mock('../../lib/graphql/ws-client', () => ({
+  getWsClient: () => ws.client,
+}));
+
+vi.mock('../../lib/session-store', () => sessionStore);
+
+vi.mock('../../lib/queue-snapshot-store', () => queueSnapshotStore);
+
+vi.mock('../../lib/active-board-store', () => ({
+  getStoredActiveBoard: activeBoard.getStoredActiveBoard,
+}));
+
+vi.mock('../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: activeBoard.stored }),
+  useSetActiveBoard: () => activeBoard.setActiveBoard,
+}));
+
+vi.mock('../../lib/graphql/client', () => ({
+  getHttpClient: () => ({ request: http.request }),
+}));
+
+vi.mock('../../lib/analytics', () => analytics);
+
+vi.mock('../toast-provider', () => ({
+  useToast: () => ({ showToast: toast.showToast }),
+}));
+
+vi.mock('../queue-snackbar-provider', () => ({
+  useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
+}));
+
+vi.mock('../party-profile-provider', () => ({
+  usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
+}));
+
+vi.mock('../../lib/error-reporting', () => ({
+  reportError: errorReporter.reportError,
+  reportHandledError: errorReporter.reportHandledError,
+}));
+
+import { QueueProvider, useQueue } from '../queue-provider';
+
+type Snapshot = {
+  state: ReturnType<typeof useQueue>['state'];
+  sessionId: string | null;
+  startSession: ReturnType<typeof useQueue>['startSession'];
+  addToQueue: ReturnType<typeof useQueue>['addToQueue'];
+};
+
+function makeQueueItem(uuid: string, climbUuid = uuid): ClimbQueueItem {
+  return {
+    uuid,
+    climb: {
+      uuid: climbUuid,
+      name: `Climb ${climbUuid}`,
+      frames: 'p1r12',
+      setter_username: 'setter',
+      angle: 40,
+      ascensionist_count: 0,
+      difficulty: 'V3',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.3',
+      benchmark_difficulty: null,
+    },
+    suggested: false,
+  };
+}
+
+// Wire-shaped queue item matching SUBSCRIPTION_CLIMB_FIELDS.
+function wireItem(uuid: string, climbUuid = uuid) {
+  return {
+    uuid,
+    climb: {
+      uuid: climbUuid,
+      name: `Climb ${climbUuid}`,
+      frames: 'p1r12',
+      setter_username: 'setter',
+      angle: 40,
+      ascensionist_count: 0,
+      difficulty: 'V3',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.3',
+      benchmark_difficulty: null,
+    },
+  };
+}
+
+// FullSync nests stateHash under `state` on the real wire response — mirror it.
+function wireFullSync(
+  sequence: number,
+  stateHash: string,
+  queue: ReturnType<typeof wireItem>[] = [],
+  currentClimbQueueItem: ReturnType<typeof wireItem> | null = null,
+) {
+  return {
+    __typename: 'FullSync',
+    sequence,
+    state: { sequence, stateHash, queue, currentClimbQueueItem },
+  };
+}
+
+function wireQueueItemAdded(sequence: number, stateHash: string, item: ReturnType<typeof wireItem>) {
+  return {
+    __typename: 'QueueItemAdded',
+    sequence,
+    stateHash,
+    addedItem: item,
+    position: null,
+  };
+}
+
+const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
+  id: 'participant-1',
+  username: 'Alex',
+  isLeader: false,
+  avatarUrl: undefined,
+  userId: 'db-user-1',
+  connectionState: 'CONNECTED',
+  ...overrides,
+});
+
+function createJoinSessionResponse() {
+  return {
+    joinSession: {
+      participantId: 'participant-self',
+      clientId: 'client-self',
+      isLeader: true,
+      lastConnectedBoardSerial: null,
+      boardPath: '/kilter/1/10/1,2/40/list',
+      users: [user({ id: 'participant-self', username: 'Self', userId: 'db-self', isLeader: true })],
+    },
+  };
+}
+
+// The new session's server id. createSession resolves to this; the seed then
+// targets it (and, in these tests, rejects).
+const NEW_SESSION_ID = 'new-session-1';
+
+function routeHttpRequest() {
+  http.request.mockImplementation(async (operation: string) => {
+    if (operation.includes('CreateSession')) {
+      return { createSession: { id: NEW_SESSION_ID } };
+    }
+    if (operation.includes('GetSessionQueueState')) {
+      // The empty room: if this ever drives an INITIAL_QUEUE_DATA the queue
+      // would be wiped — the guard exists precisely so it never does here.
+      return { session: { queueState: { sequence: 0, stateHash: 'empty', queue: [], currentClimbQueueItem: null } } };
+    }
+    if (operation.includes('SessionStatus')) {
+      return { sessionStatus: 'active' };
+    }
+    return {};
+  });
+}
+
+function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
+  const queue = useQueue();
+  useEffect(() => {
+    onSnapshot({
+      state: queue.state,
+      sessionId: queue.sessionId,
+      startSession: queue.startSession,
+      addToQueue: queue.addToQueue,
+    });
+  }, [queue.state, queue.sessionId, queue.startSession, queue.addToQueue, onSnapshot]);
+  return null;
+}
+
+function renderProvider(onSnapshot: (snapshot: Snapshot) => void) {
+  return render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot })));
+}
+
+describe('QueueProvider session-seed failure guard (#3878)', () => {
+  beforeEach(() => {
+    ws.reset();
+    ws.client.on.mockClear();
+    ws.client.subscribe.mockClear();
+    activeBoard.stored = { ...activeBoard.stored };
+    activeBoard.getStoredActiveBoard.mockReset();
+    activeBoard.getStoredActiveBoard.mockResolvedValue(activeBoard.stored);
+    activeBoard.setActiveBoard.mockClear();
+    toast.showToast.mockClear();
+    analytics.track.mockClear();
+    errorReporter.reportError.mockClear();
+    errorReporter.reportHandledError.mockClear();
+    for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
+      mutation.mockReset();
+      mutation.mockResolvedValue(undefined);
+    }
+    // No stored session — we start solo, build a local queue, then start a
+    // fresh party session whose seed fails.
+    sessionStore.getStoredSessionId.mockReset();
+    sessionStore.getStoredSessionId.mockResolvedValue(null);
+    sessionStore.setStoredSessionId.mockClear();
+    sessionStore.clearStoredSessionId.mockClear();
+    queueSnapshotStore.getStoredQueueSnapshot.mockReset();
+    queueSnapshotStore.getStoredQueueSnapshot.mockResolvedValue(null);
+    queueSnapshotStore.clearStoredQueueSnapshot.mockClear();
+    graph.execute.mockReset();
+    graph.execute.mockResolvedValue(createJoinSessionResponse());
+    http.request.mockReset();
+    routeHttpRequest();
+  });
+
+  async function renderWithLocalQueue(itemUuids: string[]) {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+    // Solo, no session, empty queue to start.
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBeNull();
+    });
+    if (itemUuids.length > 0) {
+      await act(async () => {
+        for (const uuid of itemUuids) snapshots.at(-1)?.addToQueue(makeQueueItem(uuid));
+      });
+      await waitFor(() => {
+        expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(itemUuids);
+      });
+    }
+    return snapshots;
+  }
+
+  it('keeps the live queue and re-seeds when the seed rejects and an empty FullSync arrives', async () => {
+    // Seed (setQueue call #1) rejects; the re-seed (call #2) succeeds.
+    queueMutations.setQueue.mockReset();
+    queueMutations.setQueue.mockRejectedValueOnce(new Error('seed failed'));
+    queueMutations.setQueue.mockResolvedValue(undefined);
+
+    const snapshots = await renderWithLocalQueue(['q1', 'q2']);
+
+    await act(async () => {
+      await snapshots.at(-1)?.startSession();
+    });
+
+    // The session mounted (seed failure is swallowed, session still starts).
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe(NEW_SESSION_ID);
+    });
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    // The empty room's initial FullSync lands.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'empty-hash') } });
+    });
+    // Let the re-seed promise + any (incorrectly scheduled) dispatch settle.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The live queue survived — NOT wiped to [].
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2']);
+    // The whole local queue was re-pushed so the server catches up.
+    expect(queueMutations.setQueue).toHaveBeenCalledTimes(2);
+    const setQueueCalls = queueMutations.setQueue.mock.calls as unknown as Array<
+      [ClimbQueueItem[], ClimbQueueItem | null | undefined]
+    >;
+    const reSeedQueueArg = setQueueCalls[1][0];
+    expect(reSeedQueueArg.map((item) => item.uuid)).toEqual(['q1', 'q2']);
+    // Telemetry fired so the degraded seed lifecycle is visible in the field.
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Queue Seed FullSync Guarded',
+      expect.objectContaining({ localQueueLength: 2 }),
+    );
+  });
+
+  it('applies an empty FullSync normally when the seed failed but the local queue is empty', async () => {
+    // Local queue is empty, so createSessionWithConfig never runs the seed
+    // block (nothing to seed) and never sets the guard flag. An empty FullSync
+    // must apply as usual — there is nothing to protect and no re-seed to fire.
+    const snapshots = await renderWithLocalQueue([]);
+
+    await act(async () => {
+      await snapshots.at(-1)?.startSession();
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe(NEW_SESSION_ID);
+    });
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'empty-hash') } });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(snapshots.at(-1)?.state.queue).toEqual([]);
+    // Never a seed (empty local queue), never a re-seed, never the guard event.
+    expect(queueMutations.setQueue).not.toHaveBeenCalled();
+    expect(analytics.track).not.toHaveBeenCalledWith('Queue Seed FullSync Guarded', expect.anything());
+  });
+
+  it('skips gate tracking on the guarded FullSync so later real events still apply', async () => {
+    // The subtle half of the fix: the guarded empty FullSync must NOT advance
+    // the sync gate. If it did, the gate would baseline to the empty room's
+    // sequence (1) and hash, and (a) the 60s watchdog would resync-to-empty and
+    // (b) a genuine delta at sequence 1 would be dropped as stale. We prove the
+    // gate stayed unbaselined without a 60s timer: a QueueItemAdded at sequence
+    // 1 lands (evaluateIncoming(null, 1) → 'apply'), which would be
+    // 'ignore-stale' had the empty FullSync been tracked.
+    queueMutations.setQueue.mockReset();
+    queueMutations.setQueue.mockRejectedValueOnce(new Error('seed failed'));
+    queueMutations.setQueue.mockResolvedValue(undefined);
+
+    const snapshots = await renderWithLocalQueue(['q1', 'q2']);
+
+    await act(async () => {
+      await snapshots.at(-1)?.startSession();
+    });
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    // Guarded empty FullSync (sequence 1).
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'empty-hash') } });
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2']);
+
+    // A genuine delta at sequence 1 — applies only because the gate was NOT
+    // baselined to the skipped FullSync's sequence.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(1, 'hash-add', wireItem('q3')) } });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2', 'q3']);
+    });
+
+    // And a subsequent real, non-empty FullSync applies normally (the guard is
+    // only for the empty room — the flag is cleared once the re-seed lands).
+    act(() => {
+      queueUpdatesSink.next({
+        data: {
+          queueUpdates: wireFullSync(2, 'full-hash', [wireItem('q1'), wireItem('q2'), wireItem('q3'), wireItem('q4')]),
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2', 'q3', 'q4']);
+    });
+  });
+});

--- a/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
@@ -434,6 +434,10 @@ describe('QueueProvider session-seed failure guard (#3878)', () => {
       'Queue Seed FullSync Guarded',
       expect.objectContaining({ localQueueLength: 2 }),
     );
+    // Queue ownership moved to the session once the re-seed landed, so the solo
+    // snapshot is dropped — mirroring the happy-path seed — so a later cold start
+    // can't resurrect the pre-session queue.
+    expect(queueSnapshotStore.clearStoredQueueSnapshot).toHaveBeenCalled();
   });
 
   it('applies an empty FullSync normally when the seed failed but the local queue is empty', async () => {
@@ -598,5 +602,122 @@ describe('QueueProvider session-seed failure guard (#3878)', () => {
     // re-seeded. setQueue was called once only: the original failed seed.
     expect(queueMutations.setQueue).toHaveBeenCalledTimes(1);
     expect(analytics.track).not.toHaveBeenCalledWith('Queue Seed FullSync Guarded', expect.anything());
+  });
+
+  it('serialises the re-seed: a second empty FullSync mid-flight does not fire a duplicate write', async () => {
+    // Single-flight recovery. A second empty FullSync (e.g. a reconnect) arriving
+    // while a re-seed is still in flight must NOT start a second whole-queue
+    // write — two racing setQueue snapshots could let an older one land last.
+    let resolveReSeed: (() => void) | undefined;
+    queueMutations.setQueue.mockReset();
+    queueMutations.setQueue.mockRejectedValueOnce(new Error('seed failed')); // the seed
+    queueMutations.setQueue.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveReSeed = resolve;
+        }),
+    ); // the re-seed — held open
+    queueMutations.setQueue.mockResolvedValue(undefined);
+
+    const snapshots = await renderWithLocalQueue(['q1', 'q2']);
+    await act(async () => {
+      await snapshots.at(-1)?.startSession();
+    });
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    // First empty FullSync starts the (held-open) re-seed.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'empty-hash') } });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // Second empty FullSync while the re-seed is in flight — must be a no-op push.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(2, 'empty-hash-2') } });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // seed (1) + exactly one re-seed (1) = 2. The second empty FullSync did NOT
+    // add a third write.
+    expect(queueMutations.setQueue).toHaveBeenCalledTimes(2);
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2']);
+
+    // Let the held re-seed resolve: local still matches, so it converges.
+    await act(async () => {
+      resolveReSeed?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(queueMutations.setQueue).toHaveBeenCalledTimes(2);
+    expect(queueSnapshotStore.clearStoredQueueSnapshot).toHaveBeenCalled();
+  });
+
+  it('re-pushes the latest queue when a live edit lands while the re-seed is in flight', async () => {
+    // Snapshot check. If the user edits the queue while the re-seed is in flight,
+    // clearing the guard on the stale snapshot's success would let a later
+    // FullSync drop the new edit. The re-seed must re-push the latest state and
+    // keep the guard armed until a push reflects the current queue.
+    let resolveReSeed: (() => void) | undefined;
+    queueMutations.setQueue.mockReset();
+    queueMutations.setQueue.mockRejectedValueOnce(new Error('seed failed')); // the seed
+    queueMutations.setQueue.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveReSeed = resolve;
+        }),
+    ); // re-seed #1 (snapshot [q1, q2]) — held open
+    queueMutations.setQueue.mockResolvedValue(undefined); // re-seed #2 (latest) resolves
+
+    const snapshots = await renderWithLocalQueue(['q1', 'q2']);
+    await act(async () => {
+      await snapshots.at(-1)?.startSession();
+    });
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    // Empty FullSync starts re-seed #1, capturing snapshot [q1, q2].
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'empty-hash') } });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The user adds a climb while re-seed #1 is still in flight.
+    await act(async () => {
+      snapshots.at(-1)?.addToQueue(makeQueueItem('q3'));
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2', 'q3']);
+    });
+
+    // Resolve re-seed #1: local has drifted, so it re-pushes the latest instead
+    // of clearing the guard on the stale snapshot.
+    await act(async () => {
+      resolveReSeed?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // seed (1) + re-seed #1 (stale) + re-seed #2 (latest) = 3, and the last push
+    // carried the edited queue.
+    expect(queueMutations.setQueue).toHaveBeenCalledTimes(3);
+    const setQueueCalls = queueMutations.setQueue.mock.calls as unknown as Array<
+      [ClimbQueueItem[], ClimbQueueItem | null | undefined]
+    >;
+    expect(setQueueCalls[2][0].map((item) => item.uuid)).toEqual(['q1', 'q2', 'q3']);
+    // Converged on the latest snapshot — snapshot dropped, queue intact.
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2', 'q3']);
+    expect(queueSnapshotStore.clearStoredQueueSnapshot).toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
@@ -522,4 +522,81 @@ describe('QueueProvider session-seed failure guard (#3878)', () => {
       expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2', 'q3', 'q4']);
     });
   });
+
+  it('applies a later empty FullSync normally once the successful re-seed cleared the flag', async () => {
+    // The guard must not outlive its purpose. Once the re-seed lands, the .then
+    // clears the flag, so a SUBSEQUENT empty FullSync (the room really was
+    // emptied) is applied as usual instead of being skipped forever.
+    queueMutations.setQueue.mockReset();
+    queueMutations.setQueue.mockRejectedValueOnce(new Error('seed failed'));
+    queueMutations.setQueue.mockResolvedValue(undefined);
+
+    const snapshots = await renderWithLocalQueue(['q1', 'q2']);
+
+    await act(async () => {
+      await snapshots.at(-1)?.startSession();
+    });
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    // First empty FullSync: guarded, re-seed resolves, flag cleared in the .then.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'empty-hash') } });
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2']);
+    expect(queueMutations.setQueue).toHaveBeenCalledTimes(2);
+
+    // Second empty FullSync: the flag is gone, so it applies normally — the queue
+    // is now legitimately cleared, and no extra re-seed fires.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(2, 'empty-hash-2') } });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toEqual([]);
+    });
+    expect(queueMutations.setQueue).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies a non-empty FullSync (no skip, no re-seed) while the seed-failed flag is still set', async () => {
+    // isEmptyRoom narrowing: the guard fires ONLY for the empty room. With the
+    // flag set but the FullSync NON-empty, that FullSync is authoritative server
+    // state and must apply — dropping the isEmptyRoom check would wrongly skip it
+    // and re-seed on top of real server state.
+    queueMutations.setQueue.mockReset();
+    queueMutations.setQueue.mockRejectedValueOnce(new Error('seed failed'));
+    queueMutations.setQueue.mockResolvedValue(undefined);
+
+    const snapshots = await renderWithLocalQueue(['q1', 'q2']);
+
+    await act(async () => {
+      await snapshots.at(-1)?.startSession();
+    });
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    // No empty FullSync was delivered, so the seed-failed flag is still set when
+    // this non-empty FullSync lands.
+    act(() => {
+      queueUpdatesSink.next({
+        data: { queueUpdates: wireFullSync(1, 'server-hash', [wireItem('s1'), wireItem('s2'), wireItem('s3')]) },
+      });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['s1', 's2', 's3']);
+    });
+    // The FullSync won (server state applied) — the guard neither skipped it nor
+    // re-seeded. setQueue was called once only: the original failed seed.
+    expect(queueMutations.setQueue).toHaveBeenCalledTimes(1);
+    expect(analytics.track).not.toHaveBeenCalledWith('Queue Seed FullSync Guarded', expect.anything());
+  });
 });

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -362,6 +362,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const clearSessionRef = useRef<(options?: { notifyServer?: boolean }) => Promise<void>>(async () => {});
   const locallyEndingSessionIdRef = useRef<string | null>(null);
   const suppressedRemoteEndSessionIdRef = useRef<string | null>(null);
+  // Set by createSessionWithConfig when a new session's local-queue seed throws;
+  // read by useSessionRealtime to stop the empty-room FullSync from wiping the
+  // live queue and to trigger a re-seed instead (#3878).
+  const seedFailedSessionIdRef = useRef<string | null>(null);
 
   // Transient queue-event listeners. PlaybackStateChanged (route playback
   // party-sync) doesn't mutate queue state, so the play-drawer orchestrator
@@ -404,6 +408,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     },
   });
 
+  // Stable handle to the whole-queue seed for useSessionRealtime's re-seed after
+  // a guarded empty FullSync (#3878). A ref (not an effect dep) so a new
+  // `mutations` identity never tears down and rebuilds the subscription effect.
+  const reSeedQueueRef = useRef(mutations.setQueue);
+  reSeedQueueRef.current = mutations.setQueue;
+
   // Broadcast the session's boardPath (angle/board) to party members. The
   // shared mutation already swallows transport errors and is a true no-op in
   // solo (never lazily creates a session), so callers can fire it freely.
@@ -431,6 +441,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     stateRef,
     ensureJoined,
     setQueueMutation: mutations.setQueue,
+    seedFailedSessionIdRef,
     setSessionId,
     sessionIdRef,
     dispatch,
@@ -580,6 +591,8 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     sessionIdRef,
     participantIdRef,
     stateRef,
+    seedFailedSessionIdRef,
+    reSeedQueueRef,
     activeBoardRef,
     setActiveBoardRef,
     showToastRef,

--- a/packages/mobile/src/providers/queue/use-session-commands.ts
+++ b/packages/mobile/src/providers/queue/use-session-commands.ts
@@ -30,6 +30,13 @@ type UseSessionCommandsParams = {
   ensureJoined: (sessionIdToJoin: string) => Promise<unknown>;
   /** `mutations.setQueue` — the party-sync seed used by createSessionWithConfig. */
   setQueueMutation: (queue: ClimbQueueItem[], currentClimbQueueItem?: ClimbQueueItem | null) => Promise<void>;
+  /**
+   * Holds the id of a session whose local-queue seed threw. Set here on seed
+   * failure and read by useSessionRealtime, which then refuses to let the empty
+   * room's FullSync wipe the live queue and re-seeds instead (#3878). Cleared at
+   * the clearSession teardown boundary.
+   */
+  seedFailedSessionIdRef: React.RefObject<string | null>;
   setSessionId: React.Dispatch<React.SetStateAction<string | null>>;
   sessionIdRef: React.RefObject<string | null>;
   dispatch: React.Dispatch<QueueAction>;
@@ -63,6 +70,7 @@ export function useSessionCommands({
   stateRef,
   ensureJoined,
   setQueueMutation,
+  seedFailedSessionIdRef,
   setSessionId,
   sessionIdRef,
   dispatch,
@@ -135,6 +143,14 @@ export function useSessionCommands({
               // surviving copy and a relaunch can still recover the queue.
               await clearStoredQueueSnapshot();
             } catch (seedError) {
+              // The seed never landed server-side, so the room is empty while
+              // the local queue is the truth. Flag it BEFORE setSessionId mounts
+              // the subscription: its empty-room FullSync would otherwise wipe
+              // the live queue via INITIAL_QUEUE_DATA. useSessionRealtime reads
+              // this ref, skips that FullSync, and re-seeds instead (#3878). The
+              // local snapshot is untouched (clearStoredQueueSnapshot only runs
+              // on success above), so a relaunch can still recover regardless.
+              seedFailedSessionIdRef.current = newId;
               if (__DEV__) console.warn('[queue] session queue seed failed', seedError);
               reportHandledError(seedError, { tags: { source: 'startSessionSeed' } });
             }
@@ -205,6 +221,10 @@ export function useSessionCommands({
     // Same for the coalesced-rerun flag: a pending rerun belongs to the old
     // session and must not fire a fetch into the next one.
     resyncPendingRef.current = false;
+    // Any pending seed-failure guard belongs to the session we're tearing down
+    // (it's keyed by id, so a stale value can't match the next session anyway —
+    // this just keeps the ref tidy).
+    seedFailedSessionIdRef.current = null;
     sessionIdRef.current = null;
     setSessionId(null);
     dispatch({

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -27,6 +27,7 @@ import {
   type SessionLiveStatsEvent,
 } from '../../lib/graphql/operations';
 import { getStoredActiveBoard } from '../../lib/active-board-store';
+import { clearStoredQueueSnapshot } from '../../lib/queue-snapshot-store';
 import { toClimbQueueItem, type SubscriptionQueueItem } from '../../lib/queue-conversion';
 import { toMobileSessionRuntimeEvent } from '../../lib/session-runtime-event';
 import { track } from '../../lib/analytics';
@@ -225,6 +226,48 @@ export function useSessionRealtime({
     let joinRetryCount = 0;
     let authRefreshRejoinInProgress = false;
 
+    // Single-flight, snapshot-checked recovery for a failed session seed. The
+    // empty-room FullSync guard (below) calls this to re-push the local queue so
+    // the server catches up. Serialised so a live queue edit or a second empty
+    // FullSync mid-flight can't race two whole-queue writes — an older setQueue
+    // landing last would regress newer state. The seed-failed flag clears only
+    // once the pushed snapshot still matches local (else the latest state is
+    // re-pushed), and a converged re-seed also drops the solo snapshot, mirroring
+    // the happy-path seed in createSessionWithConfig so a stale copy can't
+    // resurrect the pre-session queue on a later cold start. Effect-scoped, so it
+    // survives subscription restarts within the session and resets per session.
+    let reSeedInFlight = false;
+    const reSeedQueueAfterFailedSeed = () => {
+      if (reSeedInFlight) return;
+      const { queue, currentClimbQueueItem } = stateRef.current;
+      if (queue.length === 0 && currentClimbQueueItem == null) return;
+      reSeedInFlight = true;
+      const pushedHash = computeQueueStateHashOrdered(queue, currentClimbQueueItem?.uuid ?? null);
+      void reSeedQueueRef
+        .current(queue, currentClimbQueueItem ?? undefined)
+        .then(() => {
+          reSeedInFlight = false;
+          if (sessionIdRef.current !== sessionId) return;
+          const { queue: latestQueue, currentClimbQueueItem: latestCurrent } = stateRef.current;
+          const latestHash = computeQueueStateHashOrdered(latestQueue, latestCurrent?.uuid ?? null);
+          if (latestHash !== pushedHash) {
+            // Local changed while the push was in flight — re-push the latest and
+            // keep the guard armed until a push reflects the current queue.
+            reSeedQueueAfterFailedSeed();
+            return;
+          }
+          // Server now matches local: retire the guard and drop the solo snapshot.
+          seedFailedSessionIdRef.current = null;
+          void clearStoredQueueSnapshot();
+        })
+        .catch((reSeedError) => {
+          reSeedInFlight = false;
+          if (__DEV__) console.warn('[queue] session queue re-seed failed', reSeedError);
+          reportHandledError(reSeedError, { tags: { source: 'startSessionSeed', op: 'reseed' } });
+          // Flag stays set: the next reconnect's empty FullSync retries.
+        });
+    };
+
     // iOS suspends the WebSocket while the app is backgrounded, so a
     // JOIN_SESSION fired now never completes and trips execute()'s 30s timeout
     // — reported as a noisy `queue-sync/join` error even though it's expected
@@ -360,9 +403,11 @@ export function useSessionRealtime({
             // authoritative: skip the empty FullSync entirely (dispatch AND gate
             // tracking, so `lastServerStateHash` stays null and the watchdog
             // stays quiet), and re-push the whole queue so the server catches up.
-            // On a successful re-seed clear the flag; on failure leave it set so
-            // the next reconnect's empty FullSync retries. `reSeedQueueRef`
-            // (mutations.setQueue) self-joins, so calling it from here is safe.
+            // The re-seed (reSeedQueueAfterFailedSeed) is single-flight and
+            // snapshot-checked: it clears the flag only when the pushed snapshot
+            // still matches local, else re-pushes the latest — so a live edit or
+            // a second empty FullSync mid-flight can't race two whole-queue
+            // writes. `reSeedQueueRef` (mutations.setQueue) self-joins.
             if (event.__typename === 'FullSync' && seedFailedSessionIdRef.current === sessionId) {
               const isEmptyRoom = event.state.queue.length === 0 && event.state.currentClimbQueueItem == null;
               const { queue: localQueue, currentClimbQueueItem: localCurrent } = stateRef.current;
@@ -374,19 +419,7 @@ export function useSessionRealtime({
                   layoutId: activeBoardRef.current?.layoutId,
                   localQueueLength: localQueue.length,
                 });
-                void reSeedQueueRef
-                  .current(localQueue, localCurrent ?? undefined)
-                  .then(() => {
-                    // Clear only once the re-seed lands, and only if we're still
-                    // on the same session — the server now holds the real queue,
-                    // so subsequent (non-empty) FullSyncs apply normally.
-                    if (sessionIdRef.current === sessionId) seedFailedSessionIdRef.current = null;
-                  })
-                  .catch((reSeedError) => {
-                    if (__DEV__) console.warn('[queue] session queue re-seed failed', reSeedError);
-                    reportHandledError(reSeedError, { tags: { source: 'startSessionSeed', op: 'reseed' } });
-                    // Flag stays set: the next reconnect's empty FullSync retries.
-                  });
+                reSeedQueueAfterFailedSeed();
                 return;
               }
               // Local is also empty (nothing to protect) or the room isn't empty

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -2,7 +2,7 @@ import { useContext, useEffect } from 'react';
 import { AppState } from 'react-native';
 import { QueryClientContext } from '@tanstack/react-query';
 import { computeQueueStateHash, computeQueueStateHashOrdered } from '@boardsesh/queue';
-import type { QueueAction, QueueState } from '@boardsesh/queue';
+import type { ClimbQueueItem, QueueAction, QueueState } from '@boardsesh/queue';
 import {
   applySessionRuntimeEvent,
   createQueueSyncGate,
@@ -117,6 +117,20 @@ type UseSessionRealtimeParams = {
   sessionIdRef: React.RefObject<string | null>;
   participantIdRef: React.RefObject<string | null>;
   stateRef: React.RefObject<QueueState>;
+  /**
+   * Set by createSessionWithConfig to the id of a session whose local-queue seed
+   * failed. While it matches this session, the empty-room FullSync is treated as
+   * a stale artefact of the failed seed rather than authoritative: it's skipped
+   * (dispatch AND gate tracking) so it can't wipe the live queue, and a re-seed
+   * via `reSeedQueueRef` re-pushes the local queue (#3878).
+   */
+  seedFailedSessionIdRef: React.RefObject<string | null>;
+  /** `mutations.setQueue` — re-pushes the whole local queue when the empty-room
+   *  FullSync guard fires, so the server catches up to local instead of local
+   *  being clobbered down to the empty room. Self-joins via ensureReady. */
+  reSeedQueueRef: React.RefObject<
+    (queue: ClimbQueueItem[], currentClimbQueueItem?: ClimbQueueItem | null) => Promise<void>
+  >;
   activeBoardRef: React.RefObject<UserBoard | null | undefined>;
   setActiveBoardRef: React.RefObject<(board: UserBoard) => Promise<void>>;
   showToastRef: React.RefObject<(message: string, variant?: ToastVariant, duration?: number) => void>;
@@ -154,6 +168,8 @@ export function useSessionRealtime({
   sessionIdRef,
   participantIdRef,
   stateRef,
+  seedFailedSessionIdRef,
+  reSeedQueueRef,
   activeBoardRef,
   setActiveBoardRef,
   showToastRef,
@@ -332,6 +348,52 @@ export function useSessionRealtime({
             // returning here keeps this path a true no-op, matching pre-gate
             // behaviour exactly).
             if (queueEvent.__typename === 'PlaybackStateChanged') return;
+
+            // A brand-new session whose local-queue seed failed
+            // (createSessionWithConfig — a network blip, a rate limit, a
+            // validation reject, a timeout) still gets an initial FullSync for
+            // the empty server room. Applying it would wipe the live local queue
+            // via INITIAL_QUEUE_DATA; letting the sync gate adopt the empty
+            // room's hash would then have the 60s watchdog resync-to-empty
+            // seconds later. While the seed is known-failed for THIS session and
+            // local state is still non-empty, treat the local queue as
+            // authoritative: skip the empty FullSync entirely (dispatch AND gate
+            // tracking, so `lastServerStateHash` stays null and the watchdog
+            // stays quiet), and re-push the whole queue so the server catches up.
+            // On a successful re-seed clear the flag; on failure leave it set so
+            // the next reconnect's empty FullSync retries. `reSeedQueueRef`
+            // (mutations.setQueue) self-joins, so calling it from here is safe.
+            if (event.__typename === 'FullSync' && seedFailedSessionIdRef.current === sessionId) {
+              const isEmptyRoom = event.state.queue.length === 0 && event.state.currentClimbQueueItem == null;
+              const { queue: localQueue, currentClimbQueueItem: localCurrent } = stateRef.current;
+              const hasLocalQueue = localQueue.length > 0 || localCurrent != null;
+              if (isEmptyRoom && hasLocalQueue) {
+                if (__DEV__) console.warn('[queue] guarding empty FullSync after failed seed; re-seeding');
+                track(SHARED_EVENTS.QueueSeedFullSyncGuarded, {
+                  boardName: activeBoardRef.current?.boardType,
+                  layoutId: activeBoardRef.current?.layoutId,
+                  localQueueLength: localQueue.length,
+                });
+                void reSeedQueueRef
+                  .current(localQueue, localCurrent ?? undefined)
+                  .then(() => {
+                    // Clear only once the re-seed lands, and only if we're still
+                    // on the same session — the server now holds the real queue,
+                    // so subsequent (non-empty) FullSyncs apply normally.
+                    if (sessionIdRef.current === sessionId) seedFailedSessionIdRef.current = null;
+                  })
+                  .catch((reSeedError) => {
+                    if (__DEV__) console.warn('[queue] session queue re-seed failed', reSeedError);
+                    reportHandledError(reSeedError, { tags: { source: 'startSessionSeed', op: 'reseed' } });
+                    // Flag stays set: the next reconnect's empty FullSync retries.
+                  });
+                return;
+              }
+              // Local is also empty (nothing to protect) or the room isn't empty
+              // (the seed actually landed, or a peer populated it before this
+              // FullSync) — drop the guard and apply the FullSync normally.
+              seedFailedSessionIdRef.current = null;
+            }
 
             // Sequence-gate every other event before touching the reducer. A
             // stale duplicate (already-applied or older sequence — e.g. a

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -58,6 +58,11 @@ export const SHARED_EVENTS = {
   // field (#2860). Its volume gates the deferred periodic-resnapshot healer:
   // if this rarely fires, seed-on-subscribe alone is enough.
   SessionRosterReconciled: 'Session Roster Reconciled',
+  // Fired when a brand-new session's empty-room FullSync is skipped because the
+  // local-queue seed failed (createSessionWithConfig) — the guard that stops a
+  // failed seed from wiping the live queue, plus the re-seed it kicks off. Lets
+  // us measure how often the seed lifecycle degrades in the field (#3878).
+  QueueSeedFullSyncGuarded: 'Queue Seed FullSync Guarded',
   // Climb actions
   // Fired when the climb reaction/actions menu is opened, with a `source` prop
   // ('long_press' | 'more_button'). Powers the ⋮-button discoverability experiment:


### PR DESCRIPTION
## Summary

Fixes #3878.

When you start a party session, `createSessionWithConfig` seeds the brand-new session with your locally-built queue (`setQueue`) **before** `setSessionId` mounts the `queueUpdates` subscription. If that seed threw — a network blip, a rate limit, a validation reject, a timeout — the failure was caught, swallowed, and the function fell straight through to mounting the session anyway. The empty room's initial `FullSync` then overwrote the live in-memory queue via `INITIAL_QUEUE_DATA`, so the queue vanished mid-session with no user-facing signal. This is broader than #3857's strict-UUID reject (its highest-volume trigger, fixed there): the swallow-then-proceed pattern had no failure-mode discrimination, so *any* seed failure reproduced the wipe.

### The fix

- **Flag the failed seed**, keyed by session id (`seedFailedSessionIdRef`), in the seed `catch` before `setSessionId` runs.
- **In `useSessionRealtime`**, when the incoming event is a `FullSync` for a session with a known-failed seed and the room is empty while local state is non-empty: skip it **entirely** — both the reducer dispatch **and** the sync-gate tracking. Skipping the gate keeps `lastServerStateHash`/`lastSequence` null, so the 60s hash watchdog can't turn around and resync-to-empty seconds later.
- **Re-push the whole local queue** (`mutations.setQueue`, which self-joins) so the server catches up to local instead of local being clobbered down to the empty room. On a successful re-seed the flag clears; on failure it stays set so the next reconnect's empty `FullSync` retries.

Why re-seed and not guard-only: mobile's `addToQueue` pushes a *delta*, so a guard-only fix would leave local and server diverged; the next add + watchdog would then resync local down to the server's partial state. Re-pushing the whole queue makes the server authoritative-equal to local, so its echo converges instead of clobbering.

Why not gate `setSessionId`: `createSession` has already committed server-side state, so not-mounting would strand `sessionIdRef` and require tearing down a dangling empty room — a mutation that is itself likely to fail under the same outage. The guard + re-seed needs no server cleanup and self-heals.

Mobile-only, JS/TS-only — rides existing OTA channels.

## Residual risks (documented, out of scope)

- **`resyncQueueAfterMutationFailure` path.** A *compound* outage — the seed fails, then a queue mutation *also* fails — can fire the post-mutation-failure resync, which fetches the still-empty room and applies it. Left out of scope by design: the guard neutralises the primary vector and the watchdog auto-path (gate stays unbaselined), and the on-disk snapshot survives so a relaunch recovers. Closing it fully means guarding `resyncQueueFromServer` the same way, which lives in `queue-provider.tsx`'s hydration region (owned by #3868) — deferred to avoid the overlap.
- **Peer populates the empty room before the re-seed lands.** If another member adds a climb to the (empty) room in the window before our re-seed lands, the room converges to the peer's state and our whole-queue re-push may be superseded by the peer's deltas. Rare (brand-new session, sub-second window) and it converges to a consistent shared state rather than losing the live queue.

## Release Notes

- Your queue no longer vanishes if starting a session hiccups — a flaky connection while you tap Start keeps every climb you lined up, and your crew still sees it once you're back online.

## Test plan

- New provider-level regression test `queue-provider-seed-failure.test.tsx` (reuses the WS/HTTP/mutations mock harness), 3 cases:
  1. Seed rejects + non-empty local queue → empty `FullSync` guarded, queue survives, whole queue re-seeded, telemetry fires.
  2. Seed context but empty local queue → empty `FullSync` applies normally (no guard, no re-seed).
  3. Gate-skip: after the guarded `FullSync`, a genuine delta at the same sequence still applies (proves the gate wasn't baselined to the empty room, so the watchdog stays quiet) and a later real non-empty `FullSync` applies.
- Confirmed the tests **fail** when the guard is reverted (queue wiped to `[]` in cases 1 and 3; case 2 stays green).
- `vp run typecheck:mobile` — pass.
- `vp run test:mobile` — full mobile suite 4418 passed.
- `vp check` — clean (the one flagged file, `packages/mobile/public/index.html`, is a pre-existing repo formatting issue unchanged by this PR).
- `vp run check:mobile-bundle` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkJuDx4nCQPYQzeEjNd6Q3