### PR TITLE
fix(mobile): session-scope the deferred current-climb re-broadcast

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
@@ -105,6 +105,7 @@ type Snapshot = {
   dispatch: QueueApi['dispatch'];
   setQueue: QueueApi['setQueue'];
   setCurrentClimb: QueueApi['setCurrentClimb'];
+  setSessionId: QueueApi['setSessionId'];
 };
 
 // A fully-resolved climb (uuid + name + frames): renderable and syncable.
@@ -154,8 +155,9 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       dispatch: queue.dispatch,
       setQueue: queue.setQueue,
       setCurrentClimb: queue.setCurrentClimb,
+      setSessionId: queue.setSessionId,
     });
-  }, [queue.state, queue.dispatch, queue.setQueue, queue.setCurrentClimb, onSnapshot]);
+  }, [queue.state, queue.dispatch, queue.setQueue, queue.setCurrentClimb, queue.setSessionId, onSnapshot]);
   return null;
 }
 
@@ -565,6 +567,48 @@ describe('QueueProvider self-healing resolve of partially-synced climbs (#2527)'
 
       // The late echo is suppressed — current stays X, never reverts to q-thin.
       expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('q-x');
+    });
+
+    // PR #3894 Codex thread 3: the deferral records the session it was captured
+    // in, and the re-broadcast effect bails when the room changed, so a hydrate
+    // that completes after a session switch never leaks the old room's climb into
+    // the new one. (The precise flush-ordering window — a pending re-broadcast
+    // effect flushing after joinSession's synchronous sessionIdRef write but
+    // before the [sessionId] backstop clear — isn't reproducible under RTL, which
+    // serialises effects at act() boundaries; this locks in the session-scoped
+    // contract that closes it.)
+    it('does not re-broadcast a deferral after the session changes (session-scoped)', async () => {
+      let releaseFetch: (() => void) | undefined;
+      http.request.mockImplementation(
+        async (_query: string, variables: { climbUuid: string; angle: number }) =>
+          new Promise<{ climb: Climb }>((resolve) => {
+            releaseFetch = () => resolve({ climb: makeClimb(variables.climbUuid, 25, 'V5') });
+          }),
+      );
+
+      const snapshots = renderProvider();
+      await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+      // In session A, advance onto a thin item — the deferral captures session A.
+      await act(async () => {
+        snapshots.at(-1)?.setSessionId('session-A');
+      });
+      await act(async () => {
+        snapshots.at(-1)?.setCurrentClimb(makeItem('q-thin', makeThinClimb('climb-thin')));
+      });
+      await waitFor(() => expect(http.request).toHaveBeenCalled());
+
+      // The room changes before hydration finishes.
+      await act(async () => {
+        snapshots.at(-1)?.setSessionId('session-B');
+      });
+
+      // Hydration completes — the deferral belonged to session A, so it must NOT
+      // broadcast into session B.
+      await act(async () => {
+        releaseFetch?.();
+      });
+      expect(queueMutations.setCurrentClimb).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -169,17 +169,27 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // gate rather than one captured in a stale closure.
   const queueSyncGateRef = useRef<QueueSyncGate | null>(null);
 
-  // The queue-slot uuid of a current-climb change whose broadcast was skipped
-  // because the target climb was still unresolved (a thin peer item advanced
-  // onto by next/previousClimb — see dispatchSetCurrent, #3868). We can't send a
-  // placeholder ClimbInput (uuid may be empty; name/frames are `String!`
-  // server-side), so we defer: when useQueueResolveClimbs hydrates that slot
-  // WHILE IT'S STILL CURRENT, the effect below fires the real setCurrentClimb so
-  // peers, late joiners, and a peer-held wall LED link finally advance. Cleared
-  // by any other broadcastable change (a resolved setCurrentClimb, setQueue,
-  // clearQueue) and by the effect when current moves off this slot, so a stale
-  // hydrate can never re-broadcast an item the session already moved past.
-  const pendingUnsyncedCurrentRef = useRef<string | null>(null);
+  // A current-climb change whose broadcast was skipped because the target climb
+  // was still unresolved (a thin peer item advanced onto by next/previousClimb —
+  // see dispatchSetCurrent, #3868). We can't send a placeholder ClimbInput (uuid
+  // may be empty; name/frames are `String!` server-side), so we defer: when
+  // useQueueResolveClimbs hydrates that slot WHILE IT'S STILL CURRENT, the effect
+  // below fires the real setCurrentClimb so peers, late joiners, and a peer-held
+  // wall LED link finally advance. Cleared by any other broadcastable change (a
+  // resolved setCurrentClimb, setQueue, clearQueue) and by the effect when
+  // current moves off this slot, so a stale hydrate can never re-broadcast an
+  // item the session already moved past.
+  //
+  // The deferral carries the session it was captured in (`sessionId`) so the
+  // re-broadcast effect can bail SYNCHRONOUSLY if we've since switched rooms
+  // (PR #3894 Codex thread 3). The `[sessionId]` clear below is a passive effect,
+  // but joinSession / createSessionWithConfig write `sessionIdRef.current`
+  // synchronously before setSessionId — so a hydration-re-broadcast effect still
+  // pending from the prior commit can flush (with sessionIdRef already pointing
+  // at the new room) before that clear runs, and broadcast the old room's climb
+  // into the new one. Comparing `deferred.sessionId` to `sessionIdRef.current` at
+  // fire time closes that window; the effect-based clear stays as a backstop.
+  const pendingUnsyncedCurrentRef = useRef<{ queueItemUuid: string; sessionId: string | null } | null>(null);
 
   // The active board is the angle source of truth. Read it here so the
   // self-healing re-grade effect can compare each queued climb's display angle
@@ -342,11 +352,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     sessionIdRef.current = sessionId;
-    // Any session change — start, join, leave, or a direct A→B switch — drops a
-    // deferred re-broadcast (#3868). The pending ref holds only a queue-slot
-    // uuid, which is meaningless in a different session, and the new session's
-    // FullSync is authoritative; without this a late hydrate could push session
-    // A's current climb into session B for every peer.
+    // Backstop clear on any session change — start, join, leave, or a direct A→B
+    // switch (#3868). The primary guard is the re-broadcast effect's synchronous
+    // deferred.sessionId vs sessionIdRef.current check (PR #3894 Codex thread 3);
+    // this passive-effect clear can't fire before an already-pending re-broadcast
+    // effect flushes, so it's defence-in-depth, not the race fix.
     pendingUnsyncedCurrentRef.current = null;
   }, [sessionId]);
 
@@ -820,12 +830,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // required server-side), and next/previousClimb can navigate onto a
       // not-yet-hydrated peer item. The local reducer already applied the change,
       // and useQueueResolveClimbs hydrates the item within a tick. No pending
-      // correlation is tracked since no server echo will arrive. Remember the
-      // slot so the re-broadcast effect fires once it hydrates while still
-      // current (#3868).
+      // correlation is tracked since no server echo will arrive. Remember the slot
+      // AND the session it belongs to so the re-broadcast effect fires once it
+      // hydrates while still current, but only back into the same room (#3868).
       if (!isClimbResolved(item.climb)) {
         if (__DEV__) console.warn('[queue] skipping setCurrentClimb sync for an unresolved climb. See #2527.');
-        pendingUnsyncedCurrentRef.current = item.uuid;
+        pendingUnsyncedCurrentRef.current = { queueItemUuid: item.uuid, sessionId: sessionIdRef.current };
         return;
       }
       // A real broadcast supersedes any deferred one — drop it so a late hydrate
@@ -858,13 +868,23 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // our broadcast) to advance. Without it they stay on the old climb until the
   // next navigation.
   useEffect(() => {
-    const pendingUuid = pendingUnsyncedCurrentRef.current;
-    if (!pendingUuid) return;
+    const pending = pendingUnsyncedCurrentRef.current;
+    if (!pending) return;
+    // Room changed since we deferred (a session join/switch/leave). Read
+    // sessionIdRef, not `sessionId` state: joinSession / createSessionWithConfig
+    // write the ref synchronously before setSessionId, so this pending effect can
+    // flush after the ref already points at the new room but before the
+    // [sessionId] backstop clear runs (PR #3894 Codex thread 3). Bailing on the
+    // synchronous ref value stops the old room's climb leaking into the new one.
+    if (pending.sessionId !== sessionIdRef.current) {
+      pendingUnsyncedCurrentRef.current = null;
+      return;
+    }
     const current = state.currentClimbQueueItem;
     // Current moved off the deferred slot (local nav, a peer's server-driven
     // CurrentClimbChanged, or a removal) — drop the deferral so a stale hydrate
     // can't re-broadcast an item the session already moved past.
-    if (!current || current.uuid !== pendingUuid) {
+    if (!current || current.uuid !== pending.queueItemUuid) {
       pendingUnsyncedCurrentRef.current = null;
       return;
     }


### PR DESCRIPTION
## Summary

Follow-up to #3894, closing the P2 [Codex raised on thread 3](https://github.com/boardsesh/boardsesh/pull/3894#discussion_r3649553266).

The #3868 fix defers a current-climb broadcast when it lands on a thin (unresolved) queue item, then re-broadcasts once `useQueueResolveClimbs` hydrates the slot. The deferral recorded only the queue-slot uuid and relied on a passive `[sessionId]` effect to drop it on a room change. That effect can lose a flush-ordering race:

- `joinSession` / `createSessionWithConfig` write `sessionIdRef.current` **synchronously** before `setSessionId` (`use-session-commands.ts:279-280` / `:120-142`), and the mutation coalescer reads `getSessionId: () => sessionIdRef.current` at send time.
- A hydration-re-broadcast effect still pending from the prior commit can flush **after** the ref already points at the new room but **before** the passive `[sessionId]` clear runs.
- Result: the old room's current climb broadcasts into the new session, changing it for every peer (most plausibly on a programmatic/deep-link join that lands mid-hydration).

**Fix:** the deferral now carries the session it was captured in — `{ queueItemUuid, sessionId }` — and the re-broadcast effect bails **synchronously** when `sessionIdRef.current !== deferred.sessionId`. A synchronous ref read at fire time is immune to effect-flush ordering. The `[sessionId]` clear stays as defence-in-depth. Self-contained in `queue-provider.tsx` (no `use-session-commands.ts` / realtime changes).

Does not touch the paired-QA reducer-seeding echo-suppression design from #3894; this is orthogonal session hygiene.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- New provider test `does not re-broadcast a deferral after the session changes (session-scoped)`: defer a thin item in session A, switch to session B before hydration, assert no broadcast. Confirmed to hold **via the synchronous session check alone** (backstop `[sessionId]` clear temporarily neutralised, test still green) — so the sync guard is load-bearing, not just covered by the backstop.
- The precise flush-ordering window (a pending re-broadcast effect flushing after the synchronous `sessionIdRef` write but before the passive clear) isn't reproducible under React Testing Library, which serialises effects at `act()` boundaries; the test locks in the session-scoped contract that closes it.
- `vp run typecheck:mobile` — clean. `vp run test:mobile` — 4444 passed. `vp check` — clean for changed files (the lone `packages/mobile/public/index.html` format issue is pre-existing on `main`, untouched). `vp run check:mobile-bundle` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkJuDx4nCQPYQzeEjNd6Q3