### PR TITLE
fix(shared): stop the queue boundary stripping owner, draft and mirror state

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -128,6 +128,14 @@ The queue-action surface itself (add/remove/set-current/navigate/mirror/replace/
 
 Party mode deliberately does **not** clear the queue on navigation (`setBoardContext` early-returns while a session is active), and the reducer applies peer `CurrentClimbChanged` broadcasts unconditionally — so a member connected to a different wall can legitimately receive a current climb their board can't light. Since issue #3193, both platforms' BLE auto-senders classify the current climb against the active board (`classifyClimbBoardCompatibility` in `@boardsesh/board-config`, boardType + layoutId only; missing metadata never blocks) and skip a known mismatch instead of dark-firing the wall. The invariant: **solo** advances the local queue to the next compatible item (or clears the wall); **party** only clears its own wall and never advances the shared current climb — the session state every peer sees is untouched, and members on the right wall keep climbing. Climb identity rides the wire via `boardType`/`layoutId` on `ClimbInput` (`toClimbQueueItemInput` on web, `toClimbInput` on mobile).
 
+### Queue climb field contract (why fields "flap")
+
+A queue climb crosses several independently-maintained field lists: the write paths (`toClimbInput` on mobile, `toClimbQueueItemInput` on web), the backend's Zod `ClimbInputSchema`, and the read paths (`CLIMB_FIELDS` in `@boardsesh/graphql`, `SUBSCRIPTION_CLIMB_FIELDS` on mobile, plus mobile's `toClimbQueueItem` rebuild). When one drifts, the field does not simply go missing — it **flaps**: a peer whose read path omits it rebuilds the item without it, and that peer's next full-queue write (`setQueue` / `joinSession`) pushes the gap back to everyone, so the originator loses it on the following FullSync. A flapping field is worse than a consistently absent one.
+
+Two non-obvious narrowing points bit us in #3927: `climbToQueueItem` hand-picked a narrower set than `toClimbInput` sent, and `setQueue` / `joinSession` persist the **parsed** Zod output (the single-item mutations keep the GraphQL-coerced input instead), so any field missing from `ClimbInputSchema` is silently stripped server-side on a full-queue sync.
+
+The contract is enforced by `packages/backend/src/__tests__/queue-climb-field-contract.test.ts`, which reads every list from its live source and compares by set equality against the GraphQL `ClimbInput` type. `userAscents` / `userAttempts` are the only deliberate exception — they are per-user tick counts and must never be broadcast, at the cost of behaving exactly like the bug the test guards against.
+
 ## Technology Stack
 
 | Component          | Technology                        | Purpose                                                       |

--- a/packages/backend/src/__tests__/queue-climb-field-contract.test.ts
+++ b/packages/backend/src/__tests__/queue-climb-field-contract.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vite-plus/test';
+import { readFileSync } from 'fs';
 import { parse, visit } from 'graphql';
 import { typeDefs } from '@boardsesh/shared-schema';
+import { QUEUE_UPDATES } from '@boardsesh/graphql/operations/queue-session';
 import { ClimbInputSchema, ClimbQueueItemSchema } from '../validation/schemas/climbs';
 
 /**
@@ -34,7 +36,55 @@ function inputTypeFieldNames(typeName: string): Set<string> {
   return fields;
 }
 
+/** Field names selected inside every `climb { ... }` selection set of an operation. */
+function climbSelectionFieldNames(operationSource: string): Set<string> {
+  const fields = new Set<string>();
+  visit(parse(operationSource), {
+    Field(node) {
+      if (node.name.value !== 'climb' || !node.selectionSet) return;
+      for (const selection of node.selectionSet.selections) {
+        if (selection.kind === 'Field') fields.add(selection.name.value);
+      }
+    },
+  });
+  return fields;
+}
+
+/**
+ * Mobile hand-maintains its selection set as a plain template string, so read it
+ * out of the source text rather than importing the mobile package (which would
+ * drag React Native deps into this backend test). Same technique as
+ * `operations-schema-validation.test.ts`.
+ */
+function mobileSubscriptionClimbFields(): Set<string> {
+  const source = readFileSync(
+    new URL('../../../../packages/mobile/src/lib/graphql/operations.ts', import.meta.url),
+    'utf-8',
+  );
+  const match = source.match(/SUBSCRIPTION_CLIMB_FIELDS\s*=\s*`([\s\S]*?)`/);
+  if (!match?.[1]) {
+    throw new Error('Could not extract SUBSCRIPTION_CLIMB_FIELDS from mobile operations.ts');
+  }
+  return climbSelectionFieldNames(`{ climb { ${match[1]} } }`);
+}
+
 const climbInputFields = inputTypeFieldNames('ClimbInput');
+
+/**
+ * The ONLY fields a client may write but never broadcast.
+ *
+ * `userAscents` / `userAttempts` are the signed-in user's own tick counts for
+ * that climb. Putting them on a shared queue payload would show every peer YOUR
+ * send count on THEIR queue row, so they are deliberately absent from both read
+ * paths. The price is that they behave exactly like the bug this file guards
+ * against: a peer's full-queue write clears them, and you get them back only on
+ * the next search/detail fetch. That trade is intentional — do NOT "fix" the
+ * asymmetry by adding them to the selection sets. Broadcasting per-user data to
+ * every participant is a privacy regression, not a parity fix.
+ */
+const NEVER_BROADCAST = new Set(['userAscents', 'userAttempts']);
+
+const expectedReadPathFields = new Set([...climbInputFields].filter((field) => !NEVER_BROADCAST.has(field)));
 
 describe('queue climb field parity: GraphQL ClimbInput <-> backend Zod schema', () => {
   it('found the ClimbInput type in the schema', () => {
@@ -117,4 +167,41 @@ describe('queue climb field parity: GraphQL ClimbInput <-> backend Zod schema', 
 
     expect(result.success).toBe(true);
   });
+});
+
+describe('queue climb field parity: the two READ paths', () => {
+  const sharedFields = climbSelectionFieldNames(QUEUE_UPDATES);
+  const mobileFields = mobileSubscriptionClimbFields();
+
+  it('found a non-empty field set on both read paths', () => {
+    expect(sharedFields.size).toBeGreaterThan(0);
+    expect(mobileFields.size).toBeGreaterThan(0);
+  });
+
+  // Anchored to the schema rather than to each other. Comparing the two
+  // selection sets alone would stay green if BOTH drifted away from what
+  // clients write — which is exactly how #3927 survived: `climbToQueueItem` and
+  // both selection sets agreed with each other, and all three disagreed with
+  // `toClimbInput`.
+  for (const [name, fields] of [
+    ['shared CLIMB_FIELDS (packages/shared/graphql/src/operations/queue-session.ts)', sharedFields],
+    ['mobile SUBSCRIPTION_CLIMB_FIELDS (packages/mobile/src/lib/graphql/operations.ts)', mobileFields],
+  ] as const) {
+    it(`${name} selects exactly what ClimbInput declares, minus the never-broadcast fields`, () => {
+      const notRead = [...expectedReadPathFields].filter((field) => !fields.has(field));
+      const readButNeverWritten = [...fields].filter((field) => !expectedReadPathFields.has(field));
+
+      expect(
+        notRead,
+        `This selection set is missing fields that clients WRITE, so they will FLAP: this peer ` +
+          `rebuilds the item without them and its next full-queue write pushes the gap back to ` +
+          `everyone. Add them here, or (if per-user) to NEVER_BROADCAST with a reason.`,
+      ).toEqual([]);
+      expect(
+        readButNeverWritten,
+        'This selection set reads fields that no client writes, so they can only ever be null. ' +
+          'Either add them to ClimbInput or drop them from the selection set.',
+      ).toEqual([]);
+    });
+  }
 });

--- a/packages/backend/src/__tests__/queue-climb-field-contract.test.ts
+++ b/packages/backend/src/__tests__/queue-climb-field-contract.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { parse, visit } from 'graphql';
+import { typeDefs } from '@boardsesh/shared-schema';
+import { ClimbInputSchema, ClimbQueueItemSchema } from '../validation/schemas/climbs';
+
+/**
+ * Drift guard for the queue climb boundary (#3927).
+ *
+ * A queue climb crosses several independently-maintained field lists on its way
+ * from one client to another. When any one of them drifts, the field does not
+ * merely go missing — it FLAPS. A peer whose read path omits a field rebuilds
+ * the item without it, and that peer's next full-queue write pushes the gap back
+ * to everyone, so the originator loses the field too on the following FullSync.
+ * A flapping field is worse than a consistently absent one: it makes an Edit
+ * button and a draft badge blink in and out depending on who touched the queue
+ * last.
+ *
+ * Every list below is read from a LIVE source (the schema, the Zod shape, the
+ * operation strings) rather than hand-transcribed here, so adding a sixth field
+ * to one side only turns this red without anyone editing this file. That is the
+ * whole point — a regression test pinned to today's field names would not have
+ * stopped the drift that produced #3927 in the first place.
+ */
+
+/** Field names declared on a GraphQL input type, read from the schema. */
+function inputTypeFieldNames(typeName: string): Set<string> {
+  const fields = new Set<string>();
+  visit(parse(typeDefs.join('\n\n')), {
+    InputObjectTypeDefinition(node) {
+      if (node.name.value !== typeName) return;
+      for (const field of node.fields ?? []) fields.add(field.name.value);
+    },
+  });
+  return fields;
+}
+
+const climbInputFields = inputTypeFieldNames('ClimbInput');
+
+describe('queue climb field parity: GraphQL ClimbInput <-> backend Zod schema', () => {
+  it('found the ClimbInput type in the schema', () => {
+    expect(climbInputFields.size).toBeGreaterThan(0);
+  });
+
+  // `z.object()` STRIPS undeclared keys, and `setQueue` / `joinSession` persist
+  // the PARSED item (the single-item mutations discard the parse result and keep
+  // the GraphQL-coerced input, which is why this gap stayed invisible for so
+  // long — it only bit on a full-queue sync). So any ClimbInput field missing
+  // from the Zod shape is a field the server silently erases mid-session.
+  it('the Zod ClimbInputSchema declares exactly the ClimbInput field set', () => {
+    const zodFields = new Set(Object.keys(ClimbInputSchema.shape));
+    const strippedByZod = [...climbInputFields].filter((field) => !zodFields.has(field));
+    const unknownToSchema = [...zodFields].filter((field) => !climbInputFields.has(field));
+
+    expect(
+      strippedByZod,
+      'ClimbInputSchema is missing these ClimbInput fields, so setQueue/joinSession will STRIP them ' +
+        'and every peer loses them on the next FullSync. Add them to packages/backend/src/validation/schemas/climbs.ts.',
+    ).toEqual([]);
+    expect(
+      unknownToSchema,
+      'ClimbInputSchema declares fields the GraphQL ClimbInput does not, so they can never arrive. ' +
+        'Either add them to packages/shared-schema/src/schema/climb.ts or drop them from the Zod schema.',
+    ).toEqual([]);
+  });
+
+  // The behavioural counterpart: prove a fully-populated climb survives the
+  // exact call `setQueue` makes, rather than only asserting on key lists.
+  it('a fully-populated queue item survives the setQueue parse without losing a field', () => {
+    const climb = {
+      uuid: 'aurora-climb-uuid-fixture',
+      boardType: 'kilter',
+      layoutId: 1,
+      setter_username: 'setter',
+      userId: 'user-1',
+      name: 'Proj Braj',
+      description: 'crimpy',
+      frames: 'p1086r15',
+      angle: 40,
+      ascensionist_count: 3,
+      difficulty: 'V5',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.1',
+      mirrored: true,
+      benchmark_difficulty: null,
+      is_no_match: true,
+      characteristics: ['method_footless'],
+      is_draft: false,
+      published_at: '2026-07-01T00:00:00Z',
+      userAscents: 2,
+      userAttempts: 5,
+      framesCount: 1,
+      framesPace: 0,
+      boardseshDifficulty: 19.2,
+      boardseshConfidence: 'confirmed',
+    };
+
+    const parsed = ClimbQueueItemSchema.parse({ uuid: 'queue-slot-1', climb });
+
+    expect(new Set(Object.keys(parsed.climb))).toEqual(climbInputFields);
+    expect(parsed.climb).toMatchObject(climb);
+  });
+
+  // An unrecognised characteristic must NOT fail the item. `parseArrayTolerant`
+  // drops the whole queue slot on a schema failure, so enum-validating this
+  // field would let a newer client's unknown value silently delete a climb from
+  // everyone's queue — the failure mode #3857 fixed for `uuid`.
+  it('accepts an unknown characteristic rather than dropping the queue slot', () => {
+    const result = ClimbQueueItemSchema.safeParse({
+      uuid: 'queue-slot-1',
+      climb: {
+        uuid: 'aurora-climb-uuid-fixture',
+        angle: 40,
+        characteristics: ['some_characteristic_a_newer_client_invented'],
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -74,6 +74,20 @@ export const ClimbInputSchema = z.object({
     .transform((v) => v ?? ''),
   mirrored: z.boolean().nullish(),
   benchmark_difficulty: z.string().max(50).nullish(),
+  // `is_no_match` / `characteristics` must be declared here even though nothing
+  // server-side reads them: `z.object()` STRIPS undeclared keys, and `setQueue`
+  // / `joinSession` persist the PARSED item (unlike the single-item mutations,
+  // which discard the parse result and store the GraphQL-coerced input). Both
+  // fields ride every client's selection set already, so omitting them here made
+  // a full-queue sync silently erase the no-match / method badge the client had
+  // just sent — the same drift class as #3927, from the server side.
+  is_no_match: z.boolean().nullish(),
+  // Deliberately NOT `z.enum(CLIMB_CHARACTERISTICS)`. `parseArrayTolerant` drops
+  // the WHOLE queue item when its schema fails, so enum-validating here would let
+  // a newer client's unknown characteristic silently delete a queue slot for
+  // everyone — exactly the failure mode #3857 fixed for `uuid`. Bounded plain
+  // strings give the memory-exhaustion guard without that footgun.
+  characteristics: z.array(z.string().max(50)).max(20).nullish(),
   // Whether this climb is still an unpublished draft. Round-trips through
   // the queue so peers can gate the Edit affordance locally.
   is_draft: z.boolean().nullish(),

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -219,18 +219,22 @@ describe('climbToQueueItem board identity at the queue boundary', () => {
     expect(climb.layoutId).toBe(9);
   });
 
-  // Pins the CURRENT contract, deliberately. These five are droppable here only
-  // because the subscription selection sets (SUBSCRIPTION_CLIMB_FIELDS, and web's
-  // CLIMB_FIELDS) don't select them either, so the local copy and the peer copy agree.
-  // Carrying them here alone would make a peer's rebuild disagree with the creator's
-  // and let the next peer-side setQueue write the gap back. When #3927 lands,
-  // this expectation flips to `toMatchObject` — it is here so the boundary can't be
-  // widened by halves without someone reading this comment.
-  it('does not yet carry ownership / draft state (blocked on the subscription set)', () => {
+  // #3927 landed. Both subscription selection sets (SUBSCRIPTION_CLIMB_FIELDS and
+  // the shared CLIMB_FIELDS) now select these, so a peer's rebuild agrees with the
+  // creator's copy and no full-queue write pushes a gap back.
+  //
+  // Do NOT narrow this again without also narrowing both selection sets and
+  // `toClimbInput` in the same change. Carrying a field on the write path while a
+  // peer's read path omits it makes the field FLAP — it appears, then a peer's
+  // setQueue clears it for everyone — which is worse than consistently missing.
+  it('carries ownership / draft state so peers can gate Edit locally', () => {
     const { climb } = climbToQueueItem(peerClimb);
-    expect(climb.userId).toBeUndefined();
-    expect(climb.description).toBeUndefined();
-    expect(climb.is_draft).toBeUndefined();
-    expect(climb.published_at).toBeUndefined();
+    expect(climb).toMatchObject({
+      userId: 'user-2',
+      description: 'crimpy',
+      mirrored: true,
+      is_draft: false,
+      published_at: '2026-07-01T00:00:00Z',
+    });
   });
 });

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -380,9 +380,11 @@ export function useCreateClimbScreen({
   // sendable climb. Omitting it left a freshly created climb board-less on the wire —
   // peers received a climb they couldn't place, and the presence row lost its board.
   //
-  // Only fields `climbToQueueItem` actually forwards are set here; adding ones it
-  // strips (userId / description / mirrored / is_draft) would be dead weight until
-  // that boundary and both subscription selection sets widen together.
+  // Ownership and draft state ride along too (#3927 widened the queue boundary
+  // and both subscription selection sets to carry them). Without these the climb
+  // you just made lands in the queue as if it belonged to nobody, so the play
+  // drawer's owner-only Edit action never appears on your own fresh draft —
+  // `computeCanUpdate` reads exactly userId + is_draft + published_at.
   const buildProvisionalClimb = useCallback(
     (uuid: string, frames: string): Climb => ({
       uuid,
@@ -391,6 +393,8 @@ export function useCreateClimbScreen({
       name: name.trim() || t('createClimbForm.draftBadge'),
       frames,
       setter_username: profile?.displayName ?? '',
+      userId: profile?.id ?? null,
+      description,
       angle: board.angle,
       ascensionist_count: 0,
       difficulty: '',
@@ -399,13 +403,17 @@ export function useCreateClimbScreen({
       difficulty_error: '0',
       benchmark_difficulty: null,
       is_no_match: noMatch,
+      // Not-yet-saved climbs are drafts by definition; once saved, mirror the
+      // tracked row so a published climb doesn't queue as a draft.
+      is_draft: savedClimb?.isDraft ?? true,
+      published_at: savedClimb?.publishedAt ?? null,
       userAscents: 0,
       userAttempts: 0,
       // The editor emits a single static frame (no multi-frame playback).
       framesCount: 1,
       framesPace: null,
     }),
-    [name, noMatch, profile, board.angle, board.boardName, board.layoutId, t],
+    [name, description, noMatch, profile, savedClimb, board.angle, board.boardName, board.layoutId, t],
   );
 
   // Push the freshly saved climb into the queue as the current climb so the

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -393,6 +393,10 @@ export function useCreateClimbScreen({
       name: name.trim() || t('createClimbForm.draftBadge'),
       frames,
       setter_username: profile?.displayName ?? '',
+      // Null until the profile query resolves, same as setter_username above, so
+      // a climb queued during a cold start shows no Edit action until the next
+      // save replaces the item. Self-correcting and not worth a queue-item
+      // update path; revisit if it shows up in offline-first flows.
       userId: profile?.id ?? null,
       description,
       angle: board.angle,

--- a/packages/mobile/src/lib/__tests__/climb-to-queue-item.test.ts
+++ b/packages/mobile/src/lib/__tests__/climb-to-queue-item.test.ts
@@ -5,7 +5,7 @@ vi.mock('expo-crypto', () => ({
   randomUUID: () => 'generated-uuid',
 }));
 
-import { climbToQueueItem } from '../climb-to-queue-item';
+import { climbToQueueItem, toClimbInput } from '../climb-to-queue-item';
 
 // A climb queued from search / detail must keep its multi-frame playback
 // metadata so playback uses the setter's pace rather than DEFAULT_PACE_MS.
@@ -48,5 +48,52 @@ describe('climbToQueueItem (SEED-2 frame metadata)', () => {
 
     expect(result.climb.framesCount).toBeNull();
     expect(result.climb.framesPace).toBeNull();
+  });
+});
+
+describe('climbToQueueItem ownership / draft state (#3927)', () => {
+  it('carries the fields the owner-only Edit gate reads', () => {
+    const result = climbToQueueItem(
+      makeClimb({
+        userId: 'user-1',
+        description: 'crimpy',
+        mirrored: true,
+        is_draft: false,
+        published_at: '2026-07-01T00:00:00Z',
+      }),
+    );
+
+    expect(result.climb).toMatchObject({
+      userId: 'user-1',
+      description: 'crimpy',
+      mirrored: true,
+      is_draft: false,
+      published_at: '2026-07-01T00:00:00Z',
+    });
+  });
+
+  /**
+   * The sharpest guard in the #3927 fix, and the one that needs no allowlist.
+   *
+   * `toClimbInput` is what this client SENDS to peers; `climbToQueueItem` is what
+   * it keeps LOCALLY. A field in one but not the other is a bug in whichever
+   * direction it points:
+   *
+   *   - in `toClimbInput` only  -> the local item never has it, so we broadcast a
+   *     null over whatever a peer had, clearing it for everyone.
+   *   - in `climbToQueueItem` only -> we render it locally but never send it, so
+   *     it silently vanishes for every peer and for us on the next FullSync.
+   *
+   * They must be the same set. Both are read live via `Object.keys`, so a sixth
+   * field added to one side only turns this red with no edit to this test — which
+   * is precisely what did NOT happen when these two drifted apart and produced
+   * #3927.
+   */
+  it('keeps exactly the same field set as toClimbInput', () => {
+    const climb = makeClimb();
+    const kept = new Set(Object.keys(climbToQueueItem(climb).climb));
+    const sent = new Set(Object.keys(toClimbInput(climb)));
+
+    expect(kept).toEqual(sent);
   });
 });

--- a/packages/mobile/src/lib/__tests__/queue-conversion.test.ts
+++ b/packages/mobile/src/lib/__tests__/queue-conversion.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { toClimbQueueItem, type SubscriptionQueueItem } from '../queue-conversion';
+import { SUBSCRIPTION_CLIMB_FIELDS } from '../graphql/operations';
 
 // A reconnect FullSync wholesale-replaces the queue (and currentClimbQueueItem)
 // from the subscription payload. If toClimbQueueItem drops a field the
@@ -74,5 +75,33 @@ describe('toClimbQueueItem (SEED-2 fields)', () => {
     expect(result.climb.boardType).toBeUndefined();
     // layoutId falls through as undefined; the spill guard reads nullish as "unknown".
     expect(result.climb.layoutId).toBeUndefined();
+  });
+
+  it('carries owner identity and draft state so Edit can be gated on a queued climb', () => {
+    const result = toClimbQueueItem(
+      makeSubscriptionItem({
+        userId: 'user-1',
+        description: 'crimpy',
+        is_draft: false,
+        published_at: '2026-07-01T00:00:00Z',
+      }),
+    );
+
+    expect(result.climb.userId).toBe('user-1');
+    expect(result.climb.description).toBe('crimpy');
+    expect(result.climb.is_draft).toBe(false);
+    expect(result.climb.published_at).toBe('2026-07-01T00:00:00Z');
+  });
+
+  // Drift guard (#3927). Derived from the live selection set, never hand-listed:
+  // a field the subscription selects but this rebuild drops is silently lost on
+  // every FullSync, and a field rebuilt here that the subscription does not
+  // select can only ever be undefined. Set EQUALITY closes both directions, so
+  // adding a sixth field to one side alone turns this red.
+  it('rebuilds exactly the field set SUBSCRIPTION_CLIMB_FIELDS selects', () => {
+    const selected = new Set(SUBSCRIPTION_CLIMB_FIELDS.split(/\s+/).filter(Boolean));
+    const rebuilt = new Set(Object.keys(toClimbQueueItem(makeSubscriptionItem()).climb));
+
+    expect(rebuilt).toEqual(selected);
   });
 });

--- a/packages/mobile/src/lib/__tests__/queue-conversion.test.ts
+++ b/packages/mobile/src/lib/__tests__/queue-conversion.test.ts
@@ -1,6 +1,25 @@
 import { describe, it, expect } from 'vitest';
+import { parse, visit } from 'graphql';
 import { toClimbQueueItem, type SubscriptionQueueItem } from '../queue-conversion';
 import { SUBSCRIPTION_CLIMB_FIELDS } from '../graphql/operations';
+
+// Parse the selection set with graphql's own parser rather than splitting on
+// whitespace: an alias (`uuid: id`), an argument, or a directive would make a
+// naive split produce field names that don't exist, leaving the guard below
+// green while silently comparing the wrong set. Mirrors `climbSelectionFieldNames`
+// in the backend contract test.
+function selectedClimbFieldNames(): Set<string> {
+  const fields = new Set<string>();
+  visit(parse(`{ climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }`), {
+    Field(node) {
+      if (node.name.value !== 'climb' || !node.selectionSet) return;
+      for (const selection of node.selectionSet.selections) {
+        if (selection.kind === 'Field') fields.add(selection.alias?.value ?? selection.name.value);
+      }
+    },
+  });
+  return fields;
+}
 
 // A reconnect FullSync wholesale-replaces the queue (and currentClimbQueueItem)
 // from the subscription payload. If toClimbQueueItem drops a field the
@@ -99,9 +118,8 @@ describe('toClimbQueueItem (SEED-2 fields)', () => {
   // select can only ever be undefined. Set EQUALITY closes both directions, so
   // adding a sixth field to one side alone turns this red.
   it('rebuilds exactly the field set SUBSCRIPTION_CLIMB_FIELDS selects', () => {
-    const selected = new Set(SUBSCRIPTION_CLIMB_FIELDS.split(/\s+/).filter(Boolean));
     const rebuilt = new Set(Object.keys(toClimbQueueItem(makeSubscriptionItem()).climb));
 
-    expect(rebuilt).toEqual(selected);
+    expect(rebuilt).toEqual(selectedClimbFieldNames());
   });
 });

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -74,13 +74,14 @@ export function climbToQueueItem(climb: Climb, options?: { suggested?: boolean; 
       name: climb.name,
       frames: climb.frames,
       setter_username: climb.setter_username,
-      // NOTE: userId / description / mirrored / is_draft / published_at are deliberately
-      // NOT carried here yet. `toClimbInput` would send them to party peers, but the
-      // subscription selection set (SUBSCRIPTION_CLIMB_FIELDS in lib/graphql/operations.ts,
-      // and web's CLIMB_FIELDS) doesn't select them, so peers would rebuild the climb
-      // without them and the next peer-side setQueue would write the gap back. Widening
-      // this boundary has to land together with both selection sets and
-      // `toClimbQueueItem` — see #3927.
+      // Mirror state, so re-deriving a queue item from an already-mirrored climb
+      // keeps the flip. A search / detail response never sets this (no climbs
+      // column backs it, and no resolver populates it) — it only ever arrives on
+      // a climb that has already been through the queue, via a peer's
+      // `mirrorCurrentClimb`. The paths that would otherwise lose it all rebuild
+      // an item from such a climb: the climb-actions preview, the play-drawer
+      // open, and the "on the wall" preview.
+      mirrored: climb.mirrored,
       angle: climb.angle,
       ascensionist_count: climb.ascensionist_count,
       difficulty: climb.difficulty,

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -60,6 +60,14 @@ export function toClimbInput(climb: Climb): ClimbInput {
  * triggers a server-side validation error and surfaces as the generic
  * "Action failed" toast. Pick the exact fields here and let TypeScript verify
  * the shape, so callers can't drift.
+ *
+ * This must carry the SAME field set as `toClimbInput` above. Anything it drops
+ * that `toClimbInput` sends is a field this client silently strips on its way
+ * into the queue; anything it carries that a peer's selection set omits FLAPS,
+ * because the peer rebuilds without it and its next full-queue write pushes the
+ * gap back to everyone. `climb-to-queue-item.test.ts` asserts the two key sets
+ * are equal, and `queue-climb-field-contract.test.ts` ties both to the schema.
+ * See #3927.
  */
 export function climbToQueueItem(climb: Climb, options?: { suggested?: boolean; uuid?: string }): ClimbQueueItem {
   return {
@@ -74,6 +82,13 @@ export function climbToQueueItem(climb: Climb, options?: { suggested?: boolean; 
       name: climb.name,
       frames: climb.frames,
       setter_username: climb.setter_username,
+      // Owner identity, so the owner-only Edit action can be gated on a queued
+      // climb (use-climb-actions / ClimbActionsSheet read exactly this, and the
+      // play drawer feeds them the queue item's climb). Null for Aurora-synced
+      // climbs that predate Boardsesh accounts.
+      userId: climb.userId,
+      // Carried so forking or editing a queued climb keeps its description.
+      description: climb.description,
       // Mirror state, so re-deriving a queue item from an already-mirrored climb
       // keeps the flip. A search / detail response never sets this (no climbs
       // column backs it, and no resolver populates it) — it only ever arrives on
@@ -91,6 +106,10 @@ export function climbToQueueItem(climb: Climb, options?: { suggested?: boolean; 
       benchmark_difficulty: climb.benchmark_difficulty,
       is_no_match: climb.is_no_match,
       characteristics: climb.characteristics,
+      // Draft / publish state — the other two inputs to the Edit gate
+      // (`computeCanUpdate` reads exactly these).
+      is_draft: climb.is_draft,
+      published_at: climb.published_at,
       userAscents: climb.userAscents,
       userAttempts: climb.userAttempts,
       // Carry multi-frame playback metadata so a climb queued from search /

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -1175,16 +1175,27 @@ export type SessionUpdateEvent = {
 };
 
 // Fields the queue UI needs from each climb in a subscription payload.
-// Must stay in sync with `climbToQueueItem` in PlayDrawer.tsx and with
-// `SubscriptionClimb` in queue-conversion.ts — when these drift, queue
-// items received from the server (FullSync on connect, peer mutations)
-// arrive with empty grade / quality / rating, so the queue row and the
-// re-opened drawer can't render the grade.
-const SUBSCRIPTION_CLIMB_FIELDS = `
+//
+// Must stay in sync with `SubscriptionClimb` / `toClimbQueueItem` in
+// lib/queue-conversion.ts and with `climbToQueueItem` in
+// lib/climb-to-queue-item.ts. When these drift, queue items received from the
+// server (FullSync on connect, peer mutations) arrive with the missing field
+// blank — and worse, a field we WRITE but don't select here flaps: this client
+// rebuilds the item without it, then its next full-queue write pushes the gap
+// back to every peer. `userAscents` / `userAttempts` are the deliberate
+// exception; see the contract test for why.
+//
+// Exported so `lib/__tests__/queue-conversion.test.ts` can assert the rebuild
+// covers exactly this set instead of hand-listing it. The exact field set is
+// enforced by packages/backend/src/__tests__/queue-climb-field-contract.test.ts
+// (which reads this const straight out of the source). See #3927.
+export const SUBSCRIPTION_CLIMB_FIELDS = `
   uuid
   boardType
   layoutId
+  userId
   name
+  description
   frames
   setter_username
   angle
@@ -1197,6 +1208,8 @@ const SUBSCRIPTION_CLIMB_FIELDS = `
   mirrored
   is_no_match
   characteristics
+  is_draft
+  published_at
   framesCount
   framesPace
   boardseshDifficulty

--- a/packages/mobile/src/lib/queue-conversion.ts
+++ b/packages/mobile/src/lib/queue-conversion.ts
@@ -7,10 +7,11 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
  *
  * Keep these fields in sync with `SUBSCRIPTION_CLIMB_FIELDS` in
  * `src/lib/graphql/operations.ts` and with `climbToQueueItem` in
- * `src/components/play-drawer/PlayDrawer.tsx`. If the subscription drops a
- * field, the queue UI loses it on every server-driven update (FullSync on
- * connect, peer mutations), so the queue row's grade pill and the
- * re-opened play drawer end up blank.
+ * `src/lib/climb-to-queue-item.ts`. If the subscription drops a field, the queue
+ * UI loses it on every server-driven update (FullSync on connect, peer
+ * mutations), so the queue row's grade pill and the re-opened play drawer end up
+ * blank — and a field this client WRITES but does not rebuild here FLAPS, since
+ * its next full-queue write then pushes the gap back to every peer. See #3927.
  */
 export type SubscriptionClimb = {
   uuid: string;
@@ -19,7 +20,14 @@ export type SubscriptionClimb = {
   // peers / pre-metadata items (then the spill guard treats it as sendable).
   boardType?: string | null;
   layoutId?: number | null;
+  // Owner identity, so the owner-only Edit action can be gated locally on a
+  // queued climb without a per-climb refetch. Null for Aurora-synced climbs that
+  // predate Boardsesh accounts.
+  userId?: string | null;
   name: string;
+  // Carried so forking or editing a queued climb keeps its description
+  // (use-create-climb-navigation seeds the editor from it).
+  description?: string | null;
   frames: string;
   setter_username: string;
   angle: number;
@@ -35,6 +43,10 @@ export type SubscriptionClimb = {
   mirrored?: boolean | null;
   is_no_match?: boolean | null;
   characteristics?: string[] | null;
+  // Draft / publish state, so the 24h post-publish edit window can be evaluated
+  // locally on a queued climb (computeCanUpdate reads exactly these two).
+  is_draft?: boolean | null;
+  published_at?: string | null;
   framesCount?: number | null;
   framesPace?: number | null;
   // Boardsesh grade carried on the subscription payload so a peer-broadcast climb
@@ -61,7 +73,9 @@ export function toClimbQueueItem(subscriptionItem: SubscriptionQueueItem): Climb
       uuid: subscriptionItem.climb.uuid,
       boardType: subscriptionItem.climb.boardType ?? undefined,
       layoutId: subscriptionItem.climb.layoutId,
+      userId: subscriptionItem.climb.userId,
       name: subscriptionItem.climb.name,
+      description: subscriptionItem.climb.description,
       frames: subscriptionItem.climb.frames,
       setter_username: subscriptionItem.climb.setter_username,
       angle: subscriptionItem.climb.angle,
@@ -74,6 +88,8 @@ export function toClimbQueueItem(subscriptionItem: SubscriptionQueueItem): Climb
       mirrored: subscriptionItem.climb.mirrored,
       is_no_match: subscriptionItem.climb.is_no_match,
       characteristics: subscriptionItem.climb.characteristics,
+      is_draft: subscriptionItem.climb.is_draft,
+      published_at: subscriptionItem.climb.published_at,
       framesCount: subscriptionItem.climb.framesCount,
       framesPace: subscriptionItem.climb.framesPace,
       boardseshDifficulty: subscriptionItem.climb.boardseshDifficulty,

--- a/packages/shared/graphql/src/operations/queue-session.ts
+++ b/packages/shared/graphql/src/operations/queue-session.ts
@@ -1,13 +1,23 @@
 // GraphQL Operations for Boardsesh Queue Client
 // These operations are used by the web app to communicate with the backend
 
-// Fragment for reusable climb fields
+// Fragment for reusable climb fields.
+//
+// This selection set is the READ half of the queue climb boundary and must stay
+// in lockstep with what clients WRITE (`ClimbInput`). A field that is written
+// but not selected here does not merely go missing — it FLAPS: the peer rebuilds
+// the item without it, and that peer's next full-queue write pushes the gap back
+// to everyone, so the originator loses it on the following FullSync. The exact
+// field set is enforced by
+// `packages/backend/src/__tests__/queue-climb-field-contract.test.ts`. See #3927.
 const CLIMB_FIELDS = `
   uuid
   boardType
   layoutId
   setter_username
+  userId
   name
+  description
   frames
   framesCount
   framesPace
@@ -21,6 +31,8 @@ const CLIMB_FIELDS = `
   benchmark_difficulty
   is_no_match
   characteristics
+  is_draft
+  published_at
   boardseshDifficulty
   boardseshConfidence
 `;

--- a/packages/web/app/components/persistent-session/__tests__/to-climb-queue-item-input.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/to-climb-queue-item-input.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from 'vite-plus/test';
+import { parse, visit } from 'graphql';
+import { typeDefs } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem } from '../../queue-control/types';
 import { toClimbQueueItemInput } from '../types';
+
+/** Field names declared on the GraphQL `ClimbInput` type, read from the schema. */
+function climbInputFieldNames(): Set<string> {
+  const fields = new Set<string>();
+  visit(parse(typeDefs.join('\n\n')), {
+    InputObjectTypeDefinition(node) {
+      if (node.name.value !== 'ClimbInput') return;
+      for (const field of node.fields ?? []) fields.add(field.name.value);
+    },
+  });
+  return fields;
+}
 
 function makeItem(overrides: Partial<ClimbQueueItem['climb']> = {}): ClimbQueueItem {
   return {
@@ -48,5 +62,23 @@ describe('toClimbQueueItemInput', () => {
     const input = toClimbQueueItemInput(makeItem({ boardseshDifficulty: undefined, boardseshConfidence: undefined }));
     expect(input.climb.boardseshDifficulty).toBeNull();
     expect(input.climb.boardseshConfidence).toBeNull();
+  });
+
+  // Both subscription selection sets SELECT these two, so omitting them from the
+  // input made every web-originated write clear tags the peer was rendering.
+  it('round-trips the no-match / characteristics tags peers already select', () => {
+    const input = toClimbQueueItemInput(makeItem({ is_no_match: true, characteristics: ['method_footless'] }));
+    expect(input.climb.is_no_match).toBe(true);
+    expect(input.climb.characteristics).toEqual(['method_footless']);
+  });
+
+  // Drift guard (#3927). Derived from the schema, never hand-listed: a field
+  // added to `ClimbInput` that web forgets to send here is a field web silently
+  // clears on every write, and a field sent here that the schema doesn't declare
+  // is rejected server-side. Both directions must stay closed, so this is set
+  // EQUALITY rather than a subset check.
+  it('sends exactly the field set the GraphQL ClimbInput declares', () => {
+    const sent = new Set(Object.keys(toClimbQueueItemInput(makeItem()).climb));
+    expect(sent).toEqual(climbInputFieldNames());
   });
 });

--- a/packages/web/app/components/persistent-session/types.ts
+++ b/packages/web/app/components/persistent-session/types.ts
@@ -277,6 +277,11 @@ export function toClimbQueueItemInput(item: LocalClimbQueueItem): ClimbQueueItem
       difficulty_error: item.climb.difficulty_error,
       mirrored: item.climb.mirrored,
       benchmark_difficulty: item.climb.benchmark_difficulty,
+      // Both selection sets already SELECT these two, so leaving them off the
+      // input meant every web-originated write cleared the no-match / method
+      // tags that peers were rendering.
+      is_no_match: item.climb.is_no_match ?? null,
+      characteristics: item.climb.characteristics ?? null,
       // Round-trip draft/publish state so peers can decide locally whether
       // to surface the Edit affordance without re-querying the DB.
       is_draft: item.climb.is_draft ?? null,


### PR DESCRIPTION
## Summary

Closes #3927.

`climbToQueueItem` hand-picked a field subset that had drifted from `toClimbInput` and from both subscription selection sets, so a climb lost `userId` / `description` / `mirrored` / `is_draft` / `published_at` the moment it entered the queue. The play drawer feeds the queue item's climb straight to the Edit gate (`use-climb-actions` / `ClimbActionsSheet` read exactly `userId` + `is_draft` + `published_at`), which is why the owner-only Edit action never showed up on a queued climb.

The dangerous property is not the missing field, it's the **flap**: carrying a field client-side while a peer's selection set omits it makes the peer rebuild the item without it and push the gap back to everyone on its next full-queue write. A field that blinks in and out is worse than one that is consistently absent. That is why this had to move as a coordinated set rather than one file.

### Three corrections to the issue as filed

1. **"Today the fields are never populated, so there is nothing to lose" is false for web.** `toClimbQueueItemInput` already sent all five; `CLIMB_FIELDS` selected none of the four. Web has been flapping them in production for any climb sourced from `CLIMB_DETAIL_FIELDS`. This PR *closes* an existing web flap rather than opening one.

2. **`mirrored` is not "the sharpest one".** No column backs `Climb.mirrored` and no resolver populates it, so search and detail responses always return it null, and `mirrorCurrentClimb` is web-only. The only mobile paths that lost it re-derive an item from an already-mirrored climb (climb-actions preview, play-drawer open, wall preview). Real, narrow, and — because its wire path was already complete — zero-risk.

3. **There is a seventh drift surface the issue misses: the backend Zod schema.** `setQueue` / `joinSession` persist the *parsed* item, unlike the single-item mutations which keep the GraphQL-coerced input. `z.object()` strips, and `ClimbInputSchema` never declared `is_no_match` or `characteristics` — so the server was already erasing both on every full-queue sync. Proved with a throwaway probe before fixing.

### Commit ordering is a correctness property, not tidiness

Please don't squash. The invariant is that **no commit leaves a field on a write path whose matching read path lacks it**, and it only holds in sequence:

1. `mirrored` into `climbToQueueItem` — complete wire path already, safe alone.
2. Zod + web outbound gain `is_no_match` / `characteristics` — server and web-outbound only, no client selection set involved.
3. **Read paths** — the four into both selection sets and mobile's rebuild. Closes web's existing flap; mobile unchanged.
4. **Write path** — the four into `climbToQueueItem`, `buildProvisionalClimb` populated, tripwire flipped.

Landing 4 before 3 would briefly make mobile flap too.

### Mixed-version fleet during rollout

Stated plainly, because it is not eliminable client-side — selection sets live in the client bundle.

- **Web deploys atomically**, so web↔web is fixed immediately.
- **Backend deploys once**; the Zod widening is purely additive.
- **Mobile ships by OTA.** In a session containing an old mobile peer, that peer rebuilds items without the four and its next full-queue write pushes nulls back, so newer peers can see the fields appear and then vanish. That *is* a flap and I'm not claiming otherwise. Accepted because the degraded state is exactly today's behaviour rather than corruption, none of the four gates a destructive action (an Edit button and a draft badge), and the stale-bundle tail is ~15–20 users over 14 days. `mirrored` is immune — its wire path is already complete on old bundles — and it's the only field the reducer reads. `is_no_match` / `characteristics` are immune too, since every deployed version already selects them.
- **Considered and rejected:** server-side null-coalescing on `setQueue` so an omitted field can't clear a known value. It kills the flap permanently, but it would pin `is_draft: true` forever after publication if the last writer omitted it, and it must never touch `mirrored` (a legitimately clearable per-slot toggle). Trading a transient absence for a permanent wrong state is a bad deal. Please don't re-propose it without new evidence.

### Drift guards

A regression test over today's five fields would not have stopped the next drift, so every field list is read from a **live source** and compared by set equality. Adding a sixth field to one side only turns something red with no test edit:

- `climbToQueueItem` keys **==** `toClimbInput` keys — the sharpest one, no allowlist. Exactly the two functions that drifted apart to produce this issue.
- `toClimbQueueItem` keys **==** `SUBSCRIPTION_CLIMB_FIELDS`.
- `CLIMB_FIELDS` **==** `SUBSCRIPTION_CLIMB_FIELDS` **==** `ClimbInput` − `{userAscents, userAttempts}`, anchored to the schema rather than to each other (comparing the read paths only to each other would have stayed green through this bug — both selection sets and `climbToQueueItem` agreed with each other, and all three disagreed with `toClimbInput`).
- Zod `ClimbInputSchema` shape **==** `ClimbInput`, and web's `toClimbQueueItemInput` keys **==** `ClimbInput`.

`userAscents` / `userAttempts` are the single allowlisted exception, with a comment explaining both why (they are your own tick counts — broadcasting them would show every peer your send count on their queue row) and what it costs (they behave like the bug this file guards against). Please don't "fix" that asymmetry by adding them to the selection sets.

### Known trade-off

`description` on the read paths grows FullSync payloads. Upload is unchanged — web already sent it — only broadcast download grows, bounded by the 2000-char Zod cap. Taken anyway because `use-create-climb-navigation` seeds the editor from `climb.description`, so forking or editing a queued climb was losing it.

## Release Notes

- The Edit button now shows up on your own climbs while they're sitting in the queue, not just in search
- Drafts keep their draft state through the queue, so you can jump straight back in and keep working
- Mirrored climbs stay mirrored when you preview them, and no-match tags stop vanishing after a queue sync

## Test plan

- `vp run typecheck` — clean
- `vp check` — 4675 files correctly formatted
- `vp run codegen` — no drift (the queue-session operations are plain template strings, so codegen doesn't consume them)
- `vp run test:mobile` — pass
- `vp test run --project backend` — queue suites plus the 221 existing operation-validation tests, all green
- `vp test run --project web` — persistent-session + queue-control
- **Every new guard mutation-tested by deleting the field it protects.** Removing `is_draft` from `climbToQueueItem` fails the key-set equality test; removing `is_no_match` from web's input fails both new web tests.
- Two web render tests and two mobile screen tests flaked under parallel load on my box (5s render timeouts, `import 491s`). Each passes in isolation, and `queue-control-bar-tick-overlay` was verified green on an unmodified `origin/main` worktree and then green again on this branch once the machine settled.

Not verified: a real two-device party session. The peer round-trip is the failure mode no unit test can see, and `mirrored` is worth exercising specifically since it's the field the reducer reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL
