### PR TITLE
fix(mobile): re-send the queue add when a throttled activation is dropped

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -3,6 +3,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import { createElement, useEffect, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { isPlaylistPeekQueueItemUuid } from '@boardsesh/queue';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import type { SessionStatus, SessionUser, UserBoard } from '@boardsesh/shared-schema';
 
@@ -1890,6 +1891,68 @@ describe('QueueProvider mutation-failure resync', () => {
     expect(queueMutations.addQueueItem).not.toHaveBeenCalled();
     expect(queueStateCalls).toBe(0);
     expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('item-2');
+  });
+
+  it('re-sends the queue add when a rate-limited nextClimb promoted a playlist peek', async () => {
+    const snapshots: Snapshot[] = [];
+    const activated = makeQueueItem('item-1', 'climb-1');
+    // Second playlist climb, deliberately NOT in the queue: at the queue tail
+    // nextClimb falls through to the playlist and offers it as a transient peek.
+    const peekClimb = makeQueueItem('peek-source', 'climb-2').climb;
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([activated], activated), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    act(() => {
+      snapshots.at(-1)?.setQueue([activated], activated);
+      snapshots.at(-1)?.setPlaylistSuggestionSource({
+        playlistUuid: 'playlist-1',
+        activatedClimbUuid: activated.climb.uuid,
+        boardKey: 'kilter:1:10:1,2',
+        climbs: [activated.climb, peekClimb],
+      });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(1);
+      expect(snapshots.at(-1)?.playlistSuggestionSource?.climbs).toHaveLength(2);
+    });
+    queueMutations.addQueueItem.mockClear();
+    toast.showToast.mockClear();
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(makeRateLimitedError());
+
+    act(() => {
+      snapshots.at(-1)?.nextClimb();
+    });
+
+    // Swiping past the queue tail commits the peek: nextClimb turns it into a
+    // real queue item and passes shouldAddToQueue: true, so this pointer move
+    // carries a content change just like an activation from search does. It has
+    // to be recovered the same way — the promoted slot exists nowhere but here.
+    await waitFor(() => {
+      expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(1);
+    });
+    const [recoveredItem, recoveredPosition] = queueMutations.addQueueItem.mock.calls[0] as unknown as [
+      ClimbQueueItem,
+      number,
+    ];
+    expect(recoveredItem.climb.uuid).toBe('climb-2');
+    // The synthetic `playlist-peek:` uuid must never reach the wire (#2217's
+    // sibling constraint) — the committed item carries a fresh one.
+    expect(isPlaylistPeekQueueItemUuid(recoveredItem.uuid)).toBe(false);
+    // suggestion-origin is preserved so pruning still treats it as suggested.
+    expect(recoveredItem.suggested).toBe(true);
+    expect(recoveredPosition).toBe(1);
+    expect(snapshots.at(-1)?.state.currentClimbQueueItem?.climb.uuid).toBe('climb-2');
+    expect(queueStateCalls).toBe(0);
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
   });
 
   it('reconciles when the re-sent queue add is throttled too', async () => {

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -1846,6 +1846,9 @@ describe('QueueProvider mutation-failure resync', () => {
     // boulder, and must not fire a query into the limiter that throttled us.
     expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('local-current');
     expect(queueStateCalls).toBe(0);
+    // Recovering the slot doesn't hide the pacing: the climber still gets the
+    // "slow down" toast, just not a queue-refreshed one.
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
   });
 
@@ -1918,6 +1921,14 @@ describe('QueueProvider mutation-failure resync', () => {
     });
     expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
     expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-current']);
+    // Two toasts, deliberately: "slow down" lands immediately on the throttle,
+    // and the refresh notice follows only once reconciliation has actually
+    // replaced the queue. Collapsing them would either delay the pacing hint or
+    // leave the queue silently swapped underneath the climber.
+    expect(toast.showToast.mock.calls.map(([message]) => message)).toEqual([
+      'mobile.queue.rateLimited',
+      'mobile.queue.outOfSyncRefreshed',
+    ]);
   });
 
   it('skips the re-send when the throttled climb left the queue while the mutation was in flight', async () => {

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -2108,6 +2108,58 @@ describe('QueueProvider mutation-failure resync', () => {
     expect(queueStateCalls).toBe(0);
   });
 
+  it('does not undo the re-sent queue add once the climber has left that session', async () => {
+    const snapshots: Snapshot[] = [];
+    const alreadyQueued = makeQueueItem('item-1', 'climb-1');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([alreadyQueued], alreadyQueued), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(makeRateLimitedError());
+    const inFlightAdd = createDeferred<void>();
+    queueMutations.addQueueItem.mockReturnValueOnce(inFlightAdd.promise);
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    act(() => {
+      snapshots.at(-1)?.setQueue([alreadyQueued], alreadyQueued);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(1);
+    });
+    queueMutations.removeQueueItem.mockClear();
+
+    act(() => {
+      snapshots.at(-1)?.setCurrentClimb(makeQueueItem('local-current', 'climb-local-current'));
+    });
+    await waitFor(() => {
+      expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(1);
+    });
+
+    // The climber leaves while the recovery add is still backing off. Ending a
+    // session clears the local queue, so the membership check on its own would
+    // read that as "they dropped the climb" and fire a compensating remove —
+    // against whatever session they are in by then, not the one that got the add.
+    await act(async () => {
+      await snapshots.at(-1)?.endSession();
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBeNull();
+    });
+
+    await act(async () => {
+      inFlightAdd.resolve();
+      await Promise.resolve();
+    });
+
+    expect(queueMutations.removeQueueItem).not.toHaveBeenCalled();
+    expect(queueStateCalls).toBe(0);
+  });
+
   it('toasts "slow down" rather than the generic failure when reorderQueue is rate-limited', async () => {
     const snapshots: Snapshot[] = [];
     const first = makeQueueItem('item-1', 'climb-1');

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -1920,6 +1920,62 @@ describe('QueueProvider mutation-failure resync', () => {
     expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-current']);
   });
 
+  it('skips the re-send when the throttled climb left the queue while the mutation was in flight', async () => {
+    const snapshots: Snapshot[] = [];
+    const alreadyQueued = makeQueueItem('item-1', 'climb-1');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([alreadyQueued], alreadyQueued), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+    // Hold the mutation open so the removal below lands before it settles.
+    const inFlightSetCurrent = createDeferred<void>();
+    // The provider attaches its handler a tick later; keep node from flagging an
+    // unhandled rejection in the meantime.
+    inFlightSetCurrent.promise.catch(() => {});
+    queueMutations.setCurrentClimb.mockReturnValueOnce(inFlightSetCurrent.promise);
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    act(() => {
+      snapshots.at(-1)?.setQueue([alreadyQueued], alreadyQueued);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(1);
+    });
+    queueMutations.addQueueItem.mockClear();
+
+    act(() => {
+      snapshots.at(-1)?.setCurrentClimb(makeQueueItem('local-current', 'climb-local-current'));
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(2);
+    });
+
+    // Climber changes their mind and drops the climb before the throttle lands.
+    act(() => {
+      snapshots.at(-1)?.removeFromQueue('local-current');
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['item-1']);
+    });
+
+    await act(async () => {
+      inFlightSetCurrent.reject(makeRateLimitedError());
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+    });
+    // Recovering the slot now would resurrect a climb the user just deleted.
+    expect(queueMutations.addQueueItem).not.toHaveBeenCalled();
+    expect(queueStateCalls).toBe(0);
+  });
+
   it('toasts "slow down" rather than the generic failure when reorderQueue is rate-limited', async () => {
     const snapshots: Snapshot[] = [];
     const first = makeQueueItem('item-1', 'climb-1');

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -2048,6 +2048,7 @@ describe('QueueProvider mutation-failure resync', () => {
       expect(snapshots.at(-1)?.sessionId).toBeNull();
     });
     toast.showToast.mockClear();
+    queueMutations.addQueueItem.mockClear();
 
     const snapshot = snapshots.at(-1);
     if (!snapshot) throw new Error('queue snapshot was not captured');
@@ -2062,6 +2063,9 @@ describe('QueueProvider mutation-failure resync', () => {
     });
     expect(queueStateCalls).toBe(0);
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+    // Solo has no server to fall behind — the local queue is authoritative, so
+    // there is no lost slot to re-send even though this activation queued one.
+    expect(queueMutations.addQueueItem).not.toHaveBeenCalled();
   });
 
   it('still shows the generic failure when a solo setCurrentClimb fails for any other reason', async () => {

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -1797,6 +1797,129 @@ describe('QueueProvider mutation-failure resync', () => {
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
   });
 
+  it('re-sends the queue add when a rate-limited setCurrentClimb also queued the climb', async () => {
+    const snapshots: Snapshot[] = [];
+    const alreadyQueued = makeQueueItem('item-1', 'climb-1');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([alreadyQueued], alreadyQueued), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    // Seed one queued climb and make it current, so the activation below has a
+    // current climb to slot in behind.
+    act(() => {
+      snapshots.at(-1)?.setQueue([alreadyQueued], alreadyQueued);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(1);
+    });
+    queueMutations.addQueueItem.mockClear();
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(makeRateLimitedError());
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.setCurrentClimb(makeQueueItem('local-current', 'climb-local-current'));
+    });
+
+    // Activating a fresh climb moves the pointer AND adds a queue slot. The
+    // throttled mutation carried both, so the slot has to be re-sent on its own
+    // or it stays in this climber's queue and nobody else's.
+    await waitFor(() => {
+      expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(1);
+    });
+    const [recoveredItem, recoveredPosition] = queueMutations.addQueueItem.mock.calls[0] as unknown as [
+      ClimbQueueItem,
+      number,
+    ];
+    expect(recoveredItem.uuid).toBe('local-current');
+    // Insert-after-current (#2217): index 1, right behind the climb that was
+    // current when the activation landed.
+    expect(recoveredPosition).toBe(1);
+    // Recovering the content must not drag the pointer back to the previous
+    // boulder, and must not fire a query into the limiter that throttled us.
+    expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('local-current');
+    expect(queueStateCalls).toBe(0);
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
+  });
+
+  it('does not re-send a queue add when a rate-limited setCurrentClimb only moved the pointer', async () => {
+    const snapshots: Snapshot[] = [];
+    const first = makeQueueItem('item-1', 'climb-1');
+    const second = makeQueueItem('item-2', 'climb-2');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([first, second], first), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    act(() => {
+      snapshots.at(-1)?.setQueue([first, second], first);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(2);
+    });
+    queueMutations.addQueueItem.mockClear();
+    toast.showToast.mockClear();
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(makeRateLimitedError());
+
+    act(() => {
+      snapshots.at(-1)?.nextClimb();
+    });
+
+    await waitFor(() => {
+      expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+    });
+    // Swiping to the next queued climb changes no content — both slots are
+    // already on the server, so there is nothing to re-send and nothing to
+    // reconcile.
+    expect(queueMutations.addQueueItem).not.toHaveBeenCalled();
+    expect(queueStateCalls).toBe(0);
+    expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('item-2');
+  });
+
+  it('reconciles when the re-sent queue add is throttled too', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverCurrent = makeQueueItem('server-current', 'climb-server-current');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([serverCurrent], serverCurrent), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(makeRateLimitedError());
+    queueMutations.addQueueItem.mockRejectedValueOnce(makeRateLimitedError());
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.setCurrentClimb(makeQueueItem('local-current', 'climb-local-current'));
+    });
+
+    // Both halves failed even with their own back-off budgets, so the climb
+    // really is local-only. A refreshed queue beats a permanently diverged one.
+    await waitFor(() => {
+      expect(queueStateCalls).toBe(1);
+    });
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-current']);
+  });
+
   it('toasts "slow down" rather than the generic failure when reorderQueue is rate-limited', async () => {
     const snapshots: Snapshot[] = [];
     const first = makeQueueItem('item-1', 'climb-1');

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -2171,6 +2171,81 @@ describe('QueueProvider mutation-failure resync', () => {
     expect(queueStateCalls).toBe(0);
   });
 
+  it('does not undo the re-sent queue add into a DIFFERENT session joined mid-flight', async () => {
+    const snapshots: Snapshot[] = [];
+    // Uuids unique to this test: providers rendered by earlier cases in this
+    // file can still land in-flight mutations while this one runs, so identity
+    // beats call counts here.
+    const seeded = makeQueueItem('swap-seed', 'climb-swap-seed');
+    const activated = makeQueueItem('swap-current', 'climb-swap-current');
+    routeHttpRequest(queueStateResponse([seeded], seeded));
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    act(() => {
+      snapshots.at(-1)?.setQueue([seeded], seeded);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(1);
+    });
+
+    // Arm both mocks immediately before the activation so a straggler from an
+    // earlier test can't consume the one-shot deferred ahead of this provider.
+    const inFlightAdd = createDeferred<void>();
+    queueMutations.addQueueItem.mockReturnValueOnce(inFlightAdd.promise);
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(makeRateLimitedError());
+
+    act(() => {
+      snapshots.at(-1)?.setCurrentClimb(activated);
+    });
+    await waitFor(() => {
+      const addedUuids = (queueMutations.addQueueItem.mock.calls as unknown as Array<[ClimbQueueItem, number]>).map(
+        ([item]) => item?.uuid,
+      );
+      expect(addedUuids).toContain('swap-current');
+    });
+
+    // The climber leaves for ANOTHER room while the recovery add is still
+    // backing off. This is the case a presence-only (`!sessionIdRef.current`)
+    // guard misses: the session id is non-null throughout, it just points
+    // somewhere else. session-2 has never held this climb, so the membership
+    // check reads "they dropped it" and the undo would fire REMOVE_QUEUE_ITEM
+    // at a crew that never saw the add.
+    await act(async () => {
+      await snapshots.at(-1)?.joinSession('session-2', {
+        boardPath: '/kilter/1/10/1,2/40/list',
+        userBoard: activeBoard.stored,
+      });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-2');
+    });
+    // The new room's queue lands and does not contain the climb — exactly what
+    // the membership check below would otherwise read as "the climber dropped
+    // it". Without this the old queue lingers, the item is still found, and the
+    // early return happens for the wrong reason.
+    act(() => {
+      snapshots.at(-1)?.setQueue([], null);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(0);
+    });
+
+    await act(async () => {
+      inFlightAdd.resolve();
+      await Promise.resolve();
+    });
+
+    const removedUuids = (queueMutations.removeQueueItem.mock.calls as unknown as Array<[string]>).map(
+      ([uuid]) => uuid,
+    );
+    expect(removedUuids).not.toContain('swap-current');
+  });
+
   it('toasts "slow down" rather than the generic failure when reorderQueue is rate-limited', async () => {
     const snapshots: Snapshot[] = [];
     const first = makeQueueItem('item-1', 'climb-1');

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -1987,6 +1987,64 @@ describe('QueueProvider mutation-failure resync', () => {
     expect(queueStateCalls).toBe(0);
   });
 
+  it('undoes the re-sent queue add when the climb is removed while that add is in flight', async () => {
+    const snapshots: Snapshot[] = [];
+    const alreadyQueued = makeQueueItem('item-1', 'climb-1');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([alreadyQueued], alreadyQueued), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(makeRateLimitedError());
+    // Hold the recovery add open — this is the rate-limit back-off window where
+    // `execute` can sit for seconds before the add actually lands.
+    const inFlightAdd = createDeferred<void>();
+    queueMutations.addQueueItem.mockReturnValueOnce(inFlightAdd.promise);
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    act(() => {
+      snapshots.at(-1)?.setQueue([alreadyQueued], alreadyQueued);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(1);
+    });
+    queueMutations.removeQueueItem.mockClear();
+
+    act(() => {
+      snapshots.at(-1)?.setCurrentClimb(makeQueueItem('local-current', 'climb-local-current'));
+    });
+    await waitFor(() => {
+      expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(1);
+    });
+
+    // Climber drops the climb while the recovery add is still backing off, so
+    // their remove reaches the server first.
+    act(() => {
+      snapshots.at(-1)?.removeFromQueue('local-current');
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['item-1']);
+    });
+    expect(queueMutations.removeQueueItem).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      inFlightAdd.resolve();
+      await Promise.resolve();
+    });
+
+    // The add landed after the remove, so it put the climb back on every peer's
+    // queue. Undo it instead of leaving a climb nobody asked for.
+    await waitFor(() => {
+      expect(queueMutations.removeQueueItem).toHaveBeenCalledTimes(2);
+    });
+    expect(queueMutations.removeQueueItem.mock.calls.at(-1)).toEqual(['local-current']);
+    expect(queueStateCalls).toBe(0);
+  });
+
   it('toasts "slow down" rather than the generic failure when reorderQueue is rate-limited', async () => {
     const snapshots: Snapshot[] = [];
     const first = makeQueueItem('item-1', 'climb-1');

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -1989,16 +1989,16 @@ describe('QueueProvider mutation-failure resync', () => {
     // replaced the queue. Collapsing them would either delay the pacing hint or
     // leave the queue silently swapped underneath the climber.
     //
-    // What this assertion actually guarantees: exactly these two toasts fire and
-    // nothing else. Deleting either one turns it red, so neither can regress.
+    // What this assertion guarantees: the toast identities, the count, and the
+    // observed order. Break any of the three and it goes red.
     //
-    // What it does NOT firmly guarantee, despite reading like it does: the
-    // ORDER. That holds only because the fallback resync awaits an HTTP
-    // round-trip, so anything toasted synchronously from dispatchSetCurrent's
-    // catch necessarily lands first. Rewriting the catch to toast from a .then()
-    // AFTER the recovery still passes this assertion. If reconciliation ever
-    // becomes synchronous, pin the order with explicit call-index assertions
-    // rather than trusting this one.
+    // What it does NOT pin is WHERE the first toast is emitted from. Rewriting
+    // dispatchSetCurrent's catch to toast from a .then() after the recovery
+    // still passes, because the competing toast sits behind the fallback
+    // resync's un-awaited HTTP round-trip and lands second either way. So the
+    // order here is real but structurally incidental — it falls out of the
+    // async shape rather than being enforced. If reconciliation ever becomes
+    // synchronous, re-derive this rather than assuming it still holds.
     expect(toast.showToast.mock.calls.map(([message]) => message)).toEqual([
       'mobile.queue.rateLimited',
       'mobile.queue.outOfSyncRefreshed',

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -1988,6 +1988,17 @@ describe('QueueProvider mutation-failure resync', () => {
     // and the refresh notice follows only once reconciliation has actually
     // replaced the queue. Collapsing them would either delay the pacing hint or
     // leave the queue silently swapped underneath the climber.
+    //
+    // What this assertion actually guarantees: exactly these two toasts fire and
+    // nothing else. Deleting either one turns it red, so neither can regress.
+    //
+    // What it does NOT firmly guarantee, despite reading like it does: the
+    // ORDER. That holds only because the fallback resync awaits an HTTP
+    // round-trip, so anything toasted synchronously from dispatchSetCurrent's
+    // catch necessarily lands first. Rewriting the catch to toast from a .then()
+    // AFTER the recovery still passes this assertion. If reconciliation ever
+    // becomes synchronous, pin the order with explicit call-index assertions
+    // rather than trusting this one.
     expect(toast.showToast.mock.calls.map(([message]) => message)).toEqual([
       'mobile.queue.rateLimited',
       'mobile.queue.outOfSyncRefreshed',

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -891,7 +891,13 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // reaches the crew without the yank-back a resync would cause (#2763).
   const recoverThrottledQueueAdd = useCallback(
     async (item: ClimbQueueItem) => {
-      if (!sessionIdRef.current) return;
+      // Capture the session this slot belongs to. Every leg below runs after an
+      // await, and the undo leg in particular can wake up in a DIFFERENT session
+      // (the climber ended this one and joined another while the add was backing
+      // off) — a remove aimed at that session is aimed at the wrong crew's queue.
+      // Same discipline the coalescer applies to its own deferred sends.
+      const recoverySessionId = sessionIdRef.current;
+      if (!recoverySessionId) return;
       // Position the re-send where the optimistic insert actually landed
       // (insert-after-current, #2217) so peers see the same order we do. The
       // server clamps an out-of-range position to an append.
@@ -914,7 +920,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // climber dropped the climb inside that window their remove raced ahead
       // of this add, so the slot we just landed is back on the whole crew's
       // queue. The local queue is the record of intent — undo it rather than
-      // leave a climb nobody asked for.
+      // leave a climb nobody asked for. Only while we're still in the session
+      // the add went to: after a session swap the local queue describes the new
+      // room, and its lack of this item says nothing about the old one.
+      if (sessionIdRef.current !== recoverySessionId) return;
       if (stateRef.current.queue.some((queueItem) => queueItem.uuid === item.uuid)) return;
       mutations.removeQueueItem(item.uuid).catch((error) => {
         if (__DEV__) console.warn('[queue] undoing a resurrected queue-add failed', error);

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -908,7 +908,18 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         // every other content mutation uses — a refreshed queue beats one
         // that's permanently local-only.
         void resyncQueueAfterMutationFailure();
+        return;
       }
+      // The add can sit in `execute`'s rate-limit back-off for seconds. If the
+      // climber dropped the climb inside that window their remove raced ahead
+      // of this add, so the slot we just landed is back on the whole crew's
+      // queue. The local queue is the record of intent — undo it rather than
+      // leave a climb nobody asked for.
+      if (stateRef.current.queue.some((queueItem) => queueItem.uuid === item.uuid)) return;
+      mutations.removeQueueItem(item.uuid).catch((error) => {
+        if (__DEV__) console.warn('[queue] undoing a resurrected queue-add failed', error);
+        void resyncQueueAfterMutationFailure();
+      });
     },
     [mutations, resyncQueueAfterMutationFailure],
   );

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -676,8 +676,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // and absent from your crew's — permanently and silently. `setCurrentClimb`
   // deliberately does NOT resync when throttled: it moves a pointer that
   // self-heals on the next activation or peer broadcast, so reconciling there
-  // only yanked the climber off the boulder they just picked. `reorderQueue`
-  // never reaches this path at all — it rolls back locally instead.
+  // only yanked the climber off the boulder they just picked. When that
+  // throttled call also carried a queue-add it recovers the content half
+  // through recoverThrottledQueueAdd below — and falls back here if even that
+  // re-send fails. `reorderQueue` never reaches this path at all — it rolls
+  // back locally instead.
   const resyncQueueAfterMutationFailure = useCallback(async () => {
     if (!sessionIdRef.current) return;
     const refreshed = await resyncQueueFromServerRef.current();
@@ -877,6 +880,39 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     [setQueue],
   );
 
+  // A throttled setCurrentClimb that carried `shouldAddToQueue` lost two
+  // changes, not one. The pointer move self-heals (the next activation or any
+  // peer broadcast re-establishes it), but the brand-new queue slot the reducer
+  // optimistically inserted does not: no later activation retroactively adds
+  // the skipped item, so it would sit in this climber's queue and nobody
+  // else's, forever. Re-send just the content half as its own ADD_QUEUE_ITEM —
+  // `execute` gives it a fresh rate-limit back-off budget, the server's add is
+  // idempotent by uuid, and it leaves the current pointer alone, so the climb
+  // reaches the crew without the yank-back a resync would cause (#2763).
+  const recoverThrottledQueueAdd = useCallback(
+    async (item: ClimbQueueItem) => {
+      if (!sessionIdRef.current) return;
+      // Position the re-send where the optimistic insert actually landed
+      // (insert-after-current, #2217) so peers see the same order we do. The
+      // server clamps an out-of-range position to an append.
+      const position = stateRef.current.queue.findIndex((queueItem) => queueItem.uuid === item.uuid);
+      // Already gone locally — removed, cleared, or replaced by a server sync
+      // while the throttled mutation was in flight. Don't resurrect it.
+      if (position === -1) return;
+      try {
+        await mutations.addQueueItem(item, position);
+      } catch (error) {
+        if (__DEV__) console.warn('[queue] throttled setCurrentClimb queue-add recovery failed', error);
+        // The slot never reached the server even with its own retry budget, so
+        // this client really has diverged. Fall back to the same reconciliation
+        // every other content mutation uses — a refreshed queue beats one
+        // that's permanently local-only.
+        void resyncQueueAfterMutationFailure();
+      }
+    },
+    [mutations, resyncQueueAfterMutationFailure],
+  );
+
   // Optimistic local dispatch + correlated SET_CURRENT_CLIMB mutation. The
   // reducer stores `correlationId` in pendingCurrentClimbUpdates so the echoed
   // CurrentClimbChanged event (same id in `serverCorrelationId`) is suppressed
@@ -924,26 +960,34 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       pendingUnsyncedCurrentRef.current = null;
       coordinator.trackPendingMutation(correlationId);
       mutations.setCurrentClimb(item, shouldAddToQueue, correlationId).catch((error: unknown) => {
-        // A throttled current-climb change is not a divergence: the rate-limit
-        // gate throws before the resolver runs, so the server still holds the
-        // climb it held a moment ago and the next activation (or any peer's
+        // A throttled POINTER move is not a divergence: the rate-limit gate
+        // throws before the resolver runs, so the server still holds the climb
+        // it held a moment ago and the next activation (or any peer's
         // broadcast) re-establishes it. Resyncing here would yank the user back
         // to the previous boulder mid-swipe and fire another query into the
         // limiter that just throttled us — which is what #2763 was reported as
         // ("the connection fails every time we try to switch boulders"). Show
         // the gentle "slow down" toast instead and leave the local pointer put.
-        if (sessionIdRef.current && !isRateLimitedError(error)) {
+        const throttled = isRateLimitedError(error);
+        if (sessionIdRef.current && !throttled) {
           // Any other party-session failure means peers really did diverge —
           // reconcile against the server (and toast that we refreshed).
           void resyncQueueAfterMutationFailure();
-        } else {
-          // Solo (no server to reconcile) and the rate-limited party case both
-          // land here: toast only, no resync.
-          showQueueMutationErrorToast(error, t, showToast);
+          return;
         }
+        // Throttled while ALSO adding a fresh climb to the queue: the pointer
+        // half self-heals, the new slot doesn't. Re-send it on its own so the
+        // content change isn't stranded locally (solo no-ops — its queue is
+        // authoritative and there's no server to fall behind).
+        if (throttled && shouldAddToQueue) {
+          void recoverThrottledQueueAdd(item);
+        }
+        // Solo (no server to reconcile) and the rate-limited party case both
+        // land here: toast only, no resync.
+        showQueueMutationErrorToast(error, t, showToast);
       });
     },
-    [coordinator, mutations, resyncQueueAfterMutationFailure, showToast, t],
+    [coordinator, mutations, recoverThrottledQueueAdd, resyncQueueAfterMutationFailure, showToast, t],
   );
 
   // Re-broadcast the current climb once a deferred thin item hydrates (#3868).


### PR DESCRIPTION
## Summary

Follow-up to #2791. That PR stopped resyncing the queue when a `setCurrentClimb` mutation comes back rate-limited — correct for the pointer, which self-heals on the next activation or any peer broadcast, and resyncing was what made #2763 read as "the connection fails every time we try to switch boulders".

But activating a fresh climb from search, detail, or a playlist calls `setCurrentClimb(item, /* shouldAddToQueue */ true, …)`, so the optimistic reducer does two things: it moves the pointer **and** inserts a brand-new queue slot. Both ride on the one mutation. When that mutation was throttled we skipped rollback, retry, and resync for both halves — so the pointer healed and the slot didn't. No later activation retroactively adds the omitted item, so the climb sat in that climber's queue and nobody else's, permanently and silently.

Now only the pointer half is treated as self-healing. A throttled activation that carried a queue-add re-sends just the content half as its own `ADD_QUEUE_ITEM`, positioned where the optimistic insert actually landed (insert-after-current, #2217):

- `execute` gives the re-send a fresh rate-limit back-off budget, so it goes out after the window that throttled the original.
- The server's `addQueueItem` is idempotent by uuid and clamps an out-of-range position to an append, so a re-send is safe even if state moved on.
- The current pointer is untouched, so the crew gets the climb without the yank-back a resync would cause.
- If the item is already gone locally (removed, cleared, or replaced by a server sync while the throttled mutation was in flight) the re-send is skipped rather than resurrecting it.
- If the climber's remove lands *during* the re-send's back-off window, the add resurrects a slot they just dropped — so the recovery undoes itself with a `removeQueueItem` rather than leaving the crew a climb nobody asked for.
- The undo is pinned to the session that got the add. Ending a session clears the local queue, so the membership check on its own would read that as "they dropped it" and fire a remove at whatever room the climber joined next.
- If the re-send fails too, we fall back to the same reconciliation every other content mutation (`addToQueue` / `removeFromQueue` / `setQueue` / `clearQueue`) already uses — a refreshed queue beats a permanently local-only one.
- Solo is a no-op: with no session there's no server to fall behind, and the local queue is already authoritative.

## ⚠️ This does not make throttled queue-adds reliable — one path is still dropped

**Read this before treating the bug as closed.** The `setCurrentClimb` coalescer has three exit paths and this PR fixes one of them:

| Path | Covered here? |
| --- | --- |
| The call that **starts** a burst — rejection propagates out of `enqueue` to the caller's `.catch` (`set-current-climb-coalescer.ts:107`) | ✅ fixed by this PR |
| A call **superseded** while pending — `sendSupersededQueueAdd` fires its add separately (`:93-102`) | ⚠️ already worked, but appends instead of inserting after current — see #3936 |
| The **final pending call**, drained in the `finally` (`:113-119`) | ❌ **still dropped** |

That third row is the one to keep in mind. It is never superseded, so `sendSupersededQueueAdd` doesn't cover it, and its rejection goes to `onDrainError` (`:116-118`) which `create-queue-mutations.ts:235` maps to the dev-log-only `onBestEffortError`. Its queue-add is lost exactly as before. And it is the *last* activation of a rapid burst — the one most likely to be throttled, in the very scenario this PR targets.

It is not fixed here because `onDrainError` is `(error: unknown) => void`: it carries no `item` and no `shouldAddToQueue`, so there is no honest mobile-local wiring that could call `recoverThrottledQueueAdd(item)` from it. The fix belongs inside the shared coalescer — web goes through the same `createQueueMutations` and has the identical hole — which makes it a shared-package API decision rather than something to bolt onto a mobile bug fix.

**Tracked in #3936**, along with the superseded-add positioning bug in the middle row. This PR is a strict improvement on `main` with no regression on the paths it doesn't fix.

**Which calls carry a queue-add.** Two paths reach the recovery, and both genuinely create content:

- `setCurrentClimb` (search / detail / playlist activation), which hardcodes `shouldAddToQueue: true`.
- `nextClimb`'s **playlist-peek promotion** — swiping past the queue tail commits the transient `playlist-peek:<uuid>` item as a real queue slot with a fresh uuid, so it passes `shouldAddToQueue: true` too. An earlier draft of this description claimed `nextClimb` was always pointer-only; that was wrong about the code, not a bug in it. The peek branch has to recover, because the promoted slot exists nowhere but on this device.

The genuinely pointer-only calls — `nextClimb`'s in-queue branch, `previousClimb`, and the #3868 re-broadcast — pass `shouldAddToQueue: false` and still skip both resync and re-send: nothing about the queue's content changed, so there's nothing to recover.

Two deliberate choices worth flagging for review:

- **The position is read at recovery time, not captured at dispatch time.** If the queue was reordered while the throttled mutation was in flight, the current local index is where the item actually sits for this climber, which is what peers should match. The same read powers the already-removed guard.
- **The double-throttle path shows two toasts.** "Slow down" lands immediately on the throttle; the queue-refreshed notice follows only once reconciliation has actually swapped the queue. Collapsing them would either delay the pacing hint or change the queue underneath the climber without saying so.

## Relationship to #3929 — `Refs #3929`, does not close it

This branch was opened against #3929 but **does not fix it**, so there is no closing keyword and #3929 must stay open after merge.

#3929 is scoped to the four queue-*content* mutations — `addToQueue` (`queue-provider.tsx:729`), `removeFromQueue` (`:763`), `clearQueue` (`:815`), `setQueue` (`:838`) — each of which calls `resyncQueueAfterMutationFailure()` on any error including a rate limit, and can then go silent. This PR touches none of those four call sites, and `resyncQueueAfterMutationFailure` itself is unchanged apart from its comment. What it fixes is the adjacent `setCurrentClimb` case #2791 left behind.

One correction for whoever picks #3929 up, since it changes the fix: **#3929's stated root cause is wrong.** It claims the resync refetch "is then likely to be throttled itself". It isn't. `applyRateLimit` appears only in mutation resolvers; `packages/backend/src/graphql/resolvers/sessions/queries.ts` contains zero `applyRateLimit` calls, and the resync is the `session` HTTP *query* (`GET_SESSION_QUEUE_STATE`). The refetch is never rate-limited, so a second backoff layer on it would fix nothing. Full analysis with the five real falsy-return branches is [commented on #3929](https://github.com/boardsesh/boardsesh/issues/3929#issuecomment-5081131224).

## Release Notes

- Pick a climb while the wall is busy and it now reaches your crew's queue instead of only yours. Rattle off a fast burst of picks and the last one can still go missing — that half is tracked in #3936.
- Swipe onto the next playlist climb during a throttled session and the crew gets it too, not just you.
- Drop a climb right after picking it and it stays dropped — no phantom re-add landing on everyone's queue seconds later.

## Test plan

- `vp run test:mobile` — 4511 tests, 544 files, all passing.
- `vp run typecheck:mobile` — clean.
- `vp check` — exits 0 (0 errors; the 269 warnings are pre-existing repo-wide, none in the two files this branch touches).

Eight cases in `queue-provider-session-updates.test.tsx`, each mutation-tested by breaking the code it covers and confirming it goes red:

| Test | Guard it pins | Mutation applied | Result |
| --- | --- | --- | --- |
| Rate-limited activation re-sends the add at the right item + position, keeps the pointer, fires no refetch, still toasts "slow down" | the recovery itself, and insert-after-current positioning | `addQueueItem(item, position)` → `addQueueItem(item, 0)` | red (with the peek test) |
| Rate-limited pointer-only `nextClimb` sends no add and triggers no resync | the `shouldAddToQueue` gate on the in-queue branch | — (negative case) | green throughout |
| Rate-limited `nextClimb` **playlist-peek promotion** re-sends the add, with a non-peek uuid and `suggested: true` preserved | `dispatchSetCurrent(realItem, true)` on the peek-commit branch | flip that `true` → `false` | red, and **only** this test — the branch was previously unpinned |
| Doubly-throttled re-send reconciles once and shows exactly "slow down" then "queue refreshed" | the fallback resync, and the two-toast set | delete `void resyncQueueAfterMutationFailure()` from the recovery catch | red |
| Climb removed while the setCurrentClimb was in flight → re-send skipped | the `position === -1` early return | delete `if (position === -1) return;` | red |
| Climb removed while the *re-send* was in flight → the add is undone | the post-add membership re-check + `removeQueueItem` | delete the undo block | red |
| Session **ended** while the *re-send* was in flight → no undo fires | the undo leg's session guard | delete `if (sessionIdRef.current !== recoverySessionId) return;` | red |
| Session **swapped** to a different room mid-back-off → no undo fires | that the guard checks session *identity*, not mere presence | weaken it to `if (!sessionIdRef.current) return;` | red |

Dropping the `showQueueMutationErrorToast` call on the recovery path turns six of these red, so the "slow down" toast can't silently regress either.

**One honest caveat on the toast test.** It asserts the exact call list, so it pins the toast identities, the count, and the observed order — break any of those and it goes red. What it does *not* pin is **where in the code the first toast is emitted**: rewriting the catch to toast from a `.then()` after the recovery still passes, because the competing toast sits behind an un-awaited HTTP round-trip and therefore always lands second regardless. So the ordering is real but structurally incidental rather than enforced. Recorded in a comment at the assertion so nobody reads more into it than it checks.

*(An earlier revision of this description overstated that caveat in the other direction — claiming a synchronous-reconciliation refactor could flip the order without failing the test. It would fail it. The accurate statement is the one above.)*

## Device QA — still outstanding, and a merge gate

**Not run.** All seven tests drive the limiter through mocked rejections, so **none of them verify real limiter timing** — please don't read the table above as timing verification.

Two phones on the `pr-3934` OTA channel in one party session: rapid-fire activations from search until "Too many changes too fast" appears, then confirm on the **peer** that the climb landed exactly once, sits immediately after the current climb, and neither phone's pointer yanked back to the previous boulder. Also worth watching for the #3936 tail: the very last pick of a burst may not reach the peer, which is expected on this branch.

## CI note

If you see iOS CI `gate` flip red-then-green in the history, it isn't a code signal. Two runs fire for the same SHA (`push` and `pull_request`) into the concurrency group `ios-rn-ci-${{ github.ref }}` with `cancel-in-progress: true`, so the marginally older `push` twin gets cancelled by its `pull_request` sibling. The failing job showed 21 minutes elapsed, **zero steps executed, and no runner assigned** — it never started. The `pull_request` run for the same commit passed; a re-run of the cancelled twin also passed. Known-shaped infra race in this repo, no re-litigation needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL)_
