### PR TITLE
fix(db): stop tick recomputes minting stats rows for climbs that don't exist

### DIFF
--- a/packages/backend/src/__tests__/recompute-climb-stats.test.ts
+++ b/packages/backend/src/__tests__/recompute-climb-stats.test.ts
@@ -30,43 +30,38 @@ describe('recomputeClimbStats', () => {
     vi.clearAllMocks();
   });
 
-  it('seeds the stats row with explicit upstream=0 and boardsesh=0', async () => {
-    let capturedSeedValues: unknown = null;
+  // The seed's behaviour is asserted end to end against real Postgres in the
+  // provenance-matrix block below (a phantom key seeds nothing; a real climb at
+  // a new angle still does; quality_normalized). What this one pins is the
+  // SHAPE: the seed must stay an INSERT ... SELECT FROM board_climbs so the
+  // catalog lookup IS the guard (#3528). A regression to a plain VALUES insert
+  // — which cannot carry a WHERE — silently un-guards it.
+  it('seeds via INSERT ... SELECT FROM board_climbs so the catalog lookup guards it', async () => {
+    const executed: unknown[] = [];
     mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
-      const insertChain = {
-        onConflictDoNothing: vi.fn(),
-      };
       const tx = {
-        insert: vi.fn(() => ({
-          values: vi.fn((values: unknown) => {
-            capturedSeedValues = values;
-            return insertChain;
-          }),
-        })),
-        execute: vi.fn(async () => []),
+        execute: vi.fn(async (query: unknown) => {
+          executed.push(query);
+          return [];
+        }),
       };
       await callback(tx);
     });
 
     await recomputeClimbStats('kilter', 'CLIMB-1', 40);
 
-    expect(capturedSeedValues).toMatchObject({
-      boardType: 'kilter',
-      climbUuid: 'CLIMB-1',
-      angle: 40,
-      ascensionistCount: 0,
-      upstreamAscensionistCount: 0,
-      boardseshAscensionistCount: 0,
-    });
+    const seedSql = sqlText(executed[0]);
+    expect(seedSql).toContain('INSERT INTO board_climb_stats');
+    expect(seedSql).toMatch(/SELECT[\s\S]*FROM board_climbs bc/);
+    expect(seedSql).toMatch(/WHERE bc\.uuid =/);
+    expect(seedSql).toMatch(/AND bc\.board_type =/);
+    expect(seedSql).toContain('quality_normalized');
   });
 
-  it('runs the recompute SQL inside a single transaction', async () => {
+  it('runs the seed + recompute SQL inside a single transaction', async () => {
     let executeCount = 0;
     mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
       const tx = {
-        insert: vi.fn(() => ({
-          values: vi.fn(() => ({ onConflictDoNothing: vi.fn() })),
-        })),
         execute: vi.fn(async () => {
           executeCount += 1;
           return [];
@@ -78,7 +73,8 @@ describe('recomputeClimbStats', () => {
     await recomputeClimbStats('kilter', 'CLIMB-1', 40);
 
     expect(mockDb.transaction).toHaveBeenCalledTimes(1);
-    expect(executeCount).toBe(1);
+    // Seed + the aggregate recompute.
+    expect(executeCount).toBe(2);
   });
 
   // FRAGILE TEST WARNING — read before changing:
@@ -104,9 +100,6 @@ describe('recomputeClimbStats', () => {
     let capturedQuery: unknown = null;
     mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
       const tx = {
-        insert: vi.fn(() => ({
-          values: vi.fn(() => ({ onConflictDoNothing: vi.fn() })),
-        })),
         execute: vi.fn(async (query: unknown) => {
           capturedQuery = query;
           return [];
@@ -149,9 +142,6 @@ describe('recomputeClimbStats', () => {
     let capturedQuery: unknown = null;
     mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
       const tx = {
-        insert: vi.fn(() => ({
-          values: vi.fn(() => ({ onConflictDoNothing: vi.fn() })),
-        })),
         execute: vi.fn(async (query: unknown) => {
           capturedQuery = query;
           return [];
@@ -193,9 +183,6 @@ describe('recomputeClimbStats', () => {
     const loggerSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
     mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
       const tx = {
-        insert: vi.fn(() => ({
-          values: vi.fn(() => ({ onConflictDoNothing: vi.fn() })),
-        })),
         // The combined WITH … RETURNING query returns one diff row.
         execute: vi.fn(async () => [
           {
@@ -226,9 +213,6 @@ describe('recomputeClimbStats', () => {
     const loggerSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
     mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
       const tx = {
-        insert: vi.fn(() => ({
-          values: vi.fn(() => ({ onConflictDoNothing: vi.fn() })),
-        })),
         execute: vi.fn(async () => []),
       };
       await callback(tx);
@@ -255,9 +239,6 @@ describe('recomputeClimbStats', () => {
       const loggerSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
       mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
         const tx = {
-          insert: vi.fn(() => ({
-            values: vi.fn(() => ({ onConflictDoNothing: vi.fn() })),
-          })),
           execute: vi.fn(async () => [
             { prev_bs: 0, prev_total: 0, prev_fa: prev, new_bs: 0, new_total: 0, new_fa: next },
           ]),
@@ -1064,5 +1045,147 @@ describe('recomputeClimbStats — provenance matrix (real DB)', () => {
     expect(Number(single.bs)).toBe(1);
     expect(Number(single.total)).toBe(8); // upstream 7 + 1 native
     expect(single.fa).toBe('Mika');
+  });
+
+  // -------------------------------------------------------------------------
+  // Defensive-seed guard (#3528)
+  //
+  // A tick can name any string as its climb_uuid, so the seed must not mint a
+  // board_climb_stats row for a climb that doesn't exist. These assert the
+  // BEHAVIOUR against real Postgres — deleting the guard in recompute.ts must
+  // turn them red. (packages/db has no vitest project and nothing in CI runs
+  // its tsx --test suite, so a SQL-text assertion over there is a smoke test,
+  // not evidence.)
+  // -------------------------------------------------------------------------
+
+  async function statsRowCount(boardType: string, uuid: string, angle: number): Promise<number> {
+    const rows = (await db.execute(sql`
+      SELECT count(*)::int AS n
+        FROM board_climb_stats
+       WHERE board_type = ${boardType} AND climb_uuid = ${uuid} AND angle = ${angle}
+    `)) as unknown as Array<{ n: number }>;
+    const [row] = Array.isArray(rows) ? rows : (rows as { rows: Array<{ n: number }> }).rows;
+    return Number(row.n);
+  }
+
+  it('single-key: a tick on a climb missing from board_climbs seeds NO stats row', async () => {
+    await seedUser('u-ghost', 'Gia');
+    // Deliberately no seedClimb — this is the phantom-UUID case.
+    await seedTick({
+      boardType: 'kilter',
+      climbUuid: 'CLIMB-GHOST',
+      angle: 40,
+      userId: 'u-ghost',
+      status: 'send',
+      origin: 'native',
+      climbedAt: '2026-01-01 00:00:00',
+    });
+
+    const diff = await recomputeClimbStatsCore(db, 'kilter', 'CLIMB-GHOST', 40);
+
+    expect(await statsRowCount('kilter', 'CLIMB-GHOST', 40)).toBe(0);
+    // No row to update → the documented "UPDATE matched no row" path. Must be a
+    // quiet undefined, not a throw: the debounced publisher logs any throw as an
+    // error, and this is an expected outcome rather than a failure.
+    expect(diff).toBeUndefined();
+  });
+
+  it('bulk: a phantom key in a chunk seeds nothing and does not disturb the real key beside it', async () => {
+    await seedUser('u-mixed-chunk', 'Mo');
+    await seedClimb('kilter', 'CLIMB-REAL', null);
+    await seedStats('kilter', 'CLIMB-REAL', 40, { upstream: 3 });
+    await seedTick({
+      boardType: 'kilter',
+      climbUuid: 'CLIMB-REAL',
+      angle: 40,
+      userId: 'u-mixed-chunk',
+      status: 'send',
+      origin: 'native',
+      climbedAt: '2026-01-01 00:00:00',
+    });
+    await seedTick({
+      boardType: 'kilter',
+      climbUuid: 'CLIMB-GHOST',
+      angle: 40,
+      userId: 'u-mixed-chunk',
+      status: 'send',
+      origin: 'native',
+      climbedAt: '2026-01-01 00:00:00',
+    });
+
+    await recomputeClimbStatsBulk(db, [
+      { boardType: 'kilter', climbUuid: 'CLIMB-GHOST', angle: 40 },
+      { boardType: 'kilter', climbUuid: 'CLIMB-REAL', angle: 40 },
+    ]);
+
+    expect(await statsRowCount('kilter', 'CLIMB-GHOST', 40)).toBe(0);
+    // The guard must drop the phantom key WITHOUT collateral damage: the real
+    // key in the same chunk still counts correctly.
+    const real = await statsRow('kilter', 'CLIMB-REAL', 40);
+    expect(Number(real.bs)).toBe(1);
+    expect(Number(real.total)).toBe(4); // upstream 3 + 1 native
+  });
+
+  // KEEP: this passes both with and without the guard — it is not redundant, it
+  // is the tripwire against over-guarding. The seed exists precisely so a tick
+  // at an angle the catalog has no stats row for still gets one. Anyone who
+  // "hardens" the guard from (climb) to (climb, angle) breaks real ticks, and
+  // this is the test that tells them.
+  it('a real climb ticked at an angle with no stats row STILL seeds one', async () => {
+    await seedUser('u-newangle', 'Nia');
+    await seedClimb('kilter', 'CLIMB-ANGLES', null);
+    await seedStats('kilter', 'CLIMB-ANGLES', 40, { upstream: 5 });
+    await seedTick({
+      boardType: 'kilter',
+      climbUuid: 'CLIMB-ANGLES',
+      angle: 25,
+      userId: 'u-newangle',
+      status: 'send',
+      origin: 'native',
+      climbedAt: '2026-01-01 00:00:00',
+    });
+
+    await recomputeClimbStatsCore(db, 'kilter', 'CLIMB-ANGLES', 25);
+
+    const seeded = await statsRow('kilter', 'CLIMB-ANGLES', 25);
+    expect(Number(seeded.bs)).toBe(1);
+    expect(Number(seeded.total)).toBe(1); // no upstream at 25° — 0 + 1 native
+  });
+
+  it('seeded rows are marked quality_normalized (the #3529 seed half)', async () => {
+    async function normalizedFlags(uuid: string, angle: number): Promise<boolean[]> {
+      const rows = (await db.execute(sql`
+        SELECT quality_normalized AS flag
+          FROM board_climb_stats
+         WHERE board_type = 'kilter' AND climb_uuid = ${uuid} AND angle = ${angle}
+      `)) as unknown as Array<{ flag: boolean }>;
+      const list = Array.isArray(rows) ? rows : (rows as { rows: Array<{ flag: boolean }> }).rows;
+      return list.map((entry) => entry.flag);
+    }
+
+    await seedUser('u-norm', 'Nils');
+    // Non-owned climbs (user_id null) — the branch that PRESERVES the seeded
+    // flag verbatim, so the seed's value is the value forever. Owned climbs
+    // self-heal via the owned branch's `quality_normalized = TRUE`.
+    await seedClimb('kilter', 'CLIMB-NORM-SINGLE', null);
+    await seedClimb('kilter', 'CLIMB-NORM-BULK', null);
+    for (const uuid of ['CLIMB-NORM-SINGLE', 'CLIMB-NORM-BULK']) {
+      await seedTick({
+        boardType: 'kilter',
+        climbUuid: uuid,
+        angle: 30,
+        userId: 'u-norm',
+        status: 'send',
+        origin: 'native',
+        quality: 4,
+        climbedAt: '2026-01-01 00:00:00',
+      });
+    }
+
+    await recomputeClimbStatsCore(db, 'kilter', 'CLIMB-NORM-SINGLE', 30);
+    await recomputeClimbStatsBulk(db, [{ boardType: 'kilter', climbUuid: 'CLIMB-NORM-BULK', angle: 30 }]);
+
+    expect(await normalizedFlags('CLIMB-NORM-SINGLE', 30)).toEqual([true]);
+    expect(await normalizedFlags('CLIMB-NORM-BULK', 30)).toEqual([true]);
   });
 });

--- a/packages/backend/src/__tests__/recompute-climb-stats.test.ts
+++ b/packages/backend/src/__tests__/recompute-climb-stats.test.ts
@@ -50,6 +50,10 @@ describe('recomputeClimbStats', () => {
 
     await recomputeClimbStats('kilter', 'CLIMB-1', 40);
 
+    // Seed + aggregate. Asserted before indexing so a mock that never invoked
+    // the transaction callback fails as "0 statements" rather than as an
+    // undefined-index error inside sqlText.
+    expect(executed).toHaveLength(2);
     const seedSql = sqlText(executed[0]);
     expect(seedSql).toContain('INSERT INTO board_climb_stats');
     expect(seedSql).toMatch(/SELECT[\s\S]*FROM board_climbs bc/);

--- a/packages/backend/src/__tests__/save-tick-climb-catalog.test.ts
+++ b/packages/backend/src/__tests__/save-tick-climb-catalog.test.ts
@@ -155,6 +155,26 @@ describe('saveTick climb-catalog check (#3528, log-only)', () => {
     });
   });
 
+  // board_climbs.uuid alone is the primary key, so it is tempting to read the
+  // board_type predicate as a redundant filter and drop it. It isn't: a tick
+  // names a (boardType, climbUuid) PAIR and board_climb_stats is keyed on that
+  // pair, so a Kilter UUID arriving under boardType 'tension' names a climb
+  // that does not exist. Without this test, dropping the predicate would go
+  // unnoticed.
+  it('fires the counter for a UUID that exists only under a DIFFERENT board type', async () => {
+    await tickMutations.saveTick(
+      undefined,
+      { input: { ...tickInput(CATALOG_CLIMB), boardType: 'tension' } },
+      authCtx(),
+    );
+
+    const events = unknownCatalogEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0][1]).toMatchObject({
+      properties: { boardType: 'tension', climbUuid: CATALOG_CLIMB },
+    });
+  });
+
   // The whole point of the log-only ruling: observing must never cost a send.
   it('still saves the tick when the climb is unknown', async () => {
     const result = await tickMutations.saveTick(undefined, { input: tickInput(UNKNOWN_CLIMB) }, authCtx());

--- a/packages/backend/src/__tests__/save-tick-climb-catalog.test.ts
+++ b/packages/backend/src/__tests__/save-tick-climb-catalog.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { setupWorkerDatabase } from './worker-db';
+
+// The catalog check is observation only, so what we assert is the OBSERVATION:
+// which calls fire the counter and which don't. Mock the analytics module (the
+// counter) and let everything else run against the worker DB.
+// Typed structurally rather than off captureBackendEvent's own signature —
+// vi.hoisted runs before imports, so the real type isn't reachable here.
+type CapturedEventOptions = {
+  distinctId: string;
+  properties?: Record<string, string | number | boolean | null | undefined>;
+  processPersonProfile?: boolean;
+};
+const { captureBackendEventMock } = vi.hoisted(() => ({
+  captureBackendEventMock: vi.fn((_eventName: string, _options: CapturedEventOptions) => true),
+}));
+vi.mock('../services/analytics/posthog', () => ({
+  captureBackendEvent: captureBackendEventMock,
+}));
+
+// Side effects saveTick fires after the insert. None of them are under test and
+// they'd otherwise pull in Redis / the social event bus.
+vi.mock('../events', () => ({ publishSocialEvent: vi.fn(async () => undefined) }));
+vi.mock('../graphql/resolvers/ticks/debounced-climb-stats-publisher', () => ({
+  queueClimbStatsRecompute: vi.fn(),
+}));
+vi.mock('../graphql/resolvers/sessions/debounced-stats-publisher', () => ({
+  publishDebouncedSessionStats: vi.fn(),
+}));
+vi.mock('../graphql/resolvers/board-presence/stats', () => ({ queueBoardStatsPublish: vi.fn() }));
+
+import { db } from '../db/client';
+import { tickMutations } from '../graphql/resolvers/ticks/mutations';
+
+const USER_ID = 'u-catalog-check';
+const BOARD = 'kilter';
+
+// Prefixed so the cleanup below can't touch a neighbouring test's fixtures —
+// board_climb_aliases is NOT in the shared TRUNCATE list other suites use.
+const PREFIX = 'CATCHK-';
+const CATALOG_CLIMB = `${PREFIX}IN-CATALOG`;
+const ALIAS_CLIMB = `${PREFIX}ALIAS-ONLY`;
+const CANONICAL_CLIMB = `${PREFIX}CANONICAL`;
+const UNKNOWN_CLIMB = `${PREFIX}NEVER-HEARD-OF-IT`;
+
+function authCtx(): ConnectionContext {
+  return {
+    connectionId: `conn-${Math.random().toString(36).slice(2)}`,
+    isAuthenticated: true,
+    userId: USER_ID,
+  } as ConnectionContext;
+}
+
+function tickInput(climbUuid: string) {
+  return {
+    boardType: BOARD,
+    climbUuid,
+    angle: 40,
+    isMirror: false,
+    status: 'send',
+    attemptCount: 1,
+    quality: null,
+    difficulty: 17,
+    isBenchmark: false,
+    comment: '',
+    climbedAt: new Date().toISOString(),
+  };
+}
+
+async function tickCountFor(climbUuid: string): Promise<number> {
+  const rows = (await db.execute(sql`
+    SELECT count(*)::int AS n FROM boardsesh_ticks WHERE climb_uuid = ${climbUuid}
+  `)) as unknown as Array<{ n: number }>;
+  const [row] = Array.isArray(rows) ? rows : (rows as { rows: Array<{ n: number }> }).rows;
+  return Number(row.n);
+}
+
+function unknownCatalogEvents() {
+  return captureBackendEventMock.mock.calls.filter((call) => call[0] === 'Tick Climb Not In Catalog');
+}
+
+describe('saveTick climb-catalog check (#3528, log-only)', () => {
+  beforeAll(async () => {
+    await setupWorkerDatabase();
+
+    await db.execute(sql`
+      INSERT INTO users (id, email, name, created_at, updated_at)
+      VALUES (${USER_ID}, ${`${USER_ID}@test.com`}, 'Cat Alog', now(), now())
+      ON CONFLICT (id) DO NOTHING
+    `);
+    for (const uuid of [CATALOG_CLIMB, CANONICAL_CLIMB]) {
+      await db.execute(sql`
+        INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed)
+        VALUES (${uuid}, ${BOARD}, 1, 'setter', 'Test Climb', '', 'p1r1', true)
+        ON CONFLICT (uuid) DO NOTHING
+      `);
+    }
+    // The deduped-away shape: an alias row and deliberately NO board_climbs row
+    // for ALIAS_CLIMB — exactly what the Kilter dedup path produces.
+    await db.execute(sql`
+      INSERT INTO board_climb_aliases (board_type, alias_uuid, canonical_uuid, source)
+      VALUES (${BOARD}, ${ALIAS_CLIMB}, ${CANONICAL_CLIMB}, 'kilter')
+      ON CONFLICT (board_type, alias_uuid) DO NOTHING
+    `);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+    await db.execute(sql`DELETE FROM board_climb_aliases WHERE alias_uuid LIKE ${`${PREFIX}%`}`);
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${`${PREFIX}%`}`);
+    await db.execute(sql`DELETE FROM users WHERE id = ${USER_ID}`);
+  });
+
+  beforeEach(() => {
+    captureBackendEventMock.mockClear();
+  });
+
+  afterEach(async () => {
+    await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+  });
+
+  it('does not fire the counter for a climb that is in board_climbs', async () => {
+    await tickMutations.saveTick(undefined, { input: tickInput(CATALOG_CLIMB) }, authCtx());
+
+    expect(unknownCatalogEvents()).toHaveLength(0);
+    expect(await tickCountFor(CATALOG_CLIMB)).toBe(1);
+  });
+
+  // The anti-over-rejection test. A deduped Kilter UUID has an alias row and no
+  // board_climbs row; the climb is real and the send is real. If the alias arm
+  // of the predicate is dropped, this trips the counter — which would poison the
+  // observation window #3942 depends on and make the "is it safe to reject?"
+  // question unanswerable.
+  it('does not fire the counter for a deduped-away UUID that only board_climb_aliases knows', async () => {
+    await tickMutations.saveTick(undefined, { input: tickInput(ALIAS_CLIMB) }, authCtx());
+
+    expect(unknownCatalogEvents()).toHaveLength(0);
+    expect(await tickCountFor(ALIAS_CLIMB)).toBe(1);
+  });
+
+  it('fires the counter once for a UUID neither table has ever heard of', async () => {
+    await tickMutations.saveTick(undefined, { input: tickInput(UNKNOWN_CLIMB) }, authCtx());
+
+    const events = unknownCatalogEvents();
+    expect(events).toHaveLength(1);
+    // distinctId is the user so the metric can count USERS, not events — one
+    // looping client must not read as a fleet-wide problem.
+    expect(events[0][1]).toMatchObject({
+      distinctId: USER_ID,
+      properties: { boardType: BOARD, angle: 40 },
+    });
+  });
+
+  // The whole point of the log-only ruling: observing must never cost a send.
+  it('still saves the tick when the climb is unknown', async () => {
+    const result = await tickMutations.saveTick(undefined, { input: tickInput(UNKNOWN_CLIMB) }, authCtx());
+
+    expect(result).toBeTruthy();
+    expect(await tickCountFor(UNKNOWN_CLIMB)).toBe(1);
+  });
+});

--- a/packages/backend/src/__tests__/save-tick-climb-catalog.test.ts
+++ b/packages/backend/src/__tests__/save-tick-climb-catalog.test.ts
@@ -146,10 +146,12 @@ describe('saveTick climb-catalog check (#3528, log-only)', () => {
     const events = unknownCatalogEvents();
     expect(events).toHaveLength(1);
     // distinctId is the user so the metric can count USERS, not events — one
-    // looping client must not read as a fleet-wide problem.
+    // looping client must not read as a fleet-wide problem. climbUuid is what
+    // separates "12 phantom climbs" from "one client looping on one UUID", which
+    // is the distinction #3942 has to make.
     expect(events[0][1]).toMatchObject({
       distinctId: USER_ID,
-      properties: { boardType: BOARD, angle: 40 },
+      properties: { boardType: BOARD, angle: 40, climbUuid: UNKNOWN_CLIMB },
     });
   });
 

--- a/packages/backend/src/db/queries/climbs/climb-catalog-presence.ts
+++ b/packages/backend/src/db/queries/climbs/climb-catalog-presence.ts
@@ -26,6 +26,13 @@ export type ClimbCatalogPresence = 'catalog' | 'alias' | 'unknown';
  * (PRIMARY KEY (board_type, alias_uuid)). The alias probe only runs when the
  * board_climbs probe misses, so the hot path is a single PK lookup.
  *
+ * board_climbs.uuid alone is the PK, so the board_type predicate does nothing
+ * for uniqueness — it is a correctness filter, not an index hint. A tick names
+ * a (boardType, climbUuid) PAIR and board_climb_stats is keyed on that pair, so
+ * a Kilter UUID arriving under boardType 'tension' has to resolve `unknown`
+ * rather than quietly matching the Kilter row. The recompute's seed guard and
+ * owner CTE filter on both columns for the same reason.
+ *
  * Reads the PRIMARY, not dbRead, and that is the whole point: a climb published
  * seconds before the tick could still be in flight to a replica, and a lagging
  * replica would report a real climb as `unknown`. The tick saves either way, but

--- a/packages/backend/src/db/queries/climbs/climb-catalog-presence.ts
+++ b/packages/backend/src/db/queries/climbs/climb-catalog-presence.ts
@@ -1,0 +1,45 @@
+import { and, eq } from 'drizzle-orm';
+import { boardClimbAliases, boardClimbs } from '@boardsesh/db/schema';
+import { dbRead } from '../../client';
+
+/**
+ * Whether a climb UUID is one the catalog has ever heard of.
+ *
+ * - `catalog` — a board_climbs row exists. The normal case: every UUID a client
+ *   can hold comes from board_climbs (search, queue, playlists, and the offline
+ *   snapshot are all projections of it), and saveClimb writes board_climbs in
+ *   the same transaction that mints the UUID it returns.
+ * - `alias`  — no board_climbs row, but board_climb_aliases knows the UUID. The
+ *   Kilter dedup path deliberately folds duplicate catalog UUIDs into an alias
+ *   row and writes NO board_climbs row for them (see the FK-asymmetry note on
+ *   boardClimbAliases), so a tick can legitimately carry one. getLogbook already
+ *   canonicalises these for display. NOT a data-quality problem.
+ * - `unknown` — neither table has it. Nothing can render or count a tick here.
+ */
+export type ClimbCatalogPresence = 'catalog' | 'alias' | 'unknown';
+
+/**
+ * Resolve a (boardType, climbUuid) against the climb catalog.
+ *
+ * Two exact-match lookups on indexes that already exist — board_climbs_pkey
+ * (PRIMARY KEY (uuid)) and board_climb_aliases_board_type_alias_uuid_pk
+ * (PRIMARY KEY (board_type, alias_uuid)). The alias probe only runs when the
+ * board_climbs probe misses, so the hot path is a single PK lookup.
+ */
+export async function resolveClimbCatalogPresence(boardType: string, climbUuid: string): Promise<ClimbCatalogPresence> {
+  const [climb] = await dbRead
+    .select({ uuid: boardClimbs.uuid })
+    .from(boardClimbs)
+    .where(and(eq(boardClimbs.uuid, climbUuid), eq(boardClimbs.boardType, boardType)))
+    .limit(1);
+
+  if (climb) return 'catalog';
+
+  const [alias] = await dbRead
+    .select({ canonicalUuid: boardClimbAliases.canonicalUuid })
+    .from(boardClimbAliases)
+    .where(and(eq(boardClimbAliases.boardType, boardType), eq(boardClimbAliases.aliasUuid, climbUuid)))
+    .limit(1);
+
+  return alias ? 'alias' : 'unknown';
+}

--- a/packages/backend/src/db/queries/climbs/climb-catalog-presence.ts
+++ b/packages/backend/src/db/queries/climbs/climb-catalog-presence.ts
@@ -1,6 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 import { boardClimbAliases, boardClimbs } from '@boardsesh/db/schema';
-import { dbRead } from '../../client';
+import { db } from '../../client';
 
 /**
  * Whether a climb UUID is one the catalog has ever heard of.
@@ -25,9 +25,18 @@ export type ClimbCatalogPresence = 'catalog' | 'alias' | 'unknown';
  * (PRIMARY KEY (uuid)) and board_climb_aliases_board_type_alias_uuid_pk
  * (PRIMARY KEY (board_type, alias_uuid)). The alias probe only runs when the
  * board_climbs probe misses, so the hot path is a single PK lookup.
+ *
+ * Reads the PRIMARY, not dbRead, and that is the whole point: a climb published
+ * seconds before the tick could still be in flight to a replica, and a lagging
+ * replica would report a real climb as `unknown`. The tick saves either way, but
+ * the false positive lands in the counter — and a counter that drifts off zero
+ * for reasons that aren't real is worse than no counter, because #3942's "has it
+ * held at zero?" question becomes unanswerable. One PK probe per tick on the
+ * primary is a cheap price for a signal you can trust, and the call site overlaps
+ * it with writes that already hit the primary anyway.
  */
 export async function resolveClimbCatalogPresence(boardType: string, climbUuid: string): Promise<ClimbCatalogPresence> {
-  const [climb] = await dbRead
+  const [climb] = await db
     .select({ uuid: boardClimbs.uuid })
     .from(boardClimbs)
     .where(and(eq(boardClimbs.uuid, climbUuid), eq(boardClimbs.boardType, boardType)))
@@ -35,7 +44,7 @@ export async function resolveClimbCatalogPresence(boardType: string, climbUuid: 
 
   if (climb) return 'catalog';
 
-  const [alias] = await dbRead
+  const [alias] = await db
     .select({ canonicalUuid: boardClimbAliases.canonicalUuid })
     .from(boardClimbAliases)
     .where(and(eq(boardClimbAliases.boardType, boardType), eq(boardClimbAliases.aliasUuid, climbUuid)))

--- a/packages/backend/src/db/queries/climbs/index.ts
+++ b/packages/backend/src/db/queries/climbs/index.ts
@@ -2,6 +2,7 @@ export { searchClimbs } from './search-climbs';
 export { countClimbs } from './count-climbs';
 export { getClimbByUuid } from './get-climb';
 export { matchClimbByFrames } from './match-climb-by-frames';
+export { resolveClimbCatalogPresence, type ClimbCatalogPresence } from './climb-catalog-presence';
 // Re-export shared types for backward compatibility
 export type {
   ClimbSearchParams,

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -537,13 +537,20 @@ export const tickMutations = {
 
     // Observation only — never rejects, never throws. See the function's docs.
     //
-    // Started here but settled at the bottom of the resolver, so its lookup
-    // overlaps the board/session resolution and the insert that follow instead
-    // of adding a serial round-trip to the hot path. Deliberately not
-    // fire-and-forget: settling it keeps the counter deterministic (a test can
-    // assert the event fired, or didn't, without polling) and leaves no promise
-    // dangling past the request. It self-catches, so awaiting it cannot fail
-    // the tick.
+    // Started here but settled after the insert below, so its lookup overlaps
+    // the board/session resolution and the transaction instead of adding a
+    // serial round-trip to the hot path. Deliberately not fire-and-forget:
+    // settling it keeps the counter deterministic, so a test can assert the
+    // event fired — or, more to the point, that it did NOT fire for a
+    // deduped-away alias UUID. It self-catches, so awaiting it cannot fail the
+    // tick.
+    //
+    // If something between here and the await throws (a beta-link rejection,
+    // the transaction), the promise is abandoned unsettled. That's deliberate,
+    // not an oversight: the observation is about ticks that get SAVED, and a
+    // tick that failed shouldn't move a counter measuring saved-tick UUIDs.
+    // Nothing leaks — the helper never rejects, so an abandoned promise is
+    // inert.
     const catalogPresenceReport = reportTickClimbCatalogPresence(
       userId,
       validatedInput.boardType,
@@ -750,9 +757,8 @@ export const tickMutations = {
 
     // Settle the catalog observation started before the board/session lookups.
     // By now it has overlapped every round-trip above, so this is a no-op wait
-    // in practice — it exists so the counter is deterministic and no promise
-    // outlives the request. Placed before the early returns below so it covers
-    // every exit path from here on.
+    // in practice — it exists so the counter is deterministic. Placed before
+    // the early returns below so it covers every path that saves a tick.
     await catalogPresenceReport;
 
     if (!tick) {

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -532,7 +532,15 @@ export const tickMutations = {
     }
 
     // Observation only — never rejects, never throws. See the function's docs.
-    await reportTickClimbCatalogPresence(
+    //
+    // Started here but settled at the bottom of the resolver, so its lookup
+    // overlaps the board/session resolution and the insert that follow instead
+    // of adding a serial round-trip to the hot path. Deliberately not
+    // fire-and-forget: settling it keeps the counter deterministic (a test can
+    // assert the event fired, or didn't, without polling) and leaves no promise
+    // dangling past the request. It self-catches, so awaiting it cannot fail
+    // the tick.
+    const catalogPresenceReport = reportTickClimbCatalogPresence(
       userId,
       validatedInput.boardType,
       validatedInput.climbUuid,
@@ -735,6 +743,13 @@ export const tickMutations = {
 
       return [createdTick];
     });
+
+    // Settle the catalog observation started before the board/session lookups.
+    // By now it has overlapped every round-trip above, so this is a no-op wait
+    // in practice — it exists so the counter is deterministic and no promise
+    // outlives the request. Placed before the early returns below so it covers
+    // every exit path from here on.
+    await catalogPresenceReport;
 
     if (!tick) {
       const [existingTick] = await db

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -83,7 +83,11 @@ async function reportTickClimbCatalogPresence(
     );
     captureBackendEvent('Tick Climb Not In Catalog', {
       distinctId: userId,
-      properties: { boardType, angle },
+      // climbUuid rides along so the counter is triageable on its own. "12 hits"
+      // means nothing until you know whether it's 12 climbs or one client
+      // looping on one bad UUID — and that distinction is the answer #3942 needs.
+      // Not PII: a catalog identifier, and the same value the warn log carries.
+      properties: { boardType, angle, climbUuid },
       processPersonProfile: false,
     });
   } catch (error) {

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -23,6 +23,8 @@ import {
 } from '../../../utils/instagram-beta-validation';
 import { cacheInstagramThumbnail, isS3Configured } from '../../../lib/beta-link-thumbnails';
 import { invalidateRecentBetaLinksCache } from '../beta-videos/queries';
+import { resolveClimbCatalogPresence } from '../../../db/queries/climbs';
+import { captureBackendEvent } from '../../../services/analytics/posthog';
 import { logger } from '../../../utils/logger';
 
 // Beta links are only attached on successful ascents (flash / send), never
@@ -38,6 +40,54 @@ export function videoUrlForTickStatus(status: TickStatus, videoUrl: string | nul
       return videoUrl;
     case 'attempt':
       return null;
+  }
+}
+
+/**
+ * Log-only catalog check for an incoming tick (#3528).
+ *
+ * `SaveTickInputSchema.climbUuid` is `ExternalUUIDSchema` — a 1-50 character
+ * string, not even a UUID shape — and `boardsesh_ticks` has no FK to
+ * `board_climbs`, so a tick can name a climb that does not exist. The permanent
+ * damage that used to cause (a phantom `board_climb_stats` row, minted by the
+ * recompute's defensive seed) is fixed at the seed itself in
+ * `@boardsesh/db/queries` recomputeClimbStats, which covers every tick writer.
+ *
+ * This is the observation half, and it deliberately does NOT reject. Every
+ * client-held climb UUID is believed to originate from `board_climbs`, so a
+ * rejection should never fire on a real send — but a non-retryable GraphQL error
+ * dead-letters immediately in the offline drainer, so being wrong about one path
+ * costs a climber a send while being right only avoids a few junk rows. We take
+ * the measurement first. #3942 flips this to a rejection once the counter has
+ * held at zero over a real observation window; until then, log-only is the
+ * finished state, not a half-finished one.
+ *
+ * The alias arm keeps the counter honest: the Kilter dedup path folds duplicate
+ * catalog UUIDs into `board_climb_aliases` and writes no `board_climbs` row for
+ * them, so an alias-borne tick is a legitimate send and must not read as a hit.
+ *
+ * Never throws: an observation must not be able to fail a real tick.
+ */
+async function reportTickClimbCatalogPresence(
+  userId: string,
+  boardType: string,
+  climbUuid: string,
+  angle: number,
+): Promise<void> {
+  try {
+    const presence = await resolveClimbCatalogPresence(boardType, climbUuid);
+    if (presence !== 'unknown') return;
+
+    logger.warn(
+      `[saveTick] climb not in catalog — saving anyway (#3528): ${boardType}/${climbUuid} angle=${angle} user=${userId}`,
+    );
+    captureBackendEvent('Tick Climb Not In Catalog', {
+      distinctId: userId,
+      properties: { boardType, angle },
+      processPersonProfile: false,
+    });
+  } catch (error) {
+    logger.error('[saveTick] climb catalog presence check failed:', error);
   }
 }
 
@@ -480,6 +530,14 @@ export const tickMutations = {
         return tickResult(existingTick);
       }
     }
+
+    // Observation only — never rejects, never throws. See the function's docs.
+    await reportTickClimbCatalogPresence(
+      userId,
+      validatedInput.boardType,
+      validatedInput.climbUuid,
+      validatedInput.angle,
+    );
 
     // Resolve the tick's board_id. Two explicit-board inputs feed the same FK,
     // each from a different surface:

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -555,8 +555,10 @@ export const tickMutations = {
     // UUID", not "an unknown-UUID tick was saved".
     //
     // Consequently, if something between here and the await throws, the promise
-    // is abandoned unsettled and the event may already have fired. Nothing
-    // leaks — the helper never rejects, so an abandoned promise is inert.
+    // is simply no longer awaited — it still runs to completion on its own, and
+    // the event may already have fired. Nothing leaks: the helper never
+    // rejects, so an un-awaited promise cannot surface as an unhandled
+    // rejection.
     const catalogPresenceReport = reportTickClimbCatalogPresence(
       userId,
       validatedInput.boardType,

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -545,12 +545,18 @@ export const tickMutations = {
     // deduped-away alias UUID. It self-catches, so awaiting it cannot fail the
     // tick.
     //
-    // If something between here and the await throws (a beta-link rejection,
-    // the transaction), the promise is abandoned unsettled. That's deliberate,
-    // not an oversight: the observation is about ticks that get SAVED, and a
-    // tick that failed shouldn't move a counter measuring saved-tick UUIDs.
-    // Nothing leaks — the helper never rejects, so an abandoned promise is
-    // inert.
+    // The event fires from inside the helper the moment the probe resolves —
+    // it is NOT conditional on the tick going on to commit. That is the
+    // intended reading: what's being counted is "a client sent a climb_uuid the
+    // catalog has never heard of", which is equally true whether the tick then
+    // succeeded or failed on something unrelated (a beta-link rejection, a
+    // constraint violation). A UUID we can't resolve is worth knowing about
+    // either way, so #3942 should read a hit as "this client sent an unknown
+    // UUID", not "an unknown-UUID tick was saved".
+    //
+    // Consequently, if something between here and the await throws, the promise
+    // is abandoned unsettled and the event may already have fired. Nothing
+    // leaks — the helper never rejects, so an abandoned promise is inert.
     const catalogPresenceReport = reportTickClimbCatalogPresence(
       userId,
       validatedInput.boardType,

--- a/packages/backend/src/services/analytics/posthog.ts
+++ b/packages/backend/src/services/analytics/posthog.ts
@@ -12,7 +12,12 @@ export type BackendAnalyticsEvent =
   | 'Live Activity Push Delivery Attribution Gap'
   | 'Live Activity Started'
   | 'Live Activity Widget Navigation'
-  | 'Live Activity Widget Navigation Attribution Gap';
+  | 'Live Activity Widget Navigation Attribution Gap'
+  // Counter behind the log-only climb-existence check in saveTick (#3528).
+  // Count DISTINCT USERS, not events — one looping client would otherwise read
+  // as a fleet-wide problem. A sustained zero is the signal to turn the check
+  // into a rejection (#3942).
+  | 'Tick Climb Not In Catalog';
 
 interface CaptureBackendEventOptions {
   distinctId: string;

--- a/packages/db/src/queries/climb-stats/__tests__/recompute.test.ts
+++ b/packages/db/src/queries/climb-stats/__tests__/recompute.test.ts
@@ -33,7 +33,18 @@ void describe('recomputeClimbStatsBulk', () => {
     await recomputeClimbStatsBulk(db.handle, [{ boardType: 'kilter', climbUuid: 'A', angle: 40 }]);
 
     assert.equal(db.queries.length, 2);
-    assert.match(sqlText(db.queries[0]), /INSERT INTO board_climb_stats/);
+    const seedSql = sqlText(db.queries[0]);
+    assert.match(seedSql, /INSERT INTO board_climb_stats/);
+    // Smoke test only — the guard's BEHAVIOUR (phantom key seeds nothing; the
+    // real key beside it in the same chunk is untouched; a real climb ticked at
+    // a new angle still seeds) is asserted against real Postgres in
+    // packages/backend/src/__tests__/recompute-climb-stats.test.ts, because
+    // this package has no vitest project and CI never runs its tsx --test suite.
+    assert.match(seedSql, /WHERE EXISTS \(\s*SELECT 1\s*FROM board_climbs bc/);
+    assert.match(seedSql, /bc\.uuid = k\.climb_uuid/);
+    assert.match(seedSql, /bc\.board_type = k\.board_type/);
+    // Seeded rows are on the 1-5 scale from birth (#3529, seed half).
+    assert.match(seedSql, /quality_normalized/);
     const updateSql = sqlText(db.queries[1]);
     assert.match(updateSql, /UPDATE board_climb_stats/);
     // The counting rule + provenance guard must be present in the UPDATE. The

--- a/packages/db/src/queries/climb-stats/recompute.ts
+++ b/packages/db/src/queries/climb-stats/recompute.ts
@@ -1,6 +1,5 @@
 import { sql } from 'drizzle-orm';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
-import { boardClimbStats } from '../../schema/boards/unified';
 import { rowsOf } from '../util/rows';
 import { blendedQualityAverageSql } from './quality-blend';
 
@@ -76,6 +75,28 @@ type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
  * kilter_pull / json_import) are already reflected in upstream_quality_average and
  * are deliberately excluded here so they are not double-counted. The recompute
  * never writes upstream_quality_average (the upstream syncs own it).
+ *
+ * The defensive seed is GUARDED on the climb existing in board_climbs (#3528).
+ * A tick can carry any string as its climb_uuid — saveTick's Zod schema is
+ * shape-only and boardsesh_ticks has no FK to board_climbs — so an unguarded
+ * seed minted a permanent board_climb_stats row for whatever key a tick landed
+ * on, and the non-owned branch below then wrote real counts into it (77 such
+ * orphan rows in prod). Both seeds now insert only when board_climbs has a row
+ * for (board_type, climb_uuid); the lookup rides board_climbs_pkey.
+ *
+ * Deliberately guarded on the CLIMB, not on (climb, angle): a tick at an angle
+ * the catalog has no stats row for is legitimate and must still seed — that is
+ * the whole reason the seed exists. Tightening this to (climb, angle) would
+ * break real ticks. (MoonBoard's wrong-angle rows, #3529, are an identity
+ * problem, not an existence one; they belong to the angle-dedup work.)
+ *
+ * Seeded rows carry quality_normalized = TRUE. Every value the row can ever
+ * hold is on the canonical 1-5 scale: the Boardsesh blend is built from native
+ * ticks (validated 1-5), and the only writers of the upstream side (Aurora
+ * shared-sync, Kilter catalog-sync / stats-repair, the MoonBoard importers) all
+ * set the flag TRUE on insert AND on conflict. Leaving it at the column default
+ * FALSE is what stranded 44 MoonBoard rows outside the "all normalized"
+ * invariant (#3529, seed half).
  */
 
 export type DiffRow = {
@@ -124,19 +145,31 @@ export async function recomputeClimbStats(
   await db.transaction(async (tx) => {
     // Defensive seed: set upstream/boardsesh counts to 0 explicitly so the
     // recompute and any later upstream sync both see a sensible baseline.
-    await tx
-      .insert(boardClimbStats)
-      .values({
-        boardType,
-        climbUuid,
-        angle,
-        ascensionistCount: 0,
-        upstreamAscensionistCount: 0,
-        boardseshAscensionistCount: 0,
-      })
-      .onConflictDoNothing({
-        target: [boardClimbStats.boardType, boardClimbStats.climbUuid, boardClimbStats.angle],
-      });
+    //
+    // INSERT ... SELECT FROM board_climbs makes the catalog lookup the guard
+    // itself: board_climbs.uuid is the primary key, so the SELECT yields
+    // exactly one row for a real climb and zero rows for a phantom one, and a
+    // phantom key seeds nothing. When nothing is seeded the UPDATE below simply
+    // matches no row and this function returns undefined — the documented
+    // "UPDATE matched no row" path.
+    //
+    // Raw SQL rather than the drizzle insert builder, and not for lack of
+    // trying: `.values()` cannot carry a WHERE at all, and `.insert().select()`
+    // throws at runtime on a partial column list ("selected fields are not the
+    // same or are in a different order compared to the table definition"), so
+    // it would force us to enumerate every column of board_climb_stats and
+    // re-enumerate them on every future column addition. Same statement shape
+    // as the bulk seed below, deliberately — the two guards should diff clean.
+    await tx.execute(sql`
+      INSERT INTO board_climb_stats (board_type, climb_uuid, angle,
+                                     ascensionist_count, upstream_ascensionist_count, boardsesh_ascensionist_count,
+                                     quality_normalized)
+      SELECT ${boardType}::text, ${climbUuid}::text, ${angle}::integer, 0, 0, 0, TRUE
+        FROM board_climbs bc
+       WHERE bc.uuid = ${climbUuid}
+         AND bc.board_type = ${boardType}
+      ON CONFLICT (board_type, climb_uuid, angle) DO NOTHING;
+    `);
 
     const result = await tx.execute(sql`
       WITH before AS (
@@ -362,12 +395,21 @@ export async function recomputeClimbStatsBulk(db: DrizzleDb, keys: ClimbStatsKey
     );
 
     // Defensive seed for keys whose stats row doesn't exist yet (ticks can
-    // arrive at angles the saveClimb seed didn't cover).
+    // arrive at angles the saveClimb seed didn't cover). Guarded on the climb
+    // existing in board_climbs (#3528) — see the module doc. The EXISTS rides
+    // board_climbs_pkey, one probe per key.
     await db.execute(sql`
       INSERT INTO board_climb_stats (board_type, climb_uuid, angle,
-                                     ascensionist_count, upstream_ascensionist_count, boardsesh_ascensionist_count)
-      SELECT k.board_type, k.climb_uuid, k.angle, 0, 0, 0
+                                     ascensionist_count, upstream_ascensionist_count, boardsesh_ascensionist_count,
+                                     quality_normalized)
+      SELECT k.board_type, k.climb_uuid, k.angle, 0, 0, 0, TRUE
         FROM jsonb_to_recordset(${payload}::jsonb) AS k(board_type text, climb_uuid text, angle integer)
+       WHERE EXISTS (
+         SELECT 1
+           FROM board_climbs bc
+          WHERE bc.uuid = k.climb_uuid
+            AND bc.board_type = k.board_type
+       )
       ON CONFLICT (board_type, climb_uuid, angle) DO NOTHING;
     `);
 
@@ -403,8 +445,12 @@ export async function recomputeClimbStatsBulk(db: DrizzleDb, keys: ClimbStatsKey
           FROM boardsesh_ticks bt
           JOIN keys k
             ON k.board_type = bt.board_type AND k.climb_uuid = bt.climb_uuid AND k.angle = bt.angle
-          -- Inner join is safe: the seed INSERT above created a stats row for
-          -- every key, so upstream_synced_at is always available here.
+          -- Inner join, and since #3528 it is also load-bearing: the seed above
+          -- only creates rows for keys whose climb exists in board_climbs, so a
+          -- phantom key has no stats row and drops out here. That is the
+          -- intended outcome — the UPDATE at the bottom would match nothing for
+          -- it anyway. For every surviving key the seed guarantees a row, so
+          -- upstream_synced_at is always available.
           JOIN board_climb_stats s
             ON s.board_type = bt.board_type AND s.climb_uuid = bt.climb_uuid AND s.angle = bt.angle
          -- Kilter-detached rows are upstream-deleted; they must not count nor


### PR DESCRIPTION
## Summary

`recomputeClimbStats`' defensive seed was an unconditional `INSERT ... ON CONFLICT DO NOTHING`, so a tick at **any** `climb_uuid` minted a permanent `board_climb_stats` row for that `(board_type, uuid, angle)` — and the non-owned branch then wrote real ascent counts into it. Nothing upstream could stop it: `SaveTickInputSchema.climbUuid` is `ExternalUUIDSchema`, which is `z.string().min(1).max(50)` (not even a UUID shape), `saveTick` never looks the climb up, and `boardsesh_ticks` has no FK to `board_climbs`. 77 orphan rows in prod, 71 of them carrying counts.

Both seeds — single-key (`recompute.ts`) and bulk — now insert only when `board_climbs` has a row for the climb. The single-key seed makes the catalog lookup the guard itself (`INSERT ... SELECT ... FROM board_climbs bc WHERE bc.uuid = …`); the bulk seed adds `WHERE EXISTS`. Both ride `board_climbs_pkey`, which already exists — no new index, and the recompute's `owner` CTE was already doing the same lookup.

Fixing it at the seed rather than at `saveTick` is what makes it complete: one guard covers every tick writer — `saveTick`, `updateTick`, `deleteTick`, the legacy web `saveAscent` proxy, kilter-sync `user-sync`, aurora-sync `apply-user-logbook` and `json-import`, `moonboard-import`, and the aurora board-import backfill.

**Guarded on the CLIMB, not on `(climb, angle)`.** A tick at an angle the catalog has no stats row for is legitimate and must still seed — that is the entire reason the seed exists (`recompute.ts` bulk-seed comment). There's a test that passes today and fails only if someone "hardens" this, with a comment saying so, because it will otherwise read as redundant and get deleted.

Seeded rows also now carry `quality_normalized = TRUE`. Every value such a row can ever hold is on the canonical 1-5 scale: the Boardsesh side of the blend comes from native ticks (Zod-validated 1-5), and every writer of the upstream side — aurora `shared-sync`, kilter `catalog-sync` / `stats-repair`, all three MoonBoard importers — sets the flag `true` on insert *and* on conflict. The column default of `FALSE` was simply wrong for a seeded row, and it is what stranded 44 MoonBoard rows outside the "all normalized" invariant.

### The `saveTick` check is log-only, on purpose

`saveTick` now resolves each incoming `climbUuid` against `board_climbs` **and** `board_climb_aliases` and reports a UUID that neither knows — a warning log plus a `Tick Climb Not In Catalog` PostHog event keyed on the user, so the metric counts climbers rather than events. It does **not** reject.

The analysis says a rejection would never fire on a real send: every client-held UUID originates from `board_climbs` (search, queue, playlists and the offline snapshot are all projections of it), `saveClimb` server-generates the UUID and writes `board_climbs` in the same transaction that returns it, and the offline outbox whitelist has no `SaveClimb`, so there's no queued-tick-before-queued-climb ordering hazard. But the payoff is asymmetric — a non-retryable GraphQL error dead-letters immediately in the offline drainer, so being right buys a handful of unrenderable rows and being wrong costs a climber a send. So this ships the measurement and #3942 takes the bet later, once the counter has held at zero over a real observation window.

The alias arm is load-bearing for that, not decoration: the Kilter dedup path folds duplicate catalog UUIDs into `board_climb_aliases` and deliberately writes **no** `board_climbs` row for them (`getLogbook` already canonicalises these for display). Without the alias arm every deduped-Kilter tick would read as a hit and make the observation window unanswerable. 73 of the 77 prod orphans are Kilter — the only board with dedup — so this is likely most of them.

### Not in scope

- **The 77 existing prod rows.** Untouched. No data migration in this PR; cleaning them up is a separate, signed-off migration.
- **#3529's 42 wrong-angle MoonBoard rows.** Those climbs *do* have a `board_climbs` row, so the existence guard passes and still seeds at the ticked angle — correctly, because that is an **identity** problem, not an existence one. It dissolves when #3851 makes MoonBoard climbs angle-agnostic. This PR closes only the seed half of #3529 (the `quality_normalized` flag), so #3529 stays open.
- **#3943** covers the other direction orphans appear from: deleting a climb that already had stats (`deleteDraftClimb`, account deletion, `clear-aurora-board`). A seed guard cannot catch those.

No migration — this is SQL logic and a resolver check, no schema change.

Closes #3528

## Release Notes

- [x] No release note needed (internal / technical change)

Invisible to users: the phantom rows were never rendered on any surface.

## Test plan

`packages/db` has no vitest project and nothing in CI runs its `tsx --test` suite, so a SQL-text assertion over there is a smoke test, not evidence. Every load-bearing assertion is a real-Postgres test in `packages/backend/src/__tests__/`, extending the existing `recomputeClimbStats — provenance matrix (real DB)` block.

**Mutation-tested — I deleted each guard and confirmed the right tests go red:**

| Mutation | Tests that failed |
|---|---|
| Remove `FROM board_climbs` / `WHERE EXISTS` from both seeds | `single-key: a tick on a climb missing from board_climbs seeds NO stats row`, `bulk: a phantom key in a chunk seeds nothing and does not disturb the real key beside it`, `seeds via INSERT ... SELECT FROM board_climbs so the catalog lookup guards it` |
| Remove the alias arm from `resolveClimbCatalogPresence` | `does not fire the counter for a deduped-away UUID that only board_climb_aliases knows` |

The over-guarding tripwire (`a real climb ticked at an angle with no stats row STILL seeds one`) correctly stayed green through both — it is there to fail on a *tightening*, not a removal.

Also covered: the bulk case asserts the real key beside the phantom one in the same chunk still counts correctly, so the guard can't quietly drop good keys; the single-key case asserts a phantom returns `undefined` rather than throwing, since the debounced publisher logs any throw as an error.

Commands:

- `vp test run --project backend recompute-climb-stats save-tick-climb-catalog` — 40 passed
- `vp test run --project backend tick` — 95 passed
- `vp test run --project backend board-presence` — 82 passed (the file with the most `saveTick` call sites)
- `vp run typecheck` — clean
- `vp check` — clean for every file in this diff

Note on the test churn: the plan expected to have to seed `board_climbs` in several existing `saveTick`-driving tests. The log-only ruling removed that entirely — no existing test needed weakening or fixture changes. The only test edits here are the mocked seed-shape assertions in `recompute-climb-stats.test.ts`, which had to follow the seed from `.values()` to `INSERT ... SELECT`.

`.insert().select()` was tried first to keep this in Drizzle; drizzle-orm 0.45.2 rejects a partial column list at runtime ("selected fields are not the same or are in a different order compared to the table definition"), which would force enumerating every column of `board_climb_stats` forever. The raw `sql` is justified in a comment at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL
