### PR TITLE
chore(mobile): format public/index.html so vp check passes on main

### DIFF
--- a/packages/mobile/public/index.html
+++ b/packages/mobile/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="%LANG_ISO_CODE%">
   <head>
     <meta charset="utf-8" />
@@ -37,9 +37,7 @@
 
   <body>
     <!-- Use static rendering with Expo Router to support running without JavaScript. -->
-    <noscript>
-      You need to enable JavaScript to run this app.
-    </noscript>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
     <!-- The root element for your Expo app. -->
     <div id="root"></div>
   </body>


### PR DESCRIPTION
## Summary

`vp check` fails on `main` today with a formatting error in `packages/mobile/public/index.html`. Per-PR CI only diff-lints, so nothing flagged it on the way in — but the full-repo check reds the next push to `main` for whoever lands next. Unblocking that.

Formatter output only, from `vp check --fix`:
- `<!DOCTYPE html>` → `<!doctype html>`
- `<noscript>` collapsed onto one line

No markup, content, or behaviour change. `--fix` touched this file and nothing else.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Reproduced on a clean worktree off `origin/main`: `vp check` → `Found formatting issues in 1 file`, `packages/mobile/public/index.html`.
- `vp check --fix` → modifies only that file (`git status` clean otherwise).
- `vp check` after the fix → exits 0.

Unrelated observation, not touched here: the lint stage reports 2 pre-existing `no-floating-promises` errors in `packages/db/src/queries/__tests__/tick-offset-inference.test.ts` (Node test-runner `describe`/`it` calls). They're non-gating — `vp check` exits 0 and the `lint` CI job passes with them present — so they're out of scope for this unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL