### PR TITLE
fix(mobile): let queue swipe-to-remove survive natural swipe wobble

### DIFF
--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -152,8 +152,17 @@ function QueueItemRowComponent({
     () =>
       Gesture.Pan()
         .enabled(swipeEnabled)
+        // Activate once the drag is clearly horizontal (10px), and bail once it's
+        // clearly vertical (14px). A tighter [-5, 5] Y bail was so narrow that the
+        // normal vertical wobble of a horizontal swipe tripped it before the 10px X
+        // activation — the Pan failed, never engaged, and the row's tap fell through
+        // and just selected the climb instead of revealing Delete (#3295). 14px
+        // tolerates that wobble while still ceding to a real vertical scroll (which
+        // crosses 14px in Y well before 10px in X). Mirrors SwipeableRow, extracted
+        // from this component, which already widened this exact value for the same
+        // reason.
         .activeOffsetX([-10, 10])
-        .failOffsetY([-5, 5])
+        .failOffsetY([-14, 14])
         .onUpdate((event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
           // Only allow swiping left
           if (event.translationX > 0) {

--- a/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
@@ -19,6 +19,13 @@ const captured = vi.hoisted(() => ({
   deletePress: null as null | (() => void),
 }));
 
+// Per-instance call logs for the RNGH gestures created below, one array pushed per
+// `Gesture.Pan()` call in creation order. Lets a test inspect exactly what was
+// chained onto a specific gesture — e.g. the swipe Pan's `failOffsetY` thresholds.
+const gestureCalls = vi.hoisted(() => ({
+  panLogs: [] as { method: string; args: unknown[] }[][],
+}));
+
 vi.mock('react-native', () => {
   const passthrough =
     (tag: string) =>
@@ -71,14 +78,30 @@ vi.mock('react-native-reanimated', () => {
 });
 
 vi.mock('react-native-gesture-handler', () => {
-  const makeBuilder = () => {
+  // A chainable gesture builder that logs every method call into `log`, so a test
+  // can assert exactly how a gesture was configured (e.g. `.failOffsetY([-14, 14])`
+  // on the swipe Pan). Every method returns the same proxy so chains resolve.
+  const makeBuilder = (log: { method: string; args: unknown[] }[]) => {
     const builder: Record<string, (...args: unknown[]) => unknown> = {};
-    const proxy: typeof builder = new Proxy(builder, { get: () => () => proxy });
+    const proxy: typeof builder = new Proxy(builder, {
+      get:
+        (_target, prop: string) =>
+        (...args: unknown[]) => {
+          log.push({ method: prop, args });
+          return proxy;
+        },
+    });
     return proxy;
   };
   return {
     GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-    Gesture: { Pan: () => makeBuilder() },
+    Gesture: {
+      Pan: () => {
+        const log: { method: string; args: unknown[] }[] = [];
+        gestureCalls.panLogs.push(log);
+        return makeBuilder(log);
+      },
+    },
   };
 });
 
@@ -149,6 +172,7 @@ describe('QueueItemRow React.memo', () => {
     captured.rowPress = null;
     captured.tickPress = null;
     captured.deletePress = null;
+    gestureCalls.panLogs = [];
     vi.clearAllMocks();
   });
 
@@ -262,5 +286,37 @@ describe('QueueItemRow React.memo', () => {
     rerender(<QueueItemRow item={second} {...rowProps} />);
 
     expect(captured.deletePress).toBe(deletePress);
+  });
+
+  // Regression guard for #3295: the swipe-to-remove Pan bailed on a ±5px vertical
+  // wobble (`.failOffsetY([-5, 5])`) before its ±10px horizontal activation, so a
+  // natural horizontal swipe failed the Pan and the row's tap fell through and just
+  // selected the climb instead of revealing Delete. The Y bail must stay wider than
+  // the X activation so the swipe survives normal wobble (mirrors SwipeableRow,
+  // extracted from this component, which already widened this exact value). The real
+  // cross-gesture arbitration only exists in the native runtime — see the on-device
+  // QA matrix in the PR body — but the threshold itself is guarded here.
+  it('gives the swipe-to-remove Pan a vertical bail wide enough to survive swipe wobble', () => {
+    const item = makeItem('a', 'Crimp Master');
+    render(
+      <QueueItemRow
+        item={item}
+        position={1}
+        board={board}
+        isCurrentClimb={false}
+        onPress={onPress}
+        onRemove={onRemove}
+        onToggleSelect={onToggleSelect}
+      />,
+    );
+
+    // No `drag` prop, so the only Gesture.Pan() created is the row's swipe gesture.
+    expect(gestureCalls.panLogs).toHaveLength(1);
+    const swipeCalls = gestureCalls.panLogs[0];
+
+    const activeOffsetX = swipeCalls.find((call) => call.method === 'activeOffsetX');
+    const failOffsetY = swipeCalls.find((call) => call.method === 'failOffsetY');
+    expect(activeOffsetX?.args).toEqual([[-10, 10]]);
+    expect(failOffsetY?.args).toEqual([[-14, 14]]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3295 — on iOS, swiping a climb out of the queue "doesn't work and just selects the item."

**Root cause (one tight threshold, both symptoms).** `QueueItemRow`'s swipe Pan was configured `.activeOffsetX([-10, 10]).failOffsetY([-5, 5])`. The ±5px vertical bail is *narrower* than the ±10px horizontal activation, so the natural vertical wobble of a real horizontal swipe crosses 5px in Y before 10px in X — the Pan **fails** instead of activating. A failed Pan sends no touch-cancel to the row body, so the row's press falls through on lift and just **selects the climb**. That single threshold produces both halves of the report: the swipe "doesn't work" (Pan never engages) *and* it "just selects" (press falls through).

**Fix.** Widen the Y bail to `.failOffsetY([-14, 14])` so the swipe survives the normal wobble of a horizontal drag while still ceding to a real vertical scroll (which crosses 14px in Y well before 10px in X).

### Precedent — this value is already shipping

`SwipeableRow.tsx` was extracted from `QueueItemRow` (see its docstring) and carries the same swipe maths — except it already widened this exact value, with the comment:

> Activate once the drag is clearly horizontal (10px), and bail once it's clearly vertical (14px). The old `[-5,5]` vertical bail was so tight that the normal wobble of a horizontal swipe tripped it, so the swipe almost never engaged; 14px tolerates that wobble while still ceding to a real vertical scroll (which crosses 14px in Y well before 10px in X). The Edit button is the guaranteed-reliable path regardless of this feel.

The fix was never back-ported to `QueueItemRow`. This PR does that.

### Independence from #3890

Open PR #3890 (drag-handle-vs-reaction-menu, #3683) rewrites the row's *press* mechanism (RN-core `Pressable` → RNGH `Gesture.Exclusive(longPress, tap)` with `tap.maxDistance(15)`). That's complementary defense-in-depth for the "just selects" half, but it does **not** touch `panGesture` and leaves `failOffsetY([-5, 5])` unchanged — so on its own the swipe still fails to engage on wobble. This PR edits only the `panGesture` `failOffsetY` value, on lines #3890 never touches. The two are textually and semantically disjoint and rebase cleanly in **either** merge order; no conflict, no shared behaviour.

## Release Notes

- Swiping a queued climb left to remove it now works even when your thumb wanders a little — no more accidentally opening the climb instead.

## Test plan

- `vp check` (clean for touched files), `vp run typecheck:mobile`, `vp run test:mobile` (537 files / 4416 tests, all green), `vp run check:mobile-bundle` (iOS + Android export OK) — all pass locally.
- `packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx`: added per-gesture call-logging to the RNGH `Gesture.Pan()` mock and a regression test asserting the swipe Pan is configured `.activeOffsetX([-10, 10])` / `.failOffsetY([-14, 14])` — guards against the Y bail being re-tightened. All pre-existing memoization/callback-stability assertions preserved.

### On-device QA (this box is Linux — no iOS simulator; please run before merging)

Primary target iOS; Android shares the code path.

1. Queue drawer with **≥2 upcoming climbs**. Swipe a row left with a natural, slightly-wobbly horizontal motion → the red **Delete** reveals; the climb is **not** selected. *(the bug — confirm fixed)*
2. Tap the revealed **Delete** → row animates out and is removed.
3. **Quick tap** a row (no swipe) → still selects/navigates.
4. **Vertical drag** on a row → the list still scrolls (14px Y bail still cedes to scroll).
5. **Long-press** a row → reaction menu still opens; **≡ drag handle** still reorders.
6. Repeat 1–2 on **Android**.

### OTA vs native

Pure JS/TS change (`QueueItemRow.tsx` + its test) — no native module, no dependency bump, no `app.config.ts`/plugin change. Runtime fingerprint unaffected; ships via the existing OTA pipeline once merged.

<sub>Possible follow-up (not in this PR): `SwipeableRow` also softened its reveal threshold from -80 to -56 ("felt stiff"); `QueueItemRow` still uses -80. Left alone here to keep the fix minimal.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkJuDx4nCQPYQzeEjNd6Q3
