### PR TITLE
fix(mobile): offer Leave as well as End for a session

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -504,6 +504,19 @@ The main Traefik instance routes `*.preview.boardsesh.com` and `*.ws.preview.boa
 
 Explicit UI actions still leave or end sessions immediately: `leaveSession` removes the participant and emits `UserLeft`; `endSession` is restricted to the session creator or current leader. Passive WebSocket disconnects emit `UserPresenceChanged` first and only emit `UserLeft` if the reconnect timer expires.
 
+#### Leave vs. end on the client (#3502)
+
+Both platforms expose leave and end as distinct actions. Which one a surface *leads with* is a client concern — the server authorizes each independently.
+
+The subtlety: **one signed-in climber on two devices is a single participant.** `joinSession` resolves `participantId = client.userId || connectionId` (`room-manager/client-lifecycle.ts`), so two phones share one participant entry and one roster row. Every roster-derived signal is therefore participant-scoped and structurally cannot see the second device:
+
+- `SessionUser.isLeader` is the OR of leadership across a participant's connections (`upsertLocalParticipant` keeps it sticky-true), and the `SessionRosterSnapshot` branch in `@boardsesh/queue-runtime` re-derives the client's own `isLeader` from that row. A second device is therefore told `isLeader: true` by its very first roster snapshot, even though its connection is not the leader. **Do not build device-level UI on `isLeader`.**
+- `LocalSessionParticipant.connectionIds` (and its Redis equivalent) does distinguish connections, but is deliberately not exposed over GraphQL. It answers "how many sockets does this human hold right now", which flaps with screen locks and reconnects — and a stale value degrades toward offering the *destructive* action.
+
+Mobile instead keys the **emphasis** on device provenance (`session-store.ts` records the id of the session this device created) and the **availability** of End on `Session.createdByUserId` (member-only; redacted for the non-member preview). Provenance decides which action leads, never which actions exist — so losing it to a reinstall costs a creator the End-first default and nothing else.
+
+Mobile reads `createdByUserId` through its own `GET_SESSION_OWNER` document rather than as another field on `GET_SESSION`: that query also backs the join-by-link screen, and GraphQL validates whole documents, so a new-bundle/old-backend skew would otherwise break joining outright instead of just leaving ownership unknown.
+
 If the grace period expires, the session is evicted from memory but remains restorable from Redis until the 4-hour TTL expires. After Redis TTL expiry, the session is still not ended; the next join restores it from Postgres as long as the durable row has not been explicitly marked `ended`.
 
 **Multi-instance grace handling:** Because each instance tracks its own local clients, "the last user disconnected" is a per-instance event — another instance may still host active members. Before tearing down session state (cancelling pending Postgres writes, marking the session inactive in Redis), `leaveSession` in `room-manager/client-lifecycle.ts` queries `distributedState.getSessionMembers(sessionId)` and filters out the leaving connection. The dangerous side-effects (`writeScheduler.cancelPendingWrites`, `redisStore.markInactive`) only fire when no other instance has members. The local grace timer (memory cleanup for this instance's `sessionsMap`) still runs regardless. The filter relies on the invariant that `SessionUser.id` returned by `getSessionMembers` is the connection ID (see `distributed-state/session-ops.ts:181`); the regression test `leave-session-multi-instance.test.ts` pins this.

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -506,12 +506,12 @@ Explicit UI actions still leave or end sessions immediately: `leaveSession` remo
 
 #### Leave vs. end on the client (#3502)
 
-Both platforms expose leave and end as distinct actions. Which one a surface *leads with* is a client concern — the server authorizes each independently.
+Both platforms expose leave and end as distinct actions. Which one a surface _leads with_ is a client concern — the server authorizes each independently.
 
 The subtlety: **one signed-in climber on two devices is a single participant.** `joinSession` resolves `participantId = client.userId || connectionId` (`room-manager/client-lifecycle.ts`), so two phones share one participant entry and one roster row. Every roster-derived signal is therefore participant-scoped and structurally cannot see the second device:
 
 - `SessionUser.isLeader` is the OR of leadership across a participant's connections (`upsertLocalParticipant` keeps it sticky-true), and the `SessionRosterSnapshot` branch in `@boardsesh/queue-runtime` re-derives the client's own `isLeader` from that row. A second device is therefore told `isLeader: true` by its very first roster snapshot, even though its connection is not the leader. **Do not build device-level UI on `isLeader`.**
-- `LocalSessionParticipant.connectionIds` (and its Redis equivalent) does distinguish connections, but is deliberately not exposed over GraphQL. It answers "how many sockets does this human hold right now", which flaps with screen locks and reconnects — and a stale value degrades toward offering the *destructive* action.
+- `LocalSessionParticipant.connectionIds` (and its Redis equivalent) does distinguish connections, but is deliberately not exposed over GraphQL. It answers "how many sockets does this human hold right now", which flaps with screen locks and reconnects — and a stale value degrades toward offering the _destructive_ action.
 
 Mobile instead keys the **emphasis** on device provenance (`session-store.ts` records the id of the session this device created) and the **availability** of End on `Session.createdByUserId` (member-only; redacted for the non-member preview). Provenance decides which action leads, never which actions exist — so losing it to a reinstall costs a creator the End-first default and nothing else.
 

--- a/packages/backend/src/__tests__/build-session-payload.test.ts
+++ b/packages/backend/src/__tests__/build-session-payload.test.ts
@@ -122,6 +122,7 @@ describe('buildSessionPayload — defaults (no overrides)', () => {
       endedAt: null,
       isPermanent: false,
       color: '#ff00aa',
+      createdByUserId: 'user-1',
     });
   });
 
@@ -255,5 +256,36 @@ describe('buildSessionPayload — name / boardPath / participantId fallthrough',
 
     const fromCtx = await buildSessionPayload('session-1', makeCtx({ connectionId: 'conn-xyz' }));
     expect(fromCtx.clientId).toBe('conn-xyz');
+  });
+
+  // #3502: mobile reads this to decide whether to offer the destructive End
+  // action at all. It is NOT an authorization signal (endSession re-checks
+  // creator/leader server-side) — but a wrong value here either strands a
+  // creator or dangles an action the server will refuse.
+  describe('createdByUserId', () => {
+    it('comes from the session row by default', async () => {
+      const payload = await buildSessionPayload('session-1', makeCtx());
+      expect(payload.createdByUserId).toBe('user-1');
+    });
+
+    it('is null when the session row has vanished (cleanup race) or the creator was anonymous', async () => {
+      getSessionByIdMock.mockResolvedValue(null);
+      const vanished = await buildSessionPayload('session-1', makeCtx());
+      expect(vanished.createdByUserId).toBeNull();
+
+      getSessionByIdMock.mockResolvedValue({ ...sampleSessionData, createdByUserId: null });
+      const anonymous = await buildSessionPayload('session-1', makeCtx());
+      expect(anonymous.createdByUserId).toBeNull();
+    });
+
+    // The redaction queries.session relies on for its non-member preview: the
+    // un-redacted roster only ever carries PRESENT members' user ids, and those
+    // diverge from the creator the moment they disconnect.
+    it('honours an explicit null override without consulting the session row', async () => {
+      const payload = await buildSessionPayload('session-1', makeCtx(), { createdByUserId: null });
+      expect(payload.createdByUserId).toBeNull();
+      // Other fields still resolve normally — the override is field-scoped.
+      expect(payload.name).toBe('Tuesday sesh');
+    });
   });
 });

--- a/packages/backend/src/__tests__/session-query-gate.test.ts
+++ b/packages/backend/src/__tests__/session-query-gate.test.ts
@@ -249,6 +249,33 @@ describe('session query — membership gate compat matrix', () => {
     expect(distributedState.isConnectionInSession).not.toHaveBeenCalled();
   });
 
+  // #3502: mobile reads createdByUserId in-session to decide whether to offer
+  // the destructive End action. Members must get it (otherwise a creator loses
+  // the ability to end their own zero-tick session); non-members must not.
+  // Deleting the redaction in queries.session fails the second half.
+  it('exposes createdByUserId to members and withholds it from the stranger preview', async () => {
+    dbMock.limit.mockResolvedValueOnce([{ sessionId: 'session-1' }]);
+    const memberCtx = makeCtx({
+      connectionId: 'http-99999999-9999-9999-9999-999999999999',
+      transport: 'http',
+      userId: 'user-42',
+      isAuthenticated: true,
+    });
+    const memberResult = await sessionQueries.session(undefined, { sessionId: 'session-1' }, memberCtx);
+    expect(memberResult!.createdByUserId).toBe(sampleSessionData.createdByUserId);
+
+    const strangerCtx = makeCtx({
+      connectionId: 'http-88888888-8888-8888-8888-888888888888',
+      transport: 'http',
+      userId: undefined,
+      isAuthenticated: false,
+    });
+    const strangerResult = await sessionQueries.session(undefined, { sessionId: 'session-1' }, strangerCtx);
+    expect(strangerResult!.createdByUserId).toBeNull();
+    // The roster is still un-redacted — that contract is unchanged.
+    expect(strangerResult!.users).toEqual(sampleUsers);
+  });
+
   it('anonymous HTTP caller for a live session they were "in" gets a preview — accepted degradation, no stable identity to check durably', async () => {
     const ctx = makeCtx({
       connectionId: 'http-22222222-2222-2222-2222-222222222222',
@@ -299,6 +326,11 @@ describe('session query — membership gate compat matrix', () => {
       endedAt: null,
       isPermanent: false,
       color: '#ff00aa',
+      // Redacted for non-members (#3502). The roster above DOES carry present
+      // members' user ids by design, but that set diverges from the creator the
+      // moment they disconnect — a stranger holding only the session UUID has
+      // no business learning who started it.
+      createdByUserId: null,
     });
   });
 

--- a/packages/backend/src/graphql/resolvers/sessions/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/helpers.ts
@@ -39,6 +39,12 @@ export type SessionPayloadInputs = {
   isLeader?: boolean;
   clientId?: string | null;
   participantId?: string;
+  // `null` is a real override — used by the `session` query's non-member
+  // preview path to redact the creator's user id. Members otherwise get it
+  // from `sessionData.createdByUserId`. See the field's SDL description for
+  // why the redaction is worth the extra input key even though the
+  // non-member roster already carries every *present* member's `userId`.
+  createdByUserId?: string | null;
 };
 
 /**
@@ -117,5 +123,10 @@ export async function buildSessionPayload(
     endedAt: sessionData?.endedAt?.toISOString() || null,
     isPermanent: sessionData?.isPermanent ?? false,
     color: sessionData?.color || null,
+    // `??` (not `||`): the creator id is an opaque UUID, so there is no
+    // empty-string-means-absent convention to honour here the way `name` /
+    // `goal` have one.
+    createdByUserId:
+      inputs.createdByUserId !== undefined ? inputs.createdByUserId : (sessionData?.createdByUserId ?? null),
   };
 }

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -351,6 +351,8 @@ export const sessionMutations = {
           endedAt: null,
           isPermanent: input.isPermanent || false,
           color: input.color || null,
+          // We are the creator by construction on both createSession paths.
+          createdByUserId: ctx.userId ?? null,
         };
       }
 
@@ -378,6 +380,7 @@ export const sessionMutations = {
         endedAt: null,
         isPermanent: input.isPermanent || false,
         color: input.color || null,
+        createdByUserId: ctx.userId ?? null,
       };
     } catch (err) {
       // Rate-limit hits are expected abuse-protection noise, not a session-start
@@ -678,6 +681,10 @@ export const sessionMutations = {
       endedAt: sessionData.endedAt?.toISOString() || null,
       isPermanent: sessionData.isPermanent ?? false,
       color: sessionData.color || null,
+      // `requireSessionMember` gated this mutation, so the caller is a member
+      // and gets the un-redacted creator id (see the `session` query for the
+      // non-member redaction).
+      createdByUserId: sessionData.createdByUserId ?? null,
     };
   },
 

--- a/packages/backend/src/graphql/resolvers/sessions/queries.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/queries.ts
@@ -39,9 +39,16 @@ export const sessionQueries = {
     // session UUID — gets a redacted invite-preview: metadata plus the full
     // roster (mobile's join-confirmation screen shows who's climbing before
     // the user commits — see GET_SESSION), but no queue contents, leader
-    // status, or board serial. `isSessionMember` is the single-shot,
-    // non-throwing counterpart of `requireSessionMember` (no retry/backoff —
-    // this is a read, not a race against `joinSession` context propagation).
+    // status, board serial, or creator id. `isSessionMember` is the
+    // single-shot, non-throwing counterpart of `requireSessionMember` (no
+    // retry/backoff — this is a read, not a race against `joinSession`
+    // context propagation).
+    //
+    // `createdByUserId` is redacted for non-members even though the
+    // un-redacted roster below already carries every *present* member's
+    // `userId`: those two sets diverge the moment the creator disconnects
+    // while the session lives on, and a stranger holding only the session
+    // UUID has no business learning who started it.
     const isMember = await isSessionMember(ctx, sessionId);
 
     // `isLeader` is always false and `clientId` is empty for both branches:
@@ -53,7 +60,7 @@ export const sessionQueries = {
       users,
       isLeader: false,
       clientId: '',
-      ...(isMember ? {} : { queueState: null, lastConnectedBoardSerial: null }),
+      ...(isMember ? {} : { queueState: null, lastConnectedBoardSerial: null, createdByUserId: null }),
     });
   },
 

--- a/packages/mobile/src/components/EndSessionSheet.tsx
+++ b/packages/mobile/src/components/EndSessionSheet.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { View, KeyboardAvoidingView, StyleSheet } from 'react-native';
 import BottomSheet, {
   BottomSheetView,
@@ -14,31 +14,71 @@ import { Icon } from './Icon';
 import { useTheme } from '../providers/theme-provider';
 import { useManagedSheet } from '../providers/sheet-presentation-provider';
 import { spacing, borderRadius, sheetStyles } from '../theme/tokens';
+import type { SessionExitMode } from './session-screen/use-session-exit-options';
 
 type EndSessionSheetProps = {
   visible: boolean;
   onDismiss: () => void;
   onConfirm: () => void;
+  /** Drop out of the session without ending it for anyone else. */
+  onLeave: () => void;
   isEnding: boolean;
+  isLeaving: boolean;
   climbCount: number;
   /** Current recap text. Optional — an empty field never blocks or validates End. */
   notes: string;
   onNotesChange: (text: string) => void;
+  /**
+   * Which action the sheet opens on. The other stays one tap away via the
+   * switch link below the buttons, so this is emphasis, never availability.
+   */
+  defaultMode: SessionExitMode;
+  /** Whether to offer "end for everyone" at all (false for a known non-creator). */
+  canEnd: boolean;
 };
 
+/**
+ * The session exit confirmation. Two modes over one sheet:
+ *
+ * - `end` — terminates the session for every member and produces the summary.
+ * - `leave` — this device drops out; everyone else keeps climbing.
+ *
+ * Before #3502 only `end` existed, and it was the ONLY exit on mobile — so a
+ * climber who joined their own party from a second phone had to kill it for
+ * everyone (the HTTP endSession branch authorizes on creator user id, which
+ * their second phone passes) just to get out. Both actions are now always
+ * reachable when they're legal; `defaultMode` only decides which one leads.
+ */
 export function EndSessionSheet({
   visible,
   onDismiss,
   onConfirm,
+  onLeave,
   isEnding,
+  isLeaving,
   climbCount,
   notes,
   onNotesChange,
+  defaultMode,
+  canEnd,
 }: EndSessionSheetProps) {
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const insets = useSafeAreaInsets();
   const sheetRef = useRef<BottomSheetMethods>(null);
+
+  // Resolved mode. A known non-creator can never reach `end`, whatever mode
+  // was selected — that request would be refused server-side anyway.
+  const [mode, setMode] = useState<SessionExitMode>(defaultMode);
+  const effectiveMode = canEnd ? mode : 'leave';
+  // Re-arm on every open (and if capability resolves late) so a climber who
+  // switched modes last time doesn't inherit that choice on the next exit.
+  useEffect(() => {
+    if (visible) setMode(defaultMode);
+  }, [visible, defaultMode]);
+
+  const isEndMode = effectiveMode === 'end';
+  const busy = isEnding || isLeaving;
 
   // Present/dismiss route through the coordinator (serialized, no overlapping
   // native transitions). Always mounted by InSessionView and toggled via
@@ -66,14 +106,14 @@ export function EndSessionSheet({
             on both platforms (mirrors Sheet.tsx). BottomSheetView stays the
             sheet's single child. */}
         <KeyboardAvoidingView behavior="padding" style={styles.avoider}>
-          <Icon name="end.session" size={40} color={systemColors.secondaryLabel} />
+          <Icon name={isEndMode ? 'end.session' : 'leave.session'} size={40} color={systemColors.secondaryLabel} />
 
           <Text variant="title2" style={styles.title}>
-            {t('mobile.queue.endSession')}
+            {isEndMode ? t('mobile.queue.endSession') : t('mobile.queue.leaveSession')}
           </Text>
 
           <Text variant="body" color={systemColors.secondaryLabel} style={styles.subtitle}>
-            {t('mobile.queue.endSessionConfirm')}
+            {isEndMode ? t('mobile.queue.endSessionConfirm') : t('mobile.queue.leaveSessionConfirm')}
           </Text>
 
           <View style={styles.statRow}>
@@ -84,27 +124,68 @@ export function EndSessionSheet({
           </View>
 
           {/* Optional Strava-style recap. Typing never gates End — an empty field
-              behaves exactly as before. */}
-          <BottomSheetTextInput
-            style={[styles.notesInput, { backgroundColor: systemColors.fill, color: systemColors.label }]}
-            placeholder={t('mobile.queue.endSessionCommentPlaceholder')}
-            placeholderTextColor={systemColors.tertiaryLabel}
-            accessibilityLabel={t('mobile.queue.endSessionCommentAria')}
-            value={notes}
-            onChangeText={onNotesChange}
-            maxLength={SESSION_NOTES_MAX_LENGTH}
-            multiline
-          />
+              behaves exactly as before. Leaving produces no summary, so the recap
+              has nowhere to land and is hidden in that mode. */}
+          {isEndMode ? (
+            <BottomSheetTextInput
+              style={[styles.notesInput, { backgroundColor: systemColors.fill, color: systemColors.label }]}
+              placeholder={t('mobile.queue.endSessionCommentPlaceholder')}
+              placeholderTextColor={systemColors.tertiaryLabel}
+              accessibilityLabel={t('mobile.queue.endSessionCommentAria')}
+              value={notes}
+              onChangeText={onNotesChange}
+              maxLength={SESSION_NOTES_MAX_LENGTH}
+              multiline
+            />
+          ) : null}
 
           <View style={styles.buttonRow}>
             <Button
               title={t('mobile.queue.endSessionCancel')}
               variant="outlined"
               onPress={onDismiss}
+              disabled={busy}
               style={styles.button}
             />
-            <Button title={t('mobile.queue.endSession')} onPress={onConfirm} loading={isEnding} style={styles.button} />
+            {isEndMode ? (
+              <Button
+                title={t('mobile.queue.endSession')}
+                onPress={onConfirm}
+                loading={isEnding}
+                role="destructive"
+                style={styles.button}
+              />
+            ) : (
+              <Button
+                title={t('mobile.queue.leaveSessionAction')}
+                onPress={onLeave}
+                loading={isLeaving}
+                style={styles.button}
+              />
+            )}
           </View>
+
+          {/* The other exit, always one tap away when it's legal. Low emphasis:
+              this is the deliberate second step, not a second primary CTA. */}
+          {isEndMode ? (
+            <Button
+              title={t('mobile.queue.leaveInsteadAction')}
+              variant="text"
+              size="small"
+              onPress={() => setMode('leave')}
+              disabled={busy}
+            />
+          ) : canEnd ? (
+            <Button
+              title={t('mobile.queue.endForEveryone')}
+              variant="text"
+              size="small"
+              role="destructive"
+              tintColor={brandColors.error}
+              onPress={() => setMode('end')}
+              disabled={busy}
+            />
+          ) : null}
         </KeyboardAvoidingView>
       </BottomSheetView>
     </BottomSheet>

--- a/packages/mobile/src/components/EndSessionSheet.tsx
+++ b/packages/mobile/src/components/EndSessionSheet.tsx
@@ -71,11 +71,18 @@ export function EndSessionSheet({
   // was selected — that request would be refused server-side anyway.
   const [mode, setMode] = useState<SessionExitMode>(defaultMode);
   const effectiveMode = canEnd ? mode : 'leave';
-  // Re-arm on every open (and if capability resolves late) so a climber who
-  // switched modes last time doesn't inherit that choice on the next exit.
+  // Re-arm on OPEN only, so a climber who switched modes last time doesn't
+  // inherit that choice on the next exit. Deliberately keyed on the open
+  // transition rather than on `defaultMode` itself: device provenance resolves
+  // asynchronously, and a late resolve must not yank the sheet out from under
+  // someone who has already tapped through to the other mode.
+  const wasVisibleRef = useRef(false);
+  const latestDefaultModeRef = useRef(defaultMode);
+  latestDefaultModeRef.current = defaultMode;
   useEffect(() => {
-    if (visible) setMode(defaultMode);
-  }, [visible, defaultMode]);
+    if (visible && !wasVisibleRef.current) setMode(latestDefaultModeRef.current);
+    wasVisibleRef.current = visible;
+  }, [visible]);
 
   const isEndMode = effectiveMode === 'end';
   const busy = isEnding || isLeaving;

--- a/packages/mobile/src/components/__tests__/end-session-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/end-session-sheet.test.tsx
@@ -116,6 +116,7 @@ vi.mock('../../providers/theme-provider', () => ({
       label: '#000',
       tertiaryLabel: '#aaa',
     },
+    brandColors: { error: '#f00' },
   }),
 }));
 
@@ -124,14 +125,23 @@ vi.mock('../Text', () => ({
   Text: ({ children }: TextMockProps) => createElement('span', { 'data-text': 'true' }, children),
 }));
 
-type ButtonMockProps = { title: string; onPress?: () => void; variant?: string; loading?: boolean };
+type ButtonMockProps = {
+  title: string;
+  onPress?: () => void;
+  variant?: string;
+  loading?: boolean;
+  role?: string;
+  disabled?: boolean;
+};
 vi.mock('../Button', () => ({
-  Button: ({ title, onPress, variant, loading }: ButtonMockProps) =>
+  Button: ({ title, onPress, variant, loading, role, disabled }: ButtonMockProps) =>
     createElement('button', {
       onClick: onPress,
       'data-button': title,
       'data-variant': variant ?? 'filled',
       'data-loading': loading ? 'true' : 'false',
+      'data-role': role ?? 'default',
+      'data-disabled': disabled ? 'true' : 'false',
     }),
 }));
 
@@ -152,10 +162,16 @@ function makeProps(over: Partial<Parameters<typeof EndSessionSheet>[0]> = {}) {
     visible: true,
     onDismiss: vi.fn(),
     onConfirm: vi.fn(),
+    onLeave: vi.fn(),
     isEnding: false,
+    isLeaving: false,
     climbCount: 3,
     notes: '',
     onNotesChange: vi.fn(),
+    // The pre-#3502 sheet was end-only, so the cases below keep asserting that
+    // shape by defaulting to the end mode.
+    defaultMode: 'end' as const,
+    canEnd: true,
     ...over,
   };
 }
@@ -244,5 +260,80 @@ describe('EndSessionSheet', () => {
     expect(endButton?.getAttribute('data-loading')).toBe('false');
     fireEvent.click(endButton!);
     expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  // --- #3502: leave-vs-end ---------------------------------------------------
+
+  describe('leave mode', () => {
+    const leaveProps = (over: Partial<Parameters<typeof EndSessionSheet>[0]> = {}) =>
+      makeProps({ defaultMode: 'leave', ...over });
+
+    it('leads with Leave — not End — and calls onLeave', () => {
+      const onLeave = vi.fn();
+      const onConfirm = vi.fn();
+      const { container } = render(<EndSessionSheet {...leaveProps({ onLeave, onConfirm })} />);
+      expect(container.querySelector('[data-icon="leave.session"]')).not.toBeNull();
+      expect(container.textContent).toContain('mobile.queue.leaveSessionConfirm');
+      expect(button(container, 'mobile.queue.endSession')).toBeNull();
+
+      fireEvent.click(button(container, 'mobile.queue.leaveSessionAction')!);
+      expect(onLeave).toHaveBeenCalledTimes(1);
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it('hides the recap field — leaving produces no summary for it to land in', () => {
+      const { container } = render(<EndSessionSheet {...leaveProps()} />);
+      expect(textInput(container)).toBeNull();
+    });
+
+    // The regression this whole issue is about: before #3502 the second phone's
+    // only exit ended the party for everyone. End must stay REACHABLE for a
+    // creator (it's their session) but must never be the default here.
+    it('keeps End reachable for a creator via the destructive switch link', () => {
+      const onConfirm = vi.fn();
+      const { container } = render(<EndSessionSheet {...leaveProps({ onConfirm, canEnd: true })} />);
+      const switchLink = button(container, 'mobile.queue.endForEveryone');
+      expect(switchLink).not.toBeNull();
+      expect(switchLink?.getAttribute('data-variant')).toBe('text');
+      expect(switchLink?.getAttribute('data-role')).toBe('destructive');
+
+      fireEvent.click(switchLink!);
+      // Now in end mode: the recap appears and End is the primary action.
+      expect(textInput(container)).not.toBeNull();
+      fireEvent.click(button(container, 'mobile.queue.endSession')!);
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    // Deleting the `canEnd` gate makes this render the destructive switch to a
+    // participant the server would refuse anyway — the foreign-joiner half of
+    // the bug, which used to eject them with a generic "Action failed".
+    it('offers no End affordance at all when canEnd is false', () => {
+      const { container } = render(<EndSessionSheet {...leaveProps({ canEnd: false })} />);
+      expect(button(container, 'mobile.queue.endForEveryone')).toBeNull();
+      expect(button(container, 'mobile.queue.endSession')).toBeNull();
+      expect(button(container, 'mobile.queue.leaveSessionAction')).not.toBeNull();
+    });
+
+    it('forces leave mode when canEnd is false even if the caller asked for end', () => {
+      const { container } = render(<EndSessionSheet {...makeProps({ defaultMode: 'end', canEnd: false })} />);
+      expect(button(container, 'mobile.queue.endSession')).toBeNull();
+      expect(button(container, 'mobile.queue.leaveSessionAction')).not.toBeNull();
+    });
+
+    it('reflects the leaving state on the Leave button', () => {
+      const { container } = render(<EndSessionSheet {...leaveProps({ isLeaving: true })} />);
+      expect(button(container, 'mobile.queue.leaveSessionAction')?.getAttribute('data-loading')).toBe('true');
+    });
+  });
+
+  it('offers "just leave instead" from end mode, so ending is never the only exit', () => {
+    const onLeave = vi.fn();
+    const { container } = render(<EndSessionSheet {...makeProps({ onLeave })} />);
+    const switchLink = button(container, 'mobile.queue.leaveInsteadAction');
+    expect(switchLink).not.toBeNull();
+
+    fireEvent.click(switchLink!);
+    fireEvent.click(button(container, 'mobile.queue.leaveSessionAction')!);
+    expect(onLeave).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/components/__tests__/end-session-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/end-session-sheet.test.tsx
@@ -326,6 +326,30 @@ describe('EndSessionSheet', () => {
     });
   });
 
+  // Device provenance resolves asynchronously, so `defaultMode` can change a
+  // beat after the sheet is already open. Re-arming on that change would yank
+  // the sheet out from under someone who has already tapped through.
+  it('does not reset the chosen mode when defaultMode resolves late while open', () => {
+    const { container, rerender } = render(<EndSessionSheet {...makeProps({ defaultMode: 'end' })} />);
+    fireEvent.click(button(container, 'mobile.queue.leaveInsteadAction')!);
+    expect(button(container, 'mobile.queue.leaveSessionAction')).not.toBeNull();
+
+    // Provenance lands and flips the caller's preferred default.
+    rerender(<EndSessionSheet {...makeProps({ defaultMode: 'end' })} />);
+    expect(button(container, 'mobile.queue.leaveSessionAction')).not.toBeNull();
+    expect(button(container, 'mobile.queue.endSession')).toBeNull();
+  });
+
+  it('re-arms to the default the next time it opens', () => {
+    const { container, rerender } = render(<EndSessionSheet {...makeProps({ defaultMode: 'end' })} />);
+    fireEvent.click(button(container, 'mobile.queue.leaveInsteadAction')!);
+    expect(button(container, 'mobile.queue.endSession')).toBeNull();
+
+    rerender(<EndSessionSheet {...makeProps({ visible: false, defaultMode: 'end' })} />);
+    rerender(<EndSessionSheet {...makeProps({ visible: true, defaultMode: 'end' })} />);
+    expect(button(container, 'mobile.queue.endSession')).not.toBeNull();
+  });
+
   it('offers "just leave instead" from end mode, so ending is never the only exit', () => {
     const onLeave = vi.fn();
     const { container } = render(<EndSessionSheet {...makeProps({ onLeave })} />);

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -134,6 +134,9 @@ export const iconMap = {
   pause: { ios: 'pause', android: 'pause' },
   'minus.circle': { ios: 'minus.circle', android: 'minus-circle-outline' },
   'end.session': { ios: 'stop.circle', android: 'stop-circle-outline' },
+  // Dropping out of a session without ending it — deliberately a door-out
+  // glyph, not a stop sign, so it never reads as the destructive action.
+  'leave.session': { ios: 'rectangle.portrait.and.arrow.right', android: 'exit-to-app' },
   'skip.previous': { ios: 'backward.end', android: 'skip-previous' },
   'skip.next': { ios: 'forward.end', android: 'skip-next' },
   'drag.handle': { ios: 'line.3.horizontal', android: 'drag-horizontal-variant' },

--- a/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
+++ b/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
@@ -31,10 +31,19 @@ type RecordTopChromeProps = {
   /** Open the invite sheet. Provided only while a session is live; the share
    *  glyph then docks at the far right of the chrome's right toolbar. */
   onShare?: () => void;
-  /** Open the End-session confirmation. Provided only while a session is live; the
-   *  End glyph docks beside the share control (destructive tint) so the session's
-   *  stop lives in the nav-bar trailing slot, off the bottom edge. */
+  /** Open the session-exit confirmation. Provided only while a session is live; the
+   *  glyph docks beside the share control so the session's exit lives in the
+   *  nav-bar trailing slot, off the bottom edge. */
   onEndSession?: () => void;
+  /**
+   * What this device's exit actually does, which decides the control's label
+   * and tint: `end` is the destructive red Stop, `leave` is a neutral Leave.
+   * A red Stop that only drops you out of someone else's party is a lie, and
+   * it trains climbers to distrust the destructive colour on the one surface
+   * where that trust matters (#3502). Defaults to `end` so callers that don't
+   * know (and the existing tests) keep the original chrome.
+   */
+  exitVariant?: 'end' | 'leave';
 };
 
 /**
@@ -60,11 +69,20 @@ export function RecordTopChrome({
   onHeightChange,
   onShare,
   onEndSession,
+  exitVariant = 'end',
 }: RecordTopChromeProps) {
   const { t } = useTranslation('session');
   const { t: tBoards } = useTranslation('boards');
   const { brandColors, systemColors, variant } = useTheme();
   const insets = useSafeAreaInsets();
+
+  // Leaving is non-destructive, so it gets neither the red tint nor the stop
+  // glyph. The accessibility label reuses the string web's queue bar already
+  // ships for the same action, so the two surfaces read identically.
+  const isLeaveExit = exitVariant === 'leave';
+  const exitLabel = isLeaveExit ? t('queueBar.ariaLabels.leaveSession') : t('mobile.session.inEndSession');
+  const exitTint = isLeaveExit ? systemColors.label : brandColors.error;
+  const exitIcon = isLeaveExit ? 'leave.session' : 'flag';
 
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => onHeightChange(event.nativeEvent.layout.height),
@@ -125,10 +143,13 @@ export function RecordTopChrome({
           ) : null}
           {onEndSession ? (
             <Appbar.Action
-              icon={iconMap['flag'].android}
-              color={brandColors.error}
+              icon={iconMap[exitIcon].android}
+              // Cast matches the sibling Appbar props: Paper types `color` as a
+              // plain string, while the iOS-flavoured tokens are a dynamic-colour
+              // union.
+              color={exitTint as string}
               onPress={onEndSession}
-              accessibilityLabel={t('mobile.session.inEndSession')}
+              accessibilityLabel={exitLabel}
             />
           ) : null}
         </Appbar.Header>
@@ -137,10 +158,11 @@ export function RecordTopChrome({
   }
 
   // Liquid-glass variant: the shared collapsing chrome. While a session is live the
-  // invite/share control docks on the LEFT and a single destructive Stop control on
-  // the RIGHT, with no lightbulb — so the active header reads invite | title | stop.
-  // End sits up here rather than as a bottom bar, keeping the bottom edge to the tab
-  // bar + climb accessory.
+  // invite/share control docks on the LEFT and a single exit control on the RIGHT,
+  // with no lightbulb — so the active header reads invite | title | exit. The exit
+  // is a destructive Stop on the device that started the session and a neutral Leave
+  // everywhere else (see `exitVariant`). It sits up here rather than as a bottom bar,
+  // keeping the bottom edge to the tab bar + climb accessory.
   const inSession = onEndSession !== undefined;
   const leadingAction = onShare ? (
     <GlassToolbarAction onPress={onShare} accessibilityLabel={t('mobile.session.invite')}>
@@ -156,12 +178,12 @@ export function RecordTopChrome({
       feedback="opacity"
       hitSlop={4}
       accessibilityRole="button"
-      accessibilityLabel={t('mobile.session.inEndSession')}
+      accessibilityLabel={exitLabel}
       style={styles.stopAction}
     >
-      <Icon name="flag" size={20} color={brandColors.error} />
-      <Text variant="subheadline" color={brandColors.error} style={styles.stopLabel}>
-        {t('mobile.session.inStop')}
+      <Icon name={exitIcon} size={20} color={exitTint} />
+      <Text variant="subheadline" color={exitTint} style={styles.stopLabel}>
+        {isLeaveExit ? t('mobile.session.inLeave') : t('mobile.session.inStop')}
       </Text>
     </PressableSurface>
   ) : undefined;

--- a/packages/mobile/src/components/session-screen/SessionScreen.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreen.tsx
@@ -6,6 +6,7 @@ import type { SharedValue } from 'react-native-reanimated';
 import { countDistinctSessionUsers } from '@boardsesh/queue-runtime';
 import { useQueueSessionId, useQueueLiveStats } from '../../providers/queue-provider';
 import { SessionScreenHeader } from './SessionScreenHeader';
+import { useSessionExitOptions } from './use-session-exit-options';
 import { PreSessionView } from './pre-session/PreSessionView';
 import { InSessionView } from './in-session/InSessionView';
 import { InviteSheet } from './InviteSheet';
@@ -38,6 +39,10 @@ export function SessionScreen({ onClose, headerGesture, translateY, screenHeight
   const { sessionUsers } = useQueueLiveStats();
   const insets = useSafeAreaInsets();
   const [showInvite, setShowInvite] = useState(false);
+  // Overlay mode owns its own header strip, so it needs the same exit read
+  // InSessionView makes for the tab chrome — otherwise the two entry points
+  // into one sheet would disagree about whether the button ends or leaves.
+  const { defaultMode: exitVariant } = useSessionExitOptions();
 
   const sessionActive = sessionId !== null;
   // Teach the share affordance while solo; once a friend joins, the label drops
@@ -74,6 +79,7 @@ export function SessionScreen({ onClose, headerGesture, translateY, screenHeight
           sessionActive={sessionActive}
           onShare={onShare}
           onEndSession={onEndSession}
+          exitVariant={exitVariant}
           inviteHint={soloInvite}
           dragGesture={headerGesture}
         />

--- a/packages/mobile/src/components/session-screen/SessionScreenHeader.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreenHeader.tsx
@@ -12,9 +12,16 @@ type SessionScreenHeaderProps = {
   sessionActive: boolean;
   /** When set, a share button floats at the trailing edge to invite climbers. */
   onShare?: () => void;
-  /** When set (session live), an End glyph docks beside share (destructive tint) so
-   *  the overlay's stop control matches the tab chrome's trailing End action. */
+  /** When set (session live), an exit glyph docks beside share so the overlay's
+   *  control matches the tab chrome's trailing exit action. */
   onEndSession?: () => void;
+  /**
+   * What this device's exit actually does — `end` (destructive red stop) or
+   * `leave` (neutral drop-out). Mirrors RecordTopChrome's prop of the same
+   * name so the overlay strip and the tab chrome can't disagree about what the
+   * button will do (#3502). Defaults to `end` for callers that don't know.
+   */
+  exitVariant?: 'end' | 'leave';
   /**
    * Show a short "Invite" label beside the share glyph to teach the affordance.
    * Set while the climber is solo; collapses to the icon alone once a friend
@@ -42,11 +49,13 @@ export function SessionScreenHeader({
   onEndSession,
   inviteHint,
   dragGesture,
+  exitVariant = 'end',
 }: SessionScreenHeaderProps) {
   const { t } = useTranslation('session');
   const { systemColors, brandColors } = useTheme();
 
   const title = sessionActive ? t('mobile.session.headerActive') : t('mobile.session.headerStart');
+  const isLeaveExit = exitVariant === 'leave';
 
   const row = (
     <View style={styles.row}>
@@ -89,10 +98,16 @@ export function SessionScreenHeader({
               onPress={onEndSession}
               hitSlop={12}
               accessibilityRole="button"
-              accessibilityLabel={t('mobile.session.inEndSession')}
+              accessibilityLabel={
+                isLeaveExit ? t('queueBar.ariaLabels.leaveSession') : t('mobile.session.inEndSession')
+              }
               style={styles.iconButton}
             >
-              <Icon name="flag" size={22} color={brandColors.error} />
+              <Icon
+                name={isLeaveExit ? 'leave.session' : 'flag'}
+                size={22}
+                color={isLeaveExit ? systemColors.label : brandColors.error}
+              />
             </Pressable>
           ) : null}
         </View>

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -13,6 +13,7 @@ import type { SessionDetailTick, SessionFeedParticipant } from '@boardsesh/share
 import { getGradeTextColor } from '@boardsesh/play-view';
 import { formatTickRelativeTime, tickTimeMs } from '@boardsesh/profile-stats';
 import { countDistinctSessionUsers } from '@boardsesh/queue-runtime';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { Card } from '../../Card';
 import { ClimbListItemContent } from '../../ClimbListItemContent';
 import { EndSessionSheet } from '../../EndSessionSheet';
@@ -42,8 +43,11 @@ import { borderRadius, spacing } from '../../../theme/tokens';
 import { gradeBadgeColor } from '../../you/profile-chart-colors';
 import { hapticSelection, hapticMedium } from '../../../lib/haptics';
 import { reportHandledError } from '../../../lib/error-reporting';
+import { track } from '../../../lib/analytics';
+import { useToast } from '../../../providers/toast-provider';
 import { RecordTopChrome } from '../RecordTopChrome';
 import { SessionTitleSheet } from '../SessionTitleSheet';
+import { useSessionExitOptions } from '../use-session-exit-options';
 import { SessionAnalytics } from './SessionAnalytics';
 import { SessionLeaderboard } from './SessionLeaderboard';
 import { SessionPresenceRow } from './SessionPresenceRow';
@@ -255,9 +259,13 @@ export function InSessionView({
   const router = useRouter();
   const queryClient = useQueryClient();
   const { openPlayDrawer } = useDrawerHost();
+  const { showToast } = useToast();
   const { sessionId, participantId } = useQueueSessionControls();
-  const { setCurrentClimb, endSession } = useQueueActions();
+  const { setCurrentClimb, endSession, clearSession } = useQueueActions();
   const { liveStats, sessionUsers } = useQueueLiveStats();
+  // End-for-everyone vs. drop-out-quietly, and which of the two this device
+  // leads with. See use-session-exit-options for the id-space reasoning.
+  const { canEnd, startedOnThisDevice, defaultMode } = useSessionExitOptions();
 
   // Seed the live view from the full session detail (rich grade split, flashes,
   // per-participant flashes, and the tick list used for hardest-send names and
@@ -458,6 +466,7 @@ export function InSessionView({
   }, [translateY, screenHeight, scrollOffset, startedAtTop]);
 
   const [isEnding, setIsEnding] = useState(false);
+  const [isLeaving, setIsLeaving] = useState(false);
   // Optional end-of-session recap. Cleared whenever the active session changes
   // (start / join / end) so a new session never inherits the previous draft.
   const [endNotes, setEndNotes] = useState('');
@@ -510,6 +519,28 @@ export function InSessionView({
       setIsEnding(false);
     }
   }, [endSession, router, onEndDismiss, endNotes, sessionId]);
+
+  // Drop out WITHOUT ending the session for anyone else (#3502). Deliberately
+  // NOT `clearSession()`: `notifyServer` emits LEAVE_SESSION so peers see the
+  // departure now instead of after the 60s disconnect grace, and the driver /
+  // presence release happens immediately. No summary, no navigation, no
+  // Apple Health export — none of those belong to a member who merely left.
+  const handleConfirmLeave = useCallback(async () => {
+    setIsLeaving(true);
+    try {
+      await clearSession({ notifyServer: true });
+      track(SHARED_EVENTS.SessionLeft, { startedOnThisDevice, couldHaveEnded: canEnd });
+      onEndDismiss?.();
+      showToast(t('mobile.toast.leftSession'), 'success');
+    } catch (error) {
+      // clearSession swallows its own LEAVE_SESSION failure, so reaching here
+      // means local teardown itself threw — surface it rather than leaving the
+      // climber stuck in a session they asked to leave.
+      reportHandledError(error, { tags: { source: 'leaveSession' } });
+    } finally {
+      setIsLeaving(false);
+    }
+  }, [clearSession, onEndDismiss, showToast, t, startedOnThisDevice, canEnd]);
 
   // Stable dismiss handler so the always-mounted EndSessionSheet doesn't get a fresh
   // onDismiss ref every render (onEndDismiss is optional, hence the wrapper).
@@ -668,6 +699,7 @@ export function InSessionView({
           onHeightChange={setChromeHeight}
           onShare={onShare}
           onEndSession={onRequestEndSession}
+          exitVariant={defaultMode}
         />
       ) : null}
 
@@ -682,10 +714,14 @@ export function InSessionView({
         visible={endVisible}
         onDismiss={handleEndDismiss}
         onConfirm={() => void handleConfirmEnd()}
+        onLeave={() => void handleConfirmLeave()}
         isEnding={isEnding}
+        isLeaving={isLeaving}
         climbCount={sessionHistoryTicks.length}
         notes={endNotes}
         onNotesChange={setEndNotes}
+        defaultMode={defaultMode}
+        canEnd={canEnd}
       />
     </View>
   );

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -535,8 +535,11 @@ export function InSessionView({
     } catch (error) {
       // clearSession swallows its own LEAVE_SESSION failure, so reaching here
       // means local teardown itself threw — surface it rather than leaving the
-      // climber stuck in a session they asked to leave.
+      // climber staring at a sheet that did nothing. The sheet deliberately
+      // stays open so they can retry (same call as handleConfirmEnd's catch);
+      // "Keep climbing" and pan-down are still there to back out.
       reportHandledError(error, { tags: { source: 'leaveSession' } });
+      showToast(t('mobile.queue.actionFailed'), 'error');
     } finally {
       setIsLeaving(false);
     }

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-exit.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-exit.test.tsx
@@ -229,6 +229,25 @@ describe('InSessionView session exit (#3502)', () => {
     expect(chrome.exitVariant).toBe('end');
   });
 
+  // Provenance is a SecureStore read, so it can't be known on the first frame.
+  // Falling back to `end` there keeps that frame identical to the pre-#3502
+  // chrome — a creator must never watch the control change identity under their
+  // thumb. Collapse the fallback to `leadWithEnd = startedOnThisDevice` and this
+  // fails (verified by mutation).
+  it('renders the pre-existing End chrome on the first frame, before provenance resolves', () => {
+    render(createElement(InSessionView, { showChrome: true }));
+    expect(sheet.defaultMode).toBe('end');
+    expect(chrome.exitVariant).toBe('end');
+  });
+
+  // ...but an unresolved read must not hand a known-foreign participant the
+  // destructive mode. canEnd is computed independently of provenance.
+  it('still withholds End on the first frame for a known-foreign participant', () => {
+    session.ownerUserId = 'user-someone-else';
+    render(createElement(InSessionView, { showChrome: true }));
+    expect(sheet.canEnd).toBe(false);
+  });
+
   // THE BUG. Same climber, same session, second phone: provenance is absent, so
   // the exit must lead with Leave. Delete the `startedOnThisDevice` term in
   // useSessionExitOptions and this flips back to 'end' — i.e. back to the only
@@ -298,6 +317,19 @@ describe('InSessionView session exit (#3502)', () => {
       expect(router.push).not.toHaveBeenCalled();
       expect(integrations.runSessionEndExports).not.toHaveBeenCalled();
       expect(toast.showToast).toHaveBeenCalledWith('mobile.toast.leftSession', 'success');
+    });
+
+    // Without a toast here the climber taps Leave, the spinner vanishes, and
+    // nothing visibly happens — the sheet just sits there.
+    it('surfaces a failed local teardown instead of failing silently', async () => {
+      session.createdSessionId = null;
+      queue.clearSession.mockRejectedValue(new Error('teardown exploded'));
+      await renderInSession();
+      await act(async () => {
+        sheet.onLeave?.();
+      });
+      expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+      expect(toast.showToast).not.toHaveBeenCalledWith('mobile.toast.leftSession', 'success');
     });
 
     it('tracks the leave with the provenance split', async () => {

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-exit.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-exit.test.tsx
@@ -1,0 +1,327 @@
+// @vitest-environment jsdom
+import { act, render, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #3502 — leave-vs-end. InSessionView + the REAL useSessionExitOptions hook,
+// with only the hook's inputs stubbed (roster, owner query, device provenance),
+// so deleting the gate inside that hook fails these tests rather than passing a
+// re-implementation of itself.
+//
+// The three scenarios that matter:
+//   1. the phone that STARTED the session      → leads with End (unchanged)
+//   2. the same climber's SECOND phone         → leads with Leave, End still reachable
+//   3. someone else's session (known foreign)  → Leave only, End withheld
+
+const queue = vi.hoisted(() => ({
+  endSession: vi.fn(),
+  clearSession: vi.fn(),
+}));
+const sheet = vi.hoisted(() => ({
+  defaultMode: null as string | null,
+  canEnd: null as boolean | null,
+  onConfirm: null as (() => void) | null,
+  onLeave: null as (() => void) | null,
+}));
+const chrome = vi.hoisted(() => ({ exitVariant: null as string | null }));
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+const integrations = vi.hoisted(() => ({ runSessionEndExports: vi.fn() }));
+
+// The hook's three inputs.
+const session = vi.hoisted(() => ({
+  // Roster row for participant-1. `id` is the participant id (a user UUID for
+  // signed-in climbers), `userId` the DB user id — matched on `id`, never
+  // `clientId`, because those are different id-spaces.
+  users: [{ id: 'participant-1', username: 'Marco', isLeader: true, userId: 'user-me', connectionState: 'CONNECTED' }],
+  ownerUserId: 'user-me' as string | null,
+  createdSessionId: 'session-1' as string | null,
+}));
+
+vi.mock('react-native', () => ({
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('react-native-gesture-handler', () => ({
+  Gesture: {
+    Pan: () => ({
+      activeOffsetY: () => ({ onStart: () => ({ onUpdate: () => ({ onEnd: () => ({}) }) }) }),
+    }),
+  },
+  GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('react-native-reanimated', () => ({
+  useSharedValue: (value: number) => ({ value }),
+  withSpring: (value: number) => value,
+}));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+vi.mock('@shopify/flash-list', () => ({
+  FlashList: ({
+    ListHeaderComponent,
+    ListFooterComponent,
+  }: {
+    ListHeaderComponent?: ReactNode;
+    ListFooterComponent?: ReactNode;
+  }) => createElement('div', null, ListHeaderComponent, ListFooterComponent),
+}));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-uuid' }));
+vi.mock('expo-router', () => ({ useRouter: () => router }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ invalidateQueries: vi.fn() }) }));
+vi.mock('@boardsesh/play-view', () => ({ formatGrade: (grade: string) => grade, getGradeTextColor: () => '#fff' }));
+vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: { SessionLeft: 'Session Left' } }));
+
+vi.mock('../../../Button', () => ({ Button: () => createElement('button') }));
+vi.mock('../../../Card', () => ({
+  Card: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../../GlassSurface', () => ({ GlassSurface: () => null }));
+vi.mock('../../../ListRow', () => ({ ListRow: () => null }));
+vi.mock('../../../PressableSurface', () => ({
+  PressableSurface: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../../SectionHeader', () => ({ SectionHeader: () => null }));
+vi.mock('../../../ScreenTitle', () => ({ ScreenTitle: () => null }));
+vi.mock('../../../ClimbListItemContent', () => ({ ClimbListItemContent: () => null }));
+vi.mock('../../../Icon', () => ({ Icon: () => null }));
+vi.mock('../../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../SessionTitleSheet', () => ({ SessionTitleSheet: () => null }));
+
+// Capture what the chrome is told the exit does — a red Stop that only leaves
+// is the lie this issue is partly about.
+vi.mock('../../RecordTopChrome', () => ({
+  RecordTopChrome: ({ exitVariant }: { exitVariant?: string }) => {
+    chrome.exitVariant = exitVariant ?? null;
+    return null;
+  },
+}));
+
+vi.mock('../../../EndSessionSheet', () => ({
+  EndSessionSheet: ({
+    defaultMode,
+    canEnd,
+    onConfirm,
+    onLeave,
+  }: {
+    defaultMode?: string;
+    canEnd?: boolean;
+    onConfirm?: () => void;
+    onLeave?: () => void;
+  }) => {
+    sheet.defaultMode = defaultMode ?? null;
+    sheet.canEnd = canEnd ?? null;
+    sheet.onConfirm = onConfirm ?? null;
+    sheet.onLeave = onLeave ?? null;
+    return null;
+  },
+}));
+
+vi.mock('../../../../lib/error-reporting', () => ({ reportError: vi.fn(), reportHandledError: vi.fn() }));
+vi.mock('../../../../lib/analytics', () => ({ track: analytics.track }));
+vi.mock('../../../../providers/toast-provider', () => ({ useToast: () => toast }));
+vi.mock('../../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: 'liquidGlass',
+    systemColors: { background: '#000', secondaryBackground: '#111', secondaryLabel: '#999', separator: '#222' },
+    brandColors: { success: '#0f0', warning: '#ff0', primary: '#00f', error: '#f00' },
+    features: { inBodyLargeTitle: false },
+  }),
+}));
+vi.mock('../../../../providers/queue-provider', () => ({
+  useQueueActions: () => ({
+    endSession: queue.endSession,
+    clearSession: queue.clearSession,
+    setCurrentClimb: vi.fn(),
+  }),
+  useQueueLiveStats: () => ({ liveStats: null, sessionUsers: session.users }),
+  useQueueSessionControls: () => ({ participantId: 'participant-1', sessionId: 'session-1' }),
+}));
+vi.mock('../../../../providers/drawer-host-provider', () => ({ useDrawerHost: () => ({ openPlayDrawer: vi.fn() }) }));
+vi.mock('../../../../lib/graphql/hooks', () => ({
+  useSessionDetail: () => ({
+    data: { totalSends: 0, totalFlashes: 0, gradeDistribution: [], participants: [], hardestGrade: null, ticks: [] },
+  }),
+  useSessionSummary: () => ({ data: { startedAt: '2026-01-01T00:00:00.000Z' } }),
+  useSessionPreview: () => ({ data: null }),
+  useSessionOwnerUserId: () => ({ data: session.ownerUserId }),
+}));
+vi.mock('../../../../lib/session-store', () => ({
+  getStoredCreatedSessionId: () => Promise.resolve(session.createdSessionId),
+}));
+vi.mock('../../../../lib/store-review', () => ({
+  SESSION_STORE_REVIEW_CANDIDATE_PARAM: '1',
+  isSessionStoreReviewEligible: () => false,
+}));
+vi.mock('../../../../lib/integrations', () => ({ runSessionEndExports: integrations.runSessionEndExports }));
+vi.mock('../../../../lib/session-comment-draft-store', () => ({
+  setDraftComment: vi.fn(),
+  clearDraftComment: vi.fn(),
+}));
+vi.mock('../../../../lib/climb-to-queue-item', () => ({ climbToQueueItem: vi.fn() }));
+vi.mock('../../../../lib/playlists/board-details-for-playlist', () => ({ getBoardConfigForPlaylist: () => null }));
+vi.mock('../../../../lib/open-climb-in-play-drawer', () => ({ openClimbInPlayDrawer: vi.fn() }));
+vi.mock('../../../../lib/tick-to-climb', () => ({ tickToClimb: () => null }));
+vi.mock('../../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (grade: string | null) => grade, formatGradeByDifficultyId: () => null }),
+}));
+vi.mock('../../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({
+    fixedFooterBottom: 88,
+    jsQueueReserve: 0,
+    tabBarBottom: 50,
+    inSessionListBottom: 0,
+  }),
+}));
+vi.mock('../../../../theme/colors', () => ({ withAlpha: (color: string) => color }));
+vi.mock('../../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#999' } }));
+vi.mock('../../../../theme/animations', () => ({ springs: { gentle: {} } }));
+vi.mock('../../../../theme/tokens', () => ({ borderRadius: { lg: 16 }, spacing: { 2: 8, 3: 12, 4: 16, 5: 20 } }));
+vi.mock('../../../you/profile-chart-colors', () => ({ gradeBadgeColor: () => '#fff' }));
+vi.mock('../../../../lib/haptics', () => ({ hapticSelection: vi.fn(), hapticMedium: vi.fn() }));
+vi.mock('../../../../lib/formatTickRelativeTime', () => ({}));
+vi.mock('../SessionAnalytics', () => ({ SessionAnalytics: () => null }));
+vi.mock('../SessionLeaderboard', () => ({ SessionLeaderboard: () => null }));
+vi.mock('../SessionPresenceRow', () => ({ SessionPresenceRow: () => null }));
+
+import { InSessionView } from '../InSessionView';
+
+async function renderInSession() {
+  const result = render(createElement(InSessionView, { showChrome: true }));
+  // The provenance read is async (SecureStore); wait for it to land before
+  // asserting emphasis.
+  await waitFor(() => expect(sheet.defaultMode).not.toBeNull());
+  return result;
+}
+
+describe('InSessionView session exit (#3502)', () => {
+  beforeEach(() => {
+    queue.endSession.mockReset();
+    queue.endSession.mockResolvedValue(null);
+    queue.clearSession.mockReset();
+    queue.clearSession.mockResolvedValue(undefined);
+    router.push.mockClear();
+    toast.showToast.mockClear();
+    analytics.track.mockClear();
+    integrations.runSessionEndExports.mockReset();
+    sheet.defaultMode = null;
+    sheet.canEnd = null;
+    sheet.onConfirm = null;
+    sheet.onLeave = null;
+    chrome.exitVariant = null;
+    session.users = [
+      { id: 'participant-1', username: 'Marco', isLeader: true, userId: 'user-me', connectionState: 'CONNECTED' },
+    ];
+    session.ownerUserId = 'user-me';
+    session.createdSessionId = 'session-1';
+  });
+
+  it('leads with End on the device that started the session', async () => {
+    await renderInSession();
+    expect(sheet.defaultMode).toBe('end');
+    expect(sheet.canEnd).toBe(true);
+    expect(chrome.exitVariant).toBe('end');
+  });
+
+  // THE BUG. Same climber, same session, second phone: provenance is absent, so
+  // the exit must lead with Leave. Delete the `startedOnThisDevice` term in
+  // useSessionExitOptions and this flips back to 'end' — i.e. back to the only
+  // exit being the one that kills the party for everyone.
+  it("leads with Leave on the same climber's second phone, keeping End available", async () => {
+    session.createdSessionId = null;
+    await renderInSession();
+    expect(sheet.defaultMode).toBe('leave');
+    // Still the creator, so ending stays legal — just no longer the default.
+    expect(sheet.canEnd).toBe(true);
+    expect(chrome.exitVariant).toBe('leave');
+  });
+
+  // Delete the `isKnownForeign` gate and canEnd becomes true here, re-offering
+  // an action the server refuses — the path that used to eject a joiner with a
+  // generic "Action failed".
+  it('withholds End entirely from a climber who joined someone else’s session', async () => {
+    session.ownerUserId = 'user-someone-else';
+    session.createdSessionId = null;
+    await renderInSession();
+    expect(sheet.defaultMode).toBe('leave');
+    expect(sheet.canEnd).toBe(false);
+    expect(chrome.exitVariant).toBe('leave');
+  });
+
+  // Permissive-on-unknown is deliberate: ownership is unresolved on first
+  // render of every session, for anonymous sessions, and whenever the bundle
+  // outruns the backend. Failing closed there would strand a creator with no
+  // way to end their own session. Do not "harden" this.
+  it('still offers End while ownership is unknown', async () => {
+    session.ownerUserId = null;
+    session.createdSessionId = null;
+    await renderInSession();
+    expect(sheet.canEnd).toBe(true);
+    expect(sheet.defaultMode).toBe('leave');
+  });
+
+  it('does not treat a roster with no matching self row as foreign', async () => {
+    // Roster raced our join: we can't resolve our own userId, so ownership is
+    // unproven — permissive, same as above.
+    session.users = [];
+    session.ownerUserId = 'user-someone-else';
+    await renderInSession();
+    expect(sheet.canEnd).toBe(true);
+  });
+
+  describe('leaving', () => {
+    it('emits LEAVE_SESSION rather than only tearing down locally', async () => {
+      session.createdSessionId = null;
+      await renderInSession();
+      await act(async () => {
+        sheet.onLeave?.();
+      });
+      // EXACT argument. A bare clearSession() leaves peers waiting out the 60s
+      // disconnect grace before they see the departure — the whole reason
+      // notifyServer exists.
+      expect(queue.clearSession).toHaveBeenCalledWith({ notifyServer: true });
+      expect(queue.endSession).not.toHaveBeenCalled();
+    });
+
+    it('shows no summary and runs no session-end exports', async () => {
+      session.createdSessionId = null;
+      await renderInSession();
+      await act(async () => {
+        sheet.onLeave?.();
+      });
+      expect(router.push).not.toHaveBeenCalled();
+      expect(integrations.runSessionEndExports).not.toHaveBeenCalled();
+      expect(toast.showToast).toHaveBeenCalledWith('mobile.toast.leftSession', 'success');
+    });
+
+    it('tracks the leave with the provenance split', async () => {
+      session.createdSessionId = null;
+      await renderInSession();
+      await act(async () => {
+        sheet.onLeave?.();
+      });
+      expect(analytics.track).toHaveBeenCalledWith('Session Left', {
+        startedOnThisDevice: false,
+        couldHaveEnded: true,
+      });
+    });
+  });
+
+  it('still ends (with summary + exports) when End is confirmed', async () => {
+    queue.endSession.mockResolvedValue({ sessionId: 'session-1', totalSends: 1 });
+    await renderInSession();
+    await act(async () => {
+      sheet.onConfirm?.();
+    });
+    expect(queue.endSession).toHaveBeenCalledTimes(1);
+    expect(queue.clearSession).not.toHaveBeenCalled();
+    expect(integrations.runSessionEndExports).toHaveBeenCalledTimes(1);
+    expect(router.push).toHaveBeenCalledWith(expect.objectContaining({ pathname: '/(tabs)/record/summary' }));
+  });
+});

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
@@ -134,12 +134,20 @@ vi.mock('../../../../providers/theme-provider', () => ({
   }),
 }));
 vi.mock('../../../../providers/queue-provider', () => ({
-  useQueueActions: () => ({ endSession: queue.endSession, setCurrentClimb: vi.fn() }),
+  useQueueActions: () => ({ endSession: queue.endSession, clearSession: vi.fn(), setCurrentClimb: vi.fn() }),
   useQueueLiveStats: () => ({ liveStats: null, sessionUsers: [] }),
   useQueueSessionControls: () => ({
     participantId: 'participant-1',
     sessionId: 'session-1',
   }),
+}));
+vi.mock('../../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../../lib/analytics', () => ({ track: vi.fn() }));
+// The exit capability itself is covered by in-session-view-exit.test.tsx, which
+// drives the real hook. This file only cares about list padding, so pin the
+// capability to the pre-#3502 shape and keep the assertions here about layout.
+vi.mock('../../use-session-exit-options', () => ({
+  useSessionExitOptions: () => ({ canEnd: true, startedOnThisDevice: true, defaultMode: 'end' }),
 }));
 vi.mock('../../../../providers/drawer-host-provider', () => ({ useDrawerHost: () => ({ openPlayDrawer: vi.fn() }) }));
 vi.mock('../../../../lib/graphql/hooks', () => ({

--- a/packages/mobile/src/components/session-screen/use-session-exit-options.ts
+++ b/packages/mobile/src/components/session-screen/use-session-exit-options.ts
@@ -1,0 +1,84 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQueueSessionControls, useQueueLiveStats } from '../../providers/queue-provider';
+import { useSessionOwnerUserId } from '../../lib/graphql/hooks';
+import { getStoredCreatedSessionId } from '../../lib/session-store';
+
+export type SessionExitMode = 'end' | 'leave';
+
+export type SessionExitOptions = {
+  /**
+   * Whether to offer the destructive "end for everyone" action at all.
+   *
+   * PERMISSIVE ON UNKNOWN, and that is deliberate — do not "harden" this to
+   * fail closed. We hide End only when we POSITIVELY know we are not the
+   * creator. Ownership is unknown for the first render of every session (the
+   * owner query is in flight), for anonymous sessions, and whenever a bundle
+   * is newer than the backend — failing closed in those windows would strand a
+   * creator with no way to end their own session and no explanation. Being
+   * wrong the other way is cheap: the server re-checks creator/leader and
+   * refuses, and since #3502 that refusal leaves cleanly with an honest
+   * message instead of a generic failure. Same reasoning as `canEditTitle` in
+   * InSessionView.
+   */
+  canEnd: boolean;
+  /**
+   * Whether THIS DEVICE started the session (as opposed to joining it). Drives
+   * emphasis only — which action the confirmation sheet leads with — never
+   * whether an action exists. See session-store.ts for why device provenance,
+   * and not the roster, is the signal: one signed-in climber on two phones is
+   * a single participant server-side, so no roster-derived value can tell the
+   * two devices apart.
+   */
+  startedOnThisDevice: boolean;
+  /** The action the exit sheet opens on. The other one stays one tap away. */
+  defaultMode: SessionExitMode;
+};
+
+/**
+ * Resolves what "get me out of here" should mean for this device in this
+ * session: end it for everyone, or just drop out.
+ *
+ * Subscribes to contexts the session surfaces already consume
+ * (`useQueueSessionControls` / `useQueueLiveStats`), so it adds no new
+ * re-render sources.
+ */
+export function useSessionExitOptions(): SessionExitOptions {
+  const { sessionId, participantId } = useQueueSessionControls();
+  const { sessionUsers } = useQueueLiveStats();
+  const { data: ownerUserId } = useSessionOwnerUserId(sessionId ?? undefined);
+
+  const [createdSessionId, setCreatedSessionId] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void getStoredCreatedSessionId().then((stored) => {
+      if (!cancelled) setCreatedSessionId(stored);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Re-read per session so a start → end → join sequence can't carry stale
+    // provenance into the next session.
+  }, [sessionId]);
+
+  // Our own database user id. Matched on `participantId`, NOT `clientId`:
+  // roster entries are keyed by participant id, which equals the connection id
+  // only for anonymous users (backend: `client.userId || connectionId`).
+  const selfUserId = useMemo(
+    () => sessionUsers.find((user) => user.id === participantId)?.userId ?? null,
+    [sessionUsers, participantId],
+  );
+
+  return useMemo(() => {
+    const isKnownForeign = ownerUserId != null && selfUserId != null && ownerUserId !== selfUserId;
+    const canEnd = !isKnownForeign;
+    const startedOnThisDevice = createdSessionId != null && createdSessionId === sessionId;
+    return {
+      canEnd,
+      startedOnThisDevice,
+      // Lead with End only on the phone that started the party AND is still
+      // allowed to end it. Everything else — the same climber's second phone,
+      // a friend's party — leads with the non-destructive exit.
+      defaultMode: startedOnThisDevice && canEnd ? 'end' : 'leave',
+    };
+  }, [ownerUserId, selfUserId, createdSessionId, sessionId]);
+}

--- a/packages/mobile/src/components/session-screen/use-session-exit-options.ts
+++ b/packages/mobile/src/components/session-screen/use-session-exit-options.ts
@@ -47,9 +47,13 @@ export function useSessionExitOptions(): SessionExitOptions {
   const { sessionUsers } = useQueueLiveStats();
   const { data: ownerUserId } = useSessionOwnerUserId(sessionId ?? undefined);
 
-  const [createdSessionId, setCreatedSessionId] = useState<string | null>(null);
+  // `undefined` = the SecureStore read hasn't landed yet, which is distinct from
+  // `null` = read, and this device didn't start anything. The difference decides
+  // the first frame's emphasis (see the fallback in the memo below).
+  const [createdSessionId, setCreatedSessionId] = useState<string | null | undefined>(undefined);
   useEffect(() => {
     let cancelled = false;
+    setCreatedSessionId(undefined);
     void getStoredCreatedSessionId().then((stored) => {
       if (!cancelled) setCreatedSessionId(stored);
     });
@@ -71,14 +75,24 @@ export function useSessionExitOptions(): SessionExitOptions {
   return useMemo(() => {
     const isKnownForeign = ownerUserId != null && selfUserId != null && ownerUserId !== selfUserId;
     const canEnd = !isKnownForeign;
+    // Honest — stays false until the read lands, so the analytics split doesn't
+    // count an unresolved device as the one that started the session.
     const startedOnThisDevice = createdSessionId != null && createdSessionId === sessionId;
+    // Emphasis while the read is still in flight. Falling back to `end` keeps
+    // the first frame byte-identical to the pre-#3502 chrome, so a creator (the
+    // common case) never sees the control change identity under their thumb.
+    // The joiner's brief red Stop is safe: `canEnd` is computed independently of
+    // provenance, so a known-foreign participant is still refused the End mode
+    // by the sheet even if they tap during that window.
+    const provenanceResolved = createdSessionId !== undefined;
+    const leadWithEnd = provenanceResolved ? startedOnThisDevice : true;
     return {
       canEnd,
       startedOnThisDevice,
       // Lead with End only on the phone that started the party AND is still
       // allowed to end it. Everything else — the same climber's second phone,
       // a friend's party — leads with the non-destructive exit.
-      defaultMode: startedOnThisDevice && canEnd ? 'end' : 'leave',
+      defaultMode: leadWithEnd && canEnd ? 'end' : 'leave',
     };
   }, [ownerUserId, selfUserId, createdSessionId, sessionId]);
 }

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -1281,7 +1281,7 @@ export {
   useComments,
   useAddComment,
 } from './use-social';
-export { useSessionDetail, useSessionPreview } from './use-session-detail';
+export { useSessionDetail, useSessionPreview, useSessionOwnerUserId } from './use-session-detail';
 export { useDeleteAccountInfo, useDeleteAccount } from './use-delete-account';
 export {
   useIntegrationStatuses,

--- a/packages/mobile/src/lib/graphql/hooks/use-session-detail.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-session-detail.ts
@@ -1,6 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { GET_SESSION_DETAIL, type GetSessionDetailQueryResponse } from '@boardsesh/graphql/operations';
-import { GET_SESSION, type GetSessionQueryResponse, type SessionPreview } from '../operations';
+import {
+  GET_SESSION,
+  GET_SESSION_OWNER,
+  type GetSessionOwnerQueryResponse,
+  type GetSessionQueryResponse,
+  type SessionPreview,
+} from '../operations';
 import { getHttpClient } from '../client';
 
 const SESSION_DETAIL_STALE_TIME_MS = 30 * 1000;
@@ -38,5 +44,31 @@ export function useSessionPreview(sessionId: string | undefined) {
     enabled: !!sessionId,
     // Preview reflects live presence; keep it fresh while the screen is open.
     staleTime: 10 * 1000,
+  });
+}
+
+/**
+ * Database user UUID of whoever started a session, or null when the server
+ * won't say (non-member, anonymous creator, or a bundle newer than the backend
+ * — see GET_SESSION_OWNER's note on why this is its own document).
+ *
+ * Unlike `useSessionDetail`, this resolves for a ZERO-TICK session: sessionDetail
+ * returns null until the first ascent is logged, which is exactly when someone
+ * joins a friend's fresh party and wants back out of it. Ownership never changes
+ * for a given session id, so this is cached hard.
+ */
+export function useSessionOwnerUserId(sessionId: string | undefined) {
+  return useQuery<string | null>({
+    queryKey: ['sessionOwner', sessionId],
+    queryFn: () =>
+      getHttpClient()
+        .request<GetSessionOwnerQueryResponse>(GET_SESSION_OWNER, { sessionId })
+        .then((response) => response.session?.createdByUserId ?? null),
+    enabled: !!sessionId,
+    // Immutable for the life of a session — no reason to ever refetch it.
+    staleTime: Infinity,
+    // A failure here must degrade to "ownership unknown", never to a retry
+    // storm behind a confirmation sheet the climber is staring at.
+    retry: 1,
   });
 }

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -705,6 +705,35 @@ export type GetSessionQueryResponse = {
   session: SessionPreview | null;
 };
 
+// Who started the active session, read in-session to decide whether to offer
+// the destructive End action at all (#3502). Deliberately its OWN document
+// rather than another field on GET_SESSION: that query also backs the
+// join-by-link screen (app/join/[sessionId].tsx), and GraphQL validates whole
+// documents — a new-bundle/old-backend skew would fail the entire query and
+// break joining, which is far worse than the bug this fixes. Isolated here, the
+// same skew just leaves ownership unknown and the exit UI falls back to its
+// permissive default.
+//
+// `createdByUserId` is redacted to null for non-members server-side, and it is
+// NOT an authorization signal — endSession re-checks creator/leader.
+export const GET_SESSION_OWNER = gql`
+  query GetSessionOwner($sessionId: ID!) {
+    session(sessionId: $sessionId) {
+      id
+      createdByUserId
+    }
+  }
+`;
+
+export type SessionOwner = {
+  id: string;
+  createdByUserId: string | null;
+};
+
+export type GetSessionOwnerQueryResponse = {
+  session: SessionOwner | null;
+};
+
 // Presence-independent lifecycle check, read on cold start to decide whether a
 // persisted session id should be restored or dropped (#2683). Unlike GET_SESSION
 // (gated on live roster, so an ended session and a dormant-but-active solo

--- a/packages/mobile/src/lib/session-store.ts
+++ b/packages/mobile/src/lib/session-store.ts
@@ -19,3 +19,45 @@ export async function setStoredSessionId(sessionId: string, _owner?: UserStorage
 export async function clearStoredSessionId(_owner?: UserStorageOwner | null): Promise<void> {
   await SecureStore.deleteItemAsync(SESSION_ID_KEY);
 }
+
+/**
+ * Id of the session THIS DEVICE started (as opposed to joined). Written by
+ * createSessionWithConfig, cleared at the clearSession teardown boundary.
+ *
+ * Device provenance is the only signal that tells the phone which started a
+ * party apart from the same climber's second phone. It deliberately is NOT
+ * derived from the roster: the backend keys participants by
+ * `client.userId || connectionId`, so one signed-in climber on two devices
+ * collapses into a single participant row — every roster-derived signal
+ * (`SessionUser.isLeader`, `connectionState`, distinct-user counts) is
+ * participant-scoped and structurally blind to the second device. The
+ * per-connection `Session.isLeader` from the JOIN response looks like the free
+ * answer but is not: `upsertLocalParticipant` ORs leadership across a
+ * participant's connections (sticky true) and the SessionRosterSnapshot handler
+ * re-derives our own flag from that participant row, so the second device is
+ * told `isLeader: true` by its very first roster snapshot (see #3502 / the
+ * follow-up issue on that inconsistency).
+ *
+ * This drives EMPHASIS ONLY — which action a confirmation sheet leads with —
+ * never whether an action is available. That is what makes losing it harmless:
+ * a reinstall wipes SecureStore, the creator's original phone falls back to
+ * leading with Leave, and End is still one tap away. A signal that degrades
+ * toward offering the destructive action would be worse than no signal at all.
+ */
+const CREATED_SESSION_ID_KEY = 'boardsesh_created_session_id';
+
+export async function getStoredCreatedSessionId(): Promise<string | null> {
+  try {
+    return await SecureStore.getItemAsync(CREATED_SESSION_ID_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export async function setStoredCreatedSessionId(sessionId: string): Promise<void> {
+  await SecureStore.setItemAsync(CREATED_SESSION_ID_KEY, sessionId, SECURE_STORE_WRITE_OPTIONS);
+}
+
+export async function clearStoredCreatedSessionId(): Promise<void> {
+  await SecureStore.deleteItemAsync(CREATED_SESSION_ID_KEY);
+}

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -165,6 +165,10 @@ vi.mock('../../lib/auth', () => ({
 const clearStoredSessionIdMock = vi.fn();
 vi.mock('../../lib/session-store', () => ({
   clearStoredSessionId: (...args: unknown[]) => clearStoredSessionIdMock(...args),
+  // Device provenance for the leave-vs-end emphasis (#3502).
+  getStoredCreatedSessionId: vi.fn(async () => null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
 }));
 
 const clearStoredActiveBoardMock = vi.fn();

--- a/packages/mobile/src/providers/__tests__/queue-provider-backgrounded-join.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-backgrounded-join.test.tsx
@@ -55,6 +55,10 @@ const sessionStore = vi.hoisted(() => ({
   getStoredSessionId: vi.fn(async () => 'session-1' as string | null),
   setStoredSessionId: vi.fn(async () => {}),
   clearStoredSessionId: vi.fn(async () => {}),
+  // Device provenance for the leave-vs-end emphasis (#3502).
+  getStoredCreatedSessionId: vi.fn(async () => null as string | null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
 }));
 
 const queueSnapshotStore = vi.hoisted(() => ({

--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -65,6 +65,10 @@ const sessionStore = vi.hoisted(() => ({
   getStoredSessionId: vi.fn(async () => 'session-1'),
   setStoredSessionId: vi.fn(async () => {}),
   clearStoredSessionId: vi.fn(async () => {}),
+  // Device provenance for the leave-vs-end emphasis (#3502).
+  getStoredCreatedSessionId: vi.fn(async () => null as string | null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
 }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
@@ -106,6 +110,7 @@ type Snapshot = {
   clearSession: ReturnType<typeof useQueue>['clearSession'];
   joinSession: ReturnType<typeof useQueue>['joinSession'];
   addToQueue: ReturnType<typeof useQueue>['addToQueue'];
+  endSession: ReturnType<typeof useQueue>['endSession'];
 };
 
 function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
@@ -117,8 +122,9 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       clearSession: queue.clearSession,
       joinSession: queue.joinSession,
       addToQueue: queue.addToQueue,
+      endSession: queue.endSession,
     });
-  }, [sessionId, queue.clearSession, queue.joinSession, queue.addToQueue, onSnapshot]);
+  }, [sessionId, queue.clearSession, queue.joinSession, queue.addToQueue, queue.endSession, onSnapshot]);
   return null;
 }
 
@@ -200,7 +206,7 @@ describe('QueueProvider clearSession notifyServer', () => {
     await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBeNull());
   });
 
-  it('does NOT emit LEAVE_SESSION for a plain clearSession (remote end / endSession callers)', async () => {
+  it('does NOT emit LEAVE_SESSION for a plain clearSession (remote end / successful endSession)', async () => {
     const snapshots: Snapshot[] = [];
     render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (snap) => snapshots.push(snap) })));
 
@@ -294,5 +300,32 @@ describe('QueueProvider clearSession notifyServer', () => {
       snapshots.at(-1)?.addToQueue(queueItem);
     });
     await waitFor(() => expect(queueStateCalls()).toHaveLength(2));
+  });
+
+  // #3502: a failed endSession still drops us out of the session locally. The
+  // most common way to get here is a participant who ISN'T the creator — the
+  // HTTP endSession branch authorizes on createdByUserId alone — and until this
+  // fix they were ejected silently AND left as a ghost in everyone else's
+  // roster until the 60s disconnect grace expired.
+  it('emits LEAVE_SESSION when endSession fails, instead of leaving peers on the disconnect grace', async () => {
+    const snapshots: Snapshot[] = [];
+    render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (snap) => snapshots.push(snap) })));
+
+    await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBe('session-1'));
+
+    http.request.mockImplementation(async (operation: unknown) => {
+      if (operationText(operation).includes('SessionStatus')) return { sessionStatus: 'active' };
+      if (operationText(operation).includes('endSession')) throw new Error('Only the session creator can end this');
+      return {};
+    });
+
+    let summary: unknown = 'unset';
+    await act(async () => {
+      summary = await snapshots.at(-1)?.endSession();
+    });
+
+    expect(summary).toBeNull();
+    expect(leaveSessionCalls()).toHaveLength(1);
+    await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBeNull());
   });
 });

--- a/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
@@ -75,6 +75,10 @@ const sessionStore = vi.hoisted(() => ({
   getStoredSessionId: vi.fn(async (): Promise<string | null> => null),
   setStoredSessionId: vi.fn(async () => {}),
   clearStoredSessionId: vi.fn(async () => {}),
+  // Device provenance for the leave-vs-end emphasis (#3502).
+  getStoredCreatedSessionId: vi.fn(async (): Promise<string | null> => null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
 }));
 
 type StoredSnapshot = {

--- a/packages/mobile/src/providers/__tests__/queue-provider-narrow-contexts.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-narrow-contexts.test.tsx
@@ -73,6 +73,10 @@ const sessionStore = vi.hoisted(() => ({
   getStoredSessionId: vi.fn(async (): Promise<string | null> => null),
   setStoredSessionId: vi.fn(async () => {}),
   clearStoredSessionId: vi.fn(async () => {}),
+  // Device provenance for the leave-vs-end emphasis (#3502).
+  getStoredCreatedSessionId: vi.fn(async (): Promise<string | null> => null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
 }));
 
 type StoredSnapshot = {

--- a/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
@@ -78,6 +78,10 @@ vi.mock('../../lib/session-store', () => ({
   getStoredSessionId: vi.fn(async () => null),
   setStoredSessionId: vi.fn(async () => {}),
   clearStoredSessionId: vi.fn(async () => {}),
+  // Device provenance for the leave-vs-end emphasis (#3502).
+  getStoredCreatedSessionId: vi.fn(async () => null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
 }));
 vi.mock('../../lib/queue-snapshot-store', () => ({
   getStoredQueueSnapshot: vi.fn(async () => null),

--- a/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
@@ -78,6 +78,10 @@ vi.mock('../../lib/session-store', () => ({
   getStoredSessionId: vi.fn(async () => null),
   setStoredSessionId: vi.fn(async () => {}),
   clearStoredSessionId: vi.fn(async () => {}),
+  // Device provenance for the leave-vs-end emphasis (#3502).
+  getStoredCreatedSessionId: vi.fn(async () => null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
 }));
 vi.mock('../../lib/queue-snapshot-store', () => ({
   getStoredQueueSnapshot: vi.fn(async () => null),

--- a/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
@@ -78,6 +78,10 @@ const sessionStore = vi.hoisted(() => ({
   getStoredSessionId: vi.fn(async () => null as string | null),
   setStoredSessionId: vi.fn(async () => {}),
   clearStoredSessionId: vi.fn(async () => {}),
+  // Device provenance for the leave-vs-end emphasis (#3502).
+  getStoredCreatedSessionId: vi.fn(async () => null as string | null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
 }));
 
 const queueSnapshotStore = vi.hoisted(() => ({

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -68,6 +68,10 @@ const sessionStore = vi.hoisted(() => ({
   getStoredSessionId: vi.fn(async () => 'session-1' as string | null),
   setStoredSessionId: vi.fn(async () => {}),
   clearStoredSessionId: vi.fn(async () => {}),
+  // Device provenance for the leave-vs-end emphasis (#3502).
+  getStoredCreatedSessionId: vi.fn(async () => null as string | null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
 }));
 
 const queueSnapshotStore = vi.hoisted(() => ({
@@ -1559,7 +1563,9 @@ describe('QueueProvider session update subscription', () => {
       expect(latestSnapshot?.playlistSuggestionSource).toBeNull();
     });
     expect(clearStoredSessionId).toHaveBeenCalledTimes(1);
-    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+    // A failed end drops us out locally and notifies the server we left (#3502),
+    // so the copy is specific about that rather than the old generic failure.
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.endSessionFailedLeft', 'error');
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.toast.sessionEnded', 'success');
   });
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
@@ -69,6 +69,10 @@ const sessionStore = vi.hoisted(() => ({
   getStoredSessionId: vi.fn(async () => 'session-1' as string | null),
   setStoredSessionId: vi.fn(async () => {}),
   clearStoredSessionId: vi.fn(async () => {}),
+  // Device provenance for the leave-vs-end emphasis (#3502).
+  getStoredCreatedSessionId: vi.fn(async () => null as string | null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
 }));
 
 const queueSnapshotStore = vi.hoisted(() => ({

--- a/packages/mobile/src/providers/queue/use-session-commands.ts
+++ b/packages/mobile/src/providers/queue/use-session-commands.ts
@@ -15,7 +15,12 @@ import {
   type EndSessionMutationResponse,
 } from '../../lib/graphql/operations';
 import { getDeviceTimezone } from '../../lib/device-timezone';
-import { clearStoredSessionId, setStoredSessionId } from '../../lib/session-store';
+import {
+  clearStoredCreatedSessionId,
+  clearStoredSessionId,
+  setStoredCreatedSessionId,
+  setStoredSessionId,
+} from '../../lib/session-store';
 import { clearStoredQueueSnapshot } from '../../lib/queue-snapshot-store';
 import { track } from '../../lib/analytics';
 import { reportError, reportHandledError } from '../../lib/error-reporting';
@@ -127,6 +132,18 @@ export function useSessionCommands({
           const newId = response.createSession.id;
           sessionIdRef.current = newId;
           await setStoredSessionId(newId);
+          // Device provenance: this phone STARTED the party, as opposed to
+          // joining one. The in-session exit UI leads with End here and with
+          // Leave everywhere else, which is the whole point of #3502 — the
+          // same climber's second phone has no way to know it's the second
+          // phone from the roster alone (see session-store.ts for why).
+          // Best-effort: a failed write only costs this device the End-first
+          // emphasis, never the End action itself.
+          try {
+            await setStoredCreatedSessionId(newId);
+          } catch (provenanceError) {
+            if (__DEV__) console.warn('[queue] created-session provenance write failed', provenanceError);
+          }
           // Seed the session with the locally-built queue BEFORE setSessionId
           // mounts the queueUpdates subscription — the subscription's FullSync
           // for an empty room would wipe the local queue via INITIAL_QUEUE_DATA.
@@ -233,6 +250,10 @@ export function useSessionCommands({
     });
     setPlaylistSuggestionSourceState(null);
     await clearStoredSessionId();
+    // Provenance belongs to the session we're tearing down. It's keyed by
+    // session id so a stale value could never match the next one anyway —
+    // this just keeps the store tidy.
+    await clearStoredCreatedSessionId();
   }, []);
 
   const endSession = useCallback(
@@ -274,11 +295,24 @@ export function useSessionCommands({
         const remoteEndAlreadyApplied = suppressedRemoteEndSessionIdRef.current === currentSessionId;
         locallyEndingSessionIdRef.current = null;
         suppressedRemoteEndSessionIdRef.current = null;
-        await clearSession();
+        // A failed end still drops us out of the session locally, so tell the
+        // server we left rather than leaving peers to discover it after the
+        // 60s disconnect grace. This path is reached most often by a
+        // participant who isn't the creator (the HTTP endSession branch
+        // authorizes on createdByUserId alone), and until #3502 they were
+        // silently ejected AND left as a ghost in everyone else's roster.
+        // Best-effort with its own timeout; when the remote end already
+        // applied, LEAVE_SESSION is a no-op server-side (no ctx.sessionId).
+        await clearSession({ notifyServer: true });
         if (remoteEndAlreadyApplied) {
           showToast(t('mobile.toast.sessionEnded'), 'success');
         } else {
-          showToast(t('mobile.queue.actionFailed'), 'error');
+          // Production masks GraphQL errors to "Unexpected error", so we
+          // genuinely cannot tell an authorization refusal from a dropped
+          // network here. This message is true either way — and unlike the
+          // old generic `actionFailed` it tells the climber what actually
+          // happened to their session membership.
+          showToast(t('mobile.queue.endSessionFailedLeft'), 'error');
         }
         return null;
       }

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -397,6 +397,8 @@ type Session {
   isPermanent: Boolean!
   "Hex color for multi-session display"
   color: String
+  "Database user UUID of the climber who started this session. Null for non-members (the session query redacts it — see that resolver), for anonymously created sessions, and during the brief cleanup window where the live session outlives its durable row. Clients use it to tell a session they own from one they merely joined, so the destructive End action can be withheld from participants the server would reject anyway. It is NOT an authorization signal: endSession re-checks creator/leader server-side."
+  createdByUserId: ID
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -6114,6 +6114,8 @@ export type Session = {
   clientId: Scalars['ID']['output'];
   /** Hex color for multi-session display */
   color?: Maybe<Scalars['String']['output']>;
+  /** Database user UUID of the climber who started this session. Null for non-members (the session query redacts it — see that resolver), for anonymously created sessions, and during the brief cleanup window where the live session outlives its durable row. Clients use it to tell a session they own from one they merely joined, so the destructive End action can be withheld from participants the server would reject anyway. It is NOT an authorization signal: endSession re-checks creator/leader server-side. */
+  createdByUserId?: Maybe<Scalars['ID']['output']>;
   /**
    * Deprecated. Sessions are always-live; there is no driver. Always null. Removal of this field is DEFERRED pending the stale-bundle drain (workstream B7, reduced variant, 2026-07): a telemetry check found ~15-20 users/14d on cached mobile JS bundles whose JoinSession documents still select this field, and whole-document GraphQL validation means removing it would break join entirely for those clients. Re-check via last-14d Session Joined/Started events grouped by $app_build + ota_is_embedded; safe to remove once pre-2026-06-15 builds are ≈ 0. Do not remove without re-running that check.
    * @deprecated Sessions are always-live; there is no driver. Always null. Kept for stale clients (cached web bundles, un-OTA'd native apps); removal is telemetry-gated, see field description.
@@ -11764,6 +11766,7 @@ export type SessionResolvers<
   boardPath?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   clientId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   color?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  createdByUserId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   driverParticipantId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   endedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   goal?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/session.ts
+++ b/packages/shared-schema/src/schema/session.ts
@@ -66,6 +66,8 @@ export const sessionTypeDefs = /* GraphQL */ `
     isPermanent: Boolean!
     "Hex color for multi-session display"
     color: String
+    "Database user UUID of the climber who started this session. Null for non-members (the session query redacts it — see that resolver), for anonymously created sessions, and during the brief cleanup window where the live session outlives its durable row. Clients use it to tell a session they own from one they merely joined, so the destructive End action can be withheld from participants the server would reject anyway. It is NOT an authorization signal: endSession re-checks creator/leader server-side."
+    createdByUserId: ID
   }
 
   """

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -36,6 +36,12 @@ export const SHARED_EVENTS = {
   PlayDrawerOpened: 'Play Drawer Opened',
   SessionStarted: 'Session Started',
   SessionEnded: 'Session Ended',
+  // A climber dropped out of a session WITHOUT ending it for everyone else —
+  // the non-destructive exit added in #3502. Props: { startedOnThisDevice,
+  // couldHaveEnded } so the split between "left my own party from a second
+  // phone" and "left someone else's party" is measurable. Ending still fires
+  // Session Ended; the two are mutually exclusive per exit.
+  SessionLeft: 'Session Left',
   SessionCommentAdded: 'Session Comment Added',
   // A session's title was edited (both platforms). Props: { source:
   // 'record_chrome' | 'session_detail', nameLength } — counts only, never the

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -6111,6 +6111,8 @@ export type Session = {
   clientId: Scalars['ID']['output'];
   /** Hex color for multi-session display */
   color?: Maybe<Scalars['String']['output']>;
+  /** Database user UUID of the climber who started this session. Null for non-members (the session query redacts it — see that resolver), for anonymously created sessions, and during the brief cleanup window where the live session outlives its durable row. Clients use it to tell a session they own from one they merely joined, so the destructive End action can be withheld from participants the server would reject anyway. It is NOT an authorization signal: endSession re-checks creator/leader server-side. */
+  createdByUserId?: Maybe<Scalars['ID']['output']>;
   /**
    * Deprecated. Sessions are always-live; there is no driver. Always null. Removal of this field is DEFERRED pending the stale-bundle drain (workstream B7, reduced variant, 2026-07): a telemetry check found ~15-20 users/14d on cached mobile JS bundles whose JoinSession documents still select this field, and whole-document GraphQL validation means removing it would break join entirely for those clients. Re-check via last-14d Session Joined/Started events grouped by $app_build + ota_is_embedded; safe to remove once pre-2026-06-15 builds are ≈ 0. Do not remove without re-running that check.
    * @deprecated Sessions are always-live; there is no driver. Always null. Kept for stale clients (cached web bundles, un-OTA'd native apps); removal is telemetry-gated, see field description.

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -416,7 +416,13 @@
       "sentAtAngle": "Sent at {{angle}}°",
       "endSessionCommentPlaceholder": "Add a recap — how did it go?",
       "endSessionCommentAria": "Session recap",
-      "endSessionCancel": "Keep climbing"
+      "endSessionCancel": "Keep climbing",
+      "leaveSession": "Leave session",
+      "leaveSessionConfirm": "You'll drop out of this session. It keeps running for everyone still in it.",
+      "leaveSessionAction": "Leave",
+      "endForEveryone": "End it for everyone",
+      "leaveInsteadAction": "Just leave instead",
+      "endSessionFailedLeft": "Couldn't end the session — you've left it instead."
     },
     "queueSheet": {
       "emptyQueue": "Your queue is empty",
@@ -497,7 +503,8 @@
       }
     },
     "toast": {
-      "sessionEnded": "Session ended"
+      "sessionEnded": "Session ended",
+      "leftSession": "You left the session"
     },
     "session": {
       "headerStart": "Start a session",
@@ -567,6 +574,7 @@
       "historyRowAria": "{{name}}, {{status}}",
       "inEndSession": "End session",
       "inStop": "Stop",
+      "inLeave": "Leave",
       "notification": {
         "channelName": "Active climbing session",
         "channelDescription": "Keeps your board connected and shows session controls while Boardsesh runs in the background.",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -416,7 +416,13 @@
       "sentAtAngle": "Encadenado a {{angle}}°",
       "endSessionCommentPlaceholder": "Añade un resumen: ¿qué tal ha ido?",
       "endSessionCommentAria": "Resumen de la sesión",
-      "endSessionCancel": "Sigue escalando"
+      "endSessionCancel": "Sigue escalando",
+      "leaveSession": "Salir de la sesión",
+      "leaveSessionConfirm": "Saldrás de esta sesión. Sigue en marcha para quien se quede.",
+      "leaveSessionAction": "Salir",
+      "endForEveryone": "Terminarla para todos",
+      "leaveInsteadAction": "Solo salir",
+      "endSessionFailedLeft": "No se pudo terminar la sesión: has salido de ella."
     },
     "queueSheet": {
       "emptyQueue": "Tu cola está vacía",
@@ -497,7 +503,8 @@
       }
     },
     "toast": {
-      "sessionEnded": "Sesión terminada"
+      "sessionEnded": "Sesión terminada",
+      "leftSession": "Saliste de la sesión"
     },
     "session": {
       "headerStart": "Empezar sesión",
@@ -567,6 +574,7 @@
       "historyRowAria": "{{name}}, {{status}}",
       "inEndSession": "Terminar sesión",
       "inStop": "Parar",
+      "inLeave": "Salir",
       "notification": {
         "channelName": "Sesión de escalada activa",
         "channelDescription": "Mantiene tu plafón conectado y muestra los controles de la sesión mientras Boardsesh está en segundo plano.",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -416,7 +416,13 @@
       "sentAtAngle": "Enchaîné à {{angle}}°",
       "endSessionCommentPlaceholder": "Ajoute un récap — ça a donné quoi ?",
       "endSessionCommentAria": "Récap de la session",
-      "endSessionCancel": "Continue à grimper"
+      "endSessionCancel": "Continue à grimper",
+      "leaveSession": "Quitter la session",
+      "leaveSessionConfirm": "Tu quittes cette session. Elle continue pour ceux qui restent.",
+      "leaveSessionAction": "Quitter",
+      "endForEveryone": "La terminer pour tout le monde",
+      "leaveInsteadAction": "Juste quitter",
+      "endSessionFailedLeft": "Impossible de terminer la session — tu l'as quittée."
     },
     "queueSheet": {
       "emptyQueue": "Votre file est vide",
@@ -497,7 +503,8 @@
       }
     },
     "toast": {
-      "sessionEnded": "Session terminée"
+      "sessionEnded": "Session terminée",
+      "leftSession": "Tu as quitté la session"
     },
     "session": {
       "headerStart": "Démarrer une session",
@@ -567,6 +574,7 @@
       "historyRowAria": "{{name}}, {{status}}",
       "inEndSession": "Terminer la session",
       "inStop": "Arrêter",
+      "inLeave": "Quitter",
       "notification": {
         "channelName": "Session d'escalade active",
         "channelDescription": "Garde ta board connectée et affiche les commandes de session quand Boardsesh est en arrière-plan.",


### PR DESCRIPTION
## Summary

Joining your own session from a second phone offered **End session** as the only way out — and it worked, because the HTTP `endSession` branch authorizes on `createdByUserId` alone, which your second phone passes. The only visible exit genuinely terminated the party for everyone. 19 of 23 fingerprinted production sessions are single-user multi-device, so this was the common path, not an edge case.

The other half: a climber who joined *someone else's* party got the same button, it threw server-side, and `endSession`'s catch dropped them out locally anyway with a generic "Action failed" — while peers waited out the full 60-second disconnect grace before seeing them go.

Both exits now exist. **Emphasis** (which one the sheet leads with) comes from device provenance; **availability** of End comes from the session's creator id.

| | Chrome control | Sheet leads with | End available? |
|---|---|---|---|
| Phone that started the session | red **Stop** (unchanged) | End + recap | yes, primary |
| Same climber's second phone | neutral **Leave** | Leave | yes, via "End it for everyone" |
| Someone else's session | neutral **Leave** | Leave | **no** |

### Why not the roster

`joinSession` resolves `participantId = client.userId || connectionId`, so one signed-in climber on two devices is a **single participant with a single roster row**. Every roster-derived signal is participant-scoped and structurally blind to the second device.

`Session.isLeader` looks like the free answer and is a trap: `upsertLocalParticipant` ORs leadership across a participant's connections (`existing?.isLeader || isLeader`), and the `SessionRosterSnapshot` handler re-derives the client's own flag from that participant row. The second device is therefore told `isLeader: true` by its *very first* roster snapshot — the same `clientId`-vs-`participantId` id-space class that #3907 had to fix from the other direction. Building the gate on it would have shipped a fix that silently un-fixes itself. Filed separately as #3952.

`LocalSessionParticipant.connectionIds` does distinguish connections, and `getSessionParticipants` already computes the live count. Deliberately not used: it answers "how many sockets does this human hold right now", which flaps with screen locks, and a stale value degrades toward offering the **destructive** action.

### What drives it instead

- **Emphasis — device provenance.** `session-store.ts` records the id of the session this device created. It drives which action leads, never which actions exist, so losing it to a reinstall costs the End-first default and nothing else.
- **Availability — `Session.createdByUserId`** (new, member-only). `sessionDetail.ownerUserId` can't do this job: it returns null until the first tick, which is exactly when you join a friend's fresh party and want back out.
- Mobile reads it through its **own `GET_SESSION_OWNER` document**, not another field on `GET_SESSION` — that query also backs join-by-link, and GraphQL validates whole documents, so a new-bundle/old-backend skew would break joining outright rather than just leaving ownership unknown.
- **`canEnd` is permissive when ownership is unknown.** Failing closed would strand a creator during the fetch window and on anonymous sessions. The server re-checks regardless — this is UI, not authorization.

### Privacy

`createdByUserId` is redacted for non-members. The non-member preview roster already carries every *present* member's `userId` by design (the join-confirmation screen needs it), but that set diverges from the creator the moment they disconnect — a stranger holding only a session UUID has no business learning who started it.

### Also

- `endSession`'s failure path now emits `LEAVE_SESSION` instead of only clearing locally, so a refused end stops leaving a ghost in everyone else's roster for 60s. The message is honest about what happened: production masks GraphQL errors, so an auth refusal and a dropped network are indistinguishable client-side.
- The chrome shows a neutral Leave rather than the red Stop when the exit doesn't end anything. A destructive-looking control that performs a non-destructive action trains people to distrust the colour on the one surface where that trust matters.

Web has the equivalent hole (`queue-control-bar.tsx`'s `uniqueSessionUsers.some(...)` collapses one user's two devices into a single roster entry, so its second tab also takes the END path). Not fixed here — the web climbing surface is being replaced by the RN web build.

Closes #3502

## Release Notes

- Join your own session from a second phone and you can now just leave it — ending the session for everyone is a separate, deliberate step.
- Leave someone else's session without being offered a button that kills it for the whole crew.
- Your crew sees you drop out straight away instead of waiting a minute for the connection to time out.

## Test plan

- `vp check` — 0 errors
- `vp run typecheck:mobile`, `vp run typecheck:backend` — pass
- `vp run test:mobile` — full suite
- `vp test run --project backend` — `build-session-payload`, `session-query-gate`, `session-context`
- **Mutation-tested both gates.** Deleting `canEnd = !isKnownForeign` fails "withholds End from a climber who joined someone else's session"; deleting the `startedOnThisDevice` term in `defaultMode` fails both the second-phone and ownership-unknown cases. Neither gate is decorative.
- New coverage: `in-session-view-exit.test.tsx` drives the **real** `useSessionExitOptions` hook with only its inputs stubbed, so the tests can't pass a re-implementation of themselves. Leave asserts `clearSession` is called with **exactly** `{ notifyServer: true }` — a "simplification" to a bare call is the regression that would put peers back on the 60s grace.
- QA notes in `.boardsesh/qa-notes.md`, including a two-connection repro that needs no second phone: sign in on web and start a session, then join it from the emulator as the same account.

⚠️ **Device QA gate:** the two-connection topology itself is manual — vitest covers the decision, not the sockets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL
