### PR TITLE
test(web): A0 reposition invariants + audit doc

### DIFF
--- a/docs/web-reposition.md
+++ b/docs/web-reposition.md
@@ -1,0 +1,110 @@
+# Web reposition: Next.js as the SSR front door
+
+Tracks the initiative that strips the interactive climbing-session surfaces out of
+`packages/web` (Next.js) and leaves it as a crawlable **marketing + climb-viewing +
+gym** surface. The interactive product (queue, play drawer, party/WebSocket
+sessions, Bluetooth LED control, tick logging, board-connect, climb authoring)
+lives in the React Native app's browser target served at `/app` and standalone at
+`app.boardsesh.com`. Viewing a climb offers a **"Climb this"** hand-off into `/app`.
+
+The full phased plan (A0–A6 teardown track + B0–B5 gym-discovery track) lives with
+the maintainer; this doc records the parts the repo needs: the Phase A0 audit
+findings that gate later deletions, and the blocking pre-delete QA checklist.
+
+## Phase A0 — audit findings (gate the deletion phases)
+
+These are verified against the working tree and constrain what later phases may
+delete and how.
+
+### API routes — what's safe to delete
+
+The mobile app reaches the climbing backend through **GraphQL**, not the Next.js
+web proxies. The only web endpoints `packages/mobile/src` fetches are
+`/api/auth/session`, `/api/internal/ws-auth`, and `/api/internal/beta-link-thumbnail`.
+
+| Route                                                                     | Runtime callers                                                                                                    | Verdict                               |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| `/api/v1/[board]/proxy/{login,saveAscent,saveClimb,getLogbook,user-sync}` | **None** — already migrated to GraphQL (see `docs/branch-deploys.md`)                                              | delete (dead code)                    |
+| `/api/internal/{join,controllers,favorites}`                              | Only web session-app UI slated for teardown (`join/*` page, `settings/controllers-section.tsx`, `climb-actions/*`) | delete with that UI                   |
+| `/api/internal/ws-auth`                                                   | `use-ws-auth-token.ts` → ~85 web files incl. kiosk presence; mobile `auth-store.web.ts:343`                        | **KEEP** — `/app` + kiosk auth bridge |
+
+Loose ends to clean when the routes go (not runtime callers, but they'd go stale):
+`app/lib/api-docs/openapi-routes.ts` (documents `proxy/login`, `proxy/saveAscent`),
+`docs/branch-deploys.md` migration table, and the routes' own `__tests__`.
+
+### `/app` redirect destinations (for the route redirects in A6)
+
+| Web route removed  | `/app` destination                                          | Status                                                                                                                                         |
+| ------------------ | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `join/[sessionId]` | `/app/join/{sessionId}`                                     | exists (`packages/mobile/app/join/[sessionId].tsx`; universal-link `/join` registered)                                                         |
+| `/you`             | `/app/profile`                                              | exists (`(tabs)/profile/index.tsx`)                                                                                                            |
+| `/settings`        | `/app/profile/more`                                         | no bare `/app/settings` — redirect to `/app/profile/more`                                                                                      |
+| `/notifications`   | —                                                           | **no mobile route** — point at `/app/profile` or defer                                                                                         |
+| climb view         | `/app/climbs/{uuid}?boardName&layoutId&sizeId&setIds&angle` | exists; **all five query params required**, numeric IDs                                                                                        |
+| `/list`            | `/app/climbs`                                               | exists, but the Climbs tab reads its board from the persisted active board, **not** the URL — board context is lost on a bare `/list` redirect |
+
+### Board layout provider mounts (asymmetric — matters for A5)
+
+- **Legacy tree:** `BoardProvider` is mounted at the top in `[board_name]/layout.tsx`, wrapping **all** children. The deep `[angle]/layout.tsx` mounts the session providers (`GraphQLQueueProvider`, `WebSocketConnectionProvider`, `ConnectionSettingsProvider`, `BoardSessionBridge`, `UISearchParamsProvider`, `QueueBridgeInjector`, `BoardSeshHeader`) and the `<main id="content-for-scrollable">` shell + `I18nProvider`, but **not** `BoardProvider`.
+- **Slug tree:** no `[board_slug]`-level layout — `b/[board_slug]/[angle]/layout.tsx` mounts `BoardProvider` **and** all the session providers together (nested inside `I18nProvider`).
+- **Coupling to break first:** `b/[board_slug]/[angle]/list/layout.tsx` imports `ListLayoutClient` from the **legacy** tree (`[board_name]/…/list/layout-client.tsx`), and that client consumes the queue (`useQueueActions`/`useQueueList`). The static `/list` (A3) must replace this before the legacy tree can be deleted.
+
+### Kiosk / embed presence dependencies (relocate before A5 deletes them)
+
+`components/kiosk/presence/kiosk-presence-hub.tsx` imports, from dirs slated for
+deletion: `graphql-queue/graphql-client` (`createGraphQLClient`),
+`board-presence/board-presence-client` (`createWebBoardPresenceClient`, which
+also pulls `board-presence/board-presence-events` + `-context`), and
+`useWsAuthToken` (kept). The hub renders on `/kiosk/*`, `/embed/board/*`, and the
+gym-manage `kiosk-preview.tsx`. **Not** on `/embed/gym/*/leaderboard` (that's a
+historical period leaderboard, no presence socket). A5-pre relocates the two
+clients into a kept module and builds the login-less "now on the wall" query.
+
+### `/playlists` is NOT clean (blocks the `climb-actions/*` delete)
+
+The kept `/playlists/[playlist_uuid]` detail page depends on `climb-actions/*`:
+`playlist-detail-content.tsx` imports `PlaylistActivationProvider` directly, and
+renders `climb-list/multiboard-climb-list.tsx`, which imports both
+`FavoritesProvider` and `PlaylistsProvider` (defined only in `climb-actions/`)
+plus `useOptionalPlaylistActivation`. Refactor `multiboard-climb-list.tsx` and
+`playlist-detail-content.tsx` off `climb-actions/*` before deleting that dir. The
+`/playlists` library index page is clean.
+
+## Phase A0 — invariant tests added
+
+- `app/__tests__/crawler-classic-invariant.test.ts` — an anonymous request (no
+  session cookie) never redirects to `/app` on any board surface, even with
+  `BOARDSESH_WEB=1` + the flag cookie on. Protects the SEO/crawler audience
+  through the teardown.
+- `app/__tests__/climb-canonical-parity.test.ts` — documents that the legacy and
+  `/b` view trees self-canonicalize into different URLs today (split PageRank).
+  **Flip at A1:** once the `url-utils` helpers emit `/b`, change the legacy
+  assertion to `.startsWith('/b/')` and assert parity.
+- `b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx`
+  — the climb-view page SSR-emits `ClimbViewSeoFragment` (the crawlable payload).
+  Guards A2's drawer→static swap from dropping it.
+
+## Phase A0 — blocking pre-delete QA gate (real devices)
+
+The teardown is a **hard delete** with no retained `?classic=1` runtime fallback,
+so the RN-web interactive sheets must be proven on real devices before A5/A6
+delete the classic code. `@gorhom/bottom-sheet`'s web fallback does not implement
+the gesture-lock / keyboard contracts the native sheets rely on (see the "Expo
+web" section of `CLAUDE.md`). Run this on **real hardware** (not just simulators)
+on **both** origins — the Next-embedded `/app` and standalone `app.boardsesh.com`:
+
+Devices: a physical iPhone (iOS Safari) and a physical Android phone (Chrome).
+
+- [ ] **Log ascent (`LogAscentSheet`)** opens from a climb, the on-screen keyboard
+      does not cover the notes/grade fields, the sheet doesn't jump or dismiss on
+      focus, and submit records the tick (verify it appears in the logbook).
+- [ ] **Queue (`QueueSheet`)** opens, scrolls its virtualized list without the
+      whole sheet scrolling, reorders, and the gesture-lock holds (drag inside the
+      list doesn't dismiss the sheet).
+- [ ] Rotate the device with each sheet open — no layout break or stuck backdrop.
+- [ ] Repeat both on `app.boardsesh.com` (standalone) — it has no `?classic`
+      escape hatch after A6, so a failure here blocks the whole delete.
+- [ ] Record crash-free confirmation for each sheet × device × origin.
+
+Sign-off on every box is the gate to start A5. If any fails, hold the delete and
+fix the sheet on expo-web first.

--- a/packages/web/app/__tests__/climb-canonical-parity.test.ts
+++ b/packages/web/app/__tests__/climb-canonical-parity.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * Reposition invariant (Phase A0 → flips at A1).
+ *
+ * Today the two climb-view route trees self-canonicalize into DIFFERENT URLs for
+ * the same climb. The legacy `[board_name]/…/view` page derives its canonical
+ * via `tryConstructSlugViewUrl(...) ?? constructClimbViewUrl(...)` — both emit
+ * the legacy verbose tree (`/{board}/…`) — while `/b/[slug]/…/view` passes a
+ * `/b/…` canonical straight through. Two self-canonicalizing trees for one climb
+ * permanently splits PageRank.
+ *
+ * A1 (canonical consolidation) repoints the `url-utils` helpers to emit the `/b`
+ * form. WHEN A1 LANDS: flip the legacy assertion to `.startsWith('/b/')` (and
+ * assert parity with the slug canonical), then delete the `false`/legacy-tree
+ * markers. Until then this test documents the split and guards against it
+ * silently widening.
+ */
+
+vi.mock('server-only', () => ({}));
+vi.mock('next/navigation', () => ({ notFound: vi.fn(), permanentRedirect: vi.fn() }));
+
+vi.mock('@/app/lib/i18n/server', () => ({
+  getServerTranslation: vi.fn(async () => ({ t: (key: string) => key, locale: 'en-US' })),
+}));
+
+const CLIMB_UUID = 'abcdef1234567890abcdef1234567890';
+
+vi.mock('@/app/lib/data/queries', () => ({
+  getClimb: vi.fn(async () => ({
+    name: 'My Test Climb',
+    difficulty: 'V5',
+    setter_username: 'setter',
+    quality_average: 4,
+    ascensionist_count: 12,
+    frames: 'p1r12',
+  })),
+}));
+
+// Rich board details so the real `tryResolveBoardSlugs` (url-utils, left
+// unmocked) resolves the production named-slug legacy canonical. Also serves
+// each view page's own `getBoardDetailsForBoard` call.
+vi.mock('@/app/lib/board-utils', () => ({
+  getBoardDetailsForBoard: vi.fn(() => ({
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: [1, 20],
+    layout_name: 'Kilter Board Original',
+    size_name: '12 x 12',
+    size_description: 'Commercial',
+    set_names: ['Bolt Ons', 'Screw Ons'],
+  })),
+}));
+
+// Legacy page: numeric route params.
+vi.mock('@/app/lib/url-utils.server', () => ({
+  parseRouteParams: vi.fn(async () => ({
+    parsedParams: {
+      board_name: 'kilter',
+      layout_id: 1,
+      size_id: 10,
+      set_ids: [1, 20],
+      angle: 40,
+      climb_uuid: CLIMB_UUID,
+    },
+    isNumericFormat: true,
+  })),
+}));
+
+// Slug page: board resolution + route params for the same climb.
+vi.mock('@/app/lib/board-slug-utils', () => ({
+  resolveBoardBySlug: vi.fn(async () => ({
+    slug: 'kilter-original-12x12',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '1,20',
+  })),
+  boardToRouteParams: vi.fn(() => ({
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: [1, 20],
+    angle: 40,
+  })),
+}));
+
+vi.mock('@/app/components/board-renderer/util', () => ({
+  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb'),
+  buildOverlayUrl: vi.fn(() => '/api/internal/board-render'),
+}));
+vi.mock('@/app/lib/warm-overlay-cache', () => ({ scheduleOverlayWarming: vi.fn() }));
+vi.mock('@/app/components/board-page/board-page-climbs-list', () => ({ default: () => null }));
+vi.mock('@/app/components/climb-detail/climb-view-seo-fragment', () => ({ default: () => null }));
+
+// `@/app/lib/url-utils` is deliberately left REAL: the legacy canonical must
+// reflect the true helper output, which is exactly what A1 changes.
+
+const legacyPage = await import('@/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page');
+const slugPage = await import('@/app/b/[board_slug]/[angle]/view/[climb_uuid]/page');
+
+function canonicalPath(canonical: string | URL | { url: string | URL } | null | undefined): string {
+  if (!canonical) throw new Error('expected generateMetadata to set alternates.canonical');
+  const url = typeof canonical === 'object' && 'url' in canonical ? canonical.url : canonical;
+  return new URL(url.toString(), 'https://www.boardsesh.com').pathname;
+}
+
+describe('climb-view canonical parity (RED until A1 consolidates onto /b)', () => {
+  it('the /b slug view already self-canonicalizes into the /b tree', async () => {
+    const metadata = await slugPage.generateMetadata({
+      params: Promise.resolve({ board_slug: 'kilter-original-12x12', angle: '40', climb_uuid: CLIMB_UUID }),
+    });
+    expect(canonicalPath(metadata.alternates?.canonical).startsWith('/b/')).toBe(true);
+  });
+
+  it('documents the split: the legacy view canonicalizes into the legacy tree, NOT /b (flip at A1)', async () => {
+    const metadata = await legacyPage.generateMetadata({
+      params: Promise.resolve({
+        board_name: 'kilter',
+        layout_id: '1',
+        size_id: '10',
+        set_ids: '1,20',
+        angle: '40',
+        climb_uuid: CLIMB_UUID,
+      }),
+    });
+    const path = canonicalPath(metadata.alternates?.canonical);
+    // A1 flips these two lines to `expect(path.startsWith('/b/')).toBe(true)` and
+    // asserts equality with the slug canonical for the same climb.
+    expect(path.startsWith('/b/')).toBe(false);
+    expect(path.startsWith('/kilter/')).toBe(true);
+    // The uuid survives into the canonical either way (embedded in the name slug).
+    expect(path).toContain(CLIMB_UUID);
+  });
+});

--- a/packages/web/app/__tests__/crawler-classic-invariant.test.ts
+++ b/packages/web/app/__tests__/crawler-classic-invariant.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { NextRequest } from 'next/server';
+import { middleware } from '@/middleware';
+import { EXPO_WEB_ENABLED_COOKIE } from '@/app/lib/expo-web-rollout';
+
+/**
+ * Reposition invariant (Phase A0).
+ *
+ * An anonymous request — one carrying no next-auth session cookie — is NEVER
+ * redirected to the `/app` Expo SPA, on any board surface, even under the
+ * strongest rollout condition (`BOARDSESH_WEB=1` and the `bs_expo_web` flag
+ * cookie on). Anonymous visitors are the crawlable, SEO-bearing audience;
+ * Googlebot and logged-out humans must always receive the classic SSR page.
+ *
+ * The later teardown phases delete the classic *session* UI, but the viewing
+ * surfaces (`/view`, `/list`) stay SSR for anonymous visitors. This test locks
+ * the guarantee so a future middleware change can't silently start bouncing
+ * crawlers into the noindex SPA.
+ */
+
+const BOARD_SURFACES = [
+  '/kilter/original/12x12-square/screw_bolt/40/list', // legacy list
+  '/b/kilter-original-12x12/40/list', // slug list
+  // The numeric view is the one shape that *does* map for a logged-in flagged
+  // user — precisely why the anonymous case matters most here.
+  '/kilter/1/10/1,20/40/view/abcdef1234567890abcdef1234567890',
+  '/b/kilter-original-12x12/40/view/test-climb-abcdef1234567890abcdef1234567890', // slug view
+  '/kilter/original/12x12-square/screw_bolt/40/view/test-climb-abcdef1234567890abcdef1234567890', // named view
+];
+
+const originalExpoWebFlag = process.env.BOARDSESH_WEB;
+
+function makeRequest(pathname: string): NextRequest {
+  return new NextRequest(new URL(pathname, 'http://localhost:3000'));
+}
+
+function redirectedToAppPath(response: ReturnType<typeof middleware>): string | null {
+  const location = response.headers.get('location');
+  if (response.status !== 307 || location === null) return null;
+  return new URL(location).pathname.startsWith('/app') ? location : null;
+}
+
+describe('crawler-classic invariant: anonymous requests never redirect to /app', () => {
+  beforeEach(() => {
+    // Rollout fully enabled: the strongest condition under which the invariant
+    // must still hold for anonymous visitors.
+    process.env.BOARDSESH_WEB = '1';
+  });
+
+  afterEach(() => {
+    if (originalExpoWebFlag === undefined) delete process.env.BOARDSESH_WEB;
+    else process.env.BOARDSESH_WEB = originalExpoWebFlag;
+  });
+
+  for (const surface of BOARD_SURFACES) {
+    it(`does not redirect an anonymous visitor from ${surface} (flag cookie on, no session)`, () => {
+      const request = makeRequest(surface);
+      // Flag cookie present, but no auth session cookie — the visitor is not logged in.
+      request.cookies.set(EXPO_WEB_ENABLED_COOKIE, '1');
+      expect(redirectedToAppPath(middleware(request))).toBeNull();
+    });
+
+    it(`does not redirect an anonymous visitor from ${surface} (no cookies at all)`, () => {
+      expect(redirectedToAppPath(middleware(makeRequest(surface)))).toBeNull();
+    });
+  }
+});

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vite-plus/test';
+import ClimbViewSeoFragment from '@/app/components/climb-detail/climb-view-seo-fragment';
+
+/**
+ * Reposition invariant (Phase A0).
+ *
+ * The climb-view page SSR-emits `ClimbViewSeoFragment` — the sr-only <h1> +
+ * description that carries the crawlable SEO payload. Phase A2 swaps the
+ * interactive `BoardPageClimbsList` drawer for a static render, but the SEO
+ * fragment must remain in the server output. This test asserts the fragment is
+ * present by element identity, so a refactor can't drop it unnoticed.
+ */
+
+vi.mock('server-only', () => ({}));
+vi.mock('next/navigation', () => ({ notFound: vi.fn() }));
+
+vi.mock('@/app/lib/i18n/server', () => ({
+  getServerTranslation: vi.fn(async () => ({ t: (key: string) => key, locale: 'en-US' })),
+}));
+
+vi.mock('@/app/lib/board-slug-utils', () => ({
+  resolveBoardBySlug: vi.fn(async () => ({
+    slug: 'my-board',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 7,
+    setIds: '1,20',
+  })),
+  boardToRouteParams: vi.fn(() => ({
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 7,
+    set_ids: [1, 20],
+    angle: 40,
+  })),
+}));
+
+vi.mock('@/app/lib/board-utils', () => ({
+  getBoardDetailsForBoard: vi.fn(() => ({
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 7,
+    set_ids: [1, 20],
+    images_to_holds: {},
+    holdsData: [],
+  })),
+}));
+
+vi.mock('@/app/lib/data/queries', () => ({
+  getClimb: vi.fn(async () => ({ uuid: 'test-climb', name: 'Test Climb', difficulty: 'V5', frames: 'p1r12' })),
+}));
+
+vi.mock('@/app/lib/warm-overlay-cache', () => ({ scheduleOverlayWarming: vi.fn() }));
+vi.mock('@/app/components/board-renderer/util', () => ({
+  buildOverlayUrl: vi.fn(() => '/api/internal/board-render?variant=overlay'),
+  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb'),
+}));
+
+// The interactive list is a client component; stub it so importing the page in a
+// node test doesn't pull client-only code. It is NOT what this test asserts —
+// `ClimbViewSeoFragment` is deliberately left real for the identity check.
+vi.mock('@/app/components/board-page/board-page-climbs-list', () => ({ default: () => null }));
+
+const pageModule = await import('../page');
+
+describe('board slug climb view SEO fragment', () => {
+  it('SSR-emits ClimbViewSeoFragment in the server output', async () => {
+    const element = (await pageModule.default({
+      params: Promise.resolve({ board_slug: 'my-board', angle: '40', climb_uuid: 'test-climb' }),
+    })) as React.ReactElement<{ children?: React.ReactNode }>;
+
+    const children = React.Children.toArray(element.props.children);
+    const emitsSeoFragment = children.some(
+      (child) => React.isValidElement(child) && child.type === ClimbViewSeoFragment,
+    );
+    expect(emitsSeoFragment).toBe(true);
+  });
+});

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
@@ -64,16 +64,26 @@ vi.mock('@/app/components/board-page/board-page-climbs-list', () => ({ default: 
 
 const pageModule = await import('../page');
 
+/**
+ * Search the whole server-rendered element tree (not just the root's direct
+ * children) for an element of `type`, so the assertion survives A2 wrapping the
+ * fragment in a layout/fragment/conditional.
+ */
+function treeContainsElementOfType(node: React.ReactNode, type: React.ElementType): boolean {
+  return React.Children.toArray(node).some((child) => {
+    if (!React.isValidElement(child)) return false;
+    if (child.type === type) return true;
+    const { children } = child.props as { children?: React.ReactNode };
+    return treeContainsElementOfType(children, type);
+  });
+}
+
 describe('board slug climb view SEO fragment', () => {
   it('SSR-emits ClimbViewSeoFragment in the server output', async () => {
     const element = (await pageModule.default({
       params: Promise.resolve({ board_slug: 'my-board', angle: '40', climb_uuid: 'test-climb' }),
-    })) as React.ReactElement<{ children?: React.ReactNode }>;
+    })) as React.ReactElement;
 
-    const children = React.Children.toArray(element.props.children);
-    const emitsSeoFragment = children.some(
-      (child) => React.isValidElement(child) && child.type === ClimbViewSeoFragment,
-    );
-    expect(emitsSeoFragment).toBe(true);
+    expect(treeContainsElementOfType(element, ClimbViewSeoFragment)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

**Phase A0** of repositioning the Next.js app (`packages/web`) as the SSR front door — marketing + climb-viewing + gym — with the interactive climbing-session surfaces moving to the React Native web app served at `/app`. This is the first, deletion-free PR: it lands the pre-delete safety net (invariant tests + recorded audits + the blocking QA gate) so the later teardown phases can proceed without shipping a broken or de-indexed site.

Decisions driving the initiative: **hard-delete** the session code (no retained `?classic=1` runtime fallback), gym discovery as a **parallel track** that never gates the teardown, and web authoring **moves to the app**. Full A0 audit findings + the phase map live in `docs/web-reposition.md`.

### What's here (tests + docs only — no production code changes)

- **`crawler-classic-invariant.test.ts`** — an anonymous request (no session cookie) never redirects to `/app` on any board surface, even with `BOARDSESH_WEB=1` and the flag cookie on. Locks the SEO/crawler audience onto classic SSR through the teardown.
- **`climb-canonical-parity.test.ts`** — documents that the legacy and `/b` climb-view trees self-canonicalize into *different* URLs today (split PageRank). Designed to flip to a parity assertion at **A1**, once the `url-utils` helpers emit `/b`.
- **`view-seo-fragment.test.tsx`** — the climb-view page SSR-emits `ClimbViewSeoFragment` (the crawlable `<h1>` + description). Guards **A2**'s drawer→static swap from silently dropping it.
- **`docs/web-reposition.md`** — records the audit findings that gate the deletion phases: proxy APIs are already dead (migrated to GraphQL); `/api/internal/ws-auth` is **KEEP** (mobile + kiosk auth bridge); `/settings` and `/notifications` have no clean `/app` redirect target; the two board trees mount `BoardProvider` asymmetrically; kiosk presence depends on three session-dir modules that must be relocated first; and `/playlists/[uuid]` is coupled to `climb-actions/*`. Plus the blocking real-device QA checklist for the RN-web `LogAscentSheet`/`QueueSheet` (the gate to start deleting).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project web --reporter=agent crawler-classic-invariant climb-canonical-parity view-seo-fragment` → **3 files, 13 tests, all pass**.
- `vp check` on all four files → format + lint + type clean.
- `vp run typecheck:web` → no type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zUnAhjP8XzhyRFvXFoDMm