### PR TITLE
fix(mobile): stop a consumer clip swallowing GlassSurface's Android elevation cast

### DIFF
--- a/packages/mobile/src/components/GlassSurface.tsx
+++ b/packages/mobile/src/components/GlassSurface.tsx
@@ -200,11 +200,20 @@ const styles = StyleSheet.create({
     overflow: 'visible',
   },
   /**
-   * The hoisted clip. Sized to disappear from layout: `stretch` fills the cross
-   * axis, `flexGrow` takes any definite height the surface was given, and
-   * `flexShrink` keeps the clip bounds on the box when content overruns — so the
-   * children lay out exactly as they did when they were direct descendants. It
-   * clips at the surface's PADDING box, so a surface that both pads and clips
+   * The hoisted clip, sized so the children lay out the way they did when they
+   * were direct descendants: `stretch` fills the cross axis, `flexGrow` absorbs
+   * any definite height the surface was given, and `flexShrink` keeps the clip
+   * bounds on the box when content overruns.
+   *
+   * `flexBasis` deliberately stays `auto` — this is NOT `flex: 1`. With
+   * `flexBasis: 0` an auto-height surface would measure its only in-flow child at
+   * zero, size itself to zero, and then have no free space to grow back into, so
+   * the whole surface would collapse (the reaction menu card is exactly that
+   * shape). `auto` starts from the content size, which is what an auto-height
+   * surface wants, and still leaves free space for `flexGrow` to take when the
+   * surface does have a definite height.
+   *
+   * It clips at the surface's PADDING box, so a surface that both pads and clips
    * would round its corners inside the padding; no consumer does both today.
    */
   clipLayer: {

--- a/packages/mobile/src/components/GlassSurface.tsx
+++ b/packages/mobile/src/components/GlassSurface.tsx
@@ -55,8 +55,9 @@ type GlassSurfaceProps = {
   role?: keyof MaterialSurfaceContainers;
   /**
    * Material-only: the M3 elevation CAST (level0–5). Omit to keep the legacy
-   * `shadows.sm`. The material branch applies it on the same view as the
-   * background + radius (no `overflow:'hidden'`), so a rounded surface still casts.
+   * `shadows.sm`. The cast always lands on the outermost view; if the consumer's
+   * `style` asks for `overflow: 'hidden'`, that clip is hoisted onto an inner
+   * wrapper so it can't swallow the cast (see the material branch).
    */
   level?: MaterialElevationLevel;
 };
@@ -119,23 +120,35 @@ export function GlassSurface({
   // Material: opaque M3 tonal surface. Depth is tone-FIRST — `role` picks the
   // surface-container tone, `level` adds the elevation cast (both default to the
   // legacy base + `shadows.sm` so unmigrated consumers don't shift). Background +
-  // radius + cast live on the SAME view (no `overflow: 'hidden'`, which would clip
-  // the shadow) so even a rounded surface casts. Fallback/tint composite on top.
+  // radius + cast live on the outermost view so even a rounded surface casts;
+  // fallback/tint composite on top.
+  //
+  // Android draws the cast from the elevated view's own outline, so an
+  // `overflow: 'hidden'` on that same view clips the shadow down to nothing (the
+  // card then melts into the background — #3058). Consumers legitimately need the
+  // clip to keep scrolling content inside the rounded corners, so rather than ask
+  // every one of them to choose, hoist it: the cast stays on the unclipped outer
+  // view, and the clip moves to an inner wrapper around `children`. The wrapper is
+  // added ONLY when a clip was asked for, so unclipped consumers keep today's tree.
   if (mode === 'material') {
     const materialBg = role ? m3SurfaceContainers[role] : baseColor;
     const elevationStyle = level ? materialElevation[level] : shadows.sm;
+    const clipsChildren = StyleSheet.flatten(style)?.overflow === 'hidden';
     // When a `role` tone is given it IS the surface — an opaque `fallbackColor`
     // would paint over and hide it, so skip the fallback layer (the translucent
     // `tint` still composites). Without a role, keep the legacy fallback-over-base.
     return (
-      <View style={[style, radius, elevationStyle, { backgroundColor: materialBg }]} pointerEvents={pointerEvents}>
+      <View
+        style={[style, clipsChildren && styles.unclipped, radius, elevationStyle, { backgroundColor: materialBg }]}
+        pointerEvents={pointerEvents}
+      >
         {!role && fallbackColor ? (
           <View pointerEvents="none" style={[StyleSheet.absoluteFill, radius, { backgroundColor: fallbackColor }]} />
         ) : null}
         {tintColor ? (
           <View pointerEvents="none" style={[StyleSheet.absoluteFill, radius, { backgroundColor: tintColor }]} />
         ) : null}
-        {children}
+        {clipsChildren ? <View style={[styles.clipLayer, radius]}>{children}</View> : children}
       </View>
     );
   }
@@ -176,3 +189,24 @@ export function GlassSurface({
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  /** Cancels a consumer clip on the elevated view so the Android cast survives. */
+  unclipped: {
+    overflow: 'visible',
+  },
+  /**
+   * The hoisted clip. Sized to disappear from layout: `stretch` fills the cross
+   * axis, `flexGrow` takes any definite height the surface was given, and
+   * `flexShrink` keeps the clip bounds on the box when content overruns — so the
+   * children lay out exactly as they did when they were direct descendants. It
+   * clips at the surface's PADDING box, so a surface that both pads and clips
+   * would round its corners inside the padding; no consumer does both today.
+   */
+  clipLayer: {
+    overflow: 'hidden',
+    alignSelf: 'stretch',
+    flexGrow: 1,
+    flexShrink: 1,
+  },
+});

--- a/packages/mobile/src/components/GlassSurface.tsx
+++ b/packages/mobile/src/components/GlassSurface.tsx
@@ -133,7 +133,11 @@ export function GlassSurface({
   if (mode === 'material') {
     const materialBg = role ? m3SurfaceContainers[role] : baseColor;
     const elevationStyle = level ? materialElevation[level] : shadows.sm;
-    const clipsChildren = StyleSheet.flatten(style)?.overflow === 'hidden';
+    // `'scroll'` clips on Android exactly like `'hidden'` (a plain View never
+    // scrolls — that needs a ScrollView), so it swallows the cast the same way and
+    // collapses to the same clip on the wrapper.
+    const consumerOverflow = StyleSheet.flatten(style)?.overflow;
+    const clipsChildren = consumerOverflow === 'hidden' || consumerOverflow === 'scroll';
     // When a `role` tone is given it IS the surface — an opaque `fallbackColor`
     // would paint over and hide it, so skip the fallback layer (the translucent
     // `tint` still composites). Without a role, keep the legacy fallback-over-base.

--- a/packages/mobile/src/components/__tests__/glass-surface.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-surface.test.tsx
@@ -12,25 +12,51 @@ const ctrl = vi.hoisted(() => ({
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
 }));
 
-// Minimal RN surface. View renders a <div> exposing its background colour and
-// pointerEvents so the solid path and tint overlays are inspectable.
-vi.mock('react-native', () => ({
-  Platform: {
-    get OS() {
-      return ctrl.os;
-    },
-  },
-  StyleSheet: {
-    absoluteFill: { position: 'absolute' },
-    create: (styles: unknown) => styles,
-  },
-  View: ({ children, style, pointerEvents }: { children?: ReactNode; style?: unknown; pointerEvents?: string }) => {
-    const flat = Object.assign({}, ...(Array.isArray(style) ? style : [style]).filter(Boolean)) as {
-      backgroundColor?: string;
+// Minimal RN surface. View renders a <div> exposing its background colour, its
+// clip and its elevation so the solid path, the tint overlays and the hoisted
+// clip wrapper are all inspectable.
+vi.mock('react-native', () => {
+  // Resolve a (possibly nested) RN style array down to one object, like the real
+  // StyleSheet.flatten — later entries win, falsy entries are skipped.
+  const flattenStyle = (style: unknown): Record<string, unknown> => {
+    const out: Record<string, unknown> = {};
+    const walk = (entry: unknown) => {
+      if (!entry) return;
+      if (Array.isArray(entry)) {
+        for (const item of entry) walk(item);
+        return;
+      }
+      Object.assign(out, entry);
     };
-    return createElement('div', { 'data-bg': flat.backgroundColor, 'data-pe': pointerEvents }, children);
-  },
-}));
+    walk(style);
+    return out;
+  };
+  return {
+    Platform: {
+      get OS() {
+        return ctrl.os;
+      },
+    },
+    StyleSheet: {
+      absoluteFill: { position: 'absolute' },
+      create: (styles: unknown) => styles,
+      flatten: flattenStyle,
+    },
+    View: ({ children, style, pointerEvents }: { children?: ReactNode; style?: unknown; pointerEvents?: string }) => {
+      const flat = flattenStyle(style);
+      return createElement(
+        'div',
+        {
+          'data-bg': flat.backgroundColor,
+          'data-pe': pointerEvents,
+          'data-overflow': flat.overflow,
+          'data-elevation': flat.elevation,
+        },
+        children,
+      );
+    },
+  };
+});
 
 vi.mock('@react-native-community/blur', () => ({
   BlurView: () => createElement('div', { 'data-testid': 'blur-view' }),
@@ -183,5 +209,46 @@ describe('GlassSurface Material surface-container role', () => {
     const { container } = render(<GlassSurface role="base" fallbackColor="#FFFFFF" />);
     expect(container.querySelector('[data-bg="#303038"]')).not.toBeNull();
     expect(container.querySelector('[data-bg="#FFFFFF"]')).toBeNull();
+  });
+});
+
+// Android draws the elevation cast from the elevated view's own outline, so a
+// consumer `overflow: 'hidden'` on that view clips the shadow away entirely
+// (#3058). GlassSurface hoists the clip onto an inner wrapper instead.
+describe('GlassSurface Material elevation cast vs. a consumer clip', () => {
+  beforeEach(() => {
+    ctrl.variant = 'material';
+  });
+
+  it('keeps the cast off the clipped view: elevated outer is unclipped, children get a clipping wrapper', () => {
+    const { container } = render(
+      <GlassSurface role="high" level="level3" borderRadius={16} style={{ borderRadius: 16, overflow: 'hidden' }}>
+        <div data-testid="card-content" />
+      </GlassSurface>,
+    );
+
+    // The view carrying the cast must not clip.
+    const elevated = container.querySelector('[data-elevation="3"]');
+    expect(elevated).not.toBeNull();
+    expect(elevated?.getAttribute('data-overflow')).toBe('visible');
+
+    // ...and the clip lives on a descendant that still wraps the children.
+    const clip = container.querySelector('[data-overflow="hidden"]');
+    expect(clip).not.toBeNull();
+    expect(elevated?.contains(clip as Node)).toBe(true);
+    expect(clip?.querySelector('[data-testid="card-content"]')).not.toBeNull();
+  });
+
+  it('adds no wrapper when the consumer does not ask for a clip', () => {
+    const { container } = render(
+      <GlassSurface role="high" level="level3" borderRadius={16} style={{ borderRadius: 16 }}>
+        <div data-testid="card-content" />
+      </GlassSurface>,
+    );
+    expect(container.querySelector('[data-overflow="hidden"]')).toBeNull();
+    // Children stay direct descendants of the elevated view — no layout shift for
+    // the consumers that never clipped.
+    const elevated = container.querySelector('[data-elevation="3"]');
+    expect(elevated?.firstElementChild?.getAttribute('data-testid')).toBe('card-content');
   });
 });

--- a/packages/mobile/src/components/__tests__/glass-surface.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-surface.test.tsx
@@ -15,22 +15,9 @@ const ctrl = vi.hoisted(() => ({
 // Minimal RN surface. View renders a <div> exposing its background colour, its
 // clip and its elevation so the solid path, the tint overlays and the hoisted
 // clip wrapper are all inspectable.
-vi.mock('react-native', () => {
-  // Resolve a (possibly nested) RN style array down to one object, like the real
-  // StyleSheet.flatten — later entries win, falsy entries are skipped.
-  const flattenStyle = (style: unknown): Record<string, unknown> => {
-    const out: Record<string, unknown> = {};
-    const walk = (entry: unknown) => {
-      if (!entry) return;
-      if (Array.isArray(entry)) {
-        for (const item of entry) walk(item);
-        return;
-      }
-      Object.assign(out, entry);
-    };
-    walk(style);
-    return out;
-  };
+vi.mock('react-native', async () => {
+  // Dynamic import: Vitest hoists this factory above the file's imports.
+  const { flattenStyle } = await import('../../../test/flatten-style');
   return {
     Platform: {
       get OS() {
@@ -237,6 +224,17 @@ describe('GlassSurface Material elevation cast vs. a consumer clip', () => {
     expect(clip).not.toBeNull();
     expect(elevated?.contains(clip as Node)).toBe(true);
     expect(clip?.querySelector('[data-testid="card-content"]')).not.toBeNull();
+  });
+
+  it("hoists overflow: 'scroll' too — it clips the cast on Android just like 'hidden'", () => {
+    const { container } = render(
+      <GlassSurface role="high" level="level3" borderRadius={16} style={{ borderRadius: 16, overflow: 'scroll' }}>
+        <div data-testid="card-content" />
+      </GlassSurface>,
+    );
+    const elevated = container.querySelector('[data-elevation="3"]');
+    expect(elevated?.getAttribute('data-overflow')).toBe('visible');
+    expect(container.querySelector('[data-overflow="hidden"] [data-testid="card-content"]')).not.toBeNull();
   });
 
   it('adds no wrapper when the consumer does not ask for a clip', () => {

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -92,15 +92,23 @@ const MENU_FADE_COLORS = {
   light: ['rgba(255, 255, 255, 0)', `rgba(255, 255, 255, ${MENU_FADE_END_ALPHA})`],
 } as const;
 
-// A real blur under the scrim (iOS 26 Liquid Glass, or its < 26 blur fallback) already
-// makes the busy board-art grid recede, so a light tint finishes the dim. With no blur
-// — Android, Reduce Transparency, or the Material variant on iOS — the tint alone lets
-// the grid bleed through and the overlay stops reading as focused, so the scrim has to
-// do the receding itself. Gated on the surface mode GlassSurface switches on, so the
-// scrim and the card never disagree about which material is underneath.
+// Backdrop dim, by scheme and by whether a real blur sits underneath. A blur (iOS 26
+// Liquid Glass, or its < 26 fallback) already makes the busy board-art grid recede, so
+// a light tint finishes the dim. With no blur — Android, Reduce Transparency, or the
+// Material variant on iOS — the tint alone lets the grid bleed through and the overlay
+// stops reading as focused, so the scrim has to do the receding itself: the app's
+// shared scrim token in dark, and a deliberately lighter value in light, where 0.6 over
+// an already high-contrast screen reads as an accidental dark mode.
+const SCRIM_COLORS = {
+  blurred: { dark: 'rgba(0, 0, 0, 0.5)', light: 'rgba(0, 0, 0, 0.35)' },
+  flat: { dark: overlays.scrim, light: 'rgba(0, 0, 0, 0.4)' },
+} as const;
+
+// Gated on the surface mode GlassSurface switches on, so the scrim and the card never
+// disagree about which material is underneath.
 function resolveScrimColor(hasBlur: boolean, isDark: boolean): string {
-  if (hasBlur) return isDark ? 'rgba(0,0,0,0.5)' : 'rgba(0,0,0,0.35)';
-  return isDark ? overlays.scrim : 'rgba(0,0,0,0.4)';
+  const scheme = hasBlur ? SCRIM_COLORS.blurred : SCRIM_COLORS.flat;
+  return isDark ? scheme.dark : scheme.light;
 }
 
 // iOS portals above the persistent queue bar / tab bar via a native window overlay;

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -34,7 +34,9 @@ import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useTheme } from '../../providers/theme-provider';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { springs, timing } from '../../theme/animations';
-import { spacing, borderRadius } from '../../theme/tokens';
+import { spacing, borderRadius, overlays } from '../../theme/tokens';
+import { withAlpha, type MaterialSurfaceContainers } from '../../theme/colors';
+import { useEffectiveSurfaceMode } from '../../hooks/use-effective-surface-mode';
 import { useClimbActions, type ClimbActionId, type ClimbActionItem } from './use-climb-actions';
 import { fitBoardArt, computeReactionBoardMaxSize } from './board-art-fit';
 
@@ -72,14 +74,34 @@ type ClimbReactionMenuProps = {
 // content's horizontal padding); on tablets this caps how wide the floating card gets.
 const PREVIEW_MAX_WIDTH = 400;
 
-// Bottom-edge fade for the scrollable action list — transparent → the scheme's surface
-// base. Concrete rgba, never a systemColors PlatformColor: feeding a PlatformColor into
-// the gradient bakes the wrong scheme (the ProgressiveBlur dark-band bug). The dark value
-// tracks GlassSurface's dark base (#14111F); keep them in sync if that surface changes.
+// The card is a modal, scrim-dimming, non-anchored overlay — an M3 dialog — so on
+// Material it takes the surface-container-high tone and a level-3 cast. Named here
+// because the bottom fade has to read the same tone; see MENU_FADE_COLORS.
+const MENU_CARD_ROLE: keyof MaterialSurfaceContainers = 'high';
+
+// Bottom-edge fade for the scrollable action list — transparent → the card's own
+// surface. Concrete rgba, never a systemColors PlatformColor: feeding a PlatformColor
+// into the gradient bakes the wrong scheme (the ProgressiveBlur dark-band bug). On
+// Material the stops are derived from the very tone GlassSurface paints the card with,
+// so bumping MENU_CARD_ROLE can't leave the fade behind. Glass / blur / solid keep the
+// tuned constants — there is no opaque tone to read there, the card is real glass, and
+// the dark value tracks its #14111F base.
+const MENU_FADE_END_ALPHA = 0.92;
 const MENU_FADE_COLORS = {
-  dark: ['rgba(20, 17, 31, 0)', 'rgba(20, 17, 31, 0.92)'],
-  light: ['rgba(255, 255, 255, 0)', 'rgba(255, 255, 255, 0.92)'],
+  dark: ['rgba(20, 17, 31, 0)', `rgba(20, 17, 31, ${MENU_FADE_END_ALPHA})`],
+  light: ['rgba(255, 255, 255, 0)', `rgba(255, 255, 255, ${MENU_FADE_END_ALPHA})`],
 } as const;
+
+// A real blur under the scrim (iOS 26 Liquid Glass, or its < 26 blur fallback) already
+// makes the busy board-art grid recede, so a light tint finishes the dim. With no blur
+// — Android, Reduce Transparency, or the Material variant on iOS — the tint alone lets
+// the grid bleed through and the overlay stops reading as focused, so the scrim has to
+// do the receding itself. Gated on the surface mode GlassSurface switches on, so the
+// scrim and the card never disagree about which material is underneath.
+function resolveScrimColor(hasBlur: boolean, isDark: boolean): string {
+  if (hasBlur) return isDark ? 'rgba(0,0,0,0.5)' : 'rgba(0,0,0,0.35)';
+  return isDark ? overlays.scrim : 'rgba(0,0,0,0.4)';
+}
 
 // iOS portals above the persistent queue bar / tab bar via a native window overlay;
 // Android uses a transparent Modal (which also gives a hardware-back handler).
@@ -115,11 +137,12 @@ export function ClimbReactionMenu({
   reduceMotion,
   onClose,
 }: ClimbReactionMenuProps) {
-  const { colorScheme, systemColors } = useTheme();
+  const { colorScheme, systemColors, m3SurfaceContainers } = useTheme();
   const { t } = useTranslation('climbs');
   const insets = useSafeAreaInsets();
   const { width: windowWidth, height: windowHeight, fontScale } = useWindowDimensions();
   const { formatGrade } = useGradeFormat();
+  const surfaceMode = useEffectiveSurfaceMode();
 
   const progress = useSharedValue(0);
   // 'menu' shows the action list; 'playlist' swaps the card to the inline
@@ -333,7 +356,12 @@ export function ClimbReactionMenu({
   // case it scrolls and the bottom fade cues more. The playlist view owns its own scroll.
   const listMaxHeight = Math.max(actionRowHeight, menuMaxHeight - primaryRowHeight);
   const menuScrollable = listContentHeight > listMaxHeight + 0.5;
-  const menuFadeColors = colorScheme === 'dark' ? MENU_FADE_COLORS.dark : MENU_FADE_COLORS.light;
+  const isDark = colorScheme === 'dark';
+  const menuFadeColors = useMemo<readonly [string, string]>(() => {
+    if (surfaceMode !== 'material') return isDark ? MENU_FADE_COLORS.dark : MENU_FADE_COLORS.light;
+    const cardTone = m3SurfaceContainers[MENU_CARD_ROLE];
+    return [withAlpha(cardTone, 0), withAlpha(cardTone, MENU_FADE_END_ALPHA)];
+  }, [surfaceMode, isDark, m3SurfaceContainers]);
 
   const backdropStyle = useAnimatedStyle(() => ({ opacity: progress.value }));
   const previewStyle = useAnimatedStyle(() => ({
@@ -345,7 +373,8 @@ export function ClimbReactionMenu({
     transform: [{ translateY: (1 - progress.value) * 18 }, { scale: 0.96 + progress.value * 0.04 }],
   }));
 
-  const scrimColor = colorScheme === 'dark' ? 'rgba(0,0,0,0.5)' : 'rgba(0,0,0,0.35)';
+  const hasBlur = surfaceMode === 'glass' || surfaceMode === 'blur';
+  const scrimColor = resolveScrimColor(hasBlur, isDark);
 
   return (
     <OverlayPortal onRequestClose={handleRequestClose}>
@@ -354,9 +383,9 @@ export function ClimbReactionMenu({
             the menu first (matching the back button), and dismisses from the menu
             — so a stray tap can't tear down a half-typed create form. */}
         <Animated.View style={[StyleSheet.absoluteFill, backdropStyle]}>
-          {Platform.OS === 'ios' ? (
+          {hasBlur ? (
             <BlurView
-              blurType={colorScheme === 'dark' ? 'dark' : 'light'}
+              blurType={isDark ? 'dark' : 'light'}
               blurAmount={12}
               reducedTransparencyFallbackColor={scrimColor}
               style={StyleSheet.absoluteFill}
@@ -367,7 +396,7 @@ export function ClimbReactionMenu({
             style={StyleSheet.absoluteFill}
             onPress={handleRequestClose}
             accessibilityRole="button"
-            accessibilityLabel={climb.name}
+            accessibilityLabel={t('mobile.climbActions.closeOverlay')}
           />
         </Animated.View>
 
@@ -433,7 +462,7 @@ export function ClimbReactionMenu({
           </Animated.View>
 
           <Animated.View style={[styles.menuWrap, menuStyle]}>
-            <GlassSurface role="base" level="level2" borderRadius={borderRadius.xl} style={styles.menuCard}>
+            <GlassSurface role={MENU_CARD_ROLE} level="level3" borderRadius={borderRadius.xl} style={styles.menuCard}>
               {view === 'playlist' ? (
                 // The picker pins its own header and scrolls the list within
                 // menuMaxHeight, so "back" stays put however far you scroll.
@@ -472,14 +501,17 @@ export function ClimbReactionMenu({
                     keyboardShouldPersistTaps="handled"
                     contentContainerStyle={styles.menuContent}
                   >
-                    {listActions.map((action, index) => (
+                    {/* Dividerless, like an M3 action list and an iOS context menu —
+                        the rows already read as separate targets, and hairlines under
+                        a scrolling list fight the bottom fade. Icons at 24 to match
+                        the primary row above. */}
+                    {listActions.map((action) => (
                       <ListRow
                         key={action.id}
                         title={action.title}
-                        leading={<Icon name={action.icon} size={22} color={action.color} />}
+                        leading={<Icon name={action.icon} size={24} color={action.color} />}
                         onPress={action.run}
-                        showSeparator={index < listActions.length - 1}
-                        separatorInset={56}
+                        showSeparator={false}
                       />
                     ))}
                   </ScrollView>
@@ -590,6 +622,9 @@ const styles = StyleSheet.create({
     maxWidth: PREVIEW_MAX_WIDTH,
     alignSelf: 'center',
   },
+  // The clip keeps the scrolling list, its bottom fade and the playlist picker's
+  // pinned header inside the rounded corners. GlassSurface hoists it onto an inner
+  // wrapper on Material so it can't clip the card's own elevation cast.
   menuCard: {
     borderRadius: borderRadius.xl,
     overflow: 'hidden',

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -12,31 +12,59 @@ const captured = vi.hoisted(() => ({
   modalOnRequestClose: undefined as undefined | (() => void),
   boardImageProps: null as Record<string, unknown> | null,
   ran: undefined as undefined | string,
+  glassSurfaceProps: null as Record<string, unknown> | null,
+  fadeColors: null as readonly string[] | null,
 }));
 
-vi.mock('react-native', () => ({
-  Platform: { OS: 'android', select: (o: Record<string, unknown>) => o.android },
-  Keyboard: { addListener: () => ({ remove: () => {} }) },
-  Modal: ({ children, onRequestClose }: { children?: ReactNode; onRequestClose?: () => void }) => {
-    captured.modalOnRequestClose = onRequestClose;
-    return createElement('div', { 'data-modal': 'true' }, children);
-  },
-  Pressable: ({
-    children,
-    onPress,
-    accessibilityLabel,
-  }: {
-    children?: ReactNode;
-    onPress?: () => void;
-    accessibilityLabel?: string;
-  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
-  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  TextInput: () => null,
-  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  StyleSheet: { create: (s: Record<string, unknown>) => s, absoluteFill: {}, hairlineWidth: 1 },
-  PixelRatio: { get: () => 2 },
-  useWindowDimensions: () => ({ width: 400, height: 800, fontScale: 1 }),
-}));
+// Drives the rendering branches: which material sits under the overlay, and how
+// tall the window is (a short window forces the action list to scroll, which is
+// what mounts the bottom fade).
+const ctrl = vi.hoisted(() => ({ surfaceMode: 'material' as string, windowHeight: 800 }));
+
+vi.mock('react-native', () => {
+  const flattenStyle = (style: unknown): Record<string, unknown> => {
+    const out: Record<string, unknown> = {};
+    const walk = (entry: unknown) => {
+      if (!entry) return;
+      if (Array.isArray(entry)) {
+        for (const item of entry) walk(item);
+        return;
+      }
+      Object.assign(out, entry);
+    };
+    walk(style);
+    return out;
+  };
+  return {
+    Platform: { OS: 'android', select: (o: Record<string, unknown>) => o.android },
+    Keyboard: { addListener: () => ({ remove: () => {} }) },
+    Modal: ({ children, onRequestClose }: { children?: ReactNode; onRequestClose?: () => void }) => {
+      captured.modalOnRequestClose = onRequestClose;
+      return createElement('div', { 'data-modal': 'true' }, children);
+    },
+    Pressable: ({
+      children,
+      onPress,
+      accessibilityLabel,
+    }: {
+      children?: ReactNode;
+      onPress?: () => void;
+      accessibilityLabel?: string;
+    }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+    ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+    TextInput: () => null,
+    View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+      createElement('div', { 'data-bg': flattenStyle(style).backgroundColor }, children),
+    StyleSheet: {
+      create: (s: Record<string, unknown>) => s,
+      absoluteFill: {},
+      hairlineWidth: 1,
+      flatten: flattenStyle,
+    },
+    PixelRatio: { get: () => 2 },
+    useWindowDimensions: () => ({ width: 400, height: ctrl.windowHeight, fontScale: 1 }),
+  };
+});
 
 vi.mock('react-native-reanimated', () => ({
   default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
@@ -47,8 +75,18 @@ vi.mock('react-native-reanimated', () => ({
   runOnJS: (fn: () => void) => fn,
 }));
 
-vi.mock('@react-native-community/blur', () => ({ BlurView: () => null }));
-vi.mock('expo-linear-gradient', () => ({ LinearGradient: () => null }));
+vi.mock('@react-native-community/blur', () => ({
+  BlurView: () => createElement('div', { 'data-testid': 'blur-view' }),
+}));
+vi.mock('expo-linear-gradient', () => ({
+  LinearGradient: ({ colors }: { colors?: readonly string[] }) => {
+    captured.fadeColors = colors ?? null;
+    return createElement('div', { 'data-testid': 'menu-fade' });
+  },
+}));
+vi.mock('../../../hooks/use-effective-surface-mode', () => ({
+  useEffectiveSurfaceMode: () => ctrl.surfaceMode,
+}));
 vi.mock('react-native-screens', () => ({
   FullWindowOverlay: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));
@@ -69,8 +107,13 @@ vi.mock('../../ListRow', () => ({
   ListRow: ({ title, onPress }: { title: string; onPress?: () => void }) =>
     createElement('button', { onClick: onPress, 'aria-label': title, 'data-listrow': 'true' }, title),
 }));
+// Records the surface contract (role / level / clip) rather than throwing it away:
+// the card's M3 tone and elevation cast are exactly what this component sets.
 vi.mock('../../GlassSurface', () => ({
-  GlassSurface: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  GlassSurface: ({ children, ...props }: { children?: ReactNode } & Record<string, unknown>) => {
+    captured.glassSurfaceProps = props;
+    return createElement('div', { 'data-glass': 'true' }, children);
+  },
 }));
 vi.mock('../../BoardImageNative', () => ({
   BoardImageNative: (props: Record<string, unknown>) => {
@@ -91,12 +134,22 @@ vi.mock('../../../lib/board-details', () => ({
 vi.mock('../../../lib/format-climb-stats', () => ({ formatSends: () => '', formatQuality: () => '' }));
 vi.mock('../../../hooks/use-grade-format', () => ({ useGradeFormat: () => ({ formatGrade: () => 'V4' }) }));
 vi.mock('../../../providers/theme-provider', () => ({
-  useTheme: () => ({ colorScheme: 'dark', systemColors: { fill: '#222', label: '#fff' } }),
+  useTheme: () => ({
+    colorScheme: 'dark',
+    systemColors: { fill: '#222', label: '#fff' },
+    m3SurfaceContainers: { lowest: '#101018', low: '#202028', base: '#303038', high: '#404048', highest: '#505058' },
+  }),
 }));
 vi.mock('../../../theme/animations', () => ({ springs: { gentle: {} }, timing: { fast: 150 } }));
 vi.mock('../../../theme/tokens', () => ({
   spacing: { 1: 4, 2: 8, 3: 12, 5: 20, 6: 24 },
   borderRadius: { lg: 12, xl: 16 },
+  overlays: { scrim: 'rgba(0, 0, 0, 0.6)' },
+}));
+// Tagged rather than re-implemented: the assertions care that the fade is built
+// from the card's own tone, not that we can redo hex→rgba arithmetic in a test.
+vi.mock('../../../theme/colors', () => ({
+  withAlpha: (color: string, alpha: number) => `alpha(${color}, ${alpha})`,
 }));
 
 // The playlist action's run() calls onSelectPlaylist (mirroring the real hook), so
@@ -148,6 +201,10 @@ describe('ClimbReactionMenu view switching', () => {
     captured.modalOnRequestClose = undefined;
     captured.boardImageProps = null;
     captured.ran = undefined;
+    captured.glassSurfaceProps = null;
+    captured.fadeColors = null;
+    ctrl.surfaceMode = 'material';
+    ctrl.windowHeight = 800;
   });
 
   it('runs the action when a primary button is pressed', () => {
@@ -231,5 +288,78 @@ describe('ClimbReactionMenu view switching', () => {
     // From the menu, back dismisses the whole overlay (reduceMotion → immediate).
     act(() => captured.modalOnRequestClose?.());
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('labels the tap-to-dismiss scrim as a close control, not as the climb', () => {
+    const { queryByLabelText, onClose } = renderMenu();
+    // The climb name would make VoiceOver/TalkBack announce a climb for a button
+    // that closes the overlay.
+    expect(queryByLabelText('Big Move')).toBeNull();
+    const scrim = queryByLabelText('mobile.climbActions.closeOverlay');
+    expect(scrim).not.toBeNull();
+    act(() => fireEvent.click(scrim as Element));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The overlay is an M3 dialog: a modal, scrim-dimming, non-anchored card. On the
+// no-blur paths nothing recedes the board-art grid behind it but the scrim itself.
+describe('ClimbReactionMenu surface treatment', () => {
+  beforeEach(() => {
+    captured.glassSurfaceProps = null;
+    captured.fadeColors = null;
+    ctrl.surfaceMode = 'material';
+    ctrl.windowHeight = 800;
+  });
+
+  it('raises the card to the M3 dialog tone and cast', () => {
+    renderMenu();
+    expect(captured.glassSurfaceProps?.role).toBe('high');
+    expect(captured.glassSurfaceProps?.level).toBe('level3');
+  });
+
+  it('keeps the card clipped so the fade and the picker header stay inside the corners', () => {
+    renderMenu();
+    // GlassSurface hoists this clip off its elevated view, so asking for it no
+    // longer costs the Android cast.
+    expect((captured.glassSurfaceProps?.style as Record<string, unknown>)?.overflow).toBe('hidden');
+  });
+
+  it('dims harder and drops the blur when no blur sits under the overlay', () => {
+    for (const mode of ['material', 'solid']) {
+      ctrl.surfaceMode = mode;
+      const { container, unmount } = renderMenu();
+      expect(container.querySelector('[data-testid="blur-view"]')).toBeNull();
+      expect(container.querySelector('[data-bg="rgba(0, 0, 0, 0.6)"]')).not.toBeNull();
+      unmount();
+    }
+  });
+
+  it('keeps the lighter tint on the blurred paths, where the blur already recedes the board', () => {
+    for (const mode of ['glass', 'blur']) {
+      ctrl.surfaceMode = mode;
+      const { container, unmount } = renderMenu();
+      expect(container.querySelector('[data-testid="blur-view"]')).not.toBeNull();
+      expect(container.querySelector('[data-bg="rgba(0,0,0,0.5)"]')).not.toBeNull();
+      unmount();
+    }
+  });
+
+  it('builds the list fade from the very tone the card is painted with on Material', () => {
+    // Short window → the list is capped and scrolls, which mounts the fade.
+    ctrl.windowHeight = 200;
+    const { container } = renderMenu();
+    expect(container.querySelector('[data-testid="menu-fade"]')).not.toBeNull();
+    const cardTone = { lowest: '#101018', low: '#202028', base: '#303038', high: '#404048', highest: '#505058' }[
+      captured.glassSurfaceProps?.role as string
+    ];
+    expect(captured.fadeColors).toEqual([`alpha(${cardTone}, 0)`, `alpha(${cardTone}, 0.92)`]);
+  });
+
+  it('keeps the tuned constants for the fade on the glass path (no opaque tone to read)', () => {
+    ctrl.surfaceMode = 'glass';
+    ctrl.windowHeight = 200;
+    renderMenu();
+    expect(captured.fadeColors).toEqual(['rgba(20, 17, 31, 0)', 'rgba(20, 17, 31, 0.92)']);
   });
 });

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -16,25 +16,18 @@ const captured = vi.hoisted(() => ({
   fadeColors: null as readonly string[] | null,
 }));
 
-// Drives the rendering branches: which material sits under the overlay, and how
-// tall the window is (a short window forces the action list to scroll, which is
-// what mounts the bottom fade).
-const ctrl = vi.hoisted(() => ({ surfaceMode: 'material' as string, windowHeight: 800 }));
+// Drives the rendering branches: which material sits under the overlay, which
+// scheme, and how tall the window is (a short window forces the action list to
+// scroll, which is what mounts the bottom fade).
+const ctrl = vi.hoisted(() => ({
+  surfaceMode: 'material' as string,
+  colorScheme: 'dark' as 'dark' | 'light',
+  windowHeight: 800,
+}));
 
-vi.mock('react-native', () => {
-  const flattenStyle = (style: unknown): Record<string, unknown> => {
-    const out: Record<string, unknown> = {};
-    const walk = (entry: unknown) => {
-      if (!entry) return;
-      if (Array.isArray(entry)) {
-        for (const item of entry) walk(item);
-        return;
-      }
-      Object.assign(out, entry);
-    };
-    walk(style);
-    return out;
-  };
+vi.mock('react-native', async () => {
+  // Dynamic import: Vitest hoists this factory above the file's imports.
+  const { flattenStyle } = await import('../../../../test/flatten-style');
   return {
     Platform: { OS: 'android', select: (o: Record<string, unknown>) => o.android },
     Keyboard: { addListener: () => ({ remove: () => {} }) },
@@ -135,7 +128,7 @@ vi.mock('../../../lib/format-climb-stats', () => ({ formatSends: () => '', forma
 vi.mock('../../../hooks/use-grade-format', () => ({ useGradeFormat: () => ({ formatGrade: () => 'V4' }) }));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
-    colorScheme: 'dark',
+    colorScheme: ctrl.colorScheme,
     systemColors: { fill: '#222', label: '#fff' },
     m3SurfaceContainers: { lowest: '#101018', low: '#202028', base: '#303038', high: '#404048', highest: '#505058' },
   }),
@@ -204,6 +197,7 @@ describe('ClimbReactionMenu view switching', () => {
     captured.glassSurfaceProps = null;
     captured.fadeColors = null;
     ctrl.surfaceMode = 'material';
+    ctrl.colorScheme = 'dark';
     ctrl.windowHeight = 800;
   });
 
@@ -309,6 +303,7 @@ describe('ClimbReactionMenu surface treatment', () => {
     captured.glassSurfaceProps = null;
     captured.fadeColors = null;
     ctrl.surfaceMode = 'material';
+    ctrl.colorScheme = 'dark';
     ctrl.windowHeight = 800;
   });
 
@@ -340,9 +335,20 @@ describe('ClimbReactionMenu surface treatment', () => {
       ctrl.surfaceMode = mode;
       const { container, unmount } = renderMenu();
       expect(container.querySelector('[data-testid="blur-view"]')).not.toBeNull();
-      expect(container.querySelector('[data-bg="rgba(0,0,0,0.5)"]')).not.toBeNull();
+      expect(container.querySelector('[data-bg="rgba(0, 0, 0, 0.5)"]')).not.toBeNull();
       unmount();
     }
+  });
+
+  it('stays lighter in light mode, where a 0.6 scrim would read as an accidental dark mode', () => {
+    ctrl.colorScheme = 'light';
+    const { container, unmount } = renderMenu();
+    expect(container.querySelector('[data-bg="rgba(0, 0, 0, 0.4)"]')).not.toBeNull();
+    unmount();
+
+    ctrl.surfaceMode = 'glass';
+    const blurred = renderMenu();
+    expect(blurred.container.querySelector('[data-bg="rgba(0, 0, 0, 0.35)"]')).not.toBeNull();
   });
 
   it('builds the list fade from the very tone the card is painted with on Material', () => {

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -133,7 +133,9 @@ type Theme = {
   /**
    * M3 elevation casts keyed by level (`level0`–`level5`), each a full ViewStyle
    * (iOS `shadow*` + Android `elevation`). Scheme-independent. Apply on the same
-   * view as the tonal background — never under `overflow:'hidden'`.
+   * view as the tonal background, and never on a view that also carries
+   * `overflow: 'hidden'` — Android clips the cast away. `GlassSurface` handles
+   * that for you by hoisting a consumer clip onto an inner wrapper.
    */
   materialElevation: typeof materialElevationByLevel;
   /**

--- a/packages/mobile/src/theme/tokens.ts
+++ b/packages/mobile/src/theme/tokens.ts
@@ -79,8 +79,9 @@ export const shadows = {
  * with the tonal `m3SurfaceContainers` ramp: depth on Material is tone-FIRST,
  * with these casts layered on the components M3 actually shadows (sheet L1, nav/
  * menu L2, dialog/FAB L3+). Level 0 is flat (app-bar-at-rest, filled card). Apply
- * on the SAME view as the background + radius (never under `overflow:'hidden'`,
- * which clips the cast) — see `GlassSurface`'s material branch.
+ * on the same view as the background + radius, and never on a view that also
+ * carries `overflow: 'hidden'` — Android clips the cast away. `GlassSurface`
+ * enforces that for you by hoisting a consumer clip onto an inner wrapper.
  */
 export const materialElevationByLevel = {
   level0: { shadowColor, shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0, shadowRadius: 0, elevation: 0 },

--- a/packages/mobile/test/flatten-style.ts
+++ b/packages/mobile/test/flatten-style.ts
@@ -1,0 +1,23 @@
+/**
+ * Stand-in for `StyleSheet.flatten` in suites that mock `react-native` wholesale.
+ * Resolves a (possibly nested) RN style array down to one object — later entries
+ * win, falsy entries are skipped — so a mocked `View` can report the style it was
+ * actually handed, and code under test that calls `StyleSheet.flatten` keeps working.
+ *
+ * Import it from inside the `vi.mock('react-native', …)` factory with a dynamic
+ * `await import(…)`; a top-level import would be referenced before initialisation
+ * because Vitest hoists mock factories above the imports.
+ */
+export function flattenStyle(style: unknown): Record<string, unknown> {
+  const flattened: Record<string, unknown> = {};
+  const walk = (entry: unknown) => {
+    if (!entry) return;
+    if (Array.isArray(entry)) {
+      for (const item of entry) walk(item);
+      return;
+    }
+    Object.assign(flattened, entry);
+  };
+  walk(style);
+  return flattened;
+}

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -799,7 +799,8 @@
       "openInApp": "Open in Aurora app",
       "fork": "Remix this climb",
       "edit": "Edit climb",
-      "editEntry": "Edit logbook entry"
+      "editEntry": "Edit logbook entry",
+      "closeOverlay": "Close climb actions"
     },
     "create": {
       "brush": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -799,7 +799,8 @@
       "openInApp": "Abrir en la app Aurora",
       "fork": "Remix this climb",
       "edit": "Editar vía",
-      "editEntry": "Editar registro"
+      "editEntry": "Editar registro",
+      "closeOverlay": "Cerrar acciones de la vía"
     },
     "create": {
       "brush": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -799,7 +799,8 @@
       "openInApp": "Ouvrir dans l'app Aurora",
       "fork": "Remix this climb",
       "edit": "Modifier la voie",
-      "editEntry": "Modifier l'entrée du carnet"
+      "editEntry": "Modifier l'entrée du carnet",
+      "closeOverlay": "Fermer les actions de la voie"
     },
     "create": {
       "brush": {


### PR DESCRIPTION
## Summary

Closes #3058 (replaces it — see "Why a new PR" below).

`GlassSurface`'s Material branch composed the consumer's `style` and the elevation
cast onto **one and the same view**:

```tsx
<View style={[style, radius, elevationStyle, { backgroundColor: materialBg }]}>
```

Android draws the cast from that view's own outline, so any consumer passing
`overflow: 'hidden'` clipped its own shadow down to nothing. The climb long-press
reaction menu does exactly that, and it has to: the clip is what keeps the
scrolling action list, its bottom fade and the playlist picker's pinned header
inside the card's rounded corners. So on Android the card lost its cast and melted
into the dim behind it.

**The fix is in the shared primitive, not at the one consumer.** The cast stays on
the unclipped outer view and the clip is hoisted onto an inner wrapper around
`children` — elevation on an unclipped ancestor, clip on a descendant. The wrapper
is added *only* when a clip was actually asked for, so the 14 `GlassSurface` call
sites that never clipped render the exact same tree as before. Consumers keep
writing `overflow: 'hidden'` as normal; they no longer have to choose between a
rounded clip and a shadow.

With the cast surviving, the reaction menu gets the treatment it should have had:

- **M3 dialog tone + cast.** `role="base" level="level2"` becomes `role="high" level="level3"`.
  A modal, scrim-dimming, non-anchored overlay is an M3 dialog, so it takes
  surface-container-high and a level-3 cast.
- **The list's bottom fade is derived from that same tone.** It used to be a
  hardcoded `rgba(20, 17, 31, ...)` with a "keep them in sync" comment, which the
  role bump would have silently broken. On Material it now reads
  `m3SurfaceContainers[MENU_CARD_ROLE]` directly, so the two can't drift. Glass /
  blur / solid keep the tuned constants — there is no opaque tone to read there,
  the card is real glass.
- **Scrim and blur gate on the surface mode, not `Platform.OS`.** With no blur
  underneath, the old light tint let the colourful board-art grid bleed through and
  the overlay stopped reading as focused; the scrim now does the receding itself
  (dark 0.5 to `overlays.scrim` 0.6, light 0.35 to 0.4).
- **Dividerless rows, icons 22 to 24dp**, matching the primary button row above them.
- **The tap-to-dismiss scrim announced the climb's name.** VoiceOver/TalkBack read
  "Big Move, button" for a control that closes the overlay. Now a real close string
  (`mobile.climbActions.closeOverlay`, added to en-US / es / fr).

### This is an iOS change too

#3058's body claimed "iOS is unchanged". That was wrong and I'm not repeating it.
Swapping `Platform.OS === 'ios'` for the effective surface mode means **iOS users
with Reduce Transparency on, and iOS users on the Material variant, no longer get a
`<BlurView>`** — they get the denser scrim instead. That is the correct behaviour in
both cases (Reduce Transparency exists precisely to not blur, and Material-on-iOS
should match the Material card `GlassSurface` is already painting), but it *is* a
behaviour change and it is asserted in tests rather than assumed.

### Why a new PR instead of re-pointing #3058

GitHub can't move a PR's head branch, so "re-pointing" would mean force-pushing over
`fix/android-climb-reaction-menu` — which discards the original commits and orphans
every existing review thread against line numbers that no longer exist. The diff is
also substantially different: #3058 fixed this by **deleting** `overflow: 'hidden'`
from `menuCard`, which is no longer safe. `main` has since added a `menuScrollFade`
`LinearGradient` (absolutely positioned, near-opaque end stop) and the
`InlinePlaylistPicker` view *inside* the card; both need that clip or they paint
square corners over the card's rounded bottom edge. This PR **keeps** the clip and
makes `GlassSurface` cope with it.

## Release Notes

- Long-press a climb on Android and the action menu now floats above the wall properly instead of melting into the background
- Screen readers announce the tap-anywhere-to-close area as a close button, not as the climb

## Test plan

Automated (all green locally):

- `vp run typecheck:mobile`
- `vp run test:mobile` — 4512 tests / 544 files pass, including 9 new ones
- `vp run check:mobile-bundle`
- `vp check` — 0 errors
- `vp run check:i18n`, `vp run check:i18n:orphans`, and the `@boardsesh/i18n` catalog-parity suite

New coverage (the old suite mocked `GlassSurface` down to a bare `div` and `BlurView`
to `null`, so every single thing this PR changes was invisible to it):

- `glass-surface.test.tsx` — with a consumer clip, the elevated view is `overflow: visible` and the clip lands on a descendant that still wraps the children; with no consumer clip, no wrapper is added at all. **Mutation-checked**: reverting the `GlassSurface` change makes the first of these fail.
- `ClimbReactionMenu.test.tsx` — the card asks for `role="high" level="level3"` and keeps its clip; the scrim is `overlays.scrim` with no `BlurView` on `material`/`solid`, and the lighter tint with a `BlurView` on `glass`/`blur`; the bottom fade is built from the same tone the card is painted with on Material and keeps the tuned constants on glass; the dismiss scrim carries a close label, not the climb name.

Regression-checked every `GlassSurface` call site for the new inner view. Only three
pass children at all — `ClimbReactionMenu` `menuCard`, `zone.tsx` `modeIsland`,
`OnboardingPrompt` `footer` — and only `menuCard` passes a clipping `overflow`, so it
is the only one that gets the wrapper. The other twelve (`play.tsx`,
`record/index.tsx`, `CollapsingTopChrome`, `GlassActionToolbar`, `GlassIconButton`,
`GradeRail`, `IpadSidebar`, `PlaylistEditDoneButton`, `PlaylistFollowButton`,
`AccessoryBarSurface` x2, `SearchHeader`, `SessionStartFab`) are self-closing
`style={StyleSheet.absoluteFill}` background layers with no children and no
`overflow`, so their tree is unchanged. `GlassSurface.web.tsx` is left alone
deliberately: a CSS `box-shadow` is not clipped by the element's own
`overflow: hidden`, so the bug doesn't exist there and a wrapper would be dead weight.

### Outstanding: on-device Android visual QA

**I have not visually verified this.** This box is Linux, so
`vp run check:mobile-simulator` and `vp run mobile:screenshot` skip, and I am not
going to claim a visual result I didn't get. The pixels still need a human on an
Android device or emulator, in **both** dark and light (#3058 never captured light):

1. The card's elevation cast is actually visible against the denser scrim.
2. With enough actions to make the list scroll, the bottom `LinearGradient` is
   clipped to the card's rounded corners and its tone matches the card.
3. The `InlinePlaylistPicker` view inside the card still renders rounded.

Plus one iOS pass with Reduce Transparency ON and one on the Material variant, since
those two paths lose their `BlurView` here.

Note for whoever picks this up: #3058's `pr-3058` OTA channel is stale — it was
published against a five-week-old base. This PR needs its own `/ota-preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL
