### PR TITLE
fix(mobile): invalidate the infinite climbs list on climb save, draft delete + favorite toggle

### DIFF
--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -4,6 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // --- Hoisted mock state the test drives between cases. ---------------------
 const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+// A single shared invalidateQueries spy (unlike a fresh `vi.fn()` per render)
+// so tests can assert on it: useQueryClient() is called once per render, and a
+// per-render mock would give the closure a different identity than the one the
+// test holds.
+const reactQuery = vi.hoisted(() => ({ invalidateQueries: vi.fn() }));
 
 const board = vi.hoisted(() => ({
   isAuthenticated: true,
@@ -51,7 +56,7 @@ vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
 vi.mock('expo-router', () => ({ useRouter: () => router }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useQueryClient: () => reactQuery,
 }));
 
 vi.mock('@boardsesh/shared-schema', () => ({
@@ -142,6 +147,7 @@ beforeEach(() => {
   toast.showToast.mockClear();
   queue.setCurrentClimb.mockClear();
   router.push.mockClear();
+  reactQuery.invalidateQueries.mockClear();
   board.isAuthenticated = true;
   board.isDuplicateClimbError.mockReturnValue(false);
   board.saveClimb.mockReset();
@@ -170,6 +176,12 @@ describe('useCreateClimbScreen analytics', () => {
       holdCount: 3,
     });
     expect(analytics.track).not.toHaveBeenCalledWith('Climb Create Failed', expect.anything());
+    // #3471: create/edit/publish share one success path with useDeleteDraftClimb's
+    // key set — the Open Drafts table AND the Climbs tab's infinite list must both
+    // refresh, not just the plain searchClimbs cache.
+    expect(reactQuery.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['searchClimbs'] });
+    expect(reactQuery.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['infiniteSearchClimbs'] });
+    expect(reactQuery.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['searchClimbsCount'] });
   });
 
   it('fires "Climb Updated" when saving an existing climb in edit mode', async () => {
@@ -204,6 +216,9 @@ describe('useCreateClimbScreen analytics', () => {
       isDraft: false,
       holdCount: 3,
     });
+    expect(reactQuery.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['searchClimbs'] });
+    expect(reactQuery.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['infiniteSearchClimbs'] });
+    expect(reactQuery.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['searchClimbsCount'] });
   });
 
   it('fires "Climb Create Failed" with error_reason "duplicate" on a duplicate rejection', async () => {

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -516,9 +516,12 @@ export function useCreateClimbScreen({
         syncSavedToQueue(result.uuid, frames);
       }
       await clearDraft(draftKey);
-      // Refresh the inline Open Drafts table so the just-saved climb appears /
-      // updates (delete already invalidates these keys; save must too).
+      // Refresh the inline Open Drafts table AND the Climbs tab's infinite list
+      // so the just-saved climb appears / updates (mirrors useDeleteDraftClimb's
+      // key set in lib/graphql/hooks/index.ts — create, edit, and publish-draft
+      // all fall through to this same success path).
       void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
+      void queryClient.invalidateQueries({ queryKey: ['infiniteSearchClimbs'] });
       void queryClient.invalidateQueries({ queryKey: ['searchClimbsCount'] });
       setJustSaved(true);
       showToast(isDraft ? t('mobile.create.save.draftToast') : t('mobile.create.save.publishedToast'), 'success');

--- a/packages/mobile/src/lib/graphql/__tests__/hooks-dual-write.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/hooks-dual-write.test.ts
@@ -53,7 +53,7 @@ vi.mock('../hooks/use-social', () => ({
 }));
 vi.mock('../hooks/use-session-detail', () => ({ useSessionDetail: vi.fn(), useSessionPreview: vi.fn() }));
 
-import { useToggleFavorite } from '../hooks';
+import { useToggleFavorite, useDeleteDraftClimb } from '../hooks';
 import { runMigrations } from '@boardsesh/offline-sync';
 import { createTestDatabase, __resetDrainerStateForTests, type TestSqliteDb } from '@boardsesh/offline-sync/testing';
 
@@ -176,5 +176,65 @@ describe('useToggleFavorite dual-write', () => {
     const localWrites = await db.getAllAsync<Row>('SELECT * FROM user_favorites');
     expect(localWrites).toHaveLength(0);
     expect(await db.getAllAsync<Row>('SELECT * FROM pending_mutations')).toHaveLength(0);
+  });
+});
+
+// #3471: the infinite Climbs-tab list (['infiniteSearchClimbs']) must self-heal
+// on the same completion paths as the plain ['searchClimbs'] cache, not just on
+// a board sync — otherwise a favorited/deleted climb keeps showing stale rows
+// until staleTime expires.
+describe('useToggleFavorite onSuccess invalidation', () => {
+  it('online path: invalidates searchClimbs, infiniteSearchClimbs, and favoriteStatus', async () => {
+    request.mockResolvedValue({ toggleFavorite: { favorited: true } });
+    const { mutationFn, onSuccess } = asConfig<ToggleVariables>(useToggleFavorite());
+    const variables: ToggleVariables = {
+      input: { boardName: 'kilter', climbUuid: 'climb-online-fav', angle: 40 },
+      currentlyFavorited: false,
+    };
+
+    const data = await mutationFn(variables);
+    onSuccess?.(data, variables);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['searchClimbs'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['infiniteSearchClimbs'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['favoriteStatus', 'kilter', 'climb-online-fav', 40],
+    });
+  });
+
+  it('local-queue path: invalidates searchClimbs + infiniteSearchClimbs, skips favoriteStatus', async () => {
+    request.mockImplementation(parkedRequest);
+    const { mutationFn, onSuccess } = asConfig<ToggleVariables>(useToggleFavorite());
+    const variables: ToggleVariables = {
+      input: { boardName: 'kilter', climbUuid: 'climb-fav-queued', angle: 40 },
+      currentlyFavorited: false,
+    };
+
+    const data = await mutationFn(variables);
+    onSuccess?.(data, variables);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['searchClimbs'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['infiniteSearchClimbs'] });
+    // The server doesn't know about the toggle yet on the local-queue path — the
+    // optimistic setQueryData holds until the drainer's post-landing invalidation.
+    expect(invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: ['favoriteStatus', 'kilter', 'climb-fav-queued', 40],
+    });
+  });
+});
+
+describe('useDeleteDraftClimb onSuccess invalidation', () => {
+  it('invalidates searchClimbs, infiniteSearchClimbs, and searchClimbsCount', async () => {
+    request.mockResolvedValue({ deleteDraftClimb: true });
+    type DeleteDraftVariables = { uuid: string; boardType: string };
+    const { mutationFn, onSuccess } = asConfig<DeleteDraftVariables>(useDeleteDraftClimb());
+    const variables: DeleteDraftVariables = { uuid: 'draft-1', boardType: 'kilter' };
+
+    const data = await mutationFn(variables);
+    onSuccess?.(data, variables);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['searchClimbs'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['infiniteSearchClimbs'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['searchClimbsCount'] });
   });
 });

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -752,6 +752,7 @@ export function useDeleteDraftClimb() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
+      void queryClient.invalidateQueries({ queryKey: ['infiniteSearchClimbs'] });
       void queryClient.invalidateQueries({ queryKey: ['searchClimbsCount'] });
     },
   });
@@ -867,6 +868,7 @@ export function useToggleFavorite() {
     },
     onSuccess: (data, variables) => {
       void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
+      void queryClient.invalidateQueries({ queryKey: ['infiniteSearchClimbs'] });
       // Bust the per-climb favorite-status cache so a re-open reflects the new
       // state from the server, not a stale 5-min-cached value. Skipped on the
       // local-queue path, where the server does not know about the toggle yet —


### PR DESCRIPTION
## Summary

Fixes #3471. The Climbs tab's infinite list (`['infiniteSearchClimbs']`) never invalidated on several completion paths, so it kept serving stale rows past `staleTime`:

- `useDeleteDraftClimb`'s `onSuccess` busted `['searchClimbs']` and `['searchClimbsCount']` but not `['infiniteSearchClimbs']` — a deleted draft stayed visible in the list.
- `useToggleFavorite`'s `onSuccess` busted `['searchClimbs']` but not `['infiniteSearchClimbs']` — inconsistent with the offline drainer's own `user_favorites` invalidation, which already includes the infinite key.
- `use-create-climb-screen.ts`'s shared save-success path — the create, edit, **and publish-draft** branches (`saveClimb` / `updateClimb`) all fall through to one block — busted `['searchClimbs']`/`['searchClimbsCount']` but not `['infiniteSearchClimbs']`. Found in QA review of this PR: the block's own comment pointed at `useDeleteDraftClimb`'s key set, which this PR had just brought current, so it was left out of parity with the exact hook it references.

First two are in `packages/mobile/src/lib/graphql/hooks/index.ts`; the third is `packages/mobile/src/components/create-climb/use-create-climb-screen.ts:518-525`.

**Confirmed NOT a gap:** tick save/delete — the ascent glyph on climb rows reads from the logbook index, not from `searchClimbs`/`infiniteSearchClimbs`, so no invalidation is needed there.

**Already fixed before this PR** — the issue's other two originally-reported sites had drifted and no longer needed a change:
- `packages/shared/offline-sync/src/sync/table-config.ts:103,139` (was `packages/mobile/src/sync/table-config.ts`) — fixed incidentally by `f06489cfe` (#3564, Boardsesh-grade sync).
- `packages/shared/offline-sync/src/mutation-queue/drainer.ts:73-74` (was `packages/mobile/src/mutation-queue/drainer.ts`) — fixed incidentally by `78ac0274d` (the offline-sync package extraction refactor).

Both moved into `@boardsesh/offline-sync` as part of that refactor, and all three `pull-client.ts` invalidation call sites (delta pull, deletions, snapshot-bootstrap completion) read `invalidateKeys` from that shared config generically, so they already pick up `infiniteSearchClimbs` for free. `remove-offline-board.ts` also derives its invalidation set from the same config. Verified via `git log -S"infiniteSearchClimbs"` against both files.

Invalidation stays global/unscoped (`['infiniteSearchClimbs']`, no board/angle suffix) to match every other invalidation site for this key in the codebase — none of them scope narrower today.

## Release Notes

- The climb list now refreshes right away after saving, editing, or publishing a climb, deleting a draft, or favoriting a climb

## Test plan

- Extended `packages/mobile/src/lib/graphql/__tests__/hooks-dual-write.test.ts` with two new `describe` blocks asserting `onSuccess` invalidates `['infiniteSearchClimbs']`:
  - `useToggleFavorite onSuccess invalidation` — online path (searchClimbs + infiniteSearchClimbs + favoriteStatus) and local-queue path (searchClimbs + infiniteSearchClimbs, favoriteStatus deliberately skipped).
  - `useDeleteDraftClimb onSuccess invalidation` — searchClimbs + infiniteSearchClimbs + searchClimbsCount.
- Extended the existing `use-create-climb-screen-analytics.test.tsx` harness (no new test file scaffolded) with a shared `invalidateQueries` spy, asserting all three keys on both the new-climb save case and the edit-mode (update) save case — the two branches that funnel into the shared success block.
- `vp check` — clean (one pre-existing, unrelated formatting issue in `packages/mobile/public/index.html`, confirmed present on `main` via `git stash` before this PR touched anything).
- `vp run typecheck:mobile` — clean.
- `vp test run --project mobile --reporter=agent` — 537 files / 4415 tests passed.
- `vp run check:mobile-bundle` — OK.
