### PR TITLE
fix(mobile): claim history-row tick taps before the queue row gesture

### DIFF
--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -332,6 +332,23 @@ function QueueItemRowComponent({
     return drag.makeHandleGesture(rowIndex, item.uuid, queueIndex).blocksExternalGesture(singleTapRef, longPressRef);
   }, [isDraggable, drag, rowIndex, queueIndex, item.uuid]);
 
+  // The history-row tick button's own tap. Like the drag handle, it
+  // `blocksExternalGesture`s the row's tap/long-press so a touch that starts on the
+  // tick opens Log Ascent without also firing the row press — which would make the
+  // history climb current, open the Play Drawer, and dismiss the Queue Sheet. Only
+  // built for history rows (see showTick). Mirrors ClimbListRow's moreButtonGesture.
+  const tickGesture = useMemo(() => {
+    if (!isHistoryItem || isEditMode || !onTickHistory) return null;
+    return Gesture.Tap()
+      .maxDuration(300)
+      .maxDistance(15)
+      .blocksExternalGesture(singleTapRef, longPressRef)
+      .onStart(() => {
+        'worklet';
+        runOnJS(handleTickPress)();
+      });
+  }, [isHistoryItem, isEditMode, onTickHistory, handleTickPress]);
+
   // Take the layout event directly so the same stable function can be passed to
   // `onLayout` — an inline `(event) => ...` wrapper would be a fresh arrow each
   // render, defeating the row's memoization on the wrapping `Animated.View`.
@@ -346,7 +363,7 @@ function QueueItemRowComponent({
   // falls back to the placeholder label instead of an empty accessibility string.
   const climbName = item.climb?.name || t('mobile.queue.unknownClimb');
 
-  const showTick = isHistoryItem && !isEditMode && !!onTickHistory;
+  const showTick = !!tickGesture;
   const showDragHandle = !!dragHandleGesture && !isEditMode;
 
   // History rows pin the grade for the angle the climb was CLIMBED at, which can
@@ -405,17 +422,17 @@ function QueueItemRowComponent({
         )}
 
         {/* Trailing action: tick (history) or drag handle (upcoming) */}
-        {showTick ? (
-          <Pressable
-            testID="tick-button"
-            onPress={handleTickPress}
-            hitSlop={8}
-            accessibilityRole="button"
-            accessibilityLabel={t('mobile.queue.logAscent')}
-            style={styles.trailingButton}
-          >
-            <Icon name="tick" size={26} color={brandColors.success} />
-          </Pressable>
+        {showTick && tickGesture ? (
+          <GestureDetector gesture={tickGesture}>
+            <View
+              testID="tick-button"
+              accessibilityRole="button"
+              accessibilityLabel={t('mobile.queue.logAscent')}
+              style={styles.trailingButton}
+            >
+              <Icon name="tick" size={26} color={brandColors.success} />
+            </View>
+          </GestureDetector>
         ) : showDragHandle && dragHandleGesture ? (
           <GestureDetector gesture={dragHandleGesture}>
             <View

--- a/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
@@ -13,11 +13,14 @@ import type { QueueDragControls } from '../play-drawer/use-queue-drag';
 const renderCounter = vi.hoisted(() => ({ count: 0 }));
 
 // Capture the latest callback handed to the row's tap gesture, long-press gesture,
-// trailing tick button, and delete button so a test can assert identity across
-// re-renders. `rowPress`/`longPress` come from `Gesture.Tap()`/`Gesture.LongPress()`'s
-// `.onStart(...)` (the row moved off RN core Pressable's onPress/onLongPress onto RNGH
-// gestures — see QueueItemRow.tsx). `tapRef`/`longPressRef` capture the `.withRef(...)`
-// arguments so a test can confirm the drag handle's Pan blocks exactly those refs.
+// history-row tick-button gesture, and delete button so a test can assert identity
+// across re-renders. `rowPress`/`longPress`/`tickPress` come from `Gesture.Tap()`/
+// `Gesture.LongPress()`'s `.onStart(...)` — the row AND its trailing tick moved off RN
+// core Pressable onto RNGH gestures (see QueueItemRow.tsx). The row tap is the one that
+// calls `.withRef(...)`; a nested no-ref tap is the tick button (they'd otherwise share
+// the `rowPress` slot). `tapRef`/`longPressRef` capture the `.withRef(...)` arguments so
+// a test can confirm the drag handle and the tick both block exactly those refs.
+// `deletePress` still comes from the delete Pressable.
 const captured = vi.hoisted(() => ({
   rowPress: null as null | (() => void),
   longPress: null as null | (() => void),
@@ -48,9 +51,9 @@ vi.mock('react-native', () => {
     PlatformColor: (name: string) => name,
     View: passthrough('div'),
     // Capture by testID so any future Pressable addition doesn't silently
-    // overwrite the wrong slot.
+    // overwrite the wrong slot. (The tick button is now an RNGH gesture, not a
+    // Pressable — its callback is captured in the Gesture.Tap mock below.)
     Pressable: ({ children, onPress, testID }: { children?: ReactNode; onPress?: () => void; testID?: string }) => {
-      if (testID === 'tick-button' && onPress) captured.tickPress = onPress;
       if (testID === 'delete-button' && onPress) captured.deletePress = onPress;
       return createElement('button', null, children);
     },
@@ -116,9 +119,20 @@ vi.mock('react-native-gesture-handler', () => {
       Tap: () => {
         const log: { method: string; args: unknown[] }[] = [];
         gestureCalls.tapLogs.push(log);
+        // A history row renders two taps: its own row tap (calls `.withRef(...)`) and
+        // the tick button's tap (no ref, calls `.blocksExternalGesture(...)`). Route
+        // each tap's `onStart` by whether it carried a ref so the two don't clobber a
+        // single slot — row tap → rowPress, nested tick tap → tickPress.
+        let hasRef = false;
         return makeBuilder(log, (method, arg) => {
-          if (method === 'onStart' && typeof arg === 'function') captured.rowPress = arg as () => void;
-          if (method === 'withRef') captured.tapRef = arg;
+          if (method === 'withRef') {
+            hasRef = true;
+            captured.tapRef = arg;
+          }
+          if (method === 'onStart' && typeof arg === 'function') {
+            if (hasRef) captured.rowPress = arg as () => void;
+            else captured.tickPress = arg as () => void;
+          }
         });
       },
       LongPress: () => {
@@ -427,6 +441,42 @@ describe('QueueItemRow React.memo', () => {
 
     const blocksCall = handleGestureCalls.find((call) => call.method === 'blocksExternalGesture');
     expect(blocksCall).toBeDefined();
+    expect(blocksCall?.args).toEqual([captured.tapRef, captured.longPressRef]);
+  });
+
+  // Regression guard for the tick side of #3683: on a history row the trailing tick
+  // sits inside the row's tap/long-press arena. Without a blocking relationship a tap
+  // on the tick fires BOTH its own Log-Ascent handler and the row tap (which makes the
+  // history climb current, opens the Play Drawer, and dismisses the Queue Sheet). Like
+  // the drag handle, the tick's Tap must `blocksExternalGesture` the row's tap/long-
+  // press so a touch that starts on the tick is claimed by it alone. Mirrors
+  // ClimbListRow's moreButtonGesture. (Native arbitration only exists on-device — see
+  // the tick-tap case in the PR body's QA matrix.)
+  it('wires the history-row tick button to block the row tap/long-press gestures', () => {
+    const onTickHistory = vi.fn();
+    const item = makeItem('a', 'Crimp Master');
+    render(
+      <QueueItemRow
+        item={item}
+        position={1}
+        board={board}
+        isCurrentClimb={false}
+        isHistoryItem
+        onPress={onPress}
+        onRemove={onRemove}
+        onToggleSelect={onToggleSelect}
+        onTickHistory={onTickHistory}
+      />,
+    );
+
+    // The row registers its own tap (with a ref); the tick registers a second tap (no
+    // ref) that blocks the row gestures. Find the tick's tap by its block call and
+    // assert it targets exactly the row's tap/long-press refs.
+    expect(captured.tapRef).not.toBeNull();
+    expect(captured.longPressRef).not.toBeNull();
+    const tickLog = gestureCalls.tapLogs.find((calls) => calls.some((call) => call.method === 'blocksExternalGesture'));
+    expect(tickLog).toBeDefined();
+    const blocksCall = tickLog?.find((call) => call.method === 'blocksExternalGesture');
     expect(blocksCall?.args).toEqual([captured.tapRef, captured.longPressRef]);
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #3890 (merged) for #3683. Codex flagged one case that #3890's gesture-arena rework missed: the **history-row tick button** (✓ Log Ascent).

In #3890 the queue row's tap/long-press moved onto RNGH gestures (`Gesture.Tap()` / `Gesture.LongPress()` composed via `Gesture.Exclusive`), and the drag handle got `.blocksExternalGesture(singleTapRef, longPressRef)` so a touch on the handle is claimed by the drag alone. But the trailing tick button stayed a plain RN `Pressable` nested inside that same `GestureDetector(tapGesture)` — with **no** blocking relationship. Two independent touch systems on one touch point again: a tap on the tick could fire **both** `handleTickPress` (open Log Ascent) **and** the row tap (which on a history row makes the climb current, opens the Play Drawer, and dismisses the Queue Sheet).

#3890 was merged before this could be added to it, so it lands here.

### Fix

Wrap the tick in an RNGH `Gesture.Tap()` that `.blocksExternalGesture(singleTapRef, longPressRef)`, exactly mirroring:
- the drag handle in the same file (added in #3890), and
- `ClimbListRow`'s `moreButtonGesture` (the shipped nested-actionable-button precedent).

So a touch that starts on the tick is claimed by it alone and opens Log Ascent without also firing the row press. `handleTickPress` is unchanged; the tick's `Gesture.Tap` is only built on history rows (`isHistoryItem && !isEditMode && onTickHistory`), so non-history rows create no extra gesture.

### Not in scope (tracked separately)

Codex also raised screen-reader activation on these bare-`View` + `GestureDetector` rows. That's a **pre-existing, app-wide** characteristic of the `ClimbListRow` pattern (not introduced here), and adding `onAccessibilityTap`/`onAccessibilityAction` risks double-firing if RNGH's Tap already handles the `activate` action — it needs on-device VoiceOver/TalkBack verification. Filed as **#3914** (mobile, P3) covering both `QueueItemRow` and `ClimbListRow` so they stay consistent.

### OTA vs native

Pure JS/TS change (`QueueItemRow.tsx` + its test) — no native module, dependency, or `app.config.ts`/plugin change. Ships over-the-air.

## Release Notes

- Tapping the ✓ on a past climb in the queue now just logs the ascent — it no longer also jumps you into that climb and closes the queue.

## Test plan

- `vp check`, `vp run typecheck:mobile`, `vp run test:mobile`, `vp run check:mobile-bundle` — all green locally.
- `packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx`: new regression test `wires the history-row tick button to block the row tap/long-press gestures` asserts the tick's `Gesture.Tap()` calls `.blocksExternalGesture` with exactly the row's tap/long-press refs. The RNGH test mock now routes each tap's `onStart` by whether it carried a `.withRef(...)` (row tap → `rowPress`, nested tick tap → `tickPress`) so the two taps on a history row don't clobber one capture slot.

### On-device QA (Linux box — no iOS simulator here; please run before merging)

On a history row in the queue:
1. **Tap the ✓ tick** → opens Log Ascent only. It must NOT also make the climb current, open the Play Drawer, or dismiss the Queue Sheet. *(this is the fix)*
2. **Tap elsewhere on the row** → still selects/opens as before.
3. **Long-press elsewhere on the row** → reaction menu still opens.

Native gesture arbitration only exists on-device, so the jsdom test guards the wiring, not the actual touch dispatch — please confirm on a real device / working emulator (iOS + Android).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkJuDx4nCQPYQzeEjNd6Q3
