### PR TITLE
fix(sync): stop one unwritable logbook row wedging a user's whole Aurora sync

### DIFF
--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -353,6 +353,57 @@ Failed to decrypt credentials
 - Verify user has `syncStatus: active` or `error` (not `disabled`)
 - Check Aurora API is accessible from the environment
 
+### Skipped logbook rows (`logbook_sync_skips`)
+
+Some upstream ascents/bids can't be written at all — a non-numeric `angle`, a
+comment carrying a NUL byte, or anything else Postgres refuses. Rather than let
+one of those abort the whole cross-table sync transaction and freeze the user's
+logbook forever (#3871, the DB-execution-time sibling of #3520), the sync skips
+the offending row and records it in `logbook_sync_skips` with its payload
+intact, so the send is quarantined and replayable rather than silently dropped.
+
+The table is **state, not a log**: a row is deleted the moment that `aurora_id`
+syncs cleanly, so anything still in it is currently broken.
+
+Who is affected, and why:
+
+```sql
+SELECT reason,
+       count(*)                AS rows_skipped,
+       count(DISTINCT user_id) AS users_affected,
+       max(last_seen_at)       AS last_hit
+  FROM logbook_sync_skips
+ GROUP BY reason
+ ORDER BY rows_skipped DESC;
+```
+
+Drill into one user (the payload is what you replay from):
+
+```sql
+SELECT aurora_type, aurora_id, reason, detail, seen_count, first_seen_at, payload
+  FROM logbook_sync_skips
+ WHERE user_id = '<user-id>' AND board_type = 'kilter'
+ ORDER BY last_seen_at DESC;
+```
+
+Reason codes:
+
+| `reason`            | What happened                                                              | Recovery                                                                       |
+| ------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `invalid_angle`     | `angle` isn't a storable integer. No honest default, so the row is dropped | Fix upstream (the row re-syncs on its next upstream edit), or replay `payload` |
+| `invalid_identity`  | `climb_uuid` / `aurora_id` missing or carrying an unstorable byte          | Usually an upstream data bug; replay from `payload` once corrected             |
+| `normalize_failed`  | The row threw during parsing (bad `climbed_at`/`created_at`) — see #3520   | Same as above                                                                  |
+| `db_write_rejected` | Parsed and validated, but Postgres still refused it                        | Read `detail` for the Postgres error; usually needs a code fix                 |
+
+A skipped row is **not** re-fetched automatically: Aurora's user sync is
+incremental and the checkpoint advances past it (not advancing is the wedge this
+fixes). It comes back when the user edits it upstream, when the watermark is
+reset (`clearAuroraBoardData` drops `board_user_syncs`, so the next sync starts
+from 1970), or via the JSON export import below, which ignores the watermark.
+
+A rising `seen_count` on the same row means it keeps being re-delivered and
+re-refused — worth a look at `detail`.
+
 ## JSON Export Import (Alternative to API Sync)
 
 Since the Kilter backend has been shut down, API-based sync is no longer available for Kilter users. As an alternative, users can import their data from Aurora's JSON export file.

--- a/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
@@ -871,3 +871,54 @@ describe('logbook_sync_skips reconciliation (#3871)', () => {
     }
   });
 });
+
+describe('applyLogbookChunk — claim UPDATE isolation (#3871)', () => {
+  it('isolates a refused row in the cross-source claim UPDATE, the third write path', async () => {
+    // The claim path binds only {uuid, aurora_id}, so it looks harmless — but
+    // it is a batched statement like the other two and fails the same way.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, calls, skipRows } = createTx({
+        selectResults: [
+          [], // byAuroraId: both incoming rows are misses
+          [
+            // Claimable json_import originals at the same instant.
+            {
+              uuid: 'tick-ok',
+              climbUuid: 'climb-1',
+              angle: 40,
+              climbedAt: '2026-05-01T22:00:00.000Z',
+              status: 'send',
+            },
+            {
+              uuid: 'tick-poison',
+              climbUuid: 'climb-2',
+              angle: 40,
+              climbedAt: '2026-05-01T22:00:00.000Z',
+              status: 'send',
+            },
+          ],
+        ],
+        rejectTickWritesContaining: 'aur-poison',
+      });
+
+      await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+        ascent({ uuid: 'aur-ok', climb_uuid: 'climb-1' }),
+        ascent({ uuid: 'aur-poison', climb_uuid: 'climb-2' }),
+      ]);
+
+      // Batched claim refused, then replayed per row: the clean claim lands.
+      expect(calls.filter((c) => c.kind === 'rollback')).toHaveLength(2);
+      expect(skipRows).toHaveLength(1);
+      expect(skipRows[0]).toMatchObject({ auroraId: 'aur-poison', reason: 'db_write_rejected' });
+      // The quarantined payload carries the whole row, not just the link —
+      // {uuid, aurora_id} alone could never be replayed into a tick.
+      expect(skipRows[0].payload).toMatchObject({
+        claimedTickUuid: 'tick-poison',
+        row: { auroraId: 'aur-poison', climbUuid: 'climb-2', angle: 40 },
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
@@ -922,3 +922,63 @@ describe('applyLogbookChunk — claim UPDATE isolation (#3871)', () => {
     }
   });
 });
+
+describe('applyAuroraBids — DB-level write isolation (#3871)', () => {
+  it('isolates a refused bid the same way as an ascent, end to end through applyAuroraBids', async () => {
+    // applyAuroraBids shares applyLogbookChunk with ascents, but "shares the
+    // machinery" is an inference; bids reach it via a different entry point
+    // (no tombstone pass, different claim statuses), so drive it directly.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, insertValues, calls, skipRows } = createTx({
+        selectResults: [[], []],
+        rejectTickWritesContaining: 'bid-poison',
+      });
+
+      await expect(
+        applyAuroraBids(tx as unknown as Db, 'tension', 'user-2', [
+          bid({ uuid: 'bid-ok-1', climb_uuid: 'climb-1' }),
+          bid({ uuid: 'bid-poison', climb_uuid: 'climb-2' }),
+          bid({ uuid: 'bid-ok-2', climb_uuid: 'climb-3' }),
+        ]),
+      ).resolves.toBeUndefined();
+
+      expect(insertValues.flat().map((row) => row.auroraId)).toEqual(['bid-ok-1', 'bid-ok-2']);
+      expect(calls.filter((c) => c.kind === 'rollback')).toHaveLength(2);
+      expect(skipRows).toHaveLength(1);
+      expect(skipRows[0]).toMatchObject({
+        userId: 'user-2',
+        boardType: 'tension',
+        auroraType: 'bids',
+        auroraId: 'bid-poison',
+        reason: 'db_write_rejected',
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('quarantine payload fidelity (#3871)', () => {
+  it('keeps an absent upstream field as an explicit null instead of dropping the key', async () => {
+    // The missing field is usually the reason the row was refused, so
+    // "angle was absent" must not be indistinguishable from "the quarantine
+    // never captured angle" — JSON.stringify drops undefined-valued keys.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, skipRows } = createTx({ selectResults: [[], []] });
+
+      await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+        ascent({ uuid: 'aur-no-angle', angle: undefined }),
+      ]);
+
+      expect(skipRows).toHaveLength(1);
+      expect(skipRows[0]).toMatchObject({ auroraId: 'aur-no-angle', reason: 'invalid_angle' });
+      const payload = skipRows[0].payload as Record<string, unknown>;
+      expect('angle' in payload).toBe(true);
+      expect(payload.angle).toBeNull();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
@@ -10,22 +10,61 @@ vi.mock('@boardsesh/db/queries', async (importActual) => {
 });
 
 import { recomputeClimbStatsBulk } from '@boardsesh/db/queries';
+import { logbookSyncSkips } from '@boardsesh/db/schema';
 import { applyAuroraAscents, applyAuroraBids } from './apply-user-logbook';
 
 const recomputeMock = vi.mocked(recomputeClimbStatsBulk);
 
-type CallRecord = { kind: 'select' | 'delete' | 'update' | 'insert' | 'execute'; args: unknown[]; where?: unknown };
+type CallKind =
+  | 'select'
+  | 'delete'
+  | 'update'
+  | 'insert'
+  | 'execute'
+  // Writes to logbook_sync_skips are tracked under their own kinds so the
+  // quarantine (#3871) never inflates the tick-write counts the rest of this
+  // suite asserts on.
+  | 'skip-insert'
+  | 'skip-delete'
+  // A savepoint that rolled back — what keeps the caller's cross-table
+  // transaction alive when a batched chunk write is refused.
+  | 'rollback';
+type CallRecord = { kind: CallKind; args: unknown[]; where?: unknown };
 type Row = Record<string, unknown>;
+
+/** Everything a write carries, flattened, so a test can match a poison row in it. */
+function writeFingerprint(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? '';
+  } catch {
+    return '';
+  }
+}
 
 /**
  * Hand-rolled Drizzle-tx shim, same philosophy as the kilter-sync suite: no
  * real DB, records every call, returns seeded SELECT results in order.
+ *
+ * `rejectTickWritesContaining` simulates Postgres refusing a statement: ANY
+ * boardsesh_ticks write whose bound content mentions the marker throws, exactly
+ * as a real constraint violation would — so a batched write covering the poison
+ * row fails, and the row-by-row replay then fails only on that one row.
  */
-function createTx(opts: { selectResults?: Row[][] } = {}) {
+function createTx(opts: { selectResults?: Row[][]; rejectTickWritesContaining?: string } = {}) {
   const calls: CallRecord[] = [];
   const selectResults = opts.selectResults ?? [];
   let selectIdx = 0;
   const insertValues: Row[][] = [];
+  const skipRows: Row[] = [];
+  const marker = opts.rejectTickWritesContaining;
+
+  const refuseIfPoisoned = (fingerprint: string) => {
+    if (marker !== undefined && fingerprint.includes(marker)) {
+      const error = new Error(`null value in column "angle" violates not-null constraint (marker ${marker})`);
+      Object.assign(error, { code: '23502' });
+      throw error;
+    }
+  };
 
   const tx = {
     select(cols: unknown) {
@@ -41,10 +80,11 @@ function createTx(opts: { selectResults?: Row[][] } = {}) {
         }),
       };
     },
-    delete(_t: unknown) {
+    delete(table: unknown) {
+      const isSkips = table === logbookSyncSkips;
       return {
         where: (cond: unknown) => {
-          calls.push({ kind: 'delete', args: [cond] });
+          calls.push({ kind: isSkips ? 'skip-delete' : 'delete', args: [cond] });
           return Promise.resolve();
         },
       };
@@ -59,22 +99,48 @@ function createTx(opts: { selectResults?: Row[][] } = {}) {
         }),
       };
     },
-    insert(_t: unknown) {
+    insert(table: unknown) {
+      const isSkips = table === logbookSyncSkips;
       return {
         values: (rows: Row[]) => {
-          calls.push({ kind: 'insert', args: [rows] });
-          insertValues.push(rows);
-          return Promise.resolve();
+          calls.push({ kind: isSkips ? 'skip-insert' : 'insert', args: [rows] });
+          if (isSkips) {
+            skipRows.push(...rows);
+          } else {
+            refuseIfPoisoned(writeFingerprint(rows));
+            insertValues.push(rows);
+          }
+          // Thenable so both `await …values(rows)` and
+          // `await …values(rows).onConflictDoUpdate(…)` work.
+          const result = Promise.resolve();
+          return Object.assign(result, { onConflictDoUpdate: (_cfg: unknown) => result });
         },
       };
     },
     execute(query: unknown) {
       calls.push({ kind: 'execute', args: [query] });
+      refuseIfPoisoned(writeFingerprint(new PgDialect().sqlToQuery(query as SQL).params));
       return Promise.resolve([]);
+    },
+    /**
+     * drizzle's nested transaction — a SAVEPOINT on postgres-js. On throw the
+     * real driver issues ROLLBACK TO SAVEPOINT and rethrows, leaving the OUTER
+     * transaction usable; that is precisely the property under test, so the
+     * shim reproduces it rather than swallowing.
+     */
+    // `inner` is deliberately `unknown`: annotating it as `typeof tx` would make
+    // tx self-referential (TS7022). Production casts the handle anyway.
+    async transaction<T>(fn: (inner: unknown) => Promise<T>): Promise<T> {
+      try {
+        return await fn(tx);
+      } catch (error) {
+        calls.push({ kind: 'rollback', args: [error] });
+        throw error;
+      }
     },
   };
 
-  return { tx, calls, insertValues };
+  return { tx, calls, insertValues, skipRows };
 }
 
 type Db = Parameters<typeof applyAuroraAscents>[0];
@@ -516,6 +582,290 @@ describe('applyAuroraAscents — malformed-row isolation (#3520)', () => {
       expect(insertValues[0]).toHaveLength(1);
       expect(insertValues[0][0]).toMatchObject({ auroraId: 'aur-good' });
       expect(recomputeMock).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('applyLogbookChunk — DB-level write isolation (#3871)', () => {
+  it("does not abort the caller's transaction when Postgres refuses a row: rolls back to the savepoint and resolves", async () => {
+    // THE bug. applyAuroraAscents runs inside syncUserData's ONE transaction
+    // spanning every synced table plus the sync checkpoint, and ascents are
+    // applied BEFORE bids, tags and circuits. A throw here rolls all of them
+    // back and stops the watermark advancing, so the next cycle re-fetches the
+    // same row and re-crashes — forever. Resolving is what lets the rest of
+    // that loop run at all.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, calls } = createTx({
+        selectResults: [[], []],
+        rejectTickWritesContaining: 'aur-poison',
+      });
+
+      await expect(
+        applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+          ascent({ uuid: 'aur-poison', climb_uuid: 'climb-1' }),
+        ]),
+      ).resolves.toBeUndefined();
+
+      // The savepoint absorbed it — that is the whole mechanism.
+      expect(calls.filter((c) => c.kind === 'rollback').length).toBeGreaterThan(0);
+      // And the handle stayed usable afterwards: the quarantine write ran on it.
+      expect(calls.filter((c) => c.kind === 'skip-insert')).toHaveLength(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('replays the chunk row by row so only the refused row is lost', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, insertValues, calls } = createTx({
+        selectResults: [[], []],
+        rejectTickWritesContaining: 'aur-poison',
+      });
+
+      await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+        ascent({ uuid: 'aur-ok-1', climb_uuid: 'climb-1' }),
+        ascent({ uuid: 'aur-poison', climb_uuid: 'climb-2' }),
+        ascent({ uuid: 'aur-ok-2', climb_uuid: 'climb-3' }),
+      ]);
+
+      // Batched INSERT refused → three single-row INSERTs, two of which land.
+      const landed = insertValues.flat().map((row) => row.auroraId);
+      expect(landed).toEqual(['aur-ok-1', 'aur-ok-2']);
+      expect(calls.filter((c) => c.kind === 'rollback')).toHaveLength(2); // batch + the one bad row
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('isolates a refused row in the jsonb_to_recordset UPDATE path too, not just the INSERT', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const stored = (auroraId: string, climbUuid: string): Row => ({
+        uuid: `tick-${auroraId}`,
+        auroraId,
+        ownerUserId: 'user-1',
+        climbUuid,
+        angle: 40,
+        isMirror: false,
+        status: 'send',
+        attemptCount: 1, // differs from the incoming bid_count → a real update
+        quality: 5,
+        difficulty: 20,
+        isBenchmark: false,
+        comment: '',
+        climbedAt: '2026-05-01T22:00:00.000Z',
+        updatedAt: '2026-05-01T22:00:00.000Z',
+        auroraSyncedAt: '2026-05-01T22:30:00.000Z',
+        origin: 'aurora_pull',
+      });
+
+      const { tx, calls, skipRows } = createTx({
+        selectResults: [[stored('aur-ok-1', 'climb-1'), stored('aur-poison', 'climb-2')]],
+        rejectTickWritesContaining: 'aur-poison',
+      });
+
+      await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+        ascent({ uuid: 'aur-ok-1', climb_uuid: 'climb-1' }),
+        ascent({ uuid: 'aur-poison', climb_uuid: 'climb-2' }),
+      ]);
+
+      expect(calls.filter((c) => c.kind === 'rollback')).toHaveLength(2);
+      expect(skipRows).toHaveLength(1);
+      expect(skipRows[0]).toMatchObject({ auroraId: 'aur-poison', reason: 'db_write_rejected' });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('quarantines the refused row with its payload so the drop is replayable, not silent data loss', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, skipRows } = createTx({
+        selectResults: [[], []],
+        rejectTickWritesContaining: 'aur-poison',
+      });
+
+      await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+        ascent({ uuid: 'aur-poison', climb_uuid: 'climb-9', angle: 45 }),
+      ]);
+
+      expect(skipRows).toHaveLength(1);
+      expect(skipRows[0]).toMatchObject({
+        userId: 'user-1',
+        boardType: 'kilter',
+        auroraType: 'ascents',
+        auroraId: 'aur-poison',
+        reason: 'db_write_rejected',
+        seenCount: 1,
+      });
+      // The payload is the point: without it a drop is indistinguishable from
+      // throwing the climber's send away.
+      expect(skipRows[0].payload).toMatchObject({ auroraId: 'aur-poison', climbUuid: 'climb-9', angle: 45 });
+      expect(String(skipRows[0].detail)).toContain('not-null constraint');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('pre-write validation (#3871)', () => {
+  it('never lets a non-finite angle reach the DB or the stats recompute', async () => {
+    // The row-by-row fallback does NOT cover this: `angle` also feeds
+    // recomputeClimbStatsBulk's own jsonb_to_recordset(… angle integer) +
+    // INSERT INTO board_climb_stats, which runs after the chunk loop and
+    // outside any write fallback. Validation is the only guard there.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, insertValues, calls } = createTx({ selectResults: [[], []] });
+
+      await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+        ascent({ uuid: 'aur-bad-angle', angle: 'not-a-number' }),
+        ascent({ uuid: 'aur-good', climb_uuid: 'climb-good' }),
+      ]);
+
+      // Never bound into a statement…
+      const written = insertValues.flat().map((row) => row.auroraId);
+      expect(written).toEqual(['aur-good']);
+      // …and never handed to the recompute either.
+      const keys = recomputeMock.mock.calls[0][1];
+      expect(keys.every((key) => Number.isInteger(key.angle))).toBe(true);
+      expect(keys.some((key) => key.climbUuid === 'climb-1')).toBe(false);
+      // No DB write was even attempted, so this is validation, not the fallback.
+      expect(calls.filter((c) => c.kind === 'rollback')).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('records an angle drop under its own reason code, distinct from a DB refusal', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, skipRows } = createTx({ selectResults: [[], []] });
+
+      await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+        ascent({ uuid: 'aur-bad-angle', angle: Number.NaN }),
+      ]);
+
+      expect(skipRows).toHaveLength(1);
+      expect(skipRows[0]).toMatchObject({ auroraId: 'aur-bad-angle', reason: 'invalid_angle' });
+      // The raw upstream item is kept, so a fixed row can be replayed.
+      expect(skipRows[0].payload).toMatchObject({ uuid: 'aur-bad-angle', climb_uuid: 'climb-1' });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('coerces a garbage bid_count to the column default instead of dropping the send', async () => {
+    const { tx, insertValues } = createTx({ selectResults: [[], []] });
+
+    await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [ascent({ bid_count: 'lots' })]);
+
+    expect(insertValues[0][0]).toMatchObject({ auroraId: 'aur-1', attemptCount: 1 });
+  });
+
+  it('nulls a fractional difficulty rather than letting "21.5" hit an integer column', async () => {
+    const { tx, insertValues } = createTx({ selectResults: [[], []] });
+
+    await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [ascent({ difficulty: 21.5 })]);
+
+    expect(insertValues[0][0]).toMatchObject({ auroraId: 'aur-1', difficulty: null });
+  });
+
+  it('strips a NUL byte from a comment and still writes the send', async () => {
+    const { tx, insertValues } = createTx({ selectResults: [[], []] });
+
+    await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [ascent({ comment: 'sick \u0000line' })]);
+
+    expect(insertValues[0][0]).toMatchObject({ auroraId: 'aur-1', comment: 'sick line' });
+  });
+
+  it('drops a row whose identity column carries an unstorable byte', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, insertValues, skipRows } = createTx({ selectResults: [[], []] });
+
+      await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+        ascent({ uuid: 'aur-bad', climb_uuid: 'climb\u0000-1' }),
+        ascent({ uuid: 'aur-good', climb_uuid: 'climb-2' }),
+      ]);
+
+      expect(insertValues.flat().map((row) => row.auroraId)).toEqual(['aur-good']);
+      expect(skipRows[0]).toMatchObject({ auroraId: 'aur-bad', reason: 'invalid_identity' });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('collapses a duplicate aurora_id in one payload before it can collide on the unique index', async () => {
+    // Both copies are misses, so both would be INSERTed and
+    // boardsesh_ticks_aurora_id_unique would abort the chunk —
+    // deterministically, every cycle, forever.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, insertValues } = createTx({ selectResults: [[], []] });
+
+      await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+        ascent({ uuid: 'aur-dup', comment: 'first' }),
+        ascent({ uuid: 'aur-dup', comment: 'second' }),
+      ]);
+
+      const written = insertValues.flat();
+      expect(written).toHaveLength(1);
+      expect(written[0]).toMatchObject({ auroraId: 'aur-dup', comment: 'second' });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('logbook_sync_skips reconciliation (#3871)', () => {
+  it('clears the quarantine for a row that now syncs cleanly, so the table is state and not a growing log', async () => {
+    const { tx, calls } = createTx({ selectResults: [[], []] });
+
+    await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [ascent({ uuid: 'aur-1' })]);
+
+    expect(calls.filter((c) => c.kind === 'skip-delete')).toHaveLength(1);
+    expect(calls.filter((c) => c.kind === 'skip-insert')).toHaveLength(0);
+  });
+
+  it('does not clear the quarantine for a row that was refused again in the same run', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, calls } = createTx({
+        selectResults: [[], []],
+        rejectTickWritesContaining: 'aur-poison',
+      });
+
+      await applyAuroraAscents(tx as unknown as Db, 'kilter', 'user-1', [
+        ascent({ uuid: 'aur-poison', climb_uuid: 'climb-1' }),
+      ]);
+
+      // Nothing resolved → no DELETE at all; the record must survive to be seen.
+      expect(calls.filter((c) => c.kind === 'skip-delete')).toHaveLength(0);
+      expect(calls.filter((c) => c.kind === 'skip-insert')).toHaveLength(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('records a bid skip under aurora_type=bids', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { tx, skipRows } = createTx({ selectResults: [[], []] });
+
+      await applyAuroraBids(tx as unknown as Db, 'tension', 'user-2', [bid({ uuid: 'bid-bad', angle: undefined })]);
+
+      expect(skipRows[0]).toMatchObject({
+        userId: 'user-2',
+        boardType: 'tension',
+        auroraType: 'bids',
+        auroraId: 'bid-bad',
+        reason: 'invalid_angle',
+      });
     } finally {
       warnSpy.mockRestore();
     }

--- a/packages/aurora-sync/src/sync/apply-user-logbook.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.ts
@@ -850,12 +850,24 @@ async function applyLogbookChunk(
   // PR #3872's skip-and-log philosophy (issue #3520) one layer down, at
   // DB-execution time instead of parse time.
   //
-  // Cost bound: one open subtransaction per chunk (postgres.js does not RELEASE
-  // savepoints), and syncUserData opens a fresh transaction per Aurora PAGE, so
-  // the live count is (page size / WRITE_CHUNK_SIZE) — ~10 for a 1000-row page,
+  // Cost bound. postgres.js issues `savepoint sN` and, on error, `rollback to
+  // sN` — but on SUCCESS it issues nothing at all (see its `scope()`: the
+  // commit/release branch is guarded by `if (!name)`, which is false for a
+  // named savepoint). So each savepoint stays open until the outer COMMIT and
+  // costs one subtransaction.
+  //
+  // syncUserData opens a fresh transaction per Aurora PAGE, so the happy-path
+  // count is (page size / WRITE_CHUNK_SIZE) — ~10 for a 1000-row page,
   // comfortably under the 64-subxid backend cache threshold past which other
-  // backends fall back to pg_subtrans lookups. Raising the page size raises
-  // this: keep a page under ~6400 rows.
+  // backends fall back to pg_subtrans lookups.
+  //
+  // The replay path costs more: a chunk that falls back adds up to
+  // `claims + updates + inserts` further savepoints (≤ WRITE_CHUNK_SIZE, i.e.
+  // ~100), so ONE fully-bad chunk in a 1000-row page takes the page to ~110 and
+  // over the threshold. That is a rare, self-limiting degradation — the poison
+  // rows get quarantined and skipped on the next cycle rather than replayed
+  // forever — but it is the number to reason about when tuning either constant.
+  // Raising the page size raises both: keep a page under ~6400 rows.
   try {
     await db.transaction(async (savepoint) => {
       const sp = savepoint as unknown as DrizzleDb;

--- a/packages/aurora-sync/src/sync/apply-user-logbook.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.ts
@@ -290,6 +290,12 @@ function errorMessage(error: unknown): string {
  * transaction, so it would recreate the very wedge this table reports.
  */
 function storableJson(value: unknown): unknown {
+  // `undefined` -> null, not passthrough: JSON.stringify DROPS an
+  // undefined-valued key entirely, and "Aurora sent no angle" would then be
+  // indistinguishable from "the quarantine never captured the angle". The
+  // absent field is usually the whole reason the row was refused, so it has to
+  // survive into the record.
+  if (value === undefined) return null;
   if (typeof value === 'string') return stripUnstorableText(value);
   if (typeof value === 'number') return Number.isFinite(value) ? value : null;
   if (typeof value === 'bigint') return value.toString();

--- a/packages/aurora-sync/src/sync/apply-user-logbook.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 
-import { boardseshTicks } from '@boardsesh/db/schema';
+import { boardseshTicks, logbookSyncSkips, type LogbookSyncSkipReason } from '@boardsesh/db/schema';
 import {
   recomputeClimbStatsBulk,
   inferUserUtcOffsetSeconds,
@@ -114,18 +114,117 @@ function toNumberOrNull(value: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+// --- Pre-write validation (#3871) -------------------------------------------
+//
+// Everything below exists to stop a value that survives JS coercion from being
+// refused by Postgres inside a BATCHED statement. The row-by-row fallback in
+// applyLogbookChunk is the backstop for what this doesn't anticipate, but it is
+// NOT a substitute: `angle` also flows into recomputeClimbStatsBulk's own
+// `jsonb_to_recordset(...) AS k(..., angle integer)` + INSERT INTO
+// board_climb_stats, which runs AFTER the chunk loop and outside any write
+// fallback. Validation is the only thing standing between a NaN angle and that
+// second abort site. Deleting it does not just "lose a nicer error message".
+
+const INT4_MIN = -2147483648;
+const INT4_MAX = 2147483647;
+
+function isInt4(value: number): boolean {
+  return Number.isInteger(value) && value >= INT4_MIN && value <= INT4_MAX;
+}
+
+/** int4 or null. NaN, Infinity, 21.5 and out-of-range all become null. */
+function int4OrNull(value: unknown): number | null {
+  const parsed = toNumberOrNull(value);
+  return parsed !== null && isInt4(parsed) ? parsed : null;
+}
+
+/**
+ * Code points Postgres cannot store in `text`: a NUL byte, and an unpaired
+ * UTF-16 surrogate. Both abort the WHOLE batched statement — `::jsonb` rejects
+ * the escapes JSON.stringify emits for them ("unsupported Unicode escape
+ * sequence" / "invalid input syntax for type json"), and the text bind path
+ * rejects the raw bytes — which is exactly the deterministic chunk-killer this
+ * guard exists to stop.
+ */
+const UNSTORABLE_TEXT = /\u0000|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+function stripUnstorableText(value: string): string {
+  // String.replace resets a global regex's lastIndex itself, so this stays
+  // stateless despite the /g flag.
+  return value.replace(UNSTORABLE_TEXT, '');
+}
+
+/** A row Postgres could never accept, carrying the reason code for triage. */
+class LogbookRowRejected extends Error {
+  readonly reason: LogbookSyncSkipReason;
+
+  constructor(reason: LogbookSyncSkipReason, message: string) {
+    super(message);
+    this.name = 'LogbookRowRejected';
+    this.reason = reason;
+  }
+}
+
+/**
+ * An identity column (`aurora_id`, `climb_uuid`) must be present and storable.
+ * Unlike a comment these can't be scrubbed: they're what the row is keyed,
+ * deduped and re-synced by, so a corrupted one makes the row unusable.
+ */
+function requireStorableId(value: unknown, field: string): string {
+  const text = value === null || value === undefined ? '' : String(value);
+  if (text === '' || text === 'undefined' || text === 'null' || stripUnstorableText(text) !== text) {
+    throw new LogbookRowRejected(
+      'invalid_identity',
+      `${field} is missing or not storable (got ${JSON.stringify(value)})`,
+    );
+  }
+  return text;
+}
+
+/**
+ * `angle` is `integer NOT NULL` and there is no honest default — a tick at a
+ * guessed angle is wrong data — so an unusable angle is the one thing that
+ * costs the whole row. That drop is only acceptable because the row is
+ * quarantined in logbook_sync_skips with its payload intact and can be
+ * replayed; see the table's doc comment.
+ */
+function requireAngle(value: unknown): number {
+  const angle = int4OrNull(value);
+  if (angle === null) {
+    throw new LogbookRowRejected('invalid_angle', `angle is not a storable integer (got ${JSON.stringify(value)})`);
+  }
+  return angle;
+}
+
+/**
+ * `quality` carries a DB CHECK (boardsesh_ticks_quality_range: NULL or 1-5).
+ * convertQuality honours that today, but a future change to the star scale
+ * would re-poison the column silently — and losing a rating is much cheaper
+ * than losing the send, so out-of-range becomes NULL rather than a drop.
+ */
+function qualityWithinCheck(value: number | null): number | null {
+  if (value === null) return null;
+  return isInt4(value) && value >= 1 && value <= 5 ? value : null;
+}
+
 function normalizeAscent(item: AuroraApiRow): NormalizedLogbookRow {
   return {
-    auroraId: String(item.uuid),
-    climbUuid: String(item.climb_uuid),
-    angle: Number(item.angle),
+    auroraId: requireStorableId(item.uuid, 'uuid'),
+    climbUuid: requireStorableId(item.climb_uuid, 'climb_uuid'),
+    angle: requireAngle(item.angle),
     isMirror: toBool(item.is_mirror),
     status: Number(item.attempt_id) === 1 ? 'flash' : 'send',
-    attemptCount: Number(item.bid_count || 1),
-    quality: convertQuality(item.quality != null && item.quality !== '' ? Number(item.quality) : null),
-    difficulty: toNumberOrNull(item.difficulty),
+    // `attempt_count` is `integer NOT NULL DEFAULT 1`; fall back to that
+    // default rather than dropping a real send over a garbage bid_count.
+    attemptCount: int4OrNull(item.bid_count || 1) ?? 1,
+    quality: qualityWithinCheck(
+      convertQuality(item.quality != null && item.quality !== '' ? Number(item.quality) : null),
+    ),
+    // toNumberOrNull only guarantees finite — a fractional difficulty (21.5)
+    // is still "invalid input syntax for type integer" at the SQL layer.
+    difficulty: int4OrNull(item.difficulty),
     isBenchmark: toBool(item.is_benchmark),
-    comment: item.comment ? String(item.comment) : '',
+    comment: stripUnstorableText(item.comment ? String(item.comment) : ''),
     climbedAt: normalizeTimestamp(String(item.climbed_at)),
     createdAt: item.created_at
       ? normalizeTimestamp(String(item.created_at))
@@ -136,16 +235,16 @@ function normalizeAscent(item: AuroraApiRow): NormalizedLogbookRow {
 
 function normalizeBid(item: AuroraApiRow): NormalizedLogbookRow {
   return {
-    auroraId: String(item.uuid),
-    climbUuid: String(item.climb_uuid),
-    angle: Number(item.angle),
+    auroraId: requireStorableId(item.uuid, 'uuid'),
+    climbUuid: requireStorableId(item.climb_uuid, 'climb_uuid'),
+    angle: requireAngle(item.angle),
     isMirror: toBool(item.is_mirror),
     status: 'attempt',
-    attemptCount: Number(item.bid_count || 1),
+    attemptCount: int4OrNull(item.bid_count || 1) ?? 1,
     quality: null,
     difficulty: null,
     isBenchmark: false,
-    comment: item.comment ? String(item.comment) : '',
+    comment: stripUnstorableText(item.comment ? String(item.comment) : ''),
     climbedAt: normalizeTimestamp(String(item.climbed_at)),
     createdAt: item.created_at
       ? normalizeTimestamp(String(item.created_at))
@@ -158,6 +257,203 @@ function chunk<T>(items: T[], size: number): T[][] {
   const out: T[][] = [];
   for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
   return out;
+}
+
+// --- Skip quarantine (#3871) ------------------------------------------------
+
+/** One upstream row this sync refused, on its way to logbook_sync_skips. */
+type LogbookSkipRecord = {
+  auroraId: string;
+  auroraType: 'ascents' | 'bids';
+  reason: LogbookSyncSkipReason;
+  detail: string;
+  payload: unknown;
+};
+
+/** Params bound per DELETE when clearing resolved skips; well under PG's 65535. */
+const SKIP_RECONCILE_CHUNK_SIZE = 500;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Scrub a value into something `jsonb` will accept.
+ *
+ * The payload we quarantine is very often the row carrying the exact bytes
+ * Postgres refused, so serializing it naively would make the RECORD of the
+ * failure fail the same way — and that write lives in the caller's cross-table
+ * transaction, so it would recreate the very wedge this table reports.
+ */
+function storableJson(value: unknown): unknown {
+  if (typeof value === 'string') return stripUnstorableText(value);
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) return value.map(storableJson);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        stripUnstorableText(key),
+        storableJson(entry),
+      ]),
+    );
+  }
+  return value;
+}
+
+/**
+ * Persist this run's skips so a dropped row is quarantined-and-replayable
+ * rather than silently discarded. Best-effort by construction: wrapped in its
+ * own savepoint so a failure to RECORD the problem can never become a bigger
+ * problem than the one it was reporting.
+ */
+async function recordLogbookSyncSkips(
+  db: DrizzleDb,
+  boardName: AuroraBoardName,
+  userId: string,
+  skips: LogbookSkipRecord[],
+): Promise<void> {
+  if (skips.length === 0) return;
+
+  // ON CONFLICT DO UPDATE cannot touch the same row twice in one statement
+  // ("cannot affect row a second time"), and a duplicated upstream uuid whose
+  // copies BOTH fail is exactly the shape that produces that. Last wins.
+  const byAuroraId = new Map<string, LogbookSkipRecord>();
+  for (const skip of skips) byAuroraId.set(`${skip.auroraType} ${skip.auroraId}`, skip);
+
+  const now = new Date().toISOString();
+  try {
+    await db.transaction(async (sp) => {
+      await sp
+        .insert(logbookSyncSkips)
+        .values(
+          [...byAuroraId.values()].map((skip) => ({
+            userId,
+            boardType: boardName,
+            auroraType: skip.auroraType,
+            auroraId: skip.auroraId,
+            reason: skip.reason,
+            detail: stripUnstorableText(skip.detail).slice(0, 2000),
+            payload: storableJson(skip.payload),
+            firstSeenAt: now,
+            lastSeenAt: now,
+            seenCount: 1,
+          })),
+        )
+        .onConflictDoUpdate({
+          target: [
+            logbookSyncSkips.userId,
+            logbookSyncSkips.boardType,
+            logbookSyncSkips.auroraType,
+            logbookSyncSkips.auroraId,
+          ],
+          set: {
+            reason: sql`excluded.reason`,
+            detail: sql`excluded.detail`,
+            payload: sql`excluded.payload`,
+            lastSeenAt: sql`excluded.last_seen_at`,
+            // first_seen_at deliberately NOT overwritten: "since when" is the
+            // question triage actually asks.
+            seenCount: sql`${logbookSyncSkips.seenCount} + 1`,
+          },
+        });
+    });
+  } catch (error) {
+    console.warn(
+      `[aurora-sync] could not record ${byAuroraId.size} logbook sync skip(s) for user ${userId} on ${boardName}: ${errorMessage(error)}`,
+    );
+  }
+}
+
+/**
+ * Drop quarantine rows for upstream ids that just synced cleanly, so the table
+ * answers "what is broken right now" instead of accumulating into "what ever
+ * broke" — the difference between state and a counter, and the reason this is
+ * queryable at all (see docs/aurora-sync.md).
+ */
+async function reconcileLogbookSyncSkips(
+  db: DrizzleDb,
+  boardName: AuroraBoardName,
+  userId: string,
+  auroraType: 'ascents' | 'bids',
+  handledIds: string[],
+  skips: LogbookSkipRecord[],
+): Promise<void> {
+  const stillSkipped = new Set(skips.filter((skip) => skip.auroraType === auroraType).map((skip) => skip.auroraId));
+  const resolved = [...new Set(handledIds.filter((id) => !stillSkipped.has(id)))];
+  if (resolved.length === 0) return;
+
+  try {
+    // One savepoint around every chunk: same "reporting must not wedge the
+    // sync" rule as recordLogbookSyncSkips, at one subtransaction per payload.
+    await db.transaction(async (sp) => {
+      for (const ids of chunk(resolved, SKIP_RECONCILE_CHUNK_SIZE)) {
+        await sp
+          .delete(logbookSyncSkips)
+          .where(
+            and(
+              eq(logbookSyncSkips.userId, userId),
+              eq(logbookSyncSkips.boardType, boardName),
+              eq(logbookSyncSkips.auroraType, auroraType),
+              inArray(logbookSyncSkips.auroraId, ids),
+            ),
+          );
+      }
+    });
+  } catch (error) {
+    console.warn(
+      `[aurora-sync] could not clear resolved logbook sync skips for user ${userId} on ${boardName}: ${errorMessage(error)}`,
+    );
+  }
+}
+
+/**
+ * Turn a normalize/validate throw into a quarantine record. A LogbookRowRejected
+ * carries its own triage code; anything else is the parse-time class PR #3872
+ * (issue #3520) skips-and-logs, recorded here so those skips stop being
+ * console-only too.
+ */
+function skipFromNormalizeError(
+  item: AuroraApiRow,
+  error: unknown,
+  auroraType: 'ascents' | 'bids',
+  userId: string,
+  boardName: AuroraBoardName,
+): LogbookSkipRecord {
+  const reason: LogbookSyncSkipReason = error instanceof LogbookRowRejected ? error.reason : 'normalize_failed';
+  console.warn(
+    `[aurora-sync] skipping malformed ${auroraType === 'ascents' ? 'ascent' : 'bid'} row (uuid=${String(item.uuid)}, user=${userId}, board=${boardName}, reason=${reason}): ${errorMessage(error)}`,
+  );
+  return {
+    // String() and not requireStorableId: the id may be the very thing that's
+    // broken, and a quarantine row with a scrubbed id still beats no record.
+    auroraId: stripUnstorableText(String(item.uuid ?? '')).slice(0, 255),
+    auroraType,
+    reason,
+    detail: errorMessage(error),
+    payload: item,
+  };
+}
+
+/**
+ * Last-write-wins dedupe on aurora_id.
+ *
+ * Two rows sharing an aurora_id are both "misses" (neither is stored yet), so
+ * both would be INSERTed and boardsesh_ticks_aurora_id_unique would abort the
+ * chunk — deterministically, every cycle, forever. Deduping at PAYLOAD level
+ * rather than per chunk matters: a chunk boundary between the two copies would
+ * hide the collision from a per-chunk guard and let it reach the index.
+ *
+ * Not a quarantine case: same id means same upstream row, so keeping the last
+ * copy loses nothing (it is what the DB would have converged on anyway).
+ */
+function dedupeByAuroraId(rows: NormalizedLogbookRow[]): NormalizedLogbookRow[] {
+  const byId = new Map<string, NormalizedLogbookRow>();
+  for (const row of rows) byId.set(row.auroraId, row);
+  if (byId.size !== rows.length) {
+    console.warn(`[aurora-sync] collapsed ${rows.length - byId.size} duplicate aurora_id row(s) in one payload`);
+  }
+  return [...byId.values()];
 }
 
 /**
@@ -250,6 +546,7 @@ async function applyLogbookChunk(
   now: string,
   auroraType: 'ascents' | 'bids',
   claimStatuses: Array<'flash' | 'send' | 'attempt'>,
+  skips: LogbookSkipRecord[],
 ): Promise<ClimbStatsKey[]> {
   const touched: ClimbStatsKey[] = [];
   const addKey = (climbUuid: string, angle: number) => touched.push({ boardType: boardName, climbUuid, angle });
@@ -404,12 +701,23 @@ async function applyLogbookChunk(
   // (d) Inserts: misses that weren't claimed.
   const inserts = misses.filter((m) => !claims.has(m.auroraId));
 
-  // --- Writes ---
-  if (claims.size > 0) {
-    const claimPayload = JSON.stringify(
-      [...claims.entries()].map(([auroraId, uuid]) => ({ uuid, aurora_id: auroraId })),
-    );
-    await db.execute(sql`
+  // Touched keys are collected BEFORE the writes and deliberately left as a
+  // superset: a row that the fallback below ends up skipping leaves its
+  // (climb, angle) in the list, and recomputing stats for it is idempotent —
+  // cheaper than threading write outcomes back through the key list.
+  for (const { row, stored } of updates) {
+    // A re-sync can move a log to a different climb/angle; recompute both.
+    addKey(stored.climbUuid, stored.angle);
+    addKey(row.climbUuid, row.angle);
+  }
+  for (const row of inserts) addKey(row.climbUuid, row.angle);
+
+  const claimEntries = [...claims.entries()];
+
+  const writeClaims = async (target: DrizzleDb, entries: Array<[string, string]>): Promise<void> => {
+    if (entries.length === 0) return;
+    const claimPayload = JSON.stringify(entries.map(([auroraId, uuid]) => ({ uuid, aurora_id: auroraId })));
+    await target.execute(sql`
       UPDATE boardsesh_ticks AS t SET
         aurora_id = u.aurora_id,
         aurora_type = ${auroraType}::aurora_table_type,
@@ -426,16 +734,15 @@ async function applyLogbookChunk(
       WHERE t.uuid = u.uuid
         AND t.user_id = ${userId}
     `);
-  }
+  };
 
-  if (updates.length > 0) {
-    for (const { row, stored } of updates) {
-      // A re-sync can move a log to a different climb/angle; recompute both.
-      addKey(stored.climbUuid, stored.angle);
-      addKey(row.climbUuid, row.angle);
-    }
+  const writeUpdates = async (
+    target: DrizzleDb,
+    rows: Array<{ row: NormalizedLogbookRow; stored: ComparedRow }>,
+  ): Promise<void> => {
+    if (rows.length === 0) return;
     const updatePayload = JSON.stringify(
-      updates.map(({ row }) => ({
+      rows.map(({ row }) => ({
         aurora_id: row.auroraId,
         climb_uuid: row.climbUuid,
         angle: row.angle,
@@ -451,7 +758,7 @@ async function applyLogbookChunk(
         updated_at: now,
       })),
     );
-    await db.execute(sql`
+    await target.execute(sql`
       UPDATE boardsesh_ticks AS t SET
         climb_uuid = u.climb_uuid,
         angle = u.angle,
@@ -487,38 +794,98 @@ async function applyLogbookChunk(
       WHERE t.aurora_id = u.aurora_id
         AND t.user_id = ${userId}
     `);
-  }
+  };
 
-  if (inserts.length > 0) {
-    await db.insert(boardseshTicks).values(
-      inserts.map((row) => {
-        addKey(row.climbUuid, row.angle);
-        return {
-          uuid: randomUUID(),
-          userId,
-          boardType: boardName,
-          climbUuid: row.climbUuid,
-          angle: row.angle,
-          isMirror: row.isMirror,
-          // Freshly pulled from the user's Aurora logbook — already inside
-          // upstream_ascensionist_count, so origin excludes it from the
-          // Boardsesh double-count guard.
-          origin: 'aurora_pull' as const,
-          status: row.status,
-          attemptCount: row.attemptCount,
-          quality: row.quality,
-          difficulty: row.difficulty,
-          isBenchmark: row.isBenchmark,
-          comment: row.comment,
-          climbedAt: row.climbedAt,
-          createdAt: row.createdAt,
-          updatedAt: now,
-          auroraType: row.auroraType,
-          auroraId: row.auroraId,
-          auroraSyncedAt: now,
-        };
-      }),
+  const writeInserts = async (target: DrizzleDb, rows: NormalizedLogbookRow[]): Promise<void> => {
+    if (rows.length === 0) return;
+    await target.insert(boardseshTicks).values(
+      rows.map((row) => ({
+        uuid: randomUUID(),
+        userId,
+        boardType: boardName,
+        climbUuid: row.climbUuid,
+        angle: row.angle,
+        isMirror: row.isMirror,
+        // Freshly pulled from the user's Aurora logbook — already inside
+        // upstream_ascensionist_count, so origin excludes it from the
+        // Boardsesh double-count guard.
+        origin: 'aurora_pull' as const,
+        status: row.status,
+        attemptCount: row.attemptCount,
+        quality: row.quality,
+        difficulty: row.difficulty,
+        isBenchmark: row.isBenchmark,
+        comment: row.comment,
+        climbedAt: row.climbedAt,
+        createdAt: row.createdAt,
+        updatedAt: now,
+        auroraType: row.auroraType,
+        auroraId: row.auroraId,
+        auroraSyncedAt: now,
+      })),
     );
+  };
+
+  // --- Writes ---
+  //
+  // ONE savepoint around the chunk's three batched writes (#3871). Without it,
+  // a single row Postgres refuses aborts the caller's transaction — and that
+  // transaction spans EVERY synced table plus the sync checkpoint, so one bad
+  // ascent rolls back bids, tags and circuits and stops the watermark
+  // advancing. The next cycle re-fetches the same row and re-crashes: the
+  // user's logbook stops updating permanently, with nothing surfaced.
+  //
+  // Rolling back to the savepoint leaves the outer transaction healthy, so the
+  // chunk can be replayed row by row and lose only the offending row. This is
+  // PR #3872's skip-and-log philosophy (issue #3520) one layer down, at
+  // DB-execution time instead of parse time.
+  //
+  // Cost bound: one open subtransaction per chunk (postgres.js does not RELEASE
+  // savepoints), and syncUserData opens a fresh transaction per Aurora PAGE, so
+  // the live count is (page size / WRITE_CHUNK_SIZE) — ~10 for a 1000-row page,
+  // comfortably under the 64-subxid backend cache threshold past which other
+  // backends fall back to pg_subtrans lookups. Raising the page size raises
+  // this: keep a page under ~6400 rows.
+  try {
+    await db.transaction(async (savepoint) => {
+      const sp = savepoint as unknown as DrizzleDb;
+      await writeClaims(sp, claimEntries);
+      await writeUpdates(sp, updates);
+      await writeInserts(sp, inserts);
+    });
+  } catch (batchError) {
+    console.warn(
+      `[aurora-sync] batched ${auroraType} write failed for user ${userId} on ${boardName} (${incoming.length} row(s)); retrying row by row: ${errorMessage(batchError)}`,
+    );
+
+    // The savepoint rolled back ALL THREE writes above, so the replay redoes
+    // all three — not just whichever one threw.
+    const replay = async <T>(
+      rows: T[],
+      write: (target: DrizzleDb, subset: T[]) => Promise<void>,
+      identify: (row: T) => { auroraId: string; payload: unknown },
+    ): Promise<void> => {
+      for (const row of rows) {
+        try {
+          await db.transaction(async (savepoint) => {
+            await write(savepoint as unknown as DrizzleDb, [row]);
+          });
+        } catch (rowError) {
+          const { auroraId, payload } = identify(row);
+          console.warn(
+            `[aurora-sync] skipping ${auroraType} row Postgres refused (aurora_id=${auroraId}, user=${userId}, board=${boardName}): ${errorMessage(rowError)}`,
+          );
+          skips.push({ auroraId, auroraType, reason: 'db_write_rejected', detail: errorMessage(rowError), payload });
+        }
+      }
+    };
+
+    await replay(claimEntries, writeClaims, ([auroraId, uuid]) => ({
+      auroraId,
+      payload: { uuid, aurora_id: auroraId },
+    }));
+    await replay(updates, writeUpdates, ({ row }) => ({ auroraId: row.auroraId, payload: row }));
+    await replay(inserts, writeInserts, (row) => ({ auroraId: row.auroraId, payload: row }));
   }
 
   return touched;
@@ -538,6 +905,8 @@ export async function applyAuroraAscents(
   const now = new Date().toISOString();
   const touchedKeys: ClimbStatsKey[] = [];
 
+  const skips: LogbookSkipRecord[] = [];
+
   const tombstoneIds: string[] = [];
   const live: NormalizedLogbookRow[] = [];
   for (const item of data) {
@@ -546,29 +915,41 @@ export async function applyAuroraAscents(
     } else {
       // A single row with an unparseable timestamp (missing/garbage
       // climbed_at, or a created_at so malformed the climbed_at fallback
-      // above doesn't save it) must not abort the whole payload: this runs
-      // inside syncUserData's one cross-table transaction, so an uncaught
-      // throw here rolls back every OTHER table that already synced this
-      // attempt AND blocks the checkpoint from advancing — the next attempt
-      // just re-fetches and re-crashes on the same poison row forever (#3520).
-      // Skip-and-log the one row; every other row in the payload still lands.
+      // above doesn't save it), or one carrying a value Postgres could never
+      // store, must not abort the whole payload: this runs inside
+      // syncUserData's one cross-table transaction, so an uncaught throw here
+      // rolls back every OTHER table that already synced this attempt AND
+      // blocks the checkpoint from advancing — the next attempt just re-fetches
+      // and re-crashes on the same poison row forever (#3520). Skip-and-record
+      // the one row; every other row in the payload still lands.
       try {
         live.push(normalizeAscent(item));
       } catch (error) {
-        console.warn(
-          `[aurora-sync] skipping malformed ascent row (uuid=${String(item.uuid)}, user=${userId}, board=${boardName}): ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
+        skips.push(skipFromNormalizeError(item, error, 'ascents', userId, boardName));
       }
     }
   }
 
   touchedKeys.push(...(await applyAuroraTombstones(db, boardName, userId, tombstoneIds)));
 
-  for (const batch of chunk(live, WRITE_CHUNK_SIZE)) {
-    touchedKeys.push(...(await applyLogbookChunk(db, boardName, userId, batch, now, 'ascents', ['flash', 'send'])));
+  const unique = dedupeByAuroraId(live);
+  for (const batch of chunk(unique, WRITE_CHUNK_SIZE)) {
+    touchedKeys.push(
+      ...(await applyLogbookChunk(db, boardName, userId, batch, now, 'ascents', ['flash', 'send'], skips)),
+    );
   }
+
+  await recordLogbookSyncSkips(db, boardName, userId, skips);
+  // Tombstoned ids count as handled: a quarantined row deleted upstream is no
+  // longer a problem anyone can fix, so its record should go too.
+  await reconcileLogbookSyncSkips(
+    db,
+    boardName,
+    userId,
+    'ascents',
+    [...tombstoneIds, ...unique.map((row) => row.auroraId)],
+    skips,
+  );
 
   await recomputeClimbStatsBulk(db, touchedKeys);
 }
@@ -584,7 +965,9 @@ export async function applyAuroraBids(
   const now = new Date().toISOString();
   const touchedKeys: ClimbStatsKey[] = [];
 
-  // Same skip-and-log rationale as applyAuroraAscents above: one malformed
+  const skips: LogbookSkipRecord[] = [];
+
+  // Same skip-and-record rationale as applyAuroraAscents above: one malformed
   // bid must not throw out of the eager normalize pass and abort every other
   // table in the caller's transaction (#3520).
   const live: NormalizedLogbookRow[] = [];
@@ -592,16 +975,24 @@ export async function applyAuroraBids(
     try {
       live.push(normalizeBid(item));
     } catch (error) {
-      console.warn(
-        `[aurora-sync] skipping malformed bid row (uuid=${String(item.uuid)}, user=${userId}, board=${boardName}): ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
+      skips.push(skipFromNormalizeError(item, error, 'bids', userId, boardName));
     }
   }
-  for (const batch of chunk(live, WRITE_CHUNK_SIZE)) {
-    touchedKeys.push(...(await applyLogbookChunk(db, boardName, userId, batch, now, 'bids', ['attempt'])));
+
+  const unique = dedupeByAuroraId(live);
+  for (const batch of chunk(unique, WRITE_CHUNK_SIZE)) {
+    touchedKeys.push(...(await applyLogbookChunk(db, boardName, userId, batch, now, 'bids', ['attempt'], skips)));
   }
+
+  await recordLogbookSyncSkips(db, boardName, userId, skips);
+  await reconcileLogbookSyncSkips(
+    db,
+    boardName,
+    userId,
+    'bids',
+    unique.map((row) => row.auroraId),
+    skips,
+  );
 
   await recomputeClimbStatsBulk(db, touchedKeys);
 }

--- a/packages/aurora-sync/src/sync/apply-user-logbook.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.ts
@@ -145,7 +145,11 @@ function int4OrNull(value: unknown): number | null {
  * sequence" / "invalid input syntax for type json"), and the text bind path
  * rejects the raw bytes — which is exactly the deterministic chunk-killer this
  * guard exists to stop.
+ *
+ * Matching the NUL control character is the entire purpose of the pattern, not
+ * an accident, hence the disable below.
  */
+// oxlint-disable-next-line no-control-regex
 const UNSTORABLE_TEXT = /\u0000|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
 
 function stripUnstorableText(value: string): string {
@@ -359,8 +363,14 @@ async function recordLogbookSyncSkips(
         });
     });
   } catch (error) {
-    console.warn(
-      `[aurora-sync] could not record ${byAuroraId.size} logbook sync skip(s) for user ${userId} on ${boardName}: ${errorMessage(error)}`,
+    // console.ERROR, not warn: this is the double-failure case. The rows were
+    // already dropped from the sync, so losing the record too means they are
+    // gone with no trace and no way to replay them — strictly worse than the
+    // skips this function exists to make visible. Swallowing is still correct
+    // (throwing would abort the caller's cross-table transaction and recreate
+    // the #3871 wedge), so the log line is the only signal an operator gets.
+    console.error(
+      `[aurora-sync] FAILED to record ${byAuroraId.size} logbook sync skip(s) for user ${userId} on ${boardName} — those rows are now dropped with no quarantine record: ${errorMessage(error)}`,
     );
   }
 }
@@ -985,6 +995,11 @@ export async function applyAuroraBids(
   }
 
   await recordLogbookSyncSkips(db, boardName, userId, skips);
+  // No tombstone ids to add here (unlike ascents): Aurora does not tombstone
+  // bids, so this function has no is_listed=false path. If one is ever added,
+  // feed its ids in here too — otherwise a quarantined bid that upstream later
+  // deletes would sit in logbook_sync_skips forever, since a deleted row never
+  // comes back to resolve itself.
   await reconcileLogbookSyncSkips(
     db,
     boardName,

--- a/packages/aurora-sync/src/sync/apply-user-logbook.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.ts
@@ -890,9 +890,13 @@ async function applyLogbookChunk(
       }
     };
 
+    // Quarantine the FULL normalized row, not just the {uuid, aurora_id} link
+    // the claim statement happens to bind: the link alone can't be replayed
+    // into a tick, and triage needs to see what the row actually was.
+    const incomingByAuroraId = new Map(incoming.map((row) => [row.auroraId, row]));
     await replay(claimEntries, writeClaims, ([auroraId, uuid]) => ({
       auroraId,
-      payload: { uuid, aurora_id: auroraId },
+      payload: { claimedTickUuid: uuid, row: incomingByAuroraId.get(auroraId) ?? null },
     }));
     await replay(updates, writeUpdates, ({ row }) => ({ auroraId: row.auroraId, payload: row }));
     await replay(inserts, writeInserts, (row) => ({ auroraId: row.auroraId, payload: row }));


### PR DESCRIPTION
## Summary

One upstream logbook row that Postgres refuses used to freeze a user's entire Aurora sync, permanently and silently. Closes #3871.

`applyLogbookChunk` issues three **batched** writes per ~100 rows — a claims UPDATE, a `jsonb_to_recordset` UPDATE, and an INSERT — with no try/catch. Nothing between there and `syncUserData` catches either, and `syncUserData` wraps **every** table in one `db.transaction`. `USER_TABLES` order is `users, walls, wall_expungements, draft_climbs, ascents, bids, tags, circuits`, so a single bad **ascent** rolled back bids, tags, circuits **and** the sync checkpoint together. The next cycle re-fetched the same row and re-crashed on it. Forever, with nothing surfaced to the user.

This is the DB-execution-time sibling of the parse-time wedge PR #3872 fixed for issue #3520, and it gets that PR's skip-and-log philosophy one layer down.

### Three mechanisms, deliberately independent

**1. Savepoint + row-by-row replay.** One nested `db.transaction()` (a real `SAVEPOINT` on postgres-js) wraps a chunk's three batched writes. On failure it rolls back — leaving the caller's transaction healthy — and replays all three one row at a time, each in its own savepoint. Only the offending row is lost.

**2. Pre-write validation** of the four `integer` columns feeding the `jsonb_to_recordset` UPDATE.

> ⚠️ **This is not redundant with the fallback, and a future refactor should not delete it as such.** `angle` also flows into `recomputeClimbStatsBulk`'s own `jsonb_to_recordset(… angle integer)` + `INSERT INTO board_climb_stats`, which runs **after** the chunk loop and **outside** any write fallback. A `NaN` angle aborts the transaction at that second site no matter how good the row-by-row replay is. Validation is the only guard there.

| column | shape | failure without the guard | rule |
| --- | --- | --- | --- |
| `angle` | `integer NOT NULL` | `NaN` → `JSON.stringify` emits `null` → NOT NULL violation; `"NaN"` on the INSERT path; **plus** the recompute abort above | **drop the row** — no honest default |
| `attempt_count` | `integer NOT NULL DEFAULT 1` | same | coerce to `1` |
| `quality` | `integer` + CHECK `1..5` | safe today; a future star-scale change re-poisons it silently | coerce to `NULL` |
| `difficulty` | `integer` | `toNumberOrNull` guarantees finite but **not integral** — `21.5` is `invalid input syntax for type integer` | coerce to `NULL` |

Plus two same-class deterministic chunk-killers: a NUL byte / unpaired surrogate (rejected by `::jsonb` and by the text bind path) is stripped from `comment` and drops the row only if it corrupts an identity column; and a duplicate `aurora_id` **within one payload** is collapsed last-wins before it can collide on `boardsesh_ticks_aurora_id_unique` (deduped at payload level, since a chunk boundary between the two copies would hide it from a per-chunk guard).

Principle: **coerce what's safely coercible, drop only what's unusable.** A send with a garbage star rating still shows up in the logbook.

**3. `logbook_sync_skips`** (new table). **The quarantine is the reason a drop is allowed.** Dropping a row means a climber loses a send, and that is only defensible because the normalized payload is kept — the send is quarantined and replayable, not gone. Take the table away and mechanism 2 becomes silently discarding user data, which would not be acceptable.

`reason` is a pgEnum (`logbook_sync_skip_reason`), not free `text` — the reason codes are the grouping key of the triage query, so one off-contract string would split a cluster and quietly under-report it.

It is **state, not a counter**: a row is deleted the moment that `aurora_id` syncs cleanly, so the table always answers "what is broken right now". A per-cycle counter would report once and then clear itself on the next cycle, when Aurora's incremental delta is empty and nothing was skipped because nothing arrived — exactly how #3523's equivalent stayed hidden for years. (Same reasoning #3931 gives for making its duplicate-account check a state query rather than a per-cycle count.)

### Checkpoint advances past a skipped row

Deliberately. Not advancing **is** the wedge — a row Postgres will never accept cannot be fixed by retrying it forever. A skipped row returns when the user edits it upstream, when the watermark resets (`clearAuroraBoardData` drops `board_user_syncs`), or via the JSON export import; and `payload` makes an offline replay possible meanwhile.

### Scope

The single cross-table transaction is **untouched**. That is the right boundary, not a compromise: the data write and the checkpoint advance must commit together, or a crash between them silently drops a page of ascents. Containing the abort at the savepoint fixes the blast radius without breaking that invariant — and as a result **neither `user-sync.ts` needed changing**. Both the daemon and the web cron path share the module, so both are fixed by the same diff.

### Migration numbering — resolved, the DDL now lives in #3963

The provisional-`0187` warning that used to sit here has been actioned. Four PRs were all holding `0187` against a `main` that tops out at `0186`, so the four schema changes were collapsed into **one** regenerated migration on `chore/collapse-0187-migrations` (#3963) — never hand-renumbered, since the journal has to stay strictly ordered (a gap makes `migrate.ts` only warn and then silently skip earlier migrations, #2933).

This PR is now based on #3963 and carries no migration: the `logbook_sync_skip_reason` enum, the `logbook_sync_skips` table, its FK to `users` and its three indexes all moved there unchanged, along with `packages/db/src/schema/app/logbook-sync-skips.ts`. What stays here is the savepoint replay, the reconcile and the quarantine writes. GitHub retargets this to `main` when #3963 merges.

## Release Notes

- Your logbook keeps syncing even when one old ascent is broken beyond repair — Boardsesh sets that one aside and carries on instead of quietly freezing every send, attempt and circuit behind it.

## Test plan

- [x] 14 new tests in `packages/aurora-sync/src/sync/apply-user-logbook.test.ts`; full project green (117 tests, up from 103). The tx shim gained a `transaction()` that reproduces postgres-js savepoint semantics (rollback, then rethrow), and quarantine writes are tracked under their own call kinds so they can't inflate the tick-write counts the existing suite asserts on.
- [x] **Mutation-tested — each mechanism is independently observable:**
  - delete the row-by-row replay → **5 fail** (zero rows land instead of 2, and `applyAuroraAscents` rejects)
  - delete the `angle` validation → **3 fail**, and *the isolation tests stay green* — proving neither mechanism silently substitutes for the other
  - delete the quarantine write → **7 fail**
- [x] Behaviour exercised against a **throwaway `postgres:17` container on port 55871** (never the ambient `DB_URL`, never `db:migrate`/`dev-db-up.sh`): the `ON CONFLICT` upsert bumps `seen_count` while preserving `first_seen_at`, the reconcile `DELETE` clears the row, the FK cascades on user deletion, the triage query from the docs runs, all four reason codes are accepted and an off-contract reason is **refused** by the enum. Container removed afterwards.
- [x] The DDL itself is verified in #3963 — applied, idempotent on re-run, no stray `DROP`, and the known `boardsesh_ticks_quality_range` CHECK footgun did not fire.
- [x] `vp run typecheck` (whole repo) — clean
- [x] `vp check` — clean (`All 4675 files are correctly formatted`; remaining lint warnings are pre-existing, in `packages/mobile`)
- [x] `vp test run --project aurora-sync --project kilter-sync --project sync-runtime` — 23 files, 283 tests passing
- [x] Pre-existing failures confirmed **not mine** by re-running with the branch stashed: `packages/db`'s `user-boards-serial-uniqueness.integration.test.ts` (needs a live DB) and the backend project fail identically on a pristine tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL

