### PR TITLE
fix(mobile): only track re-seed analytics when a write actually dispatches

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
@@ -720,4 +720,58 @@ describe('QueueProvider session-seed failure guard (#3878)', () => {
     expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2', 'q3']);
     expect(queueSnapshotStore.clearStoredQueueSnapshot).toHaveBeenCalled();
   });
+
+  it('keeps the guard armed and reports the error when the re-seed itself rejects', async () => {
+    // The .catch path: reSeedQueueRef.current rejecting must not clear the
+    // seed-failed flag — the guard stays armed so the NEXT reconnect's empty
+    // FullSync retries the whole-queue push instead of silently giving up.
+    queueMutations.setQueue.mockReset();
+    queueMutations.setQueue.mockRejectedValueOnce(new Error('seed failed')); // the seed
+    queueMutations.setQueue.mockRejectedValueOnce(new Error('re-seed failed')); // re-seed attempt #1
+    queueMutations.setQueue.mockResolvedValue(undefined); // re-seed attempt #2 (retry) succeeds
+
+    const snapshots = await renderWithLocalQueue(['q1', 'q2']);
+    await act(async () => {
+      await snapshots.at(-1)?.startSession();
+    });
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    // First empty FullSync: guarded, re-seed attempt #1 rejects.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'empty-hash') } });
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The rejection is reported, not swallowed silently.
+    expect(errorReporter.reportHandledError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: { source: 'startSessionSeed', op: 'reseed' } }),
+    );
+    // The queue was never wiped, and the flag was never cleared on failure —
+    // no clearStoredQueueSnapshot call yet.
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2']);
+    expect(queueMutations.setQueue).toHaveBeenCalledTimes(2);
+    expect(queueSnapshotStore.clearStoredQueueSnapshot).not.toHaveBeenCalled();
+
+    // A later reconnect's empty FullSync retries the push, since the guard is
+    // still armed for this session.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(2, 'empty-hash-2') } });
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(queueMutations.setQueue).toHaveBeenCalledTimes(3);
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2']);
+    expect(queueSnapshotStore.clearStoredQueueSnapshot).toHaveBeenCalled();
+  });
 });

--- a/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
@@ -388,6 +388,16 @@ describe('QueueProvider session-seed failure guard (#3878)', () => {
     return snapshots;
   }
 
+  // Every `Queue Seed FullSync Guarded` emitted so far. The event is meant to
+  // count guarded empty FullSyncs one-for-one, so the re-seed tests assert an
+  // exact count rather than "was called" — a bare toHaveBeenCalledWith passes
+  // just as happily at 2 events as at 1 and hides both overcount regressions.
+  function guardedTrackCalls(): unknown[][] {
+    return (analytics.track.mock.calls as unknown as unknown[][]).filter(
+      (call) => call[0] === 'Queue Seed FullSync Guarded',
+    );
+  }
+
   it('keeps the live queue and re-seeds when the seed rejects and an empty FullSync arrives', async () => {
     // Seed (setQueue call #1) rejects; the re-seed (call #2) succeeds.
     queueMutations.setQueue.mockReset();
@@ -648,6 +658,11 @@ describe('QueueProvider session-seed failure guard (#3878)', () => {
     // add a third write.
     expect(queueMutations.setQueue).toHaveBeenCalledTimes(2);
     expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2']);
+    // ...and it did not add a second analytics event either. Two empty FullSyncs
+    // arrived but only one became a write, so only one is counted. Tracking at
+    // the FullSync call site (before the single-flight guard) counts both and
+    // overstates re-seeds in production.
+    expect(guardedTrackCalls()).toHaveLength(1);
 
     // Let the held re-seed resolve: local still matches, so it converges.
     await act(async () => {
@@ -656,6 +671,7 @@ describe('QueueProvider session-seed failure guard (#3878)', () => {
       await Promise.resolve();
     });
     expect(queueMutations.setQueue).toHaveBeenCalledTimes(2);
+    expect(guardedTrackCalls()).toHaveLength(1);
     expect(queueSnapshotStore.clearStoredQueueSnapshot).toHaveBeenCalled();
   });
 
@@ -716,6 +732,12 @@ describe('QueueProvider session-seed failure guard (#3878)', () => {
       [ClimbQueueItem[], ClimbQueueItem | null | undefined]
     >;
     expect(setQueueCalls[2][0].map((item) => item.uuid)).toEqual(['q1', 'q2', 'q3']);
+    // Still exactly ONE analytics event across all three writes. Only one empty
+    // FullSync ever arrived; the convergence re-push (#2) was driven by a local
+    // queue edit, not by a FullSync. Firing the event unconditionally inside
+    // reSeedQueueAfterFailedSeed counts it too, so a user adding climbs while
+    // the session starts inflates the metric by one per mid-flight edit.
+    expect(guardedTrackCalls()).toHaveLength(1);
     // Converged on the latest snapshot — snapshot dropped, queue intact.
     expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2', 'q3']);
     expect(queueSnapshotStore.clearStoredQueueSnapshot).toHaveBeenCalled();

--- a/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
@@ -781,6 +781,9 @@ describe('QueueProvider session-seed failure guard (#3878)', () => {
     expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2']);
     expect(queueMutations.setQueue).toHaveBeenCalledTimes(2);
     expect(queueSnapshotStore.clearStoredQueueSnapshot).not.toHaveBeenCalled();
+    // One guarded FullSync so far, so one event — a re-seed that goes on to
+    // reject still counts, since the FullSync really was guarded into a write.
+    expect(guardedTrackCalls()).toHaveLength(1);
 
     // A later reconnect's empty FullSync retries the push, since the guard is
     // still armed for this session.
@@ -795,5 +798,10 @@ describe('QueueProvider session-seed failure guard (#3878)', () => {
     expect(queueMutations.setQueue).toHaveBeenCalledTimes(3);
     expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1', 'q2']);
     expect(queueSnapshotStore.clearStoredQueueSnapshot).toHaveBeenCalled();
+    // Two genuine empty FullSyncs were guarded into two writes, so two events.
+    // This is the one re-seed path where the count legitimately climbs — pinning
+    // it stops a future "just count once per session" shortcut from silently
+    // undercounting the retry that a rejected re-seed depends on.
+    expect(guardedTrackCalls()).toHaveLength(2);
   });
 });

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -247,18 +247,25 @@ export function useSessionRealtime({
     // resurrect the pre-session queue on a later cold start. Effect-scoped, so it
     // survives subscription restarts within the session and resets per session.
     let reSeedInFlight = false;
-    const reSeedQueueAfterFailedSeed = () => {
+    // `triggeredByFullSync` keeps `Queue Seed FullSync Guarded` faithful to its
+    // name: exactly one event per empty FullSync we actually guarded and turned
+    // into a write. Only the FullSync handler below passes `true`. It is checked
+    // AFTER the single-flight and empty-queue guards, so a second empty FullSync
+    // arriving mid-re-seed — which correctly no-ops the write — no longer counts.
+    // The internal convergence re-push at the `.then` below passes nothing: no
+    // FullSync triggered it, so counting it would overcount by one per local
+    // queue edit that lands mid-push.
+    const reSeedQueueAfterFailedSeed = (triggeredByFullSync = false) => {
       if (reSeedInFlight) return;
       const { queue, currentClimbQueueItem } = stateRef.current;
       if (queue.length === 0 && currentClimbQueueItem == null) return;
-      // Track only here, right before the write is actually dispatched — the
-      // call site above no-ops on a second empty FullSync arriving while a
-      // re-seed is already in flight, and a track() there would overcount.
-      track(SHARED_EVENTS.QueueSeedFullSyncGuarded, {
-        boardName: activeBoardRef.current?.boardType,
-        layoutId: activeBoardRef.current?.layoutId,
-        localQueueLength: queue.length,
-      });
+      if (triggeredByFullSync) {
+        track(SHARED_EVENTS.QueueSeedFullSyncGuarded, {
+          boardName: activeBoardRef.current?.boardType,
+          layoutId: activeBoardRef.current?.layoutId,
+          localQueueLength: queue.length,
+        });
+      }
       reSeedInFlight = true;
       const pushedHash = computeQueueStateHashOrdered(queue, currentClimbQueueItem?.uuid ?? null);
       void reSeedQueueRef
@@ -270,7 +277,8 @@ export function useSessionRealtime({
           const latestHash = computeQueueStateHashOrdered(latestQueue, latestCurrent?.uuid ?? null);
           if (latestHash !== pushedHash) {
             // Local changed while the push was in flight — re-push the latest and
-            // keep the guard armed until a push reflects the current queue.
+            // keep the guard armed until a push reflects the current queue. No
+            // FullSync drove this re-push, so it stays untracked (see above).
             reSeedQueueAfterFailedSeed();
             return;
           }
@@ -482,7 +490,7 @@ export function useSessionRealtime({
               const hasLocalQueue = localQueue.length > 0 || localCurrent != null;
               if (isEmptyRoom && hasLocalQueue) {
                 if (__DEV__) console.warn('[queue] guarding empty FullSync after failed seed; re-seeding');
-                reSeedQueueAfterFailedSeed();
+                reSeedQueueAfterFailedSeed(true);
                 return;
               }
               // Local is also empty (nothing to protect) or the room isn't empty

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -251,6 +251,14 @@ export function useSessionRealtime({
       if (reSeedInFlight) return;
       const { queue, currentClimbQueueItem } = stateRef.current;
       if (queue.length === 0 && currentClimbQueueItem == null) return;
+      // Track only here, right before the write is actually dispatched — the
+      // call site above no-ops on a second empty FullSync arriving while a
+      // re-seed is already in flight, and a track() there would overcount.
+      track(SHARED_EVENTS.QueueSeedFullSyncGuarded, {
+        boardName: activeBoardRef.current?.boardType,
+        layoutId: activeBoardRef.current?.layoutId,
+        localQueueLength: queue.length,
+      });
       reSeedInFlight = true;
       const pushedHash = computeQueueStateHashOrdered(queue, currentClimbQueueItem?.uuid ?? null);
       void reSeedQueueRef
@@ -474,11 +482,6 @@ export function useSessionRealtime({
               const hasLocalQueue = localQueue.length > 0 || localCurrent != null;
               if (isEmptyRoom && hasLocalQueue) {
                 if (__DEV__) console.warn('[queue] guarding empty FullSync after failed seed; re-seeding');
-                track(SHARED_EVENTS.QueueSeedFullSyncGuarded, {
-                  boardName: activeBoardRef.current?.boardType,
-                  layoutId: activeBoardRef.current?.layoutId,
-                  localQueueLength: localQueue.length,
-                });
                 reSeedQueueAfterFailedSeed();
                 return;
               }


### PR DESCRIPTION
## Summary

Makes the `Queue Seed FullSync Guarded` PostHog event mean exactly one thing: **one event per empty FullSync that was actually guarded and turned into a whole-queue re-seed write.** It was overcounting on two separate paths, and this PR closes both.

The guard itself (#3878) is unchanged — no user-visible behaviour moves here, only where the analytics event fires.

**Path 1 — the single-flight no-op (commit 1).** `track()` fired at the FullSync handler's call site, *before* `reSeedQueueAfterFailedSeed()`, whose first line is `if (reSeedInFlight) return;`. A second empty FullSync arriving mid-re-seed (a reconnect inside one `setQueue` round-trip) correctly no-oped the write but still fired the event. Moved `track()` inside the function, past the in-flight and empty-queue guards.

**Path 2 — the convergence re-push (commit 2).** Moving `track()` inside the function put it on the recursive re-push at the `.then()`: when a local queue edit lands mid-push, `latestHash !== pushedHash` re-enters `reSeedQueueAfterFailedSeed()` to push the latest state. That re-entry emitted a *second* event with no FullSync behind it — so a climber adding climbs while the session starts inflated the metric by one per mid-flight edit. Fixing path 1 alone would have traded one miscount for another and left the event contradicting its own name.

`reSeedQueueAfterFailedSeed` now takes `triggeredByFullSync = false`. Only the empty-room FullSync handler passes `true`; the internal convergence re-push passes nothing. The check sits after both guards, so path 1 stays fixed.

## Coverage

The first commit shipped no coverage of the bug it fixed: reverting its source change left all 4468 mobile tests green. Rather than add parallel tests, the two existing re-seed tests — which already walk both regression paths — now assert an **exact** event count via a `guardedTrackCalls()` helper. A bare `toHaveBeenCalledWith` passes just as happily at 2 events as at 1, which is precisely what hid both overcounts.

Each assertion was mutation-tested by deleting the guard it covers:

| Mutation | Assertion that goes red | Result |
| --- | --- | --- |
| Restore `track()` to the pre-PR FullSync call site | `serialises the re-seed: a second empty FullSync mid-flight…` | `expected … length 1, got 2` |
| Delete the `if (triggeredByFullSync)` gate | `re-pushes the latest queue when a live edit lands…` | `expected … length 1, got 2` |

Both mutations are real prior states of this file (pre-PR and commit-1 head), and each fails exactly one test — so neither assertion is a tautology and neither overlaps the other.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run test:mobile --reporter=agent` — 542 files / 4468 tests passing
- `vp run typecheck:mobile` — clean
- `vp check` — clean (the pre-existing `packages/mobile/public/index.html` formatting issue was fixed on `main` by #3923; this branch is rebased past it)
- Mutation evidence above, run per the repo's "delete the guard and watch the test fail" rule
- No device QA gate: analytics-only, no change to the re-seed control flow, fully covered in vitest

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL)_
