### PR TITLE
fix: stop non-prod PostHog pollution on backend and mobile

### DIFF
--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -93,8 +93,11 @@ env:
   # doesn't enter the resolved config, so it never moves the fingerprint. Kept in
   # lockstep with the other mobile fingerprint workflows. See docs/mobile-ota-updates.md.
   EXPO_PUBLIC_USE_RN_FETCH: '1'
-  # Preview-only tag: pr-<number> OTA bundles report `environment: preview` to Sentry
-  # so testers' crashes stay out of the production view (packages/mobile/src/lib/sentry.ts).
+  # Preview-only tag: pr-<number> OTA bundles report `environment: preview` to BOTH
+  # Sentry and PostHog, so testers' crashes and product events stay out of the
+  # production view. The name is historical (Sentry came first, #3808); it is now read
+  # once by resolveAppEnvironment() in packages/mobile/src/lib/app-environment.ts, which
+  # both SDKs share (#3814) — renaming it silently untags both.
   # DELIBERATELY diverges from production — do NOT add to SHARED_ENV_KEYS in
   # scripts/mobile-ci-env-parity.test.ts. Bundle-only (EXPO_PUBLIC_*, JS-inlined), so it
   # doesn't move the fingerprint; store/production builds leave it unset → 'production'.

--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -150,7 +150,13 @@ APNS_PRODUCTION=true                 # true = production APNs (matches the app's
 # Optional server-side product analytics for Live Activity usage
 POSTHOG_PROJECT_KEY=phc_...          # Backend PostHog project key (preferred; falls back to NEXT_PUBLIC_POSTHOG_KEY)
 POSTHOG_HOST=https://us.i.posthog.com
-POSTHOG_ENVIRONMENT=production       # Defaults to SENTRY_ENVIRONMENT, then NODE_ENV, then development
+# getPosthogClient() only sends when the resolved environment is 'production' (#3814) —
+# a real backend PostHog project key is prod-only, so setting POSTHOG_ENVIRONMENT=production
+# here would send your local test events into the real prod project, indistinguishable
+# from Railway. Leave this UNSET for local testing (falls back to SENTRY_ENVIRONMENT, then
+# NODE_ENV, then 'development' — none of which is 'production' locally), or set it to
+# something else entirely, e.g. POSTHOG_ENVIRONMENT=local-dev, if you want to confirm
+# events would have sent by temporarily pointing POSTHOG_HOST at a non-prod project.
 ```
 
 When the backend starts, you should see:

--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -150,13 +150,15 @@ APNS_PRODUCTION=true                 # true = production APNs (matches the app's
 # Optional server-side product analytics for Live Activity usage
 POSTHOG_PROJECT_KEY=phc_...          # Backend PostHog project key (preferred; falls back to NEXT_PUBLIC_POSTHOG_KEY)
 POSTHOG_HOST=https://us.i.posthog.com
-# getPosthogClient() only sends when the resolved environment is 'production' (#3814) —
-# a real backend PostHog project key is prod-only, so setting POSTHOG_ENVIRONMENT=production
-# here would send your local test events into the real prod project, indistinguishable
-# from Railway. Leave this UNSET for local testing (falls back to SENTRY_ENVIRONMENT, then
-# NODE_ENV, then 'development' — none of which is 'production' locally), or set it to
-# something else entirely, e.g. POSTHOG_ENVIRONMENT=local-dev, if you want to confirm
-# events would have sent by temporarily pointing POSTHOG_HOST at a non-prod project.
+# getPosthogClient() only sends when the resolved environment is 'production' (#3814).
+# A real backend PostHog project key is prod-only, so DON'T set POSTHOG_ENVIRONMENT=production
+# here — your local test events would land in the real prod project, indistinguishable
+# from Railway. Leave it UNSET and start the backend with `vp run dev`, whose backend `dev`
+# script sets NODE_ENV=development; the environment then resolves to 'development' and
+# nothing is sent. If you run the backend some other way (e.g. plain `tsx src/index.ts`,
+# no NODE_ENV), the runtime looks prod-like and WILL send — set POSTHOG_ENVIRONMENT to
+# anything non-production, e.g. local-dev, in that case.
+POSTHOG_ENVIRONMENT=local-dev
 ```
 
 When the backend starts, you should see:

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -1816,7 +1816,14 @@ ActivityKit on every device that registered a token for this session
 
 ### Server-Side Analytics
 
-Live Activity actions that happen outside the web view are captured server-side through PostHog when `POSTHOG_PROJECT_KEY` is configured. The backend can also fall back to `NEXT_PUBLIC_POSTHOG_KEY` for compatibility with the web build env, but `POSTHOG_PROJECT_KEY` is the preferred runtime variable. `POSTHOG_HOST` defaults to `https://us.i.posthog.com`, and `POSTHOG_ENVIRONMENT` can override the event `environment` property. If `POSTHOG_ENVIRONMENT` is unset, the backend falls back to `SENTRY_ENVIRONMENT`, then `NODE_ENV`, then `development`. Server events are sent directly rather than through the browser `/api/posthog/*` proxy.
+Live Activity actions that happen outside the web view are captured server-side through PostHog when `POSTHOG_PROJECT_KEY` is configured. The backend can also fall back to `NEXT_PUBLIC_POSTHOG_KEY` for compatibility with the web build env, but `POSTHOG_PROJECT_KEY` is the preferred runtime variable. `POSTHOG_HOST` defaults to `https://us.i.posthog.com`. Server events are sent directly rather than through the browser `/api/posthog/*` proxy.
+
+**A key alone is not enough — only the production environment sends** (#3814). `getPosthogClient()` resolves an environment and short-circuits unless it is exactly `production`, so a key that leaks into a preview, staging, or local runtime can't pollute the prod project. Resolution order: `POSTHOG_ENVIRONMENT`, else `resolveSentryEnvironment()` from `@boardsesh/db/client/config` — the same helper that gates backend Sentry, so the two SDKs can never disagree about what runtime this is. That resolves `SENTRY_ENVIRONMENT` when set, otherwise `production` for any non-dev, non-test runtime, otherwise `NODE_ENV`. Consequences worth knowing:
+
+- Railway prod sets no `NODE_ENV` (`Dockerfile.backend` doesn't, and Railway injects none for an image deploy), so it resolves to `production` from the runtime inference alone — no dashboard variable is load-bearing for analytics staying on.
+- Preview/staging backends declare `SENTRY_ENVIRONMENT=preview` (`branch-deploy.yml`, #3808) and opt out for free.
+- Local dev resolves to `development` via the `dev` script's `NODE_ENV=development`; the test runner resolves to `test`. Both stay dark.
+- When the gate closes, the backend logs `[PostHog] Resolved environment '<x>' is not production; backend analytics disabled` at **warn** — same level as the missing-key branch, since both mean analytics went dark.
 
 Event taxonomy:
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -42,13 +42,15 @@ bun start
 
 Environment variables:
 
-| Variable              | Default                                                           | Description                                              |
-| --------------------- | ----------------------------------------------------------------- | -------------------------------------------------------- |
-| `PORT`                | `8080`                                                            | WebSocket server port                                    |
-| `DATABASE_URL`        | `postgresql://postgres:postgres@localhost:5432/boardsesh_backend` | PostgreSQL connection string                             |
-| `POSTHOG_PROJECT_KEY` | `NEXT_PUBLIC_POSTHOG_KEY`, then unset                             | Enables backend PostHog events for Live Activity usage   |
-| `POSTHOG_HOST`        | `https://us.i.posthog.com`                                        | PostHog ingestion host                                   |
-| `POSTHOG_ENVIRONMENT` | `SENTRY_ENVIRONMENT`, then `NODE_ENV`, then `development`         | Event environment property for backend PostHog analytics |
+| Variable              | Default                                                           | Description                                            |
+| --------------------- | ----------------------------------------------------------------- | ------------------------------------------------------ |
+| `PORT`                | `8080`                                                            | WebSocket server port                                  |
+| `DATABASE_URL`        | `postgresql://postgres:postgres@localhost:5432/boardsesh_backend` | PostgreSQL connection string                           |
+| `POSTHOG_PROJECT_KEY` | `NEXT_PUBLIC_POSTHOG_KEY`, then unset                             | Enables backend PostHog events for Live Activity usage |
+| `POSTHOG_HOST`        | `https://us.i.posthog.com`                                        | PostHog ingestion host                                 |
+| `POSTHOG_ENVIRONMENT` | `resolveSentryEnvironment()`                                      | Environment for backend PostHog analytics — see below  |
+
+`POSTHOG_ENVIRONMENT` is an override; unset, the environment comes from `resolveSentryEnvironment()` in `@boardsesh/db/client/config` (the same helper that gates backend Sentry): `SENTRY_ENVIRONMENT` when set, else `production` in any non-dev, non-test runtime, else `NODE_ENV`. **Only a resolved `production` sends** (#3814) — a project key on its own is not enough, so a key that reaches a preview, staging, or local runtime can't pollute the prod project. When the gate closes, the backend logs `[PostHog] Resolved environment '<x>' is not production; backend analytics disabled` at warn.
 
 ## Network Setup
 

--- a/packages/backend/src/__tests__/analytics-posthog.test.ts
+++ b/packages/backend/src/__tests__/analytics-posthog.test.ts
@@ -35,6 +35,12 @@ describe('backend PostHog analytics helper', () => {
         shutdown: posthogMocks.shutdown,
       };
     });
+    // vi.clearAllMocks() clears call history but NOT a custom
+    // .mockImplementation() — "logs and returns false when capture throws"
+    // below sets one that throws, which otherwise leaks into every later test
+    // in this file (masked before #3814 because no test after it in file order
+    // exercised a successful capture; the new environment-gate tests do).
+    posthogMocks.capture.mockImplementation(() => undefined);
   });
 
   afterAll(() => {
@@ -100,6 +106,7 @@ describe('backend PostHog analytics helper', () => {
   });
 
   it('can initialize if the project key appears after an earlier no-op capture', async () => {
+    vi.stubEnv('POSTHOG_ENVIRONMENT', 'production');
     const { captureBackendEvent } = await loadPosthogModule();
 
     expect(captureBackendEvent('Live Activity Started', { distinctId: 'user-1' })).toBe(false);
@@ -111,6 +118,7 @@ describe('backend PostHog analytics helper', () => {
 
   it('can use NEXT_PUBLIC_POSTHOG_KEY when the backend-specific key is missing', async () => {
     vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', 'ph_public_project');
+    vi.stubEnv('POSTHOG_ENVIRONMENT', 'production');
     const { captureBackendEvent } = await loadPosthogModule();
 
     expect(captureBackendEvent('Live Activity Started', { distinctId: 'user-1' })).toBe(true);
@@ -128,6 +136,7 @@ describe('backend PostHog analytics helper', () => {
 
   it('can disable PostHog person profiles for aggregate events', async () => {
     vi.stubEnv('POSTHOG_PROJECT_KEY', 'ph_project');
+    vi.stubEnv('POSTHOG_ENVIRONMENT', 'production');
     const { captureBackendEvent } = await loadPosthogModule();
 
     captureBackendEvent('Live Activity Push Delivery', {
@@ -148,6 +157,7 @@ describe('backend PostHog analytics helper', () => {
 
   it('logs and returns false when capture throws', async () => {
     vi.stubEnv('POSTHOG_PROJECT_KEY', 'ph_project');
+    vi.stubEnv('POSTHOG_ENVIRONMENT', 'production');
     posthogMocks.capture.mockImplementation(() => {
       throw new Error('capture exploded');
     });
@@ -163,11 +173,81 @@ describe('backend PostHog analytics helper', () => {
 
   it('flushes the client on shutdown', async () => {
     vi.stubEnv('POSTHOG_PROJECT_KEY', 'ph_project');
+    vi.stubEnv('POSTHOG_ENVIRONMENT', 'production');
     const { captureBackendEvent, shutdownPosthog } = await loadPosthogModule();
     captureBackendEvent('Live Activity Started', { distinctId: 'user-1' });
 
     await shutdownPosthog();
 
     expect(posthogMocks.shutdown).toHaveBeenCalledOnce();
+  });
+
+  // #3814: without this gate, a key present in ANY non-production runtime (a
+  // Railway shared variable, a local .env, a future staging service) would
+  // silently send to the prod PostHog project — the same class of bug #3808
+  // fixed for Sentry. The environment check must win even when a key is present.
+  it('does not initialize or capture when the resolved environment is not production, even with a key present', async () => {
+    vi.stubEnv('POSTHOG_PROJECT_KEY', 'ph_project');
+    vi.stubEnv('POSTHOG_ENVIRONMENT', 'preview');
+    const { captureBackendEvent } = await loadPosthogModule();
+
+    const captured = captureBackendEvent('Live Activity Started', {
+      distinctId: 'user-1',
+      properties: { sessionId: 'session-1' },
+    });
+
+    expect(captured).toBe(false);
+    expect(posthogMocks.PostHog).not.toHaveBeenCalled();
+    expect(posthogMocks.capture).not.toHaveBeenCalled();
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "[PostHog] Resolved environment 'preview' is not production; backend analytics disabled",
+    );
+  });
+
+  it('opts out via SENTRY_ENVIRONMENT when POSTHOG_ENVIRONMENT is unset (preview/staging backends set only SENTRY_ENVIRONMENT per #3808)', async () => {
+    vi.stubEnv('POSTHOG_PROJECT_KEY', 'ph_project');
+    vi.stubEnv('SENTRY_ENVIRONMENT', 'preview');
+    vi.stubEnv('NODE_ENV', 'production');
+    const { captureBackendEvent } = await loadPosthogModule();
+
+    const captured = captureBackendEvent('Live Activity Started', { distinctId: 'user-1' });
+
+    expect(captured).toBe(false);
+    expect(posthogMocks.PostHog).not.toHaveBeenCalled();
+  });
+
+  it('POSTHOG_ENVIRONMENT overrides SENTRY_ENVIRONMENT (the pre-existing degree of freedom)', async () => {
+    vi.stubEnv('POSTHOG_PROJECT_KEY', 'ph_project');
+    vi.stubEnv('POSTHOG_ENVIRONMENT', 'production');
+    vi.stubEnv('SENTRY_ENVIRONMENT', 'preview');
+    const { captureBackendEvent } = await loadPosthogModule();
+
+    const captured = captureBackendEvent('Live Activity Started', { distinctId: 'user-1' });
+
+    expect(captured).toBe(true);
+    expect(posthogMocks.PostHog).toHaveBeenCalledOnce();
+  });
+
+  // getAnalyticsEnvironment()'s fallback is `?? 'development'` — unlike Sentry's
+  // resolveSentryEnvironment(), it does NOT special-case "everything unset" to
+  // 'production' (see the comment on getAnalyticsEnvironment). Real Railway prod
+  // resolves to 'production' via an explicit POSTHOG_ENVIRONMENT or
+  // SENTRY_ENVIRONMENT dashboard variable, not this fallback — this test pins
+  // that the fallback stays 'development' so nobody "fixes" it into matching
+  // Sentry's special-casing and masks a genuinely-unconfigured environment.
+  it("falls back to 'development' (not 'production') when every environment var is unset", async () => {
+    vi.stubEnv('POSTHOG_PROJECT_KEY', 'ph_project');
+    vi.stubEnv('NODE_ENV', '');
+    vi.stubEnv('SENTRY_ENVIRONMENT', '');
+    vi.stubEnv('POSTHOG_ENVIRONMENT', '');
+    const { captureBackendEvent } = await loadPosthogModule();
+
+    const captured = captureBackendEvent('Live Activity Started', { distinctId: 'user-1' });
+
+    expect(captured).toBe(false);
+    expect(posthogMocks.PostHog).not.toHaveBeenCalled();
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "[PostHog] Resolved environment 'development' is not production; backend analytics disabled",
+    );
   });
 });

--- a/packages/backend/src/__tests__/analytics-posthog.test.ts
+++ b/packages/backend/src/__tests__/analytics-posthog.test.ts
@@ -199,7 +199,9 @@ describe('backend PostHog analytics helper', () => {
     expect(captured).toBe(false);
     expect(posthogMocks.PostHog).not.toHaveBeenCalled();
     expect(posthogMocks.capture).not.toHaveBeenCalled();
-    expect(loggerMock.info).toHaveBeenCalledWith(
+    // warn, not info — same severity as the missing-key branch, since both mean
+    // analytics went dark.
+    expect(loggerMock.warn).toHaveBeenCalledWith(
       "[PostHog] Resolved environment 'preview' is not production; backend analytics disabled",
     );
   });
@@ -228,16 +230,38 @@ describe('backend PostHog analytics helper', () => {
     expect(posthogMocks.PostHog).toHaveBeenCalledOnce();
   });
 
-  // getAnalyticsEnvironment()'s fallback is `?? 'development'` — unlike Sentry's
-  // resolveSentryEnvironment(), it does NOT special-case "everything unset" to
-  // 'production' (see the comment on getAnalyticsEnvironment). Real Railway prod
-  // resolves to 'production' via an explicit POSTHOG_ENVIRONMENT or
-  // SENTRY_ENVIRONMENT dashboard variable, not this fallback — this test pins
-  // that the fallback stays 'development' so nobody "fixes" it into matching
-  // Sentry's special-casing and masks a genuinely-unconfigured environment.
-  it("falls back to 'development' (not 'production') when every environment var is unset", async () => {
+  // The Railway prod shape, and the reason getAnalyticsEnvironment() delegates
+  // to resolveSentryEnvironment() instead of ending in `?? 'development'`:
+  // Dockerfile.backend never sets NODE_ENV and Railway injects none for an
+  // image deploy, so prod genuinely runs with all three vars unset. A bare
+  // 'development' fallback would resolve prod to non-production and take 100%
+  // of backend analytics dark on a dashboard-variable edit. This pins that a
+  // prod-like runtime (not dev, not the test runner) still sends.
+  it("resolves 'production' and sends when every environment var is unset in a prod-like runtime", async () => {
     vi.stubEnv('POSTHOG_PROJECT_KEY', 'ph_project');
     vi.stubEnv('NODE_ENV', '');
+    vi.stubEnv('SENTRY_ENVIRONMENT', '');
+    vi.stubEnv('POSTHOG_ENVIRONMENT', '');
+    // Vitest sets VITEST=true on the process; clear it so resolveSentryEnvironment()
+    // sees a non-test runtime, which is what Railway prod actually looks like.
+    vi.stubEnv('VITEST', '');
+    const { captureBackendEvent } = await loadPosthogModule();
+
+    const captured = captureBackendEvent('Live Activity Started', { distinctId: 'user-1' });
+
+    expect(captured).toBe(true);
+    expect(posthogMocks.PostHog).toHaveBeenCalledOnce();
+    expect(posthogMocks.capture).toHaveBeenCalledWith(
+      expect.objectContaining({ properties: expect.objectContaining({ environment: 'production' }) }),
+    );
+  });
+
+  // The other half of the same delegation: a developer box is NOT prod-like, so
+  // an unset POSTHOG_ENVIRONMENT must not open the gate. packages/backend's
+  // `dev` script sets NODE_ENV=development for exactly this reason.
+  it('stays disabled on a local dev runtime with a real key and no explicit environment var', async () => {
+    vi.stubEnv('POSTHOG_PROJECT_KEY', 'ph_project');
+    vi.stubEnv('NODE_ENV', 'development');
     vi.stubEnv('SENTRY_ENVIRONMENT', '');
     vi.stubEnv('POSTHOG_ENVIRONMENT', '');
     const { captureBackendEvent } = await loadPosthogModule();
@@ -246,7 +270,7 @@ describe('backend PostHog analytics helper', () => {
 
     expect(captured).toBe(false);
     expect(posthogMocks.PostHog).not.toHaveBeenCalled();
-    expect(loggerMock.info).toHaveBeenCalledWith(
+    expect(loggerMock.warn).toHaveBeenCalledWith(
       "[PostHog] Resolved environment 'development' is not production; backend analytics disabled",
     );
   });

--- a/packages/backend/src/services/analytics/posthog.ts
+++ b/packages/backend/src/services/analytics/posthog.ts
@@ -26,6 +26,7 @@ const POSTHOG_FLUSH_INTERVAL_MS = 10_000;
 let posthogClient: PostHog | null = null;
 let initAttempted = false;
 let missingProjectKeyLogged = false;
+let nonProductionEnvironmentLogged = false;
 const loggedQueuedEvents = new Set<BackendAnalyticsEvent>();
 
 function readOptionalEnv(envName: string): string | null {
@@ -73,6 +74,30 @@ function getPosthogClient(): PostHog | null {
     }
     return null;
   }
+  // Only the production environment sends. Without this, a key present in ANY
+  // non-prod runtime — a Railway "shared variable" wired to a future preview/
+  // staging service, or a local .env with a real key — would silently pollute
+  // the prod PostHog project (#3814), the same class of bug #3808 fixed for
+  // Sentry (`isProductionSentryEnvironment()` gating `Sentry.init({ enabled })`
+  // in instrument.ts). Historically this backend has been safe only because
+  // branch-deploy.yml's PR-preview containers never set a PostHog key — that's
+  // an absence-of-key accident, not a gate, so it's fixed here regardless of
+  // whether any leak has actually been observed. Preview/staging backends
+  // already declare SENTRY_ENVIRONMENT=preview (#3808, branch-deploy.yml), and
+  // getAnalyticsEnvironment() falls back through that var, so this opt-out is
+  // free — no new env var or workflow change needed. Checked before
+  // initAttempted (like the missing-key branch above) so the decision isn't
+  // permanently cached the one time this function runs before env vars settle.
+  const resolvedEnvironment = getAnalyticsEnvironment();
+  if (resolvedEnvironment !== 'production') {
+    if (!nonProductionEnvironmentLogged) {
+      nonProductionEnvironmentLogged = true;
+      logger.info(
+        `[PostHog] Resolved environment '${resolvedEnvironment}' is not production; backend analytics disabled`,
+      );
+    }
+    return null;
+  }
   if (initAttempted) return null;
   initAttempted = true;
 
@@ -97,6 +122,16 @@ function getPosthogClient(): PostHog | null {
   return client;
 }
 
+// Deliberately its own resolution, not a reuse of @boardsesh/db/client/config's
+// isProductionSentryEnvironment()/resolveSentryEnvironment(): those are Sentry's
+// helpers, and this one checks POSTHOG_ENVIRONMENT first — a pre-existing degree
+// of freedom that lets PostHog's environment diverge from Sentry's if that's
+// ever needed (e.g. testing PostHog's environment tagging in isolation without
+// also flipping Sentry's). Collapsing this into the Sentry-named helper would
+// quietly remove that override. Falls back through SENTRY_ENVIRONMENT so
+// preview/staging backends (which already set that per #3808) get the
+// production opt-out below for free without a new var. Do NOT "simplify" this
+// by deleting the POSTHOG_ENVIRONMENT check or delegating to the Sentry helper.
 function getAnalyticsEnvironment(): string {
   return (
     readOptionalEnv('POSTHOG_ENVIRONMENT') ??

--- a/packages/backend/src/services/analytics/posthog.ts
+++ b/packages/backend/src/services/analytics/posthog.ts
@@ -1,3 +1,4 @@
+import { resolveSentryEnvironment } from '@boardsesh/db/client/config';
 import { PostHog } from 'posthog-node';
 import { logger } from '../../utils/logger';
 
@@ -74,25 +75,21 @@ function getPosthogClient(): PostHog | null {
     }
     return null;
   }
-  // Only the production environment sends. Without this, a key present in ANY
-  // non-prod runtime — a Railway "shared variable" wired to a future preview/
-  // staging service, or a local .env with a real key — would silently pollute
-  // the prod PostHog project (#3814), the same class of bug #3808 fixed for
-  // Sentry (`isProductionSentryEnvironment()` gating `Sentry.init({ enabled })`
-  // in instrument.ts). Historically this backend has been safe only because
-  // branch-deploy.yml's PR-preview containers never set a PostHog key — that's
-  // an absence-of-key accident, not a gate, so it's fixed here regardless of
-  // whether any leak has actually been observed. Preview/staging backends
-  // already declare SENTRY_ENVIRONMENT=preview (#3808, branch-deploy.yml), and
-  // getAnalyticsEnvironment() falls back through that var, so this opt-out is
-  // free — no new env var or workflow change needed. Checked before
-  // initAttempted (like the missing-key branch above) so the decision isn't
-  // permanently cached the one time this function runs before env vars settle.
+  // Only production sends. Without this, a key present in ANY non-prod runtime —
+  // a Railway "shared variable" wired to a future staging service, or a local
+  // .env with a real key — would silently pollute the prod project (#3814), the
+  // same class of bug #3808 fixed for Sentry. Until now this was safe only
+  // because branch-deploy.yml's preview containers never set a PostHog key: an
+  // absence-of-key accident, not a gate. Checked before initAttempted (like the
+  // missing-key branch above) so one early call can't cache the decision.
   const resolvedEnvironment = getAnalyticsEnvironment();
   if (resolvedEnvironment !== 'production') {
     if (!nonProductionEnvironmentLogged) {
       nonProductionEnvironmentLogged = true;
-      logger.info(
+      // warn, not info, to match the missing-key branch above: both mean
+      // "analytics is now dark", and in prod this line is the only signal that
+      // a misconfigured environment has switched it off.
+      logger.warn(
         `[PostHog] Resolved environment '${resolvedEnvironment}' is not production; backend analytics disabled`,
       );
     }
@@ -122,23 +119,27 @@ function getPosthogClient(): PostHog | null {
   return client;
 }
 
-// Deliberately its own resolution, not a reuse of @boardsesh/db/client/config's
-// isProductionSentryEnvironment()/resolveSentryEnvironment(): those are Sentry's
-// helpers, and this one checks POSTHOG_ENVIRONMENT first — a pre-existing degree
-// of freedom that lets PostHog's environment diverge from Sentry's if that's
-// ever needed (e.g. testing PostHog's environment tagging in isolation without
-// also flipping Sentry's). Collapsing this into the Sentry-named helper would
-// quietly remove that override. Falls back through SENTRY_ENVIRONMENT so
-// preview/staging backends (which already set that per #3808) get the
-// production opt-out below for free without a new var. Do NOT "simplify" this
-// by deleting the POSTHOG_ENVIRONMENT check or delegating to the Sentry helper.
+// POSTHOG_ENVIRONMENT is a deliberate override that lets PostHog's environment
+// diverge from Sentry's (e.g. testing PostHog's tagging in isolation) — keep it.
+// Everything below it delegates to @boardsesh/db/client/config's
+// resolveSentryEnvironment(), the repo's single answer to "what runtime is this
+// backend process in": SENTRY_ENVIRONMENT, else 'production' for any non-dev,
+// non-test runtime, else NODE_ENV.
+//
+// The delegation is the point. This used to end in a bare `?? 'development'`,
+// which reintroduced the NODE_ENV assumption that issues #3183 and #3603 were
+// both filed to remove: Railway prod runs Dockerfile.backend, which never sets
+// NODE_ENV, and Railway injects none for a prebuilt-image deploy. (Confirmed
+// live: yoga.ts serves GraphiQL only when NODE_ENV !== 'production', and
+// https://ws.boardsesh.com/graphql returns the GraphiQL shell.) Under the old
+// chain, prod resolved to 'production' *only* via a dashboard-managed variable,
+// so the send gate in getPosthogClient() would have gone dark — silently, and
+// for 100% of backend analytics — the first time anyone tidied that variable
+// away. Sentry doesn't have that failure mode; now neither does this.
+// Preview/staging still opt out for free: branch-deploy.yml declares
+// SENTRY_ENVIRONMENT=preview (#3808), which wins over the runtime inference.
 function getAnalyticsEnvironment(): string {
-  return (
-    readOptionalEnv('POSTHOG_ENVIRONMENT') ??
-    readOptionalEnv('SENTRY_ENVIRONMENT') ??
-    readOptionalEnv('NODE_ENV') ??
-    'development'
-  );
+  return readOptionalEnv('POSTHOG_ENVIRONMENT') ?? resolveSentryEnvironment();
 }
 
 export function captureBackendEvent(eventName: BackendAnalyticsEvent, options: CaptureBackendEventOptions): boolean {
@@ -176,6 +177,7 @@ export async function shutdownPosthog(): Promise<void> {
   posthogClient = null;
   initAttempted = false;
   missingProjectKeyLogged = false;
+  nonProductionEnvironmentLogged = false;
   loggedQueuedEvents.clear();
 
   try {

--- a/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
+++ b/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
@@ -80,6 +80,9 @@ export function OtaUpdateTracker(): null {
       // property, so pr-* preview traffic had no way to be identified on any
       // OTHER event (#3814) — the environment super property (registerAppEnvironment,
       // posthog-client.ts) covers prod-vs-preview; this covers WHICH preview.
+      // Registered here rather than at client construction, so events fired
+      // before this effect runs carry no ota_channel. Accepted: `environment` has
+      // no such window, and prod-vs-preview is the filter that matters.
       ota_channel: properties.channel,
     });
   }, []);

--- a/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
+++ b/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
@@ -91,14 +91,21 @@ export function OtaUpdateTracker(): null {
   // from the build-time Updates.channel; the active override lives only in the
   // AsyncStorage mirror (no native read-back API). Read it async and overwrite
   // just the ota_channel tag so their reports show the channel they're actually
-  // on — matching ChannelSwitcherScreen's `override ?? buildChannel`.
+  // on — matching ChannelSwitcherScreen's `override ?? buildChannel`. Applied to
+  // BOTH sinks: Sentry's tag and the PostHog super property stamped above.
+  // Correcting only Sentry would leave PostHog reporting the build channel
+  // (`production` on a store binary — mobile-ota-preview.yml pins
+  // EXPO_UPDATES_CHANNEL there), so ota_channel could never identify which
+  // preview an event came from — the one thing it exists to do.
   useEffect(() => {
     let active = true;
     // Best-effort: a storage read failure just leaves the build channel tag from
     // the launch stamp in place, so swallow rather than leak an unhandled rejection.
     void getPreference<string>(OTA_CHANNEL_OVERRIDE_KEY)
       .then((override) => {
-        if (active && override) setOtaChannelTag(override);
+        if (!active || !override) return;
+        setOtaChannelTag(override);
+        registerSuperProperties({ ota_channel: override });
       })
       .catch(() => {});
     return () => {

--- a/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
+++ b/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
@@ -76,6 +76,11 @@ export function OtaUpdateTracker(): null {
       ota_update_id: properties.updateId,
       ota_is_embedded: properties.isEmbeddedLaunch,
       ota_runtime_version: properties.runtimeVersion,
+      // Was previously stamped only on this one-off event, not as a super
+      // property, so pr-* preview traffic had no way to be identified on any
+      // OTHER event (#3814) — the environment super property (registerAppEnvironment,
+      // posthog-client.ts) covers prod-vs-preview; this covers WHICH preview.
+      ota_channel: properties.channel,
     });
   }, []);
 

--- a/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
@@ -161,12 +161,24 @@ describe('OtaUpdateTracker', () => {
   });
 });
 
-describe('OtaUpdateTracker channel-override Sentry tag', () => {
+describe('OtaUpdateTracker channel override', () => {
   it('overrides ota_channel with a tester-stored override channel', async () => {
     prefs.getPreference.mockResolvedValue('pr-3327');
     render(createElement(OtaUpdateTracker));
 
     await waitFor(() => expect(sentry.setOtaChannelTag).toHaveBeenCalledWith('pr-3327'));
+  });
+
+  // The override has to reach PostHog too, not just Sentry. On a store binary
+  // the build-time Updates.channel stays 'production' (mobile-ota-preview.yml
+  // pins EXPO_UPDATES_CHANNEL), so without this the ota_channel super property
+  // would tag a tester's preview events as production and could never answer
+  // "which preview did this come from" — the only reason it exists.
+  it('re-registers the PostHog ota_channel super property from the override', async () => {
+    prefs.getPreference.mockResolvedValue('pr-3327');
+    render(createElement(OtaUpdateTracker));
+
+    await waitFor(() => expect(analytics.registerSuperProperties).toHaveBeenCalledWith({ ota_channel: 'pr-3327' }));
   });
 
   it('leaves the build-channel tag in place when no override is stored', async () => {
@@ -176,6 +188,9 @@ describe('OtaUpdateTracker channel-override Sentry tag', () => {
     await waitFor(() => expect(prefs.getPreference).toHaveBeenCalled());
     await flushPendingPromises();
     expect(sentry.setOtaChannelTag).not.toHaveBeenCalled();
+    // Exact-shape match: the launch stamp registers ota_channel alongside three
+    // other keys, so only the single-key override call can match this.
+    expect(analytics.registerSuperProperties).not.toHaveBeenCalledWith({ ota_channel: expect.anything() });
   });
 
   it('swallows a storage read failure without overriding the tag or throwing', async () => {

--- a/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
@@ -88,10 +88,16 @@ describe('OtaUpdateTracker', () => {
       runtimeVersion: 'abcdef123456',
       createdAtIso: '2026-06-20T07:53:51.000Z',
     });
+    // ota_channel (#3814): previously stamped only on this one-off event, not as
+    // a super property, so pr-* preview traffic had no way to be identified on
+    // any OTHER event. Registering it here makes preview traffic filterable in
+    // its own right, independent of the environment super property
+    // (registerAppEnvironment, posthog-client.ts) which only says prod-vs-preview.
     expect(analytics.registerSuperProperties).toHaveBeenCalledWith({
       ota_update_id: 'a1b2c3d4-0000-0000-0000-000000000000',
       ota_is_embedded: false,
       ota_runtime_version: 'abcdef123456',
+      ota_channel: 'production',
     });
   });
 

--- a/packages/mobile/src/lib/__tests__/analytics-reset.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-reset.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const posthogClientMocks = vi.hoisted(() => ({
+  getPostHogClient: vi.fn(),
+  registerAppSuperProperties: vi.fn(),
+}));
+const sharedAnalyticsMocks = vi.hoisted(() => ({ reset: vi.fn(() => true) }));
+
+vi.mock('../posthog-client', () => ({
+  getPostHogClient: posthogClientMocks.getPostHogClient,
+  registerAppSuperProperties: posthogClientMocks.registerAppSuperProperties,
+}));
+
+vi.mock('@boardsesh/analytics', () => ({
+  createAnalytics: () => ({
+    track: vi.fn(),
+    capture: vi.fn(),
+    identify: vi.fn(),
+    setPersonProperties: vi.fn(),
+    alias: vi.fn(),
+    reset: sharedAnalyticsMocks.reset,
+  }),
+}));
+
+// #3814: PostHog's reset() clears every registered super property, and
+// getPostHogClient() caches the singleton so its construction-time registrations
+// never run again. Sign-out paths (logout, forced sign-out, expiry, account
+// switch) all route through auth-provider's resetAnalytics, so without the
+// re-register a tester's post-logout events silently lose `environment` and read
+// as production — exactly the pollution this PR closes — and lose
+// `$raw_user_agent`, which gets them bot-filtered.
+describe('analytics reset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sharedAnalyticsMocks.reset.mockReturnValue(true);
+  });
+
+  it('re-registers the build-level super properties after resetting the client', async () => {
+    const fakeClient = { register: vi.fn() };
+    posthogClientMocks.getPostHogClient.mockReturnValue(fakeClient);
+    const { reset } = await import('../analytics');
+
+    expect(reset()).toBe(true);
+
+    expect(sharedAnalyticsMocks.reset).toHaveBeenCalledOnce();
+    expect(posthogClientMocks.registerAppSuperProperties).toHaveBeenCalledWith(fakeClient);
+  });
+
+  it('does not re-register when analytics is disabled (no client)', async () => {
+    posthogClientMocks.getPostHogClient.mockReturnValue(null);
+    const { reset } = await import('../analytics');
+
+    expect(reset()).toBe(true);
+
+    expect(posthogClientMocks.registerAppSuperProperties).not.toHaveBeenCalled();
+  });
+
+  it('propagates the underlying reset result', async () => {
+    sharedAnalyticsMocks.reset.mockReturnValue(false);
+    posthogClientMocks.getPostHogClient.mockReturnValue(null);
+    const { reset } = await import('../analytics');
+
+    expect(reset()).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/app-environment.test.ts
+++ b/packages/mobile/src/lib/__tests__/app-environment.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, it, expect } from 'vitest';
+import { resolveAppEnvironment } from '../app-environment';
+
+// Moved out of sentry.test.ts (#3814): the resolver is now shared by Sentry and
+// PostHog, so it gets its own test file rather than living under either SDK's.
+describe('resolveAppEnvironment', () => {
+  const previous = process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
+  afterEach(() => {
+    if (previous === undefined) delete process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
+    else process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT = previous;
+  });
+
+  it("defaults to 'production' when EXPO_PUBLIC_SENTRY_ENVIRONMENT is unset", () => {
+    delete process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
+    expect(resolveAppEnvironment()).toBe('production');
+  });
+
+  it("defaults to 'production' when EXPO_PUBLIC_SENTRY_ENVIRONMENT is empty", () => {
+    process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT = '';
+    expect(resolveAppEnvironment()).toBe('production');
+  });
+
+  it('uses the preview value published onto pr-* OTA bundles', () => {
+    process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT = 'preview';
+    expect(resolveAppEnvironment()).toBe('preview');
+  });
+});

--- a/packages/mobile/src/lib/__tests__/posthog-client.test.ts
+++ b/packages/mobile/src/lib/__tests__/posthog-client.test.ts
@@ -71,6 +71,10 @@ describe('registerAppEnvironment', () => {
       throw new Error('boom');
     });
     expect(() => registerAppEnvironment({ register })).not.toThrow();
+    // The warn assertion depends on __DEV__ being truthy — mobile vitest freezes it
+    // that way (see the mobile test setup). A test that stubs __DEV__ = false without
+    // restoring it turns this into a false green; the not-throwing assertion above is
+    // the load-bearing one either way.
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });

--- a/packages/mobile/src/lib/__tests__/posthog-client.test.ts
+++ b/packages/mobile/src/lib/__tests__/posthog-client.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
-import { MOBILE_USER_AGENT, registerMobileUserAgent, buildPostHogOptions } from '../posthog-client';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import {
+  MOBILE_USER_AGENT,
+  registerMobileUserAgent,
+  registerAppEnvironment,
+  buildPostHogOptions,
+} from '../posthog-client';
 
 // The whole point of MOBILE_USER_AGENT is to give mobile events a User-Agent that
 // PostHog's classifier reads as "Regular" rather than the bot it assigns to an
@@ -31,6 +36,41 @@ describe('registerMobileUserAgent', () => {
       throw new Error('boom');
     });
     expect(() => registerMobileUserAgent({ register })).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+// #3814: without this, mobile PostHog events carried no environment tag at all,
+// so `pr-*` OTA preview traffic was indistinguishable from production in every
+// event but the once-per-launch OTA Update Status one.
+describe('registerAppEnvironment', () => {
+  const previous = process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
+  afterEach(() => {
+    if (previous === undefined) delete process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
+    else process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT = previous;
+  });
+
+  it("registers 'production' as the environment super property when unset", () => {
+    delete process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
+    const register = vi.fn();
+    registerAppEnvironment({ register });
+    expect(register).toHaveBeenCalledWith({ environment: 'production' });
+  });
+
+  it('registers the preview value published onto pr-* OTA bundles', () => {
+    process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT = 'preview';
+    const register = vi.fn();
+    registerAppEnvironment({ register });
+    expect(register).toHaveBeenCalledWith({ environment: 'preview' });
+  });
+
+  it('never throws and logs when register() fails (must not block analytics init)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const register = vi.fn(() => {
+      throw new Error('boom');
+    });
+    expect(() => registerAppEnvironment({ register })).not.toThrow();
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { ComponentType } from 'react';
 
 // Spy on the SDK so we can assert the disabled-build contract. Under vitest
@@ -27,36 +27,12 @@ import {
   setOtaSentryTags,
   wrapWithSentry,
   isSentryEnabled,
-  resolveSentryEnvironment,
   toSentryTag,
 } from '../sentry';
 
 describe('isSentryEnabled', () => {
   it('is false in dev / test (no DSN + __DEV__)', () => {
     expect(isSentryEnabled).toBe(false);
-  });
-});
-
-describe('resolveSentryEnvironment', () => {
-  const previous = process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
-  afterEach(() => {
-    if (previous === undefined) delete process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
-    else process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT = previous;
-  });
-
-  it("defaults to 'production' when EXPO_PUBLIC_SENTRY_ENVIRONMENT is unset", () => {
-    delete process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT;
-    expect(resolveSentryEnvironment()).toBe('production');
-  });
-
-  it("defaults to 'production' when EXPO_PUBLIC_SENTRY_ENVIRONMENT is empty", () => {
-    process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT = '';
-    expect(resolveSentryEnvironment()).toBe('production');
-  });
-
-  it('uses the preview value published onto pr-* OTA bundles', () => {
-    process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT = 'preview';
-    expect(resolveSentryEnvironment()).toBe('preview');
   });
 });
 

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -1,6 +1,6 @@
 import type { PostHog } from 'posthog-react-native';
 import { createAnalytics } from '@boardsesh/analytics';
-import { getPostHogClient } from './posthog-client';
+import { getPostHogClient, registerAppSuperProperties } from './posthog-client';
 
 type PosthogFeatureFlagClient = {
   getFeatureFlag?: (key: string) => unknown;
@@ -121,7 +121,22 @@ const analytics = createAnalytics(getClient, {
   onDebug: __DEV__ ? (name, properties) => console.info('[analytics]', name, properties ?? {}) : undefined,
 });
 
-export const { track, identify, setPersonProperties, alias, reset } = analytics;
+export const { track, identify, setPersonProperties, alias } = analytics;
+
+// PostHog's reset() clears the distinct id AND every registered super property,
+// but getPostHogClient() caches the singleton, so the registrations it does at
+// construction never run again. Re-register the build-level ones straight after
+// so a logout / forced sign-out / account switch doesn't silently drop them for
+// the rest of the launch — `environment` (without it, a tester's preview traffic
+// reads as production again, reopening #3814) and `$raw_user_agent` (without it,
+// PostHog bot-filters the events). Person-scoped properties are meant to be
+// cleared and are deliberately not restored.
+export function reset(): boolean {
+  const didReset = analytics.reset();
+  const client = getClient();
+  if (client) registerAppSuperProperties(client);
+  return didReset;
+}
 
 // Manual screen view — the RN analogue of web's $pageview. PostHog's screen
 // autocapture can't read Expo Router's navigation, so AnalyticsScreenTracker

--- a/packages/mobile/src/lib/app-environment.ts
+++ b/packages/mobile/src/lib/app-environment.ts
@@ -1,0 +1,32 @@
+/**
+ * The resolved app "environment" for analytics / crash-reporting tags — shared by
+ * Sentry (sentry.ts) and PostHog (posthog-client.ts) so both report the same
+ * value for the same build, rather than each rolling its own resolution and
+ * risking drift.
+ *
+ * Preview OTA bundles (the `pr-*` channels) are published with
+ * EXPO_PUBLIC_SENTRY_ENVIRONMENT=preview (mobile-ota-preview.yml) — the value is
+ * inlined into that JS bundle, so a tester who switches to a pr channel reports
+ * `environment: preview` on both SDKs and their activity stays out of each
+ * tool's production view. Store / production builds leave it unset and default
+ * to 'production'.
+ *
+ * The env var is named EXPO_PUBLIC_SENTRY_ENVIRONMENT for historical reasons —
+ * it was introduced for Sentry alone (#3808) before PostHog had the same gap
+ * (#3814). It is now DELIBERATELY reused here rather than adding a second,
+ * identical EXPO_PUBLIC_POSTHOG_ENVIRONMENT var and touching every mobile CI
+ * workflow that publishes it (mobile-ota-preview.yml, mobile-ota-production.yml,
+ * mobile-ota-check.yml, mobile-ota-backport.yml, android-apk-*.yml,
+ * ios-testflight-rn.yml). Do not "clean this up" by renaming the var or
+ * splitting it back into a per-SDK one — the two SDKs are meant to agree, and a
+ * split reintroduces the risk of one being fixed and the other forgotten, which
+ * is exactly how #3814 happened for PostHog after #3808 fixed Sentry.
+ *
+ * `environment` is init-only in both SDKs (no runtime setter), so it can't be
+ * derived from Updates.channel after launch; the build-time env var is the
+ * equivalent signal. Exported as a pure function so the resolution is
+ * unit-testable independent of either SDK's enablement gate.
+ */
+export function resolveAppEnvironment(): string {
+  return process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT || 'production';
+}

--- a/packages/mobile/src/lib/posthog-client.ts
+++ b/packages/mobile/src/lib/posthog-client.ts
@@ -40,6 +40,19 @@ export function registerAppEnvironment(client: Pick<PostHog, 'register'>): void 
   }
 }
 
+// The super properties that describe the app build rather than the person, so
+// they belong on every event no matter who is signed in. Registered at client
+// construction AND re-registered after analytics.reset(): PostHog's reset()
+// clears every registered super property, and getPostHogClient() caches the
+// singleton, so without a re-register a logout / forced sign-out / account
+// switch drops them for the rest of the launch — `environment` (preview traffic
+// would look like production again, reopening #3814) and `$raw_user_agent`
+// (PostHog bot-filters events that have no UA).
+export function registerAppSuperProperties(client: Pick<PostHog, 'register'>): void {
+  registerMobileUserAgent(client);
+  registerAppEnvironment(client);
+}
+
 // PostHog project token. Intentionally the SAME project as web so a signed-in
 // user's web + mobile activity resolves to one person. `EXPO_PUBLIC_*` vars are
 // inlined into the JS bundle at build time, so this must be set when the bundle
@@ -97,8 +110,7 @@ export function getPostHogClient(): PostHog | null {
   // screen/action events start flowing.
   const bootstrapDistinctId = getAnalyticsBootstrapId();
   client = new PostHog(apiKey, buildPostHogOptions(host, bootstrapDistinctId));
-  registerMobileUserAgent(client);
-  registerAppEnvironment(client);
+  registerAppSuperProperties(client);
   return client;
 }
 

--- a/packages/mobile/src/lib/posthog-client.ts
+++ b/packages/mobile/src/lib/posthog-client.ts
@@ -1,5 +1,6 @@
 import { PostHog, type PostHogOptions } from 'posthog-react-native';
 import { getAnalyticsBootstrapId } from './analytics-bootstrap-id';
+import { resolveAppEnvironment } from './app-environment';
 
 // PostHog flags events with an empty User-Agent as bots, and the RN SDK sends no
 // UA it stores — so without this, real mobile traffic hides behind the bot filter.
@@ -19,6 +20,23 @@ export function registerMobileUserAgent(client: Pick<PostHog, 'register'>): void
     });
   } catch (error) {
     if (__DEV__) console.warn('[analytics] failed to register $raw_user_agent super property', error);
+  }
+}
+
+// Registers the resolved app environment ('production' / 'preview', shared with
+// Sentry — see app-environment.ts) as a super property on every event. Without
+// this, mobile PostHog events carried no environment tag at all — `pr-*` OTA
+// preview traffic was indistinguishable from real production usage in every
+// event except the once-per-launch `OTA Update Status` event (#3814). Exported
+// like registerMobileUserAgent so the call site is unit-testable; same
+// best-effort contract (a failure here must never block analytics init).
+export function registerAppEnvironment(client: Pick<PostHog, 'register'>): void {
+  try {
+    void Promise.resolve(client.register({ environment: resolveAppEnvironment() })).catch((error: unknown) => {
+      if (__DEV__) console.warn('[analytics] failed to register environment super property', error);
+    });
+  } catch (error) {
+    if (__DEV__) console.warn('[analytics] failed to register environment super property', error);
   }
 }
 
@@ -80,6 +98,7 @@ export function getPostHogClient(): PostHog | null {
   const bootstrapDistinctId = getAnalyticsBootstrapId();
   client = new PostHog(apiKey, buildPostHogOptions(host, bootstrapDistinctId));
   registerMobileUserAgent(client);
+  registerAppEnvironment(client);
   return client;
 }
 

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react';
 import * as Sentry from '@sentry/react-native';
 import { installGlobalErrorCapture } from './global-error-capture';
+import { resolveAppEnvironment } from './app-environment';
 
 /**
  * Triage context attached to a reported error. Defined here (not in
@@ -21,21 +22,6 @@ const sentryDsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
  * (TestFlight / internal) and production builds are both `!__DEV__`.
  */
 export const isSentryEnabled = !!sentryDsn && !__DEV__;
-
-/**
- * The Sentry `environment` for this build. Preview OTA bundles (the `pr-*`
- * channels) are published with EXPO_PUBLIC_SENTRY_ENVIRONMENT=preview
- * (mobile-ota-preview.yml) — the value is inlined into that JS bundle, so a
- * tester who switches to a pr channel reports `environment: preview` and their
- * crashes stay out of the production view. Store / production builds leave it
- * unset and default to 'production'. `environment` is init-only in this SDK
- * (there's no runtime setter), so it can't be derived from Updates.channel after
- * launch; the build-time env var is the equivalent signal. Exported as a pure
- * function so the mapping is unit-testable behind the isSentryEnabled init gate.
- */
-export function resolveSentryEnvironment(): string {
-  return process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT || 'production';
-}
 
 // @expo/ui's Android bottom sheet fires `sheetRef.partialExpand()` / `expand()`
 // fire-and-forget inside `snapToIndex` (community/bottom-sheet/BottomSheet.android.tsx).
@@ -78,8 +64,9 @@ if (isSentryEnabled) {
   Sentry.init({
     dsn: sentryDsn,
     // production for store/TestFlight bundles; 'preview' for pr-* OTA bundles so
-    // their crashes are filterable out of the prod view. See resolveSentryEnvironment.
-    environment: resolveSentryEnvironment(),
+    // their crashes are filterable out of the prod view. See resolveAppEnvironment
+    // (shared with PostHog — app-environment.ts).
+    environment: resolveAppEnvironment(),
     tracesSampleRate: 0.1,
     // Drop the benign @expo/ui Android sheet "No handler registered" unhandled rejection
     // (partialExpand/expand on a binary whose native layer predates the method). Scoped


### PR DESCRIPTION
## Summary

Follow-up to #3808 (the identical bug for Sentry) and to #3895, which already fixed the **web** half of #3814 (`analytics.ts`'s substring hostname gate → exact-host `production-hosts.ts`) without linking the issue, so it stayed open. This PR closes the **backend** and **mobile** halves.

**Backend** (`packages/backend/src/services/analytics/posthog.ts`) — `getPosthogClient()` had **no environment gate at all**. It sent whenever a `POSTHOG_PROJECT_KEY` / `NEXT_PUBLIC_POSTHOG_KEY` was present, in any runtime. That was safe only because `branch-deploy.yml`'s PR-preview containers never set that key: an absence-of-key accident, not a gate. Now only a resolved environment of exactly `production` sends. Preview/staging backends already declare `SENTRY_ENVIRONMENT=preview` (#3808), so they opt out for free — no new env var, no workflow change.

**Mobile** (`posthog-client.ts`, `OtaUpdateTracker.tsx`) — mobile PostHog events carried **no environment or channel tag at all**, except the once-per-launch `OTA Update Status` event. Ticks, BLE, session, queue — the entire product surface, 90% of all volume — was permanently unfilterable by environment. Two super properties are now registered once per launch:

- `environment` (`production` / `preview`), via a new shared `resolveAppEnvironment()` (`packages/mobile/src/lib/app-environment.ts`) that reuses the `EXPO_PUBLIC_SENTRY_ENVIRONMENT` value already published on `pr-*` OTA bundles (#3808), rather than adding a parallel `EXPO_PUBLIC_POSTHOG_ENVIRONMENT` and touching every mobile CI workflow. Sentry and PostHog now read the same resolver, so they can't drift — which is exactly how #3814 happened after #3808.
- `ota_channel` (e.g. `pr-3573`) — a one-line addition to `OtaUpdateTracker.tsx`'s existing `registerSuperProperties()` call, making `pr-*` traffic filterable in its own right.

Mobile is **JS-only** — no native code, so it rides the next OTA to store builds already installed, not just future preview channels.

## The `development` fallback was a live footgun — reconciled

The first cut of this PR resolved the backend environment with `POSTHOG_ENVIRONMENT ?? SENTRY_ENVIRONMENT ?? NODE_ENV ?? 'development'`. That fallback contradicted `packages/db/src/client/config.ts:38-41`, which records (from #3603) that **Railway prod leaves `NODE_ENV` and `SENTRY_ENVIRONMENT` unset**. Under that chain, prod would resolve to `development` and the new gate would have switched off 100% of backend analytics.

The `config.ts` claim is correct, and I confirmed it against the live production backend rather than trusting the comment. `yoga.ts` serves GraphiQL only when `NODE_ENV !== 'production'`, and production returns it:

```
$ curl -sS -H 'Accept: text/html' https://ws.boardsesh.com/graphql | grep -o '<title>[^<]*</title>'
<title>Yoga GraphiQL</title>
```

`Dockerfile.backend` never sets `NODE_ENV`, and Railway injects none for a prebuilt-image deploy. So prod today resolves to `production` **only** because a dashboard-managed variable happens to say so — one tidy-up away from silently taking backend analytics dark, in the exact shape of #3183 and #3603.

The fix is to stop having two answers to "what runtime is this process in". `getAnalyticsEnvironment()` now keeps `POSTHOG_ENVIRONMENT` as an explicit override and delegates everything below it to `resolveSentryEnvironment()` from `@boardsesh/db/client/config` — the same helper that gates backend Sentry:

| Runtime | Resolves to | Sends? |
| --- | --- | --- |
| Railway prod (all three vars unset) | `production` (runtime inference, no dashboard var needed) | yes |
| Preview / staging (`SENTRY_ENVIRONMENT=preview`, #3808) | `preview` | no |
| Local dev (`vp run dev` sets `NODE_ENV=development`) | `development` | no |
| Test runner (`VITEST`) | `test` | no |
| Any explicit `POSTHOG_ENVIRONMENT` | that value | only if `production` |

The non-production log also moves from `logger.info` to `logger.warn`, matching the missing-key branch directly above it. Both mean "analytics is now dark", and in prod that line is the only signal that a misconfigured environment switched it off.

## Two holes review caught in the mobile tagging

Both were real, and both would have quietly defeated the point of the tags. Fixed here with tests that fail when the fix is removed (verified by deleting each one).

**`reset()` wiped the tags and nothing put them back.** PostHog's `reset()` clears the distinct id *and* every registered super property, but `getPostHogClient()` caches the singleton, so the registrations it does at construction never ran again. Every sign-out path — logout, forced sign-out, token expiry, account switch — routes through `auth-provider`'s `resetAnalytics()`, so for the rest of that launch a tester's events lost `environment` and read as production again. That's the bug this PR exists to fix, reopened on a path people hit daily. It also dropped `$raw_user_agent`, which is worse and **predates this PR**: PostHog bot-filters events with no UA, so post-logout mobile events have been silently bot-filtered since that property was introduced. `registerAppSuperProperties()` now bundles the two build-level properties, and `analytics.reset()` is wrapped to re-register them. Person-scoped properties are meant to be cleared and deliberately are not restored.

**`ota_channel` reported the build channel, not the active one.** A tester who switches channels in-app keeps the build-time `Updates.channel` — `production` on a store binary, since `mobile-ota-preview.yml` pins `EXPO_UPDATES_CHANNEL`. The real channel lives only in the `OTA_CHANNEL_OVERRIDE_KEY` mirror. There was already an effect reading that override, but it corrected only Sentry's tag, so the new PostHog super property would have labelled preview events `ota_channel: production` — unable to answer "which preview did this come from", the one question it exists for. The override now updates both sinks.

## The measurement (so nobody has to re-derive it)

How much of the last 30 days of PostHog data (project 412845) is actually non-production — i.e. does any past analysis need re-running? **It doesn't.**

Total 30-day volume: 1,378,775 events / 11,566 persons.

| SDK | events (30d) | % of total |
| --- | --- | --- |
| `posthog-react-native` (mobile) | 1,246,850 | 90.4% |
| `js` (web) | 107,164 | 7.8% |
| `posthog-node` (backend) | 24,741 | 1.8% |

**Web — 0% pollution found**, checked over 90 days. Every event carries a `$host` of `boardsesh.com` or `www.boardsesh.com`. The substring bug was real, but PR-preview URLs get essentially no organic browser traffic and e2e Playwright hits `localhost:3000` with no PostHog key configured.

**Backend — 0% pollution found.** All 65,237 `posthog-node` events since the feature shipped (2026-05-16) carry `environment: production, service: boardsesh-backend`. Incidental, not defended — hence the gate regardless.

**Mobile — bounded under 1%, from 2 identifiable people.** The only pre-existing signal is the OTA-launch event's `channel`: 11,816 `production` launches vs. 20 across 7 `pr-*` channels, from 2 unique persons in 30 days. Bounding those two people's *entire* activity (legitimate prod usage included, since nothing currently separates it) gives 12,117 events — an upper bound of ≈0.9%, and it overcounts.

**Caveat, stated plainly**: for mobile that's "no evidence found", not "provably zero". 90% of volume ran through events that carried no environment tag at all, so the 2-person bound only catches testers who *also* triggered an OTA-status relaunch on a `pr-*` channel in the window. It can't catch a preview session that didn't relaunch. That gap is what this PR closes going forward; it can't be backfilled.

## Docs and comments brought in line

- `docs/websocket-implementation.md` — documented the production-only send gate and the new resolution order; it previously described `POSTHOG_ENVIRONMENT` as a pure tagging override with no gate at all.
- `packages/backend/README.md` — same, for the env-var table.
- `docs/live-activity-push-testing.md` — the local-dev setup told developers to add `POSTHOG_ENVIRONMENT=production` to `.env.local`, which with a real key makes local test events indistinguishable from Railway prod. Now tells them to set a non-production value, and explains that a backend started without `NODE_ENV` looks prod-like and will send.
- `.github/workflows/mobile-ota-preview.yml` — the comment on `EXPO_PUBLIC_SENTRY_ENVIRONMENT` said it exists so testers' crashes stay out of Sentry. It now drives PostHog too, via `app-environment.ts`. The load-bearing "do NOT add to `SHARED_ENV_KEYS`" warning is kept verbatim.

## Follow-ups, not in this diff

- **Web carries no `environment` property.** After this lands, backend stamps it per-event and mobile carries it as a super property, but web relies solely on the `isProductionHost` gate. Verified live: `js`-lib events are 100% `(none)` for `environment` over 30 days (102,331 events). A PostHog filter of `environment = 'production'` would silently drop all web volume. Either register it on web too or document `environment != 'preview'` as the correct filter.
- **Railway shared variables.** The gate covers every path visible in this repo, but Railway env vars are dashboard-managed. This can't rule out a project-wide shared variable wiring `POSTHOG_PROJECT_KEY` to some future non-prod service. Worth an audit by anyone with dashboard access.
- **Production serves GraphiQL.** Noticed while proving `NODE_ENV` is unset in prod: `https://ws.boardsesh.com/graphql` returns the GraphiQL IDE, because that gate is still a bare `NODE_ENV !== 'production'`. Same root cause as #3183/#3603, different call site. Out of scope here.

## Release Notes

- [x] none (internal analytics hygiene, no user-facing change)

## Test plan

- `vp run typecheck` — pass (full monorepo)
- `vp check` — pass, 0 errors
- `vp test run --project backend` (`VITEST_POOL_ID=solo-3814`) — pass. `analytics-posthog.test.ts` covers the gate: blocks non-prod even with a key, opts out via the `SENTRY_ENVIRONMENT` fallback, `POSTHOG_ENVIRONMENT` takes precedence, an all-unset **prod-like** runtime resolves to `production` and still sends (the Railway shape), and an all-unset **dev** runtime stays dark. Also fixes a pre-existing test-pollution bug — a `mockImplementation` that throws leaked out of one case into every later one, masked until these tests exercised a successful capture.
- `vp run test:mobile` — pass, adds `app-environment.test.ts`, `analytics-reset.test.ts`, plus `registerAppEnvironment` and `ota_channel` coverage. The two review fixes were mutation-tested: deleting either one turns its guard red.

Post-merge verification (not a merge gate — unit tests can't reach the wiring, since `isAnalyticsEnabled` is false under vitest): after the next `pr-*` OTA publish, switch a device to that channel and confirm events carry `environment=preview` and `ota_channel=pr-<number>`; confirm a store build still reports `environment=production`.
