### PR TITLE
test(sync): close busy_timeout coverage gap in upsertDocuments tests

### DIFF
--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
@@ -23,6 +23,7 @@ vi.mock('../checkpoints', () => ({
 
 import { pullSync, toSqliteValue, multiRowChunkSize } from '../pull-client';
 import { TABLE_CONFIGS } from '../table-config';
+import { OFFLINE_DB_BUSY_TIMEOUT_MS } from '../../db/pragmas';
 
 // --- Pure helpers ------------------------------------------------------------
 
@@ -132,6 +133,7 @@ type GraphqlFetchMock = ReturnType<typeof vi.fn> &
 describe('upsertDocuments batching (via pullSync)', () => {
   let db: OfflineDatabase;
   let sqlCalls: SqlCall[];
+  let mockTxn: ReturnType<typeof createMockDb>['mockTxn'];
   let queryClient: QueryInvalidator;
   let graphqlFetch: GraphqlFetchMock;
 
@@ -140,6 +142,7 @@ describe('upsertDocuments batching (via pullSync)', () => {
     const mock = createMockDb();
     db = mock.db;
     sqlCalls = mock.sqlCalls;
+    mockTxn = mock.mockTxn;
     queryClient = createMockQueryClient();
     graphqlFetch = vi.fn() as unknown as GraphqlFetchMock;
   });
@@ -154,6 +157,20 @@ describe('upsertDocuments batching (via pullSync)', () => {
       throw new Error(`Unexpected query: ${query}`);
     });
   }
+
+  it('sets busy_timeout on the transaction connection before inserting', async () => {
+    fetchServingOnly('syncTicks', [{ uuid: 'tick-1', attempt_count: 1 }]);
+
+    await pullSync(db, queryClient, graphqlFetch);
+
+    expect(mockTxn.execAsync).toHaveBeenCalledWith(`PRAGMA busy_timeout = ${OFFLINE_DB_BUSY_TIMEOUT_MS}`);
+    // Must run before the insert: a fresh transaction connection starts at
+    // busy_timeout = 0, so setting it after the first INSERT is too late to
+    // protect that statement from an instant SQLITE_BUSY.
+    const execOrder = mockTxn.execAsync.mock.invocationCallOrder[0];
+    const runOrder = mockTxn.runAsync.mock.invocationCallOrder[0];
+    expect(execOrder).toBeLessThan(runOrder);
+  });
 
   it('binds NULL for a document missing a page-wide column another document has', async () => {
     // doc1 carries `quality`; doc2 omits it entirely. The page-wide column


### PR DESCRIPTION
## Summary

Follow-up to a review note on #3887 (the WAL + `busy_timeout` fix, already merged): the mock transaction's `execAsync` in both `pull-client.test.ts` and `pull-client-upsert.test.ts` was a silent no-op, so removing the `applyBusyTimeout(transaction)` call from `upsertDocuments` in `pull-client.ts` would not have failed either suite.

Adds an assertion in `pull-client-upsert.test.ts` that:
- `execAsync` is called with `PRAGMA busy_timeout = ${OFFLINE_DB_BUSY_TIMEOUT_MS}` on the transaction connection, and
- it runs before the first `runAsync` insert (a fresh transaction connection starts at `busy_timeout = 0`, so setting it after the first insert is too late to protect that statement).

No production code changed.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Added `sets busy_timeout on the transaction connection before inserting` to `pull-client-upsert.test.ts`.
- Verified the new test fails when `applyBusyTimeout(transaction)` is removed from `upsertDocuments` in `pull-client.ts`, then confirmed it passes with the call restored (source file unchanged from `main`).
- `vp test run --reporter=agent pull-client-upsert` — 15 passed.
- `bunx tsc --noEmit` in `packages/shared/offline-sync` — no errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2tbF6VLgc2sABuqj3CCjk)_