### PR TITLE
fix(db): guard deprecated MoonBoard importers against non-local databases

### DIFF
--- a/packages/db/scripts/db-connection.test.ts
+++ b/packages/db/scripts/db-connection.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isLocalDatabaseUrl } from './db-connection.js';
+
+// Real automation paths this must recognize as local, verified against the
+// repo (see db-connection.ts's doc comment for the file:line evidence):
+//   - Dockerfile.dev-db / setup-development-db.sh: postgresql://postgres@localhost/main
+//   - docker-compose service name: postgresql://postgres:password@postgres:5432/main
+//   - scripts/dev-db-discover.ts's Tailscale fallback: a MagicDNS *.ts.net name
+//     or a 100.64.0.0/10 CGNAT address, used when local Docker isn't reachable.
+void test('recognizes every real local/dev-tooling host shape as local', () => {
+  assert.equal(isLocalDatabaseUrl('postgresql://postgres@localhost:5432/main'), true);
+  assert.equal(isLocalDatabaseUrl('postgresql://postgres@127.0.0.1:5432/main'), true);
+  assert.equal(isLocalDatabaseUrl('postgresql://postgres@[::1]:5432/main'), true);
+  assert.equal(isLocalDatabaseUrl('postgresql://postgres:password@postgres:5432/main'), true);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@foo.localtest.me:5432/db'), true);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@localtest.me:5432/db'), true);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@my-box.tailnet-name.ts.net:5432/db'), true);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@100.64.0.1:5432/db'), true);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@100.127.255.255:5432/db'), true);
+});
+
+void test('is case-insensitive on hostname', () => {
+  assert.equal(isLocalDatabaseUrl('postgresql://postgres@LOCALHOST:5432/main'), true);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@MY-BOX.TAILNET.TS.NET:5432/db'), true);
+});
+
+void test('refuses a real prod-shaped host (Railway proxy)', () => {
+  assert.equal(
+    isLocalDatabaseUrl('postgres://boardsesh_readonly:pw@tramway.proxy.rlwy.net:45638/railway?sslmode=require'),
+    false,
+  );
+});
+
+void test('refuses other plausible remote hosts', () => {
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@my-neon-project.neon.tech:5432/db'), false);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@10.0.0.5:5432/db'), false);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@192.168.1.20:5432/db'), false);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@ts.net.attacker.example:5432/db'), false);
+});
+
+void test('rejects addresses just outside the Tailscale CGNAT range', () => {
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@100.63.255.255:5432/db'), false);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@100.128.0.0:5432/db'), false);
+});
+
+void test('fails closed on malformed or empty URLs', () => {
+  assert.equal(isLocalDatabaseUrl('not a url at all'), false);
+  assert.equal(isLocalDatabaseUrl(''), false);
+  assert.equal(isLocalDatabaseUrl('postgresql://'), false);
+});

--- a/packages/db/scripts/db-connection.test.ts
+++ b/packages/db/scripts/db-connection.test.ts
@@ -44,6 +44,13 @@ void test('rejects addresses just outside the Tailscale CGNAT range', () => {
   assert.equal(isLocalDatabaseUrl('postgresql://user:pass@100.128.0.0:5432/db'), false);
 });
 
+void test('rejects octets that only look numeric to a loose parser (scientific notation, signs)', () => {
+  // `Number('1e2')` is 100 — without a strict digit check, this would parse
+  // as 100.100.0.1 and wrongly match the CGNAT range.
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@100.1e2.0.1:5432/db'), false);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@+100.64.0.1:5432/db'), false);
+});
+
 void test('fails closed on malformed or empty URLs', () => {
   assert.equal(isLocalDatabaseUrl('not a url at all'), false);
   assert.equal(isLocalDatabaseUrl(''), false);

--- a/packages/db/scripts/db-connection.test.ts
+++ b/packages/db/scripts/db-connection.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { isLocalDatabaseUrl } from './db-connection.js';
+import { isLocalDatabaseUrl, describeDatabaseHost } from './db-connection.js';
 
 // Real automation paths this must recognize as local, verified against the
 // repo (see db-connection.ts's doc comment for the file:line evidence):
@@ -51,8 +51,42 @@ void test('rejects octets that only look numeric to a loose parser (scientific n
   assert.equal(isLocalDatabaseUrl('postgresql://user:pass@+100.64.0.1:5432/db'), false);
 });
 
+void test('recognizes the whole 127.0.0.0/8 loopback block, not just 127.0.0.1', () => {
+  // Linux commonly resolves the machine's own hostname to 127.0.1.1.
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@127.0.1.1:5432/db'), true);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@127.0.0.2:5432/db'), true);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@127.255.255.255:5432/db'), true);
+});
+
+void test('rejects addresses just outside the loopback block', () => {
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@126.255.255.255:5432/db'), false);
+  assert.equal(isLocalDatabaseUrl('postgresql://user:pass@128.0.0.0:5432/db'), false);
+});
+
 void test('fails closed on malformed or empty URLs', () => {
   assert.equal(isLocalDatabaseUrl('not a url at all'), false);
   assert.equal(isLocalDatabaseUrl(''), false);
   assert.equal(isLocalDatabaseUrl('postgresql://'), false);
+});
+
+void test('describeDatabaseHost reports host:port for a normal connection string', () => {
+  assert.equal(describeDatabaseHost('postgresql://postgres:password@localhost:5432/main'), 'localhost:5432');
+  assert.equal(
+    describeDatabaseHost('postgres://boardsesh_readonly:pw@tramway.proxy.rlwy.net:45638/railway?sslmode=require'),
+    'tramway.proxy.rlwy.net:45638',
+  );
+});
+
+void test('describeDatabaseHost is not confused by "@" or "/" inside the password', () => {
+  // A naive `split('@')[1]?.split('/')[0]` would stop at the password's own
+  // "@"/"/" and report a garbage or wrong host; new URL() handles encoding.
+  assert.equal(
+    describeDatabaseHost('postgresql://user:p%40ss%2Fword@realhost.example:5432/db'),
+    'realhost.example:5432',
+  );
+});
+
+void test('describeDatabaseHost fails closed to "unknown" on a malformed URL', () => {
+  assert.equal(describeDatabaseHost('not a url at all'), 'unknown');
+  assert.equal(describeDatabaseHost(''), 'unknown');
 });

--- a/packages/db/scripts/db-connection.ts
+++ b/packages/db/scripts/db-connection.ts
@@ -30,6 +30,23 @@ export function getScriptDatabaseUrl(): string {
   return databaseUrl;
 }
 
+/**
+ * Host:port to show a human, e.g. in "Importing to: <host>" log lines. Uses
+ * `new URL()` rather than a naive `split('@')[1]?.split('/')[0]` — a
+ * password or path containing `@`/`/` can throw that off, which matters here
+ * because operators are meant to read this line and decide whether the
+ * target looks right. Falls back to 'unknown' on an unparseable URL (matches
+ * isLocalDatabaseUrl's fail-closed stance: never claim a host that wasn't
+ * actually resolved).
+ */
+export function describeDatabaseHost(databaseUrl: string): string {
+  try {
+    return new URL(databaseUrl).host || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
 // `postgres` (the docker-compose service name — setup-development-db.sh's
 // POSTGRES_HOST default) is a bare, single-label hostname with no TLD, so in
 // principle a split-DNS/VPN setup could resolve it to something other than
@@ -37,7 +54,9 @@ export function getScriptDatabaseUrl(): string {
 // hostname this repo's own dev tooling produces (unlike an invented remote
 // host, this isn't a guess), and nothing in Boardsesh's real infrastructure
 // (Railway/Neon, reached by full public hostnames) is ever named `postgres`.
-const LOOPBACK_OR_COMPOSE_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', 'postgres']);
+// 127.0.0.1 is covered by isLoopbackIpv4Address below (the whole 127.0.0.0/8
+// block), so it's deliberately not repeated here.
+const LOOPBACK_OR_COMPOSE_HOSTNAMES = new Set(['localhost', '::1', 'postgres']);
 
 // NOTE ON "LOCAL": a Tailscale address/hostname is NOT local in the everyday
 // sense — it's routed over the internet to a real machine. It counts as
@@ -61,15 +80,32 @@ const LOOPBACK_OR_COMPOSE_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', 
 // a CGNAT address.
 const DECIMAL_OCTET = /^\d{1,3}$/;
 
+// Parses a dotted-quad IPv4 hostname into four 0-255 octets, or null if it
+// isn't one (wrong segment count, non-decimal segment per DECIMAL_OCTET, or a
+// segment over 255). Shared by every IPv4-range check below so "what counts
+// as a valid octet" can't drift between them.
+function parseIpv4Octets(hostname: string): [number, number, number, number] | null {
+  const segments = hostname.split('.');
+  if (segments.length !== 4 || !segments.every((segment) => DECIMAL_OCTET.test(segment))) return null;
+  const octets = segments.map(Number);
+  if (octets.some((octet) => octet > 255)) return null;
+  return octets as [number, number, number, number];
+}
+
+// The full IPv4 loopback block (RFC 1122 §3.2.1.3), not just 127.0.0.1: Linux
+// commonly resolves the local hostname to 127.0.1.1, and any 127.x.x.x is
+// loopback by definition.
+function isLoopbackIpv4Address(hostname: string): boolean {
+  const octets = parseIpv4Octets(hostname);
+  return octets !== null && octets[0] === 127;
+}
+
 // Tailscale's CGNAT range (RFC 6598, carved out for Tailscale's own use):
 // 100.64.0.0/10, i.e. first octet 100 and second octet 64-127 inclusive.
 function isTailscaleCgnatAddress(hostname: string): boolean {
-  const octets = hostname.split('.');
-  if (octets.length !== 4) return false;
-  if (!octets.every((octet) => DECIMAL_OCTET.test(octet))) return false;
-  const parsed = octets.map(Number);
-  if (parsed.some((octet) => octet > 255)) return false;
-  const [first, second] = parsed;
+  const octets = parseIpv4Octets(hostname);
+  if (octets === null) return false;
+  const [first, second] = octets;
   return first === 100 && second >= 64 && second <= 127;
 }
 
@@ -87,8 +123,10 @@ function isLocaltestMeHostname(hostname: string): boolean {
  * True when `databaseUrl` resolves to a host that is unambiguously local or
  * dev-tooling infrastructure, never a real (prod/staging) database:
  *
- *  - Loopback / the `postgres` docker-compose service name (Dockerfile.dev-db
- *    and setup-development-db.sh always target one of these).
+ *  - The full IPv4 loopback block (`127.0.0.0/8`, not just `127.0.0.1` —
+ *    Linux commonly resolves the local hostname to `127.0.1.1`), `::1`, or
+ *    the `postgres` docker-compose service name (Dockerfile.dev-db and
+ *    setup-development-db.sh always target one of these).
  *  - `*.localtest.me` (resolves to 127.0.0.1; used elsewhere in this repo for
  *    subdomain-aware local dev).
  *  - A Tailscale-reached dev box: MagicDNS (`*.ts.net`) or CGNAT
@@ -110,6 +148,7 @@ export function isLocalDatabaseUrl(databaseUrl: string): boolean {
 
   return (
     LOOPBACK_OR_COMPOSE_HOSTNAMES.has(normalizedHost) ||
+    isLoopbackIpv4Address(normalizedHost) ||
     isLocaltestMeHostname(normalizedHost) ||
     isTailscaleMagicDnsHostname(normalizedHost) ||
     isTailscaleCgnatAddress(normalizedHost)

--- a/packages/db/scripts/db-connection.ts
+++ b/packages/db/scripts/db-connection.ts
@@ -30,6 +30,78 @@ export function getScriptDatabaseUrl(): string {
   return databaseUrl;
 }
 
+const LOOPBACK_OR_COMPOSE_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', 'postgres']);
+
+// NOTE ON "LOCAL": a Tailscale address/hostname is NOT local in the everyday
+// sense — it's routed over the internet to a real machine. It counts as
+// "local" HERE only because of what this file's callers use it for: telling
+// apart a developer's own dev database from a real (prod/staging) one.
+// scripts/dev-db-discover.ts's fallback path (used whenever local Docker isn't
+// reachable — the normal case in a sandboxed/cloud dev environment, and the
+// reason this matters at all) resolves DATABASE_URL to a Tailscale peer's
+// MagicDNS name or CGNAT address when it can't find a Docker Postgres. That
+// peer is still just the developer's own machine or a shared dev box, never
+// Boardsesh's production or staging infrastructure (those are reached by
+// public Railway/Neon hostnames, never Tailscale). So recognizing these two
+// host shapes is what makes the guard compatible with that workflow instead of
+// forcing every Tailscale-based dev setup through the manual remote-override
+// env var on every run. Do NOT remove this without confirming
+// scripts/dev-db-discover.ts no longer produces these host shapes.
+//
+// Tailscale's CGNAT range (RFC 6598, carved out for Tailscale's own use):
+// 100.64.0.0/10, i.e. first octet 100 and second octet 64-127 inclusive.
+function isTailscaleCgnatAddress(hostname: string): boolean {
+  const octets = hostname.split('.');
+  if (octets.length !== 4) return false;
+  const parsed = octets.map(Number);
+  if (parsed.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return false;
+  const [first, second] = parsed;
+  return first === 100 && second >= 64 && second <= 127;
+}
+
+// Tailscale's MagicDNS domain. Match the whole final label, not a substring,
+// so e.g. "evil-ts.net.attacker.example" can't slip through.
+function isTailscaleMagicDnsHostname(hostname: string): boolean {
+  return hostname === 'ts.net' || hostname.endsWith('.ts.net');
+}
+
+function isLocaltestMeHostname(hostname: string): boolean {
+  return hostname === 'localtest.me' || hostname.endsWith('.localtest.me');
+}
+
+/**
+ * True when `databaseUrl` resolves to a host that is unambiguously local or
+ * dev-tooling infrastructure, never a real (prod/staging) database:
+ *
+ *  - Loopback / the `postgres` docker-compose service name (Dockerfile.dev-db
+ *    and setup-development-db.sh always target one of these).
+ *  - `*.localtest.me` (resolves to 127.0.0.1; used elsewhere in this repo for
+ *    subdomain-aware local dev).
+ *  - A Tailscale-reached dev box: MagicDNS (`*.ts.net`) or CGNAT
+ *    (`100.64.0.0/10`) — see the NOTE ON "LOCAL" comment above for why these
+ *    two, despite not being local in the everyday sense, belong in this list.
+ *
+ * Fails CLOSED: an unparseable URL is treated as non-local.
+ */
+export function isLocalDatabaseUrl(databaseUrl: string): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(databaseUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  // Strip IPv6 brackets (URL#hostname keeps them, e.g. "[::1]").
+  const normalizedHost = hostname.replace(/^\[|\]$/g, '');
+  if (!normalizedHost) return false;
+
+  return (
+    LOOPBACK_OR_COMPOSE_HOSTNAMES.has(normalizedHost) ||
+    isLocaltestMeHostname(normalizedHost) ||
+    isTailscaleMagicDnsHostname(normalizedHost) ||
+    isTailscaleCgnatAddress(normalizedHost)
+  );
+}
+
 type ScriptDb = ReturnType<typeof drizzle>;
 
 export function createScriptDb(url?: string): { db: ScriptDb; close: () => Promise<void> } {

--- a/packages/db/scripts/db-connection.ts
+++ b/packages/db/scripts/db-connection.ts
@@ -30,6 +30,13 @@ export function getScriptDatabaseUrl(): string {
   return databaseUrl;
 }
 
+// `postgres` (the docker-compose service name — setup-development-db.sh's
+// POSTGRES_HOST default) is a bare, single-label hostname with no TLD, so in
+// principle a split-DNS/VPN setup could resolve it to something other than
+// the local compose network. Accepted anyway: it's the actual, confirmed
+// hostname this repo's own dev tooling produces (unlike an invented remote
+// host, this isn't a guess), and nothing in Boardsesh's real infrastructure
+// (Railway/Neon, reached by full public hostnames) is ever named `postgres`.
 const LOOPBACK_OR_COMPOSE_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', 'postgres']);
 
 // NOTE ON "LOCAL": a Tailscale address/hostname is NOT local in the everyday

--- a/packages/db/scripts/db-connection.ts
+++ b/packages/db/scripts/db-connection.ts
@@ -48,13 +48,20 @@ const LOOPBACK_OR_COMPOSE_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', 
 // env var on every run. Do NOT remove this without confirming
 // scripts/dev-db-discover.ts no longer produces these host shapes.
 //
+// A plain decimal octet — no leading `+`/`-`, no scientific notation, no
+// fractional part. Required before `Number(...)`: that coercion accepts
+// "1e2" as 100, which would otherwise let e.g. "100.1e2.0.1" slip through as
+// a CGNAT address.
+const DECIMAL_OCTET = /^\d{1,3}$/;
+
 // Tailscale's CGNAT range (RFC 6598, carved out for Tailscale's own use):
 // 100.64.0.0/10, i.e. first octet 100 and second octet 64-127 inclusive.
 function isTailscaleCgnatAddress(hostname: string): boolean {
   const octets = hostname.split('.');
   if (octets.length !== 4) return false;
+  if (!octets.every((octet) => DECIMAL_OCTET.test(octet))) return false;
   const parsed = octets.map(Number);
-  if (parsed.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return false;
+  if (parsed.some((octet) => octet > 255)) return false;
   const [first, second] = parsed;
   return first === 100 && second >= 64 && second <= 127;
 }

--- a/packages/db/scripts/import-moonboard-2024.ts
+++ b/packages/db/scripts/import-moonboard-2024.ts
@@ -9,7 +9,9 @@ import {
   mapMoonBoard2024Problem,
   type MoonBoard2024DumpFile,
 } from './moonboard-2024-helpers.js';
+import { moonBoardGradeConflictFields } from './moonboard-helpers.js';
 import { createScriptDb, getScriptDatabaseUrl } from './db-connection.js';
+import { assertMoonBoardImportAllowed } from './moonboard-import-guard.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -20,6 +22,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // boards (both angles) from the full catalog dataset with real quality +
 // ascensionist data and merges in place. Kept for reference / the older
 // single-file format.
+//
+// Refuses to run against anything but a local/dev-tooling database (see
+// moonboard-import-guard.ts) — a re-run of this no-grade export can regress
+// newer grades/benchmarks (issue #3530). To deliberately run it against a
+// restored snapshot or staging copy, set MOONBOARD_IMPORT_ALLOW_REMOTE=1.
 // =============================================================================
 // Imports the full MoonBoard 2024 catalog (~35k problems) at angle 40 from the
 // "Problems Moonboard 2024 40.json" catalog file. The format
@@ -69,6 +76,7 @@ async function importMoonBoard2024() {
   const databaseUrl = getScriptDatabaseUrl();
   const dbHost = databaseUrl.split('@')[1]?.split('/')[0] || 'unknown';
   console.info(`🔄 Importing MoonBoard 2024 problems to: ${dbHost}`);
+  assertMoonBoardImportAllowed(databaseUrl, 'import-moonboard-2024');
   console.info(`📂 Reading export from: ${exportPath}`);
   console.info(`   Layout ${layoutId}, angle ${angle}`);
 
@@ -212,9 +220,10 @@ async function importMoonBoard2024() {
           .onConflictDoUpdate({
             target: [boardClimbStats.boardType, boardClimbStats.climbUuid, boardClimbStats.angle],
             set: {
-              displayDifficulty: sql`excluded.display_difficulty`,
-              benchmarkDifficulty: sql`excluded.benchmark_difficulty`,
-              difficultyAverage: sql`excluded.difficulty_average`,
+              // COALESCEd (issue #3530): this script reads a fixed, no-grade
+              // export, so a re-run must never overwrite a newer stored
+              // grade/benchmark flag with a stale-or-absent one.
+              ...moonBoardGradeConflictFields(),
               qualityNormalized: sql`true`,
               upstreamSyncedAt: sql`excluded.upstream_synced_at`,
             },

--- a/packages/db/scripts/import-moonboard-2024.ts
+++ b/packages/db/scripts/import-moonboard-2024.ts
@@ -10,7 +10,7 @@ import {
   type MoonBoard2024DumpFile,
 } from './moonboard-2024-helpers.js';
 import { moonBoardGradeConflictFields } from './moonboard-helpers.js';
-import { createScriptDb, getScriptDatabaseUrl } from './db-connection.js';
+import { createScriptDb, getScriptDatabaseUrl, describeDatabaseHost } from './db-connection.js';
 import { assertMoonBoardImportAllowed } from './moonboard-import-guard.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -74,8 +74,7 @@ async function importMoonBoard2024() {
   }
 
   const databaseUrl = getScriptDatabaseUrl();
-  const dbHost = databaseUrl.split('@')[1]?.split('/')[0] || 'unknown';
-  console.info(`🔄 Importing MoonBoard 2024 problems to: ${dbHost}`);
+  console.info(`🔄 Importing MoonBoard 2024 problems to: ${describeDatabaseHost(databaseUrl)}`);
   assertMoonBoardImportAllowed(databaseUrl, 'import-moonboard-2024');
   console.info(`📂 Reading export from: ${exportPath}`);
   console.info(`   Layout ${layoutId}, angle ${angle}`);

--- a/packages/db/scripts/import-moonboard-problems.ts
+++ b/packages/db/scripts/import-moonboard-problems.ts
@@ -11,9 +11,11 @@ import {
   moveToHoldState,
   MOONBOARD_UUID_NAMESPACE,
   moonBoardGradeToDifficultyId,
+  moonBoardGradeConflictFields,
   type MoonBoardMove,
 } from './moonboard-helpers.js';
 import { createScriptDb, getScriptDatabaseUrl } from './db-connection.js';
+import { assertMoonBoardImportAllowed } from './moonboard-import-guard.js';
 // Import the dependency-free `./characteristics` subpath (not the package root,
 // which pulls in graphql) so this resolves in the isolated dev-db image build,
 // where shared-schema is dropped into node_modules without its deps installed.
@@ -25,6 +27,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // DEPRECATED for prod: superseded by import-moonboard-catalog.ts (full catalog
 // dataset, all 7 boards, both angles, merge-in-place). Still used by the dev-db Docker
 // bootstrap, which bakes in the 2023 community dump — leave it wired there.
+//
+// Refuses to run against anything but a local/dev-tooling database (see
+// moonboard-import-guard.ts) — a re-run of this stale 2023 snapshot can
+// regress newer grades/benchmarks (issue #3530). To deliberately run it
+// against a restored snapshot or staging copy, set
+// MOONBOARD_IMPORT_ALLOW_REMOTE=1.
 // =============================================================================
 // Data Source
 // =============================================================================
@@ -133,6 +141,7 @@ async function importMoonBoardProblems() {
   const databaseUrl = getScriptDatabaseUrl();
   const dbHost = databaseUrl.split('@')[1]?.split('/')[0] || 'unknown';
   console.info(`🔄 Importing MoonBoard problems to: ${dbHost}`);
+  assertMoonBoardImportAllowed(databaseUrl, 'import-moonboard-problems');
   console.info(`📂 Reading dump from: ${dumpPath}`);
 
   const { db, close } = createScriptDb(databaseUrl);
@@ -304,13 +313,14 @@ async function importMoonBoardProblems() {
           .onConflictDoUpdate({
             target: [boardClimbStats.boardType, boardClimbStats.climbUuid, boardClimbStats.angle],
             set: {
-              displayDifficulty: sql`excluded.display_difficulty`,
-              benchmarkDifficulty: sql`excluded.benchmark_difficulty`,
+              // COALESCEd (issue #3530): this script reads a fixed 2023
+              // snapshot, so a re-run must never overwrite a newer stored
+              // grade/benchmark flag with a stale-or-absent one.
+              ...moonBoardGradeConflictFields(),
               // Upstream is monotonic; the total is rebuilt as upstream + existing
               // Boardsesh so a re-run never clobbers accrued tick counts.
               upstreamAscensionistCount: resolvedUpstreamAscensionistCount,
               ascensionistCount: sql`${resolvedUpstreamAscensionistCount} + coalesce(${boardClimbStats.boardseshAscensionistCount}, 0)`,
-              difficultyAverage: sql`excluded.difficulty_average`,
               // Manufacturer average lands in upstream_quality_average (COALESCEd:
               // an unrated source row preserves the stored last-known rating);
               // quality_average is the blend of it and Boardsesh's own votes.

--- a/packages/db/scripts/import-moonboard-problems.ts
+++ b/packages/db/scripts/import-moonboard-problems.ts
@@ -14,7 +14,7 @@ import {
   moonBoardGradeConflictFields,
   type MoonBoardMove,
 } from './moonboard-helpers.js';
-import { createScriptDb, getScriptDatabaseUrl } from './db-connection.js';
+import { createScriptDb, getScriptDatabaseUrl, describeDatabaseHost } from './db-connection.js';
 import { assertMoonBoardImportAllowed } from './moonboard-import-guard.js';
 // Import the dependency-free `./characteristics` subpath (not the package root,
 // which pulls in graphql) so this resolves in the isolated dev-db image build,
@@ -139,8 +139,7 @@ async function importMoonBoardProblems() {
   }
 
   const databaseUrl = getScriptDatabaseUrl();
-  const dbHost = databaseUrl.split('@')[1]?.split('/')[0] || 'unknown';
-  console.info(`🔄 Importing MoonBoard problems to: ${dbHost}`);
+  console.info(`🔄 Importing MoonBoard problems to: ${describeDatabaseHost(databaseUrl)}`);
   assertMoonBoardImportAllowed(databaseUrl, 'import-moonboard-problems');
   console.info(`📂 Reading dump from: ${dumpPath}`);
 

--- a/packages/db/scripts/moonboard-helpers.test.ts
+++ b/packages/db/scripts/moonboard-helpers.test.ts
@@ -5,11 +5,13 @@ import {
   movesToFrames,
   moveToHoldState,
   moonBoardGradeToDifficultyId,
+  moonBoardGradeConflictFields,
   uuidv5,
   MOONBOARD_UUID_NAMESPACE,
   HOLD_STATE_CODES,
   type MoonBoardMove,
 } from './moonboard-helpers.js';
+import { sqlText } from '../src/test-utils/sql-text.js';
 
 void describe('coordinateToHoldId', () => {
   void it('converts A1 to hold ID 1 (first hold, bottom-left)', () => {
@@ -152,5 +154,40 @@ void describe('uuidv5', () => {
     // Well-known test vector: uuid5("python.org", DNS namespace) = "886313e1-3b8a-5372-9b90-0c9aee199e5d"
     const uuid = uuidv5('python.org', MOONBOARD_UUID_NAMESPACE);
     assert.equal(uuid, '886313e1-3b8a-5372-9b90-0c9aee199e5d');
+  });
+});
+
+// issue #3530: a re-run of the deprecated single-file MoonBoard importers must
+// never let a stale/absent incoming grade clobber a newer stored one. These
+// assertions check the actual rendered SQL text (via sqlText, the same
+// technique moonboard-catalog-helpers.test.ts uses for catalogAliasConflictUpdate)
+// so a regression that reverts any one field back to a bare `excluded.*` (no
+// fallback) fails here, not just a check for the fragment's absence. sqlText
+// can't render the interpolated Column object itself (it only walks plain
+// string/queryChunks arrays), so the stored-value side renders blank — these
+// assertions pin the part sqlText CAN see: that each field is COALESCE-wrapped
+// with `excluded.<column>` as the first (incoming) argument.
+void describe('moonBoardGradeConflictFields', () => {
+  void it('COALESCEs displayDifficulty, taking excluded.display_difficulty as the incoming side', () => {
+    const fields = moonBoardGradeConflictFields();
+    assert.match(sqlText(fields.displayDifficulty), /^coalesce\(excluded\.display_difficulty,/i);
+  });
+
+  void it('COALESCEs benchmarkDifficulty, taking excluded.benchmark_difficulty as the incoming side', () => {
+    const fields = moonBoardGradeConflictFields();
+    assert.match(sqlText(fields.benchmarkDifficulty), /^coalesce\(excluded\.benchmark_difficulty,/i);
+  });
+
+  void it('COALESCEs difficultyAverage, taking excluded.difficulty_average as the incoming side', () => {
+    const fields = moonBoardGradeConflictFields();
+    assert.match(sqlText(fields.difficultyAverage), /^coalesce\(excluded\.difficulty_average,/i);
+  });
+
+  void it('never takes any of the three fields straight from excluded with no fallback', () => {
+    const fields = moonBoardGradeConflictFields();
+    for (const [name, fragment] of Object.entries(fields)) {
+      const text = sqlText(fragment).toLowerCase();
+      assert.ok(text.startsWith('coalesce('), `${name} should be COALESCE-wrapped, got: ${text}`);
+    }
   });
 });

--- a/packages/db/scripts/moonboard-helpers.test.ts
+++ b/packages/db/scripts/moonboard-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import type { SQL } from 'drizzle-orm';
 import {
   coordinateToHoldId,
   movesToFrames,
@@ -12,6 +13,34 @@ import {
   type MoonBoardMove,
 } from './moonboard-helpers.js';
 import { sqlText } from '../src/test-utils/sql-text.js';
+
+/**
+ * sqlText (see its own doc comment) can't render an interpolated drizzle
+ * Column — it only walks plain string/queryChunks arrays, so the COALESCE
+ * fallback side renders blank there. That leaves a real gap: a regression
+ * that swaps in the WRONG stored column as a field's fallback (e.g.
+ * displayDifficulty silently falling back to benchmarkDifficulty's column)
+ * would still render as `coalesce(excluded.display_difficulty, )` and pass
+ * every sqlText-based assertion below. This helper reaches into the
+ * fragment's queryChunks directly and duck-types the drizzle Column shape
+ * (has both `name` and `table`, unlike a plain string chunk) to recover the
+ * actual stored-side column name, so that class of regression is caught too.
+ * Test-only — production code must keep using sqlText/plain SQL, not this.
+ */
+function isDrizzleColumnChunk(chunk: unknown): chunk is { name: string } {
+  return (
+    chunk !== null &&
+    typeof chunk === 'object' &&
+    'table' in chunk &&
+    typeof (chunk as { name?: unknown }).name === 'string'
+  );
+}
+
+function fallbackColumnName(fragment: SQL): string | undefined {
+  const chunks = (fragment as unknown as { queryChunks: unknown[] }).queryChunks;
+  const columnChunk = chunks.find(isDrizzleColumnChunk);
+  return columnChunk?.name;
+}
 
 void describe('coordinateToHoldId', () => {
   void it('converts A1 to hold ID 1 (first hold, bottom-left)', () => {
@@ -168,19 +197,22 @@ void describe('uuidv5', () => {
 // assertions pin the part sqlText CAN see: that each field is COALESCE-wrapped
 // with `excluded.<column>` as the first (incoming) argument.
 void describe('moonBoardGradeConflictFields', () => {
-  void it('COALESCEs displayDifficulty, taking excluded.display_difficulty as the incoming side', () => {
+  void it('COALESCEs displayDifficulty: excluded.display_difficulty incoming, display_difficulty stored fallback', () => {
     const fields = moonBoardGradeConflictFields();
     assert.match(sqlText(fields.displayDifficulty), /^coalesce\(excluded\.display_difficulty,/i);
+    assert.equal(fallbackColumnName(fields.displayDifficulty), 'display_difficulty');
   });
 
-  void it('COALESCEs benchmarkDifficulty, taking excluded.benchmark_difficulty as the incoming side', () => {
+  void it('COALESCEs benchmarkDifficulty: excluded.benchmark_difficulty incoming, benchmark_difficulty stored fallback', () => {
     const fields = moonBoardGradeConflictFields();
     assert.match(sqlText(fields.benchmarkDifficulty), /^coalesce\(excluded\.benchmark_difficulty,/i);
+    assert.equal(fallbackColumnName(fields.benchmarkDifficulty), 'benchmark_difficulty');
   });
 
-  void it('COALESCEs difficultyAverage, taking excluded.difficulty_average as the incoming side', () => {
+  void it('COALESCEs difficultyAverage: excluded.difficulty_average incoming, difficulty_average stored fallback', () => {
     const fields = moonBoardGradeConflictFields();
     assert.match(sqlText(fields.difficultyAverage), /^coalesce\(excluded\.difficulty_average,/i);
+    assert.equal(fallbackColumnName(fields.difficultyAverage), 'difficulty_average');
   });
 
   void it('never takes any of the three fields straight from excluded with no fallback', () => {

--- a/packages/db/scripts/moonboard-helpers.ts
+++ b/packages/db/scripts/moonboard-helpers.ts
@@ -1,4 +1,6 @@
 import crypto from 'crypto';
+import { sql, type SQL } from 'drizzle-orm';
+import { boardClimbStats } from '../src/schema/boards/unified.js';
 
 // =============================================================================
 // Mapping constants
@@ -128,4 +130,31 @@ export function moveToHoldState(move: MoonBoardMove): string {
   if (move.isStart) return 'STARTING';
   if (move.isEnd) return 'FINISH';
   return 'HAND';
+}
+
+/**
+ * ON CONFLICT SET fragments for the three MoonBoard grade fields
+ * (display/benchmark/average difficulty), shared by the two deprecated
+ * single-file importers (import-moonboard-problems.ts, import-moonboard-2024.ts).
+ *
+ * Both scripts read a fixed historical snapshot (the 2023 community dump / a
+ * 2024 no-grade export) that can be older than the current catalog import, so
+ * a re-run must never let an incoming `excluded.*` value overwrite a newer
+ * stored grade with a stale-or-absent one. COALESCE keeps whichever side is
+ * non-null, preferring the incoming value only when it actually has one.
+ * Unlike import-moonboard-catalog.ts (the authoritative, currently-maintained
+ * source, where an incoming benchmark flag is trusted outright), these two
+ * scripts are lower-trust snapshots, so all three fields are COALESCEd here,
+ * including benchmarkDifficulty. See issue #3530.
+ */
+export function moonBoardGradeConflictFields(): {
+  displayDifficulty: SQL;
+  benchmarkDifficulty: SQL;
+  difficultyAverage: SQL;
+} {
+  return {
+    displayDifficulty: sql`coalesce(excluded.display_difficulty, ${boardClimbStats.displayDifficulty})`,
+    benchmarkDifficulty: sql`coalesce(excluded.benchmark_difficulty, ${boardClimbStats.benchmarkDifficulty})`,
+    difficultyAverage: sql`coalesce(excluded.difficulty_average, ${boardClimbStats.difficultyAverage})`,
+  };
 }

--- a/packages/db/scripts/moonboard-helpers.ts
+++ b/packages/db/scripts/moonboard-helpers.ts
@@ -146,6 +146,16 @@ export function moveToHoldState(move: MoonBoardMove): string {
  * source, where an incoming benchmark flag is trusted outright), these two
  * scripts are lower-trust snapshots, so all three fields are COALESCEd here,
  * including benchmarkDifficulty. See issue #3530.
+ *
+ * LIMITATION (by design, not an oversight): COALESCE only stops NULL from
+ * clobbering a non-null value. It can't detect "this incoming value is a
+ * non-null but stale grade from the frozen 2023/2024 dump" — a climb whose
+ * grade genuinely changed since that dump would still take the old value on
+ * a re-run. The two defenses in this fix are independent on purpose: the host
+ * guard (moonboard-import-guard.ts) is what actually stops a re-run from
+ * touching real data; this COALESCE only bounds the damage if that guard is
+ * deliberately bypassed (MOONBOARD_IMPORT_ALLOW_REMOTE=1) or the target is a
+ * restored copy that still has a legitimate reason to re-run these scripts.
  */
 export function moonBoardGradeConflictFields(): {
   displayDifficulty: SQL;

--- a/packages/db/scripts/moonboard-import-guard.test.ts
+++ b/packages/db/scripts/moonboard-import-guard.test.ts
@@ -1,9 +1,32 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveMoonBoardImportDecision } from './moonboard-import-guard.js';
+import {
+  resolveMoonBoardImportDecision,
+  assertMoonBoardImportAllowed,
+  MOONBOARD_IMPORT_ALLOW_REMOTE_ENV_VAR,
+} from './moonboard-import-guard.js';
 
 const LOCAL_URL = 'postgresql://postgres@localhost:5432/main';
 const REMOTE_URL = 'postgres://boardsesh_readonly:pw@tramway.proxy.rlwy.net:45638/railway?sslmode=require';
+
+/** Save/restore MOONBOARD_IMPORT_ALLOW_REMOTE around a test that sets it. */
+function withAllowRemoteEnv<T>(value: string | undefined, run: () => T): T {
+  const original = process.env[MOONBOARD_IMPORT_ALLOW_REMOTE_ENV_VAR];
+  if (value === undefined) {
+    delete process.env[MOONBOARD_IMPORT_ALLOW_REMOTE_ENV_VAR];
+  } else {
+    process.env[MOONBOARD_IMPORT_ALLOW_REMOTE_ENV_VAR] = value;
+  }
+  try {
+    return run();
+  } finally {
+    if (original === undefined) {
+      delete process.env[MOONBOARD_IMPORT_ALLOW_REMOTE_ENV_VAR];
+    } else {
+      process.env[MOONBOARD_IMPORT_ALLOW_REMOTE_ENV_VAR] = original;
+    }
+  }
+}
 
 void test('a local database is always allowed, regardless of the override', () => {
   assert.equal(resolveMoonBoardImportDecision(LOCAL_URL, undefined), 'local');
@@ -27,4 +50,58 @@ void test('a remote database stays refused for any near-miss override value (fai
   assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, 'yes'), 'remote-refused');
   assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, ''), 'remote-refused');
   assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, '01'), 'remote-refused');
+});
+
+// assertMoonBoardImportAllowed is the side-effecting wrapper around
+// resolveMoonBoardImportDecision — it's what the two importer scripts
+// actually call, so its process.exit/console branches need direct coverage
+// too, not just the pure decision function. process.exit is mocked to a
+// no-op (never actually terminates the test process); console.error/warn are
+// mocked to assert on their calls instead of printing during the test run.
+void test('assertMoonBoardImportAllowed returns silently for a local database', (t) => {
+  const exitMock = t.mock.method(process, 'exit', (() => undefined) as unknown as typeof process.exit);
+  const errorMock = t.mock.method(console, 'error', () => undefined);
+  const warnMock = t.mock.method(console, 'warn', () => undefined);
+
+  assertMoonBoardImportAllowed(LOCAL_URL, 'test-script');
+
+  assert.equal(exitMock.mock.calls.length, 0);
+  assert.equal(errorMock.mock.calls.length, 0);
+  assert.equal(warnMock.mock.calls.length, 0);
+});
+
+void test('assertMoonBoardImportAllowed warns but proceeds when the override is set', (t) => {
+  const exitMock = t.mock.method(process, 'exit', (() => undefined) as unknown as typeof process.exit);
+  const errorMock = t.mock.method(console, 'error', () => undefined);
+  const warnMock = t.mock.method(console, 'warn', () => undefined);
+
+  withAllowRemoteEnv('1', () => {
+    assertMoonBoardImportAllowed(REMOTE_URL, 'test-script');
+  });
+
+  assert.equal(exitMock.mock.calls.length, 0);
+  assert.equal(errorMock.mock.calls.length, 0);
+  assert.equal(warnMock.mock.calls.length, 1);
+  const [warningMessage] = warnMock.mock.calls[0].arguments;
+  assert.match(String(warningMessage), /MOONBOARD_IMPORT_ALLOW_REMOTE=1/);
+  assert.match(String(warningMessage), /test-script/);
+});
+
+void test('assertMoonBoardImportAllowed errors and exits(1) when refused', (t) => {
+  const exitMock = t.mock.method(process, 'exit', (() => undefined) as unknown as typeof process.exit);
+  const errorMock = t.mock.method(console, 'error', () => undefined);
+  const warnMock = t.mock.method(console, 'warn', () => undefined);
+
+  withAllowRemoteEnv(undefined, () => {
+    assertMoonBoardImportAllowed(REMOTE_URL, 'test-script');
+  });
+
+  assert.equal(warnMock.mock.calls.length, 0);
+  assert.equal(exitMock.mock.calls.length, 1);
+  assert.deepEqual(exitMock.mock.calls[0].arguments, [1]);
+  assert.ok(errorMock.mock.calls.length > 0);
+  const combinedErrorOutput = errorMock.mock.calls.map((call) => String(call.arguments[0])).join('\n');
+  assert.match(combinedErrorOutput, /refuses to run against a non-local database/);
+  assert.match(combinedErrorOutput, /test-script/);
+  assert.match(combinedErrorOutput, /MOONBOARD_IMPORT_ALLOW_REMOTE=1/);
 });

--- a/packages/db/scripts/moonboard-import-guard.test.ts
+++ b/packages/db/scripts/moonboard-import-guard.test.ts
@@ -11,6 +11,9 @@ void test('a local database is always allowed, regardless of the override', () =
   assert.equal(resolveMoonBoardImportDecision(LOCAL_URL, 'true'), 'local');
 });
 
+// The override is a distinct env var from DB_URL, so pointing DB_URL at the
+// wrong host never implicitly sets it — a mistyped DB_URL alone (override
+// undefined) is exactly this "refused by default" case.
 void test('a remote database is refused by default', () => {
   assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, undefined), 'remote-refused');
 });
@@ -24,11 +27,4 @@ void test('a remote database stays refused for any near-miss override value (fai
   assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, 'yes'), 'remote-refused');
   assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, ''), 'remote-refused');
   assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, '01'), 'remote-refused');
-});
-
-void test('a mistyped DB_URL cannot accidentally carry the override — the two are independent inputs', () => {
-  // The override is a distinct env var from DB_URL, so pointing DB_URL at the
-  // wrong host never implicitly sets it; simulating "operator only set DB_URL"
-  // means allowRemoteEnvValue is undefined here.
-  assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, undefined), 'remote-refused');
 });

--- a/packages/db/scripts/moonboard-import-guard.test.ts
+++ b/packages/db/scripts/moonboard-import-guard.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveMoonBoardImportDecision } from './moonboard-import-guard.js';
+
+const LOCAL_URL = 'postgresql://postgres@localhost:5432/main';
+const REMOTE_URL = 'postgres://boardsesh_readonly:pw@tramway.proxy.rlwy.net:45638/railway?sslmode=require';
+
+void test('a local database is always allowed, regardless of the override', () => {
+  assert.equal(resolveMoonBoardImportDecision(LOCAL_URL, undefined), 'local');
+  assert.equal(resolveMoonBoardImportDecision(LOCAL_URL, '1'), 'local');
+  assert.equal(resolveMoonBoardImportDecision(LOCAL_URL, 'true'), 'local');
+});
+
+void test('a remote database is refused by default', () => {
+  assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, undefined), 'remote-refused');
+});
+
+void test('a remote database is allowed only by the exact override value "1"', () => {
+  assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, '1'), 'remote-allowed');
+});
+
+void test('a remote database stays refused for any near-miss override value (fails closed)', () => {
+  assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, 'true'), 'remote-refused');
+  assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, 'yes'), 'remote-refused');
+  assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, ''), 'remote-refused');
+  assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, '01'), 'remote-refused');
+});
+
+void test('a mistyped DB_URL cannot accidentally carry the override — the two are independent inputs', () => {
+  // The override is a distinct env var from DB_URL, so pointing DB_URL at the
+  // wrong host never implicitly sets it; simulating "operator only set DB_URL"
+  // means allowRemoteEnvValue is undefined here.
+  assert.equal(resolveMoonBoardImportDecision(REMOTE_URL, undefined), 'remote-refused');
+});

--- a/packages/db/scripts/moonboard-import-guard.ts
+++ b/packages/db/scripts/moonboard-import-guard.ts
@@ -1,0 +1,57 @@
+import { isLocalDatabaseUrl } from './db-connection.js';
+
+// The env var a human sets to deliberately bypass the guard below (e.g. to
+// re-run against a restored snapshot or a staging copy). Never set by any
+// automation in this repo, so a mistyped DB_URL can never carry it.
+export const MOONBOARD_IMPORT_ALLOW_REMOTE_ENV_VAR = 'MOONBOARD_IMPORT_ALLOW_REMOTE';
+
+export type MoonBoardImportDecision = 'local' | 'remote-allowed' | 'remote-refused';
+
+/**
+ * Pure decision logic for whether a deprecated MoonBoard importer
+ * (import-moonboard-problems.ts / import-moonboard-2024.ts) should be allowed
+ * to run against `databaseUrl`. Both importers are superseded by
+ * import-moonboard-catalog.ts and their stats upsert can regress newer grade
+ * data on a re-run (issue #3530), so they must refuse anything but a
+ * recognizably local/dev-tooling host unless a human explicitly opts in via
+ * MOONBOARD_IMPORT_ALLOW_REMOTE=1.
+ *
+ * Takes the override value as a parameter (rather than reading
+ * process.env itself) so this stays pure and unit-testable; only the exact
+ * string '1' opts in — any other value (unset, 'true', 'yes', '') fails
+ * closed to 'remote-refused'.
+ */
+export function resolveMoonBoardImportDecision(
+  databaseUrl: string,
+  allowRemoteEnvValue: string | undefined,
+): MoonBoardImportDecision {
+  if (isLocalDatabaseUrl(databaseUrl)) return 'local';
+  return allowRemoteEnvValue === '1' ? 'remote-allowed' : 'remote-refused';
+}
+
+/**
+ * Enforces resolveMoonBoardImportDecision for a deprecated MoonBoard importer
+ * script. Exits the process (never returns) when the run must not proceed.
+ * Callers must print the resolved target host themselves before calling this,
+ * so the operator sees it regardless of which branch is taken.
+ */
+export function assertMoonBoardImportAllowed(databaseUrl: string, scriptLabel: string): void {
+  const decision = resolveMoonBoardImportDecision(databaseUrl, process.env[MOONBOARD_IMPORT_ALLOW_REMOTE_ENV_VAR]);
+
+  if (decision === 'local') return;
+
+  if (decision === 'remote-allowed') {
+    console.warn(
+      `⚠️  ${MOONBOARD_IMPORT_ALLOW_REMOTE_ENV_VAR}=1 set — proceeding against a non-local database despite ${scriptLabel} being deprecated.`,
+    );
+    return;
+  }
+
+  console.error(`❌ ${scriptLabel} refuses to run against a non-local database.`);
+  console.error('   This importer is deprecated and its stats upsert can regress newer grade data on a re-run.');
+  console.error('   Use `vp run db:import-moonboard-catalog` for prod/authoritative imports instead.');
+  console.error(
+    `   If this is a deliberate run against a restored snapshot or staging copy, set ${MOONBOARD_IMPORT_ALLOW_REMOTE_ENV_VAR}=1.`,
+  );
+  process.exit(1);
+}

--- a/packages/db/scripts/moonboard-import-guard.ts
+++ b/packages/db/scripts/moonboard-import-guard.ts
@@ -31,9 +31,13 @@ export function resolveMoonBoardImportDecision(
 
 /**
  * Enforces resolveMoonBoardImportDecision for a deprecated MoonBoard importer
- * script. Exits the process (never returns) when the run must not proceed.
- * Callers must print the resolved target host themselves before calling this,
- * so the operator sees it regardless of which branch is taken.
+ * script. Callers must print the resolved target host themselves before
+ * calling this, so the operator sees it regardless of which branch is taken.
+ *
+ * Return type is `void`, not `never`: only the 'remote-refused' branch calls
+ * process.exit (which TypeScript types as `never`) — the 'local' and
+ * 'remote-allowed' branches return normally, so the function as a whole does
+ * have a reachable return path and `never` would be inaccurate here.
  */
 export function assertMoonBoardImportAllowed(databaseUrl: string, scriptLabel: string): void {
   const decision = resolveMoonBoardImportDecision(databaseUrl, process.env[MOONBOARD_IMPORT_ALLOW_REMOTE_ENV_VAR]);


### PR DESCRIPTION
## Summary

- `db:import-moonboard` (import-moonboard-problems.ts, the 2023 community dump) and `db:import-moonboard-2024` (import-moonboard-2024.ts) are both superseded by `import-moonboard-catalog.ts` but stay wired in `package.json` with no host guard. A `DB_URL=<prod>` run regressed the whole MoonBoard grade catalog to an old snapshot and nulled every benchmark grade added since, because their stats `ON CONFLICT ... SET` took `displayDifficulty`/`benchmarkDifficulty`/`difficultyAverage` straight from `excluded`.
- Both scripts now refuse to run against anything but a recognizably local/dev-tooling database via a new `isLocalDatabaseUrl()` check: loopback, the docker-compose `postgres` service name, `*.localtest.me`, or a Tailscale-reached dev box (MagicDNS `*.ts.net` or CGNAT `100.64.0.0/10` — the shape `scripts/dev-db-discover.ts`'s fallback path produces when local Docker isn't reachable). Verified this covers every real automation path in the repo (Docker build, both `setup-development-db.sh` copies, the `db:up`-backed `vp run db:import-moonboard` task).
- A human can deliberately bypass the guard with `MOONBOARD_IMPORT_ALLOW_REMOTE=1` (e.g. to re-run against a restored snapshot or staging copy). A mistyped `DB_URL` can never carry that override since it's a separate env var never set by any automation. Documented in both scripts' header comments, the guard's own source, and the runtime refusal message.
- Both scripts' stats upsert now `COALESCE`s the three grade fields against the stored value (matching `import-moonboard-catalog.ts`'s existing pattern), so a re-run can never null a newer grade or benchmark flag even if the guard is bypassed or the target DB is a restored copy.

Fixes #3530.

## Test plan

- [x] `vp check` / `vp run typecheck:db` clean for every touched file (verified via a scoped run: `Found no warnings, lint errors, or type errors in 8 files`)
- [x] 3 pre-existing, unrelated lint errors (in `packages/mobile` gorhom types + `packages/moonboard-ocr` canvas types) reproduce identically on unmodified `main` via `git stash` — not caused by this change
- [x] `tsx --test` on all new/touched test files: 40+ passing, including a manual mutation test (reverted one field's `COALESCE`, confirmed the test went red, restored, confirmed green)
- [x] Live smoke test against a throwaway `postgres:17` container on a spare port (torn down after):
  - Guard refuses a real prod-shaped host (this environment's own ambient `DB_URL`, a live Railway production connection string) before any DB connection is attempted
  - Guard allows the throwaway local host
  - Re-running `import-moonboard-2024` with a stale, ungraded, non-benchmark version of an already-graded/benchmarked climb (same name+setter+holds identity) left the stored grade and benchmark flag untouched — previously this would have nulled them
- [ ] CI (lint/typecheck/test-default) — watching

## Release Notes

- [x] No release note needed (internal / technical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL
