### PR TITLE
docs(mobile): correct the Android scan-filter attribution + pin the vouch invariant

### DIFF
--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -127,15 +127,26 @@ export class RNBleAdapter implements BluetoothAdapter {
     let selectedDeviceId: string;
     try {
       // Scan UNFILTERED and filter results in JS (isLikelyBoardDevice below).
-      // A hardware service-UUID ScanFilter never matches by name and, on Android,
-      // is unreliable for a 128-bit UUID a box carries only in its scan-response
-      // PDU — so it silently drops Aurora (Kilter/Tension) boxes whose UUID/name
-      // arrives that way, giving an empty device picker (regression 0710be7a8:
-      // Android 2.2.2 Kilter empty-picker rate ~23% vs ~6% on 2.1.0). MoonBoard
-      // already required an unfiltered scan; Aurora now matches it. The JS filter
-      // reads ble-plx's merged advertise+scan-response record, so it still
-      // surfaces both Aurora-built (`Kilter Board#serial@N`) and Kilter-built
-      // bare-name (`Kilter Board`) boxes while rejecting non-boards.
+      // A hardware service-UUID ScanFilter never matches by name, and on Android
+      // its offloaded matcher is unreliable for a 128-bit UUID a box carries only
+      // in its scan-response PDU — such a box can be dropped before JS ever sees
+      // it. MoonBoard already required an unfiltered scan; Aurora matches it since
+      // #3806. The JS filter reads ble-plx's merged advertise+scan-response
+      // record, so it still surfaces both Aurora-built (`Kilter Board#serial@N`)
+      // and Kilter-built bare-name (`Kilter Board`) boxes while rejecting
+      // non-boards.
+      //
+      // Do NOT read this as "the Aurora scan filter caused the Android
+      // empty-picker regression" — an earlier version of this comment did, and it
+      // sent at least one investigation down a dead end (#3821). The filter was
+      // cleared: 2.1.0 shipped the same filter and was healthy, and the ~2x rise
+      // in Android `devicesTotal=0` tracks the Expo 57 / React Native 0.86 native
+      // scan-reliability drop instead. #3806 (unfiltering) was explicitly
+      // robustness-only; #3811 (LowLatency, see scan-options.ts) is the
+      // root-cause mitigation. Unfiltering here buys name-only discovery, not a
+      // regression fix — and it is an ANDROID argument: iOS CoreBluetooth scans
+      // actively in the foreground and merges ADV + SCAN_RSP before filtering, so
+      // the native iOS path keeps its service filter on purpose.
       // High-power scan options (LowLatency on Android) — see scan-options.ts.
       void bleManager.startDeviceScan(null, HIGH_POWER_BOARD_SCAN_OPTIONS, (scanError, scannedDevice) => {
         if (scanError) {

--- a/packages/mobile/src/lib/ble/board-device-filter.ts
+++ b/packages/mobile/src/lib/ble/board-device-filter.ts
@@ -30,6 +30,17 @@ const STRICT_AURORA_SERIAL_SUFFIX = /#[A-Za-z0-9-]+@\d+$/;
  * native side has already vouched for the peripheral. This does not widen
  * Android or new-binary filtering; `RNBleAdapter` always passes an array
  * (possibly empty), never `undefined`.
+ *
+ * LOAD-BEARING NATIVE INVARIANT behind that vouch: `BoardBleModule.swift` gained
+ * `getConnectedDevice` and the `serviceUuids` field on the `scanResult` payload
+ * in the SAME commit (d5774dc0b). `NativeIosBleAdapter` gates unfiltered scanning
+ * on `nativeBleSupportsConnectionAdoption()`, which probes `getConnectedDevice`,
+ * so no shipped binary can scan unfiltered while omitting `serviceUuids` — the
+ * `undefined` branch below is only ever reached on a binary whose native scan
+ * really did filter. If those two capabilities are ever split across native
+ * builds, an unfiltered Aurora scan would hit this branch and surface every BLE
+ * peripheral in the gym. Keep them together, or replace the vouch with an
+ * explicit capability flag on the payload.
  */
 export function isLikelyBoardDevice({
   name,


### PR DESCRIPTION
## Summary

Two comment corrections in the mobile BLE scan path. No behaviour change.

**1. `adapter.ts` — the Android unfiltered-scan comment blamed the wrong commit.**

It attributed the ~23% Android empty-picker rate to `0710be7a8` (the Aurora service-UUID scan filter). The later causal analysis cleared the filter: 2.1.0 shipped the same filter and was healthy, and the ~2x rise in `devicesTotal=0` tracks the Expo 57 / React Native 0.86 native scan-reliability drop instead. #3806 (unfiltering) was explicitly robustness-only; #3811 (LowLatency) is the root-cause mitigation.

That comment is not harmless. It's what #3821 leaned on to propose the same unfiltering for the **native iOS** path — where it was never needed, because CoreBluetooth scans actively in the foreground and merges ADV + SCAN_RSP *before* applying the service filter. iOS Aurora empty-picker sits at 3.9% (Kilter) / 2.0% (Tension) against Android's 17%, and exactly 1 of 337 iOS users on 2.2.2 with 3+ pickers never saw a device. #3821 is closed with the full write-up; this stops the next person re-deriving it.

**2. `board-device-filter.ts` — pin a load-bearing undocumented invariant.**

The `serviceUuids === undefined` branch returns `true` for aurora unconditionally, on the grounds that "the native side already vouched." That's only safe because `getConnectedDevice` (which `nativeBleSupportsConnectionAdoption()` probes to gate unfiltered iOS scanning) and the `serviceUuids` field on the `scanResult` payload shipped in the **same** native commit, `d5774dc0b`. No binary can scan unfiltered while omitting the field. Split those two capabilities across native builds and an unfiltered Aurora scan would surface every BLE peripheral in the gym. Written down now, with the alternative (an explicit capability flag on the payload) named.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 4471 passed / 542 files.
- `vp check` — no issues in either changed file (the one reported formatting hit, `packages/mobile/public/index.html`, is pre-existing on `main` and untouched here).
- Comments only; both files' executable statements are byte-identical to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL
