### PR TITLE
fix(mobile): cap expo-image's unbounded decoded-bitmap cache

### DIFF
--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -274,7 +274,8 @@ uptime (#3803). Four contracts keep them in check:
   expo-image does not override it, so an app that never calls `Image.configureCache()` runs an
   unbounded image memory cache and only ever reclaims at a background or `memoryWarning` seam.
   `useImageCacheMemoryManagement` sets `maxMemoryCost` (`IMAGE_MEMORY_CACHE_MAX_BYTES`, 256 MB) once
-  at startup. iOS-only: expo-image's Android module exposes no `configureCache` and the call throws.
+  at startup. iOS-only: expo-image declares `configureCache` `@platform ios` and defines no Android
+  counterpart, so calling it off iOS fails at the bridge rather than quietly no-opping.
   Prefer this over any periodic wipe — NSCache enforces it continuously, and because eviction drops
   only the _cache's_ reference (a bitmap a mounted view displays is retained by
   `UIImageView.image`/`CALayer.contents`), it can never blank on-screen art or force a reload.

--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -263,24 +263,43 @@ surface the previous size's bundled background paths.
 
 ---
 
-## 7. Board-art image memory: render at display size, recycle, release on background
+## 7. Board-art image memory: cap the cache, render at display size, recycle, release on background
 
 **Rule:** Board-art surfaces are the app's largest memory consumer (decoded bitmaps live in native
 heap + as GPU textures, not the JS heap) — on iOS a 4 GB device can hit the OS watchdog OOM kill in
-the foreground while browsing (#3479). Three contracts keep them in check:
+the foreground while browsing (#3479), and an iPad can SIGSEGV inside image decode after days of
+uptime (#3803). Four contracts keep them in check:
 
-- **Size the overlay to the display, keep the photo full-res.** The play-drawer board passes
-  `renderWidth` (display px × `PixelRatio.get()`) so the per-climb holds overlay rasterizes at the
-  shown size instead of the board's native ~1080px, plus `backgroundVariant="full"` so the _shared_
-  board photo (one decode per board-config, reused across every climb) stays crisp. `renderWidth`
-  alone would downgrade the photo to the 416px `thumb` — only the overlay should shrink.
+- **Cap the decoded-bitmap cache.** SDWebImage defaults `maxMemoryCost` to `0` — _unlimited_ — and
+  expo-image does not override it, so an app that never calls `Image.configureCache()` runs an
+  unbounded image memory cache and only ever reclaims at a background or `memoryWarning` seam.
+  `useImageCacheMemoryManagement` sets `maxMemoryCost` (`IMAGE_MEMORY_CACHE_MAX_BYTES`, 256 MB) once
+  at startup. iOS-only: expo-image's Android module exposes no `configureCache` and the call throws.
+  Prefer this over any periodic wipe — NSCache enforces it continuously, and because eviction drops
+  only the _cache's_ reference (a bitmap a mounted view displays is retained by
+  `UIImageView.image`/`CALayer.contents`), it can never blank on-screen art or force a reload.
+- **Size the overlay to the display, keep the photo full-res.** The play-drawer board and the wall
+  kiosk hero pass `renderWidth` (display px × `PixelRatio.get()`) so the per-climb holds overlay
+  rasterizes at the shown size instead of the board's native ~1080px, plus `backgroundVariant="full"`
+  so the _shared_ board photo (one decode per board-config, reused across every climb) stays crisp.
+  `renderWidth` alone would downgrade the photo to the 416px `thumb` — only the overlay should shrink.
+  This matters most where a surface swaps climbs without unmounting: both layers set
+  `allowDownscaling={false}`, so a native-width overlay decodes at ~8 MB of RGBA however small it is
+  drawn. `useNativeClimbRender` clamps to native width, so it never upscales.
 - **`recyclingKey` on always-mounted board surfaces that swap climbs.** The carousel boards key on the
-  climb's `frames` so swapping releases the previous overlay instead of holding both.
+  climb's `frames` so swapping releases the previous overlay instead of holding both. **Not a blanket
+  rule:** a key change sets `sdImageView.image = nil` _before_ the new load
+  (`expo-image/ios/ImageView.swift`), so it inserts a blank frame unless the incoming art is already
+  cached. The carousel gets away with it because its peek pre-warms the cache; the wall kiosk hero
+  deliberately omits it rather than flash a wall-mounted display between climbs.
 - **Release board-art on background + memory pressure.** `LayeredClimbImage` blanks its `<Image>`
-  layers when `useIsAppBackgrounded()` is true, and `useImageCacheMemoryManagement` (mounted at the
-  app root) sweeps expo-image's memory cache on background and on the OS `memoryWarning` event. The
-  `memoryWarning` path is the direct foreground lever against the iOS OOM kill. Re-decodes from disk
-  on foreground (no network).
+  layers when `useIsAppBackgrounded()` is true or the surface is a non-focused iPad tab
+  (`BoardArtVisibilityProvider` — the iPad shell keeps every tab mounted, and
+  `Image.clearMemoryCache()` cannot reclaim a bitmap a mounted view still holds). Alongside the cap,
+  `useImageCacheMemoryManagement` sweeps expo-image's memory cache on background and on the OS
+  `memoryWarning` event, and `useIpadTabSwitchImageCacheSweep` sweeps at iPad tab switches. Note the
+  `memoryWarning` event is a _last_ resort, not a foreground lever: iOS delivers it only after an
+  allocation has already failed. Re-decodes from disk (no network).
 
 **Why:** On-device profiling (Pixel 8 Pro, Android 16) showed ~248 MB native heap idle on the feed
 and the play-drawer carousel piling a native-res (~7 MB RGBA) overlay per swiped climb into the
@@ -301,7 +320,10 @@ real risk; the OOM actually reproduces on 4 GB iPhones.
 - `packages/mobile/src/lib/app-visibility.ts` (`useIsAppBackgrounded`, one ref-counted AppState
   listener) + `packages/mobile/src/hooks/use-image-cache-memory-management.ts` (root cache sweep).
 - `renderWidth` + `backgroundVariant` threaded through `BoardImageNative.tsx` →
-  `use-native-climb-render.ts`; applied in `play-drawer/SwipeBoardCarousel.tsx`.
+  `use-native-climb-render.ts`; applied in `play-drawer/SwipeBoardCarousel.tsx` and
+  `board-presence/wall-kiosk/WallHeroStage.tsx`.
+- `IMAGE_MEMORY_CACHE_MAX_BYTES` + `Image.configureCache` in
+  `packages/mobile/src/hooks/use-image-cache-memory-management.ts` — the cache ceiling.
 - `packages/mobile/modules/memory-trim/` (Android-only) — native Glide full-clear at
   `TRIM_MEMORY_UI_HIDDEN`; policy in `MemoryTrimPolicy.kt`, activation import in `app/_layout.tsx`.
 

--- a/packages/mobile/src/components/board-presence/wall-kiosk/WallHeroStage.tsx
+++ b/packages/mobile/src/components/board-presence/wall-kiosk/WallHeroStage.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { PixelRatio, StyleSheet, View } from 'react-native';
 import type { BoardName, BoardPresenceClimb } from '@boardsesh/shared-schema';
 import { BoardImageNative } from '../../BoardImageNative';
 import { useTheme } from '../../../providers/theme-provider';
@@ -32,6 +32,18 @@ function WallHeroStageComponent({
   artHeight,
 }: WallHeroStageProps) {
   const { systemColors } = useTheme();
+  // Rasterize the holds overlay at the size the kiosk actually draws it instead of
+  // the board's native ~1080px. Both LayeredClimbImage layers set
+  // `allowDownscaling={false}`, so a native-width overlay decodes at full size
+  // (~8 MB of RGBA) no matter how small it is shown — and this surface swaps climbs
+  // on every live-wall change and every scrub step, so each one lands another
+  // full-size bitmap in the memory cache. The board PHOTO stays full-res
+  // (`backgroundVariant="full"`): it's shared by every climb on the wall, so it's
+  // one decode either way, and this is the surface where a downgraded photo would
+  // show most. Same pairing as SwipeBoardCarousel; `useNativeClimbRender` clamps to
+  // native width, so a large kiosk that already draws the board above native
+  // resolution is unchanged. Refs #3803.
+  const overlayRenderWidth = artWidth > 0 ? Math.round(artWidth * PixelRatio.get()) : undefined;
   return (
     <View style={[styles.root, { width: artWidth, height: artHeight, backgroundColor: systemColors.background }]}>
       <BoardImageNative
@@ -42,6 +54,8 @@ function WallHeroStageComponent({
         setIds={boardConfig.setIds}
         boardWidth={boardWidth}
         boardHeight={boardHeight}
+        renderWidth={overlayRenderWidth}
+        backgroundVariant="full"
         style={{ width: artWidth, height: artHeight }}
       />
     </View>

--- a/packages/mobile/src/components/board-presence/wall-kiosk/WallHeroStage.tsx
+++ b/packages/mobile/src/components/board-presence/wall-kiosk/WallHeroStage.tsx
@@ -43,6 +43,12 @@ function WallHeroStageComponent({
   // show most. Same pairing as SwipeBoardCarousel; `useNativeClimbRender` clamps to
   // native width, so a large kiosk that already draws the board above native
   // resolution is unchanged. Refs #3803.
+  //
+  // Not memoized, unlike the carousel's equivalent: that one derives from a
+  // `boardBox` OBJECT, so `useMemo` is what keeps its identity stable. This derives
+  // from the `artWidth` number and feeds a number prop, and a number compares equal
+  // by value in the memo'd child's shallow compare — a `useMemo` here would add a
+  // dependency array to guard nothing.
   const overlayRenderWidth = artWidth > 0 ? Math.round(artWidth * PixelRatio.get()) : undefined;
   return (
     <View style={[styles.root, { width: artWidth, height: artHeight, backgroundColor: systemColors.background }]}>

--- a/packages/mobile/src/components/board-presence/wall-kiosk/__tests__/wall-hero-stage.test.tsx
+++ b/packages/mobile/src/components/board-presence/wall-kiosk/__tests__/wall-hero-stage.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type ViewMockProps = { children?: ReactNode };
+
+// PixelRatio.get() is the display density the overlay is rasterized against; pin
+// it so the render-width assertions are about the component, not the host.
+const pixelRatio = vi.hoisted(() => ({ value: 2 }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: ViewMockProps) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  PixelRatio: { get: () => pixelRatio.value },
+}));
+
+// Capture what the kiosk hands the board renderer. The real BoardImageNative pulls
+// in the Rust render pipeline and the bundled-asset cache — neither is under test
+// here; the render sizing it is asked for is.
+const boardImageProps = vi.hoisted(() => ({ calls: [] as Record<string, unknown>[] }));
+vi.mock('../../../BoardImageNative', () => ({
+  BoardImageNative: (props: Record<string, unknown>) => {
+    boardImageProps.calls.push(props);
+    return createElement('div', { 'data-testid': 'board-image' });
+  },
+}));
+
+vi.mock('../../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { background: '#000' } }),
+}));
+
+import { WallHeroStage } from '../WallHeroStage';
+
+const boardConfig = {
+  boardName: 'kilter',
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,20',
+} as unknown as Parameters<typeof WallHeroStage>[0]['boardConfig'];
+
+function renderStage(artWidth: number): Record<string, unknown> {
+  boardImageProps.calls.length = 0;
+  render(
+    createElement(WallHeroStage, {
+      climb: null,
+      boardConfig,
+      boardWidth: 1080,
+      boardHeight: 1170,
+      artWidth,
+      artHeight: artWidth,
+    }),
+  );
+  const captured = boardImageProps.calls.at(-1);
+  if (!captured) throw new Error('BoardImageNative did not render');
+  return captured;
+}
+
+describe('WallHeroStage board-art sizing', () => {
+  beforeEach(() => {
+    pixelRatio.value = 2;
+  });
+
+  it('keeps the board photo full-resolution', () => {
+    // Passing renderWidth flips useNativeClimbRender's background default to the
+    // 416px `thumb` variant. The photo is one shared decode across every climb on
+    // the wall, and this is the largest surface in the app — it must stay `full`.
+    expect(renderStage(600).backgroundVariant).toBe('full');
+  });
+
+  it('sizes the holds overlay to the drawn surface rather than the board default', () => {
+    // Omitting renderWidth rasterizes at the board's native width for every climb.
+    // The assertion is the behavioural property — the request tracks the surface —
+    // not a re-computation of the component's own arithmetic.
+    const narrow = renderStage(400).renderWidth;
+    const wide = renderStage(800).renderWidth;
+    expect(typeof narrow).toBe('number');
+    expect(wide as number).toBeGreaterThan(narrow as number);
+  });
+
+  it('scales the request by display density', () => {
+    const atOneX = renderStage(500).renderWidth;
+    pixelRatio.value = 3;
+    const atThreeX = renderStage(500).renderWidth;
+    expect(atThreeX as number).toBeGreaterThan(atOneX as number);
+  });
+
+  it('falls back to the native-width render before the surface is measured', () => {
+    // A zero width would ask the Rust renderer for a 0px output. Undefined means
+    // "native width" — the pre-existing behaviour — so an unmeasured frame renders
+    // the board instead of nothing.
+    expect(renderStage(0).renderWidth).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
@@ -3,6 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 const clearMemoryCache = vi.hoisted(() => vi.fn(() => Promise.resolve(true)));
+const configureCache = vi.hoisted(() => vi.fn());
+
+// The cap effect reads Platform.OS, so tests flip this to assert the iOS gate —
+// expo-image's Android module exposes no configureCache and would throw.
+const platform = vi.hoisted(() => ({ OS: 'ios' as string }));
 
 // Capture each AppState handler by event name so tests can fire them and assert
 // the registered subscriptions are torn down on unmount.
@@ -24,10 +29,11 @@ const appState = vi.hoisted(() => {
 
 vi.mock('react-native', () => ({
   AppState: { addEventListener: appState.addEventListener },
+  Platform: platform,
 }));
 
 vi.mock('expo-image', () => ({
-  Image: { clearMemoryCache },
+  Image: { clearMemoryCache, configureCache },
 }));
 
 // Control the background flag directly so the cache-flush effect can be asserted
@@ -44,13 +50,60 @@ vi.mock('expo-router', () => ({ useSegments: () => segments.value }));
 const deviceLayout = vi.hoisted(() => ({ isPad: true }));
 vi.mock('../use-device-layout', () => ({ useDeviceLayout: () => ({ isPad: deviceLayout.isPad }) }));
 
-import { useImageCacheMemoryManagement, useIpadTabSwitchImageCacheSweep } from '../use-image-cache-memory-management';
+import {
+  IMAGE_MEMORY_CACHE_MAX_BYTES,
+  useImageCacheMemoryManagement,
+  useIpadTabSwitchImageCacheSweep,
+} from '../use-image-cache-memory-management';
+
+describe('image memory cache ceiling', () => {
+  beforeEach(() => {
+    configureCache.mockClear();
+    platform.OS = 'ios';
+    isBackgrounded.value = false;
+  });
+
+  it('caps the decoded-bitmap cache on iOS', () => {
+    renderHook(() => useImageCacheMemoryManagement());
+    // Pins the wiring, not the arithmetic: it must be maxMemoryCost (the in-memory
+    // bitmap budget), not maxDiskSize — capping the disk cache instead would evict
+    // the very PNGs a re-decode reads back and would not bound memory at all.
+    expect(configureCache).toHaveBeenCalledWith({ maxMemoryCost: IMAGE_MEMORY_CACHE_MAX_BYTES });
+  });
+
+  it('applies the cap once, not on every render', () => {
+    const { rerender } = renderHook(() => useImageCacheMemoryManagement());
+    rerender();
+    isBackgrounded.value = true;
+    rerender();
+    expect(configureCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not configure the cache on Android', () => {
+    // expo-image's Android module has no configureCache — calling it throws.
+    platform.OS = 'android';
+    renderHook(() => useImageCacheMemoryManagement());
+    expect(configureCache).not.toHaveBeenCalled();
+  });
+
+  it('picks a ceiling that holds a real working set but still bounds a long session', () => {
+    // A full-resolution board overlay decodes at roughly 8 MB of RGBA and the
+    // widest surface (the play-drawer carousel: previous + current + peek) holds
+    // three at once. Guards against a fat-fingered constant in either direction —
+    // too low and the cap evicts art a live surface is about to swap to (the
+    // peek→commit flash), too high and it stops bounding anything.
+    const fullResOverlayBytes = 8 * 1024 * 1024;
+    expect(IMAGE_MEMORY_CACHE_MAX_BYTES).toBeGreaterThan(8 * fullResOverlayBytes);
+    expect(IMAGE_MEMORY_CACHE_MAX_BYTES).toBeLessThan(512 * 1024 * 1024);
+  });
+});
 
 describe('useImageCacheMemoryManagement', () => {
   beforeEach(() => {
     clearMemoryCache.mockClear();
     appState.addEventListener.mockClear();
     isBackgrounded.value = false;
+    platform.OS = 'ios';
   });
 
   it('does not flush while foregrounded', () => {

--- a/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
@@ -79,9 +79,11 @@ describe('image memory cache ceiling', () => {
     expect(configureCache).toHaveBeenCalledTimes(1);
   });
 
-  it('does not configure the cache on Android', () => {
-    // expo-image's Android module has no configureCache — calling it throws.
-    platform.OS = 'android';
+  it.each(['android', 'web'])('does not configure the cache on %s', (os) => {
+    // expo-image declares configureCache @platform ios: the Android module defines
+    // no such function, and web has no native cache behind it. The guard is
+    // `!== 'ios'`, so both non-iOS targets must stay silent.
+    platform.OS = os;
     renderHook(() => useImageCacheMemoryManagement());
     expect(configureCache).not.toHaveBeenCalled();
   });

--- a/packages/mobile/src/hooks/use-image-cache-memory-management.ts
+++ b/packages/mobile/src/hooks/use-image-cache-memory-management.ts
@@ -41,10 +41,11 @@ export const IMAGE_MEMORY_CACHE_MAX_BYTES = 256 * 1024 * 1024;
 export function useImageCacheMemoryManagement(): void {
   const isBackgrounded = useIsAppBackgrounded();
 
-  // iOS-only: expo-image's Android module exposes no `configureCache`, so the
-  // call would throw. Android bounds Glide by its own device-RAM-derived policy
-  // plus the native `modules/memory-trim` full-clear (see
-  // docs/react-native-performance.md §7).
+  // iOS-only. expo-image declares `configureCache` `@platform ios` and its Android
+  // module defines no such function, so calling it off iOS fails at the bridge
+  // rather than quietly no-opping. Android bounds Glide by its own
+  // device-RAM-derived policy plus the native `modules/memory-trim` full-clear
+  // (docs/react-native-performance.md §7); web has no native cache to configure.
   useEffect(() => {
     if (Platform.OS !== 'ios') return;
     Image.configureCache({ maxMemoryCost: IMAGE_MEMORY_CACHE_MAX_BYTES });

--- a/packages/mobile/src/hooks/use-image-cache-memory-management.ts
+++ b/packages/mobile/src/hooks/use-image-cache-memory-management.ts
@@ -1,19 +1,54 @@
 import { useEffect, useRef } from 'react';
-import { AppState } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import { Image } from 'expo-image';
 import { useSegments } from 'expo-router';
 import { useIsAppBackgrounded } from '../lib/app-visibility';
 import { useDeviceLayout } from './use-device-layout';
 import { tabsActiveSegment } from '../lib/route-segments';
 
-// Sweep expo-image's in-memory decoded-bitmap cache on background and on OS
-// memory-pressure warnings. The foreground `memoryWarning` path is the direct
-// lever against the iOS OOM watchdog kill on low-RAM devices (#3479); the disk
-// cache is untouched, so foregrounding re-decodes from disk in tens of ms (no
-// network). LayeredClimbImage blanks its <Image> layers on background first,
-// returning their bitmaps to the pool this sweep then frees.
+/**
+ * Ceiling for expo-image's in-memory decoded-bitmap cache, in bytes.
+ *
+ * 256 MB ≈ 32 full-resolution board-art overlays (a native-width overlay decodes
+ * at roughly 8 MB of RGBA — `allowDownscaling={false}` on both LayeredClimbImage
+ * layers means the bitmap is never resampled down), or several hundred list
+ * thumbnails. That is far more than any surface holds at once — the play-drawer
+ * carousel's widest working set is three (previous, current, peek) — so the cap
+ * cannot evict art a live surface is about to swap to, while still bounding a
+ * multi-day session at a fraction of the per-app memory budget on the 4 GB
+ * iPhones where #3479 actually reproduced.
+ */
+export const IMAGE_MEMORY_CACHE_MAX_BYTES = 256 * 1024 * 1024;
+
+// Bound and reclaim expo-image's in-memory decoded-bitmap cache.
+//
+// The ceiling is the load-bearing part. SDWebImage ships `maxMemoryCost = 0`
+// (unlimited) and expo-image never overrides it, so until this hook set one the
+// app ran an UNBOUNDED image memory cache: every distinct board-art bitmap a
+// session decoded stayed resident until the app backgrounded or the OS fired a
+// memory warning — and on iOS that warning arrives only after an allocation has
+// already failed, which is the #3803 crash (SIGSEGV inside image decode) and the
+// same shape as the 4 GB-iPhone foreground OOM in #3479. NSCache enforces the cap
+// continuously, with no timer and no navigation seam to wait for, and eviction
+// drops only the CACHE's reference: a bitmap a mounted view still displays is
+// retained by that view (UIImageView.image + CALayer.contents), so trimming can
+// never blank on-screen art or trigger a reload.
+//
+// The two sweeps below stay as they are. They reclaim at moments the cap can't
+// see (going to background frees the whole working set, not just the excess) and
+// they cost nothing once the cap is in place. The disk cache is untouched
+// throughout, so anything evicted re-decodes from disk in tens of ms, no network.
 export function useImageCacheMemoryManagement(): void {
   const isBackgrounded = useIsAppBackgrounded();
+
+  // iOS-only: expo-image's Android module exposes no `configureCache`, so the
+  // call would throw. Android bounds Glide by its own device-RAM-derived policy
+  // plus the native `modules/memory-trim` full-clear (see
+  // docs/react-native-performance.md §7).
+  useEffect(() => {
+    if (Platform.OS !== 'ios') return;
+    Image.configureCache({ maxMemoryCost: IMAGE_MEMORY_CACHE_MAX_BYTES });
+  }, []);
 
   useEffect(() => {
     if (isBackgrounded) void Image.clearMemoryCache();


### PR DESCRIPTION
## Summary

The app has been running an **unbounded** decoded-bitmap cache. SDWebImage ships `maxMemoryCost = 0` (unlimited), expo-image never overrides it, and `grep -rn "configureCache" packages/` returned zero hits. So every distinct board-art bitmap a session decoded stayed resident until the app backgrounded or the OS fired a memory warning — and on iOS that warning is delivered only *after* an allocation has already failed. That is the #3803 iPad crash (`EXC_BAD_ACCESS` inside image decode, 3d16h uptime) and the same shape as the 4 GB-iPhone foreground OOM in #3479.

**Set the ceiling.** `Image.configureCache({ maxMemoryCost: 256 MB })` once at startup. This is pure JS (`expo-image/src/Image.tsx` → `ios/ImageModule.swift:340-350` → `SDImageCache.shared.config`), so it ships over OTA — no native fingerprint change. iOS-gated: expo-image's Android module exposes no `configureCache` and the call throws; Android already has its own device-RAM-derived Glide policy plus the native `modules/memory-trim` full-clear.

256 MB is ~32 full-resolution overlays. The widest working set of any surface is three (the carousel's previous + current + peek), so the cap cannot evict art a live surface is about to swap to.

**Stop the wall kiosk decoding at native width.** `WallHeroStage` swaps climbs on every live-wall change and every scrub step, and both `LayeredClimbImage` layers set `allowDownscaling={false}` — so each climb decoded ~8 MB of RGBA no matter how small it was drawn. Now passes `renderWidth` (display px × `PixelRatio.get()`) with `backgroundVariant="full"`, matching `SwipeBoardCarousel`: the shared board photo stays crisp, only the per-climb overlay shrinks. Clamped to native width upstream, so a large kiosk already drawing above native resolution is unchanged.

### Why a ceiling and not a periodic sweep

A cap dominates a timer on every axis. NSCache enforces it continuously — no interval to tune, no navigation seam to wait for, and nothing to fire on a surface that never navigates. Critically, **eviction drops only the cache's reference**: a bitmap a mounted view still displays is retained by `UIImageView.image` and `CALayer.contents`, and nothing in expo-image observes a cache clear to trigger a reload (`grep` for `NotificationCenter|addObserver|memoryWarning` over `node_modules/expo-image/ios/` returns zero). So the cap can never blank on-screen art, and it has no equivalent of the peek→commit window a periodic wipe would open in the carousel.

### Deliberately not done

- **No `recyclingKey` on the kiosk hero.** `docs/react-native-performance.md` §7 nominally mandates it for always-mounted surfaces that swap climbs, but a key change sets `sdImageView.image = nil` *before* the new load (`ImageView.swift:66-73`). On a wall-mounted display that inserts a blank frame between climbs, for a bounded 2-bitmap saving. The carousel only gets away with it because its peek pre-warms the cache. Documented as an explicit exception rather than left as an apparent oversight.
- **#3866 (expo-image 57.0.0 → 57.0.1) untouched.** Native fingerprint change; it must ride the release train.
- **#3867 untouched.** Both its levers are sound and still do work this cap can't (backgrounding frees the whole working set, not just the excess).

### What this does not prove

`Refs`, not `Closes`. The crash proves memory exhaustion but not *which* pool. Read as DenseMap bucket-count/mask, `x2 = 0x400000` / `x3 = 0x3fffff` on the crashing thread implies millions of live objects carrying associated objects — and board art at ~8 MB apiece cannot produce millions of objects. So a second, object-count leak may be in play that a bitmap-cache bound does not fix. That is a hypothesis on unsymbolicated frames, not a certainty, but it is reason enough to keep #3803 open and watch.

Scope is also still unsized: PostHog `$exception` is blind on 2.1.0+ and Sentry reads need a `sntryu_` user token nobody has wired up here. The outcome oracle — iPad crash-free rate for SIGSEGV with an ExpoImage/SDWebImage culprit, before vs. after — stays blocked on that token.

Filed separately: sharpened #3928 with the finding that `localAssetName` accepts `scheme == "file"` (`ImageView.swift:855-866`), so **every** `file://` board-art source pays a guaranteed-to-miss main-thread `UIImage(named:)` bundle scan on every reload — that is thread 0 in this crash report, and it is an allocation-churn source independent of the OOM.

## Release Notes

- iPad and iPhone: board art no longer piles up in memory without limit, so a long day on the wall won't end in a crash.
- Wall displays: the kiosk board now renders each climb at the size it's actually shown instead of full resolution.

## Test plan

- `vp check` — exit 0, no findings in changed files.
- `vp run typecheck:mobile` — pass.
- `vp run test:mobile` — 545 files, 4511 tests, all pass (9 new).
- `vp run check:mobile-bundle` — Metro bundle OK.
- **Mutation-tested every new guard** — each deletion fails exactly the intended assertion, no tautologies:
  | Mutation | Fails |
  | --- | --- |
  | drop the `Platform.OS !== 'ios'` gate | `does not configure the cache on Android` |
  | `maxMemoryCost` → `maxDiskSize` | `caps the decoded-bitmap cache on iOS` |
  | drop `backgroundVariant="full"` | `keeps the board photo full-resolution` |
  | drop `renderWidth` | `sizes the holds overlay to the drawn surface`, `scales the request by display density` |
  | drop the `artWidth > 0` guard | `falls back to the native-width render before the surface is measured` |

### Outstanding gate — not done, not claimed

No Mac and no iPad in this environment, so **there is no on-device verification here.** The device check that would settle it: publish this PR's JS to its `pr-<N>` OTA channel, park an iPad on "On the Wall" with a board bound, and watch the Xcode memory gauge for ~30 min while climbs cycle — the image-cache contribution should plateau near the cap instead of climbing. Worth pairing with an iPhone pass on the climbs list and the play-drawer carousel to confirm no thumbnail pop-in or swipe-commit flash from cache pressure at 256 MB.

Refs #3803. Refs #3479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL
