### PR TITLE
test(mobile): pin the flag-on offline miss-retry recovery path

### DIFF
--- a/packages/mobile/src/lib/graphql/__tests__/offline-request.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/offline-request.test.ts
@@ -461,16 +461,39 @@ describe('offlineAwareRequest — network-failure recovery (connected-but-unreac
     expect(searchClimbsLocal).toHaveBeenCalledWith(fakeDb, searchInput);
   });
 
-  it('serves a downloaded board from local SQLite when an online request throws (flag on, detail miss-retry)', async () => {
+  it('serves a downloaded climb from local SQLite when the flag-on miss-retry hits a dead network', async () => {
     // Flag on + online: search serves local before the network, so the only
-    // network-reaching path for a downloaded board is the detail miss-retry. On a
-    // dead network it recovers to the local (null) result instead of the throw.
+    // network-reaching path for a downloaded board is the detail miss-retry —
+    // local read misses (row not synced), retries the network, the network
+    // throws, and the catch recovers to the local (null) result. Set the flag
+    // explicitly so this path is deterministic, and assert the local-first read
+    // + network retry actually happened, not just the final shape (which the
+    // flag-off catch-only path below produces too).
+    setOfflineEngineEnabled(true);
     setOnline(true);
     isBoardDownloadedLocally.mockResolvedValue(true);
     getClimbLocal.mockResolvedValue(null); // local miss → retry over network
     request.mockRejectedValue(new Error('Network request failed'));
     const result = await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, climbVars);
     expect(result).toEqual({ climb: null });
+    // Local-first read for the miss, then the catch-block recovery read.
+    expect(getClimbLocal).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenCalledWith(GET_CLIMB, climbVars);
+  });
+
+  it('serves a downloaded climb from local SQLite when a flag-off online request throws (cold-start race, detail op)', async () => {
+    // Flag off + stale-online: no local-first probe, so the request goes straight
+    // to the network, throws, and the catch block is the ONLY thing that reads
+    // local — one read, returning the real detail. Distinct from test 1 (which
+    // covers the same recovery for SEARCH_CLIMBS) and from the flag-on path above
+    // (which reads local twice).
+    setOfflineEngineEnabled(false);
+    setOnline(true);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+    request.mockRejectedValue(new Error('Network request failed'));
+    const result = await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, climbVars);
+    expect(result).toEqual({ climb: { uuid: 'local-detail' } });
+    expect(getClimbLocal).toHaveBeenCalledTimes(1);
   });
 
   it('rethrows the network error when nothing is downloaded (not swallowed into an empty fallback)', async () => {

--- a/packages/mobile/src/lib/graphql/offline-request.ts
+++ b/packages/mobile/src/lib/graphql/offline-request.ts
@@ -179,18 +179,25 @@ registerOfflineOperation<BoardseshGradesForAnglesVariables, BoardseshGradesForAn
  */
 export async function offlineAwareRequest<TResponse>(document: string, variables?: Variables): Promise<TResponse> {
   const operation = OFFLINE_OPERATIONS.get(document);
+  // Carry a local source we already resolved on the way to the network so the
+  // network-failure catch below can reuse it instead of re-probing. Only set on
+  // the online miss-retry path — the one path that reaches the network with a
+  // confirmed-serviceable local source.
+  let localDb: SQLiteDatabase | null = null;
+  let localServiceable = false;
   if (operation) {
     const isOnline = onlineManager.isOnline();
     // Consult local sources when OFFLINE (always) or, while ONLINE, only when the
     // flag enables the local-first optimization.
     if (!isOnline || isOfflineEngineEnabled()) {
-      const db = getDatabaseHandle();
+      localDb = getDatabaseHandle();
       // The `variables !== undefined` guard makes a registered document called
       // without variables degrade to HTTP rather than throw in a destructure;
       // the offline fallback below still applies either way. `as never` re-narrows
       // the storage-erased generics — see the OFFLINE_OPERATIONS declaration.
-      if (db && variables !== undefined && (await operation.canServeLocal(db, variables as never))) {
-        const localResponse = (await operation.resolveLocal(db, variables as never)) as TResponse;
+      if (localDb && variables !== undefined && (await operation.canServeLocal(localDb, variables as never))) {
+        localServiceable = true;
+        const localResponse = (await operation.resolveLocal(localDb, variables as never)) as TResponse;
         // A known-key miss falls through to the network while online — the row
         // may simply not have synced yet. Offline, the miss stands (it has the
         // same shape as offlineFallback).
@@ -211,8 +218,10 @@ export async function offlineAwareRequest<TResponse>(document: string, variables
     // online (see the doc above). Flag-independent, like every other on-disk read.
     // Nothing local to serve → rethrow the real error unchanged.
     if (operation && variables !== undefined) {
-      const db = getDatabaseHandle();
-      if (db && (await operation.canServeLocal(db, variables as never))) {
+      // Reuse the db + canServeLocal result from the miss-retry path when we have
+      // them; otherwise (flag off, or db not resolved above) probe now.
+      const db = localDb ?? getDatabaseHandle();
+      if (db && (localServiceable || (await operation.canServeLocal(db, variables as never)))) {
         return (await operation.resolveLocal(db, variables as never)) as TResponse;
       }
     }


### PR DESCRIPTION
## Summary

The network-failure-recovery describe in `offline-request.test.ts` had a test labelled "flag on, detail miss-retry" whose only assertion was the final result shape (`{ climb: null }`). That same shape is produced by the flag-**off** catch-only path too, so the test stayed green under either flag state and pinned down neither — a misleading coverage claim, and the genuine flag-on path was effectively unverified.

This change:

- **Strengthens the flag-on test.** Sets `setOfflineEngineEnabled(true)` explicitly (deterministic, not inherited from the distant module-level `beforeEach`) and asserts the discriminating behaviour: the local-first read happens (`getClimbLocal` called twice — once for the miss, once for the catch-block recovery) and the network retry fires (`request` called with `GET_CLIMB`). This actually pins the flag-on → local miss → network retry → dead network → local `{ climb: null }` path.
- **Adds a dedicated flag-off detail-op recovery test.** Covers the cold-start-race path for `GET_CLIMB` distinctly from the existing flag-off `SEARCH_CLIMBS` case: flag off, stale-online, board downloaded, network throws → the catch block is the only local read (`getClimbLocal` called once), returning the real detail.
- **Dedupes the `canServeLocal` probe** in `offlineAwareRequest`. On the confirmed miss-retry path the local-first block already resolved the db handle and `canServeLocal === true`; the catch block now reuses those via two hoisted locals (`localDb`, `localServiceable`) instead of awaiting `canServeLocal` a second time. All other paths (flag off, null db, `canServeLocal` false) behave exactly as before.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project mobile offline-request` — 43 tests pass, including the strengthened flag-on test and the new flag-off detail test.
- `vp run typecheck:mobile` — clean (confirms the `localDb` / `localServiceable` typing).
- `vp check` on both changed files — format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5iED7USR8ReZQpUdCnmLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5iED7USR8ReZQpUdCnmLs)_