### PR TITLE
fix(sync): keep the mirror flag on JSON-imported ticks

### DIFF
--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -446,6 +446,10 @@ changes, and the `/api/board-credentials/kilter/handoff` +
 - **Same file re-imported**: Deterministic `auroraId` based on `sha256(climbUuid:angle:climbedAt:type)` ensures `onConflictDoUpdate` handles idempotency.
 - **Cross-source (API + JSON)**: Before inserting, existing ticks are fetched and matched by `(climbUuid, angle, climbedAt)` with normalized timestamps. Matching entries are skipped.
 
+Both keys are frozen, and neither includes mirror (#3521). The synthetic `auroraId` is persisted on every imported tick, so changing its inputs rewrites ids that existing rows already carry — which breaks the upsert path that in-place corrections run through, and is a migration, not a refactor. Adding mirror to the cross-source key alone is worse: two records differing only by orientation would then both pass dedup while still hashing to the same `auroraId`, and Postgres rejects two such rows in one `ON CONFLICT DO UPDATE` batch (`21000`), failing the chunk. The trade-off is that a mirrored and a non-mirrored log of the same climb at the same second collapse to one row.
+
+Because the dedup skips rather than upserts, a re-import can't correct an existing row through the insert path. Corrections are explicit `UPDATE`s scoped to the user's own `json_import` rows and matched on the natural key — `healMislabeledJsonImportAttempts` (#3301, send mislabeled as an attempt) and `healJsonImportMirrorFlags` (#3521, orientation dropped). Both are in-place and never delete.
+
 ### Climb Name Resolution
 
 Climb names are resolved via `board_climbs` table using a composite index on `(board_type, name)`. When multiple climbs share the same name (rare), listed public climbs are preferred first, then the importing user's own climbs, then unlisted Aurora catalog climbs. Within the same tier, the climb with the highest `ascensionist_count` is chosen.

--- a/packages/aurora-sync/src/sync/json-import.test.ts
+++ b/packages/aurora-sync/src/sync/json-import.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import {
+  auroraExportSchema,
   buildImportedClimbRow,
   buildJsonImportAscentTickRow,
   exportAscentToAttempt,
@@ -9,6 +10,7 @@ import {
   importedPlaceholderConflictPolicy,
   isExportAscentActuallyAttempt,
   publishedClimbKey,
+  readExportBool,
   type AuroraExportAscent,
 } from './json-import';
 
@@ -108,6 +110,135 @@ describe('merged-shape attempt reclassification (#3301)', () => {
   it('falls back to count when tries is absent', () => {
     const attempt = exportAscentToAttempt(makeAscent({ is_ascent: false, count: 3 }));
     expect(attempt.count).toBe(3);
+  });
+
+  // #3521: Tension/TB2 is both the merged-shape board and the board where a
+  // quarter of live ticks are mirrored, so orientation has to survive the
+  // ascents → attempt coercion or the fix misses exactly the affected users.
+  it('carries the mirror flag across the reclassification', () => {
+    expect(exportAscentToAttempt(makeAscent({ is_ascent: false, is_mirror: true })).is_mirror).toBe(true);
+    expect(exportAscentToAttempt(makeAscent({ is_ascent: false })).is_mirror).toBeUndefined();
+  });
+});
+
+/**
+ * #3521 — `is_mirror` was never declared on the export schema, so zod stripped
+ * it before the row builder ran and every imported tick was written
+ * non-mirrored. Whether Aurora's account export actually carries the field was
+ * NOT verified when this landed: the export is requested by emailing Aurora
+ * support, no real one was available, and its shape shares no field names with
+ * the live API (`climb` name vs `climb_uuid`, `stars` vs `quality`, `grade` vs
+ * `difficulty`) — so the live pull reading `is_mirror` proves nothing about it.
+ * These fixtures are hand-built from the shapes already in this repo, not
+ * copied from a real export. If the field is absent or spelled differently in
+ * the real file, every assertion below still holds and the importer behaves
+ * exactly as it did before.
+ */
+describe('mirrored ascents (#3521)', () => {
+  it('keeps is_mirror through schema validation instead of stripping it', () => {
+    const parsed = auroraExportSchema.parse({
+      user: { username: 'tester' },
+      ascents: [{ ...makeAscent(), is_mirror: true }],
+      attempts: [
+        {
+          climb: 'Test Climb',
+          angle: 40,
+          count: 1,
+          climbed_at: '2026-06-02 10:00:00',
+          created_at: '2026-06-02 10:00:00',
+          is_mirror: true,
+        },
+      ],
+    });
+    expect(parsed.ascents[0].is_mirror).toBe(true);
+    expect(parsed.attempts[0].is_mirror).toBe(true);
+  });
+
+  it('records a mirrored ascent as mirrored', () => {
+    const row = buildJsonImportAscentTickRow(
+      USER_ID,
+      'tension',
+      makeAscent({ is_mirror: true }),
+      CLIMB_UUID,
+      CLIMBED_AT,
+      NOW,
+    );
+    expect(row.isMirror).toBe(true);
+  });
+
+  it('leaves a record without a mirror flag non-mirrored, exactly as before', () => {
+    // Every legacy Kilter export takes this path.
+    expect(buildJsonImportAscentTickRow(USER_ID, 'kilter', makeAscent(), CLIMB_UUID, CLIMBED_AT, NOW).isMirror).toBe(
+      false,
+    );
+    expect(
+      buildJsonImportAscentTickRow(USER_ID, 'kilter', makeAscent({ is_mirror: false }), CLIMB_UUID, CLIMBED_AT, NOW)
+        .isMirror,
+    ).toBe(false);
+  });
+
+  // The export is a bespoke rendering, not the API shape, so we can't assume it
+  // encodes booleans as JSON booleans. A strict z.boolean() would 400 the WHOLE
+  // import on `1` or `"true"` — a much worse bug than the one being fixed — so
+  // the schema takes the value untyped and readExportBool coerces it, matching
+  // the live pull's toBool.
+  it.each([
+    { value: true, expected: true },
+    { value: 1, expected: true },
+    { value: '1', expected: true },
+    { value: 'true', expected: true },
+    { value: false, expected: false },
+    { value: 0, expected: false },
+    { value: 'false', expected: false },
+    { value: null, expected: false },
+    { value: undefined, expected: false },
+  ])('accepts is_mirror encoded as $value without failing validation → $expected', ({ value, expected }) => {
+    const parsed = auroraExportSchema.safeParse({
+      user: { username: 'tester' },
+      ascents: [{ ...makeAscent(), is_mirror: value }],
+    });
+    expect(parsed.success).toBe(true);
+    expect(readExportBool(value)).toBe(expected);
+  });
+});
+
+/**
+ * The synthetic aurora_id is a FROZEN key, not an implementation detail.
+ *
+ * It is persisted on every previously imported tick, where it serves as the ON
+ * CONFLICT arbiter for re-imports and as the handle the live Aurora pull uses
+ * to claim placeholders. Changing the hash inputs rewrites every existing id,
+ * which severs the upsert channel that in-place corrections rely on (the #3390
+ * quality rescale and the #3301 attempt heal both reached existing rows through
+ * it) and can leave twins behind for users whose climbed_at has since moved.
+ *
+ * If this test fails, you are looking at a data-integrity event that needs a
+ * migration and human sign-off — not a refactor to be re-baselined. #3521
+ */
+describe('generateJsonImportAuroraId is frozen', () => {
+  it('produces the same ids it produced before mirror support was added', () => {
+    expect(generateJsonImportAuroraId(USER_ID, CLIMB_UUID, 40, CLIMBED_AT, 'ascents')).toBe(
+      'json-import-0ac4059892bcc26b5e00127dc55c4791',
+    );
+    expect(generateJsonImportAuroraId(USER_ID, CLIMB_UUID, 40, CLIMBED_AT, 'bids')).toBe(
+      'json-import-19a4e6d0a89940c54fb24cc5a4c3d4e4',
+    );
+  });
+
+  it('gives a mirrored and a non-mirrored record at the same instant the same id', () => {
+    // Not an accident: mirror is deliberately absent from both the id hash and
+    // the dedup key. Letting them diverge would put two rows carrying the same
+    // aurora_id into one ON CONFLICT batch, which Postgres rejects (21000).
+    const mirrored = buildJsonImportAscentTickRow(
+      USER_ID,
+      'tension',
+      makeAscent({ is_mirror: true }),
+      CLIMB_UUID,
+      CLIMBED_AT,
+      NOW,
+    );
+    const plain = buildJsonImportAscentTickRow(USER_ID, 'tension', makeAscent(), CLIMB_UUID, CLIMBED_AT, NOW);
+    expect(mirrored.auroraId).toBe(plain.auroraId);
   });
 });
 

--- a/packages/aurora-sync/src/sync/json-import.test.ts
+++ b/packages/aurora-sync/src/sync/json-import.test.ts
@@ -167,7 +167,8 @@ describe('mirrored ascents (#3521)', () => {
   });
 
   it('leaves a record without a mirror flag non-mirrored, exactly as before', () => {
-    // Every legacy Kilter export takes this path.
+    // Every legacy Kilter export takes this path, as does any export that turns
+    // out not to carry the field at all.
     expect(buildJsonImportAscentTickRow(USER_ID, 'kilter', makeAscent(), CLIMB_UUID, CLIMBED_AT, NOW).isMirror).toBe(
       false,
     );
@@ -180,16 +181,21 @@ describe('mirrored ascents (#3521)', () => {
   // The export is a bespoke rendering, not the API shape, so we can't assume it
   // encodes booleans as JSON booleans. A strict z.boolean() would 400 the WHOLE
   // import on `1` or `"true"` — a much worse bug than the one being fixed — so
-  // the schema takes the value untyped and readExportBool coerces it, matching
-  // the live pull's toBool.
+  // the schema takes the value untyped and readExportBool coerces it, a
+  // superset of the live pull's toBool (it also reads the title-case spelling
+  // most languages produce when they stringify a boolean).
   it.each([
     { value: true, expected: true },
     { value: 1, expected: true },
     { value: '1', expected: true },
     { value: 'true', expected: true },
+    { value: 'True', expected: true },
+    { value: 'TRUE', expected: true },
     { value: false, expected: false },
     { value: 0, expected: false },
     { value: 'false', expected: false },
+    { value: 'False', expected: false },
+    { value: '', expected: false },
     { value: null, expected: false },
     { value: undefined, expected: false },
   ])('accepts is_mirror encoded as $value without failing validation → $expected', ({ value, expected }) => {

--- a/packages/aurora-sync/src/sync/json-import.ts
+++ b/packages/aurora-sync/src/sync/json-import.ts
@@ -190,7 +190,16 @@ export type ImportProgressEvent =
  * is every legacy Kilter export — as false. #3521
  */
 export function readExportBool(value: unknown): boolean {
-  return value === true || value === 1 || value === '1' || value === 'true';
+  if (typeof value === 'string') {
+    // Case-insensitive on the string form, which `toBool` isn't: the export is
+    // rendered by some Aurora-side script we've never seen, and a stringified
+    // boolean from most languages comes out title-case ("True"). Reading one
+    // more spelling costs nothing; missing it would silently drop the flag all
+    // over again.
+    const normalized = value.trim().toLowerCase();
+    return normalized === '1' || normalized === 'true';
+  }
+  return value === true || value === 1;
 }
 
 /**

--- a/packages/aurora-sync/src/sync/json-import.ts
+++ b/packages/aurora-sync/src/sync/json-import.ts
@@ -57,6 +57,15 @@ const auroraExportAscentSchema = z.object({
   grade: z.string().optional(),
   is_ascent: z.boolean().optional(),
   tries: z.number().optional(),
+  // Declared so zod stops silently stripping it: an undeclared key never
+  // reaches the row builder, which is why every imported tick was written
+  // non-mirrored (#3521). Typed `unknown` rather than `z.boolean()` on
+  // purpose — the export is a bespoke rendering, not the API shape, so we
+  // don't know how it encodes booleans. A strict boolean would reject the
+  // WHOLE import with a 400 if Aurora emits `1` / `"true"` / `null`, which
+  // is a far worse failure than the orientation bug. `readExportBool` does
+  // the coercion instead, exactly like the live pull's `toBool`.
+  is_mirror: z.unknown().optional(),
 });
 
 export type AuroraExportAscent = z.infer<typeof auroraExportAscentSchema>;
@@ -67,6 +76,11 @@ const auroraExportAttemptSchema = z.object({
   count: z.number(),
   climbed_at: z.string(),
   created_at: z.string(),
+  // Same reasoning as the ascent schema above (#3521). Attempts matter as much
+  // as sends here: Tension/TB2 — the board where a quarter of live ticks are
+  // mirrored — delivers its bids inside `ascents` with `is_ascent: false`, and
+  // those records flow through `exportAscentToAttempt` into this shape.
+  is_mirror: z.unknown().optional(),
 });
 
 export type AuroraExportAttempt = z.infer<typeof auroraExportAttemptSchema>;
@@ -169,6 +183,34 @@ export type ImportProgressEvent =
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Coerce an export flag whose wire encoding we can't pin down. Mirrors the live
+ * pull's `toBool` (apply-user-logbook.ts) so both sync paths agree on what
+ * counts as true, and treats anything else — including a missing field, which
+ * is every legacy Kilter export — as false. #3521
+ */
+export function readExportBool(value: unknown): boolean {
+  return value === true || value === 1 || value === '1' || value === 'true';
+}
+
+/**
+ * The synthetic `aurora_id` for an imported tick.
+ *
+ * FROZEN: the inputs to this hash must not change. Every previously imported
+ * tick carries the resulting id in `boardsesh_ticks.aurora_id`, where it is
+ * both the ON CONFLICT arbiter for a re-import (see `batchInsertTicks`) and the
+ * handle the live Aurora pull uses to claim placeholders (`aurora_id LIKE
+ * 'json-import-%'`). Adding a field rewrites every id in place, which severs
+ * the upsert channel that in-place corrections depend on — the #3390 quality
+ * rescale and the #3301 attempt heal both reached existing rows through it —
+ * and orphans rows whose stored climbed_at has since been moved by the live
+ * pull. Changing this is a data-integrity event needing a migration and human
+ * sign-off, not a refactor; `json-import.test.ts` pins the output to catch it.
+ *
+ * In particular, mirror is deliberately NOT part of the key (#3521): see the
+ * dedup comment in `importJsonExportData` for why the natural key can't carry
+ * it either.
+ */
 export function generateJsonImportAuroraId(
   userId: string,
   climbUuid: string,
@@ -227,7 +269,9 @@ export function buildJsonImportAscentTickRow(
     boardType,
     climbUuid,
     angle: ascent.angle,
-    isMirror: false,
+    // Absent from the export (every legacy Kilter file) → false, exactly as
+    // before. Present → recorded, instead of being thrown away. #3521
+    isMirror: readExportBool(ascent.is_mirror),
     // Conservative initial value. Aurora's `count` is attempts within a
     // single climbed_at session, not "no prior attempts ever" — so we can't
     // call this a flash here. correctFlashStatusForUser runs on the final
@@ -281,6 +325,10 @@ export function exportAscentToAttempt(ascent: AuroraExportAscent): AuroraExportA
     count: ascent.tries ?? ascent.count,
     climbed_at: ascent.climbed_at,
     created_at: ascent.created_at,
+    // Carry orientation across the reclassification, or every Tension/TB2 bid
+    // — the shape where mirrored logs actually concentrate — would lose it on
+    // the way into the attempt path. #3521
+    is_mirror: ascent.is_mirror,
   };
 }
 
@@ -978,6 +1026,90 @@ async function healMislabeledJsonImportAttempts(
 }
 
 // ---------------------------------------------------------------------------
+// Self-healing remediation for #3521
+// ---------------------------------------------------------------------------
+
+/** Natural key of an export record the user climbed mirrored. */
+type MirroredTickKey = {
+  climbUuid: string;
+  angle: number;
+  climbedAt: string;
+};
+
+/**
+ * Set `is_mirror` on rows an earlier import wrote as non-mirrored because the
+ * export's mirror field was being stripped before it ever reached the row
+ * builder (#3521).
+ *
+ * A re-import can't fix those rows on its own: the cross-source dedup below
+ * SKIPS a record whose natural key already exists, so the ON CONFLICT upsert
+ * never runs for it. This UPDATE is the only channel that reaches them, and
+ * re-importing the file is the obvious thing a user does to correct their
+ * logbook. Same shape as the #3301 heal above: matched on the natural key
+ * (climb_uuid, angle, climbed_at) of this user's own json_import rows,
+ * in-place, never a delete and never a twin.
+ *
+ * Two guards the #3301 heal doesn't have:
+ *  - Only ever flips false → true, and only from records the export marks
+ *    mirrored. An export that carries no mirror field produces an empty key
+ *    list and this never runs, so the change is inert on files that lack it.
+ *  - Skips locally-edited rows (updated_at > aurora_synced_at), the same test
+ *    the live pull uses, so a user who fixed the orientation by hand in
+ *    Boardsesh doesn't get overwritten by a stale re-import.
+ *
+ * Returns the number of rows healed.
+ */
+async function healJsonImportMirrorFlags(
+  db: PgDatabase<PgQueryResultHKT, Record<string, unknown>>,
+  boardType: BoardType,
+  userId: string,
+  keys: MirroredTickKey[],
+  now: string,
+): Promise<number> {
+  if (keys.length === 0) return 0;
+
+  let healed = 0;
+  for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+    const batch = keys.slice(i, i + BATCH_SIZE);
+    const payload = JSON.stringify(
+      batch.map((key) => ({
+        climb_uuid: key.climbUuid,
+        angle: key.angle,
+        climbed_at: key.climbedAt,
+      })),
+    );
+
+    const result = await db.execute(sql`
+      UPDATE boardsesh_ticks AS t SET
+        is_mirror = true,
+        updated_at = ${now}::timestamp,
+        aurora_synced_at = ${now}::timestamp
+      FROM jsonb_to_recordset(${payload}::jsonb) AS u(
+        climb_uuid text,
+        angle integer,
+        climbed_at text
+      )
+      WHERE t.user_id = ${userId}
+        AND t.board_type = ${boardType}
+        AND t.origin = 'json_import'
+        AND t.is_mirror IS DISTINCT FROM true
+        AND (t.aurora_synced_at IS NULL OR t.updated_at <= t.aurora_synced_at)
+        AND t.climb_uuid = u.climb_uuid
+        AND t.angle = u.angle
+        AND t.climbed_at = u.climbed_at::timestamp
+      RETURNING t.uuid
+    `);
+
+    // drizzle's execute() return shape differs by driver (postgres-js returns
+    // the rows array; Neon HTTP wraps them in { rows }), so normalize both.
+    const rows = Array.isArray(result) ? result : ((result as { rows?: unknown[] }).rows ?? []);
+    healed += rows.length;
+  }
+
+  return healed;
+}
+
+// ---------------------------------------------------------------------------
 // Main import function
 // ---------------------------------------------------------------------------
 
@@ -1276,7 +1408,34 @@ export async function importJsonExportData(
     });
   }
 
+  // Natural keys of every record the export marks mirrored, used to heal rows a
+  // pre-#3521 import wrote non-mirrored (see self-heal below). Empty whenever
+  // the export carries no mirror field, which makes the heal a no-op there.
+  const mirroredTickKeys: MirroredTickKey[] = [];
+  for (const record of [...trueAscents, ...allAttempts]) {
+    if (!readExportBool(record.is_mirror)) continue;
+    const climbUuid = nameToUuid.get(record.climb);
+    if (!climbUuid) continue;
+    mirroredTickKeys.push({
+      climbUuid,
+      angle: record.angle,
+      climbedAt: normalizeTimestamp(record.climbed_at),
+    });
+  }
+
   // Step 5: Collect ascent rows to insert (in-memory dedup first)
+  //
+  // The dedup key deliberately omits mirror (#3521). Adding it would let a
+  // mirrored and a non-mirrored record at the same (climb, angle, instant) both
+  // pass — and since `generateJsonImportAuroraId` is frozen, both would carry
+  // the SAME aurora_id and land in one INSERT … ON CONFLICT DO UPDATE batch,
+  // which Postgres rejects outright (21000, "cannot affect row a second time"),
+  // failing the whole chunk. Splitting that pair needs the id key to change
+  // too, which is a migration, not a one-liner. So the pre-existing behaviour
+  // stands: such a pair collapses to one row (the first one wins, the second is
+  // counted as skipped). It needs two logs of the same climb at the same angle
+  // in the same second, which Aurora's second-resolution climbed_at makes very
+  // rare, and the outcome is a skip, not corruption.
   const ascentRows = trueAscents.reduce<JsonImportTickRow[]>((rows, ascent) => {
     const climbUuid = nameToUuid.get(ascent.climb);
     if (!climbUuid) {
@@ -1319,7 +1478,7 @@ export async function importJsonExportData(
       boardType,
       climbUuid,
       angle: attempt.angle,
-      isMirror: false,
+      isMirror: readExportBool(attempt.is_mirror),
       status: 'attempt',
       attemptCount: attempt.count,
       quality: null,
@@ -1338,8 +1497,9 @@ export async function importJsonExportData(
   }, []);
 
   // Step 7: Batch-insert ascents and attempts, plus self-heal any pre-#3301
-  // mislabeled sends, all in one transaction.
+  // mislabeled sends and pre-#3521 dropped mirror flags, all in one transaction.
   let healedMislabeledSends = 0;
+  let healedMirrorFlags = 0;
   await db.transaction(async (tx) => {
     result.ascents.imported = await batchInsertTicks(
       tx,
@@ -1355,6 +1515,9 @@ export async function importJsonExportData(
         attemptCount: sql`excluded.attempt_count`,
         quality: sql`excluded.quality`,
         difficulty: sql`excluded.difficulty`,
+        // #3521: a row reached by the upsert (rather than skipped by the dedup)
+        // takes the export's orientation too, instead of keeping a stale false.
+        isMirror: sql`excluded.is_mirror`,
         climbedAt: sql`excluded.climbed_at`,
         updatedAt: sql`excluded.updated_at`,
         auroraSyncedAt: sql`excluded.aurora_synced_at`,
@@ -1371,6 +1534,7 @@ export async function importJsonExportData(
         climbUuid: sql`excluded.climb_uuid`,
         angle: sql`excluded.angle`,
         attemptCount: sql`excluded.attempt_count`,
+        isMirror: sql`excluded.is_mirror`,
         climbedAt: sql`excluded.climbed_at`,
         updatedAt: sql`excluded.updated_at`,
         auroraSyncedAt: sql`excluded.aurora_synced_at`,
@@ -1385,6 +1549,11 @@ export async function importJsonExportData(
     // skips inserting a twin for these keys, so this UPDATE is what actually
     // corrects the stale row. Never deletes.
     healedMislabeledSends = await healMislabeledJsonImportAttempts(tx, boardType, userId, reclassifiedAttemptKeys, now);
+
+    // Remediation (#3521): set is_mirror on rows a pre-fix import wrote
+    // non-mirrored. Same reason as above — the dedup skips these keys, so the
+    // upsert never reaches them and this UPDATE is the only correction channel.
+    healedMirrorFlags = await healJsonImportMirrorFlags(tx, boardType, userId, mirroredTickKeys, now);
   });
 
   // Structured breadcrumb (info-level, not an error) so we can measure how often
@@ -1393,6 +1562,17 @@ export async function importJsonExportData(
   // console (with key=value fields) rather than the backend winston logger on
   // purpose: this shared package must not depend on `packages/backend`, and it
   // already logs via console elsewhere. The backend captures stdout regardless.
+  // Counterpart breadcrumb for #3521. Whether Aurora's account export carries a
+  // mirror field at all was unverified when this shipped — no real export was
+  // available to check — so this is how prod answers it: a non-zero
+  // mirroredRecords on a real import confirms the field exists and is named
+  // `is_mirror`. Counts only, no user content.
+  if (mirroredTickKeys.length > 0 || healedMirrorFlags > 0) {
+    console.info(
+      `[aurora-import][3521] mirrored records: boardType=${boardType} mirroredRecords=${mirroredTickKeys.length} healedMirrorFlags=${healedMirrorFlags}`,
+    );
+  }
+
   if (reclassifiedAttempts.length > 0 || healedMislabeledSends > 0) {
     console.info(
       `[aurora-import][3301] merged-shape logbook: boardType=${boardType} reclassifiedAttempts=${reclassifiedAttempts.length} healedMislabeledSends=${healedMislabeledSends}`,

--- a/packages/backend/src/__tests__/aurora-import-mirror.test.ts
+++ b/packages/backend/src/__tests__/aurora-import-mirror.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import { auroraExportSchema, importJsonExportData } from '@boardsesh/aurora-sync/json-import';
+import { db } from '../db/client';
+import { setupWorkerDatabase } from './worker-db';
+
+/**
+ * #3521 — the export schema never declared `is_mirror`, so zod stripped it and
+ * the row builder wrote every imported tick non-mirrored. A quarter of live
+ * Tension ticks are mirrored, so an importing Tension climber's logbook
+ * misstated orientation on roughly one climb in four.
+ *
+ * These tests go through `auroraExportSchema` on purpose. The unit tests cover
+ * the row builder, and the sibling #3301 tests hand `importJsonExportData` an
+ * already-shaped object — which means a revert of the schema half alone would
+ * leave them green. Parsing first is what makes this an end-to-end assertion:
+ * strip the field from the schema and these fail.
+ *
+ * The records are hand-built from the shapes already in this repo. No real
+ * Aurora account export was available to copy (they're requested by emailing
+ * Aurora support and contain personal data), so whether the real file carries
+ * `is_mirror` was unverified when this landed.
+ */
+
+const USER_ID = 'ai3521-user';
+const BOARD = 'tension';
+const CLIMB_UUID = 'ai3521-climb-uuid';
+const CLIMB_NAME = 'Mirror Test Climb';
+const ANGLE = 40;
+
+const importDb = db as unknown as Parameters<typeof importJsonExportData>[0];
+
+type ExportOverrides = Partial<{
+  ascents: Array<Record<string, unknown>>;
+  attempts: Array<Record<string, unknown>>;
+}>;
+
+/** Parse through the real schema, exactly as the import handler does. */
+function parsedExportPayload(overrides: ExportOverrides = {}) {
+  return auroraExportSchema.parse({
+    user: { username: 'ai3521' },
+    ascents: overrides.ascents ?? [],
+    attempts: overrides.attempts ?? [],
+    circuits: [],
+    climbs: [],
+    likes: [],
+  });
+}
+
+function ascentRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    climb: CLIMB_NAME,
+    angle: ANGLE,
+    count: 2,
+    stars: 3,
+    climbed_at: '2026-06-01 10:00:00',
+    created_at: '2026-06-01 10:05:00',
+    grade: '7a',
+    ...overrides,
+  };
+}
+
+function attemptRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    climb: CLIMB_NAME,
+    angle: ANGLE,
+    count: 3,
+    climbed_at: '2026-06-02 11:00:00',
+    created_at: '2026-06-02 11:05:00',
+    ...overrides,
+  };
+}
+
+async function ticksForUser() {
+  const rows = (await db.execute(sql`
+    SELECT uuid, status, is_mirror, aurora_id, aurora_type, updated_at, aurora_synced_at, climbed_at
+    FROM boardsesh_ticks
+    WHERE user_id = ${USER_ID} AND board_type = ${BOARD}
+    ORDER BY climbed_at
+  `)) as unknown as Array<{
+    uuid: string;
+    status: string;
+    is_mirror: boolean | null;
+    aurora_id: string | null;
+    aurora_type: string | null;
+    updated_at: string;
+    aurora_synced_at: string | null;
+    climbed_at: string;
+  }>;
+  return Array.isArray(rows) ? rows : (((rows as { rows?: unknown[] }).rows as typeof rows) ?? []);
+}
+
+beforeAll(async () => {
+  await setupWorkerDatabase();
+  await db.execute(
+    sql`CREATE UNIQUE INDEX IF NOT EXISTS boardsesh_ticks_aurora_id_unique ON boardsesh_ticks (aurora_id)`,
+  );
+  await db.execute(sql`
+    INSERT INTO users (id, email, name, created_at, updated_at)
+    VALUES (${USER_ID}, ${USER_ID + '@test.com'}, 'Mirror Tester', now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at)
+    VALUES (${CLIMB_UUID}, ${BOARD}, 1, 'test-setter', ${CLIMB_NAME}, 'p1r1', 1, false, true, 0, 100, 0, 150, '2024-01-01')
+    ON CONFLICT (uuid) DO NOTHING
+  `);
+});
+
+afterEach(async () => {
+  await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+});
+
+describe('aurora import — #3521 mirrored ascents', () => {
+  it('imports a mirrored send as mirrored', async () => {
+    await importJsonExportData(
+      importDb,
+      USER_ID,
+      BOARD,
+      parsedExportPayload({ ascents: [ascentRecord({ is_mirror: true })] }),
+    );
+
+    const rows = await ticksForUser();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].is_mirror).toBe(true);
+  });
+
+  it('imports a mirrored attempt as mirrored, including a merged-shape TB2 bid', async () => {
+    await importJsonExportData(
+      importDb,
+      USER_ID,
+      BOARD,
+      parsedExportPayload({
+        attempts: [attemptRecord({ is_mirror: true })],
+        // The live Tension/TB2 shape: a never-sent bid delivered inside
+        // `ascents` with is_ascent: false. It reaches the attempt path through
+        // exportAscentToAttempt, which has to carry orientation with it.
+        ascents: [ascentRecord({ is_ascent: false, tries: 4, is_mirror: true, climbed_at: '2026-06-03 12:00:00' })],
+      }),
+    );
+
+    const rows = await ticksForUser();
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.is_mirror === true)).toBe(true);
+    expect(rows.every((row) => row.aurora_type === 'bids')).toBe(true);
+  });
+
+  it('leaves a record with no mirror field non-mirrored (every legacy Kilter export)', async () => {
+    await importJsonExportData(importDb, USER_ID, BOARD, parsedExportPayload({ ascents: [ascentRecord()] }));
+
+    const rows = await ticksForUser();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].is_mirror === true).toBe(false);
+  });
+
+  it('heals a pre-fix non-mirrored row on re-import, in place and without a twin', async () => {
+    // First import reproduces the OLD bug: the flag is stripped, so the tick is
+    // written non-mirrored.
+    await importJsonExportData(importDb, USER_ID, BOARD, parsedExportPayload({ ascents: [ascentRecord()] }));
+
+    let rows = await ticksForUser();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].is_mirror === true).toBe(false);
+    const originalUuid = rows[0].uuid;
+    const originalAuroraId = rows[0].aurora_id;
+
+    // Re-import the SAME record, now carrying the flag. The dedup skips the
+    // insert, so the heal UPDATE is the only thing that can correct the row.
+    const reimport = await importJsonExportData(
+      importDb,
+      USER_ID,
+      BOARD,
+      parsedExportPayload({ ascents: [ascentRecord({ is_mirror: true })] }),
+    );
+
+    expect(reimport.ascents.imported).toBe(0);
+    expect(reimport.ascents.skipped).toBe(1);
+
+    rows = await ticksForUser();
+    // Same row, healed — not a second tick, not a re-keyed one.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].uuid).toBe(originalUuid);
+    expect(rows[0].aurora_id).toBe(originalAuroraId);
+    expect(rows[0].is_mirror).toBe(true);
+  });
+
+  it('does not overwrite a row the climber corrected by hand in Boardsesh', async () => {
+    await importJsonExportData(
+      importDb,
+      USER_ID,
+      BOARD,
+      parsedExportPayload({ ascents: [ascentRecord({ is_mirror: true })] }),
+    );
+
+    // Simulate a local edit that turned mirror back off after the import: a
+    // local edit is any row whose updated_at is newer than its last sync, the
+    // same test the live Aurora pull uses.
+    await db.execute(sql`
+      UPDATE boardsesh_ticks
+      SET is_mirror = false, updated_at = aurora_synced_at + interval '1 hour'
+      WHERE user_id = ${USER_ID}
+    `);
+
+    await importJsonExportData(
+      importDb,
+      USER_ID,
+      BOARD,
+      parsedExportPayload({ ascents: [ascentRecord({ is_mirror: true })] }),
+    );
+
+    const rows = await ticksForUser();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].is_mirror === true).toBe(false);
+  });
+
+  it('never rewrites the synthetic aurora_id when orientation changes', async () => {
+    await importJsonExportData(importDb, USER_ID, BOARD, parsedExportPayload({ ascents: [ascentRecord()] }));
+    const before = (await ticksForUser())[0].aurora_id;
+
+    await importJsonExportData(
+      importDb,
+      USER_ID,
+      BOARD,
+      parsedExportPayload({ ascents: [ascentRecord({ is_mirror: true })] }),
+    );
+    const after = (await ticksForUser())[0].aurora_id;
+
+    // The id is the ON CONFLICT arbiter for re-imports and the handle the live
+    // Aurora pull claims placeholders by. Mirror is deliberately not part of it.
+    expect(after).toBe(before);
+  });
+});

--- a/packages/backend/src/__tests__/aurora-import-mirror.test.ts
+++ b/packages/backend/src/__tests__/aurora-import-mirror.test.ts
@@ -150,17 +150,19 @@ describe('aurora import — #3521 mirrored ascents', () => {
 
     const rows = await ticksForUser();
     expect(rows).toHaveLength(1);
-    expect(rows[0].is_mirror === true).toBe(false);
+    expect(rows[0].is_mirror).not.toBe(true);
   });
 
   it('heals a pre-fix non-mirrored row on re-import, in place and without a twin', async () => {
-    // First import reproduces the OLD bug: the flag is stripped, so the tick is
-    // written non-mirrored.
+    // Stands in for the state the old importer left behind: a tick stored
+    // non-mirrored for a climb the user actually climbed mirrored. Reached here
+    // by importing a record with no flag, since the pre-fix code path (zod
+    // stripping the flag on the way in) no longer exists to reproduce directly.
     await importJsonExportData(importDb, USER_ID, BOARD, parsedExportPayload({ ascents: [ascentRecord()] }));
 
     let rows = await ticksForUser();
     expect(rows).toHaveLength(1);
-    expect(rows[0].is_mirror === true).toBe(false);
+    expect(rows[0].is_mirror).not.toBe(true);
     const originalUuid = rows[0].uuid;
     const originalAuroraId = rows[0].aurora_id;
 
@@ -210,7 +212,7 @@ describe('aurora import — #3521 mirrored ascents', () => {
 
     const rows = await ticksForUser();
     expect(rows).toHaveLength(1);
-    expect(rows[0].is_mirror === true).toBe(false);
+    expect(rows[0].is_mirror).not.toBe(true);
   });
 
   it('never rewrites the synthetic aurora_id when orientation changes', async () => {

--- a/packages/backend/src/__tests__/aurora-import-mirror.test.ts
+++ b/packages/backend/src/__tests__/aurora-import-mirror.test.ts
@@ -150,7 +150,7 @@ describe('aurora import — #3521 mirrored ascents', () => {
 
     const rows = await ticksForUser();
     expect(rows).toHaveLength(1);
-    expect(rows[0].is_mirror).not.toBe(true);
+    expect(rows[0].is_mirror).toBe(false);
   });
 
   it('heals a pre-fix non-mirrored row on re-import, in place and without a twin', async () => {
@@ -162,7 +162,7 @@ describe('aurora import — #3521 mirrored ascents', () => {
 
     let rows = await ticksForUser();
     expect(rows).toHaveLength(1);
-    expect(rows[0].is_mirror).not.toBe(true);
+    expect(rows[0].is_mirror).toBe(false);
     const originalUuid = rows[0].uuid;
     const originalAuroraId = rows[0].aurora_id;
 
@@ -212,7 +212,7 @@ describe('aurora import — #3521 mirrored ascents', () => {
 
     const rows = await ticksForUser();
     expect(rows).toHaveLength(1);
-    expect(rows[0].is_mirror).not.toBe(true);
+    expect(rows[0].is_mirror).toBe(false);
   });
 
   it('never rewrites the synthetic aurora_id when orientation changes', async () => {

--- a/packages/backend/src/handlers/aurora-import.ts
+++ b/packages/backend/src/handlers/aurora-import.ts
@@ -97,6 +97,7 @@ const SHAPE_MAX_KEY_LENGTH = 40;
 function describeExportRecordShape(records: unknown[]): string {
   const keys = new Set<string>();
   for (const record of records.slice(0, SHAPE_SAMPLE_RECORDS)) {
+    if (keys.size >= SHAPE_MAX_KEYS) break;
     if (!record || typeof record !== 'object' || Array.isArray(record)) continue;
     for (const key of Object.keys(record)) {
       if (keys.size >= SHAPE_MAX_KEYS) break;

--- a/packages/backend/src/handlers/aurora-import.ts
+++ b/packages/backend/src/handlers/aurora-import.ts
@@ -75,6 +75,53 @@ function writeImportEvent(res: ServerResponse, event: ImportProgressEvent): void
   res.write(`${JSON.stringify(event)}\n`);
 }
 
+/** How many records to sample per array when reporting the export's shape. */
+const SHAPE_SAMPLE_RECORDS = 50;
+/** Upper bound on distinct key names reported, so a malformed file can't flood the log. */
+const SHAPE_MAX_KEYS = 40;
+/** Upper bound on a single reported key name's length. */
+const SHAPE_MAX_KEY_LENGTH = 40;
+
+/**
+ * The FIELD NAMES an export's ascent/attempt records carry — never their values.
+ *
+ * Zod strips undeclared keys silently, which is how the mirror flag went
+ * missing from every JSON-imported tick (#3521), and how `comment` /
+ * `is_benchmark` are still being dropped today. A real Aurora account export is
+ * requested by emailing Aurora support and contains personal data, so nobody on
+ * the team has one to inspect and the file's shape stays guesswork until a real
+ * import passes through here. Reporting the key names — sampled, capped,
+ * truncated, values never read — turns the next real import into that answer
+ * while retaining nothing about the climber or their logbook.
+ */
+function describeExportRecordShape(records: unknown[]): string {
+  const keys = new Set<string>();
+  for (const record of records.slice(0, SHAPE_SAMPLE_RECORDS)) {
+    if (!record || typeof record !== 'object' || Array.isArray(record)) continue;
+    for (const key of Object.keys(record)) {
+      if (keys.size >= SHAPE_MAX_KEYS) break;
+      keys.add(key.slice(0, SHAPE_MAX_KEY_LENGTH));
+    }
+  }
+  return [...keys].sort().join(',');
+}
+
+/** Log the sampled key names of one import chunk. Reads the RAW body, before zod strips it. */
+function logExportShape(body: unknown, boardType: string): void {
+  if (!body || typeof body !== 'object') return;
+  const payload = (body as { data?: unknown }).data;
+  if (!payload || typeof payload !== 'object') return;
+
+  const { ascents, attempts } = payload as { ascents?: unknown; attempts?: unknown };
+  const ascentKeys = Array.isArray(ascents) ? describeExportRecordShape(ascents) : '';
+  const attemptKeys = Array.isArray(attempts) ? describeExportRecordShape(attempts) : '';
+  if (!ascentKeys && !attemptKeys) return;
+
+  logger.info(
+    `[AuroraImport][3521] export record shape: boardType=${boardType} ascentKeys=${ascentKeys} attemptKeys=${attemptKeys}`,
+  );
+}
+
 export async function handleAuroraImport(req: IncomingMessage, res: ServerResponse): Promise<void> {
   if (!applyCorsHeaders(req, res)) return;
 
@@ -103,6 +150,10 @@ export async function handleAuroraImport(req: IncomingMessage, res: ServerRespon
   }
 
   const { boardType, data, skipFinalization } = validationResult.data;
+
+  // Before the parsed (stripped) payload is used anywhere, record what the raw
+  // file actually carried. See describeExportRecordShape: names only. #3521
+  logExportShape(body, boardType);
 
   res.writeHead(200, {
     'Content-Type': 'text/plain; charset=utf-8',


### PR DESCRIPTION
## Summary

The Aurora JSON importer wrote **every** tick as non-mirrored. `auroraExportAscentSchema` never declared `is_mirror`, so zod stripped it before the row builder ran, and `buildJsonImportAscentTickRow` hardcoded `false`. 10,037 of 39,718 live-pulled Tension ticks are mirrored, so an importing Tension climber's logbook misstated orientation on roughly one climb in four.

**Read this before assuming the bug is fixed.** Whether Aurora's account export actually carries a mirror field was **not verified** when this shipped. The export is requested by emailing Aurora support and contains personal data — no real one was available to inspect, and none exist in this repo, in the #3301 history, or in public code search. The premise the issue rests on doesn't hold either: the export shares no field names with the live API it's being compared to.

| concept | live API | JSON export |
| --- | --- | --- |
| climb | `climb_uuid` | `climb` (a **name**, resolved via `board_climbs`) |
| attempts | `bid_count` | `count` / `tries` |
| quality | `quality` | `stars` |
| grade | `difficulty` (numeric id) | `grade` (font string) |

So `apply-user-logbook.ts` reading `toBool(item.is_mirror)` tells us nothing about the export. This PR makes mirrored ascents import correctly **if** the export carries the field, and is a no-op if it doesn't — hence `Refs #3521`, not a closing keyword. The key-name logging below is what will settle it.

### What changed

- **Schema**: `is_mirror` declared on the ascent + attempt schemas as `z.unknown().optional()`, not `z.boolean()`. A strict boolean would reject the **entire** import with a 400 if Aurora encodes `1` / `"true"` / `null` — a far worse bug than the one being fixed. `readExportBool` coerces it, matching the live pull's `toBool`.
- **Row builders**: ascent and attempt rows take the flag. `exportAscentToAttempt` carries it too, or every Tension/TB2 bid (delivered inside `ascents` with `is_ascent: false`) would lose orientation on the way to the attempt path — exactly the affected board.
- **Upserts**: both conflict sets take `excluded.is_mirror`.
- **Self-heal**, same shape as the #3301 heal: a re-import sets `is_mirror` on rows a pre-fix import wrote non-mirrored. The cross-source dedup *skips* those keys, so the upsert never reaches them and this `UPDATE` is the only channel that can correct them — without it the fix would only help first-time imports, and re-importing the file is the obvious thing a user does to fix their logbook. User-scoped, in place, never a delete or a twin. Two guards: it only ever flips `false → true` from records the export marks mirrored (so it's inert on files lacking the field), and it skips locally-edited rows (`updated_at > aurora_synced_at`), which the #3301 precedent doesn't do.
- **Key-name logging** (`aurora-import.ts`): the sampled **field names** of each chunk's ascent/attempt records. **It cannot log user content** — `describeExportRecordShape` reads `Object.keys` only and never touches a value; names are sampled from the first 50 records, capped at 40 distinct keys, and truncated to 40 chars each. This turns the next real import into the answer, and also surfaces `comment` / `is_benchmark`, both hardcoded today for the same silent-strip reason.

### The keys are deliberately frozen

`generateJsonImportAuroraId` and the cross-source dedup key are unchanged, and both now carry a comment saying why.

- Adding mirror to the **dedup key alone** would let a mirrored and a non-mirrored record at the same instant both pass — and since the id hash is frozen, both would carry the **same `aurora_id`** in one `INSERT … ON CONFLICT DO UPDATE` batch, which Postgres rejects outright (`21000`, "cannot affect row a second time"), failing the whole chunk. The issue's suggested fix has this footgun.
- Adding it to the **hash** rewrites every previously imported tick's id. The real damage there isn't twins (the natural-key dedup blocks most of those) — it's severing the upsert channel that in-place corrections depend on: the #3390 quality rescale and the #3301 attempt heal both reached existing rows through it.

A test pins the hash output to known literals, so a future rekey trips CI. That's intentional: changing it is a data-integrity event needing a migration and sign-off, not a refactor.

**Known limitation, pre-existing and unchanged:** a mirrored and a non-mirrored send of the same climb at the same angle in the same second collapse to one row (first wins, second counted as skipped). Aurora's `climbed_at` is second-resolution, so this needs two logs in the same second; the outcome is a skip, not corruption.

### Already-imported rows

They're all wrong-if-mirrored and there is **no signal that identifies which** — the only candidate predicate is "every `json_import` row with `is_mirror = false`", which is all of them, and the raw export is never retained. No backfill is proposed. Two things do reach them: re-importing the file (the heal above), and — on boards with a live Aurora backend — linking the account, since the live pull's `payloadDiffersFromStored` already compares `isMirror`. Kilter has no such channel; its Aurora backend is gone, which is why JSON import exists.

## Release Notes

Deliberately none. A release note would have to promise climbers that re-importing fixes their mirrored sends, and that promise is only true if Aurora's export carries the field — which is exactly what hasn't been verified. The key-name logging will tell us; a note can ship in the follow-up once it does.

- [x] No release note needed (internal / technical change)

## Test plan

`vp check`, `vp run typecheck`, `vp test run --project aurora-sync` (118 passed), `vp test run --project backend aurora-import` (13 passed), `vp test run --project web json-import` (96 passed).

Fixtures are **hand-built from the shapes already in this repo** — no real Aurora export was available to copy, and this PR doesn't claim otherwise.

Each layer was mutation-tested by reverting it and confirming the right test — and only that test — goes red:

| reverted | fails |
| --- | --- |
| builder → `isMirror: false` | `records a mirrored ascent as mirrored` |
| `is_mirror` removed from the schema | `keeps is_mirror through schema validation instead of stripping it` |
| heal call removed | `heals a pre-fix non-mirrored row on re-import` |

The backend tests parse through `auroraExportSchema` **before** calling `importJsonExportData` on purpose: the sibling #3301 tests hand it an already-shaped object, so a revert of the schema half alone would leave them green.

Also covered: non-boolean encodings (`1`, `"1"`, `"true"`, `0`, `null`, absent) never fail validation; a record with no mirror field stays non-mirrored (every legacy Kilter export); a hand-corrected row isn't overwritten by a stale re-import; the `aurora_id` is unchanged when orientation changes.

## Not in this PR

`packages/kilter-sync/src/sync/user-sync.ts:931` hardcodes `isMirror: false` on `kilter_pull` inserts while `kilter-rest.ts:38` declares `isMirror: boolean` on the wire type — filed as #3954. It means the audit's "kilter 0/11,759 mirrored" figure is a floor, not a fact.

Refs #3521

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL
