### PR TITLE
fix(sync): match roster-snapshot self by participant id

### DIFF
--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -288,6 +288,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
             users: joined?.users ?? [],
             isLeader: joined?.isLeader ?? false,
             clientId: joined?.clientId ?? joined?.participantId ?? '',
+            // Stable participant id — the roster is keyed by this (a user UUID for
+            // signed-in members, the connection id for anonymous ones). Roster
+            // self-matching in applySessionRuntimeEvent compares against this, NOT
+            // clientId, so the snapshot handler works in authenticated sessions.
+            participantId: joined?.participantId ?? joined?.clientId ?? '',
             lastConnectedBoardSerial: joined?.lastConnectedBoardSerial ?? null,
             boardPath: joined?.boardPath ?? boardPath,
           });

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -88,20 +88,25 @@ export const createEmptySessionRuntimeState = (): MobileSessionRuntimeState => (
   users: [],
   isLeader: false,
   clientId: '',
+  participantId: '',
   lastConnectedBoardSerial: null,
   boardPath: '',
 });
 
 /**
  * Order-insensitive signature of the roster fields a SessionRosterSnapshot can
- * change (crew membership + per-user leadership + display name, own leadership,
- * boardPath). Used only to decide whether a seed/reconcile snapshot actually
- * healed dropped roster drift, so we emit `Session Roster Reconciled` telemetry
- * only when the crew list really moved — not on every (re)subscribe.
+ * change (crew membership + per-user leadership + display name + connection
+ * state, own leadership, boardPath). Used only to decide whether a seed/reconcile
+ * snapshot actually healed dropped roster drift, so we emit `Session Roster
+ * Reconciled` telemetry only when the crew list really moved — not on every
+ * (re)subscribe. `connectionState` is included so a snapshot that heals a
+ * presence-only drift (e.g. a dropped UserPresenceChanged flipping
+ * CONNECTED↔RECONNECTING) still registers — the gating metric would otherwise
+ * miss exactly the drift it exists to measure.
  */
 function rosterStateSignature(state: MobileSessionRuntimeState): string {
   const users = state.users
-    .map((user) => `${user.id}:${user.isLeader ? 1 : 0}:${user.username}`)
+    .map((user) => `${user.id}:${user.isLeader ? 1 : 0}:${user.username}:${user.connectionState ?? ''}`)
     .sort()
     .join('|');
   return `${users}#${state.isLeader ? 1 : 0}#${state.boardPath}`;
@@ -236,6 +241,56 @@ export function useSessionRealtime({
 
     const logJoinFailure = (err: unknown) => {
       if (__DEV__) console.warn('[queue] joinSession failed', err);
+    };
+
+    // Follow a session boardPath's angle onto our own active board. Shared by the
+    // SessionBoardPathChanged delta AND the SessionRosterSnapshot seed so a
+    // dropped path change is healed on the next (re)subscribe, not left stale on
+    // the wall until another peer changes the angle (PR #3907 Codex thread).
+    // Idempotent: every branch no-ops when the stored angle already matches, when
+    // the board is fixed-angle, or when the peer is on a different board — so
+    // calling it on every snapshot is safe.
+    const followSessionBoardPath = (boardPath: string) => {
+      // Named-board hosts (`/b/{slug}`) broadcast a slug path the tuple parser
+      // rejects. Follow the angle when we're on the SAME named board (slug match)
+      // — the angle table differs per board, so never cross boards.
+      const named = parseNamedBoardPath(boardPath);
+      if (named) {
+        if (named.angle == null) return;
+        const nextNamedAngle = named.angle;
+        void (async () => {
+          const stored = await getStoredActiveBoard();
+          if (sessionIdRef.current !== sessionId) return;
+          if (!stored || stored.angle === nextNamedAngle) return;
+          if (stored.isAngleAdjustable === false) return;
+          if (!stored.slug || stored.slug !== named.slug) return;
+          await setActiveBoardRef.current({ ...stored, angle: nextNamedAngle });
+        })();
+        return;
+      }
+      const parsed = parseBoardPath(boardPath);
+      if (!parsed || parsed.angle == null) return;
+      const nextAngle = parsed.angle;
+      void (async () => {
+        const stored = await getStoredActiveBoard();
+        if (sessionIdRef.current !== sessionId) return;
+        if (!stored || stored.angle === nextAngle) return;
+        // Never override a fixed-angle board (mirrors handleAngleChange's local
+        // guard) — a peer can't change an angle the board can't be set to.
+        if (stored.isAngleAdjustable === false) return;
+        // Follow ONLY the angle, and only when the peer is on the SAME board. A
+        // mixed-board session must not push a foreign angle (board angle tables
+        // differ, e.g. MoonBoard only allows 25°/40°).
+        if (
+          parsed.boardName !== stored.boardType ||
+          parsed.layoutId !== stored.layoutId ||
+          parsed.sizeId !== stored.sizeId ||
+          parsed.setIds !== stored.setIds
+        ) {
+          return;
+        }
+        await setActiveBoardRef.current({ ...stored, angle: nextAngle });
+      })();
     };
 
     const scheduleJoinRetry = (failedStartToken: number, preserveExistingSubscriptions = false) => {
@@ -535,57 +590,22 @@ export function useSessionRealtime({
                     layoutId: activeBoardRef.current?.layoutId,
                   });
                 }
+                // Heal a dropped SessionBoardPathChanged: the snapshot carries the
+                // authoritative boardPath, so re-run the angle-follow. Empty is the
+                // "keep current" sentinel — skip it. No echo suppression needed:
+                // a reconcile snapshot has no originating participant.
+                if (runtimeEvent.boardPath) followSessionBoardPath(runtimeEvent.boardPath);
               }
             }
 
-            if (event.__typename !== 'SessionBoardPathChanged' || !event.boardPath) return;
-            // Echo of our own change — we already applied it locally before
-            // broadcasting. A null local participant id (peer event before our
-            // JOIN_SESSION resolved) can't be the originator, so we apply it.
-            if (event.changedByParticipantId && event.changedByParticipantId === participantIdRef.current) return;
-            // Named-board hosts (`/b/{slug}`) broadcast a slug path the tuple
-            // parser rejects. Follow the angle when we're on the SAME named board
-            // (slug match) — the angle table differs per board, so never cross
-            // boards (mirrors the tuple-identity guard below).
-            const named = parseNamedBoardPath(event.boardPath);
-            if (named) {
-              if (named.angle == null) return;
-              const nextNamedAngle = named.angle;
-              void (async () => {
-                const stored = await getStoredActiveBoard();
-                if (sessionIdRef.current !== sessionId) return;
-                if (!stored || stored.angle === nextNamedAngle) return;
-                if (stored.isAngleAdjustable === false) return;
-                if (!stored.slug || stored.slug !== named.slug) return;
-                await setActiveBoardRef.current({ ...stored, angle: nextNamedAngle });
-              })();
-              return;
+            // Follow a peer's angle change directly from the delta.
+            if (event.__typename === 'SessionBoardPathChanged' && event.boardPath) {
+              // Echo of our own change — we already applied it locally before
+              // broadcasting. A null local participant id (peer event before our
+              // JOIN_SESSION resolved) can't be the originator, so we apply it.
+              if (event.changedByParticipantId && event.changedByParticipantId === participantIdRef.current) return;
+              followSessionBoardPath(event.boardPath);
             }
-            const parsed = parseBoardPath(event.boardPath);
-            if (!parsed || parsed.angle == null) return;
-            const nextAngle = parsed.angle;
-            void (async () => {
-              const stored = await getStoredActiveBoard();
-              if (sessionIdRef.current !== sessionId) return;
-              if (!stored || stored.angle === nextAngle) return;
-              // Never override a fixed-angle board (mirrors handleAngleChange's
-              // local guard) — a peer can't change an angle the board can't be
-              // set to.
-              if (stored.isAngleAdjustable === false) return;
-              // Follow ONLY the angle, and only when the peer is on the SAME
-              // board. A mixed-board session must not push a foreign angle (board
-              // angle tables differ, e.g. MoonBoard only allows 25°/40°). Compare
-              // the parsed board identity to our stored board before applying.
-              if (
-                parsed.boardName !== stored.boardType ||
-                parsed.layoutId !== stored.layoutId ||
-                parsed.sizeId !== stored.sizeId ||
-                parsed.setIds !== stored.setIds
-              ) {
-                return;
-              }
-              await setActiveBoardRef.current({ ...stored, angle: nextAngle });
-            })();
           },
           error: (sessionSubscriptionError) => {
             // Session-update stream errors were swallowed. Surface them for

--- a/packages/shared/queue-runtime/src/__tests__/session-events.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/session-events.test.ts
@@ -25,11 +25,16 @@ const user = (overrides: Partial<TestUser> = {}): TestUser => ({
   ...overrides,
 });
 
+// Default fixture is an ANONYMOUS session: participantId === clientId (the
+// connection id), and the roster is keyed by that same id. Authenticated
+// sessions — where participantId is a user UUID distinct from clientId — are
+// exercised explicitly in the dedicated test below.
 const session = (overrides: Partial<TestSession> = {}): TestSession => ({
   id: 'session-1',
   users: [user({ id: 'participant-1' })],
   isLeader: false,
   clientId: 'participant-1',
+  participantId: 'participant-1',
   lastConnectedBoardSerial: null,
   boardPath: '/kilter/1/10/1,2/40/list',
   ...overrides,
@@ -168,6 +173,43 @@ describe('applySessionRuntimeEvent', () => {
       );
       expect(next?.users[0].avatarUrl).toBeUndefined();
       expect(next?.users[0].custom).toBe('kept');
+    });
+
+    // Regression coverage for the id-space bug (PR #3907 Codex thread): in an
+    // AUTHENTICATED session the roster is keyed by participant id (a user UUID)
+    // while `clientId` is the WebSocket connection id, so the two DIFFER. The
+    // original applier matched self by `clientId` and never found it — leadership
+    // never re-derived and self never re-injected. The default fixture hid this
+    // because it's anonymous (participantId === clientId). Match on participantId.
+    it('matches self by participant id when it differs from clientId (authenticated session)', () => {
+      const authSession = (overrides: Partial<TestSession> = {}): TestSession =>
+        session({
+          clientId: 'conn-abc', // WebSocket connection id
+          participantId: 'user-uuid-1', // stable DB user UUID — what the roster is keyed by
+          users: [user({ id: 'user-uuid-1', userId: 'user-uuid-1', username: 'me' })],
+          ...overrides,
+        });
+
+      // Re-derives OWN leadership from the snapshot even though id !== clientId.
+      const promoted = applySessionRuntimeEvent(authSession({ isLeader: false }), {
+        __typename: 'SessionRosterSnapshot',
+        users: [
+          user({ id: 'user-uuid-1', userId: 'user-uuid-1', isLeader: true }),
+          user({ id: 'user-uuid-2', userId: 'user-uuid-2', isLeader: false }),
+        ],
+      });
+      expect(promoted?.isLeader).toBe(true);
+
+      // Re-injects OUR row when a JOIN-racing snapshot omits it (keyed by
+      // participant id, not the connection id).
+      const reinjected = applySessionRuntimeEvent(authSession(), {
+        __typename: 'SessionRosterSnapshot',
+        users: [user({ id: 'user-uuid-2', userId: 'user-uuid-2' })],
+      });
+      expect(reinjected?.users.map((entry) => entry.id).sort()).toEqual(['user-uuid-1', 'user-uuid-2']);
+      expect(reinjected?.users.find((entry) => entry.id === 'user-uuid-1')?.username).toBe('me');
+      expect(reinjected?.clientId).toBe('conn-abc');
+      expect(reinjected?.participantId).toBe('user-uuid-1');
     });
   });
 

--- a/packages/shared/queue-runtime/src/session-events.ts
+++ b/packages/shared/queue-runtime/src/session-events.ts
@@ -10,7 +10,17 @@ export type RuntimeSessionUser = {
 export type RuntimeSessionState<TUser extends RuntimeSessionUser = RuntimeSessionUser> = {
   users: TUser[];
   isLeader: boolean;
+  /** This connection's WebSocket connection id (the JOIN response's `clientId`). */
   clientId: string;
+  /**
+   * This connection's stable participant id — the key roster entries are
+   * identified by. For authenticated users it's their database user UUID; for
+   * anonymous users it equals `clientId` (the connection id). Roster
+   * `RuntimeSessionUser.id` is this participant id, NOT the connection id, so
+   * self-matching against a roster (e.g. the snapshot handler) must compare
+   * against `participantId`, not `clientId` — those diverge for signed-in users.
+   */
+  participantId: string;
   lastConnectedBoardSerial: string | null;
   boardPath: string;
 };
@@ -46,20 +56,24 @@ export function applySessionRuntimeEvent<
       // REPLACE, not merge: this is an authoritative full roster, so members
       // who dropped while we weren't watching are gone and new members appear.
       const snapshotUsers = event.users.map((user) => coerceRuntimeUser(user, options));
-      // Re-inject our own connection row if the snapshot was computed a beat
-      // before the backend registered our JOIN — otherwise a fresh subscribe
-      // would erase us from our own crew list until the next delta. Anchored on
-      // our stable connection id (`clientId`), which the snapshot preserves.
-      const selfInSnapshot = snapshotUsers.find((user) => user.id === prev.clientId);
-      const selfRow = prev.users.find((user) => user.id === prev.clientId);
+      // Re-inject our own row if the snapshot was computed a beat before the
+      // backend registered our JOIN — otherwise a fresh subscribe would erase us
+      // from our own crew list until the next delta. Match on `participantId`,
+      // NOT `clientId`: roster entries are keyed by participant id, which equals
+      // the connection id only for anonymous users. Matching by `clientId` here
+      // silently failed for every signed-in session (their participant id is a
+      // user UUID, distinct from the connection id), so self was never found —
+      // the bug this fixes (PR #3907 Codex thread).
+      const selfInSnapshot = snapshotUsers.find((user) => user.id === prev.participantId);
+      const selfRow = prev.users.find((user) => user.id === prev.participantId);
       const users = selfInSnapshot || !selfRow ? snapshotUsers : [...snapshotUsers, selfRow];
       return {
         ...prev,
         users,
-        // Re-derive top-level leadership from the snapshot's own self entry
-        // (mirrors the LeaderChanged handler's clientId check). When the snapshot
-        // omits us it has no opinion on our leadership — it raced our JOIN — so
-        // keep the prior value rather than silently demoting on incomplete data.
+        // Re-derive top-level leadership from the snapshot's own self entry (keyed
+        // by participant id). When the snapshot omits us it has no opinion on our
+        // leadership — it raced our JOIN — so keep the prior value rather than
+        // silently demoting on incomplete data.
         isLeader: selfInSnapshot ? selfInSnapshot.isLeader : prev.isLeader,
         // Falsy (empty/absent) boardPath keeps the current one — a real boardPath
         // is always a non-empty route, so `||` only ever falls through on the


### PR DESCRIPTION
Follow-up to #3907, addressing the three Codex review threads on that PR. All three are real; #3907 was already merged, so they land here.

## 1. Match roster-snapshot self by participant id (the correctness one)

`#3907` matched "self" in the `SessionRosterSnapshot` handler against `clientId` — but roster entries (`RuntimeSessionUser.id`) are keyed by **participant id**, which equals the connection id only for anonymous users. For a **signed-in** session the participant id is the user's DB UUID while `clientId` is the WebSocket connection id, so the two differ and self was never found. Consequences in authenticated party sessions: the snapshot couldn't re-derive this client's own top-level `isLeader` (a missed `LeaderChanged` stayed stale until the next one), and the self-row re-injection guard was a no-op.

Fix: carry `participantId` in `RuntimeSessionState` and match snapshot-self against it. Anonymous sessions are unaffected (participantId = connectionId there). The default test fixture is anonymous (id = clientId), which is exactly why this slipped through — added an explicit **authenticated-case applier test** (`id ≠ clientId`) covering leader re-derivation and self re-injection.

Web already carried `participantId` on its `Session` (it satisfies `RuntimeSessionState`), so it inherits this fix through the shared applier — no web plumbing needed.

## 2. Apply the snapshot's boardPath to the active board (mobile)

The angle-follow (`parseBoardPath` → `setActiveBoardRef`) was gated on the `SessionBoardPathChanged` event type, so a snapshot re-baselining `boardPath` updated the roster state but left the climb list / LED angle stale until the next explicit path change. Extracted the follow into a shared `followSessionBoardPath` helper and run it on the snapshot too (idempotent — no-ops when the angle already matches, the board is fixed-angle, or the peer is on a different board).

## 3. Include connectionState in the reconciliation signature (mobile)

`rosterStateSignature` hashed only id / leadership / username, so a snapshot that healed a `connectionState`-only presence drift produced an identical signature and `Session Roster Reconciled` didn't fire — the metric that gates the periodic-resnapshot healer (#3905) undercounted exactly the drift it measures. Added `connectionState` to the signature.

### Web scope note
Fixes #2 (angle-follow) and #3 (telemetry signature) are mobile-only. Web's party-session angle-follow (`board-session-bridge.tsx`) has the same event-type gate, but web's party-mode climbing surface is being replaced by RN-web and porting the snapshot→angle-follow there carries a reconnect-reverts-a-pending-local-angle race not worth taking on a surface being retired. Web still gets fix #1 (the correctness fix) via the shared applier. Web telemetry for #3905 is tracked separately.

## Release Notes

In signed-in party sessions, who's leading and your own presence now heal correctly after a dropped update — no more stale leader badge or ghosted-self until someone reshuffles the crew.
