### PR TITLE
chore(mobile): make the reaction-menu playlist action structurally inline-only

### DIFF
--- a/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
@@ -25,6 +25,10 @@ vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: {} }));
 vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({
     openPlayDrawer: openers.openPlayDrawer,
+    // Still surfaced by the real provider (the climb-list row / board sheet open
+    // it directly), but the hook no longer consumes it — the playlist action is
+    // structurally inline-only. Kept here so the "never opens the sheet" assertion
+    // has something to prove.
     openAddToPlaylist: openers.openAddToPlaylist,
     openLogAscent: openers.openLogAscent,
     openAddBetaVideo: openers.openAddBetaVideo,
@@ -63,8 +67,20 @@ const ownerClimb = { ...climb, userId: 'user-1', is_draft: true } as unknown as 
 const kilterBoard = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
 const tensionBoard = { ...kilterBoard, boardName: 'tension' };
 
-function ids(args: Parameters<typeof useClimbActions>[0]): ClimbActionId[] {
-  const { result } = renderHook(() => useClimbActions(args));
+// `onSelectPlaylist` is required on the hook — it MUST host the playlist picker
+// inline (no root AddToPlaylistSheet, no flash-close over a modal route; see
+// use-climb-actions.ts). Default it here so every call site is valid; the playlist
+// dispatch test overrides it with a spy.
+type ActionArgs = Omit<Parameters<typeof useClimbActions>[0], 'onSelectPlaylist'> & {
+  onSelectPlaylist?: () => void;
+};
+const noopSelectPlaylist = () => {};
+function renderActions(args: ActionArgs) {
+  return renderHook(() => useClimbActions({ onSelectPlaylist: noopSelectPlaylist, ...args }));
+}
+
+function ids(args: ActionArgs): ClimbActionId[] {
+  const { result } = renderActions(args);
   return result.current.map((action) => action.id);
 }
 
@@ -120,7 +136,7 @@ describe('useClimbActions gating', () => {
 
 describe('useClimbActions colours and dispatch', () => {
   it('colours queue/favorite by role and the rest with the accent', () => {
-    const { result } = renderHook(() => useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false }));
+    const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: false });
     const byId = Object.fromEntries(result.current.map((action) => [action.id, action.color]));
     expect(byId.queue).toBe('#0a0');
     expect(byId.favorite).toBe('#f00');
@@ -129,38 +145,34 @@ describe('useClimbActions colours and dispatch', () => {
 
   it('queue.run enqueues the climb and fires onAfterAction', () => {
     const onAfterAction = vi.fn();
-    const { result } = renderHook(() =>
-      useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false, onAfterAction }),
-    );
+    const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: false, onAfterAction });
     result.current.find((action) => action.id === 'queue')?.run();
     expect(openers.addToQueue).toHaveBeenCalledWith({ uuid: 'queue-uuid', climb });
     expect(onAfterAction).toHaveBeenCalledTimes(1);
   });
 
-  it('playlist.run opens the playlist picker for the climb + board config', () => {
-    const { result } = renderHook(() => useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false }));
-    result.current.find((action) => action.id === 'playlist')?.run();
-    expect(openers.openAddToPlaylist).toHaveBeenCalledWith(climb, kilterBoard);
-  });
-
-  it('playlist.run calls onSelectPlaylist (inline) instead of opening the sheet when provided', () => {
+  it('playlist.run always hosts the picker inline (onSelectPlaylist), never the root sheet, and does not dismiss', () => {
     const onSelectPlaylist = vi.fn();
     const onAfterAction = vi.fn();
-    const { result } = renderHook(() =>
-      useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false, onSelectPlaylist, onAfterAction }),
-    );
+    const { result } = renderActions({
+      climb,
+      boardConfig: kilterBoard,
+      isAuthenticated: false,
+      onSelectPlaylist,
+      onAfterAction,
+    });
     result.current.find((action) => action.id === 'playlist')?.run();
     expect(onSelectPlaylist).toHaveBeenCalledTimes(1);
-    // Inline host keeps the overlay up — no sheet, no dismiss.
+    // Structural guarantee: the action can never open the root AddToPlaylistSheet
+    // (which would flash closed over a modal route — the #3335 / #3294 class), and
+    // it keeps the reaction overlay up (no dismiss).
     expect(openers.openAddToPlaylist).not.toHaveBeenCalled();
     expect(onAfterAction).not.toHaveBeenCalled();
   });
 
   it('betaVideo.run opens the root beta sheet and fires onAfterAction by default', () => {
     const onAfterAction = vi.fn();
-    const { result } = renderHook(() =>
-      useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: true, onAfterAction }),
-    );
+    const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: true, onAfterAction });
     result.current.find((action) => action.id === 'betaVideo')?.run();
     expect(openers.openAddBetaVideo).toHaveBeenCalledWith(climb, kilterBoard);
     expect(onAfterAction).toHaveBeenCalledTimes(1);
@@ -169,9 +181,13 @@ describe('useClimbActions colours and dispatch', () => {
   it('betaVideo.run calls onAddBetaVideo (in-tree) instead of the root sheet when provided', () => {
     const onAddBetaVideo = vi.fn();
     const onAfterAction = vi.fn();
-    const { result } = renderHook(() =>
-      useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: true, onAddBetaVideo, onAfterAction }),
-    );
+    const { result } = renderActions({
+      climb,
+      boardConfig: kilterBoard,
+      isAuthenticated: true,
+      onAddBetaVideo,
+      onAfterAction,
+    });
     result.current.find((action) => action.id === 'betaVideo')?.run();
     // Same climb/board snapshot the root path uses, so a live queue change can't retarget it.
     expect(onAddBetaVideo).toHaveBeenCalledWith(climb, kilterBoard);
@@ -183,9 +199,7 @@ describe('useClimbActions colours and dispatch', () => {
 
   it('tick.run opens the root LogAscent sheet and fires onAfterAction by default', () => {
     const onAfterAction = vi.fn();
-    const { result } = renderHook(() =>
-      useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false, onAfterAction }),
-    );
+    const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: false, onAfterAction });
     result.current.find((action) => action.id === 'tick')?.run();
     expect(openers.openLogAscent).toHaveBeenCalledWith(
       expect.objectContaining({ climbUuid: 'climb-1', boardName: 'kilter', angle: 40 }),
@@ -196,9 +210,13 @@ describe('useClimbActions colours and dispatch', () => {
   it('tick.run calls onTick (in-tree) instead of the root sheet when provided', () => {
     const onTick = vi.fn();
     const onAfterAction = vi.fn();
-    const { result } = renderHook(() =>
-      useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false, onTick, onAfterAction }),
-    );
+    const { result } = renderActions({
+      climb,
+      boardConfig: kilterBoard,
+      isAuthenticated: false,
+      onTick,
+      onAfterAction,
+    });
     result.current.find((action) => action.id === 'tick')?.run();
     // Same climb/board snapshot the root path uses, so a live queue change can't retarget it.
     expect(onTick).toHaveBeenCalledWith(climb, kilterBoard);
@@ -209,13 +227,13 @@ describe('useClimbActions colours and dispatch', () => {
   });
 
   it('share.run opens the native share sheet', () => {
-    const { result } = renderHook(() => useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false }));
+    const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: false });
     result.current.find((action) => action.id === 'share')?.run();
     expect(openers.shareClimb).toHaveBeenCalledTimes(1);
   });
 
   it('preview.run opens the climb view-only in the play drawer', () => {
-    const { result } = renderHook(() => useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false }));
+    const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: false });
     result.current.find((action) => action.id === 'preview')?.run();
     expect(openers.openPlayDrawer).toHaveBeenCalledTimes(1);
     expect(openers.openPlayDrawer).toHaveBeenCalledWith(climb, expect.objectContaining({ source: 'climb_view' }));

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -3,12 +3,12 @@
 // colour) plus a `run()` that performs the action and then calls `onAfterAction` (the
 // reaction menu passes its animated dismiss).
 //
-// The hook self-sources every opener (preview / queue / playlist / tick / beta video)
-// from `useDrawerHost`, the favourite state + mutation from `useFavoriteStatus` /
+// The hook self-sources most openers (preview / queue / tick / beta video) from
+// `useDrawerHost`, the favourite state + mutation from `useFavoriteStatus` /
 // `useToggleFavorite`, the native share from `useShareClimb`, and the create-climb
-// routes from the router, so a caller only
-// supplies the climb, its board config, and the two contextual flags (`currentUserId`,
-// `isAuthenticated`) plus the logbook-only `onEditEntry`.
+// routes from the router, so a caller supplies the climb, its board config, the two
+// contextual flags (`currentUserId`, `isAuthenticated`), the required inline playlist
+// host (`onSelectPlaylist`), and the logbook-only `onEditEntry`.
 
 import { useCallback, useMemo } from 'react';
 import type { OpaqueColorValue } from 'react-native';
@@ -66,12 +66,18 @@ type UseClimbActionsArgs = {
   /** Run after any action fires. The sheet passes its `onClose`; the native menu omits it. */
   onAfterAction?: () => void;
   /**
-   * When provided, the "Add to playlist" action runs this INSTEAD of opening the
-   * `AddToPlaylistSheet` (and does NOT dismiss). The reaction overlay passes a
-   * view-switcher so it can host the picker inline — stacking a second native
-   * sheet dismisses the first (#3294). Omit it and playlist opens the sheet.
+   * Required in-place host for the "Add to playlist" action: `run()` calls this
+   * and does NOT dismiss the menu, so the picker renders inline (a view switch in
+   * the reaction overlay's `FullWindowOverlay`) rather than opening a native
+   * sheet. Deliberately NOT optional: a fallback that opened the root
+   * `AddToPlaylistSheet` here would present a second native sheet off the root
+   * window and, from over a modal route (`/play`), flash open and vanish — the
+   * #3335 / #3294 bug (docs/mobile-sheets-vs-routes.md, rule 1 + the in-tree-opener
+   * trap). Surfaces that genuinely want the standalone sheet (the climb-list row,
+   * the board sheet) call `useDrawerHost().openAddToPlaylist` directly, off the
+   * player, instead of going through this hook.
    */
-  onSelectPlaylist?: () => void;
+  onSelectPlaylist: () => void;
   /**
    * When provided, the "Add beta video" action runs this INSTEAD of opening the
    * root `AddBetaVideoSheet`. The play drawer passes its own in-tree sheet opener
@@ -116,13 +122,7 @@ export function useClimbActions({
   const { actionColors } = useTheme();
   const { addToQueue } = useQueueActions();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
-  const {
-    openPlayDrawer,
-    openAddToPlaylist,
-    openLogAscent,
-    openAddBetaVideo,
-    boardConfig: activeBoardConfig,
-  } = useDrawerHost();
+  const { openPlayDrawer, openLogAscent, openAddBetaVideo, boardConfig: activeBoardConfig } = useDrawerHost();
   // Native share sheet — the same action the play drawer uses.
   const shareClimb = useShareClimb({
     climb,
@@ -205,15 +205,12 @@ export function useClimbActions({
       title: t('actions.playlist.popover.title'),
       icon: 'playlist',
       color: accentColor,
+      // Always the inline host: swap the reaction overlay to its playlist view
+      // (no dismiss, no second native sheet). `onSelectPlaylist` is required so
+      // this action can never fall back to opening the root AddToPlaylistSheet
+      // over a modal route and flash closed — the #3335 / #3294 class.
       run: () => {
-        // Inline host (reaction overlay) keeps the overlay up and swaps to its
-        // playlist view; otherwise fall back to the bottom sheet.
-        if (onSelectPlaylist) {
-          onSelectPlaylist();
-          return;
-        }
-        openAddToPlaylist(climb, boardConfig);
-        after();
+        onSelectPlaylist();
       },
     });
 
@@ -397,7 +394,6 @@ export function useClimbActions({
     toggleFavoriteMutate,
     isFavorited,
     openPlayDrawer,
-    openAddToPlaylist,
     openLogAscent,
     openAddBetaVideo,
     activeBoardConfig,


### PR DESCRIPTION
## Summary

Hardens the already-landed fix for **#3335** ("Add to playlist menu appears and disappears instantly (iOS)"). #3335 is a duplicate of **#3294** (merged as PR #3452), which fixed the flash-close by moving the reaction-menu playlist action to an inline `InlinePlaylistPicker` (no second native sheet). #3335 is being closed separately — this PR does **not** claim to fix it, it removes the last way the bug could come back.

**The latent trap.** `useClimbActions`' "Add to playlist" action took `onSelectPlaylist` as *optional*: when omitted it fell back to `openAddToPlaylist(...)`, which opens the root `AddToPlaylistSheet`. That fallback is the exact flash-close shape — a second `@expo/ui` native sheet presents off the root window and, from over a modal route (`/play`), UIKit reconciles `isPresented` back to `false` and it vanishes (`docs/mobile-sheets-vs-routes.md`, rule 1 + the in-tree-opener trap the doc explicitly warns about).

Today the only consumer, `ClimbReactionMenu`, always passes `onSelectPlaylist` (a view switch to the inline picker), so the fallback is already dead code. But a future ellipsis/menu consumer of `useClimbActions` added over the player without the override would silently re-hit the bug.

**The change.** Make `onSelectPlaylist` **required**, delete the dead `openAddToPlaylist` fallback branch, and drop its now-unused `useDrawerHost` destructure + memo dep. The playlist action can no longer open a native sheet from this hook — the #3335/#3294 class is closed structurally, not just by convention. Tests tightened to assert the inline-only guarantee.

Surfaces that legitimately want the standalone bottom sheet (the climb-list row action, the board sheet row) call `useDrawerHost().openAddToPlaylist` directly, off the player — untouched.

No user-facing behaviour change; the reaction menu already behaved this way.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — green.
- `vp run test:mobile` — 4414 passed (537 files). `use-climb-actions.test.tsx` reworked: `onSelectPlaylist` defaulted at every call site (now required), the old "playlist.run opens the root sheet" fallback test replaced with one asserting playlist.run **always** calls `onSelectPlaylist`, **never** `openAddToPlaylist`, and does **not** dismiss. `ClimbReactionMenu.test.tsx` (inline view-switch coverage) still green.
- `vp check` — lint + format clean on the two changed files (a pre-existing `packages/mobile/public/index.html` format nit on `main` is untouched and out of scope).
- `vp run check:mobile-bundle` — iOS + Android bundles OK.
- Static-analysis basis: `ClimbReactionMenu` is the sole `useClimbActions` consumer and already passes `onSelectPlaylist`; the two remaining `openAddToPlaylist` call sites are off the player. No native change → OTA-eligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkJuDx4nCQPYQzeEjNd6Q3