### PR TITLE
fix(mobile): swipe-to-remove activates on leftward drag only

### DIFF
--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -152,16 +152,21 @@ function QueueItemRowComponent({
     () =>
       Gesture.Pan()
         .enabled(swipeEnabled)
-        // Activate once the drag is clearly horizontal (10px), and bail once it's
-        // clearly vertical (14px). A tighter [-5, 5] Y bail was so narrow that the
-        // normal vertical wobble of a horizontal swipe tripped it before the 10px X
-        // activation — the Pan failed, never engaged, and the row's tap fell through
-        // and just selected the climb instead of revealing Delete (#3295). 14px
-        // tolerates that wobble while still ceding to a real vertical scroll (which
-        // crosses 14px in Y well before 10px in X). Mirrors SwipeableRow, extracted
-        // from this component, which already widened this exact value for the same
-        // reason.
-        .activeOffsetX([-10, 10])
+        // Activate only on a leftward drag past 10px — the swipe is left-only (a
+        // rightward drag is discarded in onUpdate below), so it must never claim a
+        // rightward or right-diagonal gesture. A symmetric [-10, 10] activated on
+        // right-and-down drags too, and once the Y bail widened to 14px (#3295) a
+        // +11px-X/+13px-Y drag would cross +10px X before 14px Y and capture the Pan
+        // as a no-op, blocking the list from scrolling. Single-negative activeOffsetX
+        // sets only the leftward threshold, so rightward motion yields to the scroll.
+        // Bail once the drag is clearly vertical (14px). A tighter [-5, 5] Y bail was
+        // so narrow that the normal vertical wobble of a horizontal swipe tripped it
+        // before the 10px X activation — the Pan failed, never engaged, and the row's
+        // tap fell through and just selected the climb instead of revealing Delete
+        // (#3295). 14px tolerates that wobble while still ceding to a real vertical
+        // scroll (which crosses 14px in Y well before 10px in X). Mirrors SwipeableRow,
+        // extracted from this component.
+        .activeOffsetX(-10)
         .failOffsetY([-14, 14])
         .onUpdate((event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
           // Only allow swiping left

--- a/packages/mobile/src/components/SwipeableRow.tsx
+++ b/packages/mobile/src/components/SwipeableRow.tsx
@@ -92,13 +92,19 @@ function SwipeableRowComponent({
     () =>
       Gesture.Pan()
         .enabled(enabled)
-        // Activate once the drag is clearly horizontal (10px), and bail once it's
-        // clearly vertical (14px). The old [-5,5] vertical bail was so tight that
-        // the normal wobble of a horizontal swipe tripped it, so the swipe almost
-        // never engaged; 14px tolerates that wobble while still ceding to a real
-        // vertical scroll (which crosses 14px in Y well before 10px in X). The
+        // Activate only on a leftward drag past 10px — the swipe is left-only (a
+        // rightward drag is discarded in onUpdate below), so it must never claim a
+        // rightward or right-diagonal gesture. A symmetric [-10, 10] activated on
+        // right-and-down drags too, so with the 14px Y bail a +11px-X/+13px-Y drag
+        // could cross +10px X before 14px Y and capture the Pan as a no-op, blocking
+        // the list from scrolling. Single-negative activeOffsetX sets only the
+        // leftward threshold, so rightward motion yields to the scroll.
+        // Bail once the drag is clearly vertical (14px). The old [-5,5] Y bail was so
+        // tight that the normal wobble of a horizontal swipe tripped it, so the swipe
+        // almost never engaged; 14px tolerates that wobble while still ceding to a
+        // real vertical scroll (which crosses 14px in Y well before 10px in X). The
         // Edit button is the guaranteed-reliable path regardless of this feel.
-        .activeOffsetX([-10, 10])
+        .activeOffsetX(-10)
         .failOffsetY([-14, 14])
         .onUpdate((event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
           // Only allow swiping left.

--- a/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
@@ -314,9 +314,36 @@ describe('QueueItemRow React.memo', () => {
     expect(gestureCalls.panLogs).toHaveLength(1);
     const swipeCalls = gestureCalls.panLogs[0];
 
-    const activeOffsetX = swipeCalls.find((call) => call.method === 'activeOffsetX');
     const failOffsetY = swipeCalls.find((call) => call.method === 'failOffsetY');
-    expect(activeOffsetX?.args).toEqual([[-10, 10]]);
     expect(failOffsetY?.args).toEqual([[-14, 14]]);
+  });
+
+  // Regression guard for the #3900 Codex follow-up: the swipe is left-only (onUpdate
+  // discards positive-X motion), so its Pan must activate on leftward drag ONLY. A
+  // symmetric `activeOffsetX([-10, 10])` also activated on right-and-down diagonals,
+  // and once the Y bail widened to 14px a +11px-X/+13px-Y drag would cross +10px X
+  // before 14px Y and capture the Pan as a no-op — blocking the BottomSheetFlatList
+  // from scrolling. Single-negative `activeOffsetX(-10)` sets only the leftward
+  // threshold (verified against RNGH's panGesture source), so rightward motion yields
+  // to the scroll. Assert the single-negative form, never the symmetric array.
+  it('activates the swipe Pan on leftward drag only, so right-diagonal drags do not snag the scroll', () => {
+    const item = makeItem('a', 'Crimp Master');
+    render(
+      <QueueItemRow
+        item={item}
+        position={1}
+        board={board}
+        isCurrentClimb={false}
+        onPress={onPress}
+        onRemove={onRemove}
+        onToggleSelect={onToggleSelect}
+      />,
+    );
+
+    expect(gestureCalls.panLogs).toHaveLength(1);
+    const activeOffsetX = gestureCalls.panLogs[0].find((call) => call.method === 'activeOffsetX');
+    // Single negative number = leftward-only activation; NOT a symmetric [-10, 10]
+    // array (which would also activate on rightward / right-diagonal drags).
+    expect(activeOffsetX?.args).toEqual([-10]);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #3900 (queue swipe-to-remove), addressing a [Codex review finding](https://github.com/boardsesh/boardsesh/pull/3900#discussion_r3649568563) on that PR.

The swipe-to-remove Pan is **left-only** — `onUpdate` discards all positive-X motion. But it kept a **symmetric** `activeOffsetX([-10, 10])`, so it also activated on rightward drags. That was harmless while the vertical bail was tight, but #3900 widened it to `failOffsetY([-14, 14])`, which opened a gap: a **right-and-down diagonal** drag (e.g. **+11px X / +13px Y**) now crosses the +10px X activation *before* 14px Y, so the Pan activates as a **no-op** that still captures the gesture — **blocking the `BottomSheetFlatList` from scrolling**. Under the old ±5px Y band, that same drag hit Y=5 first and yielded to the list scroll.

## Fix

Switch to single-negative **`activeOffsetX(-10)`**. Verified against RNGH's `panGesture` source (2.32.0): a single negative value sets only `activeOffsetXStart` (the leftward threshold) and leaves the rightward one unset — so rightward and right-diagonal motion never activates the Pan and yields to the list scroll, while the widened `failOffsetY([-14, 14])` tolerance for genuine left swipes is retained.

```ts
- .activeOffsetX([-10, 10])
+ .activeOffsetX(-10)
```

Applied to **both** swipe rows that share the pattern:
- `QueueItemRow.tsx` — the queue swipe-to-remove (the #3900 surface).
- `SwipeableRow.tsx` — the extracted twin used by board-manage rows, same symmetric activation + `[-14, 14]` Y, also inside FlashLists. Fixed here so the latent bug doesn't surface there too.

## Test

- Updated the `#3295` regression test to drop the now-stale symmetric-activation assertion, and added a dedicated test: **"activates the swipe Pan on leftward drag only, so right-diagonal drags do not snag the scroll"** — asserts `activeOffsetX` is called with `-10` (single negative), never a `[-10, 10]` array.
- `vp check` (clean for touched files), `vp run typecheck:mobile`, `vp run test:mobile` (541 files / 4444 tests, all green), `vp run check:mobile-bundle` (iOS + Android export OK) — all pass locally.

### On-device QA (Linux box — no iOS simulator; please run before merging)

Primary target iOS; Android shares the code path.

1. Queue drawer with **≥2 upcoming climbs**. **Left swipe** a row → red **Delete** reveals; tapping it removes. *(#3900 behaviour, unchanged)*
2. **Right-and-down diagonal drag** starting on a row → the list **scrolls smoothly**, the row does not snag or half-capture. *(the fix — confirm scrolling no longer stalls)*
3. Straight **vertical scroll** on a row → scrolls as before.
4. **Quick tap** → still selects/navigates. **Long-press** → reaction menu; **≡ handle** → reorder.
5. Repeat 1–2 on the **board-manage list** (`SwipeableRow`) — left swipe still reveals its action; right-diagonal scroll no longer snags.
6. Repeat on **Android**.

## Release Notes

- Scrolling the queue no longer snags when your thumb drifts right — only a deliberate left swipe reveals Delete.

### OTA vs native

Pure JS/TS change (`QueueItemRow.tsx`, `SwipeableRow.tsx`, and the test) — no native module, no dependency bump, no `app.config.ts`/plugin change. Runtime fingerprint unaffected; ships over-the-air once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkJuDx4nCQPYQzeEjNd6Q3
