### PR TITLE
fix(mobile): log a first-go redpoint as one try, not two

### DIFF
--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -10,8 +10,8 @@ import { useTranslation } from 'react-i18next';
 import {
   createInitialTickState,
   deriveAscentType,
-  getMinAttempts,
   clampAttempts,
+  MIN_ATTEMPT_COUNT,
   type TickStatus,
 } from '@boardsesh/play-view';
 import { Text } from '../Text';
@@ -173,8 +173,12 @@ export const QuickTickBar = React.memo(function QuickTickBar({
     return grades.find((grade) => grade.difficultyId === tickState.difficulty)?.name;
   }, [tickState.difficulty, grades]);
 
+  // The ascent TYPE reacts to the tries count (1 try on a climb you've never
+  // touched is a flash), but the tries COUNT never reacts back — the picker
+  // floors at MIN_ATTEMPT_COUNT for every status, which is the same floor
+  // clampAttempts applies on save. That one-way dependency is what keeps the
+  // displayed number and the saved number identical (#2888).
   const ascentType = deriveAscentType(hasPriorHistory, tickState.attemptCount);
-  const minAttempts = useMemo(() => getMinAttempts(ascentType), [ascentType]);
 
   // Keep the dismiss-analytics snapshot current so LogAscentSheet can read
   // field-completeness at close time — its X-button/pan-down paths never
@@ -239,6 +243,10 @@ export const QuickTickBar = React.memo(function QuickTickBar({
       track(SHARED_EVENTS.TickButtonClicked, { climbUuid, layoutId: layoutId ?? null });
       setLastError(null);
 
+      // Defence in depth against the server's flash-is-one-try rule, not a
+      // second opinion on what the climber picked: for every value the picker
+      // can show and every status these buttons can produce, this is a no-op.
+      // The shared quick-tick-state test pins that.
       const finalAttempts = clampAttempts(tickState.attemptCount, status);
 
       saveTick.mutate(
@@ -368,7 +376,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
         <View style={styles.rowPicker}>
           <InlineTriesPicker
             attemptCount={tickState.attemptCount}
-            minAttempts={minAttempts}
+            minAttempts={MIN_ATTEMPT_COUNT}
             onSelect={handleTriesSelect}
           />
         </View>

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -173,11 +173,8 @@ export const QuickTickBar = React.memo(function QuickTickBar({
     return grades.find((grade) => grade.difficultyId === tickState.difficulty)?.name;
   }, [tickState.difficulty, grades]);
 
-  // The ascent TYPE reacts to the tries count (1 try on a climb you've never
-  // touched is a flash), but the tries COUNT never reacts back — the picker
-  // floors at MIN_ATTEMPT_COUNT for every status, which is the same floor
-  // clampAttempts applies on save. That one-way dependency is what keeps the
-  // displayed number and the saved number identical (#2888).
+  // Type follows the count, never the reverse — the picker floors at MIN_ATTEMPT_COUNT
+  // for every status, so what it shows and what gets saved can't drift (#2888).
   const ascentType = deriveAscentType(hasPriorHistory, tickState.attemptCount);
 
   // Keep the dismiss-analytics snapshot current so LogAscentSheet can read
@@ -243,10 +240,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
       track(SHARED_EVENTS.TickButtonClicked, { climbUuid, layoutId: layoutId ?? null });
       setLastError(null);
 
-      // Defence in depth against the server's flash-is-one-try rule, not a
-      // second opinion on what the climber picked: for every value the picker
-      // can show and every status these buttons can produce, this is a no-op.
-      // The shared quick-tick-state test pins that.
+      // Mirrors the server's flash-is-one-try rule; a no-op for every value the picker can show.
       const finalAttempts = clampAttempts(tickState.attemptCount, status);
 
       saveTick.mutate(

--- a/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
@@ -56,7 +56,36 @@ vi.mock('../../Text', () => ({
 }));
 vi.mock('../../Icon', () => ({ Icon: () => createElement('span') }));
 vi.mock('../InlineStarPicker', () => ({ InlineStarPicker: () => null }));
-vi.mock('../InlineTriesPicker', () => ({ InlineTriesPicker: () => null }));
+// Stub InlineTriesPicker as a faithful miniature of the real one: it RENDERS
+// the count it was handed and applies the same `minAttempts` floor on
+// decrement. That makes the displayed number readable from the DOM, so the
+// tries tests can assert "what the picker showed is what got saved" without
+// hardcoding the expected number on the save side (issue #2888).
+vi.mock('../InlineTriesPicker', () => ({
+  InlineTriesPicker: ({
+    attemptCount,
+    minAttempts = 1,
+    onSelect,
+  }: {
+    attemptCount: number;
+    minAttempts?: number;
+    onSelect: (value: number) => void;
+  }) =>
+    createElement(
+      'div',
+      null,
+      createElement('button', {
+        'data-testid': 'tries-decrement',
+        disabled: attemptCount <= minAttempts,
+        onClick: () => onSelect(Math.max(minAttempts, attemptCount - 1)),
+      }),
+      createElement('span', { 'data-testid': 'tries-value' }, String(attemptCount)),
+      createElement('button', {
+        'data-testid': 'tries-increment',
+        onClick: () => onSelect(attemptCount + 1),
+      }),
+    ),
+}));
 // Stub GradeSingleSelectRail: clicking the rail always selects the first
 // loaded grade, so a test can drive grade selection without the real chip UI.
 vi.mock('../../grade', () => ({
@@ -144,6 +173,30 @@ function renderBar(overrides: Partial<QuickTickBarProps> = {}) {
       ...overrides,
     }),
   );
+}
+
+/** The number the tries picker is currently showing the climber. */
+function displayedTries(container: HTMLElement): number {
+  return Number(container.querySelector('[data-testid="tries-value"]')?.textContent);
+}
+
+function buttonWithText(container: HTMLElement, text: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll('button')).find((node) => node.textContent === text);
+}
+
+/** Board fixture with a mounted provider and NO history for this climb+angle. */
+function boardWithoutHistory() {
+  return { logbook: [], logbookByClimbAngle: new Map<string, LogbookEntry[]>(), getLogbook: vi.fn() };
+}
+
+/** Board fixture with a mounted provider and one prior tick for this climb+angle. */
+function boardWithHistory() {
+  const tick = { climb_uuid: CLIMB_UUID, angle: ANGLE } as unknown as LogbookEntry;
+  return {
+    logbook: [tick],
+    logbookByClimbAngle: new Map<string, LogbookEntry[]>([[logbookClimbAngleKey(CLIMB_UUID, ANGLE), [tick]]]),
+    getLogbook: vi.fn(),
+  };
 }
 
 beforeEach(() => {
@@ -319,5 +372,120 @@ describe('QuickTickBar analytics', () => {
       SHARED_EVENTS.TickLogged,
       expect.objectContaining({ climbUuid: CLIMB_UUID, platform: 'mobile', surface: 'mobile_quick_tick' }),
     );
+  });
+});
+
+// Issue #2888. The tries picker and the save path must always agree: the
+// number the climber can see is the number that reaches their logbook. These
+// assert the SAVED value against the value read back out of the picker, never
+// against a literal, so they stay honest if the form's defaults move.
+describe('QuickTickBar tries count', () => {
+  it('saves the single try it is showing when a redpoint goes first go this session', () => {
+    boardState.current = boardWithHistory();
+    const { container } = renderBar();
+
+    // Prior history, untouched picker: one try, and the button offers a Send
+    // (not a Flash) because the climber has been on this climb before.
+    const shownTries = displayedTries(container);
+    expect(shownTries).toBe(1);
+    const sendButton = buttonWithText(container, 'playView.tickBar.sendSaveLabel');
+    expect(sendButton).toBeTruthy();
+
+    fireEvent.click(sendButton as Element);
+
+    // Read the shown count BEFORE the click — a successful save resets the
+    // form, so the picker is back at its default by the time this runs.
+    expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({
+      status: 'send',
+      attemptCount: shownTries,
+    });
+    // The try the climber never made. Before the fix this stored 2.
+    expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({ attemptCount: 1 });
+  });
+
+  it('reports the shown count to analytics, not a rewritten one', () => {
+    boardState.current = boardWithHistory();
+    const { container } = renderBar();
+
+    fireEvent.click(buttonWithText(container, 'playView.tickBar.sendSaveLabel') as Element);
+
+    expect(track).toHaveBeenCalledWith(
+      SHARED_EVENTS.QuickTickSaved,
+      expect.objectContaining({ status: 'send', attemptCount: 1 }),
+    );
+  });
+
+  it('keeps the Send label while saving one try — the label and the count are independent', () => {
+    // Guards the other half of the fix: dropping the floor must not turn a
+    // repeat ascent into a Flash. Prior history means Send at any count.
+    boardState.current = boardWithHistory();
+    const { container } = renderBar();
+
+    expect(buttonWithText(container, 'playView.tickBar.flashSaveLabel')).toBeUndefined();
+    fireEvent.click(buttonWithText(container, 'playView.tickBar.sendSaveLabel') as Element);
+
+    expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({ status: 'send', attemptCount: 1 });
+  });
+
+  it('makes the first plus press change what gets stored', () => {
+    // Before the fix, 1 and 2 both saved as 2, so the first press of + moved
+    // the display and nothing else. (2 saving as 2 passes either way — this
+    // earns its keep next to the one-try test above, not on its own.)
+    boardState.current = boardWithHistory();
+    const { container, getByTestId } = renderBar();
+
+    fireEvent.click(getByTestId('tries-increment'));
+    const shownTries = displayedTries(container);
+    expect(shownTries).toBe(2);
+
+    fireEvent.click(buttonWithText(container, 'playView.tickBar.sendSaveLabel') as Element);
+
+    expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({ attemptCount: shownTries });
+  });
+
+  it('saves the shown count when the climber logs an attempt instead of an ascent', () => {
+    boardState.current = boardWithHistory();
+    const { container, getByTestId } = renderBar();
+
+    fireEvent.click(getByTestId('tries-increment'));
+    fireEvent.click(getByTestId('tries-increment'));
+    const shownTries = displayedTries(container);
+    expect(shownTries).toBe(3);
+
+    fireEvent.click(buttonWithText(container, 'mobile.logAscent.attempt') as Element);
+
+    expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({
+      status: 'attempt',
+      attemptCount: shownTries,
+    });
+  });
+
+  it('lets a climber walk back up to Flash after over-counting their tries', () => {
+    // The old floor made Send a one-way door: bump a first-ever go to 2 tries
+    // and the minus button locked at 2, so an accidental tap cost you the
+    // flash. The round trip is safe because the button label follows the count
+    // in view — the climber sees it go Flash → Send → Flash.
+    boardState.current = boardWithoutHistory();
+    const { container, getByTestId } = renderBar();
+
+    expect(displayedTries(container)).toBe(1);
+    expect(buttonWithText(container, 'playView.tickBar.flashSaveLabel')).toBeTruthy();
+
+    fireEvent.click(getByTestId('tries-increment'));
+    expect(displayedTries(container)).toBe(2);
+    expect(buttonWithText(container, 'playView.tickBar.sendSaveLabel')).toBeTruthy();
+    expect(buttonWithText(container, 'playView.tickBar.flashSaveLabel')).toBeUndefined();
+
+    // The floor the old code raised to 2 the moment the label flipped to Send,
+    // which greyed this button out and stranded the climber on "Send".
+    expect((getByTestId('tries-decrement') as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(getByTestId('tries-decrement'));
+
+    expect(displayedTries(container)).toBe(1);
+    const flashButton = buttonWithText(container, 'playView.tickBar.flashSaveLabel');
+    expect(flashButton).toBeTruthy();
+
+    fireEvent.click(flashButton as Element);
+    expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({ status: 'flash', attemptCount: 1 });
   });
 });

--- a/packages/shared/play-view/src/__tests__/quick-tick-state.test.ts
+++ b/packages/shared/play-view/src/__tests__/quick-tick-state.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import type { TickStatus } from '@boardsesh/shared-schema';
+import { clampAttempts, createInitialTickState, deriveAscentType, MIN_ATTEMPT_COUNT } from '../quick-tick-state';
+
+// Highest tries value worth walking in the loops below. The picker's plus
+// button is unbounded, so this is a sample, not a limit.
+const SAMPLED_TRIES = [1, 2, 3, 4, 5, 8, 12, 99];
+
+describe('deriveAscentType', () => {
+  it('is a flash only on a first-ever go', () => {
+    expect(deriveAscentType(false, 1)).toBe('flash');
+  });
+
+  it('is a send once the climber has touched the climb before, even first go this session', () => {
+    expect(deriveAscentType(true, 1)).toBe('send');
+  });
+
+  it('is a send once it took more than one go, with no prior history', () => {
+    expect(deriveAscentType(false, 2)).toBe('send');
+  });
+});
+
+describe('clampAttempts', () => {
+  it('lets a redpoint that went first go this session stay at one try', () => {
+    // The regression this file exists for: this returned 2 while the picker
+    // showed 1, so every send of a climb the climber had touched before was
+    // written to the logbook with a try they never made. Issue #2888.
+    expect(clampAttempts(1, 'send')).toBe(1);
+  });
+
+  it('pins a flash to exactly one try, matching the server refine', () => {
+    expect(clampAttempts(4, 'flash')).toBe(1);
+  });
+
+  it('floors a missing or nonsense count at one try', () => {
+    expect(clampAttempts(0, 'send')).toBe(MIN_ATTEMPT_COUNT);
+    expect(clampAttempts(-3, 'attempt')).toBe(MIN_ATTEMPT_COUNT);
+  });
+
+  it('leaves a real multi-go count alone', () => {
+    expect(clampAttempts(7, 'send')).toBe(7);
+    expect(clampAttempts(7, 'attempt')).toBe(7);
+  });
+});
+
+// The contract that makes the bug structurally impossible rather than merely
+// fixed. It is stated against clampAttempts + deriveAscentType alone, with no
+// reference to any component, so it holds for whatever tries picker ships next:
+// a picker that floors at MIN_ATTEMPT_COUNT can never display a number the save
+// path would rewrite. Reintroducing a status-dependent floor above 1 fails here
+// before it can reach a logbook.
+describe('displayed tries === saved tries', () => {
+  it('never rewrites a value the picker can show, for any ascent-button status', () => {
+    for (const hasPriorHistory of [false, true]) {
+      for (const displayedTries of SAMPLED_TRIES) {
+        const status = deriveAscentType(hasPriorHistory, displayedTries);
+        expect({ hasPriorHistory, displayedTries, saved: clampAttempts(displayedTries, status) }).toEqual({
+          hasPriorHistory,
+          displayedTries,
+          saved: displayedTries,
+        });
+      }
+    }
+  });
+
+  it('never rewrites a value the picker can show when the climber logs an attempt instead', () => {
+    for (const displayedTries of SAMPLED_TRIES) {
+      expect(clampAttempts(displayedTries, 'attempt')).toBe(displayedTries);
+    }
+  });
+
+  it('opens the form on a value the save path agrees with', () => {
+    const { attemptCount } = createInitialTickState();
+    expect(attemptCount).toBe(MIN_ATTEMPT_COUNT);
+    for (const status of ['flash', 'send', 'attempt'] satisfies TickStatus[]) {
+      expect(clampAttempts(attemptCount, status)).toBe(attemptCount);
+    }
+  });
+});

--- a/packages/shared/play-view/src/quick-tick-state.ts
+++ b/packages/shared/play-view/src/quick-tick-state.ts
@@ -20,12 +20,28 @@ export function deriveAscentType(hasPriorHistory: boolean, attemptCount: number)
   return !hasPriorHistory && attemptCount === 1 ? 'flash' : 'send';
 }
 
-export function getMinAttempts(status: TickStatus): number {
-  if (status === 'send') return 2;
-  return 1;
-}
+/**
+ * Lowest tries value any tick can carry: logging an ascent or an attempt means
+ * you got on the climb at least once. The tries picker's floor and the
+ * save-time clamp both read this one constant, so the number on screen and the
+ * number on the wire cannot drift apart.
+ */
+export const MIN_ATTEMPT_COUNT = 1;
 
+/**
+ * Normalise tries before they go on the wire. Mirrors the server's
+ * `SaveTickInputSchema`: at least 1, and exactly 1 for a flash (a flash is a
+ * first-go ascent by definition).
+ *
+ * There is deliberately NO floor above 1 for `send`. A send only means "not a
+ * flash of this climb" — the flash/send split is carried by `status`, never by
+ * the number — so a redpoint that goes first go in the current session is a
+ * genuine 1-try send. Flooring `send` at 2 (which this used to do, via a
+ * `getMinAttempts` helper that no longer exists) stored a 2 behind a picker
+ * still showing 1, and made 1 unreachable for every climber who had touched
+ * the climb before. See issue #2888.
+ */
 export function clampAttempts(attemptCount: number, status: TickStatus): number {
-  const min = getMinAttempts(status);
-  return Math.max(min, attemptCount);
+  if (status === 'flash') return MIN_ATTEMPT_COUNT;
+  return Math.max(MIN_ATTEMPT_COUNT, attemptCount);
 }


### PR DESCRIPTION
## Summary

Refs #2888.

A beta tester screenshotted a tick reading **2 tries** and wrote: *"I only tried once this session and a lot of times before."* They were right, and the app was wrong in a way they couldn't see.

The mobile quick-tick bar floored `attemptCount` at 2 for any `send`:

- `deriveAscentType(hasPriorHistory, 1)` returns `'send'` for any climb you've been on before — correct, that's a redpoint, not a flash.
- `getMinAttempts('send')` returned `2`, and `clampAttempts` applied that floor at save time.
- `InlineTriesPicker` was handed the raw state and rendered **1**, minus button greyed out.

Picker said 1, logbook stored 2. And since `1` and `2` both saved as `2`, the first press of **+** was a no-op on stored data — while a first-ever go bumped to 2 tries locked the minus at 2, so the climber could never get their flash back.

### Why the floor was wrong

A "send" means *"not a flash of this climb"*, not *"took more than one go"*. A redpoint that goes first go in the current session is a genuine one-try send. Everything else in the codebase already agreed:

- **The server contract.** `SaveTickInputSchema` floors `attemptCount` at 1 for every status and constrains only flash. Its own comment: *"A send is any successful ascent — the attempt count on the row just records how many tries that particular log represents (e.g. 1 when the user is logging a single successful action…). Both are valid."*
- **Web.** `use-tick-save.ts` derives status identically and saves the count raw, no clamp.
- **The MoonBoard importer.** Maps "Session flash" to `{ status: 'send', attemptCount: 1 }`.
- **Mobile's own logbook edit sheet.** Floors at 1 and lets a send be a single try — the two mobile surfaces contradicted each other.

Production telemetry says the same (`Quick Tick Saved`, since 2026-05-24):

| surface | send @ 1 try | send @ 2 tries |
| --- | --- | --- |
| web | 1,819 | 242 |
| mobile | **0** | 3,942 |

Mobile has never recorded a one-try send. Not unpopular — unreachable.

### The change

`getMinAttempts` is **deleted** rather than retuned. A status-dependent floor is the mechanism that produced this bug; removing it means the picker floor and the save clamp read one constant (`MIN_ATTEMPT_COUNT`) and cannot drift apart. `clampAttempts` keeps a real job — floor at 1, pin a flash to exactly 1 — mirroring the server refine.

`deriveAscentType` is untouched, so flash/send labelling is unchanged. One behaviour does change: a climber who bumps a first-ever go to 2 tries can now come back down to 1 and the button returns to **Flash**. That round trip is safe because the label follows the count in view — the climber watches it go Flash → Send → Flash — and it's pinned by a test.

### Follow-ups (not in this PR)

- **#3937** — the ~3,942 ticks across 611 users already written with a phantom try. Unrepairable by design: a wrongly-inflated row and a genuine 2-try send are byte-identical, and the analytics event recorded the clamped value too, so even telemetry can't separate them. Filed as a decision for a human, with "do nothing" as the recommendation. **#2888 stays open until that's ruled on** — the code is fixed but every affected logbook is still wrong.
- **#3938** — web's `logascent-form.tsx` carries the same misreading in a client-side validation claiming to mirror a backend rule that doesn't exist. Near-dead there, and it fails loudly rather than silently rewriting, so it's left alone.

- **#3940** — the mirror-image defect in the same code block: before `getLogbook` resolves, a repeat ascent can be offered (and saved) as a **Flash**. Structural, needs a real loading state on `hasPriorHistory`, so it's not chased here.

Also checked: the `hasPriorHistory` fallback that assumes history when *no board provider is mounted* is **unreachable in production** — `BoardProviderWrapper` wraps the whole `Stack`, `DrawerHostProvider`, and both `PlayDrawer` mount sites. That one is a test-harness guard, not a defect; #3940 is the reachable path.

## Release Notes

- Log a redpoint that finally goes first try this session and it saves as **one try**, not two.
- The tries picker showed 1 while your logbook quietly stored 2 for any climb you'd been on before — so first-go sends were padding your session attempts and your try counts.
- The **+** button now moves the number that actually gets saved, and if you over-count a flash you can drop it back to 1 instead of being stuck on Send.
- Ticks logged before this fix still carry the extra try — you can correct any of them from the logbook edit sheet.

## Test plan

`vp check`, `vp run typecheck`, `vp test run --reporter=agent`, `vp run test:mobile` — all green.

Both halves of the fix are mutation-verified (reverted, confirmed red, restored):

| mutation | fails |
| --- | --- |
| `clampAttempts` floors `send` at 2 again | 4 shared + 3 mobile tests |
| picker floor goes back to `send ? 2 : 1` | the Flash round-trip test |

- `packages/shared/play-view/src/__tests__/quick-tick-state.test.ts` is **new** — these helpers had no coverage at all. It states the contract with no reference to any component: **for every value a picker can display and every status the buttons can produce, `clampAttempts` is a no-op.** A future tries picker gets that guard for free, and reintroducing a floor above 1 fails here before it can reach a logbook.
Not from this diff: `queue-provider-backgrounded-join.test.tsx` failed once in a local full-suite run on a heavily loaded machine and passes 4/4 in isolation on both re-runs — a `waitFor` timeout, in a party-rejoin test that shares nothing with this change. Green in CI.

- `quick-tick-bar.test.tsx` asserts at the seam. The `InlineTriesPicker` stub now renders the count it was handed, so the tests compare the saved payload against the number read back out of the picker rather than against a literal. Covers: one-try redpoint saves 1, analytics reports the shown count, the Send label survives a one-try save, the first **+** press changes what's stored, the Attempt button saves the shown count, and the Flash round trip.
