### PR TITLE
fix(sync): seed the party roster on subscribe and reconcile drift

### DIFF
--- a/packages/backend/src/__tests__/helpers/headless-queue-client.ts
+++ b/packages/backend/src/__tests__/helpers/headless-queue-client.ts
@@ -102,7 +102,7 @@ type RawQueueEvent =
     };
 
 type RawSessionEvent =
-  | { __typename: 'SessionRosterSnapshot'; users: SessionUserView[]; boardPath: string | null }
+  | { __typename: 'SessionRosterSnapshot'; users: SessionUserView[]; boardPath: string }
   | { __typename: 'UserJoined'; user: SessionUserView }
   | { __typename: 'UserLeft'; userId: string }
   | { __typename: 'UserPresenceChanged'; user: SessionUserView }
@@ -503,9 +503,10 @@ export class HeadlessParticipant {
     switch (event.__typename) {
       case 'SessionRosterSnapshot':
         // Full authoritative roster seeded on subscribe — REPLACE, matching the
-        // production client's applySessionRuntimeEvent handling.
+        // production client's applySessionRuntimeEvent handling. boardPath is
+        // String! on the wire (empty-string sentinel, never null).
         this.users = event.users;
-        if (event.boardPath !== null) this.boardPath = event.boardPath;
+        if (event.boardPath) this.boardPath = event.boardPath;
         this.rosterSnapshotUsers = event.users;
         break;
       case 'UserJoined':

--- a/packages/backend/src/__tests__/helpers/headless-queue-client.ts
+++ b/packages/backend/src/__tests__/helpers/headless-queue-client.ts
@@ -102,6 +102,7 @@ type RawQueueEvent =
     };
 
 type RawSessionEvent =
+  | { __typename: 'SessionRosterSnapshot'; users: SessionUserView[]; boardPath: string | null }
   | { __typename: 'UserJoined'; user: SessionUserView }
   | { __typename: 'UserLeft'; userId: string }
   | { __typename: 'UserPresenceChanged'; user: SessionUserView }
@@ -273,6 +274,11 @@ export class HeadlessParticipant {
 
   // Session-level view, fed by the SESSION_UPDATES subscription
   users: SessionUserView[] = [];
+  // Ordered __typename log of received session events (seed-first assertions).
+  sessionEventTypes: string[] = [];
+  // Users carried by the most recent SessionRosterSnapshot seed, or null before
+  // one arrives — lets a test assert the SEED payload (not the JOIN response).
+  rosterSnapshotUsers: SessionUserView[] | null = null;
   boardSerial: string | null = null;
   boardPath: string;
   wallConfirmations: Array<{ climbUuid: string; queueItemUuid: string | null }> = [];
@@ -340,6 +346,17 @@ export class HeadlessParticipant {
    *  the first FullSync proves the subscription is live. */
   async join(): Promise<void> {
     await this.connectAndJoin();
+  }
+
+  /** Wait until the SESSION_UPDATES subscription's roster seed
+   *  (SessionRosterSnapshot) has arrived. `join()` only gates on the queue
+   *  FullSync, so the session seed can land a beat later — poll for it before
+   *  asserting on the seeded roster. */
+  async waitForRosterSnapshot(timeoutMs = 5000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (this.rosterSnapshotUsers === null && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
   }
 
   /**
@@ -480,7 +497,17 @@ export class HeadlessParticipant {
   }
 
   private handleSessionEvent(event: RawSessionEvent): void {
+    // Ordered log of every session event received, so tests can assert the
+    // roster seed lands first (before any delta).
+    this.sessionEventTypes.push(event.__typename);
     switch (event.__typename) {
+      case 'SessionRosterSnapshot':
+        // Full authoritative roster seeded on subscribe — REPLACE, matching the
+        // production client's applySessionRuntimeEvent handling.
+        this.users = event.users;
+        if (event.boardPath !== null) this.boardPath = event.boardPath;
+        this.rosterSnapshotUsers = event.users;
+        break;
       case 'UserJoined':
         if (!this.users.some((u) => u.id === event.user.id)) this.users = [...this.users, event.user];
         else this.users = this.users.map((u) => (u.id === event.user.id ? event.user : u));

--- a/packages/backend/src/__tests__/session-roster-seed.test.ts
+++ b/packages/backend/src/__tests__/session-roster-seed.test.ts
@@ -1,0 +1,63 @@
+// End-to-end test for the sessionUpdates roster SEED against a REAL backend
+// (`startTestBackend`) — issue #2860 ("[RN] Board presence drift").
+//
+// Roster/presence deltas (UserJoined/UserLeft/UserPresenceChanged/…) carry no
+// sequence number and have no replay buffer, so a single dropped delta silently
+// diverges a member's crew list. The fix: `sessionUpdates` now yields a
+// `SessionRosterSnapshot` as its FIRST event, re-baselining the roster on every
+// (re)subscribe. This suite proves, over the real wire:
+//   1. the seed is the first session event a subscriber receives (before deltas);
+//   2. a late joiner's seed already carries the full existing roster — it never
+//      depends on catching an earlier member's UserJoined delta.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { randomUUID } from 'crypto';
+import { HeadlessParticipant, startTestBackend, type TestBackend } from './helpers/headless-queue-client';
+
+describe('sessionUpdates roster seed ↔ real backend (#2860)', () => {
+  let backend: TestBackend;
+
+  beforeAll(async () => {
+    backend = await startTestBackend();
+  });
+
+  afterAll(async () => {
+    await backend.teardown();
+  });
+
+  it('yields a SessionRosterSnapshot as the first session event, before any delta', async () => {
+    const sessionId = `roster-seed-${randomUUID().slice(0, 8)}`;
+    const alex = new HeadlessParticipant(backend.url, sessionId, 'Alex');
+    try {
+      await alex.join();
+      await alex.waitForRosterSnapshot();
+
+      expect(alex.sessionEventTypes[0]).toBe('SessionRosterSnapshot');
+      // The seed payload (not the JOIN response) carries the roster.
+      expect(alex.rosterSnapshotUsers?.map((u) => u.username)).toContain('Alex');
+    } finally {
+      await alex.dispose();
+    }
+  }, 30_000);
+
+  it('seeds a late joiner with the full existing roster', async () => {
+    const sessionId = `roster-seed-${randomUUID().slice(0, 8)}`;
+    const alex = new HeadlessParticipant(backend.url, sessionId, 'Alex');
+    const blake = new HeadlessParticipant(backend.url, sessionId, 'Blake');
+    try {
+      await alex.join();
+      await blake.join();
+      await blake.waitForRosterSnapshot();
+
+      // Blake's very first session event is the seed, and it already lists Alex —
+      // Blake never had to catch Alex's UserJoined delta to know Alex is present.
+      expect(blake.sessionEventTypes[0]).toBe('SessionRosterSnapshot');
+      const seededUsernames = (blake.rosterSnapshotUsers ?? []).map((u) => u.username).sort();
+      expect(seededUsernames).toContain('Alex');
+      expect(seededUsernames).toContain('Blake');
+    } finally {
+      await blake.dispose();
+      await alex.dispose();
+    }
+  }, 30_000);
+});

--- a/packages/backend/src/graphql/resolvers/sessions/subscriptions.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/subscriptions.ts
@@ -1,13 +1,26 @@
 import type { ConnectionContext, SessionEvent } from '@boardsesh/shared-schema';
 import { pubsub } from '../../../pubsub/index';
+import { roomManager } from '../../../services/room-manager';
 import { requireSessionMember } from '../shared/helpers';
-import { createAsyncIterator } from '../shared/async-iterators';
+import { createEagerAsyncIterator } from '../shared/async-iterators';
 
 export const sessionSubscriptions = {
   /**
-   * Subscribe to real-time session events
-   * Sends events when users join/leave or leadership changes
-   * Requires user to be a member of the session
+   * Subscribe to real-time session events.
+   *
+   * Eager subscribe THEN seed (mirrors `queueUpdates`' FullSync and
+   * `boardQueuePreview`'s snapshot): `createEagerAsyncIterator` awaits the Redis
+   * channel subscribe before we compute the roster seed, so a delta published
+   * during setup queues in the iterator instead of being dropped (session
+   * pub/sub has no replay). The first yielded event is a `SessionRosterSnapshot`
+   * carrying the authoritative roster + boardPath — without it the roster's only
+   * baseline is the JOIN_SESSION response, and any delta dropped between
+   * instances (Redis publish failure) or in the JOIN-to-subscribe window
+   * silently diverges a member's crew list until they fully rejoin (#2860). A
+   * delta that lands between the subscribe and the seed compute can deliver a
+   * roster event slightly older than the seed right after it; accepted — the
+   * snapshot is a self-contained REPLACE on the client and the next delta
+   * converges.
    */
   sessionUpdates: {
     subscribe: async function* (_: unknown, { sessionId }: { sessionId: string }, ctx: ConnectionContext) {
@@ -15,15 +28,39 @@ export const sessionSubscriptions = {
       // Uses retry logic to handle race conditions with joinSession
       await requireSessionMember(ctx, sessionId);
 
-      // Create async iterator for subscription
-      // NOTE: We await here to ensure Redis subscription is established
-      // before proceeding - this is critical for multi-instance sync.
-      const asyncIterator = await createAsyncIterator<SessionEvent>((push) => {
-        return pubsub.subscribeSession(sessionId, push);
-      });
+      const asyncIterable = await createEagerAsyncIterator<SessionEvent>(
+        (push) => pubsub.subscribeSession(sessionId, push),
+        `sessionUpdates:${sessionId}`,
+      );
+      // One concrete iterator, shared by the loop and the finally below, so
+      // cleanup always targets the iterator that owns the subscription.
+      const eagerIterator = asyncIterable[Symbol.asyncIterator]();
 
-      for await (const event of asyncIterator) {
-        yield { sessionUpdates: event };
+      try {
+        const [users, session] = await Promise.all([
+          roomManager.getSessionUsers(sessionId),
+          roomManager.getSessionById(sessionId),
+        ]);
+        yield {
+          sessionUpdates: {
+            __typename: 'SessionRosterSnapshot',
+            users,
+            boardPath: session?.boardPath ?? null,
+          } as SessionEvent,
+        };
+
+        for (let result = await eagerIterator.next(); !result.done; result = await eagerIterator.next()) {
+          yield { sessionUpdates: result.value };
+        }
+      } finally {
+        // graphql-ws can call `.return()` on this generator while the seed above
+        // is still being computed (client disconnects during setup). The queued
+        // return then completes at the seed `yield` — before the loop ever
+        // starts — so without this finally the eager iterator would never be
+        // closed and the pubsub callback + Redis channel subscription would leak
+        // permanently. Closing here covers every exit path; `.return()` is
+        // idempotent, so a loop that already finished cleanly is unaffected.
+        await eagerIterator.return?.(undefined);
       }
     },
   },

--- a/packages/backend/src/graphql/resolvers/sessions/subscriptions.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/subscriptions.ts
@@ -37,6 +37,13 @@ export const sessionSubscriptions = {
       const eagerIterator = asyncIterable[Symbol.asyncIterator]();
 
       try {
+        // Seed compute. This is a NEW failure surface: if getSessionUsers /
+        // getSessionById reject (they run after requireSessionMember passed), the
+        // generator throws and the subscription errors with NO in-place retry.
+        // That's a deliberate non-goal for this PR — the client's graphql-ws
+        // reconnect re-runs JOIN_SESSION + resubscribe, which re-seeds the roster,
+        // so a failed seed self-heals on the next reconnect rather than needing a
+        // bespoke retry here.
         const [users, session] = await Promise.all([
           roomManager.getSessionUsers(sessionId),
           roomManager.getSessionById(sessionId),
@@ -45,7 +52,12 @@ export const sessionSubscriptions = {
           sessionUpdates: {
             __typename: 'SessionRosterSnapshot',
             users,
-            boardPath: session?.boardPath ?? null,
+            // boardPath is String! on the wire. Emit the empty-string sentinel
+            // (not null) in the unreachable session-vanished-mid-subscribe case:
+            // a null would raise a non-null-field violation that nulls the entire
+            // sessionUpdates payload and silently drops the seed. Clients treat ''
+            // as "keep current" (applySessionRuntimeEvent's `|| prev.boardPath`).
+            boardPath: session?.boardPath ?? '',
           } as SessionEvent,
         };
 

--- a/packages/mobile/src/lib/__tests__/session-runtime-event.test.ts
+++ b/packages/mobile/src/lib/__tests__/session-runtime-event.test.ts
@@ -50,9 +50,40 @@ describe('toMobileSessionRuntimeEvent', () => {
     });
   });
 
+  it('adapts a SessionRosterSnapshot into a full-roster replace event', () => {
+    const second: SessionUser = { ...user, id: 'participant-2', username: 'Blake', isLeader: true };
+    expect(
+      toMobileSessionRuntimeEvent({
+        __typename: 'SessionRosterSnapshot',
+        users: [user, second],
+        boardPath: '/kilter/1/10/1,2/40/list',
+      }),
+    ).toEqual({
+      __typename: 'SessionRosterSnapshot',
+      users: [user, second],
+      boardPath: '/kilter/1/10/1,2/40/list',
+    });
+  });
+
+  it('maps a SessionRosterSnapshot with no users/boardPath to empty defaults', () => {
+    expect(toMobileSessionRuntimeEvent({ __typename: 'SessionRosterSnapshot' })).toEqual({
+      __typename: 'SessionRosterSnapshot',
+      users: [],
+      boardPath: null,
+    });
+  });
+
   it('ignores stats and incomplete events', () => {
     expect(toMobileSessionRuntimeEvent({ __typename: 'SessionStatsUpdated', totalSends: 1 })).toBeNull();
     expect(toMobileSessionRuntimeEvent({ __typename: 'UserJoined' })).toBeNull();
     expect(toMobileSessionRuntimeEvent({ __typename: 'SessionBoardPathChanged' })).toBeNull();
+  });
+
+  it('drops an unknown __typename (old client receiving a newer union member)', () => {
+    // Additive-safety contract: a stale bundle whose mapper predates a new
+    // SessionEvent member falls through the `default: null` guard and keeps the
+    // JOIN roster instead of crashing — the reason SessionRosterSnapshot could
+    // ship without breaking un-OTA'd clients.
+    expect(toMobileSessionRuntimeEvent({ __typename: 'SomeFutureSessionEvent' })).toBeNull();
   });
 });

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -1037,6 +1037,10 @@ export const SESSION_UPDATES_SUBSCRIPTION = `
   subscription SessionUpdates($sessionId: ID!) {
     sessionUpdates(sessionId: $sessionId) {
       __typename
+      ... on SessionRosterSnapshot {
+        users { id username isLeader avatarUrl userId connectionState }
+        boardPath
+      }
       ... on UserJoined {
         user { id username isLeader avatarUrl userId connectionState }
       }
@@ -1137,6 +1141,8 @@ export type SessionUpdateEvent = {
   name?: string | null;
   // UserJoined / UserPresenceChanged
   user?: SessionUser;
+  // SessionRosterSnapshot — full authoritative roster seeded on subscribe
+  users?: SessionUser[];
   // UserLeft
   userId?: string;
   // LeaderChanged

--- a/packages/mobile/src/lib/session-runtime-event.ts
+++ b/packages/mobile/src/lib/session-runtime-event.ts
@@ -4,6 +4,16 @@ import type { SessionUpdateEvent } from './graphql/operations';
 
 export function toMobileSessionRuntimeEvent(event: SessionUpdateEvent): RuntimeSessionEvent<SessionUser> | null {
   switch (event.__typename) {
+    case 'SessionRosterSnapshot':
+      // Seed/reconcile event: full authoritative roster. Applied as a REPLACE
+      // by applySessionRuntimeEvent (self-preserving). `users` is required on
+      // the wire type, but default to [] so a malformed payload empties rather
+      // than throws.
+      return {
+        __typename: 'SessionRosterSnapshot',
+        users: event.users ?? [],
+        boardPath: event.boardPath ?? null,
+      };
     case 'UserJoined':
     case 'UserPresenceChanged':
       return event.user ? { __typename: event.__typename, user: event.user } : null;

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -122,6 +122,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const [liveStats, setLiveStats] = useState<SessionLiveStatsEvent | null>(null);
   const [sessionRuntimeState, setSessionRuntimeState] =
     useState<MobileSessionRuntimeState>(createEmptySessionRuntimeState);
+  // Latest-committed mirror, read by the realtime engine's snapshot-reconcile
+  // telemetry (which can't observe the functional state updater's result).
+  const sessionRuntimeStateRef = useRef(sessionRuntimeState);
+  sessionRuntimeStateRef.current = sessionRuntimeState;
   const sessionUsers = sessionRuntimeState.users;
   const lastConnectedBoardSerial = sessionRuntimeState.lastConnectedBoardSerial;
   // Session-scoped "the current climb is lit on a wall" indicator. Flipped on by
@@ -566,6 +570,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     resyncQueueFromServerRef,
     setLiveStats,
     setSessionRuntimeState,
+    sessionRuntimeStateRef,
     setIsSessionWallLit,
     setParticipantId,
     locallyEndingSessionIdRef,

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -92,6 +92,21 @@ export const createEmptySessionRuntimeState = (): MobileSessionRuntimeState => (
   boardPath: '',
 });
 
+/**
+ * Order-insensitive signature of the roster fields a SessionRosterSnapshot can
+ * change (crew membership + per-user leadership + display name, own leadership,
+ * boardPath). Used only to decide whether a seed/reconcile snapshot actually
+ * healed dropped roster drift, so we emit `Session Roster Reconciled` telemetry
+ * only when the crew list really moved — not on every (re)subscribe.
+ */
+function rosterStateSignature(state: MobileSessionRuntimeState): string {
+  const users = state.users
+    .map((user) => `${user.id}:${user.isLeader ? 1 : 0}:${user.username}`)
+    .sort()
+    .join('|');
+  return `${users}#${state.isLeader ? 1 : 0}#${state.boardPath}`;
+}
+
 type UseSessionRealtimeParams = {
   authTransportRevision: number;
   sessionId: string | null;
@@ -114,6 +129,7 @@ type UseSessionRealtimeParams = {
   resyncQueueFromServerRef: React.RefObject<() => Promise<boolean>>;
   setLiveStats: React.Dispatch<React.SetStateAction<SessionLiveStatsEvent | null>>;
   setSessionRuntimeState: React.Dispatch<React.SetStateAction<MobileSessionRuntimeState>>;
+  sessionRuntimeStateRef: React.RefObject<MobileSessionRuntimeState>;
   setIsSessionWallLit: React.Dispatch<React.SetStateAction<boolean>>;
   setParticipantId: React.Dispatch<React.SetStateAction<string | null>>;
   locallyEndingSessionIdRef: React.RefObject<string | null>;
@@ -150,6 +166,7 @@ export function useSessionRealtime({
   resyncQueueFromServerRef,
   setLiveStats,
   setSessionRuntimeState,
+  sessionRuntimeStateRef,
   setIsSessionWallLit,
   setParticipantId,
   locallyEndingSessionIdRef,
@@ -497,9 +514,28 @@ export function useSessionRealtime({
 
             const runtimeEvent = toMobileSessionRuntimeEvent(event);
             if (runtimeEvent) {
+              // Keep the functional updater so rapid consecutive deltas each
+              // apply on the truly-latest roster (not a stale render snapshot).
               setSessionRuntimeState(
                 (prev) => applySessionRuntimeEvent(prev, runtimeEvent) ?? createEmptySessionRuntimeState(),
               );
+              // Best-effort drift telemetry: a SessionRosterSnapshot is the only
+              // event that can silently heal a dropped roster delta. Detect a
+              // real change against the latest-committed mirror (the functional
+              // updater's result isn't observable here) and emit only then, so
+              // this counts genuine presence-drift heals, not routine reseeds.
+              if (runtimeEvent.__typename === 'SessionRosterSnapshot') {
+                const prevRoster = sessionRuntimeStateRef.current ?? createEmptySessionRuntimeState();
+                const nextRoster =
+                  applySessionRuntimeEvent(prevRoster, runtimeEvent) ?? createEmptySessionRuntimeState();
+                if (rosterStateSignature(prevRoster) !== rosterStateSignature(nextRoster)) {
+                  track(SHARED_EVENTS.SessionRosterReconciled, {
+                    userCount: nextRoster.users.length,
+                    boardName: activeBoardRef.current?.boardType,
+                    layoutId: activeBoardRef.current?.layoutId,
+                  });
+                }
+              }
             }
 
             if (event.__typename !== 'SessionBoardPathChanged' || !event.boardPath) return;

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -6518,6 +6518,7 @@ type Subscription {
 Union of possible session events.
 """
 union SessionEvent =
+  | SessionRosterSnapshot
   | UserJoined
   | UserLeft
   | UserPresenceChanged
@@ -6530,6 +6531,27 @@ union SessionEvent =
   | SessionNameChanged
   | SessionEnded
   | SessionStatsUpdated
+
+"""
+Full roster snapshot yielded as the FIRST event of every `sessionUpdates`
+subscription (the session counterpart to `queueUpdates`' `FullSync`). The
+roster-delta events (`UserJoined`/`UserLeft`/`UserPresenceChanged`/
+`LeaderChanged`/`SessionBoardPathChanged`) carry no sequence number and have
+no replay buffer, so a single dropped delta silently diverges a party
+member's crew list until they fully rejoin. This snapshot re-baselines the
+roster on every (re)subscribe, closing the JOIN-to-subscribe race and giving
+reconnects a fresh authoritative crew list. Clients apply it as a REPLACE
+(preserving their own connection identity + re-deriving their leadership).
+Additive: a stale client whose `sessionUpdates` document lacks the
+`... on SessionRosterSnapshot` fragment drops it via its mapper's
+unknown-`__typename` default and keeps using the JOIN roster.
+"""
+type SessionRosterSnapshot {
+  "Complete participant roster at subscribe time (each entry carries its own isLeader flag)"
+  users: [SessionUser!]!
+  "Session's current stored boardPath. Non-null to match SessionBoardPathChanged.boardPath so the two can be selected together in one sessionUpdates document without a field-merge conflict; empty string in the unreachable case where the session row vanished mid-subscribe (clients treat empty as 'keep current')."
+  boardPath: String!
+}
 
 """
 Event when a user joins the session.

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -6257,6 +6257,7 @@ export type SessionEvent =
   | SessionBoardSerialChanged
   | SessionEnded
   | SessionNameChanged
+  | SessionRosterSnapshot
   | SessionStatsUpdated
   | UserJoined
   | UserLeft
@@ -6475,6 +6476,28 @@ export type SessionParticipant = {
   sends: Scalars['Int']['output'];
   /** User ID */
   userId: Scalars['String']['output'];
+};
+
+/**
+ * Full roster snapshot yielded as the FIRST event of every `sessionUpdates`
+ * subscription (the session counterpart to `queueUpdates`' `FullSync`). The
+ * roster-delta events (`UserJoined`/`UserLeft`/`UserPresenceChanged`/
+ * `LeaderChanged`/`SessionBoardPathChanged`) carry no sequence number and have
+ * no replay buffer, so a single dropped delta silently diverges a party
+ * member's crew list until they fully rejoin. This snapshot re-baselines the
+ * roster on every (re)subscribe, closing the JOIN-to-subscribe race and giving
+ * reconnects a fresh authoritative crew list. Clients apply it as a REPLACE
+ * (preserving their own connection identity + re-deriving their leadership).
+ * Additive: a stale client whose `sessionUpdates` document lacks the
+ * `... on SessionRosterSnapshot` fragment drops it via its mapper's
+ * unknown-`__typename` default and keeps using the JOIN roster.
+ */
+export type SessionRosterSnapshot = {
+  __typename?: 'SessionRosterSnapshot';
+  /** Session's current stored boardPath. Non-null to match SessionBoardPathChanged.boardPath so the two can be selected together in one sessionUpdates document without a field-merge conflict; empty string in the unreachable case where the session row vanished mid-subscribe (clients treat empty as 'keep current'). */
+  boardPath: Scalars['String']['output'];
+  /** Complete participant roster at subscribe time (each entry carries its own isLeader flag) */
+  users: Array<SessionUser>;
 };
 
 /** Event when session stats change due to logged attempts/sends. */
@@ -7747,6 +7770,7 @@ export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = Reso
     | SessionBoardSerialChanged
     | SessionEnded
     | SessionNameChanged
+    | SessionRosterSnapshot
     | SessionStatsUpdated
     | UserJoined
     | UserLeft
@@ -8047,6 +8071,7 @@ export type ResolversTypes = ResolversObject<{
   SessionHealthExportLap: ResolverTypeWrapper<SessionHealthExportLap>;
   SessionNameChanged: ResolverTypeWrapper<SessionNameChanged>;
   SessionParticipant: ResolverTypeWrapper<SessionParticipant>;
+  SessionRosterSnapshot: ResolverTypeWrapper<SessionRosterSnapshot>;
   SessionStatsUpdated: ResolverTypeWrapper<SessionStatsUpdated>;
   SessionStatus: SessionStatus;
   SessionSummary: ResolverTypeWrapper<SessionSummary>;
@@ -8386,6 +8411,7 @@ export type ResolversParentTypes = ResolversObject<{
   SessionHealthExportLap: SessionHealthExportLap;
   SessionNameChanged: SessionNameChanged;
   SessionParticipant: SessionParticipant;
+  SessionRosterSnapshot: SessionRosterSnapshot;
   SessionStatsUpdated: SessionStatsUpdated;
   SessionSummary: SessionSummary;
   SessionUser: SessionUser;
@@ -11852,6 +11878,7 @@ export type SessionEventResolvers<
     | 'SessionBoardSerialChanged'
     | 'SessionEnded'
     | 'SessionNameChanged'
+    | 'SessionRosterSnapshot'
     | 'SessionStatsUpdated'
     | 'UserJoined'
     | 'UserLeft'
@@ -12047,6 +12074,15 @@ export type SessionParticipantResolvers<
   flashes?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sends?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   userId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type SessionRosterSnapshotResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['SessionRosterSnapshot'] = ResolversParentTypes['SessionRosterSnapshot'],
+> = ResolversObject<{
+  boardPath?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  users?: Resolver<Array<ResolversTypes['SessionUser']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -12741,6 +12777,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   SessionHealthExportLap?: SessionHealthExportLapResolvers<ContextType>;
   SessionNameChanged?: SessionNameChangedResolvers<ContextType>;
   SessionParticipant?: SessionParticipantResolvers<ContextType>;
+  SessionRosterSnapshot?: SessionRosterSnapshotResolvers<ContextType>;
   SessionStatsUpdated?: SessionStatsUpdatedResolvers<ContextType>;
   SessionSummary?: SessionSummaryResolvers<ContextType>;
   SessionUser?: SessionUserResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/events.ts
+++ b/packages/shared-schema/src/schema/events.ts
@@ -3,6 +3,7 @@ export const eventsTypeDefs = /* GraphQL */ `
   Union of possible session events.
   """
   union SessionEvent =
+    | SessionRosterSnapshot
     | UserJoined
     | UserLeft
     | UserPresenceChanged
@@ -15,6 +16,27 @@ export const eventsTypeDefs = /* GraphQL */ `
     | SessionNameChanged
     | SessionEnded
     | SessionStatsUpdated
+
+  """
+  Full roster snapshot yielded as the FIRST event of every \`sessionUpdates\`
+  subscription (the session counterpart to \`queueUpdates\`' \`FullSync\`). The
+  roster-delta events (\`UserJoined\`/\`UserLeft\`/\`UserPresenceChanged\`/
+  \`LeaderChanged\`/\`SessionBoardPathChanged\`) carry no sequence number and have
+  no replay buffer, so a single dropped delta silently diverges a party
+  member's crew list until they fully rejoin. This snapshot re-baselines the
+  roster on every (re)subscribe, closing the JOIN-to-subscribe race and giving
+  reconnects a fresh authoritative crew list. Clients apply it as a REPLACE
+  (preserving their own connection identity + re-deriving their leadership).
+  Additive: a stale client whose \`sessionUpdates\` document lacks the
+  \`... on SessionRosterSnapshot\` fragment drops it via its mapper's
+  unknown-\`__typename\` default and keeps using the JOIN roster.
+  """
+  type SessionRosterSnapshot {
+    "Complete participant roster at subscribe time (each entry carries its own isLeader flag)"
+    users: [SessionUser!]!
+    "Session's current stored boardPath. Non-null to match SessionBoardPathChanged.boardPath so the two can be selected together in one sessionUpdates document without a field-merge conflict; empty string in the unreachable case where the session row vanished mid-subscribe (clients treat empty as 'keep current')."
+    boardPath: String!
+  }
 
   """
   Event when a user joins the session.

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -51,6 +51,13 @@ export const SHARED_EVENTS = {
   QueueSyncStaleEventIgnored: 'Queue Sync Stale Event Ignored',
   QueueSyncGapResync: 'Queue Sync Gap Resync',
   QueueSyncHashDrift: 'Queue Sync Hash Drift',
+  // Fired when a SessionRosterSnapshot (seeded first on every sessionUpdates
+  // subscribe) actually CHANGES the local crew list — i.e. a roster delta had
+  // been dropped and the snapshot reconciled it. The roster deltas carry no
+  // sequence, so this is the only signal that presence drift happened in the
+  // field (#2860). Its volume gates the deferred periodic-resnapshot healer:
+  // if this rarely fires, seed-on-subscribe alone is enough.
+  SessionRosterReconciled: 'Session Roster Reconciled',
   // Climb actions
   // Fired when the climb reaction/actions menu is opened, with a `source` prop
   // ('long_press' | 'more_button'). Powers the ⋮-button discoverability experiment:

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -6254,6 +6254,7 @@ export type SessionEvent =
   | SessionBoardSerialChanged
   | SessionEnded
   | SessionNameChanged
+  | SessionRosterSnapshot
   | SessionStatsUpdated
   | UserJoined
   | UserLeft
@@ -6472,6 +6473,28 @@ export type SessionParticipant = {
   sends: Scalars['Int']['output'];
   /** User ID */
   userId: Scalars['String']['output'];
+};
+
+/**
+ * Full roster snapshot yielded as the FIRST event of every `sessionUpdates`
+ * subscription (the session counterpart to `queueUpdates`' `FullSync`). The
+ * roster-delta events (`UserJoined`/`UserLeft`/`UserPresenceChanged`/
+ * `LeaderChanged`/`SessionBoardPathChanged`) carry no sequence number and have
+ * no replay buffer, so a single dropped delta silently diverges a party
+ * member's crew list until they fully rejoin. This snapshot re-baselines the
+ * roster on every (re)subscribe, closing the JOIN-to-subscribe race and giving
+ * reconnects a fresh authoritative crew list. Clients apply it as a REPLACE
+ * (preserving their own connection identity + re-deriving their leadership).
+ * Additive: a stale client whose `sessionUpdates` document lacks the
+ * `... on SessionRosterSnapshot` fragment drops it via its mapper's
+ * unknown-`__typename` default and keeps using the JOIN roster.
+ */
+export type SessionRosterSnapshot = {
+  __typename?: 'SessionRosterSnapshot';
+  /** Session's current stored boardPath. Non-null to match SessionBoardPathChanged.boardPath so the two can be selected together in one sessionUpdates document without a field-merge conflict; empty string in the unreachable case where the session row vanished mid-subscribe (clients treat empty as 'keep current'). */
+  boardPath: Scalars['String']['output'];
+  /** Complete participant roster at subscribe time (each entry carries its own isLeader flag) */
+  users: Array<SessionUser>;
 };
 
 /** Event when session stats change due to logged attempts/sends. */

--- a/packages/shared/graphql/src/operations/queue-session.ts
+++ b/packages/shared/graphql/src/operations/queue-session.ts
@@ -297,6 +297,17 @@ export const SESSION_UPDATES = `
   subscription SessionUpdates($sessionId: ID!) {
     sessionUpdates(sessionId: $sessionId) {
       __typename
+      ... on SessionRosterSnapshot {
+        users {
+          id
+          username
+          isLeader
+          avatarUrl
+          userId
+          connectionState
+        }
+        boardPath
+      }
       ... on UserJoined {
         user {
           id

--- a/packages/shared/queue-runtime/src/__tests__/session-events.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/session-events.test.ts
@@ -141,6 +141,19 @@ describe('applySessionRuntimeEvent', () => {
       expect(next?.boardPath).toBe('/kilter/1/10/1,2/40/list');
     });
 
+    it('treats the empty-string boardPath sentinel as "keep current"', () => {
+      // The wire field is String!; the backend emits '' (not null) when the
+      // session row vanished mid-subscribe. The applier must keep the prior
+      // boardPath rather than blanking it.
+      const prev = session({ boardPath: '/kilter/1/10/1,2/40/list' });
+      const next = applySessionRuntimeEvent(prev, {
+        __typename: 'SessionRosterSnapshot',
+        users: prev.users,
+        boardPath: '',
+      });
+      expect(next?.boardPath).toBe('/kilter/1/10/1,2/40/list');
+    });
+
     it('coerces snapshot users through the injected coerceUser callback', () => {
       const prev = session({ clientId: 'participant-1' });
       const next = applySessionRuntimeEvent(

--- a/packages/shared/queue-runtime/src/__tests__/session-events.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/session-events.test.ts
@@ -70,6 +70,94 @@ describe('applySessionRuntimeEvent', () => {
     expect(next?.users[1].custom).toBe('kept');
   });
 
+  describe('SessionRosterSnapshot (seed / reconcile REPLACE)', () => {
+    it('replaces the whole roster and applies boardPath while preserving own clientId', () => {
+      const prev = session({
+        clientId: 'participant-1',
+        users: [user({ id: 'participant-1' }), user({ id: 'ghost-participant' })],
+        boardPath: '/kilter/1/10/1,2/40/list',
+      });
+
+      const next = applySessionRuntimeEvent(prev, {
+        __typename: 'SessionRosterSnapshot',
+        // ghost-participant left while we weren't watching; participant-3 joined.
+        users: [user({ id: 'participant-1' }), user({ id: 'participant-3' })],
+        boardPath: '/kilter/1/10/1,2/30/list',
+      });
+
+      expect(next?.users.map((entry) => entry.id)).toEqual(['participant-1', 'participant-3']);
+      expect(next?.clientId).toBe('participant-1');
+      expect(next?.boardPath).toBe('/kilter/1/10/1,2/30/list');
+    });
+
+    it('re-injects the known-self row when the snapshot omits it (raced our JOIN)', () => {
+      const prev = session({
+        clientId: 'participant-1',
+        users: [user({ id: 'participant-1', username: 'me' })],
+      });
+
+      const next = applySessionRuntimeEvent(prev, {
+        __typename: 'SessionRosterSnapshot',
+        users: [user({ id: 'participant-2' })],
+      });
+
+      // We are never erased from our own crew list.
+      expect(next?.users.map((entry) => entry.id).sort()).toEqual(['participant-1', 'participant-2']);
+      expect(next?.users.find((entry) => entry.id === 'participant-1')?.username).toBe('me');
+    });
+
+    it('re-derives own leadership from the snapshot leader flags', () => {
+      const prev = session({ clientId: 'participant-1', isLeader: false });
+
+      const promoted = applySessionRuntimeEvent(prev, {
+        __typename: 'SessionRosterSnapshot',
+        users: [user({ id: 'participant-1', isLeader: true }), user({ id: 'participant-2', isLeader: false })],
+      });
+      expect(promoted?.isLeader).toBe(true);
+
+      const demoted = applySessionRuntimeEvent(session({ clientId: 'participant-1', isLeader: true }), {
+        __typename: 'SessionRosterSnapshot',
+        users: [user({ id: 'participant-1', isLeader: false }), user({ id: 'participant-2', isLeader: true })],
+      });
+      expect(demoted?.isLeader).toBe(false);
+    });
+
+    it('keeps prior leadership when the snapshot omits our own row', () => {
+      const prev = session({ clientId: 'participant-1', isLeader: true });
+      const next = applySessionRuntimeEvent(prev, {
+        __typename: 'SessionRosterSnapshot',
+        users: [user({ id: 'participant-2', isLeader: true })],
+      });
+      // Self re-injected with its prior isLeader, top-level isLeader unchanged.
+      expect(next?.isLeader).toBe(true);
+    });
+
+    it('keeps the prior boardPath when the snapshot carries none', () => {
+      const prev = session({ boardPath: '/kilter/1/10/1,2/40/list' });
+      const next = applySessionRuntimeEvent(prev, {
+        __typename: 'SessionRosterSnapshot',
+        users: prev.users,
+      });
+      expect(next?.boardPath).toBe('/kilter/1/10/1,2/40/list');
+    });
+
+    it('coerces snapshot users through the injected coerceUser callback', () => {
+      const prev = session({ clientId: 'participant-1' });
+      const next = applySessionRuntimeEvent(
+        prev,
+        {
+          __typename: 'SessionRosterSnapshot',
+          users: [user({ id: 'participant-1', custom: 'kept', avatarUrl: null })],
+        },
+        {
+          coerceUser: (incoming): TestUser => ({ ...incoming, avatarUrl: incoming.avatarUrl ?? undefined }),
+        },
+      );
+      expect(next?.users[0].avatarUrl).toBeUndefined();
+      expect(next?.users[0].custom).toBe('kept');
+    });
+  });
+
   it('removes users by participant id', () => {
     const prev = session({ users: [user({ id: 'participant-1' }), user({ id: 'participant-2' })] });
     const next = applySessionRuntimeEvent(prev, { __typename: 'UserLeft', userId: 'participant-1' });

--- a/packages/shared/queue-runtime/src/session-events.ts
+++ b/packages/shared/queue-runtime/src/session-events.ts
@@ -100,11 +100,13 @@ export function applySessionRuntimeEvent<
     case 'SessionEnded':
       return prev;
     default: {
-      // Exhaustiveness guard. A new RuntimeSessionEvent member that a mapper
-      // can emit but this switch doesn't handle is a COMPILE error here — not a
-      // silent roster wipe at the call sites, which both treat a missing return
-      // as "clear the roster" (mobile `?? createEmptySessionRuntimeState()`,
-      // web `setSession(undefined)`).
+      // Exhaustiveness guard — its value is the COMPILE-TIME trap: a new
+      // RuntimeSessionEvent member that a mapper can emit but this switch doesn't
+      // handle fails to typecheck here (the `never` assignment), so an unhandled
+      // event can't slip through. At runtime this default just returns prev
+      // unchanged — the same safe no-op both call sites already fall back to on
+      // the null path — so it's belt-and-suspenders; the compile error is the
+      // real protection.
       const unhandled: never = event;
       void unhandled;
       return prev;

--- a/packages/shared/queue-runtime/src/session-events.ts
+++ b/packages/shared/queue-runtime/src/session-events.ts
@@ -16,6 +16,7 @@ export type RuntimeSessionState<TUser extends RuntimeSessionUser = RuntimeSessio
 };
 
 export type RuntimeSessionEvent<TUser extends RuntimeSessionUser = RuntimeSessionUser> =
+  | { __typename: 'SessionRosterSnapshot'; users: TUser[]; boardPath?: string | null }
   | { __typename: 'UserJoined'; user: TUser }
   | { __typename: 'UserPresenceChanged'; user: TUser }
   | { __typename: 'UserLeft'; userId: string }
@@ -41,6 +42,31 @@ export function applySessionRuntimeEvent<
   if (!prev) return prev;
 
   switch (event.__typename) {
+    case 'SessionRosterSnapshot': {
+      // REPLACE, not merge: this is an authoritative full roster, so members
+      // who dropped while we weren't watching are gone and new members appear.
+      const snapshotUsers = event.users.map((user) => coerceRuntimeUser(user, options));
+      // Re-inject our own connection row if the snapshot was computed a beat
+      // before the backend registered our JOIN — otherwise a fresh subscribe
+      // would erase us from our own crew list until the next delta. Anchored on
+      // our stable connection id (`clientId`), which the snapshot preserves.
+      const selfInSnapshot = snapshotUsers.find((user) => user.id === prev.clientId);
+      const selfRow = prev.users.find((user) => user.id === prev.clientId);
+      const users = selfInSnapshot || !selfRow ? snapshotUsers : [...snapshotUsers, selfRow];
+      return {
+        ...prev,
+        users,
+        // Re-derive top-level leadership from the snapshot's own self entry
+        // (mirrors the LeaderChanged handler's clientId check). When the snapshot
+        // omits us it has no opinion on our leadership — it raced our JOIN — so
+        // keep the prior value rather than silently demoting on incomplete data.
+        isLeader: selfInSnapshot ? selfInSnapshot.isLeader : prev.isLeader,
+        // Falsy (empty/absent) boardPath keeps the current one — a real boardPath
+        // is always a non-empty route, so `||` only ever falls through on the
+        // unreachable session-vanished-mid-subscribe case the seed guards.
+        boardPath: event.boardPath || prev.boardPath,
+      };
+    }
     case 'UserJoined':
     case 'UserPresenceChanged':
       return {
@@ -73,6 +99,16 @@ export function applySessionRuntimeEvent<
       return prev;
     case 'SessionEnded':
       return prev;
+    default: {
+      // Exhaustiveness guard. A new RuntimeSessionEvent member that a mapper
+      // can emit but this switch doesn't handle is a COMPILE error here — not a
+      // silent roster wipe at the call sites, which both treat a missing return
+      // as "clear the roster" (mobile `?? createEmptySessionRuntimeState()`,
+      // web `setSession(undefined)`).
+      const unhandled: never = event;
+      void unhandled;
+      return prev;
+    }
   }
 }
 

--- a/packages/web/app/components/persistent-session/hooks/session-connection-ports.ts
+++ b/packages/web/app/components/persistent-session/hooks/session-connection-ports.ts
@@ -101,6 +101,14 @@ type WebRuntimeSessionUser = Parameters<typeof coerceSessionUser>[0];
 
 function toWebSessionRuntimeEvent(event: SessionEvent): RuntimeSessionEvent<WebRuntimeSessionUser> | null {
   switch (event.__typename) {
+    case 'SessionRosterSnapshot':
+      // Full authoritative roster seeded on subscribe. `applySessionRuntimeEvent`
+      // applies it as a REPLACE and coerces each user via `coerceSessionUser`.
+      return {
+        __typename: 'SessionRosterSnapshot',
+        users: (event.users ?? []) as unknown as WebRuntimeSessionUser[],
+        boardPath: event.boardPath ?? null,
+      };
     case 'UserJoined':
     case 'UserPresenceChanged':
       return { __typename: event.__typename, user: event.user as unknown as WebRuntimeSessionUser };


### PR DESCRIPTION
Fixes #2860.

## What was drifting

"[RN] Board presence drift" — party members' state diverging because WebSocket messages get missed mid-session. The symptom splits in two, and only half was still broken.

**The queue half is already fixed.** The mobile client gained sequence-gating, gap→resync, a 60s hash watchdog (with an order-sensitive v2 hash), and FullSync-on-subscribe over the last month. Field telemetry (PostHog, last 30 days) confirms it:

- `Queue Sync Gap Resync` — **never fired**. Sequence gaps are eliminated by FullSync-on-subscribe + reconnect reset.
- `Queue Sync Hash Drift` — 49 events across 35 users, **every one** verdict `resync-drift`, max streak 1–2 cycles. None reached backoff; every drift self-healed. Zero stuck sessions.

**The roster/presence half was not.** The `sessionUpdates` events that carry the crew list (`UserJoined`/`UserLeft`/`UserPresenceChanged`/`LeaderChanged`/`SessionBoardPathChanged`) have no sequence number, no replay buffer, no hash watchdog, and no reconciliation — and the subscription sent no initial snapshot. The roster's only baseline was the JOIN_SESSION response. So a single delta dropped between backend instances (a Redis publish blip) or in the JOIN→subscribe window silently drifted a member's crew list until they fully rejoined.

## The fix

`sessionUpdates` now yields a **`SessionRosterSnapshot`** as its first event — the session counterpart to `queueUpdates`' `FullSync`. It re-baselines the full roster + boardPath on every (re)subscribe, using the same eager-subscribe-then-seed pattern (with the leak-guarding `finally`) that the board-presence preview already uses.

Clients apply it as a self-preserving REPLACE: your own connection row and identity (`clientId`) are kept, your leadership is re-derived from the snapshot, and you're re-injected if a snapshot raced your JOIN. The applier's switch is exhaustively typed, so a future `SessionEvent` a mapper emits but the applier doesn't handle is a compile error — not a silent roster wipe at the call sites.

New `Session Roster Reconciled` telemetry fires only when a snapshot actually changes the local roster, so presence drift is finally measurable in the field. That signal gates a deferred periodic-resnapshot healer (follow-up).

Web and mobile both adopt the shared applier in this PR.

### Deviation from plan
The plan listed wall-lit in the seed, but the backend keeps no durable session-level wall-lit state — `WallConfirmedClimb`/`WallDisconnected` are ephemeral broadcasts. Seeding it would extinguish a legitimately-lit bulb on every reconnect, so the snapshot carries only the durable roster the backend owns (users + boardPath). Wall-lit stays client-derived, unchanged.

The periodic resnapshot broadcast is intentionally NOT in this PR (an unsequenced snapshot can race a newer delta and erase it for a full cycle) — it needs a monotonic `rosterEpoch` + single-instance Redis lock first. Tracked as #3905, gated on the new telemetry.

Investigation also surfaced a separate latent bug — queue sequence assignment is a non-atomic read-modify-write that concurrent party mutations can clobber (the hash watchdog can't catch it, since all clients resync to the same wrong state). Filed as #3906; out of scope here.

## Tests
- Shared applier: REPLACE semantics — roster replace + boardPath, self-row re-injection, leader re-derivation (promote/demote/omitted-self), user coercion.
- Mobile mapper: snapshot mapping + defaults, and unknown-`__typename` drop (old-client additive safety).
- Backend (real wire, `startTestBackend`): seed is the first session event before any delta; a late joiner's seed already carries the full existing roster.

## Release Notes

Your crew list stays honest — who's in the session, who's leading, always current. If a network blip drops an update mid-session, your view now re-syncs itself instead of showing a stale or ghost climber until you rejoin.
