### PR TITLE
fix(sync): guard snapshot angle-follow against a pending local change

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -232,6 +232,7 @@ type Snapshot = {
   confirmClimbOnWall: ReturnType<typeof useQueue>['confirmClimbOnWall'];
   reportWallDisconnect: ReturnType<typeof useQueue>['reportWallDisconnect'];
   setSessionBoardSerial: ReturnType<typeof useQueue>['setSessionBoardSerial'];
+  setSessionBoardPath: ReturnType<typeof useQueue>['setSessionBoardPath'];
 };
 
 type SelectorSnapshot = {
@@ -327,6 +328,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       confirmClimbOnWall: queue.confirmClimbOnWall,
       reportWallDisconnect: queue.reportWallDisconnect,
       setSessionBoardSerial: queue.setSessionBoardSerial,
+      setSessionBoardPath: queue.setSessionBoardPath,
     });
   }, [
     queue.sessionId,
@@ -346,6 +348,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
     queue.confirmClimbOnWall,
     queue.reportWallDisconnect,
     queue.setSessionBoardSerial,
+    queue.setSessionBoardPath,
     onSnapshot,
   ]);
   return null;
@@ -1224,6 +1227,75 @@ describe('QueueProvider session update subscription', () => {
       expect(snapshots.at(-1)?.lastConnectedBoardSerial).toBe('AURORA-1');
       expect(activeBoard.setActiveBoard).toHaveBeenCalledWith({ ...activeBoard.stored, angle: 30 });
     });
+  });
+
+  it('follows the angle carried by a roster snapshot (heals a dropped board-path change)', async () => {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(ws.getSessionUpdatesSink()).not.toBeNull();
+    });
+    const sessionUpdatesSink = ws.getSessionUpdatesSink();
+    if (!sessionUpdatesSink) throw new Error('session updates sink was not captured');
+
+    // The seed/reconcile snapshot carries the session's authoritative boardPath;
+    // with no local change pending, its angle is applied to the wall.
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'SessionRosterSnapshot',
+            users: [user({ id: 'participant-self' })],
+            boardPath: '/kilter/1/10/1,2/30/list',
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(activeBoard.setActiveBoard).toHaveBeenCalledWith({ ...activeBoard.stored, angle: 30 });
+    });
+  });
+
+  it('suppresses the snapshot angle-follow while a local board-path change is in flight', async () => {
+    // A local angle change whose broadcast never settles keeps the pending ref
+    // set, so a snapshot seeded before it landed must NOT revert the wall.
+    queueMutations.setSessionBoardPath.mockImplementationOnce(() => new Promise<void>(() => {}));
+
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(ws.getSessionUpdatesSink()).not.toBeNull();
+    });
+    const sessionUpdatesSink = ws.getSessionUpdatesSink();
+    if (!sessionUpdatesSink) throw new Error('session updates sink was not captured');
+
+    // Fire the local change (don't await — the hung mutation keeps it in flight).
+    act(() => {
+      void snapshots.at(-1)?.setSessionBoardPath('/kilter/1/10/1,2/30/list');
+    });
+    activeBoard.setActiveBoard.mockClear();
+
+    // A reconnect snapshot arrives carrying the session's STALE (pre-change) angle.
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'SessionRosterSnapshot',
+            users: [user({ id: 'participant-self' })],
+            boardPath: '/kilter/1/10/1,2/20/list',
+          },
+        },
+      });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Guard held: the in-flight local change is not clobbered by the stale seed.
+    expect(activeBoard.setActiveBoard).not.toHaveBeenCalledWith({ ...activeBoard.stored, angle: 20 });
   });
 
   it('ignores stale events from a previous session subscription after switching sessions', async () => {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -126,6 +126,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // telemetry (which can't observe the functional state updater's result).
   const sessionRuntimeStateRef = useRef(sessionRuntimeState);
   sessionRuntimeStateRef.current = sessionRuntimeState;
+  // The boardPath of a local angle change whose setSessionBoardPath broadcast is
+  // still in flight, else null. While set, the reconnect roster-snapshot's
+  // angle-follow is suppressed (see useSessionRealtime) so a snapshot carrying
+  // the session's not-yet-updated boardPath can't drag the wall back off the
+  // angle we just picked.
+  const pendingLocalBoardPathRef = useRef<string | null>(null);
   const sessionUsers = sessionRuntimeState.users;
   const lastConnectedBoardSerial = sessionRuntimeState.lastConnectedBoardSerial;
   // Session-scoped "the current climb is lit on a wall" indicator. Flipped on by
@@ -432,7 +438,26 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // Broadcast the session's boardPath (angle/board) to party members. The
   // shared mutation already swallows transport errors and is a true no-op in
   // solo (never lazily creates a session), so callers can fire it freely.
-  const setSessionBoardPath = useCallback((boardPath: string) => mutations.setSessionBoardPath(boardPath), [mutations]);
+  //
+  // Record the requested boardPath as pending while the broadcast is in flight
+  // so the reconnect roster-snapshot's angle-follow doesn't revert us: until the
+  // mutation lands, the backend still holds the OLD boardPath, so a snapshot
+  // seeded in that window carries it — and our own SessionBoardPathChanged echo
+  // is self-suppressed (changedByParticipantId === us), which would otherwise
+  // leave us stuck on the old angle. Clear on settle (success OR failure — on
+  // failure the server's value is authoritative again), but only if a newer
+  // local change hasn't already superseded this one.
+  const setSessionBoardPath = useCallback(
+    async (boardPath: string) => {
+      pendingLocalBoardPathRef.current = boardPath;
+      try {
+        return await mutations.setSessionBoardPath(boardPath);
+      } finally {
+        if (pendingLocalBoardPathRef.current === boardPath) pendingLocalBoardPathRef.current = null;
+      }
+    },
+    [mutations],
+  );
   // Solo-queue persistence: cold-start restore (explicit session first, then the
   // local snapshot) + the debounced solo snapshot save. See useQueuePersistence.
   useQueuePersistence({
@@ -621,6 +646,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     setLiveStats,
     setSessionRuntimeState,
     sessionRuntimeStateRef,
+    pendingLocalBoardPathRef,
     setIsSessionWallLit,
     setParticipantId,
     locallyEndingSessionIdRef,

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -132,6 +132,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // the session's not-yet-updated boardPath can't drag the wall back off the
   // angle we just picked.
   const pendingLocalBoardPathRef = useRef<string | null>(null);
+  // Monotonic token so an in-flight setSessionBoardPath only clears the guard
+  // when it's still the latest — two overlapping calls carrying the SAME
+  // boardPath string can't be told apart by value, so a token is what keeps a
+  // rapid same-value toggle from clearing the ref while a later call is live.
+  const boardPathBroadcastTokenRef = useRef(0);
   const sessionUsers = sessionRuntimeState.users;
   const lastConnectedBoardSerial = sessionRuntimeState.lastConnectedBoardSerial;
   // Session-scoped "the current climb is lit on a wall" indicator. Flipped on by
@@ -449,11 +454,14 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // local change hasn't already superseded this one.
   const setSessionBoardPath = useCallback(
     async (boardPath: string) => {
+      const token = ++boardPathBroadcastTokenRef.current;
       pendingLocalBoardPathRef.current = boardPath;
       try {
         return await mutations.setSessionBoardPath(boardPath);
       } finally {
-        if (pendingLocalBoardPathRef.current === boardPath) pendingLocalBoardPathRef.current = null;
+        // Clear only if a newer broadcast hasn't superseded us (token match) —
+        // robust against two overlapping calls with the same boardPath.
+        if (boardPathBroadcastTokenRef.current === token) pendingLocalBoardPathRef.current = null;
       }
     },
     [mutations],

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -215,6 +215,7 @@ export function useSessionRealtime({
       setSessionRuntimeState(createEmptySessionRuntimeState());
       setIsSessionWallLit(false);
       joinTracker.reset();
+      pendingLocalBoardPathRef.current = null;
       queueSyncGateRef.current = null;
       restartJoinedSubscriptionsRef.current = null;
       return;
@@ -818,6 +819,10 @@ export function useSessionRealtime({
       setParticipantId(null);
       participantIdRef.current = null;
       joinTracker.reset();
+      // Drop any pending board-path guard from the outgoing session: if its
+      // setSessionBoardPath hung on a wedged socket during an A→B switch, a stale
+      // ref would otherwise suppress every snapshot angle-follow in session B.
+      pendingLocalBoardPathRef.current = null;
     };
   }, [sessionId, coordinator, ensureJoined, joinTracker, authTransportRevision]);
 

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -150,6 +150,9 @@ type UseSessionRealtimeParams = {
   setLiveStats: React.Dispatch<React.SetStateAction<SessionLiveStatsEvent | null>>;
   setSessionRuntimeState: React.Dispatch<React.SetStateAction<MobileSessionRuntimeState>>;
   sessionRuntimeStateRef: React.RefObject<MobileSessionRuntimeState>;
+  /** Requested boardPath of a local angle change whose broadcast is still in
+   *  flight, else null. Gates the snapshot angle-follow (see below). */
+  pendingLocalBoardPathRef: React.RefObject<string | null>;
   setIsSessionWallLit: React.Dispatch<React.SetStateAction<boolean>>;
   setParticipantId: React.Dispatch<React.SetStateAction<string | null>>;
   locallyEndingSessionIdRef: React.RefObject<string | null>;
@@ -189,6 +192,7 @@ export function useSessionRealtime({
   setLiveStats,
   setSessionRuntimeState,
   sessionRuntimeStateRef,
+  pendingLocalBoardPathRef,
   setIsSessionWallLit,
   setParticipantId,
   locallyEndingSessionIdRef,
@@ -689,7 +693,19 @@ export function useSessionRealtime({
                 // authoritative boardPath, so re-run the angle-follow. Empty is the
                 // "keep current" sentinel — skip it. No echo suppression needed:
                 // a reconcile snapshot has no originating participant.
-                if (runtimeEvent.boardPath) followSessionBoardPath(runtimeEvent.boardPath);
+                //
+                // BUT skip while a local angle change is still broadcasting: the
+                // snapshot may have been seeded before our setSessionBoardPath
+                // landed, so it carries the OLD boardPath and would revert the wall
+                // off the angle we just picked — and our own SessionBoardPathChanged
+                // echo is self-suppressed, leaving us stuck. Once the broadcast
+                // settles the backend holds our value and later snapshots agree, so
+                // the follow resumes. (A snapshot seeded pre-persist but delivered
+                // post-settle is a narrower race that needs a roster epoch to
+                // resolve — deferred with the periodic-resnapshot healer, #3905.)
+                if (runtimeEvent.boardPath && !pendingLocalBoardPathRef.current) {
+                  followSessionBoardPath(runtimeEvent.boardPath);
+                }
               }
             }
 


### PR DESCRIPTION
Follow-up to #3911 (merged), addressing its paired-QA finding. #3911 landed the roster-snapshot fixes; this adds the guard that review called out, which couldn't be folded in before the PR merged.

## The race

The snapshot angle-follow added in #3911 could revert a locally-pending angle change:

1. A member picks an angle → `setActiveBoard(newAngle)` lights the wall locally, and `setSessionBoardPath` broadcasts it.
2. While that broadcast is in flight, the backend still holds the OLD boardPath.
3. A reconnect `SessionRosterSnapshot` seeded in that window carries the OLD boardPath → `followSessionBoardPath` drags the wall back to the old angle.
4. When the member's own `SessionBoardPathChanged` echo finally lands it's self-suppressed (`changedByParticipantId === participantIdRef.current`), so they're stuck on the old angle until the next manual change.

## The fix

Record the requested boardPath as **pending** in a ref while its `setSessionBoardPath` broadcast is in flight (cleared on settle — success or failure — unless a newer local change superseded it), and skip **only** the snapshot angle-follow while it's set. The delta path keeps its existing `changedByParticipantId` echo suppression untouched. Once the broadcast settles the backend holds our value and later snapshots agree, so the follow resumes.

A snapshot seeded pre-persist but *delivered* post-settle is a narrower race that needs a monotonic roster epoch to resolve — deferred with the periodic-resnapshot healer (#3905).

Mobile-only, matching #3911's scope.

## Tests
Two mobile tests: the snapshot follows an angle change when idle, and the follow is suppressed while a local board-path change is in flight.

## Release Notes

Pick an angle mid-session and it sticks — reconnecting no longer snaps the wall back to the old angle while your change is still syncing to the crew.
