### PR TITLE
fix(mobile): give MoonBoard walls their real yellow backdrop

### DIFF
--- a/packages/mobile/src/components/BoardImageNative.tsx
+++ b/packages/mobile/src/components/BoardImageNative.tsx
@@ -110,6 +110,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
       <LayeredClimbImage
         overlayUri={overlayUri}
         backgroundPaths={backgroundPaths}
+        boardName={boardName}
         missingBackgroundCount={missingBackgroundCount}
         mirrored={mirrored}
         recyclingKey={recyclingKey}

--- a/packages/mobile/src/components/ClimbListThumbnail.tsx
+++ b/packages/mobile/src/components/ClimbListThumbnail.tsx
@@ -70,6 +70,7 @@ const ClimbListThumbnail = React.memo(function ClimbListThumbnail({
       <LayeredClimbImage
         overlayUri={overlayUri}
         backgroundPaths={backgroundPaths}
+        boardName={boardName}
         missingBackgroundCount={missingBackgroundCount}
         mirrored={mirrored}
         recyclingKey={frames}

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -1,20 +1,21 @@
 import React, { useEffect, useState } from 'react';
-import { Platform, View, StyleSheet } from 'react-native';
+import { Platform, View, StyleSheet, useColorScheme } from 'react-native';
 import { Image } from 'expo-image';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { useIsAppBackgrounded } from '../lib/app-visibility';
 import { useBoardArtVisible } from './board-art-visibility-context';
-import { moonboardWallBackdrop } from '../theme/colors';
+import { useSetting } from '../settings';
+import { resolveMoonboardBackdrop } from '../theme/colors';
 
 type LayeredClimbImageProps = {
   overlayUri: string | null;
   backgroundPaths: string[];
   /**
    * Which board is rendering. Only consumed to decide whether to paint the
-   * fixed MoonBoard wall backdrop (see `moonboardWallBackdrop` in
-   * theme/colors.ts for why it's theme-independent) — every other board
-   * renders unchanged. Optional so call sites (and tests) that don't care
-   * about the backdrop keep working.
+   * MoonBoard wall backdrop (see `resolveMoonboardBackdrop` in theme/colors.ts
+   * for the preset/light-dark resolution) — every other board renders
+   * unchanged. Optional so call sites (and tests) that don't care about the
+   * backdrop keep working.
    */
   boardName?: BoardName;
   /**
@@ -80,6 +81,24 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
 }: LayeredClimbImageProps) {
   const shouldShowEmptyFallback = backgroundPaths.length === 0 && missingBackgroundCount === 0;
   const isMoonBoard = boardName === 'moonboard';
+  // Single read point for the MoonBoard backdrop preset — covers every surface
+  // that renders a board (play view, thumbnails, discovery cards, accessory
+  // bar, kiosk, reaction menu, BLE cards) with no prop-threading. MMKV's
+  // useSetting is synchronous (no flash-of-default on cold open) and returns a
+  // reference-stable primitive string, safe inside this React.memo'd leaf.
+  // Deliberately NOT useTheme(): that's a big memoized object, exactly what
+  // this perf-sensitive virtualized-list leaf avoids — RN's provider-free
+  // useColorScheme() is correct here because the theme provider mirrors the
+  // user's in-app theme override into Appearance.setColorScheme (not just the
+  // OS setting), so useColorScheme() already reflects it.
+  const [backdropPreset] = useSetting('moonboardBackdrop');
+  // useColorScheme()'s type is 'light' | 'dark' | 'unspecified' | null | undefined
+  // (the extra Android-origin 'unspecified' isn't nullish) — treat anything but
+  // an explicit 'dark' as light, same default the theme provider itself falls
+  // back to.
+  const rawColorScheme = useColorScheme();
+  const colorScheme: 'light' | 'dark' = rawColorScheme === 'dark' ? 'dark' : 'light';
+  const backdropColor = resolveMoonboardBackdrop(backdropPreset, colorScheme);
   // Only relevant when overlayTestID is set (the play-drawer board): expose the
   // testID anchor on a marker that mounts AFTER the overlay image has actually
   // painted, not when the <Image> first mounts. expo-image reports "visible" to
@@ -114,7 +133,7 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
       {/* MoonBoard's board-art webps (moonboard-bg + the holdset image) are a
           near-fully-transparent schematic — grid labels and hold icons only,
           no filled wall. Painted first so it sits behind every other layer;
-          see moonboardWallBackdrop for why this is theme-independent.
+          see resolveMoonboardBackdrop for the preset/light-dark resolution.
           This layer fills its immediate parent edge-to-edge (no contentFit
           awareness, unlike the <Image> layers below) — callers whose parent
           isn't sized to the board's real aspect ratio will see the backdrop
@@ -125,7 +144,10 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
           0.65 aspect — negligible at that size, left as-is; tracked in
           issue #3913). */}
       {isMoonBoard && (
-        <View testID="layered-climb-image-moonboard-backdrop" style={[styles.layer, styles.moonboardBackdrop]} />
+        <View
+          testID="layered-climb-image-moonboard-backdrop"
+          style={[styles.layer, { backgroundColor: backdropColor }]}
+        />
       )}
       {shouldShowEmptyFallback && (
         <View testID="layered-climb-image-empty-fallback" style={[styles.layer, styles.emptyLayer]} />
@@ -208,9 +230,6 @@ const styles = StyleSheet.create({
   },
   emptyLayer: {
     backgroundColor: 'rgba(120, 120, 128, 0.28)',
-  },
-  moonboardBackdrop: {
-    backgroundColor: moonboardWallBackdrop,
   },
   // Subtle list-only board scrim. Tunable: drop dimBackground if the filled
   // hold style already separates the climb on a given board / in light mode.

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -1,12 +1,22 @@
 import React, { useEffect, useState } from 'react';
 import { Platform, View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
+import type { BoardName } from '@boardsesh/shared-schema';
 import { useIsAppBackgrounded } from '../lib/app-visibility';
 import { useBoardArtVisible } from './board-art-visibility-context';
+import { moonboardWallBackdrop } from '../theme/colors';
 
 type LayeredClimbImageProps = {
   overlayUri: string | null;
   backgroundPaths: string[];
+  /**
+   * Which board is rendering. Only consumed to decide whether to paint the
+   * fixed MoonBoard wall backdrop (see `moonboardWallBackdrop` in
+   * theme/colors.ts for why it's theme-independent) — every other board
+   * renders unchanged. Optional so call sites (and tests) that don't care
+   * about the backdrop keep working.
+   */
+  boardName?: BoardName;
   /**
    * Number of background layers the cache couldn't resolve. Each missing
    * layer is rendered as a visible neutral-gray block so the bug is
@@ -60,6 +70,7 @@ export function backgroundImageUri(path: string): string {
 const LayeredClimbImage = React.memo(function LayeredClimbImage({
   overlayUri,
   backgroundPaths,
+  boardName,
   missingBackgroundCount = 0,
   mirrored,
   dimBackground,
@@ -68,6 +79,7 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   overlayTestID,
 }: LayeredClimbImageProps) {
   const shouldShowEmptyFallback = backgroundPaths.length === 0 && missingBackgroundCount === 0;
+  const isMoonBoard = boardName === 'moonboard';
   // Only relevant when overlayTestID is set (the play-drawer board): expose the
   // testID anchor on a marker that mounts AFTER the overlay image has actually
   // painted, not when the <Image> first mounts. expo-image reports "visible" to
@@ -99,6 +111,13 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
 
   return (
     <View style={[styles.stack, mirrored && styles.mirrored]}>
+      {/* MoonBoard's board-art webps (moonboard-bg + the holdset image) are a
+          near-fully-transparent schematic — grid labels and hold icons only,
+          no filled wall. Painted first so it sits behind every other layer;
+          see moonboardWallBackdrop for why this is theme-independent. */}
+      {isMoonBoard && (
+        <View testID="layered-climb-image-moonboard-backdrop" style={[styles.layer, styles.moonboardBackdrop]} />
+      )}
       {shouldShowEmptyFallback && (
         <View testID="layered-climb-image-empty-fallback" style={[styles.layer, styles.emptyLayer]} />
       )}
@@ -180,6 +199,9 @@ const styles = StyleSheet.create({
   },
   emptyLayer: {
     backgroundColor: 'rgba(120, 120, 128, 0.28)',
+  },
+  moonboardBackdrop: {
+    backgroundColor: moonboardWallBackdrop,
   },
   // Subtle list-only board scrim. Tunable: drop dimBackground if the filled
   // hold style already separates the climb on a given board / in light mode.

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -122,7 +122,8 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
           BoardDiscoveryCard's fixed-square thumb needed an aspect-fit inner box,
           see its thumbFit; ClimbListThumbnail's 76×96 portrait cell has a
           pre-existing, deliberately-unfit ~7px margin on MoonBoard's narrower
-          0.65 aspect — negligible at that size, left as-is). */}
+          0.65 aspect — negligible at that size, left as-is; tracked in
+          issue #3913). */}
       {isMoonBoard && (
         <View testID="layered-climb-image-moonboard-backdrop" style={[styles.layer, styles.moonboardBackdrop]} />
       )}

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -114,7 +114,15 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
       {/* MoonBoard's board-art webps (moonboard-bg + the holdset image) are a
           near-fully-transparent schematic — grid labels and hold icons only,
           no filled wall. Painted first so it sits behind every other layer;
-          see moonboardWallBackdrop for why this is theme-independent. */}
+          see moonboardWallBackdrop for why this is theme-independent.
+          This layer fills its immediate parent edge-to-edge (no contentFit
+          awareness, unlike the <Image> layers below) — callers whose parent
+          isn't sized to the board's real aspect ratio will see the backdrop
+          extend past where the letterboxed board art stops (issue #3885 review:
+          BoardDiscoveryCard's fixed-square thumb needed an aspect-fit inner box,
+          see its thumbFit; ClimbListThumbnail's 76×96 portrait cell has a
+          pre-existing, deliberately-unfit ~7px margin on MoonBoard's narrower
+          0.65 aspect — negligible at that size, left as-is). */}
       {isMoonBoard && (
         <View testID="layered-climb-image-moonboard-backdrop" style={[styles.layer, styles.moonboardBackdrop]} />
       )}

--- a/packages/mobile/src/components/__tests__/layered-climb-image-backgrounded.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image-backgrounded.test.tsx
@@ -6,6 +6,11 @@ import { createElement, type ReactNode } from 'react';
 type ViewMockProps = { children?: ReactNode; testID?: string };
 
 vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  // theme/colors.ts (imported for moonboardWallBackdrop) computes
+  // iosSystemColors at module-load time via PlatformColor — must be stubbed
+  // or the import throws before any test body runs.
+  PlatformColor: (colorName: string) => colorName,
   View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
 }));

--- a/packages/mobile/src/components/__tests__/layered-climb-image-backgrounded.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image-backgrounded.test.tsx
@@ -7,12 +7,19 @@ type ViewMockProps = { children?: ReactNode; testID?: string };
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
-  // theme/colors.ts (imported for moonboardWallBackdrop) computes
+  // theme/colors.ts (imported for resolveMoonboardBackdrop) computes
   // iosSystemColors at module-load time via PlatformColor — must be stubbed
   // or the import throws before any test body runs.
   PlatformColor: (colorName: string) => colorName,
+  useColorScheme: () => 'light',
   View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+// LayeredClimbImage reads the backdrop preset via useSetting('moonboardBackdrop')
+// (MMKV-backed) — mock the settings module directly rather than react-native-mmkv.
+vi.mock('../../settings', () => ({
+  useSetting: () => ['gold', vi.fn()],
 }));
 
 vi.mock('expo-image', () => ({

--- a/packages/mobile/src/components/__tests__/layered-climb-image-hidden.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image-hidden.test.tsx
@@ -7,6 +7,10 @@ type ViewMockProps = { children?: ReactNode; testID?: string };
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
+  // theme/colors.ts (imported by LayeredClimbImage for moonboardWallBackdrop)
+  // computes iosSystemColors at module-load time via PlatformColor — must be
+  // stubbed or the import throws before any test body runs.
+  PlatformColor: (colorName: string) => colorName,
   View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
 }));

--- a/packages/mobile/src/components/__tests__/layered-climb-image-hidden.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image-hidden.test.tsx
@@ -7,12 +7,19 @@ type ViewMockProps = { children?: ReactNode; testID?: string };
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
-  // theme/colors.ts (imported by LayeredClimbImage for moonboardWallBackdrop)
+  // theme/colors.ts (imported by LayeredClimbImage for resolveMoonboardBackdrop)
   // computes iosSystemColors at module-load time via PlatformColor — must be
   // stubbed or the import throws before any test body runs.
   PlatformColor: (colorName: string) => colorName,
+  useColorScheme: () => 'light',
   View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+// LayeredClimbImage reads the backdrop preset via useSetting('moonboardBackdrop')
+// (MMKV-backed) — mock the settings module directly rather than react-native-mmkv.
+vi.mock('../../settings', () => ({
+  useSetting: () => ['gold', vi.fn()],
 }));
 
 vi.mock('expo-image', () => ({

--- a/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
@@ -174,8 +174,11 @@ describe('LayeredClimbImage', () => {
       const backgroundImage = container.querySelector('img[src="file:///bundled/moonboard-bg.webp"]');
       expect(backdrop).toBeTruthy();
       expect(backgroundImage).toBeTruthy();
-      // DOCUMENT_POSITION_FOLLOWING (4) means `backgroundImage` comes after
-      // `backdrop` in the tree, i.e. paints on top of it.
+      // compareDocumentPosition returns a bitmask, not a single enum value (it can
+      // combine e.g. FOLLOWING with DISCONNECTED/IMPLEMENTATION_SPECIFIC bits), so
+      // the correct check is masking for the FOLLOWING bit rather than an equality
+      // check against a specific combined value. FOLLOWING set means `backgroundImage`
+      // comes after `backdrop` in the tree, i.e. paints on top of it.
       // eslint-disable-next-line no-bitwise
       expect(
         (backdrop?.compareDocumentPosition(backgroundImage as Node) ?? 0) & Node.DOCUMENT_POSITION_FOLLOWING,

--- a/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
@@ -12,6 +12,10 @@ vi.mock('react-native', () => ({
       return platform.os;
     },
   },
+  // theme/colors.ts (imported for moonboardWallBackdrop) computes
+  // iosSystemColors at module-load time via PlatformColor — must be stubbed
+  // or the import throws before any test body runs.
+  PlatformColor: (colorName: string) => colorName,
   View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
 }));
@@ -119,5 +123,63 @@ describe('LayeredClimbImage', () => {
 
     const overlay = container.querySelector('img[src="file:///overlay.png"]');
     expect(overlay?.getAttribute('data-recycling-key')).toBe('climb-frames-abc');
+  });
+
+  // MoonBoard board art (moonboard-bg + holdset webps) is a near-fully-transparent
+  // schematic with no filled wall behind it, so without a fixed backdrop dark-mode
+  // chrome shows through and swallows the holds (issue #3885, #1449).
+  describe('MoonBoard backdrop (issue #3885)', () => {
+    it('paints the fixed backdrop layer for boardName="moonboard"', () => {
+      const { container } = render(
+        createElement(LayeredClimbImage, {
+          overlayUri: null,
+          backgroundPaths: ['/bundled/moonboard-bg.webp', '/bundled/holdseta.webp'],
+          boardName: 'moonboard',
+        }),
+      );
+
+      expect(container.querySelector('[data-testid="layered-climb-image-moonboard-backdrop"]')).toBeTruthy();
+    });
+
+    it('does not paint the backdrop for other boards', () => {
+      const { container } = render(
+        createElement(LayeredClimbImage, {
+          overlayUri: null,
+          backgroundPaths: ['/bundled/kilter.webp'],
+          boardName: 'kilter',
+        }),
+      );
+
+      expect(container.querySelector('[data-testid="layered-climb-image-moonboard-backdrop"]')).toBeNull();
+    });
+
+    it('does not paint the backdrop when boardName is omitted (existing call sites/tests)', () => {
+      const { container } = render(
+        createElement(LayeredClimbImage, { overlayUri: null, backgroundPaths: ['/bundled/kilter.webp'] }),
+      );
+
+      expect(container.querySelector('[data-testid="layered-climb-image-moonboard-backdrop"]')).toBeNull();
+    });
+
+    it('sits behind (renders before) the board background image layers', () => {
+      const { container } = render(
+        createElement(LayeredClimbImage, {
+          overlayUri: null,
+          backgroundPaths: ['/bundled/moonboard-bg.webp'],
+          boardName: 'moonboard',
+        }),
+      );
+
+      const backdrop = container.querySelector('[data-testid="layered-climb-image-moonboard-backdrop"]');
+      const backgroundImage = container.querySelector('img[src="file:///bundled/moonboard-bg.webp"]');
+      expect(backdrop).toBeTruthy();
+      expect(backgroundImage).toBeTruthy();
+      // DOCUMENT_POSITION_FOLLOWING (4) means `backgroundImage` comes after
+      // `backdrop` in the tree, i.e. paints on top of it.
+      // eslint-disable-next-line no-bitwise
+      expect(
+        (backdrop?.compareDocumentPosition(backgroundImage as Node) ?? 0) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
   });
 });

--- a/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
@@ -1,10 +1,31 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
-type ViewMockProps = { children?: ReactNode; testID?: string };
+type ViewMockProps = { children?: ReactNode; testID?: string; style?: unknown };
 const platform = vi.hoisted(() => ({ os: 'ios' as 'ios' | 'web' }));
+// Drives the react-native useColorScheme() mock below — tests flip this to
+// exercise both the light and dark backdrop resolution.
+const colorSchemeCtrl = vi.hoisted(() => ({ scheme: 'light' as 'light' | 'dark' }));
+
+// RN style props are arrays of objects (StyleSheet entries mixed with inline
+// overrides); flatten and pull backgroundColor so tests can assert on the
+// resolved MoonBoard backdrop color without a real style engine.
+function readBackgroundColor(style: unknown): string {
+  if (Array.isArray(style)) {
+    for (let index = style.length - 1; index >= 0; index -= 1) {
+      const color = readBackgroundColor(style[index]);
+      if (color) return color;
+    }
+    return '';
+  }
+  if (style != null && typeof style === 'object' && 'backgroundColor' in style) {
+    const { backgroundColor } = style as { backgroundColor?: unknown };
+    return typeof backgroundColor === 'string' ? backgroundColor : '';
+  }
+  return '';
+}
 
 vi.mock('react-native', () => ({
   Platform: {
@@ -12,12 +33,22 @@ vi.mock('react-native', () => ({
       return platform.os;
     },
   },
-  // theme/colors.ts (imported for moonboardWallBackdrop) computes
+  // theme/colors.ts (imported for resolveMoonboardBackdrop) computes
   // iosSystemColors at module-load time via PlatformColor — must be stubbed
   // or the import throws before any test body runs.
   PlatformColor: (colorName: string) => colorName,
-  View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
+  useColorScheme: () => colorSchemeCtrl.scheme,
+  View: ({ children, testID, style }: ViewMockProps) =>
+    createElement('div', { 'data-testid': testID, 'data-bg': readBackgroundColor(style) }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+// LayeredClimbImage reads the backdrop preset via useSetting('moonboardBackdrop')
+// (MMKV-backed) — mock the settings module directly rather than react-native-mmkv,
+// per the same "add `useSetting` to each mock" fix noted in the other backdrop tests.
+const settingsCtrl = vi.hoisted(() => ({ preset: 'gold' as 'classic' | 'gold' | 'dim' | 'neutral' }));
+vi.mock('../../settings', () => ({
+  useSetting: () => [settingsCtrl.preset, vi.fn()],
 }));
 
 vi.mock('expo-image', () => ({
@@ -126,10 +157,15 @@ describe('LayeredClimbImage', () => {
   });
 
   // MoonBoard board art (moonboard-bg + holdset webps) is a near-fully-transparent
-  // schematic with no filled wall behind it, so without a fixed backdrop dark-mode
+  // schematic with no filled wall behind it, so without a backdrop dark-mode
   // chrome shows through and swallows the holds (issue #3885, #1449).
   describe('MoonBoard backdrop (issue #3885)', () => {
-    it('paints the fixed backdrop layer for boardName="moonboard"', () => {
+    afterEach(() => {
+      settingsCtrl.preset = 'gold';
+      colorSchemeCtrl.scheme = 'light';
+    });
+
+    it('paints the backdrop layer for boardName="moonboard"', () => {
       const { container } = render(
         createElement(LayeredClimbImage, {
           overlayUri: null,
@@ -139,6 +175,52 @@ describe('LayeredClimbImage', () => {
       );
 
       expect(container.querySelector('[data-testid="layered-climb-image-moonboard-backdrop"]')).toBeTruthy();
+    });
+
+    it('resolves gold+light (the default) to #FAD201', () => {
+      settingsCtrl.preset = 'gold';
+      colorSchemeCtrl.scheme = 'light';
+      const { container } = render(
+        createElement(LayeredClimbImage, {
+          overlayUri: null,
+          backgroundPaths: [],
+          boardName: 'moonboard',
+        }),
+      );
+
+      const backdrop = container.querySelector('[data-testid="layered-climb-image-moonboard-backdrop"]');
+      expect(backdrop?.getAttribute('data-bg')).toBe('#FAD201');
+    });
+
+    it('resolves gold+dark to the dimmed #C0932E, not the light-mode hex', () => {
+      settingsCtrl.preset = 'gold';
+      colorSchemeCtrl.scheme = 'dark';
+      const { container } = render(
+        createElement(LayeredClimbImage, {
+          overlayUri: null,
+          backgroundPaths: [],
+          boardName: 'moonboard',
+        }),
+      );
+
+      const backdrop = container.querySelector('[data-testid="layered-climb-image-moonboard-backdrop"]');
+      expect(backdrop?.getAttribute('data-bg')).toBe('#C0932E');
+    });
+
+    it('renders neutral+dark as the mid-grey field, not "no backdrop" (swallow-bug guard)', () => {
+      settingsCtrl.preset = 'neutral';
+      colorSchemeCtrl.scheme = 'dark';
+      const { container } = render(
+        createElement(LayeredClimbImage, {
+          overlayUri: null,
+          backgroundPaths: [],
+          boardName: 'moonboard',
+        }),
+      );
+
+      const backdrop = container.querySelector('[data-testid="layered-climb-image-moonboard-backdrop"]');
+      expect(backdrop).toBeTruthy();
+      expect(backdrop?.getAttribute('data-bg')).toBe('#524E47');
     });
 
     it('does not paint the backdrop for other boards', () => {

--- a/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
@@ -93,6 +93,9 @@ export function BoardDiscoveryCard({ item, onPress }: BoardDiscoveryCardProps) {
       style={[animatedStyle, styles.container]}
     >
       <View testID="board-card" style={[styles.thumb, thumbStyle]}>
+        {/* thumbFit is only null when render is — checking both (rather than just
+            render) is pure TS narrowing so `style={thumbFit}` below doesn't need a
+            non-null assertion; they can't disagree (see the thumbFit memo above). */}
         {render && thumbFit ? (
           <BoardImageNative
             frames=""

--- a/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
@@ -62,6 +62,19 @@ export function BoardDiscoveryCard({ item, onPress }: BoardDiscoveryCardProps) {
     [item.boardName, item.layoutId, item.sizeId, item.setIds],
   );
 
+  // Board art isn't square; fit it inside the square thumb at its native aspect
+  // (passing height:'100%' would override BoardImageNative's aspectRatio and
+  // stretch it — for MoonBoard that also stretched the wall backdrop into a flat
+  // yellow square instead of a letterboxed board, see issue #3885). Same pattern
+  // as BoardManageRow's thumbFit.
+  const thumbFit = useMemo(() => {
+    if (!render) return null;
+    const aspect = render.boardWidth / render.boardHeight;
+    return aspect >= 1
+      ? { width: DISCOVERY_CARD_WIDTH, height: DISCOVERY_CARD_WIDTH / aspect }
+      : { width: DISCOVERY_CARD_WIDTH * aspect, height: DISCOVERY_CARD_WIDTH };
+  }, [render]);
+
   const thumbStyle = {
     backgroundColor: systemColors.tertiaryBackground,
     borderColor: item.isActive ? brandColors.primary : systemColors.separator,
@@ -80,7 +93,7 @@ export function BoardDiscoveryCard({ item, onPress }: BoardDiscoveryCardProps) {
       style={[animatedStyle, styles.container]}
     >
       <View testID="board-card" style={[styles.thumb, thumbStyle]}>
-        {render ? (
+        {render && thumbFit ? (
           <BoardImageNative
             frames=""
             boardName={item.boardName}
@@ -96,7 +109,7 @@ export function BoardDiscoveryCard({ item, onPress }: BoardDiscoveryCardProps) {
             // picker. Matches ClimbListThumbnail's renderWidth so the thumb
             // background and overlay cache entries are shared across surfaces.
             renderWidth={400}
-            style={styles.boardImage}
+            style={thumbFit}
           />
         ) : (
           <View style={styles.thumbFallback}>
@@ -144,10 +157,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     marginBottom: spacing[2],
-  },
-  boardImage: {
-    width: '100%',
-    height: '100%',
   },
   thumbFallback: {
     flex: 1,

--- a/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
@@ -86,4 +86,21 @@ describe('BoardDiscoveryCard', () => {
     // thumb-variant background + small overlay instead of a full-res decode.
     expect(boardImageProps.last?.renderWidth).toBe(400);
   });
+
+  // Regression for the paired QA review on issue #3885's fix: the discovery
+  // card used to hand BoardImageNative a flat width:'100%'/height:'100%' style,
+  // which overrides its internal aspectRatio and stretches the art to fill the
+  // square 168×168 thumb — for MoonBoard's new opaque wall backdrop that read as
+  // a plain yellow square instead of a letterboxed board. The style must fit the
+  // board's real aspect ratio inside the square cell instead.
+  it('fits the board art to its real aspect ratio instead of stretching to the square thumb', () => {
+    render(createElement(BoardDiscoveryCard, { item, onPress: vi.fn() }));
+
+    const style = boardImageProps.last?.style as { width?: number; height?: number } | undefined;
+    // Mocked getBoardRenderData returns 1461x1144 (aspect ~1.277): width pins to
+    // the 168px cell, height shrinks below it — not a stretched 168x168 square.
+    expect(style?.width).toBe(168);
+    expect(style?.height).toBeCloseTo(168 / (1461 / 1144), 2);
+    expect(style?.height).not.toBe(168);
+  });
 });

--- a/packages/mobile/src/components/settings/AccessibilitySettingsScreen.tsx
+++ b/packages/mobile/src/components/settings/AccessibilitySettingsScreen.tsx
@@ -27,6 +27,9 @@ import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { useInfiniteSearchClimbs } from '../../lib/graphql/hooks/use-infinite-search-climbs';
 import { getBoardRenderData } from '../../lib/board-details';
 import { simulateCvd, type CvdType } from '../../lib/cvd-simulation';
+import { hapticSelection } from '../../lib/haptics';
+import { useSetting } from '../../settings';
+import { MOONBOARD_BACKDROP_PRESETS, type MoonboardBackdropPreset } from '../../theme/colors';
 import { OkhslColorPicker } from './OkhslColorPicker';
 import {
   DEFAULT_HOLD_COLOR_SIGNATURE,
@@ -123,6 +126,57 @@ function MarkerSwatch({
   );
 }
 
+// Table order from the design spec: default first, then progressively less
+// yellow.
+const MOONBOARD_BACKDROP_OPTIONS: MoonboardBackdropPreset[] = ['gold', 'classic', 'dim', 'neutral'];
+
+function labelForMoonboardBackdrop(t: TFunction<'common'>, preset: MoonboardBackdropPreset): string {
+  switch (preset) {
+    case 'gold':
+      return t('mobile.more.accessibility.wall.options.gold.label');
+    case 'classic':
+      return t('mobile.more.accessibility.wall.options.classic.label');
+    case 'dim':
+      return t('mobile.more.accessibility.wall.options.dim.label');
+    case 'neutral':
+      return t('mobile.more.accessibility.wall.options.neutral.label');
+  }
+}
+
+function descriptionForMoonboardBackdrop(t: TFunction<'common'>, preset: MoonboardBackdropPreset): string {
+  switch (preset) {
+    case 'gold':
+      return t('mobile.more.accessibility.wall.options.gold.description');
+    case 'classic':
+      return t('mobile.more.accessibility.wall.options.classic.description');
+    case 'dim':
+      return t('mobile.more.accessibility.wall.options.dim.description');
+    case 'neutral':
+      return t('mobile.more.accessibility.wall.options.neutral.description');
+  }
+}
+
+/**
+ * Two-tone swatch chip for a MoonBoard backdrop preset row: top half the
+ * preset's light-mode hex, bottom half its dark-mode hex, so the row shows
+ * both without needing the device's current theme. Mirrors MarkerSwatch's
+ * decorative-only accessibility treatment — the row itself carries the label.
+ */
+function MoonboardBackdropSwatch({ preset }: { preset: MoonboardBackdropPreset }) {
+  const { systemColors } = useTheme();
+  const { light, dark } = MOONBOARD_BACKDROP_PRESETS[preset];
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={[styles.wallSwatch, { borderColor: systemColors.separator }]}
+    >
+      <View style={[styles.wallSwatchHalf, { backgroundColor: light }]} />
+      <View style={[styles.wallSwatchHalf, { backgroundColor: dark }]} />
+    </View>
+  );
+}
+
 export function AccessibilitySettingsScreen() {
   const { t } = useTranslation('common');
   const { systemColors } = useTheme();
@@ -144,6 +198,7 @@ export function AccessibilitySettingsScreen() {
   const [thicknessSheetOpen, setThicknessSheetOpen] = useState(false);
   const [sizeSheetOpen, setSizeSheetOpen] = useState(false);
   const [cvdMode, setCvdMode] = useState<CvdMode>('none');
+  const [moonboardBackdrop, setMoonboardBackdrop] = useSetting('moonboardBackdrop');
   // renderSignature is buildHoldRenderOverrideSignature(markerOverrides), so this
   // alone is equivalent to hasHoldMarkerOverrides(markerOverrides).
   const hasOverrides = renderSignature !== DEFAULT_HOLD_COLOR_SIGNATURE;
@@ -209,6 +264,14 @@ export function AccessibilitySettingsScreen() {
     [setRoleMarkerOverride],
   );
 
+  const handleSelectMoonboardBackdrop = useCallback(
+    (preset: MoonboardBackdropPreset) => {
+      hapticSelection();
+      setMoonboardBackdrop(preset);
+    },
+    [setMoonboardBackdrop],
+  );
+
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
@@ -241,6 +304,37 @@ export function AccessibilitySettingsScreen() {
           </View>
         </View>
       ) : null}
+
+      <View style={styles.section}>
+        <SectionHeader title={t('mobile.more.accessibility.wall.title')} />
+        <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
+          <View style={styles.cardPadded}>
+            <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.description}>
+              {t('mobile.more.accessibility.wall.subtitle')}
+            </Text>
+          </View>
+          {MOONBOARD_BACKDROP_OPTIONS.map((preset, index) => {
+            const selected = moonboardBackdrop === preset;
+            const label = labelForMoonboardBackdrop(t, preset);
+            return (
+              <ListRow
+                key={preset}
+                title={label}
+                subtitle={descriptionForMoonboardBackdrop(t, preset)}
+                accessibilityLabel={
+                  selected ? t('mobile.more.accessibility.wall.optionAccessibilitySelected', { label }) : label
+                }
+                leading={<MoonboardBackdropSwatch preset={preset} />}
+                trailing={selected ? <Icon name="check.small" size={20} color={systemColors.accent} /> : undefined}
+                showChevron={false}
+                showSeparator={index < MOONBOARD_BACKDROP_OPTIONS.length - 1}
+                haptic={false}
+                onPress={() => handleSelectMoonboardBackdrop(preset)}
+              />
+            );
+          })}
+        </View>
+      </View>
 
       <View style={styles.section}>
         <SectionHeader title={t('mobile.more.accessibility.cvd.title')} />
@@ -817,6 +911,18 @@ const styles = StyleSheet.create({
     borderWidth: StyleSheet.hairlineWidth,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  // Rounded SQUARE (not the circular `swatch` above) — reads as a little wall
+  // swatch chip, not a hold marker.
+  wallSwatch: {
+    width: 32,
+    height: 32,
+    borderRadius: borderRadius.sm,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+  },
+  wallSwatchHalf: {
+    flex: 1,
   },
   pickerBody: {
     paddingHorizontal: spacing[4],

--- a/packages/mobile/src/settings/__tests__/hooks.test.ts
+++ b/packages/mobile/src/settings/__tests__/hooks.test.ts
@@ -37,6 +37,7 @@ describe('settings', () => {
       expect(getSetting('theme')).toBe('system');
       expect(getSetting('defaultBoardUuid')).toBeNull();
       expect(getSetting('syncEnabledBoards')).toEqual([]);
+      expect(getSetting('moonboardBackdrop')).toBe('gold');
     });
 
     it('returns stored value parsed from JSON', () => {
@@ -112,6 +113,7 @@ describe('settings', () => {
       expect(settings.notifyClimbComments).toBe(DEFAULT_SETTINGS.notifyClimbComments);
       expect(settings.defaultBoardUuid).toBe(DEFAULT_SETTINGS.defaultBoardUuid);
       expect(settings.syncEnabledBoards).toEqual(DEFAULT_SETTINGS.syncEnabledBoards);
+      expect(settings.moonboardBackdrop).toBe(DEFAULT_SETTINGS.moonboardBackdrop);
     });
 
     it('ignores invalid JSON entries and uses defaults', () => {
@@ -198,6 +200,11 @@ describe('settings', () => {
     it('roundtrips a string', () => {
       setSetting('theme', 'light');
       expect(getSetting('theme')).toBe('light');
+    });
+
+    it('roundtrips a MoonBoard backdrop preset', () => {
+      setSetting('moonboardBackdrop', 'neutral');
+      expect(getSetting('moonboardBackdrop')).toBe('neutral');
     });
 
     it('roundtrips an array', () => {

--- a/packages/mobile/src/settings/defaults.ts
+++ b/packages/mobile/src/settings/defaults.ts
@@ -11,4 +11,5 @@ export const DEFAULT_SETTINGS: AppSettings = {
   notifySessionInvites: true,
   notifyClimbComments: true,
   kioskHintSeen: false,
+  moonboardBackdrop: 'gold',
 };

--- a/packages/mobile/src/settings/types.ts
+++ b/packages/mobile/src/settings/types.ts
@@ -1,3 +1,5 @@
+import type { MoonboardBackdropPreset } from '../theme/colors';
+
 export type AppSettings = {
   defaultBoardUuid: string | null;
   syncEnabledBoards: string[];
@@ -11,6 +13,12 @@ export type AppSettings = {
   notifyClimbComments: boolean;
   /** One-shot: the "kiosk setup lives on the big screen" hint has been seen on My gyms. */
   kioskHintSeen: boolean;
+  /**
+   * MoonBoard wall backdrop preset (More → Accessibility → MoonBoard wall).
+   * Stored as the preset key, not a hex, so `resolveMoonboardBackdrop` in
+   * theme/colors.ts can be retuned later with no migration.
+   */
+  moonboardBackdrop: MoonboardBackdropPreset;
 };
 
 export type SettingsKey = keyof AppSettings;

--- a/packages/mobile/src/theme/__tests__/colors.test.ts
+++ b/packages/mobile/src/theme/__tests__/colors.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi } from 'vitest';
 // colors.ts touches Platform/PlatformColor at import; Android skips the iOS branch.
 vi.mock('react-native', () => ({ Platform: { OS: 'android' }, PlatformColor: (name: string) => name }));
 
-import { blendOpaque, withAlpha } from '../colors';
+import { blendOpaque, withAlpha, resolveMoonboardBackdrop, type MoonboardBackdropPreset } from '../colors';
 
 describe('withAlpha', () => {
   it('emits rgba() for hex input', () => {
@@ -33,5 +33,25 @@ describe('blendOpaque', () => {
 
   it('returns the background unchanged when an input is not hex', () => {
     expect(blendOpaque('rgba(0,0,0,1)', '#1F1A1B', 0.2)).toBe('#1F1A1B');
+  });
+});
+
+describe('resolveMoonboardBackdrop', () => {
+  // Every preset × colorScheme combination — exact hexes from the design spec
+  // (issue #3885 follow-up). `neutral` is a genuine mid-grey field, never
+  // "no backdrop", so its two values are covered here like every other preset.
+  const cases: Array<[MoonboardBackdropPreset, 'light' | 'dark', string]> = [
+    ['gold', 'light', '#FAD201'],
+    ['gold', 'dark', '#C0932E'],
+    ['classic', 'light', '#FAD201'],
+    ['classic', 'dark', '#FAD201'],
+    ['dim', 'light', '#E3B23C'],
+    ['dim', 'dark', '#9E7F30'],
+    ['neutral', 'light', '#E7E2D8'],
+    ['neutral', 'dark', '#524E47'],
+  ];
+
+  it.each(cases)('resolves %s + %s to %s', (preset, colorScheme, expectedHex) => {
+    expect(resolveMoonboardBackdrop(preset, colorScheme)).toBe(expectedHex);
   });
 });

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -102,52 +102,82 @@ export const playDrawerMaterialTint = {
 } as const;
 
 /**
- * Fixed backdrop painted behind every MoonBoard render (LayeredClimbImage),
- * regardless of light/dark mode (issue #3885, and the older #1449). MoonBoard
- * board art (moonboard-bg.webp + the holdset webps) is a near-fully-transparent
- * schematic — grid labels and hold icons only, no filled wall behind them — so
- * without an explicit backdrop it shows whatever's behind the image stack. In
- * the play view that's the modal's themed system background (app/play.tsx),
- * which turns near-black in dark mode and swallows the pale/neutral-toned
- * holds.
+ * Backdrop painted behind every MoonBoard render (LayeredClimbImage), keyed by
+ * {@link MoonboardBackdropPreset} and light/dark mode (issue #3885, and the
+ * older #1449). MoonBoard board art (moonboard-bg.webp + the holdset webps)
+ * is a near-fully-transparent schematic — grid labels and hold icons only, no
+ * filled wall behind them — so without an explicit backdrop it shows
+ * whatever's behind the image stack. In the play view that's the modal's
+ * themed system background (app/play.tsx), which turns near-black in dark
+ * mode and swallows the pale/neutral-toned holds.
  *
- * Deliberately NOT keyed by colorScheme like `playDrawerMaterialTint` above:
- * MoonBoard panels are painted a real-world yellow, so a fixed tone reads as
- * the actual board in both modes rather than as a theme artifact — and it
- * keeps LayeredClimbImage (used everywhere a board renders: thumbnails,
- * discovery cards, the play view) free of a useTheme() dependency. Depicting
- * a compatible physical product's paint colour is fine (the same basis as
- * the board-art assets we already ship); no Moon branding/logo is used here.
+ * Depicting a compatible physical product's paint colour is fine (the same
+ * basis as the board-art assets we already ship); no Moon branding/logo is
+ * used here.
  *
- * Value: RAL 1023 "Traffic Yellow" (#FAD201), the RAL code Moon Climbing
- * lists for MoonBoard panels. Cross-checked against
+ * Base value (the `gold`/`classic` presets' light hex, and `classic`'s dark
+ * hex): RAL 1023 "Traffic Yellow" (#FAD201), the RAL code Moon Climbing lists
+ * for MoonBoard panels. Cross-checked against
  * packages/moonboard-ocr/src/__tests__/fixtures/moonboard-grid-reference.jpg
  * (Moon's own board-art reference graphic, in-repo) — sampling its plain
- * background pixels averages ~#EEDF50, the same "golden yellow" family
- * (hue ~54° vs RAL 1023's ~50°) but lighter/less saturated, consistent with
- * print/JPEG reproduction rather than raw paint. Went with the RAL value:
- * closer to the paint spec, and its hue sits slightly further from the
- * MoonBoard start-hold green (see below), which is the pairing that matters
- * most for on-screen contrast.
+ * background pixels averages ~#EEDF50, the same "golden yellow" family (hue
+ * ~54° vs RAL 1023's ~50°) but lighter/less saturated, consistent with
+ * print/JPEG reproduction rather than raw paint.
  *
  * Hold-state contrast (WCAG relative-luminance ratio, MOONBOARD_HOLD_STATES
- * displayColor in moonboard-config.ts) at this value:
- *   - hand (#4444FF): 4.06:1 — passes WCAG AA for large-scale graphics (3:1).
- *   - finish (#FF3333): 2.47:1 — below 3:1, readable but not high-contrast.
- *   - start (#44FF44): 1.09:1 — effectively unreadable stroke-on-backdrop.
- * The green pairing is not fixable by tuning this hex: green and yellow are
- * adjacent, similarly-bright hues, so WCAG contrast stays under ~1.35:1 for
- * ANY backdrop light/saturated enough to still read as "yellow" — reaching
- * even 3:1 needs a backdrop luminance dark enough to look olive/khaki, which
- * defeats the fix. Verified darkening/desaturating from RAL 1023 does not
- * help here and actively worsens hand/finish contrast (a lighter backdrop
- * has MORE headroom against both blue and red), so this value is the local
- * optimum, not a compromise pending further tuning. The real fix for the
- * green pairing is a fixed dark outline on hold markers (a renderer-level
+ * displayColor in moonboard-config.ts) is not fixable by backdrop tuning for
+ * every ring simultaneously: green and yellow are adjacent, similarly-bright
+ * hues, so the start ring (#44FF44) stays under ~1.35:1 contrast for ANY
+ * backdrop light/saturated enough to still read as "yellow" — reaching even
+ * 3:1 needs a backdrop luminance dark enough to look olive/khaki, which
+ * defeats the point of a yellow wall. This is true across every preset below
+ * (see the contrast table in PR #3899's description); the real fix for the
+ * green ring is a fixed dark outline on hold markers (a renderer-level
  * change, packages/board-renderer/core/src/renderer.rs) — out of scope here,
- * tracked as a follow-up rather than solved by backdrop colour alone.
+ * tracked as a follow-up (issue #3913) rather than solved by backdrop colour
+ * alone.
+ *
+ * Light vs. dark ARE deliberately different per preset (unlike the old
+ * single-value constant this replaced) — a comfort problem, not a taste one.
+ * `#FAD201` is a max-chroma field at ~103× the luminance of the dark-mode
+ * chrome (`#141218`) once it fills most of a dark screen: a disability-glare
+ * source for a dark-adapted eye. Light mode is glare-immune (bright
+ * surround), so it keeps the literal RAL value with the best ring headroom;
+ * dark mode's `gold` default (`#C0932E`) roughly halves that glare (103×→50×)
+ * and, as a second comfort lever, warms the hue off yellow's 555 nm luminance
+ * peak (91°→83°) so it reads as a warm painted wall rather than an electric
+ * glow — while still roughly doubling the two holds the backdrop exists to
+ * reveal (white plastic 1.20:1→2.30:1, the start ring 1.09:1→2.10:1).
+ * Precedent for a light/dark split: `playDrawerMaterialTint` above.
+ *
+ * The dark values below are hand-tuned per preset, not derived from the light
+ * value via `blendOpaque` — a pure blend toward the dark chrome can't warm
+ * the hue off the 555 nm peak (it stays at RAL's 91°), and that hue shift is
+ * a real, independently-useful comfort lever alongside luminance. Two
+ * hand-specified hexes per preset (rather than one derived from the other)
+ * is an accepted drift risk in exchange for that extra control.
  */
-export const moonboardWallBackdrop = '#FAD201';
+export type MoonboardBackdropPreset = 'classic' | 'gold' | 'dim' | 'neutral';
+
+/**
+ * Per-preset {light, dark} hex pairs. `neutral` is a genuine mid-grey FIELD —
+ * never "no backdrop" — because falling back to the theme surface reintroduces
+ * the exact #3885/#1449 pale-hold-swallow bug for the user who needs zero
+ * chroma (CVD, migraine/light sensitivity) AND visible holds. `#524E47` keeps
+ * white plastic at 6.74:1 and the start ring at 6.16:1 (both pass WCAG AA)
+ * while removing the yellow-green colour confound entirely.
+ */
+export const MOONBOARD_BACKDROP_PRESETS: Record<MoonboardBackdropPreset, { light: string; dark: string }> = {
+  gold: { light: '#FAD201', dark: '#C0932E' },
+  classic: { light: '#FAD201', dark: '#FAD201' },
+  dim: { light: '#E3B23C', dark: '#9E7F30' },
+  neutral: { light: '#E7E2D8', dark: '#524E47' },
+};
+
+/** Resolves a MoonBoard backdrop preset + color scheme to its hex value. */
+export function resolveMoonboardBackdrop(preset: MoonboardBackdropPreset, colorScheme: 'light' | 'dark'): string {
+  return MOONBOARD_BACKDROP_PRESETS[preset][colorScheme];
+}
 
 /**
  * M3 surface-tint percentages for the elevation overlay (levels 1–5). The brand

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -102,6 +102,28 @@ export const playDrawerMaterialTint = {
 } as const;
 
 /**
+ * Fixed backdrop painted behind every MoonBoard render (LayeredClimbImage),
+ * regardless of light/dark mode (issue #3885, and the older #1449). MoonBoard
+ * board art (moonboard-bg.webp + the holdset webps) is a near-fully-transparent
+ * schematic — grid labels and hold icons only, no filled wall behind them — so
+ * without an explicit backdrop it shows whatever's behind the image stack. In
+ * the play view that's the modal's themed system background (app/play.tsx),
+ * which turns near-black in dark mode and swallows the pale/neutral-toned
+ * holds.
+ *
+ * Deliberately NOT keyed by colorScheme like `playDrawerMaterialTint` above:
+ * MoonBoard panels are painted a real-world yellow (RAL 1023 "Traffic
+ * Yellow" per Moon Climbing's panel spec), so a fixed warm tone reads as the
+ * actual board in both modes rather than as a theme artifact — and it keeps
+ * LayeredClimbImage (used everywhere a board renders: thumbnails, discovery
+ * cards, the play view) free of a useTheme() dependency. Toned down from the
+ * saturated RAL swatch to a paler, muted cream-yellow so a full-screen fill
+ * behind grey/beige hold icons stays comfortable to look at rather than
+ * traffic-cone bright.
+ */
+export const moonboardWallBackdrop = '#E9DBA0';
+
+/**
  * M3 surface-tint percentages for the elevation overlay (levels 1–5). The brand
  * primary is alpha-composited over the base surface at these alphas to build the
  * tonal surface-container ramp — this IS M3's mechanism for expressing depth

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -112,16 +112,42 @@ export const playDrawerMaterialTint = {
  * holds.
  *
  * Deliberately NOT keyed by colorScheme like `playDrawerMaterialTint` above:
- * MoonBoard panels are painted a real-world yellow (RAL 1023 "Traffic
- * Yellow" per Moon Climbing's panel spec), so a fixed warm tone reads as the
- * actual board in both modes rather than as a theme artifact — and it keeps
- * LayeredClimbImage (used everywhere a board renders: thumbnails, discovery
- * cards, the play view) free of a useTheme() dependency. Toned down from the
- * saturated RAL swatch to a paler, muted cream-yellow so a full-screen fill
- * behind grey/beige hold icons stays comfortable to look at rather than
- * traffic-cone bright.
+ * MoonBoard panels are painted a real-world yellow, so a fixed tone reads as
+ * the actual board in both modes rather than as a theme artifact — and it
+ * keeps LayeredClimbImage (used everywhere a board renders: thumbnails,
+ * discovery cards, the play view) free of a useTheme() dependency. Depicting
+ * a compatible physical product's paint colour is fine (the same basis as
+ * the board-art assets we already ship); no Moon branding/logo is used here.
+ *
+ * Value: RAL 1023 "Traffic Yellow" (#FAD201), the RAL code Moon Climbing
+ * lists for MoonBoard panels. Cross-checked against
+ * packages/moonboard-ocr/src/__tests__/fixtures/moonboard-grid-reference.jpg
+ * (Moon's own board-art reference graphic, in-repo) — sampling its plain
+ * background pixels averages ~#EEDF50, the same "golden yellow" family
+ * (hue ~54° vs RAL 1023's ~50°) but lighter/less saturated, consistent with
+ * print/JPEG reproduction rather than raw paint. Went with the RAL value:
+ * closer to the paint spec, and its hue sits slightly further from the
+ * MoonBoard start-hold green (see below), which is the pairing that matters
+ * most for on-screen contrast.
+ *
+ * Hold-state contrast (WCAG relative-luminance ratio, MOONBOARD_HOLD_STATES
+ * displayColor in moonboard-config.ts) at this value:
+ *   - hand (#4444FF): 4.06:1 — passes WCAG AA for large-scale graphics (3:1).
+ *   - finish (#FF3333): 2.47:1 — below 3:1, readable but not high-contrast.
+ *   - start (#44FF44): 1.09:1 — effectively unreadable stroke-on-backdrop.
+ * The green pairing is not fixable by tuning this hex: green and yellow are
+ * adjacent, similarly-bright hues, so WCAG contrast stays under ~1.35:1 for
+ * ANY backdrop light/saturated enough to still read as "yellow" — reaching
+ * even 3:1 needs a backdrop luminance dark enough to look olive/khaki, which
+ * defeats the fix. Verified darkening/desaturating from RAL 1023 does not
+ * help here and actively worsens hand/finish contrast (a lighter backdrop
+ * has MORE headroom against both blue and red), so this value is the local
+ * optimum, not a compromise pending further tuning. The real fix for the
+ * green pairing is a fixed dark outline on hold markers (a renderer-level
+ * change, packages/board-renderer/core/src/renderer.rs) — out of scope here,
+ * tracked as a follow-up rather than solved by backdrop colour alone.
  */
-export const moonboardWallBackdrop = '#E9DBA0';
+export const moonboardWallBackdrop = '#FAD201';
 
 /**
  * M3 surface-tint percentages for the elevation overlay (levels 1–5). The brand

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -52,6 +52,17 @@
           "title": "Preview",
           "caption": "Your markers on your board. Colours show as-is here — use the check below to see how they read."
         },
+        "wall": {
+          "title": "MoonBoard wall",
+          "subtitle": "How yellow the wall looks behind the holds. Only affects MoonBoard renders.",
+          "optionAccessibilitySelected": "{{label}}, selected",
+          "options": {
+            "gold": { "label": "Warm gold", "description": "Bright by day, dimmed at night. The comfortable default." },
+            "classic": { "label": "Classic yellow", "description": "Full paint-bright yellow in both modes." },
+            "dim": { "label": "Dim ochre", "description": "Deepest gold for long night sessions." },
+            "neutral": { "label": "Neutral grey", "description": "No yellow at all — easiest on sensitive eyes." }
+          }
+        },
         "cvd": {
           "title": "Colour-blind check",
           "subtitle": "See how your markers look with different types of colour blindness, so the four roles stay easy to tell apart.",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -269,6 +269,26 @@
           "title": "Vista previa",
           "caption": "Tus marcadores en tu plafón. Aquí los colores se ven tal cual; usa la comprobación de abajo para ver cómo se distinguen."
         },
+        "wall": {
+          "title": "Pared del MoonBoard",
+          "subtitle": "Cuánto amarillo se ve detrás de las presas. Solo afecta al plafón MoonBoard.",
+          "optionAccessibilitySelected": "{{label}}, seleccionado",
+          "options": {
+            "gold": {
+              "label": "Dorado cálido",
+              "description": "Brillante de día, atenuado de noche. La opción por defecto, cómoda para la vista."
+            },
+            "classic": {
+              "label": "Amarillo clásico",
+              "description": "El amarillo intenso de la pintura, en ambos modos."
+            },
+            "dim": { "label": "Ocre tenue", "description": "El dorado más oscuro, para largas sesiones nocturnas." },
+            "neutral": {
+              "label": "Gris neutro",
+              "description": "Sin nada de amarillo: lo más suave para ojos sensibles."
+            }
+          }
+        },
         "cvd": {
           "title": "Comprobación de daltonismo",
           "subtitle": "Mira cómo se ven tus marcadores con distintos tipos de daltonismo, para que los cuatro roles sigan siendo fáciles de distinguir.",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -52,6 +52,26 @@
           "title": "Aperçu",
           "caption": "Tes marqueurs sur ta board. Les couleurs sont affichées telles quelles ici — utilise la vérification ci-dessous pour voir comment elles se distinguent."
         },
+        "wall": {
+          "title": "Mur MoonBoard",
+          "subtitle": "La quantité de jaune derrière les prises. Ne concerne que le MoonBoard.",
+          "optionAccessibilitySelected": "{{label}}, sélectionné",
+          "options": {
+            "gold": {
+              "label": "Or chaud",
+              "description": "Lumineux le jour, atténué la nuit. Le réglage par défaut, confortable pour les yeux."
+            },
+            "classic": {
+              "label": "Jaune classique",
+              "description": "Le jaune vif de la peinture, dans les deux modes."
+            },
+            "dim": {
+              "label": "Ocre sombre",
+              "description": "L'or le plus sombre, pour les longues sessions nocturnes."
+            },
+            "neutral": { "label": "Gris neutre", "description": "Aucun jaune : le plus doux pour les yeux sensibles." }
+          }
+        },
         "cvd": {
           "title": "Vérification daltonisme",
           "subtitle": "Regarde comment tes marqueurs apparaissent avec différents types de daltonisme, pour que les quatre rôles restent faciles à distinguer.",


### PR DESCRIPTION
## Summary

In dark mode, MoonBoard climbs (any layout — 2016, 2024, mini, masters) were nearly unreadable: only the highlighted holds stood out, the rest of the wall vanished. Root cause: MoonBoard's board art (`moonboard-bg.webp` + the per-set holdset webps, e.g. `moonboard2016/holdseta.webp`) is a near-fully-transparent schematic — grid labels and hold icons only, no filled wall behind them. With nothing opaque in the image stack, the play view's dark themed backdrop (`app/play.tsx`'s `systemColors.secondaryBackground` + a Liquid-Glass `GlassSurface`) showed straight through and swallowed the pale/neutral-toned holds.

`LayeredClimbImage` (the shared render stack used everywhere a board renders — play view, list thumbnails, discovery cards, accessory bar, kiosk, reaction menu, BLE cards) now paints a MoonBoard backdrop resolved from a **preset + light/dark mode**. The gate is `boardName === 'moonboard'`, so it covers every layout, not just 2016 — and Kilter/Tension/Decoy are untouched (denser, brighter hold art already reads fine against the same transparent-image structure).

No native/cache changes: the Rust renderer only ever produced a holds-only overlay PNG (backgrounds have been separate bundled-asset `<Image>` layers since `RENDERER_VERSION` v2) — this is a pure JS/view-layer change, no `RENDERER_VERSION` bump, no cache invalidation, no native fingerprint change, ships OTA.

Closes the same underlying gap as the older #1449 ("hard to see moonboard climbs") — same board art, same missing-backdrop root cause.

Fixes #3885
Fixes #1449

**Web note:** the Next.js web climbing surface has the identical structural bug (confirmed: no board-image layer in `board-image-layers.tsx` / `board-canvas-renderer.tsx` / `moonboard-renderer.tsx` sets a background either), but it's deprecated in favor of the RN web deploy, which inherits this fix automatically — no separate web follow-up filed.

## Color story (design-team spec, final)

Went through two iterations on this PR:

1. First shipped a single theme-independent `#FAD201` (RAL 1023 "Traffic Yellow") in both light and dark mode.
2. Owner rejected it as too yellow/uncomfortable in dark mode after seeing it rendered. A design-team review diagnosed the actual problem as **photometric, not taste**: `#FAD201` filling most of a dark OLED screen sits at ~103× the luminance of the dark-mode chrome (`#141218`) — a disability-glare source for a dark-adapted eye — and, worse, it nearly hides the exact holds the backdrop exists to reveal (white plastic 1.20:1, the green start ring 1.09:1).

**Final treatment — light and dark now genuinely differ, not just one fixed hex:**

| Mode | Hex | Why |
|---|---|---|
| Light (unchanged) | `#FAD201` | Glare-immune (bright surround) — the complaint was dark-mode only, so light mode keeps the literal RAL 1023 paint value with the best ring headroom. |
| Dark (new default) | `#C0932E` warm gold | Halves glare vs. chrome (103×→50×), warms the hue off yellow's 555 nm luminance peak (91°→83°) as a second comfort lever, and roughly *doubles* the two things the backdrop exists to reveal: white plastic 1.20:1→2.30:1, the green start ring 1.09:1→2.10:1. |

Dark isn't derived from light via a blend — a pure blend toward the chrome can't warm the hue off the luminance peak, and that hue shift is an independently useful comfort lever. Two hand-specified hexes per preset (see below) is an accepted small drift-risk in exchange for that control.

### New: accessibility override

More → Accessibility → **"MoonBoard wall"** section (placed directly below the live board preview, so it redraws per choice). Four presets, `ListRow`s with a two-tone swatch (top = light hex, bottom = dark hex), a check mark on the selected row, and a selection haptic:

| Preset | Light | Dark | For |
|---|---|---|---|
| **Gold** (default) | `#FAD201` | `#C0932E` | Bright by day, dimmed at night — the comfortable default. |
| Classic | `#FAD201` | `#FAD201` | Full paint-bright yellow in both modes, for anyone who preferred the original. |
| Dim | `#E3B23C` | `#9E7F30` | Deepest gold, for long night sessions. |
| Neutral | `#E7E2D8` | `#524E47` | No yellow at all — for CVD or light-sensitive users. |

**Hard guardrail, worth flagging for review**: `neutral` is a genuine **mid-grey field**, not "skip the backdrop View." Falling back to no backdrop at all would reintroduce the exact #3885/#1449 pale-hold-swallow bug for the one user who most needs both zero yellow chroma AND visible holds. `#524E47` keeps white plastic at 6.74:1 and the start ring at 6.16:1 (both pass WCAG AA).

Stored as the preset key (not a hex) in the MMKV settings store (`moonboardBackdrop` in `AppSettings`, default `'gold'`) — synchronous, so no flash-of-default on cold play-view open, safe inside a `React.memo`'d leaf in virtualized lists. `LayeredClimbImage` reads it via `useSetting('moonboardBackdrop')` + RN's `useColorScheme()` — **deliberately not `useTheme()`**, which is a big memoized object this perf-sensitive leaf avoids; the theme provider mirrors the user's in-app theme override into `Appearance.setColorScheme`, so `useColorScheme()` already reflects the app setting, not just the OS. Single read point inside `LayeredClimbImage` — no prop-threading across the ~10 surfaces that render a MoonBoard.

### Contrast table (final, independently recomputed)

Ring hexes from `MOONBOARD_HOLD_STATES` in `moonboard-config.ts`: start `#44FF44`, hand `#4444FF`, finish `#FF3333`. Glare = raw-Y multiple vs. sheet chrome `#141218`.

| Pair | Dark default `#C0932E` | Light default `#FAD201` | Neutral dark `#524E47` | Verdict |
|---|---|---|---|---|
| Glare vs. chrome | **50×** (was 103×) | 103× (bright surround — not a glare context) | 12× | Core comfort fix: halved |
| Start ring `#44FF44` | 2.10:1 (was 1.09) | 1.09:1 | **6.16:1** ✓ AA | Improved ~2×; see note |
| Hand ring `#4444FF` | 2.12:1 (was 4.06) | **4.06:1** ✓ AA-large | 1.38:1 | Deliberate comfort trade; see note |
| Finish ring `#FF3333` | 1.29:1 (was 2.47) | 2.47:1 | 2.27:1 | See note |
| Black plastic `#1E1E1E` | **5.92:1** ✓ | **11.34:1** ✓ | 2.02:1 | The original #3885 job — passes |
| White plastic `#E8E8E6` | 2.30:1 (was 1.20) | 1.20:1 | **6.74:1** ✓ AA | Darkening ~doubles pale-hold legibility |

**Ring note:** no value that still reads as yellow can clear 3:1 against green, blue, and red simultaneously. Ring legibility is owned by a tracked renderer-level follow-up (#3913: a fixed dark outline on hold markers, `packages/board-renderer/core/src/renderer.rs`), not this backdrop. The blue/red drop in dark mode (4.06→2.12, 2.47→1.29) is a deliberate comfort trade, not a regression — the previously-invisible green ring and white plastic both roughly double.

### i18n

New `mobile.more.accessibility.wall.*` keys (title, subtitle, 4× label+description, selected-state a11y label) in all three catalogs (en-US/es/fr). "MoonBoard" stays untranslated everywhere; es uses "plafón" per the glossary; both es/fr use informal address matching the rest of the screen.

### Discovery-card letterboxing (earlier Codex review, already fixed)

Codex flagged that the backdrop layer fills its parent edge-to-edge (no `contentFit` awareness, unlike the board-art `<Image>` layers) — `BoardDiscoveryCard`'s fixed 168×168 square was the clear case. Fixed with a `thumbFit` aspect-fit inner box (same pattern as `BoardManageRow`'s existing `thumbFit`). `ClimbListThumbnail`'s ~7px letterbox bars are left as-is (no board-dimension data in scope there) and tracked in #3913 alongside the ring-contrast follow-up.

## Release Notes

- The MoonBoard wall eases off the bright yellow in dark mode — easier on your eyes mid-session — and you can pick your own wall tone (classic yellow, dim ochre, or no yellow at all) under More → Accessibility.

## Test plan

- `vp check` — clean (pre-existing unrelated formatting drift in `packages/mobile/public/index.html` on `main`, not touched here).
- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 541 files pass, including: `resolveMoonboardBackdrop` unit coverage (all 4 presets × 2 schemes = 8 exact hexes), `LayeredClimbImage` backdrop-color-resolution cases (gold+light, gold+dark, neutral+dark as a swallow-bug regression guard), the settings-store default/roundtrip coverage for the new `moonboardBackdrop` key, and the pre-existing discovery-card aspect-fit test.
- `vp run check:mobile-bundle` — clean.
- `vp run check:i18n:orphans` — clean, no orphaned catalog keys (`check:i18n` itself only covers `packages/web/app/**`, not mobile). The `i18n` project's `catalog-completeness` test (parity across all three locales) passes.
- **Visual verification could not be captured in this environment.** The Android emulator segfaults on boot on this box (qemu SIGSEGV under both `swiftshader_indirect` and `swangle_indirect` GPU renderers — a host limitation, unrelated to this change). `.boardsesh/qa-notes.md` (gitignored, local) has the full manual QA plan. Two manual passes are still needed:
  - **Android** (any host where the emulator/a device is available): confirm the `#FAD201`/`#C0932E` light/dark split on a MoonBoard climb across several surfaces; confirm flipping the in-app theme setting swaps the backdrop live; exercise all 4 presets under More → Accessibility and confirm the live preview + every other surface update; confirm `neutral` renders as a grey field, never blank; confirm a Kilter/Tension control climb is visually unchanged.
  - **iOS** (the platform the original report came from): `vp run mobile:ios-shots` or a real device — confirm the backdrop isn't tinted/darkened by the Liquid-Glass `GlassSurface` material.
