### PR TITLE
ci(db): auto-renumber stranded migration PRs when main takes their number

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Schema barrel files are append-only export lists, so two branches that each add
+# a table both append to the same last line and conflict on every rebase — even
+# though the resolution is always "keep both". `merge=union` is git's built-in
+# answer for exactly this file shape: it takes the lines from both sides.
+#
+# This is what makes automatic migration renumbering (vp run db:renumber, and
+# .github/workflows/db-migration-renumber.yml) useful in practice. Without it,
+# essentially every table-adding PR conflicts here and needs a human.
+#
+# Safe because the failure mode is loud: if both sides add the *same* export, the
+# union keeps both copies and TypeScript fails the build. It never silently drops
+# a line, which is the outcome that would actually hurt.
+packages/db/src/schema/**/index.ts merge=union

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,30 @@ jobs:
       - name: Typecheck (cache-driven affected)
         run: vp run typecheck
 
+  db-migrations:
+    needs: [changes]
+    # Cheap (a few file reads, no DB, no build), so it gates on the whole
+    # packages/db path rather than trying to be clever about which files matter.
+    if: needs.changes.outputs.sharedDeps == 'true' || needs.changes.outputs.rootCi == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Needs origin/main reachable to compare numbering and `when` against it.
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Validate the migration folder
+        run: |
+          git fetch --no-tags --depth=1 origin main
+          vp run check:db-migrations -- --base origin/main
+
   codegen-drift:
     needs: [changes, setup]
     # codegen.ts pulls GraphQL documents from packages/web/app/**/*.{ts,tsx}
@@ -737,6 +761,7 @@ jobs:
       - setup
       - lint
       - typecheck
+      - db-migrations
       - codegen-drift
       - i18n
       - test-default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       # PR-only guard signal: did this PR edit the OTA-owned changelog data file?
       # Defaults false off PRs (the OTA bot legitimately rewrites it on push).
       changelogData: ${{ github.event_name == 'pull_request' && steps.filter.outputs.changelogData || 'false' }}
+      dbMigrations: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.dbMigrations }}
       # True if any downstream job's gate would fire. setup gates on this so
       # docs-only / firmware-only PRs skip the bun-install + build:db pass
       # nothing downstream would consume. Must mirror the union of every
@@ -106,6 +107,11 @@ jobs:
             changelogData:
               - 'packages/mobile/src/data/changelog.generated.json'
               - 'CHANGELOG.md'
+            dbMigrations:
+              - 'packages/db/drizzle/**'
+              - 'packages/db/src/schema/**'
+              - 'scripts/check-db-migrations.ts'
+              - 'scripts/lib/drizzle-migrations.ts'
 
   setup:
     needs: [changes]
@@ -246,9 +252,10 @@ jobs:
 
   db-migrations:
     needs: [changes]
-    # Cheap (a few file reads, no DB, no build), so it gates on the whole
-    # packages/db path rather than trying to be clever about which files matter.
-    if: needs.changes.outputs.sharedDeps == 'true' || needs.changes.outputs.rootCi == 'true'
+    # Gated on the migration folder and the schema it is checked against, not on
+    # the whole sharedDeps blob (which also covers packages/shared, shared-schema,
+    # board-constants and the sync packages).
+    if: needs.changes.outputs.dbMigrations == 'true' || needs.changes.outputs.rootCi == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/db-migration-renumber-dispatch.yml
+++ b/.github/workflows/db-migration-renumber-dispatch.yml
@@ -22,9 +22,12 @@ permissions:
   pull-requests: read
 
 concurrency:
-  # Collapse a burst of migration merges into a single fan-out.
   group: db-migration-renumber-dispatch
-  cancel-in-progress: true
+  # Queue, never cancel. Cancelling a fan-out mid-loop would silently drop every PR
+  # it hadn't reached yet, and they would stay stranded until the *next* migration
+  # merge. A queued second run is cheap — it re-scans and skips anything already
+  # renumbered, because it only acts on real collisions.
+  cancel-in-progress: false
 
 jobs:
   fan-out:

--- a/.github/workflows/db-migration-renumber-dispatch.yml
+++ b/.github/workflows/db-migration-renumber-dispatch.yml
@@ -1,0 +1,139 @@
+name: DB Migration Renumber Dispatch
+
+# When a migration lands on `main`, every other open migration PR is stranded: they
+# all appended to the same `_journal.json` tail, so they go from MERGEABLE to
+# CONFLICTING the instant one of them merges. This fans out a renumber run for each
+# one, so the queue drains instead of serializing behind whoever merged first.
+#
+# Uses GITHUB_TOKEN, not the App token: `workflow_dispatch` is the documented
+# exception to "events triggered by GITHUB_TOKEN don't create a workflow run", so
+# `actions: write` is all this needs. Only the force-push in the worker needs the App.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/db/drizzle/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+  pull-requests: read
+
+concurrency:
+  # Collapse a burst of migration merges into a single fan-out.
+  group: db-migration-renumber-dispatch
+  cancel-in-progress: true
+
+jobs:
+  fan-out:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Dispatch a renumber for every stranded migration PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const DRIZZLE_DIR = 'packages/db/drizzle';
+            const MIGRATION_RE = /^(\d{4})_.+\.sql$/;
+            const pad = (index) => String(index).padStart(4, '0');
+
+            const listMigrations = async (ref) => {
+              const { data } = await github.rest.repos.getContent({
+                owner: context.repo.owner, repo: context.repo.repo, path: DRIZZLE_DIR, ref,
+              });
+              return data.filter((item) => item.type === 'file' && MIGRATION_RE.test(item.name)).map((item) => item.name);
+            };
+            const indexOf = (name) => Number(MIGRATION_RE.exec(name)[1]);
+
+            // Fail closed. If main's state can't be established we dispatch NOTHING
+            // rather than force-pushing every migration PR on a bad reading.
+            let mainFiles, mainNext;
+            try {
+              const { data: journalFile } = await github.rest.repos.getContent({
+                owner: context.repo.owner, repo: context.repo.repo,
+                path: `${DRIZZLE_DIR}/meta/_journal.json`, ref: 'main',
+              });
+              const journal = JSON.parse(Buffer.from(journalFile.content, 'base64').toString('utf8'));
+              mainFiles = await listMigrations('main');
+              // Max of the journal tail and every on-disk prefix — the two can
+              // disagree when an orphaned .sql sits above the tail.
+              mainNext = Math.max(
+                ...journal.entries.map((entry) => entry.idx),
+                ...journal.entries.map((entry) => indexOf(`${entry.tag}.sql`)),
+                ...mainFiles.map(indexOf),
+              ) + 1;
+            } catch (error) {
+              core.setFailed(`Could not read main's migration state (${error}) — dispatched nothing.`);
+              return;
+            }
+            core.info(`main's next free migration number is ${pad(mainNext)}.`);
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100,
+            });
+            const repoFull = `${context.repo.owner}/${context.repo.repo}`;
+            const baseNames = new Set(mainFiles);
+            const dispatched = [];
+            const skipped = [];
+
+            for (const pr of prs) {
+              if (!pr.labels.some((label) => label.name === 'db-migration')) continue;
+
+              if (pr.labels.some((label) => label.name === 'renumber:skip')) {
+                skipped.push([pr.number, 'opted out via renumber:skip']);
+                continue;
+              }
+              if (pr.head.repo?.full_name !== repoFull) {
+                // The App is installed on this repo only, so it cannot push to a fork
+                // even with maintainer_can_modify. Nothing to do but say so.
+                skipped.push([pr.number, 'fork PR — renumber by hand']);
+                continue;
+              }
+
+              let added;
+              try {
+                added = (await listMigrations(pr.head.sha)).filter((name) => !baseNames.has(name)).map(indexOf);
+              } catch (error) {
+                skipped.push([pr.number, `could not read its migration folder (${error.status ?? error})`]);
+                continue;
+              }
+              if (added.length === 0) {
+                skipped.push([pr.number, 'labelled but adds no migration']);
+                continue;
+              }
+              // Only act on a REAL collision. A PR already sitting above main has
+              // nothing to renumber, and force-pushing it would be pure churn.
+              if (Math.min(...added) >= mainNext) {
+                skipped.push([pr.number, `already above main (${added.map(pad).join(', ')})`]);
+                continue;
+              }
+              dispatched.push({ number: pr.number, added });
+            }
+
+            for (const entry of dispatched) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'db-migration-renumber.yml',
+                // Always the default-branch copy, so the worker's gates are never
+                // editable from the PR being acted on.
+                ref: 'main',
+                inputs: { pr: String(entry.number) },
+              });
+              core.notice(`Dispatched renumber for #${entry.number} (holds ${entry.added.map(pad).join(', ')}).`);
+            }
+
+            // A complete ledger: every labelled PR is either dispatched or has a
+            // stated reason. Silent truncation would read as "nothing to do".
+            for (const [number, reason] of skipped) core.info(`skip #${number}: ${reason}`);
+
+            await core.summary
+              .addHeading('Migration renumber fan-out', 3)
+              .addRaw(`main's next free number is \`${pad(mainNext)}\`.`)
+              .addList([
+                ...dispatched.map((entry) => `Dispatched #${entry.number} (holds ${entry.added.map(pad).join(', ')})`),
+                ...skipped.map(([number, reason]) => `Skipped #${number} — ${reason}`),
+              ])
+              .write();

--- a/.github/workflows/db-migration-renumber-dispatch.yml
+++ b/.github/workflows/db-migration-renumber-dispatch.yml
@@ -59,13 +59,20 @@ jobs:
               mainFiles = await listMigrations('main');
               // Max of the journal tail and every on-disk prefix — the two can
               // disagree when an orphaned .sql sits above the tail.
-              mainNext = Math.max(
-                ...journal.entries.map((entry) => entry.idx),
-                ...journal.entries.map((entry) => indexOf(`${entry.tag}.sql`)),
-                ...mainFiles.map(indexOf),
-              ) + 1;
+              mainNext =
+                Math.max(
+                  ...journal.entries.map((entry) => entry.idx),
+                  ...journal.entries.map((entry) => indexOf(`${entry.tag}.sql`)),
+                  ...mainFiles.map(indexOf),
+                ) + 1;
             } catch (error) {
               core.setFailed(`Could not read main's migration state (${error}) — dispatched nothing.`);
+              return;
+            }
+            // Spreading empty arrays into Math.max yields -Infinity, which would make
+            // every PR look like a collision and force-push the lot. Fail closed.
+            if (!Number.isFinite(mainNext) || mainNext <= 0) {
+              core.setFailed(`Computed an implausible next migration number (${mainNext}) — dispatched nothing.`);
               return;
             }
             core.info(`main's next free migration number is ${pad(mainNext)}.`);

--- a/.github/workflows/db-migration-renumber.yml
+++ b/.github/workflows/db-migration-renumber.yml
@@ -253,7 +253,9 @@ jobs:
               body += '\n\n> ⚠️ The branch moved while this ran, so nothing was pushed. It will retry on the next migration merge.';
             }
 
-            const { data: comments } = await github.rest.issues.listComments({
+            // Paginated: an unpaginated first-100 lookup would miss the marker on a
+            // long PR and post a duplicate comment every run instead of updating.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               ...context.repo, issue_number: Number(process.env.PR_NUMBER), per_page: 100,
             });
             const existing = comments.find((comment) => comment.body?.includes(marker));

--- a/.github/workflows/db-migration-renumber.yml
+++ b/.github/workflows/db-migration-renumber.yml
@@ -60,6 +60,18 @@ jobs:
       head_sha: ${{ steps.decide.outputs.head_sha }}
       skip_reason: ${{ steps.decide.outputs.skip_reason }}
     steps:
+      # Fail loudly rather than skipping. Without this the whole `renumber` job —
+      # including its comment step — is skipped by the `vars.OTA_PUSH_APP_ID` guard,
+      # so a missing or expired App credential looks exactly like "nothing to do":
+      # the dispatch fires, the gate passes, and stranded PRs get no explanation.
+      # This is operator misconfiguration, not a per-PR condition, so a red run is
+      # the right signal.
+      - name: Require the push credential
+        if: vars.OTA_PUSH_APP_ID == ''
+        run: |
+          echo "::error::OTA_PUSH_APP_ID is not configured, so the renumbered branch could not be pushed."
+          exit 1
+
       - name: Resolve and vet the PR
         id: decide
         uses: actions/github-script@v7

--- a/.github/workflows/db-migration-renumber.yml
+++ b/.github/workflows/db-migration-renumber.yml
@@ -141,6 +141,20 @@ jobs:
             || { echo "::error::Branch moved between the gate and checkout."; exit 1; }
           test "$BRANCH" != "main"
 
+      # Every PR in today's backlog was opened before this tooling existed, so their
+      # branches have no `scripts/db-renumber-migration.ts` and no `db:renumber`
+      # task. Run main's copy against the PR's checkout instead — the script imports
+      # nothing but Node builtins and its own lib/ sibling, so it needs no install of
+      # its own. Kept out of the workspace root would be tidier, but actions/checkout
+      # requires a path inside it; the script stages explicitly rather than
+      # `git add -A`, so this directory can never end up in the commit.
+      - name: Check out the renumber tooling from main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: .renumber-tooling
+          persist-credentials: false
+
       - uses: oven-sh/setup-bun@v2
       - uses: voidzero-dev/setup-vp@v1
         with:
@@ -155,7 +169,17 @@ jobs:
         run: |
           git config user.name 'boardsesh-repo-bot[bot]'
           git config user.email 'boardsesh-repo-bot[bot]@users.noreply.github.com'
-          vp run db:renumber -- --strategy "${{ github.event.inputs.strategy || 'rebase' }}"
+          # `bun <file>` rather than `vp run db:renumber`: bun executes TypeScript
+          # directly, so main's script runs without a second install.
+          bun .renumber-tooling/scripts/db-renumber-migration.ts \
+            --repo "$GITHUB_WORKSPACE" \
+            --strategy "${{ github.event.inputs.strategy || 'rebase' }}"
+
+      - name: Validate the resulting migration folder
+        if: steps.renumber.outputs.status == 'renumbered'
+        run: |
+          bun .renumber-tooling/scripts/check-db-migrations.ts \
+            --repo "$GITHUB_WORKSPACE" --base origin/main
 
       # The real gate. Nothing in per-PR CI applies migrations today, so this is the
       # only thing between a bad renumber and main. VERIFY_MIGRATION_JOURNAL asserts

--- a/.github/workflows/db-migration-renumber.yml
+++ b/.github/workflows/db-migration-renumber.yml
@@ -1,0 +1,230 @@
+name: DB Migration Renumber
+
+# Rebases ONE pull request onto the current `main`, moves its Drizzle migration to
+# the next free number, proves the result still applies against Postgres, and
+# force-pushes. Fanned out by db-migration-renumber-dispatch.yml whenever a
+# migration lands on main; also the manual re-run button:
+#
+#   gh workflow run db-migration-renumber.yml -f pr=3957
+#
+# ─── SECURITY — READ BEFORE EDITING ─────────────────────────────────────────────
+# Dispatch-only, so it always runs the DEFAULT-BRANCH copy of this file and its
+# gates cannot be edited from the PR it acts on (the property mobile-ota-preview.yml
+# relies on for the same reason). NEVER add `pull_request` or `pull_request_target`.
+#
+# This job runs PR-author code (`bun install` lifecycle scripts, `vp run build:db`)
+# and holds a repo-write App token, so:
+#   * SAME-REPO PRs only. The App is installed on this repo, so it could not push to
+#     a fork anyway, and running fork code next to a write token is not a trade we
+#     make. The gate enforces it.
+#   * `persist-credentials: false` on checkout. mobile-ota-production.yml deliberately
+#     does the opposite (mint-then-checkout so the push inherits the token), but that
+#     workflow does not execute PR-author code. Here the token would sit in
+#     .git/config, readable by any postinstall hook, for the whole run. It is instead
+#     injected only into the push step, after all author code has finished.
+#
+# The App token (not GITHUB_TOKEN) has to do the push: a GITHUB_TOKEN push does not
+# re-trigger workflows, so the renumbered commit would land with no CI at all.
+# Labels and comments go the other way — the App has no pull_requests permission, so
+# GITHUB_TOKEN does those.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to renumber'
+        required: true
+      strategy:
+        description: 'rebase (default) or merge'
+        required: false
+        default: rebase
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # NOT cancel-in-progress: being killed between the push and the comment would
+  # leave a silently-renumbered PR. A queued second run finds no collision and
+  # exits in seconds, so serializing is cheap.
+  group: db-migration-renumber-${{ github.event.inputs.pr }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+      branch: ${{ steps.decide.outputs.branch }}
+      head_sha: ${{ steps.decide.outputs.head_sha }}
+      skip_reason: ${{ steps.decide.outputs.skip_reason }}
+    steps:
+      - name: Resolve and vet the PR
+        id: decide
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const raw = String(context.payload.inputs.pr);
+            // Defense in depth: this value reaches git refs and shell env.
+            if (!/^[0-9]+$/.test(raw)) {
+              core.setOutput('run', 'false');
+              core.setOutput('skip_reason', 'pr input is not a number');
+              return;
+            }
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner, repo: context.repo.repo, pull_number: Number(raw),
+            });
+            const repoFull = `${context.repo.owner}/${context.repo.repo}`;
+            const defaultBranch = context.payload.repository.default_branch;
+
+            const reasons = [];
+            if (pr.state !== 'open') reasons.push('PR is not open');
+            if (pr.head.repo?.full_name !== repoFull) reasons.push('fork PR — cannot push to a fork');
+            if (pr.base.ref !== defaultBranch) reasons.push(`PR targets ${pr.base.ref}, not ${defaultBranch}`);
+            if (pr.head.ref === defaultBranch) reasons.push('head ref is the default branch');
+            if (pr.labels.some((label) => label.name === 'renumber:skip')) reasons.push('opted out via renumber:skip');
+
+            core.setOutput('run', reasons.length === 0 ? 'true' : 'false');
+            core.setOutput('skip_reason', reasons.join('; '));
+            core.setOutput('branch', pr.head.ref);
+            core.setOutput('head_sha', pr.head.sha);
+            if (reasons.length > 0) core.notice(`Skipping #${raw}: ${reasons.join('; ')}`);
+
+  renumber:
+    needs: gate
+    if: needs.gate.outputs.run == 'true' && vars.OTA_PUSH_APP_ID != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      # The only viable verification target. A from-scratch `drizzle-kit migrate` on
+      # a bare Postgres cannot work: 0000_*.sql ALTERs kilter_climbs/tension_climbs,
+      # which pgloader creates in setup-development-db.sh before drizzle ever runs.
+      # dev-db already has main's migrations applied, so this exercises exactly the
+      # real case — apply the pending set on top of main. Same recipe as e2e-tests.yml.
+      postgres:
+        image: ghcr.io/boardsesh/boardsesh-dev-db:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: main
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      PR_NUMBER: ${{ github.event.inputs.pr }}
+      BRANCH: ${{ needs.gate.outputs.branch }}
+      HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+      DATABASE_URL: postgresql://postgres:password@localhost:5432/main
+    steps:
+      - name: Mint the push token
+        id: push_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.OTA_PUSH_APP_ID }}
+          private-key: ${{ secrets.OTA_PUSH_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate.outputs.branch }}
+          fetch-depth: 0
+          # See the security note in the header — PR-author code runs in this job.
+          persist-credentials: false
+
+      - name: Assert we are on the branch the gate vetted
+        run: |
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA" \
+            || { echo "::error::Branch moved between the gate and checkout."; exit 1; }
+          test "$BRANCH" != "main"
+
+      - uses: oven-sh/setup-bun@v2
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Renumber onto main
+        id: renumber
+        run: |
+          git config user.name 'boardsesh-repo-bot[bot]'
+          git config user.email 'boardsesh-repo-bot[bot]@users.noreply.github.com'
+          vp run db:renumber -- --strategy "${{ github.event.inputs.strategy || 'rebase' }}"
+
+      # The real gate. Nothing in per-PR CI applies migrations today, so this is the
+      # only thing between a bad renumber and main. VERIFY_MIGRATION_JOURNAL asserts
+      # the journal tail actually landed — which is what catches a migration whose
+      # `when` would make it silently skipped forever.
+      - name: Verify the migrations apply
+        if: steps.renumber.outputs.status == 'renumbered'
+        env:
+          VERIFY_MIGRATION_JOURNAL: '1'
+        run: bun run --filter=@boardsesh/db db:migrate
+
+      - name: Verify re-applying is a no-op
+        if: steps.renumber.outputs.status == 'renumbered'
+        run: bun run --filter=@boardsesh/db db:migrate
+
+      - name: Re-check the PR immediately before pushing
+        id: recheck
+        if: steps.renumber.outputs.status == 'renumbered'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner, repo: context.repo.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            const ok =
+              pr.state === 'open' &&
+              pr.head.sha === process.env.HEAD_SHA &&
+              !pr.labels.some((label) => label.name === 'renumber:skip');
+            core.setOutput('ok', String(ok));
+            if (!ok) core.warning(`#${process.env.PR_NUMBER} moved during the run (head is now ${pr.head.sha}) — not pushing.`);
+
+      - name: Force-push the renumbered branch
+        if: steps.renumber.outputs.status == 'renumbered' && steps.recheck.outputs.ok == 'true'
+        env:
+          GH_APP_TOKEN: ${{ steps.push_token.outputs.token }}
+        run: |
+          # Explicit expected-SHA lease. The bare `--force-with-lease` form leases
+          # against refs/remotes/origin/<branch>, which any fetch during the run can
+          # silently refresh out from under it; naming the SHA cannot be defeated
+          # that way, so a contributor pushing mid-run aborts us instead of losing work.
+          git push --force-with-lease="$BRANCH:$HEAD_SHA" \
+            "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/$BRANCH"
+
+      - name: Comment the outcome
+        if: always() && steps.renumber.outputs.status != 'no-op'
+        uses: actions/github-script@v7
+        env:
+          COMMENT_B64: ${{ steps.renumber.outputs.comment_b64 }}
+          PUSHED: ${{ steps.recheck.outputs.ok }}
+        with:
+          script: |
+            const marker = '<!-- db-renumber -->';
+            let body = process.env.COMMENT_B64
+              ? Buffer.from(process.env.COMMENT_B64, 'base64').toString('utf8')
+              : `${marker}\n\n### 🚧 The renumber job failed\n\nSee the [run log](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}). Nothing was pushed.`;
+            if (process.env.PUSHED === 'false') {
+              body += '\n\n> ⚠️ The branch moved while this ran, so nothing was pushed. It will retry on the next migration merge.';
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number: Number(process.env.PR_NUMBER), per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: Number(process.env.PR_NUMBER), body,
+              });
+            }

--- a/.github/workflows/mobile-ota-check.yml
+++ b/.github/workflows/mobile-ota-check.yml
@@ -153,6 +153,53 @@ jobs:
               });
             }
 
+      # Makes the native train queryable: `gh pr list --label native-fingerprint`.
+      # Purely a marker — nothing dispatches on it and the check-run below stays
+      # neutral, because a native change is a legitimate outcome, not a failure.
+      # `unknown` deliberately leaves the label untouched: the resolver is ~5%
+      # non-deterministic (see MAX_DIFF_CONFIRMATIONS in the check script), and a
+      # flake must not flip a label either way.
+      - name: Label native fingerprint changes
+        if: github.event_name == 'push' && steps.ota.outputs.overall != 'unknown' && steps.ota.outputs.overall != ''
+        uses: actions/github-script@v7
+        env:
+          OVERALL: ${{ steps.ota.outputs.overall }}
+        with:
+          script: |
+            const LABEL = 'native-fingerprint';
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${context.payload.ref.replace('refs/heads/', '')}`,
+              state: 'open',
+            });
+            if (prs.length === 0) return;
+            const pr = prs[0];
+
+            const wanted = process.env.OVERALL === 'native-change-required';
+            const has = pr.labels.some((label) => label.name === LABEL);
+            if (wanted === has) return;
+
+            if (wanted) {
+              try {
+                await github.rest.issues.getLabel({ ...context.repo, name: LABEL });
+              } catch {
+                await github.rest.issues.createLabel({
+                  ...context.repo,
+                  name: LABEL,
+                  color: 'd93f0b',
+                  description: "Moves the Expo native fingerprint — needs a new store binary, won't ship OTA",
+                });
+              }
+              await github.rest.issues.addLabels({ ...context.repo, issue_number: pr.number, labels: [LABEL] });
+            } else {
+              try {
+                await github.rest.issues.removeLabel({ ...context.repo, issue_number: pr.number, name: LABEL });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }
+
       - name: Publish neutral check-run
         if: always()
         uses: actions/github-script@v7

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,101 @@
+name: PR Labels
+
+# Applies the `db-migration` label to PRs that add a Drizzle migration, and removes
+# it when they stop. The label is what .github/workflows/db-migration-renumber-dispatch.yml
+# fans out over when a migration lands on main, so it is load-bearing, not decorative:
+# an unlabelled migration PR is simply never auto-renumbered.
+#
+# Deliberately its own workflow rather than a job in ci.yml — ci.yml's `ci-status`
+# aggregator fails the whole run on any non-success job, and a label write must
+# never be able to redden a PR.
+#
+# The companion label `native-fingerprint` is applied by mobile-ota-check.yml, which
+# is where the fingerprint verdict is actually computed.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-labels-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Label migration PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const LABEL = 'db-migration';
+            const DRIZZLE_DIR = 'packages/db/drizzle';
+            const MIGRATION_RE = /^\d{4}_.+\.sql$/;
+
+            // A directory listing on each side, not `pulls.listFiles`. A branch that
+            // was already renumbered once shows its migration as a *rename*, which an
+            // added-files filter misses entirely — and those are exactly the PRs that
+            // need the label most.
+            const listMigrations = async (ref) => {
+              const { data } = await github.rest.repos.getContent({
+                owner: context.repo.owner, repo: context.repo.repo, path: DRIZZLE_DIR, ref,
+              });
+              return data
+                .filter((item) => item.type === 'file' && MIGRATION_RE.test(item.name))
+                .map((item) => item.name);
+            };
+
+            const pr = context.payload.pull_request;
+            let wanted;
+            try {
+              const base = new Set(await listMigrations(pr.base.ref));
+              wanted = (await listMigrations(pr.head.sha)).some((name) => !base.has(name));
+            } catch (error) {
+              core.warning(`Could not compare the migration folder (${error}) — leaving labels alone.`);
+              return;
+            }
+
+            const has = pr.labels.some((label) => label.name === LABEL);
+            if (wanted === has) {
+              core.info(`${LABEL} already ${has ? 'set' : 'unset'} — nothing to do.`);
+              return;
+            }
+
+            try {
+              if (wanted) {
+                // Self-installing, mirroring ensureLabels() in
+                // scripts/testflight-feedback-to-issues.ts.
+                try {
+                  await github.rest.issues.getLabel({ ...context.repo, name: LABEL });
+                } catch {
+                  await github.rest.issues.createLabel({
+                    ...context.repo,
+                    name: LABEL,
+                    color: '0052cc',
+                    description: 'Adds a Drizzle migration; auto-renumbered when main takes the number',
+                  });
+                }
+                await github.rest.issues.addLabels({ ...context.repo, issue_number: pr.number, labels: [LABEL] });
+                core.notice(`Labelled #${pr.number} ${LABEL}.`);
+              } else {
+                await github.rest.issues.removeLabel({ ...context.repo, issue_number: pr.number, name: LABEL });
+                core.notice(`Removed ${LABEL} from #${pr.number}.`);
+              }
+            } catch (error) {
+              // A fork PR's GITHUB_TOKEN is read-only regardless of `permissions:`,
+              // so this 403s. That degradation is already correct: the renumber
+              // workflow cannot push to a fork either (the App is installed on this
+              // repo only), so a fork migration PR needs a human regardless.
+              if (error.status === 403) {
+                core.notice(`No write access to labels (fork PR) — ${LABEL} not applied to #${pr.number}.`);
+              } else if (error.status === 404 && !wanted) {
+                core.info(`${LABEL} was already absent.`);
+              } else {
+                throw error;
+              }
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ Common commands:
 ### Database
 
 - `bunx drizzle-kit generate` from `packages/db/` to create migrations. **Never hand-write migration SQL** — it must be in `_journal.json`, which `drizzle-kit generate` updates for you.
+- **When main takes your migration number, run `vp run db:renumber`** — it rebases onto main, moves the migration to the next free number and keeps your SQL. CI usually does it for you: PRs adding a migration get the `db-migration` label, and a merge to main fans out a renumber for every stranded PR. `vp run check:db-migrations` guards the folder on every PR. Full details, including why the bot sometimes hands it back: `docs/db-migrations.md`.
 - Dev DB is a pre-built image (`ghcr.io/boardsesh/boardsesh-dev-db`) with all board data, a test user (`test@boardsesh.com` / `test`), and seed data. Reset: `docker compose down -v && vp run db:up`.
 
 ### Database hosting (Railway)
@@ -112,6 +113,7 @@ Read relevant `docs/` before working on the matching area; update docs when the 
 - `docs/board-snapshots.md` — nightly SQLite board-catalog snapshots (export job, client bootstrap, ops runbook); `docs/board-snapshots-dataset.md` — the same snapshots as a public downloadable dataset
 - `docs/ai-design-guidelines.md` — Velvet Send design system (mobile-canonical: palette, typography, tokens, Liquid Glass / Material variants; web now consumes it too via `@boardsesh/velvet-tokens` + the foreground/fill split — see the "Web (consuming Velvet Send)" section)
 - `docs/live-activity-push-testing.md` — APNs Live Activity push testing
+- `docs/db-migrations.md` — migration numbering, `when`-not-number apply order, the collision/renumber bot, and when it hands work back
 - `docs/logging.md` — backend structured logger (winston)
 - `docs/og-climb.md` — backend-served climb OG share cards (`GET /og/climb`: caches, env vars, timings)
 - `docs/mobile-sheets-vs-routes.md` — mobile: which surface to use (bottom sheet vs route), with the decision tree + the hard rules (incl. why `fullScreenModal` breaks the iOS 26 native tab bar)

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -39,10 +39,11 @@ bunx drizzle-kit generate --name describes_what_it_does
 and stop on an interactive prompt.
 
 Data-only migrations (backfills, one-off corrections) have no schema delta, so
-`generate` produces nothing. Write the `.sql` by hand and add the journal entry with
-`vp run db:renumber` or by hand — and give it no snapshot, so main's tail stays the
-newest. Several existing backfills use a `_bs_migration_guards` row to stay idempotent;
-that guard key is a semantic identity, **not** the filename, and must never be renumbered.
+`generate` produces nothing to diff. Use `bunx drizzle-kit generate --custom --name …`,
+which writes an empty `.sql` and the journal entry for you, then fill in the body.
+Several existing backfills use a `_bs_migration_guards` row to stay idempotent; that
+guard key is a semantic identity, **not** the filename, so it must never be renumbered —
+which is why the renumber bot never rewrites anything inside a migration body.
 
 ## When main takes your number
 

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -1,0 +1,116 @@
+# Database migrations: numbering, collisions, and the renumber bot
+
+How Drizzle migrations are numbered in this repo, what happens when two PRs claim the
+same number, and what the automation does about it.
+
+## The shape of the folder
+
+```
+packages/db/drizzle/
+  0186_backfill_sync_frozen_at.sql      # the migration
+  meta/_journal.json                    # the ordered list drizzle actually applies
+  meta/0186_snapshot.json               # the full schema state after this migration
+```
+
+Three properties matter more than they look:
+
+**Order comes from `when`, not from the number.** `packages/db/scripts/migrate.ts` and
+`scripts/dev-db-up.sh` both select entries whose `when` is newer than the last applied
+migration. A migration whose `when` is at or below an already-applied timestamp is
+skipped _forever_, silently — green PR, green deploy, DDL that never happened. The
+number is for humans; `when` is what runs.
+
+**A `.sql` with no journal entry is inert.** Nothing applies it. It looks like a
+migration in review and does nothing in production.
+
+**Snapshots are a chain.** Each one records the full schema state and names its parent
+via `prevId`. `drizzle-kit generate` diffs the built schema against the newest snapshot,
+so a broken chain produces wrong DDL — or, more often, silence.
+
+## Creating one
+
+```bash
+cd packages/db
+bunx drizzle-kit generate --name describes_what_it_does
+```
+
+`vp run build:db` runs first if your schema changed — `drizzle.config.ts` reads
+`./dist/schema/index.js`, so a stale build makes `generate` hallucinate column renames
+and stop on an interactive prompt.
+
+Data-only migrations (backfills, one-off corrections) have no schema delta, so
+`generate` produces nothing. Write the `.sql` by hand and add the journal entry with
+`vp run db:renumber` or by hand — and give it no snapshot, so main's tail stays the
+newest. Several existing backfills use a `_bs_migration_guards` row to stay idempotent;
+that guard key is a semantic identity, **not** the filename, and must never be renumbered.
+
+## When main takes your number
+
+Migration numbers are first-come-first-served, and every open migration PR appends to
+the same `_journal.json` tail. So several PRs can each hold `0187` and each report
+_mergeable_ — right up until one of them merges, at which point all the others go
+`CONFLICTING`. This is routine: 109 migrations landed in one recent three-month window,
+and git history carries 26 hand-written renumber commits.
+
+**You usually don't have to do anything.** CI labels your PR `db-migration`, and when a
+migration lands on main, `.github/workflows/db-migration-renumber-dispatch.yml` fans out
+a renumber run for every stranded PR. The bot rebases you onto main, moves your
+migration to the next free number, proves it still applies against Postgres, and
+force-pushes. Your SQL is never rewritten.
+
+To do it yourself, or when the bot stops:
+
+```bash
+vp run db:renumber                      # rebase onto origin/main and renumber
+vp run db:renumber -- --dry-run         # do the work, skip the commit
+vp run db:renumber -- --strategy merge  # merge instead of rebase (no force-push needed)
+```
+
+### When the bot stops and hands it back
+
+It blocks — pushing nothing — rather than guess, in these cases:
+
+| It says                                          | What happened                                                                                                                                                                              |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| conflicts outside the migration folder           | A real code conflict. Resolving it by rule would silently pick a side of someone's work.                                                                                                   |
+| `generate` produced no migration                 | Either main already landed your schema change, or drizzle needs you to say whether something was created or renamed. Rebase locally and run `bunx drizzle-kit generate` to see the prompt. |
+| this branch adds two migrations at one number    | Apply order is ambiguous; guessing would be worse than asking.                                                                                                                             |
+| tag referenced by files this branch didn't touch | Almost certainly a `_bs_migration_guards` key, which must not move.                                                                                                                        |
+| the rebase altered a file this branch owns       | A safety assertion tripped. Please report it.                                                                                                                                              |
+
+Add the `renumber:skip` label to opt a PR out entirely.
+
+### What it will not do
+
+- **Fork PRs.** The GitHub App is installed on this repo only, so it cannot push to a
+  fork — and fork PRs never get the label in the first place, because `pull_request`
+  hands fork workflows a read-only token.
+- **Rewrite your SQL.** If `drizzle-kit` would now generate something different, the bot
+  keeps your version and posts the difference as a comment for you to judge. Hand-tuning
+  is real here (batched backfills, explicit sequences, lock avoidance).
+
+## The guard rails
+
+`vp run check:db-migrations` runs on every PR touching `packages/db`. It has no database
+and no build — a few file reads:
+
+- a `.sql` with no journal entry, or a journal entry with no `.sql`
+- two migrations the branch adds at the same number
+- a number main has already taken
+- a `when` that is not newer than main's newest
+- new entries interleaved instead of appended
+
+It deliberately ignores six duplicate numbers that main has carried since 2024
+(`0025`, `0048`–`0052`). Both sides are journalled and applied in production; they order
+correctly by `when` and cannot be fixed now.
+
+## Why the schema barrel is union-merged
+
+`.gitattributes` marks `packages/db/src/schema/**/index.ts` as `merge=union`. The file is
+an append-only export list, so two PRs that each add a table both append to the same last
+line and conflict on every single rebase — even though the resolution is always "keep
+both". Union merge is git's built-in answer for exactly this file shape.
+
+Without it the renumber bot blocks on nearly every table-adding PR, which is most of
+them. The failure mode is loud rather than silent: if both sides add the _same_ export,
+the union keeps both copies and TypeScript fails the build.

--- a/packages/db/drizzle/0177_illegal_omega_red.sql
+++ b/packages/db/drizzle/0177_illegal_omega_red.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "board_sessions" ADD COLUMN "notes" text;

--- a/scripts/check-db-migrations.test.ts
+++ b/scripts/check-db-migrations.test.ts
@@ -117,15 +117,15 @@ describe('checkAgainstBase', () => {
 
 describe('parseArgs', () => {
   it('defaults to comparing against origin/main', () => {
-    expect(parseArgs([])).toEqual({ base: 'origin/main' });
+    expect(parseArgs([])).toEqual({ base: 'origin/main', repo: null });
   });
 
   it('skips the `--` that `vp run <task> -- <args>` forwards', () => {
-    expect(parseArgs(['--', '--base', 'HEAD~1'])).toEqual({ base: 'HEAD~1' });
+    expect(parseArgs(['--', '--base', 'HEAD~1'])).toEqual({ base: 'HEAD~1', repo: null });
   });
 
   it('supports opting out of the base comparison', () => {
-    expect(parseArgs(['--no-base'])).toEqual({ base: null });
+    expect(parseArgs(['--no-base'])).toEqual({ base: null, repo: null });
   });
 
   it('rejects an unknown flag rather than ignoring it', () => {

--- a/scripts/check-db-migrations.test.ts
+++ b/scripts/check-db-migrations.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import { checkAgainstBase, checkTree, parseArgs, type TreeState } from './check-db-migrations';
+import type { Journal, JournalEntry } from './lib/drizzle-migrations';
+
+function entry(idx: number, tag: string, when: number): JournalEntry {
+  return { idx, version: '7', when, tag, breakpoints: true };
+}
+
+function journalOf(...entries: JournalEntry[]): Journal {
+  return { version: '7', dialect: 'postgresql', entries };
+}
+
+function tree(entries: JournalEntry[], filenames: string[]): TreeState {
+  return { journal: journalOf(...entries), filenames };
+}
+
+const kinds = (problems: { kind: string }[]): string[] => problems.map((problem) => problem.kind);
+
+describe('checkTree', () => {
+  it('accepts a consistent folder', () => {
+    expect(checkTree(tree([entry(0, '0000_a', 1)], ['0000_a.sql', 'meta']))).toEqual([]);
+  });
+
+  it('flags a migration file with no journal entry', () => {
+    // The 0177_illegal_omega_red shape that reached main: reviewed as if it would
+    // run, and in fact inert.
+    const problems = checkTree(tree([entry(179, '0179_b', 2)], ['0177_orphan.sql', '0179_b.sql']));
+    expect(kinds(problems)).toEqual(['orphan-sql']);
+    expect(problems[0]?.message).toContain('0177_orphan.sql');
+  });
+
+  it('flags a journal entry with no file', () => {
+    expect(kinds(checkTree(tree([entry(1, '0001_gone', 1)], [])))).toEqual(['orphan-entry']);
+  });
+
+  it('ignores historical duplicate numbers already on main', () => {
+    // 0048_add_feed_items / 0048_add_proposals are both journalled and both applied
+    // in production. Nothing can fix them now, so they must not fail every PR.
+    const problems = checkTree(
+      tree(
+        [entry(40, '0048_add_feed_items', 1), entry(42, '0048_add_proposals', 2)],
+        ['0048_add_feed_items.sql', '0048_add_proposals.sql'],
+      ),
+    );
+    expect(problems).toEqual([]);
+  });
+
+  it('flags two NEW migrations sharing a number', () => {
+    const problems = checkTree(
+      tree([entry(1, '0187_a', 1), entry(2, '0187_b', 2)], ['0187_a.sql', '0187_b.sql']),
+      new Set(['0187_a', '0187_b']),
+    );
+    expect(kinds(problems)).toContain('duplicate-index');
+  });
+
+  it('flags a new entry whose tag prefix disagrees with its idx', () => {
+    const problems = checkTree(tree([entry(5, '0009_x', 1)], ['0009_x.sql']), new Set(['0009_x']));
+    expect(kinds(problems)).toEqual(['tag-index-mismatch']);
+  });
+
+  it('does not police tag/idx drift on entries the branch did not add', () => {
+    // Real shape from main: idx 51 carries tag 0052_add_postgis_location.
+    expect(checkTree(tree([entry(51, '0052_add_postgis_location', 1)], ['0052_add_postgis_location.sql']))).toEqual([]);
+  });
+});
+
+describe('checkAgainstBase', () => {
+  const base = tree([entry(186, '0186_tail', 1_000)], ['0186_tail.sql']);
+
+  it('is silent when the branch adds nothing', () => {
+    expect(checkAgainstBase(base, base)).toEqual([]);
+  });
+
+  it('accepts a migration that sits just above main', () => {
+    const head = tree(
+      [entry(186, '0186_tail', 1_000), entry(187, '0187_mine', 2_000)],
+      ['0186_tail.sql', '0187_mine.sql'],
+    );
+    expect(checkAgainstBase(base, head)).toEqual([]);
+  });
+
+  it('flags a number main has already taken', () => {
+    const takenBase = tree(
+      [entry(186, '0186_tail', 1_000), entry(187, '0187_theirs', 1_500)],
+      ['0186_tail.sql', '0187_theirs.sql'],
+    );
+    const head = tree(
+      [entry(186, '0186_tail', 1_000), entry(187, '0187_mine', 2_000)],
+      ['0186_tail.sql', '0187_mine.sql'],
+    );
+    const problems = checkAgainstBase(takenBase, head);
+    expect(kinds(problems)).toContain('collision');
+    expect(problems[0]?.message).toContain('vp run db:renumber');
+  });
+
+  it('flags a `when` that is not newer than main’s newest', () => {
+    // The worst silent failure: both appliers order by `when`, so this migration
+    // would never run, and nothing would report an error.
+    const head = tree(
+      [entry(186, '0186_tail', 1_000), entry(187, '0187_mine', 900)],
+      ['0186_tail.sql', '0187_mine.sql'],
+    );
+    const problems = checkAgainstBase(base, head);
+    expect(kinds(problems)).toContain('stale-when');
+    expect(problems.find((problem) => problem.kind === 'stale-when')?.message).toContain('skipped permanently');
+  });
+
+  it('flags a new entry inserted before the journal tail instead of appended', () => {
+    const head = tree(
+      [entry(187, '0187_mine', 2_000), entry(186, '0186_tail', 1_000)],
+      ['0186_tail.sql', '0187_mine.sql'],
+    );
+    expect(kinds(checkAgainstBase(base, head))).toContain('not-appended');
+  });
+});
+
+describe('parseArgs', () => {
+  it('defaults to comparing against origin/main', () => {
+    expect(parseArgs([])).toEqual({ base: 'origin/main' });
+  });
+
+  it('skips the `--` that `vp run <task> -- <args>` forwards', () => {
+    expect(parseArgs(['--', '--base', 'HEAD~1'])).toEqual({ base: 'HEAD~1' });
+  });
+
+  it('supports opting out of the base comparison', () => {
+    expect(parseArgs(['--no-base'])).toEqual({ base: null });
+  });
+
+  it('rejects an unknown flag rather than ignoring it', () => {
+    expect(() => parseArgs(['--nope'])).toThrow(/unknown argument/);
+  });
+});

--- a/scripts/check-db-migrations.ts
+++ b/scripts/check-db-migrations.ts
@@ -1,0 +1,264 @@
+/// <reference types="node" />
+
+/**
+ * Validates the Drizzle migration folder on every PR that touches `packages/db`.
+ *
+ * Migration numbering is a global, first-come-first-served resource, and until
+ * now nothing checked it. The failures that reach main are all silent — none of
+ * them break a build, so none of them get caught in review:
+ *
+ *  - A `.sql` file with no journal entry never runs. `0177_illegal_omega_red.sql`
+ *    lived on main in that state, reviewed as if it would apply, byte-identical to
+ *    a migration that had already been renumbered past it.
+ *  - A journal entry with no `.sql` file crashes the migrator at deploy time.
+ *  - A migration whose `when` is not newer than main's newest is skipped *forever*
+ *    by both appliers, because they order by `when` and not by number. That is the
+ *    worst outcome in this file: the PR is green, the deploy is green, and the DDL
+ *    simply never happens.
+ *  - A number that collides with main means the PR cannot merge without a rebase.
+ *    Flagging it here turns "discovered at merge time" into "flagged on the PR",
+ *    with the exact command to fix it.
+ *
+ * Runs without a database, a build, or drizzle-kit — it is a few file reads.
+ *
+ * Usage:
+ *   vp run check:db-migrations                  # validate the working tree
+ *   vp run check:db-migrations -- --base origin/main   # also compare against a base
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  DRIZZLE_DIR,
+  JOURNAL_PATH,
+  addedMigrations,
+  duplicateIndexes,
+  findOrphans,
+  maxWhen,
+  migrationFiles,
+  migrationIndex,
+  nextFreeIndex,
+  padIndex,
+  parseJournal,
+  type Journal,
+  type MigrationFile,
+} from './lib/drizzle-migrations';
+
+export interface Problem {
+  /** Short machine-readable kind, used by the tests and the summary grouping. */
+  kind:
+    | 'orphan-sql'
+    | 'orphan-entry'
+    | 'duplicate-index'
+    | 'tag-index-mismatch'
+    | 'collision'
+    | 'stale-when'
+    | 'not-appended';
+  message: string;
+}
+
+export interface TreeState {
+  journal: Journal;
+  filenames: string[];
+}
+
+/**
+ * PURE: everything checkable from the branch alone, with no base to compare to.
+ *
+ * `tag-index-mismatch` is scoped to entries the branch adds rather than the whole
+ * journal on purpose: 30 historical entries on main have a `tag` prefix that
+ * differs from their `idx`, and rewriting that history is not this check's job.
+ */
+export function checkTree(state: TreeState, newTags: ReadonlySet<string> = new Set()): Problem[] {
+  const problems: Problem[] = [];
+  const { journal, filenames } = state;
+
+  const orphans = findOrphans(journal, filenames);
+  for (const filename of orphans.sqlWithoutEntry) {
+    problems.push({
+      kind: 'orphan-sql',
+      message:
+        `${DRIZZLE_DIR}/${filename} has no entry in _journal.json, so it will never be applied. ` +
+        'Either add it via `bunx drizzle-kit generate` or delete the file.',
+    });
+  }
+  for (const tag of orphans.entryWithoutSql) {
+    problems.push({
+      kind: 'orphan-entry',
+      message: `_journal.json references "${tag}" but ${DRIZZLE_DIR}/${tag}.sql is missing — the migrator will throw.`,
+    });
+  }
+
+  // Scoped to migrations the branch adds. Main legitimately carries six duplicate
+  // prefixes (0025, 0048-0052) from hand-merges years ago; both sides are journalled
+  // and applied in production, so they order fine by `when` and are not fixable now.
+  // A branch that adds two migrations at one number is a different matter — that one
+  // is ambiguous and still cheap to fix. New-vs-main duplicates are reported as a
+  // `collision` instead, which carries the actionable message.
+  for (const index of duplicateIndexes(filenames)) {
+    const newAtIndex = migrationFiles(filenames).filter((file) => file.index === index && newTags.has(file.tag));
+    if (newAtIndex.length < 2) continue;
+    problems.push({
+      kind: 'duplicate-index',
+      message:
+        `This branch adds ${newAtIndex.length} migrations numbered ${padIndex(index)} ` +
+        `(${newAtIndex.map((file) => file.filename).join(', ')}) — apply order is ambiguous.`,
+    });
+  }
+
+  for (const entry of journal.entries) {
+    if (!newTags.has(entry.tag)) continue;
+    if (migrationIndex(entry.tag) !== entry.idx) {
+      problems.push({
+        kind: 'tag-index-mismatch',
+        message: `New journal entry "${entry.tag}" has idx ${entry.idx}; the tag prefix and idx must agree.`,
+      });
+    }
+  }
+
+  return problems;
+}
+
+/**
+ * PURE: the checks that need main to compare against.
+ *
+ * `stale-when` is the load-bearing one — see the file header.
+ */
+export function checkAgainstBase(base: TreeState, head: TreeState): Problem[] {
+  const problems: Problem[] = [];
+  const added = addedMigrations(base.filenames, head.filenames);
+  if (added.length === 0) return problems;
+
+  const baseNextFree = nextFreeIndex(base.journal, base.filenames);
+  for (const file of added) {
+    if (file.index < baseNextFree) {
+      problems.push({
+        kind: 'collision',
+        message:
+          `${file.filename} is numbered ${padIndex(file.index)}, but main is already at ` +
+          `${padIndex(baseNextFree - 1)}. Run \`vp run db:renumber\` to move it to ${padIndex(baseNextFree)}.`,
+      });
+    }
+  }
+
+  const baseMaxWhen = maxWhen(base.journal);
+  const addedTags = new Set(added.map((file) => file.tag));
+  for (const entry of head.journal.entries) {
+    if (!addedTags.has(entry.tag)) continue;
+    if (entry.when <= baseMaxWhen) {
+      problems.push({
+        kind: 'stale-when',
+        message:
+          `"${entry.tag}" has when=${entry.when}, which is not newer than main's newest (${baseMaxWhen}). ` +
+          'Both appliers order by `when`, so this migration would be skipped permanently. ' +
+          'Run `vp run db:renumber` to restamp it.',
+      });
+    }
+  }
+
+  const addedPositions = head.journal.entries
+    .map((entry, position) => ({ entry, position }))
+    .filter(({ entry }) => addedTags.has(entry.tag))
+    .map(({ position }) => position);
+  const tailStart = head.journal.entries.length - addedPositions.length;
+  if (addedPositions.some((position) => position < tailStart)) {
+    problems.push({
+      kind: 'not-appended',
+      message:
+        'New journal entries are interleaved with existing ones rather than appended at the end. ' +
+        'Run `vp run db:renumber` to rebuild the tail.',
+    });
+  }
+
+  return problems;
+}
+
+// ─── I/O ────────────────────────────────────────────────────────────────────
+
+function readTree(repoRoot: string): TreeState {
+  return {
+    journal: parseJournal(readFileSync(resolve(repoRoot, JOURNAL_PATH), 'utf8')),
+    filenames: readdirSync(resolve(repoRoot, DRIZZLE_DIR)),
+  };
+}
+
+/** Read the same two inputs out of a git ref without checking it out. */
+function readTreeAtRef(repoRoot: string, ref: string): TreeState | null {
+  const git = (args: readonly string[]): string =>
+    execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  try {
+    return {
+      journal: parseJournal(git(['show', `${ref}:${JOURNAL_PATH}`])),
+      filenames: git(['ls-tree', '--name-only', `${ref}:${DRIZZLE_DIR}`])
+        .split('\n')
+        .filter(Boolean),
+    };
+  } catch (error) {
+    console.warn(`::warning::Could not read ${DRIZZLE_DIR} at ${ref} (${String(error)}) — skipping base checks.`);
+    return null;
+  }
+}
+
+export interface Options {
+  base: string | null;
+}
+
+export function parseArgs(argv: readonly string[]): Options {
+  // Defaults to origin/main so a bare local run gets the collision and stale-`when`
+  // checks too, not just the tree-only ones. An unreadable ref degrades to a warning.
+  const options: Options = { base: 'origin/main' };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    switch (flag) {
+      // `vp run <task> -- <args>` forwards a literal `--` separator; it carries no meaning here.
+      case '--':
+        break;
+      case '--base': {
+        const value = argv[index + 1];
+        if (value === undefined) throw new Error('missing value for --base');
+        options.base = value;
+        index += 1;
+        break;
+      }
+      case '--no-base':
+        options.base = null;
+        break;
+      default:
+        throw new Error(`unknown argument: ${flag}`);
+    }
+  }
+  return options;
+}
+
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const options = parseArgs(argv);
+
+  const head = readTree(repoRoot);
+  const base = options.base ? readTreeAtRef(repoRoot, options.base) : null;
+
+  const addedTags = new Set<string>(
+    base ? addedMigrations(base.filenames, head.filenames).map((file: MigrationFile) => file.tag) : [],
+  );
+
+  const problems = [...checkTree(head, addedTags), ...(base ? checkAgainstBase(base, head) : [])];
+
+  if (problems.length === 0) {
+    const count = migrationFiles(head.filenames).length;
+    console.log(`[check-db-migrations] ${count} migrations, journal consistent.`);
+    return 0;
+  }
+
+  for (const problem of problems) {
+    console.error(`::error title=Migration check (${problem.kind})::${problem.message}`);
+  }
+  console.error(`[check-db-migrations] ${problems.length} problem(s) found.`);
+  return 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/scripts/check-db-migrations.ts
+++ b/scripts/check-db-migrations.ts
@@ -204,12 +204,14 @@ function readTreeAtRef(repoRoot: string, ref: string): TreeState | null {
 
 export interface Options {
   base: string | null;
+  /** The repository to validate, when it isn't the one this script lives in. */
+  repo: string | null;
 }
 
 export function parseArgs(argv: readonly string[]): Options {
   // Defaults to origin/main so a bare local run gets the collision and stale-`when`
   // checks too, not just the tree-only ones. An unreadable ref degrades to a warning.
-  const options: Options = { base: 'origin/main' };
+  const options: Options = { base: 'origin/main', repo: null };
   for (let index = 0; index < argv.length; index += 1) {
     const flag = argv[index];
     switch (flag) {
@@ -226,6 +228,13 @@ export function parseArgs(argv: readonly string[]): Options {
       case '--no-base':
         options.base = null;
         break;
+      case '--repo': {
+        const value = argv[index + 1];
+        if (value === undefined) throw new Error('missing value for --repo');
+        options.repo = value;
+        index += 1;
+        break;
+      }
       default:
         throw new Error(`unknown argument: ${flag}`);
     }
@@ -234,8 +243,8 @@ export function parseArgs(argv: readonly string[]): Options {
 }
 
 export function main(argv: readonly string[] = process.argv.slice(2)): number {
-  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
   const options = parseArgs(argv);
+  const repoRoot = options.repo ? resolve(options.repo) : resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
   const head = readTree(repoRoot);
   const base = options.base ? readTreeAtRef(repoRoot, options.base) : null;

--- a/scripts/db-renumber-migration.test.ts
+++ b/scripts/db-renumber-migration.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -137,6 +141,39 @@ describe('renderComment', () => {
     expect(renderComment(result({ rewritten: ['packages/db/src/testing/dedup-replay.ts'] }))).toContain(
       'dedup-replay.ts',
     );
+  });
+});
+
+describe('conflict-resolution orientation', () => {
+  // Guards a bug that shipped once: the merge path staged conflicted .sql files
+  // without resolving them, committing conflict markers into the author's history.
+  // `--ours`/`--theirs` mean opposite things in a merge and a rebase, so each path
+  // needs its own flag to end up with the same thing (the branch's body).
+  const source = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), 'db-renumber-migration.ts'), 'utf8');
+
+  const bodyOf = (fnName: string): string => {
+    const start = source.indexOf(`function ${fnName}(`);
+    expect(start, `${fnName} not found`).toBeGreaterThan(-1);
+    return source.slice(start, source.indexOf('\n}\n', start));
+  };
+
+  it('takes --theirs when rebasing (the replayed branch commit)', () => {
+    expect(bodyOf('rebaseOntoBase')).toContain("'--theirs'");
+  });
+
+  it('takes --ours when merging (the branch being merged into)', () => {
+    expect(bodyOf('mergeBaseRef')).toContain("'--ours'");
+  });
+
+  it('never stages a conflicted path without resolving it first', () => {
+    for (const fnName of ['rebaseOntoBase', 'mergeBaseRef']) {
+      const body = bodyOf(fnName);
+      const stageIndex = body.indexOf("git(['add', '--', path])");
+      expect(stageIndex, `${fnName} should stage the resolved path`).toBeGreaterThan(-1);
+      const resolveIndex = Math.max(body.indexOf("'--ours'"), body.indexOf("'--theirs'"));
+      expect(resolveIndex, `${fnName} must resolve the conflict at all`).toBeGreaterThan(-1);
+      expect(resolveIndex, `${fnName} resolves before staging`).toBeLessThan(stageIndex);
+    }
   });
 });
 

--- a/scripts/db-renumber-migration.test.ts
+++ b/scripts/db-renumber-migration.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  STICKY_MARKER,
+  classifyGenerate,
+  conflictsAreResolvable,
+  normalizeSql,
+  parseArgs,
+  renderComment,
+  type RenumberResult,
+} from './db-renumber-migration';
+import { migrationFiles, planRenumber } from './lib/drizzle-migrations';
+
+function result(overrides: Partial<RenumberResult> = {}): RenumberResult {
+  return {
+    status: 'renumbered',
+    reason: null,
+    strategy: 'rebase',
+    moves: planRenumber(migrationFiles(['0187_greedy_thing.sql']), 188),
+    diverged: [],
+    rewritten: [],
+    notes: [],
+    ...overrides,
+  };
+}
+
+describe('normalizeSql', () => {
+  it('ignores indentation and blank lines', () => {
+    expect(normalizeSql('ALTER TABLE "a"\n\n   ADD COLUMN "b" text;\n')).toBe(
+      normalizeSql('ALTER TABLE "a"\nADD COLUMN "b" text;'),
+    );
+  });
+
+  it('still distinguishes different statements', () => {
+    expect(normalizeSql('ADD COLUMN "b" text;')).not.toBe(normalizeSql('ADD COLUMN "b" text NOT NULL;'));
+  });
+});
+
+describe('conflictsAreResolvable', () => {
+  it('accepts conflicts confined to the migration folder', () => {
+    expect(conflictsAreResolvable(['packages/db/drizzle/meta/_journal.json', 'packages/db/drizzle/0187_x.sql'])).toBe(
+      true,
+    );
+  });
+
+  it('refuses when anything else conflicts', () => {
+    // Resolving a real code conflict by rule would silently pick a side of
+    // somebody's work; that always goes back to a human.
+    expect(conflictsAreResolvable(['packages/db/drizzle/meta/_journal.json', 'packages/web/app/page.tsx'])).toBe(false);
+  });
+
+  it('refuses an empty conflict set', () => {
+    expect(conflictsAreResolvable([])).toBe(false);
+  });
+
+  it('does not treat a sibling path prefix as inside the folder', () => {
+    expect(conflictsAreResolvable(['packages/db/drizzle-extra/x.sql'])).toBe(false);
+  });
+});
+
+describe('classifyGenerate', () => {
+  const before = ['0186_tail.sql', 'meta'];
+
+  it('reports the file drizzle-kit created', () => {
+    expect(classifyGenerate(before, [...before, '0187_new.sql'], '').generated).toBe('0187_new.sql');
+  });
+
+  it('detects a no-op even though the exit code was 0', () => {
+    // prepareAndMigratePg ends in `catch (e) { console.error(e); }` with no
+    // rethrow, so every failure mode exits 0 — the file listing is the only
+    // trustworthy signal.
+    const outcome = classifyGenerate(before, before, 'No schema changes, nothing to migrate 😴');
+    expect(outcome.generated).toBeNull();
+    expect(outcome.detail).toContain('no schema delta');
+  });
+
+  it('names a snapshot parent collision, which exits 0 silently', () => {
+    const outcome = classifyGenerate(
+      before,
+      before,
+      '[...] are pointing to a parent snapshot: x which is a collision.',
+    );
+    expect(outcome.generated).toBeNull();
+    expect(outcome.detail).toContain('meta/ was not reset');
+  });
+
+  it('reports a bare failure with no recognisable output', () => {
+    expect(classifyGenerate(before, before, '').detail).toContain('produced nothing');
+  });
+
+  it('refuses to guess when more than one migration appeared', () => {
+    const outcome = classifyGenerate(before, [...before, '0187_a.sql', '0188_b.sql'], '');
+    expect(outcome.generated).toBeNull();
+    expect(outcome.detail).toContain('2 migrations');
+  });
+
+  it('ignores non-sql files drizzle-kit writes alongside', () => {
+    expect(classifyGenerate(before, [...before, '0187_new.sql', '0187_snapshot.json'], '').generated).toBe(
+      '0187_new.sql',
+    );
+  });
+});
+
+describe('renderComment', () => {
+  it('carries the sticky marker in every state', () => {
+    for (const status of ['no-op', 'renumbered', 'blocked'] as const) {
+      expect(renderComment(result({ status }))).toContain(STICKY_MARKER);
+    }
+  });
+
+  it('names the rename and reassures about the SQL', () => {
+    const body = renderComment(result());
+    expect(body).toContain('0187_greedy_thing.sql');
+    expect(body).toContain('0188_greedy_thing.sql');
+    expect(body).toContain('Your SQL is unchanged');
+  });
+
+  it('surfaces a divergence as a review aid, stating that the author’s SQL won', () => {
+    const body = renderComment(
+      result({
+        diverged: [
+          { tag: '0188_greedy_thing', original: 'ADD COLUMN "b" text;', generated: 'ADD COLUMN "b" text NOT NULL;' },
+        ],
+      }),
+    );
+    expect(body).toContain('yours was kept');
+    expect(body).toContain('ADD COLUMN "b" text NOT NULL;');
+  });
+
+  it('says nothing was pushed when blocked, and why', () => {
+    const body = renderComment(result({ status: 'blocked', reason: 'The rebase conflicts outside the folder.' }));
+    expect(body).toContain('Nothing was pushed');
+    expect(body).toContain('conflicts outside the folder');
+  });
+
+  it('lists files whose tag references moved', () => {
+    expect(renderComment(result({ rewritten: ['packages/db/src/testing/dedup-replay.ts'] }))).toContain(
+      'dedup-replay.ts',
+    );
+  });
+});
+
+describe('parseArgs', () => {
+  it('defaults to rebase, fetching, and committing', () => {
+    expect(parseArgs([])).toEqual({
+      base: 'origin/main',
+      strategy: 'rebase',
+      dryRun: false,
+      fetch: true,
+      install: false,
+    });
+  });
+
+  it('skips the `--` that `vp run <task> -- <args>` forwards', () => {
+    expect(parseArgs(['--', '--dry-run']).dryRun).toBe(true);
+  });
+
+  it('accepts the merge strategy', () => {
+    expect(parseArgs(['--strategy', 'merge']).strategy).toBe('merge');
+  });
+
+  it('rejects an unknown strategy', () => {
+    expect(() => parseArgs(['--strategy', 'squash'])).toThrow(/rebase or merge/);
+  });
+
+  it('rejects an unknown flag rather than ignoring it', () => {
+    expect(() => parseArgs(['--force'])).toThrow(/unknown argument/);
+  });
+});

--- a/scripts/db-renumber-migration.test.ts
+++ b/scripts/db-renumber-migration.test.ts
@@ -140,6 +140,19 @@ describe('renderComment', () => {
   });
 });
 
+describe('renderComment notes', () => {
+  it('passes an inherited-orphan warning through without claiming it blocked', () => {
+    // Main can already carry an orphan (0177_illegal_omega_red sat there for weeks).
+    // Inheriting one must not wedge the renumber, so it is a note, not a block.
+    const body = renderComment(
+      result({ notes: ['`main` carries an orphaned migration (0177_illegal_omega_red.sql).'] }),
+    );
+    expect(body).toContain('Renumbered onto');
+    expect(body).toContain('0177_illegal_omega_red.sql');
+    expect(body).not.toContain('Nothing was pushed');
+  });
+});
+
 describe('parseArgs', () => {
   it('defaults to rebase, fetching, and committing', () => {
     expect(parseArgs([])).toEqual({
@@ -148,6 +161,7 @@ describe('parseArgs', () => {
       dryRun: false,
       fetch: true,
       install: false,
+      repo: null,
     });
   });
 

--- a/scripts/db-renumber-migration.ts
+++ b/scripts/db-renumber-migration.ts
@@ -239,6 +239,23 @@ function listRefDir(git: Git, ref: string, path: string): string[] {
   return output ? output.split('\n').filter(Boolean) : [];
 }
 
+/**
+ * Read a file's exact bytes out of a ref.
+ *
+ * Deliberately NOT the trimming `Git` wrapper: that is right for command output
+ * like SHAs and path lists, and wrong for file contents. Trimming here would eat a
+ * migration's trailing newline and silently rewrite the author's file — the one
+ * thing this script promises never to do.
+ */
+function readBlob(repoRoot: string, ref: string, path: string): string {
+  return execFileSync('git', ['show', `${ref}:${path}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
 class Blocked extends Error {}
 
 function block(reason: string): never {
@@ -494,7 +511,7 @@ function run(repoRoot: string, options: Options): RenumberResult {
     return result;
   }
 
-  const mainJournal = parseJournal(git(['show', `${options.base}:${JOURNAL_PATH}`]));
+  const mainJournal = parseJournal(readBlob(repoRoot, options.base, JOURNAL_PATH));
   const nextFree = nextFreeIndex(mainJournal, mainFilenames);
   if (!collides(added, nextFree)) {
     console.log(
@@ -508,7 +525,7 @@ function run(repoRoot: string, options: Options): RenumberResult {
 
   // Capture the author's bytes before any history rewrite can touch them.
   const originals = new Map<string, string>(
-    added.map((file: MigrationFile) => [file.tag, git(['show', `${originalHead}:${DRIZZLE_DIR}/${file.filename}`])]),
+    added.map((file: MigrationFile) => [file.tag, readBlob(repoRoot, originalHead, `${DRIZZLE_DIR}/${file.filename}`)]),
   );
 
   // Everything outside the migration folder that this branch, and only this branch,
@@ -560,15 +577,19 @@ function run(repoRoot: string, options: Options): RenumberResult {
 
     const outcome = runGenerate(repoRoot, tail.from.suffix);
     if (outcome.generated === null) {
-      // The branch edits schema files but produces no delta versus main — most
-      // likely main already landed the same change. Don't guess: place it by hand
-      // and let the workflow's `drizzle-kit migrate` be the real arbiter, since a
-      // duplicate DDL fails there loudly and nothing gets pushed.
-      result.notes.push(
-        `\`drizzle-kit generate\` produced no migration (${outcome.detail}). The file was renumbered as-is; ` +
-          'if `main` already made this change the verification step will fail and nothing will be pushed.',
+      // A schema migration MUST come with a regenerated snapshot. Placing it by
+      // hand would leave main's older snapshot as the newest in the chain, so the
+      // next `drizzle-kit generate` anyone runs would diff against a schema state
+      // that understates reality and propose the same DDL a second time. Better to
+      // stop and say why: the two live causes are "main already made this change"
+      // and "drizzle wants to disambiguate a rename", and both need a human.
+      block(
+        `\`drizzle-kit generate\` produced no migration for \`${tail.from.tag}\` (${outcome.detail}).\n\n` +
+          'A schema migration needs a regenerated snapshot, so it cannot be renumbered by hand. ' +
+          'Most often this means `main` already landed the same change, or drizzle needs you to say ' +
+          'whether a table/column was created or renamed. Rebase locally and run ' +
+          '`bunx drizzle-kit generate` from `packages/db` to see the prompt.',
       );
-      placeMigration(repoRoot, tail, originals.get(tail.from.tag) ?? '', when);
     } else {
       if (outcome.generated !== tail.toFilename) {
         block(
@@ -641,15 +662,29 @@ function run(repoRoot: string, options: Options): RenumberResult {
     }
   }
 
+  // Only orphans this run *introduced* are a reason to stop. Main can already carry
+  // one — 0177_illegal_omega_red.sql sat there for weeks — and inheriting it must
+  // not wedge every renumber. `vp run check:db-migrations` is what reports those.
+  const inheritedOrphans = findOrphans(mainJournal, mainFilenames);
   const orphans = findOrphans(
     parseJournal(readFileSync(resolve(repoRoot, JOURNAL_PATH), 'utf8')),
     readdirSync(resolve(repoRoot, DRIZZLE_DIR)),
   );
-  if (orphans.sqlWithoutEntry.length > 0 || orphans.entryWithoutSql.length > 0) {
+  const newOrphanFiles = orphans.sqlWithoutEntry.filter(
+    (filename) => !inheritedOrphans.sqlWithoutEntry.includes(filename),
+  );
+  const newOrphanEntries = orphans.entryWithoutSql.filter((tag) => !inheritedOrphans.entryWithoutSql.includes(tag));
+  if (newOrphanFiles.length > 0 || newOrphanEntries.length > 0) {
     block(
       'The renumber left the migration folder inconsistent ' +
-        `(orphan files: ${orphans.sqlWithoutEntry.join(', ') || 'none'}; ` +
-        `orphan entries: ${orphans.entryWithoutSql.join(', ') || 'none'}).`,
+        `(orphan files: ${newOrphanFiles.join(', ') || 'none'}; ` +
+        `orphan entries: ${newOrphanEntries.join(', ') || 'none'}).`,
+    );
+  }
+  if (inheritedOrphans.sqlWithoutEntry.length > 0) {
+    result.notes.push(
+      `\`main\` carries an orphaned migration (${inheritedOrphans.sqlWithoutEntry.join(', ')}) with no journal ` +
+        'entry, so it never runs. Not caused by this PR — worth deleting on main.',
     );
   }
 
@@ -659,7 +694,12 @@ function run(repoRoot: string, options: Options): RenumberResult {
     return result;
   }
 
-  git(['add', '-A']);
+  // Stage exactly what we touched, never `git add -A`. This commit lands on someone
+  // else's branch, so it must not be able to sweep in a stray build artifact, an
+  // untracked scratch file, or the tooling checkout CI places in the workspace.
+  git(['add', '--', DRIZZLE_DIR]);
+  for (const path of result.rewritten) git(['add', '--', path]);
+
   const subject =
     moves.length === 1 && moves[0]
       ? `chore(db): renumber ${moves[0].from.suffix} to ${padIndex(moves[0].toIndex)} after main`

--- a/scripts/db-renumber-migration.ts
+++ b/scripts/db-renumber-migration.ts
@@ -344,11 +344,24 @@ function mergeBaseRef(git: Git, base: string): void {
         tryGit(git, ['rm', '-qf', '--', path]);
       }
     } else {
+      // An add/add on the same .sql path. Resolve to the branch's body BEFORE
+      // staging — a bare `git add` here would commit the conflict markers.
+      //
+      // Note the orientation is the OPPOSITE of the rebase path above. Merging
+      // main into the branch makes `--ours` the branch and `--theirs` main; a
+      // rebase replays the branch onto main, so there `--ours` is main. Both want
+      // the branch's body, so they need different flags.
+      if (tryGit(git, ['checkout', '--ours', '--', path]) === null) {
+        git(['checkout', base, '--', path]);
+      }
       git(['add', '--', path]);
     }
   }
   git(['add', '-A', '--', DRIZZLE_DIR]);
   tryGit(git, ['-c', 'core.editor=true', 'commit', '--no-edit']);
+  if (tryGit(git, ['diff', '--name-only', '--diff-filter=U']) !== '') {
+    block('The merge left unresolved conflicts in the migration folder.');
+  }
 }
 
 /**

--- a/scripts/db-renumber-migration.ts
+++ b/scripts/db-renumber-migration.ts
@@ -1,0 +1,704 @@
+/// <reference types="node" />
+
+/**
+ * Moves a branch's Drizzle migration onto the current `main` and renumbers it.
+ *
+ * Migration numbers are handed out first-come-first-served, so whichever PR merges
+ * first takes the number and every other open migration PR goes red. Unblocking one
+ * has been a hand ritual — rebase, resolve `_journal.json`, rebuild `packages/db`,
+ * re-run `drizzle-kit generate`, paste the hand-tuned SQL back — performed 26 times
+ * in this repo's history and documented nowhere. This script is that ritual, with the
+ * parts that go wrong turned into assertions.
+ *
+ * Usage:
+ *   vp run db:renumber                     # rebase onto origin/main and renumber
+ *   vp run db:renumber -- --strategy merge # merge instead (no force-push needed)
+ *   vp run db:renumber -- --dry-run        # do the work, skip the commit
+ *
+ * Exit codes: 0 = renumbered or nothing to do, 1 = blocked (a human must look).
+ *
+ * ─── Why it is shaped this way ────────────────────────────────────────────────
+ *
+ * **The contributor's SQL always survives.** A regenerated body is only ever used
+ * as a diff to show a reviewer. Hand-tuning is real and load-bearing here (batched
+ * backfills, explicit sequences, lock avoidance), and the body is what a human
+ * reviewed — silently substituting drizzle's output would change reviewed SQL under
+ * the author.
+ *
+ * **`drizzle-kit generate`'s exit code cannot be trusted.** `prepareAndMigratePg`
+ * ends in `catch (e) { console.error(e); }` with no rethrow, and the folder reader
+ * calls a bare `process.exit(0)` on a malformed snapshot or a snapshot-parent
+ * collision. Every failure mode exits 0, so success is decided by diffing the
+ * directory listing, never by the status code.
+ *
+ * **`meta/` is reset to main's exact bytes before generating.** After a rebase,
+ * main's newest snapshot and the branch's both name the pre-fork snapshot as their
+ * parent. drizzle-kit treats that as a collision and responds with a silent
+ * `process.exit(0)`, so the reset is a correctness requirement, not tidiness.
+ *
+ * **No `--custom`.** It writes a snapshot that is a byte-copy of its predecessor.
+ * A migration with no schema delta gets a hand-written journal entry and no
+ * snapshot at all, which leaves main's tail snapshot as the newest — correct, and
+ * consistent with the 43 snapshot-less migrations already on main.
+ *
+ * **Tag references are never rewritten inside a migration body.** Seven migrations
+ * write an idempotency guard row into `_bs_migration_guards`, and that key is not
+ * the filename (`0163_merge_moonboard_duplicates.sql` guards on
+ * `0162_merge_moonboard_duplicates`). Rewriting it would make an already-applied
+ * migration run again on every machine that had the old number.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, existsSync, readFileSync, readdirSync, writeFileSync, rmSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  DRIZZLE_DIR,
+  JOURNAL_PATH,
+  addedMigrations,
+  collides,
+  findOrphans,
+  isCustomMigration,
+  journalEntryFor,
+  maxWhen,
+  nextFreeIndex,
+  nextWhen,
+  padIndex,
+  parseJournal,
+  planRenumber,
+  rewriteTagReferences,
+  serializeJournal,
+  type MigrationFile,
+  type RenumberMove,
+} from './lib/drizzle-migrations';
+
+/** drizzle-kit can sit on an interactive resolver prompt; never let that hang CI. */
+const GENERATE_TIMEOUT_MS = 300_000;
+
+export type Status = 'no-op' | 'renumbered' | 'blocked';
+export type Strategy = 'rebase' | 'merge';
+
+export interface SqlDivergence {
+  tag: string;
+  original: string;
+  generated: string;
+}
+
+export interface RenumberResult {
+  status: Status;
+  /** Set when status is `blocked` — the single reason a human needs to act. */
+  reason: string | null;
+  strategy: Strategy;
+  moves: RenumberMove[];
+  /** Migrations whose regenerated body differs from what the author wrote. */
+  diverged: SqlDivergence[];
+  /** Files outside the migration folder whose tag references were updated. */
+  rewritten: string[];
+  /** Warnings worth surfacing on the PR but not worth blocking over. */
+  notes: string[];
+}
+
+export const STICKY_MARKER = '<!-- db-renumber -->';
+
+// ─── PURE ───────────────────────────────────────────────────────────────────
+
+/** PURE: whitespace-insensitive SQL comparison, for "did drizzle produce the same thing". */
+export function normalizeSql(sql: string): string {
+  return sql
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join('\n');
+}
+
+/**
+ * PURE: can this set of rebase conflicts be resolved automatically?
+ *
+ * Only conflicts wholly inside the migration folder are mechanical (both sides
+ * appended to the journal tail, or both claimed the same number). A conflict
+ * anywhere else is a real semantic overlap and must go back to a human — resolving
+ * it by rule would silently pick a side of someone's code.
+ */
+export function conflictsAreResolvable(paths: readonly string[]): boolean {
+  return paths.length > 0 && paths.every((path) => path.startsWith(`${DRIZZLE_DIR}/`));
+}
+
+/**
+ * PURE: classify a `drizzle-kit generate` run from the folder listing around it.
+ *
+ * The status code is meaningless (see the file header), so a run "worked" only if
+ * it left a new migration file behind. `stdout` narrows the message when it didn't.
+ */
+export function classifyGenerate(
+  before: readonly string[],
+  after: readonly string[],
+  stdout: string,
+): { generated: string | null; detail: string } {
+  const known = new Set(before);
+  const fresh = after.filter((name) => !known.has(name) && name.endsWith('.sql'));
+  if (fresh.length === 1) return { generated: fresh[0] ?? null, detail: '' };
+  if (fresh.length > 1) {
+    return { generated: null, detail: `generate wrote ${fresh.length} migrations (${fresh.join(', ')})` };
+  }
+  if (stdout.includes('No schema changes')) {
+    return { generated: null, detail: 'no schema delta versus main' };
+  }
+  if (stdout.includes('pointing to a parent snapshot')) {
+    return { generated: null, detail: 'snapshot parent collision — meta/ was not reset to main' };
+  }
+  return { generated: null, detail: `generate produced nothing${stdout.trim() ? `: ${stdout.trim()}` : ''}` };
+}
+
+/** PURE: the PR comment body. */
+export function renderComment(result: RenumberResult): string {
+  const lines: string[] = [STICKY_MARKER, ''];
+
+  if (result.status === 'blocked') {
+    lines.push(
+      '### 🚧 Couldn’t renumber this migration automatically',
+      '',
+      result.reason ?? 'Unknown reason.',
+      '',
+      'Nothing was pushed. Rebase on `main` and run `vp run db:renumber` locally, or fix the',
+      'conflict by hand.',
+    );
+    return lines.join('\n');
+  }
+
+  if (result.status === 'no-op') {
+    lines.push('### ✅ Migration number is already free', '', 'Nothing to renumber against the current `main`.');
+    return lines.join('\n');
+  }
+
+  const moved = result.moves.map((move) => `\`${move.from.filename}\` → \`${move.toFilename}\``).join(', ');
+  lines.push(
+    `### 🔢 Renumbered onto \`main\` (${result.strategy})`,
+    '',
+    `${moved}. Your SQL is unchanged — only the number, the journal entry and the snapshot moved.`,
+    '',
+  );
+
+  if (result.diverged.length > 0) {
+    lines.push(
+      '<details><summary>⚠️ Regenerated SQL differs from yours — <b>yours was kept</b></summary>',
+      '',
+      'Worth a look: either your SQL is deliberately hand-tuned (fine, ignore this), or `main`',
+      'has since changed the same tables and your migration may no longer do what it did.',
+      '',
+    );
+    for (const divergence of result.diverged) {
+      lines.push(
+        `**\`${divergence.tag}\`** — what \`drizzle-kit generate\` would write now:`,
+        '',
+        '```sql',
+        divergence.generated.trim(),
+        '```',
+        '',
+      );
+    }
+    lines.push('</details>', '');
+  }
+
+  if (result.rewritten.length > 0) {
+    lines.push(`Also updated the old tag in ${result.rewritten.map((path) => `\`${path}\``).join(', ')}.`, '');
+  }
+
+  for (const note of result.notes) lines.push(`> ℹ️ ${note}`, '');
+
+  return lines.join('\n');
+}
+
+// ─── I/O ────────────────────────────────────────────────────────────────────
+
+interface Git {
+  (args: readonly string[]): string;
+}
+
+function makeGit(repoRoot: string): Git {
+  return (args: readonly string[]): string =>
+    execFileSync('git', args, {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: 64 * 1024 * 1024,
+    }).trimEnd();
+}
+
+/** Run a git command that is allowed to fail; returns null instead of throwing. */
+function tryGit(git: Git, args: readonly string[]): string | null {
+  try {
+    return git(args);
+  } catch {
+    return null;
+  }
+}
+
+function listRefDir(git: Git, ref: string, path: string): string[] {
+  const output = tryGit(git, ['ls-tree', '--name-only', `${ref}:${path}`]);
+  return output ? output.split('\n').filter(Boolean) : [];
+}
+
+class Blocked extends Error {}
+
+function block(reason: string): never {
+  throw new Blocked(reason);
+}
+
+/**
+ * Drive a rebase to completion, resolving migration-folder conflicts by rule.
+ *
+ * A PR with several commits hits the journal conflict once per commit, so this is a
+ * loop rather than a single resolve. `rerere` is disabled explicitly: a cached
+ * resolution from an earlier run on a self-hosted runner would be applied blind.
+ */
+function rebaseOntoBase(git: Git, repoRoot: string, base: string): void {
+  tryGit(git, ['-c', 'rerere.enabled=false', '-c', 'core.editor=true', 'rebase', base]);
+
+  for (let guard = 0; guard < 200; guard += 1) {
+    if (!rebaseInProgress(repoRoot, git)) return;
+
+    const unmerged = (tryGit(git, ['diff', '--name-only', '--diff-filter=U']) ?? '').split('\n').filter(Boolean);
+    if (!conflictsAreResolvable(unmerged)) {
+      tryGit(git, ['rebase', '--abort']);
+      block(
+        unmerged.length === 0
+          ? 'The rebase stopped without a resolvable conflict.'
+          : `The rebase conflicts outside the migration folder:\n${unmerged.map((path) => `- \`${path}\``).join('\n')}`,
+      );
+    }
+
+    for (const path of unmerged) {
+      if (path.startsWith(`${DRIZZLE_DIR}/meta/`)) {
+        // Metadata is always main's. Drop branch-only meta files main doesn't have.
+        if (tryGit(git, ['cat-file', '-e', `${base}:${path}`]) !== null) {
+          git(['checkout', base, '--', path]);
+        } else {
+          tryGit(git, ['rm', '-qf', '--', path]);
+        }
+      } else {
+        // An add/add on the same .sql path (both sides used the same --name).
+        // Keep the branch's body so later commits in the series still apply; the
+        // file is removed and rewritten under its new number after the rebase.
+        // `--theirs` during a rebase is the commit being replayed, i.e. the branch.
+        if (tryGit(git, ['checkout', '--theirs', '--', path]) === null) {
+          git(['checkout', base, '--', path]);
+        }
+        git(['add', '--', path]);
+      }
+    }
+    git(['add', '-A', '--', DRIZZLE_DIR]);
+
+    // A commit whose only content was the journal entry is now empty; dropping it
+    // is correct, and `rebase --continue` refuses to proceed past one.
+    const staged = tryGit(git, ['diff', '--cached', '--quiet']);
+    if (staged === null) {
+      tryGit(git, ['-c', 'core.editor=true', 'rebase', '--continue']);
+    } else {
+      tryGit(git, ['rebase', '--skip']);
+    }
+  }
+  tryGit(git, ['rebase', '--abort']);
+  block('The rebase did not converge after 200 steps.');
+}
+
+/** Is a rebase mid-flight? Both state dirs are checked; git picks one by backend. */
+function rebaseInProgress(repoRoot: string, git: Git): boolean {
+  return ['rebase-merge', 'rebase-apply'].some((stateDir) => {
+    const gitPath = tryGit(git, ['rev-parse', '--git-path', stateDir]);
+    return gitPath !== null && existsSync(resolve(repoRoot, gitPath));
+  });
+}
+
+function mergeBaseRef(git: Git, base: string): void {
+  const merged = tryGit(git, ['-c', 'core.editor=true', 'merge', '--no-edit', base]);
+  if (merged !== null) return;
+
+  const unmerged = (tryGit(git, ['diff', '--name-only', '--diff-filter=U']) ?? '').split('\n').filter(Boolean);
+  if (!conflictsAreResolvable(unmerged)) {
+    tryGit(git, ['merge', '--abort']);
+    block(`The merge conflicts outside the migration folder:\n${unmerged.map((path) => `- \`${path}\``).join('\n')}`);
+  }
+  for (const path of unmerged) {
+    if (path.startsWith(`${DRIZZLE_DIR}/meta/`)) {
+      if (tryGit(git, ['cat-file', '-e', `${base}:${path}`]) !== null) {
+        git(['checkout', base, '--', path]);
+      } else {
+        tryGit(git, ['rm', '-qf', '--', path]);
+      }
+    } else {
+      git(['add', '--', path]);
+    }
+  }
+  git(['add', '-A', '--', DRIZZLE_DIR]);
+  tryGit(git, ['-c', 'core.editor=true', 'commit', '--no-edit']);
+}
+
+/**
+ * Force `packages/db/drizzle/meta/` to be byte-identical to main.
+ *
+ * `git checkout <ref> -- <dir>` only writes; it never removes files the ref lacks,
+ * so a branch-only snapshot would survive and collide. Removing first is what makes
+ * this a reset rather than an overlay.
+ */
+function resetMetaToBase(git: Git, base: string): void {
+  for (const path of (tryGit(git, ['ls-files', '--', `${DRIZZLE_DIR}/meta/`]) ?? '').split('\n').filter(Boolean)) {
+    if (tryGit(git, ['cat-file', '-e', `${base}:${path}`]) === null) {
+      tryGit(git, ['rm', '-qf', '--', path]);
+    }
+  }
+  git(['checkout', base, '--', `${DRIZZLE_DIR}/meta/`]);
+  if (tryGit(git, ['diff', '--quiet', base, '--', `${DRIZZLE_DIR}/meta/`]) === null) {
+    block('Could not reset the migration metadata to main — refusing to generate against a mixed snapshot chain.');
+  }
+}
+
+function runGenerate(repoRoot: string, suffix: string): { generated: string | null; detail: string } {
+  const dbDir = resolve(repoRoot, 'packages/db');
+  const drizzleDir = resolve(repoRoot, DRIZZLE_DIR);
+  const before = readdirSync(drizzleDir);
+  let stdout = '';
+  try {
+    stdout = execFileSync('bunx', ['drizzle-kit', 'generate', '--name', suffix], {
+      cwd: dbDir,
+      encoding: 'utf8',
+      // No stdin: an interactive resolver prompt EOFs instead of hanging forever.
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: GENERATE_TIMEOUT_MS,
+    });
+  } catch (error) {
+    stdout = String(error);
+  }
+  return classifyGenerate(before, readdirSync(drizzleDir), stdout);
+}
+
+/** Write a migration and its journal entry by hand — no snapshot, no drizzle-kit. */
+function placeMigration(repoRoot: string, move: RenumberMove, body: string, when: number): void {
+  writeFileSync(resolve(repoRoot, DRIZZLE_DIR, move.toFilename), body);
+  const journalPath = resolve(repoRoot, JOURNAL_PATH);
+  const journal = parseJournal(readFileSync(journalPath, 'utf8'));
+  journal.entries.push(journalEntryFor(move.toIndex, move.from.suffix, when));
+  writeFileSync(journalPath, serializeJournal(journal));
+}
+
+export interface Options {
+  strategy: Strategy;
+  dryRun: boolean;
+  fetch: boolean;
+  install: boolean;
+  /** The ref to renumber against. Overridable so the flow can be exercised in a test tree. */
+  base: string;
+  /**
+   * The repository to operate on, when it isn't the one this script lives in.
+   *
+   * Every PR in today's backlog was opened before this tooling existed, so their
+   * branches have no `scripts/db-renumber-migration.ts` and no `db:renumber` task
+   * to invoke. The workflow therefore runs main's copy of the script against the
+   * PR's checkout. The script has no npm dependencies — only Node builtins and its
+   * own `lib/` sibling — so it runs fine from outside the tree it is fixing.
+   */
+  repo: string | null;
+}
+
+export function parseArgs(argv: readonly string[]): Options {
+  const options: Options = {
+    base: 'origin/main',
+    strategy: 'rebase',
+    dryRun: false,
+    fetch: true,
+    install: false,
+    repo: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    switch (flag) {
+      // `vp run <task> -- <args>` forwards a literal `--` separator; it carries no meaning here.
+      case '--':
+        break;
+      case '--base': {
+        const value = argv[index + 1];
+        if (value === undefined) throw new Error('missing value for --base');
+        options.base = value;
+        index += 1;
+        break;
+      }
+      case '--strategy': {
+        const value = argv[index + 1];
+        if (value !== 'rebase' && value !== 'merge') throw new Error('--strategy must be rebase or merge');
+        options.strategy = value;
+        index += 1;
+        break;
+      }
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      case '--no-fetch':
+        options.fetch = false;
+        break;
+      case '--install':
+        options.install = true;
+        break;
+      case '--repo': {
+        const value = argv[index + 1];
+        if (value === undefined) throw new Error('missing value for --repo');
+        options.repo = value;
+        index += 1;
+        break;
+      }
+      default:
+        throw new Error(`unknown argument: ${flag}`);
+    }
+  }
+  return options;
+}
+
+function emitGithubOutputs(result: RenumberResult): void {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  appendFileSync(
+    outputPath,
+    [
+      `status=${result.status}`,
+      `renamed_from=${result.moves.map((move) => move.from.filename).join(',')}`,
+      `renamed_to=${result.moves.map((move) => move.toFilename).join(',')}`,
+      `sql_diverged=${result.diverged.length > 0}`,
+      `comment_b64=${Buffer.from(renderComment(result), 'utf8').toString('base64')}`,
+      '',
+    ].join('\n'),
+  );
+}
+
+function run(repoRoot: string, options: Options): RenumberResult {
+  const git = makeGit(repoRoot);
+  const result: RenumberResult = {
+    status: 'no-op',
+    reason: null,
+    strategy: options.strategy,
+    moves: [],
+    diverged: [],
+    rewritten: [],
+    notes: [],
+  };
+
+  if (tryGit(git, ['diff', '--quiet', 'HEAD']) === null) {
+    block('The working tree has uncommitted changes. Commit or stash them first.');
+  }
+  if (options.fetch && options.base === 'origin/main') git(['fetch', '--no-tags', 'origin', 'main']);
+
+  const originalHead = git(['rev-parse', 'HEAD']);
+  const mainFilenames = listRefDir(git, options.base, DRIZZLE_DIR);
+  const headFilenames = listRefDir(git, originalHead, DRIZZLE_DIR);
+  const added = addedMigrations(mainFilenames, headFilenames);
+  if (added.length === 0) {
+    console.log('[db-renumber] This branch adds no migrations.');
+    return result;
+  }
+
+  const mainJournal = parseJournal(git(['show', `${options.base}:${JOURNAL_PATH}`]));
+  const nextFree = nextFreeIndex(mainJournal, mainFilenames);
+  if (!collides(added, nextFree)) {
+    console.log(
+      `[db-renumber] ${added.map((file) => file.filename).join(', ')} already sits above main (${padIndex(nextFree - 1)}).`,
+    );
+    return result;
+  }
+
+  const moves = planRenumber(added, nextFree);
+  result.moves = moves;
+
+  // Capture the author's bytes before any history rewrite can touch them.
+  const originals = new Map<string, string>(
+    added.map((file: MigrationFile) => [file.tag, git(['show', `${originalHead}:${DRIZZLE_DIR}/${file.filename}`])]),
+  );
+
+  // Everything outside the migration folder that this branch, and only this branch,
+  // touched. The rebase must leave every one of these blobs untouched.
+  const mergeBase = git(['merge-base', originalHead, options.base]);
+  const branchTouched = new Set(
+    (tryGit(git, ['diff', '--name-only', mergeBase, originalHead, '--', '.', `:(exclude)${DRIZZLE_DIR}/**`]) ?? '')
+      .split('\n')
+      .filter(Boolean),
+  );
+  const mainTouched = new Set(
+    (tryGit(git, ['diff', '--name-only', mergeBase, options.base, '--', '.', `:(exclude)${DRIZZLE_DIR}/**`]) ?? '')
+      .split('\n')
+      .filter(Boolean),
+  );
+  const branchOnly = [...branchTouched].filter((path) => !mainTouched.has(path));
+  const blobsBefore = new Map(branchOnly.map((path) => [path, tryGit(git, ['rev-parse', `${originalHead}:${path}`])]));
+
+  if (options.strategy === 'merge') mergeBaseRef(git, options.base);
+  else rebaseOntoBase(git, repoRoot, options.base);
+
+  resetMetaToBase(git, options.base);
+  for (const file of added) tryGit(git, ['rm', '-qf', '--', `${DRIZZLE_DIR}/${file.filename}`]);
+  // A conflict resolution may have left the old file on disk but unstaged.
+  for (const file of added) rmSync(resolve(repoRoot, DRIZZLE_DIR, file.filename), { force: true });
+
+  // Does this branch change the schema at all? A data/backfill migration doesn't,
+  // and then no build and no drizzle-kit run is needed.
+  const touchesSchema =
+    tryGit(git, ['diff', '--quiet', options.base, 'HEAD', '--', 'packages/db/src/schema/']) === null;
+
+  let when = nextWhen(maxWhen(mainJournal), Date.now());
+
+  if (touchesSchema) {
+    if (options.install) execFileSync('bun', ['install', '--frozen-lockfile'], { cwd: repoRoot, stdio: 'inherit' });
+    // drizzle.config.ts reads ./dist/schema/index.js — a stale build makes generate
+    // see phantom column renames and stop on an interactive prompt.
+    execFileSync('vp', ['run', 'build:db'], { cwd: repoRoot, stdio: 'inherit' });
+
+    // Everything but the last migration is hand-written; drizzle-kit can only ever
+    // emit one migration (its snapshot is always the full current schema), so the
+    // single generate lands the tail and its snapshot.
+    for (const move of moves.slice(0, -1)) {
+      placeMigration(repoRoot, move, originals.get(move.from.tag) ?? '', when);
+      when += 1;
+    }
+    const tail = moves[moves.length - 1];
+    if (!tail) block('No migrations to renumber.');
+
+    const outcome = runGenerate(repoRoot, tail.from.suffix);
+    if (outcome.generated === null) {
+      // The branch edits schema files but produces no delta versus main — most
+      // likely main already landed the same change. Don't guess: place it by hand
+      // and let the workflow's `drizzle-kit migrate` be the real arbiter, since a
+      // duplicate DDL fails there loudly and nothing gets pushed.
+      result.notes.push(
+        `\`drizzle-kit generate\` produced no migration (${outcome.detail}). The file was renumbered as-is; ` +
+          'if `main` already made this change the verification step will fail and nothing will be pushed.',
+      );
+      placeMigration(repoRoot, tail, originals.get(tail.from.tag) ?? '', when);
+    } else {
+      if (outcome.generated !== tail.toFilename) {
+        block(
+          `drizzle-kit numbered the migration \`${outcome.generated}\` but \`${tail.toFilename}\` was expected — ` +
+            'the journal and the folder disagree about the next number.',
+        );
+      }
+      const generatedPath = resolve(repoRoot, DRIZZLE_DIR, outcome.generated);
+      const generatedBody = readFileSync(generatedPath, 'utf8');
+      const originalBody = originals.get(tail.from.tag) ?? '';
+      if (normalizeSql(generatedBody) !== normalizeSql(originalBody)) {
+        result.diverged.push({ tag: tail.toTag, original: originalBody, generated: generatedBody });
+      }
+      // The author's bytes win; drizzle's version is only ever a review aid.
+      writeFileSync(generatedPath, originalBody);
+
+      // drizzle stamps its own Date.now(), which can tie with ours in the same
+      // millisecond; force the tail strictly above everything already journalled.
+      const journalPath = resolve(repoRoot, JOURNAL_PATH);
+      const journal = parseJournal(readFileSync(journalPath, 'utf8'));
+      const tailEntry = journal.entries[journal.entries.length - 1];
+      if (tailEntry) {
+        tailEntry.when = when;
+        writeFileSync(journalPath, serializeJournal(journal));
+      }
+    }
+  } else {
+    for (const move of moves) {
+      const body = originals.get(move.from.tag) ?? '';
+      if (isCustomMigration(body)) {
+        result.notes.push(`\`${move.toTag}\` is a hand-written migration — its SQL was carried over verbatim.`);
+      }
+      placeMigration(repoRoot, move, body, when);
+      when += 1;
+    }
+  }
+
+  // Update filename-shaped references to the old tag, but only in files this branch
+  // itself touched — those are provably the author's own lookups (the
+  // `dedup-replay.ts` pattern). A hit in a file the branch never touched is a
+  // pre-existing `_bs_migration_guards` key, which must not move.
+  for (const move of moves) {
+    const hits = (tryGit(git, ['grep', '-Il', move.from.tag, '--', `:(exclude)${DRIZZLE_DIR}`]) ?? '')
+      .split('\n')
+      .filter(Boolean);
+    const foreign = hits.filter((path) => !branchTouched.has(path));
+    if (foreign.length > 0) {
+      block(
+        `\`${move.from.tag}\` is referenced by files this branch didn't touch:\n` +
+          `${foreign.map((path) => `- \`${path}\``).join('\n')}\n\n` +
+          'Those are most likely `_bs_migration_guards` keys, which must not be renumbered. Renumber by hand.',
+      );
+    }
+    for (const path of hits) {
+      const absolute = resolve(repoRoot, path);
+      const before = readFileSync(absolute, 'utf8');
+      const after = rewriteTagReferences(before, move.from.tag, move.toTag);
+      if (after !== before) {
+        writeFileSync(absolute, after);
+        result.rewritten.push(path);
+      }
+    }
+  }
+
+  // Nothing may have silently changed outside the migration folder.
+  for (const [path, before] of blobsBefore) {
+    const after = tryGit(git, ['rev-parse', `HEAD:${path}`]);
+    if (before !== after) {
+      block(`The rebase altered \`${path}\`, which this branch owns. Refusing to continue.`);
+    }
+  }
+
+  const orphans = findOrphans(
+    parseJournal(readFileSync(resolve(repoRoot, JOURNAL_PATH), 'utf8')),
+    readdirSync(resolve(repoRoot, DRIZZLE_DIR)),
+  );
+  if (orphans.sqlWithoutEntry.length > 0 || orphans.entryWithoutSql.length > 0) {
+    block(
+      'The renumber left the migration folder inconsistent ' +
+        `(orphan files: ${orphans.sqlWithoutEntry.join(', ') || 'none'}; ` +
+        `orphan entries: ${orphans.entryWithoutSql.join(', ') || 'none'}).`,
+    );
+  }
+
+  result.status = 'renumbered';
+  if (options.dryRun) {
+    console.log('[db-renumber] --dry-run: leaving the changes uncommitted.');
+    return result;
+  }
+
+  git(['add', '-A']);
+  const subject =
+    moves.length === 1 && moves[0]
+      ? `chore(db): renumber ${moves[0].from.suffix} to ${padIndex(moves[0].toIndex)} after main`
+      : `chore(db): renumber ${moves.length} migrations to ${padIndex(nextFree)}+ after main`;
+  git(['commit', '-m', subject]);
+  return result;
+}
+
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
+  const options = parseArgs(argv);
+  const repoRoot = options.repo ? resolve(options.repo) : resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+  let result: RenumberResult;
+  try {
+    result = run(repoRoot, options);
+  } catch (error) {
+    if (!(error instanceof Blocked)) throw error;
+    result = {
+      status: 'blocked',
+      reason: error.message,
+      strategy: options.strategy,
+      moves: [],
+      diverged: [],
+      rewritten: [],
+      notes: [],
+    };
+  }
+
+  for (const move of result.moves) {
+    console.log(`[db-renumber] ${move.from.filename} → ${move.toFilename}`);
+  }
+  for (const note of result.notes) console.warn(`::warning::${note}`);
+  if (result.status === 'blocked') console.error(`::error::${result.reason}`);
+  console.log(`[db-renumber] status: ${result.status}`);
+
+  emitGithubOutputs(result);
+  return result.status === 'blocked' ? 1 : 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/scripts/lib/drizzle-migrations.test.ts
+++ b/scripts/lib/drizzle-migrations.test.ts
@@ -1,0 +1,242 @@
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CUSTOM_SENTINEL,
+  addedMigrations,
+  collides,
+  duplicateIndexes,
+  findOrphans,
+  isCustomMigration,
+  journalEntryFor,
+  maxWhen,
+  migrationFiles,
+  migrationIndex,
+  nextFreeIndex,
+  nextWhen,
+  padIndex,
+  parseJournal,
+  parseMigrationFilename,
+  planRenumber,
+  rewriteTagReferences,
+  serializeJournal,
+  type Journal,
+  type JournalEntry,
+} from './drizzle-migrations';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function entry(idx: number, tag: string, when: number): JournalEntry {
+  return { idx, version: '7', when, tag, breakpoints: true };
+}
+
+function journalOf(...entries: JournalEntry[]): Journal {
+  return { version: '7', dialect: 'postgresql', entries };
+}
+
+describe('parseMigrationFilename', () => {
+  it('parses a migration filename into its parts', () => {
+    expect(parseMigrationFilename('0187_greedy_thing.sql')).toEqual({
+      index: 187,
+      suffix: 'greedy_thing',
+      tag: '0187_greedy_thing',
+      filename: '0187_greedy_thing.sql',
+    });
+  });
+
+  it('rejects anything that is not a numbered migration', () => {
+    expect(parseMigrationFilename('_journal.json')).toBeNull();
+    expect(parseMigrationFilename('0187_snapshot.json')).toBeNull();
+    expect(parseMigrationFilename('187_short_prefix.sql')).toBeNull();
+    expect(parseMigrationFilename('README.md')).toBeNull();
+  });
+});
+
+describe('migrationIndex', () => {
+  it('reads the numeric prefix off a tag', () => {
+    expect(migrationIndex('0186_backfill_sync_frozen_at')).toBe(186);
+    expect(migrationIndex('not-a-tag')).toBeNull();
+  });
+});
+
+describe('serializeJournal', () => {
+  it('round-trips the real journal byte-for-byte', () => {
+    // Pins two things nothing else guards: the two-space indent, and the absent
+    // trailing newline. The folder is in .prettierignore, so a drift here would
+    // show up as noise in every future migration diff.
+    const path = resolve(repoRoot, 'packages/db/drizzle/meta/_journal.json');
+    const original = readFileSync(path, 'utf8');
+    expect(serializeJournal(parseJournal(original))).toBe(original);
+  });
+
+  it('does not append a trailing newline', () => {
+    expect(serializeJournal(journalOf(entry(0, '0000_a', 1)))).not.toMatch(/\n$/);
+  });
+});
+
+describe('parseJournal', () => {
+  it('rejects a malformed entry rather than passing it through', () => {
+    // drizzle-kit answers a malformed journal with a bare process.exit(0), so this
+    // is the only place the problem can surface.
+    expect(() => parseJournal('{"entries":[{"idx":1}]}')).toThrow(/malformed/);
+    expect(() => parseJournal('{}')).toThrow(/no entries array/);
+  });
+});
+
+describe('nextFreeIndex', () => {
+  it('takes the journal tail when the folder agrees', () => {
+    expect(nextFreeIndex(journalOf(entry(185, '0185_a', 1), entry(186, '0186_b', 2)), ['0186_b.sql'])).toBe(187);
+  });
+
+  it('respects an orphaned file above the journal tail', () => {
+    // The 0177_illegal_omega_red shape: tracked on disk, absent from the journal.
+    // drizzle-kit numbers from the journal tail alone and would re-collide here.
+    const journal = journalOf(entry(176, '0176_a', 1));
+    expect(nextFreeIndex(journal, ['0176_a.sql', '0177_illegal_omega_red.sql'])).toBe(178);
+  });
+
+  it('uses the tag prefix when it has drifted from idx', () => {
+    // Real shape from main: idx 51 carries tag 0052_add_postgis_location.
+    expect(nextFreeIndex(journalOf(entry(51, '0052_add_postgis_location', 1)), [])).toBe(53);
+  });
+
+  it('handles an empty folder', () => {
+    expect(nextFreeIndex(journalOf(), [])).toBe(0);
+  });
+});
+
+describe('addedMigrations', () => {
+  it('is a set difference, so a prior renumber still registers', () => {
+    // A branch renumbered once shows up as a rename, which `--diff-filter=A` misses.
+    const added = addedMigrations(['0186_b.sql'], ['0186_b.sql', '0187_mine.sql']);
+    expect(added.map((file) => file.filename)).toEqual(['0187_mine.sql']);
+  });
+
+  it('ignores non-migration entries in the listing', () => {
+    expect(addedMigrations([], ['meta', 'README.md', '0001_x.sql'])).toHaveLength(1);
+  });
+});
+
+describe('collides', () => {
+  const at = (index: number) => migrationFiles([`${padIndex(index)}_x.sql`]);
+
+  it('is false while the branch still holds main’s next free number', () => {
+    // Observed on the real repo: with main at 0186, four open PRs all held 0187
+    // and every one of them reported MERGEABLE. 0187 is genuinely free until
+    // somebody takes it, so renumbering then would be pure churn.
+    expect(collides(at(187), 187)).toBe(false);
+    expect(collides([], 187)).toBe(false);
+  });
+
+  it('is true once main has taken the number', () => {
+    // The instant one of those four merges, main's next free becomes 0188 and the
+    // other three are stranded — this is the moment the fan-out fires.
+    expect(collides(at(187), 188)).toBe(true);
+    expect(collides(at(185), 188)).toBe(true);
+  });
+});
+
+describe('planRenumber', () => {
+  it('assigns contiguous numbers and keeps suffixes and order', () => {
+    const added = migrationFiles(['0185_first.sql', '0186_second.sql']);
+    expect(planRenumber(added, 190).map((move) => move.toFilename)).toEqual(['0190_first.sql', '0191_second.sql']);
+  });
+
+  it('refuses a branch that already has two migrations at one number', () => {
+    const added = migrationFiles(['0187_a.sql', '0187_b.sql']);
+    expect(() => planRenumber(added, 190)).toThrow(/ambiguous/);
+  });
+});
+
+describe('nextWhen', () => {
+  it('uses the clock when it is already ahead', () => {
+    expect(nextWhen(1_000, 2_000)).toBe(2_000);
+  });
+
+  it('clamps past a future-stamped journal so the migration is never skipped', () => {
+    // Both appliers order by `when`; a value at or below the newest applied
+    // migration is skipped permanently and silently.
+    expect(nextWhen(5_000, 2_000)).toBe(5_001);
+    expect(nextWhen(5_000, 5_000)).toBe(5_001);
+  });
+});
+
+describe('maxWhen', () => {
+  it('is the maximum, not the last entry — the journal is not monotonic', () => {
+    expect(maxWhen(journalOf(entry(0, '0000_a', 900), entry(1, '0001_b', 100)))).toBe(900);
+  });
+});
+
+describe('journalEntryFor', () => {
+  it('builds a v7 entry whose tag prefix matches its idx', () => {
+    expect(journalEntryFor(188, 'greedy_thing', 42)).toEqual({
+      idx: 188,
+      version: '7',
+      when: 42,
+      tag: '0188_greedy_thing',
+      breakpoints: true,
+    });
+  });
+});
+
+describe('findOrphans', () => {
+  it('flags a file with no journal entry', () => {
+    const report = findOrphans(journalOf(entry(179, '0179_bent_kid_colt', 1)), [
+      '0177_illegal_omega_red.sql',
+      '0179_bent_kid_colt.sql',
+    ]);
+    expect(report.sqlWithoutEntry).toEqual(['0177_illegal_omega_red.sql']);
+    expect(report.entryWithoutSql).toEqual([]);
+  });
+
+  it('flags a journal entry with no file', () => {
+    const report = findOrphans(journalOf(entry(1, '0001_gone', 1)), []);
+    expect(report.entryWithoutSql).toEqual(['0001_gone']);
+  });
+
+  it('is clean for a consistent folder', () => {
+    const report = findOrphans(journalOf(entry(1, '0001_a', 1)), ['0001_a.sql', 'meta']);
+    expect(report.sqlWithoutEntry).toEqual([]);
+    expect(report.entryWithoutSql).toEqual([]);
+  });
+});
+
+describe('duplicateIndexes', () => {
+  it('finds numbers claimed more than once', () => {
+    expect(duplicateIndexes(['0048_add_feed_items.sql', '0048_add_proposals.sql', '0049_x.sql'])).toEqual([48]);
+  });
+});
+
+describe('isCustomMigration', () => {
+  it('detects the drizzle-kit --custom sentinel', () => {
+    expect(isCustomMigration(`${CUSTOM_SENTINEL}\nUPDATE foo SET bar = 1;`)).toBe(true);
+    expect(isCustomMigration('ALTER TABLE "foo" ADD COLUMN "bar" text;')).toBe(false);
+  });
+});
+
+describe('rewriteTagReferences', () => {
+  it('rewrites a whole-tag reference', () => {
+    expect(
+      rewriteTagReferences(
+        "dedupReplaySql('0165_kilter_dedup_backfill')",
+        '0165_kilter_dedup_backfill',
+        '0167_kilter_dedup_backfill',
+      ),
+    ).toBe("dedupReplaySql('0167_kilter_dedup_backfill')");
+  });
+
+  it('leaves a longer tag that merely starts the same alone', () => {
+    expect(rewriteTagReferences('0187_foo_bar', '0187_foo', '0188_foo')).toBe('0187_foo_bar');
+  });
+
+  it('leaves a hyphenated extension alone', () => {
+    expect(rewriteTagReferences('0187_foo-bar', '0187_foo', '0188_foo')).toBe('0187_foo-bar');
+  });
+
+  it('rewrites every occurrence', () => {
+    expect(rewriteTagReferences('a 0187_x b 0187_x', '0187_x', '0188_x')).toBe('a 0188_x b 0188_x');
+  });
+});

--- a/scripts/lib/drizzle-migrations.ts
+++ b/scripts/lib/drizzle-migrations.ts
@@ -1,0 +1,312 @@
+/// <reference types="node" />
+
+/**
+ * Pure helpers for reasoning about the Drizzle migration folder
+ * (`packages/db/drizzle/`) and its `meta/_journal.json`.
+ *
+ * Shared by `scripts/check-db-migrations.ts` (the PR-time validator) and
+ * `scripts/db-renumber-migration.ts` (the renumber engine). Everything here is
+ * side-effect free so both callers can be unit tested without a git tree, a
+ * database, or drizzle-kit.
+ *
+ * Three properties of the real folder drive the shapes below, and each one has
+ * bitten this repo already:
+ *
+ *  - **Ordering is by `when`, not by number.** `packages/db/scripts/migrate.ts`
+ *    and `scripts/dev-db-up.sh` both select entries whose `when` is newer than
+ *    the last applied migration. A renumbered migration whose `when` lands at or
+ *    below an already-applied timestamp is skipped *forever*, silently, in
+ *    production. Hence `nextWhen()` and its clamp.
+ *  - **Numbers are not unique and not aligned to `idx`.** Main carries duplicate
+ *    prefixes (`0025`, `0048`–`0052`, `0177`) from past hand-merges, and 30
+ *    journal entries have a `tag` prefix that differs from their `idx`. So the
+ *    next free number is `max(journal tail idx, max on-disk prefix) + 1`, never
+ *    just the journal tail — drizzle-kit itself only looks at the journal tail,
+ *    which is why an orphan above the tail would let it re-collide.
+ *  - **A `.sql` file with no journal entry is invisible and dead.** Nothing ever
+ *    applies it. `0177_illegal_omega_red.sql` sat on main in exactly that state,
+ *    left by a hand-renumber that added the new file and forgot to remove the
+ *    old one. `findOrphans()` is what catches that class.
+ */
+
+/** One `meta/_journal.json` entry, in drizzle-kit's v7 shape. */
+export interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+export interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+/** A migration file's identity, parsed from `NNNN_suffix.sql`. */
+export interface MigrationFile {
+  /** The 4-digit numeric prefix. */
+  index: number;
+  /** Everything after the prefix, without the `.sql` extension. */
+  suffix: string;
+  /** `NNNN_suffix` — how the journal and `dedup-replay.ts` refer to a migration. */
+  tag: string;
+  /** The basename, `NNNN_suffix.sql`. */
+  filename: string;
+}
+
+/** Migration filenames are always a zero-padded 4-digit index, an underscore, then a name. */
+const MIGRATION_FILE_RE = /^(\d{4})_(.+)\.sql$/;
+
+/** A journal tag is the filename without the extension. */
+const MIGRATION_TAG_RE = /^(\d{4})_(.+)$/;
+
+/**
+ * The first line `drizzle-kit generate --custom` writes. Its presence means the
+ * migration carries hand-written DDL/DML rather than a generated schema diff, so
+ * the renumber engine must preserve the body verbatim rather than trusting a
+ * regenerated one.
+ */
+export const CUSTOM_SENTINEL = '-- Custom SQL migration file, put your code below! --';
+
+/** The path of the migration folder, relative to the repo root. */
+export const DRIZZLE_DIR = 'packages/db/drizzle';
+
+/** The path of the journal, relative to the repo root. */
+export const JOURNAL_PATH = `${DRIZZLE_DIR}/meta/_journal.json`;
+
+/** PURE: zero-pad a migration index the way drizzle-kit's `index` prefix mode does. */
+export function padIndex(index: number): string {
+  return index.toFixed(0).padStart(4, '0');
+}
+
+/**
+ * PURE: parse `_journal.json`.
+ *
+ * Deliberately strict — a malformed journal must fail loudly here rather than
+ * flow into a renumber that rewrites it. drizzle-kit's own reader responds to a
+ * malformed journal with a bare `process.exit(0)`, so we cannot lean on it.
+ */
+export function parseJournal(text: string): Journal {
+  const parsed: unknown = JSON.parse(text);
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('journal is not an object');
+  }
+  const candidate = parsed as Partial<Journal>;
+  if (!Array.isArray(candidate.entries)) {
+    throw new Error('journal has no entries array');
+  }
+  for (const entry of candidate.entries) {
+    if (typeof entry.idx !== 'number' || typeof entry.when !== 'number' || typeof entry.tag !== 'string') {
+      throw new Error(`journal entry is malformed: ${JSON.stringify(entry)}`);
+    }
+  }
+  return {
+    version: candidate.version ?? '7',
+    dialect: candidate.dialect ?? 'postgresql',
+    entries: candidate.entries,
+  };
+}
+
+/**
+ * PURE: serialize `_journal.json` byte-identically to how drizzle-kit writes it —
+ * two-space indent and **no trailing newline**.
+ *
+ * The folder is in `.prettierignore` (`**\/drizzle/meta/`), so nothing else in the
+ * toolchain would normalize a formatting drift back; a stray newline would show up
+ * as noise in every future migration diff.
+ */
+export function serializeJournal(journal: Journal): string {
+  return JSON.stringify(journal, null, 2);
+}
+
+/** PURE: parse `NNNN_suffix.sql`; null when the name is not a migration file. */
+export function parseMigrationFilename(filename: string): MigrationFile | null {
+  const match = MIGRATION_FILE_RE.exec(filename);
+  if (!match) return null;
+  const [, prefix, suffix] = match;
+  return { index: Number(prefix), suffix, tag: `${prefix}_${suffix}`, filename };
+}
+
+/** PURE: the numeric prefix of a journal tag (`0187_greedy_thing` → 187); null if unparseable. */
+export function migrationIndex(tag: string): number | null {
+  const match = MIGRATION_TAG_RE.exec(tag);
+  return match ? Number(match[1]) : null;
+}
+
+/** PURE: keep only the entries of a directory listing that are migration files. */
+export function migrationFiles(filenames: readonly string[]): MigrationFile[] {
+  return filenames
+    .map(parseMigrationFilename)
+    .filter((entry): entry is MigrationFile => entry !== null)
+    .sort((left, right) => left.index - right.index || left.filename.localeCompare(right.filename));
+}
+
+/**
+ * PURE: the next migration number that is free on the given tree.
+ *
+ * Takes the max of the journal tail and every on-disk prefix, because the two can
+ * disagree: drizzle-kit derives its next number from the journal tail alone, so an
+ * orphaned `.sql` sitting above the tail would let it hand out a number that is
+ * already taken on disk.
+ */
+export function nextFreeIndex(journal: Journal, filenames: readonly string[]): number {
+  const journalTail = journal.entries.length === 0 ? -1 : (journal.entries[journal.entries.length - 1]?.idx ?? -1);
+  const journalMaxTagIndex = journal.entries.reduce(
+    (highest, entry) => Math.max(highest, migrationIndex(entry.tag) ?? -1),
+    -1,
+  );
+  const diskMax = migrationFiles(filenames).reduce((highest, file) => Math.max(highest, file.index), -1);
+  return Math.max(journalTail, journalMaxTagIndex, diskMax) + 1;
+}
+
+/**
+ * PURE: which migrations exist on the branch but not on the base.
+ *
+ * A set difference over directory listings rather than `git diff --diff-filter=A`,
+ * because a branch that was already renumbered once shows its migration as a
+ * *rename*, which an added-files filter misses entirely.
+ */
+export function addedMigrations(baseFilenames: readonly string[], headFilenames: readonly string[]): MigrationFile[] {
+  const base = new Set(migrationFiles(baseFilenames).map((file) => file.filename));
+  return migrationFiles(headFilenames).filter((file) => !base.has(file.filename));
+}
+
+/**
+ * PURE: does this branch's migration set need renumbering against a base whose
+ * next free number is `nextFree`?
+ *
+ * True when any added migration sits at or below a number the base already uses.
+ * A branch already sitting contiguously above the base is left alone — the whole
+ * point of the fan-out is to touch only PRs that actually collide.
+ */
+export function collides(added: readonly MigrationFile[], nextFree: number): boolean {
+  return added.some((file) => file.index < nextFree);
+}
+
+/** PURE: does this body carry hand-written SQL rather than a generated schema diff? */
+export function isCustomMigration(body: string): boolean {
+  return body.trimStart().startsWith(CUSTOM_SENTINEL);
+}
+
+/** PURE: the newest `when` recorded anywhere in the journal. */
+export function maxWhen(journal: Journal): number {
+  return journal.entries.reduce((highest, entry) => Math.max(highest, entry.when), 0);
+}
+
+/**
+ * PURE: a `when` for a renumbered migration.
+ *
+ * Must be strictly greater than every `when` already in the journal, or the
+ * appliers — which compare against the newest applied `created_at`, not against
+ * the migration number — skip it permanently. The clamp matters because the
+ * journal is *not* globally monotonic (seven historical entries regress), so
+ * "later in the array" does not imply "larger `when`", and a runner with a skewed
+ * clock could otherwise mint a timestamp in the past.
+ */
+export function nextWhen(previousMax: number, now: number): number {
+  return Math.max(now, previousMax + 1);
+}
+
+/** PURE: build the journal entry for a migration at a given index. */
+export function journalEntryFor(index: number, suffix: string, when: number): JournalEntry {
+  return {
+    idx: index,
+    version: '7',
+    when,
+    tag: `${padIndex(index)}_${suffix}`,
+    breakpoints: true,
+  };
+}
+
+export interface OrphanReport {
+  /** Migration files on disk that no journal entry references — dead, never applied. */
+  sqlWithoutEntry: string[];
+  /** Journal entries whose `.sql` file is missing — would crash the migrator. */
+  entryWithoutSql: string[];
+}
+
+/**
+ * PURE: cross-check the folder against the journal.
+ *
+ * `sqlWithoutEntry` is the `0177_illegal_omega_red.sql` failure mode: a file that
+ * looks like a migration, is tracked in git, is reviewed as if it will run, and is
+ * in fact inert. `entryWithoutSql` is the mirror image and is worse — the migrator
+ * throws when it cannot read a journalled file.
+ */
+export function findOrphans(journal: Journal, filenames: readonly string[]): OrphanReport {
+  const journalTags = new Set(journal.entries.map((entry) => entry.tag));
+  const diskTags = new Map(migrationFiles(filenames).map((file) => [file.tag, file.filename]));
+
+  return {
+    sqlWithoutEntry: [...diskTags.entries()]
+      .filter(([tag]) => !journalTags.has(tag))
+      .map(([, filename]) => filename)
+      .sort(),
+    entryWithoutSql: journal.entries
+      .map((entry) => entry.tag)
+      .filter((tag) => !diskTags.has(tag))
+      .sort(),
+  };
+}
+
+/** PURE: migration files sharing a numeric prefix, which makes apply order ambiguous. */
+export function duplicateIndexes(filenames: readonly string[]): number[] {
+  const seen = new Map<number, number>();
+  for (const file of migrationFiles(filenames)) {
+    seen.set(file.index, (seen.get(file.index) ?? 0) + 1);
+  }
+  return [...seen.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([index]) => index)
+    .sort((left, right) => left - right);
+}
+
+export interface RenumberMove {
+  from: MigrationFile;
+  toIndex: number;
+  toFilename: string;
+  toTag: string;
+}
+
+/**
+ * PURE: assign each added migration its new number, preserving relative order.
+ *
+ * Throws when the branch itself already contains two migrations at the same
+ * number — that input is ambiguous about apply order, and guessing would be worse
+ * than refusing.
+ */
+export function planRenumber(added: readonly MigrationFile[], nextFree: number): RenumberMove[] {
+  const duplicates = duplicateIndexes(added.map((file) => file.filename));
+  if (duplicates.length > 0) {
+    throw new Error(
+      `this branch adds more than one migration at ${duplicates.map(padIndex).join(', ')} — ` +
+        'apply order is ambiguous, renumber by hand',
+    );
+  }
+  return added.map((file, offset) => {
+    const toIndex = nextFree + offset;
+    const toTag = `${padIndex(toIndex)}_${file.suffix}`;
+    return { from: file, toIndex, toFilename: `${toTag}.sql`, toTag };
+  });
+}
+
+/**
+ * PURE: rewrite whole-tag references in a text file.
+ *
+ * Word-boundary matched with a negative lookahead so renaming `0187_foo` leaves
+ * `0187_foo_bar` alone.
+ *
+ * Callers must never apply this to a migration *body*. Seven migrations on main
+ * write an idempotency guard row into `_bs_migration_guards`, and that key is not
+ * the filename — `0163_merge_moonboard_duplicates.sql` guards on
+ * `0162_merge_moonboard_duplicates`, `0154_rescale_climb_stats_history_quality.sql`
+ * on `0154_history_quality_rescale`. The guard is a semantic identity, so rewriting
+ * it would make an already-applied migration run a second time on every machine
+ * that had applied the old number.
+ */
+export function rewriteTagReferences(text: string, oldTag: string, newTag: string): string {
+  const escaped = oldTag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return text.replace(new RegExp(String.raw`\b${escaped}\b(?![\w-])`, 'g'), newTag);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -164,6 +164,13 @@ export default defineConfig({
         dependsOn: ['db:up'],
         cache: false,
       },
+      // Rebase onto origin/main and move this branch's migration to the next free
+      // number, keeping the author's SQL. Run it when main takes your number; CI
+      // runs the same task from .github/workflows/db-migration-renumber.yml.
+      'db:renumber': {
+        command: 'tsx scripts/db-renumber-migration.ts',
+        cache: false,
+      },
       'db:seed-social': {
         command: 'bun run --filter=@boardsesh/db db:seed-social',
         dependsOn: ['db:up'],
@@ -339,6 +346,14 @@ export default defineConfig({
       'verify:graphql-treeshake': {
         command: 'bun packages/web/scripts/verify-graphql-treeshake.ts',
         dependsOn: ['build:web'],
+        cache: false,
+      },
+      // Guards the migration folder against the failures that are invisible in
+      // review and silent at deploy time: a .sql with no journal entry (never
+      // runs), a journal entry with no .sql (crashes the migrator), a duplicate
+      // number, and a `when` that isn't newer than main's (skipped forever).
+      'check:db-migrations': {
+        command: 'tsx scripts/check-db-migrations.ts',
         cache: false,
       },
       'check:i18n': {


### PR DESCRIPTION
## Summary

Migration numbers are first-come-first-served, and every open migration PR appends to the same `_journal.json` tail. Right now four open PRs (#3960, #3957, #3951, #3931) all hold `0187` and all report **MERGEABLE** — the instant one merges, the other three go `CONFLICTING`. Unblocking each one is a hand ritual (rebase → resolve the journal → rebuild `packages/db` → re-run `drizzle-kit generate` → paste the hand-tuned SQL back) that this repo has performed **26 times**, three of them on 2026-07-16 alone, documented nowhere.

This makes the collision self-healing:

1. **`db-migration` label** — `pr-labels.yml` labels any PR that adds a migration.
2. **`native-fingerprint` label** — one step added to the existing `mobile-ota-check.yml`, which already computes the verdict. Marker only; the check-run stays neutral. Makes the native train queryable: `gh pr list --label native-fingerprint`.
3. **Fan-out on main** — when a migration lands, `db-migration-renumber-dispatch.yml` dispatches a renumber for every stranded PR.
4. **`db-migration-renumber.yml`** — rebases the PR, renumbers, proves the migration still applies against Postgres, then force-pushes.

The engine ships as `vp run db:renumber`, so a human hitting a collision runs one command instead of the ritual. New `docs/db-migrations.md` writes the whole thing down for the first time.

### Verified end-to-end, not just unit-tested

Ran against a real collision — PR #3957's migration rebased onto a `main` carrying PR #3960's:

- `0187_sad_freak.sql` → `0188_sad_freak.sql`, body **byte-identical** (md5 match)
- snapshot regenerated and correctly chained: a fresh `drizzle-kit generate` afterwards reports `No schema changes, nothing to migrate`
- journal `when` strictly above main's newest
- commit shape is a pure rename + new snapshot + journal entry — exactly matching the hand-written `63873f038`
- re-running is a clean no-op

### Findings that shaped the design

Read drizzle-kit 0.31.10's bundle rather than trusting its interface:

- **`generate`'s exit code is worthless.** `prepareAndMigratePg` ends `catch (e) { console.error(e); }` with no rethrow, and the folder reader calls bare `process.exit(0)` on a malformed snapshot or snapshot-parent collision. Success is decided by diffing the directory listing.
- **The `meta/` reset is a correctness requirement, not tidiness** — post-rebase both snapshots name the same parent, which drizzle treats as a collision and answers with that silent `exit(0)`.
- **`when`, not the number, is the apply gate.** A renumbered migration whose `when` isn't newer than main's is skipped *forever*, silently, in production. Clamped and asserted.
- **Tag references are never rewritten inside a migration body.** Seven migrations write a `_bs_migration_guards` idempotency key that is *not* the filename (`0163_merge_moonboard_duplicates.sql` guards on `0162_merge_moonboard_duplicates`). Rewriting it would re-run an applied migration on every dev machine.

### Two fixes this depends on

- **Deletes `packages/db/drizzle/0177_illegal_omega_red.sql`** — verified dead: zero journal entries, zero references, byte-identical to the applied `0179_bent_kid_colt.sql`. Left by a hand-renumber that forgot the `git rm`. `meta/0177_snapshot.json` is left alone; it belongs to the journalled `0177_ordinary_anita_blake`.
- **`.gitattributes` union-merges the schema barrel.** `packages/db/src/schema/**/index.ts` is an append-only export list, so *every* pair of table-adding PRs conflicts on the last line. Found this the hard way — the bot blocked on the real test case until this was added. Failure mode is loud: a duplicated export fails the TypeScript build.

### Also adds a guard rail

`vp run check:db-migrations` (new CI job, gated on `packages/db`, no DB and no build) catches the silent failures: an orphaned `.sql`, a journal entry with no file, a `when` that would be skipped, a number main already took. It would have caught `0177` in review. It deliberately ignores the six duplicate numbers main has carried since 2024 — both sides are journalled and applied in production.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` — 0 errors
- `vp run typecheck` — clean
- 68 new unit tests across `scripts/lib/drizzle-migrations.test.ts`, `scripts/check-db-migrations.test.ts`, `scripts/db-renumber-migration.test.ts`, including a byte-for-byte `_journal.json` round-trip against the real file (pins the 2-space indent and absent trailing newline that `.prettierignore` leaves unguarded)
- `scripts/mobile-ci-env-parity.test.ts` still green after the `mobile-ota-check.yml` edit
- End-to-end renumber against real PR branches, as above
- All five touched/added workflow YAMLs parse

### Not yet exercised in CI

The workflows can only really run once they're on `main` (dispatch always targets the default-branch copy). After merge I'll land a migration and watch the fan-out, confirming the App-token push does re-trigger `ci.yml` — a `GITHUB_TOKEN` push would leave the renumbered commit with no checks.

### Known limits, stated plainly

- **Fork PRs are out of scope.** `pull_request` hands fork workflows a read-only token, so neither label lands, and the App (installed on this repo only) couldn't push to a fork anyway. Consistent with the existing OTA-comment gap; `pull_request_target` stays off the table.
- **Per your call, no draft/staleness/cap filter on the fan-out** — every labelled open PR is renumbered. It does skip PRs whose number doesn't actually collide, which is correctness rather than a scope cut. `renumber:skip` is the opt-out.
- A bot force-push dismisses approvals (`dismiss_stale_reviews` + `require_last_push_approval` are on). Acceptable because the bot only touches PRs that just became conflicting and couldn't have merged anyway.
