### PR TITLE
fix(mobile): show your created climbs on your own profile

### DIFF
--- a/packages/mobile/app/(tabs)/profile/__tests__/index.test.tsx
+++ b/packages/mobile/app/(tabs)/profile/__tests__/index.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+//
+// Own-profile ("You" tab) parity regression guard for #3049: a "Climbs"
+// (created-climbs) tab shipped on the public/other-user profile screen
+// (app/users/[userId]/index.tsx) but was never wired into this own-profile
+// screen, so a climber's own created climbs never appeared here even though
+// they showed up fine when viewing someone else's profile. This test fails
+// on a revert of that wiring.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const ctrl = vi.hoisted(() => ({
+  profileId: 'user-own-123' as string | undefined,
+}));
+
+const rendered = vi.hoisted(() => ({
+  progress: [] as Array<{ userId: string | undefined }>,
+  sessions: [] as Array<{ userId: string | undefined }>,
+  logbook: [] as Array<{ userId: string | undefined }>,
+  climbs: [] as Array<{ userId: string | undefined }>,
+  social: [] as Array<{ userId: string | undefined }>,
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+vi.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ screenshotTab: undefined }),
+}));
+vi.mock('../../../../src/lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: ctrl.profileId ? { id: ctrl.profileId } : undefined }),
+  useYouProfileData: () => ({
+    hasActiveFilters: false,
+    selectedBoard: 'all',
+    setSelectedBoard: vi.fn(),
+    timeframe: 'all',
+    setTimeframe: vi.fn(),
+  }),
+}));
+vi.mock('../../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { background: '#fff' } }),
+}));
+// Stand-in top chrome: exposes one button per known tab key so the test can
+// drive tab selection the same way a real tap would, without pulling in the
+// real chrome's native segmented control / app bar machinery.
+vi.mock('../../../../src/components/you/ProfileTopChrome', () => ({
+  ProfileTopChrome: ({ activeTab, onSelectTab }: { activeTab: string; onSelectTab: (key: string) => void }) =>
+    createElement(
+      'div',
+      { 'data-chrome': 'true', 'data-active-tab': activeTab },
+      ['progress', 'sessions', 'logbook', 'climbs', 'social'].map((key) =>
+        createElement('button', { key, 'data-select-tab': key, onClick: () => onSelectTab(key) }, key),
+      ),
+    ),
+}));
+vi.mock('../../../../src/components/you/YouFilterSheet', () => ({
+  YouFilterSheet: () => createElement('div', { 'data-filter-sheet': 'true' }),
+}));
+vi.mock('../../../../src/components/you/ProgressTab', () => ({
+  ProgressTab: ({ userId }: { userId: string | undefined }) => {
+    rendered.progress.push({ userId });
+    return createElement('div', { 'data-tab': 'progress' });
+  },
+}));
+vi.mock('../../../../src/components/you/SessionsTab', () => ({
+  SessionsTab: ({ userId }: { userId: string | undefined }) => {
+    rendered.sessions.push({ userId });
+    return createElement('div', { 'data-tab': 'sessions' });
+  },
+}));
+vi.mock('../../../../src/components/you/LogbookTab', () => ({
+  LogbookTab: ({ userId }: { userId: string | undefined }) => {
+    rendered.logbook.push({ userId });
+    return createElement('div', { 'data-tab': 'logbook' });
+  },
+}));
+vi.mock('../../../../src/components/you/ProfileClimbsTab', () => ({
+  ProfileClimbsTab: ({ userId }: { userId: string | undefined }) => {
+    rendered.climbs.push({ userId });
+    return createElement('div', { 'data-tab': 'climbs' });
+  },
+}));
+vi.mock('../../../../src/components/you/SocialTab', () => ({
+  SocialTab: ({ userId }: { userId: string | undefined }) => {
+    rendered.social.push({ userId });
+    return createElement('div', { 'data-tab': 'social' });
+  },
+}));
+
+import YouScreen from '../index';
+
+describe('YouScreen (own profile)', () => {
+  beforeEach(() => {
+    ctrl.profileId = 'user-own-123';
+    rendered.progress = [];
+    rendered.sessions = [];
+    rendered.logbook = [];
+    rendered.climbs = [];
+    rendered.social = [];
+  });
+
+  it('offers a Climbs tab alongside progress/sessions/logbook/social', () => {
+    const { container } = render(<YouScreen />);
+    const keys = Array.from(container.querySelectorAll('[data-select-tab]')).map((element) =>
+      element.getAttribute('data-select-tab'),
+    );
+    expect(keys).toEqual(['progress', 'sessions', 'logbook', 'climbs', 'social']);
+  });
+
+  it("renders ProfileClimbsTab with the signed-in user's own id once the Climbs tab is selected", () => {
+    const { container } = render(<YouScreen />);
+
+    // Not mounted before the tab is selected — progress is the default.
+    expect(container.querySelector('[data-tab="climbs"]')).toBeNull();
+
+    fireEvent.click(container.querySelector('[data-select-tab="climbs"]')!);
+
+    expect(container.querySelector('[data-tab="climbs"]')).not.toBeNull();
+    expect(rendered.climbs).toEqual([{ userId: 'user-own-123' }]);
+  });
+});

--- a/packages/mobile/app/(tabs)/profile/index.tsx
+++ b/packages/mobile/app/(tabs)/profile/index.tsx
@@ -10,12 +10,15 @@ import { YouFilterSheet } from '../../../src/components/you/YouFilterSheet';
 import { ProgressTab } from '../../../src/components/you/ProgressTab';
 import { SessionsTab } from '../../../src/components/you/SessionsTab';
 import { LogbookTab } from '../../../src/components/you/LogbookTab';
+import { ProfileClimbsTab } from '../../../src/components/you/ProfileClimbsTab';
 import { SocialTab } from '../../../src/components/you/SocialTab';
 
 // Screenshot mode selects the visible sub-tab via a `screenshotTab` deep-link
 // param so the logbook/sessions shots are deterministic.
 function isProfileTabKey(value: string | string[] | undefined): value is ProfileTabKey {
-  return value === 'progress' || value === 'sessions' || value === 'logbook' || value === 'social';
+  return (
+    value === 'progress' || value === 'sessions' || value === 'logbook' || value === 'climbs' || value === 'social'
+  );
 }
 
 export default function YouScreen() {
@@ -58,6 +61,7 @@ export default function YouScreen() {
         {activeTab === 'progress' ? <ProgressTab data={youData} topInset={chromeHeight} userId={userId} /> : null}
         {activeTab === 'sessions' ? <SessionsTab userId={userId} topInset={chromeHeight} /> : null}
         {activeTab === 'logbook' ? <LogbookTab userId={userId} topInset={chromeHeight} /> : null}
+        {activeTab === 'climbs' ? <ProfileClimbsTab userId={userId} topInset={chromeHeight} /> : null}
         {activeTab === 'social' ? <SocialTab userId={userId} topInset={chromeHeight} /> : null}
       </View>
 

--- a/packages/mobile/src/components/you/ProfileTopChrome.tsx
+++ b/packages/mobile/src/components/you/ProfileTopChrome.tsx
@@ -3,8 +3,8 @@
 // Liquid Glass: the board-agnostic CollapsingLargeTitleHeader (no board pill —
 // unlike Climbs/Discover) with an account-avatar island on the left, an optional
 // filter island on the right (the Progress sub-tab only), and the
-// Progress/Sessions/Logbook segmented control (glass-track-wrapped) as its
-// below-row content.
+// Progress/Sessions/Logbook/Climbs/Social segmented control (glass-track-wrapped)
+// as its below-row content.
 //
 // Material: an absolutely-positioned, onHeightChange-measured M3 small app bar
 // (mirroring ClimbTopChrome) — the account avatar, dashboard title via
@@ -26,7 +26,7 @@ import { MaterialTabs } from '../navigation/MaterialTabs';
 import { CollapsingLargeTitleHeader, GlassActionToolbar, GlassToolbarAction } from '../chrome';
 import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
 
-export type ProfileTabKey = 'progress' | 'sessions' | 'logbook' | 'social';
+export type ProfileTabKey = 'progress' | 'sessions' | 'logbook' | 'climbs' | 'social';
 
 export type ProfileTopChromeProps = {
   /** Selected sub-tab; drives the segmented control's pill / the active tab. */
@@ -52,6 +52,7 @@ function useSegmentOptions() {
       { key: 'progress' as const, label: t('tabs.progress') },
       { key: 'sessions' as const, label: t('tabs.sessions') },
       { key: 'logbook' as const, label: t('tabs.logbook') },
+      { key: 'climbs' as const, label: t('tabs.climbs') },
       { key: 'social' as const, label: t('tabs.social') },
     ],
     [t],

--- a/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
@@ -206,7 +206,13 @@ describe('ProfileTopChrome', () => {
     it('passes the profile tab options and selectedKey to the segmented control', () => {
       render(<ProfileTopChrome {...makeProps({ activeTab: 'sessions' })} />);
       const segment = segments.entries.at(-1)!;
-      expect(segment.options.map((option) => option.key)).toEqual(['progress', 'sessions', 'logbook', 'social']);
+      expect(segment.options.map((option) => option.key)).toEqual([
+        'progress',
+        'sessions',
+        'logbook',
+        'climbs',
+        'social',
+      ]);
       expect(segment.selectedKey).toBe('sessions');
     });
 
@@ -279,7 +285,7 @@ describe('ProfileTopChrome', () => {
     it('passes the profile tab options and selectedKey to MaterialTabs', () => {
       render(<ProfileTopChrome {...makeProps({ activeTab: 'sessions' })} />);
       const tabs = materialTabs.entries.at(-1)!;
-      expect(tabs.options.map((option) => option.key)).toEqual(['progress', 'sessions', 'logbook', 'social']);
+      expect(tabs.options.map((option) => option.key)).toEqual(['progress', 'sessions', 'logbook', 'climbs', 'social']);
       expect(tabs.selectedKey).toBe('sessions');
     });
 


### PR DESCRIPTION
## Summary

Fixes #3049 — TestFlight screenshot feedback: "Climbs doesnt show here on your own profile, only when looking at others profile".

The "Climbs" tab (a climber's created-climbs list, parity with the web profile's "Created Climbs" section) shipped on the public/other-user profile screen (`app/users/[userId]/index.tsx`) but was never wired into the own-profile "You" screen, so it was invisible on your own profile while working fine on everyone else's. Not a data/user-id bug — `useUserClimbs`/the backend `userClimbs` resolver are symmetric for self vs. other; the tab itself just didn't exist on the own-profile screen.

Fix:
- `ProfileTopChrome.tsx` — added `'climbs'` to `ProfileTabKey` and to the shared segment-options list feeding both the Material and Liquid Glass chrome (now 5 tabs: Progress, Sessions, Logbook, Climbs, Social).
- `app/(tabs)/profile/index.tsx` (`YouScreen`) — renders the existing `ProfileClimbsTab` with the signed-in user's own id when the Climbs tab is active, and extends the `screenshotTab` deep-link parsing (`isProfileTabKey`) to accept `'climbs'`.
- Updated the `ProfileTopChrome` test's tab-option assertions (4 → 5 items) and added an own-profile regression test asserting `ProfileClimbsTab` renders with the current user's id once the Climbs tab is selected.

**Needs on-device visual check (not done here):** the segmented control/tab bar went from 4 labels to 5. Paired QA review computed label lengths across locales — the new **Climbs** label itself is short everywhere ("Climbs"/"Bloques"/"Blocs") and isn't the risk; the risk is the *pre-existing* longest labels getting squeezed by the extra tab: **French "Progression"** (11 chars, highest risk) and **Spanish "Historial"** (9 chars, second). The Android emulator on this box segfaults (qemu SIGSEGV), so no simulator/emulator screenshot pass was possible. Someone with a simulator or device should confirm those two labels don't truncate/wrap on both the Material and Liquid Glass variants. Logged in `.boardsesh/qa-notes.md` on this branch.

## Release Notes

- Your setter tab isn't shy anymore — your own climbs show on your profile now.

## Test plan

- `vp check` — clean (pre-existing repo-wide lint/format debt untouched by this diff).
- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 538/538 files, 4417/4417 tests pass, including the new own-profile Climbs-tab regression test and the updated `ProfileTopChrome` tab-option assertions.
- `vp run check:mobile-bundle` — OK.
- `vp run check:i18n` — OK (no new strings; reuses the existing `tabs.climbs` key already shipped for the public profile).
- Manual: sign in → You tab → Climbs (5th tab) → shows your own created climbs (or the empty state), matches what "Climbs" shows on another user's profile; tapping a climb opens it read-only in the play drawer.
- **Outstanding:** on-device check that French "Progression" and Spanish "Historial" don't clip/wrap in the 5-label tab bar, on both Material and Liquid Glass — not verified on this box (see Summary).
