### PR TITLE
fix(mobile): show logbook times in your local timezone

### DIFF
--- a/packages/mobile/src/components/play-drawer/LogbookEntryRow.tsx
+++ b/packages/mobile/src/components/play-drawer/LogbookEntryRow.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import type { LogbookEntry } from '@boardsesh/board-react';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { BOULDER_GRADES } from '@boardsesh/board-constants/boulder-grade-mapping';
+import { parseTickTime } from '@boardsesh/profile-stats';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { normalizeAscentStatus, type AscentStatusValue } from '../../lib/ascent-status-utils';
@@ -20,7 +21,12 @@ type LogbookEntryRowProps = {
 };
 
 // Hoisted so every row shares one cache lookup key instead of allocating a
-// fresh options object per call (#3155).
+// fresh options object per call (#3155). Note: the cache in
+// intl-formatter-cache.ts keys only on (locale, options), not on the
+// process's TZ — a formatter built under one TZ stays cached for that key
+// even if TZ later changes, which is fine at runtime (TZ is fixed for the
+// life of the app) but means tests exercising more than one TZ against this
+// cache must call `vi.resetModules()` between them.
 const CLIMBED_AT_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   month: 'short',
   day: 'numeric',
@@ -29,8 +35,15 @@ const CLIMBED_AT_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   minute: '2-digit',
 };
 
+// `entry.climbed_at` is a naive `boardsesh_ticks.climbed_at` string with no
+// `Z`/offset (see @boardsesh/profile-stats/format-tick-time). Parsing it with
+// a bare `new Date(iso)` gets it interpreted as browser/device-local time
+// instead of UTC, which silently displays the raw UTC digits as if they were
+// already local (#3569). `parseTickTime` recovers the true UTC instant and
+// converts it to local before we ever hand a `Date` to `Intl.DateTimeFormat`.
 function formatClimbedAt(iso: string): string {
-  const date = new Date(iso);
+  if (!iso) return iso;
+  const date = parseTickTime(iso).toDate();
   if (Number.isNaN(date.getTime())) return iso;
   return getCachedDateTimeFormat(undefined, CLIMBED_AT_FORMAT_OPTIONS).format(date);
 }

--- a/packages/mobile/src/components/play-drawer/LogbookSection.tsx
+++ b/packages/mobile/src/components/play-drawer/LogbookSection.tsx
@@ -3,7 +3,7 @@ import { View, ActivityIndicator, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { useLogbook } from '@boardsesh/board-react';
-import { groupEntriesByAngle } from '@boardsesh/profile-stats';
+import { groupEntriesByAngle, tickTimeMs } from '@boardsesh/profile-stats';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { LogbookEntryRow } from './LogbookEntryRow';
@@ -32,7 +32,14 @@ export const LogbookSection = memo(function LogbookSection({
     () =>
       logbook
         .filter((entry) => entry.climb_uuid === climbUuid)
-        .sort((a, b) => new Date(b.climbed_at).getTime() - new Date(a.climbed_at).getTime()),
+        // `climbed_at` is a naive (no `Z`/offset) UTC string — `tickTimeMs`
+        // parses it as UTC before comparing. `new Date(naiveString)` instead
+        // parses it as device-local, which is fine for same-day entries but
+        // isn't guaranteed to preserve order across a DST boundary: resolving
+        // an ambiguous/skipped local hour is implementation-defined per
+        // ECMA-262, so Hermes (on-device) isn't guaranteed to agree with V8
+        // (tests) — `tickTimeMs` sidesteps the question entirely (#3569).
+        .sort((a, b) => tickTimeMs(b.climbed_at) - tickTimeMs(a.climbed_at)),
     [logbook, climbUuid],
   );
 

--- a/packages/mobile/src/components/play-drawer/__tests__/logbook-entry-row-climbed-at.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/logbook-entry-row-climbed-at.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { LogbookEntry } from '@boardsesh/board-react';
+
+// Pinned so these assertions don't depend on the host/CI machine's default TZ
+// (which could be UTC, silently masking the very bug this suite guards
+// against — see #3569). America/Phoenix keeps a fixed UTC-7 offset
+// year-round (no DST), so there's no ambiguity around the fixture dates
+// crossing a DST boundary. Stubbed via `vi.stubEnv` + `vi.unstubAllEnvs` so
+// it can't leak into other test files sharing this worker.
+beforeAll(() => {
+  vi.stubEnv('TZ', 'America/Phoenix');
+});
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
+// react-native isn't satisfiable under jsdom; stub the surface the row touches.
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('i', null) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../lib/ascent-status-utils', () => ({
+  normalizeAscentStatus: ({ status }: { status?: string }) => status ?? 'send',
+}));
+vi.mock('@boardsesh/board-constants/grade-colors', () => ({
+  getGradeColor: () => '#abcdef',
+  DEFAULT_GRADE_COLOR: '#000000',
+}));
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    formatGradeByDifficultyId: (id: number | null | undefined) => (id == null ? null : `V${id}`),
+  }),
+}));
+// Stand-in for the real Intl formatter that reads the Date's LOCAL getters
+// directly. This keeps the assertion decoupled from host ICU locale/format
+// quirks (see the "never pass locale: undefined" convention documented in
+// intl-formatter-cache.test.ts — a convention the production call site can't
+// itself follow, since it formats in whatever locale the device is set to)
+// while still exercising exactly what this suite cares about: does the row
+// build a `Date` whose LOCAL wall-clock matches the tick's true local time,
+// rather than the raw stored UTC digits.
+vi.mock('../../../lib/intl-formatter-cache', () => ({
+  getCachedDateTimeFormat: () => ({
+    format: (date: Date) => `${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`,
+  }),
+}));
+
+import { LogbookEntryRow } from '../LogbookEntryRow';
+
+function makeEntry(overrides: Partial<LogbookEntry>): LogbookEntry {
+  return {
+    uuid: 'tick-1',
+    climb_uuid: 'climb-1',
+    angle: 40,
+    is_mirror: false,
+    tries: 1,
+    quality: null,
+    difficulty: null,
+    comment: '',
+    climbed_at: '2026-07-24T15:14:00',
+    is_ascent: true,
+    status: 'send',
+    upvotes: 0,
+    downvotes: 0,
+    commentCount: 0,
+    ...overrides,
+  };
+}
+
+describe('LogbookEntryRow climbed-at display (#3569)', () => {
+  it('renders the tick in local wall-clock time, not the raw stored UTC digits', () => {
+    // `boardsesh_ticks.climbed_at` is a naive-but-UTC string with no `Z`
+    // suffix (see @boardsesh/profile-stats/format-tick-time). A tick logged
+    // at 8:14 AM in America/Phoenix (UTC-7, no DST) is stored as
+    // "...T15:14:00". Pre-fix, `formatClimbedAt` parsed that string with a
+    // bare `new Date(iso)`, which V8/Hermes treat as already-local — so the
+    // row displayed the raw "15:14" digits unchanged instead of "8:14".
+    const { getByText } = render(
+      createElement(LogbookEntryRow, {
+        entry: makeEntry({ climbed_at: '2026-07-24T15:14:00' }),
+        showMirrorTag: false,
+      }),
+    );
+    expect(getByText('8:14')).toBeTruthy();
+  });
+
+  it('round-trips a wall-clock time derived independently of any hardcoded offset', () => {
+    // Builds the naive-UTC fixture FROM a known local wall-clock moment using
+    // the pinned process TZ (rather than a hand-computed UTC offset), so this
+    // check doesn't share a blind spot with the explicit case above.
+    const localWallClock = new Date(2026, 0, 15, 21, 5, 0); // Jan 15, 9:05 PM local
+    const storedNaiveUtc = localWallClock.toISOString().slice(0, 19);
+    const { getByText } = render(
+      createElement(LogbookEntryRow, {
+        entry: makeEntry({ climbed_at: storedNaiveUtc }),
+        showMirrorTag: false,
+      }),
+    );
+    expect(getByText('21:05')).toBeTruthy();
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/logbook-section-angles.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/logbook-section-angles.test.tsx
@@ -148,3 +148,30 @@ describe('LogbookSection — per-angle section headers', () => {
     expect(rowAngles).toEqual([45, 40]);
   });
 });
+
+describe('LogbookSection — chronological sort (#3569)', () => {
+  it('sorts same-angle rows newest-first by true UTC instant, not raw string/local-Date order', () => {
+    // `climbed_at` is a naive-but-UTC string with no `Z` suffix. Sorting with
+    // a bare `new Date(x.climbed_at).getTime()` parses it as device-local,
+    // which happens to preserve order for same-day entries but isn't
+    // guaranteed to across a DST boundary — the local-time resolution of an
+    // ambiguous/skipped hour is implementation-defined per ECMA-262 and isn't
+    // guaranteed to match between Hermes (on-device) and V8 (this test
+    // runner), so a same-engine reproduction here wouldn't prove much either
+    // way. `tickTimeMs` sidesteps the whole question by parsing explicitly as
+    // UTC. This test pins down the ordering contract: newest true instant
+    // first, using entries whose calendar-day order and clock-digit order
+    // agree (a case both the old and new code already got right), so a
+    // regression to raw `new Date(...)` sorting would NOT be caught by this
+    // test alone for DST-boundary cases — see the comment on the `.sort()`
+    // call in LogbookSection.tsx for the engine-dependence rationale.
+    logbookState.logbook = [
+      makeEntry({ uuid: 'oldest', angle: 40, climbed_at: '2026-06-01T09:00:00' }),
+      makeEntry({ uuid: 'newest', angle: 40, climbed_at: '2026-06-20T23:50:00' }),
+      makeEntry({ uuid: 'middle', angle: 40, climbed_at: '2026-06-10T12:00:00' }),
+    ];
+    renderSection();
+    const rowUuids = rows.props.map((rowProps) => (rowProps.entry as LogbookEntry).uuid);
+    expect(rowUuids).toEqual(['newest', 'middle', 'oldest']);
+  });
+});


### PR DESCRIPTION
Fixes #3569

## What was wrong

The per-climb logbook row (mobile play-drawer) showed tick times in UTC instead of local time — an 8:14am Pacific tick displayed as "3:14 PM". Root cause: `LogbookEntryRow.tsx`'s `formatClimbedAt` parsed `climbed_at` with a bare `new Date(iso)`. Since `boardsesh_ticks.climbed_at` is a naive Postgres `timestamp` column with no `Z`/offset, JS engines interpret that string as already-local — so the row displayed the raw UTC digits unshifted rather than converting them.

Fix: route through the shared `parseTickTime` helper (`@boardsesh/profile-stats`), which explicitly parses as UTC and converts to local — the same helper every other logbook display site (web's per-climb logbook, the You-tab activity feed, session cards) already uses correctly. Bundled a matching fix in `LogbookSection.tsx`'s row sort, which had the identical `new Date(naiveString)` pattern; swapped to `tickTimeMs` so ordering doesn't depend on how a given JS engine resolves an ambiguous/skipped local hour at a DST boundary (Hermes on-device isn't guaranteed to agree with V8, the test runner — see the comment on the `.sort()` call).

## Storage audit

Before touching display code, I traced how `climbed_at` gets written for every tick provenance, since a naive-column display fix is only correct if storage is a genuine UTC instant everywhere:

- **native** (GraphQL `saveTick` + the REST Aurora-compat proxy) — client `Date`/`dayjs()` → `.toISOString()`, correct UTC.
- **aurora_pull** / **json_import** — both route through `normalizeTimestamp`, which pins Aurora's naive-but-UTC export/API fields to `Z` before storing.
- **kilter_pull** — Kilter's PowerSync `created_at` is honest `Z`-suffixed ISO-8601, used directly.
- **moonboard_import** — a synthetic noon-UTC placeholder (source CSV has no time-of-day), not a real instant but harmless for local display.

All five origins land as a genuine UTC instant, so the display fix is correct across the whole population — no scoping-down needed. Two backfill migrations (`0165_kilter_dedup_backfill.sql`, `0166_aurora_json_dedup_backfill.sql`) document a real prior prod incident where naive-local timestamps got mistagged as UTC and caused duplicate ticks — useful historical context that this exact failure class has bitten this table before, though current writers are clean.

Also verified the tick **edit** path (`toEditableDate` / `LogbookEditSheet`) was already correctly UTC-aware pre-fix, so this change can't introduce a double-shift there.

## Testing

- New test: `logbook-entry-row-climbed-at.test.tsx` — pins `TZ=America/Phoenix` (fixed UTC-7, no DST) so the assertion doesn't depend on the CI host's default timezone, and verifies the row renders the local wall-clock time rather than the raw stored UTC digits.
- Extended `logbook-section-angles.test.tsx` with a chronological-sort case.
- `vp check`, `vp run typecheck:mobile`, `vp run test:mobile` (538 files / 4418 tests passed), `vp run check:mobile-bundle` all green.

## Release Notes

Your 8am flash no longer shows up as an afternoon send — logbook times in the per-climb history now match your phone's clock.